### PR TITLE
mobile-web: fix overlapping text and remove message outline

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -219,7 +219,9 @@ exports.initialize_kitchen_sink_stuff = function () {
         }
         const row = event.msg_list.get_row(event.id);
         $(".selected_message").removeClass("selected_message");
-        row.addClass("selected_message");
+        if ($(window).width() > 775) {
+            row.addClass("selected_message");
+        }
 
         if (event.then_scroll) {
             if (row.length === 0) {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1178,12 +1178,16 @@ td.pointer {
 }
 
 .message_sender {
-    height: 0;
     vertical-align: top;
     position: relative;
 
     i.zulip-icon.bot {
         font-size: 12px;
+    }
+
+    @media (max-width: 500px) {
+        min-height: 20px;
+        display: inline-block;
     }
 }
 


### PR DESCRIPTION
The blue outline for selected message has minimal functionality since keyboard shortcuts and navigation can't be used. This also causes accidental compose box opens, and leads to not-so-smooth scrolling.
This has been fixed by not adding the selected_message class for screens of 775px and below.

When a user sends consecutive messages, the message controls bar overlaps with the message text.
This has been fixed by giving the message control bar a min height and ensuring it appears above the message text

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/16488#issue-716166322

**Testing Plan:** <!-- How have you tested? -->
Both changes were purely aesthetic and hence I haven't written any automated tests.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->![Issue#](https://user-images.githubusercontent.com/47349681/95615853-85b41880-0a86-11eb-8e9f-577484b3b9d0.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
