### PR TITLE
user_status: Show icon for common statuses.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -734,10 +734,18 @@ run_test("update_display_settings", (override) => {
         event = event_fixtures.update_display_settings__emojiset;
         called = false;
         override("settings_display.report_emojiset_change", stub.f);
+        override("activity.build_user_sidebar", noop);
         page_params.emojiset = "text";
         dispatch(event);
         assert_same(called, true);
         assert_same(page_params.emojiset, "google");
+    });
+
+    global.with_stub((stub) => {
+        event = event_fixtures.update_display_settings__emojiset;
+        override("settings_display.report_emojiset_change", noop);
+        override("activity.build_user_sidebar", stub.f);
+        dispatch(event);
     });
 
     override("starred_messages.rerender_ui", noop);

--- a/frontend_tests/node_tests/user_status.js
+++ b/frontend_tests/node_tests/user_status.js
@@ -73,6 +73,46 @@ run_test("server", () => {
     assert(called);
 });
 
+run_test("status emoji", () => {
+    const tests = [
+        {
+            status: "In a meeting",
+            expected: "1f4c5",
+        },
+        {
+            status: "Commuting",
+            expected: "1f697",
+        },
+        {
+            status: "Out sick",
+            expected: "1f915",
+        },
+        {
+            status: "Vacationing",
+            expected: "1f334",
+        },
+        {
+            status: "Working remotely",
+            expected: "1f4bb",
+        },
+        {
+            status: "some other status",
+            expected: "1f4ac",
+        },
+        {
+            status: "",
+            expected: "",
+        },
+    ];
+    tests.forEach((test) => {
+        user_status.set_status_text({
+            user_id: 2,
+            status_text: test.status,
+        });
+        assert.equal(user_status.get_status_emoji(2), test.expected);
+    });
+});
+
 run_test("defensive checks", () => {
     blueslip.expect("error", "need ints for user_id", 2);
     user_status.set_away("string");

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -180,13 +180,20 @@ exports.info_for = function (user_id) {
     const user_circle_class = exports.get_user_circle_class(user_id);
     const person = people.get_by_user_id(user_id);
     const my_user_status = exports.get_my_user_status(user_id);
+    const emojiset = page_params.emojiset;
+    let status_emoji = "";
+    if (emojiset !== "text") {
+        status_emoji = user_status.get_status_emoji(user_id);
+    }
     const user_circle_status = exports.status_description(user_id);
 
     return {
         href: hash_util.pm_with_uri(person.email),
         name: person.full_name,
         user_id,
+        emojiset,
         my_user_status,
+        status_emoji,
         is_current_user: people.is_my_user_id(user_id),
         num_unread: get_num_unread(user_id),
         user_circle_class,

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -486,6 +486,8 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                 if (current_msg_list === message_list.narrowed) {
                     message_list.narrowed.rerender();
                 }
+                // Rerender buddy list status emoji
+                activity.build_user_sidebar();
             }
             settings_display.update_page();
             break;

--- a/static/js/user_status.js
+++ b/static/js/user_status.js
@@ -49,6 +49,27 @@ exports.get_status_text = function (user_id) {
     return user_info.get(user_id);
 };
 
+exports.get_status_emoji = function (user_id) {
+    const status_text = user_info.get(user_id);
+    switch (status_text) {
+        case "In a meeting":
+            return "1f4c5"; // calendar
+        case "Commuting":
+            return "1f697"; // automobile
+        case "Out sick":
+            return "1f915"; // head bandage
+        case "Vacationing":
+            return "1f334"; // palm tree
+        case "Working remotely":
+            return "1f4bb"; // laptop
+        default:
+            if (status_text) {
+                return "1f4ac"; // speech balloon
+            }
+            return "";
+    }
+};
+
 exports.set_status_text = function (opts) {
     if (!opts.status_text) {
         user_info.delete(opts.user_id);

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2361,6 +2361,12 @@ div.topic_edit_spinner .loading_indicator_spinner {
     top: 3px;
 }
 
+.status_emoji {
+    height: 20px;
+    width: 20px;
+    top: 5px;
+}
+
 /* FIXME: Combine this rule with the one in portico.css somehow? */
 #pw_strength {
     width: 100%;

--- a/static/templates/user_presence_row.hbs
+++ b/static/templates/user_presence_row.hbs
@@ -6,8 +6,8 @@
           data-user-id="{{user_id}}"
           data-name="{{name}}">
             {{name}}
-            {{#if my_user_status}}
-            <span class="my_user_status">{{my_user_status}}</span>
+            {{#if status_emoji}}
+            <img class="status_emoji" src="/static/generated/emoji/images-{{emojiset}}-64/{{status_emoji}}.png" />
             {{/if}}
         </a>
         <span class="count"><span class="value">{{#if num_unread}}{{num_unread}}{{/if}}</span></span>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This adds hardcoded emoji for the suggested statuses.
todo: Add realm setting (completed locally)
todo: Add tests for realm setting (WIP)

This could be test deployed without the realm setting, as is.
**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/33805964/99367969-9e62ea00-28e0-11eb-8dbf-3b75d0486289.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
