### PR TITLE
drafts: Remove unused css property.

### DIFF
--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -11,10 +11,6 @@
     display: flex;
     flex-direction: column;
 
-    @media (max-width: 1130px) {
-        max-width: 60%;
-    }
-
     @media (max-width: 700px) {
         height: 95%;
         max-width: none;


### PR DESCRIPTION
Since width of drafts-container is set to 58% above, this
property never gets used.
