### PR TITLE
python: Close open files

### DIFF
--- a/scripts/lib/hash_reqs.py
+++ b/scripts/lib/hash_reqs.py
@@ -10,12 +10,13 @@ from typing import Iterable, List
 def expand_reqs_helper(fpath: str) -> List[str]:
     result = []  # type: List[str]
 
-    for line in open(fpath):
-        if line.strip().startswith(('#', '--hash')):
-            continue
-        dep = line.split(" \\", 1)[0].strip()
-        if dep:
-            result.append(dep)
+    with open(fpath) as f:
+        for line in f:
+            if line.strip().startswith(('#', '--hash')):
+                continue
+            dep = line.split(" \\", 1)[0].strip()
+            if dep:
+                result.append(dep)
     return result
 
 def expand_reqs(fpath: str) -> List[str]:

--- a/scripts/lib/setup_path.py
+++ b/scripts/lib/setup_path.py
@@ -11,7 +11,8 @@ def setup_path() -> None:
         venv = os.path.join(BASE_DIR, "zulip-py3-venv")
         activate_this = os.path.join(venv, "bin", "activate_this.py")
         activate_locals = dict(__file__=activate_this)
-        exec(open(activate_this).read(), activate_locals)
+        with open(activate_this) as f:
+            exec(f.read(), activate_locals)
         # Check that the python version running this function
         # is same as python version that created the virtualenv.
         python_version = "python{}.{}".format(*sys.version_info[:2])

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -324,14 +324,17 @@ def main(options: argparse.Namespace) -> "NoReturn":
     for apt_depedency in SYSTEM_DEPENDENCIES:
         sha_sum.update(apt_depedency.encode('utf8'))
     if "debian" in os_families():
-        sha_sum.update(open('scripts/lib/setup-apt-repo', 'rb').read())
+        with open('scripts/lib/setup-apt-repo', 'rb') as fb:
+            sha_sum.update(fb.read())
     else:
         # hash the content of setup-yum-repo*
-        sha_sum.update(open('scripts/lib/setup-yum-repo', 'rb').read())
+        with open('scripts/lib/setup-yum-repo', 'rb') as fb:
+            sha_sum.update(fb.read())
 
     # hash the content of build-pgroonga if PGroonga is built from source
     if BUILD_PGROONGA_FROM_SOURCE:
-        sha_sum.update(open('scripts/lib/build-pgroonga', 'rb').read())
+        with open('scripts/lib/build-pgroonga', 'rb') as fb:
+            sha_sum.update(fb.read())
 
     new_apt_dependencies_hash = sha_sum.hexdigest()
     last_apt_dependencies_hash = None
@@ -408,7 +411,8 @@ def main(options: argparse.Namespace) -> "NoReturn":
     # process inside the virtualenv.
     activate_this = "/srv/zulip-py3-venv/bin/activate_this.py"
     provision_inner = os.path.join(ZULIP_PATH, "tools", "lib", "provision_inner.py")
