### PR TITLE
remove default arguments

### DIFF
--- a/analytics/lib/counts.py
+++ b/analytics/lib/counts.py
@@ -70,7 +70,9 @@ class LoggingCountStat(CountStat):
 
 class DependentCountStat(CountStat):
     def __init__(self, property: str, data_collector: 'DataCollector', frequency: str,
-                 interval: Optional[timedelta] = None, dependencies: Sequence[str] = []) -> None:
+                 interval: Optional[timedelta] = None, dependencies: Sequence[str] = None) -> None:
+        if dependencies is None:
+            dependencies = []
         CountStat.__init__(self, property, data_collector, frequency, interval=interval)
         self.dependencies = dependencies
 

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -826,7 +826,9 @@ def sent_messages_report(realm: str) -> str:
 
 def ad_hoc_queries() -> List[Dict[str, str]]:
     def get_page(query: Composable, cols: Sequence[str], title: str,
-                 totals_columns: Sequence[int]=[]) -> Dict[str, str]:
+                 totals_columns: Sequence[int]=None) -> Dict[str, str]:
+        if totals_columns is None:
+            totals_columns = []
         cursor = connection.cursor()
         cursor.execute(query)
         rows = cursor.fetchall()

--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -65,7 +65,9 @@ def get_object_from_key(confirmation_key: str,
 
 def create_confirmation_link(obj: ContentType,
                              confirmation_type: int,
-                             url_args: Mapping[str, str] = {}) -> str:
+                             url_args: Mapping[str, str] = None) -> str:
+    if url_args is None:
+        url_args = {}
     key = generate_key()
     realm = None
     if hasattr(obj, 'realm'):
@@ -79,7 +81,9 @@ def create_confirmation_link(obj: ContentType,
 
 def confirmation_url(confirmation_key: str, realm: Optional[Realm],
                      confirmation_type: int,
-                     url_args: Mapping[str, str] = {}) -> str:
+                     url_args: Mapping[str, str] = None) -> str:
+    if url_args is None:
+        url_args = {}
     url_args = dict(url_args)
     url_args['confirmation_key'] = confirmation_key
     return urljoin(

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -403,7 +403,7 @@ def files_and_string_digest(filenames: Sequence[str],
 
 def is_digest_obsolete(hash_name: str,
                        filenames: Sequence[str],
-                       extra_strings: Sequence[str] = []) -> bool:
+                       extra_strings: Sequence[str] = None) -> bool:
     '''
     In order to determine if we need to run some
     process, we calculate a digest of the important
@@ -422,6 +422,8 @@ def is_digest_obsolete(hash_name: str,
         - settings values (that we stringify with
           json, deterministically)
     '''
+    if extra_strings is None:
+        extra_strings = []
     last_hash_path = os.path.join(get_dev_uuid_var_path(), hash_name)
     try:
         with open(last_hash_path) as f:
@@ -437,7 +439,9 @@ def is_digest_obsolete(hash_name: str,
 
 def write_new_digest(hash_name: str,
                      filenames: Sequence[str],
-                     extra_strings: Sequence[str] = []) -> None:
+                     extra_strings: Sequence[str] = None) -> None:
+    if extra_strings is None:
+        extra_strings = []
     hash_path = os.path.join(get_dev_uuid_var_path(), hash_name)
     new_hash = files_and_string_digest(filenames, extra_strings)
     with open(hash_path, 'w') as f:

--- a/tools/lib/html_branches.py
+++ b/tools/lib/html_branches.py
@@ -133,7 +133,9 @@ def html_branches(text: str, fn: Optional[str] = None) -> List[HtmlTreeBranch]:
     tree = html_tag_tree(text, fn)
     branches: List[HtmlTreeBranch] = []
 
-    def walk(node: Node, tag_info_list: Sequence[TagInfo] = []) -> None:
+    def walk(node: Node, tag_info_list: Sequence[TagInfo] = None) -> None:
+        if tag_info_list is None:
+            tag_info_list = []
         assert node.token is not None
         info = get_tag_info(node.token)
         tag_info_list = [*tag_info_list, info]

--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -296,12 +296,14 @@ def build_recipient(type_id: int, recipient_id: int, type: int) -> ZerverFieldsT
 
 def build_recipients(zerver_userprofile: Iterable[ZerverFieldsT],
                      zerver_stream: Iterable[ZerverFieldsT],
-                     zerver_huddle: Iterable[ZerverFieldsT] = []) -> List[ZerverFieldsT]:
+                     zerver_huddle: Iterable[ZerverFieldsT] = None) -> List[ZerverFieldsT]:
     '''
     As of this writing, we only use this in the HipChat
     conversion.  The Slack and Gitter conversions do it more
     tightly integrated with creating other objects.
     '''
