### PR TITLE
messages: Extract message info in check_message itself instead of doing it in do_send_messages.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1407,7 +1407,6 @@ def do_send_messages(messages_maybe_none: Sequence[Optional[MutableMapping[str, 
             new_messages.append(message)
     messages = new_messages
 
-    links_for_embed: Set[str] = set()
     for message_dict in messages:
         message_dict['stream'] = message_dict.get('stream', None)
         message_dict['local_id'] = message_dict.get('local_id', None)
@@ -1459,7 +1458,7 @@ def do_send_messages(messages_maybe_none: Sequence[Optional[MutableMapping[str, 
         )
         message_dict['message'].rendered_content = rendered_content
         message_dict['message'].rendered_content_version = markdown_version
-        links_for_embed |= message_dict['message'].links_for_preview
+        message_dict['links_for_embed'] = message_dict['message'].links_for_preview
 
         # Add members of the mentioned user groups into `mentions_user_ids`.
         for group_id in message_dict['message'].mentions_user_group_ids:
@@ -1620,12 +1619,12 @@ def do_send_messages(messages_maybe_none: Sequence[Optional[MutableMapping[str, 
             event['sender_queue_id'] = message['sender_queue_id']
         send_event(message['realm'], event, users)
 
-        if links_for_embed:
+        if message['links_for_embed']:
             event_data = {
                 'message_id': message['message'].id,
                 'message_content': message['message'].content,
                 'message_realm_id': message['realm'].id,
-                'urls': list(links_for_embed)}
+                'urls': list(message['links_for_embed'])}
             queue_json_publish('embed_links', event_data)
 
         if message['message'].recipient.type == Recipient.PERSONAL:

--- a/zerver/management/commands/deliver_scheduled_messages.py
+++ b/zerver/management/commands/deliver_scheduled_messages.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
-from zerver.lib.actions import do_send_messages
+from zerver.lib.actions import build_message_send_dict, do_send_messages
 from zerver.lib.logging_util import log_to_file
 from zerver.lib.management import sleep_forever
 from zerver.models import Message, ScheduledMessage, get_user_by_delivery_email
@@ -44,8 +44,9 @@ Usage: ./manage.py deliver_scheduled_messages
         elif delivery_type == ScheduledMessage.REMIND:
             message.sender = get_user_by_delivery_email(settings.NOTIFICATION_BOT, original_sender.realm)
 
-        return {'message': message, 'stream': scheduled_message.stream,
-                'realm': scheduled_message.realm}
+        message_dict = {'message': message, 'stream': scheduled_message.stream,
+                        'realm': scheduled_message.realm}
+        return build_message_send_dict(message_dict)
 
     def handle(self, *args: Any, **options: Any) -> None:
 

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -11,6 +11,7 @@ from django.utils.timezone import now as timezone_now
 
 from zerver.decorator import JsonableError
 from zerver.lib.actions import (
+    build_message_send_dict,
     check_message,
     check_send_stream_message,
     do_change_is_api_super_user,
@@ -1142,7 +1143,8 @@ class StreamMessagesTest(ZulipTestCase):
                 sending_client=sending_client,
             )
             message.set_topic_name(topic_name)
-            do_send_messages([dict(message=message)])
+            message_dict = build_message_send_dict({'message': message})
+            do_send_messages([message_dict])
 
         before_um_count = UserMessage.objects.count()
 

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -17,6 +17,7 @@ from django.utils.timezone import timedelta as timezone_timedelta
 from scripts.lib.zulip_tools import get_or_create_dev_uuid_var_path
 from zerver.lib.actions import (
     STREAM_ASSIGNMENT_COLORS,
+    build_message_send_dict,
     check_add_realm_emoji,
     do_change_user_role,
     do_send_messages,
@@ -792,7 +793,11 @@ def send_messages(messages: List[Message]) -> None:
     # up with queued events that reference objects from a previous
     # life of the database, which naturally throws exceptions.
     settings.USING_RABBITMQ = False
-    do_send_messages([{'message': message} for message in messages])
+    message_dict_list = []
+    for message in messages:
+        message_dict = build_message_send_dict({'message': message})
+        message_dict_list.append(message_dict)
+    do_send_messages(message_dict_list)
     bulk_create_reactions(messages)
     settings.USING_RABBITMQ = True
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is a prep PR for #16332 for extracting message info in check_message such that we can use]
rendered_content to handle wildcard mentions according to the setting that will be added in #16335 

 <!-- How have you tested? -->


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
