### PR TITLE
build_pygments_data: Don’t recompute the name we already have

### DIFF
--- a/tools/setup/build_pygments_data
+++ b/tools/setup/build_pygments_data
@@ -2,7 +2,7 @@
 import json
 import os
 
-from pygments.lexers import get_all_lexers, get_lexer_by_name
+from pygments.lexers import get_all_lexers
 
 ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../')
 DATA_PATH = os.path.join(ZULIP_PATH, 'tools', 'setup', 'lang.json')
@@ -12,11 +12,11 @@ with open(DATA_PATH) as f:
     langs = json.load(f)
 
 lexers = get_all_lexers()
-for lexer in lexers:
-    for name in lexer[1]:
-        langs[name] = {
-            'priority': langs.get(name, 0),
-            'pretty_name': get_lexer_by_name(name).name
+for longname, aliases, filename_patterns, mimetypes in lexers:
+    for alias in aliases:
+        langs[alias] = {
+            'priority': langs.get(alias, 0),
+            'pretty_name': longname,
         }
 
 with open(OUT_PATH, 'w') as f:


### PR DESCRIPTION
This speeds up build_pygments_data from 6 seconds to 0.5 seconds.

(Cc @sumanthvrao)

**Testing plan:** Verified that the output is identical.