### PR TITLE
puppeteer: Fix typing issue in settings test.

### DIFF
--- a/frontend_tests/puppeteer_tests/16-settings.js
+++ b/frontend_tests/puppeteer_tests/16-settings.js
@@ -41,6 +41,7 @@ async function test_change_full_name(page) {
     await page.$eval(full_name_input_selector, (el) => {
         el.value = "";
     });
+    await page.waitForFunction(() => $(":focus").attr("id") === "change_full_name_modal");
     await page.type(full_name_input_selector, "New name");
     await page.click(change_full_name_button_selector);
     await page.waitForFunction(() => $("#change_full_name").text().trim() === "New name");
@@ -52,6 +53,7 @@ async function test_change_password(page) {
     const change_password_button_selector = "#change_password_button";
     await page.waitForSelector(change_password_button_selector, {visible: true});
 
+    await page.waitForFunction(() => $(":focus").attr("id") === "change_password_modal");
     await page.type("#old_password", test_credentials.default_user.password);
     await page.type("#new_password", "new_password");
     await page.click(change_password_button_selector);
@@ -66,6 +68,7 @@ async function test_get_api_key(page) {
 
     const get_api_key_button_selector = "#get_api_key_button";
     await page.waitForSelector(get_api_key_button_selector, {visible: true});
+    await page.waitForFunction(() => $(":focus").attr("id") === "api_key_modal");
     await common.fill_form(page, "#api_key_form", {
         password: test_credentials.default_user.password,
     });


### PR DESCRIPTION
The failures saying incorrect password were caused due to
change in focus. Some actual code of ours calls focus on
the modal when opened but puppeteer was starting to type
before this occurs due to which the test was only able
to enter a part of string.

This was happening with change full name too but less
frequently as it's a relatively shorter string.

As a fix, we wait till the focus is on the modal and then
start typing.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Tested by running the test with changes in a [loop](https://app.circleci.com/pipelines/github/chdinesh1089/zulip?branch=16_debug). Found the test still seems to be a bit flaky but not as frequent as these password issues were. The failing tests suggest that the reload issue discussed at https://chat.zulip.org/#narrow/stream/49-development-help/topic/reload.20on.20changing.20password wasn't fixed.

