### PR TITLE
puppet: Permit outgoing mail from postfix.

### DIFF
--- a/puppet/zulip/templates/postfix/main.cf.erb
+++ b/puppet/zulip/templates/postfix/main.cf.erb
@@ -16,7 +16,7 @@ smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated reject_unauth_destination
-smtpd_recipient_restrictions = check_recipient_access regexp:/etc/postfix/access, reject
+smtpd_recipient_restrictions = permit_mynetworks, check_recipient_access regexp:/etc/postfix/access, reject
 myhostname = <%= @fqdn %>
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases


### PR DESCRIPTION
The configuration change made in 1c17583ad5b2 only allowed delivery to
those specific Zulip addresses.  However, they also prevent the
mailserver from being used as an outgoing email relay from Zulip,
since all mail that passed through the mailserver (from any
originator) was required to have a `RCPT TO` that matched those
regexes.

Allow mail originating from `mynetworks` to have an arbitrary
addresses in `RCPT TO`.

**Testing Plan:** Applied on a test prod instance, could RCPT TO anywhere from localhost.