+    if zerver_huddle is None:
+        zerver_huddle = []
 
     recipients = []
 
@@ -368,7 +370,9 @@ def build_usermessages(zerver_usermessage: List[ZerverFieldsT],
                        mentioned_user_ids: List[int],
                        message_id: int,
                        is_private: bool,
-                       long_term_idle: AbstractSet[int] = set()) -> Tuple[int, int]:
+                       long_term_idle: AbstractSet[int] = None) -> Tuple[int, int]:
+    if long_term_idle is None:
+        long_term_idle = set()
     user_ids = subscriber_map.get(recipient_id, set())
 
     user_messages_created = 0

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -417,8 +417,10 @@ def add_new_user_history(user_profile: UserProfile, streams: Iterable[Stream]) -
 def process_new_human_user(user_profile: UserProfile,
                            prereg_user: Optional[PreregistrationUser]=None,
                            newsletter_data: Optional[Mapping[str, str]]=None,
-                           default_stream_groups: Sequence[DefaultStreamGroup]=[],
+                           default_stream_groups: Sequence[DefaultStreamGroup]=None,
                            realm_creation: bool=False) -> None:
+    if default_stream_groups is None:
+        default_stream_groups = []
     realm = user_profile.realm
 
     mit_beta_user = realm.is_zephyr_mirror_realm
@@ -566,10 +568,13 @@ def do_create_user(email: str, password: Optional[str], realm: Realm, full_name:
                    default_all_public_streams: Optional[bool]=None,
                    prereg_user: Optional[PreregistrationUser]=None,
                    newsletter_data: Optional[Dict[str, str]]=None,
-                   default_stream_groups: Sequence[DefaultStreamGroup]=[],
+                   default_stream_groups: Sequence[DefaultStreamGroup]=None,
                    source_profile: Optional[UserProfile]=None,
                    realm_creation: bool=False,
                    acting_user: Optional[UserProfile]=None) -> UserProfile:
+    
+    if default_stream_groups is None:
+        default_stream_groups = []
 
     user_profile = create_user(email=email, password=password, realm=realm,
                                full_name=full_name,
@@ -1112,8 +1117,10 @@ class RecipientInfoResult(TypedDict):
 def get_recipient_info(recipient: Recipient,
                        sender_id: int,
                        stream_topic: Optional[StreamTopicTarget],
-                       possibly_mentioned_user_ids: AbstractSet[int]=set(),
+                       possibly_mentioned_user_ids: AbstractSet[int]=None,
                        possible_wildcard_mention: bool=True) -> RecipientInfoResult:
+    if possibly_mentioned_user_ids is None:
+        possibly_mentioned_user_ids = set()
     stream_push_user_ids: Set[int] = set()
     stream_email_user_ids: Set[int] = set()
     wildcard_mention_user_ids: Set[int] = set()
@@ -1480,11 +1487,13 @@ def build_message_send_dict(message_dict: Dict[str, Any],
 
 def do_send_messages(messages_maybe_none: Sequence[Optional[MutableMapping[str, Any]]],
                      email_gateway: bool=False,
-                     mark_as_read: Sequence[int]=[]) -> List[int]:
+                     mark_as_read: Sequence[int]=None) -> List[int]:
     """See
     https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html
     for high-level documentation on this subsystem.
     """
+    if mark_as_read is None:
+        mark_as_read = []
 
     # Filter out messages which didn't pass internal_prep_message properly
     messages = [message for message in messages_maybe_none if message is not None]
@@ -1686,7 +1695,9 @@ def create_user_messages(message: Message,
                          stream_push_user_ids: AbstractSet[int],
                          stream_email_user_ids: AbstractSet[int],
                          mentioned_user_ids: AbstractSet[int],
-                         mark_as_read: Sequence[int] = []) -> List[UserMessageLite]:
+                         mark_as_read: Sequence[int] = None) -> List[UserMessageLite]:
+    if mark_as_read is None:
+        mark_as_read = []
     ums_to_create = []
     for user_profile_id in um_eligible_user_ids:
         um = UserMessageLite(
@@ -2780,10 +2791,12 @@ def bulk_add_subscriptions(
     realm: Realm,
     streams: Iterable[Stream],
     users: Iterable[UserProfile],
-    color_map: Mapping[str, str]={},
+    color_map: Mapping[str, str]=None,
     acting_user: Optional[UserProfile]=None,
     from_user_creation: bool=False,
 ) -> SubT:
+    if color_map is None:
+        color_map = {}
     users = list(users)
 
     # Sanity check out callers
@@ -5443,7 +5456,9 @@ def do_get_user_invites(user_profile: UserProfile) -> List[Dict[str, Any]]:
     return invites
 
 def do_create_multiuse_invite_link(referred_by: UserProfile, invited_as: int,
-                                   streams: Sequence[Stream] = []) -> str:
+                                   streams: Sequence[Stream] = None) -> str:
+    if streams is None:
+        streams = []
     realm = referred_by.realm
     invite = MultiuseInvite.objects.create(realm=realm, referred_by=referred_by)
     if streams:

