### PR TITLE
actions: Refactor check_message to return a dataclass instead of Dict.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import zlib
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 import ahocorasick
@@ -77,6 +78,29 @@ class UnreadMessagesResult(TypedDict):
     huddles: List[Dict[str, Any]]
     mentions: List[int]
     count: int
+
+@dataclass
+class SendMessageRequest:
+    message: Message
+    stream: Optional[Stream]
+    local_id: Optional[int]
+    sender_queue_id: Optional[int]
+    realm: Realm
+    mention_data: MentionData
+    active_user_ids: Set[int]
+    push_notify_user_ids: Set[int]
+    stream_push_user_ids: Set[int]
+    stream_email_user_ids: Set[int]
+    um_eligible_user_ids: Set[int]
+    long_term_idle_user_ids: Set[int]
+    default_bot_user_ids: Set[int]
+    service_bot_tuples: List[Tuple[int, int]]
+    wildcard_mention_user_ids: Set[int]
+    links_for_embed: Set[str]
+    widget_content: Optional[Dict[str, Any]]
+    submessages: List[Dict[str, Any]] = field(default_factory=list)
+    deliver_at: Optional[datetime.datetime] = None
+    delivery_type: Optional[str] = None
 
 # We won't try to fetch more unread message IDs from the database than
 # this limit.  The limit is super high, in large part because it means

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, MutableMapping
+from typing import Dict, List
 
 from django.conf import settings
 from django.db.models import Count
@@ -12,6 +12,7 @@ from zerver.lib.actions import (
     internal_send_private_message,
 )
 from zerver.lib.emoji import emoji_name_to_emoji_code
+from zerver.lib.message import SendMessageRequest
 from zerver.models import Message, Realm, UserProfile, get_system_bot
 
 
@@ -95,9 +96,9 @@ def send_initial_pms(user: UserProfile) -> None:
     internal_send_private_message(user.realm, get_system_bot(settings.WELCOME_BOT),
                                   user, content)
 
-def send_welcome_bot_response(message: MutableMapping[str, Any]) -> None:
+def send_welcome_bot_response(send_request: SendMessageRequest) -> None:
     welcome_bot = get_system_bot(settings.WELCOME_BOT)
-    human_recipient_id = message['message'].sender.recipient_id
+    human_recipient_id = send_request.message.sender.recipient_id
     if Message.objects.filter(sender=welcome_bot, recipient_id=human_recipient_id).count() < 2:
         content = (
             _("Congratulations on your first reply!") +
@@ -109,7 +110,7 @@ def send_welcome_bot_response(message: MutableMapping[str, Any]) -> None:
               "skills. Or, try clicking on some of the stream names to your left!")
         )
         internal_send_private_message(
-            message['realm'], welcome_bot, message['message'].sender, content)
+            send_request.realm, welcome_bot, send_request.message.sender, content)
 
 def send_initial_realm_messages(realm: Realm) -> None:
     welcome_bot = get_system_bot(settings.WELCOME_BOT)

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -1,7 +1,8 @@
 import json
 import re
-from typing import Any, MutableMapping, Optional, Tuple
+from typing import Any, Optional, Tuple
 
+from zerver.lib.message import SendMessageRequest
 from zerver.models import SubMessage
 
 
@@ -42,20 +43,20 @@ def get_extra_data_from_widget_type(content: str,
         return extra_data
     return None
 
-def do_widget_post_save_actions(message: MutableMapping[str, Any]) -> None:
+def do_widget_post_save_actions(send_request: SendMessageRequest) -> None:
     '''
     This code works with the webapp; mobile and other
     clients should also start supporting this soon.
     '''
-    message_content = message['message'].content
-    sender_id = message['message'].sender_id
-    message_id = message['message'].id
+    message_content = send_request.message.content
+    sender_id = send_request.message.sender_id
+    message_id = send_request.message.id
 
     widget_type = None
     extra_data = None
 
     widget_type, extra_data = get_widget_data(message_content)
-    widget_content = message.get('widget_content')
+    widget_content = send_request.widget_content
     if widget_content is not None:
         # Note that we validate this data in check_message,
         # so we can trust it here.
@@ -74,4 +75,4 @@ def do_widget_post_save_actions(message: MutableMapping[str, Any]) -> None:
             content=json.dumps(content),
         )
         submessage.save()
-        message['submessages'] = SubMessage.get_raw_db_rows([message_id])
+        send_request.submessages = SubMessage.get_raw_db_rows([message_id])

--- a/zerver/management/commands/deliver_scheduled_messages.py
+++ b/zerver/management/commands/deliver_scheduled_messages.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from datetime import timedelta
-from typing import Any, Dict
+from typing import Any
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -10,6 +10,7 @@ from django.utils.timezone import now as timezone_now
 from zerver.lib.actions import build_message_send_dict, do_send_messages
 from zerver.lib.logging_util import log_to_file
 from zerver.lib.management import sleep_forever
+from zerver.lib.message import SendMessageRequest
 from zerver.models import Message, ScheduledMessage, get_user_by_delivery_email
 
 ## Setup ##
@@ -28,7 +29,7 @@ on all but one machine to make the command have no effect.)
 Usage: ./manage.py deliver_scheduled_messages
 """
 
-    def construct_message(self, scheduled_message: ScheduledMessage) -> Dict[str, Any]:
+    def construct_message(self, scheduled_message: ScheduledMessage) -> SendMessageRequest:
         message = Message()
         original_sender = scheduled_message.sender
         message.content = scheduled_message.content

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1790,7 +1790,7 @@ class InternalPrepTest(ZulipTestCase):
             recipient_user=recipient_user,
             content=content)
         assert result is not None
-        message = result['message']
+        message = result.message
         self.assertIn('message was too long', message.content)
 
         # Simulate sending a message to somebody not in the
@@ -2000,7 +2000,7 @@ class CheckMessageTest(ZulipTestCase):
         message_content = 'whatever'
         addressee = Addressee.for_stream_name(stream_name, topic_name)
         ret = check_message(sender, client, addressee, message_content)
-        self.assertEqual(ret['message'].sender.id, sender.id)
+        self.assertEqual(ret.message.sender.id, sender.id)
 
     def test_guest_user_can_send_message(self) -> None:
         # Guest users can write to web_public streams.
@@ -2019,7 +2019,7 @@ class CheckMessageTest(ZulipTestCase):
         message_content = 'whatever'
         addressee = Addressee.for_stream_name(rome_stream.name, topic_name)
         ret = check_message(sender, client, addressee, message_content)
-        self.assertEqual(ret['message'].sender.id, sender.id)
+        self.assertEqual(ret.message.sender.id, sender.id)
 
     def test_bot_pm_feature(self) -> None:
         """We send a PM to a bot's owner if their bot sends a message to
@@ -2069,7 +2069,7 @@ class CheckMessageTest(ZulipTestCase):
 
         new_count = message_stream_count(parent)
         self.assertEqual(new_count, old_count + 2)
-        self.assertEqual(ret['message'].sender.email, 'othello-bot@zulip.com')
+        self.assertEqual(ret.message.sender.email, 'othello-bot@zulip.com')
         self.assertIn("does not have any subscribers", most_recent_message(parent).content)
 
     def test_bot_pm_error_handling(self) -> None:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR refactors the `check_message` function in `zerver/lib/actions.py` to return a dataclass instead of Dict.
Also added few prep commits.

**Testing plan:** <!-- How have you tested? --> Modified the tests.


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
