### PR TITLE
docs: Update guidelines to URL-encode stream name or topic name.

### DIFF
--- a/templates/zerver/help/include/create-bot-construct-url-indented.md
+++ b/templates/zerver/help/include/create-bot-construct-url-indented.md
@@ -6,9 +6,13 @@
     {!webhook-url.md!}
 
     Modify the parameters of the URL above, where `api_key` is the API key
-    of your Zulip bot, and `stream` is the URL-encoded stream name you want the
-    notifications sent to. If you do not specify a `stream`, the bot will
-    send notifications via PMs to the creator of the bot.
+    of your Zulip bot, and `stream` is the [URL-encoded](https://www.urlencoder.org/)
+    stream name you want the notifications sent to. If you do not specify a
+    `stream`, the bot will send notifications via PMs to the creator of the bot.
 
     If you'd like this integration to always send to the topic
     `your topic`, just add `&topic=your%20topic` to the end of the URL.
+
+    To URL-encode the stream name or topic name, copy & paste it in
+    [URL-encoder](https://www.urlencoder.org/). Click on **ENCODE** and
+    copy & paste the result in the URL.


### PR DESCRIPTION
Updated guidelines to URL-encode stream name and topic name. It will especially help
them who use emoji in the stream name and topic name

Fixes #16430.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
