### PR TITLE
deliver_scheduled_messages: Don’t do_send_messages inside a transaction

### DIFF
--- a/zerver/management/commands/deliver_scheduled_messages.py
+++ b/zerver/management/commands/deliver_scheduled_messages.py
@@ -5,7 +5,6 @@ from typing import Any, Dict
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
 from zerver.lib.actions import build_message_send_dict, do_send_messages
@@ -62,12 +61,10 @@ Usage: ./manage.py deliver_scheduled_messages
                 messages_to_deliver = ScheduledMessage.objects.filter(
                     scheduled_timestamp__lte=timezone_now(),
                     delivered=False)
-                if messages_to_deliver:
-                    for message in messages_to_deliver:
-                        with transaction.atomic():
-                            do_send_messages([self.construct_message(message)])
-                            message.delivered = True
-                    Message.objects.bulk_update(messages_to_deliver, ['delivered'])
+                for message in messages_to_deliver:
+                    do_send_messages([self.construct_message(message)])
+                    message.delivered = True
+                    message.save(update_fields=['delivered'])
 
                 cur_time = timezone_now()
                 time_next_min = (cur_time + timedelta(minutes=1)).replace(second=0, microsecond=0)


### PR DESCRIPTION
`do_send_messages` has side effects outside the database and may not work reliably if its database effects are reordered by being inside a transaction.