### PR TITLE
puppet: Add an outgoing HTTP/HTTPS proxy server.

### DIFF
--- a/puppet/zulip_ops/files/supervisor/conf.d/smokescreen.conf
+++ b/puppet/zulip_ops/files/supervisor/conf.d/smokescreen.conf
@@ -1,0 +1,8 @@
+[program:smokescreen]
+command=/usr/local/bin/smokescreen
+priority=15
+autostart=true
+autorestart=true
+user=zulip
+redirect_stderr=true
+stdout_logfile=/var/log/zulip/smokescreen.log

--- a/puppet/zulip_ops/manifests/smokescreen.pp
+++ b/puppet/zulip_ops/manifests/smokescreen.pp
@@ -1,0 +1,56 @@
+# @summary Outgoing HTTP CONNECT proxy for HTTP/HTTPS on port 4750.
+#
+class zulip_ops::smokescreen {
+  include zulip_ops::base
+  include zulip::supervisor
+
+  $golang_version = '1.14.10'
+  zulip::sha256_tarball_to { 'golang':
+    url     => "https://golang.org/dl/go${golang_version}.linux-amd64.tar.gz",
+    sha256  => '66eb6858f375731ba07b0b33f5c813b141a81253e7e74071eec3ae85e9b37098',
+    install => {
+      'go/' => "/opt/golang-${golang_version}/",
+    },
+  }
+  file { '/opt/golang':
+    ensure  => 'link',
+    target  => "/opt/golang-${golang_version}/",
+    require => Zulip::Sha256_tarball_to['golang'],
+  }
+
+  $version = '0.0.2'
+  zulip::sha256_tarball_to { 'smokescreen':
+    url     => "https://github.com/stripe/smokescreen/archive/v${version}.tar.gz",
+    sha256  => '7255744f89a62a103fde97d28e3586644d30191b4e3d1f62c9a99e13d732a012',
+    install => {
+      "smokescreen-${version}/" => "/opt/smokescreen-src-${version}/",
+    },
+  }
+  exec { 'compile smokescreen':
+    command     => "/opt/golang/bin/go build -o /usr/local/bin/smokescreen-${version}",
+    cwd         => "/opt/smokescreen-src-${version}/",
+    # GOCACHE is required; nothing is written to GOPATH, but it is required to be set
+    environment => ['GOCACHE=/tmp/gocache', 'GOPATH=/root/go'],
+    creates     => "/usr/local/bin/smokescreen-${version}",
+    require     => [Zulip::Sha256_tarball_to['golang'], Zulip::Sha256_tarball_to['smokescreen']],
+  }
+
+  file { '/usr/local/bin/smokescreen':
+    ensure  => 'link',
+    target  => "/usr/local/bin/smokescreen-${version}",
+    require => Exec['compile smokescreen'],
+  }
+
+  file { '/etc/supervisor/conf.d/smokescreen.conf':
+    ensure  => file,
+    require => [
+      Package[supervisor],
+      File['/usr/local/bin/smokescreen'],
+    ],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    source  => 'puppet:///modules/zulip_ops/supervisor/conf.d/smokescreen.conf',
+    notify  => Service[supervisor],
+  }
+}

--- a/puppet/zulip_ops/templates/iptables/rules.v4.erb
+++ b/puppet/zulip_ops/templates/iptables/rules.v4.erb
@@ -32,15 +32,16 @@
 # FIXME: do something better here.
 -A INPUT -p udp -j ACCEPT
 <% else -%>
-# Accept incoming traffic on TCP ports 22 (SSH), 25 (SMTP), 80 (HTTP), 443 (HTTPS), and 5432 (Postgres)
--A INPUT -p tcp --dport   22 -j ACCEPT
--A INPUT -p tcp --dport   25 -j ACCEPT
--A INPUT -p tcp --dport   80 -j ACCEPT
--A INPUT -p tcp --dport  443 -j ACCEPT
--A INPUT -p tcp --dport 5432 -j ACCEPT
 
-# Accept incoming UDP traffic on port 8125 (statsd)
--A INPUT -p udp --dport 8125 -j ACCEPT
+# Accept incoming traffic on TCP ports:
+-A INPUT -p tcp --dport ssh        -j ACCEPT
+-A INPUT -p tcp --dport smtp       -j ACCEPT
+-A INPUT -p tcp --dport http       -j ACCEPT
+-A INPUT -p tcp --dport https      -j ACCEPT
+-A INPUT -p tcp --dport postgresql -j ACCEPT
+
+#                       statsd
+-A INPUT -p udp --dport 8125       -j ACCEPT
 <% end -%>
 
 # Drop everything else

--- a/puppet/zulip_ops/templates/iptables/rules.v4.erb
+++ b/puppet/zulip_ops/templates/iptables/rules.v4.erb
@@ -40,6 +40,9 @@
 -A INPUT -p tcp --dport https      -j ACCEPT
 -A INPUT -p tcp --dport postgresql -j ACCEPT
 
+#                       Smokescreen proxy
+-A INPUT -p tcp --dport 4750       -j ACCEPT
+
 #                       statsd
 -A INPUT -p udp --dport 8125       -j ACCEPT
 <% end -%>


### PR DESCRIPTION
Use https://github.com/stripe/smokescreen to provide a server for an
outgoing proxy, run under supervisor.  This will allow centralized
blocking of internal metadata IPs, localhost, and so forth, as well as
providing default request timeouts (10s by default).

**Testing Plan:** Deployed on a test instance.
