### PR TITLE
docs: Add more specific Big Blue Button documentation.

### DIFF
--- a/docs/production/big-blue-button-configuration.md
+++ b/docs/production/big-blue-button-configuration.md
@@ -1,0 +1,24 @@
+# Big Blue Button video calling configuration
+
+To use the [Big Blue Button](https://bigbluebutton.org/) integration on a self-hosted
+installation, you'll need to have a Big Blue Button server and configure it:
+
+1. Get the Shared Secret using the `bbb-conf --secret` command on your Big Blue Button Server. See also [the Big Blue Button documentation](https://docs.bigbluebutton.org/2.2/customize.html#extract-the-shared-secret).
+2. Get the URL to your Big Blue Button API. The URL has the form of `https://bigbluebutton.example.com/bigbluebutton/` and can also be found using the `bbb-conf --secret` command
+
+You can then configure your Zulip server to use that Big Blue Button Server as
+follows:
+
+1. In `/etc/zulip/zulip-secrets.conf`, set `big_blue_button_secret`
+   to be your Big Blue Button Server's shared secret.
+
+2. In `/etc/zulip/settings.py`, set `BIG_BLUE_BUTTON_URL` to your
+   to be your Big Blue Button Server's API URL.
+
+3. Restart the Zulip server with
+   `/home/zulip/deployments/current/scripts/restart-server`.
+
+This enables Big Blue Button support in your Zulip server.  Finally, [configure
+Big Blue Button as the video call
+provider](https://zulip.com/help/start-a-call) in the Zulip
+organization(s) where you want to use it.

--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -22,3 +22,4 @@ Zulip in production
    deployment
    email-gateway
    zoom-configuration
+   big-blue-button-configuration

--- a/templates/zerver/help/start-a-call.md
+++ b/templates/zerver/help/start-a-call.md
@@ -39,9 +39,10 @@ just set `JITSI_SERVER_URL` in `/etc/zulip/settings.py`.
 
 {tab|bigbluebutton}
 
-In order to use Big Blue Button as the video call provider, you need
-to first configure the `BIG_BLUE_BUTTON_URL` setting in
-`/etc/zulip/settings.py`.
+Using Big Blue Button as a video chat provider is currently only possible on
+self-hosted Zulip installations.
+
+For specifics on configuring Big Blue Button on a self hosted installation see [here][big-blue-button-configuration].
 
 {tab|zoom}
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds documentation for configuring Big Blue Button video call.
As it was lacking documentation and there was some confusion (not the only one I heard) in #14775. 


I used the Zoom Integration Documentation as template.