### PR TITLE
requirements: Install PycURL for Thumbor

### DIFF
--- a/requirements/thumbor-dev.txt
+++ b/requirements/thumbor-dev.txt
@@ -188,6 +188,9 @@ pyasn1==0.4.8 \
     --hash=sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d \
     --hash=sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba \
     # via pyasn1-modules, python-ldap
+pycurl==7.43.0.6 \
+    --hash=sha256:8301518689daefa53726b59ded6b48f33751c383cf987b0ccfbbc4ed40281325 \
+    # via -r requirements/thumbor.in
 python-dateutil==2.8.1 \
     --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \
     --hash=sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a \

--- a/requirements/thumbor.in
+++ b/requirements/thumbor.in
@@ -1,6 +1,9 @@
 https://github.com/kkopachev/aws/archive/0d02528b47273e143be750ba237f71a076e8f251.zip#egg=tc_aws==6.3
 thumbor>=7.dev
 
+# Not required by Thumbor, but recommended
+pycurl
+
 # Required for just importing settings from our main django app.
 django-auth-ldap
 Django==2.2.*

--- a/requirements/thumbor.txt
+++ b/requirements/thumbor.txt
@@ -188,6 +188,9 @@ pyasn1==0.4.8 \
     --hash=sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d \
     --hash=sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba \
     # via pyasn1-modules, python-ldap
+pycurl==7.43.0.6 \
+    --hash=sha256:8301518689daefa53726b59ded6b48f33751c383cf987b0ccfbbc4ed40281325 \
+    # via -r requirements/thumbor.in
 python-dateutil==2.8.1 \
     --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \
     --hash=sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a \

--- a/version.py
+++ b/version.py
@@ -44,4 +44,4 @@ API_FEATURE_LEVEL = 34
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '111.1'
+PROVISION_VERSION = '111.2'


### PR DESCRIPTION
Fixes “`thumbor:WARNING pycurl usage is advised. It could not be loaded properly. Verify install...`”.

**Testing Plan:** Dev server.