### PR TITLE
added data-placement to settings icon in left-sidebar to fix flickering bug 

### DIFF
--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -68,7 +68,7 @@
         </ul>
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-toggle="tooltip" title="{{ _('Filter streams') }}">{{ _('STREAMS') }}</h4>
-                <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" data-toggle="tooltip" title="{{ _('Subscribe, add, or configure streams') }}"></i>
+                <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" data-toggle="tooltip" data-placement="bottom" title="{{ _('Subscribe, add, or configure streams') }}"></i>
                 <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true" data-toggle="tooltip" title="{{ _('Filter streams') }} (q)"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter" type="text" autocomplete="off" placeholder="{{ _('Search streams') }}" />


### PR DESCRIPTION
This PR fixes [#16676](https://github.com/zulip/zulip/issues/16676). The placement of the tooltip is shifted from left to bottom in the keyboard icon using data-placement to fix the flickering issue.


**Testing plan:** <!-- How have you tested? -->
 I tested it manually by hovering over the icon from all directions and there was no flickering.



**GIFs or screenshots:**
Before            |  After
:-------------------------:|:-------------------------:
![settings_icon_flickering_before](https://user-images.githubusercontent.com/56607134/98704171-586acb00-23a2-11eb-9d3a-3075203aa0ac.gif)  |  ![settings_icon_flickering_after](https://user-images.githubusercontent.com/56607134/98704594-d62ed680-23a2-11eb-8ccb-f364e407478b.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
