### PR TITLE
message fetch: Pass narrow param for recent topics message list.

### DIFF
--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -296,13 +296,11 @@ run_test("initialize", () => {
 function simulate_narrow() {
     const filter = {
         predicate: () => () => false,
+        public_operators: () => [{operator: "pm-with", operand: alice.email}],
     };
 
     narrow_state.active = function () {
         return true;
-    };
-    narrow_state.public_operators = function () {
-        return [{operator: "pm-with", operand: alice.email}];
     };
 
     const msg_list = new message_list.MessageList({

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -178,8 +178,8 @@ exports.load_messages = function (opts) {
     }
     let data = {anchor: opts.anchor, num_before: opts.num_before, num_after: opts.num_after};
 
-    if (opts.msg_list.narrowed && narrow_state.active()) {
-        let operators = narrow_state.public_operators();
+    if ((opts.msg_list.narrowed && narrow_state.active()) || opts.force_fetch) {
+        let operators = opts.msg_list.data.filter.public_operators();
         if (page_params.narrow !== undefined) {
             operators = operators.concat(page_params.narrow);
         }
@@ -458,6 +458,7 @@ exports.initialize = function () {
         num_before: consts.recent_topics_initial_fetch_size,
         num_after: 0,
         msg_list: recent_topics_message_list,
+        force_fetch: true,
     });
 };
 


### PR DESCRIPTION
**Testing plan:** <!-- How have you tested? -->

Compared the `message_ids` returned before and after this commit.
This does not include the muted stream/topic's message ids.