### PR TITLE
docs: Add auth backend configuration is optional.

### DIFF
--- a/templates/zerver/apple-error.md
+++ b/templates/zerver/apple-error.md
@@ -1,5 +1,5 @@
 You are using the **Apple auth backend**, but it is not
-properly configured. Configuring Apple auth is **optional** and is required only if you are working on an issue related to Apple auth. To configure, please check the following:
+properly configured. To configure, please check the following:
 
 * You have registered `{{ root_domain_uri }}/complete/apple/`
   as the callback URL for your Services ID in Apple's developer console. You can

--- a/templates/zerver/apple-error.md
+++ b/templates/zerver/apple-error.md
@@ -1,5 +1,5 @@
 You are using the **Apple auth backend**, but it is not
-properly configured. Please check the following:
+properly configured. Configuring Apple auth is **optional** and is required only if you are working on an issue related to Apple auth. To configure, please check the following:
 
 * You have registered `{{ root_domain_uri }}/complete/apple/`
   as the callback URL for your Services ID in Apple's developer console. You can

--- a/templates/zerver/config_error.html
+++ b/templates/zerver/config_error.html
@@ -54,6 +54,9 @@
                         {"root_domain_uri": root_domain_uri, "settings_path": secrets_path, "secrets_path": secrets_path,
                         "client_id_key_name": "social_auth_" + social_backend_name + "_key"}) }}
                         <p>
+                            <b>Note: </b>Configuring auth backend is <b>optional</b> and is required only if you are working on an issue related to auth backend.
+                        </p>
+                        <p>
                             For more information, have a look at
                             the <a href="https://zulip.readthedocs.io/en/latest/development/authentication.html#{{ social_backend_name }}">authentication
                             setup guide</a> for the development environment.

--- a/templates/zerver/github-error.md
+++ b/templates/zerver/github-error.md
@@ -1,5 +1,5 @@
 You are using the **GitHub auth backend**, but it is not properly
-configured. Configuring GitHub auth is **optional** and is required only if you are working on an issue related to GitHub auth. To configure, please check the following:
+configured. To configure, please check the following:
 
 You have added `{{ root_domain_uri }}/complete/github/` as the callback URL
 in the OAuth application in GitHub. You can create OAuth apps from

--- a/templates/zerver/github-error.md
+++ b/templates/zerver/github-error.md
@@ -1,5 +1,5 @@
 You are using the **GitHub auth backend**, but it is not properly
-configured. Configuring Github auth is **optional** and is required only if you are working on an issue related to Github auth. To configure, please check the following:
+configured. Configuring GitHub auth is **optional** and is required only if you are working on an issue related to GitHub auth. To configure, please check the following:
 
 You have added `{{ root_domain_uri }}/complete/github/` as the callback URL
 in the OAuth application in GitHub. You can create OAuth apps from

--- a/templates/zerver/github-error.md
+++ b/templates/zerver/github-error.md
@@ -1,5 +1,5 @@
 You are using the **GitHub auth backend**, but it is not properly
-configured. Please check the following:
+configured. Configuring Github auth is **optional** and is required only if you are working on an issue related to Github auth. To configure, please check the following:
 
 You have added `{{ root_domain_uri }}/complete/github/` as the callback URL
 in the OAuth application in GitHub. You can create OAuth apps from

--- a/templates/zerver/gitlab-error.md
+++ b/templates/zerver/gitlab-error.md
@@ -1,5 +1,5 @@
 You are using the **GitLab auth backend**, but it is not properly
-configured. Configuring GitLab auth is **optional** and is required only if you are working on an issue related to GitLab auth. To configure, please check the following:
+configured. To configure, please check the following:
 
 * You have added `{{ root_domain_uri }}/complete/gitlab/` as the callback
 URL in the OAuth application in GitLab. You can register OAuth apps at

--- a/templates/zerver/gitlab-error.md
+++ b/templates/zerver/gitlab-error.md
@@ -1,5 +1,5 @@
 You are using the **GitLab auth backend**, but it is not properly
-configured. Please check the following:
+configured. Configuring Gitlab auth is **optional** and is required only if you are working on an issue related to Gitlab auth. To configure, please check the following:
 
 * You have added `{{ root_domain_uri }}/complete/gitlab/` as the callback
 URL in the OAuth application in GitLab. You can register OAuth apps at

--- a/templates/zerver/gitlab-error.md
+++ b/templates/zerver/gitlab-error.md
@@ -1,5 +1,5 @@
 You are using the **GitLab auth backend**, but it is not properly
-configured. Configuring Gitlab auth is **optional** and is required only if you are working on an issue related to Gitlab auth. To configure, please check the following:
+configured. Configuring GitLab auth is **optional** and is required only if you are working on an issue related to GitLab auth. To configure, please check the following:
 
 * You have added `{{ root_domain_uri }}/complete/gitlab/` as the callback
 URL in the OAuth application in GitLab. You can register OAuth apps at

--- a/templates/zerver/google-error.md
+++ b/templates/zerver/google-error.md
@@ -1,5 +1,5 @@
 You are using the **Google auth backend**, but it is not properly
-configured. Configuring Google auth is **optional** and is required only if you are working on an issue related to Google auth. To configure, please check the following:
+configured. To configure, please check the following:
 
 * You have created a Google OAuth2 client and enabled the Identity Toolkit API.
 You can create OAuth2 apps at [the Google developer console](https://console.developers.google.com).

--- a/templates/zerver/google-error.md
+++ b/templates/zerver/google-error.md
@@ -1,5 +1,5 @@
 You are using the **Google auth backend**, but it is not properly
-configured. Please check the following:
+configured. Configuring Google auth is **optional** and is required only if you are working on an issue related to Google auth. To configure, please check the following:
 
 * You have created a Google OAuth2 client and enabled the Identity Toolkit API.
 You can create OAuth2 apps at [the Google developer console](https://console.developers.google.com).


### PR DESCRIPTION
If the authorization backend for Google/GitHub/GitLab/Apple is not configured, it shows configuration error. This leads to confusion for new comers as they think there is a problem with their setup. Added documentation stating that configuring the auth backend is **optional** and is required only if one is working on an issue related to auth backend.
![Screenshot from 2020-12-12 01-24-50](https://user-images.githubusercontent.com/54909147/101948967-ebed2100-3c18-11eb-8bdb-074230f5b112.png)

