### PR TITLE
APIDocumentation: Display Data Type of Parameters in API Documentation.

### DIFF
--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -1717,6 +1717,13 @@ label.label-title {
         font-size: 12px;
         color: hsl(0, 50%, 60%);
     }
+
+    .api-argument-datatype {
+        text-transform: lowercase;
+        font-weight: 600;
+        font-size: 14px;
+        color: hsl(176, 46.4%, 41%);
+    }
 }
 
 .desktop-redirect-box {

--- a/zerver/lib/markdown/api_arguments_table_generator.py
+++ b/zerver/lib/markdown/api_arguments_table_generator.py
@@ -163,10 +163,10 @@ def generate_data_type(schema: Mapping[str, Any]) -> str:
     data_type = ""
     if 'oneOf' in schema:
         for item in schema['oneOf']:
-            data_type = data_type + generate_data_type(item) + " or "
-        data_type = data_type[:-4]
+            data_type = data_type + generate_data_type(item) + " | "
+        data_type = data_type[:-3]
     elif 'items' in schema:
-        data_type = schema['type'] + " containing (" + generate_data_type(schema['items']) + ")"
+        data_type = "(" + generate_data_type(schema['items']) + ")[]"
     else:
         data_type = schema['type']
     return data_type


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes part of #15967 

**Testing plan:** <!-- How have you tested? -->
Tested locally on the system.
Ran tests ```./tools/test-documentation``` and ```./tools/test-api```


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/56172924/101791229-4eff8a80-3b29-11eb-8807-bbb89a3268a7.png)
![image](https://user-images.githubusercontent.com/56172924/101791252-532ba800-3b29-11eb-8aa4-de59ed28a450.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
