### PR TITLE
docs: Fix typos in events-system.md

### DIFF
--- a/docs/subsystems/events-system.md
+++ b/docs/subsystems/events-system.md
@@ -152,12 +152,12 @@ garbage collected after (by default) 10 minutes of inactivity from a
 client, under the theory that the client has likely gone off the
 Internet (or no longer exists) access; this happens constantly.  If
 the client returns, it will receive a "queue not found" error when
-requesting events; it's handler for this case should just restart the
+requesting events; its handler for this case should just restart the
 client / reload the browser so that it refetches initial data the same
 way it would on startup.  Since clients have to implement their
 startup process anyway, this approach adds minimal technical
 complexity to clients.  A nice side effect is that if the Event Queue
-Server server (which stores queues in memory) were to crash and lose
+Server (which stores queues in memory) were to crash and lose
 its data, clients would recover, just as if they had lost Internet
 access briefly (there is some DoS risk to manage, though).
 


### PR DESCRIPTION
Fixes 2 typos in [events-system.md](https://zulip.readthedocs.io/en/latest/subsystems/events-system.html#delivery-system):
it's handler -> its handler
Event Queue Server server -> Event Queue Server

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<details>
<summary>Before:</summary>
<p>
<img src="https://user-images.githubusercontent.com/15276828/95779021-e772bd80-0ce6-11eb-9f3a-0d5a4c476f58.png">
</p>
</details>
<details>
<summary>Now:</summary>
<p>
<img src="https://user-images.githubusercontent.com/15276828/95779175-34ef2a80-0ce7-11eb-8b7d-42780b397bbe.png">
</p>
</details>
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
