### PR TITLE
browserslist: Drop 0.2% usage threshold to 0.15%

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,5 +1,5 @@
-> 0.2%
-> 0.2% in US
+> 0.15%
+> 0.15% in US
 last 2 versions
 Firefox ESR
 not dead


### PR DESCRIPTION
This adds back Chrome 72, Chrome 70, Firefox 68, Opera 68, Safari 12.1, and Samsung 9.2.  Firefox 68 is still Debian stable’s default browser despite reaching end of upstream ESR support a few days ago.  This probably has no practical effects with IE 11 still listed.

**Testing Plan:** Diff of `yarn browserslist`:

```diff
 and_chr 85
 and_ff 79
 and_qq 10.4
 and_uc 12.12
 android 81
 android 4.4.3-4.4.4
 baidu 7.12
 chrome 85
 chrome 84
 chrome 83
 chrome 81
 chrome 80
 chrome 79
+chrome 72
 chrome 71
+chrome 70
 chrome 49
 edge 85
 edge 84
 edge 18
 firefox 80
 firefox 79
 firefox 78
+firefox 68
 ie 11
 ios_saf 14.0
 ios_saf 13.4-13.7
 ios_saf 13.3
 ios_saf 13.2
 ios_saf 13.0-13.1
 ios_saf 12.2-12.4
 ios_saf 12.0-12.1
 ios_saf 11.3-11.4
 ios_saf 11.0-11.2
 ios_saf 10.3
 ios_saf 10.0-10.2
 ios_saf 9.3
 kaios 2.5
 op_mini all
 op_mob 59
 opera 70
 opera 69
+opera 68
 safari 14
 safari 13.1
 safari 13
+safari 12.1
 samsung 12.0
 samsung 11.1-11.2
+samsung 9.2
```