### PR TITLE
auth: Handle the case of invalid subdomain at /fetch_api_key endpoint.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3199,6 +3199,13 @@ class FetchAPIKeyTest(ZulipTestCase):
                                        password="wrong"))
         self.assert_json_error(result, "Your username or password is incorrect.", 403)
 
+    def test_invalid_subdomain(self) -> None:
+        with mock.patch("zerver.views.auth.get_realm_from_request", return_value=None):
+            result = self.client_post("/api/v1/fetch_api_key",
+                                      dict(username='hamlet',
+                                           password=initial_password(self.email)))
+        self.assert_json_error(result, "Invalid subdomain", 400)
+
     def test_password_auth_disabled(self) -> None:
         with mock.patch('zproject.backends.password_auth_enabled', return_value=False):
             result = self.client_post("/api/v1/fetch_api_key",

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -851,9 +851,12 @@ def api_dev_list_users(request: HttpRequest) -> HttpResponse:
 @has_request_variables
 def api_fetch_api_key(request: HttpRequest, username: str=REQ(), password: str=REQ()) -> HttpResponse:
     return_data: Dict[str, bool] = {}
-    subdomain = get_subdomain(request)
-    realm = get_realm(subdomain)
-    if not ldap_auth_enabled(realm=get_realm_from_request(request)):
+
+    realm = get_realm_from_request(request)
+    if realm is None:
+        return json_error(_("Invalid subdomain"))
+
+    if not ldap_auth_enabled(realm=realm):
         # In case we don't authenticate against LDAP, check for a valid
         # email. LDAP backend can authenticate against a non-email.
         validate_login_email(username)


### PR DESCRIPTION
For https://chat.zulip.org/#narrow/stream/343-kandra-errors/topic/Realm.2EDoesNotExist.3A.20Realm.20matching.20query.20does.20not.20exist.2E