### PR TITLE
message_send: Don't allow guests to post in full mem. only streams.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -362,7 +362,7 @@ run_test("validate_stream_message", () => {
     assert($("#compose-all-everyone").visible());
 });
 
-run_test("test_validate_stream_message_post_policy", () => {
+run_test("test_validate_stream_message_post_policy_admin_only", () => {
     // This test is in continuation with test_validate but it has been separated out
     // for better readability. Their relative position of execution should not be changed.
     // Although the position with respect to test_validate_stream_message does not matter
@@ -384,9 +384,45 @@ run_test("test_validate_stream_message_post_policy", () => {
         i18n.t("Only organization admins are allowed to post to this stream."),
     );
 
-    // reset compose_state.stream_name to 'social' again so that any tests occurung after this
+    // Reset error message.
+    compose_state.stream_name("social");
+
+    page_params.is_admin = false;
+    page_params.is_guest = true;
+
+    compose_state.topic("subject102");
+    compose_state.stream_name("stream102");
+    assert(!compose.validate());
+    assert.equal(
+        $("#compose-error-msg").html(),
+        i18n.t("Only organization admins are allowed to post to this stream."),
+    );
+});
+
+run_test("test_validate_stream_message_post_policy_full_members_only", () => {
+    page_params.is_admin = false;
+    page_params.is_guest = true;
+    const sub = {
+        stream_id: 103,
+        name: "stream103",
+        subscribed: true,
+        stream_post_policy: stream_data.stream_post_policy_values.non_new_members.code,
+    };
+
+    compose_state.topic("subject103");
+    compose_state.stream_name("stream103");
+    stream_data.add_sub(sub);
+    assert(!compose.validate());
+    assert.equal(
+        $("#compose-error-msg").html(),
+        i18n.t("Guests are not allowed to post to this stream."),
+    );
+
+    // reset compose_state.stream_name to 'social' again so that any tests occurring after this
     // do not reproduce this error.
     compose_state.stream_name("social");
+    // Reset page_params
+    page_params.is_guest = false;
 });
 
 run_test("markdown_rtl", () => {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -544,6 +544,11 @@ function validate_stream_message_post_policy(sub) {
         return false;
     }
 
+    if (page_params.is_guest && stream_post_policy !== stream_post_permission_type.everyone.code) {
+        compose_error(i18n.t("Guests are not allowed to post to this stream."));
+        return false;
+    }
+
     const person = people.get_by_user_id(page_params.user_id);
     const current_datetime = new Date(Date.now());
     const person_date_joined = new Date(person.date_joined);

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -184,6 +184,8 @@ def access_stream_for_send_message(sender: UserProfile,
         pass
     elif stream.stream_post_policy == Stream.STREAM_POST_POLICY_ADMINS:
         raise JsonableError(_("Only organization administrators can send to this stream."))
+    elif stream.stream_post_policy != Stream.STREAM_POST_POLICY_EVERYONE and sender.is_guest:
+        raise JsonableError(_("Guests cannot send to this stream."))
     elif stream.stream_post_policy == Stream.STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS:
         if sender.is_bot and (sender.bot_owner is not None and
                               sender.bot_owner.is_new_member):

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -194,6 +194,10 @@ class MessagePOSTTest(ZulipTestCase):
                                      'Test topic', 'Test message by notification bot')
         self.assertEqual(self.get_last_message().content, 'Test message by notification bot')
 
+        guest_profile = self.example_user("polonius")
+        # Guests cannot send to non-STREAM_POST_POLICY_EVERYONE streams
+        self._send_and_verify_message(guest_profile, stream_name, "Only organization administrators can send to this stream.")
+
     def test_sending_message_as_stream_post_policy_restrict_new_members(self) -> None:
         """
         Sending messages to streams which new members cannot create and post to.
@@ -257,6 +261,10 @@ class MessagePOSTTest(ZulipTestCase):
         internal_send_stream_message(stream.realm, notification_bot, stream,
                                      'Test topic', 'Test message by notification bot')
         self.assertEqual(self.get_last_message().content, 'Test message by notification bot')
+
+        guest_profile = self.example_user("polonius")
+        # Guests cannot send to non-STREAM_POST_POLICY_EVERYONE streams
+        self._send_and_verify_message(guest_profile, stream_name, "Guests cannot send to this stream.")
 
     def test_api_message_with_default_to(self) -> None:
         """


### PR DESCRIPTION
For streams in which only full members are allowed to post,
we block guest users from posting there.

Guests users were blocked from posting to admin only streams
already. So now, guest users can only post to
STREAM_POST_POLICY_EVERYONE streams.

This is not a new feature but a bugfix which should have
happened when implementing full member stream policy / guest users.

Discussion https://chat.zulip.org/#narrow/stream/9-issues/topic/Guests.20can.20post.20in.20streams