### PR TITLE
webhooks: Properly format the currency amount for refunds.

### DIFF
--- a/zerver/webhooks/stripe/tests.py
+++ b/zerver/webhooks/stripe/tests.py
@@ -208,12 +208,12 @@ Amount due: 0.00 INR
 
     def test_refund_event(self) -> None:
         expected_topic = "refunds"
-        expected_message = "A [refund](https://dashboard.stripe.com/refunds/re_1Gib6ZHLwdCOCoR7VrzCnXlj) for a [charge](https://dashboard.stripe.com/charges/ch_1Gib61HLwdCOCoR71rnkccye) of 30000000 INR was updated."
+        expected_message = "A [refund](https://dashboard.stripe.com/refunds/re_1Gib6ZHLwdCOCoR7VrzCnXlj) for a [charge](https://dashboard.stripe.com/charges/ch_1Gib61HLwdCOCoR71rnkccye) of 300000.00 INR was updated."
         self.check_webhook("refund_event", expected_topic, expected_message)
 
     def test_pseudo_refund_event(self) -> None:
         expected_topic = "refunds"
-        expected_message = "A [refund](https://dashboard.stripe.com/refunds/pyr_abcde12345ABCDF) for a [payment](https://dashboard.stripe.com/payments/py_abcde12345ABCDG) of 1234 EUR was updated."
+        expected_message = "A [refund](https://dashboard.stripe.com/refunds/pyr_abcde12345ABCDF) for a [payment](https://dashboard.stripe.com/payments/py_abcde12345ABCDG) of 12.34 EUR was updated."
         self.check_webhook("pseudo_refund_event", expected_topic, expected_message)
 
     @patch('zerver.webhooks.stripe.view.check_send_webhook_message')

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -99,11 +99,10 @@ def topic_and_body(payload: Dict[str, Any]) -> Tuple[str, str]:
                 status=object_['status'].replace('_', ' '))
         if resource == 'refund':
             topic = 'refunds'
-            body = 'A {resource} for a {charge} of {amount} {currency} was updated.'.format(
+            body = 'A {resource} for a {charge} of {amount} was updated.'.format(
                 resource=linkified_id(object_['id'], lower=True),
                 charge=linkified_id(object_['charge'], lower=True),
-                amount=object_['amount'],
-                currency=object_['currency'].upper(),
+                amount=amount_string(object_['amount'], object_['currency']),
             )
     if category == 'checkout_beta':  # nocoverage
         # Not sure what this is


### PR DESCRIPTION
By default, all Stripe API amounts are in the currency's smallest unit. It's up to us to convert it to a bigger unit and show it to the end-user. The refund event used to show the amount in the smallest unit. This made the output wrong for most currencies (eg: Showing 800 USD instead of 8 USD)

I was not able to test the change. The stripe cli doesn't support the `charge.refund.updated` test event. Creating a refund didn't trigger the event either. I think the event happens only when there is some issue giving refunds initially(eg: Insufficient balance). Anyway, it shouldn't be a deal-breaker since we have backend fixtures for it and we are only formatting the amount. 