### PR TITLE
registration: replace string_id with realm id

### DIFF
--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -198,7 +198,7 @@ $(() => {
     function update_full_name_section() {
         if (
             $("#source_realm_select").length &&
-            $("#source_realm_select").find(":selected").val() !== "on"
+            $("#source_realm_select").find(":selected").val() !== ""
         ) {
             $("#full_name_input_section").hide();
             $("#profile_info_section").show();

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -111,13 +111,13 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                 </div>
                 <div id="source_realm_select_section" class="input-group m-10 inline-block">
                     <select class="select" name="source_realm" id="source_realm_select">
-                        <option value="on"
-                          {% if "source_realm" in form.data and form.data["source_realm"] == "on" %}selected {% endif %}>
+                        <option value=""
+                          {% if "source_realm" in form.data and form.data["source_realm"] == "" %}selected {% endif %}>
                             {{ _('Don&rsquo;t import settings') }}
                         </option>
                         {% for account in accounts %}
-                        <option value="{{ account.string_id }}" data-full-name="{{account.full_name}}" data-avatar="{{account.avatar}}"
-                          {% if ("source_realm" in form.data and account.string_id == form.data["source_realm"])
+                        <option value="{{ account.realm_id }}" data-full-name="{{account.full_name}}" data-avatar="{{account.avatar}}"
+                          {% if ("source_realm" in form.data and account.realm_id == form.data["source_realm"]|int)
                           or ("source_realm" not in form.data and loop.index0 == 0) %} selected {% endif %}>
                             {{ account.realm_name }}
                         </option>

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -107,18 +107,18 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
 
                 {% if accounts %}
                 <div class="input-box">
-                    <label for="source_realm" class="inline-block">{{ _('Import settings from existing Zulip account') }}</label>
+                    <label for="source_realm_id" class="inline-block">{{ _('Import settings from existing Zulip account') }}</label>
                 </div>
                 <div id="source_realm_select_section" class="input-group m-10 inline-block">
-                    <select class="select" name="source_realm" id="source_realm_select">
+                    <select class="select" name="source_realm_id" id="source_realm_select">
                         <option value=""
-                          {% if "source_realm" in form.data and form.data["source_realm"] == "" %}selected {% endif %}>
+                          {% if "source_realm_id" in form.data and form.data["source_realm_id"] == "" %}selected {% endif %}>
                             {{ _('Don&rsquo;t import settings') }}
                         </option>
                         {% for account in accounts %}
                         <option value="{{ account.realm_id }}" data-full-name="{{account.full_name}}" data-avatar="{{account.avatar}}"
-                          {% if ("source_realm" in form.data and account.realm_id == form.data["source_realm"]|int)
-                          or ("source_realm" not in form.data and loop.index0 == 0) %} selected {% endif %}>
+                          {% if ("source_realm_id" in form.data and account.realm_id == form.data["source_realm_id"]|int)
+                          or ("source_realm_id" not in form.data and loop.index0 == 0) %} selected {% endif %}>
                             {{ account.realm_name }}
                         </option>
                         {% endfor %}

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -611,7 +611,7 @@ Output:
         timezone: str = "",
         realm_in_root_domain: Optional[str] = None,
         default_stream_groups: Sequence[str] = [],
-        source_realm: str = "",
+        source_realm_id: str = "",
         key: Optional[str] = None,
         **kwargs: Any,
     ) -> HttpResponse:
@@ -635,7 +635,7 @@ Output:
             "terms": True,
             "from_confirmation": from_confirmation,
             "default_stream_group": default_stream_groups,
-            "source_realm": source_realm,
+            "source_realm_id": source_realm_id,
         }
         if realm_in_root_domain is not None:
             payload["realm_in_root_domain"] = realm_in_root_domain

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -760,6 +760,10 @@ def get_realm(string_id: str) -> Realm:
     return Realm.objects.get(string_id=string_id)
 
 
+def get_realm_by_id(realm_id: int) -> Realm:
+    return Realm.objects.get(id=realm_id)
+
+
 def name_changes_disabled(realm: Optional[Realm]) -> bool:
     if realm is None:
         return settings.NAME_CHANGES_DISABLED
@@ -2932,9 +2936,9 @@ def active_non_guest_user_ids(realm_id: int) -> List[int]:
     return list(query)
 
 
-def get_source_profile(email: str, string_id: str) -> Optional[UserProfile]:
+def get_source_profile(email: str, realm_id: int) -> Optional[UserProfile]:
     try:
-        return get_user_by_delivery_email(email, get_realm(string_id))
+        return get_user_by_delivery_email(email, get_realm_by_id(realm_id))
     except (Realm.DoesNotExist, UserProfile.DoesNotExist):
         return None
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3611,7 +3611,7 @@ class UserSignUpTest(InviteUserBase):
         result = self.client_get(confirmation_url, subdomain=subdomain)
         self.assertEqual(result.status_code, 200)
         result = self.submit_reg_form_for_user(
-            email, password, source_realm="", HTTP_HOST=subdomain + ".testserver"
+            email, password, source_realm_id="", HTTP_HOST=subdomain + ".testserver"
         )
 
         hamlet = get_user(self.example_email("hamlet"), realm)
@@ -3667,7 +3667,7 @@ class UserSignUpTest(InviteUserBase):
         result = self.submit_reg_form_for_user(
             email,
             password,
-            source_realm=str(hamlet_in_zulip.realm.id),
+            source_realm_id=str(hamlet_in_zulip.realm.id),
             HTTP_HOST=subdomain + ".testserver",
         )
 
@@ -3750,7 +3750,7 @@ class UserSignUpTest(InviteUserBase):
             password,
             realm_subdomain=realm.string_id,
             realm_name=realm_name,
-            source_realm=str(realm.id),
+            source_realm_id=str(realm.id),
         )
         self.assert_in_success_response(
             [

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3748,6 +3748,7 @@ class UserSignUpTest(InviteUserBase):
         result = self.submit_reg_form_for_user(
             email,
             password,
+            # Subdomain is already used, by construction.
             realm_subdomain=realm.string_id,
             realm_name=realm_name,
             source_realm_id=str(realm.id),

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -311,7 +311,7 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
         if "timezone" in request.POST and request.POST["timezone"] in pytz.all_timezones_set:
             timezone = request.POST["timezone"]
 
-        if "source_realm" in request.POST and request.POST["source_realm"] != "":
+        if "source_realm_id" in request.POST and request.POST["source_realm_id"] != "":
             source_profile: Optional[UserProfile] = get_source_profile(
                 email, int(request.POST["source_realm_id"])
             )

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -311,10 +311,15 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
         if "timezone" in request.POST and request.POST["timezone"] in pytz.all_timezones_set:
             timezone = request.POST["timezone"]
 
-        if "source_realm_id" in request.POST and request.POST["source_realm_id"] != "":
-            source_profile: Optional[UserProfile] = get_source_profile(
-                email, int(request.POST["source_realm_id"])
-            )
+        if "source_realm_id" in request.POST:
+            # Non-integer realm_id values like "string" are treated
+            # like the "Do not import" value of "".
+            try:
+                source_realm_id = int(request.POST["source_realm_id"])
+            except ValueError:
+                source_profile: Optional[UserProfile] = None
+            else:
+                source_profile = get_source_profile(email, source_realm_id)
         else:
             source_profile = None
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -311,8 +311,10 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
         if "timezone" in request.POST and request.POST["timezone"] in pytz.all_timezones_set:
             timezone = request.POST["timezone"]
 
-        if "source_realm" in request.POST and request.POST["source_realm"] != "on":
-            source_profile = get_source_profile(email, request.POST["source_realm"])
+        if "source_realm" in request.POST and request.POST["source_realm"] != "":
+            source_profile: Optional[UserProfile] = get_source_profile(
+                email, int(request.POST["source_realm_id"])
+            )
         else:
             source_profile = None
 


### PR DESCRIPTION
## What is this PR for
This PR aims to solve the issue https://github.com/zulip/zulip/issues/14810

I have made the change in `lib/users.py` and replaced `realm.string_id` with `realm.id` in `get_accounts_for_email` function.
I have also fixed the corresponding tests.

Discussion: https://chat.zulip.org/#narrow/stream/2-general/topic/Use.20realm_id.20as.20value.20of.20the.20option.20in.20source.20realm.20selector/near/1062060


https://user-images.githubusercontent.com/53316982/113472244-86e76080-947f-11eb-963a-d94f9d0f4fa2.mp4


https://user-images.githubusercontent.com/53316982/113472263-a9797980-947f-11eb-86d7-ff174b0c3ef4.mp4


