### PR TITLE
Don't run test queue with run-dev.py.

### DIFF
--- a/tools/ci/production-verify
+++ b/tools/ci/production-verify
@@ -67,9 +67,7 @@ echo "Now confirming all the RabbitMQ queue processors are correctly registered!
 echo
 # These hacky shell scripts just extract the sorted list of queue processors, running and expected
 supervisorctl status | cut -f1 -dR | cut -f2- -d: | grep events | cut -f1 -d" " | cut -f3- -d_ | cut -f1 -d- | sort -u >/tmp/running_queue_processors.txt
-su zulip -c /home/zulip/deployments/current/scripts/lib/queue_workers.py | sort -u >/tmp/all_queue_processors.txt
-su zulip -c "/home/zulip/deployments/current/scripts/lib/queue_workers.py --queue-type test" | sort -u >/tmp/expected_test_queues.txt
-grep -v -x -f /tmp/expected_test_queues.txt /tmp/all_queue_processors.txt >/tmp/expected_queue_processors.txt
+su zulip -c /home/zulip/deployments/current/scripts/lib/queue_workers.py | sort -u >/tmp/expected_queue_processors.txt
 if ! diff /tmp/expected_queue_processors.txt /tmp/running_queue_processors.txt >/dev/null; then
     set +x
     echo "FAILURE: Runnable queue processors declared in zerver/worker/queue_processors.py "

--- a/tools/test-queue-worker-reload
+++ b/tools/test-queue-worker-reload
@@ -13,7 +13,7 @@ sanity_check.check_venv(__file__)
 
 # TODO: Convert this to use scripts/lib/queue_workers.py
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
-successful_worker_launch = '[process_queue] 18 queue worker threads were launched\n'
+successful_worker_launch = '[process_queue] 15 queue worker threads were launched\n'
 
 def check_worker_launch(run_dev: "subprocess.Popen[str]") -> bool:
     failed = False

--- a/tools/test-queue-worker-reload
+++ b/tools/test-queue-worker-reload
@@ -13,7 +13,7 @@ sanity_check.check_venv(__file__)
 
 # TODO: Convert this to use scripts/lib/queue_workers.py
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
-successful_worker_launch = '[process_queue] 16 queue worker threads were launched\n'
+successful_worker_launch = '[process_queue] 18 queue worker threads were launched\n'
 
 def check_worker_launch(run_dev: "subprocess.Popen[str]") -> bool:
     failed = False

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -647,4 +647,5 @@ class WorkerTest(ZulipTestCase):
         worker_queue_count = (len(QueueProcessingWorker.__subclasses__()) +
                               len(EmailSendingWorker.__subclasses__()) +
                               len(LoopQueueProcessingWorker.__subclasses__()) - 1)
-        self.assertEqual(worker_queue_count, len(get_active_worker_queues()))
+        self.assertEqual(worker_queue_count, len(get_active_worker_queues(include_test_queues=True)))
+        self.assertEqual(worker_queue_count - 3, len(get_active_worker_queues()))

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -138,10 +138,11 @@ def register_worker(queue_name: str, clazz: Type['QueueProcessingWorker'], queue
 def get_worker(queue_name: str) -> 'QueueProcessingWorker':
     return worker_classes[queue_name]()
 
-def get_active_worker_queues(queue_type: Optional[str]=None) -> List[str]:
+def get_active_worker_queues(queue_type: Optional[str]=None, include_test_queues: bool=False) -> List[str]:
     """Returns all the non-test worker queues."""
     if queue_type is None:
-        return list(worker_classes.keys())
+        return [queue_name for queue_name in worker_classes.keys()
+                if include_test_queues or queue_name not in queues["test"]]
     return list(queues[queue_type].keys())
 
 def check_and_send_restart_signal() -> None:


### PR DESCRIPTION
`get_active_worker_queues` is the function used for grabbing the expected queues to run. This makes it not return the test queues unless explicitly requested.

Also updates `test-queue-worker-reload` to succeed now, but that tool is still broken on a deeper level - #16565 

As pointed out by Alex, right now we only have two queue types - "consumer" (normal queues) and "test" - so it might make sense to get rid of the `queue_type` concept and replace with a simple `test_queue` bool. On the other hand, we might introduce other queue types at some point which make this code useful again, so perhaps it's worth keeping it? It's not particularly complex and simplifying it to the `bool` concept might be more trouble than just keeping it around. 

CC @alexmv 