### PR TITLE
invite: Fix text of submit-invitation button on completion.

### DIFF
--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -98,7 +98,8 @@ function submit_invitation_form() {
             }
         },
         complete() {
-            $("#submit-invitation").button("reset");
+            $("#submit-invitation").text(i18n.t("Invite"));
+            $("#submit-invitation").prop("disabled", false);
             $("#invitee_emails").focus();
             ui.get_scroll_element($("#invite_user_form .modal-body"))[0].scrollTop = 0;
         },
@@ -124,7 +125,8 @@ function generate_multiuse_invite() {
             ui_report.error("", xhr, invite_status);
         },
         complete() {
-            $("#submit-invitation").button("reset");
+            $("#submit-invitation").text(i18n.t("Generate invite link"));
+            $("#submit-invitation").prop("disabled", false);
         },
     });
 }


### PR DESCRIPTION
There is a bug in invite flow, where the button text resets
to incorrect text after the invitation process is completed.
This bug is because we are using $().button("reset") to
reset the button text, but the data-reset-text attribute of
button is not changed when toggling between multi-use link
invite and email invites.

This bug can be fixed by setting data-reset-text attribute
in a way similar to the way we set data-loading-text attribute
on toggling between multiuse and normal invites.

But according to the bootstrap [docs](https://getbootstrap.com/docs/4.0/migration/#buttons), "reset" method was removed
in v4.0.
Though we are not using Bootstrap v4.0 as of now, but it is
good to remove such methods as it will help in future when we
would upgrade to later bootstrap versions.

So instead of fixing this by above mentioned patch, we are
fixing this by removing "reset" method and instead using simple
jquery to reset the text and enable the button after the invite
process is completed.

Discussion here - https://chat.zulip.org/#narrow/stream/6-frontend/topic/Buggy.20.23.23submit-invitation.20button.20behavior

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? --> Dev server


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
