### PR TITLE
star_this_message: Change tooltip/title from "*" to "Ctrl+s" for shortcut key.

### DIFF
--- a/static/templates/message_controls.hbs
+++ b/static/templates/message_controls.hbs
@@ -24,7 +24,7 @@
 
     {{#unless msg/locally_echoed}}
     <div class="star_container {{#if msg/starred}}{{else}}empty-star{{/if}}">
-        <i role="button" tabindex="0" class="star fa {{#if msg/starred}}fa-star{{else}}fa-star-o{{/if}}" title="{{#tr this.msg}}__starred_status__ this message{{/tr}} (*)"></i>
+        <i role="button" tabindex="0" class="star fa {{#if msg/starred}}fa-star{{else}}fa-star-o{{/if}}" title="{{#tr this.msg}}__starred_status__ this message{{/tr}} (Ctrl + s)"></i>
     </div>
     {{/unless}}
 


### PR DESCRIPTION
Issue: The title/tooltip of "Star this message" is "*" but it should be "Ctrl+s".

Testing plan: I have tested it visually by hovering over the "Star this message". I have also used the tools/test-js-with-node suite.

GIFs or screenshots:

Before: 
![before_staricon](https://user-images.githubusercontent.com/59444243/99783450-71ad0d80-2b40-11eb-8a26-f536cc552c6c.gif)
After: 
![after_staricon](https://user-images.githubusercontent.com/59444243/99783473-783b8500-2b40-11eb-8163-08ee438de8de.gif)
