### PR TITLE
message_view_header: Add extended descriptions box.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -24,6 +24,7 @@ import * as message_edit from "./message_edit";
 import * as message_flags from "./message_flags";
 import * as message_lists from "./message_lists";
 import * as message_store from "./message_store";
+import * as message_view_header from "./message_view_header";
 import * as muted_topics_ui from "./muted_topics_ui";
 import * as narrow from "./narrow";
 import * as notifications from "./notifications";
@@ -827,7 +828,7 @@ export function initialize() {
             return;
         }
 
-        // Dismiss popovers if the user has clicked outside them
+        // Dismiss popovers or extended description if the user has clicked outside them
         if (
             $(
                 '.popover-inner, #user-profile-modal, .emoji-info-popover, .app-main [class^="column-"].expanded',
@@ -840,6 +841,10 @@ export function initialize() {
             // the popover without being displayed.
             const not_hide_tippy_instances = true;
             popovers.hide_all(not_hide_tippy_instances);
+        }
+
+        if ($(".extended_description").has(e.target).length === 0) {
+            message_view_header.close_extended_description_and_show_open_icon();
         }
 
         if (compose_state.composing()) {

--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import render_message_view_header from "../templates/message_view_header.hbs";
+import render_message_view_header_extended_description from "../templates/message_view_header_extended_description.hbs";
 
 import {$t} from "./i18n";
 import * as narrow_state from "./narrow_state";
@@ -118,6 +119,42 @@ function bind_title_area_handlers() {
         });
 }
 
+function insert_extended_description_box_if_needed(message_view_header_data) {
+    // closes extended_description if it was previously open
+    hide_extended_description();
+
+    if (
+        $(".narrow_description")[0] &&
+        $(".narrow_description")[0].scrollWidth > $(".narrow_description").innerWidth()
+    ) {
+        $(".open_extended_description_icon").show();
+        $(".open_extended_description_icon").on("click", (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            $(".open_extended_description_icon").hide();
+            $(".close_extended_description_icon").show();
+            const extended_description_elem = $("#message_view_header_extended_description");
+            extended_description_elem.empty();
+            const rendered =
+                render_message_view_header_extended_description(message_view_header_data);
+            extended_description_elem.append(rendered);
+            extended_description_elem.removeClass("notdisplayed");
+            $(".close_extended_description_icon").on("click", (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                $(".open_extended_description_icon").show();
+                hide_extended_description();
+            });
+        });
+    }
+}
+
+function hide_extended_description() {
+    $(".close_extended_description_icon").hide();
+    const extended_description_elem = $("#message_view_header_extended_description");
+    extended_description_elem.empty();
+}
+
 function build_message_view_header(filter) {
     // This makes sure we don't waste time appending
     // message_view_header on a template where it's never used
@@ -127,6 +164,7 @@ function build_message_view_header(filter) {
         const message_view_header_data = make_message_view_header(filter);
         append_and_display_title_area(message_view_header_data);
         bind_title_area_handlers();
+        insert_extended_description_box_if_needed(message_view_header_data);
         if (page_params.search_pills_enabled && $("#search_query").is(":focus")) {
             open_search_bar_and_close_narrow_description();
         } else {

--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -148,7 +148,7 @@ function insert_extended_description_box_if_needed(message_view_header_data) {
     }
 }
 
-function close_extended_description_and_show_open_icon() {
+export function close_extended_description_and_show_open_icon() {
     $(".open_extended_description_icon").show();
     hide_extended_description();
 }

--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -142,11 +142,15 @@ function insert_extended_description_box_if_needed(message_view_header_data) {
             $(".close_extended_description_icon").on("click", (e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                $(".open_extended_description_icon").show();
-                hide_extended_description();
+                close_extended_description_and_show_open_icon();
             });
         });
     }
+}
+
+function close_extended_description_and_show_open_icon() {
+    $(".open_extended_description_icon").show();
+    hide_extended_description();
 }
 
 function hide_extended_description() {

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -80,6 +80,7 @@ body.night-mode {
     .app-main,
     .header-main,
     #message_view_header_underpadding,
+    .extended_description,
     .floating_recipient .message-header-wrapper,
     .column-middle,
     #compose,
@@ -113,6 +114,7 @@ body.night-mode {
 
     .column-left .left-sidebar,
     #settings_page .form-sidebar,
+    .extended_description,
     .stream_name_search_section,
     .column-right .right-sidebar {
         border-color: hsla(0, 0%, 0%, 0.2);

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1823,6 +1823,11 @@ div.focused_table {
         }
     }
 
+    .open_extended_description_icon,
+    .close_extended_description_icon {
+        display: none;
+    }
+
     .search_closed {
         overflow: visible;
         flex: 0; /* makes sure search icon is always visible */
@@ -1849,6 +1854,31 @@ div.focused_table {
         &:hover ~ .search_closed {
             opacity: 1;
         }
+    }
+}
+
+.extended_description {
+    padding: 5px;
+    position: absolute;
+    overflow-wrap: anywhere;
+    background-color: hsl(0, 0%, 100%);
+    border: 1px solid hsl(0, 0%, 88%);
+    width: calc(100% - 12px);
+    @media (max-width: $xl_min) {
+        width: calc(100% - 94px);
+    }
+    @media (max-width: $md_min) {
+        margin-left: 40px;
+        width: calc(100% - 133px);
+    }
+
+    @media (max-width: $sm_min) {
+        line-height: calc(20 / 14);
+    }
+
+    .extended_description_data {
+        border: 2px solid hsl(0, 0%, 80%);
+        padding: 10px;
     }
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1846,7 +1846,7 @@ div.focused_table {
         /* Provide the visual cue that clicking this will work as expected. */
         cursor: pointer;
 
-        &:hover + .search_closed {
+        &:hover ~ .search_closed {
             opacity: 1;
         }
     }

--- a/static/templates/message_view_header.hbs
+++ b/static/templates/message_view_header.hbs
@@ -12,6 +12,12 @@
     {{t "(no description)"}}
     {{/if}}
 </span>
+<span class="open_extended_description_icon">
+    <i class="fa fa-angle-down"></i>
+</span>
+<span class="close_extended_description_icon">
+    <i class="fa fa-angle-up"></i>
+</span>
 {{else}}
 <span class="navbar-click-opens-search">
     {{> navbar_icon_and_title }}

--- a/static/templates/message_view_header_extended_description.hbs
+++ b/static/templates/message_view_header_extended_description.hbs
@@ -1,0 +1,3 @@
+<div class="extended_description rendered_markdown">
+    <div class="extended_description_data">{{rendered_markdown rendered_narrow_description}}</div>
+</div>

--- a/static/templates/navbar.hbs
+++ b/static/templates/navbar.hbs
@@ -39,6 +39,8 @@
                     </div>
                     {{/if}}
                 </div>
+                <div id="message_view_header_extended_description" class="notdisplayed">
+                </div>
             </div>
         </div>
         <div class="column-right">


### PR DESCRIPTION

Previously, there was no way to view a long description other than the
settings panel. This adds a way via the .extended_narrow_description
box.
Fixes: #14729.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![extended-descriptions](https://user-images.githubusercontent.com/33805964/102313408-9a38f380-3f96-11eb-9de2-8108e7186b4e.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
