### PR TITLE
forgot-password: Move label before input-box.

### DIFF
--- a/templates/zerver/reset.html
+++ b/templates/zerver/reset.html
@@ -16,10 +16,10 @@
                 <div class="new-style">
                     <div class="input-box horizontal moving-label">
                         <div class="inline-block relative">
+                            <label for="id_email" class="">{{ _('Email') }}</label>
                             <input id="id_email" class="required" type="text" name="email"
                               value="{% if form.email.value() %}{{ form.email.value() }}{% endif %}"
                               maxlength="100" autofocus required />
-                            <label for="id_email" class="">{{ _('Email') }}</label>
                             {% if form.email.errors %}
                                 {% for error in form.email.errors %}
                                 <div class="alert alert-error">{{ error }}</div>


### PR DESCRIPTION
Moves the label for #id_email before the input
field for correct CSS selector behavior.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<details>
<summary>Broken reset.html</summary>
<img src="https://user-images.githubusercontent.com/15276828/96374587-34e0a600-1191-11eb-8891-1ffa09ac27f1.png">
</details>

<details>
<summary>Fixed reset.html</summary>

<img src="https://user-images.githubusercontent.com/15276828/96374661-8a1cb780-1191-11eb-853d-5677df98bab3.png">

<img src="https://user-images.githubusercontent.com/15276828/96374679-a587c280-1191-11eb-99a2-7e1ea41af583.png">


</details>
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
