### PR TITLE
left_sidebar: Show title when mouse hover anywhere on the button.

### DIFF
--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -15,14 +15,14 @@
                 </a>
                 <span class="arrow all-messages-sidebar-menu-icon"><i class="zulip-icon ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_private_messages">
+            <li class="top_left_private_messages"  title="{{ _('Private messages') }} (P)">
                 <div class="private_messages_header top_left_row">
                     <a href="#narrow/is/private">
                         <span class="filter-icon">
                             <i class="fa fa-envelope" aria-hidden="true"></i>
                         </span>
                         {#- squash whitespace -#}
-                        <span title="{{ _('Private messages') }} (P)">{{ _('Private messages') }}</span>
+                        <span>{{ _('Private messages') }}</span>
                         <span class="count">
                             <span class="value"></span>
                         </span>


### PR DESCRIPTION
Instead of showing title text when user hovers over the text in
the button, show title when user hovers anywhere on the button.
