### PR TITLE
user settings: click leak through `modal` after `Esc` click

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -979,6 +979,14 @@ exports.initialize = function () {
         }
     });
 
+    // If user clicks 'Escape' on an active modal
+    $(document).on("keydown", (e) => {
+        // Enable mouse events for the background as the modal closes
+        if (e.which === 27) {
+            $(".overlay.show").attr("style", null);
+        }
+    });
+
     // Workaround for Bootstrap issue #5900, which basically makes dropdowns
     // unclickable on mobile devices.
     // https://github.com/twitter/bootstrap/issues/5900


### PR DESCRIPTION
Fixes: #16688


**Testing plan:** <!-- How have you tested? -->
Manually Tested
![1](https://user-images.githubusercontent.com/43513378/97960734-06d9a380-1dd8-11eb-93a1-95538c3038ec.gif)
Manually Tested
![2](https://user-images.githubusercontent.com/43513378/97960777-10fba200-1dd8-11eb-956d-e0a6c7a4f894.gif)




**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
