### PR TITLE
i18n: Fix quotes of help message in user group settings

### DIFF
--- a/static/templates/admin_user_group_list.hbs
+++ b/static/templates/admin_user_group_list.hbs
@@ -21,7 +21,7 @@
         <div class="input" contenteditable="true" data-placeholder="{{t 'Add member...' }}"></div>
     </div>
     <p class="save-instructions">
-        {{t 'Click outside the input box to save. We\'ll automatically notify anyone that was added or removed.'}}
+        {{t "Click outside the input box to save. We'll automatically notify anyone that was added or removed."}}
     </p>
 </div>
 {{/with}}


### PR DESCRIPTION
I have verified that the commit fixes the issue by modifying translations.json

More details at https://chat.zulip.org/#narrow/stream/58-translation/topic/Missing.20string.3F