### PR TITLE
digests: Ensure that the teaser_data can be JSON-serialized.

### DIFF
--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -65,7 +65,7 @@ class DigestTopic:
             self.sample_messages,
         )
         return {
-            "participants": self.human_senders,
+            "participants": sorted(self.human_senders),
             "count": teaser_count,
             "first_few_messages": first_few_messages,
         }


### PR DESCRIPTION
Leaving this as a set means that it fails in zerver.lib.send_email
when serializing into a ScheduledEmail object.
