### PR TITLE
webhooks: Handle dispute events with object ID prefixed with du.

### DIFF
--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -212,6 +212,7 @@ def linkified_id(object_id: str, lower: bool=False) -> str:
         'ch': ('Charge', 'charges'),
         'cus': ('Customer', 'customers'),
         'dp': ('Dispute', 'disputes'),
+        'du': ('Dispute', 'disputes'),
         'file': ('File', 'files'),
         'link': ('File link', 'file_links'),
         'pi': ('Payment intent', 'payment_intents'),


### PR DESCRIPTION
Sometimes the dispute object IDs are prefixed with `du` instead of `dp`. This is not really documented anywhere. The only place I was able to find a discussion regarding this is here.

https://freenode.logbot.info/stripe/20200605#c4059469

---

I think the correct long-term fix here would be to stop using object IDs to detect the object type of these events and instead maybe make use of "object" key instead.

https://stripe.com/docs/api/disputes/object#dispute_object-object

EDIT

~~@eeshangarg Is there anything that is stopping us from making of "object" key instead?~~

Looks like the relevant code was added by Rishi. Not Eeshan.
https://github.com/zulip/zulip/commit/9f471a3e7d2d539045326afa70de890b32dd316c#diff-b5cd08cbb3b04760cc8ad9dfa9569be0dadcb9a7e9bad3059c09ed6bb36de7a4


I will add this to my todo list to clean it up.