### PR TITLE
Fix couple of bugs with Sentry webhook configured as a webhook integration

### DIFF
--- a/zerver/webhooks/sentry/fixtures/webhook_event_for_exception_javascript.json
+++ b/zerver/webhooks/sentry/fixtures/webhook_event_for_exception_javascript.json
@@ -1,0 +1,178 @@
+{
+  "project_name": "Live",
+  "message": "",
+  "id": "1982047746",
+  "culprit": "debugger eval code",
+  "project_slug": "live",
+  "url": "https://sentry.io/organizations/foo-bar-org/issues/1982047746/?referrer=webhooks_plugin",
+  "level": "error",
+  "triggering_rules": [
+    "Send a notification for new issues"
+  ],
+  "event": {
+    "extra": {
+      "session:duration": 71705
+    },
+    "_ref_version": 2,
+    "_ref": 5481202,
+    "id": "f3bf5fc4e354451db9e885a69b2a2b51",
+    "_metrics": {
+      "bytes.ingested.event": 946,
+      "flag.processing.error": true,
+      "bytes.stored.event": 2683
+    },
+    "errors": [
+      {
+        "type": "invalid_attribute",
+        "name": "trimHeadFrames"
+      },
+      {
+        "url": "debugger eval code",
+        "type": "js_no_source"
+      }
+    ],
+    "culprit": "debugger eval code",
+    "title": "TypeError: can't access property \"bar\", x.foo is undefined",
+    "event_id": "f3bf5fc4e354451db9e885a69b2a2b51",
+    "breadcrumbs": {
+      "values": [
+        {
+          "category": "console",
+          "timestamp": 1603730322.773,
+          "message": "configured !!!!",
+          "type": "default",
+          "level": "info"
+        },
+        {
+          "category": "sentry",
+          "timestamp": 1603730337.597,
+          "message": "ReferenceError: doMoreSomethingUndefined is not defined",
+          "type": "default",
+          "level": "error"
+        }
+      ]
+    },
+    "grouping_config": {
+      "enhancements": "eJybzDhxY3J-bm5-npWRgaGlroGxrpHxBABcTQcY",
+      "id": "newstyle:2019-10-29"
+    },
+    "platform": "javascript",
+    "trimHeadFrames": null,
+    "version": "7",
+    "logger": "javascript",
+    "type": "error",
+    "metadata": {
+      "type": "TypeError",
+      "value": "can't access property \"bar\", x.foo is undefined"
+    },
+    "tags": [
+      [
+        "browser",
+        "Firefox 83.0"
+      ],
+      [
+        "browser.name",
+        "Firefox"
+      ],
+      [
+        "level",
+        "error"
+      ],
+      [
+        "logger",
+        "javascript"
+      ],
+      [
+        "os.name",
+        "Ubuntu"
+      ],
+      [
+        "sentry:user",
+        "ip:106.206.50.32"
+      ],
+      [
+        "transaction",
+        "debugger eval code"
+      ],
+      [
+        "url",
+        "file:///tmp/raven-js-test.html"
+      ]
+    ],
+    "user": {
+      "geo": {
+        "city": "Bengaluru",
+        "region": "India",
+        "country_code": "IN"
+      },
+      "ip_address": "106.206.50.32"
+    },
+    "fingerprint": [
+      "{{ default }}"
+    ],
+    "hashes": [
+      "338ec9eb220a67d39c935292df886c3f"
+    ],
+    "sdk": {
+      "version": "3.26.4",
+      "name": "raven-js"
+    },
+    "received": 1603730394.648839,
+    "exception": {
+      "values": [
+        {
+          "stacktrace": {
+            "frames": [
+              {
+                "abs_path": "debugger eval code",
+                "in_app": false,
+                "data": {
+                  "orig_in_app": 1
+                },
+                "lineno": 3,
+                "filename": "debugger eval code"
+              }
+            ]
+          },
+          "type": "TypeError",
+          "value": "can't access property \"bar\", x.foo is undefined"
+        }
+      ]
+    },
+    "transaction": "debugger eval code",
+    "_meta": {
+      "trimHeadFrames": {
+        "": {
+          "err": [
+            "invalid_attribute"
+          ]
+        }
+      }
+    },
+    "level": "error",
+    "contexts": {
+      "os": {
+        "type": "os",
+        "name": "Ubuntu"
+      },
+      "browser": {
+        "version": "83.0",
+        "type": "browser",
+        "name": "Firefox"
+      }
+    },
+    "request": {
+      "url": "file:///tmp/raven-js-test.html",
+      "headers": [
+        [
+          "User-Agent",
+          "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:83.0) Gecko/20100101 Firefox/83.0"
+        ]
+      ]
+    },
+    "project": 5481202,
+    "key_id": "1381841"
+  },
+  "project": "live",
+  "logger": "javascript"
+}

