### PR TITLE
puppet: Fix included monitoring class name.

### DIFF
--- a/puppet/zulip_ops/manifests/app_frontend.pp
+++ b/puppet/zulip_ops/manifests/app_frontend.pp
@@ -4,7 +4,7 @@ class zulip_ops::app_frontend {
   include zulip::rabbit
   include zulip::postfix_localmail
   include zulip::static_asset_compiler
-  include zulip::app_frontend_monitoring
+  include zulip_ops::app_frontend_monitoring
   $app_packages = [# Needed for the ssh tunnel to the redis server
     'autossh',
   ]


### PR DESCRIPTION
Broken in f61ac4a28d5cd930621f67b565ef8a64b5ef2a20.