### PR TITLE
Remove reload on mark all messages read.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -60,6 +60,7 @@ const submessage = mock_esm("../../static/js/submessage");
 const typing_events = mock_esm("../../static/js/typing_events");
 const ui = mock_esm("../../static/js/ui");
 const unread_ops = mock_esm("../../static/js/unread_ops");
+const unread_ui = mock_esm("../../static/js/unread_ui");
 const user_events = mock_esm("../../static/js/user_events");
 const user_groups = mock_esm("../../static/js/user_groups");
 mock_esm("../../static/js/compose");
@@ -775,6 +776,7 @@ run_test("update_global_notifications", (override) => {
 
 run_test("update_message (read)", (override) => {
     const event = event_fixtures.update_message_flags__read;
+    override(unread_ui, "hide_mark_all_read_loader", noop);
 
     const stub = make_stub();
     override(unread_ops, "process_read_messages_event", stub.f);

--- a/frontend_tests/node_tests/example2.js
+++ b/frontend_tests/node_tests/example2.js
@@ -83,7 +83,7 @@ run_test("message_store", () => {
 // app, and we use the unread object to track unread messages.
 
 run_test("unread", () => {
-    unread.declare_bankruptcy();
+    unread.clear_all_counters();
     stream_data.clear_subscriptions();
     stream_data.add_sub(denmark_stream);
 

--- a/frontend_tests/node_tests/example7.js
+++ b/frontend_tests/node_tests/example7.js
@@ -77,7 +77,7 @@ run_test("unread_ops", (override) => {
     stream_data.clear_subscriptions();
     stream_data.add_sub(denmark_stream);
     message_store.clear_for_testing();
-    unread.declare_bankruptcy();
+    unread.clear_all_counters();
 
     const message_id = 50;
     const test_messages = [

--- a/frontend_tests/node_tests/narrow_unread.js
+++ b/frontend_tests/node_tests/narrow_unread.js
@@ -42,7 +42,7 @@ function candidate_ids() {
 }
 
 run_test("get_unread_ids", () => {
-    unread.declare_bankruptcy();
+    unread.clear_all_counters();
     narrow_state.reset_current_filter();
 
     let unread_ids;

--- a/frontend_tests/node_tests/stream_topic_history.js
+++ b/frontend_tests/node_tests/stream_topic_history.js
@@ -15,7 +15,7 @@ const stream_topic_history = zrequire("stream_topic_history");
 
 function test(label, f) {
     run_test(label, (override) => {
-        unread.declare_bankruptcy();
+        unread.clear_all_counters();
         stream_topic_history.reset();
         f(override);
     });

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -573,24 +573,6 @@ test("starring", () => {
     assert.deepEqual(unread.get_msg_ids_for_starred(), []);
 });
 
-test("declare_bankruptcy", () => {
-    const message = {
-        id: 16,
-        type: "whatever",
-        stream_id: 1999,
-        topic: "whatever",
-        mentioned: true,
-    };
-
-    unread.process_loaded_messages([message]);
-
-    unread.declare_bankruptcy();
-
-    const counts = unread.get_counts();
-    assert_zero_counts(counts);
-    test_notifiable_count(counts.home_unread_messages, 0);
-});
-
 test("message_unread", () => {
     // Test some code that might be overly defensive, for line coverage sake.
     assert(!unread.message_unread(undefined));

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -55,7 +55,7 @@ function test_notifiable_count(home_unread_messages, expected_notifiable_count) 
 
 function test(label, f) {
     run_test(label, (override) => {
-        unread.declare_bankruptcy();
+        unread.clear_all_counters();
         muting.set_muted_topics([]);
         f(override);
     });

--- a/static/js/panels.js
+++ b/static/js/panels.js
@@ -109,7 +109,6 @@ export function initialize() {
     $(".accept-bankruptcy").on("click", function (e) {
         e.preventDefault();
         $(this).closest(".alert").hide();
-        $(".bankruptcy-loader").show();
         setTimeout(unread_ops.mark_all_as_read, 1000);
         resize_app();
     });

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -56,6 +56,7 @@ import * as submessage from "./submessage";
 import * as subs from "./subs";
 import * as typing_events from "./typing_events";
 import * as unread_ops from "./unread_ops";
+import * as unread_ui from "./unread_ui";
 import * as user_events from "./user_events";
 import * as user_groups from "./user_groups";
 import * as user_status from "./user_status";
@@ -651,6 +652,7 @@ export function dispatch_normal_event(event) {
                     break;
                 case "read":
                     unread_ops.process_read_messages_event(event.messages);
+                    unread_ui.hide_mark_all_read_loader();
                     break;
             }
             break;

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -384,7 +384,11 @@ export function register_click_handlers() {
         });
     });
 
-    $("#global_filters").on("click", ".all-messages-sidebar-menu-icon", build_all_messages_popover);
+    $("#global_filters").on(
+        "click",
+        ".all-messages-sidebar-menu-icon > i",
+        build_all_messages_popover,
+    );
 
     $("#global_filters").on(
         "click",

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -465,6 +465,14 @@ export function declare_bankruptcy() {
     unread_messages.clear();
 }
 
+export function clear_all_counters() {
+    // For use in tests only.
+    unread_pm_counter.clear();
+    unread_topic_counter.clear();
+    unread_mentions_counter.clear();
+    unread_messages.clear();
+}
+
 export function get_counts() {
     const res = {};
 

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -458,13 +458,6 @@ export function mark_as_read(message_id) {
     }
 }
 
-export function declare_bankruptcy() {
-    unread_pm_counter.clear();
-    unread_topic_counter.clear();
-    unread_mentions_counter.clear();
-    unread_messages.clear();
-}
-
 export function clear_all_counters() {
     // For use in tests only.
     unread_pm_counter.clear();

--- a/static/js/unread_ops.js
+++ b/static/js/unread_ops.js
@@ -11,6 +11,7 @@ import * as unread from "./unread";
 import * as unread_ui from "./unread_ui";
 
 export function mark_all_as_read() {
+    unread_ui.show_mark_all_read_loader();
     channel.post({
         url: "/json/mark_all_as_read",
         idempotent: true,

--- a/static/js/unread_ops.js
+++ b/static/js/unread_ops.js
@@ -7,27 +7,13 @@ import * as message_viewport from "./message_viewport";
 import * as notifications from "./notifications";
 import * as overlays from "./overlays";
 import * as recent_topics from "./recent_topics";
-import * as reload from "./reload";
 import * as unread from "./unread";
 import * as unread_ui from "./unread_ui";
 
 export function mark_all_as_read() {
-    unread.declare_bankruptcy();
-    unread_ui.update_unread_counts();
-
     channel.post({
         url: "/json/mark_all_as_read",
         idempotent: true,
-        success: () => {
-            // After marking all messages as read, we reload the browser.
-            // This is useful to avoid leaving ourselves deep in the past.
-            reload.initiate({
-                immediate: true,
-                save_pointer: false,
-                save_narrow: true,
-                save_compose: true,
-            });
-        },
     });
 }
 

--- a/static/js/unread_ui.js
+++ b/static/js/unread_ui.js
@@ -1,6 +1,8 @@
 import $ from "jquery";
 
 import * as activity from "./activity";
+import * as feedback_widget from "./feedback_widget";
+import {i18n} from "./i18n";
 import * as notifications from "./notifications";
 import {page_params} from "./page_params";
 import * as pm_list from "./pm_list";
@@ -87,6 +89,22 @@ export function should_display_bankruptcy_banner() {
     }
 
     return false;
+}
+
+export function show_mark_all_read_loader() {
+    $(".all-messages-sidebar-menu-icon > i").hide();
+    feedback_widget.show({
+        title_text: i18n.t("Please wait"),
+        populate(container) {
+            container.text(i18n.t("Marking all messages as read."));
+        },
+        persistant: true,
+    });
+}
+
+export function hide_mark_all_read_loader() {
+    feedback_widget.dismiss();
+    $(".all-messages-sidebar-menu-icon > i").show();
 }
 
 export function initialize() {

--- a/static/templates/feedback_container.hbs
+++ b/static/templates/feedback_container.hbs
@@ -1,7 +1,11 @@
 <div class="float-header">
     <h3 class="light no-margin small-line-height float-left feedback_title"></h3>
+    {{#if persistant}}
+    <div class="feedback_loading_indicator float-right"></div>
+    {{else}}
     <div class="exit-me float-right">&#215;</div>
     <button class="button small rounded float-right feedback_undo" type="button" name="button"></button>
+    {{/if}}
     <div class="float-clear"></div>
 </div>
 <p class="n-margin feedback_content"></p>

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4940,6 +4940,8 @@ def do_mark_all_as_read(user_profile: UserProfile, client: Client) -> int:
         where=[UserMessage.where_unread()],
     )
 
+    message_ids = list(msgs.values_list("message__id", flat=True))
+
     count = msgs.update(
         flags=F("flags").bitor(UserMessage.flags.read),
     )
@@ -4949,7 +4951,7 @@ def do_mark_all_as_read(user_profile: UserProfile, client: Client) -> int:
         op="add",
         operation="add",
         flag="read",
-        messages=[],  # we don't send messages, since the client reloads anyway
+        messages=message_ids,
         all=True,
     )
     event_time = timezone_now()


### PR DESCRIPTION
### [Do not merge]

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #16324
This PR removes the browser reload which takes place after declaring bankruptcy
or clicking "mark all messages as read" from the left sidebar.


https://chat.zulip.org/#narrow/stream/2-general/topic/Bankruptcy.20improvements

