### PR TITLE
left_sidebar: Add tooltip/title for shortcut key associated with "Recent Topics".

### DIFF
--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -62,7 +62,7 @@
                         <i class="fa fa-clock-o" aria-hidden="true"></i>
                     </span>
                     {#- squash whitespace -#}
-                    <span>{{ _('Recent topics') }}</span>
+                    <span title="{{ _('Recent topics') }} (t)">{{ _('Recent topics') }}</span>
                 </a>
             </li>
         </ul>


### PR DESCRIPTION
**Issue:** Missing tooltip/title for "Recent Topics" on the left sidebar.

**Testing plan:** I have tested it visually by hovering over the "Recent Topics". I have also used the tools/test-js-with-node suite.


**GIFs or screenshots:** 

| Before | After|
|--|--|
| ![before](https://user-images.githubusercontent.com/42413316/99399764-1b578900-290c-11eb-8907-af1cc2a33c44.gif) |![after2](https://user-images.githubusercontent.com/42413316/99494655-69fe3500-2997-11eb-87bf-08288a50a7e4.gif) |



