### PR TITLE
docs: Consistently suggest ~/.zuliprc instead of ~/zuliprc.

### DIFF
--- a/templates/zerver/api/get-events.md
+++ b/templates/zerver/api/get-events.md
@@ -14,7 +14,7 @@ import sys
 import zulip
 
 # Pass the path to your zuliprc file here.
-client = zulip.Client(config_file="~/zuliprc")
+client = zulip.Client(config_file="~/.zuliprc")
 
 # If you already have a queue registered and thus, have a queue_id
 # on hand, you may use client.get_events() and pass in the above

--- a/templates/zerver/api/real-time-events.md
+++ b/templates/zerver/api/real-time-events.md
@@ -37,7 +37,7 @@ import sys
 import zulip
 
 # Pass the path to your zuliprc file here.
-client = zulip.Client(config_file="~/zuliprc")
+client = zulip.Client(config_file="~/.zuliprc")
 
 # Print every message the current user would receive
 # This is a blocking call that will run forever

--- a/templates/zerver/integrations/twitter.md
+++ b/templates/zerver/integrations/twitter.md
@@ -52,15 +52,15 @@ To configure and deploy this bot:
         access_token_secret =
 
 2. Place your bot's `zuliprc` in a directory of your choice (for the next step,
-   `~/zuliprc` is used).
+   `~/.zuliprc` is used).
 
 3.  Test the script by running it manually:
 
         /usr/local/share/zulip/integrations/twitter/twitter-bot --search="@nprnews,quantum
-        physics" --config-file=~/zuliprc
+        physics" --config-file=~/.zuliprc
 
         /usr/local/share/zulip/integrations/twitter/twitter-bot --twitter-name="<@your-
-        twitter-handle>" --config-file=~/zuliprc
+        twitter-handle>" --config-file=~/.zuliprc
 
     Note: `twitter-bot` may install to a different location on
     your operating system distribution.
@@ -69,7 +69,7 @@ To configure and deploy this bot:
     that will process tweets every minute is:
 
         * * * * * /usr/local/share/zulip/integrations/twitter/twitter-bot --search="@nprnews,
-        quantum physics" --config-file=~/zuliprc
+        quantum physics" --config-file=~/.zuliprc
 
 When someone tweets a message containing one of your search terms,
 you’ll get a Zulip on your specified stream, with the search term as

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -31,7 +31,7 @@ PYTHON_CLIENT_CONFIG = """
 import zulip
 
 # Pass the path to your zuliprc file here.
-client = zulip.Client(config_file="~/zuliprc")
+client = zulip.Client(config_file="~/.zuliprc")
 
 """
 
@@ -41,7 +41,7 @@ PYTHON_CLIENT_ADMIN_CONFIG = """
 import zulip
 
 # The user for this zuliprc file must be an organization administrator
-client = zulip.Client(config_file="~/zuliprc-admin")
+client = zulip.Client(config_file="~/.zuliprc-admin")
 
 """
 


### PR DESCRIPTION
This was spotted by a user who noticed the inconsistency across the various docs.

We're not fully consistent in whether to use . at the start of the
filename. This commit replaces all occurences of ~/zuliprc with
~/.zuliprc to address that.
