### PR TITLE
docs: Show simple POSIX shell quoting in send-message documentation

### DIFF
--- a/templates/zerver/api/send-message.md
+++ b/templates/zerver/api/send-message.md
@@ -21,17 +21,17 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 # For stream messages
 curl -X POST {{ api_url }}/v1/messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
-    -d "type=stream" \
-    -d "to=Denmark" \
-    -d "subject=Castle" \
-    -d $"content=I come not, friends, to steal away your hearts."
+    -d 'type=stream' \
+    -d 'to=Denmark' \
+    -d 'subject=Castle' \
+    -d 'content=I come not, friends, to steal away your hearts.'
 
 # For private messages
 curl -X POST {{ api_url }}/v1/messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
-    -d "type=private" \
-    -d "to=[9]" \
-    -d $"content=With mirth and laughter let old wrinkles come."
+    -d 'type=private' \
+    -d 'to=[9]' \
+    -d 'content=With mirth and laughter let old wrinkles come.'
 ```
 
 {tab|zulip-send}
@@ -58,7 +58,7 @@ If you'd like, you can also provide the message on the command-line with the
 
 ```bash
 zulip-send --stream Denmark --subject Castle \
-    --message "I come not, friends, to steal away your hearts." \
+    --message 'I come not, friends, to steal away your hearts.' \
     --user othello-bot@example.com --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
 ```
 


### PR DESCRIPTION
This reverts commit 5275d49f0572869915973e58b00c902b532c2dfc (effectively), which created more problems than it solves.  #8484 is not a bug: a newline can be included literally with no escaping within POSIX quotes.  Meanwhile, `$""` is a bashism, and not even the correct bashism: it translates strings using the `LC_MESSAGES` catalog.  If the user wants to do something complicated, they can consult the documentation for their shell.