### PR TITLE
css: Add Liberation Mono font as option for code blocks.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -68,7 +68,7 @@ a {
 
 code,
 pre {
-    font-family: Menlo, Consolas, "Courier New", monospace;
+    font-family: Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .no-select {

--- a/static/third/bootstrap/css/bootstrap.css
+++ b/static/third/bootstrap/css/bootstrap.css
@@ -810,7 +810,7 @@ address {
 code,
 pre {
   padding: 0 3px 2px;
-  font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
+  font-family: Monaco, Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 12px;
   color: #333333;
   -webkit-border-radius: 3px;


### PR DESCRIPTION
Code blocks did not have a good font for Linux installations
available as an option, as noted in Issue #15993.
This adds Liberation Mono as an option to be used.

(Note: this PR was made due to an issue created in July. If this change doesn't need to be made any more, then that's fine).

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/15993

**Testing plan:** <!-- How have you tested? -->
Manual testing: checking code blocks.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
