### PR TITLE
wsl_dev_setup: Warn user about cloning inside windows mounted disk.

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -88,6 +88,13 @@ Store.
    NODE_PORT=5672
    ```
 
+1. Make sure you are inside the WSL disk and not in a Windows mounted disk.
+   You will run into permission issues if you run `provision` from `zulip`
+   in a Windows mounted disk.
+   ```
+   cd ~  # or cd /home/USERNAME
+   ```
+
 1. [Clone your fork of the Zulip repository][zulip-rtd-git-cloning]
    and [connecting the Zulip upstream repository][zulip-rtd-git-connect]:
 


### PR DESCRIPTION
Based on recent discussion in https://chat.zulip.org/#narrow/stream/95-new-members/topic/sushanth.20reddy.20manda