### PR TITLE
settings org: Add button to subscribe user to all default streams.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1502,6 +1502,18 @@ input[type="checkbox"] {
         color: hsl(0, 0%, 67%);
     }
 
+    #subscribe-to-default-streams {
+        width: 220px;
+    }
+
+    #subscribe-user-spinner {
+        margin-top: 0;
+
+        .loading_indicator_text {
+            line-height: 20px;
+        }
+    }
+
     #show_my_user_profile_modal {
         width: 150px;
         margin-top: 20px;

--- a/static/templates/admin_human_form.hbs
+++ b/static/templates/admin_human_form.hbs
@@ -23,6 +23,12 @@
                         {{> settings/dropdown_options_widget option_values=user_role_values}}
                     </select>
                 </div>
+                <div class="input-group">
+                    <button id="subscribe-to-default-streams" class="button rounded sea-green">
+                        {{t "Subscribe to default streams" }}
+                    </button>
+                    <div class="alert-notification" id="subscribe-user-spinner"></div>
+                </div>
                 <div class="custom-profile-field-form"></div>
             </form>
         </div>


### PR DESCRIPTION
This enables admin to subscribe any user to
all the default streams in "Change user info and role" UI.

Fixes: #16487.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![ksnip_20210316-075532](https://user-images.githubusercontent.com/30050220/111246939-2f4a9780-862d-11eb-9da8-157533ebb3fc.png)
