### PR TITLE
resize: Fixed invite link overflow on reload.

### DIFF
--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -33,6 +33,7 @@ function size_blocks(blocks, usable_height) {
 function get_new_heights() {
     const res = {};
     const viewport_height = message_viewport.height();
+    const app_height = $(".app").height();
     const top_navbar_height = $("#top_navbar").safeOuterHeight(true);
     const invite_user_link_height = $("#invite-user-link").safeOuterHeight(true) || 0;
 
@@ -54,7 +55,7 @@ function get_new_heights() {
     // RIGHT SIDEBAR
 
     const usable_height =
-        viewport_height -
+        app_height -
         Number.parseInt($("#right-sidebar").css("marginTop"), 10) -
         $("#userlist-header").safeOuterHeight(true) -
         $("#user_search_section").safeOuterHeight(true) -


### PR DESCRIPTION
Added a small fix for #16840 .

<strong>ScreenShots :</strong>

<strong>Before</strong> : 

![Screenshot from 2020-12-04 19-59-25](https://user-images.githubusercontent.com/53977614/101177854-48c36700-366e-11eb-81ba-c2d3287e87c4.png) 

<strong>After</strong> : 

![Screenshot from 2020-12-04 20-11-46](https://user-images.githubusercontent.com/53977614/101178047-83c59a80-366e-11eb-918d-0aa506a1b52c.png)


