### PR TITLE
puppet: Set a long timeout on wal-g wal-push, to prevent stalls.

### DIFF
--- a/puppet/zulip/templates/postgresql/10/postgresql.conf.centos.template.erb
+++ b/puppet/zulip/templates/postgresql/10/postgresql.conf.centos.template.erb
@@ -698,7 +698,7 @@ listen_addresses = <%= @listen_addresses %>
 wal_level = hot_standby
 max_wal_senders = 5
 archive_mode = on
-archive_command = '/usr/local/bin/env-wal-g wal-push %p'
+archive_command = '/usr/bin/timeout 10m /usr/local/bin/env-wal-g wal-push %p'
 
 # Replica settings (ignored on primary)
 hot_standby = on

--- a/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
@@ -698,7 +698,7 @@ listen_addresses = <%= @listen_addresses %>
 wal_level = hot_standby
 max_wal_senders = 5
 archive_mode = on
-archive_command = '/usr/local/bin/env-wal-g wal-push %p'
+archive_command = '/usr/bin/timeout 10m /usr/local/bin/env-wal-g wal-push %p'
 
 # Replica settings (ignored on primary)
 hot_standby = on

--- a/puppet/zulip/templates/postgresql/11/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/11/postgresql.conf.template.erb
@@ -698,7 +698,7 @@ listen_addresses = <%= @listen_addresses %>
 wal_level = hot_standby
 max_wal_senders = 5
 archive_mode = on
-archive_command = '/usr/local/bin/env-wal-g wal-push %p'
+archive_command = '/usr/bin/timeout 10m /usr/local/bin/env-wal-g wal-push %p'
 
 # Replica settings (ignored on primary)
 hot_standby = on

--- a/puppet/zulip/templates/postgresql/12/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/12/postgresql.conf.template.erb
@@ -792,7 +792,7 @@ listen_addresses = <%= @listen_addresses %>
 wal_level = hot_standby
 max_wal_senders = 5
 archive_mode = on
-archive_command = '/usr/local/bin/env-wal-g wal-push %p'
+archive_command = '/usr/bin/timeout 10m /usr/local/bin/env-wal-g wal-push %p'
 
 # Replica settings (ignored on primary)
 hot_standby = on

--- a/puppet/zulip/templates/postgresql/9.5/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/9.5/postgresql.conf.template.erb
@@ -670,7 +670,7 @@ listen_addresses = <%= @listen_addresses %>
 wal_level = hot_standby
 max_wal_senders = 5
 archive_mode = on
-archive_command = '/usr/local/bin/env-wal-g wal-push %p'
+archive_command = '/usr/bin/timeout 10m /usr/local/bin/env-wal-g wal-push %p'
 
 # Replica settings (ignored on primary)
 hot_standby = on

--- a/puppet/zulip/templates/postgresql/9.6/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/9.6/postgresql.conf.template.erb
@@ -683,7 +683,7 @@ listen_addresses = <%= @listen_addresses %>
 wal_level = hot_standby
 max_wal_senders = 5
 archive_mode = on
-archive_command = '/usr/local/bin/env-wal-g wal-push %p'
+archive_command = '/usr/bin/timeout 10m /usr/local/bin/env-wal-g wal-push %p'
 
 # Replica settings (ignored on primary)
 hot_standby = on


### PR DESCRIPTION
`wal-g wal-push` has a known bug with occasionally hanging after file
upload to S3[1]; set a rather long timeout on the upload process, so
that we don't simply stall forever when archiving WAL segments.

[1] https://github.com/wal-g/wal-g/issues/656
