### PR TITLE
markdown: Clean up markdown_help.html with frontend markdown processor

### DIFF
--- a/static/js/info_overlay.js
+++ b/static/js/info_overlay.js
@@ -1,10 +1,13 @@
 "use strict";
 
+const markdown = require("./markdown");
+
 // Make it explicit that our toggler is undefined until
 // set_up_toggler is called.
 exports.toggler = undefined;
 
 exports.set_up_toggler = function () {
+    exports.render_markdown();
     const opts = {
         selected: 0,
         child_wants_focus: true,
@@ -77,6 +80,19 @@ exports.maybe_show_keyboard_shortcuts = function () {
         return;
     }
     exports.show("keyboard-shortcuts");
+};
+
+exports.render_markdown = () => {
+    let unrendered_text;
+    let obj;
+    $.each($(".apply_markdown"), (id, element) => {
+        unrendered_text = element.textContent;
+        obj = {
+            raw_content: unrendered_text,
+        };
+        markdown.apply_markdown(obj);
+        $(element).next().append(obj.content);
+    });
 };
 
 window.info_overlay = exports;

--- a/templates/zerver/app/markdown_help.html
+++ b/templates/zerver/app/markdown_help.html
@@ -92,13 +92,11 @@
                         <td class="rendered_markdown">Some inline <code>code</code></td>
                     </tr>
                     <tr>
-                    <td class="preserve_spaces">```
+                    <td class="preserve_spaces apply_markdown">```
 def zulip():
     print "Zulip"
 ```</td>
                     <td class="rendered_markdown">
-                        <div class="codehilite"><pre>def zulip():
-    print "Zulip"</pre></div>
                     </td>
                     </tr>
                     <tr>
@@ -123,39 +121,28 @@ def zulip():
 
                     </tr>
                     <tr>
-                    <td class="preserve_spaces">```quote
+                    <td class="preserve_spaces apply_markdown">```quote
 Quoted block
 ```</td>
-                    <td class="rendered_markdown"><blockquote><p>Quoted block</p></blockquote></td>
+                    <td class="rendered_markdown"></td>
                     </tr>
                     <tr>
-                        <td class="preserve_spaces">```spoiler Always visible heading
+                        <td class="preserve_spaces apply_markdown">```spoiler Always visible heading
 This text won't be visible until the user clicks.
 ```</td>
                         <td class="rendered_markdown">
-                            <div class="spoiler-block">
-                                <div class="spoiler-header"><a class="spoiler-button"><span class="spoiler-arrow"></span></a>
-                                    <p>Always visible heading</p>
-                                </div>
-
-                                <div class="spoiler-content">
-                                    <p>This text won't be visible until the user clicks.</p>
-                                </div>
-                            </div>
                         </td>
                     </tr>
                     <tr>
-                        <td>Some inline math $$ e^{i \pi } + 1 = 0 $$</td>
+                        <td class="apply_markdown">Some inline math $$ e^{i \pi } + 1 = 0 $$</td>
                         <td class="rendered_markdown">
-                            Some inline math <span class="katex"><span class="katex-mathml"><math><semantics><mrow><msup><mi>e</mi><mrow><mi>i</mi><mi>π</mi></mrow></msup><mo>+</mo><mn>1</mn><mo>=</mo><mn>0</mn></mrow><annotation encoding="application/x-tex">e^{i\pi} + 1 = 0</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="strut" style="height: 0.874664em;"></span><span class="strut bottom" style="height: 0.957994em; vertical-align: -0.08333em;"></span><span class="base"><span class="mord"><span class="mord mathit">e</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height: 0.874664em;"><span class="" style="top: -3.113em; margin-right: 0.05em;"><span class="pstrut" style="height: 2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mathit mtight">i</span><span class="mord mathit mtight" style="margin-right: 0.03588em;">π</span></span></span></span></span></span></span></span></span><span class="mbin">+</span><span class="mord mathrm">1</span><span class="mrel">=</span><span class="mord mathrm">0</span></span></span></span>
                         </td>
                     </tr>
                     <tr>
-                        <td class="preserve_spaces">```math
+                        <td class="preserve_spaces apply_markdown">```math
 \int_{0}^{1} f(x) dx
 ```</td>
                         <td>
-                            <span class="katex-display"><span class="katex"><span class="katex-mathml"><math><semantics><mrow><msubsup><mo>∫</mo><mn>0</mn><mn>1</mn></msubsup><mi>f</mi><mo>(</mo><mi>x</mi><mo>)</mo><mi>d</mi><mi>x</mi></mrow><annotation encoding="application/x-tex">\int_{0}^{1} f(x) dx</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="strut" style="height: 1.56401em;"></span><span class="strut bottom" style="height: 2.47596em; vertical-align: -0.91195em;"></span><span class="base"><span class="mop"><span class="mop op-symbol large-op" style="margin-right: 0.44445em; position: relative; top: -0.001125em;">∫</span><span class="msupsub"><span class="vlist-t vlist-t2"><span class="vlist-r"><span class="vlist" style="height: 1.56401em;"><span class="" style="top: -1.78805em; margin-left: -0.44445em; margin-right: 0.05em;"><span class="pstrut" style="height: 2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mathrm mtight">0</span></span></span></span><span class="" style="top: -3.8129em; margin-right: 0.05em;"><span class="pstrut" style="height: 2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mathrm mtight">1</span></span></span></span></span><span class="vlist-s">​</span></span><span class="vlist-r"><span class="vlist" style="height: 0.91195em;"></span></span></span></span></span><span class="mord mathit" style="margin-right: 0.10764em;">f</span><span class="mopen">(</span><span class="mord mathit">x</span><span class="mclose">)</span><span class="mord mathit">d</span><span class="mord mathit">x</span></span></span></span></span>
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
There are some hard-coded markdown HTML in markdown_help.html, tagged with 'preserve_spaces'. This commit utilizes the frontend markdown server to render these HTML from markdown syntax before the tagger opens. 

Some changes are referencing https://github.com/zulip/zulip/pull/15626

Fixes: #15375

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


Testing plan: <!-- How have you tested? -->
I tested the resulting markdown helper page manually.

GIFs or screenshots: <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
'Spoiler' row omits an arrow in the heading after applying the frontend markdown processor
Before:
<img width="517" alt="Screen Shot 2020-12-13 at 10 53 08 PM" src="https://user-images.githubusercontent.com/39551660/102038839-4b247000-3d96-11eb-8399-893d5e7e308b.png">
After:
<img width="516" alt="Screen Shot 2020-12-13 at 10 50 22 PM" src="https://user-images.githubusercontent.com/39551660/102038846-4eb7f700-3d96-11eb-8c7c-d813c73b5827.png">



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
