### PR TITLE
Add docker registration example for push notifications

### DIFF
--- a/docs/production/mobile-push-notifications.md
+++ b/docs/production/mobile-push-notifications.md
@@ -32,6 +32,8 @@ follows:
     su zulip -c '/home/zulip/deployments/current/manage.py register_server'
     # Or as the zulip user, you can skip the `su zulip -c`:
     /home/zulip/deployments/current/manage.py register_server
+    # On docker:
+    docker exec -it -u zulip <container name> /home/zulip/deployments/current/manage.py register_server
     ```
    This command will print the registration data it would send to the
    mobile push notifications service, ask you to accept the terms of


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

No linked issue, just wish the docker command was handy so I wouldn't have to look up the command flags myself :)


**Testing Plan:** <!-- How have you tested? -->

I ran this on my own instance and received the prompt to register my server for notifications.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
