### PR TITLE
preview_message_area: Use simplebar scrollbar

### DIFF
--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -88,7 +88,7 @@
                         <div>
                             <div class="messagebox">
                                 <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{ _('Compose your message here') }}" tabindex="0" maxlength="10000" aria-label="{{ _('Compose your message here...') }}"></textarea>
-                                <div class="scrolling_list preview_message_area" id="preview_message_area" style="display:none;">
+                                <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area" style="display:none;">
                                     <div id="markdown_preview_spinner"></div>
                                     <div id="preview_content" class="preview_content rendered_markdown"></div>
                                 </div>


### PR DESCRIPTION
Add `data-simplebar` attribrute to `preview_message_area` div in
`templates/zerver/app/compose.html`.

This will cause preview_message_area div to use simplebar scrollbar
instead of normal scrollbar.

I kept `data-simplebar-autohide` to `true` (default) to reduce distraction
while previewing message.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR solves issue [#16468](https://github.com/zulip/zulip/issues/16468)

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![night-mode](https://user-images.githubusercontent.com/57325543/96331665-b0046800-107c-11eb-88ed-18bf6fcb512e.png)

![day-mode](https://user-images.githubusercontent.com/57325543/96331671-be528400-107c-11eb-8d8b-e0f61df781a7.png)