### PR TITLE
Handle race conditions caused by deleting a message and editing it.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2189,7 +2189,7 @@ def notify_reaction_update(
         stream = Stream.objects.get(id=stream_id)
         user_ids |= subscriber_ids_with_stream_history_access(stream)
 
-    send_event(user_profile.realm, event, list(user_ids))
+    transaction.on_commit(lambda: send_event(user_profile.realm, event, list(user_ids)))
 
 
 def do_add_reaction(
@@ -2199,6 +2199,11 @@ def do_add_reaction(
     emoji_code: str,
     reaction_type: str,
 ) -> None:
+    """Should be called while holding a SELECT FOR UPDATE lock
+    (e.g. via access_message(..., lock_message=True)) on the
+    Message row, to prevent race conditions.
+    """
+
     reaction = Reaction(
         user_profile=user_profile,
         message=message,
@@ -2206,13 +2211,8 @@ def do_add_reaction(
         emoji_code=emoji_code,
         reaction_type=reaction_type,
     )
-    try:
-        reaction.save()
-    except django.db.utils.IntegrityError:  # nocoverage
-        # This can happen when a race results in the check in views
-        # code not catching an attempt to double-add a reaction, or
-        # perhaps if the emoji_name/emoji_code mapping is busted.
-        raise JsonableError(_("Reaction already exists."))
+
+    reaction.save()
 
     notify_reaction_update(user_profile, message, reaction, "add")
 
@@ -2225,7 +2225,7 @@ def check_add_reaction(
     reaction_type: Optional[str],
 ) -> None:
     message, user_message = access_message(
-        user_profile, message_id, lock_message=False, lock_usermessage=False
+        user_profile, message_id, lock_message=True, lock_usermessage=False
     )
 
     if emoji_code is None:
@@ -2292,6 +2292,10 @@ def check_add_reaction(
 def do_remove_reaction(
     user_profile: UserProfile, message: Message, emoji_code: str, reaction_type: str
 ) -> None:
+    """Should be called while holding a SELECT FOR UPDATE lock
+    (e.g. via access_message(..., lock_message=True)) on the
+    Message row, to prevent race conditions.
+    """
     reaction = Reaction.objects.filter(
         user_profile=user_profile,
         message=message,
@@ -2299,6 +2303,7 @@ def do_remove_reaction(
         reaction_type=reaction_type,
     ).get()
     reaction.delete()
+
     notify_reaction_update(user_profile, message, reaction, "remove")
 
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2220,7 +2220,9 @@ def check_add_reaction(
     emoji_code: Optional[str],
     reaction_type: Optional[str],
 ) -> None:
-    message, user_message = access_message(user_profile, message_id)
+    message, user_message = access_message(
+        user_profile, message_id, lock_message=False, lock_usermessage=False
+    )
 
     if emoji_code is None:
         # The emoji_code argument is only required for rare corner
@@ -5274,7 +5276,9 @@ def do_update_message_flags(
         if flag != "starred":
             raise JsonableError(_("Invalid message(s)"))
         # Validate that the user could have read the relevant message
-        message = access_message(user_profile, messages[0])[0]
+        message = access_message(
+            user_profile, messages[0], lock_message=False, lock_usermessage=False
+        )[0]
 
         # OK, this is a message that you legitimately have access
         # to via narrowing to the stream it is on, even though you

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -1,6 +1,7 @@
 from typing import Dict, List
 
 from django.conf import settings
+from django.db import transaction
 from django.db.models import Count
 from django.utils.translation import gettext as _
 
@@ -116,6 +117,9 @@ def send_welcome_bot_response(send_request: SendMessageRequest) -> None:
         internal_send_private_message(welcome_bot, send_request.message.sender, content)
 
 
+# transaction.atomic is required to support SELECT FOR UPDATE query
+# before the do_add_reaction call.
+@transaction.atomic
 def send_initial_realm_messages(realm: Realm) -> None:
     welcome_bot = get_system_bot(settings.WELCOME_BOT)
     # Make sure each stream created in the realm creation process has at least one message below
@@ -206,6 +210,8 @@ def send_initial_realm_messages(realm: Realm) -> None:
     # We find the one of our just-sent messages with turtle.png in it,
     # and react to it.  This is a bit hacky, but works and is kinda a
     # 1-off thing.
-    turtle_message = Message.objects.get(id__in=message_ids, content__icontains="cute/turtle.png")
+    turtle_message = Message.objects.select_for_update().get(
+        id__in=message_ids, content__icontains="cute/turtle.png"
+    )
     (emoji_code, reaction_type) = emoji_name_to_emoji_code(realm, "turtle")
     do_add_reaction(welcome_bot, turtle_message, "turtle", emoji_code, reaction_type)

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -856,48 +856,55 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
     ):
         return
 
-    try:
-        (message, user_message) = access_message(
-            user_profile, missed_message["message_id"], lock_message=False, lock_usermessage=False
-        )
-    except JsonableError:
-        if ArchivedMessage.objects.filter(id=missed_message["message_id"]).exists():
-            # If the cause is a race with the message being deleted,
-            # that's normal and we have no need to log an error.
-            return
-        logging.info(
-            "Unexpected message access failure handling push notifications: %s %s",
-            user_profile.id,
-            missed_message["message_id"],
-        )
-        return
-
-    if user_message is not None:
-        # If the user has read the message already, don't push-notify.
-        #
-        # TODO: It feels like this is already handled when things are
-        # put in the queue; maybe we should centralize this logic with
-        # the `zerver/tornado/event_queue.py` logic?
-        if user_message.flags.read or user_message.flags.active_mobile_push_notification:
-            return
-
-        # Otherwise, we mark the message as having an active mobile
-        # push notification, so that we can send revocation messages
-        # later.
-        user_message.flags.active_mobile_push_notification = True
-        user_message.save(update_fields=["flags"])
-    else:
-        # Users should only be getting push notifications into this
-        # queue for messages they haven't received if they're
-        # long-term idle; anything else is likely a bug.
-        if not user_profile.long_term_idle:
-            logger.error(
-                "Could not find UserMessage with message_id %s and user_id %s",
+    # transaction.atomic is required since we use FOR UPDATE queries in access_message.
+    # We don't use the decorator for the function to make sure the RabbitMQ
+    # work happens outside the database transaction.
+    with transaction.atomic():
+        try:
+            (message, user_message) = access_message(
+                user_profile,
                 missed_message["message_id"],
-                user_profile_id,
-                exc_info=True,
+                lock_message=False,
+                lock_usermessage=False,
+            )
+        except JsonableError:
+            if ArchivedMessage.objects.filter(id=missed_message["message_id"]).exists():
+                # If the cause is a race with the message being deleted,
+                # that's normal and we have no need to log an error.
+                return
+            logging.info(
+                "Unexpected message access failure handling push notifications: %s %s",
+                user_profile.id,
+                missed_message["message_id"],
             )
             return
+
+        if user_message is not None:
+            # If the user has read the message already, don't push-notify.
+            #
+            # TODO: It feels like this is already handled when things are
+            # put in the queue; maybe we should centralize this logic with
+            # the `zerver/tornado/event_queue.py` logic?
+            if user_message.flags.read or user_message.flags.active_mobile_push_notification:
+                return
+
+            # Otherwise, we mark the message as having an active mobile
+            # push notification, so that we can send revocation messages
+            # later.
+            user_message.flags.active_mobile_push_notification = True
+            user_message.save(update_fields=["flags"])
+        else:
+            # Users should only be getting push notifications into this
+            # queue for messages they haven't received if they're
+            # long-term idle; anything else is likely a bug.
+            if not user_profile.long_term_idle:
+                logger.error(
+                    "Could not find UserMessage with message_id %s and user_id %s",
+                    missed_message["message_id"],
+                    user_profile_id,
+                    exc_info=True,
+                )
+                return
 
     message.trigger = missed_message["trigger"]
 

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -857,7 +857,9 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
         return
 
     try:
-        (message, user_message) = access_message(user_profile, missed_message["message_id"])
+        (message, user_message) = access_message(
+            user_profile, missed_message["message_id"], lock_message=False, lock_usermessage=False
+        )
     except JsonableError:
         if ArchivedMessage.objects.filter(id=missed_message["message_id"]).exists():
             # If the cause is a race with the message being deleted,

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1265,7 +1265,10 @@ Output:
         # Some code might call process_notification using keyword arguments,
         # so mypy doesn't allow assigning lst.append to process_notification
         # So explicitly change parameter name to 'notice' to work around this problem
-        yield
+
+        with self.captureOnCommitCallbacks(execute=True):
+            yield
+
         django_tornado_api.process_notification = real_event_queue_process_notification
 
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -15,7 +15,6 @@ from typing import (
     Iterable,
     Iterator,
     List,
-    Mapping,
     Optional,
     Tuple,
     TypeVar,
@@ -55,7 +54,6 @@ from zerver.models import (
     get_realm,
     get_stream,
 )
-from zerver.tornado import django_api as django_tornado_api
 from zerver.tornado.handlers import AsyncDjangoHandler, allocate_handler_id
 from zerver.worker import queue_processors
 from zproject.backends import ExternalAuthDataDict, ExternalAuthResult
@@ -92,19 +90,6 @@ def stub_event_queue_user_events(
 def simulated_queue_client(client: Callable[[], object]) -> Iterator[None]:
     with mock.patch.object(queue_processors, "SimpleQueueClient", client):
         yield
-
-
-@contextmanager
-def tornado_redirected_to_list(lst: List[Mapping[str, Any]]) -> Iterator[None]:
-    real_event_queue_process_notification = django_tornado_api.process_notification
-    django_tornado_api.process_notification = lambda notice: lst.append(notice)
-    # process_notification takes a single parameter called 'notice'.
-    # lst.append takes a single argument called 'object'.
-    # Some code might call process_notification using keyword arguments,
-    # so mypy doesn't allow assigning lst.append to process_notification
-    # So explicitly change parameter name to 'notice' to work around this problem
-    yield
-    django_tornado_api.process_notification = real_event_queue_process_notification
 
 
 class EventInfo:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -2542,12 +2542,14 @@ class UserMessage(AbstractUserMessage):
 
 
 def get_usermessage_by_message_id(
-    user_profile: UserProfile, message_id: int
+    user_profile: UserProfile, message_id: int, lock_usermessage: bool
 ) -> Optional[UserMessage]:
     try:
-        return UserMessage.objects.select_related().get(
-            user_profile=user_profile, message_id=message_id
-        )
+        base_query = UserMessage.objects.select_related()
+        if lock_usermessage:
+            base_query = base_query.select_for_update()
+        usermessage = base_query.get(user_profile=user_profile, message_id=message_id)
+        return usermessage
     except UserMessage.DoesNotExist:
         return None
 

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -17,12 +17,7 @@ from zerver.lib.bot_config import ConfigError, get_bot_config
 from zerver.lib.bot_lib import get_bot_handler
 from zerver.lib.integrations import EMBEDDED_BOTS, WebhookIntegration
 from zerver.lib.test_classes import UploadSerializeMixin, ZulipTestCase
-from zerver.lib.test_helpers import (
-    avatar_disk_path,
-    get_test_image_file,
-    queries_captured,
-    tornado_redirected_to_list,
-)
+from zerver.lib.test_helpers import avatar_disk_path, get_test_image_file, queries_captured
 from zerver.models import (
     Realm,
     Service,
@@ -171,7 +166,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.login("hamlet")
         self.assert_num_bots_equal(0)
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.create_bot()
         self.assert_num_bots_equal(1)
 
@@ -337,7 +332,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.login_user(user)
         self.assert_num_bots_equal(0)
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.create_bot()
         self.assert_num_bots_equal(1)
 
@@ -391,7 +386,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             "principals": '["' + iago.email + '"]',
         }
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.common_subscribe_to_streams(hamlet, ["Rome"], request_data)
             self.assert_json_success(result)
 
@@ -408,7 +403,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             "principals": '["hambot-bot@zulip.testserver"]',
         }
         events_bot: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events_bot):
+        with self.tornado_redirected_to_list(events_bot):
             result = self.common_subscribe_to_streams(hamlet, ["Rome"], bot_request_data)
             self.assert_json_success(result)
 
@@ -429,7 +424,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         self.assert_num_bots_equal(0)
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.create_bot(default_sending_stream="Denmark")
         self.assert_num_bots_equal(1)
         self.assertEqual(result["default_sending_stream"], "Denmark")
@@ -501,7 +496,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         self.assert_num_bots_equal(0)
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.create_bot(default_events_register_stream="Denmark")
         self.assert_num_bots_equal(1)
         self.assertEqual(result["default_events_register_stream"], "Denmark")

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -275,7 +275,10 @@ class BaseAction(ZulipTestCase):
             include_subscribers=include_subscribers,
             include_streams=include_streams,
         )
-        action()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            action()
+
         events = client.event_queue.contents()
         content = {
             "queue_id": "123.12",

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -16,7 +16,7 @@ from zerver.lib.message import (
     get_raw_unread_data,
 )
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import get_subscription, tornado_redirected_to_list
+from zerver.lib.test_helpers import get_subscription
 from zerver.lib.topic_mutes import add_topic_mute
 from zerver.models import (
     Message,
@@ -225,7 +225,7 @@ class UnreadCountTests(ZulipTestCase):
         )
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.client_post(
                 "/json/mark_stream_as_read",
                 {
@@ -296,7 +296,7 @@ class UnreadCountTests(ZulipTestCase):
             self.example_user("hamlet"), "Denmark", "hello", "Denmark2"
         )
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.client_post(
                 "/json/mark_topic_as_read",
                 {

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -10,7 +10,7 @@ from zerver.lib.emoji import emoji_name_to_emoji_code
 from zerver.lib.message import extract_message_dict
 from zerver.lib.request import JsonableError
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import tornado_redirected_to_list, zulip_reaction_info
+from zerver.lib.test_helpers import zulip_reaction_info
 from zerver.models import Message, Reaction, RealmEmoji, UserMessage, get_realm
 
 
@@ -418,7 +418,7 @@ class ReactionEventTest(ZulipTestCase):
         }
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.api_post(
                 reaction_sender, f"/api/v1/messages/{pm_id}/reactions", reaction_info
             )
@@ -463,7 +463,7 @@ class ReactionEventTest(ZulipTestCase):
         self.assert_json_success(add)
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.api_delete(
                 reaction_sender, f"/api/v1/messages/{pm_id}/reactions", reaction_info
             )
@@ -502,7 +502,7 @@ class ReactionEventTest(ZulipTestCase):
         # Hamlet and Polonius joined after the message was sent, and
         # so only Iago should receive the event.
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.api_post(
                 iago, f"/api/v1/messages/{message_before_id}/reactions", reaction_info
             )
@@ -523,7 +523,7 @@ class ReactionEventTest(ZulipTestCase):
             iago, "test_reactions_stream", "after subscription history private"
         )
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.api_post(
                 iago, f"/api/v1/messages/{message_after_id}/reactions", reaction_info
             )
@@ -544,7 +544,7 @@ class ReactionEventTest(ZulipTestCase):
         # message_before_id should notify all subscribers:
         # Iago and Hamlet.
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.api_post(
                 iago, f"/api/v1/messages/{message_before_id}/reactions", reaction_info
             )
@@ -564,7 +564,7 @@ class ReactionEventTest(ZulipTestCase):
         # For is_web_public streams, events even on old messages
         # should go to all subscribers, including guests like polonius.
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.api_post(
                 iago, f"/api/v1/messages/{message_before_id}/reactions", reaction_info
             )
@@ -586,7 +586,7 @@ class ReactionEventTest(ZulipTestCase):
             "hello to single receiver",
         )
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.api_post(
                 hamlet, f"/api/v1/messages/{private_message_id}/reactions", reaction_info
             )
@@ -604,7 +604,7 @@ class ReactionEventTest(ZulipTestCase):
             "hello message to muliple receiver",
         )
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.api_post(
                 polonius, f"/api/v1/messages/{huddle_message_id}/reactions", reaction_info
             )
@@ -1035,7 +1035,7 @@ class ReactionAPIEventTest(EmojiReactionBase):
             "reaction_type": "unicode_emoji",
         }
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             self.api_post(reaction_sender, f"/api/v1/messages/{pm_id}/reactions", reaction_info)
 
         self.assertEqual(len(events), 1)
@@ -1077,7 +1077,7 @@ class ReactionAPIEventTest(EmojiReactionBase):
         self.assert_json_success(add)
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.api_delete(
                 reaction_sender,
                 f"/api/v1/messages/{pm_id}/reactions",

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -22,7 +22,7 @@ from zerver.lib.realm_description import get_realm_rendered_description, get_rea
 from zerver.lib.send_email import send_future_email
 from zerver.lib.streams import create_stream_if_needed
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import reset_emails_in_zulip_realm, tornado_redirected_to_list
+from zerver.lib.test_helpers import reset_emails_in_zulip_realm
 from zerver.models import (
     Attachment,
     CustomProfileField,
@@ -70,7 +70,7 @@ class RealmTest(ZulipTestCase):
         realm = get_realm("zulip")
         new_name = "Puliz"
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             do_set_realm_property(realm, "name", new_name, acting_user=None)
         event = events[0]["event"]
         self.assertEqual(
@@ -87,7 +87,7 @@ class RealmTest(ZulipTestCase):
         realm = get_realm("zulip")
         new_description = "zulip dev group"
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             do_set_realm_property(realm, "description", new_description, acting_user=None)
         event = events[0]["event"]
         self.assertEqual(
@@ -105,7 +105,7 @@ class RealmTest(ZulipTestCase):
         new_description = "zulip dev group"
         data = dict(description=new_description)
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.client_patch("/json/realm", data)
             self.assert_json_success(result)
             realm = get_realm("zulip")

--- a/zerver/tests/test_submessage.py
+++ b/zerver/tests/test_submessage.py
@@ -115,7 +115,8 @@ class TestBasics(ZulipTestCase):
             content='{"name": "alice", "salary": 20}',
         )
         with mock.patch("zerver.lib.actions.send_event") as m:
-            result = self.client_post("/json/submessage", payload)
+            with self.captureOnCommitCallbacks(execute=True):
+                result = self.client_post("/json/submessage", payload)
         self.assert_json_success(result)
 
         submessage = SubMessage.objects.get(message_id=message_id)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -67,7 +67,6 @@ from zerver.lib.test_helpers import (
     most_recent_usermessage,
     queries_captured,
     reset_emails_in_zulip_realm,
-    tornado_redirected_to_list,
 )
 from zerver.models import (
     DefaultStream,
@@ -123,7 +122,7 @@ class TestCreateStreams(ZulipTestCase):
 
         # Test stream creation events.
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             ensure_stream(realm, "Public stream", invite_only=False, acting_user=None)
         self.assert_length(events, 1)
 
@@ -134,7 +133,7 @@ class TestCreateStreams(ZulipTestCase):
         self.assertEqual(events[0]["event"]["streams"][0]["name"], "Public stream")
 
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             ensure_stream(realm, "Private stream", invite_only=True, acting_user=None)
         self.assert_length(events, 1)
 
@@ -711,7 +710,7 @@ class StreamAdminTest(ZulipTestCase):
         self.subscribe(self.example_user("cordelia"), "private_stream")
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             stream_id = get_stream("private_stream", user_profile.realm).id
             result = self.client_patch(
                 f"/json/streams/{stream_id}",
@@ -730,7 +729,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertNotIn(prospero.id, notified_user_ids)
 
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             stream_id = get_stream("private_stream", user_profile.realm).id
             result = self.client_patch(
                 f"/json/streams/{stream_id}", {"new_name": orjson.dumps("whatever").decode()}
@@ -779,7 +778,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_json_success(result)
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             stream_id = get_stream("stream_name1", user_profile.realm).id
             result = self.client_patch(
                 f"/json/streams/{stream_id}", {"new_name": orjson.dumps("stream_name2").decode()}
@@ -811,7 +810,7 @@ class StreamAdminTest(ZulipTestCase):
 
         # Test case to handle Unicode stream name change
         # *NOTE: Here encoding is needed when Unicode string is passed as an argument*
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             stream_id = stream_name2_exists.id
             result = self.client_patch(
                 f"/json/streams/{stream_id}", {"new_name": orjson.dumps("नया नाम").decode()}
@@ -824,7 +823,7 @@ class StreamAdminTest(ZulipTestCase):
         # Test case to handle changing of Unicode stream name to newer name
         # NOTE: Unicode string being part of URL is handled cleanly
         # by client_patch call, encoding of URL is not needed.
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             stream_id = stream_name_uni_exists.id
             result = self.client_patch(
                 f"/json/streams/{stream_id}",
@@ -838,7 +837,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertTrue(stream_name_new_uni_exists)
 
         # Test case to change name from one language to other.
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             stream_id = stream_name_new_uni_exists.id
             result = self.client_patch(
                 f"/json/streams/{stream_id}", {"new_name": orjson.dumps("français").decode()}
@@ -848,7 +847,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertTrue(stream_name_fr_exists)
 
         # Test case to change name to mixed language name.
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             stream_id = stream_name_fr_exists.id
             result = self.client_patch(
                 f"/json/streams/{stream_id}", {"new_name": orjson.dumps("français name").decode()}
@@ -863,7 +862,7 @@ class StreamAdminTest(ZulipTestCase):
         )
         self.subscribe(self.example_user("cordelia"), "stream_private_name1")
         del events[:]
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             stream_id = get_stream("stream_private_name1", realm).id
             result = self.client_patch(
                 f"/json/streams/{stream_id}",
@@ -893,7 +892,7 @@ class StreamAdminTest(ZulipTestCase):
             acting_user=None,
         )
         del events[:]
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.client_patch(
                 f"/json/streams/{new_stream.id}",
                 {"new_name": orjson.dumps("stream_rename").decode()},
@@ -1022,7 +1021,7 @@ class StreamAdminTest(ZulipTestCase):
         self.subscribe(user_profile, "stream_name1")
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             stream_id = get_stream("stream_name1", realm).id
             result = self.client_patch(
                 f"/json/streams/{stream_id}",
@@ -1094,7 +1093,7 @@ class StreamAdminTest(ZulipTestCase):
             acting_user=None,
         )
 
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             stream_id = get_stream("stream_name1", realm).id
             result = self.client_patch(
                 f"/json/streams/{stream_id}",
@@ -1214,7 +1213,7 @@ class StreamAdminTest(ZulipTestCase):
 
         do_change_plan_type(realm, Realm.SELF_HOSTED, acting_user=None)
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.client_patch(
                 f"/json/streams/{stream.id}", {"message_retention_days": orjson.dumps(2).decode()}
             )
@@ -1242,7 +1241,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertEqual(stream.message_retention_days, 2)
 
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.client_patch(
                 f"/json/streams/{stream.id}",
                 {"message_retention_days": orjson.dumps("forever").decode()},
@@ -1265,7 +1264,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertEqual(stream.message_retention_days, -1)
 
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.client_patch(
                 f"/json/streams/{stream.id}",
                 {"message_retention_days": orjson.dumps("realm_default").decode()},
@@ -1415,7 +1414,7 @@ class StreamAdminTest(ZulipTestCase):
         ensure_stream(realm, "DB32B77" + "!DEACTIVATED:" + active_name, acting_user=None)
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.client_delete("/json/streams/" + str(stream_id))
         self.assert_json_success(result)
 
@@ -2567,7 +2566,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
 
         events: List[Mapping[str, Any]] = []
         property_name = "is_muted"
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.api_post(
                 test_user,
                 "/api/v1/users/me/subscriptions/properties",
@@ -2596,7 +2595,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
 
         events = []
         legacy_property_name = "in_home_view"
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.api_post(
                 test_user,
                 "/api/v1/users/me/subscriptions/properties",
@@ -2625,7 +2624,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         self.assertEqual(sub.is_muted, False)
 
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.api_post(
                 test_user,
                 "/api/v1/users/me/subscriptions/properties",
@@ -3084,7 +3083,7 @@ class SubscriptionAPITest(ZulipTestCase):
         add_streams = ["Verona2", "Denmark5"]
         self.assertNotEqual(len(add_streams), 0)  # necessary for full test coverage
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             self.helper_check_subs_before_and_after_add(
                 self.streams + add_streams,
                 {},
@@ -3115,7 +3114,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.test_realm.notifications_stream_id = notifications_stream.id
         self.test_realm.save()
 
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             self.helper_check_subs_before_and_after_add(
                 self.streams + add_streams,
                 other_params,
@@ -3534,7 +3533,7 @@ class SubscriptionAPITest(ZulipTestCase):
         streams_to_sub = ["multi_user_stream"]
         events: List[Mapping[str, Any]] = []
         flush_per_request_caches()
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             with queries_captured() as queries:
                 self.common_subscribe_to_streams(
                     self.test_user,
@@ -3561,7 +3560,7 @@ class SubscriptionAPITest(ZulipTestCase):
 
         # Now add ourselves
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             with queries_captured() as queries:
                 self.common_subscribe_to_streams(
                     self.test_user,
@@ -3596,7 +3595,7 @@ class SubscriptionAPITest(ZulipTestCase):
         user3 = user_profile
         realm3 = user_profile.realm
         stream = get_stream("multi_user_stream", realm)
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             bulk_add_subscriptions(realm, [stream], [user_profile], acting_user=None)
 
         self.assert_length(events, 2)
@@ -3632,7 +3631,7 @@ class SubscriptionAPITest(ZulipTestCase):
         user_profile = self.example_user("cordelia")
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             bulk_add_subscriptions(realm, [stream], [user_profile], acting_user=None)
 
         self.assert_length(events, 3)
@@ -3664,7 +3663,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # private stream creation event on stream creation.
         new_stream = ensure_stream(realm, "private stream", invite_only=True, acting_user=None)
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             bulk_add_subscriptions(
                 realm, [new_stream], [self.example_user("iago")], acting_user=None
             )
@@ -3796,7 +3795,7 @@ class SubscriptionAPITest(ZulipTestCase):
 
         new_user_ids_to_subscribe = [iago.id, cordelia.id]
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             self.common_subscribe_to_streams(
                 self.test_user,
                 streams_to_sub,
@@ -3845,7 +3844,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.subscribe(user3, "private_stream")
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             with queries_captured() as query_count:
                 with cache_tries_captured() as cache_count:
                     bulk_remove_subscriptions(
@@ -3902,7 +3901,7 @@ class SubscriptionAPITest(ZulipTestCase):
             stream.save()
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             with queries_captured() as queries:
                 self.common_subscribe_to_streams(
                     mit_user,
@@ -3917,7 +3916,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assert_length(queries, 4)
 
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             bulk_remove_subscriptions(
                 users=[mit_user],
                 streams=streams,

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -3,7 +3,7 @@ from typing import Any, List, Mapping
 import orjson
 
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import queries_captured, tornado_redirected_to_list
+from zerver.lib.test_helpers import queries_captured
 from zerver.models import Huddle, get_huddle_hash
 
 
@@ -149,7 +149,7 @@ class TypingHappyPathTestPMs(ZulipTestCase):
 
         events: List[Mapping[str, Any]] = []
         with queries_captured() as queries:
-            with tornado_redirected_to_list(events):
+            with self.tornado_redirected_to_list(events):
                 result = self.api_post(sender, "/api/v1/typing", params)
 
         self.assert_json_success(result)
@@ -186,7 +186,7 @@ class TypingHappyPathTestPMs(ZulipTestCase):
         )
 
         with queries_captured() as queries:
-            with tornado_redirected_to_list(events):
+            with self.tornado_redirected_to_list(events):
                 result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)
@@ -219,7 +219,7 @@ class TypingHappyPathTestPMs(ZulipTestCase):
         expected_recipient_emails = {email}
         expected_recipient_ids = {user.id}
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.api_post(
                 user,
                 "/api/v1/typing",
@@ -260,7 +260,7 @@ class TypingHappyPathTestPMs(ZulipTestCase):
         )
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.api_post(sender, "/api/v1/typing", params)
 
         self.assert_json_success(result)
@@ -289,7 +289,7 @@ class TypingHappyPathTestPMs(ZulipTestCase):
         expected_recipient_ids = {user.id}
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             params = dict(
                 to=orjson.dumps([user.id]).decode(),
                 op="stop",
@@ -323,7 +323,7 @@ class TypingHappyPathTestPMs(ZulipTestCase):
         expected_recipient_ids = {user.id for user in expected_recipients}
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             params = dict(
                 to=orjson.dumps([recipient.id]).decode(),
                 op="stop",
@@ -367,7 +367,7 @@ class TypingHappyPathTestStreams(ZulipTestCase):
 
         events: List[Mapping[str, Any]] = []
         with queries_captured() as queries:
-            with tornado_redirected_to_list(events):
+            with self.tornado_redirected_to_list(events):
                 result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)
@@ -403,7 +403,7 @@ class TypingHappyPathTestStreams(ZulipTestCase):
 
         events: List[Mapping[str, Any]] = []
         with queries_captured() as queries:
-            with tornado_redirected_to_list(events):
+            with self.tornado_redirected_to_list(events):
                 result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
         self.assertEqual(len(events), 1)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -38,7 +38,6 @@ from zerver.lib.test_helpers import (
     queries_captured,
     reset_emails_in_zulip_realm,
     simulated_empty_cache,
-    tornado_redirected_to_list,
 )
 from zerver.lib.topic_mutes import add_topic_mute
 from zerver.lib.upload import upload_avatar_image
@@ -181,7 +180,7 @@ class PermissionTest(ZulipTestCase):
 
         req = dict(role=UserProfile.ROLE_REALM_OWNER)
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.client_patch(f"/json/users/{othello.id}", req)
         self.assert_json_success(result)
         owner_users = realm.get_human_owner_users()
@@ -192,7 +191,7 @@ class PermissionTest(ZulipTestCase):
 
         req = dict(role=UserProfile.ROLE_MEMBER)
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.client_patch(f"/json/users/{othello.id}", req)
         self.assert_json_success(result)
         owner_users = realm.get_human_owner_users()
@@ -205,7 +204,7 @@ class PermissionTest(ZulipTestCase):
         self.login("desdemona")
         req = dict(role=UserProfile.ROLE_MEMBER)
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.client_patch(f"/json/users/{iago.id}", req)
         self.assert_json_success(result)
         owner_users = realm.get_human_owner_users()
@@ -213,7 +212,7 @@ class PermissionTest(ZulipTestCase):
         person = events[0]["event"]["person"]
         self.assertEqual(person["user_id"], iago.id)
         self.assertEqual(person["role"], UserProfile.ROLE_MEMBER)
-        with tornado_redirected_to_list([]):
+        with self.tornado_redirected_to_list([]):
             result = self.client_patch(f"/json/users/{desdemona.id}", req)
         self.assert_json_error(
             result, "The owner permission cannot be removed from the only organization owner."
@@ -221,7 +220,7 @@ class PermissionTest(ZulipTestCase):
 
         do_change_user_role(iago, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         self.login("iago")
-        with tornado_redirected_to_list([]):
+        with self.tornado_redirected_to_list([]):
             result = self.client_patch(f"/json/users/{desdemona.id}", req)
         self.assert_json_error(result, "Must be an organization owner")
 
@@ -246,7 +245,7 @@ class PermissionTest(ZulipTestCase):
         req = dict(role=orjson.dumps(UserProfile.ROLE_REALM_ADMINISTRATOR).decode())
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.client_patch(f"/json/users/{othello.id}", req)
         self.assert_json_success(result)
         admin_users = realm.get_human_admin_users()
@@ -258,7 +257,7 @@ class PermissionTest(ZulipTestCase):
         # Taketh away
         req = dict(role=orjson.dumps(UserProfile.ROLE_MEMBER).decode())
         events = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.client_patch(f"/json/users/{othello.id}", req)
         self.assert_json_success(result)
         admin_users = realm.get_human_admin_users()
@@ -494,7 +493,7 @@ class PermissionTest(ZulipTestCase):
 
         req = dict(role=orjson.dumps(new_role).decode())
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             result = self.client_patch(f"/json/users/{user_profile.id}", req)
         self.assert_json_success(result)
 
@@ -760,7 +759,7 @@ class QueryCountTest(ZulipTestCase):
 
         with queries_captured() as queries:
             with cache_tries_captured() as cache_tries:
-                with tornado_redirected_to_list(events):
+                with self.tornado_redirected_to_list(events):
                     fred = do_create_user(
                         email="fred@zulip.com",
                         password="password",
@@ -1162,7 +1161,7 @@ class UserProfileTest(ZulipTestCase):
             UserHotspot.objects.create(user=cordelia, hotspot=hotspot)
 
         events: List[Mapping[str, Any]] = []
-        with tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events):
             copy_user_settings(cordelia, iago)
 
         # Check that we didn't send an realm_user update events to

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -84,7 +84,9 @@ def get_message_edit_history(
 ) -> HttpResponse:
     if not user_profile.realm.allow_edit_history:
         return json_error(_("Message edit history is disabled in this organization"))
-    message, ignored_user_message = access_message(user_profile, message_id)
+    message, ignored_user_message = access_message(
+        user_profile, message_id, lock_message=False, lock_usermessage=False
+    )
 
     # Extract the message edit history from the message
     if message.edit_history is not None:
@@ -120,7 +122,9 @@ def update_message_backend(
     if propagate_mode != "change_one" and topic_name is None and stream_id is None:
         raise JsonableError(_("Invalid propagate_mode without topic edit"))
 
-    message, ignored_user_message = access_message(user_profile, message_id)
+    message, ignored_user_message = access_message(
+        user_profile, message_id, lock_message=False, lock_usermessage=False
+    )
     is_no_topic_msg = message.topic_name() == "(no topic)"
 
     # You only have permission to edit a message if:
@@ -286,7 +290,9 @@ def delete_message_backend(
     user_profile: UserProfile,
     message_id: int = REQ(converter=to_non_negative_int, path_only=True),
 ) -> HttpResponse:
-    message, ignored_user_message = access_message(user_profile, message_id)
+    message, ignored_user_message = access_message(
+        user_profile, message_id, lock_message=False, lock_usermessage=False
+    )
     validate_can_delete_message(user_profile, message)
     try:
         do_delete_messages(user_profile.realm, [message])
@@ -301,5 +307,7 @@ def json_fetch_raw_message(
     user_profile: UserProfile,
     message_id: int = REQ(converter=to_non_negative_int, path_only=True),
 ) -> HttpResponse:
-    (message, user_message) = access_message(user_profile, message_id)
+    (message, user_message) = access_message(
+        user_profile, message_id, lock_message=False, lock_usermessage=False
+    )
     return json_success({"raw_content": message.content})

--- a/zerver/views/reactions.py
+++ b/zerver/views/reactions.py
@@ -35,7 +35,9 @@ def remove_reaction(
     emoji_code: Optional[str] = REQ(default=None),
     reaction_type: str = REQ(default="unicode_emoji"),
 ) -> HttpResponse:
-    message, user_message = access_message(user_profile, message_id)
+    message, user_message = access_message(
+        user_profile, message_id, lock_message=False, lock_usermessage=False
+    )
 
     if emoji_code is None:
         if emoji_name is None:

--- a/zerver/views/reactions.py
+++ b/zerver/views/reactions.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
@@ -12,6 +13,8 @@ from zerver.lib.response import json_success
 from zerver.models import Reaction, UserProfile
 
 
+# transaction.atomic is required since we use FOR UPDATE queries in access_message
+@transaction.atomic
 @has_request_variables
 def add_reaction(
     request: HttpRequest,
@@ -26,6 +29,8 @@ def add_reaction(
     return json_success()
 
 
+# transaction.atomic is required since we use FOR UPDATE queries in access_message
+@transaction.atomic
 @has_request_variables
 def remove_reaction(
     request: HttpRequest,
@@ -36,7 +41,7 @@ def remove_reaction(
     reaction_type: str = REQ(default="unicode_emoji"),
 ) -> HttpResponse:
     message, user_message = access_message(
-        user_profile, message_id, lock_message=False, lock_usermessage=False
+        user_profile, message_id, lock_message=True, lock_usermessage=False
     )
 
     if emoji_code is None:

--- a/zerver/views/submessage.py
+++ b/zerver/views/submessage.py
@@ -18,7 +18,9 @@ def process_submessage(
     msg_type: str = REQ(),
     content: str = REQ(),
 ) -> HttpResponse:
-    message, user_message = access_message(user_profile, message_id)
+    message, user_message = access_message(
+        user_profile, message_id, lock_message=False, lock_usermessage=False
+    )
 
     try:
         orjson.loads(content)

--- a/zerver/views/submessage.py
+++ b/zerver/views/submessage.py
@@ -1,4 +1,5 @@
 import orjson
+from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
@@ -10,6 +11,8 @@ from zerver.lib.validator import check_int
 from zerver.models import UserProfile
 
 
+# transaction.atomic is required since we use FOR UPDATE queries in access_message.
+@transaction.atomic
 @has_request_variables
 def process_submessage(
     request: HttpRequest,
@@ -19,7 +22,7 @@ def process_submessage(
     content: str = REQ(),
 ) -> HttpResponse:
     message, user_message = access_message(
-        user_profile, message_id, lock_message=False, lock_usermessage=False
+        user_profile, message_id, lock_message=True, lock_usermessage=False
     )
 
     try:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #16502 

**Issue**
Anything which updates a message can race with deleting it, leading to `DatabaseError`s. 
Messages are updated like-
- Fetch the Message and/or UserMessage with the `zerver/lib/message.py/access_message` function
- Update the instance
- Save the changes using `.save()` or `.update()`

If another thread deletes the Message after point 1 and before point 3, it leads to either `DatabaseError`s (when the Message itself was being saved) or `IntegrityError` (when some related field was being saved).

**Fix**
Both of these errors can be avoided by using `SELECT FOR UPDATE` database queries whenever the Message or related model is updated, which will lock the involved database rows untill the transaction is complete, and the message will be deleted after that.

**Testing**
The race conditions described above can be reproduced on the development server by opening two tabs- one normal and one private/incognito. Login with two different users, making sure one of them has rights to delete messages.
Add latency/delay in the message editing codepath, by using `time.sleep(5)` which will "pause" the request for 5 seconds. In those 5 seconds, delete the message from the other tab.




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
