### PR TITLE
navbar: Add JS tooltip to show title for searchicon.

### DIFF
--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -84,6 +84,11 @@ function bind_title_area_handlers() {
         search.initiate_search();
         e.preventDefault();
         e.stopPropagation();
+
+        $(".search_closed").tooltip({
+            title: "Search (/)",
+            placement: "bottom",
+        });
     });
 
     $("#message_view_header span:nth-last-child(2)").on("click", (e) => {


### PR DESCRIPTION
Issue: Missing tooltip/title for "Search icon" on the navbar.

Testing plan: I have tested it visually by hovering over the "Search icon". I have also used the tools/test-js-with-node suite.

GIFs or screenshots;

Before:
![Before searchicon](https://user-images.githubusercontent.com/59444243/99506281-e8fb6980-29a7-11eb-9cf1-475f38c3b8a7.gif)
After:
![After searchicon](https://user-images.githubusercontent.com/59444243/99506289-f0bb0e00-29a7-11eb-8733-a65544358582.gif)
