### PR TITLE
run-dev: Wait for children to exit on Ctrl+C after killing them

### DIFF
--- a/tools/lib/test_server.py
+++ b/tools/lib/test_server.py
@@ -93,6 +93,7 @@ def test_server_running(force: bool=False, external_host: str='testserver',
     finally:
         assert_server_running(server, log_file)
         server.terminate()
+        server.wait()
 
 if __name__ == '__main__':
     # The code below is for testing this module works

--- a/zerver/lib/management.py
+++ b/zerver/lib/management.py
@@ -1,5 +1,5 @@
 # Library code for use in management commands
-import time
+import signal
 from argparse import ArgumentParser, RawTextHelpFormatter
 from typing import Any, Dict, List, Optional
 
@@ -31,7 +31,7 @@ def check_config() -> None:
 
 def sleep_forever() -> None:
     while True:  # nocoverage
-        time.sleep(10**9)
+        signal.pause()
 
 class ZulipBaseCommand(BaseCommand):
 


### PR DESCRIPTION
In addition to being generally more correct, this works around a bug in Node.js that causes `webpack-dev-server` to corrupt the terminal state when exiting as a background process.

**Testing Plan:** Dev server.