### PR TITLE
todo_widget: Add task creation shorthand.

### DIFF
--- a/static/js/todo_widget.js
+++ b/static/js/todo_widget.js
@@ -6,6 +6,17 @@ import render_widgets_todo_widget_tasks from "../templates/widgets/todo_widget_t
 export class TaskData {
     task_map = new Map();
 
+    constructor(todos) {
+        for (const [i, todo] of todos.entries()) {
+            this.handle.new_task.inbound("canned", {
+                key: i,
+                task: todo.task,
+                desc: todo.description,
+                completed: todo.completed,
+            });
+        }
+    }
+
     get_new_index() {
         let idx = 0;
 
@@ -125,7 +136,12 @@ export function activate(opts) {
     const elem = opts.elem;
     const callback = opts.callback;
 
-    const task_data = new TaskData();
+    let todos = [];
+    if (opts.extra_data) {
+        todos = opts.extra_data.todos || [];
+    }
+
+    const task_data = new TaskData(todos);
 
     function render() {
         const html = render_widgets_todo_widget();

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -96,7 +96,7 @@ class WidgetContentTestCase(ZulipTestCase):
             self.assertEqual(get_widget_data(content=message), (None, None))
 
         # Add a positive check for context
-        self.assertEqual(get_widget_data(content="/todo"), ("todo", None))
+        self.assertEqual(get_widget_data(content="/todo"), ("todo", {"todos": []}))
 
     def test_explicit_widget_content(self) -> None:
         # Users can send widget_content directly on messages
@@ -147,7 +147,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         sender = self.example_user("cordelia")
         stream_name = "Verona"
-        content = "/todo"
+        content = "/todo \nkeep walking - forward\n[x] step outside - into the bright sun  \n\n  - [] sleep\n - for 8 hours\n [ ] drink water - one glass"
 
         payload = dict(
             type="stream",
@@ -164,7 +164,19 @@ class WidgetContentTestCase(ZulipTestCase):
 
         expected_submessage_content = dict(
             widget_type="todo",
-            extra_data=None,
+            extra_data={
+                "todos": [
+                    {"completed": False, "description": "forward", "task": "keep walking"},
+                    {
+                        "completed": True,
+                        "description": "into the bright sun",
+                        "task": "step outside",
+                    },
+                    {"completed": False, "description": "", "task": "sleep"},
+                    {"completed": False, "description": "", "task": "for 8 hours"},
+                    {"completed": False, "description": "one glass", "task": "drink water"},
+                ]
+            },
         )
 
         submessage = SubMessage.objects.get(message_id=message.id)


### PR DESCRIPTION
Previously, there was no shorthand way to create task items while
creating the todo widget. This adds a shorthand way to create a todo
widget with one or more tasks, including descriptions and completion.


<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![todo_shorthand](https://user-images.githubusercontent.com/33805964/100518949-d14b8e80-31ba-11eb-88f9-c474b23b3487.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
