### PR TITLE
message_edit: Reorder buttons to match compose.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1371,9 +1371,10 @@ div.focused_table {
 }
 
 .message-edit-feature-group {
-    display: inline-block;
+    display: inline-flex;
     margin-left: 10px;
     margin-bottom: -5px;
+    align-items: baseline;
 }
 
 .topic_edit {

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -63,16 +63,16 @@
                 {{#if is_content_editable}}
                 <div class="message-edit-feature-group">
                     <input type="file" id="message_edit_file_input_{{message_id}}" class="notvisible pull-left" multiple />
-                    <a role="button" tabindex=0 class="message-control-button fa fa-smile-o" aria-label="{{t 'Add emoji' }}" id="emoji_map" data-message-id="{{message_id}}" title="{{t 'Add emoji' }}"></a>
-                    <a role="button" tabindex=0 class="message-control-button fa fa-font" aria-label="{{t 'Formatting' }}" title="{{t 'Formatting' }}" data-overlay-trigger="message-formatting" ></a>
                     {{#if file_upload_enabled}}
                     <a role="button" tabindex=0 class="message-control-button fa fa-paperclip notdisplayed" aria-label="{{t "Attach files" }}" id="attach_files_{{message_id}}" title="{{t "Attach files" }}"></a>
                     {{/if}}
+                    <a role="button" tabindex=0 id="markdown_preview_{{message_id}}" class="message-control-button fa fa-eye" aria-label="{{t 'Preview' }}" title="{{t 'Preview' }}"></a>
+                    <a role="button" tabindex=0 id="undo_markdown_preview_{{message_id}}" class="message-control-button fa fa-edit" aria-label="{{t 'Write' }}" style="display:none;" title="{{t 'Write' }}"></a>
                     {{#if show_video_chat_button}}
                     <a role="button" tabindex=0 class="message-control-button fa fa-video-camera video_link" aria-label="{{t "Add video call" }}" data-message-id="{{message_id}}" title="{{t "Add video call" }}"></a>
                     {{/if}}
-                    <a role="button" tabindex=0 id="undo_markdown_preview_{{message_id}}" class="message-control-button fa fa-edit" aria-label="{{t 'Write' }}" style="display:none;" title="{{t 'Write' }}"></a>
-                    <a role="button" tabindex=0 id="markdown_preview_{{message_id}}" class="message-control-button fa fa-eye" aria-label="{{t 'Preview' }}" title="{{t 'Preview' }}"></a>
+                    <a role="button" tabindex=0 class="message-control-button fa fa-smile-o" aria-label="{{t 'Add emoji' }}" id="emoji_map" data-message-id="{{message_id}}" title="{{t 'Add emoji' }}"></a>
+                    <a role="button" tabindex=0 class="message-control-button fa fa-font" aria-label="{{t 'Formatting' }}" title="{{t 'Formatting' }}" data-overlay-trigger="message-formatting" ></a>
                 </div>
                 {{/if}}
             {{else}}

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -72,7 +72,7 @@
                     <a role="button" tabindex=0 class="message-control-button fa fa-video-camera video_link" aria-label="{{t "Add video call" }}" data-message-id="{{message_id}}" title="{{t "Add video call" }}"></a>
                     {{/if}}
                     <a role="button" tabindex=0 class="message-control-button fa fa-smile-o" aria-label="{{t 'Add emoji' }}" id="emoji_map" data-message-id="{{message_id}}" title="{{t 'Add emoji' }}"></a>
-                    <a role="button" tabindex=0 class="message-control-button fa fa-font" aria-label="{{t 'Formatting' }}" title="{{t 'Formatting' }}" data-overlay-trigger="message-formatting" ></a>
+                    <a role="button" tabindex=0 class="message-control-link" data-overlay-trigger="message-formatting" >{{t 'Help' }}</a>
                 </div>
                 {{/if}}
             {{else}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

In #16399 I reordered the compose button to:

![image](https://user-images.githubusercontent.com/47354597/94891932-adeab880-0483-11eb-8b4f-676bc0ff357e.png)

This PR applies the same change to the message action buttons in the message edit form (to make them consistent).

before:
![image](https://user-images.githubusercontent.com/47354597/94891603-cefed980-0482-11eb-8d59-f0aba8903445.png)

after:
![image](https://user-images.githubusercontent.com/47354597/94891674-08cfe000-0483-11eb-9941-e053f66cb89a.png)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
