### PR TITLE
api docs: Fix JavaScript example for /streams api endpoint.

### DIFF
--- a/templates/zerver/api/get-streams.md
+++ b/templates/zerver/api/get-streams.md
@@ -13,7 +13,7 @@
 
 More examples and documentation can be found [here](https://github.com/zulip/zulip-js).
 
-{generate_code_example(python)|/streams:get|example}
+{generate_code_example(javascript)|/streams:get|example}
 
 {tab|curl}
 


### PR DESCRIPTION
This commit fixes the JavaScript tab in 'Usage example'
for 'Get all streams' that currently shows python code.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<details><summary>Earlier</summary>

![Screenshot from 2020-10-10 16-39-38](https://user-images.githubusercontent.com/30050220/95654924-3bcc4080-0b21-11eb-8875-47844ffaf54c.png)

</details>
<details><summary>Now</summary>

![Screenshot from 2020-10-10 17-32-15](https://user-images.githubusercontent.com/30050220/95654927-3d960400-0b21-11eb-971d-55b47814bca9.png)

</details>
