### PR TITLE
upgrade: Adjust puppet class names even with --skip-puppet.

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -256,24 +256,25 @@ if (not args.skip_puppet or migrations_needed) and IS_SERVER_UP:
     # state.
     shutdown_server()
 
-if not args.skip_puppet:
-    # Adjust Puppet class names for the rename after 3.x
-    class_renames = {
-        'zulip::app_frontend': 'zulip::profile::app_frontend',
-        'zulip::dockervoyager': 'zulip::profile::docker',
-        'zulip::memcached': 'zulip::profile::memcached',
-        'zulip::postgres_appdb_tuned': 'zulip::profile::postgresql',
-        'zulip::rabbit': 'zulip::profile::rabbitmq',
-        'zulip::thumbor': 'zulip::profile::thumbor',
-        'zulip::voyager': 'zulip::profile::standalone',
-    }
-    classes = re.split(r'\s*,\s*', get_config(config_file, 'machine', 'puppet_classes'))
-    new_classes = [class_renames.get(c, c) for c in classes if c != 'zulip::base']
-    if classes != new_classes:
-        logging.info("Adjusting Puppet classes for renames...")
-        subprocess.check_call(["crudini", "--set", "/etc/zulip/zulip.conf",
-                               "machine", "puppet_classes", ", ".join(new_classes)])
+# Adjust Puppet class names for the rename after 3.x
+class_renames = {
+    'zulip::app_frontend': 'zulip::profile::app_frontend',
+    'zulip::dockervoyager': 'zulip::profile::docker',
+    'zulip::memcached': 'zulip::profile::memcached',
+    'zulip::postgres_appdb_tuned': 'zulip::profile::postgresql',
+    'zulip::rabbit': 'zulip::profile::rabbitmq',
+    'zulip::thumbor': 'zulip::profile::thumbor',
+    'zulip::voyager': 'zulip::profile::standalone',
+}
+classes = re.split(r'\s*,\s*', get_config(config_file, 'machine', 'puppet_classes'))
+new_classes = [class_renames.get(c, c) for c in classes if c != 'zulip::base']
+if classes != new_classes:
+    logging.info("Adjusting Puppet classes for renames...")
+    subprocess.check_call(["crudini", "--set", "/etc/zulip/zulip.conf",
+                           "machine", "puppet_classes", ", ".join(new_classes)])
 
+
+if not args.skip_puppet:
     logging.info("Applying Puppet changes...")
     subprocess.check_call(["./scripts/zulip-puppet-apply", "--force"])
     subprocess.check_call(["apt-get", "-y", "upgrade"])


### PR DESCRIPTION
The class names need to be renamed even if we are not about to run
puppet ourselves; otherwise, deployments which rely on running puppet
themselves will still have the wrong class names.
