### PR TITLE
[WIP] Making 2FA viable for production.

### DIFF
--- a/templates/two_factor/_base.html
+++ b/templates/two_factor/_base.html
@@ -1,0 +1,21 @@
+<!-- Copied from the upstream two_factor/_base.html template with an alert div removed, to provide
+a very basic, but usable page until a proper way to deal with the templates is figured out. -->
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>{% block title %}{% endblock %}</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.2/css/bootstrap.min.css" rel="stylesheet" media="screen">
+    </head>
+    <body>
+
+        {% block content_wrapper %}
+        <div class="container">
+            {% block content %}{% endblock %}
+        </div>
+        {% endblock %}
+
+        <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.2/js/bootstrap.min.js"></script>
+    </body>
+</html>

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -10,6 +10,7 @@ from bs4 import BeautifulSoup
 # this list without any modification.
 IGNORED_PHRASES = [
     # Proper nouns and acronyms
+    r"2FA",
     r"Android",
     r"API",
     r"APNS",

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.conf.urls.i18n import is_language_prefix_patterns_used
 from django.core.handlers.wsgi import WSGIRequest
 from django.db import connection
+from django.db.models.signals import post_save, pre_delete
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, StreamingHttpResponse
 from django.middleware.common import CommonMiddleware
 from django.middleware.locale import LocaleMiddleware as DjangoLocaleMiddleware
@@ -17,10 +18,17 @@ from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import ugettext as _
 from django.views.csrf import csrf_failure as html_csrf_failure
+from django_otp.middleware import OTPMiddleware as BaseOTPMiddleware
+from django_otp.models import Device
 from sentry_sdk import capture_exception
 from sentry_sdk.integrations.logging import ignore_logger
 
-from zerver.lib.cache import get_remote_cache_requests, get_remote_cache_time
+from zerver.lib.cache import (
+    cache_set,
+    cache_with_key,
+    get_remote_cache_requests,
+    get_remote_cache_time,
+)
 from zerver.lib.db import reset_queries
 from zerver.lib.debug import maybe_tracemalloc_listen
 from zerver.lib.exceptions import ErrorCode, JsonableError, MissingAuthenticationError
@@ -494,3 +502,46 @@ class ZulipCommonMiddleware(CommonMiddleware):
         if settings.RUNNING_INSIDE_TORNADO:
             return False
         return super().should_redirect_with_slash(request)
+
+class OTPMiddleware(BaseOTPMiddleware):
+    """
+    The original implementation does a database query on every request due to doing
+    lookups for devices by persisted_id. We do this override in order to take advantage
+    of caching.
+    """
+
+    # TODO: Consider using a hard-coded list instead of grabbing all subclasses?
+    device_classes = Device.__subclasses__()
+
+    @cache_with_key(
+        lambda instance, persistent_id: otp_middleware_device_from_persistent_id_cache_key(persistent_id)
+    )
+    def _device_from_persistent_id(self, persistent_id: str) -> Optional[Device]:
+        result = super()._device_from_persistent_id(persistent_id)
+        if result is not None:
+            # Ensure the device being used is in our list - the list is used
+            # for registering signal handlers to keep the cache up-to-date.
+            # An unexpected device class that doesn't have registered signal handlers
+            # would have stale cache issues, which could cause security problems.
+            assert result.__class__ in self.device_classes
+
+        return result
+
+def otp_middleware_device_from_persistent_id_cache_key(persistent_id: str) -> str:
+    return f'otp_middleware_device_{persistent_id}'
+
+def update_otp_middleware_device_cache(sender: Any, **kwargs: Any) -> None:
+    device = kwargs['instance']
+    cache_set(otp_middleware_device_from_persistent_id_cache_key(device.persistent_id),
+              device,
+              timeout=3600*24*7)
+
+def clear_otp_middleware_device_cache(sender: Any, **kwargs: Any) -> None:
+    device = kwargs['instance']
+    cache_set(otp_middleware_device_from_persistent_id_cache_key(device.persistent_id),
+              None,
+              timeout=3600*24*7)
+
+for cls in OTPMiddleware.device_classes:
+    post_save.connect(update_otp_middleware_device_cache, sender=cls)
+    pre_delete.connect(clear_otp_middleware_device_cache, sender=cls)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3517,8 +3517,6 @@ class TestTwoFactor(ZulipTestCase):
         password = self.ldap_password('hamlet')
 
         user_profile = self.example_user('hamlet')
-        user_profile.set_password(password)
-        user_profile.save()
         self.create_default_device(user_profile)
 
         def totp(*args: Any, **kwargs: Any) -> int:

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3191,6 +3191,14 @@ class FetchAPIKeyTest(ZulipTestCase):
                                        password=initial_password(self.email)))
         self.assert_json_success(result)
 
