### PR TITLE
puppeteer: Add clear success message at end of a test run.

### DIFF
--- a/tools/test-js-with-puppeteer
+++ b/tools/test-js-with-puppeteer
@@ -5,6 +5,9 @@ import shlex
 import subprocess
 import sys
 
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from scripts.lib.zulip_tools import ENDC, FAIL, OKGREEN
+
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Request the special webpack setup for frontend integration tests,
@@ -85,8 +88,9 @@ def run_tests(files: Iterable[str], external_host: str) -> None:
             ret = 1
             ret = run_tests()[0]
     if ret != 0:
-        print("""
-The Puppeteer frontend tests failed! For help debugging, read:
+        print(f"""
+{FAIL}The Puppeteer frontend tests failed!{ENDC}
+For help debugging, read:
   https://zulip.readthedocs.io/en/latest/testing/testing-with-puppeteer.html
 or report and ask for help in chat.zulip.org""", file=sys.stderr)
         if os.environ.get("CIRCLECI"):
@@ -101,4 +105,5 @@ external_host = "zulipdev.com:9981"
 assert_provisioning_status_ok(options.force)
 prepare_puppeteer_run()
 run_tests(options.tests, external_host)
+print(f"{OKGREEN}All tests passed!{ENDC}")
 sys.exit(0)


### PR DESCRIPTION
Also makes the failure message more noticeable.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/44665669/100523683-601ad400-31d8-11eb-94bd-d320ba3cc155.png)
![image](https://user-images.githubusercontent.com/44665669/100523684-65781e80-31d8-11eb-90fd-c64c30bed1f4.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
