### PR TITLE
keyboard_shortcuts: Correct the shortcut key for Create new stream.

### DIFF
--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -320,7 +320,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Create new stream{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>N</kbd></span></td>
+                    <td><span class="hotkey"><kbd>n</kbd></span></td>
                 </tr>
             </table>
         </div>


### PR DESCRIPTION
Issue: Wrong shortcut key is mentioned in the keyboard shortcut list. The shortcut key to Create new stream is 'n' .

Testing plan: 

GIF or Screenshot: 

Before:
![wrong-shortcut-before](https://user-images.githubusercontent.com/59444243/100533491-13acb400-322b-11eb-8216-5d84dd3adc02.jpg)

After:
![wrong-shortcut-after](https://user-images.githubusercontent.com/59444243/100533494-1effdf80-322b-11eb-917a-6445692b5adb.jpg)

