### PR TITLE
Comfortable mode

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -142,6 +142,7 @@
                 "click_handlers": false,
                 "color_data": false,
                 "colorspace": false,
+                "comfortable_mode": false,
                 "common": false,
                 "components": false,
                 "compose": false,

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -104,6 +104,7 @@ import "../message_scroll";
 import "../info_overlay";
 import "../ui";
 import "../night_mode";
+import "../comfortable_mode";
 import "../ui_util";
 import "../click_handlers";
 import "../settings_panel_menu";
@@ -225,6 +226,7 @@ import "../../styles/recent_topics.css";
 import "../../styles/typing_notifications.css";
 import "../../styles/hotspots.css";
 import "../../styles/night_mode.css";
+import "../../styles/comfortable_mode.css";
 import "../../styles/user_status.css";
 import "../../styles/widgets.css";
 

--- a/static/js/comfortable_mode.js
+++ b/static/js/comfortable_mode.js
@@ -1,2 +1,2 @@
-$("html").css("font-size", "110%");
+$("html").css("font-size", "107%");
 $("body").addClass("comfortable-mode");

--- a/static/js/comfortable_mode.js
+++ b/static/js/comfortable_mode.js
@@ -1,0 +1,2 @@
+$("html").css("font-size", "110%");
+$("body").addClass("comfortable-mode");

--- a/static/js/global.d.ts
+++ b/static/js/global.d.ts
@@ -25,6 +25,7 @@ declare let channel: any;
 declare let click_handlers: any;
 declare let color_data: any;
 declare let colorspace: any;
+declare let comfortable_mode: any;
 declare let common: any;
 declare let components: any;
 declare let compose: any;

--- a/static/styles/alerts.css
+++ b/static/styles/alerts.css
@@ -99,7 +99,7 @@ $alert-error-red: hsl(0, 80%, 40%);
             margin-top: 1rem;
 
             .stackframe {
-                padding-left: calc(3.3rem - 14px);
+                padding-left: calc(3.3rem - 0.875rem);
                 padding-right: 1rem;
             }
         }
@@ -156,9 +156,9 @@ $alert-error-red: hsl(0, 80%, 40%);
         position: relative;
 
         /* gives room for the error icon. */
-        padding-left: 50px;
-        padding-top: 10px;
-        padding-bottom: 10px;
+        padding-left: 3.125rem;
+        padding-top: 0.625rem;
+        padding-bottom: 0.625rem;
 
         text-shadow: none;
 

--- a/static/styles/alerts.css
+++ b/static/styles/alerts.css
@@ -32,11 +32,11 @@ $alert-error-red: hsl(0, 80%, 40%);
     @extend .alert-display;
 
     &#organization-status {
-        margin: 20px;
+        margin: 1.25rem;
     }
 
     &.stream_create_info {
-        margin: 10px 10px 0 10px;
+        margin: 0.625rem 0.625rem 0 0.625rem;
     }
 
     .bankruptcy_unread_count {
@@ -49,8 +49,8 @@ $alert-error-red: hsl(0, 80%, 40%);
     position: absolute;
     top: 0;
     left: 0;
-    width: 900px;
-    margin-left: calc(50% - 450px);
+    width: 56.25rem;
+    margin-left: calc(50% - 28.125rem);
     z-index: 220;
     max-height: 100%;
     overflow-y: auto;
@@ -62,7 +62,7 @@ $alert-error-red: hsl(0, 80%, 40%);
         font-size: 1rem;
         color: hsl(0, 80%, 40%);
 
-        margin-top: 5px;
+        margin-top: 0.3125rem;
         padding: 1rem 0;
 
         background-color: hsl(0, 100%, 98%);

--- a/static/styles/alerts.css
+++ b/static/styles/alerts.css
@@ -199,7 +199,7 @@ $alert-error-red: hsl(0, 80%, 40%);
             cursor: pointer;
 
             &::after {
-                padding: 10px;
+                padding: 0.625rem;
                 content: "\d7";
             }
         }

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -343,8 +343,8 @@
         background: none;
         border: none;
         text-align: center;
-        padding-top: 8px;
-        padding-left: 4px;
+        padding-top: 0.5rem;
+        padding-left: 0.25rem;
         color: hsl(0, 0%, 80%);
         text-shadow: none;
         outline: none !important;
@@ -354,7 +354,7 @@
         .user_status_overlay & {
             margin-left: -26px;
             right: 0;
-            padding-top: 6px;
+            padding-top: 0.375rem;
         }
     }
 }

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -53,7 +53,7 @@
     .button {
         padding: 0.4375rem 0.875rem;
         margin: 0;
-        min-width: 130px;
+        min-width: 8.125rem;
 
         font-weight: 400;
         line-height: normal;
@@ -94,7 +94,7 @@
         }
 
         &.standalone {
-            margin-top: 10px;
+            margin-top: 0.625rem;
         }
 
         &.small {
@@ -195,13 +195,13 @@
 
     .tab-switcher {
         font-weight: initial;
-        margin: 2px 4px;
+        margin: 0.125rem 0.25rem;
         display: inline-block;
 
         .ind-tab {
             display: inline-block;
-            width: 90px;
-            margin: 0 -0.5px;
+            width: 5.625rem;
+            margin: 0 -0.0.3125rem;
             text-align: center;
             text-overflow: ellipsis;
             white-space: nowrap;
@@ -352,7 +352,7 @@
         z-index: 5;
 
         .user_status_overlay & {
-            margin-left: -26px;
+            margin-left: -1.625rem;
             right: 0;
             padding-top: 0.375rem;
         }
@@ -394,8 +394,8 @@
     /* Override Bootstrap's responsive grid to display input at full width */
     .input-append .stream-list-filter {
         /* Input width = 100% - 10px margin x2 - 6px padding x2 - 1px border x2. */
-        width: calc(100% - 34px);
-        margin-left: 10px;
+        width: calc(100% - 2.125rem);
+        margin-left: 0.625rem;
     }
 }
 
@@ -404,14 +404,14 @@
     box-shadow: inset 0 2px 1px -2px hsl(0, 0%, 20%),
         inset 2px 0 1px -2px hsl(0, 0%, 20%),
         inset 0 -2px 1px -2px hsl(0, 0%, 20%);
-    width: 10px;
+    width: 0.625rem;
     border-radius: 3px 0 0 3px;
     border-bottom: 0;
 }
 
 .stream_header_colorblock {
     @extend .stream-selection-header-colorblock;
-    margin-bottom: 5px;
+    margin-bottom: 0.3125rem;
     z-index: 1000;
 }
 
@@ -420,7 +420,7 @@
     font-size: 0.9em;
     -webkit-text-stroke: 0.05em;
     position: relative;
-    margin: 0 5px;
+    margin: 0 0.3125rem;
     top: 9px;
 }
 
@@ -428,18 +428,18 @@
 .loading_indicator_spinner {
     /* If you change these, make sure to adjust the constants in
        loading.make_indicator as well */
-    height: 38px;
-    width: 38px;
+    height: 2.375rem;
+    width: 2.375rem;
     float: left;
 }
 
 .loading_indicator_text {
     /* If you change these, make sure to adjust the constants in
        loading.make_indicator as well */
-    margin-left: 5px;
+    margin-left: 0.3125rem;
     font-size: 1.2em;
     font-weight: 300;
-    line-height: 38px;
+    line-height: 2.375rem;
 }
 
 .upgrade-tip {
@@ -464,14 +464,14 @@
     border: 1px solid hsl(49, 20%, 84%);
     border-radius: 4px;
     padding: 0.625rem;
-    margin: 10px 0;
+    margin: 0.625rem 0;
     font-size: 1rem;
     line-height: 1.5;
     color: hsl(0, 0%, 40%);
 
     &::before {
         display: inline;
-        margin-right: 8px;
+        margin-right: 0.5rem;
 
         font-family: FontAwesome, Yantramanav, "Source Sans Pro";
         font-weight: 600;

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -51,7 +51,7 @@
 .new-style {
     /* -- base button styling -- */
     .button {
-        padding: 7px 14px;
+        padding: 0.4375rem 0.875rem;
         margin: 0;
         min-width: 130px;
 
@@ -100,7 +100,7 @@
         &.small {
             font-size: 0.8rem;
             min-width: inherit;
-            padding: 6px 10px;
+            padding: 0.375rem 0.625rem;
         }
 
         &.small-flex {
@@ -207,7 +207,7 @@
             white-space: nowrap;
             overflow: hidden;
             vertical-align: bottom; /* See https://stackoverflow.com/a/43266155/ */
-            padding: 3px 10px;
+            padding: 0.1875rem 0.625rem;
             background-color: hsl(0, 0%, 100%);
             cursor: pointer;
             justify-content: center;
@@ -361,7 +361,7 @@
 
 .grey-box {
     margin: 0;
-    padding: 5px 10px;
+    padding: 0.3125rem 0.625rem;
     background-color: hsl(0, 0%, 98%);
     border: 1px solid hsl(0, 0%, 87%);
     border-radius: 4px;
@@ -463,7 +463,7 @@
     background-color: hsl(46, 63%, 95%);
     border: 1px solid hsl(49, 20%, 84%);
     border-radius: 4px;
-    padding: 10px;
+    padding: 0.625rem;
     margin: 10px 0;
     font-size: 1rem;
     line-height: 1.5;

--- a/static/styles/comfortable_mode.css
+++ b/static/styles/comfortable_mode.css
@@ -1,0 +1,3 @@
+body.comfortable-mode {
+
+}

--- a/static/styles/components.css
+++ b/static/styles/components.css
@@ -19,9 +19,9 @@
                 top: -2px;
 
                 padding: 0.125rem;
-                margin: 0 5px 0 0;
-                height: 10px;
-                width: 10px;
+                margin: 0 0.3125rem 0 0;
+                height: 0.625rem;
+                width: 0.625rem;
 
                 font-weight: 300;
                 line-height: 0.8;
@@ -82,7 +82,7 @@ a.no-underline:hover {
         transition: width 0.2s ease 1s;
 
         &.simplebar-hover {
-            width: 15px;
+            width: 0.9375rem;
             transition: width 0.2s ease;
         }
     }
@@ -91,7 +91,7 @@ a.no-underline:hover {
         transition: height 0.2s ease 1s;
 
         &.simplebar-hover {
-            height: 15px;
+            height: 0.9375rem;
             transition: height 0.2s ease;
         }
 
@@ -99,7 +99,7 @@ a.no-underline:hover {
             transition: height 0.2s ease 1s;
 
             &.simplebar-hover {
-                height: 11px;
+                height: 0.6875rem;
                 transition: height 0.2s ease;
             }
         }

--- a/static/styles/components.css
+++ b/static/styles/components.css
@@ -18,7 +18,7 @@
                 position: relative;
                 top: -2px;
 
-                padding: 2px;
+                padding: 0.125rem;
                 margin: 0 5px 0 0;
                 height: 10px;
                 width: 10px;
@@ -109,5 +109,5 @@ a.no-underline:hover {
 i.zulip-icon.bot {
     color: hsl(180, 5%, 74%);
     vertical-align: top;
-    padding: 0 2px;
+    padding: 0 0.125rem;
 }

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -334,7 +334,7 @@ input.recipient_box {
     }
 
     &.lock-padding {
-        padding-left: 18px;
+        padding-left: 1.125rem;
     }
 }
 
@@ -354,8 +354,8 @@ input.recipient_box {
        to float right, so that tabbing from the compose box goes here and then
        to the message controls to its left, to ensure "Tab then Enter" sends messages. */
     border-radius: 4px;
-    padding-top: 3px;
-    padding-bottom: 3px;
+    padding-top: 0.1875rem;
+    padding-bottom: 0.1875rem;
     margin-bottom: 0;
     font-weight: 600;
     border: 1px solid hsl(170, 68%, 41%);
@@ -406,7 +406,7 @@ a.message-control-button {
     width: 14px;
     height: 14px;
     margin-right: 8px;
-    padding-top: 5px;
+    padding-top: 0.3125rem;
     text-align: center;
     float: left;
 
@@ -474,9 +474,9 @@ a#undo_markdown_preview {
 
     .typeahead-header {
         margin: 0;
-        padding-left: 20px;
-        padding-right: 20px;
-        padding-top: 4px;
+        padding-left: 1.25rem;
+        padding-right: 1.25rem;
+        padding-top: 0.25rem;
         border-top: 1px solid hsla(0, 0%, 0%, 0.2);
         display: flex;
         align-items: center;

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -26,7 +26,7 @@
         }
 
         .alert-draft {
-            font-size: 14px;
+            font-size: 0.875rem;
             color: hsl(170, 48%, 54%);
             padding: 3px 12px;
             font-weight: 400;
@@ -251,7 +251,7 @@ div[id^="message-edit-send-status"],
 /* Like .alert .close */
 .send-status-close,
 .compose-send-status-close {
-    font-size: 17px;
+    font-size: 1.0625rem;
     font-weight: bold;
     color: hsl(0, 0%, 0%);
     text-shadow: 0 1px 0 hsl(0, 0%, 100%);
@@ -277,7 +277,7 @@ div[id^="message-edit-send-status"],
         position: absolute;
         right: 8px;
         top: 4px;
-        font-size: 17px;
+        font-size: 1.0625rem;
         font-weight: bold;
         color: hsl(0, 0%, 0%);
         text-shadow: 0 1px 0 hsl(0, 0%, 100%);
@@ -402,7 +402,7 @@ a.message-control-button {
     opacity: 0.4;
     color: inherit;
     text-decoration: none;
-    font-size: 14px;
+    font-size: 0.875rem;
     width: 14px;
     height: 14px;
     margin-right: 8px;
@@ -458,7 +458,7 @@ a.message-control-button {
 a#undo_markdown_preview {
     text-decoration: none;
     position: relative;
-    font-size: 15px;
+    font-size: 0.9375rem;
 }
 
 #markdown_preview_spinner {
@@ -483,7 +483,7 @@ a#undo_markdown_preview {
     }
 
     #typeahead-header-text {
-        font-size: 12px;
+        font-size: 0.75rem;
     }
 
     &.typeahead {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -47,8 +47,8 @@
     transition: background-color 200ms linear;
 
     padding: 0.5rem 0.625rem 0.5rem 0.625rem;
-    margin-left: 250px;
-    margin-right: 250px;
+    margin-left: 15.625rem;
+    margin-right: 15.625rem;
     position: relative;
 
     border-left: 1px solid hsl(0, 0%, 93%);
@@ -56,7 +56,7 @@
 }
 
 .ztable_comp_col1 {
-    width: 10px;
+    width: 0.625rem;
 }
 
 .message_comp {
@@ -91,13 +91,13 @@
             font-size: 0.9em;
             -webkit-text-stroke: 0.05em;
             position: relative;
-            margin: 0 5px;
+            margin: 0 0.3125rem;
         }
     }
 
     .pm_recipient {
-        margin-left: 5px;
-        margin-right: 20px;
+        margin-left: 0.3125rem;
+        margin-right: 1.25rem;
         display: flex;
         width: 100%;
     }
@@ -128,7 +128,7 @@
 
     .message-control-link {
         position: relative;
-        margin-right: 5px;
+        margin-right: 0.3125rem;
         top: 2px;
     }
 }
@@ -152,7 +152,7 @@
 
 #below-compose-content {
     width: 100%;
-    margin-top: 6px;
+    margin-top: 0.375rem;
 }
 
 #compose {
@@ -168,7 +168,7 @@
 #compose-container {
     width: 100%;
     /* This should match the value for .app-main */
-    max-width: 1400px;
+    max-width: 87.5rem;
     margin: auto;
 }
 
@@ -181,7 +181,7 @@
 #compose_invite_users,
 #compose_private_stream_alert {
     /* Don't overlap into the compose_close × */
-    margin-right: 10px;
+    margin-right: 0.625rem;
 }
 
 .compose_invite_user,
@@ -203,9 +203,9 @@
 .compose_invite_close,
 .compose_private_stream_alert_close {
     display: inline-block;
-    margin-top: 4px;
+    margin-top: 0.25rem;
 
-    width: 10px;
+    width: 0.625rem;
 }
 
 .compose-all-everyone-controls,
@@ -220,31 +220,31 @@
 .compose_not_subscribed p {
     margin: 0;
     display: inline-block;
-    max-width: calc(100% - 100px);
+    max-width: calc(100% - 6.25rem);
 }
 
 #error-message-sub-button {
-    margin-right: 30px;
+    margin-right: 1.875rem;
 }
 
 /* Like .nav-tabs > li > a */
 div[id^="message-edit-send-status"],
 #compose-send-status {
     padding: 0.5rem 0.875rem 0.5rem 0.875rem;
-    margin-bottom: 8px;
-    line-height: 20px;
+    margin-bottom: 0.5rem;
+    line-height: 1.25rem;
     display: none;
 }
 
 #compose-send-status .progress {
-    height: 10px;
-    margin-bottom: 10px;
+    height: 0.625rem;
+    margin-bottom: 0.625rem;
 }
 
 #nonexistent_stream_reply_error {
     padding: 0.5rem 0.875rem 0.5rem 0.875rem;
-    margin-bottom: 8px;
-    line-height: 20px;
+    margin-bottom: 0.5rem;
+    line-height: 1.25rem;
     display: none;
 }
 
@@ -267,7 +267,7 @@ div[id^="message-edit-send-status"],
 
 #out-of-view-notification {
     position: relative;
-    margin-bottom: 6px;
+    margin-bottom: 0.375rem;
 
     background-color: hsla(152, 51%, 63%, 0.25);
     border: 1px solid hsla(0, 0%, 0%, 0.1);
@@ -296,13 +296,13 @@ div[id^="message-edit-send-status"],
 
 textarea.new_message_textarea {
     display: table-cell;
-    width: calc(100% - 12px);
+    width: calc(100% - 0.75rem);
     padding: 0.3125rem;
     height: 1.5em;
     max-height: 22em;
     margin-bottom: 0;
     resize: vertical !important;
-    margin-top: 5px;
+    margin-top: 0.3125rem;
 }
 
 textarea.new_message_textarea,
@@ -327,7 +327,7 @@ input.recipient_box {
     width: 20%;
     border-radius: 0 3px 3px 0;
     border-left: 0;
-    min-width: 120px;
+    min-width: 7.5rem;
 
     &:focus {
         border-left: none;
@@ -339,9 +339,9 @@ input.recipient_box {
 }
 
 #stream_message_recipient_topic.recipient_box {
-    width: calc(20% + 14px);
-    min-width: 140px;
-    max-width: 165px;
+    width: calc(20% + 0.875rem);
+    min-width: 8.75rem;
+    max-width: 10.3125rem;
 }
 
 #private_message_recipient.recipient_box {
@@ -377,7 +377,7 @@ input.recipient_box {
 
     .compose_checkbox_label {
         color: hsl(0, 0%, 67%);
-        margin: 4px;
+        margin: 0.25rem;
     }
 }
 
@@ -403,9 +403,9 @@ a.message-control-button {
     color: inherit;
     text-decoration: none;
     font-size: 0.875rem;
-    width: 14px;
-    height: 14px;
-    margin-right: 8px;
+    width: 0.875rem;
+    height: 0.875rem;
+    margin-right: 0.5rem;
     padding-top: 0.3125rem;
     text-align: center;
     float: left;
@@ -417,7 +417,7 @@ a.message-control-button {
 
 .drag {
     display: none;
-    height: 18px;
+    height: 1.125rem;
     width: 100%;
     top: 23px;
     position: relative;
@@ -426,22 +426,22 @@ a.message-control-button {
 
 #enter_sends {
     vertical-align: middle;
-    margin-top: -2px;
-    margin-right: 4px;
+    margin-top: -0.125rem;
+    margin-right: 0.25rem;
 }
 
 .inline-subscribe-error {
-    margin-left: 5px;
+    margin-left: 0.3125rem;
 }
 
 .preview_message_area {
     /* minus 5px padding. */
-    width: calc(100% - 12px);
+    width: calc(100% - 0.75rem);
     padding: 0.3125rem;
     /* the maximum height the textarea gets to. */
-    max-height: 308px;
+    max-height: 19.25rem;
     /* the minimum height the textarea collapses to. */
-    min-height: 36px;
+    min-height: 2.25rem;
     overflow: auto;
 
     border: 1px solid hsl(0, 0%, 67%);
@@ -451,8 +451,8 @@ a.message-control-button {
 }
 
 #preview_message_area {
-    margin-top: 5px;
-    min-height: 42px;
+    margin-top: 0.3125rem;
+    min-height: 2.625rem;
 }
 
 a#undo_markdown_preview {
@@ -493,20 +493,20 @@ a#undo_markdown_preview {
 
 .compose_mobile_stream_button i,
 .compose_mobile_private_button i {
-    margin-right: 4px;
+    margin-right: 0.25rem;
 }
 
 /* This max-width must be synced with message_viewport.is_narrow */
 @media (max-width: 1165px) {
     .compose-content {
-        margin-right: 7px;
+        margin-right: 0.4375rem;
     }
 }
 
 @media (max-width: 775px) {
     .compose-content {
-        margin-right: 7px;
-        margin-left: 7px;
+        margin-right: 0.4375rem;
+        margin-left: 0.4375rem;
     }
 }
 
@@ -518,19 +518,19 @@ a#undo_markdown_preview {
     }
 
     textarea.new_message_textarea {
-        height: 30px !important;
-        min-height: 30px !important;
+        height: 1.875rem !important;
+        min-height: 1.875rem !important;
     }
 }
 
 @media (max-width: 370px) {
     #stream_message_recipient_topic.recipient_box {
-        width: calc(100% - 175px);
-        min-width: 95px;
+        width: calc(100% - 10.9375rem);
+        min-width: 5.9375rem;
     }
 
     .compose-content {
-        margin-right: 5px;
-        margin-left: 5px;
+        margin-right: 0.3125rem;
+        margin-left: 0.3125rem;
     }
 }

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -6,7 +6,7 @@
 
         .button.small {
             font-size: 1em;
-            padding: 3px 10px;
+            padding: 0.1875rem 0.625rem;
         }
 
         .compose_mobile_button {
@@ -28,7 +28,7 @@
         .alert-draft {
             font-size: 0.875rem;
             color: hsl(170, 48%, 54%);
-            padding: 3px 12px;
+            padding: 0.1875rem 0.75rem;
             font-weight: 400;
             display: none;
         }
@@ -46,7 +46,7 @@
     border-top: 1px solid hsla(0, 0%, 0%, 0.07);
     transition: background-color 200ms linear;
 
-    padding: 8px 10px 8px 10px;
+    padding: 0.5rem 0.625rem 0.5rem 0.625rem;
     margin-left: 250px;
     margin-right: 250px;
     position: relative;
@@ -61,7 +61,7 @@
 
 .message_comp {
     display: none;
-    padding: 10px 10px 8px 5px;
+    padding: 0.625rem 0.625rem 0.5rem 0.3125rem;
 }
 
 .autocomplete_secondary {
@@ -189,7 +189,7 @@
 .compose-all-everyone,
 .compose-announce,
 .compose_not_subscribed {
-    padding: 4px 0 4px 0;
+    padding: 0.25rem 0 0.25rem 0;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -230,7 +230,7 @@
 /* Like .nav-tabs > li > a */
 div[id^="message-edit-send-status"],
 #compose-send-status {
-    padding: 8px 14px 8px 14px;
+    padding: 0.5rem 0.875rem 0.5rem 0.875rem;
     margin-bottom: 8px;
     line-height: 20px;
     display: none;
@@ -242,7 +242,7 @@ div[id^="message-edit-send-status"],
 }
 
 #nonexistent_stream_reply_error {
-    padding: 8px 14px 8px 14px;
+    padding: 0.5rem 0.875rem 0.5rem 0.875rem;
     margin-bottom: 8px;
     line-height: 20px;
     display: none;
@@ -286,7 +286,7 @@ div[id^="message-edit-send-status"],
 }
 
 .compose-notifications-content {
-    padding: 4px 22px 4px 22px;
+    padding: 0.25rem 1.375rem 0.25rem 1.375rem;
     text-align: center;
 }
 
@@ -297,7 +297,7 @@ div[id^="message-edit-send-status"],
 textarea.new_message_textarea {
     display: table-cell;
     width: calc(100% - 12px);
-    padding: 5px;
+    padding: 0.3125rem;
     height: 1.5em;
     max-height: 22em;
     margin-bottom: 0;
@@ -437,7 +437,7 @@ a.message-control-button {
 .preview_message_area {
     /* minus 5px padding. */
     width: calc(100% - 12px);
-    padding: 5px;
+    padding: 0.3125rem;
     /* the maximum height the textarea gets to. */
     max-height: 308px;
     /* the minimum height the textarea collapses to. */
@@ -514,7 +514,7 @@ a#undo_markdown_preview {
     .compose_stream_button,
     .compose_private_button,
     .compose_reply_button {
-        padding: 5px 10px 5px 10px;
+        padding: 0.3125rem 0.625rem 0.3125rem 0.625rem;
     }
 
     textarea.new_message_textarea {

--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -53,7 +53,7 @@
     }
 
     .drafts-list {
-        padding: 10px 0;
+        padding: 0.625rem 0;
         overflow: auto;
 
         .no-drafts {
@@ -76,7 +76,7 @@
 }
 
 .draft-row {
-    padding: 5px 25px;
+    padding: 0.3125rem 1.5625rem;
 
     > div {
         display: inline-block;

--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -6,8 +6,8 @@
     padding: 0;
     width: 58%;
     overflow: hidden;
-    max-width: 1200px;
-    max-height: 1000px;
+    max-width: 75.0rem;
+    max-height: 62.5rem;
     display: flex;
     flex-direction: column;
 
@@ -44,7 +44,7 @@
             .exit-sign {
                 position: relative;
                 top: 3px;
-                margin-left: 3px;
+                margin-left: 0.1875rem;
                 font-size: 1.5rem;
                 font-weight: 600;
                 cursor: pointer;
@@ -58,7 +58,7 @@
 
         .no-drafts {
             display: block;
-            margin-top: calc(45vh - 30px - 1.5em);
+            margin-top: calc(45vh - 1.875rem - 1.5em);
             text-align: center;
             font-size: 1.5em;
             color: hsl(0, 0%, 67%);
@@ -86,7 +86,7 @@
     .draft-info-box {
         width: 100%;
         border: 1px solid hsl(0, 0%, 88%);
-        margin-bottom: 10px;
+        margin-bottom: 0.625rem;
 
         &.active {
             outline: 2px solid hsl(215, 47%, 50%);
@@ -121,7 +121,7 @@
 
             .restore-draft {
                 cursor: pointer;
-                margin-right: 5px;
+                margin-right: 0.3125rem;
                 color: hsl(170, 48%, 54%);
                 opacity: 0.7;
 
@@ -132,7 +132,7 @@
 
             .delete-draft {
                 cursor: pointer;
-                margin-left: 5px;
+                margin-left: 0.3125rem;
                 color: hsl(357, 52%, 57%);
                 opacity: 0.7;
 

--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -22,8 +22,8 @@
     }
 
     .drafts-header {
-        padding-top: 4px;
-        padding-bottom: 8px;
+        padding-top: 0.25rem;
+        padding-bottom: 0.5rem;
         text-align: center;
         border-bottom: 1px solid hsl(0, 0%, 87%);
 
@@ -103,8 +103,8 @@
 
         .message_content {
             line-height: 1;
-            padding-top: 10px;
-            padding-bottom: 10px;
+            padding-top: 0.625rem;
+            padding-bottom: 0.625rem;
             margin-left: 0;
         }
 

--- a/static/styles/hotspots.css
+++ b/static/styles/hotspots.css
@@ -5,9 +5,9 @@
     z-index: 100;
 
     .dot {
-        width: 25px;
-        height: 25px;
-        margin: -12.5px 0 0 -12.5px;
+        width: 1.5625rem;
+        height: 1.5625rem;
+        margin: -12.0.3125rem 0 0 -12.0.3125rem;
         border-radius: 50%;
         position: absolute;
         background-color: hsla(196, 100%, 82%, 0.3);
@@ -17,9 +17,9 @@
     }
 
     .pulse {
-        width: 25px;
-        height: 25px;
-        margin: -11.5px 0 0 -11.5px;
+        width: 1.5625rem;
+        height: 1.5625rem;
+        margin: -11.0.3125rem 0 0 -11.0.3125rem;
         position: absolute;
         top: 50%;
         left: 50%;
@@ -78,7 +78,7 @@
 
     .hotspot-popover {
         position: fixed;
-        width: 250px;
+        width: 15.625rem;
         text-align: left;
         box-shadow: 0 5px 10px hsla(223, 4%, 54%, 0.2);
         border: 1px solid hsl(0, 0%, 80%);
@@ -96,11 +96,11 @@
         }
 
         &::after {
-            border-width: 12px;
+            border-width: 0.75rem;
         }
 
         &::before {
-            border-width: 13px;
+            border-width: 0.8125rem;
         }
 
         &.arrow-top {
@@ -112,12 +112,12 @@
 
             &::after {
                 border-bottom-color: hsl(164, 44%, 47%);
-                margin-right: -12px;
+                margin-right: -0.75rem;
             }
 
             &::before {
                 border-bottom-color: hsl(0, 0%, 80%);
-                margin-right: -13px;
+                margin-right: -0.8125rem;
             }
         }
 
@@ -130,12 +130,12 @@
 
             &::after {
                 border-right-color: hsl(0, 0%, 100%);
-                margin-top: -12px;
+                margin-top: -0.75rem;
             }
 
             &::before {
                 border-right-color: hsl(0, 0%, 80%);
-                margin-top: -13px;
+                margin-top: -0.8125rem;
             }
         }
 
@@ -148,12 +148,12 @@
 
             &::after {
                 border-top-color: hsl(0, 0%, 100%);
-                margin-right: -12px;
+                margin-right: -0.75rem;
             }
 
             &::before {
                 border-top-color: hsl(0, 0%, 80%);
-                margin-right: -13px;
+                margin-right: -0.8125rem;
             }
         }
 
@@ -166,12 +166,12 @@
 
             &::after {
                 border-left-color: hsl(0, 0%, 100%);
-                margin-top: -12px;
+                margin-top: -0.75rem;
             }
 
             &::before {
                 border-left-color: hsl(0, 0%, 80%);
-                margin-top: -13px;
+                margin-top: -0.8125rem;
             }
         }
     }
@@ -197,7 +197,7 @@
 
     .hotspot-popover-bottom {
         background-color: hsl(0, 0%, 100%);
-        height: 90px;
+        height: 5.625rem;
         border-bottom-left-radius: 4px;
         border-bottom-right-radius: 4px;
     }
@@ -216,12 +216,12 @@
 }
 
 .hotspot-img {
-    height: 83px;
+    height: 5.1875rem;
 }
 
 .hotspot-confirm {
-    max-width: 125px;
-    max-height: 70px;
+    max-width: 7.8125rem;
+    max-height: 4.375rem;
     border: none;
     font-size: 1.15em;
     font-weight: 600;
@@ -245,7 +245,7 @@
 }
 
 .hotspot-inline {
-    width: 350px;
+    width: 21.875rem;
     max-width: 95%;
     box-shadow: 0 5px 10px hsla(220, 4%, 54%, 0.1);
     border-radius: 4px;
@@ -254,7 +254,7 @@
     position: relative;
 
     .hotspot-img {
-        margin-left: 5px;
+        margin-left: 0.3125rem;
     }
 
     .hotspot-confirm {
@@ -266,7 +266,7 @@
         margin: 0;
         color: hsl(0, 0%, 100%);
         font-weight: 600;
-        line-height: 24px;
+        line-height: 1.5rem;
         padding: 0.3125rem 0.8125rem;
         font-size: 1.15em;
         border-top-left-radius: 4px;
@@ -275,13 +275,13 @@
 
     .hotspot-inline-left {
         display: inline-block;
-        width: 90px;
+        width: 5.625rem;
     }
 
     .hotspot-inline-right {
         display: inline-block;
         width: auto;
-        margin-left: 10px;
+        margin-left: 0.625rem;
         vertical-align: middle;
     }
 }

--- a/static/styles/hotspots.css
+++ b/static/styles/hotspots.css
@@ -177,7 +177,7 @@
     }
 
     .hotspot-popover-top {
-        padding: 0 15px;
+        padding: 0 0.9375rem;
         border-top-left-radius: 4px;
         border-top-right-radius: 4px;
         background-color: hsl(164, 44%, 47%);
@@ -192,7 +192,7 @@
 
     .hotspot-popover-content {
         background-color: hsl(0, 0%, 100%);
-        padding: 15px;
+        padding: 0.9375rem;
     }
 
     .hotspot-popover-bottom {
@@ -229,7 +229,7 @@
     background-color: hsl(164, 44%, 47%);
     border-radius: 4px;
     white-space: normal;
-    padding: 7px 20px;
+    padding: 0.4375rem 1.25rem;
     outline: none;
 
     &:hover {
@@ -267,7 +267,7 @@
         color: hsl(0, 0%, 100%);
         font-weight: 600;
         line-height: 24px;
-        padding: 5px 13px;
+        padding: 0.3125rem 0.8125rem;
         font-size: 1.15em;
         border-top-left-radius: 4px;
         border-top-right-radius: 4px;

--- a/static/styles/image_upload_widget.css
+++ b/static/styles/image_upload_widget.css
@@ -106,7 +106,7 @@
     position: relative;
 
     .inline-block {
-        margin: 5px 20px 0 0;
+        margin: 0.3125rem 1.25rem 0 0;
         vertical-align: top;
         border-radius: 4px;
     }
@@ -137,15 +137,15 @@
     .image_upload_spinner {
         top: 40%;
         right: 40%;
-        width: 50px;
-        height: 50px;
+        width: 3.125rem;
+        height: 3.125rem;
     }
 
     .image-block {
         border-radius: 5px;
         box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
-        width: 200px;
-        height: 200px;
+        width: 12.5rem;
+        height: 12.5rem;
         top: 0;
     }
 }
@@ -161,8 +161,8 @@
 
 /* CSS related to settings page realm icon upload widget only */
 #realm-icon-upload-widget {
-    width: 100px;
-    height: 100px;
+    width: 6.25rem;
+    height: 6.25rem;
     border-radius: 5px;
     box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
 
@@ -177,8 +177,8 @@
     }
 
     .image_upload_spinner {
-        width: 40px;
-        height: 40px;
+        width: 2.5rem;
+        height: 2.5rem;
         top: 30%;
         right: 30%;
     }
@@ -186,17 +186,17 @@
 
 .realm-icon-section {
     float: none;
-    margin-bottom: 20px;
+    margin-bottom: 1.25rem;
     display: inline-block;
 }
 
 /* CSS related to settings page realm day/night logo upload widget only */
 #realm-day-logo-upload-widget,
 #realm-night-logo-upload-widget {
-    width: 220px;
-    height: 55px;
+    width: 13.75rem;
+    height: 3.4375rem;
     text-align: center;
-    margin: 0 80px 0 20px;
+    margin: 0 5.0rem 0 1.25rem;
 
     .image-upload-text,
     .image-delete-text {
@@ -209,8 +209,8 @@
     }
 
     .image_upload_spinner {
-        width: 45px;
-        height: 55px;
+        width: 2.8125rem;
+        height: 3.4375rem;
         top: 5%;
         right: 40%;
     }
@@ -225,7 +225,7 @@
 }
 
 .realm-logo-section {
-    margin-bottom: 20px;
+    margin-bottom: 1.25rem;
 }
 
 .realm-logo-block {

--- a/static/styles/informational_overlays.css
+++ b/static/styles/informational_overlays.css
@@ -2,7 +2,7 @@
     .overlay-content {
         /* because zoom breaks at 525px perhaps due to rounding errors, so add a
            trivial amount of width so it doesn't break. */
-        width: 550px;
+        width: 34.375rem;
         margin: 0 auto;
         position: relative;
         top: calc((30vh - 50px) / 2);
@@ -17,7 +17,7 @@
         border-bottom: 1px solid hsla(0, 0%, 0%, 0.2);
 
         .tab-switcher {
-            margin-left: 15px;
+            margin-left: 0.9375rem;
         }
 
         .exit {
@@ -25,7 +25,7 @@
             font-size: 1.5rem;
             color: hsl(0, 0%, 67%);
             font-weight: 600;
-            margin: 1px 15px;
+            margin: 0.0625rem 0.9375rem;
         }
     }
 
@@ -64,7 +64,7 @@
 
     td.definition {
         /* keeps dividing line at same width for all tables in model. */
-        width: calc(50% - 11px);
+        width: calc(50% - 0.6875rem);
         text-align: right;
     }
 
@@ -74,7 +74,7 @@
 
     .small_hotkey {
         font-size: 0.9em !important;
-        line-height: 12px;
+        line-height: 0.75rem;
 
         kbd {
             font-size: 0.9em;
@@ -102,7 +102,7 @@
     }
 
     th {
-        width: 245px;
+        width: 15.3125rem;
         text-align: center;
         /* aligns table name with dividing line */
     }
@@ -119,13 +119,13 @@
 }
 
 #keyboard-shortcuts table {
-    margin-bottom: 10px !important;
+    margin-bottom: 0.625rem !important;
 }
 
 @media only screen and (max-width: 768px) {
     .informational-overlays {
         .overlay-content {
-            width: calc(100% - 20px);
+            width: calc(100% - 1.25rem);
         }
 
         .tab-switcher {

--- a/static/styles/informational_overlays.css
+++ b/static/styles/informational_overlays.css
@@ -13,7 +13,7 @@
     }
 
     .overlay-tabs {
-        padding: 10px 0;
+        padding: 0.625rem 0;
         border-bottom: 1px solid hsla(0, 0%, 0%, 0.2);
 
         .tab-switcher {

--- a/static/styles/informational_overlays.css
+++ b/static/styles/informational_overlays.css
@@ -30,7 +30,7 @@
     }
 
     .overlay-modal {
-        padding-bottom: 10px;
+        padding-bottom: 0.625rem;
 
         .modal-header h3 {
             font-weight: 300;

--- a/static/styles/informational_overlays.css
+++ b/static/styles/informational_overlays.css
@@ -113,7 +113,7 @@
         font-weight: bold;
 
         :not(kbd) {
-            font-size: 14px;
+            font-size: 0.875rem;
         }
     }
 }

--- a/static/styles/input_pill.css
+++ b/static/styles/input_pill.css
@@ -59,7 +59,7 @@
         padding: 0;
 
         .pill {
-            padding-right: 4px;
+            padding-right: 0.25rem;
             cursor: not-allowed;
 
             &:focus {

--- a/static/styles/input_pill.css
+++ b/static/styles/input_pill.css
@@ -2,7 +2,7 @@
     display: inline-flex;
     flex-wrap: wrap;
 
-    padding: 2px;
+    padding: 0.125rem;
     border: 1px solid hsla(0, 0%, 0%, 0.15);
     border-radius: 4px;
 
@@ -76,7 +76,7 @@
 
     .input {
         display: inline-block;
-        padding: 2px 4px;
+        padding: 0.125rem 0.25rem;
 
         min-width: 2px;
         word-break: break-all;
@@ -93,7 +93,7 @@
 }
 
 .pm_recipient .pill-container {
-    padding: 0 2px;
+    padding: 0 0.125rem;
     border: none;
     flex-grow: 1;
     align-content: center;

--- a/static/styles/input_pill.css
+++ b/static/styles/input_pill.css
@@ -14,8 +14,8 @@
         display: inline-flex;
         align-items: center;
 
-        height: 20px;
-        margin: 1px 2px;
+        height: 1.25rem;
+        margin: 0.0625rem 0.125rem;
 
         color: inherit;
         border: 1px solid hsla(0, 0%, 0%, 0.15);
@@ -32,19 +32,19 @@
         }
 
         .pill-image {
-            height: 20px;
-            width: 20px;
+            height: 1.25rem;
+            width: 1.25rem;
             border-radius: 4px 0 0 4px;
         }
 
         .pill-value {
-            margin: 0 5px;
+            margin: 0 0.3125rem;
         }
 
         .exit {
             opacity: 0.5;
             font-size: 1.3em;
-            margin-right: 3px;
+            margin-right: 0.1875rem;
         }
 
         &:hover .exit {
@@ -78,7 +78,7 @@
         display: inline-block;
         padding: 0.125rem 0.25rem;
 
-        min-width: 2px;
+        min-width: 0.125rem;
         word-break: break-all;
 
         outline: none;
@@ -99,7 +99,7 @@
     align-content: center;
 
     .input {
-        height: 20px;
+        height: 1.25rem;
 
         &:first-child:empty::before {
             content: attr(data-no-recipients-text);

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -19,14 +19,14 @@ $topic_indent: calc($far_left_gutter_size + $left_col_size + 4px);
         &::after {
             content: "#";
             line-height: 0;
-            font-size: 18px;
+            font-size: 1.125rem;
             font-weight: 800;
         }
     }
 }
 
 .stream-privacy {
-    font-size: 15px;
+    font-size: 0.9375rem;
     font-weight: 800;
     min-width: $left_col_size;
     text-align: center;
@@ -44,13 +44,13 @@ $topic_indent: calc($far_left_gutter_size + $left_col_size + 4px);
 
 #stream_filters,
 #global_filters {
-    font-size: 14px;
+    font-size: 0.875rem;
     margin-right: 12px;
 }
 
 li.show-more-topics {
     a {
-        font-size: 12px;
+        font-size: 0.75rem;
     }
 }
 
@@ -58,7 +58,7 @@ li.show-more-topics {
 #streams_filter_icon {
     float: right;
     opacity: 0.5;
-    font-size: 13px;
+    font-size: 0.8125rem;
     margin-top: 3px;
     margin-left: 10px;
 
@@ -276,18 +276,18 @@ li.top_left_recent_topics {
 
 .top_left_all_messages i.fa-home {
     position: relative;
-    font-size: 15px;
+    font-size: 0.9375rem;
 }
 
 .top_left_private_messages i.fa-envelope {
     position: relative;
     top: -1px;
-    font-size: 11px;
+    font-size: 0.6875rem;
 }
 
 .top_left_mentions i.fa-at,
 .top_left_starred_messages i.fa-star {
-    font-size: 13px;
+    font-size: 0.8125rem;
 }
 
 /* We are mostly consistent in how we style
@@ -305,7 +305,7 @@ li.top_left_recent_topics {
     padding: 0 4px;
     height: 16px;
     line-height: 16px;
-    font-size: 12px;
+    font-size: 0.75rem;
     font-weight: normal;
     letter-spacing: 0.6px;
     border-radius: 4px;
@@ -428,7 +428,7 @@ ul.topic-list {
 
 ul.expanded_private_messages {
     list-style-type: none;
-    font-size: 13px;
+    font-size: 0.8125rem;
     font-weight: 400;
     margin-left: 0;
     padding-bottom: 2px;

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -85,7 +85,7 @@ li.show-more-topics {
 
     li {
         a {
-            padding: 1px 0;
+            padding: 0.0625rem 0;
         }
 
         ul {
@@ -302,7 +302,7 @@ li.top_left_recent_topics {
 .topic-unread-count,
 .private_message_count {
     float: right;
-    padding: 0 4px;
+    padding: 0 0.25rem;
     height: 16px;
     line-height: 16px;
     font-size: 0.75rem;
@@ -317,7 +317,7 @@ li.top_left_recent_topics {
 .top_left_starred_messages .count {
     background-color: transparent;
     color: inherit;
-    padding: 2px 1px 0 3px;
+    padding: 0.125rem 0.0625rem 0 0.1875rem;
     border-color: hsl(105, 2%, 50%);
 }
 
@@ -392,7 +392,7 @@ li.top_left_recent_topics {
     right: 0;
     font-size: 1em;
     text-align: center;
-    padding: 0 6px 0 6px;
+    padding: 0 0.375rem 0 0.375rem;
 }
 
 /*
@@ -405,7 +405,7 @@ li.top_left_recent_topics {
     right: 0;
     font-size: 0.9em;
     text-align: center;
-    padding: 1px 6px 0 6px;
+    padding: 0.0625rem 0.375rem 0 0.375rem;
 }
 
 /*

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -45,7 +45,7 @@ $topic_indent: calc($far_left_gutter_size + $left_col_size + 4px);
 #stream_filters,
 #global_filters {
     font-size: 0.875rem;
-    margin-right: 12px;
+    margin-right: 0.75rem;
 }
 
 li.show-more-topics {
@@ -59,8 +59,8 @@ li.show-more-topics {
     float: right;
     opacity: 0.5;
     font-size: 0.8125rem;
-    margin-top: 3px;
-    margin-left: 10px;
+    margin-top: 0.1875rem;
+    margin-left: 0.625rem;
 
     &:hover {
         opacity: 1;
@@ -69,7 +69,7 @@ li.show-more-topics {
 }
 
 #streams_inline_cog {
-    margin-right: 10px;
+    margin-right: 0.625rem;
 }
 
 .tooltip {
@@ -78,8 +78,8 @@ li.show-more-topics {
 
 #stream_filters {
     overflow: visible;
-    margin-bottom: 10px;
-    margin-right: 12px;
+    margin-bottom: 0.625rem;
+    margin-right: 0.75rem;
     padding: 0;
     font-weight: normal;
 
@@ -101,12 +101,12 @@ li.show-more-topics {
     }
 
     .count {
-        margin-right: 15px;
+        margin-right: 0.9375rem;
     }
 
     .subscription_block {
         padding: 0;
-        margin-right: 25px;
+        margin-right: 1.5625rem;
         margin-left: $far_left_gutter_size;
         display: flex;
         justify-content: space-between;
@@ -131,7 +131,7 @@ li.show-more-topics {
         }
 
         &.stream-with-count {
-            margin-right: 15px;
+            margin-right: 0.9375rem;
         }
     }
 
@@ -141,9 +141,9 @@ li.show-more-topics {
 }
 
 .narrows_panel {
-    margin-bottom: 4px;
+    margin-bottom: 0.25rem;
     li a {
-        margin-top: 1px;
+        margin-top: 0.0625rem;
         &:hover {
             text-decoration: none;
         }
@@ -160,7 +160,7 @@ li.show-more-topics {
 }
 
 #private-container {
-    max-height: 200px;
+    max-height: 12.5rem;
 }
 
 :not(.active-sub-filter) {
@@ -174,10 +174,10 @@ li.show-more-topics {
 
 #add-stream-link {
     text-decoration: none;
-    margin-left: 10px;
-    margin-bottom: 18px;
+    margin-left: 0.625rem;
+    margin-bottom: 1.125rem;
     i {
-        min-width: 19px;
+        min-width: 1.1875rem;
         text-align: center;
         &::before {
             padding-right: 0.1875rem;
@@ -194,8 +194,8 @@ ul.filters {
     }
 
     hr {
-        margin-top: 10px;
-        margin-bottom: 10px;
+        margin-top: 0.625rem;
+        margin-bottom: 0.625rem;
     }
 
     li.muted_topic,
@@ -226,7 +226,7 @@ li.active-sub-filter {
 }
 
 #global_filters {
-    margin-bottom: 16px;
+    margin-bottom: 1.0rem;
 
     .filter-icon {
         display: inline-block;
@@ -235,8 +235,8 @@ li.active-sub-filter {
     }
 
     .count {
-        margin-right: 20px;
-        margin-top: 2px;
+        margin-right: 1.25rem;
+        margin-top: 0.125rem;
         display: none;
     }
 
@@ -303,8 +303,8 @@ li.top_left_recent_topics {
 .private_message_count {
     float: right;
     padding: 0 0.25rem;
-    height: 16px;
-    line-height: 16px;
+    height: 1.0rem;
+    line-height: 1.0rem;
     font-size: 0.75rem;
     font-weight: normal;
     letter-spacing: 0.6px;
@@ -334,13 +334,13 @@ li.top_left_recent_topics {
 
 .topic-box {
     padding-left: 0.3125rem;
-    margin-right: 30px;
+    margin-right: 1.875rem;
 }
 
 .conversation-partners,
 .topic-name {
     display: block;
-    width: calc(100% - 5px);
+    width: calc(100% - 0.3125rem);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -367,7 +367,7 @@ li.top_left_recent_topics {
     i {
         padding-right: 0.25em;
         display: inline-block;
-        width: 13px;
+        width: 0.8125rem;
         vertical-align: middle;
     }
 
@@ -432,7 +432,7 @@ ul.expanded_private_messages {
     font-weight: 400;
     margin-left: 0;
     padding-bottom: 0.125rem;
-    margin-top: 3px;
+    margin-top: 0.1875rem;
 }
 
 li.topic-list-item {
@@ -446,7 +446,7 @@ li.expanded_private_message {
     padding-bottom: 0.0625rem;
 
     a {
-        margin: 1px 0;
+        margin: 0.0625rem 0;
     }
 }
 
@@ -469,15 +469,15 @@ li.expanded_private_message {
 }
 
 .pm-box {
-    margin-right: 20px;
+    margin-right: 1.25rem;
     align-items: center;
 
     .user_circle {
-        min-width: 8px;
-        height: 8px;
+        min-width: 0.5rem;
+        height: 0.5rem;
         margin-top: 0;
         margin-bottom: 0;
-        margin-left: 2px;
+        margin-left: 0.125rem;
         position: relative;
         top: 0;
     }
@@ -486,7 +486,7 @@ li.expanded_private_message {
 .zero-pm-unreads .pm-box,
 .zero-topic-unreads .more-topics-box,
 .zero-topic-unreads .topic-box {
-    margin-right: 15px;
+    margin-right: 0.9375rem;
 }
 
 .zoom-out {
@@ -496,14 +496,14 @@ li.expanded_private_message {
 }
 
 #topics_header {
-    margin-right: 10px;
+    margin-right: 0.625rem;
     color: hsl(0, 0%, 43%);
     a {
         color: inherit;
         text-decoration: none;
         text-transform: uppercase;
         i {
-            margin: 0 5px 0 10px;
+            margin: 0 0.3125rem 0 0.625rem;
             position: relative;
             top: 1px;
         }
@@ -514,7 +514,7 @@ li.expanded_private_message {
     margin-right: 0;
     padding-left: $far_left_gutter_size;
     cursor: pointer;
-    margin-top: 3px;
+    margin-top: 0.1875rem;
 }
 
 .zero_count {
@@ -522,8 +522,8 @@ li.expanded_private_message {
 }
 
 .searching-for-more-topics img {
-    height: 16px;
-    margin-left: 6px;
+    height: 1.0rem;
+    margin-left: 0.375rem;
 }
 
 .zoom-in {

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -10,7 +10,7 @@ $topic_indent: calc($far_left_gutter_size + $left_col_size + 4px);
 
 #left-sidebar {
     #user-list {
-        padding-left: 10px;
+        padding-left: 0.625rem;
     }
 }
 
@@ -35,7 +35,7 @@ $topic_indent: calc($far_left_gutter_size + $left_col_size + 4px);
 /* Ideally we'd handle hashtags using an <i> and just have a single rule here. */
 .stream-privacy span.hashtag,
 #left-sidebar .filter-icon i {
-    padding-right: 3px;
+    padding-right: 0.1875rem;
 }
 
 .pm_left_col {
@@ -92,9 +92,9 @@ li.show-more-topics {
             margin-left: 0;
 
             &.topic-list li {
-                padding-top: 2px;
+                padding-top: 0.125rem;
                 padding-right: 0;
-                padding-bottom: 2px;
+                padding-bottom: 0.125rem;
                 padding-left: $topic_indent;
             }
         }
@@ -127,7 +127,7 @@ li.show-more-topics {
             text-overflow: ellipsis;
             position: relative;
             width: 100%;
-            padding-right: 2px;
+            padding-right: 0.125rem;
         }
 
         &.stream-with-count {
@@ -180,7 +180,7 @@ li.show-more-topics {
         min-width: 19px;
         text-align: center;
         &::before {
-            padding-right: 3px;
+            padding-right: 0.1875rem;
         }
     }
 }
@@ -251,8 +251,8 @@ li.top_left_mentions,
 li.top_left_starred_messages,
 li.top_left_recent_topics {
     position: relative;
-    padding-top: 1px;
-    padding-bottom: 1px;
+    padding-top: 0.0625rem;
+    padding-bottom: 0.0625rem;
 
     a {
         display: block;
@@ -261,7 +261,7 @@ li.top_left_recent_topics {
 
 .top_left_row {
     padding-left: $far_left_gutter_size;
-    padding-right: 10px;
+    padding-right: 0.625rem;
 }
 
 .top_left_row,
@@ -333,7 +333,7 @@ li.top_left_recent_topics {
 }
 
 .topic-box {
-    padding-left: 5px;
+    padding-left: 0.3125rem;
     margin-right: 30px;
 }
 
@@ -344,7 +344,7 @@ li.top_left_recent_topics {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding-right: 2px;
+    padding-right: 0.125rem;
 }
 
 .topic-name {
@@ -431,19 +431,19 @@ ul.expanded_private_messages {
     font-size: 0.8125rem;
     font-weight: 400;
     margin-left: 0;
-    padding-bottom: 2px;
+    padding-bottom: 0.125rem;
     margin-top: 3px;
 }
 
 li.topic-list-item {
     position: relative;
-    padding-right: 5px;
+    padding-right: 0.3125rem;
 }
 
 li.expanded_private_message {
     position: relative;
-    padding-top: 1px;
-    padding-bottom: 1px;
+    padding-top: 0.0625rem;
+    padding-bottom: 0.0625rem;
 
     a {
         margin: 1px 0;
@@ -464,7 +464,7 @@ li.expanded_private_message {
 .topic-box {
     display: flex;
     justify-content: center;
-    padding-top: 1px;
+    padding-top: 0.0625rem;
     cursor: pointer;
 }
 

--- a/static/styles/lightbox.css
+++ b/static/styles/lightbox.css
@@ -80,7 +80,7 @@
 
             margin: 0;
             margin-right: 5px;
-            padding: 0 5px;
+            padding: 0 0.3125rem;
 
             border-radius: 4px;
 
@@ -123,7 +123,7 @@
         .button {
             font-size: 0.9rem;
             min-width: inherit;
-            padding: 4px 10px;
+            padding: 0.25rem 0.625rem;
             border: 1px solid hsla(0, 0%, 100%, 0.6);
             background-color: transparent;
             color: hsl(0, 0%, 100%);
@@ -203,7 +203,7 @@
             display: inline-block;
             vertical-align: top;
             margin-top: 25px;
-            padding: 5px 10px;
+            padding: 0.3125rem 0.625rem;
 
             color: hsl(0, 0%, 100%);
             font-size: 1.8em;
@@ -223,7 +223,7 @@
         .image-list {
             position: relative;
             display: inline-block;
-            padding: 15px 0 12px 0;
+            padding: 0.9375rem 0 0.75rem 0;
             height: 50px;
             font-size: 0;
 

--- a/static/styles/lightbox.css
+++ b/static/styles/lightbox.css
@@ -7,7 +7,7 @@
         justify-content: center;
         position: relative;
         width: 100%;
-        height: calc(100% - 65px - 95px);
+        height: calc(100% - 4.0625rem - 5.9375rem);
         margin: 0;
 
         background-size: contain;
@@ -43,7 +43,7 @@
 
         color: hsla(0, 0%, 100%, 0.8);
         font-size: 2rem;
-        margin: 24px 20px 0 0;
+        margin: 1.5rem 1.25rem 0 0;
 
         transform: scaleY(0.75);
         font-weight: 300;
@@ -66,7 +66,7 @@
     .image-description,
     .image-actions {
         float: left;
-        margin: 20px 20px;
+        margin: 1.25rem 1.25rem;
     }
 
     .image-actions {
@@ -76,10 +76,10 @@
             display: inline-block;
             vertical-align: top;
 
-            min-width: 75px;
+            min-width: 4.6875rem;
 
             margin: 0;
-            margin-right: 5px;
+            margin-right: 0.3125rem;
             padding: 0 0.3125rem;
 
             border-radius: 4px;
@@ -101,7 +101,7 @@
             }
 
             .status {
-                margin-top: -7px;
+                margin-top: -0.4375rem;
 
                 &::after {
                     content: attr(data-disabled);
@@ -130,7 +130,7 @@
             border-radius: 4px;
             text-decoration: none;
             display: inline-block;
-            margin: 0 5px;
+            margin: 0 0.3125rem;
 
             &:hover {
                 background-color: hsl(0, 0%, 100%);
@@ -143,11 +143,11 @@
     .image-description {
         width: 100%;
         /* approx width of screen minus action buttons on the side. */
-        max-width: calc(100% - 450px);
+        max-width: calc(100% - 28.125rem);
         /* add some extra margin top and remove some bottom to keep the
         height the same. and vertically center the text with the buttons. */
-        margin-top: 25px;
-        margin-bottom: 15px;
+        margin-top: 1.5625rem;
+        margin-bottom: 0.9375rem;
 
         font-size: 1.3rem;
         color: hsl(0, 0%, 100%);
@@ -158,7 +158,7 @@
 
             font-weight: 400;
             line-height: normal;
-            max-width: calc(100% - 110px);
+            max-width: calc(100% - 6.875rem);
 
             /* Required for text-overflow */
             white-space: nowrap;
@@ -167,7 +167,7 @@
         }
 
         .user {
-            max-width: 200px;
+            max-width: 12.5rem;
             display: inline-block;
             vertical-align: top;
             font-weight: 300;
@@ -177,14 +177,14 @@
             white-space: pre;
 
             &::before {
-                margin-right: 5px;
+                margin-right: 0.3125rem;
                 content: "\2014";
             }
         }
     }
 
     .player-container {
-        height: calc(100% - 65px - 95px);
+        height: calc(100% - 4.0625rem - 5.9375rem);
         display: flex;
         text-align: center;
         justify-content: center;
@@ -192,7 +192,7 @@
 
         iframe {
             /* maintain 16:9 ratio. */
-            width: calc((100vh - 65px - 95px) * 16 / 9);
+            width: calc((100vh - 4.0625rem - 5.9375rem) * 16 / 9);
             height: 100%;
             margin: auto;
         }
@@ -202,7 +202,7 @@
         .arrow {
             display: inline-block;
             vertical-align: top;
-            margin-top: 25px;
+            margin-top: 1.5625rem;
             padding: 0.3125rem 0.625rem;
 
             color: hsl(0, 0%, 100%);
@@ -224,7 +224,7 @@
             position: relative;
             display: inline-block;
             padding: 0.9375rem 0 0.75rem 0;
-            height: 50px;
+            height: 3.125rem;
             font-size: 0;
 
             max-width: 40vw;
@@ -234,9 +234,9 @@
             .image {
                 display: inline-block;
                 vertical-align: top;
-                width: 50px;
-                height: 50px;
-                margin: 0 2px;
+                width: 3.125rem;
+                height: 3.125rem;
+                margin: 0 0.125rem;
 
                 background-color: hsla(0, 0%, 94%, 0.2);
                 opacity: 0.5;
@@ -261,14 +261,14 @@
         }
 
         .image-description {
-            max-width: calc(100% - 100px);
+            max-width: calc(100% - 6.25rem);
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
-            margin-bottom: 5px;
+            margin-bottom: 0.3125rem;
 
             .title {
-                max-width: calc(100% - 70px);
+                max-width: calc(100% - 4.375rem);
             }
         }
 
@@ -284,7 +284,7 @@
         }
 
         .image-preview {
-            height: calc(100% - 101px - 95px);
+            height: calc(100% - 6.3125rem - 5.9375rem);
         }
     }
 }

--- a/static/styles/message_edit_history.css
+++ b/static/styles/message_edit_history.css
@@ -10,12 +10,12 @@
     .author_details {
         display: block;
         font-size: 0.75rem;
-        padding: 1px;
+        padding: 0.0625rem;
         text-align: right;
     }
 
     .messagebox-content {
-        padding: 0 10px;
+        padding: 0 0.625rem;
     }
 
     .message_edit_history_content {

--- a/static/styles/message_edit_history.css
+++ b/static/styles/message_edit_history.css
@@ -9,7 +9,7 @@
 
     .author_details {
         display: block;
-        font-size: 12px;
+        font-size: 0.75rem;
         padding: 1px;
         text-align: right;
     }

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -171,7 +171,7 @@ on a dark background, and don't change the dark labels dark either. */
 
     .pill-container {
         border-style: solid;
-        border-width: 1px;
+        border-width: 0.0625rem;
     }
 
     #search_arrows .pill,

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -518,7 +518,7 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     .draft-row .message_header_private_message .message_label_clickable {
-        padding: 4px 6px 3px 6px;
+        padding: 0.25rem 0.375rem 0.1875rem 0.375rem;
         color: inherit;
     }
 

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -88,7 +88,7 @@
                 border: 1px solid hsl(0, 0%, 80%);
                 border-radius: 4px;
                 color: hsl(0, 0%, 25%);
-                font-size: 12px;
+                font-size: 0.75rem;
                 padding: 6px;
                 text-transform: capitalize;
                 text-align: center;
@@ -125,7 +125,7 @@ ul {
             margin-bottom: 5px;
 
             .fa-chevron-right {
-                font-size: 12px;
+                font-size: 0.75rem;
             }
         }
 
@@ -133,7 +133,7 @@ ul {
             display: flex;
             align-items: center;
             text-align: center;
-            font-size: 10px;
+            font-size: 0.625rem;
 
             &::before,
             &::after {
@@ -278,7 +278,7 @@ ul {
     }
 
     #default-section {
-        font-size: 15px;
+        font-size: 0.9375rem;
         display: inline-block;
         vertical-align: top;
 
@@ -298,14 +298,14 @@ ul {
         }
 
         #name {
-            font-size: 26px;
+            font-size: 1.625rem;
             font-weight: 700;
             margin-bottom: 5px;
             max-width: 300px;
             line-height: 30px;
 
             #edit-button {
-                font-size: 18px;
+                font-size: 1.125rem;
                 margin-left: 10px;
             }
         }
@@ -328,7 +328,7 @@ ul {
             }
 
             .value {
-                font-size: 15px;
+                font-size: 0.9375rem;
             }
 
             &[data-type="2"] .value {

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -3,8 +3,8 @@
     max-width: 100%;
 
     hr {
-        margin-top: 5px;
-        margin-bottom: 5px;
+        margin-top: 0.3125rem;
+        margin-bottom: 0.3125rem;
     }
 
     .sub_disable_btn_hint {
@@ -38,7 +38,7 @@
 
 .popover-left,
 .popover-right {
-    max-width: 200px;
+    max-width: 12.5rem;
 }
 
 .sp-container {
@@ -51,20 +51,20 @@
     right: 8px;
     bottom: 48px;
     left: auto !important;
-    width: 175px;
-    height: 65px;
+    width: 10.9375rem;
+    height: 4.0625rem;
 }
 
 .streams_popover {
     .topic-name {
         text-align: center;
-        margin-top: 5px;
-        margin-bottom: 5px;
+        margin-top: 0.3125rem;
+        margin-bottom: 0.3125rem;
     }
 
     .colorpicker-container {
         display: none;
-        margin-right: 10px;
+        margin-right: 0.625rem;
 
         .sp-container {
             background-color: hsl(0, 0%, 100%);
@@ -79,7 +79,7 @@
                 box-sizing: inherit; /* IE */
                 box-sizing: initial;
 
-                width: calc(100% - 13px);
+                width: calc(100% - 0.8125rem);
             }
 
             button {
@@ -113,16 +113,16 @@ ul {
     &.streams_popover i,
     &.topics_popover i {
         display: inline-block;
-        width: 14px;
+        width: 0.875rem;
         text-align: center;
-        margin-right: 3px;
+        margin-right: 0.1875rem;
     }
 
     &.topics_popover {
         .topic-name {
             text-align: center;
-            margin-top: 5px;
-            margin-bottom: 5px;
+            margin-top: 0.3125rem;
+            margin-bottom: 0.3125rem;
 
             .fa-chevron-right {
                 font-size: 0.75rem;
@@ -144,11 +144,11 @@ ul {
             }
 
             &::before {
-                margin-right: 8px;
+                margin-right: 0.5rem;
             }
 
             &::after {
-                margin-left: 8px;
+                margin-left: 0.5rem;
             }
         }
     }
@@ -158,15 +158,15 @@ ul {
     }
 
     &.topic-move_popover {
-        max-height: 200px;
+        max-height: 12.5rem;
         overflow-y: auto;
     }
 }
 
 .user_popover {
-    width: 240px;
+    width: 15.0rem;
 
-    margin: -14px;
+    margin: -0.875rem;
     padding: 0;
 
     .popover-title {
@@ -181,7 +181,7 @@ ul {
 
 .message-info-popover,
 .user-info-popover {
-    width: 240px;
+    width: 15.0rem;
     padding: 0;
 
     .popover-title {
@@ -205,7 +205,7 @@ ul {
 
     .member-list {
         position: relative;
-        max-height: 300px;
+        max-height: 18.75rem;
         overflow-y: auto;
         list-style: none;
         margin-left: 0;
@@ -213,7 +213,7 @@ ul {
         .bot {
             color: hsl(180, 5%, 74%);
             vertical-align: top;
-            width: 20px;
+            width: 1.25rem;
             padding-top: 3.0.3125rem;
             text-align: center;
         }
@@ -221,9 +221,9 @@ ul {
 }
 
 .popover_user_presence {
-    width: 8px;
-    height: 8px;
-    margin: 0 5px;
+    width: 0.5rem;
+    height: 0.5rem;
+    margin: 0 0.3125rem;
     display: inline-block;
     float: initial;
     position: relative;
@@ -240,8 +240,8 @@ ul {
 }
 
 .popover-avatar {
-    height: 240px;
-    width: 240px;
+    height: 15.0rem;
+    width: 15.0rem;
     background-size: cover;
     background-position: center;
     position: relative;
@@ -251,7 +251,7 @@ ul {
     }
 
     .popover-inner {
-        width: 240px;
+        width: 15.0rem;
     }
 }
 
@@ -264,12 +264,12 @@ ul {
 
     #avatar {
         display: inline-block;
-        height: 180px;
-        width: 180px;
+        height: 11.25rem;
+        width: 11.25rem;
         background-size: cover;
         background-position: center;
         border-radius: 5px;
-        margin-right: 10px;
+        margin-right: 0.625rem;
         border: 1px solid hsla(0, 0%, 0%, 0.2);
 
         &.guest-avatar::after {
@@ -283,44 +283,44 @@ ul {
         vertical-align: top;
 
         .default-field {
-            margin-bottom: 5px;
+            margin-bottom: 0.3125rem;
 
             .name {
                 color: hsl(0, 0%, 20%);
                 display: inline-block;
-                min-width: 120px;
+                min-width: 7.5rem;
                 font-weight: 600;
             }
         }
 
         #user-type {
-            margin-bottom: 15px;
+            margin-bottom: 0.9375rem;
         }
 
         #name {
             font-size: 1.625rem;
             font-weight: 700;
-            margin-bottom: 5px;
-            max-width: 300px;
-            line-height: 30px;
+            margin-bottom: 0.3125rem;
+            max-width: 18.75rem;
+            line-height: 1.875rem;
 
             #edit-button {
                 font-size: 1.125rem;
-                margin-left: 10px;
+                margin-left: 0.625rem;
             }
         }
     }
 
     hr {
         border: 1px solid hsl(0, 0%, 93%);
-        margin: 5px 0;
+        margin: 0.3125rem 0;
     }
 
     #content {
-        margin-top: 10px;
+        margin-top: 0.625rem;
 
         .field-section {
-            margin-top: 8px;
+            margin-top: 0.5rem;
 
             .name {
                 color: hsl(0, 0%, 20%);
@@ -348,7 +348,7 @@ ul {
         #body {
             padding-bottom: 0.625rem;
             padding-top: 0.25rem;
-            margin: 10px 0;
+            margin: 0.625rem 0;
         }
     }
 }
@@ -435,10 +435,10 @@ ul {
         border-left: 0;
         padding-left: 0;
         border-radius: 3px;
-        margin: 0 5px 5px -10px;
+        margin: 0 0.3125rem 0.3125rem -0.625rem;
         text-indent: 10px;
     }
     .inline_topic_edit {
-        margin-left: 5px !important;
+        margin-left: 0.3125rem !important;
     }
 }

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -16,7 +16,7 @@
 }
 
 .popover-content {
-    padding: 5px 0;
+    padding: 0.3125rem 0;
 }
 
 .popover-title {
@@ -89,7 +89,7 @@
                 border-radius: 4px;
                 color: hsl(0, 0%, 25%);
                 font-size: 0.75rem;
-                padding: 6px;
+                padding: 0.375rem;
                 text-transform: capitalize;
                 text-align: center;
                 text-shadow: none;
@@ -418,7 +418,7 @@ ul {
 
 .user_info_status_text {
     opacity: 0.8;
-    padding: 2px 0 3px 0;
+    padding: 0.125rem 0 0.1875rem 0;
 }
 
 #topic_stream_edit_form_error {

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -8,8 +8,8 @@
     }
 
     .sub_disable_btn_hint {
-        padding-left: 5px;
-        padding-right: 5px;
+        padding-left: 0.3125rem;
+        padding-right: 0.3125rem;
         font-size: small;
         text-align: justify;
     }
@@ -214,7 +214,7 @@ ul {
             color: hsl(180, 5%, 74%);
             vertical-align: top;
             width: 20px;
-            padding-top: 3.5px;
+            padding-top: 3.0.3125rem;
             text-align: center;
         }
     }
@@ -346,8 +346,8 @@ ul {
 
     &:not(.no-fields) {
         #body {
-            padding-bottom: 10px;
-            padding-top: 4px;
+            padding-bottom: 0.625rem;
+            padding-top: 0.25rem;
             margin: 10px 0;
         }
     }

--- a/static/styles/portico/activity.css
+++ b/static/styles/portico/activity.css
@@ -64,7 +64,7 @@ tr.admin td:first-child {
 }
 
 .support-realm-icon {
-    max-width: 25px;
+    max-width: 1.5625rem;
     position: relative;
     top: -2px;
 }

--- a/static/styles/portico/archive.css
+++ b/static/styles/portico/archive.css
@@ -1,7 +1,7 @@
 body {
     font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial,
         sans-serif;
-    font-size: 14px;
+    font-size: 0.875rem;
 }
 
 .header {

--- a/static/styles/portico/archive.css
+++ b/static/styles/portico/archive.css
@@ -6,36 +6,36 @@ body {
 
 .header {
     padding: 5px 0 5px 15px;
-    line-height: 10px;
+    line-height: 0.625rem;
 }
 
 .header-main .logo {
-    margin-top: 5px;
+    margin-top: 0.3125rem;
     .brand-logo {
-        margin-top: 4px;
+        margin-top: 0.25rem;
     }
 }
 
 .message_area_padder {
-    margin-top: 60px;
+    margin-top: 3.75rem;
 }
 
 .top-links {
     position: relative;
     right: 20px;
-    margin-top: 12px;
+    margin-top: 0.75rem;
 }
 
 @media (max-width: 500px) {
     .header {
-        height: 40px;
-        line-height: 10px;
+        height: 2.5rem;
+        line-height: 0.625rem;
     }
 
     .header-main .logo {
-        margin-top: 5px;
+        margin-top: 0.3125rem;
         .brand-logo {
-            margin-top: 4px;
+            margin-top: 0.25rem;
         }
     }
 

--- a/static/styles/portico/billing.css
+++ b/static/styles/portico/billing.css
@@ -164,7 +164,7 @@
     }
 
     .invoice-button {
-        font-size: 17px;
+        font-size: 1.0625rem;
         font-weight: 700 !important;
     }
 

--- a/static/styles/portico/billing.css
+++ b/static/styles/portico/billing.css
@@ -16,13 +16,13 @@
     }
 
     .main {
-        width: 800px;
+        width: 50.0rem;
         max-width: 90%;
         margin: 0 auto;
     }
 
     h1 {
-        margin: 30px 0;
+        margin: 1.875rem 0;
         font-weight: bold;
     }
 
@@ -48,7 +48,7 @@
     }
 
     .support-link {
-        margin: 10px 20px;
+        margin: 0.625rem 1.25rem;
         a,
         a:hover,
         a:visited {
@@ -73,8 +73,8 @@
             }
         }
         .box {
-            width: 120px;
-            height: 70px;
+            width: 7.5rem;
+            height: 4.375rem;
             background-color: hsl(0, 0%, 94%);
             transition: all 0.2s ease;
             display: inline-block;
@@ -83,7 +83,7 @@
             position: relative;
             border: 1px solid hsl(0, 0%, 91%);
             border-radius: 8px;
-            margin: 0 10px 5px 0;
+            margin: 0 0.625rem 0.3125rem 0;
             padding: 30px 20px;
             vertical-align: top;
             &:hover {
@@ -93,12 +93,12 @@
             .schedule-time {
                 font-weight: bold;
                 font-size: 1.2em;
-                margin-top: 10px;
+                margin-top: 0.625rem;
             }
             .schedule-amount {
-                margin-top: 5px;
+                margin-top: 0.3125rem;
                 font-size: 1.1em;
-                height: 50px;
+                height: 3.125rem;
             }
             .schedule-amount-2 {
                 font-size: 0.9em;
@@ -106,11 +106,11 @@
             .management-type {
                 font-weight: bold;
                 font-size: 1.2em;
-                margin-top: 10px;
+                margin-top: 0.625rem;
             }
             .management-type-text {
                 font-size: 1.1em;
-                margin-top: 5px;
+                margin-top: 0.3125rem;
             }
         }
     }
@@ -126,14 +126,14 @@
         );
         box-shadow: 0 3px 10px hsla(0, 0%, 0%, 0.2);
         border: 0;
-        height: 40px;
-        margin: 5px 0 0 0;
+        height: 2.5rem;
+        margin: 0.3125rem 0 0 0;
         span {
             background: 0;
             box-shadow: none;
             font-family: "Source Sans Pro", Helvetica, Arial;
             font-size: 1.4em;
-            line-height: 20px;
+            line-height: 1.25rem;
         }
     }
 
@@ -171,11 +171,11 @@
     #mix_license_count,
     #manual_license_count,
     #invoiced_licenses {
-        width: 50px;
+        width: 3.125rem;
     }
 
     #error-message-box {
-        margin-top: 10px;
+        margin-top: 0.625rem;
         font-weight: 600;
         display: none;
     }
@@ -186,7 +186,7 @@
     #invoice-loading,
     #autopay-loading {
         display: none;
-        min-height: 55px;
+        min-height: 3.4375rem;
         text-align: center;
     }
 
@@ -210,13 +210,13 @@
 
     #update-card-button-span {
         display: block;
-        min-height: 30px;
+        min-height: 1.875rem;
     }
 
     .zulip-loading-logo {
         margin: 0 auto;
-        width: 24px;
-        height: 24px;
+        width: 1.5rem;
+        height: 1.5rem;
     }
 
     .zulip-loading-logo svg circle {
@@ -234,7 +234,7 @@
     #cardchange_loading_indicator,
     #invoice_loading_indicator,
     #autopay_loading_indicator {
-        margin: 10px auto;
+        margin: 0.625rem auto;
     }
 
     #sponsorship_loading_indicator_box_container,
@@ -263,7 +263,7 @@
     #cardchange_loading_indicator .loading_indicator_text,
     #invoice_loading_indicator .loading_indicator_text,
     #autopay_loading_indicator .loading_indicator_text {
-        margin-left: -25px;
+        margin-left: -1.5625rem;
     }
 
     #license-automatic-section,

--- a/static/styles/portico/integrations.css
+++ b/static/styles/portico/integrations.css
@@ -155,7 +155,7 @@ $category-text: hsl(219, 23%, 33%);
                     position: absolute;
                     left: 20px;
                     top: 13px;
-                    font-size: 19px;
+                    font-size: 1.1875rem;
                     color: $border-green;
                 }
 
@@ -251,7 +251,7 @@ $category-text: hsl(219, 23%, 33%);
 
             i {
                 margin-right: 10px;
-                font-size: 24px;
+                font-size: 1.5rem;
             }
 
             .dropdown-list {
@@ -361,7 +361,7 @@ $category-text: hsl(219, 23%, 33%);
         }
 
         .fa-plus {
-            font-size: 59px;
+            font-size: 3.6875rem;
         }
 
         .integration-name {
@@ -390,7 +390,7 @@ $category-text: hsl(219, 23%, 33%);
             }
 
             .fa-plus {
-                font-size: 45px;
+                font-size: 2.8125rem;
             }
 
             .integration-name {
@@ -520,7 +520,7 @@ $category-text: hsl(219, 23%, 33%);
                 }
 
                 @media (max-width: 768px) {
-                    font-size: 22px;
+                    font-size: 1.375rem;
                 }
             }
 

--- a/static/styles/portico/integrations.css
+++ b/static/styles/portico/integrations.css
@@ -21,8 +21,8 @@ $category-text: hsl(219, 23%, 33%);
     }
 
     .main {
-        width: calc(100% - 100px);
-        max-width: 1170px;
+        width: calc(100% - 6.25rem);
+        max-width: 73.125rem;
         margin: 0 auto;
 
         background-color: hsl(0, 0%, 100%);
@@ -40,7 +40,7 @@ $category-text: hsl(219, 23%, 33%);
         }
 
         @media (max-width: 686px) {
-            width: calc(100% - 50px);
+            width: calc(100% - 3.125rem);
             margin: 0 auto;
         }
 
@@ -53,7 +53,7 @@ $category-text: hsl(219, 23%, 33%);
         padding: 50px 0;
 
         .inner-content {
-            min-height: 870px;
+            min-height: 54.375rem;
 
             .show {
                 opacity: 1;
@@ -113,13 +113,13 @@ $category-text: hsl(219, 23%, 33%);
     }
 
     #integration-search {
-        margin-bottom: 30px;
+        margin-bottom: 1.875rem;
 
         .searchbar {
-            width: calc(100% - 40px);
+            width: calc(100% - 2.5rem);
             display: flex;
             justify-content: center;
-            margin: 30px auto 0;
+            margin: 1.875rem auto 0;
 
             .searchbar-reset {
                 position: relative;
@@ -130,8 +130,8 @@ $category-text: hsl(219, 23%, 33%);
                     font-size: 1em;
                     font-family: inherit;
 
-                    width: 500px;
-                    height: 45px;
+                    width: 31.25rem;
+                    height: 2.8125rem;
                     padding: 0 20px 0 50px;
                     border-radius: 40px;
                     border: 1px solid $light-blue-border;
@@ -142,12 +142,12 @@ $category-text: hsl(219, 23%, 33%);
                     }
 
                     @media (max-width: 768px) {
-                        width: 375px;
+                        width: 23.4375rem;
                         margin: 0 auto;
                     }
 
                     @media (max-width: 550px) {
-                        width: calc(100% - 80px);
+                        width: calc(100% - 5.0rem);
                     }
                 }
 
@@ -160,7 +160,7 @@ $category-text: hsl(219, 23%, 33%);
                 }
 
                 @media (max-width: 768px) {
-                    width: 445px;
+                    width: 27.8125rem;
                 }
 
                 @media (max-width: 550px) {
@@ -171,13 +171,13 @@ $category-text: hsl(219, 23%, 33%);
     }
 
     .catalog {
-        margin-top: 20px;
+        margin-top: 1.25rem;
         padding: 0 30px;
-        min-height: 500px;
+        min-height: 31.25rem;
 
         .integration-categories-sidebar {
             float: left;
-            width: 200px;
+            width: 12.5rem;
             padding: 0 30px 0 0;
             margin: 0;
 
@@ -185,7 +185,7 @@ $category-text: hsl(219, 23%, 33%);
                 position: sticky;
                 top: 40px;
                 margin: auto;
-                height: 490px;
+                height: 30.625rem;
                 z-index: 10;
             }
 
@@ -199,7 +199,7 @@ $category-text: hsl(219, 23%, 33%);
                 font-weight: 400;
                 font-size: 0.95em;
                 padding: 6px 10px 3px;
-                margin: 3px 0;
+                margin: 0.1875rem 0;
                 border-radius: 5px;
                 transition: all 0.3s ease;
                 color: $category-text;
@@ -219,7 +219,7 @@ $category-text: hsl(219, 23%, 33%);
     }
 
     .integration-categories-dropdown {
-        margin: 30px auto;
+        margin: 1.875rem auto;
         display: none;
 
         .heading {
@@ -228,7 +228,7 @@ $category-text: hsl(219, 23%, 33%);
 
         @media (max-width: 906px) {
             display: block;
-            width: 670px;
+            width: 41.875rem;
 
             h3,
             h4 {
@@ -244,13 +244,13 @@ $category-text: hsl(219, 23%, 33%);
                 padding: 0;
                 align-items: center;
                 justify-content: space-between;
-                margin-left: 25px;
-                margin-right: 25px;
+                margin-left: 1.5625rem;
+                margin-right: 1.5625rem;
                 border: 1px solid $light-blue-border;
             }
 
             i {
-                margin-right: 10px;
+                margin-right: 0.625rem;
                 font-size: 1.5rem;
             }
 
@@ -258,8 +258,8 @@ $category-text: hsl(219, 23%, 33%);
                 display: none;
                 cursor: pointer;
                 padding: 0;
-                margin-left: 25px;
-                margin-right: 25px;
+                margin-left: 1.5625rem;
+                margin-right: 1.5625rem;
             }
 
             h3 {
@@ -283,27 +283,27 @@ $category-text: hsl(219, 23%, 33%);
         }
 
         @media (max-width: 830px) {
-            width: 666px;
+            width: 41.625rem;
         }
 
         @media (max-width: 786px) {
-            width: 509px;
+            width: 31.8125rem;
         }
 
         @media (max-width: 768px) {
-            width: 666px;
+            width: 41.625rem;
         }
 
         @media (max-width: 686px) {
-            width: 509px;
+            width: 31.8125rem;
         }
 
         @media (max-width: 578px) {
-            width: 351px;
+            width: 21.9375rem;
         }
 
         @media (max-width: 357px) {
-            width: 299px;
+            width: 18.6875rem;
         }
     }
 
@@ -319,10 +319,10 @@ $category-text: hsl(219, 23%, 33%);
     .integration-lozenge {
         display: inline-block;
         vertical-align: top;
-        width: 153px;
-        height: 200px;
+        width: 9.5625rem;
+        height: 12.5rem;
         padding: 0 4px;
-        margin: 7px 5px;
+        margin: 0.4375rem 0.3125rem;
         border-radius: 5px;
         border: 1px solid $light-blue-border;
         color: $category-text;
@@ -339,25 +339,25 @@ $category-text: hsl(219, 23%, 33%);
 
         .integration-secondary-line-text {
             margin: 0;
-            line-height: 10px;
+            line-height: 0.625rem;
             font-size: 0.65em;
             font-weight: 400;
         }
 
         .integration-category {
             font-size: 0.85em;
-            margin-top: 5px;
+            margin-top: 0.3125rem;
             font-weight: 400;
             color: hsla(216, 23%, 13%, 0.5);
         }
 
         &.without-category {
-            height: 180px;
+            height: 11.25rem;
         }
 
         .integration-logo {
-            margin: 34px auto 20px;
-            height: 60px;
+            margin: 2.125rem auto 1.25rem;
+            height: 3.75rem;
         }
 
         .fa-plus {
@@ -367,26 +367,26 @@ $category-text: hsl(219, 23%, 33%);
         .integration-name {
             font-size: 1.2em;
             font-weight: 400;
-            margin: 10px 4px 0 4px;
+            margin: 0.625rem 0.25rem 0 0.25rem;
 
             &.create-your-own {
-                margin-top: 27px;
+                margin-top: 1.6875rem;
                 font-size: 1.1em !important;
             }
 
             &.with-secondary {
                 font-size: 1.1em;
-                margin-top: 4px;
+                margin-top: 0.25rem;
             }
         }
 
         @media (max-width: 830px) {
-            width: 134px;
-            height: 180px;
+            width: 8.375rem;
+            height: 11.25rem;
 
             .integration-logo {
-                margin: 34px auto 15px;
-                height: 45px;
+                margin: 2.125rem auto 0.9375rem;
+                height: 2.8125rem;
             }
 
             .fa-plus {
@@ -407,20 +407,20 @@ $category-text: hsl(219, 23%, 33%);
         }
 
         @media (max-width: 375px) {
-            width: 120px;
+            width: 7.5rem;
         }
 
         @media (max-width: 357px) {
-            width: 108px;
-            height: 160px;
+            width: 6.75rem;
+            height: 10.0rem;
 
             &.without-category {
-                height: 140px;
+                height: 8.75rem;
             }
 
             .integration-logo {
-                margin: 28px auto 10px;
-                height: 45px;
+                margin: 1.75rem auto 0.625rem;
+                height: 2.8125rem;
             }
 
             .integration-name {
@@ -443,9 +443,9 @@ $category-text: hsl(219, 23%, 33%);
             flex-direction: column;
 
             .integration-lozenge {
-                width: 125px;
-                height: 170px;
-                margin: 0 21px 20px;
+                width: 7.8125rem;
+                height: 10.625rem;
+                margin: 0 1.3125rem 1.25rem;
                 order: 1;
 
                 .integration-category {
@@ -468,7 +468,7 @@ $category-text: hsl(219, 23%, 33%);
 
                     .integration-name {
                         font-size: 1.2em !important;
-                        margin-left: 20px;
+                        margin-left: 1.25rem;
                     }
                 }
             }
@@ -487,8 +487,8 @@ $category-text: hsl(219, 23%, 33%);
                     font-size: 0.9em;
                     font-weight: 400;
                     padding: 6px 3px;
-                    margin: 7px 0;
-                    width: 165px;
+                    margin: 0.4375rem 0;
+                    width: 10.3125rem;
                     text-align: center;
                     border-radius: 5px;
                     transition: all 0.3s ease;
@@ -503,15 +503,15 @@ $category-text: hsl(219, 23%, 33%);
             }
 
             #integration-list-link {
-                margin-left: 30px;
+                margin-left: 1.875rem;
                 order: 3;
 
                 span {
                     display: inline-block;
-                    margin-left: 5px;
+                    margin-left: 0.3125rem;
 
                     @media (min-width: 768px) {
-                        margin-top: 15px;
+                        margin-top: 0.9375rem;
                     }
 
                     @media (max-width: 768px) {
@@ -528,7 +528,7 @@ $category-text: hsl(219, 23%, 33%);
                 flex-direction: row;
                 justify-content: space-between;
                 align-items: center;
-                margin-bottom: 20px;
+                margin-bottom: 1.25rem;
                 padding-bottom: 20px;
                 border-bottom: 1px solid $light-blue-border;
             }
@@ -546,11 +546,11 @@ $category-text: hsl(219, 23%, 33%);
 
         .integration-instructions {
             .help-content h3 {
-                margin: 20px 0;
+                margin: 1.25rem 0;
             }
 
             @media (min-width: 768px) {
-                width: calc(100% - 200px);
+                width: calc(100% - 12.5rem);
             }
 
             @media (max-width: 768px) {

--- a/static/styles/portico/integrations_dev_panel.css
+++ b/static/styles/portico/integrations_dev_panel.css
@@ -5,7 +5,7 @@ button {
 
 #custom_http_headers {
     width: 100%;
-    height: 60px;
+    height: 3.75rem;
     resize: vertical;
 }
 
@@ -23,13 +23,13 @@ button {
 
 #fixture_body {
     width: 90%;
-    height: 500px;
+    height: 31.25rem;
     resize: vertical;
 }
 
 #idp-results {
     width: 100%;
-    height: 500px;
+    height: 31.25rem;
     resize: vertical;
     background-color: hsl(0, 0%, 100%);
 }
@@ -67,7 +67,7 @@ button {
 }
 
 .pad-small {
-    height: 100px;
+    height: 6.25rem;
     width: 100%;
 }
 

--- a/static/styles/portico/integrations_dev_panel.css
+++ b/static/styles/portico/integrations_dev_panel.css
@@ -51,7 +51,7 @@ button {
 }
 
 .centerpiece {
-    font-size: 30px;
+    font-size: 1.875rem;
     text-align: center;
 }
 

--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -1663,7 +1663,7 @@ nav {
     color: hsl(0, 0%, 100%);
     opacity: 0.5;
     position: absolute;
-    font-size: 36px;
+    font-size: 2.25rem;
     top: 40%;
 }
 
@@ -1968,7 +1968,7 @@ nav {
 
 .portico-landing.hello .integrations .integration-name {
     margin-top: 20px;
-    font-size: 22px;
+    font-size: 1.375rem;
     font-weight: 400;
 }
 
@@ -1976,7 +1976,7 @@ nav {
     width: 120px;
     margin: 0 auto 20px;
     font-weight: 400;
-    font-size: 14px;
+    font-size: 0.875rem;
 }
 
 .portico-landing.hello .call-to-action-bottom {
@@ -3873,6 +3873,6 @@ nav {
 #download-android-apk a {
     display: inline-block;
     color: hsl(0, 0%, 100%);
-    font-size: 13px;
+    font-size: 0.8125rem;
     padding-left: 10px;
 }

--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -17,7 +17,7 @@ body {
 h1,
 h2,
 h3 {
-    margin: 10px 0;
+    margin: 0.625rem 0;
 
     font-weight: 300;
     line-height: 1.2;
@@ -32,7 +32,7 @@ h2 {
 }
 
 p {
-    margin: 10px 0;
+    margin: 0.625rem 0;
     font-weight: normal;
     line-height: 1.5;
 }
@@ -60,12 +60,12 @@ a {
             content: " ";
             display: inline-block;
             position: relative;
-            height: 17px;
-            width: 17px;
+            height: 1.0625rem;
+            width: 1.0625rem;
             top: 3px;
             background-image: url(../../images/landing-page/arrow.png);
             background-size: 100%;
-            margin-left: 5px;
+            margin-left: 0.3125rem;
         }
     }
 
@@ -149,7 +149,7 @@ button {
     background-color: hsl(0, 0%, 100%);
     color: hsl(0, 0%, 27%);
 
-    line-height: 20px;
+    line-height: 1.25rem;
     border-radius: 4px;
     border: 1px solid hsl(0, 0%, 80%);
     outline: none;
@@ -196,7 +196,7 @@ button {
 /* -- navbar styling -- */
 
 nav {
-    width: calc(100% - 80px);
+    width: calc(100% - 5.0rem);
     position: absolute;
     color: hsl(0, 0%, 100%);
 
@@ -244,11 +244,11 @@ nav {
         display: none;
         fill: hsl(0, 0%, 100%);
         cursor: pointer;
-        margin-top: 3px;
+        margin-top: 0.1875rem;
     }
 
     .content {
-        margin: 0 5px 0 10px;
+        margin: 0 0.3125rem 0 0.625rem;
         position: relative;
         z-index: 2;
     }
@@ -290,7 +290,7 @@ nav {
         li {
             position: relative;
             display: inline-block;
-            margin: 10px;
+            margin: 0.625rem;
 
             color: hsl(0, 0%, 100%);
 
@@ -327,7 +327,7 @@ nav {
 
 /* -- main panel styling -- */
 .main {
-    width: calc(100% - 200px - 20px);
+    width: calc(100% - 12.5rem - 1.25rem);
     margin: 0 auto;
 }
 
@@ -364,12 +364,12 @@ nav {
     z-index: 2;
 
     section {
-        max-width: 1440px;
+        max-width: 90.0rem;
         display: flex;
         flex: 1 1 auto;
         flex-flow: row wrap;
         justify-content: space-around;
-        margin: 40px auto;
+        margin: 2.5rem auto;
         padding: 0 30px;
         color: hsl(219, 21%, 21%);
 
@@ -378,7 +378,7 @@ nav {
             align-items: center;
             justify-content: center;
 
-            height: 400px;
+            height: 25.0rem;
             padding: 100px 100px 50px 100px;
 
             margin: 0;
@@ -390,7 +390,7 @@ nav {
             background-color: hsla(0, 0%, 0%, 0.1);
 
             .copy {
-                max-width: 800px;
+                max-width: 50.0rem;
                 margin: 0 auto;
 
                 text-align: center;
@@ -403,14 +403,14 @@ nav {
 
             h2 {
                 font-size: 1.8em;
-                margin: 30px auto 0 auto;
+                margin: 1.875rem auto 0 auto;
 
-                max-width: 600px;
+                max-width: 37.5rem;
                 line-height: 1.3;
             }
 
             .image {
-                height: 400px;
+                height: 25.0rem;
                 width: 40%;
                 background-color: hsla(0, 0%, 0%, 0.05);
             }
@@ -430,15 +430,15 @@ nav {
 
             img {
                 &.overflow-wave {
-                    width: 685px;
+                    width: 42.8125rem;
                     right: 0;
                     top: -168px;
                     position: absolute;
                 }
 
                 &.image {
-                    width: 600px;
-                    margin-left: 100px;
+                    width: 37.5rem;
+                    margin-left: 6.25rem;
                 }
             }
 
@@ -465,17 +465,17 @@ nav {
             justify-content: center;
             align-items: center;
 
-            margin: 50px auto;
+            margin: 3.125rem auto;
             padding: 0 50px;
 
             .image {
-                width: calc(100% - 500px - 100px);
-                margin: 50px 0 50px 50px;
-                max-width: 500px;
+                width: calc(100% - 31.25rem - 6.25rem);
+                margin: 3.125rem 0 3.125rem 3.125rem;
+                max-width: 31.25rem;
             }
 
             .features {
-                max-width: 500px;
+                max-width: 31.25rem;
 
                 h2 {
                     margin: 0;
@@ -483,7 +483,7 @@ nav {
 
                 .feature-block {
                     display: block;
-                    margin: 30px 0;
+                    margin: 1.875rem 0;
                 }
             }
         }
@@ -492,13 +492,13 @@ nav {
             position: relative;
 
             padding: 50px 100px;
-            max-width: calc(1000px);
+            max-width: calc(62.5rem);
 
             background-color: hsl(0, 0%, 100%);
             border-radius: 10px;
 
             box-shadow: 10px 20px 80px hsla(0, 0%, 0%, 0.15);
-            margin: 100px auto 150px auto;
+            margin: 6.25rem auto 9.375rem auto;
             text-align: center;
 
             .envelope {
@@ -512,7 +512,7 @@ nav {
             h2 {
                 position: relative;
 
-                margin-bottom: 120px;
+                margin-bottom: 7.5rem;
                 top: 0;
             }
 
@@ -523,14 +523,14 @@ nav {
                 vertical-align: top;
                 text-align: left;
 
-                margin: 35px 0 0 20px;
+                margin: 2.1875rem 0 0 1.25rem;
 
                 z-index: 1;
 
                 h3 {
                     position: relative;
 
-                    margin: 15px 0 15px 50px;
+                    margin: 0.9375rem 0 0.9375rem 3.125rem;
 
                     font-size: 1.2em;
                     font-weight: 400;
@@ -544,8 +544,8 @@ nav {
 
                         left: -35px;
                         top: 0;
-                        width: 20px;
-                        height: 20px;
+                        width: 1.25rem;
+                        height: 1.25rem;
 
                         border-radius: 4px;
 
@@ -558,8 +558,8 @@ nav {
             }
 
             .image-block {
-                width: 400px;
-                height: 280px;
+                width: 25.0rem;
+                height: 17.5rem;
 
                 background: linear-gradient(
                     135deg,
@@ -584,15 +584,15 @@ nav {
 
         .headliner {
             .feature-block {
-                margin: 0 10px;
-                width: calc(100% - 250px - 20px);
+                margin: 0 0.625rem;
+                width: calc(100% - 15.625rem - 1.25rem);
             }
         }
 
         h2 {
             font-size: 2.5em;
             text-align: center;
-            margin: 0 10px;
+            margin: 0 0.625rem;
             line-height: 1.6;
             flex: 1 0 100%;
         }
@@ -620,7 +620,7 @@ nav {
         &::after {
             content: "\2192";
 
-            margin-left: 5px;
+            margin-left: 0.3125rem;
             transform: scaleX(2);
 
             transition: all 0.3s ease;
@@ -628,7 +628,7 @@ nav {
 
         &:hover {
             &::after {
-                margin-left: 10px;
+                margin-left: 0.625rem;
             }
         }
     }
@@ -719,7 +719,7 @@ nav {
     }
 
     header {
-        width: 850px;
+        width: 53.125rem;
         display: inline-block;
         text-align: left;
 
@@ -731,7 +731,7 @@ nav {
         }
 
         p {
-            margin: 30px 0;
+            margin: 1.875rem 0;
 
             font-size: 1.5em;
             font-weight: 300;
@@ -742,7 +742,7 @@ nav {
 
         a {
             display: block;
-            margin: 20px auto 0 auto;
+            margin: 1.25rem auto 0 auto;
             text-align: center;
         }
 
@@ -771,12 +771,12 @@ nav {
         }
 
         .download-button {
-            margin-top: 10px;
+            margin-top: 0.625rem;
         }
 
         #see_all_apps {
             display: inline-block;
-            margin-top: 10px;
+            margin-top: 0.625rem;
 
             font-weight: normal;
         }
@@ -787,7 +787,7 @@ nav {
     position: absolute;
     left: 0;
     width: 100%;
-    height: 1100px;
+    height: 68.75rem;
 
     &.dark-blue {
         background: linear-gradient(
@@ -861,7 +861,7 @@ nav {
 .portico-landing.hello .col-3-5,
 .portico-landing.hello .col-2,
 .portico-landing.hello .col-4 {
-    margin-right: -4px;
+    margin-right: -0.25rem;
     display: inline-block;
     vertical-align: top;
 }
@@ -892,7 +892,7 @@ nav {
     }
 
     .padded-content {
-        width: 900px;
+        width: 56.25rem;
         margin: 0 auto;
     }
 
@@ -907,7 +907,7 @@ nav {
 
         thead th {
             &:last-of-type {
-                width: 120px;
+                width: 7.5rem;
             }
 
             &.uniform {
@@ -951,8 +951,8 @@ nav {
                 content: " ";
                 display: inline-block;
 
-                width: 27px;
-                height: 27px;
+                width: 1.6875rem;
+                height: 1.6875rem;
                 background-image: url(../../images/landing-page/checkmark.png);
                 background-size: 100% auto;
             }
@@ -985,7 +985,7 @@ nav {
     }
 
     .terms {
-        margin-top: 30px;
+        margin-top: 1.875rem;
         font-weight: 400;
         font-size: 0.7em;
 
@@ -1010,7 +1010,7 @@ nav {
     }
 
     header {
-        max-width: 700px;
+        max-width: 43.75rem;
         margin: 0 auto;
 
         h1 span {
@@ -1019,8 +1019,8 @@ nav {
     }
 
     .faq {
-        margin: 50px auto;
-        max-width: 700px;
+        margin: 3.125rem auto;
+        max-width: 43.75rem;
         font-size: 1.2em;
         color: hsl(223, 6%, 25%);
 
@@ -1031,22 +1031,22 @@ nav {
         }
 
         .answer {
-            margin: 20px 0 0 0;
+            margin: 1.25rem 0 0 0;
             font-weight: 400;
         }
     }
 
     /* the last faq in the box shouldn't have an extra 50px of margin. */
     .faq-box div:last-of-type {
-        margin-bottom: 10px;
+        margin-bottom: 0.625rem;
     }
 }
 
 .screen {
     .line {
         width: 100%;
-        height: 6px;
-        margin: 8px 0;
+        height: 0.375rem;
+        margin: 0.5rem 0;
 
         background-color: hsl(0, 0%, 93%);
         border-radius: 3px;
@@ -1095,10 +1095,10 @@ nav {
     }
 
     .col-4 .action-block {
-        margin: 20px;
+        margin: 1.25rem;
 
         .sub-block {
-            margin: 0 10px;
+            margin: 0 0.625rem;
         }
     }
 
@@ -1107,8 +1107,8 @@ nav {
             display: inline-block;
             vertical-align: top;
 
-            width: 20px;
-            height: 20px;
+            width: 1.25rem;
+            height: 1.25rem;
             background-color: hsl(0, 0%, 73%);
             border-radius: 4px;
         }
@@ -1117,7 +1117,7 @@ nav {
             display: inline-block;
             vertical-align: top;
 
-            width: 50px;
+            width: 3.125rem;
             margin-top: 0;
 
             background-color: hsl(0, 0%, 73%);
@@ -1136,8 +1136,8 @@ nav {
         overflow: hidden;
 
         .message-feed {
-            height: calc(100% - 20px);
-            margin-top: 20px;
+            height: calc(100% - 1.25rem);
+            margin-top: 1.25rem;
 
             transition: all 0.1s ease;
         }
@@ -1145,14 +1145,14 @@ nav {
 
     .message-feed {
         .message .content {
-            margin-left: 24px;
+            margin-left: 1.5rem;
             position: relative;
             top: -15px;
         }
 
         .stream {
             padding: 3px 5px 0 5px;
-            margin: 0 5px;
+            margin: 0 0.3125rem;
 
             background-color: hsl(0, 0%, 100%);
             border-radius: 4px;
@@ -1164,10 +1164,10 @@ nav {
 
 .portico-landing.hello .screen {
     position: relative;
-    margin: -300px auto 0 auto;
+    margin: -18.75rem auto 0 auto;
 
-    width: 600px;
-    height: 350px;
+    width: 37.5rem;
+    height: 21.875rem;
 
     padding: 10px 30px 10px 30px;
 
@@ -1180,7 +1180,7 @@ nav {
 
     &.hero-screen {
         padding: 95px 170px;
-        height: 385px;
+        height: 24.0625rem;
 
         background-image: url(../../images/landing-page/macbook-empty.png);
         background-size: 100% auto;
@@ -1206,8 +1206,8 @@ nav {
         top: calc(50% - 5px);
         left: 20px;
 
-        width: 10px;
-        height: 10px;
+        width: 0.625rem;
+        height: 0.625rem;
 
         border-radius: 5px;
         background-color: hsl(0, 0%, 13%);
@@ -1219,8 +1219,8 @@ nav {
         top: calc(50% - 12.5px);
         right: 8px;
 
-        width: 25px;
-        height: 25px;
+        width: 1.5625rem;
+        height: 1.5625rem;
 
         border-radius: 13px;
         background-color: hsl(0, 0%, 73%);
@@ -1229,9 +1229,9 @@ nav {
     .main-page {
         display: inline-block;
 
-        height: calc(100% - 30px);
-        width: calc(100% - 30px);
-        margin: 10px;
+        height: calc(100% - 1.875rem);
+        width: calc(100% - 1.875rem);
+        margin: 0.625rem;
 
         border: 5px solid hsl(0, 0%, 13%);
         border-radius: 4px;
@@ -1252,9 +1252,9 @@ nav {
         z-index: 1;
 
         img {
-            margin-bottom: 20px;
+            margin-bottom: 1.25rem;
             width: 100%;
-            max-width: 300px;
+            max-width: 18.75rem;
         }
 
         .il-block {
@@ -1285,7 +1285,7 @@ nav {
     img {
         margin: 0 2%;
         width: 28%;
-        max-width: 500px;
+        max-width: 31.25rem;
         display: inline-block;
     }
 
@@ -1293,7 +1293,7 @@ nav {
         display: inline-block;
         vertical-align: top;
         width: 50%;
-        max-width: 700px;
+        max-width: 43.75rem;
         text-align: left;
     }
 
@@ -1342,15 +1342,15 @@ nav {
 
 .portico-landing .tour {
     color: hsl(0, 0%, 0%);
-    width: 1200px;
+    width: 75.0rem;
     max-width: 100%;
     margin: 0 auto;
 }
 
 .tour .carousel-inner .item-container {
     width: 80%;
-    height: 520px;
-    margin: 20px auto;
+    height: 32.5rem;
+    margin: 1.25rem auto;
     padding: 30px 20px;
     background: linear-gradient(
         hsla(220, 20%, 97%, 0.4),
@@ -1371,11 +1371,11 @@ nav {
     border: 0;
     position: absolute;
     left: 50%;
-    margin-left: -100px;
+    margin-left: -6.25rem;
     top: 50%;
-    margin-top: -25px;
-    width: 200px;
-    height: 50px;
+    margin-top: -1.5625rem;
+    width: 12.5rem;
+    height: 3.125rem;
     z-index: 10;
 
     &:hover {
@@ -1395,14 +1395,14 @@ nav {
 }
 
 .tour .carousel-inner .tour-item-header {
-    margin: 0 0 30px 54px;
-    max-width: 700px;
+    margin: 0 0 1.875rem 3.375rem;
+    max-width: 43.75rem;
     font-size: 1.3em;
     text-align: left;
 }
 
 .tour .carousel-inner .tour-item-header-top-push {
-    margin-top: 40px;
+    margin-top: 2.5rem;
 }
 
 .tour .carousel-inner .tour-item-header-centered {
@@ -1414,45 +1414,45 @@ nav {
 .tour .carousel-inner .zulip-slack-comparison {
     display: flex;
     text-align: left;
-    width: 850px;
+    width: 53.125rem;
     max-width: 100%;
-    margin: 20px auto 0;
+    margin: 1.25rem auto 0;
     position: relative;
 
     .comparison-zulip {
-        width: 500px;
+        width: 31.25rem;
     }
 
     .comparison-slack {
-        width: 300px;
+        width: 18.75rem;
     }
 
     img {
         max-width: 100%;
 
         &.zulip-streams-selected {
-            width: 320px;
+            width: 20.0rem;
             border: 0;
         }
 
         &.slack-streams-selected {
-            width: 200px;
+            width: 12.5rem;
         }
 
         &.zulip-unreads-arrows {
-            width: 406px;
+            width: 25.375rem;
             border: 0;
         }
 
         &.slack-stream-unreads {
-            width: 200px;
+            width: 12.5rem;
         }
     }
 
     .caption {
         text-align: left;
         font-weight: bold;
-        margin-bottom: 10px;
+        margin-bottom: 0.625rem;
     }
 }
 
@@ -1465,28 +1465,28 @@ nav {
     }
 
     &.zulip-streams {
-        width: 200px;
+        width: 12.5rem;
     }
 
     &.slack-streams {
-        width: 200px;
+        width: 12.5rem;
     }
 
     &.zulip-topic {
-        margin: -10px 0 0 50px;
-        width: 800px;
+        margin: -0.625rem 0 0 3.125rem;
+        width: 50.0rem;
     }
 
     &.slack-overwhelming {
         border: none;
-        width: 750px;
-        margin: -30px 0 0 50px;
+        width: 46.875rem;
+        margin: -1.875rem 0 0 3.125rem;
     }
 
     &.zulip-easy {
         border: none;
-        width: 700px;
-        margin-left: 50px;
+        width: 43.75rem;
+        margin-left: 3.125rem;
     }
 }
 
@@ -1506,15 +1506,15 @@ nav {
     margin: 0;
 
     &.slack-unreads {
-        width: 250px;
-        margin: 15px 0 0 -10px;
+        width: 15.625rem;
+        margin: 0.9375rem 0 0 -0.625rem;
     }
 }
 
 .tour .carousel-inner .other-resources {
     text-align: left;
-    margin: 30px auto;
-    max-width: 600px;
+    margin: 1.875rem auto;
+    max-width: 37.5rem;
 
     .other-resources-section {
         display: inline-block;
@@ -1532,11 +1532,11 @@ nav {
 
 .tour .carousel-inner .call-to-action {
     display: inline-block;
-    margin: 40px auto;
+    margin: 2.5rem auto;
     padding: 11px 25px 11px 25px;
 
     font-size: 1.2rem;
-    line-height: 20px;
+    line-height: 1.25rem;
     font-weight: 400;
     color: hsl(0, 0%, 100%);
 
@@ -1574,7 +1574,7 @@ nav {
 }
 
 .carousel-indicators {
-    margin: 20px 0 0 0;
+    margin: 1.25rem 0 0 0;
     display: flex;
     justify-content: center;
     padding-left: 0;
@@ -1586,11 +1586,11 @@ nav {
     li {
         position: relative;
         flex: 0 1 auto;
-        width: 10px;
-        height: 10px;
+        width: 0.625rem;
+        height: 0.625rem;
         border-radius: 10px;
-        margin-right: 10px;
-        margin-left: 10px;
+        margin-right: 0.625rem;
+        margin-left: 0.625rem;
         text-indent: -999px;
         cursor: pointer;
         background-color: hsl(222, 12%, 66%);
@@ -1602,7 +1602,7 @@ nav {
             left: 0;
             display: inline-block;
             width: 100%;
-            height: 10px;
+            height: 0.625rem;
             content: "";
         }
 
@@ -1612,7 +1612,7 @@ nav {
             left: 0;
             display: inline-block;
             width: 100%;
-            height: 10px;
+            height: 0.625rem;
             content: "";
         }
 
@@ -1633,19 +1633,19 @@ nav {
 
 .portico-landing .testimonials .text-header .action-content {
     float: right;
-    margin-top: 18px;
+    margin-top: 1.125rem;
 }
 
 .portico-landing .testimonials .quote-container {
     width: 98%;
-    margin: 30px auto 20px auto;
+    margin: 1.875rem auto 1.25rem auto;
     padding-left: 2%;
 
     font-size: 1.2rem;
 }
 
 .portico-landing .testimonials .carousel {
-    min-height: 250px;
+    min-height: 15.625rem;
 }
 
 .portico-landing .testimonials .carousel-quotes {
@@ -1682,8 +1682,8 @@ nav {
 
 .portico-landing .testimonials blockquote::before {
     content: "“";
-    margin-left: -10px;
-    margin-right: -3px;
+    margin-left: -0.625rem;
+    margin-right: -0.1875rem;
 }
 
 .portico-landing .testimonials blockquote::after {
@@ -1692,8 +1692,8 @@ nav {
 
 .portico-landing .testimonials blockquote + cite {
     display: block;
-    margin-top: 5px;
-    margin-bottom: 30px;
+    margin-top: 0.3125rem;
+    margin-bottom: 1.875rem;
 
     color: hsl(0, 0%, 100%);
     opacity: 0.7;
@@ -1720,12 +1720,12 @@ nav {
 
 .portico-landing .testimonials .company-container {
     width: 60%;
-    margin: 30px auto;
+    margin: 1.875rem auto;
     text-align: left;
 }
 
 .portico-landing .testimonials .company-box {
-    margin-top: 20px;
+    margin-top: 1.25rem;
 }
 
 .portico-landing .testimonials .company-container header h2 {
@@ -1734,16 +1734,16 @@ nav {
 }
 
 .portico-landing .testimonials .company-container header .arrow {
-    margin-top: 12px;
+    margin-top: 0.75rem;
     font-weight: normal;
 }
 
 .portico-landing .testimonials .company-box .company {
     display: inline-block;
-    margin: 10px 20px;
+    margin: 0.625rem 1.25rem;
 
-    height: 60px;
-    width: calc(25% - 44px);
+    height: 3.75rem;
+    width: calc(25% - 2.75rem);
 
     background-color: hsl(0, 0%, 67%);
     background-size: contain;
@@ -1810,7 +1810,7 @@ nav {
 .portico-landing .testimonials .company-box .company.infinispan {
     background-image: url(../../images/landing-page/logos/infinispan.png);
     background-color: transparent;
-    height: 50px;
+    height: 3.125rem;
 }
 
 .portico-landing .testimonials .company-box .company.hail {
@@ -1841,13 +1841,13 @@ nav {
 .portico-landing .testimonials .company-box .company.mixxx {
     background-image: url(../../images/landing-page/logos/mixxx.png);
     background-color: transparent;
-    height: 45px;
+    height: 2.8125rem;
 }
 
 .portico-landing.hello .apps {
     position: relative;
     padding: 200px 80px 100px 80px;
-    margin-top: -50px;
+    margin-top: -3.125rem;
 
     background: linear-gradient(145deg, hsl(191, 56%, 55%), hsl(169, 65%, 42%));
 
@@ -1861,7 +1861,7 @@ nav {
     width: 0;
     height: 0;
     border-style: solid;
-    border-width: 150px 100vw 0 0;
+    border-width: 9.375rem 100vw 0 0;
     border-color: hsl(0, 0%, 98%) transparent transparent transparent;
 }
 
@@ -1881,17 +1881,17 @@ nav {
 }
 
 .portico-landing.hello .apps .left-side {
-    width: calc(60% - 4px);
+    width: calc(60% - 0.25rem);
 }
 
 .portico-landing.hello .apps .right-side {
-    width: calc(40% - 4px);
+    width: calc(40% - 0.25rem);
     text-align: center;
 }
 
 .portico-landing.hello .apps .left-side .content {
-    width: 650px;
-    margin: 50px auto;
+    width: 40.625rem;
+    margin: 3.125rem auto;
 }
 
 .portico-landing.hello .apps .left-side .platform-icons {
@@ -1905,7 +1905,7 @@ nav {
 .portico-landing.hello .apps .left-side .platform-icons .group {
     display: inline-block;
     vertical-align: top;
-    margin: 0 30px;
+    margin: 0 1.875rem;
 
     text-align: center;
 }
@@ -1916,7 +1916,7 @@ nav {
 
 .portico-landing.hello .apps .left-side .platform-icons .group i {
     display: inline-block;
-    width: 80px;
+    width: 5.0rem;
 
     font-size: 3.5em;
     opacity: 0.8;
@@ -1935,23 +1935,23 @@ nav {
 }
 
 .portico-landing.hello .integrations .content {
-    margin-left: 50px;
+    margin-left: 3.125rem;
 }
 
 .portico-landing.hello .integrations .integration-icons {
     width: 100%;
-    margin: 20px 0;
+    margin: 1.25rem 0;
     text-align: center;
 }
 
 .portico-landing.hello .integrations .integration-icons .group {
     display: inline-block;
     vertical-align: top;
-    width: 155px;
-    height: 220px;
+    width: 9.6875rem;
+    height: 13.75rem;
     padding: 0 5px;
     transition: all 0.3s ease;
-    margin: 10px 5px;
+    margin: 0.625rem 0.3125rem;
     color: hsl(219, 23%, 33%);
     border-radius: 5px;
     border: 1px solid hsl(206, 44%, 93%);
@@ -1962,19 +1962,19 @@ nav {
 }
 
 .portico-landing.hello .integrations .integration-logo {
-    margin-top: 20px;
-    width: 80px;
+    margin-top: 1.25rem;
+    width: 5.0rem;
 }
 
 .portico-landing.hello .integrations .integration-name {
-    margin-top: 20px;
+    margin-top: 1.25rem;
     font-size: 1.375rem;
     font-weight: 400;
 }
 
 .portico-landing.hello .integrations .integration-description {
-    width: 120px;
-    margin: 0 auto 20px;
+    width: 7.5rem;
+    margin: 0 auto 1.25rem;
     font-weight: 400;
     font-size: 0.875rem;
 }
@@ -1987,7 +1987,7 @@ nav {
 
 .portico-landing.hello .call-to-action-bottom .button {
     display: table;
-    margin: 20px auto 0 auto;
+    margin: 1.25rem auto 0 auto;
     padding: 10px 20px;
     font-size: 1em;
     font-weight: 600;
@@ -1995,20 +1995,20 @@ nav {
 
 .portico-landing.hello .call-to-action-bottom h1 {
     text-align: center;
-    margin-top: 20px;
+    margin-top: 1.25rem;
 }
 
 .portico-landing.hello .call-to-action-bottom .atlassian-migration {
-    margin-top: 60px;
+    margin-top: 3.75rem;
     text-align: center;
     font-size: 1.3rem;
     font-weight: 300;
 }
 
 .portico-landing.hello .call-to-action-bottom .zulip-octopus {
-    margin: 130px auto 0 auto;
-    width: 32px;
-    height: 30px;
+    margin: 8.125rem auto 0 auto;
+    width: 2.0rem;
+    height: 1.875rem;
     background-image: url(../../images/landing-page/zulip-octopus.png);
     background-size: cover;
 
@@ -2042,7 +2042,7 @@ nav {
 
     padding: 100px 50px 50px 50px;
     background: linear-gradient(35deg, hsl(197, 100%, 16%), hsl(166, 45%, 49%));
-    height: 600px;
+    height: 37.5rem;
 
     color: hsl(0, 0%, 100%);
 
@@ -2050,7 +2050,7 @@ nav {
 }
 
 .portico-landing.apps .hero .inner-content {
-    max-width: 1600px;
+    max-width: 100.0rem;
     margin: 0 auto;
 }
 
@@ -2089,7 +2089,7 @@ nav {
 
 .portico-landing.apps .hero .info .cta {
     text-shadow: 0 0 60px hsla(0, 0%, 0%, 0.3);
-    max-width: 600px;
+    max-width: 37.5rem;
 }
 
 .portico-landing.apps
@@ -2112,7 +2112,7 @@ nav {
 
 .portico-landing.apps .hero .info .flex,
 .portico-landing.apps .hero .image .flex {
-    height: 500px;
+    height: 31.25rem;
     min-height: 0;
 }
 
@@ -2136,7 +2136,7 @@ nav {
 }
 
 .portico-landing.apps .other-apps h2 {
-    width: 600px;
+    width: 37.5rem;
     margin: 0 auto;
 
     text-align: center;
@@ -2144,13 +2144,13 @@ nav {
 
 .portico-landing.apps .other-apps .apps {
     display: inline-block;
-    margin: 50px 0 0 0;
+    margin: 3.125rem 0 0 0;
 }
 
 .portico-landing.apps .other-apps .apps .icon {
     vertical-align: top;
 
-    width: 50px;
+    width: 3.125rem;
     padding: 20px 30px;
     border-radius: 70px;
 
@@ -2173,7 +2173,7 @@ nav {
 }
 
 .portico-landing.apps .other-apps .apps .icon.fa-mobile-phone::after {
-    margin-top: 1px;
+    margin-top: 0.0625rem;
 }
 
 .portico-landing.apps .other-apps .apps .icon::after {
@@ -2183,16 +2183,16 @@ nav {
     font-size: 0.8rem;
     font-weight: 600;
     font-family: "Source Sans Pro", sans-serif;
-    margin-top: 10px;
+    margin-top: 0.625rem;
 }
 
 .download-from-google-play-store img {
-    height: 42px;
+    height: 2.625rem;
     padding: 15px 0 15px 0;
 }
 
 .download-from-apple-app-store img {
-    height: 42px;
+    height: 2.625rem;
     padding: 15px 0 15px 0;
 }
 
@@ -2203,7 +2203,7 @@ nav {
 }
 
 .portico-landing.why-page .main {
-    max-width: 800px;
+    max-width: 50.0rem;
 }
 
 .portico-landing.why-page .hero {
@@ -2218,7 +2218,7 @@ nav {
 }
 
 .portico-landing.why-page .hero h1 {
-    margin: 0 0 20px 0;
+    margin: 0 0 1.25rem 0;
 
     font-size: 3.5em;
     font-weight: 300;
@@ -2241,7 +2241,7 @@ nav {
     background-color: hsl(0, 0%, 100%);
     border-color: hsl(168, 24%, 51%);
     padding: 20px 30px;
-    margin-top: 20px;
+    margin-top: 1.25rem;
     font-size: 1.05em;
     p {
         line-height: 1.5;
@@ -2250,7 +2250,7 @@ nav {
         color: hsl(220, 23%, 33%);
     }
     p:last-child {
-        margin-top: 10px;
+        margin-top: 0.625rem;
     }
 }
 
@@ -2263,15 +2263,15 @@ nav {
 }
 
 .portico-landing.why-page .main .slack-image {
-    width: 500px;
+    width: 31.25rem;
 }
 
 .portico-landing.why-page .main .zulip-topics-image {
-    width: 300px;
+    width: 18.75rem;
 }
 
 .portico-landing.why-page .main .zulip-reply-later-image {
-    width: 600px;
+    width: 37.5rem;
 }
 
 .portico-landing.why-page .photo-description {
@@ -2286,7 +2286,7 @@ nav {
 }
 
 .portico-landing.why-page .team h2 {
-    margin-top: 20px;
+    margin-top: 1.25rem;
 }
 
 .portico-landing.why-page .bg-pycon {
@@ -2339,12 +2339,12 @@ nav {
 .portico-landing.why-page .testimonials {
     background-color: hsl(168, 43%, 24%);
     color: hsl(0, 0%, 100%);
-    margin-bottom: 40px;
+    margin-bottom: 2.5rem;
 }
 
 .portico-landing.why-page .testimonials .quote-container {
     width: 98%;
-    margin: 30px auto 20px auto;
+    margin: 1.875rem auto 1.25rem auto;
     padding-left: 2%;
 
     font-size: 1.2rem;
@@ -2362,8 +2362,8 @@ nav {
 
 .portico-landing.why-page .testimonials blockquote::before {
     content: "“";
-    margin-left: -10px;
-    margin-right: -3px;
+    margin-left: -0.625rem;
+    margin-right: -0.1875rem;
 }
 
 .portico-landing.why-page .testimonials blockquote::after {
@@ -2372,8 +2372,8 @@ nav {
 
 .portico-landing.why-page .testimonials blockquote + cite {
     display: block;
-    margin-top: 5px;
-    margin-bottom: 30px;
+    margin-top: 0.3125rem;
+    margin-bottom: 1.875rem;
 
     color: hsl(0, 0%, 100%);
     opacity: 0.7;
@@ -2395,13 +2395,13 @@ nav {
 /* -- hello page styling -- */
 .portico-landing.hello .apps .screen {
     display: inline-block;
-    margin: 0 10px;
+    margin: 0 0.625rem;
     text-align: left;
 }
 
 .portico-landing.hello .apps .screen.ios {
-    width: 200px;
-    height: 350px;
+    width: 12.5rem;
+    height: 21.875rem;
     padding: 30px 0;
     border-radius: 20px;
 
@@ -2411,8 +2411,8 @@ nav {
 }
 
 .portico-landing.hello .apps .screen.android {
-    width: 200px;
-    height: 370px;
+    width: 12.5rem;
+    height: 23.125rem;
     padding: 10px 0 30px 0;
     border-radius: 20px;
 
@@ -2428,19 +2428,19 @@ nav {
 }
 
 .portico-landing.hello .apps .screen .center-page {
-    height: calc(100% - 20px);
+    height: calc(100% - 1.25rem);
 }
 
 .portico-landing.hello .apps .screen .center-page .message-feed {
-    margin-top: 10px;
+    margin-top: 0.625rem;
 }
 
 .portico-landing.hello .apps .screen.ios::before {
     top: 17px;
     left: calc(50% - 20px);
 
-    width: 40px;
-    height: 5px;
+    width: 2.5rem;
+    height: 0.3125rem;
     background-color: hsl(0, 0%, 80%);
 }
 
@@ -2462,8 +2462,8 @@ nav {
 
     border-radius: 8px;
     background-color: hsl(0, 0%, 13%);
-    width: 35px;
-    height: 20px;
+    width: 2.1875rem;
+    height: 1.25rem;
 }
 
 .portico-landing.hello .apps .screen.ios .main-page {
@@ -2486,7 +2486,7 @@ nav {
     position: absolute;
     left: 0;
     width: 100%;
-    height: 1100px;
+    height: 68.75rem;
 }
 
 .gradients .gradient.dark-blue {
@@ -2547,7 +2547,7 @@ nav {
 
     font-size: 1.5em;
 
-    margin-bottom: 50px;
+    margin-bottom: 3.125rem;
 
     color: hsl(0, 0%, 100%);
 }
@@ -2558,12 +2558,12 @@ nav {
 
 .pricing-model .pricing-container .block {
     display: inline-block;
-    margin: 40px 20px 20px 20px;
+    margin: 2.5rem 1.25rem 1.25rem 1.25rem;
 }
 
 .pricing-model .pricing-container .block .plan-title {
     padding: 10px;
-    margin-bottom: 3px;
+    margin-bottom: 0.1875rem;
 
     color: hsl(0, 0%, 100%);
 
@@ -2576,8 +2576,8 @@ nav {
     display: inline-block;
     vertical-align: bottom;
     margin: 0;
-    width: 300px;
-    height: 500px;
+    width: 18.75rem;
+    height: 31.25rem;
 
     box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
 
@@ -2590,7 +2590,7 @@ nav {
 }
 
 .pricing-model .pricing-container .text-content {
-    margin: 20px;
+    margin: 1.25rem;
 }
 
 .pricing-model .padded-content .text-header .text-content h1 {
@@ -2608,7 +2608,7 @@ nav {
 .pricing-model .pricing-container hr {
     border: none;
     border-bottom: 2px solid hsl(170, 47%, 53%);
-    margin: 15px 0 15px 0;
+    margin: 0.9375rem 0 0.9375rem 0;
 }
 
 .pricing-model .pricing-container .text-content .description {
@@ -2636,8 +2636,8 @@ nav {
     position: absolute;
     top: 10px;
     left: 0;
-    width: 20px;
-    height: 18px;
+    width: 1.25rem;
+    height: 1.125rem;
 
     background-image: url(../../images/checkbox-green.svg);
     background-size: contain;
@@ -2651,7 +2651,7 @@ nav {
     position: absolute;
     bottom: 0;
     width: 100%;
-    height: 150px;
+    height: 9.375rem;
 
     background-color: hsl(0, 0%, 93%);
 }
@@ -2670,7 +2670,7 @@ nav {
 
 .pricing-model .pricing-container .text-content .price {
     display: inline-block;
-    margin-right: 2px;
+    margin-right: 0.125rem;
 
     font-size: 3.5em;
     font-weight: 600;
@@ -2680,8 +2680,8 @@ nav {
 .pricing-model .pricing-container .bottom .details {
     display: inline-block;
     vertical-align: top;
-    margin-left: 15px;
-    margin-top: 4px;
+    margin-left: 0.9375rem;
+    margin-top: 0.25rem;
 
     font-size: 0.9em;
     font-weight: 400;
@@ -2691,7 +2691,7 @@ nav {
 }
 
 .pricing-model .pricing-container .bottom .button {
-    margin-top: 20px;
+    margin-top: 1.25rem;
     display: block;
     text-align: center;
 
@@ -2711,7 +2711,7 @@ nav {
 
 .pricing-model .pricing-container .text-content .standard-price-box {
     display: flex;
-    height: 55px;
+    height: 3.4375rem;
 }
 
 .pricing-model .pricing-container .text-content .price .price-cents {
@@ -2761,9 +2761,9 @@ nav {
     position: relative;
     display: inline-block;
     vertical-align: top;
-    margin-left: 50px;
-    margin-top: -2px;
-    width: calc(100% - 300px - 50px);
+    margin-left: 3.125rem;
+    margin-top: -0.125rem;
+    width: calc(100% - 18.75rem - 3.125rem);
 
     background-color: hsl(0, 0%, 100%);
     opacity: 0;
@@ -2780,8 +2780,8 @@ nav {
 .pricing-overlay.pricing-model .info-box .text-content {
     position: relative;
     display: inline-block;
-    height: calc(100% - 40px);
-    width: calc(100% - 300px - 40px);
+    height: calc(100% - 2.5rem);
+    width: calc(100% - 18.75rem - 2.5rem);
 }
 
 .pricing-overlay.pricing-model .info-box .text-content h1 {
@@ -2805,15 +2805,15 @@ nav {
     .feature-detail-box
     .feature {
     display: inline-block;
-    width: calc(33% - 21px);
-    height: 200px;
+    width: calc(33% - 1.3125rem);
+    height: 12.5rem;
     background-color: hsl(0, 0%, 93%);
-    margin: 10px;
+    margin: 0.625rem;
 }
 
 .text-content .pricing-details {
     padding: 15px 0 15px 0;
-    height: 25px;
+    height: 1.5625rem;
 
     font-weight: 400;
     color: hsl(0, 0%, 53%);
@@ -2822,7 +2822,7 @@ nav {
 }
 
 .pricing-overlay.pricing-model .info-box .image {
-    width: 300px;
+    width: 18.75rem;
     height: 100%;
 
     float: right;
@@ -2832,12 +2832,12 @@ nav {
 
 .portico-landing.jobs h2 {
     line-height: 1.4;
-    margin: 20px 0 5px 0;
+    margin: 1.25rem 0 0.3125rem 0;
 }
 
 .portico-landing.jobs h3 {
     line-height: 1.4;
-    margin: 20px 0 7px 0;
+    margin: 1.25rem 0 0.4375rem 0;
 }
 
 .portico-landing.jobs .open-positions-top .padded-content {
@@ -2877,7 +2877,7 @@ nav {
     }
 
     .portico-landing.integrations .integration-lozenge {
-        width: 135px;
+        width: 8.4375rem;
     }
 }
 
@@ -2892,7 +2892,7 @@ nav {
 
 @media (max-width: 1376px) {
     .portico-landing.plans .price-box {
-        margin: 20px;
+        margin: 1.25rem;
     }
 
     .portico-landing.apps .main .details-container {
@@ -2926,7 +2926,7 @@ nav {
         .platform,
     .portico-landing.apps .main .details-box[data-name="linux"] .instructions {
         text-align: center;
-        width: calc(100% - 40px);
+        width: calc(100% - 2.5rem);
     }
 }
 
@@ -2947,21 +2947,21 @@ nav {
     }
 
     .portico-landing.hello .integrations .content {
-        max-width: 750px;
+        max-width: 46.875rem;
         margin: 0 auto;
     }
 
     .portico-landing.hello .integrations .integration-icons {
-        max-width: 600px;
+        max-width: 37.5rem;
         margin: 0 auto;
     }
 
     .portico-landing.hello .apps .left-side .content {
-        margin: 0 auto 50px;
+        margin: 0 auto 3.125rem;
     }
 
     .portico-landing .testimonials .company-box .company {
-        width: calc(33% - 44px);
+        width: calc(33% - 2.75rem);
     }
 }
 
@@ -2978,7 +2978,7 @@ nav {
     }
 
     .tour .carousel-inner .tour-item-header {
-        margin: 0 0 30px 0;
+        margin: 0 0 1.875rem 0;
     }
 
     .tour .carousel-control {
@@ -2992,22 +2992,22 @@ nav {
     }
 
     .tour .carousel-inner .zulip-slack-comparison {
-        width: 650px;
+        width: 40.625rem;
         max-width: 100%;
 
         .comparison-zulip {
-            width: 450px;
+            width: 28.125rem;
         }
 
         .comparison-slack {
-            width: 200px;
+            width: 12.5rem;
         }
     }
 }
 
 @media (max-width: 1024px) {
     .portico-landing.hello .gradients .gradient {
-        height: 1400px;
+        height: 87.5rem;
     }
 
     .portico-landing {
@@ -3032,7 +3032,7 @@ nav {
 
         ul {
             display: block;
-            margin: 20px auto 0 auto;
+            margin: 1.25rem auto 0 auto;
             float: none;
             text-align: center;
         }
@@ -3042,12 +3042,12 @@ nav {
         section {
             .headliner {
                 .image {
-                    width: 200px;
-                    height: 200px;
+                    width: 12.5rem;
+                    height: 12.5rem;
                 }
 
                 .feature-box {
-                    width: calc(100% - 200px - 20px);
+                    width: calc(100% - 12.5rem - 1.25rem);
                 }
             }
 
@@ -3077,7 +3077,7 @@ nav {
     .features .feature-box .text-content {
         width: 100%;
         height: auto;
-        margin-bottom: 20px;
+        margin-bottom: 1.25rem;
     }
 
     .features .feature-box .image {
@@ -3096,8 +3096,8 @@ nav {
     }
 
     .portico-landing.hello .screen.hero-screen {
-        width: 420px;
-        height: 282px;
+        width: 26.25rem;
+        height: 17.625rem;
         padding: 65px 117px;
 
         .main-page {
@@ -3107,7 +3107,7 @@ nav {
     }
 
     .screen.hero-screen .col-4 .action-block {
-        margin: 10px;
+        margin: 0.625rem;
     }
 
     .portico-landing .testimonials .carousel-quotes {
@@ -3123,8 +3123,8 @@ nav {
     }
 
     .screen.hero-screen .line {
-        height: 4px;
-        margin: 4px 0;
+        height: 0.25rem;
+        margin: 0.25rem 0;
     }
 
     .screen .message-feed .message .content {
@@ -3156,7 +3156,7 @@ nav {
     }
 
     .portico-landing .testimonials .company-box .company {
-        width: calc(25% - 44px);
+        width: calc(25% - 2.75rem);
     }
 
     .tour .carousel-inner img {
@@ -3169,7 +3169,7 @@ nav {
 
     .portico-landing.hello .hero {
         header {
-            width: calc(100% - 50px);
+            width: calc(100% - 3.125rem);
         }
     }
 }
@@ -3208,9 +3208,9 @@ nav {
                 display: inline-flex;
 
                 width: auto;
-                height: 250px;
+                height: 15.625rem;
 
-                margin: 50px;
+                margin: 3.125rem;
 
                 justify-content: center;
                 align-items: center;
@@ -3219,7 +3219,7 @@ nav {
     }
 
     .portico-landing.hello .apps .left-side .platform-icons .group {
-        margin: 50px 30px;
+        margin: 3.125rem 1.875rem;
         display: block;
     }
 
@@ -3264,7 +3264,7 @@ nav {
     nav {
         padding-left: 50px;
         padding-right: 50px;
-        width: calc(100% - 100px);
+        width: calc(100% - 6.25rem);
 
         .hamburger {
             position: relative;
@@ -3279,7 +3279,7 @@ nav {
 
         img {
             display: block;
-            width: 300px;
+            width: 18.75rem;
             margin: 0 auto;
         }
 
@@ -3335,7 +3335,7 @@ nav {
 
     .portico-landing.hello .hero {
         header {
-            width: 600px;
+            width: 37.5rem;
         }
     }
 
@@ -3344,8 +3344,8 @@ nav {
     }
 
     .portico-landing.hello .screen.hero-screen {
-        width: 300px;
-        height: 201px;
+        width: 18.75rem;
+        height: 12.5625rem;
         padding: 43px 73px;
     }
 
@@ -3381,7 +3381,7 @@ nav {
     }
 
     .portico-landing.apps .hero {
-        height: 350px;
+        height: 21.875rem;
     }
 
     .portico-landing.apps .hero h1 {
@@ -3391,7 +3391,7 @@ nav {
 
     .portico-landing.apps .hero .info .flex,
     .portico-landing.apps .hero .image .flex {
-        height: 200px;
+        height: 12.5rem;
         min-height: 0;
         width: 100%;
     }
@@ -3407,7 +3407,7 @@ nav {
 
     .portico-landing.apps .other-apps .apps .icon {
         padding: 0 14px;
-        width: 30px;
+        width: 1.875rem;
         padding-top: 8px;
         padding-bottom: 0;
         font-size: 2.3em;
@@ -3415,7 +3415,7 @@ nav {
 
     .portico-landing.apps .other-apps .apps .icon.fa-mobile-phone {
         padding: 7px 10px 5px 10px;
-        width: 35px;
+        width: 2.1875rem;
         font-size: 2.5em;
     }
 
@@ -3437,7 +3437,7 @@ nav {
     }
 
     .main {
-        width: calc(100% - 50px);
+        width: calc(100% - 3.125rem);
         margin: 0 auto;
     }
 
@@ -3445,7 +3445,7 @@ nav {
         padding-bottom: 100px;
 
         .waves {
-            height: 450px;
+            height: 28.125rem;
         }
 
         header {
@@ -3481,7 +3481,7 @@ nav {
             top: 0;
             left: 0;
             height: 100vh;
-            width: 300px;
+            width: 18.75rem;
             padding-left: 30px;
 
             background-color: hsl(0, 0%, 100%);
@@ -3513,7 +3513,7 @@ nav {
                 line-height: 1.5;
 
                 &:first-of-type {
-                    margin-top: 20px;
+                    margin-top: 1.25rem;
                 }
 
                 &.active {
@@ -3534,15 +3534,15 @@ nav {
     .portico-header .content > ul::before {
         content: "Zulip";
         display: block;
-        margin-top: 20px;
+        margin-top: 1.25rem;
         padding-top: 5px;
-        margin-left: 10px;
+        margin-left: 0.625rem;
 
-        width: 100px;
-        height: 40px;
+        width: 6.25rem;
+        height: 2.5rem;
 
         font-size: 1.5rem;
-        line-height: 30px;
+        line-height: 1.875rem;
         text-align: right;
         color: hsl(0, 0%, 27%);
 
@@ -3554,7 +3554,7 @@ nav {
     .portico-header .dropdown ul {
         width: 100%;
         height: auto;
-        margin: 42px 0 0 0;
+        margin: 2.625rem 0 0 0;
         font-size: 0.8em;
     }
 
@@ -3567,13 +3567,13 @@ nav {
     .portico-landing.apps .main ul.sidebar {
         display: block;
         text-align: center;
-        margin-bottom: 10px;
+        margin-bottom: 0.625rem;
     }
 
     .portico-landing.apps .main ul.sidebar li {
         display: inline-block;
         padding: 10px;
-        width: 80px;
+        width: 5.0rem;
         text-align: center;
         border-radius: 4px;
     }
@@ -3583,8 +3583,8 @@ nav {
     }
 
     .portico-landing .testimonials .company-box .company {
-        margin: 10px;
-        width: calc(33% - 24px);
+        margin: 0.625rem;
+        width: calc(33% - 1.5rem);
     }
 
     .tour .carousel-control {
@@ -3604,17 +3604,17 @@ nav {
     }
 
     .portico-landing.hello .tour .carousel-inner .item-container {
-        height: 450px;
+        height: 28.125rem;
     }
 
     .tour .carousel-inner .call-to-action {
-        margin: 10px auto;
+        margin: 0.625rem auto;
     }
 }
 
 @media (max-width: 640px) {
     .portico-landing.hello .integrations .integration-icons .group {
-        margin: 10px 16px 0 16px;
+        margin: 0.625rem 1.0rem 0 1.0rem;
     }
 
     .portico-landing.features-app {
@@ -3646,7 +3646,7 @@ nav {
 
                 .features {
                     .feature-block {
-                        margin: 20px 0;
+                        margin: 1.25rem 0;
                     }
                 }
             }
@@ -3658,7 +3658,7 @@ nav {
     }
 
     .portico-landing.hello .tour .carousel-inner .item-container {
-        height: 400px;
+        height: 25.0rem;
     }
 
     .tour .carousel-control {
@@ -3682,7 +3682,7 @@ nav {
             max-width: 100%;
 
             &.zulip-streams {
-                max-width: 140px;
+                max-width: 8.75rem;
             }
 
             &.zulip-streams-selected {
@@ -3700,8 +3700,8 @@ nav {
     .billing-upgrade-page {
         .payment-schedule {
             .box {
-                width: 100px;
-                height: 80px;
+                width: 6.25rem;
+                height: 5.0rem;
             }
         }
     }
@@ -3711,11 +3711,11 @@ nav {
     .portico-landing.plans .price-box {
         display: inline-flex;
         flex-direction: column;
-        min-height: 500px;
+        min-height: 31.25rem;
         height: auto;
-        max-width: 300px;
+        max-width: 18.75rem;
         width: auto;
-        margin: 10px 0;
+        margin: 0.625rem 0;
     }
 
     .pricing-model .pricing-container .text-content {
@@ -3740,7 +3740,7 @@ nav {
     }
 
     .portico-landing.hello .integrations .integration-icons .group {
-        margin: 4px 2px;
+        margin: 0.25rem 0.125rem;
     }
 
     .main {
@@ -3805,16 +3805,16 @@ nav {
 
 @media (max-width: 375px) {
     .portico-landing.hello .integrations .integration-icons .group {
-        width: 130px;
-        height: 215px;
+        width: 8.125rem;
+        height: 13.4375rem;
     }
 
     .portico-landing.hello .integrations .integration-icons .integration-logo {
-        width: 60px;
+        width: 3.75rem;
     }
 
     .portico-landing.integrations .integration-categories-dropdown {
-        width: 323px;
+        width: 20.1875rem;
     }
 
     .portico-landing.features-app {

--- a/static/styles/portico/markdown.css
+++ b/static/styles/portico/markdown.css
@@ -19,20 +19,20 @@
     h3[id],
     h4[id] {
         &::before {
-            margin-top: -10px;
-            height: 10px;
+            margin-top: -0.625rem;
+            height: 0.625rem;
         }
     }
 
     h1 {
         border-bottom: 1px solid hsl(0, 0%, 93%);
         padding-bottom: 10px;
-        margin-bottom: 15px;
+        margin-bottom: 0.9375rem;
 
         &[id] {
             &::before {
-                margin-top: -30px;
-                height: 30px;
+                margin-top: -1.875rem;
+                height: 1.875rem;
             }
         }
         &#using-zulip,
@@ -47,14 +47,14 @@
     h2 {
         font-size: 1.5em;
         line-height: 1.25;
-        margin: 20px 0 5px 0;
+        margin: 1.25rem 0 0.3125rem 0;
     }
 
     h3 {
         font-size: 1.25em;
         line-height: 1.25;
         opacity: 1;
-        margin-bottom: 7px;
+        margin-bottom: 0.4375rem;
     }
 
     h1,
@@ -72,7 +72,7 @@
 
                 cursor: pointer;
                 content: "\f0c1";
-                margin-left: 5px;
+                margin-left: 0.3125rem;
                 vertical-align: middle;
             }
         }
@@ -80,7 +80,7 @@
 
     ul,
     ol {
-        margin-left: 30px;
+        margin-left: 1.875rem;
     }
 
     li {
@@ -93,14 +93,14 @@
 
         & > li {
             counter-increment: item;
-            margin-bottom: 5px;
+            margin-bottom: 0.3125rem;
 
             &::before {
                 content: counter(item);
                 display: inline-block;
                 vertical-align: top;
                 padding: 3px 6.5px 3px 7.5px;
-                margin-right: 5px;
+                margin-right: 0.3125rem;
                 background-color: hsl(170, 48%, 54%);
                 color: hsl(0, 0%, 100%);
                 border-radius: 100%;
@@ -112,7 +112,7 @@
             & > p {
                 display: inline-block;
                 vertical-align: top;
-                max-width: calc(100% - 32px);
+                max-width: calc(100% - 2.0rem);
                 position: relative;
                 top: -2px;
             }
@@ -120,7 +120,7 @@
             & > .codehilite,
             & > p:not(:first-child) {
                 padding-left: 24px;
-                margin-left: 5px;
+                margin-left: 0.3125rem;
             }
 
             .codehilite {
@@ -134,12 +134,12 @@
             .warn,
             .tip,
             .keyboard_tip {
-                margin: 5px 25px 5px;
+                margin: 0.3125rem 1.5625rem 0.3125rem;
             }
         }
 
         p {
-            margin: 0 0 2px;
+            margin: 0 0 0.125rem;
         }
 
         @media (max-width: 500px) {
@@ -148,10 +148,10 @@
     }
 
     ul {
-        margin: 0 10px 15px 25px;
+        margin: 0 0.625rem 0.9375rem 1.5625rem;
 
         & > li {
-            margin: 5px 0;
+            margin: 0.3125rem 0;
 
             ::before {
                 content: none;
@@ -161,7 +161,7 @@
 
     .content {
         padding: 30px;
-        max-width: 768px;
+        max-width: 48.0rem;
         background-color: hsl(0, 0%, 100%);
 
         ol li p:not(:first-child) {
@@ -169,7 +169,7 @@
         }
 
         i.zulip-icon {
-            margin: 0 2px 2px 2px;
+            margin: 0 0.125rem 0.125rem 0.125rem;
             vertical-align: middle;
         }
 
@@ -199,14 +199,14 @@
         }
 
         &.emoji-small {
-            width: 20px;
+            width: 1.25rem;
             box-shadow: none;
             border: none;
             vertical-align: sub;
         }
 
         &.emoji-big {
-            width: 25px;
+            width: 1.5625rem;
             box-shadow: none;
             border: none;
         }
@@ -221,7 +221,7 @@
         border: 1px solid hsl(210, 22%, 90%);
         border-radius: 4px;
         padding: 10px;
-        margin: 5px 0;
+        margin: 0.3125rem 0;
 
         p {
             margin-bottom: 0;
@@ -270,10 +270,10 @@
             &::after {
                 content: "";
                 background: hsl(0, 0%, 80%);
-                height: 1.5px;
-                width: 6px;
+                height: 1.0.3125rem;
+                width: 0.375rem;
                 display: block;
-                margin: 0.5px -2px;
+                margin: 0.0.3125rem -0.125rem;
             }
         }
 
@@ -308,7 +308,7 @@
     }
 
     pre {
-        line-height: 15px;
+        line-height: 0.9375rem;
         code {
             white-space: pre-wrap;
         }
@@ -316,8 +316,8 @@
 
     .code-section {
         ol {
-            margin-left: 15px;
-            margin-top: 10px;
+            margin-left: 0.9375rem;
+            margin-top: 0.625rem;
         }
         ul.nav {
             margin: 0;
@@ -331,7 +331,7 @@
 
                 &.active {
                     color: hsl(176, 46%, 41%);
-                    margin-bottom: -1px;
+                    margin-bottom: -0.0625rem;
 
                     border: 1px solid hsl(0, 0%, 87%);
                     border-bottom: 1px solid hsl(0, 0%, 100%);
@@ -346,7 +346,7 @@
 
         .blocks {
             padding: 10px;
-            margin-bottom: 10px;
+            margin-bottom: 0.625rem;
             border: 1px solid hsl(0, 0%, 87%);
 
             & > div {

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -4,7 +4,7 @@ body {
     line-height: 150%;
     height: 100%;
     font-weight: 300;
-    font-size: 17px;
+    font-size: 1.0625rem;
 }
 
 html {
@@ -19,12 +19,12 @@ html {
 .digest-address-link {
     margin-top: 10px;
     color: hsl(0, 0%, 60%);
-    font-size: 12px;
+    font-size: 0.75rem;
     text-align: center;
 }
 
 .mac-cmd-key {
-    font-size: 15px;
+    font-size: 0.9375rem;
     font-family: monospace;
 }
 
@@ -275,7 +275,7 @@ html {
 
 .title {
     font-family: Helvetica;
-    font-size: 100px;
+    font-size: 6.25rem;
     font-weight: bold;
     margin-top: 50px;
     margin-bottom: 60px;
@@ -694,7 +694,7 @@ input.text-error {
 a.bottom-signup-button {
     color: hsl(0, 0%, 100%) !important;
     text-decoration: none !important;
-    font-size: 20px;
+    font-size: 1.25rem;
     padding: 20px;
     margin-top: 30px;
     margin-bottom: 30px;
@@ -711,17 +711,17 @@ a.bottom-signup-button {
     margin-bottom: 20px;
     padding-top: 0;
     text-align: center;
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 .portico-large-text {
-    font-size: 16px;
+    font-size: 1rem;
     line-height: 20px;
 }
 
 .portico-secondary-header {
     font-weight: 300;
-    font-size: 25px;
+    font-size: 1.5625rem;
 }
 
 .table.table-striped {
@@ -898,7 +898,7 @@ input#terminal:checked ~ #tab-terminal {
 
 .login-page-subheader {
     font-weight: 300;
-    font-size: 24px;
+    font-size: 1.5rem;
     display: block;
     margin: auto;
     width: 300px;
@@ -909,7 +909,7 @@ input#terminal:checked ~ #tab-terminal {
 
 .apps-muted {
     font-weight: 300;
-    font-size: 20px;
+    font-size: 1.25rem;
     display: block;
     margin: auto;
     text-align: center;
@@ -918,11 +918,11 @@ input#terminal:checked ~ #tab-terminal {
 
 .apps-instructions-header {
     font-weight: 300;
-    font-size: 25px;
+    font-size: 1.5625rem;
 }
 
 .btn-app-download {
-    font-size: 25px;
+    font-size: 1.5625rem;
     margin-top: 15px;
     margin-bottom: 15px;
 }
@@ -931,7 +931,7 @@ input#terminal:checked ~ #tab-terminal {
     margin-top: 0;
     margin-bottom: 0;
     padding: 8px;
-    font-size: 18px;
+    font-size: 1.125rem;
     border-radius: 0;
     min-width: 300px;
 }
@@ -1051,13 +1051,13 @@ input.new-organization-button {
     font-weight: 300;
 
     .tagline {
-        font-size: 40px;
+        font-size: 2.5rem;
         line-height: 42px;
     }
 
     .footnote {
         display: block;
-        font-size: 18px;
+        font-size: 1.125rem;
         color: hsl(0, 0%, 0%);
         margin-top: 15px;
     }
@@ -1066,7 +1066,7 @@ input.new-organization-button {
 .main-signup-button {
     margin-top: 15px;
     margin-bottom: 15px;
-    font-size: 22px;
+    font-size: 1.375rem;
 }
 
 .app-main,
@@ -1122,7 +1122,7 @@ input.new-organization-button {
         color: hsl(0, 0%, 100%);
         padding: 2px 7px 1px 8px;
         font-weight: 600;
-        font-size: 16px;
+        font-size: 1rem;
         transition: all 0.2s ease-in;
         border-radius: 4px;
 
@@ -1140,7 +1140,7 @@ input.new-organization-button {
 
 .button-muted {
     display: block;
-    font-size: 12px;
+    font-size: 0.75rem;
     color: hsl(0, 0%, 87%);
 }
 
@@ -1290,7 +1290,7 @@ input.new-organization-button {
         margin-top: 20px;
         padding: 5px 10px;
         border-radius: 2px;
-        font-size: 16px;
+        font-size: 1rem;
         font-weight: 300;
     }
 }
@@ -1324,7 +1324,7 @@ input.new-organization-button {
     max-width: 500px;
     background-color: hsl(0, 0%, 100%);
     box-shadow: 0 0 4px hsl(163, 43%, 46%);
-    font-size: 18px;
+    font-size: 1.125rem;
 
     &.config-error {
         max-width: 750px;
@@ -1342,7 +1342,7 @@ input.new-organization-button {
 
 .error_page .lead {
     color: hsl(163, 49%, 44%);
-    font-size: 35px;
+    font-size: 2.1875rem;
     margin-bottom: 20px;
     line-height: normal;
 }
@@ -1544,7 +1544,7 @@ input.new-organization-button {
 
     .main-headline-text {
         .tagline {
-            font-size: 32px;
+            font-size: 2rem;
             line-height: 34px;
         }
     }
@@ -1700,21 +1700,21 @@ label.label-title {
     .api-argument-required {
         text-transform: uppercase;
         font-weight: 600;
-        font-size: 12px;
+        font-size: 0.75rem;
         color: hsl(14, 75%, 60%);
     }
 
     .api-argument-optional {
         text-transform: uppercase;
         font-weight: 400;
-        font-size: 12px;
+        font-size: 0.75rem;
         color: hsl(0, 0%, 47%);
     }
 
     .api-argument-deprecated {
         text-transform: uppercase;
         font-weight: 600;
-        font-size: 12px;
+        font-size: 0.75rem;
         color: hsl(0, 50%, 60%);
     }
 }

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -17,7 +17,7 @@ html {
 }
 
 .digest-address-link {
-    margin-top: 10px;
+    margin-top: 0.625rem;
     color: hsl(0, 0%, 60%);
     font-size: 0.75rem;
     text-align: center;
@@ -36,7 +36,7 @@ html {
     height: auto !important;
     height: 100%;
 
-    margin: 0 auto -56px;
+    margin: 0 auto -3.5rem;
 }
 
 .normal {
@@ -55,7 +55,7 @@ html {
     position: relative;
 
     padding: 15px 0;
-    height: 29px;
+    height: 1.8125rem;
 
     background-color: hsl(0, 0%, 100%);
     box-shadow: 0 0 4px hsla(0, 0%, 0%, 0.1);
@@ -65,7 +65,7 @@ html {
 
 .navbar.footer .nav {
     > li {
-        line-height: 56px;
+        line-height: 3.5rem;
 
         > a {
             padding-top: 0;
@@ -75,7 +75,7 @@ html {
 }
 
 .push {
-    height: 56px;
+    height: 3.5rem;
 }
 
 .breakpoint {
@@ -100,7 +100,7 @@ html {
 /* The Help Center tabbed content tends to be a lot short sentences.
    We also want the Help Center tabbed content to pop more. */
 .help-center .code-section .blocks {
-    max-width: 500px;
+    max-width: 31.25rem;
 }
 
 .digest-container {
@@ -110,7 +110,7 @@ html {
 .digest-email-container {
     display: block;
     margin: 0 auto !important;
-    max-width: 700px;
+    max-width: 43.75rem;
     padding-bottom: 30px;
 }
 
@@ -136,7 +136,7 @@ html {
 .help {
     .app-main {
         padding: 0;
-        margin-top: 59px;
+        margin-top: 3.6875rem;
     }
 
     /* Markdown processor generates lots of spurious <p></p> */
@@ -145,10 +145,10 @@ html {
     }
 
     .sidebar {
-        width: 300px;
+        width: 18.75rem;
         z-index: 1;
         /* 100vh - navbar - paddingTop - paddingBottom - bottomNav */
-        height: calc(100vh - 59px);
+        height: calc(100vh - 3.6875rem);
 
         border-right: 1px solid hsl(219, 10%, 97%);
         overflow: auto;
@@ -170,7 +170,7 @@ html {
             border-bottom: 1px solid hsla(0, 0, 100%, 0.6);
 
             &:not(:first-of-type) {
-                margin-top: 20px;
+                margin-top: 1.25rem;
             }
 
             &:first-of-type,
@@ -180,7 +180,7 @@ html {
 
             &.home-link {
                 font-size: 1em;
-                margin-bottom: 17px;
+                margin-bottom: 1.0625rem;
 
                 a::before {
                     display: inline-block;
@@ -188,7 +188,7 @@ html {
                     font-size: inherit;
 
                     content: "\f0d9";
-                    margin-right: 10px;
+                    margin-right: 0.625rem;
                 }
             }
 
@@ -202,7 +202,7 @@ html {
             font-weight: 400;
             font-size: 1.2em;
             line-height: 1.05;
-            margin-bottom: 5px;
+            margin-bottom: 0.3125rem;
         }
 
         &.slide h2 {
@@ -214,7 +214,7 @@ html {
                 font-size: inherit;
 
                 content: "\f107";
-                margin-right: 5px;
+                margin-right: 0.3125rem;
                 float: right;
 
                 opacity: 0.5;
@@ -222,11 +222,11 @@ html {
         }
 
         ul {
-            margin: 5px 0 10px 12px;
+            margin: 0.3125rem 0 0.625rem 0.75rem;
         }
 
         &.slide ul {
-            margin-left: 19px;
+            margin-left: 1.1875rem;
             display: none;
         }
 
@@ -251,8 +251,8 @@ html {
                 /* Extend highlight to entire width of sidebar, not just link area */
                 /* This has been changed from "+" to "- -" because of issue #8403.
                    If the issue has been fixed, please change this back to "+" again. */
-                width: calc(100% + 20px);
-                margin-left: -40px;
+                width: calc(100% + 1.25rem);
+                margin-left: -2.5rem;
                 padding-left: 40px;
 
                 /* Don't show the focus outline for the highlighted page. */
@@ -264,8 +264,8 @@ html {
 
 .help .markdown {
     background-color: hsl(0, 0%, 100%);
-    width: calc(100vw - 300px);
-    height: calc(100vh - 59px);
+    width: calc(100vw - 18.75rem);
+    height: calc(100vh - 3.6875rem);
 }
 
 .help-center ol,
@@ -277,8 +277,8 @@ html {
     font-family: Helvetica;
     font-size: 6.25rem;
     font-weight: bold;
-    margin-top: 50px;
-    margin-bottom: 60px;
+    margin-top: 3.125rem;
+    margin-bottom: 3.75rem;
 }
 
 #digest-page-title {
@@ -290,15 +290,15 @@ html {
 }
 
 .pitch {
-    width: 600px;
+    width: 37.5rem;
     max-width: 100%;
 }
 
 .help-box {
-    max-width: 500px;
+    max-width: 31.25rem;
 
     padding: 10px;
-    margin: 10px 0;
+    margin: 0.625rem 0;
 
     font-size: 0.9rem;
     font-weight: 400;
@@ -345,13 +345,13 @@ img.screenshot {
 }
 
 .android-screenshot {
-    margin-top: -30px;
-    width: 221px;
+    margin-top: -1.875rem;
+    width: 13.8125rem;
 }
 
 .iphone-screenshot {
-    width: 184px;
-    margin: 0 32px;
+    width: 11.5rem;
+    margin: 0 2.0rem;
 }
 
 .full-width-screenshot {
@@ -387,13 +387,13 @@ img.screenshot {
 
 #pw_strength {
     /* Same width as a Bootstrap default text <input> with padding */
-    width: 220px;
-    height: 8px;
+    width: 13.75rem;
+    height: 0.5rem;
 }
 
 #registration #pw_strength {
-    width: 325px;
-    margin: 7px auto 0;
+    width: 20.3125rem;
+    margin: 0.4375rem auto 0;
 }
 
 .def::before {
@@ -444,8 +444,8 @@ img.screenshot {
 }
 
 .laptop-image {
-    width: 787px;
-    height: 414px;
+    width: 49.1875rem;
+    height: 25.875rem;
     background-image: url(../../images/landing-page/laptop.png);
     background-size: contain;
 }
@@ -453,7 +453,7 @@ img.screenshot {
 .laptop-screen {
     position: relative;
     top: 32px;
-    width: 507px;
+    width: 31.6875rem;
 }
 
 .platform-icon {
@@ -503,9 +503,9 @@ input.text-error {
 
 /* -- new footer -- */
 .footer {
-    margin: 20px;
+    margin: 1.25rem;
     z-index: 100;
-    width: calc(100% - 40px);
+    width: calc(100% - 2.5rem);
     text-align: center;
     font-size: 0.9em;
 
@@ -519,9 +519,9 @@ input.text-error {
     }
 
     section {
-        width: calc(25% - 40px);
-        margin: 0 20px;
-        max-width: 150px;
+        width: calc(25% - 2.5rem);
+        margin: 0 1.25rem;
+        max-width: 9.375rem;
         display: inline-block;
         vertical-align: top;
         text-align: left;
@@ -531,7 +531,7 @@ input.text-error {
             font-size: 1em;
             font-weight: 600;
             line-height: 1.2;
-            margin-bottom: 5px;
+            margin-bottom: 0.3125rem;
         }
 
         ul {
@@ -565,7 +565,7 @@ input.text-error {
     }
 
     .portico-logo {
-        height: 28px;
+        height: 1.75rem;
         width: auto;
         padding: 6px 0 6px 0;
     }
@@ -580,9 +580,9 @@ input.text-error {
             display: none;
             position: absolute;
             right: 0;
-            margin: 10px 0 0 0;
+            margin: 0.625rem 0 0 0;
             list-style-type: none;
-            width: 200px;
+            width: 12.5rem;
             background-color: hsl(0, 0%, 100%);
             padding: 5px 0;
             border-radius: 4px;
@@ -614,7 +614,7 @@ input.text-error {
 
                 a {
                     display: block;
-                    margin: 2px 0;
+                    margin: 0.125rem 0;
                     padding: 0;
                     transition: none;
                     font-size: 0.9em;
@@ -627,7 +627,7 @@ input.text-error {
                 }
 
                 a i {
-                    margin-right: 5px;
+                    margin-right: 0.3125rem;
                 }
             }
         }
@@ -640,14 +640,14 @@ input.text-error {
     .dropdown-pill {
         border: 1px solid hsla(0, 0%, 0%, 0.2);
         border-radius: 4px;
-        margin-left: 10px;
+        margin-left: 0.625rem;
         font-weight: 400;
         cursor: pointer;
 
         .realm-name {
             display: inline-block;
             vertical-align: top;
-            margin: 0 5px 0 -4px;
+            margin: 0 0.3125rem 0 -0.25rem;
             padding: 1px 0 1px 5px;
             font-size: 0.9em;
             font-weight: 600;
@@ -658,7 +658,7 @@ input.text-error {
             position: relative;
             top: -2px;
             font-size: 0.6em;
-            margin-left: 5px;
+            margin-left: 0.3125rem;
             opacity: 0.5;
             transition: all 0.2s ease;
         }
@@ -668,8 +668,8 @@ input.text-error {
         }
 
         .header-realm-icon {
-            width: 26px;
-            height: 26px;
+            width: 1.625rem;
+            height: 1.625rem;
             vertical-align: top;
             border-radius: 4px;
         }
@@ -677,7 +677,7 @@ input.text-error {
 }
 
 .portico-page-container .portico-header .dropdown-pill .realm-name {
-    margin-left: -3px;
+    margin-left: -0.1875rem;
 }
 
 .app {
@@ -696,19 +696,19 @@ a.bottom-signup-button {
     text-decoration: none !important;
     font-size: 1.25rem;
     padding: 20px;
-    margin-top: 30px;
-    margin-bottom: 30px;
+    margin-top: 1.875rem;
+    margin-bottom: 1.875rem;
     font-weight: 300;
 }
 
 .signup-signature {
-    margin-top: 20px;
+    margin-top: 1.25rem;
     padding-bottom: 50px;
 }
 
 .devlogin_subheader {
-    margin-top: 10px;
-    margin-bottom: 20px;
+    margin-top: 0.625rem;
+    margin-bottom: 1.25rem;
     padding-top: 0;
     text-align: center;
     font-size: 1rem;
@@ -716,7 +716,7 @@ a.bottom-signup-button {
 
 .portico-large-text {
     font-size: 1rem;
-    line-height: 20px;
+    line-height: 1.25rem;
 }
 
 .portico-secondary-header {
@@ -731,8 +731,8 @@ a.bottom-signup-button {
 
 .team-profiles {
     /* Compensate for gutter width */
-    margin: -10px;
-    margin-bottom: 3px;
+    margin: -0.625rem;
+    margin-bottom: 0.1875rem;
 }
 
 .team {
@@ -756,8 +756,8 @@ a.bottom-signup-button {
 
         .profile-picture {
             flex: 0 auto;
-            width: 200px;
-            margin: 10px;
+            width: 12.5rem;
+            margin: 0.625rem;
 
             > img {
                 height: auto;
@@ -768,13 +768,13 @@ a.bottom-signup-button {
         .profile-information {
             flex: 1;
             /* Wrap when screen is small to prevent very short line */
-            min-width: 300px;
+            min-width: 18.75rem;
             font-size: 1.4em;
-            margin: 10px 10px 0 10px;
+            margin: 0.625rem 0.625rem 0 0.625rem;
         }
 
         .profile-description {
-            margin-top: 5px;
+            margin-top: 0.3125rem;
             font-weight: 400;
             font-size: 0.8em;
             opacity: 0.8;
@@ -800,7 +800,7 @@ a.bottom-signup-button {
         display: inline-block;
         padding: 10px;
         border: 1px solid transparent;
-        margin: 0 0 -1px 0;
+        margin: 0 0 -0.0625rem 0;
 
         &:hover {
             cursor: pointer;
@@ -809,8 +809,8 @@ a.bottom-signup-button {
 }
 
 .contributors-list {
-    margin-left: -40px;
-    width: calc(100% + 80px);
+    margin-left: -2.5rem;
+    width: calc(100% + 5.0rem);
 }
 
 .contributors {
@@ -832,7 +832,7 @@ a.bottom-signup-button {
         }
 
         .avatar {
-            width: 60px;
+            width: 3.75rem;
             text-align: center;
             display: inline-block;
             vertical-align: top;
@@ -843,7 +843,7 @@ a.bottom-signup-button {
             text-align: left;
             display: inline-block;
             vertical-align: top;
-            margin-left: 10px;
+            margin-left: 0.625rem;
         }
     }
 }
@@ -886,8 +886,8 @@ input#terminal:checked ~ #tab-terminal {
     justify-content: center;
 
     .sponsor-picture img {
-        height: 170px;
-        margin: 0 20px 0 20px;
+        height: 10.625rem;
+        margin: 0 1.25rem 0 1.25rem;
         pointer-events: none;
     }
 }
@@ -901,10 +901,10 @@ input#terminal:checked ~ #tab-terminal {
     font-size: 1.5rem;
     display: block;
     margin: auto;
-    width: 300px;
+    width: 18.75rem;
     text-align: center;
-    margin-top: -30px;
-    margin-bottom: 50px;
+    margin-top: -1.875rem;
+    margin-bottom: 3.125rem;
 }
 
 .apps-muted {
@@ -913,7 +913,7 @@ input#terminal:checked ~ #tab-terminal {
     display: block;
     margin: auto;
     text-align: center;
-    margin-bottom: 30px;
+    margin-bottom: 1.875rem;
 }
 
 .apps-instructions-header {
@@ -923,8 +923,8 @@ input#terminal:checked ~ #tab-terminal {
 
 .btn-app-download {
     font-size: 1.5625rem;
-    margin-top: 15px;
-    margin-bottom: 15px;
+    margin-top: 0.9375rem;
+    margin-bottom: 0.9375rem;
 }
 
 .btn-direct {
@@ -933,7 +933,7 @@ input#terminal:checked ~ #tab-terminal {
     padding: 8px;
     font-size: 1.125rem;
     border-radius: 0;
-    min-width: 300px;
+    min-width: 18.75rem;
 }
 
 .btn-user {
@@ -954,10 +954,10 @@ input#terminal:checked ~ #tab-terminal {
     text-align: center;
 
     .alert {
-        width: 320px;
+        width: 20.0rem;
         margin: auto;
-        margin-top: -30px;
-        margin-bottom: 15px;
+        margin-top: -1.875rem;
+        margin-bottom: 0.9375rem;
         text-align: center;
     }
 }
@@ -968,11 +968,11 @@ input#terminal:checked ~ #tab-terminal {
 }
 
 .register-button {
-    margin-left: 10px;
+    margin-left: 0.625rem;
 }
 
 .new-organization-button {
-    margin-top: 10px;
+    margin-top: 0.625rem;
 }
 
 input.new-organization-button {
@@ -984,29 +984,29 @@ input.new-organization-button {
 .login-form {
     margin: auto;
     /* plus input padding. */
-    width: calc(300px - -28px);
-    margin-bottom: 10px;
+    width: calc(18.75rem - -1.75rem);
+    margin-bottom: 0.625rem;
 
     .direct-label {
-        margin-top: 50px;
-        margin-bottom: 6px;
+        margin-top: 3.125rem;
+        margin-bottom: 0.375rem;
     }
 }
 
 .login-form,
 .register-form {
     .control-label {
-        margin-bottom: 2px;
+        margin-bottom: 0.125rem;
     }
 
     .control-group {
-        margin-right: 10px;
+        margin-right: 0.625rem;
     }
 }
 
 .login-forgot-password {
     float: right;
-    line-height: 40px;
+    line-height: 2.5rem;
     position: relative;
     right: -15px;
     font-weight: 300;
@@ -1014,10 +1014,10 @@ input.new-organization-button {
 
 .login-social {
     max-width: 100%;
-    min-width: 300px;
+    min-width: 18.75rem;
     margin: auto;
     text-align: center;
-    margin-top: 10px;
+    margin-top: 0.625rem;
 }
 
 .main-headline-container {
@@ -1028,17 +1028,17 @@ input.new-organization-button {
 
 .main-headline-logo {
     display: block;
-    width: 200px;
+    width: 12.5rem;
     height: auto;
     margin: auto;
-    margin-bottom: 20px;
+    margin-bottom: 1.25rem;
 }
 
 .main-image {
     display: block;
     margin: auto;
     width: 100%;
-    max-width: 900px;
+    max-width: 56.25rem;
     height: auto;
     position: relative;
     bottom: -10px;
@@ -1052,27 +1052,27 @@ input.new-organization-button {
 
     .tagline {
         font-size: 2.5rem;
-        line-height: 42px;
+        line-height: 2.625rem;
     }
 
     .footnote {
         display: block;
         font-size: 1.125rem;
         color: hsl(0, 0%, 0%);
-        margin-top: 15px;
+        margin-top: 0.9375rem;
     }
 }
 
 .main-signup-button {
-    margin-top: 15px;
-    margin-bottom: 15px;
+    margin-top: 0.9375rem;
+    margin-bottom: 0.9375rem;
     font-size: 1.375rem;
 }
 
 .app-main,
 .header-main,
 .footer-main {
-    min-width: 350px;
+    min-width: 21.875rem;
     margin: 0 auto;
     padding: 0 20px 0 20px;
     position: relative;
@@ -1110,8 +1110,8 @@ input.new-organization-button {
 
 .little-bullet {
     display: inline-block;
-    margin-left: 5px;
-    margin-right: 5px;
+    margin-left: 0.3125rem;
+    margin-right: 0.3125rem;
 }
 
 .top-links {
@@ -1148,15 +1148,15 @@ input.new-organization-button {
 .password-reset {
     display: inline-block;
     text-align: left;
-    width: 328px;
+    width: 20.5rem;
 
     form {
         margin: 0;
     }
 
     #pw_strength {
-        width: 328px;
-        margin-top: 20px;
+        width: 20.5rem;
+        margin-top: 1.25rem;
     }
 
     .control-group .control-label {
@@ -1168,11 +1168,11 @@ input.new-organization-button {
     }
 
     .input-group {
-        margin: 15px 0;
+        margin: 0.9375rem 0;
 
         input[type="text"],
         input[type="password"] {
-            width: calc(100% - 14px);
+            width: calc(100% - 0.875rem);
         }
 
         #pw_strength {
@@ -1180,7 +1180,7 @@ input.new-organization-button {
         }
 
         &.m-t-30 {
-            margin-top: 30px;
+            margin-top: 1.875rem;
         }
     }
 
@@ -1200,19 +1200,19 @@ input.new-organization-button {
 
 .input-group {
     &.margin {
-        margin: 10px 0;
+        margin: 0.625rem 0;
     }
 
     .progress {
         margin: 0;
-        margin-top: 5px;
+        margin-top: 0.3125rem;
         display: inline-block;
     }
 
     /* --- new settings styling --- */
     input[type="radio"],
     input[type="checkbox"] {
-        margin: 0 10px 0 0;
+        margin: 0 0.625rem 0 0;
     }
 
     input[type="radio"] {
@@ -1226,12 +1226,12 @@ input.new-organization-button {
 
         &.inline-block {
             /* eyeballing off-centered aesth. */
-            margin-top: 1px;
+            margin-top: 0.0625rem;
         }
     }
 
     &.radio {
-        margin-left: 25px;
+        margin-left: 1.5625rem;
     }
 
     &.grid {
@@ -1239,14 +1239,14 @@ input.new-organization-button {
         border-bottom: 1px solid hsl(0, 0%, 87%);
 
         label.inline-block {
-            width: 200px;
+            width: 12.5rem;
         }
     }
 }
 
 .center-container {
-    min-height: calc(100vh - 94px);
-    min-height: 700px;
+    min-height: calc(100vh - 5.875rem);
+    min-height: 43.75rem;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1263,11 +1263,11 @@ input.new-organization-button {
 
     .pitch {
         width: 100%;
-        margin-bottom: 20px;
+        margin-bottom: 1.25rem;
     }
 
     .control-group {
-        margin-bottom: 10px;
+        margin-bottom: 0.625rem;
 
         label {
             width: 100%;
@@ -1283,11 +1283,11 @@ input.new-organization-button {
     }
 
     #send_confirm input[type="text"] {
-        margin-top: 20px;
+        margin-top: 1.25rem;
     }
 
     .button {
-        margin-top: 20px;
+        margin-top: 1.25rem;
         padding: 5px 10px;
         border-radius: 2px;
         font-size: 1rem;
@@ -1296,7 +1296,7 @@ input.new-organization-button {
 }
 
 .error_page {
-    min-height: calc(100vh - 290px);
+    min-height: calc(100vh - 18.125rem);
     height: 100%;
     background-color: hsl(163, 42%, 85%);
     font-family: "Source Sans Pro", Helvetica, Arial, sans-serif;
@@ -1307,27 +1307,27 @@ input.new-organization-button {
 }
 
 .error_page .row-fluid {
-    margin-top: 60px;
+    margin-top: 3.75rem;
 }
 
 .error_page img {
     display: block;
     clear: right;
     margin: 0 auto;
-    max-width: 500px;
+    max-width: 31.25rem;
     width: 100%;
 }
 
 .error_page .errorbox {
     margin: auto;
     border: 2px solid hsl(163, 43%, 46%);
-    max-width: 500px;
+    max-width: 31.25rem;
     background-color: hsl(0, 0%, 100%);
     box-shadow: 0 0 4px hsl(163, 43%, 46%);
     font-size: 1.125rem;
 
     &.config-error {
-        max-width: 750px;
+        max-width: 46.875rem;
     }
 }
 
@@ -1343,13 +1343,13 @@ input.new-organization-button {
 .error_page .lead {
     color: hsl(163, 49%, 44%);
     font-size: 2.1875rem;
-    margin-bottom: 20px;
+    margin-bottom: 1.25rem;
     line-height: normal;
 }
 
 .hourglass-img {
     width: initial !important;
-    margin-bottom: 25px !important;
+    margin-bottom: 1.5625rem !important;
 }
 
 @media (max-width: 800px) {
@@ -1359,7 +1359,7 @@ input.new-organization-button {
 
             .content {
                 max-width: none;
-                margin-left: 50px;
+                margin-left: 3.125rem;
             }
         }
 
@@ -1380,7 +1380,7 @@ input.new-organization-button {
             right: calc(100vw - 50px);
             width: 100%;
             min-width: unset;
-            height: calc(100vh - 59px);
+            height: calc(100vh - 3.6875rem);
             pointer-events: none;
             overflow: hidden;
             transform: translateX(0);
@@ -1428,12 +1428,12 @@ input.new-organization-button {
 
 @media (max-width: 815px) {
     .footer {
-        width: 450px;
+        width: 28.125rem;
         margin-left: auto;
         margin-right: auto;
 
         section {
-            width: calc(50% - 40px);
+            width: calc(50% - 2.5rem);
         }
     }
 }
@@ -1447,13 +1447,13 @@ input.new-organization-button {
     .input-large {
         display: block !important;
         width: 100% !important;
-        min-height: 30px !important;
+        min-height: 1.875rem !important;
         margin: 0 !important;
         padding: 4px 6px !important;
-        line-height: 20px !important;
+        line-height: 1.25rem !important;
         box-sizing: border-box !important;
-        margin-top: 10px !important;
-        margin-bottom: 10px !important;
+        margin-top: 0.625rem !important;
+        margin-bottom: 0.625rem !important;
     }
 
     .postal-envelope {
@@ -1470,7 +1470,7 @@ input.new-organization-button {
 
     .signup-section {
         display: inline-block;
-        margin-top: 10px;
+        margin-top: 0.625rem;
     }
 
     .line-break-desktop {
@@ -1485,7 +1485,7 @@ input.new-organization-button {
 
 @media (max-height: 600px) {
     .password-container {
-        margin-top: 10px;
+        margin-top: 0.625rem;
     }
 }
 
@@ -1504,7 +1504,7 @@ input.new-organization-button {
     .app.help {
         .sidebar {
             top: 39px;
-            height: calc(100vh - 39px);
+            height: calc(100vh - 2.4375rem);
         }
 
         .hamburger {
@@ -1513,16 +1513,16 @@ input.new-organization-button {
     }
 
     .help .app-main {
-        margin-top: 39px;
+        margin-top: 2.4375rem;
     }
 
     .help .markdown {
-        height: calc(100vh - 39px);
+        height: calc(100vh - 2.4375rem);
     }
 
     .error_page .lead {
         font-size: 1.5em;
-        margin-bottom: 10px;
+        margin-bottom: 0.625rem;
     }
 
     .brand.logo .light {
@@ -1545,7 +1545,7 @@ input.new-organization-button {
     .main-headline-text {
         .tagline {
             font-size: 2rem;
-            line-height: 34px;
+            line-height: 2.125rem;
         }
     }
 
@@ -1560,8 +1560,8 @@ input.new-organization-button {
         width: auto;
 
         section {
-            margin: 0 3px;
-            width: calc(50% - 8px);
+            margin: 0 0.1875rem;
+            width: calc(50% - 0.5rem);
         }
     }
 }
@@ -1569,7 +1569,7 @@ input.new-organization-button {
 @media (max-width: 400px) {
     .footer {
         section {
-            width: calc(100% - 40px);
+            width: calc(100% - 2.5rem);
             max-width: none;
             text-align: center;
         }
@@ -1577,13 +1577,13 @@ input.new-organization-button {
 }
 
 .emoji {
-    height: 25px;
-    width: 25px;
+    height: 1.5625rem;
+    width: 1.5625rem;
     vertical-align: text-bottom;
 }
 
 .m-v-20 {
-    margin: 20px 0;
+    margin: 1.25rem 0;
 }
 
 label.label-title {
@@ -1598,7 +1598,7 @@ label.label-title {
 .button-new {
     padding: 8px 15px;
     margin: 0;
-    min-width: 130px;
+    min-width: 8.125rem;
 
     font-weight: 400;
 
@@ -1635,11 +1635,11 @@ label.label-title {
 }
 
 #find_account .form-control {
-    height: 30px;
+    height: 1.875rem;
 }
 
 #find_account .btn {
-    height: 40px;
+    height: 2.5rem;
     border-radius: 5px;
 }
 
@@ -1660,7 +1660,7 @@ label.label-title {
 }
 
 #devtools-page {
-    max-width: 800px;
+    max-width: 50.0rem;
     margin: 0 auto;
 }
 
@@ -1673,7 +1673,7 @@ label.label-title {
 }
 
 #third-party-apps {
-    margin-top: 20px;
+    margin-top: 1.25rem;
     padding-right: 10px;
 }
 
@@ -1733,13 +1733,13 @@ label.label-title {
 }
 
 .desktop-redirect-links {
-    margin-top: 20px;
+    margin-top: 1.25rem;
     text-decoration: underline;
     color: hsl(0, 0%, 50%);
 }
 
 .desktop-redirect-image {
-    margin-bottom: 20px;
+    margin-bottom: 1.25rem;
 }
 
 .unsupported_browser_page {

--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -127,7 +127,7 @@ html {
         }
 
         p {
-            font-size: 19px;
+            font-size: 1.1875rem;
         }
     }
 }
@@ -924,7 +924,7 @@ button#register_auth_button_gitlab {
     position: relative;
     top: 15px;
     margin-bottom: 20px;
-    font-size: 22px;
+    font-size: 1.375rem;
 }
 
 #source_realm_select {
@@ -944,7 +944,7 @@ button#register_auth_button_gitlab {
     }
 
     #realm_redirect_external_host {
-        font-size: 20px;
+        font-size: 1.25rem;
         top: 13px;
         left: 5px;
         position: relative;
@@ -1028,7 +1028,7 @@ button#register_auth_button_gitlab {
             line-height: 38px;
 
             &::before {
-                font-size: 30px;
+                font-size: 1.875rem;
             }
         }
     }

--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -1,5 +1,5 @@
 html {
-    min-height: 500px;
+    min-height: 31.25rem;
 }
 
 .flex {
@@ -8,11 +8,11 @@ html {
     align-items: center;
     justify-content: center;
 
-    min-height: calc(100vh - 402px);
+    min-height: calc(100vh - 25.125rem);
 }
 
 .m-10 {
-    margin: 10px;
+    margin: 0.625rem;
 }
 
 .white-box {
@@ -28,7 +28,7 @@ html {
 
 .bottom-text {
     text-align: center;
-    margin-top: 20px;
+    margin-top: 1.25rem;
     font-weight: 500;
     font-size: 0.9em;
 
@@ -63,7 +63,7 @@ html {
     .login-page-container.dev-login {
         .login-page-header {
             height: auto;
-            margin-top: 20px;
+            margin-top: 1.25rem;
             transform: none;
             text-align: center;
         }
@@ -77,7 +77,7 @@ html {
             display: inline-block;
             vertical-align: top;
 
-            margin: 0 20px;
+            margin: 0 1.25rem;
         }
     }
 
@@ -86,12 +86,12 @@ html {
     }
 
     &.find-account-page-container {
-        width: 500px;
+        width: 31.25rem;
         font-weight: 400;
     }
 
     &.goto-account-page-container {
-        width: 500px;
+        width: 31.25rem;
         font-weight: 400;
 
         .realm-redirect-form {
@@ -104,11 +104,11 @@ html {
     }
 
     &.confirm-continue-page-container {
-        width: 400px;
+        width: 25.0rem;
         font-weight: 400;
 
         .white-box {
-            min-width: 365px;
+            min-width: 22.8125rem;
         }
 
         .form-inline {
@@ -134,7 +134,7 @@ html {
 
 .login-page-container {
     &.dev-login {
-        margin-top: 20px;
+        margin-top: 1.25rem;
         border: none;
 
         .login-form {
@@ -143,7 +143,7 @@ html {
     }
 
     .group {
-        margin: 0 20px;
+        margin: 0 1.25rem;
         display: inline-block;
     }
 
@@ -203,7 +203,7 @@ html {
         line-height: 1;
 
         i {
-            margin-right: 5px;
+            margin-right: 0.3125rem;
         }
     }
 }
@@ -217,7 +217,7 @@ html {
 }
 
 .forgot-password-container {
-    width: 503px;
+    width: 31.4375rem;
 
     h3,
     form {
@@ -226,7 +226,7 @@ html {
 }
 
 .deactivated-realm-container {
-    width: 503px;
+    width: 31.4375rem;
 }
 
 .header {
@@ -251,8 +251,8 @@ html {
     #errors {
         font-size: 0.8em;
         font-weight: 400;
-        margin-bottom: 20px;
-        margin-top: 10px;
+        margin-bottom: 1.25rem;
+        margin-top: 0.625rem;
 
         &:empty {
             margin-top: 0;
@@ -260,25 +260,25 @@ html {
     }
 
     button {
-        margin-top: 22px;
+        margin-top: 1.375rem;
     }
 
     .new-organization-button {
-        margin-top: 25px;
+        margin-top: 1.5625rem;
     }
 }
 
 .account-accept-terms-page .terms-of-service .input-group {
-    width: 450px;
-    margin: 0 auto 10px;
+    width: 28.125rem;
+    margin: 0 auto 0.625rem;
 }
 
 .register-account {
     .terms-of-service .input-group,
     .default-stream-groups .input-group,
     .default-stream-groups p {
-        width: 330px;
-        margin: 0 auto 10px;
+        width: 20.625rem;
+        margin: 0 auto 0.625rem;
     }
 
     .terms-of-service .text-error {
@@ -332,8 +332,8 @@ html {
         color: hsl(0, 0%, 100%);
         background-color: hsl(213, 23%, 25%);
 
-        margin: 25px 0 5px;
-        height: 50px;
+        margin: 1.5625rem 0 0.3125rem;
+        height: 3.125rem;
 
         border: none;
         border-radius: 4px;
@@ -386,11 +386,11 @@ html {
         font-size: 2.5rem;
         text-align: center;
         color: hsl(0, 0%, 40%);
-        margin-bottom: 20px;
+        margin-bottom: 1.25rem;
     }
 
     .right-side .alert {
-        max-width: 328px;
+        max-width: 20.5rem;
     }
 
     .input-box {
@@ -402,14 +402,14 @@ html {
         input[type="email"],
         input[type="password"] {
             padding: 10px 32px 10px 12px;
-            margin: 25px 0 5px;
+            margin: 1.5625rem 0 0.3125rem;
 
             font-family: "Source Sans Pro";
             font-size: 1.2rem;
             line-height: normal;
             height: auto;
 
-            width: 280px;
+            width: 17.5rem;
 
             border: 1px solid hsl(0, 0%, 87%);
             box-shadow: none;
@@ -428,7 +428,7 @@ html {
         }
 
         input[type="email"] {
-            margin-bottom: 10px;
+            margin-bottom: 0.625rem;
         }
 
         label {
@@ -436,7 +436,7 @@ html {
             top: 0;
             left: 0;
 
-            margin-top: 1px;
+            margin-top: 0.0625rem;
 
             transition: all 0.3s ease;
         }
@@ -522,8 +522,8 @@ html {
         vertical-align: top;
         position: relative;
 
-        height: 30px;
-        margin-top: -10px;
+        height: 1.875rem;
+        margin-top: -0.625rem;
         top: 5px;
     }
 }
@@ -532,7 +532,7 @@ html {
 .portico-page {
     .pitch {
         h1 {
-            margin-bottom: 5px;
+            margin-bottom: 0.3125rem;
         }
 
         p {
@@ -544,7 +544,7 @@ html {
     .or {
         width: 100%;
         display: block;
-        margin: 10px auto;
+        margin: 0.625rem auto;
         color: hsl(0, 0%, 34%);
         font-weight: 600;
         text-align: center;
@@ -556,7 +556,7 @@ html {
 
             display: inline-block;
             position: absolute;
-            width: calc(100% - 5px);
+            width: calc(100% - 0.3125rem);
             top: calc(50% - 2px);
             left: 0;
             z-index: -1;
@@ -573,7 +573,7 @@ html {
 
 .register-account .pitch,
 .account-accept-terms-page .pitch {
-    margin-bottom: 5px;
+    margin-bottom: 0.3125rem;
     text-align: center;
 }
 
@@ -584,8 +584,8 @@ html {
         .info-box {
             display: inline-block;
             position: relative;
-            margin: 20px 0 0 20px;
-            width: calc(100% - 125px);
+            margin: 1.25rem 0 0 1.25rem;
+            width: calc(100% - 7.8125rem);
 
             /* full width minus the avatar + padding + borders */
             text-align: left;
@@ -593,7 +593,7 @@ html {
     }
 
     .left-side {
-        width: 500px;
+        width: 31.25rem;
         border-right: 1px solid hsl(0, 0%, 93%);
         position: relative;
         left: -1px;
@@ -602,8 +602,8 @@ html {
             text-align: left;
             font-weight: normal;
 
-            margin-top: 20px;
-            margin-right: 10px;
+            margin-top: 1.25rem;
+            margin-right: 0.625rem;
         }
 
         + .right-side {
@@ -611,12 +611,12 @@ html {
             /* this is to make sure the borders of the left and right side overlap
                each other. */
             padding-left: 15px;
-            margin-left: -5px;
+            margin-left: -0.3125rem;
         }
     }
 
     .right-side .form-inline {
-        width: 328px;
+        width: 20.5rem;
     }
 }
 
@@ -631,8 +631,8 @@ html {
     display: inline-block;
     vertical-align: top;
 
-    width: 100px;
-    height: 100px;
+    width: 6.25rem;
+    height: 6.25rem;
 }
 
 .info-box {
@@ -653,16 +653,16 @@ html {
     .organization-path {
         font-weight: 400;
         color: hsl(0, 0%, 47%);
-        margin-top: 5px;
+        margin-top: 0.3125rem;
     }
 }
 
 .confirm-email-change-page .white-box {
-    max-width: 500px;
+    max-width: 31.25rem;
 }
 
 button.login-social-button {
-    width: 328px;
+    width: 20.5rem;
     padding-left: 35px;
 
     background-size: auto 60%;
@@ -695,7 +695,7 @@ button#register_auth_button_gitlab {
 
 .login-page-container .right-side .actions,
 .back-to-login-wrapper {
-    margin: 20px 0 0;
+    margin: 1.25rem 0 0;
     text-align: left;
 }
 
@@ -742,10 +742,10 @@ button#register_auth_button_gitlab {
 #registration {
     width: auto;
     padding: 0;
-    margin: 30px;
+    margin: 1.875rem;
 
     fieldset {
-        margin: 30px;
+        margin: 1.875rem;
 
         .input-box:last-child {
             margin-bottom: 0;
@@ -753,26 +753,26 @@ button#register_auth_button_gitlab {
     }
 
     .info-box {
-        margin: 10px 0 0 20px;
+        margin: 0.625rem 0 0 1.25rem;
 
         .organization-name {
-            max-width: 228px;
+            max-width: 14.25rem;
         }
     }
 
     .input-box {
         display: block;
         text-align: center;
-        width: 330px;
-        margin: 25px auto 10px;
+        width: 20.625rem;
+        margin: 1.5625rem auto 0.625rem;
         position: relative;
 
         &.with-top-space {
-            margin-top: 50px;
+            margin-top: 3.125rem;
         }
 
         &.full-width {
-            width: calc(100% - 20px);
+            width: calc(100% - 1.25rem);
         }
 
         label {
@@ -785,7 +785,7 @@ button#register_auth_button_gitlab {
                 width: 100%;
                 text-align: left;
                 position: static !important;
-                margin-left: 2px;
+                margin-left: 0.125rem;
             }
         }
     }
@@ -799,8 +799,8 @@ button#register_auth_button_gitlab {
     }
 
     .register-button {
-        margin: 25px auto 30px;
-        width: 330px;
+        margin: 1.5625rem auto 1.875rem;
+        width: 20.625rem;
         border-radius: 4px;
     }
 
@@ -810,11 +810,11 @@ button#register_auth_button_gitlab {
         position: relative;
         padding-right: 10px;
 
-        width: 150px;
+        width: 9.375rem;
 
         + .realm_subdomain_label {
             top: 15px;
-            margin-left: 180px;
+            margin-left: 11.25rem;
             display: inline-block;
 
             font-weight: normal;
@@ -834,7 +834,7 @@ button#register_auth_button_gitlab {
 
     #id_email {
         font-weight: normal;
-        margin: 2px;
+        margin: 0.125rem;
         padding-top: 25px;
         text-align: left;
         overflow-wrap: break-word;
@@ -843,7 +843,7 @@ button#register_auth_button_gitlab {
     .help-text {
         width: 100%;
         max-width: none;
-        margin: 2px 0;
+        margin: 0.125rem 0;
         text-align: left;
         color: hsl(0, 0%, 47%);
         font-size: 0.9rem;
@@ -859,12 +859,12 @@ button#register_auth_button_gitlab {
         margin-bottom: 0;
 
         + .input-box {
-            margin-top: 20px;
+            margin-top: 1.25rem;
         }
     }
 
     .external-host {
-        margin: 25px 0 0 -3px;
+        margin: 1.5625rem 0 0 -0.1875rem;
         padding: 11.5px 10px;
 
         font-weight: 400;
@@ -882,7 +882,7 @@ button#register_auth_button_gitlab {
             font-size: 1rem;
 
             &.inline-block {
-                margin-top: -1px;
+                margin-top: -0.0625rem;
             }
         }
 
@@ -893,7 +893,7 @@ button#register_auth_button_gitlab {
     }
 
     .org-url {
-        margin-bottom: 5px !important;
+        margin-bottom: 0.3125rem !important;
     }
 }
 
@@ -909,9 +909,9 @@ button#register_auth_button_gitlab {
     #profile_avatar {
         border: 1px solid hsl(0, 0%, 80%);
         border-radius: 8px;
-        width: 120px;
-        height: 120px;
-        margin: 0 auto 10px;
+        width: 7.5rem;
+        height: 7.5rem;
+        margin: 0 auto 0.625rem;
     }
 
     #profile_full_name {
@@ -923,14 +923,14 @@ button#register_auth_button_gitlab {
 #source_realm_select_section {
     position: relative;
     top: 15px;
-    margin-bottom: 20px;
+    margin-bottom: 1.25rem;
     font-size: 1.375rem;
 }
 
 #source_realm_select {
     font-size: 1.2rem;
-    height: 45px;
-    width: 325px;
+    height: 2.8125rem;
+    width: 20.3125rem;
     &:focus {
         outline: none;
     }
@@ -956,11 +956,11 @@ button#register_auth_button_gitlab {
     }
 
     #enter-realm-button {
-        margin-top: 14px;
+        margin-top: 0.875rem;
     }
 
     #find-account-section {
-        margin-top: 20px;
+        margin-top: 1.25rem;
         text-align: center;
         font-weight: 500;
         font-size: 0.9em;
@@ -975,7 +975,7 @@ button#register_auth_button_gitlab {
     flex-direction: column;
 
     .white-box {
-        min-width: 450px;
+        min-width: 28.125rem;
         padding: 30px 0 50px 0;
     }
 
@@ -995,7 +995,7 @@ button#register_auth_button_gitlab {
 
     .choose-email-box {
         padding: 13px 0;
-        margin: 0 30px;
+        margin: 0 1.875rem;
         border-bottom: 1px solid hsl(0, 0%, 95%);
         display: flex;
         align-items: center;
@@ -1016,16 +1016,16 @@ button#register_auth_button_gitlab {
 
         img,
         i {
-            width: 35px;
-            height: 35px;
-            margin-right: 10px;
+            width: 2.1875rem;
+            height: 2.1875rem;
+            margin-right: 0.625rem;
             border-radius: 3px;
         }
 
         i.fa {
             color: hsl(0, 0%, 67%);
             text-align: center;
-            line-height: 38px;
+            line-height: 2.375rem;
 
             &::before {
                 font-size: 1.875rem;
@@ -1038,19 +1038,19 @@ button#register_auth_button_gitlab {
 
 @media (max-width: 950px) {
     .split-view .left-side {
-        width: 400px;
+        width: 25.0rem;
     }
 }
 
 @media (max-width: 850px) {
     .split-view .left-side {
-        width: 350px;
+        width: 21.875rem;
     }
 }
 
 @media (max-width: 815px) {
     .flex {
-        min-height: calc(100vh - 530px);
+        min-height: calc(100vh - 33.125rem);
     }
 }
 
@@ -1061,15 +1061,15 @@ button#register_auth_button_gitlab {
 
     .register-page-container,
     .login-page-container {
-        width: 400px;
+        width: 25.0rem;
         text-align: center;
     }
 
     .split-view {
         .org-header {
             .avatar {
-                width: 50px;
-                height: 50px;
+                width: 3.125rem;
+                height: 3.125rem;
             }
 
             .info-box {
@@ -1098,11 +1098,11 @@ button#register_auth_button_gitlab {
             border: none;
             margin-right: 0;
             min-height: 0;
-            margin-bottom: 20px;
-            width: 324px;
+            margin-bottom: 1.25rem;
+            width: 20.25rem;
 
             .description {
-                margin: 20px 0;
+                margin: 1.25rem 0;
 
                 a {
                     color: hsl(200, 100%, 36%);
@@ -1111,7 +1111,7 @@ button#register_auth_button_gitlab {
         }
 
         .right-side {
-            width: 324px;
+            width: 20.25rem;
         }
     }
 }
@@ -1128,7 +1128,7 @@ button#register_auth_button_gitlab {
     .app-main.forgot-password-container {
         display: inline-block;
         padding: 20px;
-        width: calc(100% - 40px);
+        width: calc(100% - 2.5rem);
     }
 
     .forgot-password-container form {
@@ -1137,7 +1137,7 @@ button#register_auth_button_gitlab {
         }
 
         button {
-            width: 328px;
+            width: 20.5rem;
         }
     }
 
@@ -1156,12 +1156,12 @@ button#register_auth_button_gitlab {
 
     .flex {
         /* the header becomes smaller, so comp for that. */
-        min-height: calc(100vh - 505px);
+        min-height: calc(100vh - 31.5625rem);
     }
 }
 
 @media (max-width: 400px) {
     .flex {
-        min-height: calc(100vh - 560px);
+        min-height: calc(100vh - 35.0rem);
     }
 }

--- a/static/styles/portico/stats.css
+++ b/static/styles/portico/stats.css
@@ -4,7 +4,7 @@ body {
 }
 
 hr {
-    border-width: 2px;
+    border-width: 0.125rem;
 }
 
 p {
@@ -18,12 +18,12 @@ p {
 }
 
 .svg-container {
-    margin: 20px;
+    margin: 1.25rem;
 }
 
 .center-charts {
-    margin: 30px auto;
-    width: 790px; /* chart = 750px + 20px padding */
+    margin: 1.875rem auto;
+    width: 49.375rem; /* chart = 750px + 20px padding */
 }
 
 .stats-page .alert {
@@ -33,7 +33,7 @@ p {
 .chart-container {
     display: inline-block;
     vertical-align: top;
-    margin: 10px 0;
+    margin: 0.625rem 0;
     padding: 20px;
     border: 2px solid hsl(0, 0%, 93%);
     background-color: hsl(0, 0%, 100%);
@@ -54,7 +54,7 @@ p {
     }
 
     &.pie-chart hr {
-        margin-bottom: 8px;
+        margin-bottom: 0.5rem;
     }
 
     .button-container {
@@ -62,7 +62,7 @@ p {
         z-index: 1;
 
         label {
-            margin: 3px;
+            margin: 0.1875rem;
         }
 
         > * {
@@ -73,7 +73,7 @@ p {
 }
 
 .analytics-page-header {
-    margin-left: 10px;
+    margin-left: 0.625rem;
 }
 
 .rangeslider-container {
@@ -123,7 +123,7 @@ p {
     }
 
     &[data-user="everyone"] {
-        margin-right: 10px;
+        margin-right: 0.625rem;
     }
 }
 
@@ -135,7 +135,7 @@ p {
 
 .tooltip-inner {
     padding: 10px;
-    max-width: 350px;
+    max-width: 21.875rem;
 
     font-size: 0.75rem;
     font-weight: 400;
@@ -144,7 +144,7 @@ p {
 }
 
 .last-update {
-    margin: 0 0 30px 0;
+    margin: 0 0 1.875rem 0;
 
     font-size: 0.8em;
     font-weight: 400;
@@ -155,25 +155,25 @@ p {
 #users_hover_humans,
 #read_hover_everyone,
 #hover_human {
-    margin-left: 10px;
+    margin-left: 0.625rem;
 }
 
 #id_messages_sent_by_client {
-    min-height: 100px;
-    width: 750px;
+    min-height: 6.25rem;
+    width: 46.875rem;
     position: relative;
 }
 
 #id_messages_sent_by_message_type {
-    height: 300px;
-    width: 750px;
+    height: 18.75rem;
+    width: 46.875rem;
     position: relative;
 }
 
 #id_messages_sent_over_time,
 #id_messages_read_over_time {
-    height: 400px;
-    width: 750px;
+    height: 25.0rem;
+    width: 46.875rem;
     position: relative;
 
     &[last_value_is_partial="true"] .points path:last-of-type {
@@ -182,8 +182,8 @@ p {
 }
 
 #id_number_of_users {
-    height: 370px;
-    width: 750px;
+    height: 23.125rem;
+    width: 46.875rem;
     position: relative;
 }
 
@@ -209,10 +209,10 @@ p {
     position: absolute;
     top: 50%;
     left: 50%;
-    width: 30px;
-    height: 30px;
-    margin-top: -15px;
-    margin-left: -15px;
+    width: 1.875rem;
+    height: 1.875rem;
+    margin-top: -0.9375rem;
+    margin-left: -0.9375rem;
     border-radius: 50%;
     border: 1px solid hsl(0, 0%, 80%);
     border-top-color: hsl(155, 93%, 42%);
@@ -235,8 +235,8 @@ p {
         .right {
             display: inline-block;
             vertical-align: top;
-            margin: 0 10px;
-            width: 790px;
+            margin: 0 0.625rem;
+            width: 49.375rem;
         }
     }
 }

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -8,7 +8,7 @@
         float: left;
         margin: 0.15em;
         padding: 0 0.125rem 0 0;
-        height: 19px;
+        height: 1.1875rem;
         cursor: pointer;
         background-color: hsl(0, 0%, 100%);
         border: 1px solid hsl(194, 37%, 84%);
@@ -25,9 +25,9 @@
         + .reaction_button {
             visibility: hidden;
             pointer-events: none;
-            margin: 2px 0.1em 3px 0.1em;
+            margin: 0.125rem 0.1em 0.1875rem 0.1em;
             padding: 0.1875rem;
-            height: 14px;
+            height: 0.875rem;
             border-radius: 4px;
             padding-left: 0.3em;
             border: 1px solid hsl(0, 0%, 73%);
@@ -39,10 +39,10 @@
             display: inline-block;
             vertical-align: top;
             top: 0;
-            margin: 1px 3px;
+            margin: 0.0625rem 0.1875rem;
 
-            height: 17px;
-            width: 17px;
+            height: 1.0625rem;
+            width: 1.0625rem;
             position: relative;
         }
     }
@@ -54,7 +54,7 @@
         display: inline-block;
         vertical-align: top;
         color: hsl(200, 100%, 40%);
-        margin: 0 1px 0 0;
+        margin: 0 0.0625rem 0 0;
         line-height: 1em;
     }
 
@@ -73,7 +73,7 @@
     .reaction_button {
         i {
             font-size: 1em;
-            margin-right: 3px;
+            margin-right: 0.1875rem;
         }
 
         &:hover i {
@@ -95,7 +95,7 @@
         .message_reaction_count {
             font-size: 1.1em;
             color: hsl(0, 0%, 33%);
-            margin-left: 3px;
+            margin-left: 0.1875rem;
             top: 0.5px;
         }
 
@@ -123,7 +123,7 @@
 
 .emoji-info-popover {
     padding: 0;
-    height: 370px;
+    height: 23.125rem;
     user-select: none;
 
     .popover-content {
@@ -140,7 +140,7 @@
 
     .emoji-popover {
         display: block;
-        width: 250px;
+        width: 15.625rem;
 
         .reacted {
             background-color: hsl(195, 50%, 95%);
@@ -168,7 +168,7 @@
             .emoji-popover-filter {
                 margin: auto;
                 padding-left: 1.375rem;
-                width: calc(100% - 22px - 8px);
+                width: calc(100% - 1.375rem - 0.5rem);
                 font-size: 90%;
             }
         }
@@ -184,8 +184,8 @@
             .emoji-popover-tab-item {
                 display: inline-block;
                 padding-top: 0.5rem;
-                width: 25px;
-                height: 25px;
+                width: 1.5625rem;
+                height: 1.5625rem;
                 text-align: center;
                 font-size: 1rem;
                 cursor: pointer;
@@ -205,12 +205,12 @@
             overflow-x: hidden;
             overflow-y: auto;
             display: block;
-            width: 247px;
+            width: 15.4375rem;
             padding-left: 0.1875rem;
         }
 
         .emoji-search-results-container {
-            height: 283px;
+            height: 17.6875rem;
 
             .emoji-popover-results-heading {
                 font-weight: 600;
@@ -220,7 +220,7 @@
         }
 
         .emoji-popover-emoji-map {
-            height: 250px;
+            height: 15.625rem;
 
             .emoji-popover-subheading {
                 font-weight: 600;
@@ -234,8 +234,8 @@
             padding: 0.375rem;
             cursor: pointer;
             border-radius: 0.5em;
-            height: 25px;
-            width: 25px;
+            height: 1.5625rem;
+            width: 1.5625rem;
 
             &.reacted.reaction:focus {
                 background-color: hsl(195, 55%, 88%);
@@ -260,13 +260,13 @@
     .emoji-showcase-container {
         position: relative;
         background-color: hsl(0, 0%, 93%);
-        min-height: 44px;
-        width: 250px;
+        min-height: 2.75rem;
+        width: 15.625rem;
 
         .emoji-preview {
             position: absolute;
-            width: 32px;
-            height: 32px;
+            width: 2.0rem;
+            height: 2.0rem;
             left: 5px;
             top: 6px;
             margin-top: 0;
@@ -275,7 +275,7 @@
         .emoji-canonical-name {
             position: relative;
             top: 12px;
-            margin-left: 50px;
+            margin-left: 3.125rem;
             font-size: 1rem;
             font-weight: 600;
             white-space: nowrap;
@@ -291,7 +291,7 @@
     font-size: 0.8em;
     display: inline-block;
     vertical-align: top;
-    margin: 0 1px 0 0;
+    margin: 0 0.0625rem 0 0;
     line-height: 1em;
 }
 

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -187,7 +187,7 @@
                 width: 25px;
                 height: 25px;
                 text-align: center;
-                font-size: 16px;
+                font-size: 1rem;
                 cursor: pointer;
                 /* Flex needed here to work around #7511 (90% zoom issues in firefox) */
                 flex-grow: 1;
@@ -215,7 +215,7 @@
             .emoji-popover-results-heading {
                 font-weight: 600;
                 padding: 5px 3px 3px 5px;
-                font-size: 17px;
+                font-size: 1.0625rem;
             }
         }
 
@@ -276,7 +276,7 @@
             position: relative;
             top: 12px;
             margin-left: 50px;
-            font-size: 16px;
+            font-size: 1rem;
             font-weight: 600;
             white-space: nowrap;
             text-overflow: ellipsis;

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -1,5 +1,5 @@
 .message_reactions {
-    padding-left: 46px;
+    padding-left: 2.875rem;
     overflow: hidden;
 
     user-select: none;
@@ -167,7 +167,7 @@
 
             .emoji-popover-filter {
                 margin: auto;
-                padding-left: 22px;
+                padding-left: 1.375rem;
                 width: calc(100% - 22px - 8px);
                 font-size: 90%;
             }
@@ -183,7 +183,7 @@
 
             .emoji-popover-tab-item {
                 display: inline-block;
-                padding-top: 8px;
+                padding-top: 0.5rem;
                 width: 25px;
                 height: 25px;
                 text-align: center;
@@ -206,7 +206,7 @@
             overflow-y: auto;
             display: block;
             width: 247px;
-            padding-left: 3px;
+            padding-left: 0.1875rem;
         }
 
         .emoji-search-results-container {

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -7,7 +7,7 @@
     .message_reaction {
         float: left;
         margin: 0.15em;
-        padding: 0 2px 0 0;
+        padding: 0 0.125rem 0 0;
         height: 19px;
         cursor: pointer;
         background-color: hsl(0, 0%, 100%);
@@ -26,7 +26,7 @@
             visibility: hidden;
             pointer-events: none;
             margin: 2px 0.1em 3px 0.1em;
-            padding: 3px;
+            padding: 0.1875rem;
             height: 14px;
             border-radius: 4px;
             padding-left: 0.3em;
@@ -150,7 +150,7 @@
         .emoji-popover-top {
             position: relative;
 
-            padding: 8px 10px;
+            padding: 0.5rem 0.625rem;
             margin-bottom: 0;
 
             background-color: hsl(0, 0%, 93%);
@@ -214,7 +214,7 @@
 
             .emoji-popover-results-heading {
                 font-weight: 600;
-                padding: 5px 3px 3px 5px;
+                padding: 0.3125rem 0.1875rem 0.1875rem 0.3125rem;
                 font-size: 1.0625rem;
             }
         }
@@ -224,14 +224,14 @@
 
             .emoji-popover-subheading {
                 font-weight: 600;
-                padding: 5px 3px;
+                padding: 0.3125rem 0.1875rem;
             }
         }
 
         .emoji-popover-emoji {
             display: inline-block;
             margin: 0;
-            padding: 6px;
+            padding: 0.375rem;
             cursor: pointer;
             border-radius: 0.5em;
             height: 25px;

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -22,8 +22,8 @@
     }
 
     .recent_topics_header {
-        padding-top: 4px;
-        padding-bottom: 8px;
+        padding-top: 0.25rem;
+        padding-bottom: 0.5rem;
         text-align: center;
         border-bottom: 1px solid hsl(0, 0%, 87%);
 
@@ -98,7 +98,7 @@
         }
 
         .fa-lock {
-            padding-right: 3px;
+            padding-right: 0.1875rem;
         }
 
         .table_fix_head {
@@ -132,7 +132,7 @@
 
         .clear_search_button {
             /* Overrides app_components.css property. */
-            padding-top: 6px !important;
+            padding-top: 0.375rem !important;
         }
 
         .btn-recent-filters {
@@ -253,7 +253,7 @@
                 white-space: pre;
                 display: inline-block;
                 position: absolute;
-                padding-top: 3px;
+                padding-top: 0.1875rem;
                 font: normal normal normal 12px/1 FontAwesome;
                 font-size: inherit;
             }

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -2,8 +2,8 @@
     position: relative;
     height: 95%;
     width: 70%;
-    max-width: 1200px;
-    max-height: 1000px;
+    max-width: 75.0rem;
+    max-height: 62.5rem;
     padding: 0;
     border-radius: 4px;
     background-color: hsl(0, 0%, 100%);
@@ -44,7 +44,7 @@
             .exit-sign {
                 position: relative;
                 top: 3px;
-                margin-left: 3px;
+                margin-left: 0.1875rem;
                 font-size: 1.5rem;
                 font-weight: 600;
                 cursor: pointer;
@@ -114,7 +114,7 @@
         }
 
         #recent_topics_filter_buttons {
-            margin: 0 10px 0 10px;
+            margin: 0 0.625rem 0 0.625rem;
             display: flex;
             flex-wrap: wrap;
             justify-content: flex-start;
@@ -123,7 +123,7 @@
         .search_group {
             display: flex;
             flex-grow: 1;
-            margin: 0 0 10px 0;
+            margin: 0 0 0.625rem 0;
         }
 
         #recent_topics_search {
@@ -137,7 +137,7 @@
 
         .btn-recent-filters {
             border-radius: 40px;
-            margin: 0 5px 10px 0;
+            margin: 0 0.3125rem 0.625rem 0;
 
             &:focus {
                 background-color: hsl(0, 0%, 80%);
@@ -152,14 +152,14 @@
         .recent_topic_unread_count {
             background-color: hsl(105, 2%, 50%) !important;
             color: hsl(0, 0%, 100%);
-            height: 16px;
-            line-height: 16px;
+            height: 1.0rem;
+            line-height: 1.0rem;
             font-size: 0.75rem;
             font-weight: 400;
             letter-spacing: 0.6px;
             border-radius: 4px;
             padding: 0 0.25rem;
-            margin-right: 10px;
+            margin-right: 0.625rem;
             align-self: center;
         }
 
@@ -186,7 +186,7 @@
             display: inline-flex; /* Causes LI items to display in row. */
             list-style-type: none;
             margin: auto; /* Centers vertically / horizontally in flex container. */
-            height: 24px;
+            height: 1.5rem;
             padding: 0.25rem;
             border-radius: 6px;
             overflow: hidden;
@@ -202,11 +202,11 @@
         }
 
         .recent_avatars_item {
-            height: 24px;
+            height: 1.5rem;
             margin: 0;
             padding: 0 1.0.3125rem 0 1.0.3125rem;
             position: relative;
-            min-width: 24px;
+            min-width: 1.5rem;
         }
 
         .recent_avatars_img,
@@ -215,14 +215,14 @@
             border-radius: 6px;
             color: hsl(0, 0%, 100%);
             display: block;
-            height: 24px;
+            height: 1.5rem;
             text-align: center;
             background-color: hsl(0, 0%, 88%);
         }
 
         .recent_avatars_others {
             color: hsl(0, 0%, 0%);
-            line-height: 24px;
+            line-height: 1.5rem;
         }
 
         tr {
@@ -235,7 +235,7 @@
 
         .last_msg_time {
             float: left;
-            margin-right: 5px;
+            margin-right: 0.3125rem;
         }
 
         thead th {

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -54,14 +54,14 @@
 
     .recent_topics_table {
         margin: 0;
-        padding: 15px;
+        padding: 0.9375rem;
         overflow: hidden !important;
         display: flex;
         flex-direction: column;
 
         td {
             vertical-align: middle;
-            padding: 3px 8px 3px 8px;
+            padding: 0.1875rem 0.5rem 0.1875rem 0.5rem;
         }
 
         .recent_topics_focusable {
@@ -94,7 +94,7 @@
 
         .fa-check-square-o,
         .fa-square-o {
-            padding: 0 2px 0 2px;
+            padding: 0 0.125rem 0 0.125rem;
         }
 
         .fa-lock {
@@ -102,7 +102,7 @@
         }
 
         .table_fix_head {
-            padding: 10px;
+            padding: 0.625rem;
             padding-top: 0 !important;
             overflow-y: auto;
             max-height: 89%;
@@ -158,7 +158,7 @@
             font-weight: 400;
             letter-spacing: 0.6px;
             border-radius: 4px;
-            padding: 0 4px;
+            padding: 0 0.25rem;
             margin-right: 10px;
             align-self: center;
         }
@@ -187,7 +187,7 @@
             list-style-type: none;
             margin: auto; /* Centers vertically / horizontally in flex container. */
             height: 24px;
-            padding: 4px;
+            padding: 0.25rem;
             border-radius: 6px;
             overflow: hidden;
 
@@ -204,7 +204,7 @@
         .recent_avatars_item {
             height: 24px;
             margin: 0;
-            padding: 0 1.5px 0 1.5px;
+            padding: 0 1.0.3125rem 0 1.0.3125rem;
             position: relative;
             min-width: 24px;
         }

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -154,7 +154,7 @@
             color: hsl(0, 0%, 100%);
             height: 16px;
             line-height: 16px;
-            font-size: 12px;
+            font-size: 0.75rem;
             font-weight: 400;
             letter-spacing: 0.6px;
             border-radius: 4px;

--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -47,7 +47,7 @@
     h4,
     h5,
     h6 {
-        font-size: 14px;
+        font-size: 0.875rem;
         font-weight: 600;
         line-height: 1.4;
         margin-top: 0;
@@ -265,7 +265,7 @@
         height: 40px;
         border: none;
         border-radius: 3px;
-        font-size: 25px;
+        font-size: 1.5625rem;
         color: hsl(0, 0%, 100%);
     }
 
@@ -362,7 +362,7 @@
         position: absolute;
         margin: var(--margin-top, 32px) 0 0 var(--margin-left, 45px);
         padding: 5px 8px 5px 10px;
-        font-size: 12px;
+        font-size: 0.75rem;
         border-radius: 4px;
         background-color: hsl(0, 0%, 0%);
         color: hsl(0, 0%, 100%);

--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -2,42 +2,42 @@
     /* The default top/bottom margins for paragraphs are small, to make sure
        they look nice next to blockquotes, lists, etc. */
     p {
-        margin: 3px 0 3px 0;
+        margin: 0.1875rem 0 0.1875rem 0;
     }
 
     /* The spacing between two paragraphs is significantly larger.  We
        arrange things so that this spacing matches the spacing between
        paragraphs in two consecutive 1-line messages. */
     p + p {
-        margin-top: 10px;
+        margin-top: 0.625rem;
     }
 
     /* Ensure bulleted lists are nicely centered in 1-line messages */
     ul {
-        margin: 2px 0 5px 20px;
+        margin: 0.125rem 0 0.3125rem 1.25rem;
     }
 
     /* Swap the left and right margins of bullets for Right-To-Left languages */
     &.rtl ul {
-        margin-right: 20px;
+        margin-right: 1.25rem;
         margin-left: 0;
     }
 
     /* Ensure ordered lists are nicely centered in 1-line messages */
     ol {
-        margin: 2px 0 5px 20px;
+        margin: 0.125rem 0 0.3125rem 1.25rem;
     }
 
     /* Swap the left and right margins of ordered list for Right-To-Left languages */
     &.rtl ol {
-        margin-right: 8px;
+        margin-right: 0.5rem;
         margin-left: 0;
     }
 
     /* Reduce top-margin when a paragraph is followed by an ordered or bulleted list */
     p + ul,
     p + ol {
-        margin-top: -3px;
+        margin-top: -0.1875rem;
     }
 
     /* Headings: We need to make sure our headings are less prominent than our sender names styling. */
@@ -51,16 +51,16 @@
         font-weight: 600;
         line-height: 1.4;
         margin-top: 0;
-        margin-bottom: 5px;
+        margin-bottom: 0.3125rem;
         text-decoration: underline;
     }
 
     /* Formatting for blockquotes */
     blockquote {
         padding-left: 0.3125rem;
-        margin-left: 10px;
-        margin-top: 5px;
-        margin-bottom: 6px;
+        margin-left: 0.625rem;
+        margin-top: 0.3125rem;
+        margin-bottom: 0.375rem;
         border-left-color: hsl(0, 0%, 87%);
 
         p {
@@ -73,7 +73,7 @@
         padding-left: unset;
         padding-right: 0.3125rem;
         margin-left: unset;
-        margin-right: 10px;
+        margin-right: 0.625rem;
         border-left: unset;
         border-right: 5px solid hsl(0, 0%, 87%);
     }
@@ -81,7 +81,7 @@
     /* Formatting for Markdown tables */
     table {
         padding-right: 0.625rem;
-        margin: 5px 5px 5px 5px;
+        margin: 0.3125rem 0.3125rem 0.3125rem 0.3125rem;
         width: 99%;
         display: block;
         max-width: fit-content;
@@ -111,8 +111,8 @@
 
     /* Emoji; sized to be easily understood while not overwhelming text. */
     .emoji {
-        height: 20px;
-        width: 20px;
+        height: 1.25rem;
+        width: 1.25rem;
     }
 
     /* Mentions and alert words */
@@ -125,8 +125,8 @@
         border-radius: 3px;
         padding: 0 0.2em;
         box-shadow: 0 0 0 1px hsl(0, 0%, 80%);
-        margin-right: 2px;
-        margin-left: 2px;
+        margin-right: 0.125rem;
+        margin-left: 0.125rem;
         white-space: nowrap;
         background: linear-gradient(
             to bottom,
@@ -134,7 +134,7 @@
             hsla(0, 0%, 0%, 0) 100%
         );
         display: inline-block;
-        margin-bottom: 1px;
+        margin-bottom: 0.0625rem;
     }
 
     .alert-word {
@@ -148,10 +148,10 @@
         padding: 0 0.2em;
         box-shadow: 0 0 0 1px hsl(0, 0%, 80%);
         white-space: nowrap;
-        margin-left: 2px;
-        margin-right: 2px;
+        margin-left: 0.125rem;
+        margin-right: 0.125rem;
         display: inline-block;
-        margin-bottom: 1px;
+        margin-bottom: 0.0625rem;
     }
 
     /* LaTeX styling */
@@ -171,7 +171,7 @@
         position: relative;
         top: 1px;
         display: block;
-        margin: 5px 0 15px 0;
+        margin: 0.3125rem 0 0.9375rem 0;
 
         .spoiler-header {
             padding: 0.3125rem;
@@ -197,8 +197,8 @@
 
         .spoiler-button {
             float: right;
-            width: 25px;
-            height: 25px;
+            width: 1.5625rem;
+            height: 1.5625rem;
             &:hover .spoiler-arrow {
                 &::before,
                 &::after {
@@ -209,14 +209,14 @@
 
         .spoiler-arrow {
             float: right;
-            width: 13px;
-            height: 13px;
+            width: 0.8125rem;
+            height: 0.8125rem;
             position: relative;
             bottom: -5px;
             left: -10px;
             cursor: pointer;
             transition: 0.4s ease;
-            margin-top: 2px;
+            margin-top: 0.125rem;
             text-align: left;
             transform: rotate(45deg);
             &::before,
@@ -224,8 +224,8 @@
                 position: absolute;
                 content: "";
                 display: inline-block;
-                width: 12px;
-                height: 3px;
+                width: 0.75rem;
+                height: 0.1875rem;
                 background-color: hsl(0, 0%, 83%);
                 transition: 0.4s ease;
             }
@@ -249,20 +249,20 @@
 
     /* CSS for message content widgets */
     table.tictactoe {
-        width: 80px;
+        width: 5.0rem;
         margin-left: 0;
     }
 
     td.tictactoe {
-        width: 15px;
+        width: 0.9375rem;
         border: none;
         padding: 0.125rem;
     }
 
     button.tictactoe-square {
         background-color: hsl(156, 30%, 62%);
-        width: 40px;
-        height: 40px;
+        width: 2.5rem;
+        height: 2.5rem;
         border: none;
         border-radius: 3px;
         font-size: 1.5625rem;
@@ -285,9 +285,9 @@
     .twitter-image,
     .message_inline_image {
         position: relative;
-        margin-bottom: 5px;
-        margin-left: 5px;
-        height: 100px;
+        margin-bottom: 0.3125rem;
+        margin-left: 0.3125rem;
+        height: 6.25rem;
         display: block !important;
         border: none !important;
     }
@@ -295,7 +295,7 @@
     &.rtl .twitter-image,
     &.rtl .message_inline_image {
         margin-left: unset;
-        margin-right: 5px;
+        margin-right: 0.3125rem;
     }
 
     .twitter-tweet {
@@ -303,27 +303,27 @@
         padding: 0.5em 0.75em;
         margin-bottom: 0.25em;
         word-break: break-word;
-        min-height: 48px;
+        min-height: 3.0rem;
     }
 
     .twitter-avatar {
         float: left;
-        width: 48px;
-        height: 48px;
+        width: 3.0rem;
+        height: 3.0rem;
         margin-right: 0.75em;
     }
 
     .message_inline_ref {
-        margin-bottom: 5px;
-        margin-left: 5px;
-        height: 50px;
+        margin-bottom: 0.3125rem;
+        margin-left: 0.3125rem;
+        height: 3.125rem;
         display: block !important;
         border: none !important;
     }
 
     &.rtl .message_inline_ref {
         margin-left: unset;
-        margin-right: 5px;
+        margin-right: 0.3125rem;
     }
 
     .twitter-image img,
@@ -332,7 +332,7 @@
         height: auto;
         max-height: 100%;
         float: left;
-        margin-right: 10px;
+        margin-right: 0.625rem;
     }
 
     .message_inline_image img {
@@ -350,7 +350,7 @@
     &.rtl .message_inline_ref img {
         float: right;
         margin-right: unset;
-        margin-left: 10px;
+        margin-left: 0.625rem;
     }
 
     li .message_inline_image img {
@@ -360,7 +360,7 @@
     .youtube-video .fa-play::before,
     .embed-video .fa-play::before {
         position: absolute;
-        margin: var(--margin-top, 32px) 0 0 var(--margin-left, 45px);
+        margin: var(--margin-top, 2.0rem) 0 0 var(--margin-left, 2.8125rem);
         padding: 0.3125rem 0.5rem 0.3125rem 0.625rem;
         font-size: 0.75rem;
         border-radius: 4px;
@@ -374,10 +374,10 @@
     .message_embed {
         display: block;
         position: relative;
-        margin: 5px 0;
+        margin: 0.3125rem 0;
         border: none;
         border-left: 3px solid hsl(0, 0%, 93%);
-        height: 80px;
+        height: 5.0rem;
         padding: 0.3125rem;
         z-index: 1;
         text-shadow: hsla(0, 0%, 0%, 0.01) 0 0 1px;
@@ -385,7 +385,7 @@
         .message_embed_title {
             padding-top: 0;
             /* to remove the spacing that the font has from the top of the container. */
-            margin-top: -5px;
+            margin-top: -0.3125rem;
 
             font-size: 1.2em;
             line-height: normal;
@@ -393,8 +393,8 @@
 
         .message_embed_description {
             position: relative;
-            max-width: 500px;
-            margin-top: 3px;
+            max-width: 31.25rem;
+            margin-top: 0.1875rem;
 
             /* to put it below the container gradient. */
             z-index: -1;
@@ -402,8 +402,8 @@
 
         .message_embed_image {
             display: inline-block;
-            width: 70px;
-            height: 70px;
+            width: 4.375rem;
+            height: 4.375rem;
             background-size: cover;
             background-position: center;
         }
@@ -413,8 +413,8 @@
             padding: 0 0.3125rem;
             display: inline-block;
             vertical-align: top;
-            max-width: calc(100% - 115px);
-            max-height: 80px;
+            max-width: calc(100% - 7.1875rem);
+            max-height: 5.0rem;
             overflow: hidden;
         }
 
@@ -463,14 +463,14 @@
         doesn't scroll along with the code div in narrow windows */
         position: absolute;
         right: 2px;
-        margin-top: -6px;
+        margin-top: -0.375rem;
     }
 
     .code_external_link {
         visibility: hidden;
         position: absolute;
         right: 23px;
-        margin-top: -2px;
+        margin-top: -0.125rem;
         font-size: 1.4em;
         /* The default icon and on-hover colors are inherited from <a> tag.
         so we set our own to match the copy-to-clipbord icon */
@@ -500,13 +500,13 @@
 
         .message_embed_image {
             width: 100%;
-            height: 100px;
+            height: 6.25rem;
         }
 
         .data-container {
             display: block;
             max-width: 100%;
-            margin-top: 10px;
+            margin-top: 0.625rem;
         }
     }
 }
@@ -548,8 +548,8 @@ pre {
     overflow-x: auto;
     word-wrap: normal;
     /* Bootstrap's default here is top: 0px, bottom: 10px */
-    margin-top: 5px;
-    margin-bottom: 5px;
+    margin-top: 0.3125rem;
+    margin-bottom: 0.3125rem;
     /* Bootstrap's default here is 9.5 on all sides */
     padding-top: 0.3125rem;
     padding-bottom: 0.1875rem;
@@ -569,8 +569,8 @@ pre {
 pre {
     /* Ensure the horizontal scrollbar is visible on Mac */
     &::-webkit-scrollbar {
-        height: 8px;
-        width: 10px;
+        height: 0.5rem;
+        width: 0.625rem;
         background-color: hsla(0, 0%, 0%, 0.05);
     }
 

--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -100,13 +100,13 @@
 
     tr th {
         border: 1px solid hsl(0, 0%, 80%);
-        padding: 4px;
+        padding: 0.25rem;
         text-align: left;
     }
 
     tr td {
         border: 1px solid hsl(0, 0%, 80%);
-        padding: 4px;
+        padding: 0.25rem;
     }
 
     /* Emoji; sized to be easily understood while not overwhelming text. */
@@ -166,7 +166,7 @@
     /* Spoiler styling */
     .spoiler-block {
         border: hsl(0, 0%, 50%) 1px solid;
-        padding: 2px 8px 2px 10px;
+        padding: 0.125rem 0.5rem 0.125rem 0.625rem;
         border-radius: 10px;
         position: relative;
         top: 1px;
@@ -174,7 +174,7 @@
         margin: 5px 0 15px 0;
 
         .spoiler-header {
-            padding: 5px;
+            padding: 0.3125rem;
             font-weight: bold;
         }
 
@@ -190,7 +190,7 @@
                 border-top: hsl(0, 0%, 50%) 1px solid;
                 transition: height 0.4s ease-in-out, border-top 0.4s step-start,
                     padding 0.4s step-start;
-                padding: 5px;
+                padding: 0.3125rem;
                 height: auto;
             }
         }
@@ -256,7 +256,7 @@
     td.tictactoe {
         width: 15px;
         border: none;
-        padding: 2px;
+        padding: 0.125rem;
     }
 
     button.tictactoe-square {
@@ -361,7 +361,7 @@
     .embed-video .fa-play::before {
         position: absolute;
         margin: var(--margin-top, 32px) 0 0 var(--margin-left, 45px);
-        padding: 5px 8px 5px 10px;
+        padding: 0.3125rem 0.5rem 0.3125rem 0.625rem;
         font-size: 0.75rem;
         border-radius: 4px;
         background-color: hsl(0, 0%, 0%);
@@ -378,7 +378,7 @@
         border: none;
         border-left: 3px solid hsl(0, 0%, 93%);
         height: 80px;
-        padding: 5px;
+        padding: 0.3125rem;
         z-index: 1;
         text-shadow: hsla(0, 0%, 0%, 0.01) 0 0 1px;
 
@@ -410,7 +410,7 @@
 
         .data-container {
             position: relative;
-            padding: 0 5px;
+            padding: 0 0.3125rem;
             display: inline-block;
             vertical-align: top;
             max-width: calc(100% - 115px);
@@ -445,7 +445,7 @@
 
     .message_embed > * {
         display: inherit;
-        padding: 5px;
+        padding: 0.3125rem;
         border: none;
     }
 
@@ -529,7 +529,7 @@ code {
 
 .rendered_markdown code {
     white-space: pre-wrap;
-    padding: 0 4px;
+    padding: 0 0.25rem;
     background-color: hsl(0, 0%, 100%);
 }
 

--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -57,7 +57,7 @@
 
     /* Formatting for blockquotes */
     blockquote {
-        padding-left: 5px;
+        padding-left: 0.3125rem;
         margin-left: 10px;
         margin-top: 5px;
         margin-bottom: 6px;
@@ -71,7 +71,7 @@
 
     &.rtl blockquote {
         padding-left: unset;
-        padding-right: 5px;
+        padding-right: 0.3125rem;
         margin-left: unset;
         margin-right: 10px;
         border-left: unset;
@@ -80,7 +80,7 @@
 
     /* Formatting for Markdown tables */
     table {
-        padding-right: 10px;
+        padding-right: 0.625rem;
         margin: 5px 5px 5px 5px;
         width: 99%;
         display: block;
@@ -551,10 +551,10 @@ pre {
     margin-top: 5px;
     margin-bottom: 5px;
     /* Bootstrap's default here is 9.5 on all sides */
-    padding-top: 5px;
-    padding-bottom: 3px;
-    padding-left: 7px;
-    padding-right: 7px;
+    padding-top: 0.3125rem;
+    padding-bottom: 0.1875rem;
+    padding-left: 0.4375rem;
+    padding-right: 0.4375rem;
 }
 
 .rendered_markdown pre code {

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -1,5 +1,5 @@
 .right-sidebar {
-    font-size: 14px;
+    font-size: 0.875rem;
 
     a:hover {
         text-decoration: none;
@@ -120,7 +120,7 @@
         padding: 0 4px;
         background-color: hsl(105, 2%, 50%);
         color: hsl(0, 0%, 100%);
-        font-size: 12px;
+        font-size: 0.75rem;
         line-height: 14px;
         height: 15px;
         font-weight: normal;
@@ -178,7 +178,7 @@
     }
 
     #user_filter_icon {
-        font-size: 13px;
+        font-size: 0.8125rem;
         opacity: 0.5;
         margin-right: 5px;
     }
@@ -188,7 +188,7 @@
     position: fixed;
     bottom: 8px; /* bottom padding of .compose-content */
     cursor: pointer;
-    font-size: 20px;
+    font-size: 1.25rem;
 }
 
 #sidebar-keyboard-shortcuts {

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -34,7 +34,7 @@
             font-size: 1em;
             display: none;
             text-align: center;
-            padding: 0 6px 0 6px;
+            padding: 0 0.375rem 0 0.375rem;
 
             i {
                 padding-right: 0.25em;
@@ -117,7 +117,7 @@
 
     .count {
         float: right;
-        padding: 0 4px;
+        padding: 0 0.25rem;
         background-color: hsl(105, 2%, 50%);
         color: hsl(0, 0%, 100%);
         font-size: 0.75rem;

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -23,9 +23,9 @@
         text-overflow: ellipsis;
         list-style-type: none;
         border-radius: 4px;
-        padding-right: 15px;
-        padding-top: 1px;
-        padding-bottom: 2px;
+        padding-right: 0.9375rem;
+        padding-top: 0.0625rem;
+        padding-bottom: 0.125rem;
 
         .user-list-sidebar-menu-icon {
             position: absolute;
@@ -153,8 +153,8 @@
     display: block;
     width: 45px;
     height: 19px;
-    padding-top: 12px;
-    padding-bottom: 9px;
+    padding-top: 0.75rem;
+    padding-bottom: 0.5625rem;
 
     &:hover {
         color: inherit;

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -39,7 +39,7 @@
             i {
                 padding-right: 0.25em;
                 display: inline-block;
-                width: 13px;
+                width: 0.8125rem;
                 vertical-align: middle;
             }
 
@@ -65,12 +65,12 @@
     }
 
     .user_circle {
-        width: 8px;
-        height: 8px;
+        width: 0.5rem;
+        height: 0.5rem;
         margin-top: 0;
         margin-bottom: 0;
-        margin-left: 5px;
-        margin-right: 5px;
+        margin-left: 0.3125rem;
+        margin-right: 0.3125rem;
         display: block;
     }
 
@@ -82,8 +82,8 @@
 
 #invite-user-link i {
     text-decoration: none;
-    margin-right: 3px;
-    margin-left: 5px;
+    margin-right: 0.1875rem;
+    margin-left: 0.3125rem;
 }
 
 .user-presence-link,
@@ -93,13 +93,13 @@
 }
 
 .user_sidebar_entry .selectable_sidebar_block {
-    width: calc(100% - 16px);
+    width: calc(100% - 1.0rem);
     display: flex;
     flex-direction: row;
 }
 
 .user-presence-link {
-    width: calc(100% - 24px);
+    width: calc(100% - 1.5rem);
 }
 
 .my_user_status {
@@ -121,14 +121,14 @@
         background-color: hsl(105, 2%, 50%);
         color: hsl(0, 0%, 100%);
         font-size: 0.75rem;
-        line-height: 14px;
-        height: 15px;
+        line-height: 0.875rem;
+        height: 0.9375rem;
         font-weight: normal;
         letter-spacing: 0.6px;
         position: relative;
         top: 3px;
         border-radius: 4px;
-        margin-left: 5px;
+        margin-left: 0.3125rem;
         display: none;
     }
 
@@ -151,8 +151,8 @@
     text-decoration: none;
     color: hsl(0, 0%, 60%);
     display: block;
-    width: 45px;
-    height: 19px;
+    width: 2.8125rem;
+    height: 1.1875rem;
     padding-top: 0.75rem;
     padding-bottom: 0.5625rem;
 
@@ -171,7 +171,7 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    margin-right: 10px;
+    margin-right: 0.625rem;
 
     #userlist-title {
         margin: 0;
@@ -180,7 +180,7 @@
     #user_filter_icon {
         font-size: 0.8125rem;
         opacity: 0.5;
-        margin-right: 5px;
+        margin-right: 0.3125rem;
     }
 }
 
@@ -213,18 +213,18 @@
 @media (max-width: 775px) {
     #user_search_section .user-list-filter {
         /* input should be 100% - 6px padding x2 - 1px border x2. */
-        width: calc(100% - 12px - 2px);
+        width: calc(100% - 0.75rem - 0.125rem);
     }
 }
 
 @media (max-width: 500px) {
     #userlist-toggle {
-        height: 30px;
-        line-height: 30px;
+        height: 1.875rem;
+        line-height: 1.875rem;
     }
 
     #userlist-toggle-button {
-        height: 30px;
+        height: 1.875rem;
         padding-top: 0;
         padding-bottom: 0;
     }

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -139,7 +139,7 @@ h3 .fa-question-circle-o {
     margin-right: 4px;
 
     i {
-        font-size: 22px;
+        font-size: 1.375rem;
         cursor: pointer;
     }
 }
@@ -315,7 +315,7 @@ td .button {
     }
 
     .loading_indicator_text {
-        font-size: 12px;
+        font-size: 0.75rem;
         font-weight: 400;
         vertical-align: middle;
         line-height: 20px;
@@ -513,7 +513,7 @@ input[type="checkbox"] {
     margin-left: 10px;
     color: hsl(156, 30%, 50%);
     padding: 3px 10px;
-    font-size: 15px;
+    font-size: 0.9375rem;
 
     &:not(:empty) {
         border: 1px solid hsl(156, 30%, 50%);
@@ -587,7 +587,7 @@ input[type="checkbox"] {
         padding-top: 0;
         padding-bottom: 0;
         margin-top: 0;
-        font-size: 14px;
+        font-size: 0.875rem;
         padding-left: 0;
         margin-left: 5px;
         border: none;
@@ -863,7 +863,7 @@ input[type="checkbox"] {
 
 .edit_bot_email {
     font-weight: 400;
-    font-size: 18px;
+    font-size: 1.125rem;
     text-align: left;
     margin-top: 0;
     margin-bottom: 10px;
@@ -1093,7 +1093,7 @@ input[type="checkbox"] {
     .save-discard-widget-button {
         border-radius: 5px;
         border: 1px solid hsl(0, 0%, 80%);
-        font-size: 14px;
+        font-size: 0.875rem;
         padding: 3px 14px 4px 11px;
         text-decoration: none;
         color: hsl(0, 0%, 47%);
@@ -1135,7 +1135,7 @@ input[type="checkbox"] {
             vertical-align: bottom;
             margin-right: 3px;
             margin-bottom: 1px;
-            font-size: 15px;
+            font-size: 0.9375rem;
             font-weight: 500;
         }
     }

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -42,22 +42,22 @@ h3 .fa-question-circle-o {
         width: 70%;
     }
     .w-200 {
-        width: 200px;
+        width: 12.5rem;
     }
     .m-t-20 {
-        margin-top: 20px;
+        margin-top: 1.25rem;
     }
     .m-t-10 {
-        margin-top: 10px;
+        margin-top: 0.625rem;
     }
     .grid {
         label {
-            min-width: 200px;
+            min-width: 12.5rem;
         }
         .warning {
             display: inline-block;
             vertical-align: top;
-            width: 150px;
+            width: 9.375rem;
             padding: 0.3125rem 0.625rem;
             text-align: left;
         }
@@ -65,20 +65,20 @@ h3 .fa-question-circle-o {
     #account-settings {
         .grid {
             label {
-                min-width: 120px;
+                min-width: 7.5rem;
             }
             .warning {
                 display: block;
-                width: calc(100% - 20px - 5px);
+                width: calc(100% - 1.25rem - 0.3125rem);
                 text-align: right;
             }
         }
     }
     .warning {
         #pw_strength {
-            width: 140px;
-            height: 8px;
-            margin: 6px 0 0 0;
+            width: 8.75rem;
+            height: 0.5rem;
+            margin: 0.375rem 0 0 0;
         }
     }
     .button {
@@ -86,14 +86,14 @@ h3 .fa-question-circle-o {
             text-align: left;
         }
         &.button i.fa.fa-pencil {
-            margin-left: 3px;
+            margin-left: 0.1875rem;
         }
     }
     /* this is because the input[type=text] is also 200px wide but has
     12px of padding and 2px worth of borders. These don't apply to
     buttons however. */
     .input-size {
-        width: 214px;
+        width: 13.375rem;
     }
 }
 
@@ -101,7 +101,7 @@ h3 .fa-question-circle-o {
     float: right;
 
     .avatar-controls {
-        margin-top: 20px;
+        margin-top: 1.25rem;
         box-shadow: none;
     }
 
@@ -111,17 +111,17 @@ h3 .fa-question-circle-o {
 }
 
 #change_email_modal {
-    max-width: 460px;
+    max-width: 28.75rem;
 }
 
 #change_full_name_modal {
-    max-width: 480px;
+    max-width: 30.0rem;
 }
 
 .admin-realm-description {
     height: 16em;
     width: 100%;
-    max-width: 500px;
+    max-width: 31.25rem;
     box-sizing: border-box;
 }
 
@@ -136,7 +136,7 @@ h3 .fa-question-circle-o {
 #notification_sound,
 #play_notification_sound {
     display: inline;
-    margin-right: 4px;
+    margin-right: 0.25rem;
 
     i {
         font-size: 1.375rem;
@@ -145,7 +145,7 @@ h3 .fa-question-circle-o {
 }
 
 .attributions_title {
-    margin-top: 24px;
+    margin-top: 1.5rem;
 }
 
 .table {
@@ -193,7 +193,7 @@ h3 .fa-question-circle-o {
 }
 
 td .button {
-    margin: 2px 0;
+    margin: 0.125rem 0;
     box-shadow: none;
 }
 
@@ -213,8 +213,8 @@ td .button {
 
 .settings-section {
     display: none;
-    width: calc(100% - 40px);
-    margin: 20px;
+    width: calc(100% - 2.5rem);
+    margin: 1.25rem;
 
     &.show {
         display: block;
@@ -231,7 +231,7 @@ td .button {
     .settings-section-title {
         font-size: 1.4em;
         font-weight: 500;
-        margin: 10px 0 10px 0;
+        margin: 0.625rem 0 0.625rem 0;
 
         &.transparent {
             background-color: transparent;
@@ -241,10 +241,10 @@ td .button {
         .table-title {
             display: inline-block;
             padding: 0.375rem 0;
-            margin-left: 5px;
+            margin-left: 0.3125rem;
 
             i {
-                margin-right: 5px;
+                margin-right: 0.3125rem;
             }
         }
     }
@@ -302,7 +302,7 @@ td .button {
 
     input[type="text"].search {
         float: right;
-        margin: 2px 5px 2px 0;
+        margin: 0.125rem 0.3125rem 0.125rem 0;
         padding: 0.125rem 0.3125rem;
         font-size: 0.9em;
     }
@@ -318,16 +318,16 @@ td .button {
         font-size: 0.75rem;
         font-weight: 400;
         vertical-align: middle;
-        line-height: 20px;
+        line-height: 1.25rem;
         display: inline-block;
         float: none;
-        margin-top: 9px;
+        margin-top: 0.5625rem;
     }
 
     .loading_indicator_spinner {
         width: 30%;
-        height: 30px;
-        margin-top: 7px;
+        height: 1.875rem;
+        margin-top: 0.4375rem;
         vertical-align: middle;
         display: inline-block;
     }
@@ -339,7 +339,7 @@ td .button {
     #default_language_modal {
         table {
             width: 90%;
-            margin-top: 20px;
+            margin-top: 1.25rem;
         }
 
         td {
@@ -366,7 +366,7 @@ td .button {
     border: 1px solid hsl(0, 0%, 80%);
     border-radius: 3px;
     transition: box-shadow 0.3s ease;
-    min-width: 208px;
+    min-width: 13.0rem;
 
     &:hover {
         outline: none;
@@ -380,7 +380,7 @@ td .button {
     }
 
     div {
-        margin-right: -2px;
+        margin-right: -0.125rem;
 
         &:empty::after {
             content: "username";
@@ -400,12 +400,12 @@ td .button {
 
 .button,
 .input-group {
-    margin: 0 0 20px 0;
+    margin: 0 0 1.25rem 0;
 }
 
 .input-group {
     .thinner {
-        margin: 10px 0;
+        margin: 0.625rem 0;
     }
 
     label.checkbox + label {
@@ -414,12 +414,12 @@ td .button {
 }
 
 .dependent-block {
-    margin: -5px 0 15px 35px;
+    margin: -0.3125rem 0 0.9375rem 2.1875rem;
 }
 
 .dependent-inline-block {
     display: inline-block;
-    margin: 0 0 0 10px !important;
+    margin: 0 0 0 0.625rem !important;
 }
 
 .no-margin {
@@ -428,11 +428,11 @@ td .button {
 
 input[type="checkbox"] {
     + .inline-block {
-        margin-left: 10px;
+        margin-left: 0.625rem;
     }
 
     .inline-block {
-        margin: -2px 0 0 0;
+        margin: -0.125rem 0 0 0;
     }
 }
 
@@ -447,7 +447,7 @@ input[type="checkbox"] {
 
 .admin-realm-form {
     h3 {
-        margin-bottom: 10px;
+        margin-bottom: 0.625rem;
     }
 
     .subsection-header h3 {
@@ -456,7 +456,7 @@ input[type="checkbox"] {
 }
 
 .organization-settings-parent > div:first-of-type {
-    margin-top: 10px;
+    margin-top: 0.625rem;
 }
 
 .org-settings-form .organization-submission {
@@ -464,19 +464,19 @@ input[type="checkbox"] {
 }
 
 #id_org_profile_preview {
-    margin-bottom: 20px;
+    margin-bottom: 1.25rem;
 }
 
 .inline-block.organization-permissions-parent div:first-of-type {
-    margin-top: 10px;
+    margin-top: 0.625rem;
 }
 
 #default_language {
-    margin-left: 20px;
+    margin-left: 1.25rem;
 }
 
 .remove-attachment {
-    margin-right: 5px !important;
+    margin-right: 0.3125rem !important;
     font-size: 1.1em !important;
     padding-left: 0 !important;
 }
@@ -489,7 +489,7 @@ input[type="checkbox"] {
 .alert-word-information-box {
     position: relative;
     padding: 0.4375rem;
-    margin: 2px;
+    margin: 0.125rem;
     width: 50%;
 }
 
@@ -498,7 +498,7 @@ input[type="checkbox"] {
 }
 
 .remove-alert-word {
-    margin-top: 1px;
+    margin-top: 0.0625rem;
 }
 
 .alert-notification {
@@ -509,8 +509,8 @@ input[type="checkbox"] {
 
     background-color: transparent;
     border-radius: 4px;
-    margin-top: 14px;
-    margin-left: 10px;
+    margin-top: 0.875rem;
+    margin-left: 0.625rem;
     color: hsl(156, 30%, 50%);
     padding: 0.1875rem 0.625rem;
     font-size: 0.9375rem;
@@ -525,8 +525,8 @@ input[type="checkbox"] {
     }
 
     .loading_indicator_spinner {
-        width: 13px;
-        height: 20px;
+        width: 0.8125rem;
+        height: 1.25rem;
         margin: 0;
     }
 
@@ -542,14 +542,14 @@ input[type="checkbox"] {
     }
 
     img {
-        margin-right: 6px;
+        margin-right: 0.375rem;
         vertical-align: middle;
-        margin-top: -2px;
+        margin-top: -0.125rem;
     }
 }
 
 #profile-field-settings #admin-add-profile-field-status {
-    margin-top: 4px;
+    margin-top: 0.25rem;
 }
 
 #notification-settings {
@@ -589,7 +589,7 @@ input[type="checkbox"] {
         margin-top: 0;
         font-size: 0.875rem;
         padding-left: 0;
-        margin-left: 5px;
+        margin-left: 0.3125rem;
         border: none;
     }
 }
@@ -603,8 +603,8 @@ input[type="checkbox"] {
 }
 
 .disableable {
-    margin-left: 22px;
-    margin-top: -10px;
+    margin-left: 1.375rem;
+    margin-top: -0.625rem;
 }
 
 .admin-realm-message-content-delete-limit-minutes {
@@ -621,21 +621,21 @@ input[type="checkbox"] {
     text-align: center;
     width: 50%;
     margin: auto;
-    margin-bottom: 20px;
+    margin-bottom: 1.25rem;
 }
 
 .add-new-emoji-box,
 .add-new-user-group-box,
 .add-new-alert-word-box,
 .add-new-export-box {
-    margin-bottom: 20px;
+    margin-bottom: 1.25rem;
 }
 
 .add-new-emoji-box .new-emoji-form,
 .add-new-user-group-box .new-user-group-form,
 .add-new-alert-word-box .new-alert-word-form,
 .add-new-export-box {
-    margin: 10px 0;
+    margin: 0.625rem 0;
 }
 
 .add-new-emoji-box,
@@ -666,12 +666,12 @@ input[type="checkbox"] {
 .add-new-profile-field-box,
 .add-new-filter-box {
     button {
-        margin-left: calc(10em + 20px) !important;
+        margin-left: calc(10em + 1.25rem) !important;
     }
 }
 
 .grey-box .wrapper {
-    margin: 10px 0;
+    margin: 0.625rem 0;
 }
 
 .admin_profile_fields_table,
@@ -683,7 +683,7 @@ input[type="checkbox"] {
             position: relative;
             top: 1px;
             + i {
-                margin-right: 5px;
+                margin-right: 0.3125rem;
             }
         }
     }
@@ -691,18 +691,18 @@ input[type="checkbox"] {
 
 #admin-filter-pattern-status,
 #admin-filter-format-status {
-    margin: 20px 0 0 0;
+    margin: 1.25rem 0 0 0;
 }
 
 .progressive-table-wrapper {
     position: relative;
-    max-height: calc(95vh - 220px);
+    max-height: calc(95vh - 13.75rem);
     overflow: auto;
     width: 100%;
 }
 
 #admin-default-streams-list .progressive-table-wrapper {
-    max-height: calc(95vh - 280px);
+    max-height: calc(95vh - 17.5rem);
 }
 
 .bots_list {
@@ -717,7 +717,7 @@ input[type="checkbox"] {
     .name {
         font-weight: 600;
         font-size: 1.1rem;
-        margin: 7px 5px;
+        margin: 0.4375rem 0.3125rem;
 
         overflow: hidden;
         line-height: 1.3em;
@@ -727,7 +727,7 @@ input[type="checkbox"] {
 
     .regenerate_bot_api_key {
         position: relative;
-        margin-left: 5px;
+        margin-left: 0.3125rem;
         color: hsl(0, 0%, 67%);
         transition: all 0.3s ease;
 
@@ -767,9 +767,9 @@ input[type="checkbox"] {
     .bot-information-box {
         position: relative;
         display: inline-block;
-        width: calc(50% - 10px);
-        max-height: 220px;
-        margin: 5px;
+        width: calc(50% - 0.625rem);
+        max-height: 13.75rem;
+        margin: 0.3125rem;
 
         border-radius: 4px;
         box-sizing: border-box;
@@ -778,14 +778,14 @@ input[type="checkbox"] {
 
         .details {
             display: inline-block;
-            width: calc(100% - 75px);
+            width: calc(100% - 4.6875rem);
         }
     }
 
     img.avatar {
-        margin: 10px 5px 0 10px;
-        height: 50px;
-        width: 50px;
+        margin: 0.625rem 0.3125rem 0 0.625rem;
+        height: 3.125rem;
+        width: 3.125rem;
         border-radius: 4px;
         vertical-align: top;
         box-shadow: 0 0 4px hsla(0, 0%, 0%, 0.1);
@@ -793,7 +793,7 @@ input[type="checkbox"] {
 
     .email,
     .type {
-        margin-bottom: 5px;
+        margin-bottom: 0.3125rem;
     }
 
     .email .value,
@@ -823,7 +823,7 @@ input[type="checkbox"] {
 }
 
 .bot_error {
-    margin-top: 10px;
+    margin-top: 0.625rem;
     margin-bottom: 0 !important;
 }
 
@@ -837,7 +837,7 @@ input[type="checkbox"] {
 }
 
 #inactive_bots_list .bot_info .reactivate_bot {
-    margin-top: 5px;
+    margin-top: 0.3125rem;
 }
 
 .edit_bot_form_container {
@@ -853,11 +853,11 @@ input[type="checkbox"] {
         text-transform: uppercase;
         font-weight: 600;
         color: hsl(0, 0%, 67%);
-        margin-top: 5px;
+        margin-top: 0.3125rem;
     }
 
     .buttons {
-        margin: 10px 0 5px 0;
+        margin: 0.625rem 0 0.3125rem 0;
     }
 }
 
@@ -866,7 +866,7 @@ input[type="checkbox"] {
     font-size: 1.125rem;
     text-align: left;
     margin-top: 0;
-    margin-bottom: 10px;
+    margin-bottom: 0.625rem;
 
     overflow: hidden;
     max-height: 1.1em;
@@ -883,7 +883,7 @@ input[type="checkbox"] {
     .control-label {
         width: 10em;
         text-align: right;
-        margin-right: 20px;
+        margin-right: 1.25rem;
     }
 }
 
@@ -913,7 +913,7 @@ input[type="checkbox"] {
 
         &.alert-word-item:first-child {
             background: none;
-            margin-top: 8px;
+            margin-top: 0.5rem;
         }
     }
 
@@ -935,12 +935,12 @@ input[type="checkbox"] {
 }
 
 .emojiset_choices {
-    width: 250px;
+    width: 15.625rem;
     padding: 0 0.625rem;
 
     .emoji {
-        height: 22px;
-        width: 22px;
+        height: 1.375rem;
+        width: 1.375rem;
     }
 
     label {
@@ -954,7 +954,7 @@ input[type="checkbox"] {
         input[type="radio"] {
             position: relative;
             top: -2px;
-            margin: 0 5px 0 0;
+            margin: 0 0.3125rem 0 0;
 
             &:checked + span {
                 font-weight: 600;
@@ -975,7 +975,7 @@ input[type="checkbox"] {
     display: inline-flex;
 
     .regenerate_api_key {
-        margin-right: 5px;
+        margin-right: 0.3125rem;
     }
 }
 
@@ -985,12 +985,12 @@ input[type="checkbox"] {
 
 .invite-user-link i {
     text-decoration: none;
-    margin-right: 5px;
+    margin-right: 0.3125rem;
 }
 
 #user-groups {
     .user-group {
-        margin-bottom: 20px;
+        margin-bottom: 1.25rem;
         padding: 0.625rem;
         border-radius: 5px;
 
@@ -1015,7 +1015,7 @@ input[type="checkbox"] {
         span[contenteditable]:focus,
         span[contenteditable="true"]:hover {
             border-bottom: 1px solid hsl(0, 0%, 80%);
-            margin-bottom: -1px;
+            margin-bottom: -0.0625rem;
             outline: none;
         }
 
@@ -1026,7 +1026,7 @@ input[type="checkbox"] {
     }
 
     .user-group-status {
-        margin-bottom: 10px;
+        margin-bottom: 0.625rem;
     }
 
     p {
@@ -1035,7 +1035,7 @@ input[type="checkbox"] {
     }
 
     .spacer {
-        margin: 0 2px;
+        margin: 0 0.125rem;
     }
 
     .subscribers,
@@ -1058,15 +1058,15 @@ input[type="checkbox"] {
         background-color: transparent;
         padding: 0.125rem 0.3125rem;
         border-radius: 4px;
-        margin-left: 10px;
+        margin-left: 0.625rem;
         border-style: solid;
-        border-width: 1px;
+        border-width: 0.0625rem;
         display: none;
         opacity: 0;
     }
 
     .checkmark {
-        height: 12px;
+        height: 0.75rem;
     }
 
     .delete {
@@ -1085,7 +1085,7 @@ input[type="checkbox"] {
 #settings_page {
     height: 95vh;
     width: 97vw;
-    max-width: 1024px;
+    max-width: 64.0rem;
     margin: 2.5vh auto;
     overflow: hidden;
     border-radius: 4px;
@@ -1097,8 +1097,8 @@ input[type="checkbox"] {
         padding: 0.1875rem 0.875rem 0.25rem 0.6875rem;
         text-decoration: none;
         color: hsl(0, 0%, 47%);
-        min-width: 80px;
-        line-height: 16px;
+        min-width: 5.0rem;
+        line-height: 1.0rem;
 
         &:hover {
             background-color: hsl(0, 0%, 100%);
@@ -1133,8 +1133,8 @@ input[type="checkbox"] {
 
         .save-discard-widget-button-icon {
             vertical-align: bottom;
-            margin-right: 3px;
-            margin-bottom: 1px;
+            margin-right: 0.1875rem;
+            margin-bottom: 0.0625rem;
             font-size: 0.9375rem;
             font-weight: 500;
         }
@@ -1142,7 +1142,7 @@ input[type="checkbox"] {
 
     .save-button-controls {
         display: inline;
-        margin-left: 15px;
+        margin-left: 0.9375rem;
 
         &.hide {
             display: none;
@@ -1150,7 +1150,7 @@ input[type="checkbox"] {
     }
 
     .save-button {
-        margin-right: 5px;
+        margin-right: 0.3125rem;
 
         .save-discard-widget-button-loading {
             display: none;
@@ -1163,7 +1163,7 @@ input[type="checkbox"] {
 
             .save-discard-widget-button-loading {
                 display: inline-block;
-                margin-right: 2px;
+                margin-right: 0.125rem;
             }
         }
     }
@@ -1191,7 +1191,7 @@ input[type="checkbox"] {
 
     input.search {
         font-size: 0.9rem;
-        margin: 10px 0 20px 0;
+        margin: 0.625rem 0 1.25rem 0;
     }
 
     .form-sidebar {
@@ -1199,8 +1199,8 @@ input[type="checkbox"] {
         top: 45px;
         right: 0;
         transform: translateX(303px);
-        width: 300px;
-        height: calc(100% - 45px);
+        width: 18.75rem;
+        height: calc(100% - 2.8125rem);
 
         background-color: hsl(0, 0%, 100%);
         border-left: 1px solid hsl(0, 0%, 87%);
@@ -1216,7 +1216,7 @@ input[type="checkbox"] {
         }
 
         input[type="text"] {
-            width: calc(100% - 10px - 4px);
+            width: calc(100% - 0.625rem - 0.25rem);
         }
 
         input[type="submit"],
@@ -1249,7 +1249,7 @@ input[type="checkbox"] {
                 float: right;
                 font-size: 2rem;
                 font-weight: 300;
-                margin-top: 11px;
+                margin-top: 0.6875rem;
                 cursor: pointer;
             }
         }
@@ -1258,7 +1258,7 @@ input[type="checkbox"] {
     .sidebar {
         float: left;
         position: relative;
-        width: 250px;
+        width: 15.625rem;
         height: 100%;
         overflow-y: auto;
         border-top-left-radius: 4px;
@@ -1267,7 +1267,7 @@ input[type="checkbox"] {
         .header {
             height: auto;
             position: relative;
-            width: calc(100% - 20px);
+            width: calc(100% - 1.25rem);
             padding: 0.625rem;
             text-align: center;
             text-transform: uppercase;
@@ -1311,15 +1311,15 @@ input[type="checkbox"] {
             }
 
             .text {
-                width: calc(100% - 90px);
+                width: calc(100% - 5.625rem);
                 padding: 0.625rem 0.75rem 0.625rem 0;
                 white-space: nowrap;
             }
 
             .icon {
-                width: 18px;
-                height: 18px;
-                margin: 10px 10px;
+                width: 1.125rem;
+                height: 1.125rem;
+                margin: 0.625rem 0.625rem;
                 text-align: center;
 
                 font-size: 1.4em;
@@ -1330,9 +1330,9 @@ input[type="checkbox"] {
             }
 
             .locked {
-                width: 18px;
-                height: 18px;
-                margin: 14px 8px 6px;
+                width: 1.125rem;
+                height: 1.125rem;
+                margin: 0.875rem 0.5rem 0.375rem;
 
                 font-size: 1em;
                 color: hsl(0, 0%, 62%);
@@ -1382,7 +1382,7 @@ input[type="checkbox"] {
             text-align: center;
             font-size: 1.1em;
             line-height: 1;
-            margin: 15px;
+            margin: 0.9375rem;
             text-transform: uppercase;
         }
 
@@ -1399,7 +1399,7 @@ input[type="checkbox"] {
             float: right;
             position: relative;
             top: 3px;
-            margin-left: 3px;
+            margin-left: 0.1875rem;
             font-size: 1.5rem;
             font-weight: 600;
             cursor: pointer;
@@ -1414,8 +1414,8 @@ input[type="checkbox"] {
         padding-bottom: 1.25rem;
 
         textarea {
-            width: 320px;
-            height: 80px;
+            width: 20.0rem;
+            height: 5.0rem;
         }
 
         &:hover .remove_date {
@@ -1440,7 +1440,7 @@ input[type="checkbox"] {
         }
 
         .person_picker {
-            min-width: 206px;
+            min-width: 12.875rem;
         }
     }
 
@@ -1448,13 +1448,13 @@ input[type="checkbox"] {
         position: absolute;
         left: 251px;
         /* the width of the settings sidbar this is right of is 250px + 1px border. */
-        width: calc(100% - 250px - 1px);
+        width: calc(100% - 15.625rem - 0.0625rem);
         height: 100%;
         overflow: hidden;
 
         .settings-header {
             width: 100%;
-            height: 43px;
+            height: 2.6875rem;
             border-bottom: 1px solid hsl(0, 0%, 87%);
 
             h1 .section {
@@ -1467,7 +1467,7 @@ input[type="checkbox"] {
         #settings_content {
             position: relative;
             width: 100%;
-            height: calc(100% - 45px);
+            height: calc(100% - 2.8125rem);
 
             float: left;
             overflow-y: auto;
@@ -1478,14 +1478,14 @@ input[type="checkbox"] {
     }
 
     .display-settings-form select {
-        width: 245px;
+        width: 15.3125rem;
     }
 
     #change_full_name_modal .change_full_name_info,
     #change_email_modal .change_email_info,
     #change_password_modal .change_password_info,
     #api_key_modal #api_key_status {
-        margin-top: 3px;
+        margin-top: 0.1875rem;
     }
 }
 
@@ -1519,8 +1519,8 @@ input[type="checkbox"] {
     }
 
     #show_my_user_profile_modal {
-        width: 150px;
-        margin-top: 20px;
+        width: 9.375rem;
+        margin-top: 1.25rem;
     }
 
     #show_my_user_profile_modal i {
@@ -1550,21 +1550,21 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 }
 
 .m-t-10 {
-    margin-top: 10px;
+    margin-top: 0.625rem;
 }
 
 #do_deactivate_self_button .loader {
     display: none;
     vertical-align: top;
     position: relative;
-    height: 30px;
-    margin-top: -10px;
+    height: 1.875rem;
+    margin-top: -0.625rem;
     top: 5px;
 }
 
 .dropdown-list-widget {
     button {
-        margin: 0 5px;
+        margin: 0 0.3125rem;
 
         &.dropdown_list_reset_button {
             /* Prevent night mode from overriding background. */
@@ -1581,7 +1581,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     }
 
     .dropdown-search > input[type="text"] {
-        margin: 9px;
+        margin: 0.5625rem;
     }
 
     .dropdown-menu {
@@ -1592,7 +1592,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     .dropdown-list-wrapper {
         position: relative;
         height: auto;
-        max-height: 200px;
+        max-height: 12.5rem;
         overflow-y: auto;
         margin-top: 0;
         display: block;
@@ -1615,7 +1615,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
             padding: 0.1875rem 1.25rem;
             clear: both;
             font-weight: normal;
-            line-height: 20px;
+            line-height: 1.25rem;
             color: hsl(0, 0%, 20%);
             white-space: nowrap;
 
@@ -1639,7 +1639,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     background-color: hsl(0, 43%, 91%);
     padding: 0.125rem 0.375rem;
     border-radius: 4px;
-    margin: 0 0 0 5px;
+    margin: 0 0 0 0.3125rem;
 }
 
 #muted_topics_table {
@@ -1652,7 +1652,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 }
 
 #admin-user-list .last_active {
-    width: 100px;
+    width: 6.25rem;
 }
 
 .required-text {
@@ -1672,17 +1672,17 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 #payload_url_inputbox,
 #service_name_list {
     input[type="text"] {
-        width: 340px;
+        width: 21.25rem;
     }
 }
 
 .dropdown-title {
-    margin-bottom: 3px;
+    margin-bottom: 0.1875rem;
 }
 
 .invited-as-admin {
     opacity: 0.5;
-    margin-left: 2px;
+    margin-left: 0.125rem;
 }
 
 @supports (-moz-appearance: none) {
@@ -1699,14 +1699,14 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 
     hr {
         margin-top: 0;
-        margin-bottom: 5px;
+        margin-bottom: 0.3125rem;
     }
 
     .choice-row {
-        margin-top: 5px;
+        margin-top: 0.3125rem;
 
         input {
-            width: 190px;
+            width: 11.875rem;
         }
 
         button {
@@ -1721,8 +1721,8 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 
 .custom_user_field .pill-container {
     padding: 0.125rem 0.375rem;
-    min-height: 24px;
-    max-width: 206px;
+    min-height: 1.5rem;
+    max-width: 12.875rem;
     background-color: hsl(0, 0%, 100%);
 
     &:focus-within {
@@ -1741,7 +1741,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 
 #attachment-stats-holder {
     position: relative;
-    margin-top: 13px;
+    margin-top: 0.8125rem;
     display: inline-block;
 }
 
@@ -1750,7 +1750,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 }
 
 .collapse-settings-btn {
-    margin: 10px 0 0 10px;
+    margin: 0.625rem 0 0 0.625rem;
     color: hsl(200, 100%, 40%);
 
     &:hover {
@@ -1760,12 +1760,12 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 }
 
 #toggle_collapse {
-    margin-left: 2px;
+    margin-left: 0.125rem;
     display: inline-block;
 }
 
 .admin_exports_table {
-    margin: 20px;
+    margin: 1.25rem;
 }
 
 @media (max-width: 953px) {
@@ -1777,7 +1777,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 
     .user-avatar-section .avatar-controls {
         display: inline-block;
-        margin-top: 10px;
+        margin-top: 0.625rem;
     }
 
     #settings_content .warning {
@@ -1785,7 +1785,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     }
 
     .subsection-failed-status p {
-        margin: 5px 0 0 0;
+        margin: 0.3125rem 0 0 0;
     }
 }
 
@@ -1824,7 +1824,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
         .sidebar {
             float: left;
             position: relative;
-            width: 250px;
+            width: 15.625rem;
             height: 100%;
 
             li.active {
@@ -1859,7 +1859,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     #filter-settings .new-filter-form .control-label,
     #profile-field-settings .new-profile-field-form .control-label {
         display: block;
-        width: 120px;
+        width: 7.5rem;
         padding: 0;
         padding-top: 0;
         text-align: center;
@@ -1875,7 +1875,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 
     #settings_page .save-button-controls {
         display: block;
-        margin: 10px 0 0 0;
+        margin: 0.625rem 0 0 0;
     }
 }
 
@@ -1883,7 +1883,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     #api_key_buttons,
     #download_zuliprc {
         flex-direction: column;
-        margin-top: 5px;
+        margin-top: 0.3125rem;
     }
 }
 
@@ -1891,20 +1891,20 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     /* selects the label (inline-block)
        immediately following the checkbox */
     .settings-box .checkbox + .inline-block {
-        width: calc(100% - 25px);
+        width: calc(100% - 1.5625rem);
     }
 }
 
 @media only screen and (min-width: 700px) and (max-width: 875px) {
     .bots_list .bot-information-box {
-        width: calc(100% - 10px);
+        width: calc(100% - 0.625rem);
         max-height: unset;
     }
 }
 
 @media only screen and (max-width: 625px) {
     .bots_list .bot-information-box {
-        width: calc(100% - 10px);
+        width: calc(100% - 0.625rem);
         max-height: unset;
     }
 }

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -198,7 +198,7 @@ td .button {
 }
 
 .settings-info-icon {
-    padding-left: 3px;
+    padding-left: 0.1875rem;
     opacity: 0.9;
 }
 
@@ -268,7 +268,7 @@ td .button {
                 white-space: pre;
                 display: inline-block;
                 position: absolute;
-                padding-top: 3px;
+                padding-top: 0.1875rem;
                 font: normal normal normal 12px/1 FontAwesome;
                 font-size: inherit;
             }
@@ -343,7 +343,7 @@ td .button {
         }
 
         td {
-            padding-left: 80px;
+            padding-left: 5.0rem;
         }
     }
 
@@ -737,7 +737,7 @@ input[type="checkbox"] {
     }
 
     .edit-bot-buttons {
-        padding-top: 5px;
+        padding-top: 0.3125rem;
 
         button {
             background-color: transparent;
@@ -1363,7 +1363,7 @@ input[type="checkbox"] {
     }
 
     .settings-header {
-        padding-top: 1px;
+        padding-top: 0.0625rem;
 
         &.mobile {
             display: none;
@@ -1410,7 +1410,7 @@ input[type="checkbox"] {
     }
 
     .custom_user_field {
-        padding-bottom: 20px;
+        padding-bottom: 1.25rem;
 
         textarea {
             width: 320px;
@@ -1523,7 +1523,7 @@ input[type="checkbox"] {
     }
 
     #show_my_user_profile_modal i {
-        padding-left: 2px;
+        padding-left: 0.125rem;
         vertical-align: middle;
     }
 }
@@ -1689,7 +1689,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
         appearance: none;
         background: hsl(0, 0%, 100%) url(../images/dropdown.png) right / 20px
             no-repeat;
-        padding-right: 20px;
+        padding-right: 1.25rem;
     }
 }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -58,7 +58,7 @@ h3 .fa-question-circle-o {
             display: inline-block;
             vertical-align: top;
             width: 150px;
-            padding: 5px 10px;
+            padding: 0.3125rem 0.625rem;
             text-align: left;
         }
     }
@@ -126,11 +126,11 @@ h3 .fa-question-circle-o {
 }
 
 .padded-container {
-    padding: 20px;
+    padding: 1.25rem;
 }
 
 .side-padded-container {
-    padding: 0 20px;
+    padding: 0 1.25rem;
 }
 
 #notification_sound,
@@ -240,7 +240,7 @@ td .button {
 
         .table-title {
             display: inline-block;
-            padding: 6px 0;
+            padding: 0.375rem 0;
             margin-left: 5px;
 
             i {
@@ -303,7 +303,7 @@ td .button {
     input[type="text"].search {
         float: right;
         margin: 2px 5px 2px 0;
-        padding: 2px 5px;
+        padding: 0.125rem 0.3125rem;
         font-size: 0.9em;
     }
 
@@ -361,7 +361,7 @@ td .button {
 
 .dynamic-input {
     display: inline-block;
-    padding: 5px;
+    padding: 0.3125rem;
     background-color: hsl(0, 0%, 100%);
     border: 1px solid hsl(0, 0%, 80%);
     border-radius: 3px;
@@ -488,7 +488,7 @@ input[type="checkbox"] {
 
 .alert-word-information-box {
     position: relative;
-    padding: 7px;
+    padding: 0.4375rem;
     margin: 2px;
     width: 50%;
 }
@@ -512,7 +512,7 @@ input[type="checkbox"] {
     margin-top: 14px;
     margin-left: 10px;
     color: hsl(156, 30%, 50%);
-    padding: 3px 10px;
+    padding: 0.1875rem 0.625rem;
     font-size: 0.9375rem;
 
     &:not(:empty) {
@@ -642,7 +642,7 @@ input[type="checkbox"] {
 .add-new-user-group-box,
 .add-new-default-stream-box {
     input[type="text"] {
-        padding: 6px;
+        padding: 0.375rem;
     }
 }
 
@@ -744,7 +744,7 @@ input[type="checkbox"] {
         }
 
         .btn {
-            padding: 4px;
+            padding: 0.25rem;
         }
 
         .sea-green {
@@ -812,7 +812,7 @@ input[type="checkbox"] {
     }
 
     .bot_info {
-        padding: 10px;
+        padding: 0.625rem;
     }
 
     .field {
@@ -841,7 +841,7 @@ input[type="checkbox"] {
 }
 
 .edit_bot_form_container {
-    padding: 15px;
+    padding: 0.9375rem;
 }
 
 .edit_bot_form {
@@ -901,7 +901,7 @@ input[type="checkbox"] {
     background-color: hsl(0, 0%, 100%);
 
     &:empty {
-        padding: 10px;
+        padding: 0.625rem;
     }
 }
 
@@ -936,7 +936,7 @@ input[type="checkbox"] {
 
 .emojiset_choices {
     width: 250px;
-    padding: 0 10px;
+    padding: 0 0.625rem;
 
     .emoji {
         height: 22px;
@@ -945,7 +945,7 @@ input[type="checkbox"] {
 
     label {
         border-bottom: 1px solid hsla(0, 0%, 0%, 0.2);
-        padding: 8px 0 10px 0;
+        padding: 0.5rem 0 0.625rem 0;
 
         &:last-of-type {
             border-bottom: none;
@@ -991,7 +991,7 @@ input[type="checkbox"] {
 #user-groups {
     .user-group {
         margin-bottom: 20px;
-        padding: 10px;
+        padding: 0.625rem;
         border-radius: 5px;
 
         h4 {
@@ -1056,7 +1056,7 @@ input[type="checkbox"] {
 
     .save-status {
         background-color: transparent;
-        padding: 2px 5px;
+        padding: 0.125rem 0.3125rem;
         border-radius: 4px;
         margin-left: 10px;
         border-style: solid;
@@ -1094,7 +1094,7 @@ input[type="checkbox"] {
         border-radius: 5px;
         border: 1px solid hsl(0, 0%, 80%);
         font-size: 0.875rem;
-        padding: 3px 14px 4px 11px;
+        padding: 0.1875rem 0.875rem 0.25rem 0.6875rem;
         text-decoration: none;
         color: hsl(0, 0%, 47%);
         min-width: 80px;
@@ -1231,11 +1231,11 @@ input[type="checkbox"] {
 
         .title,
         .content {
-            padding: 20px;
+            padding: 1.25rem;
         }
 
         .title {
-            padding: 10px 20px;
+            padding: 0.625rem 1.25rem;
             background-color: hsl(0, 0%, 98%);
             border-bottom: 1px solid hsl(0, 0%, 87%);
 
@@ -1268,7 +1268,7 @@ input[type="checkbox"] {
             height: auto;
             position: relative;
             width: calc(100% - 20px);
-            padding: 10px;
+            padding: 0.625rem;
             text-align: center;
             text-transform: uppercase;
 
@@ -1283,7 +1283,7 @@ input[type="checkbox"] {
         }
 
         li {
-            padding: 5px 0;
+            padding: 0.3125rem 0;
             outline: none;
             cursor: pointer;
             transition: all 0.2s ease;
@@ -1312,7 +1312,7 @@ input[type="checkbox"] {
 
             .text {
                 width: calc(100% - 90px);
-                padding: 10px 12px 10px 0;
+                padding: 0.625rem 0.75rem 0.625rem 0;
             }
 
             .icon {
@@ -1352,7 +1352,7 @@ input[type="checkbox"] {
         }
 
         .tab-container {
-            padding: 6px;
+            padding: 0.375rem;
             border-bottom: 1px solid hsl(0, 0%, 87%);
         }
 
@@ -1611,7 +1611,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
         from bootstrap to here. */
         li a {
             display: block;
-            padding: 3px 20px;
+            padding: 0.1875rem 1.25rem;
             clear: both;
             font-weight: normal;
             line-height: 20px;
@@ -1636,7 +1636,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 
 .subsection-failed-status p {
     background-color: hsl(0, 43%, 91%);
-    padding: 2px 6px;
+    padding: 0.125rem 0.375rem;
     border-radius: 4px;
     margin: 0 0 0 5px;
 }
@@ -1719,7 +1719,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 }
 
 .custom_user_field .pill-container {
-    padding: 2px 6px;
+    padding: 0.125rem 0.375rem;
     min-height: 24px;
     max-width: 206px;
     background-color: hsl(0, 0%, 100%);

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1313,6 +1313,7 @@ input[type="checkbox"] {
             .text {
                 width: calc(100% - 90px);
                 padding: 0.625rem 0.75rem 0.625rem 0;
+                white-space: nowrap;
             }
 
             .icon {

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -100,7 +100,7 @@
 
 .stream-email {
     font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
-    padding: 5px;
+    padding: 0.3125rem;
     font-size: 0.9em;
     background-color: hsl(0, 0%, 98%);
     border: 1px solid hsl(0, 0%, 87%);
@@ -111,7 +111,7 @@
     display: inline-block;
     vertical-align: middle;
     line-height: 18px;
-    padding: 5px;
+    padding: 0.3125rem;
 }
 
 .sp-preview {
@@ -165,7 +165,7 @@
 .preview-stream {
     display: none;
     float: right;
-    padding: 3px 10px;
+    padding: 0.1875rem 0.625rem;
     border: 1px solid hsl(0, 0%, 80%);
     margin: 9px 10px 0 0;
     color: hsl(0, 0%, 20%);
@@ -258,7 +258,7 @@ form#add_new_subscription {
                 }
 
                 td {
-                    padding: 4px 0;
+                    padding: 0.25rem 0;
 
                     &:first-of-type {
                         padding-left: 10px;
@@ -289,7 +289,7 @@ form#add_new_subscription {
 
             &:empty {
                 display: block;
-                padding: 5px;
+                padding: 0.3125rem;
             }
         }
     }
@@ -297,14 +297,14 @@ form#add_new_subscription {
 
 .hide-subscriber-list {
     display: block;
-    padding: 5px;
+    padding: 0.3125rem;
     text-align: center;
     color: hsl(0, 0%, 67%);
 }
 
 .subscriber-name,
 .subscriber-email {
-    padding: 5px;
+    padding: 0.3125rem;
 }
 
 .subscriber-email {
@@ -394,7 +394,7 @@ form#add_new_subscription {
     color: hsl(0, 0%, 67%);
 
     float: left;
-    padding: 2px 10px;
+    padding: 0.125rem 0.625rem;
 
     cursor: pointer;
 
@@ -424,7 +424,7 @@ form#add_new_subscription {
     }
 
     .subscriptions-header {
-        padding: 12px;
+        padding: 0.75rem;
         text-align: center;
         text-transform: uppercase;
         font-weight: 700;
@@ -473,7 +473,7 @@ form#add_new_subscription {
         border-right: 1px solid hsl(0, 0%, 87%);
 
         .search-container {
-            padding: 6px 8px;
+            padding: 0.375rem 0.5rem;
             border-bottom: 1px solid hsl(0, 0%, 87%);
             display: flex;
             justify-content: space-between;
@@ -494,14 +494,14 @@ form#add_new_subscription {
             }
 
             button {
-                padding: 6px 10px 8px 10px;
+                padding: 0.375rem 0.625rem 0.5rem 0.625rem;
                 display: block;
                 margin: 0 auto 10px auto;
             }
         }
 
         .display-type {
-            padding: 6px;
+            padding: 0.375rem;
             text-align: center;
             font-weight: 600;
             border-bottom: 1px solid hsl(0, 0%, 87%);
@@ -539,7 +539,7 @@ form#add_new_subscription {
     input[type="text"].small {
         border: 1px solid hsl(0, 0%, 80%);
         border-radius: 4px;
-        padding: 3px;
+        padding: 0.1875rem;
         outline: none;
         color: hsl(0, 0%, 27%);
         text-align: center;
@@ -556,7 +556,7 @@ form#add_new_subscription {
 
 #search_stream_name {
     width: 100%;
-    padding: 3px 5px;
+    padding: 0.1875rem 0.3125rem;
     margin: 8px 0;
     margin-left: 10px;
     margin-right: -15px !important;
@@ -623,7 +623,7 @@ form#add_new_subscription {
 }
 
 .stream-row {
-    padding: 15px 10px 11px 10px;
+    padding: 0.9375rem 0.625rem 0.6875rem 0.625rem;
     border-bottom: 1px solid hsl(0, 0%, 93%);
     cursor: pointer;
 
@@ -804,7 +804,7 @@ form#add_new_subscription {
         }
 
         .stream-creation-body {
-            padding: 15px;
+            padding: 0.9375rem;
         }
 
         .add-user-label {
@@ -1036,7 +1036,7 @@ ul.grey-box {
         #stream_privacy_modal &,
         #subscription_overlay & {
             border-bottom: 1px solid hsl(0, 0%, 87%);
-            padding: 5px 0;
+            padding: 0.3125rem 0;
         }
 
         input[type="checkbox"] {

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -1,9 +1,9 @@
 #subs_page_loading_indicator {
-    margin: 10px auto;
+    margin: 0.625rem auto;
 }
 
 .subscriber_list_loading_indicator {
-    margin: 10px auto;
+    margin: 0.625rem auto;
 }
 
 .subscriber_list_loading_indicator:empty {
@@ -12,7 +12,7 @@
 
 .subscription-email-hint-image {
     float: right;
-    width: 80px;
+    width: 5.0rem;
 }
 
 .subscription_header.collapsed {
@@ -21,10 +21,10 @@
 
 .color_swatch {
     display: inline-block;
-    height: 18px;
-    width: 18px;
+    height: 1.125rem;
+    width: 1.125rem;
     padding: 0;
-    margin: 0 0 0 10px;
+    margin: 0 0 0 0.625rem;
     vertical-align: middle;
 }
 
@@ -40,9 +40,9 @@
 .subscription-info-container {
     display: inline-block;
     /* subtract out the width of the subscribe button and arrow. */
-    width: calc(100% - 260px);
+    width: calc(100% - 16.25rem);
     /* to center the container vertically. */
-    margin-top: 13px;
+    margin-top: 0.8125rem;
 }
 
 .subscription-setting-icon {
@@ -53,8 +53,8 @@
 .subscription-info {
     display: inline-block;
     /* to provide space for the setting-icon. */
-    max-width: calc(100% - 31px);
-    margin-top: 1px;
+    max-width: calc(100% - 1.9375rem);
+    margin-top: 0.0625rem;
     overflow: hidden;
     word-wrap: normal;
     white-space: nowrap;
@@ -70,7 +70,7 @@
 }
 
 .subscription_header {
-    min-height: 47px;
+    min-height: 2.9375rem;
 }
 
 .subscription-name-row {
@@ -86,8 +86,8 @@
     font-size: 1.4375rem;
     display: inline-block;
     vertical-align: middle;
-    margin-left: 12px;
-    margin-right: 1px;
+    margin-left: 0.75rem;
+    margin-right: 0.0625rem;
 }
 
 .subscription_settings .btn {
@@ -110,18 +110,18 @@
 .subscription-control-label {
     display: inline-block;
     vertical-align: middle;
-    line-height: 18px;
+    line-height: 1.125rem;
     padding: 0.3125rem;
 }
 
 .sp-preview {
-    width: 20px;
+    width: 1.25rem;
     border: none;
     box-shadow: 0 0 1px hsla(0, 0%, 0%, 1);
 }
 
 .sp-replacer {
-    margin-right: 12px;
+    margin-right: 0.75rem;
     border: none;
     box-shadow: 0 0 2px hsla(0, 0%, 0%, 0.8);
 }
@@ -140,7 +140,7 @@
 }
 
 .sub_setting_checkbox .checkbox span {
-    margin-top: 7px !important;
+    margin-top: 0.4375rem !important;
 }
 
 .sub_setting_checkbox .muted-sub label,
@@ -159,7 +159,7 @@
 
 .sub_setting_control {
     display: inline-block;
-    margin-right: 10px;
+    margin-right: 0.625rem;
 }
 
 .preview-stream {
@@ -167,7 +167,7 @@
     float: right;
     padding: 0.1875rem 0.625rem;
     border: 1px solid hsl(0, 0%, 80%);
-    margin: 9px 10px 0 0;
+    margin: 0.5625rem 0.625rem 0 0;
     color: hsl(0, 0%, 20%);
 }
 
@@ -183,7 +183,7 @@ form#add_new_subscription {
 }
 
 .create_stream_button {
-    margin: 0 0 0 5px;
+    margin: 0 0 0 0.3125rem;
 
     border: none;
     outline: none;
@@ -205,28 +205,28 @@ form#add_new_subscription {
 }
 
 #create_stream_description {
-    width: calc(100% - 15px);
+    width: calc(100% - 0.9375rem);
 }
 
 .stream_creation_error {
     display: none;
-    margin-left: 2px;
+    margin-left: 0.125rem;
     color: hsl(0, 100%, 50%);
 }
 
 .sub_settings_title {
-    line-height: 30px;
-    margin: 10px 0 0 0;
+    line-height: 1.875rem;
+    margin: 0.625rem 0 0 0;
     font-size: 1rem;
 }
 
 .new-stream-name,
 .stream-rename-button {
-    margin-top: 10px;
+    margin-top: 0.625rem;
 }
 
 .settings_committed {
-    margin: 10px;
+    margin: 0.625rem;
 }
 
 .subscriber-list-box {
@@ -236,7 +236,7 @@ form#add_new_subscription {
 
     .subscriber_list_container {
         position: relative;
-        max-height: 300px;
+        max-height: 18.75rem;
         overflow: auto;
         text-align: left;
         -webkit-overflow-scrolling: touch;
@@ -308,13 +308,13 @@ form#add_new_subscription {
 }
 
 .subscriber-email {
-    margin-left: 20px;
+    margin-left: 1.25rem;
     padding-right: 0.5rem;
 }
 
 .subscriber_list_add {
     width: 100%;
-    margin: 10px auto;
+    margin: 0.625rem auto;
 
     .stream_subscription_info {
         a {
@@ -324,7 +324,7 @@ form#add_new_subscription {
 }
 
 .subscriber-search {
-    margin: 10px 0 0 0;
+    margin: 0.625rem 0 0 0;
 }
 
 .subscriber_list_add .form-inline {
@@ -346,10 +346,10 @@ form#add_new_subscription {
 }
 
 #subscription-status {
-    width: 200px;
+    width: 12.5rem;
     position: absolute;
     left: 50%;
-    margin-left: -100px;
+    margin-left: -6.25rem;
     bottom: 30px;
     text-align: center;
     border-radius: 2px;
@@ -362,7 +362,7 @@ form#add_new_subscription {
 }
 
 #subscriptions .streams-icon {
-    margin-right: 10px;
+    margin-right: 0.625rem;
     font-size: 1.25rem;
 }
 
@@ -416,8 +416,8 @@ form#add_new_subscription {
     padding: 0;
     width: 97%;
     overflow: hidden;
-    max-width: 1200px;
-    max-height: 1000px;
+    max-width: 75.0rem;
+    max-height: 62.5rem;
 
     .search-container .tab-switcher .ind-tab {
         width: auto;
@@ -453,7 +453,7 @@ form#add_new_subscription {
     .exit-sign {
         position: relative;
         top: 3px;
-        margin-left: 3px;
+        margin-left: 0.1875rem;
         font-size: 1.5rem;
         font-weight: 600;
         cursor: pointer;
@@ -465,8 +465,8 @@ form#add_new_subscription {
         display: inline-block;
         vertical-align: top;
         width: 50%;
-        height: calc(100% - 45px);
-        margin: 0 -2px;
+        height: calc(100% - 2.8125rem);
+        margin: 0 -0.125rem;
     }
 
     .left {
@@ -481,11 +481,11 @@ form#add_new_subscription {
     }
 
     .right {
-        width: calc(50% + 1px);
+        width: calc(50% + 0.0625rem);
 
         .nothing-selected {
             display: block;
-            margin-top: calc(45vh - 75px);
+            margin-top: calc(45vh - 4.6875rem);
             text-align: center;
             font-size: 1em;
 
@@ -496,7 +496,7 @@ form#add_new_subscription {
             button {
                 padding: 0.375rem 0.625rem 0.5rem 0.625rem;
                 display: block;
-                margin: 0 auto 10px auto;
+                margin: 0 auto 0.625rem auto;
             }
         }
 
@@ -518,14 +518,14 @@ form#add_new_subscription {
                 display: none;
                 font-size: 1em;
                 line-height: 1;
-                margin: 9px 0;
+                margin: 0.5625rem 0;
                 font-weight: 600;
             }
         }
 
         #preview_iframe {
             width: 100%;
-            height: calc(100% - 45px);
+            height: calc(100% - 2.8125rem);
             border: none;
             background-color: hsl(0, 0%, 98%);
             box-shadow: inset 0 0 50px hsla(0, 0%, 0%, 0.5);
@@ -557,9 +557,9 @@ form#add_new_subscription {
 #search_stream_name {
     width: 100%;
     padding: 0.1875rem 0.3125rem;
-    margin: 8px 0;
-    margin-left: 10px;
-    margin-right: -15px !important;
+    margin: 0.5rem 0;
+    margin-left: 0.625rem;
+    margin-right: -0.9375rem !important;
     display: inline-block;
     border-radius: 5px;
     box-shadow: none;
@@ -579,7 +579,7 @@ form#add_new_subscription {
     position: relative;
     overflow: auto;
     -webkit-overflow-scrolling: touch;
-    height: calc(100% - 85px);
+    height: calc(100% - 5.3125rem);
     width: 100%;
 }
 
@@ -594,30 +594,30 @@ form#add_new_subscription {
 
 .stream-creation-info {
     font-style: italic;
-    margin-bottom: 10px;
+    margin-bottom: 0.625rem;
 }
 
 .stream-creation-body {
     section.block {
-        margin-bottom: 20px;
+        margin-bottom: 1.25rem;
     }
 
     #make-invite-only {
         .radio {
-            margin: 5px;
+            margin: 0.3125rem;
         }
 
         .grey-box .checkbox {
-            margin: 5px;
+            margin: 0.3125rem;
         }
     }
 
     #announce-new-stream {
-        margin-top: 10px;
+        margin-top: 0.625rem;
 
         div[class^="fa"] {
-            margin-left: 3px;
-            margin-right: 8px;
+            margin-left: 0.1875rem;
+            margin-right: 0.5rem;
         }
     }
 }
@@ -628,11 +628,11 @@ form#add_new_subscription {
     cursor: pointer;
 
     .check {
-        width: 25px;
-        height: 25px;
+        width: 1.5625rem;
+        height: 1.5625rem;
         position: relative;
-        margin-right: 8px;
-        margin-top: 9px;
+        margin-right: 0.5rem;
+        margin-top: 0.5625rem;
         background-size: 60% auto;
         background-repeat: no-repeat;
         background-position: center center;
@@ -674,10 +674,10 @@ form#add_new_subscription {
     }
 
     .icon {
-        width: 35px;
-        height: 35px;
-        margin-right: 8px;
-        margin-top: 4px;
+        width: 2.1875rem;
+        height: 2.1875rem;
+        margin-right: 0.5rem;
+        margin-top: 0.25rem;
         background-color: hsl(300, 100%, 25%);
         border-radius: 4px;
         color: hsl(0, 0%, 100%);
@@ -698,7 +698,7 @@ form#add_new_subscription {
     }
 
     .sub-info-box {
-        width: calc(100% - 90px);
+        width: calc(100% - 5.625rem);
 
         .top-bar,
         .bottom-bar {
@@ -723,7 +723,7 @@ form#add_new_subscription {
         .top-bar .subscriber-count-text,
         .top-bar .subscriber-count-lock,
         .bottom-bar .stream-message-count-text {
-            margin-right: 5px;
+            margin-right: 0.3125rem;
         }
 
         .top-bar > div {
@@ -736,7 +736,7 @@ form#add_new_subscription {
         }
 
         .bottom-bar {
-            margin-top: 2px;
+            margin-top: 0.125rem;
             line-height: 1.5;
         }
 
@@ -757,7 +757,7 @@ form#add_new_subscription {
 
     .settings-dropdown-trigger {
         float: right;
-        margin-left: 10px;
+        margin-left: 0.625rem;
         color: hsl(0, 0%, 67%);
     }
 
@@ -792,7 +792,7 @@ form#add_new_subscription {
 
 #subscription_overlay {
     #stream-creation {
-        max-height: calc(100% - 102px);
+        max-height: calc(100% - 6.375rem);
         overflow: auto;
         outline: none;
         -webkit-overflow-scrolling: touch;
@@ -800,7 +800,7 @@ form#add_new_subscription {
         .modal-footer {
             position: absolute;
             bottom: 0;
-            width: calc(100% - 27px);
+            width: calc(100% - 1.6875rem);
         }
 
         .stream-creation-body {
@@ -808,11 +808,11 @@ form#add_new_subscription {
         }
 
         .add-user-label {
-            margin: 8px 0;
+            margin: 0.5rem 0;
         }
 
         .add-user-list-filter {
-            width: calc(100% - 10px);
+            width: calc(100% - 0.625rem);
         }
 
         #stream_creation_form {
@@ -822,7 +822,7 @@ form#add_new_subscription {
                 &:not(:empty) {
                     position: absolute;
                     width: 100% !important;
-                    height: calc(100% - 105px) !important;
+                    height: calc(100% - 6.5625rem) !important;
                     display: flex !important;
                     justify-content: center;
                     align-items: center;
@@ -838,11 +838,11 @@ form#add_new_subscription {
     }
 
     .inner-box {
-        margin: 20px;
+        margin: 1.25rem;
     }
 
     .stream-header {
-        margin-bottom: 20px;
+        margin-bottom: 1.25rem;
         white-space: nowrap;
 
         .stream-name {
@@ -850,10 +850,10 @@ form#add_new_subscription {
             position: relative;
             font-size: 1.5em;
             font-weight: 600;
-            margin-left: -3px;
+            margin-left: -0.1875rem;
             padding-bottom: 0.3125rem;
             white-space: nowrap;
-            max-width: 260px;
+            max-width: 16.25rem;
 
             .stream-name-editable {
                 display: block;
@@ -872,8 +872,8 @@ form#add_new_subscription {
         .deactivate,
         .subscribe-button {
             float: right;
-            margin-top: -5px;
-            margin-right: 5px;
+            margin-top: -0.3125rem;
+            margin-right: 0.3125rem;
         }
 
         .button-group {
@@ -892,7 +892,7 @@ form#add_new_subscription {
         .large-icon {
             display: inline-block;
             vertical-align: top;
-            margin-right: 5px;
+            margin-right: 0.3125rem;
             font-size: 1.5em;
 
             &.hash::after {
@@ -903,20 +903,20 @@ form#add_new_subscription {
 
     .stream-description {
         font-size: 0.9em;
-        margin-bottom: 5px;
+        margin-bottom: 0.3125rem;
     }
 
     #preview-stream-button {
         float: right;
-        margin-top: -5px;
-        margin-right: 5px;
+        margin-top: -0.3125rem;
+        margin-right: 0.3125rem;
         text-decoration: none;
     }
 
     .editable-section {
         position: relative;
         display: inline;
-        min-width: 10px;
+        min-width: 0.625rem;
         max-width: 100%;
 
         &[contenteditable="true"] {
@@ -933,7 +933,7 @@ form#add_new_subscription {
     .editable {
         position: relative;
         top: -1px;
-        margin-left: 5px;
+        margin-left: 0.3125rem;
         color: hsl(0, 0%, 67%);
         cursor: pointer;
         font-size: 1.4rem;
@@ -960,7 +960,7 @@ form#add_new_subscription {
 
     .checkmark {
         display: none;
-        margin-left: 5px;
+        margin-left: 0.3125rem;
         font-size: 0.9rem;
         color: hsl(0, 0%, 67%);
 
@@ -972,7 +972,7 @@ form#add_new_subscription {
     }
 
     .subscription-type {
-        margin-bottom: 10px;
+        margin-bottom: 0.625rem;
         font-size: 0.9em;
         opacity: 0.5;
 
@@ -994,7 +994,7 @@ form#add_new_subscription {
 
     .settings {
         position: relative;
-        height: calc(100% - 45px);
+        height: calc(100% - 2.8125rem);
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
     }
@@ -1013,17 +1013,17 @@ form#add_new_subscription {
     }
 
     #personal_settings_label_container {
-        margin-bottom: 5px;
+        margin-bottom: 0.3125rem;
     }
 
     .alert-notification:not(:empty) {
         vertical-align: unset;
-        margin-top: 10px;
+        margin-top: 0.625rem;
     }
 
     .loading_indicator_text {
         font-weight: 400;
-        line-height: 20px;
+        line-height: 1.25rem;
     }
 }
 
@@ -1041,7 +1041,7 @@ ul.grey-box {
 
         input[type="checkbox"] {
             #stream_privacy_modal & {
-                margin-top: 4px;
+                margin-top: 0.25rem;
             }
 
             #subscription_overlay & {
@@ -1066,7 +1066,7 @@ ul.grey-box {
         input[type="radio"] {
             #stream_privacy_modal &,
             #subscription_overlay & {
-                margin-right: 5px;
+                margin-right: 0.3125rem;
             }
         }
 
@@ -1097,7 +1097,7 @@ ul.grey-box {
         }
 
         .right {
-            width: calc(60% - 1px);
+            width: calc(60% - 0.0625rem);
         }
     }
 }
@@ -1114,8 +1114,8 @@ ul.grey-box {
 
     .subscriber_list_settings input {
         float: left;
-        margin: 0 5px 0 0;
-        width: calc(50% - 45px);
+        margin: 0 0.3125rem 0 0;
+        width: calc(50% - 2.8125rem);
     }
 }
 
@@ -1146,7 +1146,7 @@ ul.grey-box {
         display: block;
         margin: 0;
         width: 100%;
-        height: calc(100% - 45px);
+        height: calc(100% - 2.8125rem);
 
         border: none;
     }
@@ -1179,7 +1179,7 @@ ul.grey-box {
 
         .settings {
             overflow: auto;
-            height: calc(100% - 20px);
+            height: calc(100% - 1.25rem);
             -webkit-overflow-scrolling: touch;
         }
     }
@@ -1187,7 +1187,7 @@ ul.grey-box {
 
 @media (max-width: 367px) {
     #subscription_overlay .subscription_settings .button-group {
-        margin-top: 10px;
+        margin-top: 0.625rem;
         float: none;
         display: inline-block;
         vertical-align: top;

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -83,7 +83,7 @@
 }
 
 .subscription_header .subscription_lock {
-    font-size: 23px;
+    font-size: 1.4375rem;
     display: inline-block;
     vertical-align: middle;
     margin-left: 12px;
@@ -217,7 +217,7 @@ form#add_new_subscription {
 .sub_settings_title {
     line-height: 30px;
     margin: 10px 0 0 0;
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 .new-stream-name,
@@ -356,14 +356,14 @@ form#add_new_subscription {
 }
 
 #subscriptions h1 {
-    font-size: 25px;
+    font-size: 1.5625rem;
     font-weight: 300;
     padding-top: 40px;
 }
 
 #subscriptions .streams-icon {
     margin-right: 10px;
-    font-size: 20px;
+    font-size: 1.25rem;
 }
 
 .change-stream-privacy {

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -261,11 +261,11 @@ form#add_new_subscription {
                     padding: 0.25rem 0;
 
                     &:first-of-type {
-                        padding-left: 10px;
+                        padding-left: 0.625rem;
                     }
 
                     &:last-of-type {
-                        padding-right: 10px;
+                        padding-right: 0.625rem;
                     }
 
                     &.unsubscribe {
@@ -309,7 +309,7 @@ form#add_new_subscription {
 
 .subscriber-email {
     margin-left: 20px;
-    padding-right: 8px;
+    padding-right: 0.5rem;
 }
 
 .subscriber_list_add {
@@ -337,7 +337,7 @@ form#add_new_subscription {
     align-items: center;
 
     .add_subscriber_btn_wrapper {
-        padding-left: 5px;
+        padding-left: 0.3125rem;
     }
 }
 
@@ -358,7 +358,7 @@ form#add_new_subscription {
 #subscriptions h1 {
     font-size: 1.5625rem;
     font-weight: 300;
-    padding-top: 40px;
+    padding-top: 2.5rem;
 }
 
 #subscriptions .streams-icon {
@@ -851,7 +851,7 @@ form#add_new_subscription {
             font-size: 1.5em;
             font-weight: 600;
             margin-left: -3px;
-            padding-bottom: 5px;
+            padding-bottom: 0.3125rem;
             white-space: nowrap;
             max-width: 260px;
 

--- a/static/styles/typing_notifications.css
+++ b/static/styles/typing_notifications.css
@@ -1,6 +1,6 @@
 #typing_notifications {
     display: none;
-    margin-left: 10px;
+    margin-left: 0.625rem;
     font-style: italic;
     color: hsl(0, 0%, 53%);
 }
@@ -13,13 +13,13 @@
 /* This max-width must be synced with message_viewport.is_narrow */
 @media (max-width: 1165px) {
     #typing_notifications {
-        margin-right: 7px;
+        margin-right: 0.4375rem;
     }
 }
 
 @media (max-width: 775px) {
     #typing_notifications {
-        margin-right: 7px;
-        margin-left: 7px;
+        margin-right: 0.4375rem;
+        margin-left: 0.4375rem;
     }
 }

--- a/static/styles/user_circles.css
+++ b/static/styles/user_circles.css
@@ -39,9 +39,9 @@
     &::after {
         content: "";
         background: hsl(0, 0%, 50%);
-        height: 1.5px; /* 1px is too thin, 2px is too thick */
-        width: 6px;
+        height: 1.0.3125rem; /* 1px is too thin, 2px is too thick */
+        width: 0.375rem;
         display: block;
-        margin: 3.25px auto 0 auto; /* (total height - line height) / 2 = 3.25px */
+        margin: 3.1.5625rem auto 0 auto; /* (total height - line height) / 2 = 3.25px */
     }
 }

--- a/static/styles/user_status.css
+++ b/static/styles/user_status.css
@@ -14,8 +14,8 @@
     }
 
     .user-status-header {
-        padding-top: 4px;
-        padding-bottom: 4px;
+        padding-top: 0.25rem;
+        padding-bottom: 0.25rem;
         height: 5%;
         width: 100%;
         text-align: center;

--- a/static/styles/user_status.css
+++ b/static/styles/user_status.css
@@ -1,6 +1,6 @@
 .user_status_overlay {
     .overlay-content {
-        width: 384px;
+        width: 24.0rem;
         margin: 0 auto;
         position: relative;
         top: calc((30vh - 50px) / 2);
@@ -10,7 +10,7 @@
     }
 
     input.user_status {
-        width: 336px;
+        width: 21.0rem;
     }
 
     .user-status-header {
@@ -39,7 +39,7 @@
     .user-status-header .exit-sign {
         position: relative;
         top: 3px;
-        margin-left: 3px;
+        margin-left: 0.1875rem;
         font-size: 1.5rem;
         font-weight: 600;
         cursor: pointer;
@@ -55,7 +55,7 @@
         .user-status-value {
             width: 100%;
             text-align: left;
-            margin-bottom: 10px;
+            margin-bottom: 0.625rem;
             line-height: 1.1em;
         }
     }

--- a/static/styles/user_status.css
+++ b/static/styles/user_status.css
@@ -46,7 +46,7 @@
     }
 
     .user-status-options {
-        padding: 0 20px 3px;
+        padding: 0 1.25rem 0.1875rem;
 
         button.user-status-value:hover {
             color: hsl(200, 100%, 40%);

--- a/static/styles/widgets.css
+++ b/static/styles/widgets.css
@@ -21,7 +21,7 @@
 .todo-widget,
 .poll-widget {
     h4 {
-        font-size: 18px;
+        font-size: 1.125rem;
         font-weight: 600;
     }
 
@@ -38,7 +38,7 @@
 
 .poll-widget {
     .poll-names .todo-widget {
-        font-size: 14px;
+        font-size: 0.875rem;
         color: hsl(120, 100%, 25%);
     }
 
@@ -109,7 +109,7 @@ button {
 
 .widget-error {
     color: hsl(1, 45%, 50%);
-    font-size: 12px;
+    font-size: 0.75rem;
 }
 
 .poll-question-check,

--- a/static/styles/widgets.css
+++ b/static/styles/widgets.css
@@ -1,10 +1,10 @@
 .widget-choices {
     ul {
-        padding: 3px;
+        padding: 0.1875rem;
     }
 
     li {
-        padding: 2px;
+        padding: 0.125rem;
         list-style: none;
     }
 
@@ -102,7 +102,7 @@ button {
     &.add-desc,
     &.poll-option,
     &.poll-question {
-        padding: 4px 6px;
+        padding: 0.25rem 0.375rem;
         margin: 2px 0 2px 0;
     }
 }

--- a/static/styles/widgets.css
+++ b/static/styles/widgets.css
@@ -27,11 +27,11 @@
 
     li {
         list-style: none;
-        margin: 2px 2px 2px 0;
+        margin: 0.125rem 0.125rem 0.125rem 0;
     }
 
     ul {
-        margin: 0 0 5px 0;
+        margin: 0 0 0.3125rem 0;
         padding: 0;
     }
 }
@@ -49,7 +49,7 @@
     .poll-vote {
         color: hsl(156, 41%, 40%);
         border-color: hsl(156, 28%, 70%);
-        margin-right: 4px;
+        margin-right: 0.25rem;
         background-color: hsl(0, 0%, 100%);
 
         &:hover {
@@ -60,11 +60,11 @@
 
 button {
     &.task {
-        height: 20px;
-        width: 20px;
+        height: 1.25rem;
+        width: 1.25rem;
         background-color: transparent;
         border-color: hsl(156, 28%, 70%);
-        margin-right: 4px;
+        margin-right: 0.25rem;
         border-radius: 3px;
 
         &:hover {
@@ -84,7 +84,7 @@ button {
         border-radius: 3px;
         border: 1px solid hsl(0, 0%, 80%);
         background-color: hsl(0, 0%, 100%);
-        width: 100px;
+        width: 6.25rem;
 
         &:hover {
             border-color: hsl(0, 0%, 60%);
@@ -93,7 +93,7 @@ button {
 }
 
 img.task-completed {
-    width: 15px;
+    width: 0.9375rem;
 }
 
 input,
@@ -103,7 +103,7 @@ button {
     &.poll-option,
     &.poll-question {
         padding: 0.25rem 0.375rem;
-        margin: 2px 0 2px 0;
+        margin: 0.125rem 0 0.125rem 0;
     }
 }
 
@@ -114,8 +114,8 @@ button {
 
 .poll-question-check,
 .poll-question-remove {
-    width: 28px !important;
-    height: 28px;
+    width: 1.75rem !important;
+    height: 1.75rem;
     border-radius: 3px;
     border: 1px solid hsl(0, 0%, 80%);
     background-color: hsl(0, 0%, 100%);
@@ -128,7 +128,7 @@ button {
 .poll-edit-question {
     opacity: 0.4;
     display: inline-block;
-    margin-left: 5px;
+    margin-left: 0.3125rem;
 
     &:hover {
         opacity: 1;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -133,13 +133,13 @@ p.n-margin {
     height: 28px;
     font-size: 1rem;
     margin: 0 auto 12px;
-    padding: 5px;
+    padding: 0.3125rem;
     i {
         margin: 0 3px 0 1px;
     }
     p {
         margin: 0;
-        padding: 4px;
+        padding: 0.25rem;
     }
 }
 
@@ -172,7 +172,7 @@ p.n-margin {
     width: 400px;
     top: 0;
     left: calc(50vw - 220px);
-    padding: 15px;
+    padding: 0.9375rem;
 
     background-color: hsl(0, 0%, 98%);
     border-radius: 5px;
@@ -435,7 +435,7 @@ li,
     outline-color: hsl(0, 0%, 73%);
     height: 18px;
     width: 10px;
-    padding: 6px 6px;
+    padding: 0.375rem 0.375rem;
     display: block;
     /* The below two avoids the padded element from displaying
     it's own border and background color */
@@ -524,7 +524,7 @@ strong {
 
     .tooltip-inner {
         background-color: hsla(0, 0%, 7%, 0.8);
-        padding: 3px 5px;
+        padding: 0.1875rem 0.3125rem;
     }
 }
 
@@ -570,7 +570,7 @@ strong {
     li {
         a {
             display: block;
-            padding: 3px 20px;
+            padding: 0.1875rem 1.25rem;
             clear: both;
             font-weight: normal;
             line-height: 20px;
@@ -635,7 +635,7 @@ li.actual-dropdown-menu i {
 }
 
 .settings-dropdown-cog {
-    padding: 6px 12px;
+    padding: 0.375rem 0.75rem;
 }
 
 .message_area_padder {
@@ -730,7 +730,7 @@ td.pointer {
     display: block;
     font-size: 0.75rem;
     opacity: 0.4;
-    padding: 1px;
+    padding: 0.0625rem;
     font-weight: 400;
     position: absolute;
     right: -105px;
@@ -912,7 +912,7 @@ td.pointer {
 
 .stream_label {
     display: inline-block;
-    padding: 4px 6px 3px 6px;
+    padding: 0.25rem 0.375rem 0.1875rem 0.375rem;
     font-weight: normal;
     height: 17px;
     line-height: 17px;
@@ -970,7 +970,7 @@ td.pointer {
 
 .stream_topic {
     display: inline-block;
-    padding: 3px 3px 2px 9px;
+    padding: 0.1875rem 0.1875rem 0.125rem 0.5625rem;
     height: 17px;
     line-height: 17px;
     overflow: hidden;
@@ -985,7 +985,7 @@ td.pointer {
     color: hsl(0, 0%, 53%);
     font-size: 0.75rem;
     font-weight: 600;
-    padding: 3px 11px 2px 10px;
+    padding: 0.1875rem 0.6875rem 0.125rem 0.625rem;
     height: 17px;
     line-height: 17px;
 
@@ -1001,7 +1001,7 @@ td.pointer {
 
 .summary_row {
     .message_header {
-        padding: 5px 0 4px 5px;
+        padding: 0.3125rem 0 0.25rem 0.3125rem;
         border-radius: 0;
     }
 
@@ -1080,7 +1080,7 @@ td.pointer {
     .message_label_clickable {
         background-color: hsl(0, 0%, 27%);
         display: inline-block;
-        padding: 3px 6px 2px 6px;
+        padding: 0.1875rem 0.375rem 0.125rem 0.375rem;
         font-weight: normal;
         font-size: 0.875rem;
         height: 17px;
@@ -1389,7 +1389,7 @@ div.focused_table {
     .alert {
         display: inline-block;
         margin: 0;
-        padding: 0 10px;
+        padding: 0 0.625rem;
         line-height: 17px;
         font-size: 0.875rem;
     }
@@ -1401,7 +1401,7 @@ div.focused_table {
     &.header-v {
         height: 18px;
         display: inline-block;
-        padding: 0 3px;
+        padding: 0 0.1875rem;
         vertical-align: baseline;
 
         line-height: 0px;
@@ -1485,7 +1485,7 @@ div.focused_table {
 }
 
 .messagebox-content {
-    padding: 4px 115px 1px 10px;
+    padding: 0.25rem 7.1875rem 0.0625rem 0.625rem;
 }
 
 .bookend {
@@ -1575,10 +1575,10 @@ div.focused_table {
         font-size: 1rem;
         line-height: 16px;
         margin: 0 -4px 0 0;
-        padding: 12px 6px;
+        padding: 0.75rem 0.375rem;
 
         @media (max-width: 500px) {
-            padding: 7px 3.5px; /* based on having ~41.66% decrease */
+            padding: 0.4375rem 3.0.3125rem; /* based on having ~41.66% decrease */
         }
         i {
             margin-right: 3px;
@@ -1662,16 +1662,16 @@ div.focused_table {
         overflow: hidden;
         white-space: nowrap;
         margin: 0;
-        padding: 12px 0;
+        padding: 0.75rem 0;
         padding-left: 10px;
 
         @media (max-width: 500px) {
-            padding: 7px 0;
+            padding: 0.4375rem 0;
             padding-left: 10px;
         }
 
         & > a {
-            padding: 12px 0;
+            padding: 0.75rem 0;
         }
     }
 
@@ -1681,9 +1681,9 @@ div.focused_table {
         cursor: pointer;
         font-size: 1.25rem;
 
-        padding: 10px 15px 0 0;
+        padding: 0.625rem 0.9375rem 0 0;
         @media (max-width: 500px) {
-            padding: 5px 15px 0 0;
+            padding: 0.3125rem 0.9375rem 0 0;
         }
     }
 
@@ -1782,7 +1782,7 @@ div.focused_table {
         border: none;
         height: 30px;
         text-align: center;
-        padding: 4px;
+        padding: 0.25rem;
         color: hsl(0, 0%, 80%);
         font-size: 1.125rem;
         box-shadow: none;
@@ -1803,7 +1803,7 @@ div.focused_table {
         height: 100%;
         color: hsl(0, 0%, 80%);
         text-decoration: none;
-        padding: 0 10px;
+        padding: 0 0.625rem;
         font-size: 1.25rem;
         z-index: 5;
         left: 0;
@@ -1831,7 +1831,7 @@ div.focused_table {
 
     @media (min-width: 500px) {
         .pill {
-            padding: 2px 0 2px 0 !important;
+            padding: 0.125rem 0 0.125rem 0 !important;
             font-size: 0.875rem;
         }
     }
@@ -1949,7 +1949,7 @@ div.focused_table {
     border: 1px solid hsl(0, 0%, 93%);
     box-shadow: 0 0 1px hsla(0, 0%, 0%, 0.2);
     border-radius: 12px;
-    padding: 1px 1px 1px 1px;
+    padding: 0.0625rem 0.0625rem 0.0625rem 0.0625rem;
     font-size: 0.5625rem;
     z-index: 15;
     font-weight: normal;
@@ -2199,7 +2199,7 @@ div.topic_edit_spinner {
     width: 18px;
     height: 18px;
     margin-top: -1px;
-    padding: 2px;
+    padding: 0.125rem;
     vertical-align: middle;
 }
 
@@ -2249,7 +2249,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 #invite-user {
     .modal-header {
-        padding: 7px 15px;
+        padding: 0.4375rem 0.9375rem;
         border-color: hsl(0, 0%, 87%);
 
         .exit {
@@ -2406,7 +2406,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 .sub-unsub-message span,
 .date_row span {
     display: block;
-    padding: 4px;
+    padding: 0.25rem;
     overflow: hidden;
     text-transform: uppercase;
     font-size: 0.8em;
@@ -2567,7 +2567,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
     visibility: hidden;
     opacity: 0;
     position: relative;
-    padding: 5px 8px;
+    padding: 0.3125rem 0.5rem;
     left: -50%;
     top: 10px;
     border-radius: 6px;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1,7 +1,7 @@
 /*
 This is the header, aka the navbar.
 */
-$header_height: 40px;
+$header_height: 2.5rem;
 
 /*
 We have a 10px gutter below the header,
@@ -9,7 +9,7 @@ which often needs to be respected by both
 the elements above it and below it on
 the y-axis, due to absolute positioning.
 */
-$header_padding_bottom: 10px;
+$header_padding_bottom: 0.625rem;
 
 /*
 Our sidebars (and anything that top-align
@@ -84,7 +84,7 @@ pre {
 }
 
 p.n-margin {
-    margin: 10px 0 0 0;
+    margin: 0.625rem 0 0 0;
 }
 
 .small-line-height {
@@ -130,12 +130,12 @@ p.n-margin {
 .all-messages-search-caution {
     border-radius: 4px;
     display: none;
-    height: 28px;
+    height: 1.75rem;
     font-size: 1rem;
-    margin: 0 auto 12px;
+    margin: 0 auto 0.75rem;
     padding: 0.3125rem;
     i {
-        margin: 0 3px 0 1px;
+        margin: 0 0.1875rem 0 0.0625rem;
     }
     p {
         margin: 0;
@@ -149,9 +149,9 @@ p.n-margin {
 
 .top-messages-logo,
 .bottom-messages-logo {
-    width: 24px;
-    height: 24px;
-    margin: 0 auto 12px;
+    width: 1.5rem;
+    height: 1.5rem;
+    margin: 0 auto 0.75rem;
 
     svg {
         circle {
@@ -169,7 +169,7 @@ p.n-margin {
 #feedback_container {
     display: none;
     position: absolute;
-    width: 400px;
+    width: 25.0rem;
     top: 0;
     left: calc(50vw - 220px);
     padding: 0.9375rem;
@@ -192,13 +192,13 @@ p.n-margin {
 
     h3 {
         font-size: 16pt;
-        margin-top: 2px;
+        margin-top: 0.125rem;
     }
 
     .exit-me {
         font-size: 30pt;
         font-weight: 200;
-        margin: 5px 0 0 10px;
+        margin: 0.3125rem 0 0 0.625rem;
         cursor: pointer;
     }
 }
@@ -271,7 +271,7 @@ p.n-margin {
         }
 
         .close {
-            line-height: 24px;
+            line-height: 1.5rem;
             position: absolute;
             right: 18px;
             top: 50%;
@@ -288,7 +288,7 @@ p.n-margin {
         }
 
         .buttons .alert-link {
-            margin: 0 5px;
+            margin: 0 0.3125rem;
         }
     }
 }
@@ -314,8 +314,8 @@ p.n-margin {
        max-width at all.  The consequence is that if you reload a
        Zulip window, there's a brief flash where the content is
        misplaced before the JS code can fix it. */
-    max-width: 1400px;
-    min-width: 950px;
+    max-width: 87.5rem;
+    min-width: 59.375rem;
     margin: 0 auto;
     padding: 0;
     position: relative;
@@ -331,8 +331,8 @@ p.n-margin {
 
 .column-left,
 .column-right {
-    width: 250px;
-    max-width: 250px;
+    width: 15.625rem;
+    max-width: 15.625rem;
 }
 
 .column-left {
@@ -359,13 +359,13 @@ p.n-margin {
     }
 
     .column-left .left-sidebar {
-        width: 242px;
+        width: 15.125rem;
         padding-left: 0;
     }
 
     .column-right .right-sidebar {
         padding-left: 0.625rem;
-        width: 240px;
+        width: 15.0rem;
     }
 
     .column-middle {
@@ -374,8 +374,8 @@ p.n-margin {
 }
 
 .column-middle {
-    margin-right: 250px;
-    margin-left: 250px;
+    margin-right: 15.625rem;
+    margin-left: 15.625rem;
     position: relative;
 }
 
@@ -433,8 +433,8 @@ li,
 /* Classes which style copy buttons */
 .copy_button_base {
     outline-color: hsl(0, 0%, 73%);
-    height: 18px;
-    width: 10px;
+    height: 1.125rem;
+    width: 0.625rem;
     padding: 0.375rem 0.375rem;
     display: block;
     /* The below two avoids the padded element from displaying
@@ -455,12 +455,12 @@ li,
     position: relative;
     top: 27px;
     left: -10px;
-    margin-top: -24px;
+    margin-top: -1.5rem;
 }
 
 #clipboard_image {
-    margin-top: -5px;
-    margin-left: -8px;
+    margin-top: -0.3125rem;
+    margin-left: -0.5rem;
 }
 
 .btn-large {
@@ -494,7 +494,7 @@ strong {
 }
 
 .sp-input {
-    width: calc(100% - 14px);
+    width: calc(100% - 0.875rem);
     box-sizing: initial !important;
 }
 
@@ -517,8 +517,8 @@ strong {
         opacity: 1;
 
         &.left {
-            margin-left: -12px;
-            margin-top: 3px;
+            margin-left: -0.75rem;
+            margin-top: 0.1875rem;
         }
     }
 
@@ -536,8 +536,8 @@ strong {
     float: right;
     color: hsl(0, 0%, 0%);
     font-size: 0.8125rem;
-    margin-top: 3px;
-    margin-left: 6px;
+    margin-top: 0.1875rem;
+    margin-left: 0.375rem;
     opacity: 0.5;
     cursor: pointer;
 
@@ -547,7 +547,7 @@ strong {
 }
 
 .message-edit-tooltip-inner {
-    width: 200px;
+    width: 12.5rem;
     position: absolute;
     right: 7px;
     top: -18px;
@@ -573,7 +573,7 @@ strong {
             padding: 0.1875rem 1.25rem;
             clear: both;
             font-weight: normal;
-            line-height: 20px;
+            line-height: 1.25rem;
             color: hsl(0, 0%, 20%);
             white-space: nowrap;
 
@@ -629,9 +629,9 @@ li.actual-dropdown-menu > a:focus {
 li.actual-dropdown-menu i {
     /* In gear menu, make icons the same width so labels line up. */
     display: inline-block;
-    width: 14px;
+    width: 0.875rem;
     text-align: center;
-    margin-right: 3px;
+    margin-right: 0.1875rem;
 }
 
 .settings-dropdown-cog {
@@ -640,7 +640,7 @@ li.actual-dropdown-menu i {
 
 .message_area_padder {
     /* The height of the header and the message_view_header plus a small gap */
-    margin-top: 57px;
+    margin-top: 3.5625rem;
     /* This is needed for the floating recipient bar
        in Firefox only, for some reason;
        otherwise it gets a scrollbar */
@@ -666,7 +666,7 @@ td.pointer {
     .message_edit_notice {
         display: inline-block;
         vertical-align: top;
-        line-height: 14px;
+        line-height: 0.875rem;
         margin-left: 0;
         position: static;
         padding: 0;
@@ -686,40 +686,40 @@ td.pointer {
     }
 
     .message_top_line {
-        margin-top: 6px;
+        margin-top: 0.375rem;
     }
 
     .message_content:not(:empty) {
-        margin-top: -18px;
+        margin-top: -1.125rem;
     }
 
     .message_edit {
-        margin-top: -14px;
+        margin-top: -0.875rem;
     }
 }
 
 .sender-status {
     display: inline-block;
-    margin: 8px 0 8px -3px;
+    margin: 0.5rem 0 0.5rem -0.1875rem;
     /* this normalizes the margin of the emoji reactions with normal messages. */
     padding-bottom: 0.3125rem;
     vertical-align: middle;
-    line-height: 18px;
+    line-height: 1.125rem;
     font-size: 0.875rem;
     position: relative;
-    max-width: calc(100% - 50px);
+    max-width: calc(100% - 3.125rem);
 
     .message_edit_notice {
-        line-height: 18px;
+        line-height: 1.125rem;
     }
 }
 
 .message_edit_notice {
     font-size: 0.625rem;
     opacity: 0.5;
-    line-height: 0px;
+    line-height: 0.0rem;
     text-align: right;
-    width: 45px;
+    width: 2.8125rem;
     position: absolute;
     left: 0;
     top: 16px;
@@ -734,7 +734,7 @@ td.pointer {
     font-weight: 400;
     position: absolute;
     right: -105px;
-    line-height: 20px;
+    line-height: 1.25rem;
     text-align: right;
     transition: background-color 1.5s ease-in, color 1.5s ease-in;
 }
@@ -764,8 +764,8 @@ td.pointer {
     position: absolute;
     top: -1px;
     right: -56px;
-    width: 54px;
-    height: 22px;
+    width: 3.375rem;
+    height: 1.375rem;
     z-index: 1;
 
     /* This is a bit tricky; we need to reserve space for the message
@@ -777,7 +777,7 @@ td.pointer {
         opacity: 0;
         visibility: hidden;
         transition: all 0.2s ease;
-        width: 16px;
+        width: 1.0rem;
         text-align: center;
 
         > i {
@@ -803,7 +803,7 @@ td.pointer {
         display: inline-flex;
         justify-content: space-between;
         /* error icon width is 11px, gap between icons equals 28px - 2*11px = 6px */
-        width: 30px;
+        width: 1.875rem;
         cursor: pointer;
         font-weight: bold;
         color: hsl(0, 100%, 50%);
@@ -875,7 +875,7 @@ td.pointer {
     text-overflow: ellipsis;
     white-space: nowrap;
     font-weight: 600;
-    line-height: 14px;
+    line-height: 0.875rem;
     position: relative;
     z-index: 0;
 }
@@ -883,7 +883,7 @@ td.pointer {
 .message_list {
     .recipient_row {
         border-bottom: 1px solid hsl(0, 0%, 88%);
-        margin-bottom: 10px;
+        margin-bottom: 0.625rem;
     }
 }
 
@@ -914,8 +914,8 @@ td.pointer {
     display: inline-block;
     padding: 0.25rem 0.375rem 0.1875rem 0.375rem;
     font-weight: normal;
-    height: 17px;
-    line-height: 17px;
+    height: 1.0625rem;
+    line-height: 1.0625rem;
     border-top-color: hsla(0, 0%, 0%, 0);
     border-right-color: hsla(0, 0%, 0%, 0);
     border-bottom-color: hsla(0, 0%, 0%, 0);
@@ -927,7 +927,7 @@ td.pointer {
 
     .invite-stream-icon {
         font-size: 0.75rem;
-        line-height: 17px;
+        line-height: 1.0625rem;
     }
 
     &:hover {
@@ -942,9 +942,9 @@ td.pointer {
         width: 0;
         position: absolute;
         pointer-events: none;
-        margin-top: -11px;
+        margin-top: -0.6875rem;
         border-style: solid;
-        border-width: 11px 0 11px 5px;
+        border-width: 0.6875rem 0 0.6875rem 0.3125rem;
         border-color: inherit;
         z-index: 2;
         transform: scale(0.9999);
@@ -958,9 +958,9 @@ td.pointer {
         width: 0;
         position: absolute;
         pointer-events: none;
-        margin-top: -14px;
+        margin-top: -0.875rem;
         border-style: solid;
-        border-width: 14px 0 14px 6px;
+        border-width: 0.875rem 0 0.875rem 0.375rem;
         border-color: hsla(0, 0%, 0%, 0) hsla(0, 0%, 0%, 0) hsla(0, 0%, 0%, 0)
             transparent;
         z-index: 1;
@@ -971,8 +971,8 @@ td.pointer {
 .stream_topic {
     display: inline-block;
     padding: 0.1875rem 0.1875rem 0.125rem 0.5625rem;
-    height: 17px;
-    line-height: 17px;
+    height: 1.0625rem;
+    line-height: 1.0625rem;
     overflow: hidden;
     text-overflow: ellipsis;
 }
@@ -986,8 +986,8 @@ td.pointer {
     font-size: 0.75rem;
     font-weight: 600;
     padding: 0.1875rem 0.6875rem 0.125rem 0.625rem;
-    height: 17px;
-    line-height: 17px;
+    height: 1.0625rem;
+    line-height: 1.0625rem;
 
     &.hide-date {
         display: none;
@@ -1083,8 +1083,8 @@ td.pointer {
         padding: 0.1875rem 0.375rem 0.125rem 0.375rem;
         font-weight: normal;
         font-size: 0.875rem;
-        height: 17px;
-        line-height: 17px;
+        height: 1.0625rem;
+        line-height: 1.0625rem;
         border-left-color: hsl(0, 0%, 27%);
     }
 
@@ -1146,7 +1146,7 @@ td.pointer {
 
 .unread-marker-fill {
     background-color: hsl(107, 74%, 29%);
-    width: 3px;
+    width: 0.1875rem;
     height: 100%;
 }
 
@@ -1191,13 +1191,13 @@ td.pointer {
     display: inline-block;
     font-weight: 700;
     vertical-align: top;
-    line-height: 12px;
+    line-height: 0.75rem;
     font-size: 0.875rem;
-    margin-left: -3px;
+    margin-left: -0.1875rem;
 }
 
 .sender_name-in-status {
-    margin-right: 3px;
+    margin-right: 0.1875rem;
     font-weight: 700;
 }
 
@@ -1209,7 +1209,7 @@ td.pointer {
 }
 
 .popover_info i.zulip-icon.bot {
-    margin-top: 3px;
+    margin-top: 0.1875rem;
 }
 
 .actions_hover:hover {
@@ -1238,7 +1238,7 @@ td.pointer {
 }
 
 .edit_content {
-    width: 12px;
+    width: 0.75rem;
     display: inline-block;
     position: relative;
     color: hsl(0, 0%, 73%);
@@ -1325,9 +1325,9 @@ div.focused_table {
 
 .message_content {
     line-height: 1.214;
-    min-height: 17px;
+    min-height: 1.0625rem;
     font-size: 0.875rem;
-    margin-left: 46px;
+    margin-left: 2.875rem;
     display: block;
     position: relative;
     overflow: hidden;
@@ -1354,7 +1354,7 @@ div.focused_table {
 }
 
 .message_edit_content {
-    line-height: 18px;
+    line-height: 1.125rem;
     resize: vertical !important;
     max-height: 24em;
 }
@@ -1373,38 +1373,38 @@ div.focused_table {
 .message-edit-timer-control-group {
     float: right;
     display: none;
-    margin-top: 5px;
+    margin-top: 0.3125rem;
 }
 
 .message-edit-feature-group {
     display: inline-flex;
-    margin-left: 10px;
-    margin-bottom: -5px;
+    margin-left: 0.625rem;
+    margin-bottom: -0.3125rem;
     align-items: baseline;
 }
 
 .topic_edit {
     display: none;
-    line-height: 22px;
+    line-height: 1.375rem;
     .alert {
         display: inline-block;
         margin: 0;
         padding: 0 0.625rem;
-        line-height: 17px;
+        line-height: 1.0625rem;
         font-size: 0.875rem;
     }
 }
 
 #inline_topic_edit {
-    margin-bottom: 5px;
+    margin-bottom: 0.3125rem;
 
     &.header-v {
-        height: 18px;
+        height: 1.125rem;
         display: inline-block;
         padding: 0 0.1875rem;
         vertical-align: baseline;
 
-        line-height: 0px;
+        line-height: 0.0rem;
         font-size: 0.875rem;
 
         box-shadow: none;
@@ -1412,7 +1412,7 @@ div.focused_table {
 }
 
 #message_edit_topic {
-    margin: 0 5px 5px 0;
+    margin: 0 0.3125rem 0.3125rem 0;
 }
 
 .message_edit_header {
@@ -1422,11 +1422,11 @@ div.focused_table {
 }
 
 .select_edit_stream {
-    margin-bottom: 5px !important;
+    margin-bottom: 0.3125rem !important;
     border-left: 0;
     padding-left: 0;
     border-radius: 3px;
-    margin-left: -10px;
+    margin-left: -0.625rem;
     text-indent: 10px;
 }
 
@@ -1437,14 +1437,14 @@ div.focused_table {
 
 .message_edit_topic_propagate {
     display: inline-block;
-    width: 300px;
-    margin-bottom: 5px !important;
+    width: 18.75rem;
+    margin-bottom: 0.3125rem !important;
     max-width: 100%;
 }
 
 .topic_move_breadcrumb_messages,
 .message_edit_breadcrumb_messages {
-    margin: 0 5px 5px 0 !important;
+    margin: 0 0.3125rem 0.3125rem 0 !important;
     align-self: center;
     width: 100%;
     white-space: nowrap;
@@ -1460,12 +1460,12 @@ div.focused_table {
 
     label {
         display: inline-block;
-        margin-right: 10px;
+        margin-right: 0.625rem;
     }
 }
 
 .topic_move_breadcrumb_messages {
-    margin-top: 10px !important;
+    margin-top: 0.625rem !important;
 }
 
 .message_length_controller {
@@ -1474,10 +1474,10 @@ div.focused_table {
     color: hsl(200, 100%, 40%);
 
     /* to match .message_content */
-    margin-left: 5px;
-    margin-right: 35px;
+    margin-left: 0.3125rem;
+    margin-right: 2.1875rem;
     /* to make message-uncollapse easier */
-    margin-top: 10px;
+    margin-top: 0.625rem;
 
     &:hover {
         text-decoration: underline;
@@ -1489,7 +1489,7 @@ div.focused_table {
 }
 
 .bookend {
-    margin-top: 10px;
+    margin-top: 0.625rem;
     background-color: transparent;
 }
 
@@ -1500,9 +1500,9 @@ div.focused_table {
 
 .inline_profile_picture {
     display: inline-block;
-    width: 35px;
-    height: 35px;
-    margin-right: 11px;
+    width: 2.1875rem;
+    height: 2.1875rem;
+    margin-right: 0.6875rem;
     vertical-align: top;
     border-radius: 4px;
     overflow: hidden;
@@ -1513,7 +1513,7 @@ div.focused_table {
 }
 
 .home-error-bar {
-    margin-top: 5px;
+    margin-top: 0.3125rem;
     display: none;
 
     .alert {
@@ -1573,26 +1573,26 @@ div.focused_table {
         position: relative;
         font-weight: 600;
         font-size: 1rem;
-        line-height: 16px;
-        margin: 0 -4px 0 0;
+        line-height: 1.0rem;
+        margin: 0 -0.25rem 0 0;
         padding: 0.75rem 0.375rem;
 
         @media (max-width: 500px) {
             padding: 0.4375rem 3.0.3125rem; /* based on having ~41.66% decrease */
         }
         i {
-            margin-right: 3px;
+            margin-right: 0.1875rem;
         }
         .fa {
-            margin: 0 3px 0 5px;
+            margin: 0 0.1875rem 0 0.3125rem;
             .fa-envelope {
                 font-size: 0.875rem;
-                margin: 0 5px 0 5px;
+                margin: 0 0.3125rem 0 0.3125rem;
             }
             .fa-hashtag {
                 font-size: 1.2rem;
                 /* font-weight: 800; */
-                margin: 0 2px 0 5px;
+                margin: 0 0.125rem 0 0.3125rem;
             }
         }
     }
@@ -1612,14 +1612,14 @@ div.focused_table {
         font-size: 0.875rem;
         color: hsl(0, 0%, 40%);
         font-weight: 400;
-        line-height: 20px;
+        line-height: 1.25rem;
     }
 
     .sub_count {
         padding-left: 0.625rem;
-        margin-left: 1px;
+        margin-left: 0.0625rem;
         padding-right: 0.625rem;
-        margin-right: 1px;
+        margin-right: 0.0625rem;
         .fa.fa-user-o {
             margin-left: 0;
         }
@@ -1726,11 +1726,11 @@ div.focused_table {
     .navbar-search.expanded {
         overflow: hidden;
         margin-top: 0;
-        width: calc(100% - 2px);
+        width: calc(100% - 0.125rem);
         position: absolute;
         .search_button {
             display: inline;
-            margin-right: 15px;
+            margin-right: 0.9375rem;
         }
     }
 
@@ -1780,7 +1780,7 @@ div.focused_table {
         background: none;
         border-radius: 0;
         border: none;
-        height: 30px;
+        height: 1.875rem;
         text-align: center;
         padding: 0.25rem;
         color: hsl(0, 0%, 80%);
@@ -1837,7 +1837,7 @@ div.focused_table {
     }
     @media (max-width: 500px) {
         #search_arrows .pill {
-            line-height: 20px;
+            line-height: 1.25rem;
 
             .exit {
                 top: 0;
@@ -1858,7 +1858,7 @@ div.focused_table {
     }
     .navbar-search.expanded {
         .search_button {
-            margin-right: 14px;
+            margin-right: 0.875rem;
         }
     }
 }
@@ -1873,8 +1873,8 @@ div.focused_table {
 
 #navbar-buttons {
     white-space: nowrap;
-    margin-left: 15px;
-    margin-top: 7px;
+    margin-left: 0.9375rem;
+    margin-top: 0.4375rem;
     display: inline-block;
     float: right;
 
@@ -1908,8 +1908,8 @@ div.focused_table {
         }
 
         li.dropdown li.divider {
-            margin-left: 15px;
-            margin-right: 15px;
+            margin-left: 0.9375rem;
+            margin-right: 0.9375rem;
         }
     }
 }
@@ -1930,8 +1930,8 @@ div.focused_table {
     display: block;
     position: relative;
     background-color: hsl(0, 0%, 89%);
-    width: 40px;
-    height: 19px;
+    width: 2.5rem;
+    height: 1.1875rem;
     padding-top: 0.75rem;
     padding-bottom: 0.5625rem;
 }
@@ -1940,9 +1940,9 @@ div.focused_table {
 #userlist-toggle-unreadcount {
     position: absolute;
     display: none;
-    height: 12px;
-    min-width: 12px;
-    line-height: 12px;
+    height: 0.75rem;
+    min-width: 0.75rem;
+    line-height: 0.75rem;
     background-color: hsl(0, 100%, 20%);
     top: 4px;
     right: 4px;
@@ -1960,7 +1960,7 @@ div.focused_table {
     left: auto;
     right: 0;
     top: 30px;
-    min-width: 180px;
+    min-width: 11.25rem;
     box-shadow: 0 0 5px hsla(0, 0%, 0%, 0.2);
 
     &::after {
@@ -1990,8 +1990,8 @@ div.focused_table {
         .unsubscribed_icon {
             display: block;
             float: right;
-            margin-top: 5px;
-            margin-right: -12px;
+            margin-top: 0.3125rem;
+            margin-right: -0.75rem;
             font-size: 0.8em;
             color: hsl(96, 7%, 73%);
         }
@@ -2004,10 +2004,10 @@ div.focused_table {
 
 .typeahead-image {
     display: inline-block;
-    height: 21px;
-    width: 21px;
+    height: 1.3125rem;
+    width: 1.3125rem;
     position: relative;
-    margin-top: -7px;
+    margin-top: -0.4375rem;
     vertical-align: middle;
     top: 2px;
     right: 8px;
@@ -2025,17 +2025,17 @@ nav {
         .nav-logo {
             display: inline-block;
             vertical-align: top;
-            margin-top: 8px;
-            height: 25px;
-            max-width: 200px;
+            margin-top: 0.5rem;
+            height: 1.5625rem;
+            max-width: 12.5rem;
         }
 
         .company-name {
             display: inline-block;
             vertical-align: top;
             text-transform: uppercase;
-            margin-top: 12px;
-            margin-left: 8px;
+            margin-top: 0.75rem;
+            margin-left: 0.5rem;
             font-size: 1.2rem;
             font-weight: 600;
             color: hsl(170, 48%, 54%);
@@ -2072,7 +2072,7 @@ div.floating_recipient {
 
 #bottom_whitespace {
     display: block;
-    height: 300px;
+    height: 18.75rem;
 }
 
 .operator_value {
@@ -2086,7 +2086,7 @@ div.floating_recipient {
 
 #loading_older_messages_indicator,
 #loading_newer_messages_indicator {
-    margin: 10px;
+    margin: 0.625rem;
 }
 
 #loading_older_messages_indicator_box_container,
@@ -2105,7 +2105,7 @@ div.floating_recipient {
 }
 
 #page_loading_indicator {
-    margin: 10px auto;
+    margin: 0.625rem auto;
 }
 
 #page_loading_indicator_box_container {
@@ -2127,20 +2127,20 @@ div.floating_recipient {
 }
 
 #user-checkboxes {
-    margin-top: 10px;
+    margin-top: 0.625rem;
 
     .checkbox {
         display: block;
 
         input[type="checkbox"] {
-            margin: 5px 0;
+            margin: 0.3125rem 0;
             float: none;
         }
     }
 }
 
 #stream-checkboxes {
-    margin-top: 10px;
+    margin-top: 0.625rem;
     display: none;
 
     .checkbox {
@@ -2148,7 +2148,7 @@ div.floating_recipient {
     }
 
     input[type="checkbox"] {
-        margin: 5px 0;
+        margin: 0.3125rem 0;
         float: none;
     }
 }
@@ -2165,10 +2165,10 @@ div.floating_recipient {
     padding: 0;
     border: none;
     font-size: 0.75rem;
-    width: 18px;
-    height: 18px;
+    width: 1.125rem;
+    height: 1.125rem;
     border-radius: 4px;
-    margin-bottom: 3px;
+    margin-bottom: 0.1875rem;
 
     &:focus {
         outline: none;
@@ -2196,26 +2196,26 @@ div.floating_recipient {
 
 div.topic_edit_spinner {
     display: inline-block;
-    width: 18px;
-    height: 18px;
-    margin-top: -1px;
+    width: 1.125rem;
+    height: 1.125rem;
+    margin-top: -0.0625rem;
     padding: 0.125rem;
     vertical-align: middle;
 }
 
 div.topic_edit_spinner .loading_indicator_spinner {
-    width: 14px;
-    height: 14px;
+    width: 0.875rem;
+    height: 0.875rem;
 }
 
 .message_edit_spinner {
-    margin-right: 8px;
+    margin-right: 0.5rem;
     padding-top: 0.3125rem;
 }
 
 .message_edit_spinner .loading_indicator_spinner {
-    width: 20px;
-    height: 20px;
+    width: 1.25rem;
+    height: 1.25rem;
 }
 
 .topic_move_spinner,
@@ -2241,8 +2241,8 @@ div.topic_edit_spinner .loading_indicator_spinner {
 }
 
 #invitee_emails {
-    min-height: 40px;
-    max-height: 300px;
+    min-height: 2.5rem;
+    max-height: 18.75rem;
     width: 96%;
     max-width: 96%;
 }
@@ -2266,23 +2266,23 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
     .overlay-content {
         position: relative;
-        width: 500px;
+        width: 31.25rem;
         border-radius: 4px;
     }
 
     .modal-body {
-        margin-bottom: 58px;
+        margin-bottom: 3.625rem;
         position: relative;
     }
 
     .modal-footer {
         position: absolute;
         bottom: 0;
-        width: calc(100% - 30px);
+        width: calc(100% - 1.875rem);
     }
 
     .invite-stream-controls {
-        margin-top: 5px;
+        margin-top: 0.3125rem;
     }
 }
 
@@ -2299,8 +2299,8 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 #multiuse_invite_status {
     display: none;
-    margin-top: 7px;
-    margin-bottom: -5px;
+    margin-top: 0.4375rem;
+    margin-bottom: -0.3125rem;
     text-align: left;
 }
 
@@ -2309,12 +2309,12 @@ div.topic_edit_spinner .loading_indicator_spinner {
 }
 
 #invite-method-choice {
-    margin-top: 2px;
+    margin-top: 0.125rem;
 }
 
 #multiuse_radio_section {
-    margin-top: 4px;
-    margin-bottom: -2px;
+    margin-top: 0.25rem;
+    margin-bottom: -0.125rem;
     display: none;
 }
 
@@ -2328,13 +2328,13 @@ div.topic_edit_spinner .loading_indicator_spinner {
     z-index: 10;
     bottom: 0;
     right: 20px;
-    width: 200px;
+    width: 12.5rem;
     height: auto;
 }
 
 .notifications-gravatar img {
-    max-width: 25px;
-    max-height: 25px;
+    max-width: 1.5625rem;
+    max-height: 1.5625rem;
     padding-left: 0.25rem;
     padding-top: 0.25rem;
 }
@@ -2355,10 +2355,10 @@ div.topic_edit_spinner .loading_indicator_spinner {
 }
 
 .emoji {
-    height: 25px;
-    width: 25px;
+    height: 1.5625rem;
+    width: 1.5625rem;
     position: relative;
-    margin-top: -7px;
+    margin-top: -0.4375rem;
     vertical-align: middle;
     top: 3px;
 }
@@ -2366,7 +2366,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 /* FIXME: Combine this rule with the one in portico.css somehow? */
 #pw_strength {
     width: 100%;
-    height: 10px;
+    height: 0.625rem;
     margin-bottom: 0;
 }
 
@@ -2399,7 +2399,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
         width: 33%;
         border-top: 1px solid hsl(0, 0%, 88%);
         border-bottom: 1px solid hsl(0, 0%, 100%);
-        margin: 0 5px 0 5px;
+        margin: 0 0.3125rem 0 0.3125rem;
     }
 }
 
@@ -2446,14 +2446,14 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 .message_edit {
     display: none;
-    margin-top: 5px;
-    margin-left: 47px;
+    margin-top: 0.3125rem;
+    margin-left: 2.9375rem;
     position: relative;
 }
 
 /* Reduce some of the heavy padding from Bootstrap. */
 #message_edit_form {
-    margin-bottom: 10px;
+    margin-bottom: 0.625rem;
     cursor: default;
 
     .edit-controls {
@@ -2463,7 +2463,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
     textarea {
         width: 100%;
-        min-width: 206px;
+        min-width: 12.875rem;
         box-sizing: border-box;
         /* Setting resize as none hides the bottom right diagonal box
            (which even has a background color of its own!). */
@@ -2475,22 +2475,22 @@ div.topic_edit_spinner .loading_indicator_spinner {
     }
 
     .action-buttons {
-        margin: 10px 0;
+        margin: 0.625rem 0;
     }
 }
 
 #topic_edit_form {
     display: inline-block;
     margin: 0 0 0 0;
-    height: 22px;
+    height: 1.375rem;
     padding-left: 1.25rem;
     padding-right: 0.1875rem;
-    line-height: 22px;
-    margin-left: -15px;
+    line-height: 1.375rem;
+    margin-left: -0.9375rem;
 }
 
 #message_feed_container {
-    margin-top: 41px;
+    margin-top: 2.5625rem;
 }
 
 .screen {
@@ -2503,19 +2503,19 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 .tutorial-done-button {
     text-align: right;
-    margin-top: 9px;
-    margin-bottom: 8px;
+    margin-top: 0.5625rem;
+    margin-bottom: 0.5rem;
 }
 
 .btn-skip {
     position: relative;
     left: -10px;
-    margin-right: 25px;
+    margin-right: 1.5625rem;
 }
 
 .deactivated_user .deactivated-user-icon {
     color: inherit;
-    margin-left: 2px;
+    margin-left: 0.125rem;
     font-size: 0.9em;
 }
 
@@ -2580,8 +2580,8 @@ div.topic_edit_spinner .loading_indicator_spinner {
         position: absolute;
         top: -47%;
         left: 50%;
-        margin-left: -5px;
-        border-width: 7px;
+        margin-left: -0.3125rem;
+        border-width: 0.4375rem;
         border-style: solid;
         border-color: transparent;
         border-bottom: hsl(0, 0%, 30%) solid 7px;
@@ -2605,7 +2605,7 @@ select.inline_select_topic_edit {
 @media (max-width: 1165px) {
     .app-main,
     .header-main {
-        min-width: 750px;
+        min-width: 46.875rem;
     }
 
     .column-right {
@@ -2640,15 +2640,15 @@ select.inline_select_topic_edit {
 
     .header-main .column-right {
         display: inline-block;
-        width: 30px;
+        width: 1.875rem;
     }
 
     #top_navbar.rightside-userlist #navbar-buttons {
-        margin-right: 41px;
+        margin-right: 2.5625rem;
     }
 
     .nav .dropdown-menu {
-        min-width: 180px;
+        min-width: 11.25rem;
         box-shadow: 0 0 5px hsla(0, 0%, 0%, 0.2);
 
         &::after {
@@ -2657,13 +2657,13 @@ select.inline_select_topic_edit {
     }
 
     .column-middle {
-        margin-right: 7px;
+        margin-right: 0.4375rem;
     }
 
     .top-navbar-container,
     #searchbox_legacy .navbar-search.expanded,
     #searchbox .navbar-search.expanded {
-        width: calc(100% - 84px);
+        width: calc(100% - 5.25rem);
     }
 
     .search_closed .fa-search {
@@ -2677,7 +2677,7 @@ select.inline_select_topic_edit {
         .top-navbar-border,
         #searchbox_legacy .navbar-search.expanded,
         #searchbox .navbar-search.expanded {
-            width: calc(100% - 50px);
+            width: calc(100% - 3.125rem);
         }
     }
 }
@@ -2710,7 +2710,7 @@ select.inline_select_topic_edit {
 
                 height: 100%;
                 padding-left: 0.625rem;
-                width: 250px;
+                width: 15.625rem;
             }
         }
     }
@@ -2719,13 +2719,13 @@ select.inline_select_topic_edit {
     html,
     .app-main,
     .header-main {
-        min-width: 350px;
+        min-width: 21.875rem;
     }
 
     .column-middle,
     .app-main .column-middle {
-        margin-left: 7px;
-        margin-right: 7px;
+        margin-left: 0.4375rem;
+        margin-right: 0.4375rem;
     }
 
     .header-main .column-middle {
@@ -2734,7 +2734,7 @@ select.inline_select_topic_edit {
 
     .column-middle-inner {
         margin-left: 0;
-        margin-right: 15px;
+        margin-right: 0.9375rem;
     }
 
     .app-main .column-middle .column-middle-inner {
@@ -2751,15 +2751,15 @@ select.inline_select_topic_edit {
     }
 
     .top-navbar-border {
-        margin-left: 40px;
-        width: calc(100% - 108px);
+        margin-left: 2.5rem;
+        width: calc(100% - 6.75rem);
     }
     /* todo: Figure out why this has to be different
        from above at this width and resolve it
        #searchbox_legacy .navbar-search.expanded, */
     #searchbox_legacy .navbar-search.expanded,
     #searchbox .navbar-search.expanded {
-        width: calc(100% - 123px);
+        width: calc(100% - 7.6875rem);
     }
 
     .search_closed .fa-search {
@@ -2771,11 +2771,11 @@ select.inline_select_topic_edit {
                right: 115px;
            } */
         .top-navbar-border {
-            width: calc(100% - 75px);
+            width: calc(100% - 4.6875rem);
         }
         #searchbox_legacy .navbar-search.expanded,
         #searchbox .navbar-search.expanded {
-            width: calc(100% - 90px);
+            width: calc(100% - 5.625rem);
         }
     }
 }
@@ -2783,7 +2783,7 @@ select.inline_select_topic_edit {
 @media (max-width: 500px) {
     .column-right.expanded .right-sidebar,
     .column-left.expanded .left-sidebar {
-        margin-top: 31px;
+        margin-top: 1.9375rem;
     }
 
     .column-left.expanded {
@@ -2796,7 +2796,7 @@ select.inline_select_topic_edit {
         }
 
         .narrows_panel {
-            margin-top: 10px;
+            margin-top: 0.625rem;
         }
     }
 
@@ -2811,17 +2811,17 @@ select.inline_select_topic_edit {
     #searchbox,
     #searchbox_legacy,
     .header {
-        height: 30px;
-        line-height: 30px;
+        height: 1.875rem;
+        line-height: 1.875rem;
     }
 
     #search_query {
-        height: 30px !important;
+        height: 1.875rem !important;
         vertical-align: text-bottom;
     }
 
     #streamlist-toggle-button {
-        height: 30px;
+        height: 1.875rem;
         padding-top: 0;
         padding-bottom: 0;
     }
@@ -2845,7 +2845,7 @@ select.inline_select_topic_edit {
 
     #message_view_header_underpadding {
         top: 30px;
-        height: 10px;
+        height: 0.625rem;
     }
 
     .messagebox-content {
@@ -2869,11 +2869,11 @@ select.inline_select_topic_edit {
     }
 
     .sender_name {
-        max-width: 250px;
+        max-width: 15.625rem;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
-        line-height: 15px;
+        line-height: 0.9375rem;
     }
 
     #floating_recipient_bar {
@@ -2894,13 +2894,13 @@ select.inline_select_topic_edit {
     html,
     .app-main,
     .header-main {
-        min-width: 320px;
+        min-width: 20.0rem;
     }
 }
 
 @media only screen and (min-width: 300px) and (max-width: 700px) {
     #feedback_container {
-        width: calc(90% - 30px);
+        width: calc(90% - 1.875rem);
         left: 5%;
         top: 5%;
     }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -252,8 +252,8 @@ p.n-margin {
 
     .alert {
         margin: 0;
-        padding-top: 12px;
-        padding-bottom: 12px;
+        padding-top: 0.75rem;
+        padding-bottom: 0.75rem;
 
         border: none;
         border-radius: 0;
@@ -364,7 +364,7 @@ p.n-margin {
     }
 
     .column-right .right-sidebar {
-        padding-left: 10px;
+        padding-left: 0.625rem;
         width: 240px;
     }
 
@@ -649,7 +649,7 @@ li.actual-dropdown-menu i {
 
 td.pointer {
     vertical-align: top;
-    padding-top: 10px;
+    padding-top: 0.625rem;
     background-color: hsl(0, 0%, 100%);
 }
 
@@ -702,7 +702,7 @@ td.pointer {
     display: inline-block;
     margin: 8px 0 8px -3px;
     /* this normalizes the margin of the emoji reactions with normal messages. */
-    padding-bottom: 5px;
+    padding-bottom: 0.3125rem;
     vertical-align: middle;
     line-height: 18px;
     font-size: 0.875rem;
@@ -749,8 +749,8 @@ td.pointer {
     color: hsl(170, 48%, 54%);
     background-color: hsl(0, 0%, 100%);
     z-index: 999;
-    padding-left: 20px;
-    padding-right: 40px;
+    padding-left: 1.25rem;
+    padding-right: 2.5rem;
     font-weight: 400;
     display: none;
 }
@@ -995,8 +995,8 @@ td.pointer {
 }
 
 .recipient_bar_icon {
-    padding-left: 2px;
-    padding-right: 2px;
+    padding-left: 0.125rem;
+    padding-right: 0.125rem;
 }
 
 .summary_row {
@@ -1156,7 +1156,7 @@ td.pointer {
     }
 
     .messagebox-content {
-        padding-bottom: 1px;
+        padding-bottom: 0.0625rem;
     }
 }
 
@@ -1603,7 +1603,7 @@ div.focused_table {
         color: inherit;
         text-decoration: none;
         /* The first ~3px of padding here overlaps with the left padding from sub_count for some reason. */
-        padding-right: calc(3px + 10px);
+        padding-right: calc(0.1875rem + 0.625rem);
     }
 
     .sub_count,
@@ -1616,9 +1616,9 @@ div.focused_table {
     }
 
     .sub_count {
-        padding-left: 10px;
+        padding-left: 0.625rem;
         margin-left: 1px;
-        padding-right: 10px;
+        padding-right: 0.625rem;
         margin-right: 1px;
         .fa.fa-user-o {
             margin-left: 0;
@@ -1663,11 +1663,11 @@ div.focused_table {
         white-space: nowrap;
         margin: 0;
         padding: 0.75rem 0;
-        padding-left: 10px;
+        padding-left: 0.625rem;
 
         @media (max-width: 500px) {
             padding: 0.4375rem 0;
-            padding-left: 10px;
+            padding-left: 0.625rem;
         }
 
         & > a {
@@ -1759,8 +1759,8 @@ div.focused_table {
         font-size: 1rem;
         height: $header_height;
         padding: 0;
-        padding-left: 5px;
-        padding-right: 20px;
+        padding-left: 0.3125rem;
+        padding-right: 1.25rem;
         border: none;
         border-radius: 0;
         font-family: "Source Sans Pro";
@@ -1816,7 +1816,7 @@ div.focused_table {
     }
 
     #search_arrows {
-        padding-left: 35px;
+        padding-left: 2.1875rem;
         font-size: 90%;
         letter-spacing: normal;
     }
@@ -1851,7 +1851,7 @@ div.focused_table {
         padding-left: 0;
     }
     #search_query {
-        padding-left: 35px;
+        padding-left: 2.1875rem;
     }
     .search_button {
         right: 0;
@@ -1932,8 +1932,8 @@ div.focused_table {
     background-color: hsl(0, 0%, 89%);
     width: 40px;
     height: 19px;
-    padding-top: 12px;
-    padding-bottom: 9px;
+    padding-top: 0.75rem;
+    padding-bottom: 0.5625rem;
 }
 
 #streamlist-toggle-unreadcount,
@@ -2210,7 +2210,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 .message_edit_spinner {
     margin-right: 8px;
-    padding-top: 5px;
+    padding-top: 0.3125rem;
 }
 
 .message_edit_spinner .loading_indicator_spinner {
@@ -2305,7 +2305,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 }
 
 #invite-stream-checkboxes {
-    padding-bottom: 26px;
+    padding-bottom: 1.625rem;
 }
 
 #invite-method-choice {
@@ -2335,8 +2335,8 @@ div.topic_edit_spinner .loading_indicator_spinner {
 .notifications-gravatar img {
     max-width: 25px;
     max-height: 25px;
-    padding-left: 4px;
-    padding-top: 4px;
+    padding-left: 0.25rem;
+    padding-top: 0.25rem;
 }
 
 .empty_feed_notice {
@@ -2382,15 +2382,15 @@ div.topic_edit_spinner .loading_indicator_spinner {
 .sub-unsub-message,
 .date_row {
     text-align: center;
-    padding-bottom: 10px;
+    padding-bottom: 0.625rem;
 }
 
 .date_row {
-    padding-left: 2px;
+    padding-left: 0.125rem;
 
     .date-direction {
         display: inline-block;
-        padding-right: 5px;
+        padding-right: 0.3125rem;
     }
 
     .date-line {
@@ -2483,8 +2483,8 @@ div.topic_edit_spinner .loading_indicator_spinner {
     display: inline-block;
     margin: 0 0 0 0;
     height: 22px;
-    padding-left: 20px;
-    padding-right: 3px;
+    padding-left: 1.25rem;
+    padding-right: 0.1875rem;
     line-height: 22px;
     margin-left: -15px;
 }
@@ -2630,8 +2630,8 @@ select.inline_select_topic_edit {
                 padding-top: $header_padding_bottom;
 
                 padding-bottom: 0;
-                padding-left: 15px;
-                padding-right: 15px;
+                padding-left: 0.9375rem;
+                padding-right: 0.9375rem;
                 height: 100%;
                 right: 0;
             }
@@ -2709,7 +2709,7 @@ select.inline_select_topic_edit {
                 padding-top: $header_padding_bottom;
 
                 height: 100%;
-                padding-left: 10px;
+                padding-left: 0.625rem;
                 width: 250px;
             }
         }
@@ -2791,7 +2791,7 @@ select.inline_select_topic_edit {
             padding: 0;
 
             #streams_header {
-                padding-right: 10px;
+                padding-right: 0.625rem;
             }
         }
 
@@ -2849,7 +2849,7 @@ select.inline_select_topic_edit {
     }
 
     .messagebox-content {
-        padding-right: 15px;
+        padding-right: 0.9375rem;
     }
 
     /* In mobile views we place it just to the right of the time element */
@@ -2881,7 +2881,7 @@ select.inline_select_topic_edit {
     }
 
     .message_content {
-        padding-right: 50px;
+        padding-right: 3.125rem;
     }
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -131,7 +131,7 @@ p.n-margin {
     border-radius: 4px;
     display: none;
     height: 28px;
-    font-size: 16px;
+    font-size: 1rem;
     margin: 0 auto 12px;
     padding: 5px;
     i {
@@ -503,7 +503,7 @@ strong {
 }
 
 .sidebar-title {
-    font-size: 14px;
+    font-size: 0.875rem;
     color: hsl(0, 0%, 43%);
     font-weight: normal;
     display: inline;
@@ -511,7 +511,7 @@ strong {
 
 .tooltip {
     &.in {
-        font-size: 12px;
+        font-size: 0.75rem;
         line-height: 1.3;
 
         opacity: 1;
@@ -535,7 +535,7 @@ strong {
 #message_edit_tooltip {
     float: right;
     color: hsl(0, 0%, 0%);
-    font-size: 13px;
+    font-size: 0.8125rem;
     margin-top: 3px;
     margin-left: 6px;
     opacity: 0.5;
@@ -705,7 +705,7 @@ td.pointer {
     padding-bottom: 5px;
     vertical-align: middle;
     line-height: 18px;
-    font-size: 14px;
+    font-size: 0.875rem;
     position: relative;
     max-width: calc(100% - 50px);
 
@@ -715,7 +715,7 @@ td.pointer {
 }
 
 .message_edit_notice {
-    font-size: 10px;
+    font-size: 0.625rem;
     opacity: 0.5;
     line-height: 0px;
     text-align: right;
@@ -728,7 +728,7 @@ td.pointer {
 
 .message_time {
     display: block;
-    font-size: 12px;
+    font-size: 0.75rem;
     opacity: 0.4;
     padding: 1px;
     font-weight: 400;
@@ -745,7 +745,7 @@ td.pointer {
 .alert-msg {
     position: absolute;
     right: -110px;
-    font-size: 14px;
+    font-size: 0.875rem;
     color: hsl(170, 48%, 54%);
     background-color: hsl(0, 0%, 100%);
     z-index: 999;
@@ -830,7 +830,7 @@ td.pointer {
 }
 
 .star {
-    font-size: 14px;
+    font-size: 0.875rem;
 
     &:hover {
         cursor: pointer;
@@ -926,7 +926,7 @@ td.pointer {
     text-decoration: none;
 
     .invite-stream-icon {
-        font-size: 12px;
+        font-size: 0.75rem;
         line-height: 17px;
     }
 
@@ -983,7 +983,7 @@ td.pointer {
 
 .recipient_row_date {
     color: hsl(0, 0%, 53%);
-    font-size: 12px;
+    font-size: 0.75rem;
     font-weight: 600;
     padding: 3px 11px 2px 10px;
     height: 17px;
@@ -1082,7 +1082,7 @@ td.pointer {
         display: inline-block;
         padding: 3px 6px 2px 6px;
         font-weight: normal;
-        font-size: 14px;
+        font-size: 0.875rem;
         height: 17px;
         line-height: 17px;
         border-left-color: hsl(0, 0%, 27%);
@@ -1183,7 +1183,7 @@ td.pointer {
     position: relative;
 
     i.zulip-icon.bot {
-        font-size: 12px;
+        font-size: 0.75rem;
     }
 }
 
@@ -1192,7 +1192,7 @@ td.pointer {
     font-weight: 700;
     vertical-align: top;
     line-height: 12px;
-    font-size: 14px;
+    font-size: 0.875rem;
     margin-left: -3px;
 }
 
@@ -1293,7 +1293,7 @@ a.dark_background:hover,
 .info {
     display: inline-block;
     position: relative;
-    font-size: 14px;
+    font-size: 0.875rem;
     color: hsl(0, 0%, 73%);
 }
 
@@ -1326,7 +1326,7 @@ div.focused_table {
 .message_content {
     line-height: 1.214;
     min-height: 17px;
-    font-size: 14px;
+    font-size: 0.875rem;
     margin-left: 46px;
     display: block;
     position: relative;
@@ -1391,7 +1391,7 @@ div.focused_table {
         margin: 0;
         padding: 0 10px;
         line-height: 17px;
-        font-size: 14px;
+        font-size: 0.875rem;
     }
 }
 
@@ -1405,7 +1405,7 @@ div.focused_table {
         vertical-align: baseline;
 
         line-height: 0px;
-        font-size: 14px;
+        font-size: 0.875rem;
 
         box-shadow: none;
     }
@@ -1552,7 +1552,7 @@ div.focused_table {
     height: $header_height;
     width: 100%;
     line-height: $header_height;
-    font-size: 16px;
+    font-size: 1rem;
     display: flex;
     align-content: flex-start;
     flex-wrap: nowrap;
@@ -1572,7 +1572,7 @@ div.focused_table {
         vertical-align: top;
         position: relative;
         font-weight: 600;
-        font-size: 16px;
+        font-size: 1rem;
         line-height: 16px;
         margin: 0 -4px 0 0;
         padding: 12px 6px;
@@ -1586,7 +1586,7 @@ div.focused_table {
         .fa {
             margin: 0 3px 0 5px;
             .fa-envelope {
-                font-size: 14px;
+                font-size: 0.875rem;
                 margin: 0 5px 0 5px;
             }
             .fa-hashtag {
@@ -1609,7 +1609,7 @@ div.focused_table {
     .sub_count,
     .narrow_description {
         background: none;
-        font-size: 14px;
+        font-size: 0.875rem;
         color: hsl(0, 0%, 40%);
         font-weight: 400;
         line-height: 20px;
@@ -1631,7 +1631,7 @@ div.focused_table {
             top: 25%;
             height: 50%;
             color: hsl(0, 0%, 88%);
-            font-size: 20px;
+            font-size: 1.25rem;
             @media (max-width: 500px) {
                 top: 10%;
             }
@@ -1679,7 +1679,7 @@ div.focused_table {
         flex: 0; /* makes sure search icon is always visible */
 
         cursor: pointer;
-        font-size: 20px;
+        font-size: 1.25rem;
 
         padding: 10px 15px 0 0;
         @media (max-width: 500px) {
@@ -1742,7 +1742,7 @@ div.focused_table {
 
         .fa-search {
             padding: 0;
-            font-size: 20px;
+            font-size: 1.25rem;
             position: absolute;
             left: 10px;
             top: 10px;
@@ -1756,7 +1756,7 @@ div.focused_table {
 
     #search_query {
         width: 100%;
-        font-size: 16px;
+        font-size: 1rem;
         height: $header_height;
         padding: 0;
         padding-left: 5px;
@@ -1784,7 +1784,7 @@ div.focused_table {
         text-align: center;
         padding: 4px;
         color: hsl(0, 0%, 80%);
-        font-size: 18px;
+        font-size: 1.125rem;
         box-shadow: none;
         text-shadow: none;
         z-index: 5;
@@ -1804,7 +1804,7 @@ div.focused_table {
         color: hsl(0, 0%, 80%);
         text-decoration: none;
         padding: 0 10px;
-        font-size: 20px;
+        font-size: 1.25rem;
         z-index: 5;
         left: 0;
     }
@@ -1832,7 +1832,7 @@ div.focused_table {
     @media (min-width: 500px) {
         .pill {
             padding: 2px 0 2px 0 !important;
-            font-size: 14px;
+            font-size: 0.875rem;
         }
     }
     @media (max-width: 500px) {
@@ -1883,7 +1883,7 @@ div.focused_table {
 
         .dropdown-toggle,
         li.active .dropdown-toggle {
-            font-size: 20px;
+            font-size: 1.25rem;
             color: inherit;
             opacity: 0.5;
             text-shadow: none;
@@ -1950,7 +1950,7 @@ div.focused_table {
     box-shadow: 0 0 1px hsla(0, 0%, 0%, 0.2);
     border-radius: 12px;
     padding: 1px 1px 1px 1px;
-    font-size: 9px;
+    font-size: 0.5625rem;
     z-index: 15;
     font-weight: normal;
     color: hsl(0, 0%, 100%);
@@ -2014,7 +2014,7 @@ div.focused_table {
     border-radius: 4px;
 
     /* For FontAwesome icons used in place of images for some users. */
-    font-size: 19px;
+    font-size: 1.1875rem;
     text-align: center;
 }
 
@@ -2164,7 +2164,7 @@ div.floating_recipient {
 .small_square_button {
     padding: 0;
     border: none;
-    font-size: 12px;
+    font-size: 0.75rem;
     width: 18px;
     height: 18px;
     border-radius: 4px;

--- a/static/third/bootstrap-notify/css/bootstrap-notify.css
+++ b/static/third/bootstrap-notify/css/bootstrap-notify.css
@@ -179,4 +179,3 @@
 .fade.alert-success{color:#000;background-color:#FFF;border-color:green;}
 .above-composebox .alert{width:200px; margin-left:auto; margin-right:0px}
 .compose-notifications-content{margin-left:0px;}
-

--- a/static/third/bootstrap-tooltip/tooltip.css
+++ b/static/third/bootstrap-tooltip/tooltip.css
@@ -1,9 +1,8 @@
-
 .tooltip {
     position: absolute;
     z-index: 1030;
     display: block;
-    padding: 5px;
+    padding: 0.3125rem;
     font-size: 0.6875rem;
     opacity: 0;
     filter: alpha(opacity=0);
@@ -27,7 +26,7 @@
 }
 .tooltip-inner {
   max-width: 200px;
-  padding: 3px 8px;
+  padding: 0.1875rem 0.5rem;
   color: #ffffff;
   text-align: center;
   text-decoration: none;
@@ -78,7 +77,7 @@
   z-index: 1010;
   display: none;
   width: 236px;
-  padding: 1px;
+  padding: 0.0625rem;
   background-color: #ffffff;
   border: 1px solid #ccc;
   border: 1px solid rgba(0, 0, 0, 0.2);
@@ -105,7 +104,7 @@
   margin-right: 10px;
 }
 .popover-title {
-  padding: 8px 14px;
+  padding: 0.5rem 0.875rem;
   margin: 0;
   font-size: 0.875rem;
   font-weight: normal;
@@ -117,7 +116,7 @@
           border-radius: 5px 5px 0 0;
 }
 .popover-content {
-  padding: 9px 14px;
+  padding: 0.5625rem 0.875rem;
 }
 .popover-content p,
 .popover-content ul,

--- a/static/third/bootstrap-tooltip/tooltip.css
+++ b/static/third/bootstrap-tooltip/tooltip.css
@@ -4,7 +4,7 @@
     z-index: 1030;
     display: block;
     padding: 5px;
-    font-size: 11px;
+    font-size: 0.6875rem;
     opacity: 0;
     filter: alpha(opacity=0);
     visibility: visible;
@@ -107,7 +107,7 @@
 .popover-title {
   padding: 8px 14px;
   margin: 0;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: normal;
   line-height: 18px;
   background-color: #f7f7f7;

--- a/static/third/bootstrap-tooltip/tooltip.css
+++ b/static/third/bootstrap-tooltip/tooltip.css
@@ -13,19 +13,19 @@
   filter: alpha(opacity=80);
 }
 .tooltip.top {
-  margin-top: -3px;
+  margin-top: -0.1875rem;
 }
 .tooltip.right {
-  margin-left: 3px;
+  margin-left: 0.1875rem;
 }
 .tooltip.bottom {
-  margin-top: 3px;
+  margin-top: 0.1875rem;
 }
 .tooltip.left {
-  margin-left: -3px;
+  margin-left: -0.1875rem;
 }
 .tooltip-inner {
-  max-width: 200px;
+  max-width: 12.5rem;
   padding: 0.1875rem 0.5rem;
   color: #ffffff;
   text-align: center;
@@ -45,30 +45,30 @@
 .tooltip.top .tooltip-arrow {
   bottom: 0;
   left: 50%;
-  margin-left: -5px;
+  margin-left: -0.3125rem;
   border-top-color: #000000;
-  border-width: 5px 5px 0;
+  border-width: 0.3125rem 0.3125rem 0;
 }
 .tooltip.right .tooltip-arrow {
   top: 50%;
   left: 0;
-  margin-top: -5px;
+  margin-top: -0.3125rem;
   border-right-color: #000000;
-  border-width: 5px 5px 5px 0;
+  border-width: 0.3125rem 0.3125rem 0.3125rem 0;
 }
 .tooltip.left .tooltip-arrow {
   top: 50%;
   right: 0;
-  margin-top: -5px;
+  margin-top: -0.3125rem;
   border-left-color: #000000;
-  border-width: 5px 0 5px 5px;
+  border-width: 0.3125rem 0 0.3125rem 0.3125rem;
 }
 .tooltip.bottom .tooltip-arrow {
   top: 0;
   left: 50%;
-  margin-left: -5px;
+  margin-left: -0.3125rem;
   border-bottom-color: #000000;
-  border-width: 0 5px 5px;
+  border-width: 0 0.3125rem 0.3125rem;
 }
 .popover {
   position: absolute;
@@ -76,7 +76,7 @@
   left: 0;
   z-index: 1010;
   display: none;
-  width: 236px;
+  width: 14.75rem;
   padding: 0.0625rem;
   background-color: #ffffff;
   border: 1px solid #ccc;
@@ -92,23 +92,23 @@
           background-clip: padding-box;
 }
 .popover.top {
-  margin-bottom: 10px;
+  margin-bottom: 0.625rem;
 }
 .popover.right {
-  margin-left: 10px;
+  margin-left: 0.625rem;
 }
 .popover.bottom {
-  margin-top: 10px;
+  margin-top: 0.625rem;
 }
 .popover.left {
-  margin-right: 10px;
+  margin-right: 0.625rem;
 }
 .popover-title {
   padding: 0.5rem 0.875rem;
   margin: 0;
   font-size: 0.875rem;
   font-weight: normal;
-  line-height: 18px;
+  line-height: 1.125rem;
   background-color: #f7f7f7;
   border-bottom: 1px solid #ebebeb;
   -webkit-border-radius: 5px 5px 0 0;
@@ -139,53 +139,53 @@
 .popover.top .arrow {
   bottom: -10px;
   left: 50%;
-  margin-left: -10px;
+  margin-left: -0.625rem;
   border-top-color: #ffffff;
-  border-width: 10px 10px 0;
+  border-width: 0.625rem 0.625rem 0;
 }
 .popover.top .arrow:after {
   bottom: -1px;
   left: -11px;
   border-top-color: rgba(0, 0, 0, 0.25);
-  border-width: 11px 11px 0;
+  border-width: 0.6875rem 0.6875rem 0;
 }
 .popover.right .arrow {
   top: 50%;
   left: -10px;
-  margin-top: -10px;
+  margin-top: -0.625rem;
   border-right-color: #ffffff;
-  border-width: 10px 10px 10px 0;
+  border-width: 0.625rem 0.625rem 0.625rem 0;
 }
 .popover.right .arrow:after {
   bottom: -11px;
   left: -1px;
   border-right-color: rgba(0, 0, 0, 0.25);
-  border-width: 11px 11px 11px 0;
+  border-width: 0.6875rem 0.6875rem 0.6875rem 0;
 }
 .popover.bottom .arrow {
   top: -10px;
   left: 50%;
-  margin-left: -10px;
+  margin-left: -0.625rem;
   border-bottom-color: #ffffff;
-  border-width: 0 10px 10px;
+  border-width: 0 0.625rem 0.625rem;
 }
 .popover.bottom .arrow:after {
   top: -1px;
   left: -11px;
   margin-left: 0;
   border-bottom-color: rgba(0, 0, 0, 0.25);
-  border-width: 0 11px 11px;
+  border-width: 0 0.6875rem 0.6875rem;
 }
 .popover.left .arrow {
   top: 50%;
   right: -10px;
-  margin-top: -10px;
+  margin-top: -0.625rem;
   border-left-color: #ffffff;
-  border-width: 10px 0 10px 10px;
+  border-width: 0.625rem 0 0.625rem 0.625rem;
 }
 .popover.left .arrow:after {
   right: -1px;
   bottom: -11px;
   border-left-color: rgba(0, 0, 0, 0.25);
-  border-width: 11px 0 11px 11px;
+  border-width: 0.6875rem 0 0.6875rem 0.6875rem;
 }

--- a/static/third/bootstrap/css/bootstrap-btn.css
+++ b/static/third/bootstrap/css/bootstrap-btn.css
@@ -386,7 +386,7 @@ fieldset[disabled] .btn-link:focus {
   padding-left: 0;
 }
 .btn-block + .btn-block {
-  margin-top: 5px;
+  margin-top: 0.3125rem;
 }
 input[type="submit"].btn-block,
 input[type="reset"].btn-block,

--- a/static/third/bootstrap/css/bootstrap-btn.css
+++ b/static/third/bootstrap/css/bootstrap-btn.css
@@ -35,7 +35,7 @@ THE SOFTWARE.
   display: inline-block;
   padding: 6px 12px;
   margin-bottom: 0;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: normal;
   line-height: 1.42857143;
   text-align: center;
@@ -361,21 +361,21 @@ fieldset[disabled] .btn-link:focus {
 .btn-large,
 .btn-group-large > .btn {
   padding: 10px 16px;
-  font-size: 18px;
+  font-size: 1.125rem;
   line-height: 1.33;
   border-radius: 0px;
 }
 .btn-small,
 .btn-group-small > .btn {
   padding: 5px 10px;
-  font-size: 12px;
+  font-size: 0.75rem;
   line-height: 1.5;
   border-radius: 0px;
 }
 .btn-mini,
 .btn-group-mini > .btn {
   padding: 1px 5px;
-  font-size: 12px;
+  font-size: 0.75rem;
   line-height: 1.5;
   border-radius: 0px;
 }

--- a/static/third/bootstrap/css/bootstrap-btn.css
+++ b/static/third/bootstrap/css/bootstrap-btn.css
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
 .btn {
   display: inline-block;
-  padding: 6px 12px;
+  padding: 0.375rem 0.75rem;
   margin-bottom: 0;
   font-size: 0.875rem;
   font-weight: normal;
@@ -360,21 +360,21 @@ fieldset[disabled] .btn-link:focus {
 }
 .btn-large,
 .btn-group-large > .btn {
-  padding: 10px 16px;
+  padding: 0.625rem 1.0rem;
   font-size: 1.125rem;
   line-height: 1.33;
   border-radius: 0px;
 }
 .btn-small,
 .btn-group-small > .btn {
-  padding: 5px 10px;
+  padding: 0.3125rem 0.625rem;
   font-size: 0.75rem;
   line-height: 1.5;
   border-radius: 0px;
 }
 .btn-mini,
 .btn-group-mini > .btn {
-  padding: 1px 5px;
+  padding: 0.0625rem 0.3125rem;
   font-size: 0.75rem;
   line-height: 1.5;
   border-radius: 0px;

--- a/static/third/bootstrap/css/bootstrap.css
+++ b/static/third/bootstrap/css/bootstrap.css
@@ -532,8 +532,8 @@ a:focus {
   clear: both;
 }
 .container-fluid {
-  padding-right: 20px;
-  padding-left: 20px;
+  padding-right: 1.25rem;
+  padding-left: 1.25rem;
   *zoom: 1;
 }
 .container-fluid:before,
@@ -669,7 +669,7 @@ h4 small {
   font-size: 0.875rem;
 }
 .page-header {
-  padding-bottom: 9px;
+  padding-bottom: 0.5625rem;
   margin: 20px 0 30px;
   border-bottom: 1px solid #eeeeee;
 }
@@ -704,8 +704,8 @@ ol.inline > li {
   /* IE7 inline-block hack */
 
   *zoom: 1;
-  padding-left: 5px;
-  padding-right: 5px;
+  padding-left: 0.3125rem;
+  padding-right: 0.3125rem;
 }
 dl {
   margin-bottom: 20px;
@@ -780,7 +780,7 @@ blockquote small:before {
 }
 blockquote.pull-right {
   float: right;
-  padding-right: 15px;
+  padding-right: 0.9375rem;
   padding-left: 0;
   border-right: 5px solid #eeeeee;
   border-left: 0;
@@ -875,8 +875,8 @@ pre code {
   border-radius: 3px;
 }
 .badge {
-  padding-left: 9px;
-  padding-right: 9px;
+  padding-left: 0.5625rem;
+  padding-right: 0.5625rem;
   -webkit-border-radius: 9px;
   -moz-border-radius: 9px;
   border-radius: 9px;
@@ -1388,7 +1388,7 @@ textarea::-webkit-input-placeholder {
 .radio,
 .checkbox {
   min-height: 20px;
-  padding-left: 20px;
+  padding-left: 1.25rem;
 }
 .radio input[type="radio"],
 .checkbox input[type="checkbox"] {
@@ -1397,12 +1397,12 @@ textarea::-webkit-input-placeholder {
 }
 .controls > .radio:first-child,
 .controls > .checkbox:first-child {
-  padding-top: 5px;
+  padding-top: 0.3125rem;
 }
 .radio.inline,
 .checkbox.inline {
   display: inline-block;
-  padding-top: 5px;
+  padding-top: 0.3125rem;
   margin-bottom: 0;
   vertical-align: middle;
 }
@@ -1537,7 +1537,7 @@ textarea.span1,
 }
 .controls-row .checkbox[class*="span"],
 .controls-row .radio[class*="span"] {
-  padding-top: 5px;
+  padding-top: 0.3125rem;
 }
 input[disabled],
 select[disabled],
@@ -1736,7 +1736,7 @@ select:focus:invalid:focus {
 
   *zoom: 1;
   vertical-align: middle;
-  padding-left: 5px;
+  padding-left: 0.3125rem;
 }
 .input-append,
 .input-prepend {
@@ -1879,10 +1879,10 @@ select:focus:invalid:focus {
   margin-left: 0;
 }
 input.search-query {
-  padding-right: 14px;
-  padding-right: 4px \9;
-  padding-left: 14px;
-  padding-left: 4px \9;
+  padding-right: 0.875rem;
+  padding-right: 0.25rem \9;
+  padding-left: 0.875rem;
+  padding-left: 0.25rem \9;
   /* IE7-8 doesn't have border-radius, so don't indent the padding */
 
   margin-bottom: 0;
@@ -2002,17 +2002,17 @@ legend + .control-group {
 .form-horizontal .control-label {
   float: left;
   width: 160px;
-  padding-top: 5px;
+  padding-top: 0.3125rem;
   text-align: right;
 }
 .form-horizontal .controls {
   *display: inline-block;
-  *padding-left: 20px;
+  *padding-left: 1.25rem;
   margin-left: 180px;
   *margin-left: 0;
 }
 .form-horizontal .controls:first-child {
-  *padding-left: 180px;
+  *padding-left: 11.25rem;
 }
 .form-horizontal .help-block {
   margin-bottom: 0;
@@ -2026,7 +2026,7 @@ legend + .control-group {
   margin-top: 10px;
 }
 .form-horizontal .form-actions {
-  padding-left: 180px;
+  padding-left: 11.25rem;
 }
 /* Removed .btn related code */
 [class^="icon-"],
@@ -2519,8 +2519,8 @@ legend + .control-group {
   margin-top: 9px;
 }
 .nav-list {
-  padding-left: 15px;
-  padding-right: 15px;
+  padding-left: 0.9375rem;
+  padding-right: 0.9375rem;
   margin-bottom: 0;
 }
 .nav-list > li > a,
@@ -2574,8 +2574,8 @@ legend + .control-group {
 }
 .nav-tabs > li > a,
 .nav-pills > li > a {
-  padding-right: 12px;
-  padding-left: 12px;
+  padding-right: 0.75rem;
+  padding-left: 0.75rem;
   margin-right: 2px;
   line-height: 14px;
 }
@@ -2586,8 +2586,8 @@ legend + .control-group {
   margin-bottom: -1px;
 }
 .nav-tabs > li > a {
-  padding-top: 8px;
-  padding-bottom: 8px;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
   line-height: 20px;
   border: 1px solid transparent;
   -webkit-border-radius: 4px 4px 0 0;
@@ -2608,8 +2608,8 @@ legend + .control-group {
   cursor: default;
 }
 .nav-pills > li > a {
-  padding-top: 8px;
-  padding-bottom: 8px;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
   margin-top: 2px;
   margin-bottom: 2px;
   -webkit-border-radius: 5px;
@@ -2840,8 +2840,8 @@ legend + .control-group {
 }
 .navbar-inner {
   min-height: 40px;
-  padding-left: 20px;
-  padding-right: 20px;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
   background-color: #fafafa;
   background-image: -moz-linear-gradient(top, #ffffff, #f2f2f2);
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ffffff), to(#f2f2f2));
@@ -3647,8 +3647,8 @@ a.thumbnail:focus {
   color: #3a87ad;
 }
 .alert-block {
-  padding-top: 14px;
-  padding-bottom: 14px;
+  padding-top: 0.875rem;
+  padding-bottom: 0.875rem;
 }
 .alert-block > p,
 .alert-block > ul {
@@ -4400,8 +4400,8 @@ a.thumbnail:focus {
   border-radius: 6px 0 6px 6px;
 }
 .dropdown .dropdown-menu .nav-header {
-  padding-left: 20px;
-  padding-right: 20px;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
 }
 .typeahead {
   z-index: 1051;
@@ -4714,8 +4714,8 @@ button.close {
 }
 @media (max-width: 767px) {
   body {
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
   }
   .navbar-fixed-top,
   .navbar-fixed-bottom,
@@ -4832,8 +4832,8 @@ button.close {
     padding-top: 0;
   }
   .form-horizontal .form-actions {
-    padding-left: 10px;
-    padding-right: 10px;
+    padding-left: 0.625rem;
+    padding-right: 0.625rem;
   }
   .media .pull-left,
   .media .pull-right {
@@ -5569,8 +5569,8 @@ button.close {
     padding: 0;
   }
   .navbar .brand {
-    padding-left: 10px;
-    padding-right: 10px;
+    padding-left: 0.625rem;
+    padding-right: 0.625rem;
     margin: 0 0 0 -5px;
   }
   .nav-collapse {
@@ -5693,8 +5693,8 @@ button.close {
     display: block;
   }
   .navbar-static .navbar-inner {
-    padding-left: 10px;
-    padding-right: 10px;
+    padding-left: 0.625rem;
+    padding-right: 0.625rem;
   }
 }
 @media (min-width: 980px) {

--- a/static/third/bootstrap/css/bootstrap.css
+++ b/static/third/bootstrap/css/bootstrap.css
@@ -29,7 +29,7 @@
 .input-block-level {
   display: block;
   width: 100%;
-  min-height: 30px;
+  min-height: 1.875rem;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
@@ -207,7 +207,7 @@ body {
   margin: 0;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 0.875rem;
-  line-height: 20px;
+  line-height: 1.25rem;
   color: #333333;
   background-color: #ffffff;
 }
@@ -240,7 +240,7 @@ a:focus {
   border-radius: 500px;
 }
 .row {
-  margin-left: -20px;
+  margin-left: -1.25rem;
   *zoom: 1;
 }
 .row:before,
@@ -254,86 +254,86 @@ a:focus {
 }
 [class*="span"] {
   float: left;
-  min-height: 1px;
-  margin-left: 20px;
+  min-height: 0.0625rem;
+  margin-left: 1.25rem;
 }
 .container,
 .navbar-static-top .container,
 .navbar-fixed-top .container,
 .navbar-fixed-bottom .container {
-  width: 940px;
+  width: 58.75rem;
 }
 .span12 {
-  width: 940px;
+  width: 58.75rem;
 }
 .span11 {
-  width: 860px;
+  width: 53.75rem;
 }
 .span10 {
-  width: 780px;
+  width: 48.75rem;
 }
 .span9 {
-  width: 700px;
+  width: 43.75rem;
 }
 .span8 {
-  width: 620px;
+  width: 38.75rem;
 }
 .span7 {
-  width: 540px;
+  width: 33.75rem;
 }
 .span6 {
-  width: 460px;
+  width: 28.75rem;
 }
 .span5 {
-  width: 380px;
+  width: 23.75rem;
 }
 .span4 {
-  width: 300px;
+  width: 18.75rem;
 }
 .span3 {
-  width: 220px;
+  width: 13.75rem;
 }
 .span2 {
-  width: 140px;
+  width: 8.75rem;
 }
 .span1 {
-  width: 60px;
+  width: 3.75rem;
 }
 .offset12 {
-  margin-left: 980px;
+  margin-left: 61.25rem;
 }
 .offset11 {
-  margin-left: 900px;
+  margin-left: 56.25rem;
 }
 .offset10 {
-  margin-left: 820px;
+  margin-left: 51.25rem;
 }
 .offset9 {
-  margin-left: 740px;
+  margin-left: 46.25rem;
 }
 .offset8 {
-  margin-left: 660px;
+  margin-left: 41.25rem;
 }
 .offset7 {
-  margin-left: 580px;
+  margin-left: 36.25rem;
 }
 .offset6 {
-  margin-left: 500px;
+  margin-left: 31.25rem;
 }
 .offset5 {
-  margin-left: 420px;
+  margin-left: 26.25rem;
 }
 .offset4 {
-  margin-left: 340px;
+  margin-left: 21.25rem;
 }
 .offset3 {
-  margin-left: 260px;
+  margin-left: 16.25rem;
 }
 .offset2 {
-  margin-left: 180px;
+  margin-left: 11.25rem;
 }
 .offset1 {
-  margin-left: 100px;
+  margin-left: 6.25rem;
 }
 .row-fluid {
   width: 100%;
@@ -351,7 +351,7 @@ a:focus {
 .row-fluid [class*="span"] {
   display: block;
   width: 100%;
-  min-height: 30px;
+  min-height: 1.875rem;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
@@ -546,13 +546,13 @@ a:focus {
   clear: both;
 }
 p {
-  margin: 0 0 10px;
+  margin: 0 0 0.625rem;
 }
 .lead {
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
   font-size: 1.3125rem;
   font-weight: 200;
-  line-height: 30px;
+  line-height: 1.875rem;
 }
 small {
   font-size: 85%;
@@ -616,10 +616,10 @@ h3,
 h4,
 h5,
 h6 {
-  margin: 10px 0;
+  margin: 0.625rem 0;
   font-family: inherit;
   font-weight: bold;
-  line-height: 20px;
+  line-height: 1.25rem;
   color: inherit;
   text-rendering: optimizelegibility;
 }
@@ -636,7 +636,7 @@ h6 small {
 h1,
 h2,
 h3 {
-  line-height: 40px;
+  line-height: 2.5rem;
 }
 h1 {
   font-size: 2.375rem;
@@ -670,13 +670,13 @@ h4 small {
 }
 .page-header {
   padding-bottom: 0.5625rem;
-  margin: 20px 0 30px;
+  margin: 1.25rem 0 1.875rem;
   border-bottom: 1px solid #eeeeee;
 }
 ul,
 ol {
   padding: 0;
-  margin: 0 0 10px 25px;
+  margin: 0 0 0.625rem 1.5625rem;
 }
 ul ul,
 ul ol,
@@ -685,7 +685,7 @@ ol ul {
   margin-bottom: 0;
 }
 li {
-  line-height: 20px;
+  line-height: 1.25rem;
 }
 ul.unstyled,
 ol.unstyled {
@@ -708,17 +708,17 @@ ol.inline > li {
   padding-right: 0.3125rem;
 }
 dl {
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
 }
 dt,
 dd {
-  line-height: 20px;
+  line-height: 1.25rem;
 }
 dt {
   font-weight: bold;
 }
 dd {
-  margin-left: 10px;
+  margin-left: 0.625rem;
 }
 .dl-horizontal {
   *zoom: 1;
@@ -734,7 +734,7 @@ dd {
 }
 .dl-horizontal dt {
   float: left;
-  width: 160px;
+  width: 10.0rem;
   clear: left;
   text-align: right;
   overflow: hidden;
@@ -742,10 +742,10 @@ dd {
   white-space: nowrap;
 }
 .dl-horizontal dd {
-  margin-left: 180px;
+  margin-left: 11.25rem;
 }
 hr {
-  margin: 20px 0;
+  margin: 1.25rem 0;
   border: 0;
   border-top: 1px solid #eeeeee;
   border-bottom: 1px solid #ffffff;
@@ -761,7 +761,7 @@ abbr.initialism {
 }
 blockquote {
   padding: 0 0 0 0.9375rem;
-  margin: 0 0 20px;
+  margin: 0 0 1.25rem;
   border-left: 5px solid #eeeeee;
 }
 blockquote p {
@@ -772,7 +772,7 @@ blockquote p {
 }
 blockquote small {
   display: block;
-  line-height: 20px;
+  line-height: 1.25rem;
   color: #999999;
 }
 blockquote small:before {
@@ -803,9 +803,9 @@ blockquote:after {
 }
 address {
   display: block;
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
   font-style: normal;
-  line-height: 20px;
+  line-height: 1.25rem;
 }
 code,
 pre {
@@ -827,9 +827,9 @@ code {
 pre {
   display: block;
   padding: 9.0.3125rem;
-  margin: 0 0 10px;
+  margin: 0 0 0.625rem;
   font-size: 0.8125rem;
-  line-height: 20px;
+  line-height: 1.25rem;
   word-break: break-all;
   word-wrap: break-word;
   white-space: pre;
@@ -842,7 +842,7 @@ pre {
   border-radius: 4px;
 }
 pre.prettyprint {
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
 }
 pre code {
   padding: 0;
@@ -853,7 +853,7 @@ pre code {
   border: 0;
 }
 .pre-scrollable {
-  max-height: 340px;
+  max-height: 21.25rem;
   overflow-y: scroll;
 }
 .label,
@@ -862,7 +862,7 @@ pre code {
   padding: 0.125rem 0.25rem;
   font-size: 0.6875rem;
   font-weight: bold;
-  line-height: 14px;
+  line-height: 0.875rem;
   color: #ffffff;
   vertical-align: baseline;
   white-space: nowrap;
@@ -950,12 +950,12 @@ table {
 }
 .table {
   width: 100%;
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
 }
 .table th,
 .table td {
   padding: 0.5rem;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-align: left;
   vertical-align: top;
   border-top: 1px solid #dddddd;
@@ -1085,73 +1085,73 @@ table th[class*="span"],
 .table td.span1,
 .table th.span1 {
   float: none;
-  width: 44px;
+  width: 2.75rem;
   margin-left: 0;
 }
 .table td.span2,
 .table th.span2 {
   float: none;
-  width: 124px;
+  width: 7.75rem;
   margin-left: 0;
 }
 .table td.span3,
 .table th.span3 {
   float: none;
-  width: 204px;
+  width: 12.75rem;
   margin-left: 0;
 }
 .table td.span4,
 .table th.span4 {
   float: none;
-  width: 284px;
+  width: 17.75rem;
   margin-left: 0;
 }
 .table td.span5,
 .table th.span5 {
   float: none;
-  width: 364px;
+  width: 22.75rem;
   margin-left: 0;
 }
 .table td.span6,
 .table th.span6 {
   float: none;
-  width: 444px;
+  width: 27.75rem;
   margin-left: 0;
 }
 .table td.span7,
 .table th.span7 {
   float: none;
-  width: 524px;
+  width: 32.75rem;
   margin-left: 0;
 }
 .table td.span8,
 .table th.span8 {
   float: none;
-  width: 604px;
+  width: 37.75rem;
   margin-left: 0;
 }
 .table td.span9,
 .table th.span9 {
   float: none;
-  width: 684px;
+  width: 42.75rem;
   margin-left: 0;
 }
 .table td.span10,
 .table th.span10 {
   float: none;
-  width: 764px;
+  width: 47.75rem;
   margin-left: 0;
 }
 .table td.span11,
 .table th.span11 {
   float: none;
-  width: 844px;
+  width: 52.75rem;
   margin-left: 0;
 }
 .table td.span12,
 .table th.span12 {
   float: none;
-  width: 924px;
+  width: 57.75rem;
   margin-left: 0;
 }
 .table tbody tr.success > td {
@@ -1179,7 +1179,7 @@ table th[class*="span"],
   background-color: #c4e3f3;
 }
 form {
-  margin: 0 0 20px;
+  margin: 0 0 1.25rem;
 }
 fieldset {
   padding: 0;
@@ -1190,9 +1190,9 @@ legend {
   display: block;
   width: 100%;
   padding: 0;
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
   font-size: 1.3125rem;
-  line-height: 40px;
+  line-height: 2.5rem;
   color: #333333;
   border: 0;
   border-bottom: 1px solid #e5e5e5;
@@ -1208,7 +1208,7 @@ select,
 textarea {
   font-size: 0.875rem;
   font-weight: normal;
-  line-height: 20px;
+  line-height: 1.25rem;
 }
 input,
 button,
@@ -1218,7 +1218,7 @@ textarea {
 }
 label {
   display: block;
-  margin-bottom: 5px;
+  margin-bottom: 0.3125rem;
 }
 select,
 textarea,
@@ -1238,11 +1238,11 @@ input[type="tel"],
 input[type="color"],
 .uneditable-input {
   display: inline-block;
-  height: 20px;
+  height: 1.25rem;
   padding: 0.25rem 0.375rem;
-  margin-bottom: 10px;
+  margin-bottom: 0.625rem;
   font-size: 0.875rem;
-  line-height: 20px;
+  line-height: 1.25rem;
   color: #555555;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
@@ -1252,7 +1252,7 @@ input[type="color"],
 input,
 textarea,
 .uneditable-input {
-  width: 206px;
+  width: 12.875rem;
 }
 textarea {
   height: auto;
@@ -1310,11 +1310,11 @@ input[type="color"]:focus,
 }
 input[type="radio"],
 input[type="checkbox"] {
-  margin: 4px 0 0;
+  margin: 0.25rem 0 0;
   *margin-top: 0;
   /* IE7 */
 
-  margin-top: 1px \9;
+  margin-top: 0.0625rem \9;
   /* IE8-9 */
 
   line-height: normal;
@@ -1330,16 +1330,16 @@ input[type="checkbox"] {
 }
 select,
 input[type="file"] {
-  height: 30px;
+  height: 1.875rem;
   /* In IE7, the height of the select element cannot be changed by height, only font-size */
 
-  *margin-top: 4px;
+  *margin-top: 0.25rem;
   /* For IE7, add top margin to align select with labels */
 
-  line-height: 30px;
+  line-height: 1.875rem;
 }
 select {
-  width: 220px;
+  width: 13.75rem;
   border: 1px solid #cccccc;
   background-color: #ffffff;
 }
@@ -1387,13 +1387,13 @@ textarea::-webkit-input-placeholder {
 }
 .radio,
 .checkbox {
-  min-height: 20px;
+  min-height: 1.25rem;
   padding-left: 1.25rem;
 }
 .radio input[type="radio"],
 .checkbox input[type="checkbox"] {
   float: left;
-  margin-left: -20px;
+  margin-left: -1.25rem;
 }
 .controls > .radio:first-child,
 .controls > .checkbox:first-child {
@@ -1408,25 +1408,25 @@ textarea::-webkit-input-placeholder {
 }
 .radio.inline + .radio.inline,
 .checkbox.inline + .checkbox.inline {
-  margin-left: 10px;
+  margin-left: 0.625rem;
 }
 .input-mini {
-  width: 60px;
+  width: 3.75rem;
 }
 .input-small {
-  width: 90px;
+  width: 5.625rem;
 }
 .input-medium {
-  width: 150px;
+  width: 9.375rem;
 }
 .input-large {
-  width: 210px;
+  width: 13.125rem;
 }
 .input-xlarge {
-  width: 270px;
+  width: 16.875rem;
 }
 .input-xxlarge {
-  width: 530px;
+  width: 33.125rem;
 }
 input[class*="span"],
 select[class*="span"],
@@ -1457,67 +1457,67 @@ textarea,
   margin-left: 0;
 }
 .controls-row [class*="span"] + [class*="span"] {
-  margin-left: 20px;
+  margin-left: 1.25rem;
 }
 input.span12,
 textarea.span12,
 .uneditable-input.span12 {
-  width: 926px;
+  width: 57.875rem;
 }
 input.span11,
 textarea.span11,
 .uneditable-input.span11 {
-  width: 846px;
+  width: 52.875rem;
 }
 input.span10,
 textarea.span10,
 .uneditable-input.span10 {
-  width: 766px;
+  width: 47.875rem;
 }
 input.span9,
 textarea.span9,
 .uneditable-input.span9 {
-  width: 686px;
+  width: 42.875rem;
 }
 input.span8,
 textarea.span8,
 .uneditable-input.span8 {
-  width: 606px;
+  width: 37.875rem;
 }
 input.span7,
 textarea.span7,
 .uneditable-input.span7 {
-  width: 526px;
+  width: 32.875rem;
 }
 input.span6,
 textarea.span6,
 .uneditable-input.span6 {
-  width: 446px;
+  width: 27.875rem;
 }
 input.span5,
 textarea.span5,
 .uneditable-input.span5 {
-  width: 366px;
+  width: 22.875rem;
 }
 input.span4,
 textarea.span4,
 .uneditable-input.span4 {
-  width: 286px;
+  width: 17.875rem;
 }
 input.span3,
 textarea.span3,
 .uneditable-input.span3 {
-  width: 206px;
+  width: 12.875rem;
 }
 input.span2,
 textarea.span2,
 .uneditable-input.span2 {
-  width: 126px;
+  width: 7.875rem;
 }
 input.span1,
 textarea.span1,
 .uneditable-input.span1 {
-  width: 46px;
+  width: 2.875rem;
 }
 .controls-row {
   *zoom: 1;
@@ -1706,8 +1706,8 @@ select:focus:invalid:focus {
 }
 .form-actions {
   padding: 1.1875rem 1.25rem 1.25rem;
-  margin-top: 20px;
-  margin-bottom: 20px;
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
   background-color: #f5f5f5;
   border-top: 1px solid #e5e5e5;
   *zoom: 1;
@@ -1727,7 +1727,7 @@ select:focus:invalid:focus {
 }
 .help-block {
   display: block;
-  margin-bottom: 10px;
+  margin-bottom: 0.625rem;
 }
 .help-inline {
   display: inline-block;
@@ -1741,7 +1741,7 @@ select:focus:invalid:focus {
 .input-append,
 .input-prepend {
   display: inline-block;
-  margin-bottom: 10px;
+  margin-bottom: 0.625rem;
   vertical-align: middle;
   font-size: 0;
   white-space: nowrap;
@@ -1784,12 +1784,12 @@ select:focus:invalid:focus {
 .input-prepend .add-on {
   display: inline-block;
   width: auto;
-  height: 20px;
-  min-width: 16px;
+  height: 1.25rem;
+  min-width: 1.0rem;
   padding: 0.25rem 0.3125rem;
   font-size: 0.875rem;
   font-weight: normal;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-align: center;
   text-shadow: 0 1px 0 #ffffff;
   background-color: #eeeeee;
@@ -1813,7 +1813,7 @@ select:focus:invalid:focus {
 }
 .input-prepend .add-on,
 .input-prepend .btn {
-  margin-right: -1px;
+  margin-right: -0.0625rem;
 }
 .input-prepend .add-on:first-child,
 .input-prepend .btn:first-child {
@@ -1838,7 +1838,7 @@ select:focus:invalid:focus {
 .input-append .add-on,
 .input-append .btn,
 .input-append .btn-group {
-  margin-left: -1px;
+  margin-left: -0.0625rem;
 }
 .input-append .add-on:last-child,
 .input-append .btn:last-child,
@@ -1863,14 +1863,14 @@ select:focus:invalid:focus {
 }
 .input-prepend.input-append .add-on:first-child,
 .input-prepend.input-append .btn:first-child {
-  margin-right: -1px;
+  margin-right: -0.0625rem;
   -webkit-border-radius: 4px 0 0 4px;
   -moz-border-radius: 4px 0 0 4px;
   border-radius: 4px 0 0 4px;
 }
 .input-prepend.input-append .add-on:last-child,
 .input-prepend.input-append .btn:last-child {
-  margin-left: -1px;
+  margin-left: -0.0625rem;
   -webkit-border-radius: 0 4px 4px 0;
   -moz-border-radius: 0 4px 4px 0;
   border-radius: 0 4px 4px 0;
@@ -1976,18 +1976,18 @@ input.search-query {
 .form-inline .radio input[type="radio"],
 .form-inline .checkbox input[type="checkbox"] {
   float: left;
-  margin-right: 3px;
+  margin-right: 0.1875rem;
   margin-left: 0;
 }
 .control-group {
-  margin-bottom: 10px;
+  margin-bottom: 0.625rem;
 }
 legend + .control-group {
-  margin-top: 20px;
+  margin-top: 1.25rem;
   -webkit-margin-top-collapse: separate;
 }
 .form-horizontal .control-group {
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
   *zoom: 1;
 }
 .form-horizontal .control-group:before,
@@ -2001,14 +2001,14 @@ legend + .control-group {
 }
 .form-horizontal .control-label {
   float: left;
-  width: 160px;
+  width: 10.0rem;
   padding-top: 0.3125rem;
   text-align: right;
 }
 .form-horizontal .controls {
   *display: inline-block;
   *padding-left: 1.25rem;
-  margin-left: 180px;
+  margin-left: 11.25rem;
   *margin-left: 0;
 }
 .form-horizontal .controls:first-child {
@@ -2023,7 +2023,7 @@ legend + .control-group {
 .form-horizontal .uneditable-input + .help-block,
 .form-horizontal .input-prepend + .help-block,
 .form-horizontal .input-append + .help-block {
-  margin-top: 10px;
+  margin-top: 0.625rem;
 }
 .form-horizontal .form-actions {
   padding-left: 11.25rem;
@@ -2032,15 +2032,15 @@ legend + .control-group {
 [class^="icon-"],
 [class*=" icon-"] {
   display: inline-block;
-  width: 14px;
-  height: 14px;
+  width: 0.875rem;
+  height: 0.875rem;
   *margin-right: .3em;
-  line-height: 14px;
+  line-height: 0.875rem;
   vertical-align: text-top;
   background-image: url("../img/glyphicons-halflings.png");
   background-position: 14px 14px;
   background-repeat: no-repeat;
-  margin-top: 1px;
+  margin-top: 0.0625rem;
 }
 /* White icons with optional class, or on hover/focus/active states of certain elements */
 .icon-white,
@@ -2391,7 +2391,7 @@ legend + .control-group {
 }
 .icon-random {
   background-position: -216px -120px;
-  width: 16px;
+  width: 1.0rem;
 }
 .icon-comment {
   background-position: -240px -120px;
@@ -2413,11 +2413,11 @@ legend + .control-group {
 }
 .icon-folder-close {
   background-position: -384px -120px;
-  width: 16px;
+  width: 1.0rem;
 }
 .icon-folder-open {
   background-position: -408px -120px;
-  width: 16px;
+  width: 1.0rem;
 }
 .icon-resize-vertical {
   background-position: -432px -119px;
@@ -2488,7 +2488,7 @@ legend + .control-group {
 /* Removed .btn related code */
 .nav {
   margin-left: 0;
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
   list-style: none;
 }
 .nav > li > a {
@@ -2510,13 +2510,13 @@ legend + .control-group {
   padding: 0.1875rem 0.9375rem;
   font-size: 0.6875rem;
   font-weight: bold;
-  line-height: 20px;
+  line-height: 1.25rem;
   color: #999999;
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
   text-transform: uppercase;
 }
 .nav li + .nav-header {
-  margin-top: 9px;
+  margin-top: 0.5625rem;
 }
 .nav-list {
   padding-left: 0.9375rem;
@@ -2525,8 +2525,8 @@ legend + .control-group {
 }
 .nav-list > li > a,
 .nav-list .nav-header {
-  margin-left: -15px;
-  margin-right: -15px;
+  margin-left: -0.9375rem;
+  margin-right: -0.9375rem;
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
 }
 .nav-list > li > a {
@@ -2541,13 +2541,13 @@ legend + .control-group {
 }
 .nav-list [class^="icon-"],
 .nav-list [class*=" icon-"] {
-  margin-right: 2px;
+  margin-right: 0.125rem;
 }
 .nav-list .divider {
   *width: 100%;
-  height: 1px;
-  margin: 9px 1px;
-  *margin: -5px 0 5px;
+  height: 0.0625rem;
+  margin: 0.5625rem 0.0625rem;
+  *margin: -0.3125rem 0 0.3125rem;
   overflow: hidden;
   background-color: #e5e5e5;
   border-bottom: 1px solid #ffffff;
@@ -2576,19 +2576,19 @@ legend + .control-group {
 .nav-pills > li > a {
   padding-right: 0.75rem;
   padding-left: 0.75rem;
-  margin-right: 2px;
-  line-height: 14px;
+  margin-right: 0.125rem;
+  line-height: 0.875rem;
 }
 .nav-tabs {
   border-bottom: 1px solid #ddd;
 }
 .nav-tabs > li {
-  margin-bottom: -1px;
+  margin-bottom: -0.0625rem;
 }
 .nav-tabs > li > a {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
-  line-height: 20px;
+  line-height: 1.25rem;
   border: 1px solid transparent;
   -webkit-border-radius: 4px 4px 0 0;
   -moz-border-radius: 4px 4px 0 0;
@@ -2610,8 +2610,8 @@ legend + .control-group {
 .nav-pills > li > a {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
-  margin-top: 2px;
-  margin-bottom: 2px;
+  margin-top: 0.125rem;
+  margin-bottom: 0.125rem;
   -webkit-border-radius: 5px;
   -moz-border-radius: 5px;
   border-radius: 5px;
@@ -2659,10 +2659,10 @@ legend + .control-group {
   z-index: 2;
 }
 .nav-pills.nav-stacked > li > a {
-  margin-bottom: 3px;
+  margin-bottom: 0.1875rem;
 }
 .nav-pills.nav-stacked > li:last-child > a {
-  margin-bottom: 1px;
+  margin-bottom: 0.0625rem;
 }
 .nav-tabs .dropdown-menu {
   -webkit-border-radius: 0 0 6px 6px;
@@ -2677,7 +2677,7 @@ legend + .control-group {
 .nav .dropdown-toggle .caret {
   border-top-color: #0088cc;
   border-bottom-color: #0088cc;
-  margin-top: 6px;
+  margin-top: 0.375rem;
 }
 .nav .dropdown-toggle:hover .caret,
 .nav .dropdown-toggle:focus .caret {
@@ -2686,7 +2686,7 @@ legend + .control-group {
 }
 /* move down carets for tabs */
 .nav-tabs .dropdown-toggle .caret {
-  margin-top: 8px;
+  margin-top: 0.5rem;
 }
 .nav .active .dropdown-toggle .caret {
   border-top-color: #fff;
@@ -2753,7 +2753,7 @@ legend + .control-group {
   border-top: 1px solid #ddd;
 }
 .tabs-below > .nav-tabs > li {
-  margin-top: -1px;
+  margin-top: -0.0625rem;
   margin-bottom: 0;
 }
 .tabs-below > .nav-tabs > li > a {
@@ -2777,17 +2777,17 @@ legend + .control-group {
 }
 .tabs-left > .nav-tabs > li > a,
 .tabs-right > .nav-tabs > li > a {
-  min-width: 74px;
+  min-width: 4.625rem;
   margin-right: 0;
-  margin-bottom: 3px;
+  margin-bottom: 0.1875rem;
 }
 .tabs-left > .nav-tabs {
   float: left;
-  margin-right: 19px;
+  margin-right: 1.1875rem;
   border-right: 1px solid #ddd;
 }
 .tabs-left > .nav-tabs > li > a {
-  margin-right: -1px;
+  margin-right: -0.0625rem;
   -webkit-border-radius: 4px 0 0 4px;
   -moz-border-radius: 4px 0 0 4px;
   border-radius: 4px 0 0 4px;
@@ -2804,11 +2804,11 @@ legend + .control-group {
 }
 .tabs-right > .nav-tabs {
   float: right;
-  margin-left: 19px;
+  margin-left: 1.1875rem;
   border-left: 1px solid #ddd;
 }
 .tabs-right > .nav-tabs > li > a {
-  margin-left: -1px;
+  margin-left: -0.0625rem;
   -webkit-border-radius: 0 4px 4px 0;
   -moz-border-radius: 0 4px 4px 0;
   border-radius: 0 4px 4px 0;
@@ -2834,12 +2834,12 @@ legend + .control-group {
 }
 .navbar {
   overflow: visible;
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
   *position: relative;
   *z-index: 2;
 }
 .navbar-inner {
-  min-height: 40px;
+  min-height: 2.5rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
   background-color: #fafafa;
@@ -2879,7 +2879,7 @@ legend + .control-group {
   float: left;
   display: block;
   padding: 0.625rem 1.25rem 0.625rem;
-  margin-left: -20px;
+  margin-left: -1.25rem;
   font-size: 1.25rem;
   font-weight: 200;
   color: #777777;
@@ -2891,7 +2891,7 @@ legend + .control-group {
 }
 .navbar-text {
   margin-bottom: 0;
-  line-height: 40px;
+  line-height: 2.5rem;
   color: #777777;
 }
 .navbar-link {
@@ -2902,14 +2902,14 @@ legend + .control-group {
   color: #333333;
 }
 .navbar .divider-vertical {
-  height: 40px;
-  margin: 0 9px;
+  height: 2.5rem;
+  margin: 0 0.5625rem;
   border-left: 1px solid #f2f2f2;
   border-right: 1px solid #ffffff;
 }
 .navbar .btn,
 .navbar .btn-group {
-  margin-top: 5px;
+  margin-top: 0.3125rem;
 }
 .navbar .btn-group .btn,
 .navbar .input-prepend .btn,
@@ -2935,7 +2935,7 @@ legend + .control-group {
 .navbar-form select,
 .navbar-form .radio,
 .navbar-form .checkbox {
-  margin-top: 5px;
+  margin-top: 0.3125rem;
 }
 .navbar-form input,
 .navbar-form select,
@@ -2946,11 +2946,11 @@ legend + .control-group {
 .navbar-form input[type="image"],
 .navbar-form input[type="checkbox"],
 .navbar-form input[type="radio"] {
-  margin-top: 3px;
+  margin-top: 0.1875rem;
 }
 .navbar-form .input-append,
 .navbar-form .input-prepend {
-  margin-top: 5px;
+  margin-top: 0.3125rem;
   white-space: nowrap;
 }
 .navbar-form .input-append input,
@@ -2960,7 +2960,7 @@ legend + .control-group {
 .navbar-search {
   position: relative;
   float: left;
-  margin-top: 5px;
+  margin-top: 0.3125rem;
   margin-bottom: 0;
 }
 .navbar-search .search-query {
@@ -2993,10 +2993,10 @@ legend + .control-group {
 }
 .navbar-fixed-top .navbar-inner,
 .navbar-static-top .navbar-inner {
-  border-width: 0 0 1px;
+  border-width: 0 0 0.0625rem;
 }
 .navbar-fixed-bottom .navbar-inner {
-  border-width: 1px 0 0;
+  border-width: 0.0625rem 0 0;
 }
 .navbar-fixed-top .navbar-inner,
 .navbar-fixed-bottom .navbar-inner {
@@ -3009,7 +3009,7 @@ legend + .control-group {
 .navbar-static-top .container,
 .navbar-fixed-top .container,
 .navbar-fixed-bottom .container {
-  width: 940px;
+  width: 58.75rem;
 }
 .navbar-fixed-top {
   top: 0;
@@ -3033,7 +3033,7 @@ legend + .control-group {
   left: 0;
   display: block;
   float: left;
-  margin: 0 10px 0 0;
+  margin: 0 0.625rem 0 0;
 }
 .navbar .nav.pull-right {
   float: right;
@@ -3050,7 +3050,7 @@ legend + .control-group {
   text-shadow: 0 1px 0 #ffffff;
 }
 .navbar .nav .dropdown-toggle .caret {
-  margin-top: 8px;
+  margin-top: 0.5rem;
 }
 .navbar .nav > li > a:focus,
 .navbar .nav > li > a:hover {
@@ -3072,8 +3072,8 @@ legend + .control-group {
   display: none;
   float: right;
   padding: 0.4375rem 0.625rem;
-  margin-left: 5px;
-  margin-right: 5px;
+  margin-left: 0.3125rem;
+  margin-right: 0.3125rem;
   color: #ffffff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #ededed;
@@ -3110,8 +3110,8 @@ legend + .control-group {
 }
 .navbar .btn-navbar .icon-bar {
   display: block;
-  width: 18px;
-  height: 2px;
+  width: 1.125rem;
+  height: 0.125rem;
   background-color: #f5f5f5;
   -webkit-border-radius: 1px;
   -moz-border-radius: 1px;
@@ -3121,7 +3121,7 @@ legend + .control-group {
   box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
 }
 .btn-navbar .icon-bar + .icon-bar {
-  margin-top: 3px;
+  margin-top: 0.1875rem;
 }
 .navbar .nav > li > .dropdown-menu:before {
   content: '';
@@ -3198,7 +3198,7 @@ legend + .control-group {
   left: auto;
   right: 100%;
   margin-left: 0;
-  margin-right: -1px;
+  margin-right: -0.0625rem;
   -webkit-border-radius: 6px 0 6px 6px;
   -moz-border-radius: 6px 0 6px 6px;
   border-radius: 6px 0 6px 6px;
@@ -3341,7 +3341,7 @@ legend + .control-group {
 }
 .breadcrumb {
   padding: 0.5rem 0.9375rem;
-  margin: 0 0 20px;
+  margin: 0 0 1.25rem;
   list-style: none;
   background-color: #f5f5f5;
   -webkit-border-radius: 4px;
@@ -3364,7 +3364,7 @@ legend + .control-group {
   color: #999999;
 }
 .pagination {
-  margin: 20px 0;
+  margin: 1.25rem 0;
 }
 .pagination ul {
   display: inline-block;
@@ -3388,7 +3388,7 @@ legend + .control-group {
 .pagination ul > li > span {
   float: left;
   padding: 0.25rem 0.75rem;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-decoration: none;
   background-color: #ffffff;
   border: 1px solid #dddddd;
@@ -3415,7 +3415,7 @@ legend + .control-group {
 }
 .pagination ul > li:first-child > a,
 .pagination ul > li:first-child > span {
-  border-left-width: 1px;
+  border-left-width: 0.0625rem;
   -webkit-border-top-left-radius: 4px;
   -moz-border-radius-topleft: 4px;
   border-top-left-radius: 4px;
@@ -3494,7 +3494,7 @@ legend + .control-group {
   font-size: 0.625rem;
 }
 .pager {
-  margin: 20px 0;
+  margin: 1.25rem 0;
   list-style: none;
   text-align: center;
   *zoom: 1;
@@ -3543,7 +3543,7 @@ legend + .control-group {
   cursor: default;
 }
 .thumbnails {
-  margin-left: -20px;
+  margin-left: -1.25rem;
   list-style: none;
   *zoom: 1;
 }
@@ -3561,13 +3561,13 @@ legend + .control-group {
 }
 .thumbnails > li {
   float: left;
-  margin-bottom: 20px;
-  margin-left: 20px;
+  margin-bottom: 1.25rem;
+  margin-left: 1.25rem;
 }
 .thumbnail {
   display: block;
   padding: 0.25rem;
-  line-height: 20px;
+  line-height: 1.25rem;
   border: 1px solid #ddd;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
@@ -3599,7 +3599,7 @@ a.thumbnail:focus {
 }
 .alert {
   padding: 0.5rem 2.1875rem 0.5rem 0.875rem;
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
   background-color: #fcf8e3;
   border: 1px solid #fbeed5;
@@ -3618,7 +3618,7 @@ a.thumbnail:focus {
   position: relative;
   top: -2px;
   right: -21px;
-  line-height: 20px;
+  line-height: 1.25rem;
 }
 .alert-success {
   background-color: #dff0d8;
@@ -3655,7 +3655,7 @@ a.thumbnail:focus {
   margin-bottom: 0;
 }
 .alert-block p + p {
-  margin-top: 5px;
+  margin-top: 0.3125rem;
 }
 @-webkit-keyframes progress-bar-stripes {
   from {
@@ -3699,8 +3699,8 @@ a.thumbnail:focus {
 }
 .progress {
   overflow: hidden;
-  height: 20px;
-  margin-bottom: 20px;
+  height: 1.25rem;
+  margin-bottom: 1.25rem;
   background-color: #f7f7f7;
   background-image: -moz-linear-gradient(top, #f5f5f5, #f9f9f9);
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#f5f5f5), to(#f9f9f9));
@@ -3849,10 +3849,10 @@ a.thumbnail:focus {
 }
 .hero-unit {
   padding: 3.75rem;
-  margin-bottom: 30px;
+  margin-bottom: 1.875rem;
   font-size: 1.125rem;
   font-weight: 200;
-  line-height: 30px;
+  line-height: 1.875rem;
   color: inherit;
   background-color: #eeeeee;
   -webkit-border-radius: 6px;
@@ -3867,7 +3867,7 @@ a.thumbnail:focus {
   letter-spacing: -1px;
 }
 .hero-unit li {
-  line-height: 30px;
+  line-height: 1.875rem;
 }
 .media,
 .media-body {
@@ -3877,7 +3877,7 @@ a.thumbnail:focus {
 }
 .media,
 .media .media {
-  margin-top: 15px;
+  margin-top: 0.9375rem;
 }
 .media:first-child {
   margin-top: 0;
@@ -3886,13 +3886,13 @@ a.thumbnail:focus {
   display: block;
 }
 .media-heading {
-  margin: 0 0 5px;
+  margin: 0 0 0.3125rem;
 }
 .media > .pull-left {
-  margin-right: 10px;
+  margin-right: 0.625rem;
 }
 .media > .pull-right {
-  margin-left: 10px;
+  margin-left: 0.625rem;
 }
 .media-list {
   margin-left: 0;
@@ -3913,23 +3913,23 @@ a.thumbnail:focus {
   filter: alpha(opacity=80);
 }
 .tooltip.top {
-  margin-top: -3px;
+  margin-top: -0.1875rem;
   padding: 0.3125rem 0;
 }
 .tooltip.right {
-  margin-left: 3px;
+  margin-left: 0.1875rem;
   padding: 0 0.3125rem;
 }
 .tooltip.bottom {
-  margin-top: 3px;
+  margin-top: 0.1875rem;
   padding: 0.3125rem 0;
 }
 .tooltip.left {
-  margin-left: -3px;
+  margin-left: -0.1875rem;
   padding: 0 0.3125rem;
 }
 .tooltip-inner {
-  max-width: 200px;
+  max-width: 12.5rem;
   padding: 0.5rem;
   color: #ffffff;
   text-align: center;
@@ -3949,29 +3949,29 @@ a.thumbnail:focus {
 .tooltip.top .tooltip-arrow {
   bottom: 0;
   left: 50%;
-  margin-left: -5px;
-  border-width: 5px 5px 0;
+  margin-left: -0.3125rem;
+  border-width: 0.3125rem 0.3125rem 0;
   border-top-color: #000000;
 }
 .tooltip.right .tooltip-arrow {
   top: 50%;
   left: 0;
-  margin-top: -5px;
-  border-width: 5px 5px 5px 0;
+  margin-top: -0.3125rem;
+  border-width: 0.3125rem 0.3125rem 0.3125rem 0;
   border-right-color: #000000;
 }
 .tooltip.left .tooltip-arrow {
   top: 50%;
   right: 0;
-  margin-top: -5px;
-  border-width: 5px 0 5px 5px;
+  margin-top: -0.3125rem;
+  border-width: 0.3125rem 0 0.3125rem 0.3125rem;
   border-left-color: #000000;
 }
 .tooltip.bottom .tooltip-arrow {
   top: 0;
   left: 50%;
-  margin-left: -5px;
-  border-width: 0 5px 5px;
+  margin-left: -0.3125rem;
+  border-width: 0 0.3125rem 0.3125rem;
   border-bottom-color: #000000;
 }
 .popover {
@@ -3980,7 +3980,7 @@ a.thumbnail:focus {
   left: 0;
   z-index: 1010;
   display: none;
-  max-width: 276px;
+  max-width: 17.25rem;
   padding: 0.0625rem;
   text-align: left;
   background-color: #ffffff;
@@ -3998,23 +3998,23 @@ a.thumbnail:focus {
   white-space: normal;
 }
 .popover.top {
-  margin-top: -10px;
+  margin-top: -0.625rem;
 }
 .popover.right {
-  margin-left: 10px;
+  margin-left: 0.625rem;
 }
 .popover.bottom {
-  margin-top: 10px;
+  margin-top: 0.625rem;
 }
 .popover.left {
-  margin-left: -10px;
+  margin-left: -0.625rem;
 }
 .popover-title {
   margin: 0;
   padding: 0.5rem 0.875rem;
   font-size: 0.875rem;
   font-weight: normal;
-  line-height: 18px;
+  line-height: 1.125rem;
   background-color: #f7f7f7;
   border-bottom: 1px solid #ebebeb;
   -webkit-border-radius: 5px 5px 0 0;
@@ -4037,15 +4037,15 @@ a.thumbnail:focus {
   border-style: solid;
 }
 .popover .arrow {
-  border-width: 11px;
+  border-width: 0.6875rem;
 }
 .popover .arrow:after {
-  border-width: 10px;
+  border-width: 0.625rem;
   content: "";
 }
 .popover.top .arrow {
   left: 50%;
-  margin-left: -11px;
+  margin-left: -0.6875rem;
   border-bottom-width: 0;
   border-top-color: #999;
   border-top-color: rgba(0, 0, 0, 0.25);
@@ -4053,14 +4053,14 @@ a.thumbnail:focus {
 }
 .popover.top .arrow:after {
   bottom: 1px;
-  margin-left: -10px;
+  margin-left: -0.625rem;
   border-bottom-width: 0;
   border-top-color: #ffffff;
 }
 .popover.right .arrow {
   top: 50%;
   left: -11px;
-  margin-top: -11px;
+  margin-top: -0.6875rem;
   border-left-width: 0;
   border-right-color: #999;
   border-right-color: rgba(0, 0, 0, 0.25);
@@ -4073,7 +4073,7 @@ a.thumbnail:focus {
 }
 .popover.bottom .arrow {
   left: 50%;
-  margin-left: -11px;
+  margin-left: -0.6875rem;
   border-top-width: 0;
   border-bottom-color: #999;
   border-bottom-color: rgba(0, 0, 0, 0.25);
@@ -4081,14 +4081,14 @@ a.thumbnail:focus {
 }
 .popover.bottom .arrow:after {
   top: 1px;
-  margin-left: -10px;
+  margin-left: -0.625rem;
   border-top-width: 0;
   border-bottom-color: #ffffff;
 }
 .popover.left .arrow {
   top: 50%;
   right: -11px;
-  margin-top: -11px;
+  margin-top: -0.6875rem;
   border-right-width: 0;
   border-left-color: #999;
   border-left-color: rgba(0, 0, 0, 0.25);
@@ -4121,8 +4121,8 @@ a.thumbnail:focus {
   top: 10%;
   left: 50%;
   z-index: 1050;
-  width: 560px;
-  margin-left: -280px;
+  width: 35.0rem;
+  margin-left: -17.5rem;
   background-color: #ffffff;
   border: 1px solid #999;
   border: 1px solid rgba(0, 0, 0, 0.3);
@@ -4155,16 +4155,16 @@ a.thumbnail:focus {
   border-bottom: 1px solid #eee;
 }
 .modal-header .close {
-  margin-top: 2px;
+  margin-top: 0.125rem;
 }
 .modal-header h3 {
   margin: 0;
-  line-height: 30px;
+  line-height: 1.875rem;
 }
 .modal-body {
   position: relative;
   overflow-y: auto;
-  max-height: 400px;
+  max-height: 25.0rem;
   padding: 0.9375rem;
 }
 .modal-form {
@@ -4194,11 +4194,11 @@ a.thumbnail:focus {
   clear: both;
 }
 .modal-footer .btn + .btn {
-  margin-left: 5px;
+  margin-left: 0.3125rem;
   margin-bottom: 0;
 }
 .modal-footer .btn-group .btn + .btn {
-  margin-left: -1px;
+  margin-left: -0.0625rem;
 }
 .modal-footer .btn-block + .btn-block {
   margin-left: 0;
@@ -4208,7 +4208,7 @@ a.thumbnail:focus {
   position: relative;
 }
 .dropdown-toggle {
-  *margin-bottom: -3px;
+  *margin-bottom: -0.1875rem;
 }
 .dropdown-toggle:active,
 .open .dropdown-toggle {
@@ -4225,8 +4225,8 @@ a.thumbnail:focus {
   content: "";
 }
 .dropdown .caret {
-  margin-top: 8px;
-  margin-left: 2px;
+  margin-top: 0.5rem;
+  margin-left: 0.125rem;
 }
 .dropdown-menu {
   position: absolute;
@@ -4235,15 +4235,15 @@ a.thumbnail:focus {
   z-index: 1000;
   display: none;
   float: left;
-  min-width: 160px;
+  min-width: 10.0rem;
   padding: 0.3125rem 0;
-  margin: 2px 0 0;
+  margin: 0.125rem 0 0;
   list-style: none;
   background-color: #ffffff;
   border: 1px solid #ccc;
   border: 1px solid rgba(0, 0, 0, 0.2);
-  *border-right-width: 2px;
-  *border-bottom-width: 2px;
+  *border-right-width: 0.125rem;
+  *border-bottom-width: 0.125rem;
   -webkit-border-radius: 6px;
   -moz-border-radius: 6px;
   border-radius: 6px;
@@ -4260,9 +4260,9 @@ a.thumbnail:focus {
 }
 .dropdown-menu .divider {
   *width: 100%;
-  height: 1px;
-  margin: 9px 1px;
-  *margin: -5px 0 5px;
+  height: 0.0625rem;
+  margin: 0.5625rem 0.0625rem;
+  *margin: -0.3125rem 0 0.3125rem;
   overflow: hidden;
   background-color: #e5e5e5;
   border-bottom: 1px solid #ffffff;
@@ -4272,7 +4272,7 @@ a.thumbnail:focus {
   padding: 0.1875rem 1.25rem;
   clear: both;
   font-weight: normal;
-  line-height: 20px;
+  line-height: 1.25rem;
   color: #333333;
   white-space: nowrap;
 }
@@ -4347,7 +4347,7 @@ a.thumbnail:focus {
 .navbar-fixed-bottom .dropdown .dropdown-menu {
   top: auto;
   bottom: 100%;
-  margin-bottom: 1px;
+  margin-bottom: 0.0625rem;
 }
 .dropdown-submenu {
   position: relative;
@@ -4355,8 +4355,8 @@ a.thumbnail:focus {
 .dropdown-submenu > .dropdown-menu {
   top: 0;
   left: 100%;
-  margin-top: -6px;
-  margin-left: -1px;
+  margin-top: -0.375rem;
+  margin-left: -0.0625rem;
   -webkit-border-radius: 0 6px 6px 6px;
   -moz-border-radius: 0 6px 6px 6px;
   border-radius: 0 6px 6px 6px;
@@ -4368,7 +4368,7 @@ a.thumbnail:focus {
   top: auto;
   bottom: 0;
   margin-top: 0;
-  margin-bottom: -2px;
+  margin-bottom: -0.125rem;
   -webkit-border-radius: 5px 5px 5px 0;
   -moz-border-radius: 5px 5px 5px 0;
   border-radius: 5px 5px 5px 0;
@@ -4381,10 +4381,10 @@ a.thumbnail:focus {
   height: 0;
   border-color: transparent;
   border-style: solid;
-  border-width: 5px 0 5px 5px;
+  border-width: 0.3125rem 0 0.3125rem 0.3125rem;
   border-left-color: #cccccc;
-  margin-top: 5px;
-  margin-right: -10px;
+  margin-top: 0.3125rem;
+  margin-right: -0.625rem;
 }
 .dropdown-submenu:hover > a:after {
   border-left-color: #ffffff;
@@ -4394,7 +4394,7 @@ a.thumbnail:focus {
 }
 .dropdown-submenu.pull-left > .dropdown-menu {
   left: -100%;
-  margin-left: 10px;
+  margin-left: 0.625rem;
   -webkit-border-radius: 6px 0 6px 6px;
   -moz-border-radius: 6px 0 6px 6px;
   border-radius: 6px 0 6px 6px;
@@ -4405,16 +4405,16 @@ a.thumbnail:focus {
 }
 .typeahead {
   z-index: 1051;
-  margin-top: 2px;
+  margin-top: 0.125rem;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
 }
 .accordion {
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
 }
 .accordion-group {
-  margin-bottom: 2px;
+  margin-bottom: 0.125rem;
   border: 1px solid #e5e5e5;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
@@ -4436,7 +4436,7 @@ a.thumbnail:focus {
 }
 .carousel {
   position: relative;
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
   line-height: 1;
 }
 .carousel-inner {
@@ -4491,12 +4491,12 @@ a.thumbnail:focus {
   position: absolute;
   top: 40%;
   left: 15px;
-  width: 40px;
-  height: 40px;
-  margin-top: -20px;
+  width: 2.5rem;
+  height: 2.5rem;
+  margin-top: -1.25rem;
   font-size: 3.75rem;
   font-weight: 100;
-  line-height: 30px;
+  line-height: 1.875rem;
   color: #ffffff;
   text-align: center;
   background: #222222;
@@ -4529,9 +4529,9 @@ a.thumbnail:focus {
 .carousel-indicators li {
   display: block;
   float: left;
-  width: 10px;
-  height: 10px;
-  margin-left: 5px;
+  width: 0.625rem;
+  height: 0.625rem;
+  margin-left: 0.3125rem;
   text-indent: -999px;
   background-color: #ccc;
   background-color: rgba(255, 255, 255, 0.25);
@@ -4552,18 +4552,18 @@ a.thumbnail:focus {
 .carousel-caption h4,
 .carousel-caption p {
   color: #ffffff;
-  line-height: 20px;
+  line-height: 1.25rem;
 }
 .carousel-caption h4 {
-  margin: 0 0 5px;
+  margin: 0 0 0.3125rem;
 }
 .carousel-caption p {
   margin-bottom: 0;
 }
 .well {
-  min-height: 20px;
+  min-height: 1.25rem;
   padding: 1.1875rem;
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
   background-color: #f5f5f5;
   border: 1px solid #e3e3e3;
   -webkit-border-radius: 4px;
@@ -4593,7 +4593,7 @@ a.thumbnail:focus {
   float: right;
   font-size: 1.25rem;
   font-weight: bold;
-  line-height: 20px;
+  line-height: 1.25rem;
   color: #000000;
   text-shadow: 0 1px 0 #ffffff;
   opacity: 0.2;
@@ -4777,7 +4777,7 @@ button.close {
   .uneditable-input {
     display: block;
     width: 100%;
-    min-height: 30px;
+    min-height: 1.875rem;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
@@ -4813,7 +4813,7 @@ button.close {
   }
   .page-header h1 small {
     display: block;
-    line-height: 20px;
+    line-height: 1.25rem;
   }
   input[type="checkbox"],
   input[type="radio"] {
@@ -4839,7 +4839,7 @@ button.close {
   .media .pull-right {
     float: none;
     display: block;
-    margin-bottom: 10px;
+    margin-bottom: 0.625rem;
   }
   .media-object {
     margin-right: 0;
@@ -4852,7 +4852,7 @@ button.close {
   }
   .modal-header .close {
     padding: 0.625rem;
-    margin: -10px;
+    margin: -0.625rem;
   }
   .carousel-caption {
     position: static;
@@ -4860,7 +4860,7 @@ button.close {
 }
 @media (min-width: 768px) and (max-width: 979px) {
   .row {
-    margin-left: -20px;
+    margin-left: -1.25rem;
     *zoom: 1;
   }
   .row:before,
@@ -4874,86 +4874,86 @@ button.close {
   }
   [class*="span"] {
     float: left;
-    min-height: 1px;
-    margin-left: 20px;
+    min-height: 0.0625rem;
+    margin-left: 1.25rem;
   }
   .container,
   .navbar-static-top .container,
   .navbar-fixed-top .container,
   .navbar-fixed-bottom .container {
-    width: 724px;
+    width: 45.25rem;
   }
   .span12 {
-    width: 724px;
+    width: 45.25rem;
   }
   .span11 {
-    width: 662px;
+    width: 41.375rem;
   }
   .span10 {
-    width: 600px;
+    width: 37.5rem;
   }
   .span9 {
-    width: 538px;
+    width: 33.625rem;
   }
   .span8 {
-    width: 476px;
+    width: 29.75rem;
   }
   .span7 {
-    width: 414px;
+    width: 25.875rem;
   }
   .span6 {
-    width: 352px;
+    width: 22.0rem;
   }
   .span5 {
-    width: 290px;
+    width: 18.125rem;
   }
   .span4 {
-    width: 228px;
+    width: 14.25rem;
   }
   .span3 {
-    width: 166px;
+    width: 10.375rem;
   }
   .span2 {
-    width: 104px;
+    width: 6.5rem;
   }
   .span1 {
-    width: 42px;
+    width: 2.625rem;
   }
   .offset12 {
-    margin-left: 764px;
+    margin-left: 47.75rem;
   }
   .offset11 {
-    margin-left: 702px;
+    margin-left: 43.875rem;
   }
   .offset10 {
-    margin-left: 640px;
+    margin-left: 40.0rem;
   }
   .offset9 {
-    margin-left: 578px;
+    margin-left: 36.125rem;
   }
   .offset8 {
-    margin-left: 516px;
+    margin-left: 32.25rem;
   }
   .offset7 {
-    margin-left: 454px;
+    margin-left: 28.375rem;
   }
   .offset6 {
-    margin-left: 392px;
+    margin-left: 24.5rem;
   }
   .offset5 {
-    margin-left: 330px;
+    margin-left: 20.625rem;
   }
   .offset4 {
-    margin-left: 268px;
+    margin-left: 16.75rem;
   }
   .offset3 {
-    margin-left: 206px;
+    margin-left: 12.875rem;
   }
   .offset2 {
-    margin-left: 144px;
+    margin-left: 9.0rem;
   }
   .offset1 {
-    margin-left: 82px;
+    margin-left: 5.125rem;
   }
   .row-fluid {
     width: 100%;
@@ -4971,7 +4971,7 @@ button.close {
   .row-fluid [class*="span"] {
     display: block;
     width: 100%;
-    min-height: 30px;
+    min-height: 1.875rem;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
@@ -5135,72 +5135,72 @@ button.close {
     margin-left: 0;
   }
   .controls-row [class*="span"] + [class*="span"] {
-    margin-left: 20px;
+    margin-left: 1.25rem;
   }
   input.span12,
   textarea.span12,
   .uneditable-input.span12 {
-    width: 710px;
+    width: 44.375rem;
   }
   input.span11,
   textarea.span11,
   .uneditable-input.span11 {
-    width: 648px;
+    width: 40.5rem;
   }
   input.span10,
   textarea.span10,
   .uneditable-input.span10 {
-    width: 586px;
+    width: 36.625rem;
   }
   input.span9,
   textarea.span9,
   .uneditable-input.span9 {
-    width: 524px;
+    width: 32.75rem;
   }
   input.span8,
   textarea.span8,
   .uneditable-input.span8 {
-    width: 462px;
+    width: 28.875rem;
   }
   input.span7,
   textarea.span7,
   .uneditable-input.span7 {
-    width: 400px;
+    width: 25.0rem;
   }
   input.span6,
   textarea.span6,
   .uneditable-input.span6 {
-    width: 338px;
+    width: 21.125rem;
   }
   input.span5,
   textarea.span5,
   .uneditable-input.span5 {
-    width: 276px;
+    width: 17.25rem;
   }
   input.span4,
   textarea.span4,
   .uneditable-input.span4 {
-    width: 214px;
+    width: 13.375rem;
   }
   input.span3,
   textarea.span3,
   .uneditable-input.span3 {
-    width: 152px;
+    width: 9.5rem;
   }
   input.span2,
   textarea.span2,
   .uneditable-input.span2 {
-    width: 90px;
+    width: 5.625rem;
   }
   input.span1,
   textarea.span1,
   .uneditable-input.span1 {
-    width: 28px;
+    width: 1.75rem;
   }
 }
 @media (min-width: 1180px) {
   .row {
-    margin-left: -30px;
+    margin-left: -1.875rem;
     *zoom: 1;
   }
   .row:before,
@@ -5214,86 +5214,86 @@ button.close {
   }
   [class*="span"] {
     float: left;
-    min-height: 1px;
-    margin-left: 30px;
+    min-height: 0.0625rem;
+    margin-left: 1.875rem;
   }
   .container,
   .navbar-static-top .container,
   .navbar-fixed-top .container,
   .navbar-fixed-bottom .container {
-    width: 1170px;
+    width: 73.125rem;
   }
   .span12 {
-    width: 1170px;
+    width: 73.125rem;
   }
   .span11 {
-    width: 1070px;
+    width: 66.875rem;
   }
   .span10 {
-    width: 970px;
+    width: 60.625rem;
   }
   .span9 {
-    width: 870px;
+    width: 54.375rem;
   }
   .span8 {
-    width: 770px;
+    width: 48.125rem;
   }
   .span7 {
-    width: 670px;
+    width: 41.875rem;
   }
   .span6 {
-    width: 570px;
+    width: 35.625rem;
   }
   .span5 {
-    width: 470px;
+    width: 29.375rem;
   }
   .span4 {
-    width: 370px;
+    width: 23.125rem;
   }
   .span3 {
-    width: 270px;
+    width: 16.875rem;
   }
   .span2 {
-    width: 170px;
+    width: 10.625rem;
   }
   .span1 {
-    width: 70px;
+    width: 4.375rem;
   }
   .offset12 {
-    margin-left: 1230px;
+    margin-left: 76.875rem;
   }
   .offset11 {
-    margin-left: 1130px;
+    margin-left: 70.625rem;
   }
   .offset10 {
-    margin-left: 1030px;
+    margin-left: 64.375rem;
   }
   .offset9 {
-    margin-left: 930px;
+    margin-left: 58.125rem;
   }
   .offset8 {
-    margin-left: 830px;
+    margin-left: 51.875rem;
   }
   .offset7 {
-    margin-left: 730px;
+    margin-left: 45.625rem;
   }
   .offset6 {
-    margin-left: 630px;
+    margin-left: 39.375rem;
   }
   .offset5 {
-    margin-left: 530px;
+    margin-left: 33.125rem;
   }
   .offset4 {
-    margin-left: 430px;
+    margin-left: 26.875rem;
   }
   .offset3 {
-    margin-left: 330px;
+    margin-left: 20.625rem;
   }
   .offset2 {
-    margin-left: 230px;
+    margin-left: 14.375rem;
   }
   .offset1 {
-    margin-left: 130px;
+    margin-left: 8.125rem;
   }
   .row-fluid {
     width: 100%;
@@ -5311,7 +5311,7 @@ button.close {
   .row-fluid [class*="span"] {
     display: block;
     width: 100%;
-    min-height: 30px;
+    min-height: 1.875rem;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
@@ -5475,73 +5475,73 @@ button.close {
     margin-left: 0;
   }
   .controls-row [class*="span"] + [class*="span"] {
-    margin-left: 30px;
+    margin-left: 1.875rem;
   }
   input.span12,
   textarea.span12,
   .uneditable-input.span12 {
-    width: 1156px;
+    width: 72.25rem;
   }
   input.span11,
   textarea.span11,
   .uneditable-input.span11 {
-    width: 1056px;
+    width: 66.0rem;
   }
   input.span10,
   textarea.span10,
   .uneditable-input.span10 {
-    width: 956px;
+    width: 59.75rem;
   }
   input.span9,
   textarea.span9,
   .uneditable-input.span9 {
-    width: 856px;
+    width: 53.5rem;
   }
   input.span8,
   textarea.span8,
   .uneditable-input.span8 {
-    width: 756px;
+    width: 47.25rem;
   }
   input.span7,
   textarea.span7,
   .uneditable-input.span7 {
-    width: 656px;
+    width: 41.0rem;
   }
   input.span6,
   textarea.span6,
   .uneditable-input.span6 {
-    width: 556px;
+    width: 34.75rem;
   }
   input.span5,
   textarea.span5,
   .uneditable-input.span5 {
-    width: 456px;
+    width: 28.5rem;
   }
   input.span4,
   textarea.span4,
   .uneditable-input.span4 {
-    width: 356px;
+    width: 22.25rem;
   }
   input.span3,
   textarea.span3,
   .uneditable-input.span3 {
-    width: 256px;
+    width: 16.0rem;
   }
   input.span2,
   textarea.span2,
   .uneditable-input.span2 {
-    width: 156px;
+    width: 9.75rem;
   }
   input.span1,
   textarea.span1,
   .uneditable-input.span1 {
-    width: 56px;
+    width: 3.5rem;
   }
   .thumbnails {
-    margin-left: -30px;
+    margin-left: -1.875rem;
   }
   .thumbnails > li {
-    margin-left: 30px;
+    margin-left: 1.875rem;
   }
   .row-fluid .thumbnails {
     margin-left: 0;
@@ -5555,36 +5555,36 @@ button.close {
   .navbar-fixed-bottom {
   }
   .navbar-fixed-top {
-    margin-bottom: 20px;
+    margin-bottom: 1.25rem;
   }
   .navbar-fixed-bottom {
-    margin-top: 20px;
+    margin-top: 1.25rem;
   }
   .navbar-fixed-top .navbar-inner,
   .navbar-fixed-bottom .navbar-inner {
   }
   .navbar .container {
     width: auto;
-    max-width: 724px; /* same as a normal container */
+    max-width: 45.25rem; /* same as a normal container */
     padding: 0;
   }
   .navbar .brand {
     padding-left: 0.625rem;
     padding-right: 0.625rem;
-    margin: 0 0 0 -5px;
+    margin: 0 0 0 -0.3125rem;
   }
   .nav-collapse {
     clear: both;
   }
   .nav-collapse .nav {
     float: none;
-    margin: 0 0 10px;
+    margin: 0 0 0.625rem;
   }
   .nav-collapse .nav > li {
     float: none;
   }
   .nav-collapse .nav > li > a {
-    margin-bottom: 2px;
+    margin-bottom: 0.125rem;
   }
   .nav-collapse .nav > .divider-vertical {
     display: none;
@@ -5610,7 +5610,7 @@ button.close {
     border-radius: 4px;
   }
   .nav-collapse .dropdown-menu li + li a {
-    margin-bottom: 2px;
+    margin-bottom: 0.125rem;
   }
   .nav-collapse .nav > li > a:hover,
   .nav-collapse .nav > li > a:focus,
@@ -5629,7 +5629,7 @@ button.close {
     background-color: #111111;
   }
   .nav-collapse.in .btn-group {
-    margin-top: 5px;
+    margin-top: 0.3125rem;
     padding: 0;
   }
   .nav-collapse .dropdown-menu {
@@ -5639,7 +5639,7 @@ button.close {
     float: none;
     display: none;
     max-width: none;
-    margin: 0 15px;
+    margin: 0 0.9375rem;
     padding: 0;
     background-color: transparent;
     border: none;
@@ -5668,7 +5668,7 @@ button.close {
   .nav-collapse .navbar-search {
     float: none;
     padding: 0.625rem 0.9375rem;
-    margin: 10px 0;
+    margin: 0.625rem 0;
     border-top: 1px solid #f2f2f2;
     border-bottom: 1px solid #f2f2f2;
     -webkit-box-shadow: inset 0 1px 0 rgba(255,255,255,.1), 0 1px 0 rgba(255,255,255,.1);

--- a/static/third/bootstrap/css/bootstrap.css
+++ b/static/third/bootstrap/css/bootstrap.css
@@ -226,7 +226,7 @@ a:focus {
   border-radius: 6px;
 }
 .img-polaroid {
-  padding: 4px;
+  padding: 0.25rem;
   background-color: #fff;
   border: 1px solid #ccc;
   border: 1px solid rgba(0, 0, 0, 0.2);
@@ -760,7 +760,7 @@ abbr.initialism {
   text-transform: uppercase;
 }
 blockquote {
-  padding: 0 0 0 15px;
+  padding: 0 0 0 0.9375rem;
   margin: 0 0 20px;
   border-left: 5px solid #eeeeee;
 }
@@ -809,7 +809,7 @@ address {
 }
 code,
 pre {
-  padding: 0 3px 2px;
+  padding: 0 0.1875rem 0.125rem;
   font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
   font-size: 0.75rem;
   color: #333333;
@@ -818,7 +818,7 @@ pre {
   border-radius: 3px;
 }
 code {
-  padding: 2px 4px;
+  padding: 0.125rem 0.25rem;
   color: #d14;
   background-color: #f7f7f9;
   border: 1px solid #e1e1e8;
@@ -826,7 +826,7 @@ code {
 }
 pre {
   display: block;
-  padding: 9.5px;
+  padding: 9.0.3125rem;
   margin: 0 0 10px;
   font-size: 0.8125rem;
   line-height: 20px;
@@ -859,7 +859,7 @@ pre code {
 .label,
 .badge {
   display: inline-block;
-  padding: 2px 4px;
+  padding: 0.125rem 0.25rem;
   font-size: 0.6875rem;
   font-weight: bold;
   line-height: 14px;
@@ -954,7 +954,7 @@ table {
 }
 .table th,
 .table td {
-  padding: 8px;
+  padding: 0.5rem;
   line-height: 20px;
   text-align: left;
   vertical-align: top;
@@ -982,7 +982,7 @@ table {
 }
 .table-condensed th,
 .table-condensed td {
-  padding: 4px 5px;
+  padding: 0.25rem 0.3125rem;
 }
 .table-bordered {
   border: 1px solid #dddddd;
@@ -1239,7 +1239,7 @@ input[type="color"],
 .uneditable-input {
   display: inline-block;
   height: 20px;
-  padding: 4px 6px;
+  padding: 0.25rem 0.375rem;
   margin-bottom: 10px;
   font-size: 0.875rem;
   line-height: 20px;
@@ -1705,7 +1705,7 @@ select:focus:invalid:focus {
   box-shadow: 0 0 6px #f8b9b7;
 }
 .form-actions {
-  padding: 19px 20px 20px;
+  padding: 1.1875rem 1.25rem 1.25rem;
   margin-top: 20px;
   margin-bottom: 20px;
   background-color: #f5f5f5;
@@ -1786,7 +1786,7 @@ select:focus:invalid:focus {
   width: auto;
   height: 20px;
   min-width: 16px;
-  padding: 4px 5px;
+  padding: 0.25rem 0.3125rem;
   font-size: 0.875rem;
   font-weight: normal;
   line-height: 20px;
@@ -2507,7 +2507,7 @@ legend + .control-group {
 }
 .nav-header {
   display: block;
-  padding: 3px 15px;
+  padding: 0.1875rem 0.9375rem;
   font-size: 0.6875rem;
   font-weight: bold;
   line-height: 20px;
@@ -2530,7 +2530,7 @@ legend + .control-group {
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
 }
 .nav-list > li > a {
-  padding: 3px 15px;
+  padding: 0.1875rem 0.9375rem;
 }
 .nav-list > .active > a,
 .nav-list > .active > a:hover,
@@ -2878,7 +2878,7 @@ legend + .control-group {
 .navbar .brand {
   float: left;
   display: block;
-  padding: 10px 20px 10px;
+  padding: 0.625rem 1.25rem 0.625rem;
   margin-left: -20px;
   font-size: 1.25rem;
   font-weight: 200;
@@ -2965,7 +2965,7 @@ legend + .control-group {
 }
 .navbar-search .search-query {
   margin-bottom: 0;
-  padding: 4px 14px;
+  padding: 0.25rem 0.875rem;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 0.8125rem;
   font-weight: normal;
@@ -3044,7 +3044,7 @@ legend + .control-group {
 }
 .navbar .nav > li > a {
   float: none;
-  padding: 10px 15px 10px;
+  padding: 0.625rem 0.9375rem 0.625rem;
   color: #777777;
   text-decoration: none;
   text-shadow: 0 1px 0 #ffffff;
@@ -3071,7 +3071,7 @@ legend + .control-group {
 .navbar .btn-navbar {
   display: none;
   float: right;
-  padding: 7px 10px;
+  padding: 0.4375rem 0.625rem;
   margin-left: 5px;
   margin-right: 5px;
   color: #ffffff;
@@ -3297,7 +3297,7 @@ legend + .control-group {
 }
 .navbar-inverse .navbar-search .search-query:focus,
 .navbar-inverse .navbar-search .search-query.focused {
-  padding: 5px 15px;
+  padding: 0.3125rem 0.9375rem;
   color: #333333;
   text-shadow: 0 1px 0 #ffffff;
   background-color: #ffffff;
@@ -3340,7 +3340,7 @@ legend + .control-group {
   background-color: #000000 \9;
 }
 .breadcrumb {
-  padding: 8px 15px;
+  padding: 0.5rem 0.9375rem;
   margin: 0 0 20px;
   list-style: none;
   background-color: #f5f5f5;
@@ -3357,7 +3357,7 @@ legend + .control-group {
   text-shadow: 0 1px 0 #ffffff;
 }
 .breadcrumb > li > .divider {
-  padding: 0 5px;
+  padding: 0 0.3125rem;
   color: #ccc;
 }
 .breadcrumb > .active {
@@ -3387,7 +3387,7 @@ legend + .control-group {
 .pagination ul > li > a,
 .pagination ul > li > span {
   float: left;
-  padding: 4px 12px;
+  padding: 0.25rem 0.75rem;
   line-height: 20px;
   text-decoration: none;
   background-color: #ffffff;
@@ -3440,7 +3440,7 @@ legend + .control-group {
 }
 .pagination-large ul > li > a,
 .pagination-large ul > li > span {
-  padding: 11px 19px;
+  padding: 0.6875rem 1.1875rem;
   font-size: 1.0625rem;
 }
 .pagination-large ul > li:first-child > a,
@@ -3485,12 +3485,12 @@ legend + .control-group {
 }
 .pagination-small ul > li > a,
 .pagination-small ul > li > span {
-  padding: 2px 10px;
+  padding: 0.125rem 0.625rem;
   font-size: 0.6875rem;
 }
 .pagination-mini ul > li > a,
 .pagination-mini ul > li > span {
-  padding: 0 6px;
+  padding: 0 0.375rem;
   font-size: 0.625rem;
 }
 .pager {
@@ -3514,7 +3514,7 @@ legend + .control-group {
 .pager li > a,
 .pager li > span {
   display: inline-block;
-  padding: 5px 14px;
+  padding: 0.3125rem 0.875rem;
   background-color: #fff;
   border: 1px solid #ddd;
   -webkit-border-radius: 15px;
@@ -3566,7 +3566,7 @@ legend + .control-group {
 }
 .thumbnail {
   display: block;
-  padding: 4px;
+  padding: 0.25rem;
   line-height: 20px;
   border: 1px solid #ddd;
   -webkit-border-radius: 4px;
@@ -3594,11 +3594,11 @@ a.thumbnail:focus {
   margin-right: auto;
 }
 .thumbnail .caption {
-  padding: 9px;
+  padding: 0.5625rem;
   color: #555555;
 }
 .alert {
-  padding: 8px 35px 8px 14px;
+  padding: 0.5rem 2.1875rem 0.5rem 0.875rem;
   margin-bottom: 20px;
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
   background-color: #fcf8e3;
@@ -3848,7 +3848,7 @@ a.thumbnail:focus {
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 }
 .hero-unit {
-  padding: 60px;
+  padding: 3.75rem;
   margin-bottom: 30px;
   font-size: 1.125rem;
   font-weight: 200;
@@ -3914,23 +3914,23 @@ a.thumbnail:focus {
 }
 .tooltip.top {
   margin-top: -3px;
-  padding: 5px 0;
+  padding: 0.3125rem 0;
 }
 .tooltip.right {
   margin-left: 3px;
-  padding: 0 5px;
+  padding: 0 0.3125rem;
 }
 .tooltip.bottom {
   margin-top: 3px;
-  padding: 5px 0;
+  padding: 0.3125rem 0;
 }
 .tooltip.left {
   margin-left: -3px;
-  padding: 0 5px;
+  padding: 0 0.3125rem;
 }
 .tooltip-inner {
   max-width: 200px;
-  padding: 8px;
+  padding: 0.5rem;
   color: #ffffff;
   text-align: center;
   text-decoration: none;
@@ -3981,7 +3981,7 @@ a.thumbnail:focus {
   z-index: 1010;
   display: none;
   max-width: 276px;
-  padding: 1px;
+  padding: 0.0625rem;
   text-align: left;
   background-color: #ffffff;
   -webkit-background-clip: padding-box;
@@ -4011,7 +4011,7 @@ a.thumbnail:focus {
 }
 .popover-title {
   margin: 0;
-  padding: 8px 14px;
+  padding: 0.5rem 0.875rem;
   font-size: 0.875rem;
   font-weight: normal;
   line-height: 18px;
@@ -4025,7 +4025,7 @@ a.thumbnail:focus {
   display: none;
 }
 .popover-content {
-  padding: 9px 14px;
+  padding: 0.5625rem 0.875rem;
 }
 .popover .arrow,
 .popover .arrow:after {
@@ -4151,7 +4151,7 @@ a.thumbnail:focus {
   top: 10%;
 }
 .modal-header {
-  padding: 9px 15px;
+  padding: 0.5625rem 0.9375rem;
   border-bottom: 1px solid #eee;
 }
 .modal-header .close {
@@ -4165,13 +4165,13 @@ a.thumbnail:focus {
   position: relative;
   overflow-y: auto;
   max-height: 400px;
-  padding: 15px;
+  padding: 0.9375rem;
 }
 .modal-form {
   margin-bottom: 0;
 }
 .modal-footer {
-  padding: 14px 15px 15px;
+  padding: 0.875rem 0.9375rem 0.9375rem;
   margin-bottom: 0;
   text-align: right;
   background-color: #f5f5f5;
@@ -4236,7 +4236,7 @@ a.thumbnail:focus {
   display: none;
   float: left;
   min-width: 160px;
-  padding: 5px 0;
+  padding: 0.3125rem 0;
   margin: 2px 0 0;
   list-style: none;
   background-color: #ffffff;
@@ -4269,7 +4269,7 @@ a.thumbnail:focus {
 }
 .dropdown-menu > li > a {
   display: block;
-  padding: 3px 20px;
+  padding: 0.1875rem 1.25rem;
   clear: both;
   font-weight: normal;
   line-height: 20px;
@@ -4425,13 +4425,13 @@ a.thumbnail:focus {
 }
 .accordion-heading .accordion-toggle {
   display: block;
-  padding: 8px 15px;
+  padding: 0.5rem 0.9375rem;
 }
 .accordion-toggle {
   cursor: pointer;
 }
 .accordion-inner {
-  padding: 9px 15px;
+  padding: 0.5625rem 0.9375rem;
   border-top: 1px solid #e5e5e5;
 }
 .carousel {
@@ -4545,7 +4545,7 @@ a.thumbnail:focus {
   left: 0;
   right: 0;
   bottom: 0;
-  padding: 15px;
+  padding: 0.9375rem;
   background: #333333;
   background: rgba(0, 0, 0, 0.75);
 }
@@ -4562,7 +4562,7 @@ a.thumbnail:focus {
 }
 .well {
   min-height: 20px;
-  padding: 19px;
+  padding: 1.1875rem;
   margin-bottom: 20px;
   background-color: #f5f5f5;
   border: 1px solid #e3e3e3;
@@ -4578,13 +4578,13 @@ a.thumbnail:focus {
   border-color: rgba(0, 0, 0, 0.15);
 }
 .well-large {
-  padding: 24px;
+  padding: 1.5rem;
   -webkit-border-radius: 6px;
   -moz-border-radius: 6px;
   border-radius: 6px;
 }
 .well-small {
-  padding: 9px;
+  padding: 0.5625rem;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;
@@ -4851,7 +4851,7 @@ button.close {
     right: 10px;
   }
   .modal-header .close {
-    padding: 10px;
+    padding: 0.625rem;
     margin: -10px;
   }
   .carousel-caption {
@@ -5595,7 +5595,7 @@ button.close {
   }
   .nav-collapse .nav > li > a,
   .nav-collapse .dropdown-menu a {
-    padding: 9px 15px;
+    padding: 0.5625rem 0.9375rem;
     font-weight: bold;
     color: #777777;
     -webkit-border-radius: 3px;
@@ -5603,7 +5603,7 @@ button.close {
     border-radius: 3px;
   }
   .nav-collapse .btn {
-    padding: 4px 10px 4px;
+    padding: 0.25rem 0.625rem 0.25rem;
     font-weight: normal;
     -webkit-border-radius: 4px;
     -moz-border-radius: 4px;
@@ -5667,7 +5667,7 @@ button.close {
   .nav-collapse .navbar-form,
   .nav-collapse .navbar-search {
     float: none;
-    padding: 10px 15px;
+    padding: 0.625rem 0.9375rem;
     margin: 10px 0;
     border-top: 1px solid #f2f2f2;
     border-bottom: 1px solid #f2f2f2;

--- a/static/third/bootstrap/css/bootstrap.css
+++ b/static/third/bootstrap/css/bootstrap.css
@@ -206,7 +206,7 @@ textarea {
 body {
   margin: 0;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 20px;
   color: #333333;
   background-color: #ffffff;
@@ -550,7 +550,7 @@ p {
 }
 .lead {
   margin-bottom: 20px;
-  font-size: 21px;
+  font-size: 1.3125rem;
   font-weight: 200;
   line-height: 30px;
 }
@@ -639,34 +639,34 @@ h3 {
   line-height: 40px;
 }
 h1 {
-  font-size: 38.5px;
+  font-size: 2.375rem;
 }
 h2 {
-  font-size: 31.5px;
+  font-size: 1.9375rem;
 }
 h3 {
-  font-size: 24.5px;
+  font-size: 1.5rem;
 }
 h4 {
-  font-size: 17.5px;
+  font-size: 1.0625rem;
 }
 h5 {
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 h6 {
-  font-size: 11.9px;
+  font-size: 0.6875rem;
 }
 h1 small {
-  font-size: 24.5px;
+  font-size: 1.5rem;
 }
 h2 small {
-  font-size: 17.5px;
+  font-size: 1.0625rem;
 }
 h3 small {
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 h4 small {
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 .page-header {
   padding-bottom: 9px;
@@ -766,7 +766,7 @@ blockquote {
 }
 blockquote p {
   margin-bottom: 0;
-  font-size: 17.5px;
+  font-size: 1.0625rem;
   font-weight: 300;
   line-height: 1.25;
 }
@@ -811,7 +811,7 @@ code,
 pre {
   padding: 0 3px 2px;
   font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
-  font-size: 12px;
+  font-size: 0.75rem;
   color: #333333;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
@@ -828,7 +828,7 @@ pre {
   display: block;
   padding: 9.5px;
   margin: 0 0 10px;
-  font-size: 13px;
+  font-size: 0.8125rem;
   line-height: 20px;
   word-break: break-all;
   word-wrap: break-word;
@@ -860,7 +860,7 @@ pre code {
 .badge {
   display: inline-block;
   padding: 2px 4px;
-  font-size: 11.844px;
+  font-size: 0.6875rem;
   font-weight: bold;
   line-height: 14px;
   color: #ffffff;
@@ -1191,14 +1191,14 @@ legend {
   width: 100%;
   padding: 0;
   margin-bottom: 20px;
-  font-size: 21px;
+  font-size: 1.3125rem;
   line-height: 40px;
   color: #333333;
   border: 0;
   border-bottom: 1px solid #e5e5e5;
 }
 legend small {
-  font-size: 15px;
+  font-size: 0.9375rem;
   color: #999999;
 }
 label,
@@ -1206,7 +1206,7 @@ input,
 button,
 select,
 textarea {
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: normal;
   line-height: 20px;
 }
@@ -1241,7 +1241,7 @@ input[type="color"],
   height: 20px;
   padding: 4px 6px;
   margin-bottom: 10px;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 20px;
   color: #555555;
   -webkit-border-radius: 4px;
@@ -1756,7 +1756,7 @@ select:focus:invalid:focus {
 .input-prepend .dropdown-menu,
 .input-append .popover,
 .input-prepend .popover {
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 .input-append input,
 .input-prepend input,
@@ -1787,7 +1787,7 @@ select:focus:invalid:focus {
   height: 20px;
   min-width: 16px;
   padding: 4px 5px;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: normal;
   line-height: 20px;
   text-align: center;
@@ -2508,7 +2508,7 @@ legend + .control-group {
 .nav-header {
   display: block;
   padding: 3px 15px;
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: bold;
   line-height: 20px;
   color: #999999;
@@ -2880,7 +2880,7 @@ legend + .control-group {
   display: block;
   padding: 10px 20px 10px;
   margin-left: -20px;
-  font-size: 20px;
+  font-size: 1.25rem;
   font-weight: 200;
   color: #777777;
   text-shadow: 0 1px 0 #ffffff;
@@ -2967,7 +2967,7 @@ legend + .control-group {
   margin-bottom: 0;
   padding: 4px 14px;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: normal;
   line-height: 1;
   -webkit-border-radius: 15px;
@@ -3441,7 +3441,7 @@ legend + .control-group {
 .pagination-large ul > li > a,
 .pagination-large ul > li > span {
   padding: 11px 19px;
-  font-size: 17.5px;
+  font-size: 1.0625rem;
 }
 .pagination-large ul > li:first-child > a,
 .pagination-large ul > li:first-child > span {
@@ -3486,12 +3486,12 @@ legend + .control-group {
 .pagination-small ul > li > a,
 .pagination-small ul > li > span {
   padding: 2px 10px;
-  font-size: 11.9px;
+  font-size: 0.6875rem;
 }
 .pagination-mini ul > li > a,
 .pagination-mini ul > li > span {
   padding: 0 6px;
-  font-size: 10.5px;
+  font-size: 0.625rem;
 }
 .pager {
   margin: 20px 0;
@@ -3721,7 +3721,7 @@ a.thumbnail:focus {
   height: 100%;
   color: #ffffff;
   float: left;
-  font-size: 12px;
+  font-size: 0.75rem;
   text-align: center;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #0e90d2;
@@ -3850,7 +3850,7 @@ a.thumbnail:focus {
 .hero-unit {
   padding: 60px;
   margin-bottom: 30px;
-  font-size: 18px;
+  font-size: 1.125rem;
   font-weight: 200;
   line-height: 30px;
   color: inherit;
@@ -3861,7 +3861,7 @@ a.thumbnail:focus {
 }
 .hero-unit h1 {
   margin-bottom: 0;
-  font-size: 60px;
+  font-size: 3.75rem;
   line-height: 1;
   color: inherit;
   letter-spacing: -1px;
@@ -3903,7 +3903,7 @@ a.thumbnail:focus {
   z-index: 1030;
   display: block;
   visibility: visible;
-  font-size: 11px;
+  font-size: 0.6875rem;
   line-height: 1.4;
   opacity: 0;
   filter: alpha(opacity=0);
@@ -4012,7 +4012,7 @@ a.thumbnail:focus {
 .popover-title {
   margin: 0;
   padding: 8px 14px;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: normal;
   line-height: 18px;
   background-color: #f7f7f7;
@@ -4494,7 +4494,7 @@ a.thumbnail:focus {
   width: 40px;
   height: 40px;
   margin-top: -20px;
-  font-size: 60px;
+  font-size: 3.75rem;
   font-weight: 100;
   line-height: 30px;
   color: #ffffff;
@@ -4591,7 +4591,7 @@ a.thumbnail:focus {
 }
 .close {
   float: right;
-  font-size: 20px;
+  font-size: 1.25rem;
   font-weight: bold;
   line-height: 20px;
   color: #000000;

--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -42,15 +42,15 @@ table td {
 .container {
     display: block;
     margin: 0 auto !important;
-    max-width: 500px;
+    max-width: 31.25rem;
     padding: 10px;
 }
 
 .content {
     box-sizing: border-box;
     display: block;
-    margin: 20px auto 0 auto;
-    max-width: 580px;
+    margin: 1.25rem auto 0 auto;
+    max-width: 36.25rem;
     padding: 10px;
 }
 
@@ -70,7 +70,7 @@ table td {
     padding-top: 10px;
     text-align: center;
     width: 100%;
-    margin-top: 20px;
+    margin-top: 1.25rem;
 }
 
 .footer td,
@@ -95,7 +95,7 @@ h4 {
     font-weight: 400;
     line-height: 1.4;
     margin: 0;
-    margin-bottom: 30px;
+    margin-bottom: 1.875rem;
 }
 
 h1 {
@@ -111,14 +111,14 @@ ol {
     font-family: sans-serif;
     font-size: 0.875rem;
     font-weight: normal;
-    margin: 10px 0;
+    margin: 0.625rem 0;
 }
 
 p li,
 ul li,
 ol li {
     list-style-position: inside;
-    margin-left: 5px;
+    margin-left: 0.3125rem;
 }
 
 a {
@@ -137,8 +137,8 @@ a:hover {
 .button {
     display: block;
     padding: 10px 0;
-    margin: 20px auto;
-    width: 200px;
+    margin: 1.25rem auto;
+    width: 12.5rem;
     border: 1px solid #80d1ba;
     background-color: #80d1ba;
     border-radius: 4px;
@@ -176,7 +176,7 @@ a.button:hover {
 }
 
 #private-messages {
-    width: 600px;
+    width: 37.5rem;
     font-size: 0.75rem;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
@@ -184,7 +184,7 @@ a.button:hover {
 .recipient_block {
     background-color: #f0f4f5;
     border: 1px solid #000;
-    margin-bottom: 4px;
+    margin-bottom: 0.25rem;
 }
 
 .recipient_header {
@@ -197,8 +197,8 @@ a.button:hover {
 
 .message_content {
     background-color: #eff3f4;
-    margin-left: 1px;
-    margin-right: 2px;
+    margin-left: 0.0625rem;
+    margin-right: 0.125rem;
 }
 
 .message_sender {
@@ -212,7 +212,7 @@ a.button:hover {
 }
 
 .messages {
-    width: 600px;
+    width: 37.5rem;
     font-size: 0.75rem;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     overflow-y: auto;
@@ -220,7 +220,7 @@ a.button:hover {
 
 .hot_convo_recipient_block {
     border: 1px solid #000;
-    margin-bottom: 4px;
+    margin-bottom: 0.25rem;
 }
 
 .hot_convo_recipient_header {
@@ -231,8 +231,8 @@ a.button:hover {
 }
 
 .hot_convo_message_content {
-    margin-left: 1px;
-    margin-right: 2px;
+    margin-left: 0.0625rem;
+    margin-right: 0.125rem;
 }
 
 .hot_convo_message_sender {
@@ -242,7 +242,7 @@ a.button:hover {
 
 .recipient_block_with_messages {
     border: 1px solid #000;
-    margin-bottom: 4px;
+    margin-bottom: 0.25rem;
 }
 
 .recipient_header_with_messages {
@@ -253,14 +253,14 @@ a.button:hover {
 }
 
 .message_content_with_messages {
-    margin-left: 1px;
-    margin-right: 2px;
+    margin-left: 0.0625rem;
+    margin-right: 0.125rem;
 }
 
 .recipient_block_without_messages {
     background-color: #f0f4f5;
     border: 1px solid #000;
-    margin-bottom: 4px;
+    margin-bottom: 0.25rem;
 }
 
 .recipient_header_without_messages {
@@ -273,8 +273,8 @@ a.button:hover {
 
 .message_content_without_messages {
     background-color: #f0f4f5;
-    margin-left: 1px;
-    margin-right: 2px;
+    margin-left: 0.0625rem;
+    margin-right: 0.125rem;
 }
 
 .hot_convo_message_content_block {
@@ -306,7 +306,7 @@ a.button:hover {
 @media only screen and (max-width: 620px) {
     table[class="body"] h1 {
         font-size: 28px !important;
-        margin-bottom: 10px !important;
+        margin-bottom: 0.625rem !important;
     }
 
     table[class="body"] p,

--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -13,7 +13,7 @@ img {
 body {
     background-color: #f5f9f8;
     font-family: sans-serif;
-    font-size: 14px;
+    font-size: 0.875rem;
     line-height: 1.4;
     margin: 0;
     padding: 0;
@@ -30,7 +30,7 @@ table {
 
 table td {
     font-family: sans-serif;
-    font-size: 14px;
+    font-size: 0.875rem;
     vertical-align: top;
 }
 
@@ -78,7 +78,7 @@ table td {
 .footer span,
 .footer a {
     color: #999;
-    font-size: 12px;
+    font-size: 0.75rem;
     text-align: center;
 }
 
@@ -99,7 +99,7 @@ h4 {
 }
 
 h1 {
-    font-size: 35px;
+    font-size: 2.1875rem;
     font-weight: 300;
     text-align: center;
     text-transform: capitalize;
@@ -109,7 +109,7 @@ p,
 ul,
 ol {
     font-family: sans-serif;
-    font-size: 14px;
+    font-size: 0.875rem;
     font-weight: normal;
     margin: 10px 0;
 }
@@ -142,7 +142,7 @@ a:hover {
     border: 1px solid #80d1ba;
     background-color: #80d1ba;
     border-radius: 4px;
-    font-size: 16px;
+    font-size: 1rem;
     outline: none;
     color: #fff;
     font-family: sans-serif;
@@ -177,7 +177,7 @@ a.button:hover {
 
 #private-messages {
     width: 600px;
-    font-size: 12px;
+    font-size: 0.75rem;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
@@ -213,7 +213,7 @@ a.button:hover {
 
 .messages {
     width: 600px;
-    font-size: 12px;
+    font-size: 0.75rem;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     overflow-y: auto;
 }


### PR DESCRIPTION
We convert font-size and padding from px to rem units. Then, we set font-size to 110% for `<html>` in comfortable-mode. We could also opt for explicit font sizes of 14px and 15.4px for compact and comfortable mode, so that we have more control over what we are showing to the user.

This PR is at a state of minimal effort. 

Issues noticed:
- [ ] There is a common issue that text / icons are a little lower than middle alignment level.

Script used for conversion:

```python
import os, re

def ctorem(matchobj):
    return str(int(matchobj.group(1))/16) + 'rem'

def rep(matchobj):
    return 'padding: ' + re.sub('(\d+)px', ctorem, str(matchobj.group(1))) + ';'

for dname, dirs, files in os.walk("."):
    for fname in files:
        if fname[-3:] == 'css':
            fpath = os.path.join(dname, fname)
            print(fpath)
            with open(fpath, 'r') as f:
                s = f.read()
                x = re.sub(r'padding: (.*);', rep, s)
                print(x.strip(), file=open(fpath, 'w'))


```

Deployed on https://nightly.zulipdev.org/