### PR TITLE
lightbox: Fix images not opening after navigating through back button.

### DIFF
--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -216,7 +216,9 @@ exports.close_active_modal = function () {
 
 exports.close_for_hash_change = function () {
     $(".overlay.show").removeClass("show");
-    reset_state();
+    if (active_overlay) {
+        close_handler();
+    }
 };
 
 exports.open_settings = function () {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/16726

After exiting lightbox view by pressing the browser back button, future
requests to open images was failing. This was because the is_open
remained true, when exiting the view this way. This commit fixes the
problem by resetting the is_open variable to false, when a new image is
clicked.

Fixes #16726 
