### PR TITLE
activity: Show server time rather than browser time

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -738,7 +738,7 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
     content = loader.render_to_string(
         'analytics/realm_summary_table.html',
         dict(rows=rows, num_active_sites=num_active_sites,
-             now=now.strftime('%Y-%m-%dT%H:%M:%SZ')),
+             utctime=now.strftime('%Y-%m-%d %H:%MZ')),
     )
     return content
 

--- a/templates/analytics/realm_summary_table.html
+++ b/templates/analytics/realm_summary_table.html
@@ -1,12 +1,6 @@
 <h2 style="text-align: center;">{{ num_active_sites }} active sites</h2>
 
-<p id="utctime" style="text-align: center;"></p>
-<p id="localtime" style="text-align: center;"></p>
-<script>
-    var now = moment('{{ now }}');
-    $('#utctime')[0].innerHTML = moment.utc(now).format('YYYY-MM-DD HH:mm') + 'Z';
-    $('#localtime')[0].innerHTML = '(' + now.format('YYYY-MM-DD HH:mm ZZ') + ')';
-</script>
+<p style="text-align: center;">{{ utctime }}</p>
 
 <ul>
     <li><strong>active (site)</strong> - has ≥5 DAUs</li>


### PR DESCRIPTION
This gets rid of an inline `<script>` that was blocking #16451.

**Testing Plan:** Dev server.