--- a/zerver/webhooks/sentry/tests.py
+++ b/zerver/webhooks/sentry/tests.py
@@ -105,6 +105,17 @@ Traceback:
 ```"""
         self.check_webhook("webhook_event_for_exception_python", expected_topic, expected_message)
 
+    def test_webhook_event_for_exception_javascript(self) -> None:
+        expected_topic = 'TypeError: can\'t access property "bar", x.foo is undefined'
+        expected_message = """
+**New exception:** [TypeError: can't access property "bar", x.foo is undefined](https://sentry.io/organizations/foo-bar-org/issues/1982047746/event/f3bf5fc4e354451db9e885a69b2a2b51/)
+```quote
+**level:** error
+**timestamp:** 2020-10-26 16:39:54
+**filename:** None
+```"""
+        self.check_webhook("webhook_event_for_exception_javascript", expected_topic, expected_message)
+
     def test_event_for_message_golang(self) -> None:
         expected_topic = "A test message event from golang."
         expected_message = """

--- a/zerver/webhooks/sentry/tests.py
+++ b/zerver/webhooks/sentry/tests.py
@@ -85,7 +85,7 @@ Traceback:
     def test_webhook_event_for_exception_python(self) -> None:
         expected_topic = "ValueError: new sentry error."
         expected_message = """
-**New exception:** [ValueError: new sentry error.](https://sentry.io/organizations/bar-foundation/issues/1972208801/event/c916dccfd58e41dcabaebef0091f0736/)
+**New exception:** [ValueError: new sentry error.](https://sentry.io/organizations/bar-foundation/issues/1972208801/events/c916dccfd58e41dcabaebef0091f0736/)
 ```quote
 **level:** error
 **timestamp:** 2020-10-21 23:25:11
@@ -108,7 +108,7 @@ Traceback:
     def test_webhook_event_for_exception_javascript(self) -> None:
         expected_topic = 'TypeError: can\'t access property "bar", x.foo is undefined'
         expected_message = """
-**New exception:** [TypeError: can't access property "bar", x.foo is undefined](https://sentry.io/organizations/foo-bar-org/issues/1982047746/event/f3bf5fc4e354451db9e885a69b2a2b51/)
+**New exception:** [TypeError: can't access property "bar", x.foo is undefined](https://sentry.io/organizations/foo-bar-org/issues/1982047746/events/f3bf5fc4e354451db9e885a69b2a2b51/)
 ```quote
 **level:** error
 **timestamp:** 2020-10-26 16:39:54

--- a/zerver/webhooks/sentry/view.py
+++ b/zerver/webhooks/sentry/view.py
@@ -236,7 +236,7 @@ def transform_webhook_payload(payload: Dict[str, Any]) -> Optional[Dict[str, Any
     if not event_id:
         return None
 
-    event_path = f"event/{event_id}/"
+    event_path = f"events/{event_id}/"
     event['web_url'] = urljoin(payload['url'], event_path)
     timestamp = event.get('timestamp', event['received'])
     event['datetime'] = datetime.fromtimestamp(timestamp).isoformat()

--- a/zerver/webhooks/sentry/view.py
+++ b/zerver/webhooks/sentry/view.py
@@ -238,7 +238,8 @@ def transform_webhook_payload(payload: Dict[str, Any]) -> Optional[Dict[str, Any
 
     event_path = f"event/{event_id}/"
     event['web_url'] = urljoin(payload['url'], event_path)
-    event['datetime'] = datetime.fromtimestamp(event['timestamp']).isoformat()
+    timestamp = event.get('timestamp', event['received'])
+    event['datetime'] = datetime.fromtimestamp(timestamp).isoformat()
     return payload
 
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
1. The generated URL is incorrect #16783 
2. The payload doesn't always have the 'timestamp' key
