### PR TITLE
settings UI: Remove guest option for open organizations.

### DIFF
--- a/templates/zerver/app/invite_user.html
+++ b/templates/zerver/app/invite_user.html
@@ -41,7 +41,9 @@
                             {% if is_admin %}
                             <option name="invite_as" value="{{ invite_as.REALM_ADMIN }}">{{ _('Organization administrators') }}</option>
                             {% endif %}
+                            {% if guests_enabled %}
                             <option name="invite_as" value="{{ invite_as.GUEST_USER }}">{{ _('Guests') }}</option>
+                            {% endif %}
                             {% if is_owner %}
                             <option name="invite_as" value="{{ invite_as.REALM_OWNER }}">{{ _('Organization owners') }}</option>
                             {% endif %}

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -211,6 +211,8 @@ def home_real(request: HttpRequest) -> HttpResponse:
 
     navbar_logo_url = compute_navbar_logo_url(page_params)
 
+    guests_enabled = realm.invite_required
+
     response = render(request, 'zerver/app/index.html',
                       context={'user_profile': user_profile,
                                'page_params': page_params,
@@ -224,6 +226,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
                                'is_owner': user_permission_info.is_realm_owner,
                                'is_admin': user_permission_info.is_realm_admin,
                                'is_guest': user_permission_info.is_guest,
+                               'guests_enabled': guests_enabled,
                                'color_scheme': user_permission_info.color_scheme,
                                'navbar_logo_url': navbar_logo_url,
                                'show_webathena': user_permission_info.show_webathena,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#16081
This change hides the option to invite users to an organization as "guest" if the organization does not require invites in the first place.
*repushed https://github.com/zulip/zulip/pull/16892 changes with an appropriate commit message and from a different branch

**Testing plan:** <!-- How have you tested? -->
Other than running all tests locally, I have tested with the Zulip Dev login. I used an account that was an organization owner (Desdemona) and tried all 4 settings for "are invitations required for joining this organization?":
Yes, only admins can send - Guest option not hidden
Yes, members and admins can send - Guest option not hidden
No, only admins can send - Guest option hidden
No, members and admins can send - Guest option hidden

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
https://gyazo.com/89bc578f2c67430c4b2b2a7a9edd0af5

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
