### PR TITLE
puppet: Move frontend monitoring into its own file.

### DIFF
--- a/puppet/zulip_ops/manifests/app_frontend.pp
+++ b/puppet/zulip_ops/manifests/app_frontend.pp
@@ -4,6 +4,7 @@ class zulip_ops::app_frontend {
   include zulip::rabbit
   include zulip::postfix_localmail
   include zulip::static_asset_compiler
+  include zulip::app_frontend_monitoring
   $app_packages = [# Needed for the ssh tunnel to the redis server
     'autossh',
   ]
@@ -44,26 +45,5 @@ class zulip_ops::app_frontend {
     group  => 'root',
     mode   => '0644',
     source => 'puppet:///modules/zulip_ops/cron.d/fetch-contributor-data',
-  }
-
-  # Enable some munin plugins
-  $munin_plugins = [
-    'rabbitmq_connections',
-    'rabbitmq_consumers',
-    'rabbitmq_messages',
-    'rabbitmq_messages_unacknowledged',
-    'rabbitmq_messages_uncommitted',
-    'rabbitmq_queue_memory',
-    'zulip_send_receive_timing',
-  ]
-  zulip_ops::munin_plugin { $munin_plugins: }
-
-  file { '/etc/cron.d/rabbitmq-monitoring':
-    ensure  => file,
-    require => Package[rabbitmq-server],
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    source  => 'puppet:///modules/zulip/cron.d/rabbitmq-monitoring',
   }
 }

--- a/puppet/zulip_ops/manifests/app_frontend_monitoring.pp
+++ b/puppet/zulip_ops/manifests/app_frontend_monitoring.pp
@@ -1,0 +1,24 @@
+# @summary Munin monitoring of a Django frontend and RabbitMQ server.
+#
+class zulip_ops::app_frontend_monitoring {
+  include zulip_ops::munin_node
+  $munin_plugins = [
+    'rabbitmq_connections',
+    'rabbitmq_consumers',
+    'rabbitmq_messages',
+    'rabbitmq_messages_unacknowledged',
+    'rabbitmq_messages_uncommitted',
+    'rabbitmq_queue_memory',
+    'zulip_send_receive_timing',
+  ]
+  zulip_ops::munin_plugin { $munin_plugins: }
+
+  file { '/etc/cron.d/rabbitmq-monitoring':
+    ensure  => file,
+    require => Package[rabbitmq-server],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    source  => 'puppet:///modules/zulip/cron.d/rabbitmq-monitoring',
+  }
+}


### PR DESCRIPTION
This allows it to be pulled in for deploys like czo, which don't use
the full `zulip_ops::app_frontend`, but we wish to monitor.

**Testing Plan:** Added `zulip_ops::app_frontend_monitoring` to `machine.classes` on a test prod machine.
