### PR TITLE
stream setting: Switch webapp to subscribe/unsubscribe from streams by ID.

### DIFF
--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -848,7 +848,7 @@ function hide_subscribe_toggle_spinner(stream_row) {
     loading.destroy_indicator(spinner);
 }
 
-function ajaxSubscribe(stream, color, stream_row) {
+function ajaxSubscribe(stream_id, color, stream_row) {
     // Subscribe yourself to a single stream.
     let true_stream_name;
 
@@ -857,7 +857,7 @@ function ajaxSubscribe(stream, color, stream_row) {
     }
     return channel.post({
         url: "/json/users/me/subscriptions",
-        data: {subscriptions: JSON.stringify([{name: stream, color}])},
+        data: {subscriptions: JSON.stringify([{id: stream_id, color}])},
         success(resp, statusText, xhr) {
             if (overlays.streams_open()) {
                 $("#create_stream_name").val("");
@@ -894,14 +894,14 @@ function ajaxSubscribe(stream, color, stream_row) {
     });
 }
 
-function ajaxUnsubscribe(sub, stream_row) {
+function ajaxUnsubscribe(stream_id, stream_row) {
     // TODO: use stream_id when backend supports it
     if (stream_row !== undefined) {
         display_subscribe_toggle_spinner(stream_row);
     }
     return channel.del({
         url: "/json/users/me/subscriptions",
-        data: {subscriptions: JSON.stringify([sub.name])},
+        data: {subscriptions: JSON.stringify([stream_id])},
         success() {
             $(".stream_change_property_info").hide();
             // The rest of the work is done via the unsubscribe event we will get
@@ -932,7 +932,7 @@ export function do_open_create_stream() {
     if (!should_list_all_streams()) {
         // Realms that don't allow listing streams should simply be subscribed to.
         stream_create.set_name(stream);
-        ajaxSubscribe($("#search_stream_name").val());
+        ajaxSubscribe(stream_data.get_stream_id($("#search_stream_name").val()));
         return;
     }
 
@@ -960,7 +960,7 @@ export function unsubscribe_from_private_stream(sub, from_stream_popover) {
             );
         }
 
-        ajaxUnsubscribe(sub, stream_row);
+        ajaxUnsubscribe(sub.stream_id, stream_row);
     }
 
     confirm_dialog.launch({
@@ -982,9 +982,9 @@ export function sub_or_unsub(sub, from_stream_popover, stream_row) {
             unsubscribe_from_private_stream(sub, from_stream_popover);
             return;
         }
-        ajaxUnsubscribe(sub, stream_row);
+        ajaxUnsubscribe(sub.stream_id, stream_row);
     } else {
-        ajaxSubscribe(sub.name, sub.color, stream_row);
+        ajaxSubscribe(sub.stream_id, sub.color, stream_row);
     }
 }
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -70,7 +70,7 @@ from zerver.lib.cache import (
     delete_user_profile_caches,
     display_recipient_cache_key,
     flush_user_profile,
-    get_stream_cache_key,
+    get_stream_cache_key_for_stream_name,
     to_dict_cache_key_id,
     user_profile_by_api_key_cache_key,
     user_profile_delivery_email_cache_key,
@@ -1303,7 +1303,7 @@ def do_deactivate_stream(
         do_remove_streams_from_default_stream_group(stream.realm, group, [stream])
 
     # Remove the old stream information from remote cache.
-    old_cache_key = get_stream_cache_key(old_name, stream.realm_id)
+    old_cache_key = get_stream_cache_key_for_stream_name(old_name, stream.realm_id)
     cache_delete(old_cache_key)
 
     stream_dict = stream.to_dict()
@@ -4801,8 +4801,8 @@ def do_rename_stream(stream: Stream, new_name: str, user_profile: UserProfile) -
 
     # Update the display recipient and stream, which are easy single
     # items to set.
-    old_cache_key = get_stream_cache_key(old_name, stream.realm_id)
-    new_cache_key = get_stream_cache_key(stream.name, stream.realm_id)
+    old_cache_key = get_stream_cache_key_for_stream_name(old_name, stream.realm_id)
+    new_cache_key = get_stream_cache_key_for_stream_name(stream.name, stream.realm_id)
     if old_cache_key != new_cache_key:
         cache_delete(old_cache_key)
         cache_set(new_cache_key, stream)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3714,7 +3714,7 @@ def bulk_add_subscriptions(
     realm: Realm,
     streams: Collection[Stream],
     users: Iterable[UserProfile],
-    color_map: Mapping[str, str] = {},
+    color_map: Mapping[Union[int, str], str] = {},
     from_user_creation: bool = False,
     *,
     acting_user: Optional[UserProfile],
@@ -3762,6 +3762,8 @@ def bulk_add_subscriptions(
 
             if stream.name in color_map:
                 color = color_map[stream.name]
+            elif stream.id in color_map:
+                color = color_map[stream.id]
             else:
                 color = pick_color(user_profile, used_colors)
             used_colors.add(color)

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -572,7 +572,7 @@ def bot_dicts_in_realm_cache_key(realm: "Realm") -> str:
     return f"bot_dicts_in_realm:{realm.id}"
 
 
-def get_stream_cache_key(stream_name: str, realm_id: int) -> str:
+def get_stream_cache_key_for_stream_name(stream_name: str, realm_id: int) -> str:
     return f"stream_by_realm_and_name:{realm_id}:{make_safe_digest(stream_name.strip().lower())}"
 
 
@@ -719,9 +719,11 @@ def flush_stream(
     items_for_remote_cache = {}
 
     if update_fields is None:
-        cache_delete(get_stream_cache_key(stream.name, stream.realm_id))
+        cache_delete(get_stream_cache_key_for_stream_name(stream.name, stream.realm_id))
     else:
-        items_for_remote_cache[get_stream_cache_key(stream.name, stream.realm_id)] = (stream,)
+        items_for_remote_cache[
+            get_stream_cache_key_for_stream_name(stream.name, stream.realm_id)
+        ] = (stream,)
         cache_set_many(items_for_remote_cache)
 
     if (

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -576,6 +576,10 @@ def get_stream_cache_key(stream_name: str, realm_id: int) -> str:
     return f"stream_by_realm_and_name:{realm_id}:{make_safe_digest(stream_name.strip().lower())}"
 
 
+def get_stream_cache_key_for_stream_id(stream_id: int, realm_id: int) -> str:
+    return f"stream_by_realm_and_id:{realm_id}:{stream_id}"
+
+
 def delete_user_profile_caches(user_profiles: Iterable["UserProfile"]) -> None:
     # Imported here to avoid cyclic dependency.
     from zerver.lib.users import get_all_api_keys

--- a/zerver/lib/cache_helpers.py
+++ b/zerver/lib/cache_helpers.py
@@ -16,7 +16,7 @@ from zerver.lib.cache import (
     cache_set_many,
     get_remote_cache_requests,
     get_remote_cache_time,
-    get_stream_cache_key,
+    get_stream_cache_key_for_stream_name,
     to_dict_cache_key_id,
     user_profile_by_api_key_cache_key,
     user_profile_cache_key,
@@ -70,7 +70,9 @@ def user_cache_items(
 
 
 def stream_cache_items(items_for_remote_cache: Dict[str, Tuple[Stream]], stream: Stream) -> None:
-    items_for_remote_cache[get_stream_cache_key(stream.name, stream.realm_id)] = (stream,)
+    items_for_remote_cache[get_stream_cache_key_for_stream_name(stream.name, stream.realm_id)] = (
+        stream,
+    )
 
 
 def client_cache_items(items_for_remote_cache: Dict[str, Tuple[Client]], client: Client) -> None:

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -17,7 +17,7 @@ from zerver.models import (
     Subscription,
     UserProfile,
     active_non_guest_user_ids,
-    bulk_get_streams,
+    bulk_get_streams_by_names,
     get_realm_stream,
     get_stream,
     get_stream_by_id_in_realm,
@@ -628,7 +628,7 @@ def list_to_streams(
 
     existing_streams: List[Stream] = []
     missing_stream_dicts: List[StreamDict] = []
-    existing_stream_map = bulk_get_streams(user_profile.realm, stream_set)
+    existing_stream_map = bulk_get_streams_by_names(user_profile.realm, stream_set)
 
     if admin_access_required:
         existing_recipient_ids = [stream.recipient_id for stream in existing_stream_map.values()]

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1011,15 +1011,18 @@ Output:
     def common_subscribe_to_streams(
         self,
         user: UserProfile,
-        streams: Iterable[str],
+        streams: Iterable[Union[str, int]],
         extra_post_data: Dict[str, Any] = {},
         invite_only: bool = False,
         is_web_public: bool = False,
         allow_fail: bool = False,
         **kwargs: Any,
     ) -> HttpResponse:
+        stream_selector = "name" if streams and isinstance(next(iter(streams), ""), str) else "id"
         post_data = {
-            "subscriptions": orjson.dumps([{"name": stream} for stream in streams]).decode(),
+            "subscriptions": orjson.dumps(
+                [{stream_selector: stream} for stream in streams]
+            ).decode(),
             "is_web_public": orjson.dumps(is_web_public).decode(),
             "invite_only": orjson.dumps(invite_only).decode(),
         }

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -190,6 +190,36 @@ def check_none_or(sub_validator: Validator[ResultT]) -> Validator[Optional[Resul
     return f
 
 
+# It'd first check if dict contains stream name or id and then procceds to other checks.
+def check_dict_for_add_subscription_schema(
+    optional_keys: Collection[Tuple[str, Validator[ResultT]]] = []
+) -> Validator[Dict[str, ResultT]]:
+    def f(var_name: str, val: object) -> Dict[str, ResultT]:
+        if not isinstance(val, dict):
+            raise ValidationError(_("{var_name} is not a dict").format(var_name=var_name))
+        for k in val:
+            check_string(f"{var_name} key", k)
+
+        either_required_keys = [("name", check_string), ("id", check_int)]
+        required_keys = []
+        for k, sub_validator in either_required_keys:
+            if k in val:
+                vname = f'{var_name}["{k}"]'
+                sub_validator(vname, val[k])
+                required_keys.append((k, sub_validator))
+                break
+
+        if not required_keys:
+            raise ValidationError(_("Stream name or id must be passed."))
+
+        return cast(
+            Validator[Dict[str, ResultT]],
+            check_dict(required_keys, optional_keys, _allow_only_listed_keys=True),
+        )(var_name, val)
+
+    return f
+
+
 def check_list(
     sub_validator: Validator[ResultT], length: Optional[int] = None
 ) -> Validator[List[ResultT]]:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -55,8 +55,8 @@ from zerver.lib.cache import (
     flush_used_upload_space_cache,
     flush_user_profile,
     get_realm_used_upload_space_cache_key,
-    get_stream_cache_key,
     get_stream_cache_key_for_stream_id,
+    get_stream_cache_key_for_stream_name,
     realm_alert_words_automaton_cache_key,
     realm_alert_words_cache_key,
     realm_user_dict_fields,
@@ -2194,7 +2194,7 @@ def get_client_remote_cache(name: str) -> Client:
     return client
 
 
-@cache_with_key(get_stream_cache_key, timeout=3600 * 24 * 7)
+@cache_with_key(get_stream_cache_key_for_stream_name, timeout=3600 * 24 * 7)
 def get_realm_stream(stream_name: str, realm_id: int) -> Stream:
     return Stream.objects.select_related().get(name__iexact=stream_name.strip(), realm_id=realm_id)
 
@@ -2221,7 +2221,7 @@ def get_stream_by_id_in_realm(stream_id: int, realm: Realm) -> Stream:
     return Stream.objects.select_related().get(id=stream_id, realm=realm)
 
 
-def bulk_get_streams(realm: Realm, stream_names: STREAM_NAMES) -> Dict[str, Any]:
+def bulk_get_streams_by_names(realm: Realm, stream_names: STREAM_NAMES) -> Dict[str, Any]:
     def fetch_streams_by_name(stream_names: List[str]) -> Sequence[Stream]:
         #
         # This should be just
@@ -2241,7 +2241,7 @@ def bulk_get_streams(realm: Realm, stream_names: STREAM_NAMES) -> Dict[str, Any]
         )
 
     def stream_name_to_cache_key(stream_name: str) -> str:
-        return get_stream_cache_key(stream_name, realm.id)
+        return get_stream_cache_key_for_stream_name(stream_name, realm.id)
 
     def stream_to_lower_name(stream: Stream) -> str:
         return stream.name.lower()

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -33,7 +33,7 @@ from zerver.lib.actions import (
     send_rate_limited_pm_notification_to_bot_owner,
 )
 from zerver.lib.addressee import Addressee
-from zerver.lib.cache import cache_delete, get_stream_cache_key
+from zerver.lib.cache import cache_delete, get_stream_cache_key_for_stream_name
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import MessageDict, get_raw_unread_data, get_recent_private_conversations
 from zerver.lib.test_classes import ZulipTestCase
@@ -1606,7 +1606,7 @@ class StreamMessagesTest(ZulipTestCase):
         # persistent, so our test can also fail if cache is invalidated
         # during the course of the unit test.
         flush_per_request_caches()
-        cache_delete(get_stream_cache_key(stream_name, realm.id))
+        cache_delete(get_stream_cache_key_for_stream_name(stream_name, realm.id))
         with queries_captured() as queries:
             check_send_stream_message(
                 sender=sender,

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2612,7 +2612,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
         user = self.example_user("hamlet")
         self.login_user(user)
 
-        # add
+        # add with stream name
         request = {
             "add": orjson.dumps([{"name": "my_test_stream_1"}]).decode(),
         }
@@ -2621,7 +2621,26 @@ class SubscriptionRestApiTest(ZulipTestCase):
         streams = self.get_streams(user)
         self.assertTrue("my_test_stream_1" in streams)
 
-        # now delete the same stream
+        # add with stream id
+        new_stream = self.make_stream(
+            stream_name="test_stream", realm=user.realm, is_web_public=True
+        )
+        request = {
+            "add": orjson.dumps([{"id": new_stream.id}]).decode(),
+        }
+        result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_success(result)
+        streams = self.get_streams(user)
+        self.assertTrue(new_stream.name in streams)
+
+        # add with neither stream name or id should raise error
+        request = {
+            "add": orjson.dumps([{}]).decode(),
+        }
+        result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_error(result, "Stream name or id must be passed.")
+
+        # now delete the same stream with name
         request = {
             "delete": orjson.dumps(["my_test_stream_1"]).decode(),
         }
@@ -2630,22 +2649,48 @@ class SubscriptionRestApiTest(ZulipTestCase):
         streams = self.get_streams(user)
         self.assertTrue("my_test_stream_1" not in streams)
 
+        # now delete the same stream with id
+        request = {
+            "delete": orjson.dumps([new_stream.id]).decode(),
+        }
+        result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_success(result)
+        streams = self.get_streams(user)
+        self.assertTrue(new_stream.name not in streams)
+
     def test_add_with_color(self) -> None:
         user = self.example_user("hamlet")
         self.login_user(user)
 
-        # add with color proposition
+        # add with color proposition using stream name
         request = {
             "add": orjson.dumps([{"name": "my_test_stream_2", "color": "#afafaf"}]).decode(),
         }
         result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
         self.assert_json_success(result)
 
-        # incorrect color format
+        # add with color proposition using stream id
+        new_stream = self.make_stream(
+            stream_name="test_stream2", realm=user.realm, is_web_public=True
+        )
+        request = {
+            "add": orjson.dumps([{"id": new_stream.id, "color": "#a2d39b"}]).decode(),
+        }
+        result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_success(result)
+
+        # incorrect color format using stream name
         request = {
             "subscriptions": orjson.dumps(
                 [{"name": "my_test_stream_3", "color": "#0g0g0g"}]
             ).decode(),
+        }
+        result = self.api_post(user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_error(result, 'subscriptions[0]["color"] is not a valid hex color code')
+
+        # incorrect color format using stream id
+        request = {
+            "subscriptions": orjson.dumps([{"id": new_stream.id, "color": "#0g0g0g"}]).decode(),
         }
         result = self.api_post(user, "/api/v1/users/me/subscriptions", request)
         self.assert_json_error(result, 'subscriptions[0]["color"] is not a valid hex color code')
@@ -2707,7 +2752,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
             self.assert_json_error(result, expected_message)
 
         check_for_error(["foo"], "add[0] is not a dict")
-        check_for_error([{"bogus": "foo"}], "name key is missing from add[0]")
+        check_for_error([{"bogus": "foo"}], "Stream name or id must be passed.")
         check_for_error([{"name": {}}], 'add[0]["name"] is not a string')
 
     def test_bad_principals(self) -> None:
@@ -2729,7 +2774,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
             "delete": orjson.dumps([{"name": "my_test_stream_1"}]).decode(),
         }
         result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
-        self.assert_json_error(result, "delete[0] is not a string")
+        self.assert_json_error(result, "delete[0] is not a string or integer")
 
     def test_add_or_delete_not_specified(self) -> None:
         user = self.example_user("hamlet")
@@ -2932,6 +2977,25 @@ class SubscriptionAPITest(ZulipTestCase):
                 self.streams + add_streams,
                 self.test_realm,
             )
+
+    def test_unsuccessful_subscriptions_add(self) -> None:
+        """
+        Calling POST /json/users/me/subscriptions should raise error
+        as stream id does not exists.
+        This error occurs because it tries to fetch stream with some
+        stream id which is not present in database.
+        """
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        invalid_stream_id = 992
+        valid_stream = self.get_streams(user)[0]
+        result = self.common_subscribe_to_streams(
+            user,
+            [self.get_stream_id(valid_stream), invalid_stream_id],
+            dict(principals=orjson.dumps([user.id]).decode()),
+            allow_fail=True,
+        )
+        self.assert_json_error(result, f"No stream with id '{invalid_stream_id}' found.")
 
     def test_successful_subscriptions_add_with_announce(self) -> None:
         """


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Modified subscribe/unsubscribe API to select streams from either `id` or `name` 
using a common attribute `stream`.

Also changing frontend to subscribe/unsubscribe streams by id.
Fixes: #10744


**Testing plan:** <!-- How have you tested? -->
Modified and add a test to get 100% test coverage.



**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