-    exec(open(activate_this).read(), dict(__file__=activate_this))
+    with open(activate_this) as f:
+        exec(f.read(), dict(__file__=activate_this))
     os.execvp(
         provision_inner,
         [

--- a/tools/lib/provision_inner.py
+++ b/tools/lib/provision_inner.py
@@ -319,7 +319,8 @@ def main(options: argparse.Namespace) -> int:
 
     version_file = os.path.join(UUID_VAR_PATH, 'provision_version')
     print(f'writing to {version_file}\n')
-    open(version_file, 'w').write(PROVISION_VERSION + '\n')
+    with open(version_file, 'w') as f:
+        f.write(PROVISION_VERSION + '\n')
 
     print()
     print(OKBLUE + "Zulip development environment setup succeeded!" + ENDC)

--- a/zerver/lib/dev_ldap_directory.py
+++ b/zerver/lib/dev_ldap_directory.py
@@ -22,8 +22,10 @@ def generate_dev_ldap_dir(mode: str, num_users: int=8) -> Dict[str, Dict[str, An
         birthdate = f'19{i:02}-{i:02}-{i:02}'
         ldap_data.append((name, email, phone_number, birthdate))
 
-    profile_images = [open(path, "rb").read() for path in
-                      glob.glob(os.path.join(static_path("images/team"), "*"))]
+    profile_images = []
+    for path in glob.glob(os.path.join(static_path("images/team"), "*")):
+        with open(path, "rb") as f:
+            profile_images.append(f.read())
     ldap_dir = {}
     for i, user_data in enumerate(ldap_data):
         email = user_data[1].lower()

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -814,7 +814,8 @@ Output:
             os.path.dirname(__file__),
             f"../webhooks/{type}/fixtures/{action}.{file_type}",
         )
-        return open(fn).read()
+        with open(fn) as f:
+            return f.read()
 
     def fixture_file_name(self, file_name: str, type: str='') -> str:
         return os.path.join(
@@ -824,7 +825,8 @@ Output:
 
     def fixture_data(self, file_name: str, type: str='') -> str:
         fn = self.fixture_file_name(file_name, type)
-        return open(fn).read()
+        with open(fn) as f:
+            return f.read()
 
     def make_stream(self, stream_name: str, realm: Optional[Realm]=None,
                     invite_only: bool=False,

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -4657,8 +4657,7 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
     @use_s3_backend
     def test_update_user_avatar_for_s3(self) -> None:
         bucket = create_s3_buckets(settings.S3_AVATAR_BUCKET)[0]
-        test_image_file = get_test_image_file('img.png').name
-        with open(test_image_file, 'rb') as f:
+        with get_test_image_file('img.png') as f:
             test_image_data = f.read()
         self.change_ldap_user_attr('hamlet', 'jpegPhoto', test_image_data)
         with self.settings(AUTH_LDAP_USER_ATTR_MAP={'full_name': 'cn',

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1802,15 +1802,16 @@ class TestUserAgentParsing(ZulipTestCase):
         """Test for our user agent parsing logic, using a large data set."""
         user_agents_parsed: Dict[str, int] = defaultdict(int)
         user_agents_path = os.path.join(settings.DEPLOY_ROOT, "zerver/tests/fixtures/user_agents_unique")
-        for line in open(user_agents_path).readlines():
-            line = line.strip()
-            match = re.match('^(?P<count>[0-9]+) "(?P<user_agent>.*)"$', line)
-            assert match is not None
-            groupdict = match.groupdict()
-            count = groupdict["count"]
-            user_agent = groupdict["user_agent"]
-            ret = parse_user_agent(user_agent)
-            user_agents_parsed[ret["name"]] += int(count)
+        with open(user_agents_path) as f:
+            for line in f:
+                line = line.strip()
+                match = re.match('^(?P<count>[0-9]+) "(?P<user_agent>.*)"$', line)
+                assert match is not None
+                groupdict = match.groupdict()
+                count = groupdict["count"]
+                user_agent = groupdict["user_agent"]
+                ret = parse_user_agent(user_agent)
+                user_agents_parsed[ret["name"]] += int(count)
 
 
 class TestIgnoreUnhashableLRUCache(ZulipTestCase):

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -275,8 +275,6 @@ class ImportExportTest(ZulipTestCase):
             upload_emoji_image(img_file, '1.png', user_profile)
         with get_test_image_file('img.png') as img_file:
             upload_avatar_image(img_file, user_profile, user_profile)
-        with open(get_test_image_file('img.png').name, 'rb') as f:
-            test_image = f.read()
 
         with get_test_image_file('img.png') as img_file:
             upload.upload_backend.upload_realm_icon_image(img_file, user_profile)
@@ -289,7 +287,8 @@ class ImportExportTest(ZulipTestCase):
             upload.upload_backend.upload_realm_logo_image(img_file, user_profile, night=True)
             do_change_logo_source(realm, Realm.LOGO_UPLOADED, True, acting_user=user_profile)
 
-        test_image = get_test_image_file('img.png').read()
+        with get_test_image_file('img.png') as img_file:
+            test_image = img_file.read()
         message.sender.avatar_source = 'U'
         message.sender.save()
 
@@ -334,7 +333,8 @@ class ImportExportTest(ZulipTestCase):
         for record in records:
             image_path = os.path.join(full_data['realm_icons_dir'], record["path"])
             if image_path[-9:] == ".original":
-                image_data = open(image_path, 'rb').read()
+                with open(image_path, 'rb') as image_file:
+                    image_data = image_file.read()
                 self.assertEqual(image_data, test_image)
             else:
                 self.assertTrue(os.path.exists(image_path))
@@ -400,7 +400,8 @@ class ImportExportTest(ZulipTestCase):
         for record in records:
             image_path = os.path.join(full_data['realm_icons_dir'], record["s3_path"])
             if image_path[-9:] == ".original":
-                image_data = open(image_path, 'rb').read()
+                with open(image_path, 'rb') as image_file:
+                    image_data = image_file.read()
                 self.assertEqual(image_data, test_image)
             else:
                 self.assertTrue(os.path.exists(image_path))
@@ -1053,7 +1054,7 @@ class ImportExportTest(ZulipTestCase):
         upload_path = upload.upload_backend.realm_avatar_and_logo_path(imported_realm)
         full_upload_path = os.path.join(settings.LOCAL_UPLOADS_DIR, upload_path)
 
-        with open(get_test_image_file('img.png').name, 'rb') as f:
+        with get_test_image_file('img.png') as f:
             test_image_data = f.read()
         self.assertIsNotNone(test_image_data)
 
@@ -1086,7 +1087,7 @@ class ImportExportTest(ZulipTestCase):
             with patch('logging.info'):
                 do_import_realm(os.path.join(settings.TEST_WORKER_DIR, 'test-export'), 'test-zulip')
         imported_realm = Realm.objects.get(string_id='test-zulip')
-        with open(get_test_image_file('img.png').name, 'rb') as f:
+        with get_test_image_file('img.png') as f:
             test_image_data = f.read()
 
         # Test attachments

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3099,8 +3099,10 @@ class UserSignUpTest(InviteUserBase):
 
         zulip_path_id = avatar_disk_path(hamlet_in_zulip)
         lear_path_id = avatar_disk_path(hamlet_in_lear)
-        zulip_avatar_bits = open(zulip_path_id, 'rb').read()
-        lear_avatar_bits = open(lear_path_id, 'rb').read()
+        with open(zulip_path_id, 'rb') as f:
+            zulip_avatar_bits = f.read()
+        with open(lear_path_id, 'rb') as f:
+            lear_avatar_bits = f.read()
 
         self.assertTrue(len(zulip_avatar_bits) > 500)
         self.assertEqual(zulip_avatar_bits, lear_avatar_bits)

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from io import BytesIO
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 from unittest import mock
 from unittest.mock import ANY, call
@@ -767,7 +768,8 @@ class SlackImporter(ZulipTestCase):
         user_data_fixture = orjson.loads(self.fixture_data('user_data.json', type='slack_fixtures'))
         team_info_fixture = orjson.loads(self.fixture_data('team_info.json', type='slack_fixtures'))
         mock_get_slack_api_data.side_effect = [user_data_fixture['members'], {}, team_info_fixture["team"]]
-        mock_requests_get.return_value.raw = get_test_image_file("img.png")
+        with get_test_image_file("img.png") as f:
+            mock_requests_get.return_value.raw = BytesIO(f.read())
 
         with self.assertLogs(level="INFO"):
             do_convert_data(test_slack_zip_file, output_dir, token)

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -62,10 +62,10 @@ class ThumbnailTest(ZulipTestCase):
 
         # Test custom emoji URLs in Zulip messages.
         user_profile = self.example_user("hamlet")
-        image_file = get_test_image_file("img.png")
         file_name = "emoji.png"
 
-        upload_emoji_image(image_file, file_name, user_profile)
+        with get_test_image_file("img.png") as image_file:
+            upload_emoji_image(image_file, file_name, user_profile)
         custom_emoji_url = upload_backend.get_emoji_url(file_name, user_profile.realm_id)
         emoji_url_base = '/user_avatars/'
         self.assertEqual(emoji_url_base, custom_emoji_url[:len(emoji_url_base)])
@@ -206,10 +206,10 @@ class ThumbnailTest(ZulipTestCase):
 
         # Test custom emoji urls in Zulip messages.
         user_profile = self.example_user("hamlet")
-        image_file = get_test_image_file("img.png")
         file_name = "emoji.png"
 
-        upload_emoji_image(image_file, file_name, user_profile)
+        with get_test_image_file("img.png") as image_file:
+            upload_emoji_image(image_file, file_name, user_profile)
         custom_emoji_url = upload_backend.get_emoji_url(file_name, user_profile.realm_id)
         emoji_url_base = '/user_avatars/'
         self.assertEqual(emoji_url_base, custom_emoji_url[:len(emoji_url_base)])

--- a/zilencer/management/commands/add_mock_conversation.py
+++ b/zilencer/management/commands/add_mock_conversation.py
@@ -37,7 +37,8 @@ From image editing program:
 """
 
     def set_avatar(self, user: UserProfile, filename: str) -> None:
-        upload_avatar_image(open(filename, 'rb'), user, user)
+        with open(filename, 'rb') as f:
+            upload_avatar_image(f, user, user)
         do_change_avatar_fields(user, UserProfile.AVATAR_FROM_USER, acting_user=None)
 
     def add_message_formatting_conversation(self) -> None:

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -13,7 +13,6 @@
 # settings.AUTHENTICATION_BACKENDS that have a function signature
 # matching the args/kwargs passed in the authenticate() call.
 import binascii
-import copy
 import json
 import logging
 from abc import ABC, abstractmethod
@@ -550,13 +549,12 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
                 # Don't do work to replace the avatar with itself.
                 return
 
-            io = BytesIO(ldap_avatar)
             # Structurally, to make the S3 backend happy, we need to
             # provide a Content-Type; since that isn't specified in
             # any metadata, we auto-detect it.
-            content_type = magic.from_buffer(copy.deepcopy(io).read()[0:1024], mime=True)
+            content_type = magic.from_buffer(ldap_avatar[:1024], mime=True)
             if content_type.startswith("image/"):
-                upload_avatar_image(io, user, user, content_type=content_type)
+                upload_avatar_image(BytesIO(ldap_avatar), user, user, content_type=content_type)
                 do_change_avatar_fields(user, UserProfile.AVATAR_FROM_USER, acting_user=None)
                 # Update avatar hash.
                 user.avatar_hash = user_avatar_content_hash(ldap_avatar)


### PR DESCRIPTION
Fixes various instances of ‘ResourceWarning: unclosed file’ with `python -Wd`.