### PR TITLE
puppet: Allow unattended upgrades of -updates in addition to -security

### DIFF
--- a/puppet/zulip_ops/files/apt/apt.conf.d/50unattended-upgrades
+++ b/puppet/zulip_ops/files/apt/apt.conf.d/50unattended-upgrades
@@ -6,6 +6,7 @@
 Unattended-Upgrade::Allowed-Origins {
     "${distro_id}:${distro_codename}";
     "${distro_id}:${distro_codename}-security";
+    "${distro_id}:${distro_codename}-updates";
     // Extended Security Maintenance; doesn't necessarily exist for
     // every release and this system may not have it installed, but if
     // available, the policy for updates is such that unattended-upgrades


### PR DESCRIPTION
This ensures that software will be fully up-to-date, not just with
security patches.
