### PR TITLE
emoji: Add padding around the gif on GIF emoji upload.

### DIFF
--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -159,7 +159,7 @@ def resize_gif(im: GifImageFile, size: int=DEFAULT_EMOJI_SIZE) -> bytes:
         im.seek(frame_num)
         new_frame = Image.new("RGBA", im.size)
         new_frame.paste(im, (0, 0), im.convert("RGBA"))
-        new_frame = ImageOps.fit(new_frame, (size, size), Image.ANTIALIAS)
+        new_frame = ImageOps.pad(new_frame, (size, size), Image.ANTIALIAS)
         frames.append(new_frame)
         duration_info.append(im.info['duration'])
     out = io.BytesIO()


### PR DESCRIPTION
This adds padding to the gif on GIF emoji upload, as mentioned in #16370 .

**Testing Plan:**
I picked up gif from [GIPHY](https://giphy.com) for testing purposes.
Following I am attaching the test results.

**GIFs or Screenshots:**
Before | After
--- | --- 
![man_bad](https://user-images.githubusercontent.com/67277428/94967015-eb9b2000-051b-11eb-9076-55f09a80f31d.gif)  | ![man](https://user-images.githubusercontent.com/67277428/94966996-de7e3100-051b-11eb-84ed-a19f06ad0062.gif) 
![nice_bad](https://user-images.githubusercontent.com/67277428/94967226-4896d600-051c-11eb-8d42-cee813e95135.gif) | ![nice](https://user-images.githubusercontent.com/67277428/94967206-42a0f500-051c-11eb-83d7-7f45b39e213b.gif) 
![nice2_bad](https://user-images.githubusercontent.com/67277428/94967453-be02a680-051c-11eb-8b2f-66963e7b66b7.gif) | ![nice2](https://user-images.githubusercontent.com/67277428/94967469-c78c0e80-051c-11eb-96c7-336be64da2a7.gif)
![pokemon_bad](https://user-images.githubusercontent.com/67277428/94967499-d1157680-051c-11eb-9655-39362c4fbeaa.gif) | ![pokemon](https://user-images.githubusercontent.com/67277428/94967514-d70b5780-051c-11eb-814c-d21c80bd1853.gif)
![sunday_bad](https://user-images.githubusercontent.com/67277428/94967529-df639280-051c-11eb-8894-04fe6445eacd.gif) | ![sunday](https://user-images.githubusercontent.com/67277428/94967542-e5597380-051c-11eb-96d4-ad391a1947a9.gif)
