### PR TITLE
support: Allow user look up through full name search

### DIFF
--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -433,6 +433,11 @@ class TestSupportEndpoint(ZulipTestCase):
                                              'class="copy-button" data-copytext="desdemona@zulip.com, iago@zulip.com"',
                                              ], result)
 
+        def check_othello_user_query_result(result: HttpResponse) -> None:
+            self.assert_in_success_response(['<span class="label">user</span>\n', '<h3>Othello, the Moor of Venice</h3>',
+                                             '<b>Email</b>: othello@zulip.com', '<b>Is active</b>: True<br>'
+                                             ], result)
+
         def check_zulip_realm_query_result(result: HttpResponse) -> None:
             zulip_realm = get_realm("zulip")
             self.assert_in_success_response([f'<input type="hidden" name="realm_id" value="{zulip_realm.id}"',
@@ -536,6 +541,15 @@ class TestSupportEndpoint(ZulipTestCase):
         check_hamlet_user_query_result(result)
         check_zulip_realm_query_result(result)
         check_lear_realm_query_result(result)
+
+        result = self.client_get("/activity/support", {"q": "King hamlet,lear"})
+        check_hamlet_user_query_result(result)
+        check_zulip_realm_query_result(result)
+        check_lear_realm_query_result(result)
+
+        result = self.client_get("/activity/support", {"q": "Othello, the Moor of Venice"})
+        check_othello_user_query_result(result)
+        check_zulip_realm_query_result(result)
 
         result = self.client_get("/activity/support", {"q": "lear, Hamlet <hamlet@zulip.com>"})
         check_hamlet_user_query_result(result)

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -1181,7 +1181,7 @@ def support(request: HttpRequest) -> HttpResponse:
     if query:
         key_words = get_invitee_emails_set(query)
 
-        context["users"] = UserProfile.objects.filter(delivery_email__in=key_words)
+        users = set(UserProfile.objects.filter(delivery_email__in=key_words))
         realms = set(Realm.objects.filter(string_id__in=key_words))
 
         for key_word in key_words:
@@ -1198,7 +1198,7 @@ def support(request: HttpRequest) -> HttpResponse:
                 except Realm.DoesNotExist:
                     pass
             except ValidationError:
-                pass
+                users.update(UserProfile.objects.filter(full_name__iexact=key_word))
 
         for realm in realms:
             realm.customer = get_customer_by_realm(realm)
@@ -1214,6 +1214,10 @@ def support(request: HttpRequest) -> HttpResponse:
                     realm.current_plan.licenses = last_ledger_entry.licenses
                     realm.current_plan.licenses_used = get_latest_seat_count(realm)
 
+        # full_names can have , in them
+        users.update(UserProfile.objects.filter(full_name__iexact=query))
+
+        context["users"] = users
         context["realms"] = realms
 
         confirmations: List[Dict[str, Any]] = []

--- a/templates/analytics/support.html
+++ b/templates/analytics/support.html
@@ -13,7 +13,7 @@
     <br>
     <form class="new-style">
         <center>
-            <input type="text" name="q" class="input-xxlarge search-query" placeholder="emails, string_ids, organization URLs separated by commas" value="{{ request.GET.get('q', '') }}" autofocus>
+            <input type="text" name="q" class="input-xxlarge search-query" placeholder="full names, emails, string_ids, organization URLs separated by commas" value="{{ request.GET.get('q', '') }}" autofocus>
             <button type="submit" class="button small support-search-button">Search</button>
         </center>
     </form>


### PR DESCRIPTION
This would allow to lookup users through their full name in /support page. The search is case insensitive but partial names won't return any results.

Was requested https://app.frontapp.com/inboxes/teammates/472523/shared-with-me/open/2631377635/search/global/full%20name/13546310147?around=74863219395

![Screenshot from 2020-10-31 00-57-33](https://user-images.githubusercontent.com/7190633/97748835-19bc5180-1b14-11eb-92d8-818d5c6bf8f7.png)
![Screenshot from 2020-10-31 00-57-17](https://user-images.githubusercontent.com/7190633/97748838-1aed7e80-1b14-11eb-88c1-81bd01c5660d.png)
