### PR TITLE
desktop_integration: Handle logout et al. events from desktop app

### DIFF
--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -193,6 +193,7 @@ import "../search_pill";
 import "../search_pill_widget";
 import "../stream_ui_updates";
 import "../spoilers";
+import "../desktop_integration";
 
 // Import styles
 

--- a/static/js/desktop_integration.js
+++ b/static/js/desktop_integration.js
@@ -1,0 +1,15 @@
+if (window.electron_bridge !== undefined) {
+    window.electron_bridge.on_event("logout", () => {
+        $("#logout_form").trigger("submit");
+    });
+
+    window.electron_bridge.on_event("show-keyboard-shortcuts", () => {
+        hashchange.go_to_location("keyboard-shortcuts");
+    });
+
+    window.electron_bridge.on_event("show-notification-settings", () => {
+        hashchange.go_to_location("settings/notifications");
+    });
+}
+
+export {};

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -49,6 +49,7 @@ EXEMPT_FILES = {
     'static/js/copy_and_paste.js',
     'static/js/csrf.js',
     'static/js/debug.js',
+    'static/js/desktop_integration.js',
     'static/js/drafts.js',
     'static/js/echo.js',
     'static/js/emoji_picker.js',


### PR DESCRIPTION
I added these hooks in Zulip Desktop 5.5.0 (zulip/zulip-desktop@79808e8ee99f290fb7c468ae5112fe6c7d42b029); handling these events in the frontend will let us remove the janky desktop-side fallback code that uses fake click events on menu items with specific indexes.

**Testing plan:** With Zulip Desktop 5.5.0 connected to the dev server, tested File → Log Out of Organization, File → Keyboard Shortcuts, and sidebar right click → Notification settings.