### PR TITLE
lint: Update semgrep.yml

### DIFF
--- a/tools/semgrep.yml
+++ b/tools/semgrep.yml
@@ -1,4 +1,4 @@
-# See https://github.com/returntocorp/semgrep/blob/experimental/docs/config/advanced.md
+# See https://semgrep.dev/docs/writing-rules/rule-syntax/ for documentation on YAML rule syntax
 
 rules:
   ####################### PYTHON RULES #######################


### PR DESCRIPTION
Semgrep recently updated documentation paths and the old path in the YAML comment is a 404. Updated to the correct link path.

Testing plan: No testing as this is only a documentation change to a comment

cc @amanagr 