### PR TITLE
Add a new /digress slash command.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -382,6 +382,13 @@ export const slash_commands = [
         name: "day",
     },
     {
+        text: $t({
+            defaultMessage:
+                "/digress #stream name>topic name (Shift conversation to another topic)",
+        }),
+        name: "digress",
+    },
+    {
         text: $t({defaultMessage: "/fixed-width (Toggle fixed width mode)"}),
         name: "fixed-width",
     },

--- a/static/js/zcommand.js
+++ b/static/js/zcommand.js
@@ -30,9 +30,11 @@ What in the heck is a zcommand?
 
 export function send(opts) {
     const command = opts.command;
+    const command_data = opts.command_data;
     const on_success = opts.on_success;
     const data = {
         command,
+        command_data: JSON.stringify(command_data),
     };
 
     channel.post({
@@ -43,8 +45,12 @@ export function send(opts) {
                 on_success(data);
             }
         },
-        error() {
-            tell_user("server did not respond");
+        error(xhr) {
+            if (xhr.responseText) {
+                tell_user(JSON.parse(xhr.responseText).msg);
+            } else {
+                tell_user("server did not respond");
+            }
         },
     });
 }

--- a/static/js/zcommand.js
+++ b/static/js/zcommand.js
@@ -1,12 +1,15 @@
 import $ from "jquery";
 
+import render_digress_zcommand_message from "../templates/digress_zcommand_message.hbs";
 import marked from "../third/marked/lib/marked";
 
 import * as browser_history from "./browser_history";
 import * as channel from "./channel";
 import * as common from "./common";
+import * as compose_state from "./compose_state";
 import * as feedback_widget from "./feedback_widget";
 import {$t} from "./i18n";
+import * as narrow from "./narrow";
 import * as night_mode from "./night_mode";
 import * as scroll_bar from "./scroll_bar";
 
@@ -154,6 +157,38 @@ export function enter_fixed_mode() {
     });
 }
 
