### PR TITLE
integration: generate dynamic name and higher security for Big Blue Button video calls.

### DIFF
--- a/frontend_tests/node_tests/compose_video.js
+++ b/frontend_tests/node_tests/compose_video.js
@@ -27,6 +27,7 @@ set_global("ResizeObserver", function () {
 
 const server_events_dispatch = zrequire("server_events_dispatch");
 const compose_ui = zrequire("compose_ui");
+const compose_closed = zrequire("compose_closed_ui");
 const compose = zrequire("compose");
 function stub_out_video_calls() {
     const $elem = $("#below-compose-content .video_link");
@@ -210,8 +211,11 @@ test("videos", ({override, override_rewire}) => {
         page_params.realm_video_chat_provider =
             realm_available_video_chat_providers.big_blue_button.id;
 
+        compose_closed.get_recipient_label = () => "a";
+
         channel.get = (options) => {
             assert.equal(options.url, "/json/calls/bigbluebutton/create");
+            assert.equal(options.data.meeting_name, "a meeting");
             options.success({
                 url: "/calls/bigbluebutton/join?meeting_id=%22zulip-1%22&password=%22AAAAAAAAAA%22&checksum=%2232702220bff2a22a44aee72e96cfdb4c4091752e%22",
             });

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -5,6 +5,7 @@ import _ from "lodash";
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
 import * as compose_actions from "./compose_actions";
+import {get_recipient_label} from "./compose_closed_ui";
 import * as compose_error from "./compose_error";
 import * as compose_fade from "./compose_fade";
 import * as compose_state from "./compose_state";
@@ -616,8 +617,12 @@ export function initialize() {
             available_providers.big_blue_button &&
             page_params.realm_video_chat_provider === available_providers.big_blue_button.id
         ) {
+            const meeting_name = get_recipient_label() + " meeting";
             channel.get({
                 url: "/json/calls/bigbluebutton/create",
+                data: {
+                    meeting_name,
+                },
                 success(response) {
                     insert_video_call_url(response.url, $target_textarea);
                 },

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13868,6 +13868,16 @@ paths:
       description: |
         Create a video call URL for a BigBlueButton video call.
         Requires BigBlueButton to be configured on the Zulip server.
+      parameters:
+        - in: query
+          name: meeting_name
+          schema:
+            type: string
+          required: true
+          description: |
+            Title to use for the BigBlueButton meeting.
+
+            A good choice is something like "{stream_name} meeting".
       responses:
         "200":
           description: Success.
@@ -13885,12 +13895,12 @@ paths:
                         description: |
                           The URL for the BigBlueButton video call.
                         type: string
-                        example: "/calls/bbb/join?meeting_id=%22zulip-something%22&password=%22something%22&checksum=%22somechecksum%22"
+                        example: "/calls/bigbluebutton/join?meeting_id=%22zulip-something%22&password=%22something%22&name=%22your_meeting_name%22&checksum=%22somechecksum%22"
                     example:
                       {
                         "msg": "",
                         "result": "success",
-                        "url": "/calls/bbb/join?meeting_id=%22zulip-something%22&password=%22something%22&checksum=%22somechecksum%22",
+                        "url": "/calls/bigbluebutton/join?meeting_id=%22zulip-something%22&password=%22something%22&checksum=%22somechecksum%22",
                       }
 
 components:

--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -10,6 +10,7 @@ from urllib.parse import quote, urlencode, urljoin
 import requests
 from defusedxml import ElementTree
 from django.conf import settings
+from django.core.signing import Signer
 from django.http import HttpRequest, HttpResponse
 from django.middleware import csrf
 from django.shortcuts import redirect, render
@@ -168,35 +169,27 @@ def deauthorize_zoom_user(request: HttpRequest) -> HttpResponse:
     return json_success(request)
 
 
-def get_bigbluebutton_url(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
+@has_request_variables
+def get_bigbluebutton_url(
+    request: HttpRequest, user_profile: UserProfile, meeting_name: str = REQ()
+) -> HttpResponse:
     # https://docs.bigbluebutton.org/dev/api.html#create for reference on the API calls
     # https://docs.bigbluebutton.org/dev/api.html#usage for reference for checksum
     id = "zulip-" + str(random.randint(100000000000, 999999999999))
-    password = b32encode(secrets.token_bytes(7))[:10].decode()
-    checksum = hashlib.sha256(
-        (
-            "create"
-            + "meetingID="
-            + id
-            + "&moderatorPW="
-            + password
-            + "&attendeePW="
-            + password
-            + "a"
-            + settings.BIG_BLUE_BUTTON_SECRET
-        ).encode()
-    ).hexdigest()
-    url = append_url_query_string(
-        "/calls/bigbluebutton/join",
-        urlencode(
-            {
-                "meeting_id": id,
-                "password": password,
-                "checksum": checksum,
-            }
-        ),
+    password = b32encode(secrets.token_bytes(7))[:20].decode()
+
+    # We sign our data here to ensure a Zulip user can not tamper with
+    # the join link to gain access to other meetings that are on the
+    # same bigbluebutton server.
+    signed = Signer().sign_object(
+        {
+            "meeting_id": id,
+            "name": meeting_name,
+            "password": password,
+        }
     )
-    return json_success(request, data={"url": url})
+    url = append_url_query_string("/calls/bigbluebutton/join", "bigbluebutton=" + signed)
+    return json_success(request, {"url": url})
 
 
 # We use zulip_login_required here mainly to get access to the user's
@@ -207,55 +200,78 @@ def get_bigbluebutton_url(request: HttpRequest, user_profile: UserProfile) -> Ht
 @zulip_login_required
 @never_cache
 @has_request_variables
-def join_bigbluebutton(
-    request: HttpRequest,
-    meeting_id: str = REQ(),
-    password: str = REQ(),
-    checksum: str = REQ(),
-) -> HttpResponse:
+def join_bigbluebutton(request: HttpRequest, bigbluebutton: str = REQ()) -> HttpResponse:
     assert request.user.is_authenticated
 
     if settings.BIG_BLUE_BUTTON_URL is None or settings.BIG_BLUE_BUTTON_SECRET is None:
         raise JsonableError(_("BigBlueButton is not configured."))
-    else:
-        try:
-            response = VideoCallSession().get(
-                append_url_query_string(
-                    settings.BIG_BLUE_BUTTON_URL + "api/create",
-                    urlencode(
-                        {
-                            "meetingID": meeting_id,
-                            "moderatorPW": password,
-                            "attendeePW": password + "a",
-                            "checksum": checksum,
-                        }
-                    ),
-                )
-            )
-            response.raise_for_status()
-        except requests.RequestException:
-            raise JsonableError(_("Error connecting to the BigBlueButton server."))
 
-        payload = ElementTree.fromstring(response.text)
-        if payload.find("messageKey").text == "checksumError":
-            raise JsonableError(_("Error authenticating to the BigBlueButton server."))
+    try:
+        bigbluebutton_data = Signer().unsign_object(bigbluebutton)
+    except Exception:
+        raise JsonableError(_("Invalid signature."))
 
-        if payload.find("returncode").text != "SUCCESS":
-            raise JsonableError(_("BigBlueButton server returned an unexpected error."))
+    create_params = urlencode(
+        {
+            "meetingID": bigbluebutton_data["meeting_id"],
+            "name": bigbluebutton_data["name"],
+            "moderatorPW": bigbluebutton_data["password"],
+            # We generate the attendee password from moderatorPW,
+            # because the BigBlueButton API requires a separate
+            # password. This integration is designed to have all users
+            # join as moderators, so we generate attendeePW by
+            # truncating the moderatorPW while keeping it long enough
+            # to not be vulnerable to brute force attacks.
+            "attendeePW": bigbluebutton_data["password"][:16],
+        },
+        quote_via=quote,
+    )
 
-        join_params = urlencode(
-            {
-                "meetingID": meeting_id,
-                "password": password,
-                "fullName": request.user.full_name,
-            },
-            quote_via=quote,
+    checksum = hashlib.sha256(
+        ("create" + create_params + settings.BIG_BLUE_BUTTON_SECRET).encode()
+    ).hexdigest()
+
+    try:
+        response = VideoCallSession().get(
+            append_url_query_string(settings.BIG_BLUE_BUTTON_URL + "api/create", create_params)
+            + "&checksum="
+            + checksum
         )
+        response.raise_for_status()
+    except requests.RequestException:
+        raise JsonableError(_("Error connecting to the BigBlueButton server."))
 
-        checksum = hashlib.sha256(
-            ("join" + join_params + settings.BIG_BLUE_BUTTON_SECRET).encode()
-        ).hexdigest()
-        redirect_url_base = append_url_query_string(
-            settings.BIG_BLUE_BUTTON_URL + "api/join", join_params
-        )
-        return redirect(append_url_query_string(redirect_url_base, "checksum=" + checksum))
+    payload = ElementTree.fromstring(response.text)
+    if payload.find("messageKey").text == "checksumError":
+        raise JsonableError(_("Error authenticating to the BigBlueButton server."))
+
+    if payload.find("returncode").text != "SUCCESS":
+        raise JsonableError(_("BigBlueButton server returned an unexpected error."))
+
+    join_params = urlencode(
+        {
+            "meetingID": bigbluebutton_data["meeting_id"],
+            # We use the moderator password here to grant ever user
+            # full moderator permissions to the bigbluebutton session.
+            "password": bigbluebutton_data["password"],
+            "fullName": request.user.full_name,
+            # https://docs.bigbluebutton.org/dev/api.html#create
+            # The createTime option is used to have the user redirected to a link
+            # that is only valid for this meeting.
+            #
+            # Even if the same link in Zulip is used again, a new
+            # createTime parameter will be created, as the meeting on
+            # the BigBlueButton server has to be recreated. (after a
+            # few minutes)
+            "createTime": payload.find("createTime").text,
+        },
+        quote_via=quote,
+    )
+
+    checksum = hashlib.sha256(
+        ("join" + join_params + settings.BIG_BLUE_BUTTON_SECRET).encode()
+    ).hexdigest()
+    redirect_url_base = append_url_query_string(
+        settings.BIG_BLUE_BUTTON_URL + "api/join", join_params
+    )
+    return redirect(append_url_query_string(redirect_url_base, "checksum=" + checksum))


### PR DESCRIPTION
Resolve #16498 
This will also probably fix #20509


Generate dynamic name for Big Blue Button video calls.

As discussed in #16498 this PR does __not__ set a custom id, but the id of the meeting
is still generated randomly.

~~This PR also generates a (attendee) password that only the server knows not the client. 
_(Instead of using the moderator password + a, as before)_~~
We do not longer expose the checksum of the create API call to the user, but generate them shortly before making the API call. To prevent tampering with the Link data we use Django signing.
This is to prevent the data of the link from being reused by a user without
requiring authentication in zulip, by directly contacting the Big Blue Button API.

Furthermore we now use the [createTime](https://docs.bigbluebutton.org/dev/api.html#join) parameter in the Big Blue Button join request to also prevent reuse of the join URL (as it is exposed to the client).

**Testing Plan:** <!-- How have you tested? -->
Edited the tests to fit the changes.