### PR TITLE
docs: Add work around for pinning messages.

### DIFF
--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -28,7 +28,7 @@
             </div>
         </div>
         <div class="stream-description">
-            <span class="stream-description-editable editable-section description rendered_markdown" data-no-description="{{t 'No description.' }}">{{rendered_markdown rendered_description}}</span>
+            <span class="stream-description-editable editable-section description rendered_markdown" data-no-description="{{t 'No description. Describe the stream\'s purpose briefly in Markdown; link to messages or topics for more detail.' }}">{{rendered_markdown rendered_description}}</span>
             {{#if can_change_name_description}}
             <span class="editable" data-make-editable=".stream-description-editable"></span>
             <span class="checkmark" data-finish-editing=".stream-description-editable">✓</span>

--- a/templates/zerver/help/highlight-messages.md
+++ b/templates/zerver/help/highlight-messages.md
@@ -1,0 +1,21 @@
+# Highlight a message
+
+Messages can be highlighted in a stream by
+putting Markdown in the stream description.
+
+### Highlight a message
+
+{start_tabs}
+
+1. Hover over a message.
+
+1. Click on the ellipsis (<i class="zulip-icon ellipsis-v-solid"></i>).
+
+1. Click **Copy link to Conversation**.
+{!stream-actions.md!}
+
+1. Click **Stream Settings**.
+
+1. Edit description of the stream using Markdown.
+
+{end_tabs}

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -66,6 +66,7 @@
 * [Message a stream by email](/help/message-a-stream-by-email)
 * [Start a new topic](/help/start-a-new-topic)
 * [Change the topic of a message](/help/change-the-topic-of-a-message)
+* [Highlight a message](/help/highlight-messages)
 * [Rename a topic](/help/rename-a-topic)
 * [Manage inactive streams](/help/manage-inactive-streams)
 


### PR DESCRIPTION
Described a workaround for pinning stream messages in the user documentation.
The workaround is to put Markdown in the stream description.
And changed the empty stream description message, suggesting
to put Markdown.

Resolves zulip/zulip#16701

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested locally

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![description](https://user-images.githubusercontent.com/58626718/101587500-57ad6f00-3a0a-11eb-9d2e-5539503bb886.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
