### PR TITLE
ui: Hide loading indicators for non-existant narrows.

### DIFF
--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -248,6 +248,7 @@ exports.load_messages = function (opts) {
                 // retry or display a connection error.
                 //
                 // FIXME: Warn the user when this has happened?
+                message_scroll.hide_indicators();
                 const data = {
                     messages: [],
                 };


### PR DESCRIPTION
We were still displaying the loading spinner
even after displaying the error text, which
was confusing as we do not try to fetch again.
This fixes it.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