+    def test_disallowed_if_2fa_enabled(self) -> None:
+        with self.settings(TWO_FACTOR_AUTHENTICATION_ENABLED=True):
+            self.create_default_device(self.user_profile)
+            result = self.client_post("/api/v1/fetch_api_key",
+                                      dict(username=self.email,
+                                           password=initial_password(self.email)))
+            self.assert_json_error(result, "This endpoint is forbidden for users with 2FA enabled.", 403)
+
     def test_invalid_email(self) -> None:
         result = self.client_post("/api/v1/fetch_api_key",
                                   dict(username='hamlet',

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1617,7 +1617,7 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
             self.login_user(hamlet)
             request.session = self.client.session
             request.get_host = lambda: 'zulip.testserver'
-            self.create_default_device(request.user)
+            self.create_default_device(self.example_user('hamlet'))
 
             response = test_view(request)
 
@@ -1643,7 +1643,7 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
             self.login_user(hamlet)
             request.session = self.client.session
             request.get_host = lambda: 'zulip.testserver'
-            self.create_default_device(request.user)
+            self.create_default_device(self.example_user('hamlet'))
 
             response = test_view(request)
             content = getattr(response, 'content')

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1599,6 +1599,7 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
         request.META['PATH_INFO'] = ''
         request.user = hamlet = self.example_user('hamlet')
         request.user.is_verified = lambda: False
+        request.user._otp_middleware_verify_user_applied = True
         self.login_user(hamlet)
         request.session = self.client.session
         request.get_host = lambda: 'zulip.testserver'
@@ -1614,6 +1615,7 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
             request.META['PATH_INFO'] = ''
             request.user = hamlet = self.example_user('hamlet')
             request.user.is_verified = lambda: False
+            request.user._otp_middleware_verify_user_applied = True
             self.login_user(hamlet)
             request.session = self.client.session
             request.get_host = lambda: 'zulip.testserver'
@@ -1640,6 +1642,7 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
             request.META['PATH_INFO'] = ''
             request.user = hamlet = self.example_user('hamlet')
             request.user.is_verified = lambda: True
+            request.user._otp_middleware_verify_user_applied = True
             self.login_user(hamlet)
             request.session = self.client.session
             request.get_host = lambda: 'zulip.testserver'

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -314,9 +314,9 @@ class HomeTest(ZulipTestCase):
             self.create_default_device(user_profile)
             self.login_user(user_profile)
             result = self._get_home_page()
-            # User should not log in because otp device is configured but
-            # 2fa login function was not called.
-            self.assertEqual(result.status_code, 302)
+            # Home is web-public in DEVELOPMENT, so users are allowed through without
+            # being 2fa-verified even if it's enabled for the account.
+            self.assertEqual(result.status_code, 200)
 
             self.login_2fa(user_profile)
             result = self._get_home_page()

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -742,30 +742,6 @@ def login_page(
 def start_two_factor_auth(request: HttpRequest,
                           extra_context: ExtraContext=None,
                           **kwargs: Any) -> HttpResponse:
-    two_fa_form_field = 'two_factor_login_view-current_step'
-    if two_fa_form_field not in request.POST:
-        # Here we inject the 2FA step in the request context if it's missing to
-        # force the user to go to the first step of 2FA authentication process.
-        # This seems a bit hackish but simplifies things from testing point of
-        # view. I don't think this can result in anything bad because all the
-        # authentication logic runs after the auth step.
-        #
-        # If we don't do this, we will have to modify a lot of auth tests to
-        # insert this variable in the request.
-        request.POST = request.POST.copy()
-        request.POST.update({two_fa_form_field: 'auth'})
-
-    """
-    This is how Django implements as_view(), so extra_context will be passed
-    to the __init__ method of TwoFactorLoginView.
-
-    def as_view(cls, **initkwargs):
-        def view(request, *args, **kwargs):
-            self = cls(**initkwargs)
-            ...
-
-        return view
-    """
     two_fa_view = TwoFactorLoginView.as_view(extra_context=extra_context,
                                              **kwargs)
     return two_fa_view(request, **kwargs)

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -11,7 +11,6 @@ from django.contrib.auth import authenticate
 from django.contrib.auth.views import LoginView as DjangoLoginView
 from django.contrib.auth.views import PasswordResetView as DjangoPasswordResetView
 from django.contrib.auth.views import logout_then_login as django_logout_then_login
-from django.forms import Form
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, HttpResponseServerError
 from django.shortcuts import redirect, render
 from django.template.response import SimpleTemplateResponse
@@ -658,23 +657,12 @@ class TwoFactorLoginView(BaseTwoFactorLoginView):
         )
         return context
 
-    def done(self, form_list: List[Form], **kwargs: Any) -> HttpResponse:
+    def get_success_url(self) -> str:
         """
-        Login the user and redirect to the desired page.
-
         We need to override this function so that we can redirect to
-        realm.uri instead of '/'.
+        realm.uri instead of '/' upon successful authentication attempt.
         """
-        realm_uri = self.get_user().realm.uri
-        # This mock.patch business is an unpleasant hack that we'd
-        # ideally like to remove by instead patching the upstream
-        # module to support better configurability of the
-        # LOGIN_REDIRECT_URL setting.  But until then, it works.  We
-        # import mock.patch here because mock has an expensive import
-        # process involving pbr -> pkgresources (which is really slow).
-        from unittest.mock import patch
-        with patch.object(settings, 'LOGIN_REDIRECT_URL', realm_uri):
-            return super().done(form_list, **kwargs)
+        return self.get_user().realm.uri
 
 @has_request_variables
 def login_page(

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -368,6 +368,10 @@ RATE_LIMITING_RULES = {
         (3600, 2),  # 2 reset emails per hour
         (86400, 5),  # 5 per day
     ],
+    '2fa_attempts_by_user': [
+        (180, 5),
+        (3600, 40),
+    ],
 }
 
 # List of domains that, when applied to a request in a Tornado process,

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -165,7 +165,7 @@ ALLOWED_HOSTS += REALM_HOSTS.values()
 class TwoFactorLoader(app_directories.Loader):
     def get_dirs(self) -> List[str]:
         dirs = super().get_dirs()
-        return [d for d in dirs if 'two_factor' in d]
+        return [os.path.join(DEPLOY_ROOT, 'templates')] + [d for d in dirs if 'two_factor' in d]
 
 MIDDLEWARE = (
     # With the exception of it's dependencies,

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -184,7 +184,7 @@ MIDDLEWARE = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     # Make sure 2FA middlewares come after authentication middleware.
-    'django_otp.middleware.OTPMiddleware',  # Required by two factor auth.
+    'zerver.middleware.OTPMiddleware',  # Required by two factor auth.
     'two_factor.middleware.threadlocals.ThreadLocals',  # Required by Twilio
     # Needs to be after CommonMiddleware, which sets Content-Length
     'zerver.middleware.FinalizeOpenGraphDescription',

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -253,6 +253,7 @@ RATE_LIMITING_RULES: Dict[str, List[Tuple[int, int]]] = {
     'api_by_user': [],
     'authenticate_by_username': [],
     'password_reset_form_by_email': [],
+    '2fa_attempts_by_user': [],
 }
 
 FREE_TRIAL_DAYS = None


### PR DESCRIPTION
This isn't complete yet, but the remaining TODOs are reasonably simple or require additional discussion to figure out how we want things to work.

- [ ] Adding caching of `user_has_device` to make the last commit viable - otherwise it does database queries on user.is_authenticated calls. 
- [x] Fixing the monkey-patching of `TwoFactorLoginView` point of #9521 (we don't need to submit anything upstream as they've  merged some code that will allow us to do what we need here)
- [ ] Styling the HTML templates

Discussion is required on how this should work with mobile and zulip-terminal apps. What should be the right way of fetching a user's API key? Besides that, do we want to keep giving full API access with just the API key to users with 2FA enabled? Without some additional protections/restrictions, leaked API keys completely bypass the point of 2FA, so that might be considered a problem.