### PR TITLE
puppet: Log the "Host" header and total response time.

### DIFF
--- a/puppet/zulip/templates/nginx.conf.template.erb
+++ b/puppet/zulip/templates/nginx.conf.template.erb
@@ -23,7 +23,10 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    access_log /var/log/nginx/access.log;
+    log_format combined_with_host_and_time '$remote_addr - $remote_user [$time_local] '
+                                           '"$request" $status $body_bytes_sent '
+                                           '"$http_referer" "$http_user_agent" $host $request_time';
+    access_log /var/log/nginx/access.log combined_with_host_and_time;
     error_log /var/log/nginx/error.log;
 
     reset_timedout_connection on;


### PR DESCRIPTION
Logging `Host` is useful for determining access patterns to realms,
especially if ROOT_DOMAIN_LANDING_PAGE is set.  Total response time is
useful in debugging access and performance patterns.