### PR TITLE
Disable tooltip for touch-enabled devices.

### DIFF
--- a/static/third/bootstrap-tooltip/tooltip.js
+++ b/static/third/bootstrap-tooltip/tooltip.js
@@ -19,6 +19,28 @@
  * ========================================================== */
 
 
+/*
+  Function to find whether the device is touch-enabled or not. 
+  Important to disable the tooltip for touch-based devices and allow
+  uninterrupted user events.
+  Source of Code: https://patrickhlauke.github.io/touch/touchscreen-detection/
+*/ 
+function isTouchScreen(){
+  var result = false
+  if (window.PointerEvent && ('maxTouchPoints' in navigator)) {
+    if (navigator.maxTouchPoints > 0) {
+      result = true
+    }
+  } else {
+    if (window.matchMedia && window.matchMedia("(any-pointer:coarse)").matches) {
+      result = true
+    } else if (window.TouchEvent || ('ontouchstart' in window)) {
+      result = true
+    }
+  }
+  return result
+}
+
 !function ($) {
 
     "use strict"; // jshint ;_;
@@ -42,7 +64,7 @@
         this.type = type
         this.$element = $(element)
         this.options = this.getOptions(options)
-        this.enabled = true
+        this.enabled = !isTouchScreen()
 
         if (this.options.trigger == 'click') {
           this.$element.on('click.' + this.type, this.options.selector, $.proxy(this.toggle, this))


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #16674 
The tooltip is displayed when the given target is clicked and remain suspended until the next event for mobile(touch) devices. Hence this PR disables the tooltip for such devices.
**Testing plan:** <!-- How have you tested? -->

Test : Tested on dev server.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![ezgif com-gif-maker](https://user-images.githubusercontent.com/55033316/98214939-281fc880-1f6d-11eb-93b7-073eee2d4ce0.gif)
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
