### PR TITLE
python: Convert os.open(…, O_EXCL) to open(…, "x")

### DIFF
--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -85,13 +85,10 @@ def get_or_create_key_prefix() -> str:
 
     filename = os.path.join(settings.DEPLOY_ROOT, "var", "remote_cache_prefix")
     try:
-        fd = os.open(filename, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o444)
-        prefix = secrets.token_hex(16) + ':'
-        # This does close the underlying file
-        with os.fdopen(fd, 'w') as f:
+        with open(filename, 'x') as f:
+            prefix = secrets.token_hex(16) + ':'
             f.write(prefix + "\n")
-    except OSError:
-        # The file already exists
+    except FileExistsError:
         tries = 1
         while tries < 10:
             with open(filename) as f:

--- a/zerver/management/commands/export.py
+++ b/zerver/management/commands/export.py
@@ -173,7 +173,8 @@ class Command(ZulipBaseCommand):
 
         tarball_path = output_dir.rstrip("/") + ".tar.gz"
         try:
-            os.close(os.open(tarball_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o666))
+            with open(tarball_path, "x"):
+                pass
         except FileExistsError:
             raise CommandError(f"Refusing to overwrite existing tarball: {tarball_path}. Aborting...")
 


### PR DESCRIPTION
(The `"x"` mode is [new in Python 3.3](https://docs.python.org/3/library/functions.html#open).)

**Testing plan:** Ran `tools/provision` with and without `var/remote_cache_prefix` existing; checked that `./manage.py export` works normally and fails when the tarball exists.