### PR TITLE
Style: Make appearance of Deactivate Organization button gray for non-owner users

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -177,7 +177,7 @@
             }
         }
 
-        &[disabled="disabled"] {
+        &:disabled {
             cursor: not-allowed;
             filter: saturate(0);
             background-color: hsl(0, 0%, 93%);

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -95,6 +95,10 @@ h3 .fa-question-circle-o {
     .input-size {
         width: 214px;
     }
+    .btn-danger:hover {
+        color: hsl(0, 0%, 100%);
+        background-color: hsl(354, 70%, 54%);
+    }
 }
 
 .user-avatar-section {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes https://github.com/zulip/zulip/issues/16080

**Testing Plan:** <!-- How have you tested? -->
Since the issue is already resolved and only a change in ui was required to make the button look disabled I have removed the default class of danger and added the necessary ui requirements.


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot (141)](https://user-images.githubusercontent.com/55033316/95836780-7ae6d580-0d5d-11eb-8b4c-f66829d4df71.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
