### PR TITLE
updated function parse_anchor_val to clamp values to max anchor value

### DIFF
--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -839,6 +839,8 @@ def parse_anchor_value(anchor_val: Optional[str],
         anchor = int(anchor_val)
         if anchor < 0:
             return 0
+        elif anchor > LARGER_THAN_MAX_MESSAGE_ID:
+            return LARGER_THAN_MAX_MESSAGE_ID
         return anchor
     except ValueError:
         raise JsonableError(_("Invalid anchor"))


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Hey guys. This is my first PR. I went through https://github.com/zulip/zulip/issues/16768 thread and implemented @andersk 's fix. Also, I don't think there were any tests for this function. Should I write tests for this function? Thanks.

**Testing plan:** <!-- How have you tested? -->
I will write tests for parse_anchor_val function after discussion.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
