### PR TITLE
notifications: Fix composebox notification escaping

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -564,19 +564,21 @@ exports.send_test_notification = function (content) {
     ]);
 };
 
+// Note that this returns values that are not HTML-escaped, for use in
+// handlebars templates that will do further escaping.
 function get_message_header(message) {
     if (message.type === "stream") {
         return message.stream + " > " + message.topic;
     }
     if (message.display_recipient.length > 2) {
-        return i18n.t("group private messages with __recipient__", {
+        return i18n.t("group private messages with __- recipient__", {
             recipient: message.display_reply_to,
         });
     }
     if (people.is_current_user(message.reply_to)) {
         return i18n.t("private messages with yourself");
     }
-    return i18n.t("private messages with __recipient__", {recipient: message.display_reply_to});
+    return i18n.t("private messages with __- recipient__", {recipient: message.display_reply_to});
 }
 
 exports.get_local_notify_mix_reason = function (message) {

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -140,8 +140,8 @@ IGNORED_PHRASES = [
     r"\bN\b",
     # Capital c feels obtrusive in clear status option
     r"clear",
-    r"group private messages with __recipient__",
-    r"private messages with __recipient__",
+    r"group private messages with __- recipient__",
+    r"private messages with __- recipient__",
     r"private messages with yourself",
     # TO CLEAN UP
     # Just want to avoid churning login.html right now


### PR DESCRIPTION
The "Narrow to PM with" notification above the composebox was
double-escaped, mangling names with single quotes in them. This removes
the escaping in i18next, causing the name to be escaped only in
handlebars.

**Testing plan:** manually tested.


**GIFs or screenshots:**

before:
![before](https://user-images.githubusercontent.com/5001092/100542917-14bffe80-3288-11eb-9022-b6c408e90683.png)

after:
![after](https://user-images.githubusercontent.com/5001092/100542920-1689c200-3288-11eb-81d3-0b419c9d97d0.png)
