### PR TITLE
auth: Expect name in request params in Apple auth.

### DIFF
--- a/templates/zerver/apple-error.md
+++ b/templates/zerver/apple-error.md
@@ -8,7 +8,7 @@ properly configured. Please check the following:
 
 * You have set `SOCIAL_AUTH_APPLE_SERVICES_ID`,
   `SOCIAL_AUTH_APPLE_APP_ID`, `SOCIAL_AUTH_APPLE_TEAM`,
-  `SOCIAL_AUTH_APPLE_KEY` and `SOCIAL_AUTH_APPLE_TEAM` in `{{
+  and `SOCIAL_AUTH_APPLE_KEY` in `{{
   settings_path }}` and stored the private key provided by Apple at
   `/etc/zulip/apple-auth-key.p8` on the Zulip server, with
   proper permissions set.


### PR DESCRIPTION
The name used to be included in the id_token, but this seems to have
been changed by Apple and now it's sent in the `user` request param.

https://github.com/python-social-auth/social-core/pull/483 is the
upstream PR for this - but upstream is currently unmaintained, so we
have to monkey patch.

We also alter the tests to reflect this situation. Tests no longer put
the name in the id_token, but rather in the `user` request param in the
browser flow, just like it happens in reality.

An adaptation has to be made in the native flow - since the name won't
be included by Apple in the id_token anymore, the app, when POSTing
to the /complete/apple/ endpoint,
can (and should for better user experience)
add the `user` param formatted as json of
`{"email": "hamlet@zulip.com", "name": {"firstName": "Full", "lastName": "Name"}}`
dict. This is also reflected by the change in the
native flow tests.

CC @gnprice @chrisbobbe 