### PR TITLE
webhooks: Do not log RateLimited exception to webhook logger.

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -349,7 +349,8 @@ class OurAuthenticationForm(AuthenticationForm):
                 self.user_cache = authenticate(request=self.request, username=username, password=password,
                                                realm=realm, return_data=return_data)
             except RateLimited as e:
-                secs_to_freedom = int(float(str(e)))
+                assert e.secs_to_freedom is not None
+                secs_to_freedom = int(e.secs_to_freedom)
                 raise ValidationError(AUTHENTICATION_RATE_LIMITED_ERROR.format(secs_to_freedom))
 
             if return_data.get("inactive_realm"):

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -53,7 +53,7 @@ class RateLimitedObject(ABC):
         # Abort this request if the user is over their rate limits
         if ratelimited:
             # Pass information about what kind of entity got limited in the exception:
-            raise RateLimited(str(time))
+            raise RateLimited(time)
 
         calls_remaining, seconds_until_reset = self.api_calls_left()
 

--- a/zerver/lib/response.py
+++ b/zerver/lib/response.py
@@ -66,10 +66,15 @@ def json_response_from_error(exception: JsonableError) -> HttpResponse:
     middleware takes care of transforming it into a response by
     calling this function.
     '''
-    return json_response('error',
-                         msg=exception.msg,
-                         data=exception.data,
-                         status=exception.http_status_code)
+    response = json_response('error',
+                             msg=exception.msg,
+                             data=exception.data,
+                             status=exception.http_status_code)
+
+    for header, value in exception.extra_headers.items():
+        response[header] = value
+
+    return response
 
 def json_error(msg: str, data: Mapping[str, Any]={}, status: int=400) -> HttpResponse:
     return json_response(res_type="error", msg=msg, data=data, status=status)

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -23,7 +23,7 @@ from sentry_sdk.integrations.logging import ignore_logger
 from zerver.lib.cache import get_remote_cache_requests, get_remote_cache_time
 from zerver.lib.db import reset_queries
 from zerver.lib.debug import maybe_tracemalloc_listen
-from zerver.lib.exceptions import ErrorCode, JsonableError, MissingAuthenticationError, RateLimited
+from zerver.lib.exceptions import ErrorCode, JsonableError, MissingAuthenticationError
 from zerver.lib.html_to_text import get_content_description
 from zerver.lib.markdown import get_markdown_requests, get_markdown_time
 from zerver.lib.rate_limiter import RateLimitResult
@@ -407,20 +407,6 @@ class RateLimitMiddleware(MiddlewareMixin):
             self.set_response_headers(response, request._ratelimits_applied)
 
         return response
-
-    def process_exception(self, request: HttpRequest,
-                          exception: Exception) -> Optional[HttpResponse]:
-        if isinstance(exception, RateLimited):
-            # secs_to_freedom is passed to RateLimited when raising
-            secs_to_freedom = float(str(exception))
-            resp = json_error(
-                _("API usage exceeded rate limit"),
-                data={'retry-after': secs_to_freedom},
-                status=429,
-            )
-            resp['Retry-After'] = secs_to_freedom
-            return resp
-        return None
 
 class FlushDisplayRecipientCache(MiddlewareMixin):
     def process_response(self, request: HttpRequest, response: HttpResponse) -> HttpResponse:

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -98,7 +98,8 @@ def json_change_settings(request: HttpRequest, user_profile: UserProfile,
                                 realm=user_profile.realm, return_data=return_data):
                 return json_error(_("Wrong password!"))
         except RateLimited as e:
-            secs_to_freedom = int(float(str(e)))
+            assert e.secs_to_freedom is not None
+            secs_to_freedom = int(e.secs_to_freedom)
             return json_error(
                 _("You're making too many attempts! Try again in {} seconds.").format(secs_to_freedom),
             )


### PR DESCRIPTION
In `authenticated_rest_api_view` (but not `webhook_view`) the rate
limiting happens inside the `try` / `catch` block that potentially
reports errors to the webhook logger (and thus Sentry, if so
configured).  Rate limits are `RateLimited` exceptions, which do not
descend from `JsonableError` (the `RateLimitMiddleware` deals with
transforming them), and as such are, by default, logged; .

Skip logging `RateLimited` exceptions to the webhook logger.