### PR TITLE
WIP css: Custom scrollbar for compose message box

### DIFF
--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -233,6 +233,25 @@ on a dark background, and don't change the dark labels dark either. */
         border-color: hsla(0, 0%, 0%, 0.9);
     }
 
+    /* custom scrollbar for new and preview message_textarea */
+    textarea.new_message_textarea::-webkit-scrollbar,
+    .preview_message_area::-webkit-scrollbar {
+        height: 8px;
+        width: 10px;
+        background-color: hsla(0, 0%, 0%, 0.05);
+    }
+    /* custom scrollbar draggable handle for new and preview message_textarea */
+    textarea.new_message_textarea::-webkit-scrollbar-thumb,
+    .preview_message_area::-webkit-scrollbar-thumb {
+        background-color: hsla(0, 0%, 0%, 0.3);
+        border-radius: 20px;
+        transition: all 0.2s ease;
+    }
+    textarea.new_message_textarea::-webkit-scrollbar-thumb:hover,
+    .preview_message_area::-webkit-scrollbar-thumb:hover {
+        background-color: hsla(0, 0%, 0%, 0.6);
+    }
+
     .message-header-contents,
     .message_header_private_message .message-header-contents {
         background-color: hsla(0, 0%, 0%, 0.2);


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR solves issue [#16468](https://github.com/zulip/zulip/issues/16468)

1. Add psuedo scrollbar element
   `textarea.new_message_textarea::-webkit-scrollbar`
   to compose box in static/styles/night_mode.css
2. preview_message_area has different style from new_message_textarea,
   so I had to add the same psuedo scrollbar element to
   preview_message_area to make style more consistent
3. This makes the scrollbar in compose box area more
   consistent with the theme.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot of changes](https://user-images.githubusercontent.com/57325543/95647219-49ff6a00-0aeb-11eb-95e4-9882a6b1885e.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
