### PR TITLE
star_this_message: Change tooltip/title from "*" to "Ctrl+s" for shortcut key.

### DIFF
--- a/static/templates/message_controls.hbs
+++ b/static/templates/message_controls.hbs
@@ -24,7 +24,7 @@
 
     {{#unless msg/locally_echoed}}
     <div class="star_container {{#if msg/starred}}{{else}}empty-star{{/if}}">
-        <i role="button" tabindex="0" class="star fa {{#if msg/starred}}fa-star{{else}}fa-star-o{{/if}}" title="{{#tr this.msg}}__starred_status__ this message{{/tr}} (*)"></i>
+        <i role="button" tabindex="0" class="star fa {{#if msg/starred}}fa-star{{else}}fa-star-o{{/if}}" title="{{#tr this.msg}}__starred_status__ this message{{/tr}} (Ctrl+s)"></i>
     </div>
     {{/unless}}
 


### PR DESCRIPTION
**Issue:** The title/tooltip of "Star this message" is "*" but it should be "Ctrl+s".

**Testing plan:** I have tested it visually by hovering over the "Star this message". I have also used the tools/test-js-with-node suite.

**GIFs or screenshots:** 

| Before | After|
|--|--|
| ![before3](https://user-images.githubusercontent.com/42413316/99631556-cc236c80-2a61-11eb-9948-20fcf6f2b0fd.gif) |![after3](https://user-images.githubusercontent.com/42413316/99631613-e65d4a80-2a61-11eb-8b4f-340f2de1513a.gif) |


