### PR TITLE
users: Canonicalize the timezone identifier

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -496,7 +496,7 @@ run_test("realm_user", (override) => {
     const added_person = people.get_by_user_id(event.person.user_id);
     // sanity check a few individual fields
     assert.equal(added_person.full_name, "Test User");
-    assert.equal(added_person.timezone, "US/Eastern");
+    assert.equal(added_person.timezone, "America/New_York");
 
     // ...but really the whole struct gets copied without any
     // manipulation

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -453,7 +453,7 @@ exports.fixtures = {
             is_bot: false,
             is_guest: false,
             profile_data: {},
-            timezone: "US/Eastern",
+            timezone: "America/New_York",
             date_joined: "2020-01-01",
         },
     },

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -35,7 +35,7 @@ const me = {
     email: "me@example.com",
     user_id: 30,
     full_name: "Me Myself",
-    timezone: "US/Pacific",
+    timezone: "America/Los_Angeles",
     is_admin: false,
     is_guest: false,
     is_bot: false,
@@ -387,7 +387,7 @@ run_test("bot_custom_profile_data", () => {
 
 run_test("user_timezone", () => {
     const expected_pref = {
-        timezone: "US/Pacific",
+        timezone: "America/Los_Angeles",
         format: "H:mm",
     };
 
@@ -630,7 +630,7 @@ run_test("message_methods", () => {
                     value: "Field value",
                 },
             },
-            timezone: "US/Pacific",
+            timezone: "America/Los_Angeles",
             user_id: 30,
         },
     ]);

--- a/frontend_tests/node_tests/people_errors.js
+++ b/frontend_tests/node_tests/people_errors.js
@@ -16,7 +16,7 @@ const me = {
     email: "me@example.com",
     user_id: 30,
     full_name: "Me Myself",
-    timezone: "US/Pacific",
+    timezone: "America/Los_Angeles",
 };
 
 people.init();

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -62,7 +62,7 @@ const me = {
     email: "me@example.com",
     user_id: 30,
     full_name: "Me Myself",
-    timezone: "US/Pacific",
+    timezone: "America/Los_Angeles",
 };
 
 const target = $.create("click target");

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -142,6 +142,7 @@ from zerver.lib.streams import (
     subscribed_to_stream,
 )
 from zerver.lib.timestamp import datetime_to_timestamp, timestamp_to_datetime
+from zerver.lib.timezone import canonicalize_timezone
 from zerver.lib.topic import (
     LEGACY_PREV_TOPIC,
     ORIG_TOPIC,
@@ -3868,7 +3869,7 @@ def do_set_user_display_setting(user_profile: UserProfile,
     if setting_name == "timezone":
         payload = dict(email=user_profile.email,
                        user_id=user_profile.id,
-                       timezone=user_profile.timezone)
+                       timezone=canonicalize_timezone(user_profile.timezone))
         send_event(user_profile.realm,
                    dict(type='realm_user', op='update', person=payload),
                    active_user_ids(user_profile.realm_id))

--- a/zerver/lib/timezone.py
+++ b/zerver/lib/timezone.py
@@ -4,9 +4,6 @@ from typing import Any, Dict, Union
 import pytz
 
 
-def get_timezone(tz: str) -> pytz.BaseTzInfo:
-    return pytz.timezone(tz)
-
 # This method carefully trims a list of common timezones in the pytz
 # database and handles duplicate abbreviations in favor of the most
 # common/popular offset. The output of this can be directly passed as

--- a/zerver/lib/timezone.py
+++ b/zerver/lib/timezone.py
@@ -1,11 +1,8 @@
 import datetime
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, Union
 
 import pytz
 
-
-def get_all_timezones() -> List[str]:
-    return sorted(pytz.all_timezones)
 
 def get_timezone(tz: str) -> pytz.BaseTzInfo:
     return pytz.timezone(tz)

--- a/zerver/lib/timezone.py
+++ b/zerver/lib/timezone.py
@@ -1,9 +1,25 @@
 import datetime
 from functools import lru_cache
+from io import TextIOWrapper
 from typing import Any, Dict, Union
 
 import pytz
 
+
+@lru_cache(maxsize=None)
+def get_canonical_timezone_map() -> Dict[str, str]:
+    canonical = {}
+    with TextIOWrapper(
+        pytz.open_resource("tzdata.zi")  # type: ignore[attr-defined] # Unclear if this is part of the public pytz API
+    ) as f:
+        for line in f:
+            if line.startswith("L "):
+                l, name, alias = line.split()
+                canonical[alias] = name
+    return canonical
+
+def canonicalize_timezone(key: str) -> str:
+    return get_canonical_timezone_map().get(key, key)
 
 # This method carefully trims a list of common timezones in the pytz
 # database and handles duplicate abbreviations in favor of the most

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -19,6 +19,7 @@ from zerver.lib.cache import (
 )
 from zerver.lib.exceptions import OrganizationAdministratorRequired
 from zerver.lib.request import JsonableError
+from zerver.lib.timezone import canonicalize_timezone
 from zerver.models import (
     CustomProfileField,
     CustomProfileFieldValue,
@@ -329,7 +330,7 @@ def format_user_row(realm: Realm, acting_user: Optional[UserProfile], row: Dict[
         is_guest=is_guest,
         is_bot=is_bot,
         full_name=row['full_name'],
-        timezone=row['timezone'],
+        timezone=canonicalize_timezone(row['timezone']),
         is_active = row['is_active'],
         date_joined = row['date_joined'].isoformat(),
     )

--- a/zerver/signals.py
+++ b/zerver/signals.py
@@ -1,5 +1,6 @@
 from typing import Any, Optional
 
+import pytz
 from django.conf import settings
 from django.contrib.auth.signals import user_logged_in, user_logged_out
 from django.dispatch import receiver
@@ -11,7 +12,6 @@ from confirmation.models import one_click_unsubscribe_link
 from zerver.lib.actions import do_set_zoom_token
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.send_email import FromAddress
-from zerver.lib.timezone import get_timezone
 from zerver.models import UserProfile
 
 JUST_CREATED_THRESHOLD = 60
@@ -81,7 +81,7 @@ def email_on_new_login(sender: Any, user: UserProfile, request: Any, **kwargs: A
         user_tz = user.timezone
         if user_tz == '':
             user_tz = timezone_get_current_timezone_name()
-        local_time = timezone_now().astimezone(get_timezone(user_tz))
+        local_time = timezone_now().astimezone(pytz.timezone(user_tz))
         if user.twenty_four_hour_time:
             hhmm_string = local_time.strftime('%H:%M')
         else:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1792,7 +1792,7 @@ class UserDisplayActionTest(BaseAction):
         test_changes: Dict[str, Any] = dict(
             emojiset = ['twitter'],
             default_language = ['es', 'de', 'en'],
-            timezone = ['US/Mountain', 'US/Samoa', 'Pacific/Galapogos', ''],
+            timezone = ['America/Denver', 'Pacific/Pago_Pago', 'Pacific/Galapagos', ''],
             demote_inactive_streams = [2, 3, 1],
             color_scheme = [2, 3, 1]
         )

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -3,6 +3,7 @@ from typing import Any, Optional, Set
 from unittest import mock
 
 import orjson
+import pytz
 from django.conf import settings
 from django.db.models import Q
 from django.http import HttpResponse
@@ -44,7 +45,6 @@ from zerver.lib.test_helpers import (
     reset_emails_in_zulip_realm,
 )
 from zerver.lib.timestamp import convert_to_UTC, datetime_to_timestamp
-from zerver.lib.timezone import get_timezone
 from zerver.models import (
     MAX_MESSAGE_LENGTH,
     MAX_TOPIC_NAME_LENGTH,
@@ -1013,7 +1013,7 @@ class ScheduledMessageTest(ZulipTestCase):
         message = self.last_scheduled_message()
         self.assert_json_success(result)
         self.assertEqual(message.content, 'Test message 6')
-        local_tz = get_timezone(tz_guess)
+        local_tz = pytz.timezone(tz_guess)
         utz_defer_until = local_tz.normalize(local_tz.localize(defer_until))
         self.assertEqual(message.scheduled_timestamp,
                          convert_to_UTC(utz_defer_until))
@@ -1029,7 +1029,7 @@ class ScheduledMessageTest(ZulipTestCase):
         message = self.last_scheduled_message()
         self.assert_json_success(result)
         self.assertEqual(message.content, 'Test message 7')
-        local_tz = get_timezone(user.timezone)
+        local_tz = pytz.timezone(user.timezone)
         utz_defer_until = local_tz.normalize(local_tz.localize(defer_until))
         self.assertEqual(message.scheduled_timestamp,
                          convert_to_UTC(utz_defer_until))

--- a/zerver/tests/test_timezone.py
+++ b/zerver/tests/test_timezone.py
@@ -1,0 +1,9 @@
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.timezone import canonicalize_timezone
+
+
+class TimeZoneTest(ZulipTestCase):
+    def test_canonicalize_timezone(self) -> None:
+        self.assertEqual(canonicalize_timezone("America/Los_Angeles"), "America/Los_Angeles")
+        self.assertEqual(canonicalize_timezone("US/Pacific"), "America/Los_Angeles")
+        self.assertEqual(canonicalize_timezone("Gondor/Minas_Tirith"), "Gondor/Minas_Tirith")

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -1,5 +1,6 @@
 from typing import Iterable, Optional, Sequence, Union, cast
 
+import pytz
 from dateutil.parser import parse as dateparser
 from django.core import validators
 from django.core.exceptions import ValidationError
@@ -20,7 +21,6 @@ from zerver.lib.actions import (
 from zerver.lib.message import render_markdown
 from zerver.lib.response import json_error, json_success
 from zerver.lib.timestamp import convert_to_UTC
-from zerver.lib.timezone import get_timezone
 from zerver.lib.topic import REQ_topic
 from zerver.lib.zcommand import process_zcommands
 from zerver.lib.zephyr import compute_mit_user_fullname
@@ -143,7 +143,7 @@ def handle_deferred_message(sender: UserProfile, client: Client,
 
     deliver_at_usertz = deliver_at
     if deliver_at_usertz.tzinfo is None:
-        user_tz = get_timezone(local_tz)
+        user_tz = pytz.timezone(local_tz)
         deliver_at_usertz = user_tz.normalize(user_tz.localize(deliver_at))
     deliver_at = convert_to_UTC(deliver_at_usertz)
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -3,6 +3,7 @@ import smtplib
 import urllib
 from typing import Dict, List, Optional
 
+import pytz
 from django.conf import settings
 from django.contrib.auth import authenticate, get_backends
 from django.core import validators
@@ -50,7 +51,6 @@ from zerver.lib.pysa import mark_sanitized
 from zerver.lib.send_email import FromAddress, send_email
 from zerver.lib.sessions import get_expirable_session_var
 from zerver.lib.subdomains import get_subdomain, is_root_domain_available
-from zerver.lib.timezone import get_all_timezones
 from zerver.lib.url_encoding import add_query_to_redirect_url
 from zerver.lib.users import get_accounts_for_email
 from zerver.lib.zephyr import compute_mit_user_fullname
@@ -290,7 +290,7 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
         default_stream_groups = lookup_default_stream_groups(default_stream_group_names, realm)
 
         timezone = ""
-        if 'timezone' in request.POST and request.POST['timezone'] in get_all_timezones():
+        if 'timezone' in request.POST and request.POST['timezone'] in pytz.all_timezones_set:
             timezone = request.POST['timezone']
 
         if 'source_realm' in request.POST and request.POST["source_realm"] != "on":

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Optional
 
+import pytz
 from django.conf import settings
 from django.contrib.auth import authenticate, update_session_auth_hash
 from django.core.exceptions import ValidationError
@@ -40,7 +41,6 @@ from zerver.lib.rate_limiter import RateLimited
 from zerver.lib.request import JsonableError
 from zerver.lib.response import json_error, json_success
 from zerver.lib.send_email import FromAddress, send_email
-from zerver.lib.timezone import get_all_timezones
 from zerver.lib.upload import upload_avatar_image
 from zerver.lib.validator import check_bool, check_int, check_int_in, check_string, check_string_in
 from zerver.models import UserProfile, avatar_changes_disabled, name_changes_disabled
@@ -158,7 +158,6 @@ def json_change_settings(request: HttpRequest, user_profile: UserProfile,
 
     return json_success(result)
 
-all_timezones = set(get_all_timezones())
 emojiset_choices = {emojiset['key'] for emojiset in UserProfile.emojiset_choices()}
 
 @human_users_only
@@ -179,7 +178,7 @@ def update_display_settings_backend(
             emojiset_choices), default=None),
         demote_inactive_streams: Optional[int]=REQ(validator=check_int_in(
             UserProfile.DEMOTE_STREAMS_CHOICES), default=None),
-        timezone: Optional[str]=REQ(validator=check_string_in(all_timezones),
+        timezone: Optional[str]=REQ(validator=check_string_in(pytz.all_timezones_set),
                                     default=None)) -> HttpResponse:
 
     # We can't use REQ for this widget because


### PR DESCRIPTION
While working on shifting toward native browser time zone APIs (#16451), it was found that all but very recent Chrome and Node versions reject certain legacy timezone aliases like US/Pacific (https://crbug.com/364374).

For now, we only canonicalize the `timezone` property returned in user objects and not the `timezone` setting itself.

**Testing plan:** Dev server.