### PR TITLE
billing: Use name selector for overriding the spin button for licenses

### DIFF
--- a/static/styles/portico/billing.css
+++ b/static/styles/portico/billing.css
@@ -273,11 +273,11 @@
     }
 }
 
-input[type="number"]::-webkit-outer-spin-button,
-input[type="number"]::-webkit-inner-spin-button {
+input[name="licenses"]::-webkit-outer-spin-button,
+input[name="licenses"]::-webkit-inner-spin-button {
     appearance: none;
     margin: 0;
 }
-input[type="number"] {
+input[name="licenses"] {
     appearance: textfield;
 }


### PR DESCRIPTION
We should not  unconditionally disable the expected native functionality for all `<input type="number">` controls. 

PS: At the moment there are only two `<input type="number>` fields and we want both of their spin buttons to be overridden. So functionally, this PR doesn't change any behavior.

Followup of https://github.com/zulip/zulip/pull/16049