### PR TITLE
popover: Fixed color-picker popover responsiveness.

### DIFF
--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -470,6 +470,10 @@ exports.register_stream_handlers = function () {
         $(".streams_popover").on("click", "a.sp-cancel", () => {
             exports.hide_stream_popover();
         });
+        if ($(window).width() <= 768) {
+            $(".popover-inner").hide().fadeIn(300);
+            $(".popover").addClass("colorpicker-popover");
+        }
     });
 };
 

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -379,6 +379,39 @@ ul {
         }
     }
 
+    .colorpicker-popover {
+        display: flex !important;
+        justify-content: center;
+        align-items: center;
+
+        /* these are to override JS embedded inline styles. */
+        top: 0 !important;
+        left: 0 !important;
+        margin: 0 !important;
+        width: 100%;
+        height: 100%;
+
+        background-color: hsla(0, 0%, 0%, 0.7);
+        border-radius: 0;
+        border: none;
+
+        pointer-events: none;
+
+        .popover-inner {
+            background-color: hsl(0, 0%, 100%);
+            pointer-events: all;
+        }
+
+        @media (max-width: 500px) {
+            .popover-inner {
+                width: 70%;
+            }
+            .sp-picker-container {
+                border-left: none !important;
+            }
+        }
+    }
+
     .popover-flex {
         position: absolute;
         top: 0 !important;


### PR DESCRIPTION
The color picker popover overflows the screen width when an user attempts to change the stream color in devices with narrow screen width size ( <500px ) .
Made suitable changes as suggested by @timabbott <a href = 'https://github.com/zulip/zulip/issues/16477#issuecomment-704477907'>here</a> .

Fixes #16477 

<strong>Before :</strong> 

![Screen Shot 2020-10-06 at 12 58 04](https://user-images.githubusercontent.com/53977614/95171520-a0129b80-07d3-11eb-929b-d4955bc9b65c.png)

<strong>After</strong>

768<=width<=400             |   width < 400
:-------------------------:|:-------------------------:
![Screen Shot 2020-10-22 at 23 37 09](https://user-images.githubusercontent.com/53977614/96912195-94a3bd80-14bf-11eb-87c1-f422a705efc1.png)  |  ![Screen Shot 2020-10-22 at 23 45 03](https://user-images.githubusercontent.com/53977614/96912917-a20d7780-14c0-11eb-8784-c98ab8f4fa03.png)




