### PR TITLE
custom_profile_fields: Don't allow leading/trailing whitespaces.

### DIFF
--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -70,6 +70,15 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         field = CustomProfileField.objects.get(name="Phone", realm=realm)
         self.assertEqual(field.id, field.order)
 
+        data["name"] = "Name "
+        data["hint"] = "Some name"
+        data["field_type"] = CustomProfileField.SHORT_TEXT
+        result = self.client_post("/json/realm/profile_fields", info=data)
+        self.assert_json_success(result)
+
+        field = CustomProfileField.objects.get(name="Name", realm=realm)
+        self.assertEqual(field.id, field.order)
+
         result = self.client_post("/json/realm/profile_fields", info=data)
         self.assert_json_error(result,
                                'A field with that label already exists.')
@@ -412,6 +421,15 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assertEqual(field.name, 'New phone number')
         self.assertEqual(field.hint, 'New contact number')
         self.assertEqual(field.field_type, CustomProfileField.SHORT_TEXT)
+
+        result = self.client_patch(
+            f"/json/realm/profile_fields/{field.id}",
+            info={'name': 'Name ',
+                  'field_type': CustomProfileField.SHORT_TEXT},
+        )
+        self.assert_json_success(result)
+        field.refresh_from_db()
+        self.assertEqual(field.name, 'Name')
 
         field = CustomProfileField.objects.get(name="Favorite editor", realm=realm)
         result = self.client_patch(

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -90,7 +90,7 @@ def validate_custom_profile_field(name: str, hint: str, field_type: int,
 @has_request_variables
 def create_realm_custom_profile_field(request: HttpRequest,
                                       user_profile: UserProfile,
-                                      name: str=REQ(default=''),
+                                      name: str=REQ(default='', converter=lambda x: x.strip()),
                                       hint: str=REQ(default=''),
                                       field_data: ProfileFieldData=REQ(default={},
                                                                        converter=orjson.loads),
@@ -133,7 +133,7 @@ def delete_realm_custom_profile_field(request: HttpRequest, user_profile: UserPr
 @has_request_variables
 def update_realm_custom_profile_field(request: HttpRequest, user_profile: UserProfile,
                                       field_id: int,
-                                      name: str=REQ(default=''),
+                                      name: str=REQ(default='', converter=lambda x: x.strip()),
                                       hint: str=REQ(default=''),
                                       field_data: ProfileFieldData=REQ(default={},
                                                                        converter=orjson.loads),


### PR DESCRIPTION
Allowing such whitespaces can lead to hard to debug issues e.g. with
ldap sync.

https://chat.zulip.org/#narrow/stream/2-general/topic/ldap.20and.20custom.20fields