### PR TITLE
openapi: Note that a user's `avatar_url` may be missing.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4354,7 +4354,7 @@ paths:
                       avatar_version:
                         type: integer
                         description: |
-                          Version for the the user's avatar.  Used for cache-busting requests
+                          Version for the user's avatar.  Used for cache-busting requests
                           for the user's avatar.  Clients generally shouldn't need to use this;
                           most avatar URLs sent by Zulip will already end with `?v={avatar_version}`.
 
@@ -4664,7 +4664,7 @@ paths:
         - name: subscriptions
           in: query
           description: |
-            A list of dictionaries containing the the key `name` and value
+            A list of dictionaries containing the key `name` and value
             specifying the name of the stream to subscribe. If the stream does not
             exist a new stream is created. The description of the stream created can
             be specified by setting the dictionary key `description` with an
@@ -6237,7 +6237,7 @@ paths:
                                 sender_id:
                                   type: integer
                                   description: |
-                                    The user id of the the other participant in a PM conversation.
+                                    The user id of the other participant in a PM conversation.
                                 message_ids:
                                   type: array
                                   description: |
@@ -9782,7 +9782,7 @@ components:
           type: string
           nullable: true
           description: |
-            URL for the the user's avatar.  Will be `null` if the `client_gravatar`
+            URL for the user's avatar.  Will be `null` if the `client_gravatar`
             query parameter was set to `True` and the user's avatar is hosted by
             the Gravatar provider (i.e. the user has never uploaded an avatar).
 
@@ -9792,7 +9792,7 @@ components:
         avatar_version:
           type: integer
           description: |
-            Version for the the user's avatar.  Used for cache-busting requests
+            Version for the user's avatar.  Used for cache-busting requests
             for the user's avatar.  Clients generally shouldn't need to use this;
             most avatar URLs sent by Zulip will already end with `?v={avatar_version}`.
         full_name:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9785,6 +9785,10 @@ components:
             URL for the the user's avatar.  Will be `null` if the `client_gravatar`
             query parameter was set to `True` and the user's avatar is hosted by
             the Gravatar provider (i.e. the user has never uploaded an avatar).
+
+            **Changes**: In Zulip 3.0 (feature level 18), if the client has the
+            `user_avatar_url_field_optional` capability, this will be missing at
+            the server's sole discretion.
         avatar_version:
           type: integer
           description: |


### PR DESCRIPTION
Like it already says in the detail about
`user_avatar_url_field_optional`, but on the field itself [1].

[1] https://github.com/zulip/zulip-mobile/pull/4230#discussion_r493109645