### PR TITLE
Improve subscriptions overlay.

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -1180,6 +1180,14 @@ ul.grey-box {
     }
 }
 
+@media (max-width: 575px) {
+    #subscription_overlay .subscription_settings .button-group {
+        display: block;
+        float: unset;
+        margin-top: 10px;
+    }
+}
+
 #stream-creation #invites-warning-modal .modal-footer {
     position: static;
 }

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -22,7 +22,9 @@
                     <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}}title="{{t 'Toggle subscription'}} (S)" {{else}}disabled="disabled"{{/if}}>
                         {{#if subscribed }}{{#tr oneself }}Unsubscribe{{/tr}}{{else}}{{#tr oneself }}Subscribe{{/tr}}{{/if}}</button>
                 </div>
-                <a href="{{preview_url}}" class="button small rounded" id="preview-stream-button" role="button" title="{{t 'View stream'}} (V)" {{#unless should_display_preview_button }}style="display: none"{{/unless}}>{{t "View stream"}}</a>
+                <a href="{{preview_url}}" class="button small rounded" id="preview-stream-button" role="button" title="{{t 'View stream'}} (V)" {{#unless should_display_preview_button }}style="display: none"{{/unless}}>
+                    <i class="fa fa-eye"></i>
+                </a>
             </div>
         </div>
         <div class="stream-description">


### PR DESCRIPTION
1st commit:
<img width="571" alt="Screenshot 2020-11-01 at 10 17 55 AM" src="https://user-images.githubusercontent.com/25124304/97795539-75c6c900-1c2d-11eb-8ce1-974f4f0ea52a.png">
2nd commit:
<img width="771" alt="Screenshot 2020-11-01 at 10 25 47 AM" src="https://user-images.githubusercontent.com/25124304/97795540-7a8b7d00-1c2d-11eb-9d5e-208f42052560.png">
3rd commit:
<img width="771" alt="Screenshot 2020-11-01 at 10 29 06 AM" src="https://user-images.githubusercontent.com/25124304/97795543-7eb79a80-1c2d-11eb-8c0e-dd392ef8080e.png">

