### PR TITLE
api docs: Use normal async/await code in JavaScript examples

### DIFF
--- a/zerver/openapi/javascript_examples.js
+++ b/zerver/openapi/javascript_examples.js
@@ -1,10 +1,6 @@
 "use strict";
 
-/* eslint-disable arrow-body-style */
 /*
-  This file makes use of functional comments in a way that makes the
-  code confusing with the arrow-body-style lint rule applied.
-
   Zulip's OpenAPI-based API documentation system is documented at
   https://zulip.readthedocs.io/en/latest/documentation/api.html
 
@@ -34,16 +30,14 @@ const examples_handler = function () {
     };
 
     const generate_validation_data = async (client, example) => {
-        const result = await example.func(client);
-        if (Array.isArray(result)) {
-            // Handle special cases where some examples make
-            // more than 1 API requests.
-            result.forEach((r, index) => {
-                response_data.push(make_result_object(example, r, index));
-            });
-        } else {
-            response_data.push(make_result_object(example, result));
-        }
+        let count = 0;
+        const console = {
+            log(result) {
+                response_data.push(make_result_object(example, result, count));
+                count += 1;
+            },
+        };
+        await example.func(client, console);
     };
 
     const main = async () => {
@@ -108,7 +102,7 @@ const send_test_message = async (client) => {
 
 // Declare all the examples below.
 
-add_example("send_message", "/messages:post", 200, async (client) => {
+add_example("send_message", "/messages:post", 200, async (client, console) => {
     // {code_example|start}
     // Send a stream message
     let params = {
@@ -117,10 +111,8 @@ add_example("send_message", "/messages:post", 200, async (client) => {
         topic: "Castle",
         content: "I come not, friends, to steal away your hearts.",
     };
-    const result_1 = await client.messages.send(params);
-    // {code_example|end}
+    console.log(await client.messages.send(params));
 
-    // {code_example|start}
     // Send a private message
     const user_id = 9;
     params = {
@@ -128,12 +120,11 @@ add_example("send_message", "/messages:post", 200, async (client) => {
         type: "private",
         content: "With mirth and laughter let old wrinkles come.",
     };
-    const result_2 = await client.messages.send(params);
+    console.log(await client.messages.send(params));
     // {code_example|end}
-    return [result_1, result_2];
 });
 
-add_example("create_user", "/users:post", 200, async (client) => {
+add_example("create_user", "/users:post", 200, async (client, console) => {
     // {code_example|start}
     const params = {
         email: "notnewbie@zulip.com",
@@ -141,17 +132,17 @@ add_example("create_user", "/users:post", 200, async (client) => {
         full_name: "New User",
     };
 
-    return await client.users.create(params);
+    console.log(await client.users.create(params));
     // {code_example|end}
 });
 
-add_example("get_custom_emoji", "/realm/emoji:get", 200, async (client) => {
+add_example("get_custom_emoji", "/realm/emoji:get", 200, async (client, console) => {
     // {code_example|start}
-    return await client.emojis.retrieve();
+    console.log(await client.emojis.retrieve());
     // {code_example|end}
 });
 
-add_example("delete_queue", "/events:delete", 200, async (client) => {
+add_example("delete_queue", "/events:delete", 200, async (client, console) => {
     // {code_example|start}
     // Register a queue
     const queueParams = {
@@ -164,11 +155,11 @@ add_example("delete_queue", "/events:delete", 200, async (client) => {
         queue_id: res.queue_id,
     };
 
-    return await client.queues.deregister(deregisterParams);
+    console.log(await client.queues.deregister(deregisterParams));
     // {code_example|end}
 });
 
-add_example("get_messages", "/messages:get", 200, async (client) => {
+add_example("get_messages", "/messages:get", 200, async (client, console) => {
     // {code_example|start}
     const readParams = {
         anchor: "newest",
@@ -181,75 +172,77 @@ add_example("get_messages", "/messages:get", 200, async (client) => {
     };
 
     // Get the 100 last messages sent by "iago@zulip.com" to the stream "Verona"
-    return await client.messages.retrieve(readParams);
+    console.log(await client.messages.retrieve(readParams));
     // {code_example|end}
 });
 
-add_example("get_own_user", "/users/me:get", 200, async (client) => {
+add_example("get_own_user", "/users/me:get", 200, async (client, console) => {
     // {code_example|start}
     // Get the profile of the user/bot that requests this endpoint,
     // which is `client` in this case:
-    return await client.users.me.getProfile();
+    console.log(await client.users.me.getProfile());
     // {code_example|end}
 });
 
-add_example("get_stream_id", "/get_stream_id:get", 200, async (client) => {
+add_example("get_stream_id", "/get_stream_id:get", 200, async (client, console) => {
     // {code_example|start}
     // Get the ID of a given stream
-    return await client.streams.getStreamId("Denmark");
+    console.log(await client.streams.getStreamId("Denmark"));
     // {code_example|end}
 });
 
-add_example("get_stream_topics", "/users/me/{stream_id}/topics:get", 200, async (client) => {
-    // {code_example|start}
-    // Get all the topics in stream with ID 1
-    return client.streams.topics.retrieve({stream_id: 1});
-    // {code_example|end}
-});
+add_example(
+    "get_stream_topics",
+    "/users/me/{stream_id}/topics:get",
+    200,
+    async (client, console) => {
+        // {code_example|start}
+        // Get all the topics in stream with ID 1
+        console.log(await client.streams.topics.retrieve({stream_id: 1}));
+        // {code_example|end}
+    },
+);
 
-add_example("get_subscriptions", "/users/me/subscriptions:get", 200, async (client) => {
+add_example("get_subscriptions", "/users/me/subscriptions:get", 200, async (client, console) => {
     // {code_example|start}
     // Get all streams that the user is subscribed to
-    return await client.streams.subscriptions.retrieve();
+    console.log(await client.streams.subscriptions.retrieve());
     // {code_example|end}
 });
 
-add_example("get_users", "/users:get", 200, async (client) => {
+add_example("get_users", "/users:get", 200, async (client, console) => {
     // {code_example|start}
     // Get all users in the realm
-    const result_1 = await client.users.retrieve();
-    // {code_example|end}
+    console.log(await client.users.retrieve());
 
-    // {code_example|start}
     // You may pass the `client_gravatar` query parameter as follows:
-    const result_2 = await client.users.retrieve({client_gravatar: true});
+    console.log(await client.users.retrieve({client_gravatar: true}));
     // {code_example|end}
-    return [result_1, result_2];
 });
 
-add_example("register_queue", "/register:post", 200, async (client) => {
+add_example("register_queue", "/register:post", 200, async (client, console) => {
     // {code_example|start}
     // Register a queue
     const params = {
         event_types: ["message"],
     };
 
-    return await client.queues.register(params);
+    console.log(await client.queues.register(params));
     // {code_example|end}
 });
 
-add_example("render_message", "/messages/render:post", 200, async (client) => {
+add_example("render_message", "/messages/render:post", 200, async (client, console) => {
     // {code_example|start}
     // Render a message
     const params = {
         content: "**foo**",
     };
 
-    return await client.messages.render(params);
+    console.log(await client.messages.render(params));
     // {code_example|end}
 });
 
-add_example("set_typing_status", "/typing:post", 200, async (client) => {
+add_example("set_typing_status", "/typing:post", 200, async (client, console) => {
     // {code_example|start}
     const user_id1 = 9;
     const user_id2 = 10;
@@ -260,20 +253,18 @@ add_example("set_typing_status", "/typing:post", 200, async (client) => {
     };
 
     // The user has started to type in the group PM with Iago and Polonius
-    return await client.typing.send(typingParams);
+    console.log(await client.typing.send(typingParams));
     // {code_example|end}
 });
 
-add_example("add_subscriptions", "/users/me/subscriptions:post", 200, async (client) => {
+add_example("add_subscriptions", "/users/me/subscriptions:post", 200, async (client, console) => {
     // {code_example|start}
     // Subscribe to the streams "Verona" and "Denmark"
     const meParams = {
         subscriptions: JSON.stringify([{name: "Verona"}, {name: "Denmark"}]),
     };
-    const result_1 = await client.users.me.subscriptions.add(meParams);
-    // {code_example|end}
+    console.log(await client.users.me.subscriptions.add(meParams));
 
-    // {code_example|start}
     // To subscribe another user to a stream, you may pass in
     // the `principals` parameter, like so:
     const user_id = 7;
@@ -281,33 +272,34 @@ add_example("add_subscriptions", "/users/me/subscriptions:post", 200, async (cli
         subscriptions: JSON.stringify([{name: "Verona"}, {name: "Denmark"}]),
         principals: JSON.stringify([user_id]),
     };
-    const result_2 = await client.users.me.subscriptions.add(anotherUserParams);
+    console.log(await client.users.me.subscriptions.add(anotherUserParams));
     // {code_example|end}
-    return [result_1, result_2];
 });
 
-add_example("remove_subscriptions", "/users/me/subscriptions:delete", 200, async (client) => {
-    // {code_example|start}
-    // Unsubscribe from the stream "Denmark"
-    const meParams = {
-        subscriptions: JSON.stringify(["Denmark"]),
-    };
-    const result_1 = await client.users.me.subscriptions.remove(meParams);
-    // {code_example|end}
+add_example(
+    "remove_subscriptions",
+    "/users/me/subscriptions:delete",
+    200,
+    async (client, console) => {
+        // {code_example|start}
+        // Unsubscribe from the stream "Denmark"
+        const meParams = {
+            subscriptions: JSON.stringify(["Denmark"]),
+        };
+        console.log(await client.users.me.subscriptions.remove(meParams));
 
-    // {code_example|start}
-    const user_id = 7;
-    // Unsubscribe Zoe from the stream "Denmark"
-    const zoeParams = {
-        subscriptions: JSON.stringify(["Denmark"]),
-        principals: JSON.stringify([user_id]),
-    };
-    const result_2 = await client.users.me.subscriptions.remove(zoeParams);
-    // {code_example|end}
-    return [result_1, result_2];
-});
+        const user_id = 7;
+        // Unsubscribe Zoe from the stream "Denmark"
+        const zoeParams = {
+            subscriptions: JSON.stringify(["Denmark"]),
+            principals: JSON.stringify([user_id]),
+        };
+        console.log(await client.users.me.subscriptions.remove(zoeParams));
+        // {code_example|end}
+    },
+);
 
-add_example("update_message_flags", "/messages/flags:post", 200, async (client) => {
+add_example("update_message_flags", "/messages/flags:post", 200, async (client, console) => {
     // Send 3 messages to run this example on
     const message_ids = [...new Array(3)];
     for (let i = 0; i < message_ids.length; i = i + 1) {
@@ -320,21 +312,18 @@ add_example("update_message_flags", "/messages/flags:post", 200, async (client) 
         messages: message_ids,
         flag: "read",
     };
-    const result_1 = await client.messages.flags.add(addflag);
-    // {code_example|end}
+    console.log(await client.messages.flags.add(addflag));
 
-    // {code_example|start}
     // Remove the "starred" flag from the messages with IDs in "message_ids"
     const removeflag = {
         messages: message_ids,
         flag: "starred",
     };
-    const result_2 = await client.messages.flags.remove(removeflag);
+    console.log(await client.messages.flags.remove(removeflag));
     // {code_example|end}
-    return [result_1, result_2];
 });
 
-add_example("update_message", "/messages/{message_id}:patch", 200, async (client) => {
+add_example("update_message", "/messages/{message_id}:patch", 200, async (client, console) => {
     const request = {
         to: "Denmark",
         type: "stream",
@@ -351,11 +340,11 @@ add_example("update_message", "/messages/{message_id}:patch", 200, async (client
         content: "New Content",
     };
 
-    return await client.messages.update(params);
+    console.log(await client.messages.update(params));
     // {code_example|end}
 });
 
-add_example("get_events", "/events:get", 200, async (client) => {
+add_example("get_events", "/events:get", 200, async (client, console) => {
     // Register queue to receive messages for user.
     const queueParams = {
         event_types: ["message"],
@@ -373,14 +362,14 @@ add_example("get_events", "/events:get", 200, async (client) => {
         last_event_id: -1,
     };
 
-    return await client.events.retrieve(eventParams);
+    console.log(await client.events.retrieve(eventParams));
     // {code_example|end}
 });
 
-add_example("get_streams", "/streams:get", 200, async (client) => {
+add_example("get_streams", "/streams:get", 200, async (client, console) => {
     // {code_example|start}
     // Get all streams that the user has access to
-    return await client.streams.retrieve();
+    console.log(await client.streams.retrieve());
     // {code_example|end}
 });
 

--- a/zerver/openapi/javascript_examples.py
+++ b/zerver/openapi/javascript_examples.py
@@ -19,7 +19,7 @@ def test_js_bindings(client: Client) -> None:
     os.environ['ZULIP_REALM'] = client.base_url[:-5]
 
     output = subprocess.check_output(
-        args=['node', 'zerver/openapi/javascript_examples.js'],
+        args=['node', '--unhandled-rejections=strict', 'zerver/openapi/javascript_examples.js'],
         universal_newlines=True,
     )
     endpoint_responses = json.loads(output)


### PR DESCRIPTION
```diff
 const zulipInit = require('zulip-js');
 
 // Pass the path to your zuliprc file here.
 const config = { zuliprc: 'zuliprc' };
 
-Zulip(config).then(async (client) => {
+(async () => {
+    const client = await zulipInit(config);
+
     // Send a stream message
     let params = {
         to: "social",
         type: "stream",
         topic: "Castle",
         content: "I come not, friends, to steal away your hearts.",
     };
-    return await client.messages.send(params);
-}).then(console.log).catch(console.err);
+    console.log(await client.messages.send(params));
 
-Zulip(config).then(async (client) => {
     // Send a private message
     const user_id = 9;
     params = {
         to: [user_id],
         type: "private",
         content: "With mirth and laughter let old wrinkles come.",
     };
-    return await client.messages.send(params);
-}).then(console.log).catch(console.err);
+    console.log(await client.messages.send(params));
+})();
```