### PR TITLE
login: Fix alignment of error message in login form.

### DIFF
--- a/static/styles/portico/portico-signin.css
+++ b/static/styles/portico/portico-signin.css
@@ -402,7 +402,6 @@ html {
         input[type="email"],
         input[type="password"] {
             padding: 10px 32px 10px 12px;
-            margin: 25px 0 5px;
 
             font-family: "Source Sans Pro";
             font-size: 1.2rem;
@@ -425,20 +424,6 @@ html {
             &:focus {
                 border: 1px solid hsl(0, 0%, 53%);
             }
-        }
-
-        input[type="email"] {
-            margin-bottom: 10px;
-        }
-
-        label {
-            position: absolute;
-            top: 0;
-            left: 0;
-
-            margin-top: 1px;
-
-            transition: all 0.3s ease;
         }
 
         &.moving-label {
@@ -486,8 +471,8 @@ html {
 
         label.text-error {
             display: block;
-
-            top: 66px;
+            position: relative;
+            top: -8px;
             color: hsl(0, 54%, 61%);
             font-size: 0.7em;
             font-weight: 600;

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -52,10 +52,6 @@ page can be easily identified in it's respective JavaScript file. -->
                             <!-- .no-validation is for removing the red star in CSS -->
                             {% if not two_factor_authentication_enabled or wizard.steps.current == 'auth' %}
                             <div class="input-box no-validation">
-                                <input id="id_username" type="{% if not require_email_format_usernames %}text{% else %}email{% endif %}"
-                                  name="username" class="{% if require_email_format_usernames %}email {% endif %}required"
-                                  {% if email %} value="{{ email }}" {% else %} value="" autofocus {% endif %}
-                                  maxlength="72" required />
                                 <label for="id_username">
                                     {% if not require_email_format_usernames and email_auth_enabled %}
                                     {{ _('Email or username') }}
@@ -65,13 +61,17 @@ page can be easily identified in it's respective JavaScript file. -->
                                     {{ _('Email') }}
                                     {% endif %}
                                 </label>
+                                <input id="id_username" type="{% if not require_email_format_usernames %}text{% else %}email{% endif %}"
+                                  name="username" class="{% if require_email_format_usernames %}email {% endif %}required"
+                                  {% if email %} value="{{ email }}" {% else %} value="" autofocus {% endif %}
+                                  maxlength="72" required />
                             </div>
 
                             <div class="input-box no-validation">
+                                <label for="id_password" class="control-label">{{ _('Password') }}</label>
                                 <input id="id_password" name="password" class="required" type="password"
                                   {% if email %} autofocus {% endif %}
                                   required />
-                                <label for="id_password" class="control-label">{{ _('Password') }}</label>
                             </div>
                             {% else %}
                             {% include "two_factor/_wizard_forms.html" %}


### PR DESCRIPTION
before:
<img width="499" alt="Screenshot 2020-10-06 at 1 19 03 PM" src="https://user-images.githubusercontent.com/25124304/95174258-78253700-07d7-11eb-8385-c6c501072037.png">

after:
<img width="499" alt="Screenshot 2020-10-06 at 1 19 08 PM" src="https://user-images.githubusercontent.com/25124304/95174270-7bb8be00-07d7-11eb-9bd2-fba598e8e4e0.png">
