### PR TITLE
feature: Added new feature to view code blocks in a separate window.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -524,6 +524,9 @@ exports.toggle_actions_popover = function (element, id) {
             .replace(/\(/g, "%28")
             .replace(/\)/g, "%29");
 
+        const should_display_code_block = 
+            message.content.includes("<code>")
+
         const should_display_delete_option = message_edit.get_deletability(message);
         const args = {
             message_id: message.id,
@@ -544,6 +547,7 @@ exports.toggle_actions_popover = function (element, id) {
             should_display_reminder_option: feature_flags.reminders_in_message_action_menu,
             should_display_edit_and_view_source,
             should_display_quote_and_reply,
+            should_display_code_block,
         };
 
         const ypos = elt.offset().top;

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1260,6 +1260,7 @@ exports.register_click_handlers = function () {
         let code_start = message.content.indexOf('<div class="codehilite"><pre>');
         let code_end = 0;
         const myWindow = window.open("", "_blank", "");
+
         while (code_start !== -1) {
             code_end = message.content.indexOf("</pre></div>", code_start) + 11;
             code_str = message.content.slice(code_start, code_end);

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1256,7 +1256,7 @@ exports.register_click_handlers = function () {
         const message_id = $(e.currentTarget).data("message-id");
         const row = current_msg_list.get_row(message_id);
         const message = current_msg_list.get(rows.id(row));
-        var myWindow = window.open("", "Code block", "");
+        var myWindow = window.open("", "_blank", "");
         myWindow.document.write(message.content);
 
         e.stopPropagation();

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1256,8 +1256,17 @@ exports.register_click_handlers = function () {
         const message_id = $(e.currentTarget).data("message-id");
         const row = current_msg_list.get_row(message_id);
         const message = current_msg_list.get(rows.id(row));
+
+        var code_str = "";
+        var code_start = message.content.indexOf('<div class="codehilite"><pre>')
+        var code_end = 0
         var myWindow = window.open("", "_blank", "");
-        myWindow.document.write(message.content);
+        while(code_start != -1) {
+            code_end = message.content.indexOf("</pre></div>", code_start) + 11;
+            code_str = message.content.substring(code_start, code_end)
+            code_start = message.content.indexOf('<div class="codehilite"><pre>', code_end)
+            myWindow.document.write(code_str);
+        }
 
         e.stopPropagation();
         e.preventDefault();

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -524,8 +524,7 @@ exports.toggle_actions_popover = function (element, id) {
             .replace(/\(/g, "%28")
             .replace(/\)/g, "%29");
 
-        const should_display_code_block = 
-            message.content.includes("<code>")
+        const should_display_code_block = message.content.includes("<code>")
 
         const should_display_delete_option = message_edit.get_deletability(message);
         const args = {
@@ -1252,20 +1251,19 @@ exports.register_click_handlers = function () {
 
     $("body").on("click", ".view_lightbox", function (e) {
         exports.hide_actions_popover();
-              
+
         const message_id = $(e.currentTarget).data("message-id");
         const row = current_msg_list.get_row(message_id);
         const message = current_msg_list.get(rows.id(row));
 
-        var code_str = "";
-        var code_start = message.content.indexOf('<div class="codehilite"><pre>')
-        var code_end = 0
-        var myWindow = window.open("", "_blank", "");
-        while(code_start != -1) {
+        let code_str = "";
+        let code_start = message.content.indexOf('<div class="codehilite"><pre>')
+        let code_end = 0
+        let myWindow = window.open("", "_blank", "");
+        while(code_start !== -1) {
             code_end = message.content.indexOf("</pre></div>", code_start) + 11;
-            code_str = message.content.substring(code_start, code_end)
-            code_start = 
-                message.content.indexOf('<div class="codehilite"><pre>', code_end)
+            code_str = message.content.slice(code_start, code_end)
+            code_start = message.content.indexOf('<div class="codehilite"><pre>', code_end)
             myWindow.document.write(code_str);
         }
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -524,7 +524,7 @@ exports.toggle_actions_popover = function (element, id) {
             .replace(/\(/g, "%28")
             .replace(/\)/g, "%29");
 
-        const should_display_code_block = message.content.includes("<code>")
+        const should_display_code_block = message.content.includes("<code>");
 
         const should_display_delete_option = message_edit.get_deletability(message);
         const args = {
@@ -1257,13 +1257,13 @@ exports.register_click_handlers = function () {
         const message = current_msg_list.get(rows.id(row));
 
         let code_str = "";
-        let code_start = message.content.indexOf('<div class="codehilite"><pre>')
-        let code_end = 0
+        let code_start = message.content.indexOf('<div class="codehilite"><pre>');
+        let code_end = 0;
         const myWindow = window.open("", "_blank", "");
-        while(code_start !== -1) {
+        while (code_start !== -1) {
             code_end = message.content.indexOf("</pre></div>", code_start) + 11;
-            code_str = message.content.slice(code_start, code_end)
-            code_start = message.content.indexOf('<div class="codehilite"><pre>', code_end)
+            code_str = message.content.slice(code_start, code_end);
+            code_start = message.content.indexOf('<div class="codehilite"><pre>', code_end);
             myWindow.document.write(code_str);
         }
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1264,7 +1264,8 @@ exports.register_click_handlers = function () {
         while(code_start != -1) {
             code_end = message.content.indexOf("</pre></div>", code_start) + 11;
             code_str = message.content.substring(code_start, code_end)
-            code_start = message.content.indexOf('<div class="codehilite"><pre>', code_end)
+            code_start = 
+                message.content.indexOf('<div class="codehilite"><pre>', code_end)
             myWindow.document.write(code_str);
         }
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1248,6 +1248,21 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
+    new ClipboardJS(".view_lightbox");
+
+    $("body").on("click", ".view_lightbox", function (e) {
+        exports.hide_actions_popover();
+              
+        const message_id = $(e.currentTarget).data("message-id");
+        const row = current_msg_list.get_row(message_id);
+        const message = current_msg_list.get(rows.id(row));
+        var myWindow = window.open("", "Code block", "");
+        myWindow.document.write(message.content);
+
+        e.stopPropagation();
+        e.preventDefault();
+    });
+
     new ClipboardJS(".copy_mention_syntax");
 
     $("body").on("click", ".copy_mention_syntax", (e) => {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1249,7 +1249,7 @@ exports.register_click_handlers = function () {
 
     new ClipboardJS(".view_lightbox");
 
-    $("body").on("click", ".view_lightbox", function (e) {
+    $("body").on("click", ".view_lightbox", (e) => {
         exports.hide_actions_popover();
 
         const message_id = $(e.currentTarget).data("message-id");
@@ -1259,7 +1259,7 @@ exports.register_click_handlers = function () {
         let code_str = "";
         let code_start = message.content.indexOf('<div class="codehilite"><pre>')
         let code_end = 0
-        let myWindow = window.open("", "_blank", "");
+        const myWindow = window.open("", "_blank", "");
         while(code_start !== -1) {
             code_end = message.content.indexOf("</pre></div>", code_start) + 11;
             code_str = message.content.slice(code_start, code_end)

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -97,7 +97,7 @@
 
     {{#if should_display_code_block}}
     <li>
-        <a href="#" class="view_lightbox" data-message-id="{{message_id}}" data-clipboard-text="{{ conversation_time_uri }}">
+        <a href="#" class="view_lightbox" data-message-id="{{message_id}}">
             <i class="fa fa-code" aria-hidden="true"></i> {{t "View Code" }}
         </a>
     </li>

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -94,4 +94,12 @@
     {{#if historical}}
     <li class="small">({{t "Message sent when you were not subscribed" }})</li>
     {{/if}}
+
+    {{#if should_display_code_block}}
+    <li>
+        <a href="#" class="view_lightbox" data-message-id="{{message_id}}" data-clipboard-text="{{ conversation_time_uri }}">
+            <i class="fa fa-code" aria-hidden="true"></i> {{t "View Code" }}
+        </a>
+    </li>
+    {{/if}}
 </ul>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/5595
Added new option to each message where if it contains a code block, you can view the code block in a different window.
This feature is able to isolate out every code block if there are multiple code blocks in a message, and it ignores any lines that
are not a code block.

**Testing plan:** <!-- How have you tested? -->
Tested manually.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