--- a/zerver/lib/data_types.py
+++ b/zerver/lib/data_types.py
@@ -31,8 +31,10 @@ class DictType:
     def __init__(
         self,
         required_keys: Sequence[Tuple[str, Any]],
-        optional_keys: Sequence[Tuple[str, Any]] = [],
+        optional_keys: Sequence[Tuple[str, Any]] = None,
     ) -> None:
+        if optional_keys is None:
+            optional_keys = []
         self.required_keys = required_keys
         self.optional_keys = optional_keys
 
@@ -237,7 +239,7 @@ class UrlType:
 
 def event_dict_type(
     required_keys: Sequence[Tuple[str, Any]],
-    optional_keys: Sequence[Tuple[str, Any]] = [],
+    optional_keys: Sequence[Tuple[str, Any]] = None,
 ) -> DictType:
 
     """
@@ -250,6 +252,8 @@ def event_dict_type(
         - sanity check that we have no duplicate keys
 
     """
+    if optional_keys is None:
+        optional_keys = []
     rkeys = [key[0] for key in required_keys]
     okeys = [key[0] for key in optional_keys]
     keys = rkeys + okeys

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -915,10 +915,14 @@ def do_events_register(
     all_public_streams: bool = False,
     include_subscribers: bool = True,
     include_streams: bool = True,
-    client_capabilities: Dict[str, bool] = {},
-    narrow: Iterable[Sequence[str]] = [],
+    client_capabilities: Dict[str, bool] = None,
+    narrow: Iterable[Sequence[str]] = None,
     fetch_event_types: Optional[Iterable[str]] = None
 ) -> Dict[str, Any]:
+    if client_capabilities is None:
+        client_capabilities = {}
+    if narrow is None:
+        narrow = []
     # Technically we don't need to check this here because
     # build_narrow_filter will check it, but it's nicer from an error
     # handling perspective to do it before contacting Tornado

--- a/zerver/lib/html_to_text.py
+++ b/zerver/lib/html_to_text.py
@@ -7,7 +7,9 @@ from django.utils.html import escape
 from zerver.lib.cache import cache_with_key, open_graph_description_cache_key
 
 
-def html_to_text(content: Union[str, bytes], tags: Mapping[str, str] = {'p': ' | '}) -> str:
+def html_to_text(content: Union[str, bytes], tags: Mapping[str, str] = None) -> str: 
+    if tags is None:
+        tags = {'p': ' | '}
     bs = BeautifulSoup(content, features='lxml')
     # Skip any admonition (warning) blocks, since they're
     # usually something about users needing to be an

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -57,7 +57,9 @@ class Integration:
                  logo: Optional[str]=None, secondary_line_text: Optional[str]=None,
                  display_name: Optional[str]=None, doc: Optional[str]=None,
                  stream_name: Optional[str]=None, legacy: bool=False,
-                 config_options: Sequence[Tuple[str, str, Validator[object]]]=[]) -> None:
+                 config_options: Sequence[Tuple[str, str, Validator[object]]]=None) -> None:
+        if config_options is None:
+            config_options = []
         self.name = name
         self.client_name = client_name
         self.secondary_line_text = secondary_line_text
@@ -159,7 +161,9 @@ class WebhookIntegration(Integration):
                  function: Optional[str]=None, url: Optional[str]=None,
                  display_name: Optional[str]=None, doc: Optional[str]=None,
                  stream_name: Optional[str]=None, legacy: bool=False,
