### PR TITLE
url_preview: Allow Beautiful Soup to get the charset from <meta>

### DIFF
--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -314,6 +314,7 @@ class HostRequestMock:
 
 class MockPythonResponse:
     def __init__(self, text: str, status_code: int, headers: Optional[Dict[str, str]]=None) -> None:
+        self.content = text.encode()
         self.text = text
         self.status_code = status_code
         if headers is None:

--- a/zerver/lib/url_preview/parsers/base.py
+++ b/zerver/lib/url_preview/parsers/base.py
@@ -1,13 +1,17 @@
-from typing import Any
+import cgi
+from typing import Any, Optional
 
 
 class BaseParser:
-    def __init__(self, html_source: str) -> None:
+    def __init__(self, html_source: bytes, content_type: Optional[str]) -> None:
         # We import BeautifulSoup here, because it's not used by most
         # processes in production, and bs4 is big enough that
         # importing it adds 10s of milliseconds to manage.py startup.
         from bs4 import BeautifulSoup
-        self._soup = BeautifulSoup(html_source, "lxml")
+        charset = None
+        if content_type is not None:
+            charset = cgi.parse_header(content_type)[1].get("charset")
+        self._soup = BeautifulSoup(html_source, "lxml", from_encoding=charset)
 
     def extract_data(self) -> Any:
         raise NotImplementedError()

--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -91,12 +91,16 @@ def get_link_embed_data(url: str,
 
     response = requests.get(mark_sanitized(url), stream=True, headers=HEADERS, timeout=TIMEOUT)
     if response.ok:
-        og_data = OpenGraphParser(response.text).extract_data()
+        og_data = OpenGraphParser(
+            response.content, response.headers.get("Content-Type")
+        ).extract_data()
         for key in ['title', 'description', 'image']:
             if not data.get(key) and og_data.get(key):
                 data[key] = og_data[key]
 
-        generic_data = GenericParser(response.text).extract_data() or {}
+        generic_data = GenericParser(
+            response.content, response.headers.get("Content-Type")
+        ).extract_data() or {}
         for key in ['title', 'description', 'image']:
             if not data.get(key) and generic_data.get(key):
                 data[key] = generic_data[key]


### PR DESCRIPTION
An HTML document sent without a charset in the Content-Type header needs to be scanned for a charset in `<meta>` tags. We need to pass `bytes` instead of `str` to Beautiful Soup to allow it to do this.

Fixes #16843.