### PR TITLE
configure-rabbitmq: Wait for RabbitMQ to start up.

### DIFF
--- a/scripts/setup/configure-rabbitmq
+++ b/scripts/setup/configure-rabbitmq
@@ -5,22 +5,21 @@
 set -e
 set -x
 
-RABBITMQ_FLAGS=()
+if [ "$EUID" -eq 0 ]; then
+    rabbitmqctl=(rabbitmqctl)
+else
+    rabbitmqctl=(sudo rabbitmqctl)
+fi
+
 if [ -n "$RABBITMQ_NODE" ]; then
-    RABBITMQ_FLAGS=(-n "$RABBITMQ_NODE")
+    rabbitmqctl+=(-n "$RABBITMQ_NODE")
 fi
 RABBITMQ_USERNAME=$("$(dirname "$0")/../get-django-setting" RABBITMQ_USERNAME)
 RABBITMQ_PASSWORD=$("$(dirname "$0")/../get-django-setting" RABBITMQ_PASSWORD)
 
-if [ "$EUID" -eq 0 ]; then
-    RABBITMQCTL_COMMAND="rabbitmqctl"
-else
-    RABBITMQCTL_COMMAND="sudo rabbitmqctl"
-fi
-
-$RABBITMQCTL_COMMAND "${RABBITMQ_FLAGS[@]}" delete_user "$RABBITMQ_USERNAME" || true
-$RABBITMQCTL_COMMAND "${RABBITMQ_FLAGS[@]}" delete_user zulip || true
-$RABBITMQCTL_COMMAND "${RABBITMQ_FLAGS[@]}" delete_user guest || true
-$RABBITMQCTL_COMMAND "${RABBITMQ_FLAGS[@]}" add_user "$RABBITMQ_USERNAME" "$RABBITMQ_PASSWORD"
-$RABBITMQCTL_COMMAND "${RABBITMQ_FLAGS[@]}" set_user_tags "$RABBITMQ_USERNAME" administrator
-$RABBITMQCTL_COMMAND "${RABBITMQ_FLAGS[@]}" set_permissions -p / "$RABBITMQ_USERNAME" '.*' '.*' '.*'
+"${rabbitmqctl[@]}" delete_user "$RABBITMQ_USERNAME" || true
+"${rabbitmqctl[@]}" delete_user zulip || true
+"${rabbitmqctl[@]}" delete_user guest || true
+"${rabbitmqctl[@]}" add_user "$RABBITMQ_USERNAME" "$RABBITMQ_PASSWORD"
+"${rabbitmqctl[@]}" set_user_tags "$RABBITMQ_USERNAME" administrator
+"${rabbitmqctl[@]}" set_permissions -p / "$RABBITMQ_USERNAME" '.*' '.*' '.*'

--- a/scripts/setup/configure-rabbitmq
+++ b/scripts/setup/configure-rabbitmq
@@ -17,6 +17,20 @@ fi
 RABBITMQ_USERNAME=$("$(dirname "$0")/../get-django-setting" RABBITMQ_USERNAME)
 RABBITMQ_PASSWORD=$("$(dirname "$0")/../get-django-setting" RABBITMQ_PASSWORD)
 
+# Wait for RabbitMQ to start up
+try_ping() {
+    # `rabbitmqctl ping` requires 3.7.6 or newer
+    out="$("${rabbitmqctl[@]}" eval 'net_adm:ping(node()).')" && [ "$out" = 'pong' ]
+}
+retries=9
+while ! try_ping 2>/dev/null; do
+    sleep 1
+    if ! ((retries -= 1)); then
+        try_ping
+        break
+    fi
+done
+
 "${rabbitmqctl[@]}" delete_user "$RABBITMQ_USERNAME" || true
 "${rabbitmqctl[@]}" delete_user zulip || true
 "${rabbitmqctl[@]}" delete_user guest || true


### PR DESCRIPTION
Fixes an occasional failure in `vagrant up --provision`.

**Testing Plan:** Dev server.