+export function digress(command_data) {
+    send({
+        command: "/digress",
+        command_data,
+        on_success() {
+            let operators = [
+                {operator: "stream", operand: command_data.new_stream},
+                {operator: "topic", operand: command_data.new_topic},
+            ];
+            narrow.activate(operators);
+            feedback_widget.show({
+                populate(container) {
+                    const rendered_message = render_digress_zcommand_message({
+                        stream_name: command_data.new_stream,
+                        topic: command_data.new_topic,
+                    });
+                    container.html(rendered_message);
+                },
+                on_undo() {
+                    operators = [
+                        {operator: "stream", operand: command_data.old_stream},
+                        {operator: "topic", operand: command_data.old_topic},
+                    ];
+                    narrow.activate(operators);
+                },
+                title_text: $t({defaultMessage: "Digress"}),
+                undo_button_text: $t({defaultMessage: "Go back"}),
+            });
+        },
+    });
+}
+
 export function process(message_content) {
     const content = message_content.trim();
 
@@ -198,6 +233,42 @@ export function process(message_content) {
     if (content === "/settings") {
         browser_history.go_to_location("settings/your-account");
         return true;
+    }
+
+    if (content.indexOf("/digress") === 0) {
+        if (compose_state.get_message_type() !== "stream") {
+            // digress can be used only in streams
+            return true;
+        }
+
+        let param = content.slice(8);
+        param = param.trim();
+
+        // A valid param will now be of the form #**stream name>topic name**
+        const new_stream_name_start = param.indexOf("#**") + 3;
+        const new_topic_start = param.indexOf(">") + 1;
+        const new_topic_end = param.lastIndexOf("**");
+
+        if (
+            new_stream_name_start === 3 &&
+            new_topic_start > new_stream_name_start &&
+            new_topic_end > new_topic_start &&
+            param.endsWith("**")
+        ) {
+            const new_stream_name = param.slice(new_stream_name_start, new_topic_start - 1);
+            const new_topic = param.slice(new_topic_start, new_topic_end);
+
+            const old_stream_name = compose_state.stream_name();
+            const old_topic = compose_state.topic();
+
+            digress({
+                old_stream: old_stream_name,
+                old_topic,
+                new_stream: new_stream_name,
+                new_topic,
+            });
+            return true;
+        }
     }
 
     // It is incredibly important here to return false

--- a/static/templates/digress_zcommand_message.hbs
+++ b/static/templates/digress_zcommand_message.hbs
@@ -1,0 +1,6 @@
+<p>
+    {{#tr}}
+        Switched to new topic <stream-topic></stream-topic>
+        {{#*inline "stream-topic"}}{{> stream_topic_widget}}{{/inline}}
+    {{/tr}}
+</p>

--- a/zerver/lib/zcommand.py
+++ b/zerver/lib/zcommand.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from django.utils.translation import gettext as _
 
@@ -7,7 +7,9 @@ from zerver.lib.exceptions import JsonableError
 from zerver.models import UserProfile
 
 
-def process_zcommands(content: str, user_profile: UserProfile) -> Dict[str, Any]:
+def process_zcommands(
+    content: str, data: Optional[Dict[str, Any]], user_profile: UserProfile
+) -> Dict[str, Any]:
     def change_mode_setting(
         command: str, switch_command: str, setting: str, setting_value: int
     ) -> str:

--- a/zerver/lib/zcommand.py
+++ b/zerver/lib/zcommand.py
@@ -2,8 +2,15 @@ from typing import Any, Dict, Optional
 
 from django.utils.translation import gettext as _
 
-from zerver.lib.actions import do_set_user_display_setting
+from zerver.lib.actions import do_set_user_display_setting, send_message_moved_breadcrumbs
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.message import truncate_topic
+from zerver.lib.streams import (
+    access_stream_by_name,
+    access_stream_for_send_message,
+    subscribed_to_stream,
+)
+from zerver.lib.topic import messages_for_topic, user_message_exists_for_topic
 from zerver.models import UserProfile
 
 
@@ -75,4 +82,69 @@ def process_zcommands(
                 setting_value=False,
             )
         )
+    elif command == "digress":
+        data_keys = [
+            "old_stream",
+            "old_topic",
+            "new_stream",
+            "new_topic",
+        ]
+        if not data or not all(key in data for key in data_keys):
+            raise JsonableError(_("Invalid data."))
+
+        if data["old_stream"] == data["new_stream"] and data["old_topic"] == data["new_topic"]:
+            raise JsonableError(_("Cannot digress to the same topic."))
+
+        (old_stream, ignored_old_stream_sub) = access_stream_by_name(
+            user_profile, data["old_stream"]
+        )
+
+        (new_stream, ignored_new_stream_sub) = access_stream_by_name(
+            user_profile, data["new_stream"]
+        )
+
+        # Because /digress is just a shortcut for manually sending messages,
+        # we make sure that the user has permission to send messages to these
+        # streams themselves.
+        access_stream_for_send_message(user_profile, old_stream, None)
+        access_stream_for_send_message(user_profile, new_stream, None)
+
+        # Allow digressing from a topic only if it isn't empty for the user.
+        error_message = _("Old topic #**{}>{}** does not exist.").format(
+            data["old_stream"], data["old_topic"]
+        )
+
+        if old_stream.is_history_realm_public() or (
+            subscribed_to_stream(user_profile, old_stream.id)
+            and old_stream.is_history_public_to_subscribers()
+        ):
+            # Stream history is visible to the user. Allow digress if the topic
+            # isn't empty (that is, at least one Message exists).
+            messages = messages_for_topic(old_stream.recipient.id, data["old_topic"])
+            if len(messages) < 1:
+                raise JsonableError(error_message)
+
+        if (not old_stream.is_public()) and (not old_stream.is_history_public_to_subscribers()):
+            # Stream history isn't visible. Allow digress if there is at least
+            # one UserMessage.
+            if not user_message_exists_for_topic(
+                user_profile=user_profile,
+                recipient_id=old_stream.recipient_id,
+                topic_name=data["old_topic"],
+            ):
+                raise JsonableError(error_message)
+
+        data["new_topic"] = truncate_topic(data["new_topic"])
+        old_thread_notification_string = _("{user} digressed to the new topic: {new_location}")
+        new_thread_notification_string = _("{user} digressed this from old topic: {old_location}")
+        send_message_moved_breadcrumbs(
+            user_profile,
+            old_stream,
+            data["old_topic"],
+            old_thread_notification_string,
+            new_stream,
+            data["new_topic"],
+            new_thread_notification_string,
+        )
+        return {}
     raise JsonableError(_("No such command: {}").format(command))

--- a/zerver/tests/test_zcommand.py
+++ b/zerver/tests/test_zcommand.py
@@ -1,3 +1,8 @@
+from typing import Any, Dict
+
+import orjson
+
+from zerver.lib.actions import do_change_stream_invite_only
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import UserProfile
 
@@ -80,3 +85,245 @@ class ZcommandTest(ZulipTestCase):
         result = self.client_post("/json/zcommand", payload)
         self.assert_json_success(result)
         self.assert_in_response("You are still in fixed width mode", result)
+
+    def get_digress_payload(self, data: Dict[str, str]) -> Dict[str, Any]:
+        return dict(
+            command="/digress",
+            command_data=orjson.dumps(data).decode(),
+        )
+
+    def test_digress_incomplete_data(self) -> None:
+        self.login("hamlet")
+        payload = self.get_digress_payload(dict(old_stream="general"))
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_error(result, "Invalid data.")
+
+    def test_digress_same_thread(self) -> None:
+        self.login("hamlet")
+        payload = self.get_digress_payload(
+            dict(
+                old_stream="general",
+                old_topic="old topic name",
+                new_stream="general",
+                new_topic="old topic name",
+            )
+        )
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_error(result, "Cannot digress to the same topic.")
+
+    def test_digress_from_public_stream(self) -> None:
+        self.login("hamlet")
+        hamlet = self.example_user("hamlet")
+        self.make_stream("general")
+        self.subscribe(hamlet, "general")
+        self.make_stream("test")
+        self.subscribe(hamlet, "test")
+        payload = self.get_digress_payload(
+            dict(
+                old_stream="general",
+                old_topic="old topic name",
+                new_stream="test",
+                new_topic="new topic name",
+            )
+        )
+
+        # Empty topic.
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_error(result, "Old topic #**general>old topic name** does not exist.")
+
+        self.client_post(
+            "/json/messages",
+            {
+                "type": "stream",
+                "to": "general",
+                "client": "test suite",
+                "content": "Test message",
+                "topic": "old topic name",
+            },
+        )
+
+        # Happy path.
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        message = self.get_last_message()
+        self.assertEqual(message.topic_name(), "old topic name")
+        self.assertEqual(
+            message.content,
+            f"@_**King Hamlet|{hamlet.id}** digressed to the new topic: #**test>new topic name**",
+        )
+
+        message = self.get_second_to_last_message()
+        self.assertEqual(message.topic_name(), "new topic name")
+        self.assertEqual(
+            message.content,
+            f"@_**King Hamlet|{hamlet.id}** digressed this from old topic: #**general>old topic name**",
+        )
+
+    def test_digress_from_private_stream_with_shared_history(self) -> None:
+        # Data setup.
+        self.login("hamlet")
+        desdemona = self.example_user("desdemona")
+        hamlet = self.example_user("hamlet")
+        general = self.make_stream("general")
+        self.subscribe(desdemona, "general")
+        self.make_stream("test")
+        self.subscribe(hamlet, "test")
+        payload = self.get_digress_payload(
+            dict(
+                old_stream="general",
+                old_topic="old topic name",
+                new_stream="test",
+                new_topic="new topic name",
+            )
+        )
+        do_change_stream_invite_only(general, invite_only=True, history_public_to_subscribers=True)
+
+        # Inaccessible stream.
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_error(result, "Invalid stream name 'general'")
+
+        # Accessible stream, empty topic.
+        self.subscribe(hamlet, "general")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_error(result, "Old topic #**general>old topic name** does not exist.")
+
+        # Have Desmodena send a message to #general while Hamlet was not subscribed,
+        # to make sure Hamlet does not have a UserMessage object.
+        # Hamlet should still be able to digress, because history is visible.
+        self.unsubscribe(hamlet, "general")
+        self.login("desdemona")
+        self.client_post(
+            "/json/messages",
+            {
+                "type": "stream",
+                "to": "general",
+                "client": "test suite",
+                "content": "Test message",
+                "topic": "old topic name",
+            },
+        )
+        self.login("hamlet")
+        self.subscribe(hamlet, "general")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        message = self.get_last_message()
+        self.assertEqual(message.topic_name(), "old topic name")
+        self.assertEqual(
+            message.content,
+            f"@_**King Hamlet|{hamlet.id}** digressed to the new topic: #**test>new topic name**",
+        )
+
+        message = self.get_second_to_last_message()
+        self.assertEqual(message.topic_name(), "new topic name")
+        self.assertEqual(
+            message.content,
+            f"@_**King Hamlet|{hamlet.id}** digressed this from old topic: #**general>old topic name**",
+        )
+
+    def test_digress_from_private_stream_with_protected_history(self) -> None:
+        # Data setup.
+        self.login("hamlet")
+        desdemona = self.example_user("desdemona")
+        hamlet = self.example_user("hamlet")
+        general = self.make_stream("general")
+        self.subscribe(desdemona, "general")
+        self.make_stream("test")
+        self.subscribe(hamlet, "test")
+        payload = self.get_digress_payload(
+            dict(
+                old_stream="general",
+                old_topic="old topic name",
+                new_stream="test",
+                new_topic="new topic name",
+            )
+        )
+        do_change_stream_invite_only(general, invite_only=True, history_public_to_subscribers=False)
+
+        # Inaccessible stream.
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_error(result, "Invalid stream name 'general'")
+
+        # Accessible stream, empty topic.
+        self.subscribe(hamlet, "general")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_error(result, "Old topic #**general>old topic name** does not exist.")
+
+        # Have Desmodena send a message to #general while Hamlet was not subscribed,
+        # to make sure Hamlet does not have a UserMessage object.
+        # Hamlet should not be able to digress, because the old topic is technically
+        # empty (for Hamlet).
+        self.unsubscribe(hamlet, "general")
+        self.login("desdemona")
+        self.client_post(
+            "/json/messages",
+            {
+                "type": "stream",
+                "to": "general",
+                "client": "test suite",
+                "content": "Test message",
+                "topic": "old topic name",
+            },
+        )
+        self.login("hamlet")
+        self.subscribe(hamlet, "general")
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_error(result, "Old topic #**general>old topic name** does not exist.")
+
+        # Message sent while Hamlet is subscribed.
+        self.client_post(
+            "/json/messages",
+            {
+                "type": "stream",
+                "to": "general",
+                "client": "test suite",
+                "content": "Test message",
+                "topic": "old topic name",
+            },
+        )
+        # Happy path.
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        message = self.get_last_message()
+        self.assertEqual(message.topic_name(), "old topic name")
+        self.assertEqual(
+            message.content,
+            f"@_**King Hamlet|{hamlet.id}** digressed to the new topic: #**test>new topic name**",
+        )
+
+        message = self.get_second_to_last_message()
+        self.assertEqual(message.topic_name(), "new topic name")
+        self.assertEqual(
+            message.content,
+            f"@_**King Hamlet|{hamlet.id}** digressed this from old topic: #**general>old topic name**",
+        )
+
+    def test_digress_new_topic_cleaned(self) -> None:
+        self.login("hamlet")
+        hamlet = self.example_user("hamlet")
+        self.make_stream("general")
+        self.make_stream("test")
+        self.subscribe(hamlet, "test")
+        self.client_post(
+            "/json/messages",
+            {
+                "type": "stream",
+                "to": "general",
+                "client": "test suite",
+                "content": "Test message",
+                "topic": "old topic name",
+            },
+        )
+        payload = self.get_digress_payload(
+            dict(
+                old_stream="general",
+                old_topic="old topic name",
+                new_stream="test",
+                new_topic=" This topic is really really really really really really really long.",
+            )
+        )
+        result = self.client_post("/json/zcommand", payload)
+        self.assert_json_success(result)
+        message = self.get_second_to_last_message()
+        self.assertEqual(
+            message.topic_name(), "This topic is really really really really really really ..."
+        )

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional, Sequence, Union, cast
+from typing import Any, Dict, Iterable, Optional, Sequence, Union, cast
 
 import pytz
 from dateutil.parser import parse as dateparser
@@ -22,6 +22,7 @@ from zerver.lib.message import render_markdown
 from zerver.lib.response import json_error, json_success
 from zerver.lib.timestamp import convert_to_UTC
 from zerver.lib.topic import REQ_topic
+from zerver.lib.validator import check_dict, check_string
 from zerver.lib.zcommand import process_zcommands
 from zerver.lib.zephyr import compute_mit_user_fullname
 from zerver.models import (
@@ -311,9 +312,14 @@ def send_message_backend(
 
 @has_request_variables
 def zcommand_backend(
-    request: HttpRequest, user_profile: UserProfile, command: str = REQ("command")
+    request: HttpRequest,
+    user_profile: UserProfile,
+    command: str = REQ("command"),
+    command_data: Optional[Dict[str, Any]] = REQ(
+        default=None, json_validator=check_dict(value_validator=check_string)
+    ),
 ) -> HttpResponse:
-    return json_success(process_zcommands(command, user_profile))
+    return json_success(process_zcommands(command, command_data, user_profile))
 
 
 @has_request_variables


### PR DESCRIPTION
#14531
This PR adds a new digress slash command which will send two breadcrumb messages to old and new threads.
CZO topic: https://chat.zulip.org/#narrow/stream/101-design/topic/.2Fdigress
Screenshots
<details><summary>Successful digress (GIF)</summary>
<img src="https://user-images.githubusercontent.com/55339528/102993248-cdedbd80-4542-11eb-8c81-6d2e419163b3.gif" />

</details>

<details><summary>Successful digress (Feedback widget)</summary>
<img src="https://user-images.githubusercontent.com/55339528/101726140-f94ec200-3ad7-11eb-8151-76d5304364f0.png" />
</details>

<details><summary>Successful digress (Notification messages)</summary>
<img src="https://user-images.githubusercontent.com/55339528/101726599-d83aa100-3ad8-11eb-94d0-42554d07abed.png" />
</details>

<details><summary>Errors (above composebox)</summary>
<img src="https://user-images.githubusercontent.com/55339528/102992772-df829580-4541-11eb-8a90-8fc5614a6e45.png" />

<img src="https://user-images.githubusercontent.com/55339528/102992694-b235e780-4541-11eb-9ec5-cd6c271b1100.png" />


</details>