### PR TITLE
mobile-web: Fix colorpicker popover not being responsive

### DIFF
--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -66,6 +66,10 @@
         display: none;
         margin-right: 10px;
 
+        @media (max-width: 485px) {
+            display: flex;
+        }
+
         .sp-container {
             background-color: hsl(0, 0%, 100%);
             cursor: pointer;


### PR DESCRIPTION
The colorpicker popover that shows up when attempting to change the stream color overflows from the screen when the device size
is approximately 500px or lower. This has been fixed using a media query and setting the popover to display: flex

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
[https://github.com/zulip/zulip/issues/16477](url)

**Testing Plan:** <!-- How have you tested? -->
I haven't written any tests for this as it's a one-line CSS fix. 

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot](https://user-images.githubusercontent.com/47349681/95357874-04be1b00-08e6-11eb-9541-d9a74c6ec7e2.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
