### PR TITLE
shortcuts : Fixed Keyboard shortcuts in Mozilla Firefox

### DIFF
--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -150,6 +150,7 @@ exports.exit_search = function () {
         // for "searching narrows", we redirect
         window.location.replace(filter.generate_redirect_url());
     }
+    $(".app").trigger("focus");
 };
 
 exports.initialize = function () {


### PR DESCRIPTION
As mentioned in issue #16394 , Keyboard shortcuts tend to fail in firefox as it doesn't seems to work when the user presses the escape button to exit a search bar . (Instead would open a quick find toolbar )

Hence , added a small fix for the same .

<strong>Earlier : <strong/>

![5f86db27f408f175646772](https://user-images.githubusercontent.com/53977614/95980676-22860580-0e3b-11eb-8564-2d5c63139b78.gif)


<strong>Now :</strong>

![5f86db5712075312416618](https://user-images.githubusercontent.com/53977614/95980752-3df11080-0e3b-11eb-92f3-4ece8e86dfb1.gif)
