### PR TITLE
[WIP] Digest Topic rank

### DIFF
--- a/templates/zerver/digest_base.html
+++ b/templates/zerver/digest_base.html
@@ -11,19 +11,19 @@
             <div class="portico-page" id="digest-page-title">
                 <h1> Zulip Digest </h1>
             </div>
-        <div>
-            <form>
-                <label for="start">Start date:</label>
-                <input type="date" id="start" name="start" value="2020-11-24">
-                <label for="end">End date:</label>
-                <input type="date" id="end" name="end" value="2020-11-11">
-                <label for="message-weight">Message weight:</label>
-                <input type="number" id="message-weight" name="message-weight" value="1">
-                <label for="sender-weight">Sender weight:</label>
-                <input type="number" id="sender-weight" name="sender-weight" value="1">
-                <input type="hidden" id="react-weight" name="react-weight" value="1">
-            </form>
-        </div>
+            <div>
+                <form>
+                    <label for="start">Start date:</label>
+                    <input type="date" id="start" name="start" value="2020-11-24">
+                    <label for="end">End date:</label>
+                    <input type="date" id="end" name="end" value="2020-11-11">
+                    <label for="message-weight">Message weight:</label>
+                    <input type="number" id="message-weight" name="message-weight" value="1">
+                    <label for="sender-weight">Sender weight:</label>
+                    <input type="number" id="sender-weight" name="sender-weight" value="1">
+                    <input type="hidden" id="react-weight" name="react-weight" value="1">
+                </form>
+            </div>
             <div class="digest-email-html">
                 {% include 'zerver/emails/compiled/digest.html' %}
                 <img id="digest-footer" src="/static/images/emails/footer.png"/>

--- a/templates/zerver/digest_base.html
+++ b/templates/zerver/digest_base.html
@@ -13,9 +13,9 @@
             </div>
             <div>
                 <form>
-                    <label for="start">Start date:</label>
+                    <label for="start">Start date (yyyy-mm-dd):</label>
                     <input type="date" id="start" name="start" value="2020-11-24">
-                    <label for="end">End date:</label>
+                    <label for="end">End date (yyyy-mm-dd):</label>
                     <input type="date" id="end" name="end" value="2020-11-11">
                     <label for="message-weight">Message weight:</label>
                     <input type="number" id="message-weight" name="message-weight" value="1">

--- a/templates/zerver/digest_base.html
+++ b/templates/zerver/digest_base.html
@@ -11,6 +11,19 @@
             <div class="portico-page" id="digest-page-title">
                 <h1> Zulip Digest </h1>
             </div>
+        <div>
+            <form>
+                <label for="start">Start date:</label>
+                <input type="date" id="start" name="start" value="2020-11-24">
+                <label for="end">End date:</label>
+                <input type="date" id="end" name="end" value="2020-11-11">
+                <label for="message-weight">Message weight:</label>
+                <input type="number" id="message-weight" name="message-weight" value="1">
+                <label for="sender-weight">Sender weight:</label>
+                <input type="number" id="sender-weight" name="sender-weight" value="1">
+                <input type="hidden" id="react-weight" name="react-weight" value="1">
+            </form>
+        </div>
             <div class="digest-email-html">
                 {% include 'zerver/emails/compiled/digest.html' %}
                 <img id="digest-footer" src="/static/images/emails/footer.png"/>

--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -70,6 +70,16 @@ class DigestTopic:
             "first_few_messages": first_few_messages,
         }
 
+    def score(
+        self,
+        message_weight: int,
+        sender_weight: int,
+        react_weight: int
+    ) -> int:
+        score = message_weight * self.num_human_messages
+        score += sender_weight * len(self.human_senders)
+        return score
+
 # Digests accumulate 2 types of interesting traffic for a user:
 # 1. New streams
 # 2. Interesting stream traffic, as determined by the longest and most

--- a/zerver/views/digest.py
+++ b/zerver/views/digest.py
@@ -26,7 +26,8 @@ def digest_page(request: HttpRequest) -> HttpResponse:
         # do something else
         start_date = 1
     cutoff = time.mktime((timezone_now() - timedelta(days=DIGEST_CUTOFF)).timetuple())
+    end_date = timezone_now()
 
-    context = get_digest_context(user_profile, cutoff)
+    context = get_digest_context(user_profile, cutoff, end_date)
     context.update(physical_address=settings.PHYSICAL_ADDRESS)
     return render(request, 'zerver/digest_base.html', context=context)

--- a/zerver/views/digest.py
+++ b/zerver/views/digest.py
@@ -20,7 +20,7 @@ def digest_page(request: HttpRequest) -> HttpResponse:
     react_weight = request.GET.get('react-weight', 1)
 
     if start_date:
-        #do something
+        # do something
         start_date += 1
     else:
         # do something else

--- a/zerver/views/digest.py
+++ b/zerver/views/digest.py
@@ -13,6 +13,18 @@ from zerver.lib.digest import DIGEST_CUTOFF, get_digest_context
 @zulip_login_required
 def digest_page(request: HttpRequest) -> HttpResponse:
     user_profile = request.user
+    start_date = request.GET.get('start-date', None)
+    end_date = request.GET.get('end-date', None)
+    message_weight = request.GET.get('message-weight', 1)
+    sender_weight = request.GET.get('sender-weight', 1)
+    react_weight = request.GET.get('react-weight', 1)
+
+    if start_date:
+        #do something
+        start_date += 1
+    else:
+        # do something else
+        start_date = 1
     cutoff = time.mktime((timezone_now() - timedelta(days=DIGEST_CUTOFF)).timetuple())
 
     context = get_digest_context(user_profile, cutoff)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
WIP: Feedback needed.
I have been working on issue #16718 for a bit now and I am a little stuck at this point.
I currently added default parameters to the functions used for retrieving the digest context.
After making the changes, the digest tests are no longer passing which I am not sure why because I set the default values to the current time and compared to see if the times were less than or equal to the end_date.

I have a couple questions:
- Will the new logic be replacing the hot_topics list or hot_topics and new_streams?
- Since the /digest page is currently dependent on the code for sending email digests, should I try and make the new /digest page work with it or make it separate so the emails aren't changed?