-                 config_options: Sequence[Tuple[str, str, Validator[object]]]=[]) -> None:
+                 config_options: Sequence[Tuple[str, str, Validator[object]]]=None) -> None:
+        if config_options is None:
+            config_options = []
         if client_name is None:
             client_name = self.DEFAULT_CLIENT_NAME.format(name=name.title())
         super().__init__(

--- a/zerver/lib/markdown/api_arguments_table_generator.py
+++ b/zerver/lib/markdown/api_arguments_table_generator.py
@@ -14,7 +14,9 @@ REGEXP = re.compile(r'\{generate_api_arguments_table\|\s*(.+?)\s*\|\s*(.+)\s*\}'
 
 
 class MarkdownArgumentsTableGenerator(Extension):
-    def __init__(self, configs: Mapping[str, Any] = {}) -> None:
+    def __init__(self, configs: Mapping[str, Any] = None) -> None:
+        if configs is None:
+            configs = {}
         self.config = {
             'base_path': ['.', 'Default location from which to evaluate relative paths for the JSON files.'],
         }

--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -12,7 +12,9 @@ from zerver.openapi.openapi import get_openapi_return_values, likely_deprecated_
 REGEXP = re.compile(r'\{generate_return_values_table\|\s*(.+?)\s*\|\s*(.+)\s*\}')
 
 class MarkdownReturnValuesTableGenerator(Extension):
-    def __init__(self, configs: Mapping[str, Any] = {}) -> None:
+    def __init__(self, configs: Mapping[str, Any] = None) -> None:
+        if configs is None:
+            configs = {}
         self.config: Dict[str, Any] = {}
 
     def extendMarkdown(self, md: markdown.Markdown) -> None:

--- a/zerver/lib/markdown/fenced_code.py
+++ b/zerver/lib/markdown/fenced_code.py
@@ -138,7 +138,9 @@ CODE_VALIDATORS = {
 }
 
 class FencedCodeExtension(markdown.Extension):
-    def __init__(self, config: Mapping[str, Any] = {}) -> None:
+    def __init__(self, config: Mapping[str, Any] = None) -> None:
+        if config is None:
+            config = {}
         self.config = {
             'run_content_validators': [
                 config.get('run_content_validators', False),

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -636,13 +636,17 @@ def get_apns_alert_subtitle(message: Message) -> str:
     # For group PMs, or regular messages to a stream, just use a colon to indicate this is the sender.
     return message.sender.full_name + ":"
 
-def get_apns_badge_count(user_profile: UserProfile, read_messages_ids: Optional[Sequence[int]]=[]) -> int:
+def get_apns_badge_count(user_profile: UserProfile, read_messages_ids: Optional[Sequence[int]]=None) -> int:
+    if read_messages_ids is None:
+        read_messages_ids = []
     # NOTE: We have temporarily set get_apns_badge_count to always
     # return 0 until we can debug a likely mobile app side issue with
     # handling notifications while the app is open.
     return 0
 
-def get_apns_badge_count_future(user_profile: UserProfile, read_messages_ids: Optional[Sequence[int]]=[]) -> int:
+def get_apns_badge_count_future(user_profile: UserProfile, read_messages_ids: Optional[Sequence[int]]=None) -> int:
+    if read_messages_ids is None:
+        read_messages_ids = []
     # Future implementation of get_apns_badge_count; unused but
     # we expect to use this once we resolve client-side bugs.
     return UserMessage.objects.filter(

--- a/zerver/lib/remote_server.py
+++ b/zerver/lib/remote_server.py
@@ -25,7 +25,7 @@ def send_to_push_bouncer(
     method: str,
     endpoint: str,
     post_data: Union[bytes, Mapping[str, Union[str, bytes]]],
-    extra_headers: Mapping[str, str] = {},
+    extra_headers: Mapping[str, str] = None,
 ) -> Dict[str, object]:
     """While it does actually send the notice, this function has a lot of
     code and comments around error handling for the push notifications
@@ -43,6 +43,8 @@ def send_to_push_bouncer(
       vs. client-side errors like and invalid token.
 
     """
+    if extra_headers is None:
+        extra_headers = {}
     url = urllib.parse.urljoin(settings.PUSH_NOTIFICATION_BOUNCER_URL,
                                '/api/v1/remotes/' + endpoint)
     api_auth = requests.auth.HTTPBasicAuth(settings.ZULIP_ORG_ID,

--- a/zerver/lib/response.py
+++ b/zerver/lib/response.py
@@ -38,8 +38,10 @@ def json_method_not_allowed(methods: List[str]) -> HttpResponseNotAllowed:
 
 def json_response(res_type: str="success",
                   msg: str="",
-                  data: Mapping[str, Any]={},
+                  data: Mapping[str, Any]=None,
                   status: int=200) -> HttpResponse:
+    if data is None:
+        data = {}
     content = {"result": res_type, "msg": msg}
     content.update(data)
 
@@ -55,7 +57,9 @@ def json_response(res_type: str="success",
         status=status,
     )
 
-def json_success(data: Mapping[str, Any]={}) -> HttpResponse:
+def json_success(data: Mapping[str, Any]=None) -> HttpResponse:
+    if data is None:
+        data = {}
     return json_response(data=data)
 
 def json_response_from_error(exception: JsonableError) -> HttpResponse:
@@ -71,5 +75,7 @@ def json_response_from_error(exception: JsonableError) -> HttpResponse:
                          data=exception.data,
                          status=exception.http_status_code)
 
-def json_error(msg: str, data: Mapping[str, Any]={}, status: int=400) -> HttpResponse:
+def json_error(msg: str, data: Mapping[str, Any]=None, status: int=400) -> HttpResponse:
+    if data is None:
+        data = {}
     return json_response(res_type="error", msg=msg, data=data, status=status)

--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -163,7 +163,9 @@ def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
 
 def rest_path(
     route: str,
-    kwargs: Mapping[str, object] = {},
+    kwargs: Mapping[str, object] = None,
     **handlers: Union[Callable[..., HttpResponse], Tuple[Callable[..., HttpResponse], Set[str]]],
 ) -> URLPattern:
+    if kwargs is None:
+        kwargs = {}
     return path(route, rest_dispatch, {**kwargs, **handlers})

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -57,9 +57,11 @@ class FromAddress:
 def build_email(template_prefix: str, to_user_ids: Optional[List[int]]=None,
                 to_emails: Optional[List[str]]=None, from_name: Optional[str]=None,
                 from_address: Optional[str]=None, reply_to_email: Optional[str]=None,
-                language: Optional[str]=None, context: Mapping[str, Any]={},
+                language: Optional[str]=None, context: Mapping[str, Any]=None,
                 realm: Optional[Realm]=None
                 ) -> EmailMultiAlternatives:
+    if context is None:
+        context = {}
     # Callers should pass exactly one of to_user_id and to_email.
     assert (to_user_ids is None) ^ (to_emails is None)
     if to_user_ids is not None:
@@ -164,8 +166,10 @@ class NoEmailArgumentException(CommandError):
 def send_email(template_prefix: str, to_user_ids: Optional[List[int]]=None,
                to_emails: Optional[List[str]]=None, from_name: Optional[str]=None,
                from_address: Optional[str]=None, reply_to_email: Optional[str]=None,
-               language: Optional[str]=None, context: Dict[str, Any]={},
+               language: Optional[str]=None, context: Dict[str, Any]=None,
                realm: Optional[Realm]=None) -> None:
+    if context is None:
+        context = {}
     mail = build_email(template_prefix, to_user_ids=to_user_ids, to_emails=to_emails,
                        from_name=from_name, from_address=from_address,
                        reply_to_email=reply_to_email, language=language, context=context,
@@ -183,7 +187,9 @@ def send_email_from_dict(email_dict: Mapping[str, Any]) -> None:
 def send_future_email(template_prefix: str, realm: Realm, to_user_ids: Optional[List[int]]=None,
                       to_emails: Optional[List[str]]=None, from_name: Optional[str]=None,
                       from_address: Optional[str]=None, language: Optional[str]=None,
-                      context: Dict[str, Any]={}, delay: datetime.timedelta=datetime.timedelta(0)) -> None:
+                      context: Dict[str, Any]=None, delay: datetime.timedelta=datetime.timedelta(0)) -> None:
+    if context is None:
+        context = {}
     template_name = template_prefix.split('/')[-1]
     email_fields = {'template_prefix': template_prefix, 'from_name': from_name, 'from_address': from_address,
                     'language': language, 'context': context}
@@ -217,7 +223,9 @@ def send_future_email(template_prefix: str, realm: Realm, to_user_ids: Optional[
 
 def send_email_to_admins(template_prefix: str, realm: Realm, from_name: Optional[str]=None,
                          from_address: Optional[str]=None, language: Optional[str]=None,
-                         context: Dict[str, Any]={}) -> None:
+                         context: Dict[str, Any]=None) -> None:
+    if context is None:
+        context = {}
     admins = realm.get_human_admin_users()
     admin_user_ids = [admin.id for admin in admins]
     send_email(template_prefix, to_user_ids=admin_user_ids, from_name=from_name,

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -239,10 +239,12 @@ Output:
                              intentionally_undocumented=intentionally_undocumented)
 
     @instrument_url
-    def client_patch(self, url: str, info: Dict[str, Any]={}, intentionally_undocumented: bool=False, **kwargs: Any) -> HttpResponse:
+    def client_patch(self, url: str, info: Dict[str, Any]=None, intentionally_undocumented: bool=False, **kwargs: Any) -> HttpResponse:
         """
         We need to urlencode, since Django's function won't do it for us.
         """
+        if info is None:
+            info = {}
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
@@ -251,7 +253,7 @@ Output:
         return result
 
     @instrument_url
-    def client_patch_multipart(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_patch_multipart(self, url: str, info: Dict[str, Any]=None, **kwargs: Any) -> HttpResponse:
         """
         Use this for patch requests that have file uploads or
         that need some sort of multi-part content.  In the future
@@ -260,6 +262,8 @@ Output:
         with the Django test client, it deals with MULTIPART_CONTENT
         automatically, but not patch.)
         """
+        if info is None:
+            info = {}
         encoded = encode_multipart(BOUNDARY, info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
@@ -272,14 +276,18 @@ Output:
         return result
 
     @instrument_url
-    def client_put(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_put(self, url: str, info: Dict[str, Any]=None, **kwargs: Any) -> HttpResponse:
+        if info is None:
+            info = {}
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
         return django_client.put(url, encoded, **kwargs)
 
     @instrument_url
-    def client_delete(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_delete(self, url: str, info: Dict[str, Any]=None, **kwargs: Any) -> HttpResponse:
+        if info is None:
+            info = {}
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
@@ -288,14 +296,18 @@ Output:
         return result
 
     @instrument_url
-    def client_options(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_options(self, url: str, info: Dict[str, Any]=None, **kwargs: Any) -> HttpResponse:
+        if info is None:
+            info = {}
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
         return django_client.options(url, encoded, **kwargs)
 
     @instrument_url
-    def client_head(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_head(self, url: str, info: Dict[str, Any]=None, **kwargs: Any) -> HttpResponse:
+        if info is None:
+            info = {}
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
@@ -305,9 +317,11 @@ Output:
     def client_post(
         self,
         url: str,
-        info: Union[str, bytes, Dict[str, Any]] = {},
+        info: Union[str, bytes, Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> HttpResponse:
+        if info is None:
+            info = {}
         intentionally_undocumented: bool = kwargs.pop("intentionally_undocumented", False)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
@@ -330,7 +344,9 @@ Output:
         return match.func(req)
 
     @instrument_url
-    def client_get(self, url: str, info: Dict[str, Any] = {}, **kwargs: Any) -> HttpResponse:
+    def client_get(self, url: str, info: Dict[str, Any] = None, **kwargs: Any) -> HttpResponse:
+        if info is None:
+            info = {}
         intentionally_undocumented: bool = kwargs.pop("intentionally_undocumented", False)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
@@ -553,7 +569,7 @@ Output:
             realm_subdomain: str="zuliptest",
             from_confirmation: str='', full_name: Optional[str]=None,
             timezone: str='', realm_in_root_domain: Optional[str]=None,
-            default_stream_groups: Sequence[str]=[],
+            default_stream_groups: Sequence[str]=None,
             source_realm: str='',
             key: Optional[str]=None, **kwargs: Any) -> HttpResponse:
         """
@@ -564,6 +580,8 @@ Output:
 
         You can pass the HTTP_HOST variable for subdomains via kwargs.
         """
+        if default_stream_groups is None:
+            default_stream_groups = []
         if full_name is None:
             full_name = email.replace("@", "_")
         payload = {
@@ -886,10 +904,12 @@ Output:
 
     # Subscribe to a stream by making an API request
     def common_subscribe_to_streams(self, user: UserProfile, streams: Iterable[str],
-                                    extra_post_data: Dict[str, Any]={}, invite_only: bool=False,
+                                    extra_post_data: Dict[str, Any]=None, invite_only: bool=False,
                                     is_web_public: bool=False,
                                     allow_fail: bool=False,
                                     **kwargs: Any) -> HttpResponse:
+        if extra_post_data is None:
+            extra_post_data = {}
         post_data = {'subscriptions': orjson.dumps([{"name": stream} for stream in streams]).decode(),
                      'is_web_public': orjson.dumps(is_web_public).decode(),
                      'invite_only': orjson.dumps(invite_only).decode()}

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -339,8 +339,10 @@ def instrument_url(f: UrlFuncT) -> UrlFuncT:
     if not INSTRUMENTING:  # nocoverage -- option is always enabled; should we remove?
         return f
     else:
-        def wrapper(self: 'ZulipTestCase', url: str, info: object = {},
+        def wrapper(self: 'ZulipTestCase', url: str, info: object = None,
                     **kwargs: Any) -> HttpResponse:
+            if info is None:
+                info = {}
             start = time.time()
             result = f(self, url, info, **kwargs)
             delay = time.time() - start

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -175,23 +175,35 @@ def check_tuple(sub_validators: List[Validator[ResultT]]) -> Validator[Tuple[Any
 
 # https://zulip.readthedocs.io/en/latest/testing/mypy.html#using-overload-to-accurately-describe-variations
 @overload
-def check_dict(required_keys: Iterable[Tuple[str, Validator[object]]]=[],
-               optional_keys: Iterable[Tuple[str, Validator[object]]]=[],
+def check_dict(required_keys: Iterable[Tuple[str, Validator[object]]]=None,
+               optional_keys: Iterable[Tuple[str, Validator[object]]]=None,
                *,
                _allow_only_listed_keys: bool=False) -> Validator[Dict[str, object]]:
+    if required_keys is None:
+        required_keys = []
+    if optional_keys is None:
+        optional_keys = []
     ...
 @overload
-def check_dict(required_keys: Iterable[Tuple[str, Validator[ResultT]]]=[],
-               optional_keys: Iterable[Tuple[str, Validator[ResultT]]]=[],
+def check_dict(required_keys: Iterable[Tuple[str, Validator[ResultT]]]=None,
+               optional_keys: Iterable[Tuple[str, Validator[ResultT]]]=None,
                *,
                value_validator: Validator[ResultT],
                _allow_only_listed_keys: bool=False) -> Validator[Dict[str, ResultT]]:
+    if required_keys is None:
+        required_keys = []
+    if optional_keys is None:
+        optional_keys = []
     ...
-def check_dict(required_keys: Iterable[Tuple[str, Validator[ResultT]]]=[],
-               optional_keys: Iterable[Tuple[str, Validator[ResultT]]]=[],
+def check_dict(required_keys: Iterable[Tuple[str, Validator[ResultT]]]=None,
+               optional_keys: Iterable[Tuple[str, Validator[ResultT]]]=None,
                *,
                value_validator: Optional[Validator[ResultT]]=None,
                _allow_only_listed_keys: bool=False) -> Validator[Dict[str, ResultT]]:
+    if required_keys is None:
+        required_keys = []
+    if optional_keys is None:
+        optional_keys = []
     def f(var_name: str, val: object) -> Dict[str, ResultT]:
         if not isinstance(val, dict):
             raise ValidationError(_('{var_name} is not a dict').format(var_name=var_name))
@@ -230,7 +242,9 @@ def check_dict(required_keys: Iterable[Tuple[str, Validator[ResultT]]]=[],
     return f
 
 def check_dict_only(required_keys: Iterable[Tuple[str, Validator[ResultT]]],
-                    optional_keys: Iterable[Tuple[str, Validator[ResultT]]]=[]) -> Validator[Dict[str, ResultT]]:
+                    optional_keys: Iterable[Tuple[str, Validator[ResultT]]]=None) -> Validator[Dict[str, ResultT]]:
+    if optional_keys is None:
+        optional_keys = []
     return cast(
         Validator[Dict[str, ResultT]],
         check_dict(required_keys, optional_keys, _allow_only_listed_keys=True),

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -76,13 +76,15 @@ docs_without_macros = [
 @items_tuple_to_dict
 @register.filter(name='render_markdown_path', is_safe=True)
 def render_markdown_path(markdown_file_path: str,
-                         context: Mapping[str, Any]={},
+                         context: Mapping[str, Any]=None,
                          pure_markdown: bool=False) -> str:
     """Given a path to a Markdown file, return the rendered HTML.
 
     Note that this assumes that any HTML in the Markdown file is
     trusted; it is intended to be used for documentation, not user
     data."""
+    if context is None:
+        context = {}
 
     # We set this global hackishly
     from zerver.lib.markdown.help_settings_links import set_relative_settings_links

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1546,12 +1546,14 @@ class SAMLAuthBackendTest(SocialAuthBase):
 
         return result
 
-    def generate_saml_response(self, email: str, name: str, extra_attributes: Mapping[str, List[str]]={}) -> str:
+    def generate_saml_response(self, email: str, name: str, extra_attributes: Mapping[str, List[str]]=None) -> str:
         """
         The samlresponse.txt fixture has a pre-generated SAMLResponse,
         with {email}, {first_name}, {last_name} placeholders, that can
         be filled out with the data we want.
         """
+        if extra_attributes is None:
+            extra_attributes = {}
         name_parts = name.split(' ')
         first_name = name_parts[0]
         last_name = name_parts[1]
@@ -2206,10 +2208,12 @@ class AppleAuthBackendNativeFlowTest(AppleAuthMixin, SocialAuthBase):
         multiuse_object_key: str='',
         alternative_start_url: Optional[str]=None,
         id_token: Optional[str]=None,
-        account_data_dict: Dict[str, str]={},
+        account_data_dict: Dict[str, str]=None,
         *,
         user_agent: Optional[str]=None,
     ) -> Tuple[str, Dict[str, Any]]:
+        if account_data_dict is None:
+            account_data_dict = {}
         url, headers = super().prepare_login_url_and_headers(
             subdomain, mobile_flow_otp, desktop_flow_otp, is_signup, next,
             multiuse_object_key, alternative_start_url=alternative_start_url,
@@ -3372,7 +3376,9 @@ class ExternalMethodDictsTests(ZulipTestCase):
 
 class FetchAuthBackends(ZulipTestCase):
     def test_get_server_settings(self) -> None:
-        def check_result(result: HttpResponse, extra_fields: Sequence[Tuple[str, Validator[object]]] = []) -> None:
+        def check_result(result: HttpResponse, extra_fields: Sequence[Tuple[str, Validator[object]]] = None) -> None:
+            if extra_fields is None:
+                extra_fields = []
             authentication_methods_list = [
                 ('password', check_bool),
             ]

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -34,9 +34,13 @@ class DocPageTest(ZulipTestCase):
             print("ERROR: {}".format(content.get('msg')))
             print()
 
-    def _test(self, url: str, expected_content: str, extra_strings: Sequence[str]=[],
-              landing_missing_strings: Sequence[str]=[], landing_page: bool=True,
+    def _test(self, url: str, expected_content: str, extra_strings: Sequence[str]=None,
+              landing_missing_strings: Sequence[str]=None, landing_page: bool=True,
               doc_html_str: bool=False) -> None:
+        if extra_strings is None:
+            extra_strings = []
+        if landing_missing_strings is None:
+            landing_missing_strings = []
 
         # Test the URL on the "zephyr" subdomain
         result = self.get_doc(url, subdomain="zephyr")

--- a/zerver/tests/test_type_debug.py
+++ b/zerver/tests/test_type_debug.py
@@ -10,7 +10,9 @@ T = TypeVar('T')
 def add(x: Any=0, y: Any=0) -> Any:
     return x + y
 
-def to_dict(v: Iterable[Tuple[Any, Any]]=[]) -> Dict[Any, Any]:
+def to_dict(v: Iterable[Tuple[Any, Any]]=None) -> Dict[Any, Any]:
+    if v is None:
+        v = []
     return dict(v)
 
 class TypesPrintTest(ZulipTestCase):
@@ -104,7 +106,9 @@ class TypesPrintTest(ZulipTestCase):
         class A(Dict[Any, Any]):
             pass
 
-        def to_A(v: Iterable[Tuple[Any, Any]]=[]) -> A:
+        def to_A(v: Iterable[Tuple[Any, Any]]=None) -> A:
+            if v is None:
+                v = []
             return A(v)
 
         self.check_signature("to_A() -> A([])", A(()), to_A)

--- a/zerver/tornado/django_api.py
+++ b/zerver/tornado/django_api.py
@@ -59,8 +59,10 @@ def request_event_queue(user_profile: UserProfile, user_client: Client, apply_ma
                         client_gravatar: bool, slim_presence: bool, queue_lifespan_secs: int,
                         event_types: Optional[Iterable[str]]=None,
                         all_public_streams: bool=False,
-                        narrow: Iterable[Sequence[str]]=[],
+                        narrow: Iterable[Sequence[str]]=None,
                         bulk_message_deletion: bool=False) -> Optional[str]:
+    if narrow is None:
+        narrow = []
 
     if not settings.USING_TORNADO:
         return None

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -441,9 +441,11 @@ def oauth_redirect_to_root(
     url: str,
     sso_type: str,
     is_signup: bool=False,
-    extra_url_params: Dict[str, str]={},
+    extra_url_params: Dict[str, str]=None,
     next: Optional[str] = REQ(default=None),
 ) -> HttpResponse:
+    if extra_url_params is None:
+        extra_url_params = {}
     main_site_uri = settings.ROOT_DOMAIN_URI + url
     if settings.SOCIAL_AUTH_SUBDOMAIN is not None and sso_type == 'social':
         main_site_uri = (settings.EXTERNAL_URI_SCHEME +


### PR DESCRIPTION
This PR removes dangerous default arguments. 

Do not use a mutable `like` list or `dictionary` as a default value to an argument. Python’s default arguments are evaluated once when the function is defined. Using a mutable default argument and mutating it will mutate that object for all future calls to the function as well.