### PR TITLE
puppet: Remove non-working apt::source.

### DIFF
--- a/puppet/zulip_ops/manifests/zmirror.pp
+++ b/puppet/zulip_ops/manifests/zmirror.pp
@@ -23,15 +23,6 @@ class zulip_ops::zmirror {
     require => Exec['setup_apt_repo_debathena'],
   }
 
-  apt::source {'debathena':
-    location    => 'http://debathena.mit.edu/apt',
-    release     => $zulip::base::release_name,
-    repos       => 'debathena debathena-config',
-    key         => 'D1CD49BDD30B677273A75C66E4EE62700D8A9E8F',
-    key_source  => 'https://debathena.mit.edu/apt/debathena-archive.asc',
-    include_src => true,
-  }
-
   file { '/etc/supervisor/conf.d/zmirror.conf':
     ensure  => file,
     require => Package[supervisor],


### PR DESCRIPTION
d2aa81858cb2 replaced the `apt::source` to set up debathena with
`Exec['setup-apt-repo-debathena']`, but mistakenly left the
`apt::source` in place in `zmirror` (but not `zmirror_personals`).
The `apt::source` resource type was later removed in c9d54f785455,
making the manifest to apply on `zmirror`.

Remove the broken and unnecessary `apt::source` resource.

**Testing Plan:** Found this un-checked-in on zmirror.