### PR TITLE
Clarify to encode include_subscribers parameter as dict in python bindings.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10286,6 +10286,9 @@ components:
         Whether each returned stream object should include a `subscribers`
         field containing a list of the user IDs of its subscribers.
 
+        **Note**: Pass the parameters as dictionary rather than as arguments to function
+        in python i.e. ```client.list_subscriptions(dict(include_subscribers=True)) ```.
+
         (This may be significantly slower in organizations with
         thousands of users subscribed to many streams.)
 


### PR DESCRIPTION
Fixes #16698.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Clarify in the documentation to encode include_subscribers parameter as dict to the function list_subscriptions() in python bindings.

**Testing plan:** <!-- How have you tested? -->
Tested on dev server.
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![Screenshot (153)](https://user-images.githubusercontent.com/55033316/98715674-7e976780-23b0-11eb-89ea-0b7a42e301ca.png)
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
