### PR TITLE
node_tests: Remove all non-computed uses of ‘global’

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -361,7 +361,6 @@
         {
             "files": ["frontend_tests/**"],
             "globals": {
-                "assert": false,
                 "document": false,
                 "reset_module": false,
                 "set_global": false,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -362,11 +362,7 @@
             "files": ["frontend_tests/**"],
             "globals": {
                 "document": false,
-                "reset_module": false,
-                "set_global": false,
-                "window": false,
-                "with_field": false,
-                "zrequire": false
+                "window": false
             },
             "rules": {
                 "no-sync": "off"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -361,6 +361,7 @@
             "files": ["frontend_tests/**"],
             "globals": {
                 "document": false,
+                "navigator": false,
                 "window": false
             },
             "rules": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -228,7 +228,6 @@
                 "resize": false,
                 "rows": false,
                 "rtl": false,
-                "run_test": false,
                 "schema": false,
                 "scroll_bar": false,
                 "scroll_util": false,

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("$", global.make_zjquery());
 const window_stub = $.create("window-stub");
 set_global("to_$", () => window_stub);

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -696,9 +696,9 @@ run_test("initialize", () => {
     channel.post = function (payload) {
         payload.success({});
     };
-    global.server_events = {
+    set_global("server_events", {
         check_for_unsuspend() {},
-    };
+    });
 
     let scroll_handler_started;
     buddy_list.start_scroll_handler = () => {
@@ -725,7 +725,7 @@ run_test("initialize", () => {
             presences: {},
         });
     };
-    global.setInterval = (func) => func();
+    set_global("setInterval", (func) => func());
 
     $(window).off("focus");
     activity.initialize();

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 const window_stub = $.create("window-stub");
 set_global("to_$", () => window_stub);

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -3,8 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 const window_stub = $.create("window-stub");
 set_global("to_$", () => window_stub);
 $(window).idle = () => {};

--- a/frontend_tests/node_tests/alert_words.js
+++ b/frontend_tests/node_tests/alert_words.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const params = {
     alert_words: ["alertone", "alerttwo", "alertthree", "al*rt.*s", ".+", "emoji"],
 };

--- a/frontend_tests/node_tests/alert_words.js
+++ b/frontend_tests/node_tests/alert_words.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 const params = {
     alert_words: ["alertone", "alerttwo", "alertthree", "al*rt.*s", ".+", "emoji"],
 };

--- a/frontend_tests/node_tests/alert_words.js
+++ b/frontend_tests/node_tests/alert_words.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const params = {
     alert_words: ["alertone", "alerttwo", "alertthree", "al*rt.*s", ".+", "emoji"],

--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 
 set_global("channel", {});

--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -3,8 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 set_global("channel", {});
 

--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("$", global.make_zjquery());
 
 set_global("channel", {});

--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -2,6 +2,7 @@
 
 const {strict: assert} = require("assert");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -26,7 +27,7 @@ run_test("render_alert_words_ui", () => {
     const alert_word_items = $.create("alert_word_items");
     word_list.set_find_results(".alert-word-item", alert_word_items);
 
-    global.stub_templates((name, args) => {
+    stub_templates((name, args) => {
         assert.equal(name, "settings/alert_word_settings_item");
         return "stub-" + args.word;
     });

--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -6,6 +6,7 @@ const fs = require("fs");
 const {JSDOM} = require("jsdom");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = () => {};

--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -1,10 +1,11 @@
 "use strict";
 
-const noop = () => {};
+const {strict: assert} = require("assert");
 const fs = require("fs");
 
 const {JSDOM} = require("jsdom");
 
+const noop = () => {};
 const template = fs.readFileSync("templates/corporate/billing.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});
 const document = dom.window.document;

--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -5,6 +5,8 @@ const fs = require("fs");
 
 const {JSDOM} = require("jsdom");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const noop = () => {};
 const template = fs.readFileSync("templates/corporate/billing.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});

--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -6,6 +6,7 @@ const fs = require("fs");
 const {JSDOM} = require("jsdom");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = () => {};
 const template = fs.readFileSync("templates/corporate/billing.html", "utf-8");
@@ -24,7 +25,7 @@ set_global("StripeCheckout", {
 });
 
 zrequire("billing", "js/billing/billing");
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 run_test("initialize", () => {
     let token_func;

--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -15,9 +15,9 @@ const dom = new JSDOM(template, {pretendToBeVisual: true});
 const document = dom.window.document;
 
 let jquery_init;
-global.$ = (f) => {
+set_global("$", (f) => {
     jquery_init = f;
-};
+});
 set_global("helpers", {
     set_tab: noop,
 });

--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -14,10 +14,6 @@ const template = fs.readFileSync("templates/corporate/billing.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});
 const document = dom.window.document;
 
-let jquery_init;
-set_global("$", (f) => {
-    jquery_init = f;
-});
 set_global("helpers", {
     set_tab: noop,
 });
@@ -25,7 +21,6 @@ set_global("StripeCheckout", {
     configure: noop,
 });
 
-zrequire("billing", "js/billing/billing");
 set_global("$", make_zjquery());
 
 run_test("initialize", () => {
@@ -75,7 +70,7 @@ run_test("initialize", () => {
     $("#payment-method").data = (key) =>
         document.querySelector("#payment-method").getAttribute("data-" + key);
 
-    jquery_init();
+    zrequire("billing", "js/billing/billing");
 
     assert(set_tab_called);
     assert(stripe_checkout_configure_called);

--- a/frontend_tests/node_tests/billing_helpers.js
+++ b/frontend_tests/node_tests/billing_helpers.js
@@ -7,6 +7,7 @@ const JQuery = require("jquery");
 const {JSDOM} = require("jsdom");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const template = fs.readFileSync("templates/corporate/upgrade.html", "utf-8");

--- a/frontend_tests/node_tests/billing_helpers.js
+++ b/frontend_tests/node_tests/billing_helpers.js
@@ -6,6 +6,8 @@ const fs = require("fs");
 const JQuery = require("jquery");
 const {JSDOM} = require("jsdom");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const template = fs.readFileSync("templates/corporate/upgrade.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});
 const jquery = JQuery(dom.window);

--- a/frontend_tests/node_tests/billing_helpers.js
+++ b/frontend_tests/node_tests/billing_helpers.js
@@ -7,12 +7,13 @@ const JQuery = require("jquery");
 const {JSDOM} = require("jsdom");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const template = fs.readFileSync("templates/corporate/upgrade.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});
 const jquery = JQuery(dom.window);
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("page_params", {});
 set_global("loading", {});
 set_global("history", {});

--- a/frontend_tests/node_tests/billing_helpers.js
+++ b/frontend_tests/node_tests/billing_helpers.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const {strict: assert} = require("assert");
 const fs = require("fs");
 
 const JQuery = require("jquery");

--- a/frontend_tests/node_tests/blueslip_stacktrace.js
+++ b/frontend_tests/node_tests/blueslip_stacktrace.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const blueslip_stacktrace = zrequire("blueslip_stacktrace");
 
 run_test("clean_path", () => {

--- a/frontend_tests/node_tests/blueslip_stacktrace.js
+++ b/frontend_tests/node_tests/blueslip_stacktrace.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 const blueslip_stacktrace = zrequire("blueslip_stacktrace");
 
 run_test("clean_path", () => {

--- a/frontend_tests/node_tests/blueslip_stacktrace.js
+++ b/frontend_tests/node_tests/blueslip_stacktrace.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const blueslip_stacktrace = zrequire("blueslip_stacktrace");
 

--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const _settings_bots = {
     render_bots: () => {},

--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const _settings_bots = {
     render_bots: () => {},
 };

--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const _settings_bots = {
     render_bots: () => {},
 };

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const _page_params = {};

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const _ = require("lodash");
 
 const _page_params = {};

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const _page_params = {};
 
 set_global("page_params", _page_params);

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -5,11 +5,12 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const _page_params = {};
 
 set_global("page_params", _page_params);
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 const people = zrequire("people");
 zrequire("presence");
 zrequire("user_status");

--- a/frontend_tests/node_tests/buddy_list.js
+++ b/frontend_tests/node_tests/buddy_list.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/buddy_list.js
+++ b/frontend_tests/node_tests/buddy_list.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const _ = require("lodash");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/buddy_list.js
+++ b/frontend_tests/node_tests/buddy_list.js
@@ -5,8 +5,9 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 const people = zrequire("people");
 zrequire("buddy_data");
 zrequire("buddy_list");

--- a/frontend_tests/node_tests/buddy_list.js
+++ b/frontend_tests/node_tests/buddy_list.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 const people = zrequire("people");
 zrequire("buddy_data");

--- a/frontend_tests/node_tests/channel.js
+++ b/frontend_tests/node_tests/channel.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const _ = require("lodash");
 
 set_global("$", {});

--- a/frontend_tests/node_tests/channel.js
+++ b/frontend_tests/node_tests/channel.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", {});
 
 set_global("reload", {});
@@ -249,7 +251,7 @@ run_test("retry", () => {
         },
 
         check_ajax_options(options) {
-            global.patch_builtin("setTimeout", (f, delay) => {
+            set_global("setTimeout", (f, delay) => {
                 assert.equal(delay, 0);
                 f();
             });

--- a/frontend_tests/node_tests/channel.js
+++ b/frontend_tests/node_tests/channel.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 set_global("$", {});
 

--- a/frontend_tests/node_tests/color_data.js
+++ b/frontend_tests/node_tests/color_data.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("color_data");
 

--- a/frontend_tests/node_tests/color_data.js
+++ b/frontend_tests/node_tests/color_data.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("color_data");
 
 run_test("pick_color", () => {

--- a/frontend_tests/node_tests/color_data.js
+++ b/frontend_tests/node_tests/color_data.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 zrequire("color_data");
 
 run_test("pick_color", () => {

--- a/frontend_tests/node_tests/colorspace.js
+++ b/frontend_tests/node_tests/colorspace.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("colorspace");
 

--- a/frontend_tests/node_tests/colorspace.js
+++ b/frontend_tests/node_tests/colorspace.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 zrequire("colorspace");
 
 run_test("sRGB_to_linear", () => {

--- a/frontend_tests/node_tests/colorspace.js
+++ b/frontend_tests/node_tests/colorspace.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("colorspace");
 
 run_test("sRGB_to_linear", () => {

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -3,10 +3,11 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = () => {};
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 const input = $.create("input");
 set_global("document", {
     createElement: () => input,

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const noop = () => {};
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const noop = () => {};
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = () => {};

--- a/frontend_tests/node_tests/components.js
+++ b/frontend_tests/node_tests/components.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("keydown_util");
 zrequire("components");

--- a/frontend_tests/node_tests/components.js
+++ b/frontend_tests/node_tests/components.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const _ = require("lodash");
 
 zrequire("keydown_util");

--- a/frontend_tests/node_tests/components.js
+++ b/frontend_tests/node_tests/components.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("keydown_util");
 zrequire("components");
 

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -6,6 +6,7 @@ const {JSDOM} = require("jsdom");
 const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const events = require("./lib/events");
 
@@ -13,7 +14,7 @@ set_global("bridge", false);
 
 const noop = function () {};
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("DOMParser", new JSDOM().window.DOMParser);
 set_global("compose_actions", {
     update_placeholder_text: noop,
@@ -108,7 +109,7 @@ function stub_out_video_calls() {
 
 function reset_jquery() {
     // Avoid leaks.
-    set_global("$", global.make_zjquery());
+    set_global("$", make_zjquery());
 }
 
 const new_user = {
@@ -201,7 +202,7 @@ run_test("validate_stream_message_address_info", () => {
 
 run_test("validate", () => {
     function initialize_pm_pill() {
-        set_global("$", global.make_zjquery());
+        set_global("$", make_zjquery());
 
         $("#compose-send-button").prop("disabled", false);
         $("#compose-send-button").trigger("focus");
@@ -1892,7 +1893,7 @@ run_test("create_message_object", () => {
 });
 
 run_test("nonexistent_stream_reply_error", () => {
-    set_global("$", global.make_zjquery());
+    set_global("$", make_zjquery());
 
     const actions = [];
     $("#nonexistent_stream_reply_error").show = () => {

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const {JSDOM} = require("jsdom");
 const rewiremock = require("rewiremock/node");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -156,7 +157,7 @@ run_test("validate_stream_message_address_info", () => {
 
     sub.subscribed = false;
     stream_data.add_sub(sub);
-    global.stub_templates((template_name) => {
+    stub_templates((template_name) => {
         assert.equal(template_name, "compose_not_subscribed");
         return "compose_not_subscribed_stub";
     });
@@ -220,7 +221,7 @@ run_test("validate", () => {
 
         $("#zephyr-mirror-error").is = noop;
 
-        global.stub_templates((fn) => {
+        stub_templates((fn) => {
             assert.equal(fn, "input_pill");
             return "<div>pill-html</div>";
         });
@@ -393,7 +394,7 @@ run_test("validate_stream_message", () => {
         assert.equal(stream_id, 101);
         return 16;
     };
-    global.stub_templates((template_name, data) => {
+    stub_templates((template_name, data) => {
         assert.equal(template_name, "compose_all_everyone");
         assert.equal(data.count, 16);
         return "compose_all_everyone_stub";
@@ -988,7 +989,7 @@ run_test("warn_if_private_stream_is_linked", () => {
     const checks = [
         (function () {
             let called;
-            global.stub_templates((template_name, context) => {
+            stub_templates((template_name, context) => {
                 called = true;
                 assert.equal(template_name, "compose_private_stream_alert");
                 assert.equal(context.stream_name, "Denmark");
@@ -1283,7 +1284,7 @@ run_test("warn_if_mentioning_unsubscribed_user", () => {
 
         (function () {
             let called;
-            global.stub_templates((template_name, context) => {
+            stub_templates((template_name, context) => {
                 called = true;
                 assert.equal(template_name, "compose_invite_users");
                 assert.equal(context.user_id, 34);
@@ -1344,7 +1345,7 @@ run_test("warn_if_mentioning_unsubscribed_user", () => {
 
     // Now try to mention the same person again. The template should
     // not render.
-    global.stub_templates(noop);
+    stub_templates(noop);
     compose.warn_if_mentioning_unsubscribed_user(mentioned);
     assert.equal($("#compose_invite_users").visible(), true);
     assert(looked_for_existing);

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -729,11 +729,11 @@ run_test("send_message", () => {
     set_global("setTimeout", (func) => {
         func();
     });
-    global.server_events = {
+    set_global("server_events", {
         assert_get_events_running() {
             stub_state.get_events_running_called += 1;
         },
-    };
+    });
 
     // Tests start here.
     (function test_message_send_success_codepath() {
@@ -1045,8 +1045,8 @@ run_test("initialize", () => {
     });
     $("#compose #attach_files").addClass("notdisplayed");
 
-    global.document = "document-stub";
-    global.csrf_token = "fake-csrf-token";
+    set_global("document", "document-stub");
+    set_global("csrf_token", "fake-csrf-token");
 
     page_params.max_file_upload_size_mib = 512;
 
@@ -1097,13 +1097,13 @@ run_test("initialize", () => {
     function set_up_compose_start_mock(expected_opts) {
         compose_actions_start_checked = false;
 
-        global.compose_actions = {
+        set_global("compose_actions", {
             start(msg_type, opts) {
                 assert.equal(msg_type, "stream");
                 assert.deepEqual(opts, expected_opts);
                 compose_actions_start_checked = true;
             },
-        };
+        });
     }
 
     (function test_page_params_narrow_path() {
@@ -1152,7 +1152,7 @@ run_test("update_fade", () => {
     let set_focused_recipient_checked = false;
     let update_all_called = false;
 
-    global.compose_fade = {
+    set_global("compose_fade", {
         set_focused_recipient(msg_type) {
             assert.equal(msg_type, "private");
             set_focused_recipient_checked = true;
@@ -1160,7 +1160,7 @@ run_test("update_fade", () => {
         update_all() {
             update_all_called = true;
         },
-    };
+    });
 
     compose_state.set_message_type(false);
     keyup_handler_func();
@@ -1850,13 +1850,11 @@ run_test("create_message_object", () => {
         "#compose-textarea": "burrito",
     };
 
-    global.$ = function (selector) {
-        return {
-            val() {
-                return page[selector];
-            },
-        };
-    };
+    set_global("$", (selector) => ({
+        val() {
+            return page[selector];
+        },
+    }));
 
     global.compose_state.get_message_type = function () {
         return "stream";

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -70,8 +70,8 @@ set_global("ui_util", {});
 
 // Setting these up so that we can test that links to uploads within messages are
 // automatically converted to server relative links.
-global.document.location.protocol = "https:";
-global.document.location.host = "foo.com";
+document.location.protocol = "https:";
+document.location.host = "foo.com";
 
 zrequire("zcommand");
 zrequire("compose_ui");
@@ -542,10 +542,10 @@ run_test("markdown_shortcuts", () => {
     let compose_value = $("#compose_textarea").val();
     let selected_word = "";
 
-    global.document.queryCommandEnabled = function () {
+    document.queryCommandEnabled = function () {
         return queryCommandEnabled;
     };
-    global.document.execCommand = function (cmd, bool, markdown) {
+    document.execCommand = function (cmd, bool, markdown) {
         const compose_textarea = $("#compose-textarea");
         const value = compose_textarea.val();
         $("#compose-textarea").val(
@@ -1856,7 +1856,7 @@ run_test("create_message_object", () => {
         },
     }));
 
-    global.compose_state.get_message_type = function () {
+    compose_state.get_message_type = function () {
         return "stream";
     };
 
@@ -1873,7 +1873,7 @@ run_test("create_message_object", () => {
     assert.equal(message.topic, "lunch");
     assert.equal(message.content, "burrito");
 
-    global.compose_state.get_message_type = function () {
+    compose_state.get_message_type = function () {
         return "private";
     };
     compose_state.private_message_recipient = function () {

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -7,6 +7,7 @@ const rewiremock = require("rewiremock/node");
 
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const events = require("./lib/events");

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -5,6 +5,8 @@ const {strict: assert} = require("assert");
 const {JSDOM} = require("jsdom");
 const rewiremock = require("rewiremock/node");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const events = require("./lib/events");
 
 set_global("bridge", false);
@@ -721,7 +723,7 @@ run_test("send_message", () => {
         return stub_state;
     }
 
-    global.patch_builtin("setTimeout", (func) => {
+    set_global("setTimeout", (func) => {
         func();
     });
     global.server_events = {

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const {JSDOM} = require("jsdom");
 const rewiremock = require("rewiremock/node");
 

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = function () {};
 const return_false = function () {
@@ -18,7 +19,7 @@ set_global("document", {
 
 set_global("page_params", {});
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 set_global("compose_pm_pill", {});
 

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -44,8 +44,6 @@ const respond_to_message = compose_actions.respond_to_message;
 const reply_with_mention = compose_actions.reply_with_mention;
 const quote_and_reply = compose_actions.quote_and_reply;
 
-const compose_state = global.compose_state;
-
 compose_state.private_message_recipient = (function () {
     let recipient;
 
@@ -129,7 +127,7 @@ run_test("start", () => {
     compose_actions.clear_textarea = noop;
 
     // Start stream message
-    global.narrow_state.set_compose_defaults = function () {
+    narrow_state.set_compose_defaults = function () {
         const opts = {};
         opts.stream = "stream1";
         opts.topic = "topic1";
@@ -156,7 +154,7 @@ run_test("start", () => {
     };
     stream_data.add_sub(denmark);
 
-    global.narrow_state.set_compose_defaults = function () {
+    narrow_state.set_compose_defaults = function () {
         const opts = {};
         opts.trigger = "new topic button";
         return opts;
@@ -167,7 +165,7 @@ run_test("start", () => {
     assert.equal($("#stream_message_recipient_stream").val(), "Denmark");
     assert.equal($("#stream_message_recipient_topic").val(), "");
 
-    global.narrow_state.set_compose_defaults = function () {
+    narrow_state.set_compose_defaults = function () {
         const opts = {};
         opts.trigger = "compose_hotkey";
         return opts;
@@ -194,7 +192,7 @@ run_test("start", () => {
     stream_data.clear_subscriptions();
 
     // Start PM
-    global.narrow_state.set_compose_defaults = function () {
+    narrow_state.set_compose_defaults = function () {
         const opts = {};
         opts.private_message_recipient = "foo@example.com";
         return opts;

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const noop = function () {};
 const return_false = function () {
     return false;

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const noop = function () {};
 const return_false = function () {
     return false;

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = function () {};

--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 zrequire("stream_data");
 const people = zrequire("people");
 zrequire("compose_fade");

--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("stream_data");
 const people = zrequire("people");
 zrequire("compose_fade");

--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {zrequire} = require("../zjsunit/namespace");
+const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 zrequire("stream_data");
@@ -43,7 +43,7 @@ run_test("set_focused_recipient", () => {
     stream_data.add_sub(sub);
     stream_data.set_subscribers(sub, [me.user_id, alice.user_id]);
 
-    global.$ = function (selector) {
+    set_global("$", (selector) => {
         switch (selector) {
             case "#stream_message_recipient_stream":
                 return {
@@ -60,7 +60,7 @@ run_test("set_focused_recipient", () => {
             default:
                 throw new Error(`Unknown selector ${selector}`);
         }
-    };
+    });
 
     compose_fade.set_focused_recipient("stream");
 

--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("stream_data");
 const people = zrequire("people");

--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -3,8 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 const people = zrequire("people");
 

--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 
 const people = zrequire("people");

--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("$", global.make_zjquery());
 
 const people = zrequire("people");

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const autosize = require("autosize");
 
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("compose_ui");
 const people = zrequire("people");
@@ -16,7 +17,7 @@ set_global("document", {
     },
 });
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 const alice = {
     email: "alice@zulip.com",

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const autosize = require("autosize");
 
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("compose_ui");

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const autosize = require("autosize");
 
 zrequire("compose_ui");

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const autosize = require("autosize");
 
+const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+
 zrequire("compose_ui");
 const people = zrequire("people");
 zrequire("user_status");

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const emoji = zrequire("emoji", "shared/js/emoji");
 const typeahead = zrequire("typeahead", "shared/js/typeahead");
 zrequire("compose_state");
@@ -331,7 +333,7 @@ run_test("content_typeahead_selected", () => {
         },
     });
     let set_timeout_called = false;
-    global.patch_builtin("setTimeout", (f, time) => {
+    set_global("setTimeout", (f, time) => {
         f();
         assert.equal(time, 0);
         set_timeout_called = true;

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -285,9 +285,9 @@ const call_center = {
     members: [],
 };
 
-global.user_groups.add(hamletcharacters);
-global.user_groups.add(backend);
-global.user_groups.add(call_center);
+user_groups.add(hamletcharacters);
+user_groups.add(backend);
+user_groups.add(call_center);
 
 const make_emoji = function (emoji_dict) {
     return {emoji_name: emoji_dict.name, emoji_code: emoji_dict.emoji_code};
@@ -1100,7 +1100,7 @@ run_test("initialize", () => {
     $("#compose-send-button").fadeOut = noop;
     $("#compose-send-button").fadeIn = noop;
     let channel_post_called = false;
-    global.channel.post = function (params) {
+    channel.post = function (params) {
         assert.equal(params.url, "/json/users/me/enter-sends");
         assert.equal(params.idempotent, true);
         assert.deepEqual(params.data, {enter_sends: page_params.enter_sends});

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -21,7 +21,6 @@ zrequire("composebox_typeahead");
 zrequire("recent_senders");
 zrequire("settings_org");
 const settings_config = zrequire("settings_config");
-set_global("md5", (s) => "md5-" + s);
 
 // To be eliminated in next commit:
 stream_data.update_calculated_fields = () => {};

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const emoji = zrequire("emoji", "shared/js/emoji");

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const emoji = zrequire("emoji", "shared/js/emoji");
 const typeahead = zrequire("typeahead", "shared/js/typeahead");
@@ -171,7 +172,7 @@ stream_data.add_sub(sweden_stream);
 stream_data.add_sub(denmark_stream);
 stream_data.add_sub(netherland_stream);
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 set_global("page_params", {});
 set_global("channel", {});

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const emoji = zrequire("emoji", "shared/js/emoji");
 const typeahead = zrequire("typeahead", "shared/js/typeahead");
 zrequire("compose_state");

--- a/frontend_tests/node_tests/copy_and_paste.js
+++ b/frontend_tests/node_tests/copy_and_paste.js
@@ -4,10 +4,8 @@ const {strict: assert} = require("assert");
 
 const {JSDOM} = require("jsdom");
 
-const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-
-stub_out_jquery();
 
 set_global("page_params", {
     development_environment: true,

--- a/frontend_tests/node_tests/copy_and_paste.js
+++ b/frontend_tests/node_tests/copy_and_paste.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 global.stub_out_jquery();
 
 set_global("page_params", {

--- a/frontend_tests/node_tests/copy_and_paste.js
+++ b/frontend_tests/node_tests/copy_and_paste.js
@@ -2,14 +2,16 @@
 
 const {strict: assert} = require("assert");
 
-global.stub_out_jquery();
+const {JSDOM} = require("jsdom");
+
+const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+
+stub_out_jquery();
 
 set_global("page_params", {
     development_environment: true,
 });
 set_global("compose_ui", {});
-
-const {JSDOM} = require("jsdom");
 
 const {window} = new JSDOM("<!DOCTYPE html><p>Hello world</p>");
 const {DOMParser, document} = window;

--- a/frontend_tests/node_tests/copy_and_paste.js
+++ b/frontend_tests/node_tests/copy_and_paste.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const {JSDOM} = require("jsdom");
 
 const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 stub_out_jquery();
 

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -74,7 +74,6 @@ set_global("page_params", {
     is_admin: true,
     realm_description: "already set description",
 });
-const page_params = global.page_params;
 
 // For data-oriented modules, just use them, don't stub them.
 zrequire("alert_words");
@@ -181,7 +180,7 @@ run_test("custom profile fields", (override) => {
     override("settings_profile_fields.populate_profile_fields", noop);
     override("settings_account.add_custom_profile_fields_to_settings", noop);
     dispatch(event);
-    assert_same(global.page_params.custom_profile_fields, event.fields);
+    assert_same(page_params.custom_profile_fields, event.fields);
 });
 
 run_test("default_streams", (override) => {

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_stub, with_stub} = require("../zjsunit/stub");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = function () {};
 
@@ -15,7 +16,7 @@ const test_user = events.test_user;
 const test_streams = events.test_streams;
 const typing_person1 = events.typing_person1;
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 set_global("setTimeout", (func) => func());
 

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const noop = function () {};
 
 const events = require("./lib/events");
@@ -14,7 +16,7 @@ const typing_person1 = events.typing_person1;
 
 set_global("$", global.make_zjquery());
 
-global.patch_builtin("setTimeout", (func) => func());
+set_global("setTimeout", (func) => func());
 
 set_global("activity", {});
 set_global("alert_words_ui", {});

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_stub, with_stub} = require("../zjsunit/stub");
 
 const noop = function () {};
 
@@ -126,7 +127,7 @@ run_test("alert_words", (override) => {
 
 run_test("attachments", (override) => {
     const event = event_fixtures.attachment__add;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         // attachments_ui is hard to test deeply
         override("attachments_ui.update_attachments", stub.f);
         dispatch(event);
@@ -137,7 +138,7 @@ run_test("attachments", (override) => {
 run_test("user groups", (override) => {
     let event = event_fixtures.user_group__add;
     override("settings_user_groups.reload", noop);
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("user_groups.add", stub.f);
         dispatch(event);
         const args = stub.get_args("group");
@@ -145,7 +146,7 @@ run_test("user groups", (override) => {
     });
 
     event = event_fixtures.user_group__add_members;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("user_groups.add_members", stub.f);
         dispatch(event);
         const args = stub.get_args("group_id", "user_ids");
@@ -154,7 +155,7 @@ run_test("user groups", (override) => {
     });
 
     event = event_fixtures.user_group__remove_members;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("user_groups.remove_members", stub.f);
         dispatch(event);
         const args = stub.get_args("group_id", "user_ids");
@@ -163,7 +164,7 @@ run_test("user groups", (override) => {
     });
 
     event = event_fixtures.user_group__update;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("user_groups.update", stub.f);
         dispatch(event);
         const args = stub.get_args("event");
@@ -184,7 +185,7 @@ run_test("custom profile fields", (override) => {
 run_test("default_streams", (override) => {
     const event = event_fixtures.default_streams;
     override("settings_streams.update_default_streams_table", noop);
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("stream_data.set_realm_default_streams", stub.f);
         dispatch(event);
         const args = stub.get_args("realm_default_streams");
@@ -202,7 +203,7 @@ run_test("hotspots", (override) => {
 run_test("invites_changed", (override) => {
     const event = event_fixtures.invites_changed;
     $("#admin-invites-list").length = 1;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("settings_invites.set_up", stub.f);
         dispatch(event); // stub automatically checks if stub.f is called once
     });
@@ -211,7 +212,7 @@ run_test("invites_changed", (override) => {
 run_test("muted_topics", (override) => {
     const event = event_fixtures.muted_topics;
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("muting_ui.handle_updates", stub.f);
         dispatch(event);
         const args = stub.get_args("muted_topics");
@@ -222,7 +223,7 @@ run_test("muted_topics", (override) => {
 run_test("presence", (override) => {
     const event = event_fixtures.presence;
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("activity.update_presence_info", stub.f);
         dispatch(event);
         const args = stub.get_args("user_id", "presence", "server_time");
@@ -234,7 +235,7 @@ run_test("presence", (override) => {
 
 run_test("reaction", (override) => {
     let event = event_fixtures.reaction__add;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("reactions.add_reaction", stub.f);
         dispatch(event);
         const args = stub.get_args("event");
@@ -243,7 +244,7 @@ run_test("reaction", (override) => {
     });
 
     event = event_fixtures.reaction__remove;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("reactions.remove_reaction", stub.f);
         dispatch(event);
         const args = stub.get_args("event");
@@ -391,8 +392,8 @@ run_test("realm settings", (override) => {
 
 run_test("realm_bot", (override) => {
     let event = event_fixtures.realm_bot__add;
-    global.with_stub((bot_stub) => {
-        global.with_stub((admin_stub) => {
+    with_stub((bot_stub) => {
+        with_stub((admin_stub) => {
             override("bot_data.add", bot_stub.f);
             override("settings_users.update_bot_data", admin_stub.f);
             dispatch(event);
@@ -404,8 +405,8 @@ run_test("realm_bot", (override) => {
     });
 
     event = event_fixtures.realm_bot__remove;
-    global.with_stub((bot_stub) => {
-        global.with_stub((admin_stub) => {
+    with_stub((bot_stub) => {
+        with_stub((admin_stub) => {
             override("bot_data.deactivate", bot_stub.f);
             override("settings_users.update_bot_data", admin_stub.f);
             dispatch(event);
@@ -421,8 +422,8 @@ run_test("realm_bot", (override) => {
     dispatch(event);
 
     event = event_fixtures.realm_bot__update;
-    global.with_stub((bot_stub) => {
-        global.with_stub((admin_stub) => {
+    with_stub((bot_stub) => {
+        with_stub((admin_stub) => {
             override("bot_data.update", bot_stub.f);
             override("settings_users.update_bot_data", admin_stub.f);
 
@@ -450,7 +451,7 @@ run_test("realm_emoji", (override) => {
     const ui_stubs = [];
 
     for (const func_name of ui_func_names) {
-        const ui_stub = global.make_stub();
+        const ui_stub = make_stub();
         override(func_name, ui_stub.f);
         ui_stubs.push(ui_stub);
     }
@@ -519,7 +520,7 @@ run_test("realm_user", (override) => {
     assert(!people.is_active_user_for_popover(event.person.user_id));
 
     event = event_fixtures.realm_user__update;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("user_events.update_person", stub.f);
         dispatch(event);
         const args = stub.get_args("person");
@@ -529,7 +530,7 @@ run_test("realm_user", (override) => {
 
 run_test("restart", (override) => {
     const event = event_fixtures.restart;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("reload.initiate", stub.f);
         dispatch(event);
         const args = stub.get_args("options");
@@ -541,7 +542,7 @@ run_test("restart", (override) => {
 run_test("stream", (override) => {
     let event = event_fixtures.stream__update;
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("stream_events.update_property", stub.f);
         override("settings_streams.update_default_streams_table", noop);
         dispatch(event);
@@ -553,7 +554,7 @@ run_test("stream", (override) => {
 
     // stream create
     event = event_fixtures.stream__create;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("stream_data.create_streams", stub.f);
         override("stream_data.get_sub_by_id", noop);
         override("stream_data.update_calculated_fields", noop);
@@ -569,7 +570,7 @@ run_test("stream", (override) => {
 
     // stream delete
     event = event_fixtures.stream__delete;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("subs.remove_stream", noop);
         override("stream_data.delete_sub", noop);
         override("settings_streams.update_default_streams_table", noop);
@@ -608,7 +609,7 @@ run_test("stream", (override) => {
 
 run_test("submessage", (override) => {
     const event = event_fixtures.submessage;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("submessage.handle_event", stub.f);
         dispatch(event);
         const submsg = stub.get_args("submsg").submsg;
@@ -626,7 +627,7 @@ run_test("submessage", (override) => {
 
 run_test("typing", (override) => {
     let event = event_fixtures.typing__start;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("typing_events.display_notification", stub.f);
         dispatch(event);
         const args = stub.get_args("event");
@@ -634,7 +635,7 @@ run_test("typing", (override) => {
     });
 
     event = event_fixtures.typing__stop;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("typing_events.hide_notification", stub.f);
         dispatch(event);
         const args = stub.get_args("event");
@@ -707,7 +708,7 @@ run_test("update_display_settings", (override) => {
         assert_same(secs, 300);
     };
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         event = event_fixtures.update_display_settings__color_scheme_dark;
         page_params.color_scheme = 1;
         override("night_mode.enable", stub.f); // automatically checks if called
@@ -716,7 +717,7 @@ run_test("update_display_settings", (override) => {
         assert(page_params.color_scheme, 2);
     });
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         event = event_fixtures.update_display_settings__color_scheme_light;
         page_params.color_scheme = 1;
         override("night_mode.disable", stub.f); // automatically checks if called
@@ -725,7 +726,7 @@ run_test("update_display_settings", (override) => {
         assert(page_params.color_scheme, 3);
     });
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         event = event_fixtures.update_display_settings__color_scheme_automatic;
         page_params.color_scheme = 2;
         override("night_mode.default_preference_checker", stub.f); // automatically checks if called
@@ -734,7 +735,7 @@ run_test("update_display_settings", (override) => {
         assert(page_params.color_scheme, 1);
     });
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         event = event_fixtures.update_display_settings__emojiset;
         called = false;
         override("settings_display.report_emojiset_change", stub.f);
@@ -756,7 +757,7 @@ run_test("update_display_settings", (override) => {
     dispatch(event);
     assert_same(page_params.fluid_layout_width, true);
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         event = event_fixtures.update_display_settings__demote_inactive_streams;
         override("stream_data.set_filter_out_inactives", noop);
         override("stream_list.update_streams_sidebar", stub.f);
@@ -768,7 +769,7 @@ run_test("update_display_settings", (override) => {
 
 run_test("update_global_notifications", (override) => {
     const event = event_fixtures.update_global_notifications;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("notifications.handle_global_notification_updates", stub.f);
         override("settings_notifications.update_page", noop);
         dispatch(event);
@@ -781,7 +782,7 @@ run_test("update_global_notifications", (override) => {
 run_test("update_message (read)", (override) => {
     const event = event_fixtures.update_message_flags__read;
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("unread_ops.process_read_messages_event", stub.f);
         dispatch(event);
         const args = stub.get_args("message_ids");
@@ -793,7 +794,7 @@ run_test("update_message (stars)", (override) => {
     override("starred_messages.rerender_ui", noop);
 
     let event = event_fixtures.update_message_flags__starred_add;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("ui.update_starred_view", stub.f);
         dispatch(event);
         const args = stub.get_args("message_id", "new_value");
@@ -804,7 +805,7 @@ run_test("update_message (stars)", (override) => {
     });
 
     event = event_fixtures.update_message_flags__starred_remove;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("ui.update_starred_view", stub.f);
         dispatch(event);
         const args = stub.get_args("message_id", "new_value");
@@ -819,20 +820,20 @@ run_test("delete_message", (override) => {
     const event = event_fixtures.delete_message;
 
     override("stream_list.update_streams_sidebar", noop);
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("unread_ops.process_read_messages_event", noop);
         override("message_events.remove_messages", stub.f);
         dispatch(event);
         const args = stub.get_args("message_ids");
         assert_same(args.message_ids, [1337]);
     });
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("unread_ops.process_read_messages_event", stub.f);
         dispatch(event);
         const args = stub.get_args("message_ids");
         assert_same(args.message_ids, [1337]);
     });
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("stream_topic_history.remove_messages", stub.f);
         dispatch(event);
         const args = stub.get_args("opts");
@@ -845,7 +846,7 @@ run_test("delete_message", (override) => {
 
 run_test("user_status", (override) => {
     let event = event_fixtures.user_status__set_away;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("activity.on_set_away", stub.f);
         dispatch(event);
         const args = stub.get_args("user_id");
@@ -853,7 +854,7 @@ run_test("user_status", (override) => {
     });
 
     event = event_fixtures.user_status__revoke_away;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("activity.on_revoke_away", stub.f);
         dispatch(event);
         const args = stub.get_args("user_id");
@@ -861,7 +862,7 @@ run_test("user_status", (override) => {
     });
 
     event = event_fixtures.user_status__set_status_text;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("activity.redraw_user", stub.f);
         dispatch(event);
         const args = stub.get_args("user_id");
@@ -875,7 +876,7 @@ run_test("realm_export", (override) => {
     const event = event_fixtures.realm_export;
     override("settings_exports.populate_exports_table", noop);
     dispatch(event);
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("settings_exports.populate_exports_table", stub.f);
         dispatch(event);
 

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const noop = function () {};
 
 const events = require("./lib/events");

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_stub, with_stub} = require("../zjsunit/stub");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = function () {};

--- a/frontend_tests/node_tests/dispatch_subs.js
+++ b/frontend_tests/node_tests/dispatch_subs.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const events = require("./lib/events");
 
 const event_fixtures = events.fixtures;

--- a/frontend_tests/node_tests/dispatch_subs.js
+++ b/frontend_tests/node_tests/dispatch_subs.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_stub, with_stub} = require("../zjsunit/stub");
 
 const events = require("./lib/events");
 
@@ -40,7 +41,7 @@ test("add", (override) => {
         name: sub.name,
     });
 
-    global.with_stub((subscription_stub) => {
+    with_stub((subscription_stub) => {
         override("stream_events.mark_subscribed", subscription_stub.f);
         dispatch(event);
         const args = subscription_stub.get_args("sub", "subscribers");
@@ -57,10 +58,10 @@ test("peer add/remove", (override) => {
         stream_id: event.stream_ids[0],
     });
 
-    const subs_stub = global.make_stub();
+    const subs_stub = make_stub();
     override("subs.update_subscribers_ui", subs_stub.f);
 
-    const compose_fade_stub = global.make_stub();
+    const compose_fade_stub = make_stub();
     override("compose_fade.update_faded_users", compose_fade_stub.f);
 
     dispatch(event);
@@ -85,7 +86,7 @@ test("remove", (override) => {
 
     stream_data.add_sub(sub);
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("stream_events.mark_unsubscribed", stub.f);
         dispatch(event);
         const args = stub.get_args("sub");
@@ -95,7 +96,7 @@ test("remove", (override) => {
 
 test("update", (override) => {
     const event = event_fixtures.subscription__update;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("stream_events.update_property", stub.f);
         dispatch(event);
         const args = stub.get_args("stream_id", "property", "value");
@@ -108,7 +109,7 @@ test("update", (override) => {
 test("add error handling", (override) => {
     // test blueslip errors/warns
     const event = event_fixtures.subscription__add;
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         override("blueslip.error", stub.f);
         dispatch(event);
         assert.deepEqual(stub.get_args("param").param, "Subscribing to unknown stream with ID 101");

--- a/frontend_tests/node_tests/dispatch_subs.js
+++ b/frontend_tests/node_tests/dispatch_subs.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const events = require("./lib/events");
 
 const event_fixtures = events.fixtures;

--- a/frontend_tests/node_tests/dispatch_subs.js
+++ b/frontend_tests/node_tests/dispatch_subs.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_stub, with_stub} = require("../zjsunit/stub");
+const {run_test} = require("../zjsunit/test");
 
 const events = require("./lib/events");
 

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const XDate = require("xdate");
 
+const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 
 zrequire("localstorage");

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const XDate = require("xdate");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const XDate = require("xdate");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -308,7 +309,7 @@ run_test("format_drafts", (override) => {
         return stub_render_now(time, new XDate(1549958107000));
     };
 
-    global.stub_templates((template_name, data) => {
+    stub_templates((template_name, data) => {
         assert.equal(template_name, "draft_table_body");
         // Tests formatting and sorting of drafts
         assert.deepEqual(data.drafts, expected);

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -5,8 +5,9 @@ const {strict: assert} = require("assert");
 const XDate = require("xdate");
 
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 zrequire("localstorage");
 zrequire("drafts");

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -6,6 +6,7 @@ const XDate = require("xdate");
 
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -148,22 +148,22 @@ run_test("draft_model", () => {
 
 run_test("snapshot_message", () => {
     function stub_draft(draft) {
-        global.compose_state.get_message_type = function () {
+        compose_state.get_message_type = function () {
             return draft.type;
         };
-        global.compose_state.composing = function () {
+        compose_state.composing = function () {
             return Boolean(draft.type);
         };
-        global.compose_state.message_content = function () {
+        compose_state.message_content = function () {
             return draft.content;
         };
-        global.compose_state.private_message_recipient = function () {
+        compose_state.private_message_recipient = function () {
             return draft.private_message_recipient;
         };
-        global.compose_state.stream_name = function () {
+        compose_state.stream_name = function () {
             return draft.stream;
         };
-        global.compose_state.topic = function () {
+        compose_state.topic = function () {
             return draft.topic;
         };
     }
@@ -182,7 +182,7 @@ run_test("snapshot_message", () => {
 });
 
 run_test("initialize", () => {
-    global.window.addEventListener = function (event_name, f) {
+    window.addEventListener = function (event_name, f) {
         assert.equal(event_name, "beforeunload");
         let called = false;
         drafts.update_draft = function () {

--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -3,10 +3,11 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("dropdown_list_widget");
 zrequire("scroll_util");
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 const noop = () => {};
 const _list_render = {

--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("dropdown_list_widget");
 zrequire("scroll_util");
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("dropdown_list_widget");

--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("dropdown_list_widget");
 zrequire("scroll_util");
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -3,8 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("markdown", {});
 set_global("local_message", {
     now: () => "timestamp",

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 set_global("markdown", {});
 set_global("local_message", {

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("$", global.make_zjquery());
 set_global("markdown", {});
 set_global("local_message", {

--- a/frontend_tests/node_tests/emoji.js
+++ b/frontend_tests/node_tests/emoji.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const emoji_codes = zrequire("emoji_codes", "generated/emoji/emoji_codes.json");
 

--- a/frontend_tests/node_tests/emoji.js
+++ b/frontend_tests/node_tests/emoji.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const emoji_codes = zrequire("emoji_codes", "generated/emoji/emoji_codes.json");
 
 const events = require("./lib/events");

--- a/frontend_tests/node_tests/emoji.js
+++ b/frontend_tests/node_tests/emoji.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 const emoji_codes = zrequire("emoji_codes", "generated/emoji/emoji_codes.json");
 
 const events = require("./lib/events");

--- a/frontend_tests/node_tests/emoji_picker.js
+++ b/frontend_tests/node_tests/emoji_picker.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const emoji = zrequire("emoji", "shared/js/emoji");
 zrequire("emoji_picker");

--- a/frontend_tests/node_tests/emoji_picker.js
+++ b/frontend_tests/node_tests/emoji_picker.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 const emoji = zrequire("emoji", "shared/js/emoji");
 zrequire("emoji_picker");
 

--- a/frontend_tests/node_tests/emoji_picker.js
+++ b/frontend_tests/node_tests/emoji_picker.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const _ = require("lodash");
 
 const emoji = zrequire("emoji", "shared/js/emoji");

--- a/frontend_tests/node_tests/fenced_code.js
+++ b/frontend_tests/node_tests/fenced_code.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 const fenced_code = zrequire("fenced_code", "shared/js/fenced_code");
 
 run_test("get_unused_fence", () => {

--- a/frontend_tests/node_tests/fenced_code.js
+++ b/frontend_tests/node_tests/fenced_code.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const fenced_code = zrequire("fenced_code", "shared/js/fenced_code");
 

--- a/frontend_tests/node_tests/fenced_code.js
+++ b/frontend_tests/node_tests/fenced_code.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const fenced_code = zrequire("fenced_code", "shared/js/fenced_code");
 
 run_test("get_unused_fence", () => {

--- a/frontend_tests/node_tests/fetch_status.js
+++ b/frontend_tests/node_tests/fetch_status.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const FetchStatus = zrequire("fetch_status");
 set_global("message_scroll", {
     hide_loading_older: () => {},

--- a/frontend_tests/node_tests/fetch_status.js
+++ b/frontend_tests/node_tests/fetch_status.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const FetchStatus = zrequire("fetch_status");
 set_global("message_scroll", {

--- a/frontend_tests/node_tests/fetch_status.js
+++ b/frontend_tests/node_tests/fetch_status.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const FetchStatus = zrequire("fetch_status");
 set_global("message_scroll", {
     hide_loading_older: () => {},

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -2,10 +2,12 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+
 zrequire("unread");
 zrequire("stream_data");
 const people = zrequire("people");
-global.stub_out_jquery();
+stub_out_jquery();
 set_global("$", global.make_zjquery());
 zrequire("message_util", "js/message_util");
 zrequire("Filter", "js/filter");

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("unread");
 zrequire("stream_data");
 const people = zrequire("people");

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -3,12 +3,13 @@
 const {strict: assert} = require("assert");
 
 const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("unread");
 zrequire("stream_data");
 const people = zrequire("people");
 stub_out_jquery();
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 zrequire("message_util", "js/message_util");
 zrequire("Filter", "js/filter");
 

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -2,14 +2,13 @@
 
 const {strict: assert} = require("assert");
 
-const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("unread");
 zrequire("stream_data");
 const people = zrequire("people");
-stub_out_jquery();
 set_global("$", make_zjquery());
 zrequire("message_util", "js/message_util");
 zrequire("Filter", "js/filter");

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -448,7 +448,7 @@ run_test("public_operators", () => {
     assert_same_operators(filter.public_operators(), operators);
     assert(filter.can_bucket_by("stream"));
 
-    global.page_params.narrow_stream = "default";
+    page_params.narrow_stream = "default";
     operators = [{operator: "stream", operand: "default"}];
     filter = new Filter(operators);
     assert_same_operators(filter.public_operators(), []);
@@ -534,7 +534,7 @@ function make_sub(name, stream_id) {
         name,
         stream_id,
     };
-    global.stream_data.add_sub(sub);
+    stream_data.add_sub(sub);
 }
 
 run_test("predicate_basics", () => {
@@ -604,7 +604,7 @@ run_test("predicate_basics", () => {
     predicate = get_predicate([["in", "home"]]);
     assert(!predicate({stream_id: unknown_stream_id, stream: "unknown"}));
     assert(predicate({type: "private"}));
-    global.page_params.narrow_stream = "kiosk";
+    page_params.narrow_stream = "kiosk";
     assert(predicate({stream: "kiosk"}));
 
     predicate = get_predicate([["near", 5]]);
@@ -782,7 +782,7 @@ run_test("negated_predicates", () => {
 });
 
 run_test("mit_exceptions", () => {
-    global.page_params.realm_is_zephyr_mirror_realm = true;
+    page_params.realm_is_zephyr_mirror_realm = true;
 
     let predicate = get_predicate([
         ["stream", "Foo"],
@@ -1294,7 +1294,7 @@ function make_private_sub(name, stream_id) {
         stream_id,
         invite_only: true,
     };
-    global.stream_data.add_sub(sub);
+    stream_data.add_sub(sub);
 }
 
 function make_web_public_sub(name, stream_id) {
@@ -1303,7 +1303,7 @@ function make_web_public_sub(name, stream_id) {
         stream_id,
         is_web_public: true,
     };
-    global.stream_data.add_sub(sub);
+    stream_data.add_sub(sub);
 }
 
 run_test("navbar_helpers", () => {

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("unread");

--- a/frontend_tests/node_tests/fold_dict.js
+++ b/frontend_tests/node_tests/fold_dict.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 const {FoldDict} = zrequire("fold_dict");
 
 run_test("basic", () => {

--- a/frontend_tests/node_tests/fold_dict.js
+++ b/frontend_tests/node_tests/fold_dict.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const {FoldDict} = zrequire("fold_dict");
 

--- a/frontend_tests/node_tests/fold_dict.js
+++ b/frontend_tests/node_tests/fold_dict.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const {FoldDict} = zrequire("fold_dict");
 
 run_test("basic", () => {

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 // This is a general tour of how to write node tests that
 // may also give you some quick insight on how the Zulip
 // browser app is constructed.  Let's start with testing

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 // This is a general tour of how to write node tests that
 // may also give you some quick insight on how the Zulip

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 // This is a general tour of how to write node tests that
 // may also give you some quick insight on how the Zulip
 // browser app is constructed.  Let's start with testing

--- a/frontend_tests/node_tests/hash_util.js
+++ b/frontend_tests/node_tests/hash_util.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("hash_util");
 zrequire("stream_data");
@@ -12,7 +13,7 @@ zrequire("narrow_state");
 
 set_global(
     "$",
-    global.make_zjquery({
+    make_zjquery({
         silent: true,
     }),
 );

--- a/frontend_tests/node_tests/hash_util.js
+++ b/frontend_tests/node_tests/hash_util.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("hash_util");
 zrequire("stream_data");
 const people = zrequire("people");

--- a/frontend_tests/node_tests/hash_util.js
+++ b/frontend_tests/node_tests/hash_util.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("hash_util");
 zrequire("stream_data");
 const people = zrequire("people");

--- a/frontend_tests/node_tests/hash_util.js
+++ b/frontend_tests/node_tests/hash_util.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("hash_util");

--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -275,7 +275,7 @@ run_test("save_narrow", () => {
     assert.equal(window.location.hash, "#narrow/is/private");
 
     let url_pushed;
-    global.history.pushState = (state, title, url) => {
+    history.pushState = (state, title, url) => {
         url_pushed = url;
     };
 

--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 const window_stub = $.create("window-stub");
 set_global("location", {

--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("$", global.make_zjquery());
 const window_stub = $.create("window-stub");
 set_global("location", {

--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -3,8 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 const window_stub = $.create("window-stub");
 set_global("location", {
     protocol: "http:",

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, with_overrides, zrequire} = require("../zjsunit/namespace");
+
 // Important note on these tests:
 //
 // The way the Zulip hotkey tests work is as follows.  First, we set
@@ -80,7 +82,7 @@ function return_false() {
 }
 
 function stubbing(func_name_to_stub, test_function) {
-    global.with_overrides((override) => {
+    with_overrides((override) => {
         global.with_stub((stub) => {
             override(func_name_to_stub, stub.f);
             test_function(stub);

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, with_overrides, zrequire} = require("../zjsunit/namespace");
 const {with_stub} = require("../zjsunit/stub");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 // Important note on these tests:
 //
@@ -30,7 +31,7 @@ set_global("overlays", {});
 
 // jQuery stuff should go away if we make an initialize() method.
 set_global("document", "document-stub");
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 const emoji = zrequire("emoji", "shared/js/emoji");
 

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -159,7 +159,7 @@ run_test("mappings", () => {
     assert.equal(map_down(219, true, true, false), undefined); // Shift + Ctrl + [
 
     // Cmd tests for MacOS
-    global.navigator.platform = "MacIntel";
+    navigator.platform = "MacIntel";
     assert.equal(map_down(219, false, true, false).name, "escape"); // Ctrl + [
     assert.equal(map_down(219, false, false, true), undefined); // Cmd + [
     assert.equal(map_down(67, false, true, true).name, "copy_with_c"); // Ctrl + C
@@ -171,7 +171,7 @@ run_test("mappings", () => {
     assert.equal(map_down(190, false, false, true).name, "narrow_to_compose_target"); // Cmd + .
     assert.equal(map_down(190, false, true, false), undefined); // Ctrl + .
     // Reset platform
-    global.navigator.platform = "";
+    navigator.platform = "";
 });
 
 run_test("basic_chars", () => {
@@ -314,10 +314,10 @@ run_test("basic_chars", () => {
     const message_view_only_keys = "@+>RjJkKsSuvi:GM";
 
     // Check that they do nothing without a selected message
-    global.current_msg_list.empty = return_true;
+    current_msg_list.empty = return_true;
     assert_unmapped(message_view_only_keys);
 
-    global.current_msg_list.empty = return_false;
+    current_msg_list.empty = return_false;
 
     // Check that they do nothing while in the settings overlay
     overlays.settings_open = return_true;
@@ -351,9 +351,9 @@ run_test("basic_chars", () => {
     overlays.is_active = return_false;
     assert_mapping("v", "lightbox.show_from_selected_message");
 
-    global.emoji_picker.reactions_popped = return_true;
+    emoji_picker.reactions_popped = return_true;
     assert_mapping(":", "emoji_picker.navigate", true);
-    global.emoji_picker.reactions_popped = return_false;
+    emoji_picker.reactions_popped = return_false;
 
     assert_mapping("G", "navigate.to_end");
     assert_mapping("M", "muting_ui.toggle_mute");
@@ -363,9 +363,9 @@ run_test("basic_chars", () => {
     assert_mapping("n", "narrow.narrow_to_next_topic");
     assert_mapping("p", "narrow.narrow_to_next_pm_string");
 
-    global.current_msg_list.empty = return_true;
+    current_msg_list.empty = return_true;
     assert_mapping("n", "narrow.narrow_to_next_topic");
-    global.current_msg_list.empty = return_false;
+    current_msg_list.empty = return_false;
 });
 
 run_test("motion_keys", () => {
@@ -412,7 +412,7 @@ run_test("motion_keys", () => {
     }
 
     list_util.inside_list = return_false;
-    global.current_msg_list.empty = return_true;
+    current_msg_list.empty = return_true;
     overlays.settings_open = return_false;
     overlays.streams_open = return_false;
     overlays.lightbox_open = return_false;
@@ -425,12 +425,12 @@ run_test("motion_keys", () => {
     assert_unmapped("spacebar");
     assert_unmapped("up_arrow");
 
-    global.list_util.inside_list = return_true;
+    list_util.inside_list = return_true;
     assert_mapping("up_arrow", "list_util.go_up");
     assert_mapping("down_arrow", "list_util.go_down");
     list_util.inside_list = return_false;
 
-    global.current_msg_list.empty = return_false;
+    current_msg_list.empty = return_false;
     assert_mapping("down_arrow", "navigate.down");
     assert_mapping("end", "navigate.to_end");
     assert_mapping("home", "navigate.to_home");

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, with_overrides, zrequire} = require("../zjsunit/namespace");
 const {with_stub} = require("../zjsunit/stub");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 // Important note on these tests:

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, with_overrides, zrequire} = require("../zjsunit/namespace");
+const {with_stub} = require("../zjsunit/stub");
 
 // Important note on these tests:
 //
@@ -83,7 +84,7 @@ function return_false() {
 
 function stubbing(func_name_to_stub, test_function) {
     with_overrides((override) => {
-        global.with_stub((stub) => {
+        with_stub((stub) => {
             override(func_name_to_stub, stub.f);
             test_function(stub);
         });

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 // Important note on these tests:
 //
 // The way the Zulip hotkey tests work is as follows.  First, we set

--- a/frontend_tests/node_tests/i18n.js
+++ b/frontend_tests/node_tests/i18n.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("templates");
 

--- a/frontend_tests/node_tests/i18n.js
+++ b/frontend_tests/node_tests/i18n.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("templates");
 
 // We download our translations in `page_params` (which

--- a/frontend_tests/node_tests/i18n.js
+++ b/frontend_tests/node_tests/i18n.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("templates");
 
 // We download our translations in `page_params` (which

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("$", global.make_zjquery());
 zrequire("input_pill");
 

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -3,8 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 zrequire("input_pill");
 
 zrequire("templates");
@@ -91,7 +92,7 @@ run_test("basics", () => {
 });
 
 function set_up() {
-    set_global("$", global.make_zjquery());
+    set_global("$", make_zjquery());
     const items = {
         blue: {
             display_value: "BLUE",

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 zrequire("input_pill");
 

--- a/frontend_tests/node_tests/keydown_util.js
+++ b/frontend_tests/node_tests/keydown_util.js
@@ -1,8 +1,9 @@
 "use strict";
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 zrequire("keydown_util");
 

--- a/frontend_tests/node_tests/keydown_util.js
+++ b/frontend_tests/node_tests/keydown_util.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/keydown_util.js
+++ b/frontend_tests/node_tests/keydown_util.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 
 zrequire("keydown_util");

--- a/frontend_tests/node_tests/lazy_set.js
+++ b/frontend_tests/node_tests/lazy_set.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const {LazySet} = zrequire("lazy_set");
 

--- a/frontend_tests/node_tests/lazy_set.js
+++ b/frontend_tests/node_tests/lazy_set.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 const {LazySet} = zrequire("lazy_set");
 
 /*

--- a/frontend_tests/node_tests/lazy_set.js
+++ b/frontend_tests/node_tests/lazy_set.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const {LazySet} = zrequire("lazy_set");
 
 /*

--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("rows");

--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("rows");
 zrequire("lightbox");
 

--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("rows");
 zrequire("lightbox");
@@ -20,7 +21,7 @@ set_global("popovers", {
 
 rows.is_draft_row = () => false;
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 run_test("pan_and_zoom", () => {
     $.clear_all_elements();

--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("rows");
 zrequire("lightbox");
 

--- a/frontend_tests/node_tests/list_cursor.js
+++ b/frontend_tests/node_tests/list_cursor.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("list_cursor");
 

--- a/frontend_tests/node_tests/list_cursor.js
+++ b/frontend_tests/node_tests/list_cursor.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("list_cursor");
 
 run_test("config errors", () => {

--- a/frontend_tests/node_tests/list_cursor.js
+++ b/frontend_tests/node_tests/list_cursor.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 zrequire("list_cursor");
 
 run_test("config errors", () => {

--- a/frontend_tests/node_tests/list_render.js
+++ b/frontend_tests/node_tests/list_render.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("list_render");
 
 // We need these stubs to get by instanceof checks.

--- a/frontend_tests/node_tests/list_render.js
+++ b/frontend_tests/node_tests/list_render.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("list_render");
 
 // We need these stubs to get by instanceof checks.

--- a/frontend_tests/node_tests/list_render.js
+++ b/frontend_tests/node_tests/list_render.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("list_render");
 

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -2,6 +2,7 @@
 
 const {strict: assert} = require("assert");
 
+const markdown_test_cases = require("../../zerver/tests/fixtures/markdown_test_cases.json");
 const markdown_assert = require("../zjsunit/markdown_assert");
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
@@ -197,8 +198,6 @@ run_test("fenced_block_defaults", () => {
 
 markdown.initialize(page_params.realm_filters, markdown_config.get_helpers());
 
-const markdown_data = global.read_fixture_data("markdown_test_cases.json");
-
 run_test("markdown_detection", () => {
     const no_markup = [
         "This is a plaintext message",
@@ -246,7 +245,7 @@ run_test("markdown_detection", () => {
 });
 
 run_test("marked_shared", () => {
-    const tests = markdown_data.regular_tests;
+    const tests = markdown_test_cases.regular_tests;
 
     tests.forEach((test) => {
         // Ignore tests if specified

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+
 zrequire("hash_util");
 
 const emoji = zrequire("emoji", "shared/js/emoji");

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const markdown_test_cases = require("../../zerver/tests/fixtures/markdown_test_cases.json");
 const markdown_assert = require("../zjsunit/markdown_assert");
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("hash_util");

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("hash_util");
 
 const emoji = zrequire("emoji", "shared/js/emoji");

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -2,6 +2,7 @@
 
 const {strict: assert} = require("assert");
 
+const markdown_assert = require("../zjsunit/markdown_assert");
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -259,12 +260,12 @@ run_test("marked_shared", () => {
         const output = message.content;
         const error_message = `Failure in test: ${test.name}`;
         if (test.marked_expected_output) {
-            global.markdown_assert.notEqual(test.expected_output, output, error_message);
-            global.markdown_assert.equal(test.marked_expected_output, output, error_message);
+            markdown_assert.notEqual(test.expected_output, output, error_message);
+            markdown_assert.equal(test.marked_expected_output, output, error_message);
         } else if (test.backend_only_rendering) {
             assert.equal(markdown.contains_backend_only_syntax(test.input), true);
         } else {
-            global.markdown_assert.equal(test.expected_output, output, error_message);
+            markdown_assert.equal(test.expected_output, output, error_message);
         }
     });
 });

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("hash_util");
 
@@ -58,7 +59,7 @@ fenced_code.initialize(pygments_data);
 const doc = "";
 set_global("document", doc);
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 const cordelia = {
     full_name: "Cordelia Lear",

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -137,12 +137,11 @@ const amp_group = {
     members: [],
 };
 
-global.user_groups.add(hamletcharacters);
-global.user_groups.add(backend);
-global.user_groups.add(edgecase_group);
-global.user_groups.add(amp_group);
+user_groups.add(hamletcharacters);
+user_groups.add(backend);
+user_groups.add(edgecase_group);
+user_groups.add(amp_group);
 
-const stream_data = global.stream_data;
 const denmark = {
     subscribed: false,
     color: "blue",

--- a/frontend_tests/node_tests/markdown_katex.js
+++ b/frontend_tests/node_tests/markdown_katex.js
@@ -9,6 +9,8 @@
 
 const rewiremock = require("rewiremock/node");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const markdown_config = zrequire("markdown_config");
 
 set_global("page_params", {});

--- a/frontend_tests/node_tests/markdown_katex.js
+++ b/frontend_tests/node_tests/markdown_katex.js
@@ -10,6 +10,7 @@
 const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const markdown_config = zrequire("markdown_config");
 

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -102,19 +102,19 @@ run_test("get_editability", () => {
     assert.equal(message_edit.is_topic_editable(message), true);
 
     message.sent_by_me = true;
-    global.page_params.realm_allow_community_topic_editing = false;
+    page_params.realm_allow_community_topic_editing = false;
     assert.equal(message_edit.is_topic_editable(message), true);
 
     message.sent_by_me = false;
-    global.page_params.realm_allow_community_topic_editing = false;
+    page_params.realm_allow_community_topic_editing = false;
     assert.equal(message_edit.is_topic_editable(message), false);
 
     message.sent_by_me = false;
-    global.page_params.realm_allow_community_topic_editing = false;
-    global.page_params.is_admin = true;
+    page_params.realm_allow_community_topic_editing = false;
+    page_params.is_admin = true;
     assert.equal(message_edit.is_topic_editable(message), true);
 
-    global.page_params.realm_allow_message_editing = false;
+    page_params.realm_allow_message_editing = false;
     assert.equal(message_edit.is_topic_editable(message), false);
 });
 
@@ -133,7 +133,7 @@ run_test("get_deletability", () => {
     assert.equal(message_edit.get_deletability(message), true);
 
     // Non-admin can't delete message sent by others
-    global.page_params.is_admin = false;
+    page_params.is_admin = false;
     assert.equal(message_edit.get_deletability(message), false);
 
     // Locally echoed messages are not deletable
@@ -143,14 +143,14 @@ run_test("get_deletability", () => {
     message.locally_echoed = false;
     assert.equal(message_edit.get_deletability(message), false);
 
-    global.page_params.realm_allow_message_deleting = true;
+    page_params.realm_allow_message_deleting = true;
     assert.equal(message_edit.get_deletability(message), true);
 
     const now = new Date();
     const current_timestamp = now / 1000;
     message.timestamp = current_timestamp - 5;
 
-    global.page_params.realm_message_content_delete_limit_seconds = 10;
+    page_params.realm_message_content_delete_limit_seconds = 10;
     assert.equal(message_edit.get_deletability(message), true);
 
     message.timestamp = current_timestamp - 60;

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("document", null);
 set_global("page_params", {
     realm_community_topic_editing_limit_seconds: 86400,

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 set_global("document", null);
 set_global("page_params", {

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -2,12 +2,14 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+
 set_global("document", null);
 set_global("page_params", {
     realm_community_topic_editing_limit_seconds: 86400,
 });
 
-global.stub_out_jquery();
+stub_out_jquery();
 
 zrequire("message_edit");
 

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -54,22 +54,22 @@ run_test("get_editability", () => {
         sent_by_me: true,
     };
 
-    global.page_params = {
+    set_global("page_params", {
         realm_allow_message_editing: false,
-    };
+    });
     assert.equal(get_editability(message), editability_types.NO);
 
-    global.page_params = {
+    set_global("page_params", {
         realm_allow_message_editing: true,
         // Limit of 0 means no time limit on editing messages
         realm_message_content_edit_limit_seconds: 0,
-    };
+    });
     assert.equal(get_editability(message), editability_types.FULL);
 
-    global.page_params = {
+    set_global("page_params", {
         realm_allow_message_editing: true,
         realm_message_content_edit_limit_seconds: 10,
-    };
+    });
     const now = new Date();
     const current_timestamp = now / 1000;
     message.timestamp = current_timestamp - 60;
@@ -88,13 +88,13 @@ run_test("get_editability", () => {
         sent_by_me: false,
         type: "stream",
     };
-    global.page_params = {
+    set_global("page_params", {
         realm_allow_community_topic_editing: true,
         realm_allow_message_editing: true,
         realm_message_content_edit_limit_seconds: 0,
         realm_community_topic_editing_limit_seconds: 86400,
         is_admin: false,
-    };
+    });
     message.timestamp = current_timestamp - 60;
     assert.equal(get_editability(message), editability_types.TOPIC_ONLY);
 
@@ -119,11 +119,11 @@ run_test("get_editability", () => {
 });
 
 run_test("get_deletability", () => {
-    global.page_params = {
+    set_global("page_params", {
         is_admin: true,
         realm_allow_message_deleting: false,
         realm_message_content_delete_limit_seconds: 0,
-    };
+    });
     const message = {
         sent_by_me: false,
         locally_echoed: true,

--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("message_events");
 zrequire("message_store");
 zrequire("muting");

--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("message_events");
 zrequire("message_store");
@@ -13,7 +14,7 @@ zrequire("stream_data");
 zrequire("stream_topic_history");
 zrequire("unread");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("alert_words", {});
 set_global("condense", {});
 set_global("current_msg_list", {});

--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("message_events");

--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("message_events");
 zrequire("message_store");
 zrequire("muting");

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 set_global("document", "document-stub");
 

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -5,8 +5,9 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("document", "document-stub");
 
 zrequire("message_fetch");

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const _ = require("lodash");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/message_flags.js
+++ b/frontend_tests/node_tests/message_flags.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("unread");
 zrequire("unread_ops");
 zrequire("message_flags");

--- a/frontend_tests/node_tests/message_flags.js
+++ b/frontend_tests/node_tests/message_flags.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("unread");
 zrequire("unread_ops");

--- a/frontend_tests/node_tests/message_flags.js
+++ b/frontend_tests/node_tests/message_flags.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("unread");
 zrequire("unread_ops");
 zrequire("message_flags");

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -74,7 +74,7 @@ run_test("basics", () => {
 
     assert.deepEqual(list.all_messages(), messages);
 
-    global.$.Event = function (ev) {
+    $.Event = function (ev) {
         assert.equal(ev, "message_selected.zulip");
     };
     list.select_id(50);

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {with_stub} = require("../zjsunit/stub");
 // These unit tests for static/js/message_list.js emphasize the model-ish
 // aspects of the MessageList class.  We have to stub out a few functions
 // related to views and events to get the tests working.
@@ -311,7 +312,7 @@ run_test("bookend", (override) => {
     override("stream_data.is_subscribed", () => true);
     override("stream_data.get_sub", () => ({invite_only: false}));
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         list.view.render_trailing_bookend = stub.f;
         list.update_trailing_bookend();
         const bookend = stub.get_args("content", "subscribed", "show_button");
@@ -324,7 +325,7 @@ run_test("bookend", (override) => {
     list.last_message_historical = false;
     override("stream_data.is_subscribed", () => false);
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         list.view.render_trailing_bookend = stub.f;
         list.update_trailing_bookend();
         const bookend = stub.get_args("content", "subscribed", "show_button");
@@ -339,7 +340,7 @@ run_test("bookend", (override) => {
 
     override("stream_data.get_sub", () => ({invite_only: true}));
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         list.view.render_trailing_bookend = stub.f;
         list.update_trailing_bookend();
         const bookend = stub.get_args("content", "subscribed", "show_button");
@@ -351,7 +352,7 @@ run_test("bookend", (override) => {
     expected = "translated: You are not subscribed to stream IceCream";
     list.last_message_historical = true;
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         list.view.render_trailing_bookend = stub.f;
         list.update_trailing_bookend();
         const bookend = stub.get_args("content", "subscribed", "show_button");
@@ -410,7 +411,7 @@ run_test("add_remove_rerender", () => {
     list.add_messages(messages);
     assert.equal(list.num_items(), 3);
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         list.rerender = stub.f;
         const message_ids = messages.map((msg) => msg.id);
         list.remove_and_rerender(message_ids);

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
 const {with_stub} = require("../zjsunit/stub");
+const {run_test} = require("../zjsunit/test");
 // These unit tests for static/js/message_list.js emphasize the model-ish
 // aspects of the MessageList class.  We have to stub out a few functions
 // related to views and events to get the tests working.

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -1,6 +1,8 @@
 "use strict";
 
 const {strict: assert} = require("assert");
+
+const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
 // These unit tests for static/js/message_list.js emphasize the model-ish
 // aspects of the MessageList class.  We have to stub out a few functions
 // related to views and events to get the tests working.
@@ -8,7 +10,7 @@ const {strict: assert} = require("assert");
 const noop = function () {};
 
 set_global("Filter", noop);
-global.stub_out_jquery();
+stub_out_jquery();
 set_global("document", null);
 set_global("narrow_state", {});
 set_global("stream_data", {});

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const {strict: assert} = require("assert");
 // These unit tests for static/js/message_list.js emphasize the model-ish
 // aspects of the MessageList class.  We have to stub out a few functions
 // related to views and events to get the tests working.

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("unread");
 
 zrequire("Filter", "js/filter");

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("unread");
 
 zrequire("Filter", "js/filter");
@@ -11,7 +13,7 @@ zrequire("MessageListData", "js/message_list_data");
 set_global("page_params", {});
 set_global("muting", {});
 
-global.patch_builtin("setTimeout", (f, delay) => {
+set_global("setTimeout", (f, delay) => {
     assert.equal(delay, 0);
     return f();
 });

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("unread");
 

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 set_global("document", "document-stub");
 

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const _ = require("lodash");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -5,8 +5,9 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("document", "document-stub");
 
 zrequire("Filter", "js/filter");

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {with_stub} = require("../zjsunit/stub");
 
 const util = zrequire("util");
 zrequire("pm_conversations");
@@ -350,7 +351,7 @@ run_test("message_id_change", () => {
         new_id: 402,
     };
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         home_msg_list.change_message_id = stub.f;
         message_store.reify_message_id(opts);
         const msg_id = stub.get_args("old", "new");
@@ -359,7 +360,7 @@ run_test("message_id_change", () => {
     });
 
     home_msg_list.view = {};
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         home_msg_list.view.change_message_id = stub.f;
         message_store.reify_message_id(opts);
         const msg_id = stub.get_args("old", "new");

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const util = zrequire("util");
 zrequire("pm_conversations");
 const people = zrequire("people");

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const util = zrequire("util");
 zrequire("pm_conversations");
 const people = zrequire("people");

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {with_stub} = require("../zjsunit/stub");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const util = zrequire("util");
 zrequire("pm_conversations");
@@ -12,7 +13,7 @@ zrequire("message_store");
 
 const noop = function () {};
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("document", "document-stub");
 
 set_global("alert_words", {

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {with_stub} = require("../zjsunit/stub");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const util = zrequire("util");

--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("timerender");
 zrequire("muting");
 zrequire("stream_data");

--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("timerender");
 zrequire("muting");
 zrequire("stream_data");

--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("timerender");
 zrequire("muting");

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -3,8 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 zrequire("hash_util");
 zrequire("hashchange");
 zrequire("narrow_state");

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("$", global.make_zjquery());
 zrequire("hash_util");
 zrequire("hashchange");

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -64,13 +64,13 @@ run_test("uris", () => {
     uri = hash_util.by_sender_uri(ray.email);
     assert.equal(uri, "#narrow/sender/22-ray");
 
-    let emails = global.hash_util.decode_operand("pm-with", "22,23-group");
+    let emails = hash_util.decode_operand("pm-with", "22,23-group");
     assert.equal(emails, "alice@example.com,ray@example.com");
 
-    emails = global.hash_util.decode_operand("pm-with", "5,22,23-group");
+    emails = hash_util.decode_operand("pm-with", "5,22,23-group");
     assert.equal(emails, "alice@example.com,ray@example.com");
 
-    emails = global.hash_util.decode_operand("pm-with", "5-group");
+    emails = hash_util.decode_operand("pm-with", "5-group");
     assert.equal(emails, "me@example.com");
 });
 
@@ -260,26 +260,26 @@ run_test("narrow_to_compose_target", () => {
     };
 
     // No-op when not composing.
-    global.compose_state.composing = () => false;
+    compose_state.composing = () => false;
     narrow.to_compose_target();
     assert.equal(args.called, false);
-    global.compose_state.composing = () => true;
+    compose_state.composing = () => true;
 
     // No-op when empty stream.
-    global.compose_state.get_message_type = () => "stream";
-    global.compose_state.stream_name = () => "";
+    compose_state.get_message_type = () => "stream";
+    compose_state.stream_name = () => "";
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, false);
 
     // --- Tests for stream messages ---
-    global.compose_state.get_message_type = () => "stream";
+    compose_state.get_message_type = () => "stream";
     stream_data.add_sub({name: "ROME", stream_id: 99});
-    global.compose_state.stream_name = () => "ROME";
-    global.stream_topic_history.get_recent_topic_names = () => ["one", "two", "three"];
+    compose_state.stream_name = () => "ROME";
+    stream_topic_history.get_recent_topic_names = () => ["one", "two", "three"];
 
     // Test with existing topic
-    global.compose_state.topic = () => "one";
+    compose_state.topic = () => "one";
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
@@ -290,41 +290,41 @@ run_test("narrow_to_compose_target", () => {
     ]);
 
     // Test with new topic
-    global.compose_state.topic = () => "four";
+    compose_state.topic = () => "four";
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
     assert.deepEqual(args.operators, [{operator: "stream", operand: "ROME"}]);
 
     // Test with blank topic
-    global.compose_state.topic = () => "";
+    compose_state.topic = () => "";
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
     assert.deepEqual(args.operators, [{operator: "stream", operand: "ROME"}]);
 
     // Test with no topic
-    global.compose_state.topic = () => {};
+    compose_state.topic = () => {};
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
     assert.deepEqual(args.operators, [{operator: "stream", operand: "ROME"}]);
 
     // --- Tests for PMs ---
-    global.compose_state.get_message_type = () => "private";
+    compose_state.get_message_type = () => "private";
     people.add_active_user(ray);
     people.add_active_user(alice);
     people.add_active_user(me);
 
     // Test with valid person
-    global.compose_state.private_message_recipient = () => "alice@example.com";
+    compose_state.private_message_recipient = () => "alice@example.com";
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
     assert.deepEqual(args.operators, [{operator: "pm-with", operand: "alice@example.com"}]);
 
     // Test with valid persons
-    global.compose_state.private_message_recipient = () => "alice@example.com,ray@example.com";
+    compose_state.private_message_recipient = () => "alice@example.com,ray@example.com";
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
@@ -333,22 +333,21 @@ run_test("narrow_to_compose_target", () => {
     ]);
 
     // Test with some invalid persons
-    global.compose_state.private_message_recipient = () =>
-        "alice@example.com,random,ray@example.com";
+    compose_state.private_message_recipient = () => "alice@example.com,random,ray@example.com";
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
     assert.deepEqual(args.operators, [{operator: "is", operand: "private"}]);
 
     // Test with all invalid persons
-    global.compose_state.private_message_recipient = () => "alice,random,ray";
+    compose_state.private_message_recipient = () => "alice,random,ray";
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
     assert.deepEqual(args.operators, [{operator: "is", operand: "private"}]);
 
     // Test with no persons
-    global.compose_state.private_message_recipient = () => "";
+    compose_state.private_message_recipient = () => "";
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 zrequire("hash_util");
 zrequire("hashchange");

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const util = zrequire("util");
 set_global("$", global.make_zjquery());
 
@@ -54,7 +56,7 @@ set_global("search_pill_widget", {
 //
 // We have strange hacks in narrow.activate to sleep 0
 // seconds.
-global.patch_builtin("setTimeout", (f, t) => {
+set_global("setTimeout", (f, t) => {
     assert.equal(t, 0);
     f();
 });

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -3,9 +3,10 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const util = zrequire("util");
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 zrequire("narrow_state");
 set_global("resize", {

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const util = zrequire("util");

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const util = zrequire("util");
 set_global("$", global.make_zjquery());
 

--- a/frontend_tests/node_tests/narrow_local.js
+++ b/frontend_tests/node_tests/narrow_local.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("Filter", "js/filter");
 zrequire("FetchStatus", "js/fetch_status");

--- a/frontend_tests/node_tests/narrow_local.js
+++ b/frontend_tests/node_tests/narrow_local.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("Filter", "js/filter");
 zrequire("FetchStatus", "js/fetch_status");
 zrequire("MessageListData", "js/message_list_data");

--- a/frontend_tests/node_tests/narrow_local.js
+++ b/frontend_tests/node_tests/narrow_local.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("Filter", "js/filter");
 zrequire("FetchStatus", "js/fetch_status");
 zrequire("MessageListData", "js/message_list_data");

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const people = zrequire("people");
 zrequire("Filter", "js/filter");
 zrequire("stream_data");

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const people = zrequire("people");
 zrequire("Filter", "js/filter");
 zrequire("stream_data");

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const people = zrequire("people");
 zrequire("Filter", "js/filter");

--- a/frontend_tests/node_tests/narrow_unread.js
+++ b/frontend_tests/node_tests/narrow_unread.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("Filter", "js/filter");
 const people = zrequire("people");
 zrequire("stream_data");

--- a/frontend_tests/node_tests/narrow_unread.js
+++ b/frontend_tests/node_tests/narrow_unread.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("Filter", "js/filter");
 const people = zrequire("people");

--- a/frontend_tests/node_tests/narrow_unread.js
+++ b/frontend_tests/node_tests/narrow_unread.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("Filter", "js/filter");
 const people = zrequire("people");
 zrequire("stream_data");

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const rewiremock = require("rewiremock/node");
 
 // Dependencies

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 // Dependencies

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const rewiremock = require("rewiremock/node");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 // Dependencies
 set_global(
     "$",

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -5,11 +5,12 @@ const {strict: assert} = require("assert");
 const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 // Dependencies
 set_global(
     "$",
-    global.make_zjquery({
+    make_zjquery({
         silent: true,
     }),
 );

--- a/frontend_tests/node_tests/password.js
+++ b/frontend_tests/node_tests/password.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("zxcvbn", zrequire("zxcvbn", "zxcvbn"));
 zrequire("common");
 

--- a/frontend_tests/node_tests/password.js
+++ b/frontend_tests/node_tests/password.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("zxcvbn", zrequire("zxcvbn", "zxcvbn"));
 zrequire("common");
 

--- a/frontend_tests/node_tests/password.js
+++ b/frontend_tests/node_tests/password.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 set_global("zxcvbn", zrequire("zxcvbn", "zxcvbn"));
 zrequire("common");

--- a/frontend_tests/node_tests/password.js
+++ b/frontend_tests/node_tests/password.js
@@ -72,7 +72,7 @@ run_test("basics", () => {
     warning = common.password_warning(password, password_field(6));
     assert.equal(warning, 'Repeats like "aaa" are easy to guess');
 
-    delete global.zxcvbn;
+    set_global("zxcvbn", undefined);
     password = "aaaaaaaa";
     accepted = common.password_quality(password, bar, password_field(6, 1e100));
     assert(accepted === undefined);

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -396,18 +396,18 @@ run_test("user_timezone", () => {
         format: "H:mm",
     };
 
-    global.page_params.twenty_four_hour_time = true;
+    page_params.twenty_four_hour_time = true;
     assert.deepEqual(people.get_user_time_preferences(me.user_id), expected_pref);
 
     expected_pref.format = "h:mm A";
-    global.page_params.twenty_four_hour_time = false;
+    page_params.twenty_four_hour_time = false;
     assert.deepEqual(people.get_user_time_preferences(me.user_id), expected_pref);
 
-    global.page_params.twenty_four_hour_time = true;
+    page_params.twenty_four_hour_time = true;
     assert.equal(people.get_user_time(me.user_id), "0:09");
 
     expected_pref.format = "h:mm A";
-    global.page_params.twenty_four_hour_time = false;
+    page_params.twenty_four_hour_time = false;
     assert.equal(people.get_user_time(me.user_id), "12:09 AM");
 });
 
@@ -1004,9 +1004,9 @@ run_test("initialize", () => {
     const fetched_retiree = people.get_by_user_id(15);
     assert.equal(fetched_retiree.full_name, "Retiree");
 
-    assert.equal(global.page_params.realm_users, undefined);
-    assert.equal(global.page_params.cross_realm_bots, undefined);
-    assert.equal(global.page_params.realm_non_active_users, undefined);
+    assert.equal(page_params.realm_users, undefined);
+    assert.equal(page_params.cross_realm_bots, undefined);
+    assert.equal(page_params.realm_non_active_users, undefined);
 });
 
 run_test("filter_for_user_settings_search", () => {

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -7,6 +7,7 @@ const moment = require("moment-timezone");
 const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const people = rewiremock.proxy(() => zrequire("people"), {
     "moment-timezone": () => moment("20130208T080910"),

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const _ = require("lodash");
 const moment = require("moment-timezone");
 const rewiremock = require("rewiremock/node");

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -6,6 +6,8 @@ const _ = require("lodash");
 const moment = require("moment-timezone");
 const rewiremock = require("rewiremock/node");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const people = rewiremock.proxy(() => zrequire("people"), {
     "moment-timezone": () => moment("20130208T080910"),
 });

--- a/frontend_tests/node_tests/people_errors.js
+++ b/frontend_tests/node_tests/people_errors.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const people = zrequire("people");
 
 const return_false = function () {

--- a/frontend_tests/node_tests/people_errors.js
+++ b/frontend_tests/node_tests/people_errors.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const people = zrequire("people");
 

--- a/frontend_tests/node_tests/people_errors.js
+++ b/frontend_tests/node_tests/people_errors.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const people = zrequire("people");
 
 const return_false = function () {

--- a/frontend_tests/node_tests/pm_conversations.js
+++ b/frontend_tests/node_tests/pm_conversations.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 const pmc = zrequire("pm_conversations");
 
 run_test("partners", () => {

--- a/frontend_tests/node_tests/pm_conversations.js
+++ b/frontend_tests/node_tests/pm_conversations.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const pmc = zrequire("pm_conversations");
 

--- a/frontend_tests/node_tests/pm_conversations.js
+++ b/frontend_tests/node_tests/pm_conversations.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const pmc = zrequire("pm_conversations");
 
 run_test("partners", () => {

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -71,7 +71,7 @@ run_test("build_private_messages_list", () => {
     const timestamp = 0;
     pm_conversations.recent.insert([101, 102], timestamp);
 
-    global.unread.num_unread_for_person = function () {
+    unread.num_unread_for_person = function () {
         return 1;
     };
 
@@ -100,7 +100,7 @@ run_test("build_private_messages_list", () => {
 
     assert.deepEqual(pm_data, expected_data);
 
-    global.unread.num_unread_for_person = function () {
+    unread.num_unread_for_person = function () {
         return 0;
     };
     pm_list._build_private_messages_list();
@@ -117,7 +117,7 @@ run_test("build_private_messages_list_bot", () => {
     const timestamp = 0;
     pm_conversations.recent.insert([314], timestamp);
 
-    global.unread.num_unread_for_person = function () {
+    unread.num_unread_for_person = function () {
         return 1;
     };
 

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -3,8 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 set_global("narrow_state", {});
 set_global("ui", {

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 
 set_global("narrow_state", {});

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("$", global.make_zjquery());
 
 set_global("narrow_state", {});

--- a/frontend_tests/node_tests/poll_widget.js
+++ b/frontend_tests/node_tests/poll_widget.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("poll_widget");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/poll_widget.js
+++ b/frontend_tests/node_tests/poll_widget.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("poll_widget");

--- a/frontend_tests/node_tests/poll_widget.js
+++ b/frontend_tests/node_tests/poll_widget.js
@@ -2,6 +2,7 @@
 
 const {strict: assert} = require("assert");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -141,7 +142,7 @@ run_test("PollData my question", () => {
 
 run_test("activate another person poll", () => {
     people.is_my_user_id = return_false;
-    global.stub_templates((template_name) => {
+    stub_templates((template_name) => {
         if (template_name === "widgets/poll_widget") {
             return "widgets/poll_widget";
         }
@@ -290,7 +291,7 @@ run_test("activate own poll", () => {
     $.clear_all_elements();
 
     people.is_my_user_id = return_true;
-    global.stub_templates((template_name) => {
+    stub_templates((template_name) => {
         if (template_name === "widgets/poll_widget") {
             return "widgets/poll_widget";
         }

--- a/frontend_tests/node_tests/poll_widget.js
+++ b/frontend_tests/node_tests/poll_widget.js
@@ -3,10 +3,11 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("poll_widget");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 const people = zrequire("people");
 

--- a/frontend_tests/node_tests/poll_widget.js
+++ b/frontend_tests/node_tests/poll_widget.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("poll_widget");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const rewiremock = require("rewiremock/node");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -144,7 +145,7 @@ run_test("sender_hover", (override) => {
         return {};
     };
 
-    global.stub_templates((fn, opts) => {
+    stub_templates((fn, opts) => {
         switch (fn) {
             case "no_arrow_popover":
                 assert.deepEqual(opts, {
@@ -242,7 +243,7 @@ run_test("actions_popover", (override) => {
         };
     };
 
-    global.stub_templates((fn, opts) => {
+    stub_templates((fn, opts) => {
         // TODO: Test all the properties of the popover
         switch (fn) {
             case "actions_popover_content":

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -6,6 +6,7 @@ const rewiremock = require("rewiremock/node");
 
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -5,8 +5,9 @@ const {strict: assert} = require("assert");
 const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 zrequire("hash_util");
 zrequire("narrow");

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const rewiremock = require("rewiremock/node");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 
 zrequire("hash_util");

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const rewiremock = require("rewiremock/node");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const XDate = require("xdate");
 
 const people = zrequire("people");

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const XDate = require("xdate");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const people = zrequire("people");
 zrequire("presence");

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const XDate = require("xdate");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const people = zrequire("people");
 zrequire("presence");
 

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+
 set_global("document", "document-stub");
 set_global("$", global.make_zjquery());
 

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
 const {with_stub} = require("../zjsunit/stub");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("document", "document-stub");

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -4,9 +4,10 @@ const {strict: assert} = require("assert");
 
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
 const {with_stub} = require("../zjsunit/stub");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("document", "document-stub");
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 const emoji_codes = zrequire("emoji_codes", "generated/emoji/emoji_codes.json");
 const emoji = zrequire("emoji", "shared/js/emoji");

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -265,7 +265,7 @@ run_test("sending", (override) => {
     override("reactions.remove_reaction", () => {});
 
     with_stub((stub) => {
-        global.channel.del = stub.f;
+        channel.del = stub.f;
         reactions.toggle_emoji_reaction(message_id, emoji_name);
         const args = stub.get_args("args").args;
         assert.equal(args.url, "/json/messages/1001/reactions");
@@ -280,14 +280,14 @@ run_test("sending", (override) => {
         // similarly, we only exercise the failure codepath
         // Since this path calls blueslip.warn, we need to handle it.
         blueslip.expect("warn", "XHR Error Message.");
-        global.channel.xhr_error_message = function () {
+        channel.xhr_error_message = function () {
             return "XHR Error Message.";
         };
         args.error();
     });
     emoji_name = "alien"; // not set yet
     with_stub((stub) => {
-        global.channel.post = stub.f;
+        channel.post = stub.f;
         reactions.toggle_emoji_reaction(message_id, emoji_name);
         const args = stub.get_args("args").args;
         assert.equal(args.url, "/json/messages/1001/reactions");
@@ -304,7 +304,7 @@ run_test("sending", (override) => {
         // deactivated realm emoji only by clicking on a reaction, hence, only
         // `process_reaction_click()` codepath supports deleting/adding a deactivated
         // realm emoji.
-        global.channel.del = stub.f;
+        channel.del = stub.f;
         reactions.process_reaction_click(message_id, "realm_emoji,992");
         const args = stub.get_args("args").args;
         assert.equal(args.url, "/json/messages/1001/reactions");
@@ -317,7 +317,7 @@ run_test("sending", (override) => {
 
     emoji_name = "zulip"; // Test adding zulip emoji.
     with_stub((stub) => {
-        global.channel.post = stub.f;
+        channel.post = stub.f;
         reactions.toggle_emoji_reaction(message_id, emoji_name);
         const args = stub.get_args("args").args;
         assert.equal(args.url, "/json/messages/1001/reactions");
@@ -679,7 +679,7 @@ run_test("with_view_stubs", () => {
 });
 
 run_test("error_handling", () => {
-    global.message_store.get = function () {
+    message_store.get = function () {
         return;
     };
 
@@ -768,7 +768,7 @@ run_test("process_reaction_click", () => {
         reaction_type: "unicode_emoji",
         emoji_code: "1f3b1",
     };
-    global.message_store.get = function (message_id) {
+    message_store.get = function (message_id) {
         assert.equal(message_id, 1001);
         return message;
     };
@@ -779,7 +779,7 @@ run_test("process_reaction_click", () => {
         emoji_code: "1f642",
     };
     with_stub((stub) => {
-        global.channel.del = stub.f;
+        channel.del = stub.f;
         reactions.process_reaction_click(message_id, "unicode_emoji,1f642");
         const args = stub.get_args("args").args;
         assert.equal(args.url, "/json/messages/1001/reactions");
@@ -834,12 +834,12 @@ run_test("duplicates", () => {
 });
 
 run_test("process_reaction_click errors", () => {
-    global.message_store.get = () => undefined;
+    message_store.get = () => undefined;
     blueslip.expect("error", "reactions: Bad message id: 55");
     blueslip.expect("error", "message_id for reaction click is unknown: 55");
     reactions.process_reaction_click(55, "whatever");
 
-    global.message_store.get = () => message;
+    message_store.get = () => message;
     blueslip.expect(
         "error",
         "Data integrity problem for reaction bad-local-id (message some-msg-id)",

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {with_stub} = require("../zjsunit/stub");
 
 set_global("document", "document-stub");
 set_global("$", global.make_zjquery());
@@ -260,7 +261,7 @@ run_test("sending", (override) => {
     override("reactions.add_reaction", () => {});
     override("reactions.remove_reaction", () => {});
 
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         global.channel.del = stub.f;
         reactions.toggle_emoji_reaction(message_id, emoji_name);
         const args = stub.get_args("args").args;
@@ -282,7 +283,7 @@ run_test("sending", (override) => {
         args.error();
     });
     emoji_name = "alien"; // not set yet
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         global.channel.post = stub.f;
         reactions.toggle_emoji_reaction(message_id, emoji_name);
         const args = stub.get_args("args").args;
@@ -295,7 +296,7 @@ run_test("sending", (override) => {
     });
 
     emoji_name = "inactive_realm_emoji";
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         // Test removing a deactivated realm emoji. An user can interact with a
         // deactivated realm emoji only by clicking on a reaction, hence, only
         // `process_reaction_click()` codepath supports deleting/adding a deactivated
@@ -312,7 +313,7 @@ run_test("sending", (override) => {
     });
 
     emoji_name = "zulip"; // Test adding zulip emoji.
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         global.channel.post = stub.f;
         reactions.toggle_emoji_reaction(message_id, emoji_name);
         const args = stub.get_args("args").args;
@@ -774,7 +775,7 @@ run_test("process_reaction_click", () => {
         emoji_name: "smile",
         emoji_code: "1f642",
     };
-    global.with_stub((stub) => {
+    with_stub((stub) => {
         global.channel.del = stub.f;
         reactions.process_reaction_click(message_id, "unicode_emoji,1f642");
         const args = stub.get_args("args").args;

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("document", "document-stub");
 set_global("$", global.make_zjquery());
 

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -2,6 +2,7 @@
 
 const {strict: assert} = require("assert");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
 const {with_stub} = require("../zjsunit/stub");
 const {make_zjquery} = require("../zjsunit/zjquery");
@@ -388,7 +389,7 @@ run_test("add_and_remove_reaction", () => {
     };
 
     let template_called;
-    global.stub_templates((template_name, data) => {
+    stub_templates((template_name, data) => {
         template_called = true;
         assert.equal(template_name, "message_reaction");
         assert.equal(data.class, "message_reaction reacted");
@@ -478,7 +479,7 @@ run_test("add_and_remove_reaction", () => {
     };
 
     template_called = false;
-    global.stub_templates((template_name, data) => {
+    stub_templates((template_name, data) => {
         assert.equal(data.class, "message_reaction");
         assert(data.is_realm_emoji);
         template_called = true;

--- a/frontend_tests/node_tests/recent_senders.js
+++ b/frontend_tests/node_tests/recent_senders.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const rs = zrequire("recent_senders");
 
 let next_id = 0;

--- a/frontend_tests/node_tests/recent_senders.js
+++ b/frontend_tests/node_tests/recent_senders.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const rs = zrequire("recent_senders");
 
 let next_id = 0;

--- a/frontend_tests/node_tests/recent_senders.js
+++ b/frontend_tests/node_tests/recent_senders.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const rs = zrequire("recent_senders");
 

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {stub_templates} = require("../zjsunit/handlebars");
 const {reset_module, set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("message_util");

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("message_util");
 
 const noop = () => {};

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -3,13 +3,14 @@
 const {strict: assert} = require("assert");
 
 const {reset_module, set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("message_util");
 
 const noop = () => {};
 set_global(
     "$",
-    global.make_zjquery({
+    make_zjquery({
         silent: true,
     }),
 );

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -2,6 +2,7 @@
 
 const {strict: assert} = require("assert");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {reset_module, set_global, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -310,7 +311,7 @@ run_test("test_recent_topics_launch", () => {
         search_val: "",
     };
 
-    global.stub_templates((template_name, data) => {
+    stub_templates((template_name, data) => {
         if (template_name === "recent_topics_table") {
             assert.deepEqual(data, expected);
         } else if (template_name === "recent_topics_filters") {
@@ -343,7 +344,7 @@ run_test("test_filter_all", () => {
     };
     let row_data;
     let i;
-    global.stub_templates((template_name, data) => {
+    stub_templates((template_name, data) => {
         if (template_name === "recent_topic_row") {
             // All the row will be processed.
             i -= 1;
@@ -399,12 +400,12 @@ run_test("test_filter_unread", () => {
 
     rt = reset_module("recent_topics");
 
-    global.stub_templates(() => "<recent_topics table stub>");
+    stub_templates(() => "<recent_topics table stub>");
     rt.process_messages(messages);
     assert.equal(rt.inplace_rerender("1:topic-1"), true);
 
     $("#recent_topics_filter_buttons").removeClass("btn-recent-selected");
-    global.stub_templates((template_name, data) => {
+    stub_templates((template_name, data) => {
         assert.equal(template_name, "recent_topics_filters");
         assert.equal(data.filter_unread, expected.filter_unread);
         assert.equal(data.filter_participated, expected.filter_participated);
@@ -414,7 +415,7 @@ run_test("test_filter_unread", () => {
     rt.set_filter("unread");
     rt.update_filters_view();
 
-    global.stub_templates((template_name, data) => {
+    stub_templates((template_name, data) => {
         if (template_name === "recent_topic_row") {
             // All the row will be processed.
             assert.deepEqual(data, row_data[i]);
@@ -462,7 +463,7 @@ run_test("test_filter_participated", () => {
     let i = 0;
 
     rt = reset_module("recent_topics");
-    global.stub_templates(() => "<recent_topics table stub>");
+    stub_templates(() => "<recent_topics table stub>");
     rt.process_messages(messages);
     assert.equal(rt.inplace_rerender("1:topic-4"), true);
 
@@ -474,7 +475,7 @@ run_test("test_filter_participated", () => {
     rt.set_filter("muted");
 
     $("#recent_topics_filter_buttons").removeClass("btn-recent-selected");
-    global.stub_templates((template_name, data) => {
+    stub_templates((template_name, data) => {
         assert.equal(template_name, "recent_topics_filters");
         assert.equal(data.filter_unread, expected.filter_unread);
         assert.equal(data.filter_participated, expected.filter_participated);
@@ -483,7 +484,7 @@ run_test("test_filter_participated", () => {
     rt.set_filter("participated");
     rt.update_filters_view();
 
-    global.stub_templates((template_name, data) => {
+    stub_templates((template_name, data) => {
         if (template_name === "recent_topic_row") {
             // All the row will be processed.
             assert.deepEqual(data, row_data[i]);
@@ -502,7 +503,7 @@ run_test("test_filter_participated", () => {
 run_test("test_update_unread_count", () => {
     rt = reset_module("recent_topics");
     rt.set_filter("all");
-    global.stub_templates(() => "<recent_topics table stub>");
+    stub_templates(() => "<recent_topics table stub>");
     rt.process_messages(messages);
 
     // update a message
@@ -511,7 +512,7 @@ run_test("test_update_unread_count", () => {
 });
 
 // template rendering is tested in test_recent_topics_launch.
-global.stub_templates(() => "<recent_topics table stub>");
+stub_templates(() => "<recent_topics table stub>");
 
 run_test("basic assertions", () => {
     rt = reset_module("recent_topics");

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {reset_module, set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("message_util");
 
 const noop = () => {};

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -196,7 +196,7 @@ run_test("timestamp-twenty-four-hour-time", () => {
     $content.set_find_results("time", $array([$timestamp]));
 
     // We will temporarily change the 24h setting for this test.
-    const old_page_params = global.page_params;
+    const old_page_params = page_params;
 
     set_global("page_params", {...old_page_params, twenty_four_hour_time: true});
     rm.update_elements($content);

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -3,13 +3,14 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const rm = zrequire("rendered_markdown");
 const people = zrequire("people");
 zrequire("user_groups");
 zrequire("stream_data");
 zrequire("timerender");
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 set_global("rtl", {
     get_direction: () => "ltr",

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const rm = zrequire("rendered_markdown");
 const people = zrequire("people");
 zrequire("user_groups");

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const rm = zrequire("rendered_markdown");

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const rm = zrequire("rendered_markdown");
 const people = zrequire("people");
 zrequire("user_groups");

--- a/frontend_tests/node_tests/rtl.js
+++ b/frontend_tests/node_tests/rtl.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const rtl = zrequire("rtl");
 
 run_test("get_direction", () => {

--- a/frontend_tests/node_tests/rtl.js
+++ b/frontend_tests/node_tests/rtl.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 const rtl = zrequire("rtl");
 
 run_test("get_direction", () => {

--- a/frontend_tests/node_tests/rtl.js
+++ b/frontend_tests/node_tests/rtl.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const rtl = zrequire("rtl");
 

--- a/frontend_tests/node_tests/schema.js
+++ b/frontend_tests/node_tests/schema.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 zrequire("schema");
 
 run_test("basics", () => {

--- a/frontend_tests/node_tests/schema.js
+++ b/frontend_tests/node_tests/schema.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("schema");
 

--- a/frontend_tests/node_tests/schema.js
+++ b/frontend_tests/node_tests/schema.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("schema");
 
 run_test("basics", () => {

--- a/frontend_tests/node_tests/scroll_util.js
+++ b/frontend_tests/node_tests/scroll_util.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("scroll_util");
 set_global("ui", {
     get_scroll_element: (element) => element,

--- a/frontend_tests/node_tests/scroll_util.js
+++ b/frontend_tests/node_tests/scroll_util.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("scroll_util");
 set_global("ui", {
     get_scroll_element: (element) => element,

--- a/frontend_tests/node_tests/scroll_util.js
+++ b/frontend_tests/node_tests/scroll_util.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("scroll_util");
 set_global("ui", {

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("page_params", {
     search_pills_enabled: true,
 });
@@ -28,7 +30,7 @@ set_global("search_pill_widget", {
     },
 });
 
-global.patch_builtin("setTimeout", (func) => func());
+set_global("setTimeout", (func) => func());
 
 run_test("clear_search_form", () => {
     $("#search_query").val("noise");

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("page_params", {
     search_pills_enabled: true,
@@ -16,7 +17,7 @@ const noop = () => {};
 const return_true = () => true;
 const return_false = () => false;
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("narrow_state", {filter: return_false});
 set_global("search_suggestion", {});
 set_global("ui_util", {

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("page_params", {

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("page_params", {
     search_pills_enabled: true,
 });

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("page_params", {
     search_pills_enabled: false,
 });

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("page_params", {

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("page_params", {
     search_pills_enabled: false,
@@ -14,7 +15,7 @@ const noop = () => {};
 const return_true = () => true;
 const return_false = () => false;
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("narrow_state", {});
 set_global("search_suggestion", {});
 set_global("ui_util", {

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("page_params", {
     search_pills_enabled: false,
 });
@@ -21,7 +23,7 @@ set_global("ui_util", {
 set_global("narrow", {});
 set_global("Filter", {});
 
-global.patch_builtin("setTimeout", (func) => func());
+set_global("setTimeout", (func) => func());
 
 run_test("update_button_visibility", () => {
     const search_query = $("#search_query");

--- a/frontend_tests/node_tests/search_pill.js
+++ b/frontend_tests/node_tests/search_pill.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 zrequire("search_pill");
 zrequire("input_pill");
 zrequire("Filter", "js/filter");

--- a/frontend_tests/node_tests/search_pill.js
+++ b/frontend_tests/node_tests/search_pill.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("search_pill");
 zrequire("input_pill");

--- a/frontend_tests/node_tests/search_pill.js
+++ b/frontend_tests/node_tests/search_pill.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("search_pill");
 zrequire("input_pill");
 zrequire("Filter", "js/filter");

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -87,11 +87,11 @@ function get_suggestions(base_query, query) {
 run_test("basic_get_suggestions", () => {
     const query = "fred";
 
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return [];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return "office";
     };
 
@@ -105,11 +105,11 @@ run_test("subset_suggestions", () => {
     const query = "shakespeare";
     const base_query = "stream:Denmark topic:Hamlet";
 
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return [];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -121,11 +121,11 @@ run_test("subset_suggestions", () => {
 });
 
 run_test("private_suggestions", () => {
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return [];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -242,11 +242,11 @@ run_test("private_suggestions", () => {
 });
 
 run_test("group_suggestions", () => {
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return [];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -387,11 +387,11 @@ init();
 run_test("empty_query_suggestions", () => {
     const query = "";
 
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return ["devel", "office"];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -433,10 +433,10 @@ run_test("has_suggestions", () => {
     // Checks that category wise suggestions are displayed instead of a single
     // default suggestion when suggesting `has` operator.
     let query = "h";
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return ["devel", "office"];
     };
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -491,10 +491,10 @@ run_test("has_suggestions", () => {
 
 run_test("check_is_suggestions", () => {
     let query = "i";
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return ["devel", "office"];
     };
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -598,11 +598,11 @@ run_test("check_is_suggestions", () => {
 });
 
 run_test("sent_by_me_suggestions", () => {
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return [];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -681,18 +681,18 @@ run_test("topic_suggestions", () => {
     let suggestions;
     let expected;
 
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return ["office"];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return "office";
     };
 
     const devel_id = 44;
     const office_id = 77;
 
-    global.stream_data.get_stream_id = function (stream_name) {
+    stream_data.get_stream_id = function (stream_name) {
         switch (stream_name) {
             case "office":
                 return office_id;
@@ -774,11 +774,11 @@ run_test("topic_suggestions", () => {
 run_test("whitespace_glitch", () => {
     const query = "stream:office "; // note trailing space
 
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return ["office"];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -792,11 +792,11 @@ run_test("whitespace_glitch", () => {
 });
 
 run_test("stream_completion", () => {
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return ["office", "dev help"];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -819,8 +819,8 @@ run_test("stream_completion", () => {
 });
 
 function people_suggestion_setup() {
-    global.stream_data.subscribed_streams = () => [];
-    global.narrow_state.stream = noop;
+    stream_data.subscribed_streams = () => [];
+    narrow_state.stream = noop;
 
     const ted = {
         email: "ted@zulip.com",
@@ -966,11 +966,11 @@ run_test("operator_suggestions", () => {
 });
 
 run_test("queries_with_spaces", () => {
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return ["office", "dev help"];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 set_global("page_params", {
     search_pills_enabled: true,

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("page_params", {
     search_pills_enabled: true,
 });

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("page_params", {
     search_pills_enabled: true,
 });

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("page_params", {
     search_pills_enabled: false,
 });

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("page_params", {
     search_pills_enabled: false,
 });

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 set_global("page_params", {
     search_pills_enabled: false,

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -85,11 +85,11 @@ function get_suggestions(base_query, query) {
 run_test("basic_get_suggestions", () => {
     const query = "fred";
 
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return [];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return "office";
     };
 
@@ -102,11 +102,11 @@ run_test("basic_get_suggestions", () => {
 run_test("subset_suggestions", () => {
     const query = "stream:Denmark topic:Hamlet shakespeare";
 
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return [];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -122,11 +122,11 @@ run_test("subset_suggestions", () => {
 });
 
 run_test("private_suggestions", () => {
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return [];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -239,11 +239,11 @@ run_test("private_suggestions", () => {
 });
 
 run_test("group_suggestions", () => {
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return [];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -391,11 +391,11 @@ init();
 run_test("empty_query_suggestions", () => {
     const query = "";
 
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return ["devel", "office"];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -437,10 +437,10 @@ run_test("has_suggestions", () => {
     // Checks that category wise suggestions are displayed instead of a single
     // default suggestion when suggesting `has` operator.
     let query = "h";
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return ["devel", "office"];
     };
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -497,10 +497,10 @@ run_test("has_suggestions", () => {
 });
 
 run_test("check_is_suggestions", () => {
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return ["devel", "office"];
     };
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -570,11 +570,11 @@ run_test("check_is_suggestions", () => {
 });
 
 run_test("sent_by_me_suggestions", () => {
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return [];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -648,18 +648,18 @@ run_test("topic_suggestions", () => {
     let suggestions;
     let expected;
 
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return ["office"];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return "office";
     };
 
     const devel_id = 44;
     const office_id = 77;
 
-    global.stream_data.get_stream_id = function (stream_name) {
+    stream_data.get_stream_id = function (stream_name) {
         switch (stream_name) {
             case "office":
                 return office_id;
@@ -747,11 +747,11 @@ run_test("topic_suggestions", () => {
 run_test("whitespace_glitch", () => {
     const query = "stream:office "; // note trailing space
 
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return ["office"];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -765,11 +765,11 @@ run_test("whitespace_glitch", () => {
 });
 
 run_test("stream_completion", () => {
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return ["office", "dev help"];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -794,11 +794,11 @@ run_test("stream_completion", () => {
 run_test("people_suggestions", () => {
     let query = "te";
 
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return [];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 
@@ -912,11 +912,11 @@ run_test("operator_suggestions", () => {
 });
 
 run_test("queries_with_spaces", () => {
-    global.stream_data.subscribed_streams = function () {
+    stream_data.subscribed_streams = function () {
         return ["office", "dev help"];
     };
 
-    global.narrow_state.stream = function () {
+    narrow_state.stream = function () {
         return;
     };
 

--- a/frontend_tests/node_tests/server_events.js
+++ b/frontend_tests/node_tests/server_events.js
@@ -2,11 +2,13 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+
 const noop = function () {};
 
 set_global("document", {});
 set_global("addEventListener", noop);
-global.stub_out_jquery();
+stub_out_jquery();
 
 zrequire("message_store");
 zrequire("server_events_dispatch");

--- a/frontend_tests/node_tests/server_events.js
+++ b/frontend_tests/node_tests/server_events.js
@@ -94,7 +94,7 @@ run_test("event_dispatch_error", () => {
     setup();
 
     const data = {events: [{type: "stream", op: "update", id: 1, other: "thing"}]};
-    global.channel.get = function (options) {
+    channel.get = function (options) {
         options.success(data);
     };
 
@@ -114,7 +114,7 @@ run_test("event_new_message_error", () => {
     setup();
 
     const data = {events: [{type: "message", id: 1, other: "thing", message: {}}]};
-    global.channel.get = function (options) {
+    channel.get = function (options) {
         options.success(data);
     };
 
@@ -130,7 +130,7 @@ run_test("event_new_message_error", () => {
 run_test("event_edit_message_error", () => {
     setup();
     const data = {events: [{type: "update_message", id: 1, other: "thing"}]};
-    global.channel.get = function (options) {
+    channel.get = function (options) {
         options.success(data);
     };
     blueslip.expect("error", "Failed to update messages\nupdate error");

--- a/frontend_tests/node_tests/server_events.js
+++ b/frontend_tests/node_tests/server_events.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const noop = function () {};
 

--- a/frontend_tests/node_tests/server_events.js
+++ b/frontend_tests/node_tests/server_events.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const noop = function () {};
 
 set_global("document", {});

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const rewiremock = require("rewiremock/node");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("page_params", {
     realm_uri: "https://chat.example.com",
     realm_embedded_bots: [

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const rewiremock = require("rewiremock/node");
 
 set_global("page_params", {

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("page_params", {
     realm_uri: "https://chat.example.com",
@@ -29,7 +30,7 @@ const bot_data_params = {
 
 set_global("avatar", {});
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 zrequire("bot_data");
 zrequire("people");
@@ -120,7 +121,7 @@ function test_create_bot_type_input_box_toggle(f) {
 }
 
 function set_up() {
-    set_global("$", global.make_zjquery());
+    set_global("$", make_zjquery());
 
     // bunch of stubs
 

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("page_params", {

--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const settings_data = zrequire("settings_data");
 const settings_config = zrequire("settings_config");

--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const settings_data = zrequire("settings_data");
 const settings_config = zrequire("settings_config");
 

--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const settings_data = zrequire("settings_data");
 const settings_config = zrequire("settings_config");
 

--- a/frontend_tests/node_tests/settings_emoji.js
+++ b/frontend_tests/node_tests/settings_emoji.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("$", global.make_zjquery());
 set_global("upload_widget", {});
 zrequire("settings_emoji");

--- a/frontend_tests/node_tests/settings_emoji.js
+++ b/frontend_tests/node_tests/settings_emoji.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/settings_emoji.js
+++ b/frontend_tests/node_tests/settings_emoji.js
@@ -3,8 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("upload_widget", {});
 zrequire("settings_emoji");
 

--- a/frontend_tests/node_tests/settings_emoji.js
+++ b/frontend_tests/node_tests/settings_emoji.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 set_global("upload_widget", {});
 zrequire("settings_emoji");

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 set_global("XDate", zrequire("XDate", "xdate"));
 

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -3,8 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("XDate", zrequire("XDate", "xdate"));
 
 zrequire("timerender");

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("$", global.make_zjquery());
 set_global("XDate", zrequire("XDate", "xdate"));
 

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -6,6 +6,7 @@ const rewiremock = require("rewiremock/node");
 
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -653,9 +653,7 @@ function test_parse_time_limit() {
     const elem = $("#id_realm_message_content_edit_limit_minutes");
     const test_function = (value, expected_value = value) => {
         elem.val(value);
-        global.page_params.realm_message_content_edit_limit_seconds = settings_org.parse_time_limit(
-            elem,
-        );
+        page_params.realm_message_content_edit_limit_seconds = settings_org.parse_time_limit(elem);
         assert.equal(
             settings_org.get_realm_time_limits_in_minutes(
                 "realm_message_content_edit_limit_seconds",

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const rewiremock = require("rewiremock/node");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -42,7 +43,7 @@ const _page_params = {
 const _realm_icon = {};
 const _channel = {};
 
-global.stub_templates((name, data) => {
+stub_templates((name, data) => {
     if (name === "settings/admin_realm_domains_list") {
         assert(data.realm_domain.domain);
         return "stub-domains-list";

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const rewiremock = require("rewiremock/node");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -5,8 +5,9 @@ const {strict: assert} = require("assert");
 const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 const noop = () => {};
 

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const rewiremock = require("rewiremock/node");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 
 const noop = () => {};
@@ -200,7 +202,7 @@ function test_submit_settings_form(submit_form) {
         realm_create_stream_policy: settings_config.create_stream_policy_values.by_members.code,
     });
 
-    global.patch_builtin("setTimeout", (func) => func());
+    set_global("setTimeout", (func) => func());
     const ev = {
         preventDefault: noop,
         stopPropagation: noop,

--- a/frontend_tests/node_tests/settings_profile_fields.js
+++ b/frontend_tests/node_tests/settings_profile_fields.js
@@ -5,9 +5,10 @@ const {strict: assert} = require("assert");
 const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("page_params", {});
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("loading", {});
 
 const SHORT_TEXT_ID = 1;

--- a/frontend_tests/node_tests/settings_profile_fields.js
+++ b/frontend_tests/node_tests/settings_profile_fields.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const rewiremock = require("rewiremock/node");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -59,7 +60,7 @@ function test_populate(opts) {
     loading.destroy_indicator = () => {};
 
     const template_data = [];
-    global.stub_templates((fn, data) => {
+    stub_templates((fn, data) => {
         assert.equal(fn, "admin_profile_field_list");
         template_data.push(data);
         return "whatever";

--- a/frontend_tests/node_tests/settings_profile_fields.js
+++ b/frontend_tests/node_tests/settings_profile_fields.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const rewiremock = require("rewiremock/node");
 
 set_global("page_params", {});

--- a/frontend_tests/node_tests/settings_profile_fields.js
+++ b/frontend_tests/node_tests/settings_profile_fields.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const rewiremock = require("rewiremock/node");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("page_params", {});
 set_global("$", global.make_zjquery());
 set_global("loading", {});

--- a/frontend_tests/node_tests/settings_profile_fields.js
+++ b/frontend_tests/node_tests/settings_profile_fields.js
@@ -6,6 +6,7 @@ const rewiremock = require("rewiremock/node");
 
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("page_params", {});

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -132,7 +133,7 @@ run_test("populate_user_groups", () => {
 
     let templates_render_called = false;
     const fake_rendered_temp = $.create("fake_admin_user_group_list_template_rendered");
-    global.stub_templates((template, args) => {
+    stub_templates((template, args) => {
         assert.equal(template, "admin_user_group_list");
         assert.equal(args.user_group.id, 1);
         assert.equal(args.user_group.name, "Mobile");
@@ -375,7 +376,7 @@ run_test("with_external_user", () => {
         return noop;
     };
 
-    global.stub_templates(() => noop);
+    stub_templates(() => noop);
 
     people.get_by_user_id = function () {
         return noop;

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -6,6 +6,7 @@ const _ = require("lodash");
 
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("user_pill");

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const _ = require("lodash");
 
 zrequire("user_pill");

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("user_pill");
 zrequire("pill_typeahead");
 zrequire("settings_user_groups");
@@ -329,7 +331,7 @@ run_test("populate_user_groups", () => {
     }
 
     pills.onPillRemove = function (handler) {
-        global.patch_builtin("setTimeout", (func) => {
+        set_global("setTimeout", (func) => {
             func();
         });
         realm_user_group.members = new Set([2, 31]);
@@ -789,7 +791,7 @@ run_test("on_events", () => {
             assert.equal(opts.data.description, "translated: All mobile members");
             api_endpoint_called = true;
             (function test_post_success() {
-                global.patch_builtin("setTimeout", (func) => {
+                set_global("setTimeout", (func) => {
                     func();
                 });
                 opts.success();

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -5,12 +5,13 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("user_pill");
 zrequire("pill_typeahead");
 zrequire("settings_user_groups");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("confirm_dialog", {});
 
 const noop = function () {};
@@ -391,7 +392,7 @@ run_test("with_external_user", () => {
     };
 
     // Reset zjquery to test stuff with user who cannot edit
-    set_global("$", global.make_zjquery());
+    set_global("$", make_zjquery());
 
     let user_group_find_called = 0;
     const user_group_stub = $('div.user-group[id="1"]');

--- a/frontend_tests/node_tests/spoilers.js
+++ b/frontend_tests/node_tests/spoilers.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 zrequire("spoilers");
 

--- a/frontend_tests/node_tests/spoilers.js
+++ b/frontend_tests/node_tests/spoilers.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/spoilers.js
+++ b/frontend_tests/node_tests/spoilers.js
@@ -3,8 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 zrequire("spoilers");
 
 // This function is taken from rendered_markdown.js and slightly modified.

--- a/frontend_tests/node_tests/spoilers.js
+++ b/frontend_tests/node_tests/spoilers.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("$", global.make_zjquery());
 zrequire("spoilers");
 

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 set_global("page_params", {
     is_admin: false,

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -100,7 +100,7 @@ run_test("basics", () => {
     assert(!stream_data.get_invite_only("unknown"));
 
     assert.equal(stream_data.get_color("social"), "red");
-    assert.equal(stream_data.get_color("unknown"), global.stream_color.default_color);
+    assert.equal(stream_data.get_color("unknown"), stream_color.default_color);
 
     assert.equal(stream_data.get_name("denMARK"), "Denmark");
     assert.equal(stream_data.get_name("unknown Stream"), "unknown Stream");
@@ -427,7 +427,7 @@ run_test("admin_options", () => {
     }
 
     // non-admins can't do anything
-    global.page_params.is_admin = false;
+    page_params.is_admin = false;
     let sub = make_sub();
     stream_data.update_calculated_fields(sub);
     assert(!sub.is_realm_admin);
@@ -437,7 +437,7 @@ run_test("admin_options", () => {
     assert.equal(sub.color, "blue");
 
     // the remaining cases are for admin users
-    global.page_params.is_admin = true;
+    page_params.is_admin = true;
 
     // admins can make public streams become private
     sub = make_sub();
@@ -530,7 +530,7 @@ run_test("stream_settings", () => {
     // For guest user only retrieve subscribed streams
     sub_rows = stream_data.get_updated_unsorted_subs();
     assert.equal(sub_rows.length, 3);
-    global.page_params.is_guest = true;
+    page_params.is_guest = true;
     sub_rows = stream_data.get_updated_unsorted_subs();
     assert.equal(sub_rows[0].name, "c");
     assert.equal(sub_rows[1].name, "a");

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
+const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+
 set_global("page_params", {
     is_admin: false,
     realm_users: [],
@@ -13,7 +15,7 @@ set_global("page_params", {
 set_global("$", () => {});
 
 set_global("document", null);
-global.stub_out_jquery();
+stub_out_jquery();
 
 zrequire("color_data");
 zrequire("hash_util");

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const _ = require("lodash");
 
 set_global("page_params", {

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -13,8 +13,6 @@ set_global("page_params", {
     is_guest: false,
 });
 
-set_global("$", () => {});
-
 set_global("document", null);
 stub_out_jquery();
 

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -2,13 +2,14 @@
 
 const {strict: assert} = require("assert");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const {LazySet} = zrequire("lazy_set");
 
 const noop = () => {};
-global.stub_templates(() => noop);
+stub_templates(() => noop);
 
 set_global("channel", {});
 set_global("hashchange", {update_browser_history: noop});

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const {LazySet} = zrequire("lazy_set");
 
@@ -32,7 +33,7 @@ set_global("typeahead_helper", {});
 set_global("ui", {
     get_scroll_element: noop,
 });
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 zrequire("input_pill");
 const people = zrequire("people");

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const {LazySet} = zrequire("lazy_set");
 
 const noop = () => {};

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const {LazySet} = zrequire("lazy_set");
 
 const noop = () => {};

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const {LazySet} = zrequire("lazy_set");

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_stub, with_stub} = require("../zjsunit/stub");
 
 const noop = function () {};
 const return_true = function () {
@@ -68,7 +69,7 @@ run_test("update_property", (override) => {
 
     // Test update color
     {
-        global.with_stub((stub) => {
+        with_stub((stub) => {
             override("stream_color.update_stream_color", stub.f);
             stream_events.update_property(1, "color", "blue");
             const args = stub.get_args("sub", "val");
@@ -79,7 +80,7 @@ run_test("update_property", (override) => {
 
     // Test in home view
     {
-        global.with_stub((stub) => {
+        with_stub((stub) => {
             override("stream_muting.update_is_muted", stub.f);
             stream_events.update_property(1, "in_home_view", false);
             const args = stub.get_args("sub", "val");
@@ -120,7 +121,7 @@ run_test("update_property", (override) => {
 
     // Test name change
     {
-        global.with_stub((stub) => {
+        with_stub((stub) => {
             override("subs.update_stream_name", stub.f);
             stream_events.update_property(1, "name", "the frontend");
             const args = stub.get_args("sub", "val");
@@ -131,7 +132,7 @@ run_test("update_property", (override) => {
 
     // Test description change
     {
-        global.with_stub((stub) => {
+        with_stub((stub) => {
             override("subs.update_stream_description", stub.f);
             stream_events.update_property(1, "description", "we write code", {
                 rendered_description: "we write code",
@@ -156,7 +157,7 @@ run_test("update_property", (override) => {
 
     // Test stream privacy change event
     {
-        global.with_stub((stub) => {
+        with_stub((stub) => {
             override("subs.update_stream_privacy", stub.f);
             stream_events.update_property(1, "invite_only", true, {
                 history_public_to_subscribers: true,
@@ -172,7 +173,7 @@ run_test("update_property", (override) => {
 
     // Test stream stream_post_policy change event
     {
-        global.with_stub((stub) => {
+        with_stub((stub) => {
             override("subs.update_stream_post_policy", stub.f);
             stream_events.update_property(
                 1,
@@ -187,7 +188,7 @@ run_test("update_property", (override) => {
 
     // Test stream message_retention_days change event
     {
-        global.with_stub((stub) => {
+        with_stub((stub) => {
             override("subs.update_message_retention_setting", stub.f);
             stream_events.update_property(1, "message_retention_days", 20);
             const args = stub.get_args("sub", "val");
@@ -243,9 +244,9 @@ run_test("marked_subscribed", (override) => {
         let args;
         let list_updated = false;
 
-        const stream_list_stub = global.make_stub();
-        const message_view_header_stub = global.make_stub();
-        const message_util_stub = global.make_stub();
+        const stream_list_stub = make_stub();
+        const message_view_header_stub = make_stub();
+        const message_util_stub = make_stub();
 
         override("stream_color.update_stream_color", noop);
         override("stream_list.add_sidebar_row", stream_list_stub.f);
@@ -280,7 +281,7 @@ run_test("marked_subscribed", (override) => {
         });
 
         // narrow state is undefined
-        global.with_stub((stub) => {
+        with_stub((stub) => {
             override("message_util.do_unread_count_updates", noop);
             override("stream_list.add_sidebar_row", noop);
             override("subs.set_color", stub.f);
@@ -299,7 +300,7 @@ run_test("marked_subscribed", (override) => {
         override("message_util.do_unread_count_updates", noop);
         override("stream_list.add_sidebar_row", noop);
 
-        global.with_stub((stub) => {
+        with_stub((stub) => {
             override("stream_data.set_subscribers", stub.f);
             const user_ids = [15, 20, 25];
             stream_events.mark_subscribed(frontend, user_ids, "");
@@ -309,7 +310,7 @@ run_test("marked_subscribed", (override) => {
         });
 
         // assign self as well
-        global.with_stub((stub) => {
+        with_stub((stub) => {
             override("stream_data.subscribe_myself", stub.f);
             stream_events.mark_subscribed(frontend, [], "");
             const args = stub.get_args("sub");
@@ -317,7 +318,7 @@ run_test("marked_subscribed", (override) => {
         });
 
         // and finally update subscriber settings
-        global.with_stub((stub) => {
+        with_stub((stub) => {
             override("subs.update_settings_for_subscribed", stub.f);
             stream_events.mark_subscribed(frontend, [], "");
             const args = stub.get_args("sub");
@@ -351,7 +352,7 @@ run_test("mark_unsubscribed", (override) => {
     // Test unsubscribe
     frontend.subscribed = true;
     {
-        global.with_stub((stub) => {
+        with_stub((stub) => {
             override("stream_data.unsubscribe_myself", stub.f);
             override("subs.update_settings_for_unsubscribed", noop);
             override("stream_list.remove_sidebar_row", noop);
@@ -363,7 +364,7 @@ run_test("mark_unsubscribed", (override) => {
 
     // Test update settings after unsubscribe
     {
-        global.with_stub((stub) => {
+        with_stub((stub) => {
             override("subs.update_settings_for_unsubscribed", stub.f);
             override("stream_data.unsubscribe_myself", noop);
             override("stream_list.remove_sidebar_row", noop);
@@ -376,7 +377,7 @@ run_test("mark_unsubscribed", (override) => {
     // Test update bookend and remove done event
     narrow_state.set_current_filter(frontend_filter);
     {
-        const message_view_header_stub = global.make_stub();
+        const message_view_header_stub = make_stub();
         override("message_view_header.render_title_area", message_view_header_stub.f);
         override("stream_data.unsubscribe_myself", noop);
         override("subs.update_settings_for_unsubscribed", noop);
@@ -413,7 +414,7 @@ const dev_help = {
 stream_data.add_sub(dev_help);
 
 run_test("remove_deactivated_user_from_all_streams", () => {
-    const subs_stub = global.make_stub();
+    const subs_stub = make_stub();
     subs.update_subscribers_ui = subs_stub.f;
 
     dev_help.can_access_subscribers = true;

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -4,12 +4,13 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_stub, with_stub} = require("../zjsunit/stub");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = function () {};
 const return_true = function () {
     return true;
 };
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 const _settings_notifications = {
     update_page: () => {},
 };

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_stub, with_stub} = require("../zjsunit/stub");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = function () {};

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const noop = function () {};
 const return_true = function () {
     return true;

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const noop = function () {};
 const return_true = function () {
     return true;

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -2,6 +2,7 @@
 
 const {strict: assert} = require("assert");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -79,7 +80,7 @@ run_test("create_sidebar_row", () => {
         devel_count.set_find_results(".value", devel_value);
         devel_count.set_parent(sidebar_row);
 
-        global.stub_templates((template_name, data) => {
+        stub_templates((template_name, data) => {
             assert.equal(template_name, "stream_sidebar_row");
             assert.equal(data.uri, "#narrow/stream/100-devel");
             return "<devel sidebar row>";
@@ -98,7 +99,7 @@ run_test("create_sidebar_row", () => {
         social_count.set_find_results(".value", social_value);
         social_count.set_parent(sidebar_row);
 
-        global.stub_templates((template_name, data) => {
+        stub_templates((template_name, data) => {
             assert.equal(template_name, "stream_sidebar_row");
             assert.equal(data.uri, "#narrow/stream/200-social");
             return "<social sidebar row>";
@@ -144,7 +145,7 @@ run_test("create_sidebar_row", () => {
 
     social.invite_only = true;
     social.color = "#222222";
-    global.stub_templates((template_name, data) => {
+    stub_templates((template_name, data) => {
         assert.equal(template_name, "stream_privacy");
         assert.equal(data.invite_only, true);
         assert.equal(data.dark_background, "dark_background");
@@ -673,7 +674,7 @@ run_test("rename_stream", () => {
     const li_stub = $.create("li stub");
     li_stub.length = 0;
 
-    global.stub_templates((name, payload) => {
+    stub_templates((name, payload) => {
         assert.equal(name, "stream_sidebar_row");
         assert.deepEqual(payload, {
             name: "Development",
@@ -721,7 +722,7 @@ run_test("refresh_pin", () => {
     const li_stub = $.create("li stub");
     li_stub.length = 0;
 
-    global.stub_templates(() => ({to_$: () => li_stub}));
+    stub_templates(() => ({to_$: () => li_stub}));
 
     stream_list.update_count_in_dom = noop;
     $("#stream_filters").append = noop;
@@ -750,7 +751,7 @@ run_test("create_initial_sidebar_rows", () => {
 
     stream_list.update_count_in_dom = noop;
 
-    global.stub_templates((template_name, data) => {
+    stub_templates((template_name, data) => {
         assert.equal(template_name, "stream_sidebar_row");
         return "<div>stub-html-" + data.name;
     });

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("document", "document-stub");

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -3,9 +3,10 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("document", "document-stub");
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 zrequire("unread_ui");
 zrequire("Filter", "js/filter");
@@ -229,7 +230,7 @@ run_test("pinned_streams_never_inactive", () => {
     assert(!devel_sidebar.hasClass("inactive_stream"));
 });
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 function add_row(sub) {
     global.stream_data.add_sub(sub);
@@ -383,7 +384,7 @@ run_test("zoom_in_and_zoom_out", () => {
     assert($("#streams_list").hasClass("zoom-out"));
 });
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 run_test("narrowing", () => {
     initialize_stream_data();
@@ -698,7 +699,7 @@ run_test("rename_stream", () => {
     assert(count_updated);
 });
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 run_test("refresh_pin", () => {
     initialize_stream_data();

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("document", "document-stub");
 set_global("$", global.make_zjquery());
 

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -57,7 +57,7 @@ run_test("create_sidebar_row", () => {
         subscribed: true,
         pin_to_top: true,
     };
-    global.stream_data.add_sub(devel);
+    stream_data.add_sub(devel);
 
     const social = {
         name: "social",
@@ -65,9 +65,9 @@ run_test("create_sidebar_row", () => {
         color: "green",
         subscribed: true,
     };
-    global.stream_data.add_sub(social);
+    stream_data.add_sub(social);
 
-    global.unread.num_unread_for_stream = function () {
+    unread.num_unread_for_stream = function () {
         return 42;
     };
 
@@ -190,7 +190,7 @@ run_test("pinned_streams_never_inactive", () => {
         subscribed: true,
         pin_to_top: true,
     };
-    global.stream_data.add_sub(devel);
+    stream_data.add_sub(devel);
 
     const social = {
         name: "social",
@@ -198,7 +198,7 @@ run_test("pinned_streams_never_inactive", () => {
         color: "green",
         subscribed: true,
     };
-    global.stream_data.add_sub(social);
+    stream_data.add_sub(social);
 
     // we use social and devel created in create_social_sidebar_row() and create_devel_sidebar_row()
 
@@ -235,7 +235,7 @@ run_test("pinned_streams_never_inactive", () => {
 set_global("$", make_zjquery());
 
 function add_row(sub) {
-    global.stream_data.add_sub(sub);
+    stream_data.add_sub(sub);
     const row = {
         update_whether_active() {},
         get_li() {
@@ -468,7 +468,7 @@ run_test("sort_streams", () => {
 
     initialize_stream_data();
 
-    global.stream_data.is_active = function (sub) {
+    stream_data.is_active = function (sub) {
         return sub.name !== "cars";
     };
 
@@ -493,7 +493,7 @@ run_test("sort_streams", () => {
 
     assert.deepEqual(appended_elems, expected_elems);
 
-    const streams = global.stream_sort.get_streams();
+    const streams = stream_sort.get_streams();
 
     assert.deepEqual(streams, [
         // three groups: pinned, normal, dormant
@@ -550,7 +550,7 @@ run_test("separators_only_pinned_and_dormant", () => {
     };
     add_row(DenmarkSub);
 
-    global.stream_data.is_active = function (sub) {
+    stream_data.is_active = function (sub) {
         return sub.name !== "Denmark";
     };
 

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("document", "document-stub");
 set_global("$", global.make_zjquery());
 

--- a/frontend_tests/node_tests/stream_pill.js
+++ b/frontend_tests/node_tests/stream_pill.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("stream_data");
 zrequire("stream_pill");
 

--- a/frontend_tests/node_tests/stream_pill.js
+++ b/frontend_tests/node_tests/stream_pill.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("stream_data");
 zrequire("stream_pill");

--- a/frontend_tests/node_tests/stream_pill.js
+++ b/frontend_tests/node_tests/stream_pill.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 zrequire("stream_data");
 zrequire("stream_pill");
 

--- a/frontend_tests/node_tests/stream_search.js
+++ b/frontend_tests/node_tests/stream_search.js
@@ -3,10 +3,11 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 // This tests the stream searching functionality which currently
 // lives in stream_list.js.
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 zrequire("stream_list");
 
 const noop = () => {};

--- a/frontend_tests/node_tests/stream_search.js
+++ b/frontend_tests/node_tests/stream_search.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const {strict: assert} = require("assert");
 // This tests the stream searching functionality which currently
 // lives in stream_list.js.
 

--- a/frontend_tests/node_tests/stream_search.js
+++ b/frontend_tests/node_tests/stream_search.js
@@ -1,6 +1,8 @@
 "use strict";
 
 const {strict: assert} = require("assert");
+
+const {set_global, zrequire} = require("../zjsunit/namespace");
 // This tests the stream searching functionality which currently
 // lives in stream_list.js.
 

--- a/frontend_tests/node_tests/stream_search.js
+++ b/frontend_tests/node_tests/stream_search.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 // This tests the stream searching functionality which currently
 // lives in stream_list.js.

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("stream_data");
 zrequire("stream_sort");
 

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 zrequire("stream_data");
 zrequire("stream_sort");
 

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("stream_data");
 zrequire("stream_sort");

--- a/frontend_tests/node_tests/stream_topic_history.js
+++ b/frontend_tests/node_tests/stream_topic_history.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("unread");
 zrequire("stream_data");
 zrequire("stream_topic_history");

--- a/frontend_tests/node_tests/stream_topic_history.js
+++ b/frontend_tests/node_tests/stream_topic_history.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("unread");
 zrequire("stream_data");
 zrequire("stream_topic_history");

--- a/frontend_tests/node_tests/stream_topic_history.js
+++ b/frontend_tests/node_tests/stream_topic_history.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("unread");
 zrequire("stream_data");

--- a/frontend_tests/node_tests/submessage.js
+++ b/frontend_tests/node_tests/submessage.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("submessage");
 

--- a/frontend_tests/node_tests/submessage.js
+++ b/frontend_tests/node_tests/submessage.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("submessage");
 
 set_global("channel", {});

--- a/frontend_tests/node_tests/submessage.js
+++ b/frontend_tests/node_tests/submessage.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("submessage");
 
 set_global("channel", {});

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -2,6 +2,7 @@
 
 const {strict: assert} = require("assert");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -94,7 +95,7 @@ run_test("filter_table", () => {
 
     let populated_subs;
 
-    global.stub_templates((fn, data) => {
+    stub_templates((fn, data) => {
         assert.equal(fn, "subscriptions");
         populated_subs = data.subscriptions;
     });

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 stub_out_jquery();
 
@@ -20,7 +21,7 @@ set_global("location", {
 
 zrequire("subs");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("hash_util", {
     by_stream_uri: () => {},
 });

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -2,7 +2,9 @@
 
 const {strict: assert} = require("assert");
 
-global.stub_out_jquery();
+const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+
+stub_out_jquery();
 
 set_global("ui", {
     get_content_element: (element) => element,

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 stub_out_jquery();

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 global.stub_out_jquery();
 
 set_global("ui", {

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -3,11 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {stub_templates} = require("../zjsunit/handlebars");
-const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
-
-stub_out_jquery();
 
 set_global("ui", {
     get_content_element: (element) => element,

--- a/frontend_tests/node_tests/support.js
+++ b/frontend_tests/node_tests/support.js
@@ -14,9 +14,9 @@ const dom = new JSDOM(template, {pretendToBeVisual: true});
 const document = dom.window.document;
 
 let jquery_init;
-global.$ = (f) => {
+set_global("$", (f) => {
     jquery_init = f;
-};
+});
 zrequire("support", "js/analytics/support");
 set_global("$", make_zjquery());
 

--- a/frontend_tests/node_tests/support.js
+++ b/frontend_tests/node_tests/support.js
@@ -6,6 +6,7 @@ const fs = require("fs");
 const {JSDOM} = require("jsdom");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const template = fs.readFileSync("templates/analytics/realm_details.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});
@@ -16,7 +17,7 @@ global.$ = (f) => {
     jquery_init = f;
 };
 zrequire("support", "js/analytics/support");
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 run_test("scrub_realm", () => {
     jquery_init();

--- a/frontend_tests/node_tests/support.js
+++ b/frontend_tests/node_tests/support.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const {strict: assert} = require("assert");
 const fs = require("fs");
 
 const {JSDOM} = require("jsdom");

--- a/frontend_tests/node_tests/support.js
+++ b/frontend_tests/node_tests/support.js
@@ -5,6 +5,8 @@ const fs = require("fs");
 
 const {JSDOM} = require("jsdom");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const template = fs.readFileSync("templates/analytics/realm_details.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});
 const document = dom.window.document;

--- a/frontend_tests/node_tests/support.js
+++ b/frontend_tests/node_tests/support.js
@@ -6,6 +6,7 @@ const fs = require("fs");
 const {JSDOM} = require("jsdom");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const template = fs.readFileSync("templates/analytics/realm_details.html", "utf-8");

--- a/frontend_tests/node_tests/support.js
+++ b/frontend_tests/node_tests/support.js
@@ -13,15 +13,10 @@ const template = fs.readFileSync("templates/analytics/realm_details.html", "utf-
 const dom = new JSDOM(template, {pretendToBeVisual: true});
 const document = dom.window.document;
 
-let jquery_init;
-set_global("$", (f) => {
-    jquery_init = f;
-});
-zrequire("support", "js/analytics/support");
 set_global("$", make_zjquery());
 
 run_test("scrub_realm", () => {
-    jquery_init();
+    zrequire("support", "js/analytics/support");
     const click_handler = $("body").get_on_handler("click", ".scrub-realm-button");
 
     const fake_this = $.create("fake-.scrub-realm-button");

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const moment = require("moment");
 const XDate = require("xdate");
 

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -6,6 +6,7 @@ const moment = require("moment");
 const XDate = require("xdate");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -6,8 +6,9 @@ const moment = require("moment");
 const XDate = require("xdate");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("page_params", {
     twenty_four_hour_time: true,
 });

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -5,6 +5,8 @@ const {strict: assert} = require("assert");
 const moment = require("moment");
 const XDate = require("xdate");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 set_global("page_params", {
     twenty_four_hour_time: true,

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 
 zrequire("Filter", "js/filter");

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -3,8 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 zrequire("Filter", "js/filter");
 zrequire("unread_ui");

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("$", global.make_zjquery());
 
 zrequire("Filter", "js/filter");

--- a/frontend_tests/node_tests/topic_generator.js
+++ b/frontend_tests/node_tests/topic_generator.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const pm_conversations = zrequire("pm_conversations");
 pm_conversations.recent = {};

--- a/frontend_tests/node_tests/topic_generator.js
+++ b/frontend_tests/node_tests/topic_generator.js
@@ -200,7 +200,7 @@ run_test("streams", () => {
         assert.equal(actual, expected);
     }
 
-    global.stream_sort.get_streams = function () {
+    stream_sort.get_streams = function () {
         return ["announce", "muted", "devel", "test here"];
     };
 
@@ -251,7 +251,7 @@ run_test("topics", () => {
     // Now test the deeper function that is wired up to
     // real functions stream_data/stream_sort/unread.
 
-    global.stream_sort.get_streams = function () {
+    stream_sort.get_streams = function () {
         return ["announce", "muted", "devel", "test here"];
     };
 
@@ -274,19 +274,19 @@ run_test("topics", () => {
         return [];
     };
 
-    global.stream_data.get_stream_id = function (stream_name) {
+    stream_data.get_stream_id = function (stream_name) {
         return stream_id_dct[stream_name];
     };
 
-    global.stream_data.is_stream_muted_by_name = function (stream_name) {
+    stream_data.is_stream_muted_by_name = function (stream_name) {
         return stream_name === "muted";
     };
 
-    global.unread.topic_has_any_unread = function (stream_id) {
+    unread.topic_has_any_unread = function (stream_id) {
         return [devel_stream_id, muted_stream_id].includes(stream_id);
     };
 
-    global.muting.is_topic_muted = function (stream_name, topic) {
+    muting.is_topic_muted = function (stream_name, topic) {
         return topic === "muted";
     };
 

--- a/frontend_tests/node_tests/topic_generator.js
+++ b/frontend_tests/node_tests/topic_generator.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const pm_conversations = zrequire("pm_conversations");
 pm_conversations.recent = {};
 

--- a/frontend_tests/node_tests/topic_generator.js
+++ b/frontend_tests/node_tests/topic_generator.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 const pm_conversations = zrequire("pm_conversations");
 pm_conversations.recent = {};
 

--- a/frontend_tests/node_tests/topic_list_data.js
+++ b/frontend_tests/node_tests/topic_list_data.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const _ = require("lodash");
 
 set_global("narrow_state", {});

--- a/frontend_tests/node_tests/topic_list_data.js
+++ b/frontend_tests/node_tests/topic_list_data.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("narrow_state", {});
 set_global("unread", {});
 set_global("muting", {});

--- a/frontend_tests/node_tests/topic_list_data.js
+++ b/frontend_tests/node_tests/topic_list_data.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 set_global("narrow_state", {});
 set_global("unread", {});

--- a/frontend_tests/node_tests/transmit.js
+++ b/frontend_tests/node_tests/transmit.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const noop = function () {};
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/transmit.js
+++ b/frontend_tests/node_tests/transmit.js
@@ -3,10 +3,11 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = function () {};
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("page_params", {});
 set_global("channel", {});
 set_global("reload", {});

--- a/frontend_tests/node_tests/transmit.js
+++ b/frontend_tests/node_tests/transmit.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const noop = function () {};
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/transmit.js
+++ b/frontend_tests/node_tests/transmit.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = function () {};

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const typeahead = zrequire("typeahead", "shared/js/typeahead");
 

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 const typeahead = zrequire("typeahead", "shared/js/typeahead");
 
 // The data structures here may be different for

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const typeahead = zrequire("typeahead", "shared/js/typeahead");
 
 // The data structures here may be different for

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("page_params", {realm_is_zephyr_mirror_realm: false});
 set_global("md5", (s) => "md5-" + s);
 

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -7,7 +7,6 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 set_global("page_params", {realm_is_zephyr_mirror_realm: false});
-set_global("md5", (s) => "md5-" + s);
 
 const settings_config = zrequire("settings_config");
 const pm_conversations = zrequire("pm_conversations");

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -56,7 +56,7 @@ run_test("sort_streams", () => {
     ];
     test_streams.forEach(stream_data.update_calculated_fields);
 
-    global.stream_data.is_active = function (sub) {
+    stream_data.is_active = function (sub) {
         return sub.name !== "dead";
     };
 
@@ -261,19 +261,19 @@ run_test("sort_recipients", () => {
     pm_conversations.set_partner(7);
 
     // For splitting based on recency
-    global.recent_senders.process_message_for_senders({
+    recent_senders.process_message_for_senders({
         sender_id: 7,
         stream_id: 1,
         topic: "Dev Topic",
         id: (next_id += 1),
     });
-    global.recent_senders.process_message_for_senders({
+    recent_senders.process_message_for_senders({
         sender_id: 5,
         stream_id: 1,
         topic: "Dev Topic",
         id: (next_id += 1),
     });
-    global.recent_senders.process_message_for_senders({
+    recent_senders.process_message_for_senders({
         sender_id: 6,
         stream_id: 1,
         topic: "Dev Topic",
@@ -291,13 +291,13 @@ run_test("sort_recipients", () => {
         "a_bot@zulip.com",
     ]);
 
-    global.recent_senders.process_message_for_senders({
+    recent_senders.process_message_for_senders({
         sender_id: 5,
         stream_id: 2,
         topic: "Linux Topic",
         id: (next_id += 1),
     });
-    global.recent_senders.process_message_for_senders({
+    recent_senders.process_message_for_senders({
         sender_id: 7,
         stream_id: 2,
         topic: "Linux Topic",

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("page_params", {realm_is_zephyr_mirror_realm: false});
 set_global("md5", (s) => "md5-" + s);
 

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 set_global("page_params", {realm_is_zephyr_mirror_realm: false});
 set_global("md5", (s) => "md5-" + s);

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -2,6 +2,7 @@
 
 const {strict: assert} = require("assert");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 
 set_global("page_params", {realm_is_zephyr_mirror_realm: false});
@@ -462,7 +463,7 @@ run_test("render_person when emails hidden", () => {
     // Test render_person with regular person, under hidden email visibility case
     page_params.is_admin = false;
     let rendered = false;
-    global.stub_templates((template_name, args) => {
+    stub_templates((template_name, args) => {
         assert.equal(template_name, "typeahead_list_item");
         assert.equal(args.primary, b_user_1.full_name);
         assert.equal(args.secondary, undefined);
@@ -477,7 +478,7 @@ run_test("render_person", () => {
     page_params.is_admin = true;
     // Test render_person with regular person
     let rendered = false;
-    global.stub_templates((template_name, args) => {
+    stub_templates((template_name, args) => {
         assert.equal(template_name, "typeahead_list_item");
         assert.equal(args.primary, a_user.full_name);
         assert.equal(args.secondary, a_user.email);
@@ -497,7 +498,7 @@ run_test("render_person", () => {
         special_item_text: "special_text",
     };
     rendered = false;
-    global.stub_templates((template_name, args) => {
+    stub_templates((template_name, args) => {
         assert.equal(template_name, "typeahead_list_item");
         assert.equal(args.primary, special_person.special_item_text);
         rendered = true;
@@ -509,7 +510,7 @@ run_test("render_person", () => {
 
 run_test("clear_rendered_person", () => {
     let rendered = false;
-    global.stub_templates((template_name, args) => {
+    stub_templates((template_name, args) => {
         assert.equal(template_name, "typeahead_list_item");
         assert.equal(args.primary, b_bot.full_name);
         assert.equal(args.secondary, b_bot.email);
@@ -540,7 +541,7 @@ run_test("render_stream", () => {
         stream_id: 42,
         name: "Short Description",
     };
-    global.stub_templates((template_name, args) => {
+    stub_templates((template_name, args) => {
         assert.equal(template_name, "typeahead_list_item");
         assert.equal(args.primary, stream.name);
         assert.equal(args.secondary, stream.description);
@@ -557,7 +558,7 @@ run_test("render_stream", () => {
         stream_id: 43,
         name: "Long Description",
     };
-    global.stub_templates((template_name, args) => {
+    stub_templates((template_name, args) => {
         assert.equal(template_name, "typeahead_list_item");
         assert.equal(args.primary, stream.name);
         const short_desc = stream.description.slice(0, 35);
@@ -576,7 +577,7 @@ run_test("clear_rendered_stream", () => {
         stream_id: 44,
         name: "Stream To Be Cleared",
     };
-    global.stub_templates((template_name, args) => {
+    stub_templates((template_name, args) => {
         assert.equal(template_name, "typeahead_list_item");
         assert.equal(args.primary, stream.name);
         assert.equal(args.secondary, stream.description);
@@ -609,7 +610,7 @@ run_test("render_emoji", () => {
         }),
     );
 
-    global.stub_templates((template_name, args) => {
+    stub_templates((template_name, args) => {
         assert.equal(template_name, "typeahead_list_item");
         assert.deepEqual(args, {
             primary: "thumbs up",
@@ -631,7 +632,7 @@ run_test("render_emoji", () => {
         emoji_url: "TBD",
     };
 
-    global.stub_templates((template_name, args) => {
+    stub_templates((template_name, args) => {
         assert.equal(template_name, "typeahead_list_item");
         assert.deepEqual(args, {
             primary: "realm emoji",

--- a/frontend_tests/node_tests/typing_data.js
+++ b/frontend_tests/node_tests/typing_data.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("typing_data");
 

--- a/frontend_tests/node_tests/typing_data.js
+++ b/frontend_tests/node_tests/typing_data.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("typing_data");
 
 run_test("basics", () => {

--- a/frontend_tests/node_tests/typing_data.js
+++ b/frontend_tests/node_tests/typing_data.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("typing_data");
 
 run_test("basics", () => {
@@ -85,8 +87,8 @@ run_test("timers", () => {
         typing_data.clear_inbound_timer(stub_group);
     }
 
-    global.patch_builtin("setTimeout", set_timeout);
-    global.patch_builtin("clearTimeout", clear_timeout);
+    set_global("setTimeout", set_timeout);
+    set_global("clearTimeout", clear_timeout);
 
     // first time, we set
     kickstart();

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("typing");
 zrequire("people");
 zrequire("compose_pm_pill");
@@ -38,8 +40,8 @@ run_test("basics", () => {
         events.timer_cleared = true;
     }
 
-    global.patch_builtin("setTimeout", set_timeout);
-    global.patch_builtin("clearTimeout", clear_timeout);
+    set_global("setTimeout", set_timeout);
+    set_global("clearTimeout", clear_timeout);
 
     function notify_server_start(recipient) {
         assert.equal(recipient, "alice");

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("typing");
 zrequire("people");
 zrequire("compose_pm_pill");

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("typing");
 zrequire("people");

--- a/frontend_tests/node_tests/ui.js
+++ b/frontend_tests/node_tests/ui.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const ui = zrequire("ui");
 
 set_global("navigator", {

--- a/frontend_tests/node_tests/ui.js
+++ b/frontend_tests/node_tests/ui.js
@@ -19,12 +19,12 @@ run_test("get_hotkey_deprecation_notice", () => {
 });
 
 run_test("get_hotkey_deprecation_notice_mac", () => {
-    global.navigator.userAgent =
+    navigator.userAgent =
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.167 Safari/537.36";
     const expected =
         'translated: We\'ve replaced the "*" hotkey with "Cmd + s" to make this common shortcut easier to trigger.';
     const actual = ui.get_hotkey_deprecation_notice("*", "Cmd + s");
     assert.equal(actual, expected);
     // Reset userAgent
-    global.navigator.userAgent = "";
+    navigator.userAgent = "";
 });

--- a/frontend_tests/node_tests/ui.js
+++ b/frontend_tests/node_tests/ui.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const ui = zrequire("ui");
 

--- a/frontend_tests/node_tests/ui.js
+++ b/frontend_tests/node_tests/ui.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const ui = zrequire("ui");
 
 set_global("navigator", {

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -2,6 +2,8 @@
 
 const rewiremock = require("rewiremock/node");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 /*
     This test suite is designed to find errors
     in our initialization sequence.  It doesn't

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -4,6 +4,7 @@ const rewiremock = require("rewiremock/node");
 
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 /*

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -2,6 +2,7 @@
 
 const rewiremock = require("rewiremock/node");
 
+const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -74,7 +75,7 @@ for (const mod of ignore_modules) {
 }
 
 util.is_mobile = () => false;
-global.stub_templates(() => "some-html");
+stub_templates(() => "some-html");
 ui.get_scroll_element = (element) => element;
 
 zrequire("alert_words");

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -3,6 +3,7 @@
 const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 /*
     This test suite is designed to find errors
@@ -130,7 +131,7 @@ const ui_init = rewiremock.proxy(() => zrequire("ui_init"), {
     },
 });
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 const document_stub = $.create("document-stub");
 document.to_$ = () => document_stub;

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("muting");
 const people = zrequire("people");

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const _ = require("lodash");
 
 zrequire("muting");

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 zrequire("muting");
 const people = zrequire("people");
 zrequire("stream_data");

--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -6,6 +6,7 @@ const fs = require("fs");
 const {JSDOM} = require("jsdom");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = () => {};

--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -6,6 +6,7 @@ const fs = require("fs");
 const {JSDOM} = require("jsdom");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = () => {};
 const template = fs.readFileSync("templates/corporate/upgrade.html", "utf-8");
@@ -34,7 +35,7 @@ set_global("page_params", {
 
 zrequire("helpers", "js/billing/helpers");
 zrequire("upgrade", "js/billing/upgrade");
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 run_test("initialize", () => {
     let token_func;

--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -5,6 +5,8 @@ const fs = require("fs");
 
 const {JSDOM} = require("jsdom");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const noop = () => {};
 const template = fs.readFileSync("templates/corporate/upgrade.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});

--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -13,11 +13,6 @@ const noop = () => {};
 const template = fs.readFileSync("templates/corporate/upgrade.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});
 const document = dom.window.document;
-let jquery_init;
-
-set_global("$", (f) => {
-    jquery_init = f;
-});
 
 set_global("helpers", {
     set_tab: noop,
@@ -35,7 +30,6 @@ set_global("page_params", {
 });
 
 zrequire("helpers", "js/billing/helpers");
-zrequire("upgrade", "js/billing/upgrade");
 set_global("$", make_zjquery());
 
 run_test("initialize", () => {
@@ -109,7 +103,7 @@ run_test("initialize", () => {
     $("#autopay-form").data = (key) =>
         document.querySelector("#autopay-form").getAttribute("data-" + key);
 
-    jquery_init();
+    zrequire("upgrade", "js/billing/upgrade");
 
     const e = {
         preventDefault: noop,

--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -1,10 +1,11 @@
 "use strict";
 
-const noop = () => {};
+const {strict: assert} = require("assert");
 const fs = require("fs");
 
 const {JSDOM} = require("jsdom");
 
+const noop = () => {};
 const template = fs.readFileSync("templates/corporate/upgrade.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});
 const document = dom.window.document;

--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -15,9 +15,9 @@ const dom = new JSDOM(template, {pretendToBeVisual: true});
 const document = dom.window.document;
 let jquery_init;
 
-global.$ = (f) => {
+set_global("$", (f) => {
     jquery_init = f;
-};
+});
 
 set_global("helpers", {
     set_tab: noop,

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -23,8 +23,8 @@ set_global("bridge", false);
 
 // Setting these up so that we can test that links to uploads within messages are
 // automatically converted to server relative links.
-global.document.location.protocol = "https:";
-global.document.location.host = "foo.com";
+document.location.protocol = "https:";
+document.location.host = "foo.com";
 
 zrequire("compose_ui");
 zrequire("compose_state");

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -4,6 +4,8 @@ const {strict: assert} = require("assert");
 
 const rewiremock = require("rewiremock/node");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 set_global("document", {
     location: {},
@@ -273,7 +275,7 @@ run_test("upload_files", () => {
     upload.upload_files(uppy, config, files);
     assert.equal(add_file_counter, 1);
 
-    global.patch_builtin("setTimeout", (func) => {
+    set_global("setTimeout", (func) => {
         func();
     });
     hide_upload_status_called = false;
@@ -542,7 +544,7 @@ run_test("uppy_events", () => {
     assert.equal(compose_ui_autosize_textarea_called, false);
 
     const on_complete_callback = callbacks.complete;
-    global.patch_builtin("setTimeout", (func) => {
+    set_global("setTimeout", (func) => {
         func();
     });
     let hide_upload_status_called = false;

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -5,8 +5,9 @@ const {strict: assert} = require("assert");
 const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("document", {
     location: {},
 });
@@ -360,7 +361,7 @@ run_test("uppy_config", () => {
 });
 
 run_test("file_input", () => {
-    set_global("$", global.make_zjquery());
+    set_global("$", make_zjquery());
 
     upload.setup_upload({mode: "compose"});
 
@@ -383,7 +384,7 @@ run_test("file_input", () => {
 });
 
 run_test("file_drop", () => {
-    set_global("$", global.make_zjquery());
+    set_global("$", make_zjquery());
 
     upload.setup_upload({mode: "compose"});
 
@@ -423,7 +424,7 @@ run_test("file_drop", () => {
 });
 
 run_test("copy_paste", () => {
-    set_global("$", global.make_zjquery());
+    set_global("$", make_zjquery());
 
     upload.setup_upload({mode: "compose"});
 
@@ -464,7 +465,7 @@ run_test("copy_paste", () => {
 });
 
 run_test("uppy_events", () => {
-    set_global("$", global.make_zjquery());
+    set_global("$", make_zjquery());
     const callbacks = {};
     let uppy_cancel_all_called = false;
     let state = {};

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const rewiremock = require("rewiremock/node");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 
 const people = zrequire("people");

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("$", global.make_zjquery());
 
 const people = zrequire("people");

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -113,7 +113,7 @@ run_test("updates", () => {
 
     let user_id;
     let full_name;
-    global.message_live_update.update_user_full_name = function (user_id_arg, full_name_arg) {
+    message_live_update.update_user_full_name = function (user_id_arg, full_name_arg) {
         user_id = user_id_arg;
         full_name = full_name_arg;
     };
@@ -129,7 +129,7 @@ run_test("updates", () => {
         user_id: me.user_id,
         role: settings_config.user_role_values.member.code,
     });
-    assert(!global.page_params.is_admin);
+    assert(!page_params.is_admin);
 
     user_events.update_person({user_id: me.user_id, full_name: "Me V2"});
     assert.equal(people.my_full_name(), "Me V2");
@@ -147,7 +147,7 @@ run_test("updates", () => {
     assert.equal(person.full_name, "Me V2");
 
     let avatar_url;
-    global.message_live_update.update_avatar = function (user_id_arg, avatar_url_arg) {
+    message_live_update.update_avatar = function (user_id_arg, avatar_url_arg) {
         user_id = user_id_arg;
         avatar_url = avatar_url_arg;
     };

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -3,8 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 const people = zrequire("people");
 const settings_config = zrequire("settings_config");

--- a/frontend_tests/node_tests/user_groups.js
+++ b/frontend_tests/node_tests/user_groups.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("user_groups");
 

--- a/frontend_tests/node_tests/user_groups.js
+++ b/frontend_tests/node_tests/user_groups.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("user_groups");
 
 run_test("user_groups", () => {

--- a/frontend_tests/node_tests/user_groups.js
+++ b/frontend_tests/node_tests/user_groups.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 zrequire("user_groups");
 
 run_test("user_groups", () => {

--- a/frontend_tests/node_tests/user_pill.js
+++ b/frontend_tests/node_tests/user_pill.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 const people = zrequire("people");
 set_global("md5", (s) => "md5-" + s);

--- a/frontend_tests/node_tests/user_pill.js
+++ b/frontend_tests/node_tests/user_pill.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const people = zrequire("people");
 set_global("md5", (s) => "md5-" + s);
 zrequire("user_pill");

--- a/frontend_tests/node_tests/user_pill.js
+++ b/frontend_tests/node_tests/user_pill.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 const people = zrequire("people");
 set_global("md5", (s) => "md5-" + s);
 zrequire("user_pill");

--- a/frontend_tests/node_tests/user_pill.js
+++ b/frontend_tests/node_tests/user_pill.js
@@ -6,7 +6,6 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 const people = zrequire("people");
-set_global("md5", (s) => "md5-" + s);
 zrequire("user_pill");
 zrequire("pill_typeahead");
 

--- a/frontend_tests/node_tests/user_status.js
+++ b/frontend_tests/node_tests/user_status.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("channel", {});
 zrequire("user_status");
 

--- a/frontend_tests/node_tests/user_status.js
+++ b/frontend_tests/node_tests/user_status.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("channel", {});
 zrequire("user_status");
 

--- a/frontend_tests/node_tests/user_status.js
+++ b/frontend_tests/node_tests/user_status.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 set_global("channel", {});
 zrequire("user_status");

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const {JSDOM} = require("jsdom");
 const _ = require("lodash");
 

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -140,10 +140,10 @@ run_test("get_edit_event_prev_topic", () => {
 });
 
 run_test("is_mobile", () => {
-    global.window.navigator = {userAgent: "Android"};
+    window.navigator = {userAgent: "Android"};
     assert(util.is_mobile());
 
-    global.window.navigator = {userAgent: "Not mobile"};
+    window.navigator = {userAgent: "Not mobile"};
     assert(!util.is_mobile());
 });
 

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -6,6 +6,7 @@ const {JSDOM} = require("jsdom");
 const _ = require("lodash");
 
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -6,8 +6,9 @@ const {JSDOM} = require("jsdom");
 const _ = require("lodash");
 
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("DOMParser", new JSDOM().window.DOMParser);
 set_global("document", {});
 const util = zrequire("util");

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -5,6 +5,8 @@ const {strict: assert} = require("assert");
 const {JSDOM} = require("jsdom");
 const _ = require("lodash");
 
+const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 set_global("DOMParser", new JSDOM().window.DOMParser);
 set_global("document", {});

--- a/frontend_tests/node_tests/vdom.js
+++ b/frontend_tests/node_tests/vdom.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 
 zrequire("vdom");
 

--- a/frontend_tests/node_tests/vdom.js
+++ b/frontend_tests/node_tests/vdom.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {zrequire} = require("../zjsunit/namespace");
+
 zrequire("vdom");
 
 run_test("basics", () => {

--- a/frontend_tests/node_tests/vdom.js
+++ b/frontend_tests/node_tests/vdom.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 zrequire("vdom");
 
 run_test("basics", () => {

--- a/frontend_tests/node_tests/widgetize.js
+++ b/frontend_tests/node_tests/widgetize.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());

--- a/frontend_tests/node_tests/widgetize.js
+++ b/frontend_tests/node_tests/widgetize.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global, zrequire} = require("../zjsunit/namespace");
+
 set_global("$", global.make_zjquery());
 set_global("poll_widget", {});
 set_global("todo_widget", {});

--- a/frontend_tests/node_tests/widgetize.js
+++ b/frontend_tests/node_tests/widgetize.js
@@ -3,8 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 set_global("poll_widget", {});
 set_global("todo_widget", {});
 set_global("zform", {});

--- a/frontend_tests/node_tests/widgetize.js
+++ b/frontend_tests/node_tests/widgetize.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 set_global("$", global.make_zjquery());
 set_global("poll_widget", {});
 set_global("todo_widget", {});

--- a/frontend_tests/node_tests/zblueslip.js
+++ b/frontend_tests/node_tests/zblueslip.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 /*
 
 This test module actually tests our test code, particularly zblueslip, and

--- a/frontend_tests/node_tests/zblueslip.js
+++ b/frontend_tests/node_tests/zblueslip.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {run_test} = require("../zjsunit/test");
+
 /*
 
 This test module actually tests our test code, particularly zblueslip, and

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 /*

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {set_global} = require("../zjsunit/namespace");
+
 /*
 
 This test module actually tests our test code, particularly zjquery, and

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {set_global} = require("../zjsunit/namespace");
+const {make_zjquery} = require("../zjsunit/zjquery");
 
 /*
 
@@ -32,7 +33,7 @@ The code we are testing lives here:
 // with zjquery as follows.  This call gives us our own instance of a
 // zjquery stub variable.  Like with real jQuery, the '$' function will
 // be the gateway to a bigger API.
-set_global("$", global.make_zjquery());
+set_global("$", make_zjquery());
 
 run_test("basics", () => {
     // Let's create a sample piece of code to test:

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 /*
 
 This test module actually tests our test code, particularly zjquery, and

--- a/frontend_tests/zjsunit/handlebars.js
+++ b/frontend_tests/zjsunit/handlebars.js
@@ -28,7 +28,7 @@ class ZJavaScriptCompiler extends hb.JavaScriptCompiler {
 ZJavaScriptCompiler.prototype.compiler = ZJavaScriptCompiler;
 hb.JavaScriptCompiler = ZJavaScriptCompiler;
 
-require.extensions[".hbs"] = (module, filename) => {
+function compile_hbs(module, filename) {
     const code = fs.readFileSync(filename, "utf-8");
     const name = path.relative(templates_path, filename).slice(0, -".hbs".length);
     const pc = hb.precompile(code, {preventIndent: true, srcName: filename});
@@ -54,4 +54,8 @@ require.extensions[".hbs"] = (module, filename) => {
             Buffer.from(out.map.toString()).toString("base64"),
         filename,
     );
+}
+
+exports.hook_require = () => {
+    require.extensions[".hbs"] = compile_hbs;
 };

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -35,13 +35,12 @@ if (files.length === 0) {
 }
 
 // Set up our namespace helpers.
-global.window = new Proxy(global, {
+const window = new Proxy(global, {
     set: (obj, prop, value) => {
         namespace.set_global(prop, value);
         return true;
     },
 });
-global.to_$ = () => window;
 
 // Set up Handlebars
 handlebars.hook_require();
@@ -77,6 +76,8 @@ test.set_verbose(files.length === 1);
 
 try {
     files.forEach((file) => {
+        namespace.set_global("window", window);
+        namespace.set_global("to_$", () => window);
         namespace.set_global("location", {
             hash: "#",
         });

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -44,7 +44,7 @@ global.window = new Proxy(global, {
 global.to_$ = () => window;
 
 // Set up Handlebars
-global.stub_templates = handlebars.stub_templates;
+handlebars.hook_require();
 
 const noop = function () {};
 

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -9,6 +9,7 @@ const _ = require("lodash");
 const handlebars = require("./handlebars");
 const stub_i18n = require("./i18n");
 const namespace = require("./namespace");
+const test = require("./test");
 const {make_zblueslip} = require("./zblueslip");
 
 require("@babel/register")({
@@ -66,29 +67,13 @@ function short_tb(tb) {
     return lines.splice(0, i + 1).join("\n") + "\n(...)\n";
 }
 
-let current_file_name;
-
 function run_one_module(file) {
     console.info("running test " + path.basename(file, ".js"));
-    current_file_name = file;
+    test.set_current_file_name(file);
     require(file);
 }
 
-global.run_test = (label, f) => {
-    if (files.length === 1) {
-        console.info("        test: " + label);
-    }
-    try {
-        namespace.with_overrides(f);
-    } catch (error) {
-        console.info("-".repeat(50));
-        console.info(`test failed: ${current_file_name} > ${label}`);
-        console.info();
-        throw error;
-    }
-    // defensively reset blueslip after each test.
-    blueslip.reset();
-};
+test.set_verbose(files.length === 1);
 
 try {
     files.forEach((file) => {

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const fs = require("fs");
 const Module = require("module");
 const path = require("path");
 
@@ -51,13 +50,6 @@ const noop = function () {};
 // Set up fake module.hot
 Module.prototype.hot = {
     accept: noop,
-};
-
-// Set up fixtures.
-global.read_fixture_data = (fn) => {
-    const full_fn = path.join(__dirname, "../../zerver/tests/fixtures/", fn);
-    const data = JSON.parse(fs.readFileSync(full_fn, "utf8", "r"));
-    return data;
 };
 
 function short_tb(tb) {

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -74,9 +74,6 @@ function short_tb(tb) {
     return lines.splice(0, i + 1).join("\n") + "\n(...)\n";
 }
 
-// Set up Markdown comparison helper
-global.markdown_assert = require("./markdown_assert");
-
 let current_file_name;
 
 function run_one_module(file) {

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -25,8 +25,6 @@ require("@babel/register")({
     plugins: ["rewire-ts"],
 });
 
-global.assert = require("assert").strict;
-
 // Create a helper function to avoid sneaky delays in tests.
 function immediate(f) {
     return () => f();

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -11,7 +11,6 @@ const handlebars = require("./handlebars");
 const stub_i18n = require("./i18n");
 const namespace = require("./namespace");
 const {make_zblueslip} = require("./zblueslip");
-const zjquery = require("./zjquery");
 
 require("@babel/register")({
     extensions: [".es6", ".es", ".jsx", ".js", ".mjs", ".ts"],
@@ -43,9 +42,6 @@ global.window = new Proxy(global, {
     },
 });
 global.to_$ = () => window;
-
-// Set up fake jQuery
-global.make_zjquery = zjquery.make_zjquery;
 
 // Set up Handlebars
 global.stub_templates = handlebars.stub_templates;

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -17,9 +17,9 @@ const zjquery = require("./zjquery");
 require("@babel/register")({
     extensions: [".es6", ".es", ".jsx", ".js", ".mjs", ".ts"],
     only: [
-        new RegExp("^" + _.escapeRegExp(path.resolve(__dirname, "../../static/js")) + path.sep),
+        new RegExp("^" + _.escapeRegExp(path.resolve(__dirname, "../../static/js") + path.sep)),
         new RegExp(
-            "^" + _.escapeRegExp(path.resolve(__dirname, "../../static/shared/js")) + path.sep,
+            "^" + _.escapeRegExp(path.resolve(__dirname, "../../static/shared/js") + path.sep),
         ),
     ],
     plugins: ["rewire-ts"],

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -37,14 +37,6 @@ if (files.length === 0) {
 }
 
 // Set up our namespace helpers.
-global.with_field = namespace.with_field;
-global.set_global = namespace.set_global;
-global.patch_builtin = namespace.set_global;
-global.zrequire = namespace.zrequire;
-global.reset_module = namespace.reset_module;
-global.stub_out_jquery = namespace.stub_out_jquery;
-global.with_overrides = namespace.with_overrides;
-
 global.window = new Proxy(global, {
     set: (obj, prop, value) => {
         namespace.set_global(prop, value);
@@ -107,7 +99,7 @@ global.run_test = (label, f) => {
         console.info("        test: " + label);
     }
     try {
-        global.with_overrides(f);
+        namespace.with_overrides(f);
     } catch (error) {
         console.info("-".repeat(50));
         console.info(`test failed: ${current_file_name} > ${label}`);
@@ -120,16 +112,16 @@ global.run_test = (label, f) => {
 
 try {
     files.forEach((file) => {
-        set_global("location", {
+        namespace.set_global("location", {
             hash: "#",
         });
-        global.patch_builtin("setTimeout", noop);
-        global.patch_builtin("setInterval", noop);
+        namespace.set_global("setTimeout", noop);
+        namespace.set_global("setInterval", noop);
         _.throttle = immediate;
         _.debounce = immediate;
 
-        set_global("blueslip", make_zblueslip());
-        set_global("i18n", stub_i18n);
+        namespace.set_global("blueslip", make_zblueslip());
+        namespace.set_global("i18n", stub_i18n);
         namespace.clear_zulip_refs();
 
         run_one_module(file);

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -10,7 +10,6 @@ const _ = require("lodash");
 const handlebars = require("./handlebars");
 const stub_i18n = require("./i18n");
 const namespace = require("./namespace");
-const stub = require("./stub");
 const {make_zblueslip} = require("./zblueslip");
 const zjquery = require("./zjquery");
 
@@ -44,10 +43,6 @@ global.window = new Proxy(global, {
     },
 });
 global.to_$ = () => window;
-
-// Set up stub helpers.
-global.make_stub = stub.make_stub;
-global.with_stub = stub.with_stub;
 
 // Set up fake jQuery
 global.make_zjquery = zjquery.make_zjquery;

--- a/frontend_tests/zjsunit/markdown_assert.js
+++ b/frontend_tests/zjsunit/markdown_assert.js
@@ -22,6 +22,8 @@
  * HTML.  This makes it easier to spot relevant differences.
  */
 
+const {strict: assert} = require("assert");
+
 const {JSDOM} = require("jsdom");
 const _ = require("lodash");
 

--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -73,7 +73,7 @@ exports.restore = function () {
 };
 
 exports.stub_out_jquery = function () {
-    set_global("$", () => ({
+    exports.set_global("$", () => ({
         on() {},
         trigger() {},
         hide() {},

--- a/frontend_tests/zjsunit/test.js
+++ b/frontend_tests/zjsunit/test.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const namespace = require("./namespace");
+
+let current_file_name;
+let verbose = false;
+
+exports.set_current_file_name = (value) => {
+    current_file_name = value;
+};
+
+exports.set_verbose = (value) => {
+    verbose = value;
+};
+
+exports.run_test = (label, f) => {
+    if (verbose) {
+        console.info("        test: " + label);
+    }
+    try {
+        namespace.with_overrides(f);
+    } catch (error) {
+        console.info("-".repeat(50));
+        console.info(`test failed: ${current_file_name} > ${label}`);
+        console.info();
+        throw error;
+    }
+    // defensively reset blueslip after each test.
+    blueslip.reset();
+};

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const {strict: assert} = require("assert");
+
 const noop = function () {};
 
 class Event {


### PR DESCRIPTION
Also improve modularity and fix a number of inter-test global variable leaks that would be caught by ESLint and/or `"use strict"` if `global` hadn’t been used.