### PR TITLE
settings: Remove extra dropdown for wildcard mention setting.

### DIFF
--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -150,13 +150,6 @@
                         {{> dropdown_options_widget option_values=private_message_policy_values}}
                     </select>
                 </div>
-
-                <div class="input-group">
-                    <label for="realm_wildcard_mention_policy" class="dropdown-title">{{t "Who can use wildcard mentions in large streams" }}</label>
-                    <select name="realm_wildcard_mention_policy" id="id_realm_wildcard_mention_policy" class="prop-element" data-setting-widget-type="number">
-                        {{> dropdown_options_widget option_values=wildcard_mention_policy_values}}
-                    </select>
-                </div>
             </div>
         </div>
     </form>


### PR DESCRIPTION
There are actually two dropdowns for wildcard mention setting,
which would have been added mistakenly while changing the
label and position during merging the original commit for adding
this setting.

This PR removes the extra dropdown in Other Permissions 
subsection and retains the one in the Stream Permissions subsection.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? --> Dev Server


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
