### PR TITLE
[WIP] test_events faliure are giant.

### DIFF
--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -297,9 +297,9 @@ def validate_against_openapi_schema(content: Dict[str, Any], path: str,
     except JsonSchemaValidationError as error:
         brief_error_display_schema = {
             "nullable": False,
-            "oneOf": []
+            "oneOf": list()
         }
-
+        brief_error_display_schema_oneOf = []
         brief_error_validator_value = []
         if display_brief_error:
             for validator_value in error.validator_value:
@@ -308,7 +308,8 @@ def validate_against_openapi_schema(content: Dict[str, Any], path: str,
 
             for i_schema in error.schema['oneOf']:
                 if i_schema["example"]["type"] == error.instance["type"]:
-                    brief_error_display_schema['oneOf'].append(i_schema)
+                    brief_error_display_schema_oneOf.append(i_schema)
+            brief_error_display_schema['oneOf'] = brief_error_display_schema_oneOf
 
             raise JsonSchemaValidationError(
                 message=error.message, validator=error.validator, path=error.path, instance=error.instance,

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -305,14 +305,14 @@ def validate_against_openapi_schema(content: Dict[str, Any], path: str,
             for validator_value in error.validator_value:
                 if validator_value.get("example").get("type") == error.instance.get("type"):
                     to_be_display_validator_value.append(validator_value)
-        except:
+        except Exception:
             pass
 
         try:
             for i_schema in error.schema.get('oneOf'):
                 if i_schema.get("example").get("type") == error.instance.get("type"):
                     to_be_display_schema.get('oneOf').append(i_schema)
-        except:
+        except Exception:
             pass
         raise ValidationError(
             message=error.message, validator=error.validator, path=error.path, instance=error.instance,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -255,7 +255,7 @@ class BaseAction(ZulipTestCase):
             'msg': '',
             'result': 'success'
         }
-        validate_against_openapi_schema(content, '/events', 'get', '200')
+        validate_against_openapi_schema(content, '/events', 'get', '200', display_brief_error=True)
         self.assertEqual(len(events), num_events)
         initial_state = copy.deepcopy(hybrid_state)
         post_process_state(self.user_profile, initial_state, notification_settings_null)


### PR DESCRIPTION
Issue #16023 

```
    try:
        validator.validate(content)
    except ValidationError as error:
        to_be_display_schema = {
            "nullable": False,
            "oneOf": []
        }

        to_be_display_validator_value = []
        try:
            for validator_value in error.validator_value:
                if validator_value.get("example").get("type") == error.instance.get("type"):
                    to_be_display_validator_value.append(validator_value)
        except:
            pass

        try:
            for i_schema in error.schema.get('oneOf'):
                if i_schema.get("example").get("type") == error.instance.get("type"):
                    to_be_display_schema.get('oneOf').append(i_schema)
        except:
            pass
        raise ValidationError(
            message=error.message, validator=error.validator, path=error.path, instance=error.instance,
            schema_path=error.schema_path, schema=to_be_display_schema,
            validator_value=to_be_display_validator_value,
            cause=error.cause
        )
```

With this I am getting this output

```
-- Running tests in serial mode.
Destroying test database for alias 'default'...
Using existing clone for alias 'default'...
Running zerver.tests.test_events.NormalActionsTest.test_add_attachment
Running zerver.tests.test_events.NormalActionsTest.test_add_reaction
Running zerver.tests.test_events.NormalActionsTest.test_add_submessage
Running zerver.tests.test_events.NormalActionsTest.test_alert_words_events

======================================================================
ERROR: test_alert_words_events (zerver.tests.test_events.NormalActionsTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/harsh/Documents/zulip/zerver/tests/test_events.py", line 801, in test_alert_words_events
    events = self.verify_action(
  File "/home/harsh/Documents/zulip/zerver/tests/test_events.py", line 258, in verify_action
    validate_against_openapi_schema(content, '/events', 'get', '200')
  File "/home/harsh/Documents/zulip/zerver/openapi/openapi.py", line 312, in validate_against_openapi_schema
    raise ValidationError(
jsonschema.exceptions.ValidationError: {'type': 'alert_words', 'alert_words': ['grammar', 'objective', 'study', 'complexity', 'alert_word'], 'id': 0} is not valid under any of the given schemas

Failed validating 'oneOf' in schema['properties']['events']['items']:
    {'nullable': False,
     'oneOf': [{'additionalProperties': False,
                'description': "Event sent to a user's clients when that "
                               "user's set of configured\n"
                               '[alert words](/help/add-an-alert-word) '
                               'have changed.\n',
                'example': {'alert_words': ['alert_word'],
                            'id': 0,
                            'type': 'alert_words'},
                'nullable': False,
                'properties': {'id': {'nullable': False, 'type': 'integer'},
                               'type': {'enum': ['alert_words'],
                                        'nullable': False,
                                        'type': 'string'}},
                'type': 'object'}]}

On instance['events'][0]:
    {'alert_words': ['grammar',
                     'objective',
                     'study',
                     'complexity',
                     'alert_word'],
     'id': 0,
     'type': 'alert_words'}

----------------------------------------------------------------------
Ran 4 tests in 1.407s

FAILED (errors=1)
Destroying test database for alias 'default'...

```