### PR TITLE
navbar: Use location.href instead of location.replace.

### DIFF
--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -148,7 +148,7 @@ exports.exit_search = function () {
         exports.close_search_bar_and_open_narrow_description();
     } else {
         // for "searching narrows", we redirect
-        window.location.replace(filter.generate_redirect_url());
+        window.location.href = filter.generate_redirect_url();
     }
 };
 


### PR DESCRIPTION
As per https://stackoverflow.com/questions/1865837/ location.href
should be preferred to location.replace in some places due to the
fact that location.replace violates browser history and breaks back key.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
There were other locations that used .replace but it does not seem to make sense to change them. (manually tested the one that was spoken about last time we tried this)

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
