### PR TITLE
[WIP] upload: Save file directly to uploads dir or S3 without creating temp file

### DIFF
--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -16,6 +16,7 @@ from zerver.decorator import (
 from zerver.lib.exceptions import MissingAuthenticationError
 from zerver.lib.response import json_method_not_allowed
 from zerver.lib.types import ViewFuncT
+from zerver.lib.upload import is_file_upload_request
 
 METHODS = ('GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH')
 FLAGS = ('override_api_url_scheme')
@@ -84,7 +85,9 @@ def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
 
     # Override requested method if magic method=??? parameter exists
     method_to_use = request.method
-    if request.POST and 'method' in request.POST:
+    # We skip this for file upload urls, since accessing request.POST will
+    # trigger FileUploadHandlers which needs access to request.user.
+    if not is_file_upload_request(request) and request.POST and 'method' in request.POST:
         method_to_use = request.POST['method']
 
     if method_to_use in supported_methods:

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -44,6 +44,7 @@ from zerver.lib.cache import get_cache_backend
 from zerver.lib.db import Params, ParamsT, Query, TimeTrackingCursor
 from zerver.lib.integrations import WEBHOOK_INTEGRATIONS
 from zerver.lib.upload import LocalUploadBackend, S3UploadBackend
+from zerver.lib.uploadhandlers import LocalFileUploadHandler, S3FileUploadHandler
 from zerver.models import (
     Client,
     Message,
@@ -480,10 +481,12 @@ def use_s3_backend(method: FuncT) -> FuncT:
     @override_settings(LOCAL_UPLOADS_DIR=None)
     def new_method(*args: Any, **kwargs: Any) -> Any:
         zerver.lib.upload.upload_backend = S3UploadBackend()
+        zerver.lib.uploadhandlers.ZulipUserFileUploadHandler = S3FileUploadHandler
         try:
             return method(*args, **kwargs)
         finally:
             zerver.lib.upload.upload_backend = LocalUploadBackend()
+            zerver.lib.uploadhandlers.ZulipUserFileUploadHandler = LocalFileUploadHandler
     return new_method
 
 def create_s3_buckets(*bucket_names: str) -> List[ServiceResource]:

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -327,12 +327,14 @@ def get_file_info(request: HttpRequest, user_file: File) -> Tuple[str, int, Opti
 
     return uploaded_file_name, uploaded_file_size, content_type
 
+def get_s3_client() -> Any:
+    return boto3.client('s3', aws_access_key_id=settings.S3_KEY,
+                        aws_secret_access_key=settings.S3_SECRET_KEY,
+                        region_name=settings.S3_REGION,
+                        endpoint_url=settings.S3_ENDPOINT_URL)
 
 def get_signed_upload_url(path: str) -> str:
-    client = boto3.client('s3', aws_access_key_id=settings.S3_KEY,
-                          aws_secret_access_key=settings.S3_SECRET_KEY,
-                          region_name=settings.S3_REGION,
-                          endpoint_url=settings.S3_ENDPOINT_URL)
+    client = get_s3_client()
     return client.generate_presigned_url(ClientMethod='get_object',
                                          Params={
                                              'Bucket': settings.S3_AUTH_UPLOADS_BUCKET,

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -279,6 +279,11 @@ def get_bucket(bucket_name: str, session: Optional[Session]=None) -> ServiceReso
                               endpoint_url=settings.S3_ENDPOINT_URL).Bucket(bucket_name)
     return bucket
 
+def get_content_disposition(content_type: str) -> str:
+    if content_type not in INLINE_MIME_TYPES:
+        return "attachment"
+    return ""
+
 def upload_image_to_s3(
         # See https://github.com/python/typeshed/issues/2706
         bucket: ServiceResource,
@@ -291,15 +296,10 @@ def upload_image_to_s3(
         "user_profile_id": str(user_profile.id),
         "realm_id": str(user_profile.realm_id),
     }
-
-    content_disposition = ''
     if content_type is None:
-        content_type = ''
-    if content_type not in INLINE_MIME_TYPES:
-        content_disposition = "attachment"
-
+        content_type = ""
     key.put(Body=contents, Metadata=metadata, ContentType=content_type,
-            ContentDisposition=content_disposition)
+            ContentDisposition=get_content_disposition(content_type))
 
 def check_upload_within_quota(realm: Realm, uploaded_file_size: int) -> None:
     upload_quota = realm.upload_quota_bytes()

--- a/zerver/lib/uploadhandlers.py
+++ b/zerver/lib/uploadhandlers.py
@@ -1,0 +1,223 @@
+import logging
+import os
+from typing import Any, Callable, Dict, List, Optional, Union
+
+import botocore
+from django.conf import settings
+from django.core.files.uploadedfile import UploadedFile
+from django.core.files.uploadhandler import FileUploadHandler, StopFutureHandlers
+from django.http import HttpRequest
+from django.utils.translation import ugettext as _
+
+from zerver.lib.upload import (
+    check_upload_within_quota,
+    create_attachment,
+    get_file_info,
+    get_s3_client,
+    is_file_upload_request,
+    upload_backend,
+)
+
+logger = logging.getLogger(__name__)
+
+class UploadFileSizeLimitExceeded(Exception):
+    pass
+
+class UploadError(Exception):
+    pass
+
+class S3File(UploadedFile):
+    def __init__(self, name: str, request: HttpRequest, content_type: Optional[str]=None, size: Optional[int]=None, charset: Optional[str]=None,
+                 content_type_extra: Optional[Dict[Any, Any]]=None) -> None:
+        self.path = upload_backend.get_target_file_path(name, request.user.realm)
+        super().__init__(None, name, content_type, size, charset, content_type_extra)
+
+class LocalFile(UploadedFile):
+    def __init__(self, name: str, request: HttpRequest, content_type: Optional[str]=None, size: Optional[int]=None, charset: Optional[str]=None,
+                 content_type_extra: Optional[Dict[Any, Any]]=None) -> None:
+        self.path = upload_backend.get_target_file_path(name, request.user.realm)
+        self.absolute_path = os.path.join(settings.LOCAL_UPLOADS_DIR, "files", self.path)
+        os.makedirs(os.path.dirname(self.absolute_path), exist_ok=True)
+        file = open(self.absolute_path, "wb+")
+
+        super().__init__(file, name, content_type, size, charset, content_type_extra)
+
+    def close(self) -> None:
+        try:
+            self.file.close()
+        except FileNotFoundError:  # nocoverage
+            pass
+class UserFileUploadHandler(FileUploadHandler):
+    def handle_raw_input(self, input_data: HttpRequest, META: Dict[Any, Any], content_length: int, boundary: str, encoding: Optional[str]=None) -> None:
+        if not is_file_upload_request(self.request):
+            self.activated = False
+            return
+
+        self.activated = True
+        if settings.MAX_FILE_UPLOAD_SIZE * 1024 * 1024 < content_length:
+            raise UploadFileSizeLimitExceeded(_("Uploaded file is larger than the allowed limit of {} MiB").format(
+                settings.MAX_FILE_UPLOAD_SIZE,
+            ))
+        check_upload_within_quota(self.request.user.realm, content_length)
+
+        self.file: Optional[Union[S3File, LocalFile]] = None
+        self.file_completed = False
+
+        self.GENERIC_ERROR_MESSAGE = _("Error while uploading the file. Please try again.")
+
+def catch_errors(func: Callable[..., Optional[Union[S3File, bytes]]]) -> Callable[..., Optional[Union[S3File, bytes]]]:
+    def _catch_errors(self: UserFileUploadHandler, *args: Any, **kwargs: Any) -> Optional[Union[S3File, bytes]]:
+        try:
+            return func(self, *args, **kwargs)
+        except botocore.exceptions.ClientError:
+            logger.error("Error during S3 multipart file upload")
+            self.s3_upload_errored = True
+            if func.__name__ == "file_complete":
+                return self.file
+            return None
+        except StopFutureHandlers:
+            raise
+    return _catch_errors
+
+class S3FileUploadHandler(UserFileUploadHandler):
+    @catch_errors
+    def new_file(self, field_name: str, file_name: str, content_type: str, content_length: int, charset: Optional[str]=None,
+                 content_type_extra: Optional[Dict[Any, Any]]=None) -> None:
+        if not self.activated:
+            return
+
+        cleaned_file_name: str
+        self.s3_upload_errored = False
+        self.mpu = {}
+
+        cleaned_file_name, content_type = get_file_info(self.request, file_name)
+        super().new_file(field_name, cleaned_file_name, content_type, content_length, charset, content_type_extra)
+        self.file = S3File(self.file_name, self.request, self.content_type, 0, self.charset, self.content_type_extra)
+        self.bucket = settings.S3_AUTH_UPLOADS_BUCKET
+        self.s3 = get_s3_client()
+        metadata = {
+            "user_profile_id": str(self.request.user.id),
+            "realm_id": str(self.request.user.realm_id),
+        }
+        self.mpu = self.s3.create_multipart_upload(
+            Bucket=self.bucket, Key=self.file.path, Metadata=metadata, ContentType=content_type
+        )
+        self.multipart_content = bytearray()
+        self.multiparts: List[Dict[str, Any]] = []
+        self.multipart_number = 0
+
+        raise StopFutureHandlers()
+
+    @catch_errors
+    def receive_data_chunk(self, raw_data: bytes, start: int) -> Optional[bytes]:
+        if not self.activated:
+            return raw_data
+
+        if self.s3_upload_errored or not self.file:
+            return None
+
+        self.multipart_content.extend(raw_data)
+
+        INITIAL_MULITIPARTS_MIN_SIZE = 5 * 1024 * 1024
+        if len(self.multipart_content) > INITIAL_MULITIPARTS_MIN_SIZE:
+            self.multipart_number += 1
+
+            multipart = self.s3.upload_part(Bucket=self.bucket, Key=self.file.path, PartNumber=self.multipart_number,
+                                            UploadId=self.mpu['UploadId'], Body=self.multipart_content)
+            self.multiparts.append({
+                "PartNumber":  self.multipart_number,
+                "ETag": multipart["ETag"]
+            })
+            self.multipart_content = bytearray()
+
+        return None
+
+    @catch_errors
+    def file_complete(self, file_size: int) -> Optional[S3File]:
+        if not self.activated or not self.file:
+            return None
+
+        if self.s3_upload_errored:
+            return self.file
+
+        if self.multipart_content:
+            self.multipart_number += 1
+            multipart = self.s3.upload_part(Bucket=self.bucket, Key=self.file.path, PartNumber=self.multipart_number,
+                                            UploadId=self.mpu['UploadId'], Body=self.multipart_content)
+            self.multiparts.append({
+                "PartNumber":  self.multipart_number,
+                "ETag": multipart["ETag"]
+            })
+
+        part_info = {}
+        part_info["Parts"] = self.multiparts
+        self.s3.complete_multipart_upload(Bucket=self.bucket, Key=self.file.path, UploadId=self.mpu['UploadId'],
+                                          MultipartUpload=part_info)
+        create_attachment(self.file.name, self.file.path, self.request.user, file_size)
+        self.file_completed = True
+        return self.file
+
+    def upload_complete(self) -> None:
+        if not self.activated or not self.file:
+            return
+
+        if not self.s3_upload_errored and self.file_completed:
+            return
+
+        if self.mpu:
+            try:
+                self.s3.abort_multipart_upload(
+                    Bucket=self.bucket,
+                    Key=self.file.path,
+                    UploadId=self.mpu['UploadId'],
+                )
+            except botocore.exceptions.ClientError:
+                logger.error("Error while aborting S3 multipart file upload")
+                pass
+
+        raise UploadError(self.GENERIC_ERROR_MESSAGE)
+
+class LocalFileUploadHandler(UserFileUploadHandler):
+    def new_file(self, field_name: str, file_name: str, content_type: str, content_length: int, charset: Optional[str]=None,
+                 content_type_extra: Optional[Dict[Any, Any]]=None) -> None:
+        if not self.activated:
+            return
+
+        cleaned_file_name, _ = get_file_info(self.request, file_name)
+        super().new_file(field_name, cleaned_file_name, content_type, content_length, charset, content_type_extra)
+        self.file = LocalFile(self.file_name, self.request, self.content_type, 0, self.charset, self.content_type_extra)
+        raise StopFutureHandlers()
+
+    def receive_data_chunk(self, raw_data: bytes, start: int) -> Optional[bytes]:
+        if not self.activated or not self.file:
+            return raw_data
+        self.file.write(raw_data)
+        return None
+
+    def file_complete(self, file_size: int) -> Optional[LocalFile]:
+        if not self.activated or not self.file:
+            return None
+
+        self.file.seek(0)
+        self.file.size = file_size
+        create_attachment(self.file.name, self.file.path, self.request.user, file_size)
+        self.file_completed = True
+        return self.file
+
+    def upload_complete(self) -> None:
+        if not self.activated or not self.file:
+            return
+
+        if self.file_completed:
+            return
+
+        try:
+            os.remove(self.file.absolute_path)
+        except FileNotFoundError:  # nocoverage
+            pass
+        raise UploadError(self.GENERIC_ERROR_MESSAGE)
+
+if settings.LOCAL_UPLOADS_DIR is not None:
+    ZulipUserFileUploadHandler: Any  = LocalFileUploadHandler
+else:
+    ZulipUserFileUploadHandler = S3FileUploadHandler  # nocoverage

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -31,6 +31,8 @@ from zerver.lib.request import set_request, unset_request
 from zerver.lib.response import json_error, json_response_from_error, json_unauthorized
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.types import ViewFuncT
+from zerver.lib.upload import RealmUploadQuotaError
+from zerver.lib.uploadhandlers import UploadError, UploadFileSizeLimitExceeded
 from zerver.lib.utils import statsd
 from zerver.models import Realm, flush_per_request_caches, get_realm
 
@@ -330,6 +332,9 @@ class JsonErrorHandler(MiddlewareMixin):
             else:
                 # For /json routes, ask for session authentication.
                 return json_unauthorized(www_authenticate='session')
+
+        if isinstance(exception, (UploadFileSizeLimitExceeded, RealmUploadQuotaError, UploadError)):
+            return json_error(str(exception), status=422)
 
         if isinstance(exception, JsonableError):
             return json_response_from_error(exception)

--- a/zerver/views/upload.py
+++ b/zerver/views/upload.py
@@ -10,12 +10,10 @@ from django_sendfile import sendfile
 from zerver.lib.response import json_error, json_success
 from zerver.lib.upload import (
     INLINE_MIME_TYPES,
-    check_upload_within_quota,
     generate_unauthed_file_access_url,
     get_local_file_path,
     get_local_file_path_id_from_token,
     get_signed_upload_url,
-    upload_message_image_from_request,
 )
 from zerver.models import UserProfile, validate_attachment_request
 
@@ -103,14 +101,5 @@ def upload_file_backend(request: HttpRequest, user_profile: UserProfile) -> Http
         return json_error(_("You must specify a file to upload"))
     if len(request.FILES) != 1:
         return json_error(_("You may only upload one file at a time"))
-
-    user_file = list(request.FILES.values())[0]
-    file_size = user_file.size
-    if settings.MAX_FILE_UPLOAD_SIZE * 1024 * 1024 < file_size:
-        return json_error(_("Uploaded file is larger than the allowed limit of {} MiB").format(
-            settings.MAX_FILE_UPLOAD_SIZE,
-        ))
-    check_upload_within_quota(user_profile.realm, file_size)
-
-    uri = upload_message_image_from_request(request, user_file, user_profile)
-    return json_success({'uri': uri})
+    for key in request.FILES:
+        return json_success({'uri': "/user_uploads/" + request.FILES[key].path})

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -433,6 +433,10 @@ ROOT_DOMAIN_URI = EXTERNAL_URI_SCHEME + EXTERNAL_HOST
 S3_KEY = get_secret("s3_key")
 S3_SECRET_KEY = get_secret("s3_secret_key")
 
+if DEVELOPMENT:
+    S3_AUTH_UPLOADS_BUCKET = get_secret("s3_auth_uploads_bucket", "")
+    S3_AVATAR_BUCKET = get_secret("s3_avatar_bucket", "")
+
 if LOCAL_UPLOADS_DIR is not None:
     if SENDFILE_BACKEND is None:
         SENDFILE_BACKEND = 'django_sendfile.backends.nginx'

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -559,6 +559,12 @@ LOCALE_PATHS = (os.path.join(DEPLOY_ROOT, 'locale'),)
 # We want all temporary uploaded files to be stored on disk.
 FILE_UPLOAD_MAX_MEMORY_SIZE = 0
 
+FILE_UPLOAD_HANDLERS = [
+    'zerver.lib.uploadhandlers.ZulipUserFileUploadHandler',
+    'django.core.files.uploadhandler.MemoryFileUploadHandler',
+    'django.core.files.uploadhandler.TemporaryFileUploadHandler'
+]
+
 STATICFILES_DIRS = ['static/']
 
 if DEBUG:


### PR DESCRIPTION
Not ready for a review yet.

See https://chat.zulip.org/#narrow/stream/2-general/topic/TUS for more details

Todo

- [x] Set metada of S3 file

- [x] Take care of return value of `s3FileUploadHandler.file_complete`

-  [x] Set the path of in the file returned by UploadHandler

- [x] Add checks for multiple files/no file case.

- [x] Handle errors during upload
    * Abort the S3 multipart upload
    * Delete the local file.


- [ ] Update Nginx config files to disable request buffering for upload endpoint

- [ ] docs:  Mention the bucket lifecycle rule that can be enabled to automatically abort incomplete multi part uploads
https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html. Likely not required since we are aborting the upload in case of error.

- [x] Tests 
