### PR TITLE
dev_tools: Fix dev-secrets.conf path.

### DIFF
--- a/templates/zerver/dev_tools.html
+++ b/templates/zerver/dev_tools.html
@@ -122,7 +122,7 @@
                     <li>Host: 127.0.0.1 (don't use localhost)</li>
                     <li>Maintenance database: zulip</li>
                     <li>Username: zulip</li>
-                    <li>password: stored as <code>local_database_password</code> in <code>zulip/zerver/dev-secrets.conf</code></li>
+                    <li>password: stored as <code>local_database_password</code> in <code>zulip/zproject/dev-secrets.conf</code></li>
                 </ul>
             </li>
         </ul>


### PR DESCRIPTION
At /devtools 'Connecting to the local PostgreSQL database',
path for `dev-secrets.conf` should zulip/zproject/dev-secrets.conf
instead of zulip/zerver/dev-secrets.conf.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
