### PR TITLE
puppet: Allow unattended-upgrades for all but servers.

### DIFF
--- a/docs/production/troubleshooting.md
+++ b/docs/production/troubleshooting.md
@@ -132,15 +132,17 @@ problems and how to resolve them:
   a virtual machine with broken DNS configuration; you can often
   correct this by configuring `/etc/hosts` properly.
 
-### Disabling unattended upgrades
+### Restrict unattended upgrades
 
 ```eval_rst
 .. important::
-    We recommend that you `disable Ubuntu's unattended-upgrades
-    <https://linoxide.com/ubuntu-how-to/enable-disable-unattended-upgrades-ubuntu-16-04/>`_
-    and instead install apt upgrades manually.  With unattended upgrades
-    enabled, the moment a new Postgres release is published, your Zulip
-    server will have its Postgres server upgraded (and thus restarted).
+    We recommend that you `disable or limit Ubuntu's unattended-upgrades
+    to skip some server packages
+    <https://linoxide.com/ubuntu-how-to/enable-disable-unattended-upgrades-ubuntu-16-04/>`;
+    if you disable them, do not forget to regularly install apt upgrades
+    manually.  With unattended upgrades enabled but not limited, the
+    moment a new Postgres release is published, your Zulip server will
+    have its Postgres server upgraded (and thus restarted).
 ```
 
 Restarting one of the system services that Zulip uses (Postgres,
@@ -168,9 +170,22 @@ restarting the Zulip server with
 installing system package updates to Postgres, memcached,
 RabbitMQ, or Redis.
 
-Few system administrators enjoy outages at random times (even if only
-brief) or the resulting distribution of error emails, which is why we
-recommend disabling `unattended-upgrades`.
+You can ensure that the `unattended-upgrades` package never upgrades
+PostgreSQL, memcached, Redis, or RabbitMQ, by configuring in
+`/etc/apt/apt.conf.d/50unattended-upgrades`:
+
+```
+// Python regular expressions, matching packages to exclude from upgrading
+Unattended-Upgrade::Package-Blacklist {
+    "libc\d+";
+    "memcached$";
+    "nginx-full$";
+    "postgresql-\d+$";
+    "rabbitmq-server$";
+    "redis-server$";
+    "supervisor$";
+};
+```
 
 ## Monitoring
 

--- a/puppet/zulip_ops/files/apt/apt.conf.d/50unattended-upgrades
+++ b/puppet/zulip_ops/files/apt/apt.conf.d/50unattended-upgrades
@@ -1,59 +1,56 @@
 // Automatically upgrade packages from these (origin:archive) pairs
+//
+// Note that in Ubuntu security updates may pull in new dependencies
+// from non-security sources (e.g. chromium). By allowing the release
+// pocket these get automatically pulled in.
 Unattended-Upgrade::Allowed-Origins {
-//	"${distro_id}:${distro_codename}-security";
-//	"${distro_id}:${distro_codename}-updates";
-//	"${distro_id}:${distro_codename}-proposed";
-//	"${distro_id}:${distro_codename}-backports";
+    "${distro_id}:${distro_codename}";
+    "${distro_id}:${distro_codename}-security";
+    // Extended Security Maintenance; doesn't necessarily exist for
+    // every release and this system may not have it installed, but if
+    // available, the policy for updates is such that unattended-upgrades
+    // should also install from here by default.
+    "${distro_id}ESMApps:${distro_codename}-apps-security";
+    "${distro_id}ESM:${distro_codename}-infra-security";
 };
 
-// List of packages to not update (regexp are supported)
+// Python regular expressions, matching packages to exclude from upgrading
 Unattended-Upgrade::Package-Blacklist {
-//	"vim";
-//	"libc6";
-//	"libc6-dev";
-//	"libc6-i686";
+    "libc\d+";
+    "memcached$";
+    "nginx-full$";
+    "postgresql-\d+$";
+    "rabbitmq-server$";
+    "redis-server$";
+    "supervisor$";
 };
+
+// This option controls whether the development release of Ubuntu will be
+// upgraded automatically. Valid values are "true", "false", and "auto".
+Unattended-Upgrade::DevRelease "false";
 
 // This option allows you to control if on a unclean dpkg exit
-// unattended-upgrades will automatically run 
+// unattended-upgrades will automatically run
 //   dpkg --force-confold --configure -a
-// The default is true, to ensure updates keep getting installed
-//Unattended-Upgrade::AutoFixInterruptedDpkg "false";
+Unattended-Upgrade::AutoFixInterruptedDpkg "true";
 
 // Split the upgrade into the smallest possible chunks so that
-// they can be interrupted with SIGUSR1. This makes the upgrade
+// they can be interrupted with SIGTERM. This makes the upgrade
 // a bit slower but it has the benefit that shutdown while a upgrade
 // is running is possible (with a small delay)
-//Unattended-Upgrade::MinimalSteps "true";
+Unattended-Upgrade::MinimalSteps "true";
 
-// Install all unattended-upgrades when the machine is shutting down
-// instead of doing it in the background while the machine is running
-// This will (obviously) make shutdown slower
-//Unattended-Upgrade::InstallOnShutdown "true";
+// Remove unused automatically installed kernel-related packages
+// (kernel images, kernel headers and kernel version locked tools).
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
 
-// Send email to this address for problems or packages upgrades
-// If empty or unset then no email is sent, make sure that you
-// have a working mail setup on your system. A package that provides
-// 'mailx' must be installed. E.g. "user@example.com"
-//Unattended-Upgrade::Mail "root";
+// Do automatic removal of newly unused dependencies after the upgrade
+Unattended-Upgrade::Remove-New-Unused-Dependencies "true";
 
-// Set this value to "true" to get emails only on errors. Default
-// is to always send a mail if Unattended-Upgrade::Mail is set
-//Unattended-Upgrade::MailOnlyOnError "true";
-
-// Do automatic removal of new unused dependencies after the upgrade
+// Do automatic removal of unused packages after the upgrade
 // (equivalent to apt-get autoremove)
 //Unattended-Upgrade::Remove-Unused-Dependencies "false";
 
 // Automatically reboot *WITHOUT CONFIRMATION*
 //  if the file /var/run/reboot-required is found after the upgrade 
-//Unattended-Upgrade::Automatic-Reboot "false";
-
-// If automatic reboot is enabled and needed, reboot at the specific
-// time instead of immediately
-//  Default: "now"
-//Unattended-Upgrade::Automatic-Reboot-Time "02:00";
-
-// Use apt bandwidth limit feature, this example limits the download
-// speed to 70kb/sec
-//Acquire::http::Dl-Limit "70";
+Unattended-Upgrade::Automatic-Reboot "false";


### PR DESCRIPTION
Restarting servers is what can cause service interruptions, and
increase risk.  Add all of the servers that we use to the list of
ignored packages, and uncomment the default allowed-origins in order
to enable unattended upgrades.

**Testing Plan:** Applied and ran `unattended-upgrades -d --dry-run` on a few prod hosts.
