### PR TITLE
slack: Check token access scopes before importing.

### DIFF
--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -756,7 +756,7 @@ class SlackImporter(ZulipTestCase):
 
         test_realm_subdomain = 'test-slack-import'
         output_dir = os.path.join(settings.DEPLOY_ROOT, "var", "test-slack-importer-data")
-        token = 'valid-token'
+        token = 'xoxp-valid-token'
 
         # If the test fails, the 'output_dir' would not be deleted and hence it would give an
         # error when we run the tests next time, as 'do_convert_data' expects an empty 'output_dir'


### PR DESCRIPTION
The Slack API always (even for failed requests) puts the access scopes
of the token passed in, into "X-OAuth-Scopes"[1], which can be used to
determine if any are missing -- and if so, which.

[1] https://api.slack.com/legacy/oauth-scopes#working-with-scopes

**Testing plan:** Ran it locally.
