### PR TITLE
[WIP] Created "Skip To Main Content" link Issue15948

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -6,6 +6,8 @@ import {activate_correct_tab} from "./tabbed-instructions";
 function registerCodeSection($codeSection) {
     const $li = $codeSection.find("ul.nav li");
     const $blocks = $codeSection.find(".blocks div");
+    const $skiplink = $codeSection.find(".skip-link");
+    $skiplink.addClass("active"); //Activating the "Skip To Main Content" link
 
     $li.on("click", function () {
         const language = this.dataset.language;
@@ -44,7 +46,7 @@ function highlight_current_article() {
     // Highlight current article link and the heading of the same
     article.closest("ul").css("display", "block");
     article.addClass("highlighted");
-    article.attr("tabindex", "-1");
+    article.attr("tabindex", "1");
 }
 
 function render_code_sections() {

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -136,7 +136,7 @@ html {
 .help {
     .app-main {
         padding: 0;
-        margin-top: 59px;
+        margin-top: 0;
     }
 
     /* Markdown processor generates lots of spurious <p></p> */
@@ -241,6 +241,7 @@ html {
             a {
                 color: inherit;
                 display: block;
+                padding: 1px 4px;
             }
         }
 
@@ -678,6 +679,31 @@ input.text-error {
 
 .portico-page-container .portico-header .dropdown-pill .realm-name {
     margin-left: -3px;
+}
+
+.skip-link {
+    position: absolute;
+    top: -100px;
+    left: 5px;
+    overflow: hidden;
+    margin-left: 5px;
+    border-radius: 6px;
+    padding: 6px 10px;
+    cursor: pointer;
+    background-color: hsl(153, 32%, 55%);
+    color: hsl(0, 0%, 98%);
+    font-size: 18px;
+    font-weight: 400px;
+
+    &:focus {
+        z-index: 5000;
+        transition: ease-in-out 0.5s;
+        top: -3px;
+        width: auto;
+        height: 25px;
+        outline: 5px auto hsl(152, 40%, 42%);
+        color: hsl(0, 0%, 98%);
+    }
 }
 
 .app {

--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -232,7 +232,6 @@ html {
 .header {
     color: hsl(0, 0%, 27%);
     background-color: hsl(0, 0%, 100%);
-    position: fixed;
     width: 100%;
     top: 0;
 

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -20,7 +20,7 @@
         <path d="M4,10h24c1.104,0,2-0.896,2-2s-0.896-2-2-2H4C2.896,6,2,6.896,2,8S2.896,10,4,10z M28,14H4c-1.104,0-2,0.896-2,2  s0.896,2,2,2h24c1.104,0,2-0.896,2-2S29.104,14,28,14z M28,22H4c-1.104,0-2,0.896-2,2s0.896,2,2,2h24c1.104,0,2-0.896,2-2  S29.104,22,28,22z"></path>
     </svg>
 
-    <div class="markdown">
+    <div class="markdown" id="skip-link-target">
         <div class="content">
             {{ render_markdown_path(article, api_uri_context) }}
 

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -1,5 +1,8 @@
 <div class="header portico-header">
     <div class="header-main" id="top_navbar">
+        {% if page_is_help_center or page_is_api_center %}
+        <a class="skip-link " href="#skip-link-target" tabindex="0">Skip To Main Content</a>
+        {% endif %}
         <div class="float-left">
             {% if custom_logo_url %}
             <a class="brand logo" href="{{ root_domain_uri }}/"><img draggable="false" src="{{ custom_logo_url }}" class="portico-logo" alt="{{ _('Zulip') }}" content="Zulip" /></a>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Extracted from [#15948](https://github.com/zulip/zulip/issues/15948). Added the "Skip To Main Content" feature which is accessible with Tab key.
There were few CSS changes also done to enhance the readability of `/help` and `/api` documentation. 

**Testing plan:** <!-- How have you tested? -->
I ran the feature in deployment server in my WSL with Ubuntu 18.04 . It passed predefined tests like:
`./tools/lint zerver/lib/actions.py` 
`./tools/test-backend zerver.tests.test_markdown.MarkdownTest.test_inline_youtube`
`./tools/test-backend MarkdownTest`
`./tools/test-js-with-puppeteer 07-navigation.js`
`./tools/test-js-with-node utils.js `
`./tools/test-documentation`
`./tools/test-help-documentation`

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
The changes will reflect like this:

![_help gif](https://user-images.githubusercontent.com/55028535/101815829-2934ae80-3b46-11eb-8052-cb99556874c9.gif)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
