### PR TITLE
message editing: Issue 3938

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -723,6 +723,7 @@ exports.initialize = function () {
                 compose_actions.respond_to_message({trigger: "message click"});
                 $("#compose-textarea").val(""); // Makes the new message blank
                 $("#stream_message_recipient_topic").val(current_topic);
+                $("#compose-textarea").data("draft-id", null); //Doesn't overwrite draft
                 e.stopPropagation();
             }
         }

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -703,6 +703,22 @@ exports.initialize = function () {
         if (!$(e.target).is("a")) {
             e.stopPropagation();
         }
+
+        //area that should trigger response
+        if (!$(e.target).is("textarea, a, button, i, label, span, input, #below-compose-content")) {
+            if (document.getSelection().type === "Range") {
+                // Drags on the message (to copy message text) shouldn't trigger a reply.
+                return;
+            }
+            
+            //gets subject and recipiant of the draft 
+            current_msg_list.select_id(current_msg_list.selected_id());
+            compose_actions.respond_to_message({trigger: "message click"});
+            $("#compose-textarea").val(""); //makes the new message blank
+            e.stopPropagation();
+            popovers.hide_all();
+            //Should we return here? maybe delete above line instead? 
+        }
         // Still hide the popovers, however
         popovers.hide_all();
     }

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -708,7 +708,7 @@ exports.initialize = function () {
         // Will trigger reply behavior
         // It will save the current message as a draft
         // And open up a new message with the same topic and recipient
-        if (compose_state.get_message_type() != "private") {
+        if (compose_state.get_message_type() !== "private") {
             if (!$(e.target).is("textarea, a, button, i, label, span, input, #below-compose-content")) {
                 if (document.getSelection().type === "Range") {
                     // Drags on the message (to copy message text) shouldn't trigger a reply.

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -704,20 +704,24 @@ exports.initialize = function () {
             e.stopPropagation();
         }
 
-        //area that should trigger response
-        if (!$(e.target).is("textarea, a, button, i, label, span, input, #below-compose-content")) {
-            if (document.getSelection().type === "Range") {
-                // Drags on the message (to copy message text) shouldn't trigger a reply.
-                return;
+        // Clicking on a draft as long is not a private message
+        // Will trigger reply behavior 
+        // It will save the current message as a draft
+        // And open up a new message with the same topic and recipient
+        if (compose_state.get_message_type() != "private") {
+            if (!$(e.target).is("textarea, a, button, i, label, span, input, #below-compose-content")) {
+                if (document.getSelection().type === "Range") {
+                    // Drags on the message (to copy message text) shouldn't trigger a reply.
+                    return;
+                }
+                
+                // Gets subject and recipiant of the draft 
+                const current_topic = $("#stream_message_recipient_topic").val();
+                compose_actions.respond_to_message({trigger: "message click"});
+                $("#compose-textarea").val(""); // Makes the new message blank
+                $("#stream_message_recipient_topic").val(current_topic);
+                e.stopPropagation();
             }
-            
-            //gets subject and recipiant of the draft 
-            current_msg_list.select_id(current_msg_list.selected_id());
-            compose_actions.respond_to_message({trigger: "message click"});
-            $("#compose-textarea").val(""); //makes the new message blank
-            e.stopPropagation();
-            popovers.hide_all();
-            //Should we return here? maybe delete above line instead? 
         }
         // Still hide the popovers, however
         popovers.hide_all();

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -705,7 +705,7 @@ exports.initialize = function () {
         }
 
         // Clicking on a draft as long is not a private message
-        // Will trigger reply behavior 
+        // Will trigger reply behavior
         // It will save the current message as a draft
         // And open up a new message with the same topic and recipient
         if (compose_state.get_message_type() != "private") {
@@ -714,8 +714,7 @@ exports.initialize = function () {
                     // Drags on the message (to copy message text) shouldn't trigger a reply.
                     return;
                 }
-                
-                // Gets subject and recipiant of the draft 
+                // Gets topic and recipiant of the draft
                 const current_topic = $("#stream_message_recipient_topic").val();
                 compose_actions.respond_to_message({trigger: "message click"});
                 $("#compose-textarea").val(""); // Makes the new message blank

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -709,7 +709,11 @@ exports.initialize = function () {
         // It will save the current message as a draft
         // And open up a new message with the same topic and recipient
         if (compose_state.get_message_type() !== "private") {
-            if (!$(e.target).is("textarea, a, button, i, label, span, input, #below-compose-content")) {
+            if (
+                !$(e.target).is(
+                    "textarea, a, button, i, label, span, input, #below-compose-content",
+                )
+            ) {
                 if (document.getSelection().type === "Range") {
                     // Drags on the message (to copy message text) shouldn't trigger a reply.
                     return;

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -143,7 +143,7 @@ exports.update_draft = function () {
 
     const draft_id = $("#compose-textarea").data("draft-id");
 
-    if (draft_id !== undefined) {
+    if (draft_id !== undefined && draft_id !== null) {
         // We don't save multiple drafts of the same message;
         // just update the existing draft.
         draft_model.editDraft(draft_id, draft);

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -62,6 +62,8 @@
 .message_comp {
     display: none;
     padding: 10px 10px 8px 5px;
+    /*makes message area clickable*/
+    cursor: pointer;
 }
 
 .autocomplete_secondary {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -62,7 +62,7 @@
 .message_comp {
     display: none;
     padding: 10px 10px 8px 5px;
-    /*makes message area clickable*/
+    /* Makes message area look clickable */
     cursor: pointer;
 }
 


### PR DESCRIPTION
#3938 
We (@nataliebrotherton and I) worked to make it such that clicking on a draft triggers a response message. This happens on all drafts except private messages. The message that is being composed will be saved as a draft and a new message will open with the same recipient and topic as the message selected. 

Testing Plan: 
https://zulip.readthedocs.io/en/latest/testing/manual-testing.html#composing-messages
We used this list to test our patch while we were developing. We also tested most features of the compose box, such as attaching files or editing the topic to make sure we didn’t change the behavior of these buttons or text areas. 


Here is a link to a video that walks through the new behavior: 
https://youtu.be/WGfXOalCEG0
