### PR TITLE
subscription_settings: Fix subscriber search box width.

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -1111,12 +1111,6 @@ ul.grey-box {
     .search-container {
         text-align: center;
     }
-
-    .subscriber_list_settings input {
-        float: left;
-        margin: 0 5px 0 0;
-        width: calc(50% - 45px);
-    }
 }
 
 /* Note that this block has settings_page CSS as well, and thus needs


### PR DESCRIPTION
These properties were causing the search box to have a very small
width. Removing it returns search box to normal width.
before:
![image](https://user-images.githubusercontent.com/25124304/97782595-6a858600-1bb8-11eb-88c0-a7e6a265f16b.png)
after:
![image](https://user-images.githubusercontent.com/25124304/97782591-66596880-1bb8-11eb-825a-b3e8b096e19b.png)
