### PR TITLE
Clean up puppet resources marked as ensure absent

### DIFF
--- a/puppet/zulip/manifests/apache_sso.pp
+++ b/puppet/zulip/manifests/apache_sso.pp
@@ -4,13 +4,11 @@ class zulip::apache_sso {
   case $::osfamily {
     'debian': {
       $apache_packages = [ 'apache2', 'libapache2-mod-wsgi-py3', ]
-      $apache_former_packages = [ 'libapache2-mod-wsgi', ]
       $conf_dir = '/etc/apache2'
       $apache2 = 'apache2'
     }
     'redhat': {
       $apache_packages = [ 'httpd', 'python36u-mod_wsgi', ]
-      $apache_former_packages = []
       $conf_dir = '/etc/httpd'
       $apache2 = 'httpd'
     }
@@ -19,7 +17,6 @@ class zulip::apache_sso {
     }
   }
   package { $apache_packages: ensure => 'installed' }
-  package { $apache_former_packages: ensure => 'absent' }
 
   apache2mod { [ 'headers', 'proxy', 'proxy_http', 'rewrite', 'ssl', 'wsgi', ]:
     ensure  => present,

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -145,9 +145,6 @@ class zulip::app_frontend_base {
     group  => 'zulip',
     mode   => '0755',
   }
-  file { '/etc/cron.d/email-mirror':
-    ensure => absent,
-  }
   file { "${zulip::common::nagios_plugins_dir}/zulip_app_frontend":
     require => Package[$zulip::common::nagios_plugins],
     recurse => true,

--- a/puppet/zulip/manifests/app_frontend_once.pp
+++ b/puppet/zulip/manifests/app_frontend_once.pp
@@ -42,10 +42,6 @@ class zulip::app_frontend_once {
     source => 'puppet:///modules/zulip/cron.d/archive-messages',
   }
 
-  file { '/etc/cron.d/calculate-first-visible-message-id':
-    ensure => absent,
-  }
-
   file { '/etc/cron.d/clearsessions':
     ensure => file,
     owner  => 'root',

--- a/puppet/zulip_ops/manifests/app_frontend.pp
+++ b/puppet/zulip_ops/manifests/app_frontend.pp
@@ -26,10 +26,6 @@ class zulip_ops::app_frontend {
     source => 'puppet:///modules/zulip_ops/log2zulip.conf',
   }
 
-  file { '/etc/cron.d/log2zulip':
-    ensure => absent,
-  }
-
   file { '/etc/log2zulip.zuliprc':
     ensure => file,
     owner  => 'zulip',

--- a/puppet/zulip_ops/manifests/app_frontend.pp
+++ b/puppet/zulip_ops/manifests/app_frontend.pp
@@ -33,9 +33,6 @@ class zulip_ops::app_frontend {
     mode   => '0600',
     source => 'puppet:///modules/zulip_ops/log2zulip.zuliprc',
   }
-  file { '/etc/cron.d/check-apns-tokens':
-    ensure => absent,
-  }
 
   file { '/etc/supervisor/conf.d/redis_tunnel.conf':
     ensure  => file,


### PR DESCRIPTION
These are cruft from when we removed a file we used to install, and needed to leave a marker in puppet so folks upgrading would remove the file.  This is only necessary for so long as it is likely that folks are upgrading from a version prior to when the file was removed.

The most recent possible version for all of these was version 2.0.0; any upgrade path to current 4.0-dev passes through that version, and thus will have run puppet to remove the files.