### PR TITLE
Composebox enter as send code block

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -112,6 +112,33 @@ function get_topic_matcher(query) {
         return typeahead.query_matches_source_attrs(query, obj, ["topic"], " ");
     };
 }
+let enter_sends_label_deny = false;
+function maybe_change_enter_send_label(contains_code_block) {
+    const label = $("#enter-sends-label");
+    if (contains_code_block && !enter_sends_label_deny) {
+        label.text(i18n.t("code block disables enter"));
+        enter_sends_label_deny = true;
+    } else if (!contains_code_block && enter_sends_label_deny) {
+        label.text(i18n.t("woops"));
+        enter_sends_label_deny = false;
+    }
+    // console.log(label);
+}
+
+function does_contain_code_block() {
+    let contains_code_block = false;
+    const compose_box_elem = $("#compose-textarea");
+    const fences = ["```", "~~~"];
+    fences.forEach((fence) => {
+        contains_code_block =
+            contains_code_block ||
+            compose_box_elem.val().startsWith(fence) ||
+            compose_box_elem.val().includes("\n" + fence);
+    });
+    // console.log(contains_code_block);
+    maybe_change_enter_send_label(contains_code_block);
+    return contains_code_block;
+}
 
 exports.should_enter_send = function (e) {
     const has_non_shift_modifier_key = e.ctrlKey || e.metaKey || e.altKey;
@@ -132,7 +159,7 @@ exports.should_enter_send = function (e) {
         // chat products where Enter-always-sends.
         this_enter_sends = has_non_shift_modifier_key;
     }
-    return this_enter_sends;
+    return this_enter_sends && !does_contain_code_block();
 };
 
 exports.handle_enter = function (textarea, e) {


### PR DESCRIPTION
todo: have signifier change as early as possible.
currently changes reflect on-enter-press, which is
incorrect as they should reflect as soon as the code
fence is placed or removed.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![commposeboxenterproofofconcept](https://user-images.githubusercontent.com/33805964/96365564-24173c80-115f-11eb-943f-20e52e28ce95.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
