### PR TITLE
outgoing_webhooks: Catch JsonableError in do_rest_call.

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -340,3 +340,10 @@ def do_rest_call(base_url: str,
         fail_with_message(event, response_message)
         notify_bot_owner(event, exception=e)
         return None
+
+    except JsonableError as e:
+        response_message = (e.msg)
+        logging.exception("Outhook trigger failed:", stack_info=True)
+        fail_with_message(event, response_message)
+        notify_bot_owner(event, exception=e)
+        return None


### PR DESCRIPTION
Added an except clause to catch JsonableError caused when parsing widget_content.
Logs the error and notifies bot owner.

Fixes #16850.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
So, I went through the code and from what I understood a `JsonableError` will always be raised with a `GenericOutgoingWebhookService` that gets a non-empty `widget_content` in response as my test case shows. This is happening since json.loads is called on response, and orjson.loads is called again on a dict or a string in `check_message`. Is this how it is supposed to be and am I missing something, or is this a bug? 
Please let me know. Thank you.

**Testing plan:** <!-- How have you tested? -->
I added the test. I think I need to change its name if this is fine.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
