### PR TITLE
left_sidebar:Add JS tooltip to setting icon to prevent flickering Fixes #16676

### DIFF
--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -503,6 +503,11 @@ exports.set_event_handlers = function () {
             exports.toggle_filter_displayed(e);
         });
 
+    $("#streams_inline_cog").tooltip({
+        title: i18n.t("Subscribe, add, or configure streams"),
+        animation: false,
+        placement: "bottom",
+    });
     // check for user scrolls on streams list for first time
     ui.get_scroll_element($("#stream-filters-container")).on("scroll", function () {
         has_scrolled = true;

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -68,7 +68,7 @@
         </ul>
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-toggle="tooltip" title="{{ _('Filter streams') }}">{{ _('STREAMS') }}</h4>
-                <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" data-toggle="tooltip" title="{{ _('Subscribe, add, or configure streams') }}"></i>
+                <i id="streams_inline_cog" class='fa fa-cog'></i>
                 <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true" data-toggle="tooltip" title="{{ _('Filter streams') }} (q)"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter" type="text" autocomplete="off" placeholder="{{ _('Search streams') }}" />


### PR DESCRIPTION
This PR fixes #16676 . The tooltip has been implemented using jQuery, and the placement of the tooltip has been changed to be on the bottom so as to avoid the flickering issue on hovering.

Testing Plan:
I have tested the tooltip myself by hovering over it.

GIFs or Screenshots:
![Flickeringissue](https://user-images.githubusercontent.com/59444243/98113225-5cda4400-1ec9-11eb-92ba-074d7819e810.gif)
