### PR TITLE
fixed left_sidebar tooltip flickering bug

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -273,6 +273,12 @@ exports.initialize_kitchen_sink_stuff = function () {
 
     $('.copy_message[data-toggle="tooltip"]').tooltip();
 
+    $("#streams_inline_cog").tooltip({
+        title: "Subscribe, add, or configure streams",
+        animation: false,
+        placement: "bottom",
+    });
+
     // We disable animations here because they can cause the tooltip
     // to change shape while fading away in weird way.
     $("#keyboard-icon").tooltip({placement: "left", animation: false});

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -68,7 +68,7 @@
         </ul>
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-toggle="tooltip" title="{{ _('Filter streams') }}">{{ _('STREAMS') }}</h4>
-                <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" data-toggle="tooltip" title="{{ _('Subscribe, add, or configure streams') }}"></i>
+                <i id="streams_inline_cog" class='fa fa-cog'></i>
                 <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true" data-toggle="tooltip" title="{{ _('Filter streams') }} (q)"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter" type="text" autocomplete="off" placeholder="{{ _('Search streams') }}" />


### PR DESCRIPTION
**This PR Fixes #16676 :** Settings icon tooltip in left sidebar of webapp UI is buggy 


**Testing Plan:** I have tested the tooltip myself by hovering over it. I have also used the tools/test-js-with-node suite.


**GIFs or screenshots:** 
![flickering_bug_fix](https://user-images.githubusercontent.com/42413316/98663535-3dcb2e80-236f-11eb-93ac-a562de085796.gif)

I have created this PR because the older PR #16730 was not having clean commit history (I was learning about the squashing commits and how to actually manage two remote repositories).
