### PR TITLE
typeahead: Fix stream+topic completions for empty query.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -481,6 +481,21 @@ run_test("content_typeahead_selected", () => {
     expected_value = "#**Sweden** ";
     assert.equal(actual_value, expected_value);
 
+    // topic_list
+    fake_this.completing = "topic_list";
+
+    fake_this.query = "Hello #**Sweden>test";
+    fake_this.token = "test";
+    actual_value = ct.content_typeahead_selected.call(fake_this, "testing");
+    expected_value = "Hello #**Sweden>testing** ";
+    assert.equal(actual_value, expected_value);
+
+    fake_this.query = "Hello #**Sweden>";
+    fake_this.token = "";
+    actual_value = ct.content_typeahead_selected.call(fake_this, "testing");
+    expected_value = "Hello #**Sweden>testing** ";
+    assert.equal(actual_value, expected_value);
+
     // syntax
     fake_this.completing = "syntax";
 

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -855,7 +855,15 @@ exports.content_typeahead_selected = function (item, event) {
         // Stream + topic mention typeahead; close the stream+topic mention syntax
         // with the topic and the final **.
         const start = -this.token.length;
-        beginning = beginning.slice(0, start) + item + "** ";
+        if (start !== 0) {
+            // This is the only case where we can set
+            // up the typeahead for an empty token.
+            // Thus, we do not perform string slicing
+            // when the token length is 0 as it returns
+            // an empty string.
+            beginning = beginning.slice(0, start);
+        }
+        beginning = beginning + item + "** ";
     } else if (this.completing === "time_jump") {
         let timestring = beginning.slice(Math.max(0, beginning.lastIndexOf("<time:")));
         if (timestring.startsWith("<time:") && timestring.endsWith(">")) {


### PR DESCRIPTION
Fixes #16599 .

I'm not sure whether I have to add any tests for this as I dont see any topic completion tests under `content_typeahead_selected` in `node_tests/composebox_typeahead.js`.

