### PR TITLE
settings: Rework user_group save_discard widget.

### DIFF
--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -524,14 +524,16 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         case "user_group":
             if (event.op === "add") {
                 user_groups.add(event.group);
+                settings_user_groups.reload();
             } else if (event.op === "add_members") {
                 user_groups.add_members(event.group_id, event.user_ids);
             } else if (event.op === "remove_members") {
                 user_groups.remove_members(event.group_id, event.user_ids);
             } else if (event.op === "update") {
                 user_groups.update(event);
+            } else {
+                settings_user_groups.reload();
             }
-            settings_user_groups.reload();
             break;
 
         case "user_status":

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -57,6 +57,7 @@ exports.populate_user_groups = function () {
                 },
             }),
         );
+
         const pill_container = $('.pill-container[data-group-pills="' + data.id + '"]');
         const pills = user_pill.create_pills(pill_container);
 
@@ -118,6 +119,7 @@ exports.populate_user_groups = function () {
             }
             return true;
         }
+
         function show_hide_element(show, fadeout_delay) {
             const $element = $("#user-groups #" + data.id).find(".save-button-controls");
             if (show) {
@@ -128,6 +130,7 @@ exports.populate_user_groups = function () {
                 $element.fadeOut(300);
             }, fadeout_delay);
         }
