### PR TITLE
Copy-to-clipboard button was added to invite users via generated url

### DIFF
--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -1,7 +1,9 @@
 "use strict";
 
 const autosize = require("autosize");
+const ClipboardJS = require("clipboard");
 
+const copy_invite_link = require("../templates/copy_invite_link.hbs");
 const render_invitation_failed_error = require("../templates/invitation_failed_error.hbs");
 const render_invite_subscription = require("../templates/invite_subscription.hbs");
 const render_settings_dev_env_email_access = require("../templates/settings/dev_env_email_access.hbs");
@@ -109,17 +111,24 @@ function submit_invitation_form() {
 function generate_multiuse_invite() {
     const invite_status = $("#multiuse_invite_status");
     const data = get_common_invitation_data();
+    const copy_link_btn = copy_invite_link(data);
     channel.post({
         url: "/json/invites/multiuse",
         data,
         beforeSend,
         success(data) {
             ui_report.success(
-                i18n.t('Invitation link: <a href="__link__">__link__</a>', {
-                    link: data.invite_link,
-                }),
+                i18n.t(
+                    'Invitation link:<a href="__link__" id="multiuse_invite_link">__link__</a>',
+                    {
+                        link: data.invite_link,
+                    },
+                ),
                 invite_status,
             );
+            invite_status.append(copy_link_btn);
+            // function called here for copying
+            new ClipboardJS("#copy_generated_invite_link");
         },
         error(xhr) {
             ui_report.error("", xhr, invite_status);

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -458,6 +458,12 @@ li,
     margin-top: -24px;
 }
 
+#copy_generated_invite_link {
+    position: relative;
+    margin-right: -22px;
+    margin-top: -1px;
+}
+
 #clipboard_image {
     margin-top: -5px;
     margin-left: -8px;

--- a/static/templates/copy_invite_link.hbs
+++ b/static/templates/copy_invite_link.hbs
@@ -1,0 +1,1 @@
+<a class="btn pull-right copy_button_base" data-toggle="tooltip" title="{{t "Copy link" }}" aria-label="{{t "Copy link" }}" id='copy_generated_invite_link' data-clipboard-target="#multiuse_invite_link">{{> copy_to_clipboard_svg }}</a>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
While generating a link, to invite users, existing users had to manually copy the link by highlighting it. I've added the COPY-LINK button for cleaner interface and ease of copying the url.
This PR is in reference for issue #16442 . The copy link button was added to invite users via GENERATED LINK.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Zulip Dev - Zulip and 16 more pages - Personal - Microsoft_ Edge 2020-11-01 11-35-32](https://user-images.githubusercontent.com/56171163/97796391-6f3d4f00-1c37-11eb-91cd-421116f259d9.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->