### PR TITLE
puppet: Drop all log2zulip configuration.

### DIFF
--- a/puppet/zulip_ops/files/cron.d/log2zulip
+++ b/puppet/zulip_ops/files/cron.d/log2zulip
@@ -1,3 +1,0 @@
-MAILTO=root
-
-* * * * *   zulip cd /home/zulip/deployments/current && python3 ./zulip-current-venv/share/zulip/integrations/log2zulip/log2zulip

--- a/puppet/zulip_ops/files/log2zulip.conf
+++ b/puppet/zulip_ops/files/log2zulip.conf
@@ -1,1 +1,0 @@
-["/var/log/nginx/error.log"]

--- a/puppet/zulip_ops/files/log2zulip.zuliprc
+++ b/puppet/zulip_ops/files/log2zulip.zuliprc
@@ -1,4 +1,0 @@
-[api]
-email = log-bot@zulip.com
-key = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-site = https://zulip.com

--- a/puppet/zulip_ops/manifests/app_frontend.pp
+++ b/puppet/zulip_ops/manifests/app_frontend.pp
@@ -18,22 +18,6 @@ class zulip_ops::app_frontend {
     source => 'puppet:///modules/zulip/logrotate/zulip',
   }
 
-  file { '/etc/log2zulip.conf':
-    ensure => file,
-    owner  => 'zulip',
-    group  => 'zulip',
-    mode   => '0644',
-    source => 'puppet:///modules/zulip_ops/log2zulip.conf',
-  }
-
-  file { '/etc/log2zulip.zuliprc':
-    ensure => file,
-    owner  => 'zulip',
-    group  => 'zulip',
-    mode   => '0600',
-    source => 'puppet:///modules/zulip_ops/log2zulip.zuliprc',
-  }
-
   file { '/etc/supervisor/conf.d/redis_tunnel.conf':
     ensure  => file,
     require => Package['supervisor', 'autossh'],

--- a/puppet/zulip_ops/manifests/loadbalancer.pp
+++ b/puppet/zulip_ops/manifests/loadbalancer.pp
@@ -28,27 +28,8 @@ class zulip_ops::loadbalancer {
     notify  => Service['nginx'],
   }
 
-  file { '/etc/log2zulip.conf':
-    ensure => file,
-    owner  => 'zulip',
-    group  => 'zulip',
-    mode   => '0644',
-    source => 'puppet:///modules/zulip_ops/log2zulip.conf',
-  }
-
+  # Can be removed if you see it deployed:
   file { '/etc/cron.d/log2zulip':
-    ensure => file,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0644',
-    source => 'puppet:///modules/zulip_ops/cron.d/log2zulip',
-  }
-
-  file { '/etc/log2zulip.zuliprc':
-    ensure => file,
-    owner  => 'zulip',
-    group  => 'zulip',
-    mode   => '0600',
-    source => 'puppet:///modules/zulip_ops/log2zulip.zuliprc',
+    ensure => absent,
   }
 }


### PR DESCRIPTION
Disabled on webservers in 047817b6b0f2, it has since lingered in
configuration, as well as running (to no effect) every minute on the
loadbalancer.

Remove the vestiges of its configuration.
