### PR TITLE
compilemessages: Sort language list with Unicode Collation Algorithm

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -189,3 +189,6 @@ sentry-sdk
 
 # For detecting URLs to link
 tlds
+
+# Unicode Collation Algorithm for sorting multilingual strings
+pyuca

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -947,6 +947,10 @@ pytz==2020.1 \
     --hash=sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed \
     --hash=sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048 \
     # via -r requirements/common.in, babel, django, moto, twilio
+pyuca==1.2 \
+    --hash=sha256:8a382fe74627f08c0d18908c0713ca4a20aad5385f077579e56208beea2893b2 \
+    --hash=sha256:abaa12e1bd2c7c68ca8396ff8383bc0654a739cef3ae68fd7af58bf29af0a91e \
+    # via -r requirements/common.in
 pywatchman==1.4.1 \
     --hash=sha256:d0047eb275deafb0011eda0a1a815fbd9742478c3d2b5ad6956d300e447dc2f9 \
     # via pyre-check

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -669,6 +669,10 @@ pytz==2020.1 \
     --hash=sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed \
     --hash=sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048 \
     # via -r requirements/common.in, babel, django, twilio
+pyuca==1.2 \
+    --hash=sha256:8a382fe74627f08c0d18908c0713ca4a20aad5385f077579e56208beea2893b2 \
+    --hash=sha256:abaa12e1bd2c7c68ca8396ff8383bc0654a739cef3ae68fd7af58bf29af0a91e \
+    # via -r requirements/common.in
 pyyaml==5.3.1 \
     --hash=sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97 \
     --hash=sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76 \

--- a/version.py
+++ b/version.py
@@ -44,4 +44,4 @@ API_FEATURE_LEVEL = 34
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '112.2'
+PROVISION_VERSION = '113.0'

--- a/zerver/management/commands/compilemessages.py
+++ b/zerver/management/commands/compilemessages.py
@@ -13,6 +13,7 @@ from django.core.management.commands import compilemessages
 from django.utils.translation import override as override_language
 from django.utils.translation import ugettext as _
 from django.utils.translation.trans_real import to_language
+from pyuca import Collator
 
 
 class Command(compilemessages.Command):
@@ -45,7 +46,8 @@ class Command(compilemessages.Command):
                 del lang_info['name_local']
                 lang_list.append(lang_info)
 
-            lang_list.sort(key=lambda lang: lang['name'])
+            collator = Collator()
+            lang_list.sort(key=lambda lang: collator.sort_key(lang['name']))
 
         with open(output_path, 'wb') as output_file:
             output_file.write(


### PR DESCRIPTION
Right now the list of languages in Display settings → Default language is sorted in an unintuitive order due to the varying case conventions:

British English
Chinese (Taiwan)
Deutsch
English
Hindi
Indonesian (Indonesia)
Lietuviškai
Magyar
Malayalam
Nederlands
Português
Română
Tiếng Việt
Türkçe
català
español
français
galego
italiano
polski
suomi
svenska
česky
Русский
Українська
български
српски
فارسی
தமிழ்
日本語
简体中文
繁體中文
한국어

Fix the sort to use the locale-independent Unicode Collation Algorithm:

British English
català
česky
Chinese (Taiwan)
Deutsch
English
español
français
galego
Hindi
Indonesian (Indonesia)
italiano
Lietuviškai
Magyar
Malayalam
Nederlands
polski
Português
Română
suomi
svenska
Tiếng Việt
Türkçe
български
Русский
српски
Українська
فارسی
தமிழ்
한국어
日本語
简体中文
繁體中文

**Testing Plan:** Dev server.