### PR TITLE
ui: Make the set-status modal mobile responsive

### DIFF
--- a/static/styles/user_status.css
+++ b/static/styles/user_status.css
@@ -7,10 +7,17 @@
         border-radius: 4px;
         overflow: hidden;
         background-color: hsl(0, 0%, 100%);
+
+        @media (max-width: 384px) {
+            width: 100%;
+        }
     }
 
     input.user_status {
         width: 336px;
+        @media (max-width: 384px) {
+            width: 94%;
+        }
     }
 
     .user-status-header {


### PR DESCRIPTION
The set status modal to add/remove/update user status was not
visible properly on devices with a small width. This commit fixes
the issue by adding appropriate media queries to the css to make
the modal mobile responsive.
Partially Fixes #16817.

**Testing plan:**
Tested manually for both low width and normal width devices.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before: 
![image](https://user-images.githubusercontent.com/20909078/100973135-ff84f180-355f-11eb-9008-ee07d22902c9.png)

After:
![image](https://user-images.githubusercontent.com/20909078/100973167-0f9cd100-3560-11eb-93ef-030d7f2e2a61.png)
