### PR TITLE
markdown: Remove border colour on inline code links

### DIFF
--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -564,12 +564,10 @@ pre code {
    to look more like a normal link */
 a code {
     color: hsl(200, 100%, 40%);
-    border-color: hsl(200, 100%, 40%);
 }
 
 a:hover code {
     color: hsl(200, 100%, 25%);
-    border-color: hsl(200, 100%, 25%);
 }
 
 /* Search highlight used in both topics and rendered_markdown */


### PR DESCRIPTION
The visual noise from the blue border has bothered me forever and I
finally decided to do something about it. I don't know if this is the
best solution, but I do think it's a lot better than the status quo!

**Testing plan:**
Tested this out via browser devtools.


**GIFs or screenshots:**
| Current | Changed |
| --- | --- |
| ![border](https://user-images.githubusercontent.com/50936/98208295-0ee63000-1f0b-11eb-8dcf-b34d514252a3.gif) | ![no-border](https://user-images.githubusercontent.com/50936/98208298-0ee63000-1f0b-11eb-8519-3f66b37bc59b.gif) |