### PR TITLE
ux: Improve delete message warning.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -865,8 +865,16 @@ function hide_delete_btn_show_spinner(deleting) {
     }
 }
 
+exports.populate_message_details_in_delete_model = function (msg_id) {
+    const msg = message_list.all.get(msg_id);
+    $("#delete-message-model-details-author").text(msg.sender_full_name);
+    $("#delete-message-model-details-stream").text(msg.stream);
+    $("#delete-message-model-details-topic").text(msg.topic);
+};
+
 exports.delete_message = function (msg_id) {
     $("#delete-message-error").html("");
+    this.populate_message_details_in_delete_model(msg_id);
     $("#delete_message_modal").modal("show");
     if (currently_deleting_messages.includes(msg_id)) {
         hide_delete_btn_show_spinner(true);

--- a/templates/zerver/app/delete_message.html
+++ b/templates/zerver/app/delete_message.html
@@ -6,6 +6,14 @@
     <div class="modal-body">
         <div class="content">
             <p><strong>{{ _("Are you sure you want to delete this message?") }}</strong></p>
+            <p id="delete-message-model-details">
+                <div> <strong>Author:</strong>  <span id="delete-message-model-details-author"></span> </div>
+                <div> <strong>Stream:</strong>  <span id="delete-message-model-details-stream"></span> </div>
+                <div> <strong>Topic:</strong> <span id="delete-message-model-details-topic"></span> </div>
+
+            </p>
+            <p><strong>Please note that this will permanently delete the message </strong> <a href="https://zulipchat.com/help/edit-or-delete-a-message#delete-a-message" target="_blank"><i class="fa fa-question-circle" aria-hidden="true"></i></a></p>
+
         </div>
         <div id="delete-message-error"></div>
     </div>


### PR DESCRIPTION
Adds details about the author, stream, topic in the modal for delete
message warning.

Also adds a warning saying that this message will be permanantly
deleted.

Fixes: #16426

Signed-off-by: Adwait Thattey <coderdude1999@gmail.com>

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** no tests added or modified

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
