### PR TITLE
updated_zulipcss_copyicon_padding

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -435,7 +435,7 @@ li,
     outline-color: hsl(0, 0%, 73%);
     height: 18px;
     width: 10px;
-    padding: 6px 6px;
+    padding: 7px 3px 0px 12px;
     display: block;
     /* The below two avoids the padded element from displaying
     it's own border and background color */


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/16868


**Front End : About changing the location of the Copy Icon {General Invite Link}** 
Its about the position of the Copy icon in the General Invite link ;when we press it is dislocated . 
So task is to adjust it  when we click it. 
Changed the Padding of the object to adjust its position .


**Testing plan:** <!-- How have you tested? -->
Yes , after changing the code ; Its working now . 

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot (37)](https://user-images.githubusercontent.com/60990123/101993791-684c3680-3ce3-11eb-91c2-4f78fba0e575.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
