### PR TITLE
added JS tooltip to keyboard icon in right sidebar

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -275,7 +275,11 @@ exports.initialize_kitchen_sink_stuff = function () {
 
     // We disable animations here because they can cause the tooltip
     // to change shape while fading away in weird way.
-    $("#keyboard-icon").tooltip({animation: false});
+    $("#keyboard-icon").tooltip({
+        title: i18n.t("Keyboard shortcuts __hotkey__", {hotkey: "(?)"}),
+        animation: false,
+        placement: "left",
+    });
 
     $("body").on("mouseover", ".message_edit_content", function () {
         $(this).closest(".message_row").find(".copy_message").show();

--- a/templates/zerver/app/right_sidebar.html
+++ b/templates/zerver/app/right_sidebar.html
@@ -20,7 +20,7 @@
         <a id="invite-user-link" href="#invite"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Invite more users') }}</a>
         {% endif %}
         <a id="sidebar-keyboard-shortcuts" data-overlay-trigger="keyboard-shortcuts">
-            <i class="fa fa-keyboard-o fa-2x" id="keyboard-icon" data-html="true" data-toggle="tooltip" title="{{ _('Keyboard shortcuts') }} <span class='hotkey-hint'>(?)</span>"></i>
+            <i class="fa fa-keyboard-o fa-2x" id="keyboard-icon"></i>
         </a>
     </div>
 </div>


### PR DESCRIPTION
This PR fixes https://github.com/zulip/zulip/issues/16438. The tooltip has been implemented using jQuery, and the placement of the tooltip has been changed to be on the left so as to avoid the flickering issue on hovering.


**Testing Plan:** <!-- How have you tested? -->
I have tested the tooltip myself by hovering over it, as well as using the `tools/test-js-with-node` suite.

**GIFs or Screenshots:**
![keyboard_icon_tooltip](https://user-images.githubusercontent.com/51477130/96491435-dfbf9580-125f-11eb-98de-8780951930f9.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
