### PR TITLE
Default to 2018 edition for Rust Playground

### DIFF
--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -366,7 +366,7 @@ const map_language_to_playground_info = {
     Rust: [
         {
             name: "Rust playground",
-            url_prefix: "https://play.rust-lang.org/?code=",
+            url_prefix: "https://play.rust-lang.org/?edition=2018&code=",
         },
     ],
     Julia: [


### PR DESCRIPTION
rustc's default edition is 2015 to preserve backwards compatibility, and
the playground appears to follow this scheme. However, 2018 edition Rust
is the current standard and is the default that Cargo uses when
initializing new projects. It adds support for various features,
including async/await and a new module system. As a result, I think
Zulip should default to 2018 edition when linking to the playground.
Users can always select a different edition once in the playground if
they would like.