### PR TITLE
left_sidebar: Move add streams icon to STREAMS navbar.

### DIFF
--- a/frontend_tests/puppeteer_tests/04-subscriptions.js
+++ b/frontend_tests/puppeteer_tests/04-subscriptions.js
@@ -38,7 +38,7 @@ async function stream_name_error(page) {
 }
 
 async function open_streams_modal(page) {
-    const all_streams_selector = 'a[href="#streams/all"]';
+    const all_streams_selector = "#browse_streams_icon";
     await page.waitForSelector(all_streams_selector, {visible: true});
     await page.click(all_streams_selector);
 

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -714,6 +714,11 @@ exports.initialize = function () {
         compose_actions.cancel();
     });
 
+    $("#browse_streams_icon").on("click", (e) => {
+        e.stopPropagation();
+        hashchange.go_to_location("streams/all");
+    });
+
     $("#streams_inline_cog").on("click", (e) => {
         e.stopPropagation();
         hashchange.go_to_location("streams/subscribed");

--- a/static/styles/left-sidebar.css
+++ b/static/styles/left-sidebar.css
@@ -55,7 +55,8 @@ li.show-more-topics {
 }
 
 #streams_inline_cog,
-#streams_filter_icon {
+#streams_filter_icon,
+#browse_streams_icon {
     float: right;
     opacity: 0.5;
     font-size: 13px;
@@ -68,7 +69,7 @@ li.show-more-topics {
     }
 }
 
-#streams_inline_cog {
+#browse_streams_icon {
     margin-right: 10px;
 }
 
@@ -169,19 +170,6 @@ li.show-more-topics {
     &#stream_filters li.highlighted_stream {
         background-color: hsla(120, 12.3%, 71.4%, 0.38);
         border-radius: 4px;
-    }
-}
-
-#add-stream-link {
-    text-decoration: none;
-    margin-left: 10px;
-    margin-bottom: 18px;
-    i {
-        min-width: 19px;
-        text-align: center;
-        &::before {
-            padding-right: 3px;
-        }
     }
 }
 

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -68,6 +68,9 @@
         </ul>
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-toggle="tooltip" title="{{ _('Filter streams') }}">{{ _('STREAMS') }}</h4>
+                {% if show_add_streams %}
+                <i id="browse_streams_icon" class='fa fa-plus' aria-hidden="true" data-toggle="tooltip" title="{{ _('Browse all streams') }}"></i>
+                {% endif %}
                 <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" data-toggle="tooltip" title="{{ _('Subscribe, add, or configure streams') }}"></i>
                 <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true" data-toggle="tooltip" title="{{ _('Filter streams') }} (q)"></i>
                 <div class="input-append notdisplayed stream_search_section">
@@ -82,11 +85,6 @@
             </div>
             <div id="stream-filters-container" class="scrolling_list" data-simplebar>
                 <ul id="stream_filters" class="filters"></ul>
-                {% if show_add_streams %}
-                <div id="add-stream-link">
-                    <a href="#streams/all"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Add streams') }}</a>
-                </div>
-                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
The add streams icon is not visible to users when the streams
list is more than browser height. Moving it the STREAMS nav
makes it instantly visible. Also, we have had complains that
users don't know that there are more streams that exist.

Also, this new design is consistent with our competitors, hence
making it easy for users to understand it.

<img width="508" alt="Screenshot 2020-10-18 at 7 41 05 AM" src="https://user-images.githubusercontent.com/25124304/96357145-7b90ba80-1115-11eb-8175-a9b3cc62413b.png">
