### PR TITLE
build_pygments_data: Include zulip specific data in langs.

### DIFF
--- a/tools/setup/build_pygments_data
+++ b/tools/setup/build_pygments_data
@@ -5,10 +5,10 @@ import os
 from pygments.lexers import get_all_lexers
 
 ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../')
-PRIORITIES_PATH = os.path.join(ZULIP_PATH, 'tools', 'setup', 'lang.json')
+DATA_PATH = os.path.join(ZULIP_PATH, 'tools', 'setup', 'lang.json')
 OUT_PATH = os.path.join(ZULIP_PATH, 'static', 'generated', 'pygments_data.json')
 
-with open(PRIORITIES_PATH) as f:
+with open(DATA_PATH) as f:
     priorities = json.load(f)
 
 lexers = get_all_lexers()
@@ -20,6 +20,13 @@ langs = {
     for longname, aliases, filename_patterns, mimetypes in lexers
     for alias in aliases
 }
+
+for name in priorities:
+    if langs.get(name) is None:
+        langs[name] = {
+            'priority': priorities[name],
+            'pretty_name': name,
+        }
 
 with open(OUT_PATH, 'w') as f:
     json.dump({"langs": langs}, f)

--- a/version.py
+++ b/version.py
@@ -43,4 +43,4 @@ API_FEATURE_LEVEL = 35
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '117.2'
+PROVISION_VERSION = '118.0'


### PR DESCRIPTION
This fixes a bug where the typeahead did not include the
zulip specific langs (such a `quote`, `spoiler` and `math`)
as these weren't passed to the typeahead's source.

Introduced in af64c52166d4794fd7a24172d2e893c692ddb508.

Fixes #16862.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