+
         function update_cancel_button() {
             if (!exports.can_edit(data.id)) {
                 return;
@@ -216,15 +219,25 @@ exports.populate_user_groups = function () {
         }
 
         $("#user-groups #" + data.id).on("click", ".subsection-changes-discard .button", () => {
-            exports.reload();
+            show_hide_element(false, 0);
+            $("#user-groups #" + data.id + " .name").text(data.name);
+            $("#user-groups #" + data.id + " .description").text(data.description);
+            $("#user-groups #" + data.id + " .pill-container .pill").remove();
+            data.members.forEach((user_id) => {
+                const user = people.get_by_user_id(user_id);
+                user_pill.append_user(user, pills);
+            });
         });
+
         $("#user-groups #" + data.id).on("click", ".subsection-changes-save .button", () => {
             show_hide_element(false, 0);
             auto_save();
         });
+
         $("#user-groups #" + data.id).on("input", ".name", () => {
             update_cancel_button();
         });
+
         $("#user-groups #" + data.id).on("input", ".description", () => {
             update_cancel_button();
         });

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -118,38 +118,36 @@ exports.populate_user_groups = function () {
             }
             return true;
         }
-
+        function show_hide_element(show, fadeout_delay) {
+            const $element = $("#user-groups #" + data.id).find(".save-button-controls");
+            if (show) {
+                $element.removeClass("hide").addClass(".show").fadeIn(300);
+                return;
+            }
+            setTimeout(() => {
+                $element.fadeOut(300);
+            }, fadeout_delay);
+        }
         function update_cancel_button() {
             if (!exports.can_edit(data.id)) {
                 return;
             }
-            const cancel_button = $("#user-groups #" + data.id + " .save-status.btn-danger");
             const saved_button = $("#user-groups #" + data.id + " .save-status.sea-green");
-            const save_instructions = $("#user-groups #" + data.id + " .save-instructions");
-
-            if (is_user_group_changed() && !cancel_button.is(":visible")) {
+            if (is_user_group_changed()) {
                 saved_button.fadeOut(0);
-                cancel_button.css({display: "inline-block", opacity: "0"}).fadeTo(400, 1);
-                save_instructions.css({display: "block", opacity: "0"}).fadeTo(400, 1);
-            } else if (!is_user_group_changed() && cancel_button.is(":visible")) {
-                cancel_button.fadeOut();
-                save_instructions.fadeOut();
+                show_hide_element(true, 0);
+            } else if (!is_user_group_changed()) {
+                show_hide_element(false, 0);
             }
         }
 
         function show_saved_button() {
-            const cancel_button = $("#user-groups #" + data.id + " .save-status.btn-danger");
             const saved_button = $("#user-groups #" + data.id + " .save-status.sea-green");
-            const save_instructions = $("#user-groups #" + data.id + " .save-instructions");
-            if (!saved_button.is(":visible")) {
-                cancel_button.fadeOut(0);
-                save_instructions.fadeOut(0);
-                saved_button
-                    .css({display: "inline-block", opacity: "0"})
-                    .fadeTo(400, 1)
-                    .delay(2000)
-                    .fadeTo(400, 0);
-            }
+            saved_button
+                .css({display: "inline-block", opacity: "0"})
+                .fadeTo(400, 1)
+                .delay(2000)
+                .fadeTo(400, 0);
         }
 
         function save_members() {
@@ -209,56 +207,23 @@ exports.populate_user_groups = function () {
             });
         }
 
-        function do_not_blur(except_class, event) {
-            // Event generated from or inside the typeahead.
-            if ($(event.relatedTarget).closest(".typeahead").length) {
-                return true;
-            }
-
-            const blur_exceptions = _.without(
-                [".pill-container", ".name", ".description", ".input", ".delete"],
-                except_class,
-            );
-            if ($(event.relatedTarget).closest("#user-groups #" + data.id).length) {
-                return blur_exceptions.some(
-                    (class_name) => $(event.relatedTarget).closest(class_name).length,
-                );
-            }
-            return false;
-        }
-
-        function auto_save(class_name, event) {
+        function auto_save() {
             if (!exports.can_edit(data.id)) {
-                return;
-            }
-
-            if (do_not_blur(class_name, event)) {
-                return;
-            }
-            if (
-                $(event.relatedTarget).closest("#user-groups #" + data.id) &&
-                $(event.relatedTarget).closest(".save-status.btn-danger").length
-            ) {
-                exports.reload();
                 return;
             }
             save_name_desc();
             save_members();
         }
 
-        $("#user-groups #" + data.id).on("blur", ".input", (event) => {
-            auto_save(".input", event);
+        $("#user-groups #" + data.id).on("click", ".subsection-changes-discard .button", () => {
+            exports.reload();
         });
-
-        $("#user-groups #" + data.id).on("blur", ".name", (event) => {
-            auto_save(".name", event);
+        $("#user-groups #" + data.id).on("click", ".subsection-changes-save .button", () => {
+            show_hide_element(false, 0);
+            auto_save();
         });
         $("#user-groups #" + data.id).on("input", ".name", () => {
             update_cancel_button();
-        });
-
-        $("#user-groups #" + data.id).on("blur", ".description", (event) => {
-            auto_save(".description", event);
         });
         $("#user-groups #" + data.id).on("input", ".description", () => {
             update_cancel_button();

--- a/static/templates/admin_user_group_list.hbs
+++ b/static/templates/admin_user_group_list.hbs
@@ -9,9 +9,25 @@
             <img class="checkmark" src="/static/images/checkbox-green.svg" />
             {{t 'Saved' }}
         </button>
-        <button class="button save-status btn-danger small">
-            {{t 'Discard changes' }}
-        </button>
+        <div class="save-button-controls hide">
+            <div class="inline-block organization-submission subsection-changes-save">
+                <div class="save-discard-widget-button button primary save-button" type="button" data-status="save">
+                    <span class="fa fa-spinner fa-spin save-discard-widget-button-loading"></span>
+                    <span class="fa fa-check save-discard-widget-button-icon"></span>
+                    <span class="save-discard-widget-button-text">
+                        {{t 'Save changes' }}
+                    </span>
+                </div>
+            </div>
+            <div class="inline-block subsection-changes-discard">
+                <div class="save-discard-widget-button button discard-button" type="button" id="org-discard-{{section_name}}">
+                    <span class="fa fa-times save-discard-widget-button-icon"></span>
+                    <span class="save-discard-widget-button-text">
+                        {{t 'Discard' }}
+                    </span>
+                </div>
+            </div>
+        </div>
         <button class="button rounded small delete btn-danger">
             {{t 'Delete' }}
         </button>
@@ -20,8 +36,5 @@
     <div class="pill-container" data-group-pills="{{id}}">
         <div class="input" contenteditable="true" data-placeholder="{{t 'Add member...' }}"></div>
     </div>
-    <p class="save-instructions">
-        {{t "Click outside the input box to save. We'll automatically notify anyone that was added or removed."}}
-    </p>
 </div>
 {{/with}}


### PR DESCRIPTION
Fixes: #16453
Changed "Click outside to save and discard to discard" UI of user_group
origanization settings to save/discard widget to maintain consistency.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![zulip_user_group](https://user-images.githubusercontent.com/32800267/94999244-d5ea3100-05d5-11eb-9e6a-b765610779bc.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
