### PR TITLE
settings: Remove unused css property.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1345,12 +1345,6 @@ input[type="checkbox"] {
             display: none;
         }
 
-        .sidebar-bottom-anchor {
-            width: 100%;
-            position: absolute;
-            bottom: 0;
-        }
-
         .tab-container {
             padding: 6px;
             border-bottom: 1px solid hsl(0, 0%, 87%);
@@ -1831,16 +1825,6 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
                 background: inherit;
                 border-bottom: 1px solid hsl(0, 0%, 93%);
             }
-        }
-    }
-}
-
-@media (max-height: 530px) {
-    #settings_page .sidebar .sidebar-bottom-anchor {
-        position: static;
-
-        .border-top {
-            border: none;
         }
     }
 }


### PR DESCRIPTION
There is no sidebar-bottom-anchor in our codebase.
