### PR TITLE
support: Add ability to change subdomain of realms.

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -1125,57 +1125,57 @@ def support(request: HttpRequest) -> HttpResponse:
             current_plan_type = realm.plan_type
             do_change_plan_type(realm, new_plan_type)
             msg = f"Plan type of {realm.string_id} changed from {get_plan_name(current_plan_type)} to {get_plan_name(new_plan_type)} "
-            context["message"] = msg
+            context["success_message"] = msg
         elif request.POST.get("discount", None) is not None:
             new_discount = Decimal(request.POST.get("discount"))
             current_discount = get_discount_for_realm(realm)
             attach_discount_to_realm(realm, new_discount)
             msg = f"Discount of {realm.string_id} changed to {new_discount} from {current_discount} "
-            context["message"] = msg
+            context["success_message"] = msg
         elif request.POST.get("status", None) is not None:
             status = request.POST.get("status")
             if status == "active":
                 do_send_realm_reactivation_email(realm)
-                context["message"] = f"Realm reactivation email sent to admins of {realm.string_id}."
+                context["success_message"] = f"Realm reactivation email sent to admins of {realm.string_id}."
             elif status == "deactivated":
                 do_deactivate_realm(realm, request.user)
-                context["message"] = f"{realm.string_id} deactivated."
+                context["success_message"] = f"{realm.string_id} deactivated."
         elif request.POST.get("billing_method", None) is not None:
             billing_method = request.POST.get("billing_method")
             if billing_method == "send_invoice":
                 update_billing_method_of_current_plan(realm, charge_automatically=False)
-                context["message"] = f"Billing method of {realm.string_id} updated to pay by invoice."
+                context["success_message"] = f"Billing method of {realm.string_id} updated to pay by invoice."
             elif billing_method == "charge_automatically":
                 update_billing_method_of_current_plan(realm, charge_automatically=True)
-                context["message"] = f"Billing method of {realm.string_id} updated to charge automatically."
+                context["success_message"] = f"Billing method of {realm.string_id} updated to charge automatically."
         elif request.POST.get("sponsorship_pending", None) is not None:
             sponsorship_pending = request.POST.get("sponsorship_pending")
             if sponsorship_pending == "true":
                 update_sponsorship_status(realm, True)
-                context["message"] = f"{realm.string_id} marked as pending sponsorship."
+                context["success_message"] = f"{realm.string_id} marked as pending sponsorship."
             elif sponsorship_pending == "false":
                 update_sponsorship_status(realm, False)
-                context["message"] = f"{realm.string_id} is no longer pending sponsorship."
+                context["success_message"] = f"{realm.string_id} is no longer pending sponsorship."
         elif request.POST.get('approve_sponsorship') is not None:
             if request.POST.get('approve_sponsorship') == "approve_sponsorship":
                 approve_sponsorship(realm)
-                context["message"] = f"Sponsorship approved for {realm.string_id}"
+                context["success_message"] = f"Sponsorship approved for {realm.string_id}"
         elif request.POST.get('downgrade_method', None) is not None:
             downgrade_method = request.POST.get('downgrade_method')
             if downgrade_method == "downgrade_at_billing_cycle_end":
                 downgrade_at_the_end_of_billing_cycle(realm)
-                context["message"] = f"{realm.string_id} marked for downgrade at the end of billing cycle"
+                context["success_message"] = f"{realm.string_id} marked for downgrade at the end of billing cycle"
             elif downgrade_method == "downgrade_now_without_additional_licenses":
                 downgrade_now_without_creating_additional_invoices(realm)
-                context["message"] = f"{realm.string_id} downgraded without creating additional invoices"
+                context["success_message"] = f"{realm.string_id} downgraded without creating additional invoices"
             elif downgrade_method == "downgrade_now_void_open_invoices":
                 downgrade_now_without_creating_additional_invoices(realm)
                 voided_invoices_count = void_all_open_invoices(realm)
-                context["message"] = f"{realm.string_id} downgraded and voided {voided_invoices_count} open invoices"
+                context["success_message"] = f"{realm.string_id} downgraded and voided {voided_invoices_count} open invoices"
         elif request.POST.get("scrub_realm", None) is not None:
             if request.POST.get("scrub_realm") == "scrub_realm":
                 do_scrub_realm(realm, acting_user=request.user)
-                context["message"] = f"{realm.string_id} scrubbed."
+                context["success_message"] = f"{realm.string_id} scrubbed."
 
     query = request.GET.get("q", None)
     if query:

--- a/static/styles/portico/activity.css
+++ b/static/styles/portico/activity.css
@@ -76,7 +76,7 @@ tr.admin td:first-child {
 
 .support-plan-type-form {
     position: relative;
-    top: -25px;
+    top: -10px;
 }
 
 .sponsorship-pending-form {
@@ -86,7 +86,7 @@ tr.admin td:first-child {
 
 .current-plan-details {
     position: relative;
-    top: -50px;
+    top: -15px;
 }
 
 .approve-sponsorship-form {
@@ -120,7 +120,7 @@ tr.admin td:first-child {
 
 .support-submit-button {
     position: relative;
-    top: -5px;
+    top: -3px;
     border-color: hsl(0, 0%, 83%);
     border-radius: 2px;
 }

--- a/templates/analytics/realm_details.html
+++ b/templates/analytics/realm_details.html
@@ -18,6 +18,13 @@
     </select>
     <button type="submit" class="button rounded small support-submit-button">Update</button>
 </form>
+<form method="POST">
+    <b>New subdomain</b>:<br>
+    {{ csrf_input }}
+    <input type="hidden" name="realm_id" value="{{ realm.id }}" />
+    <input type="text" name="new_subdomain" required>
+    <button type="submit" class="button rounded small support-submit-button">Update</button>
+</form>
 <form method="POST" class="support-plan-type-form">
     <b>Plan type</b>:<br>
     {{ csrf_input }}

--- a/templates/analytics/support.html
+++ b/templates/analytics/support.html
@@ -7,7 +7,6 @@
 <title>Info</title>
 {% endblock %}
 
-
 {% block content %}
 <div class="container">
     <br>
@@ -18,7 +17,13 @@
         </center>
     </form>
 
-    {% if success_message %}
+    {% if error_message %}
+    <div class="alert alert-danger">
+        <center>
+            {{ error_message }}
+        </center>
+    </div>
+    {% elif success_message %}
     <div class="alert alert-success">
         <center>
             {{ success_message }}

--- a/templates/analytics/support.html
+++ b/templates/analytics/support.html
@@ -18,10 +18,10 @@
         </center>
     </form>
 
-    {% if message %}
+    {% if success_message %}
     <div class="alert alert-success">
         <center>
-            {{ message }}
+            {{ success_message }}
         </center>
     </div>
     {% endif %}


### PR DESCRIPTION
This PR is for the issue https://github.com/zulip/zulip/issues/12613

The aim is to:
- [x] Add ability in the backend to accept the `/activity/support` request with 'change_realm_subdomain' key and invoke `do_change_realm_subdomain` 
- [x] Create a text box in the `/activity/support/` page in the frontend

I have added the condition to identify if the admin wants to change the realm's subdomain and have called `do_change_realm_subdomain` from there. The caching system should take care of flushing the cache.

Following gif shows the process of updation of realm name:
![subdomain](https://user-images.githubusercontent.com/53316982/101275036-9e138b80-37c8-11eb-964e-3160572c3c67.gif)


The following shows the error message when we try to update the subdomain name to an existing subdomain.
![2](https://user-images.githubusercontent.com/53316982/98468153-2c631480-21ff-11eb-9657-5d33123c9966.gif)





