### PR TITLE
navbar: Add JS tooltip to setting-icon.

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -261,6 +261,11 @@ exports.initialize_kitchen_sink_stuff = function () {
         timerender.set_full_datetime(message, time_elem);
     });
 
+    $("#settings-dropdown").tooltip({
+        animation: false,
+        placement: "bottom",
+    });
+
     $("#streams_header h4").tooltip({placement: "right", animation: false});
 
     $('#streams_header i[data-toggle="tooltip"]').tooltip({placement: "left", animation: false});


### PR DESCRIPTION
Issue: Implementing all titles using JS tooltip as discussed [here](https://chat.zulip.org/#narrow/stream/9-issues/topic/Different.20styles.20of.20title) 

Testing plan: I have tested it by hovering over setting-icon and running `tools/test-js-with-node` suite.

GIF or Screenshot:

Before: 
![beforenavbarsettingicon](https://user-images.githubusercontent.com/59444243/100514791-8d965c00-319d-11eb-87cf-a964a7cfec7f.gif)

After:
![afternavbarsettingicon](https://user-images.githubusercontent.com/59444243/100514798-9b4be180-319d-11eb-9ed1-f0f9fc7ae381.gif)

