### PR TITLE
upgrade-postgres: Catch failed pg_upgradecluster exit code.

### DIFF
--- a/scripts/setup/upgrade-postgres
+++ b/scripts/setup/upgrade-postgres
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
 
 if [ "$EUID" -ne 0 ]; then
     echo "Error: This script must be run as root" >&2


### PR DESCRIPTION
Because the command is part of a pipe sequence, the exitcode defaults
to the last in the sequence, which is not the most important one here.

Set pipefail, which sets the exit status to the exit code of the last
program in the sequence to exit non-zero, or 0 if all succeeded.  This
prevents the upgrade from barreling onward and setting
`postgres.version` improperly if the database upgrade step failed.