### PR TITLE
auth: Handle the case of invalid subdomain at various points.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3175,6 +3175,16 @@ class JSONFetchAPIKeyTest(ZulipTestCase):
                                   dict(password="wrong"))
         self.assert_json_error(result, "Your username or password is incorrect.", 400)
 
+    def test_invalid_subdomain(self) -> None:
+        username = 'hamlet'
+        user = self.example_user(username)
+        self.login_user(user)
+        with mock.patch("zerver.views.auth.get_realm_from_request", return_value=None):
+            result = self.client_post("/json/fetch_api_key",
+                                      dict(username=username,
+                                           password=initial_password(user.delivery_email)))
+        self.assert_json_error(result, "Invalid subdomain", 400)
+
 class FetchAPIKeyTest(ZulipTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -3280,6 +3290,13 @@ class DevFetchAPIKeyTest(ZulipTestCase):
             result = self.client_post("/api/v1/dev_fetch_api_key",
                                       dict(username=self.email))
             self.assert_json_error_contains(result, "DevAuthBackend not enabled.", 400)
+
+    def test_invalid_subdomain(self) -> None:
+        with mock.patch("zerver.views.auth.get_realm_from_request", return_value=None):
+            result = self.client_post("/api/v1/dev_fetch_api_key",
+                                      dict(username=self.email,
+                                           password=initial_password(self.email)))
+            self.assert_json_error_contains(result, "Invalid subdomain", 400)
 
 class DevGetEmailsTest(ZulipTestCase):
     def test_success(self) -> None:

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -818,10 +818,9 @@ def api_dev_fetch_api_key(request: HttpRequest, username: str=REQ()) -> HttpResp
     # this condition of Django so no need to check if LDAP backend is
     # enabled.
     validate_login_email(username)
-
-    subdomain = get_subdomain(request)
-    realm = get_realm(subdomain)
-
+    realm = get_realm_from_request(request)
+    if realm is None:
+        return json_error(_("Invalid subdomain"))
     return_data: Dict[str, bool] = {}
     user_profile = authenticate(dev_auth_username=username,
                                 realm=realm,
@@ -958,8 +957,9 @@ def api_get_server_settings(request: HttpRequest) -> HttpResponse:
 @has_request_variables
 def json_fetch_api_key(request: HttpRequest, user_profile: UserProfile,
                        password: str=REQ(default='')) -> HttpResponse:
-    subdomain = get_subdomain(request)
-    realm = get_realm(subdomain)
+    realm = get_realm_from_request(request)
+    if realm is None:
+        return json_error(_("Invalid subdomain"))
     if password_auth_enabled(user_profile.realm):
         if not authenticate(request=request, username=user_profile.delivery_email, password=password,
                             realm=realm):


### PR DESCRIPTION
[Issue#16770
](https://github.com/zulip/zulip/issues/16770)
In `zerver/views/auth.py`, handled case of Invalid Subdomain while calling `get_realm` by using `get_realm_from_request` at multiple points.
**Testing plan:** Added two test cases for the respective additions in `zerver/tests/test_auth_backends.py`
