### PR TITLE
fenced_code escaping fixes

### DIFF
--- a/static/shared/js/fenced_code.js
+++ b/static/shared/js/fenced_code.js
@@ -46,8 +46,10 @@ export function wrap_code(code, lang) {
     // the `/shared` folder. To handle such a case we check if pygments data is empty and fallback to
     // using the default header if it is.
     if (lang !== undefined && lang !== "" && Object.keys(pygments_data).length > 0) {
-        const code_language = _.get(pygments_data, [lang, "pretty_name"], _.escape(lang));
-        header = `<div class="codehilite" data-code-language="${code_language}"><pre><span></span><code>`;
+        const code_language = _.get(pygments_data, [lang, "pretty_name"], lang);
+        header = `<div class="codehilite" data-code-language="${_.escape(
+            code_language,
+        )}"><pre><span></span><code>`;
     }
     // Trim trailing \n until there's just one left
     // This mirrors how pygments handles code input

--- a/zerver/lib/markdown/fenced_code.py
+++ b/zerver/lib/markdown/fenced_code.py
@@ -415,12 +415,7 @@ class FencedBlockPreprocessor(markdown.preprocessors.Preprocessor):
                 # still tag it with the user's data-code-language
                 # value, since this allows hooking up a "playground"
                 # for custom "languages" that aren't known to Pygments.
-                #
-                # The escaping isn't strictly necessary, in that the
-                # characters allowed for language values should all be
-                # safe, but doing escaping here makes it easy to
-                # reason about.
-                code_language = self._escape(lang)
+                code_language = lang
 
             div_tag.attrib['data-code-language'] = code_language
             code = lxml.html.tostring(div_tag, encoding="unicode")


### PR DESCRIPTION
* Revert "markdown: Escape lang when echoing back custom non-pygments languages."

  This reverts commit 564b199fe61bad9f8b4dfd7080857d1c521ffad3, which was part of #16308.

  Escaping is either required or incorrect; it is never “defensive”. This escaping is incorrect.  lxml already escapes attributes during serialization (any other behavior would be a serious bug), and additional escaping just results in double escaping.

* fenced_code: Escape code_language on output in wrapped_code.

  Strings should be escaped at the point of interpolation into a template, not before.  In this case, the early escape was hiding the bug that `code_language` was only escaped if it was not found in `pygments_data`.

Cc @sumanthvrao
