### PR TITLE
desktop-login: Add missing labels to input fields. 

### DIFF
--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -1722,6 +1722,10 @@ label.label-title {
 .desktop-redirect-box {
     text-align: center;
 
+    label {
+        text-align: initial;
+    }
+
     .copy-token-info {
         font-weight: normal;
     }

--- a/templates/zerver/desktop_login.html
+++ b/templates/zerver/desktop_login.html
@@ -11,6 +11,7 @@
 
             <form id="form" action="blob:">
                 <span class="input-box">
+                    <label for="token">Token</label>
                     <input id="token" placeholder="{% trans %}Paste token here{% endtrans %}" type="text"/>
                 </span>
                 <button id="submit" disabled>{% trans %}Finish{% endtrans %}</button>

--- a/templates/zerver/desktop_redirect.html
+++ b/templates/zerver/desktop_redirect.html
@@ -8,6 +8,7 @@
         <p class="copy-token-info">{% trans %}Copy this login token and return to your Zulip app to finish logging in:{% endtrans %}</p>
         <p>
             <span class="input-box">
+                <label for="desktop-data">Token</label>
                 <input id="desktop-data" value="{{ desktop_data }}" type="text" readonly />
             </span>
             <button id="copy" tabindex="0" data-clipboard-target="#desktop-data">{% trans %}Copy{% endtrans %}</button>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Adding the missing labels fixes the horizontal
alignment of the input and button. The CSS assumes
the existence of a label for all input fields.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<details>
<summary>Current UI:</summary>
<img src="https://user-images.githubusercontent.com/15276828/96375225-462bb180-1195-11eb-9f64-d03e79dbf64b.png">
<img src="https://user-images.githubusercontent.com/15276828/96375233-50e64680-1195-11eb-8ee2-ca82cda6d3ba.png">
</details>

<details>
<summary>New UI:</summary>
<img src="https://user-images.githubusercontent.com/15276828/96375100-a66e2380-1194-11eb-9633-ed16d52362c6.png">
<img src="https://user-images.githubusercontent.com/15276828/96375107-b0902200-1194-11eb-8023-61615d82fbb9.png">
</details>


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
