### PR TITLE
create_stream: Remove no longer required condition.

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -244,17 +244,7 @@ exports.new_stream_clicked = function (stream_name) {
         $("#create_stream_name").val(stream_name);
     }
     exports.show_new_stream_modal();
-
-    // at less than 700px we have a @media query that when you tap the
-    // .create_stream_button, the stream prompt slides in. However, when you
-    // focus  the button on that page, the entire app view jumps over to
-    // the other tab, and the animation breaks.
-    // it is unclear whether this is a browser bug or "feature", however what
-    // is clear is that this shouldn't be touched unless you're also changing
-    // the mobile @media query at 700px.
-    if (window.innerWidth > 700) {
-        $("#create_stream_name").trigger("focus");
-    }
+    $("#create_stream_name").trigger("focus");
 };
 
 function clear_error_display() {


### PR DESCRIPTION
The issue raised in the comment here seems to have been
fixed on its own. Tested on chrome and safari on macOS.
![stream_create](https://user-images.githubusercontent.com/25124304/97794603-2a5aed80-1c22-11eb-814a-ab169ffc2cb1.gif)
