### PR TITLE
nginx: Increase file upload size from 25mb to 80mb.

### DIFF
--- a/puppet/zulip/templates/nginx.conf.template.erb
+++ b/puppet/zulip/templates/nginx.conf.template.erb
@@ -18,7 +18,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     types_hash_max_size 2048;
-    client_max_body_size 25m;
+    client_max_body_size 80m;
 
     include /etc/nginx/mime.types;
     default_type application/octet-stream;

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -409,9 +409,10 @@ LOCAL_UPLOADS_DIR = "/home/zulip/uploads"
 #S3_REGION = None
 #S3_ENDPOINT_URL = None
 
-# Maximum allowed size of uploaded files, in megabytes.  DO NOT SET
-# ABOVE 80MB.  The file upload implementation doesn't support chunked
-# uploads, so browsers will crash if you try uploading larger files.
+# Maximum allowed size of uploaded files, in megabytes.  This value is
+# capped at 80MB in the nginx configuration, because the file upload
+# implementation doesn't use chunked uploads, and browser may crash
+# with larger uploads.
 # Set MAX_FILE_UPLOAD_SIZE to 0 to disable file uploads completely
 # (including hiding upload-related options from UI).
 MAX_FILE_UPLOAD_SIZE = 25


### PR DESCRIPTION
This will increase file upload size upto 80mb from 25mb and user can increase max upload file size by modifying **settings.py**  in their own deployment.

The limit of 80 in the nginx configuration will prevent them from being able to raise it above 80 in settings.py.

Fixes #16741 