### PR TITLE
django3: Remove remaining postgresql_psycopg2 use.

### DIFF
--- a/zerver/migrations/0261_pregistrationuser_clear_invited_as_admin.py
+++ b/zerver/migrations/0261_pregistrationuser_clear_invited_as_admin.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
-from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
+from django.db.backends.postgresql.schema import DatabaseSchemaEditor
 from django.db.migrations.state import StateApps
 
 


### PR DESCRIPTION
Removed in Django 3.0.

This wraps up the `Removed features` point of #16030