### PR TITLE
Check only the file and directory GitHub urls of zulip/zulip.

### DIFF
--- a/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
+++ b/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
@@ -74,11 +74,14 @@ class BaseDocumentationSpider(scrapy.Spider):
             # homepage, there's no need to check those (which can
             # cause errors when chat.zulip.org is being updated).
             return True
-        if "zulip.readthedocs" in url or "zulip.com" in url or "zulip.org" in url or "github.com/zulip/zulip/" in url:
+        if "zulip.readthedocs" in url or "zulip.com" in url or "zulip.org" in url:
             # We want CI to check any links to Zulip sites.
             return False
         if (len(url) > 4 and url[:4] == "file") or ("localhost" in url):
             # We also want CI to check any links to built documentation.
+            return False
+        if url.startswith(ZULIP_SERVER_GITHUB_FILE_URL_PREFIX) or url.startswith(ZULIP_SERVER_GITHUB_DIRECTORY_URL_PREFIX):
+            # We can verify these links directly in the local git repo without making any requests to GitHub servers.
             return False
         if 'github.com/zulip' in url:
             # We want to check these links but due to rate limiting from GitHub, these checks often

--- a/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
+++ b/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
@@ -45,8 +45,8 @@ VNU_IGNORE_REGEX = re.compile(r'|'.join(VNU_IGNORE))
 
 DEPLOY_ROOT = os.path.abspath(os.path.join(__file__, "../../../../../.."))
 
-GITHUB_FILE_URL_PREFIX = "https://github.com/zulip/zulip/blob/master"
-GITHUB_DIRECTORY_URL_PREFIX = "https://github.com/zulip/zulip/tree/master"
+ZULIP_SERVER_GITHUB_FILE_URL_PREFIX = "https://github.com/zulip/zulip/blob/master"
+ZULIP_SERVER_GITHUB_DIRECTORY_URL_PREFIX = "https://github.com/zulip/zulip/tree/master"
 
 class BaseDocumentationSpider(scrapy.Spider):
     name: Optional[str] = None
@@ -132,16 +132,16 @@ class BaseDocumentationSpider(scrapy.Spider):
             callback = self.check_existing
             method = 'HEAD'
 
-            if url.startswith(GITHUB_FILE_URL_PREFIX):
-                file_path = url.replace(GITHUB_FILE_URL_PREFIX, DEPLOY_ROOT)
+            if url.startswith(ZULIP_SERVER_GITHUB_FILE_URL_PREFIX):
+                file_path = url.replace(ZULIP_SERVER_GITHUB_FILE_URL_PREFIX, DEPLOY_ROOT)
                 hash_index = file_path.find("#")
                 if hash_index != -1:
                     file_path = file_path[:hash_index]
                 if not os.path.isfile(file_path):
                     self.logger.error("There is no local file associated with the GitHub URL: %s", url)
                 return
-            elif url.startswith(GITHUB_DIRECTORY_URL_PREFIX):
-                dir_path = url.replace(GITHUB_DIRECTORY_URL_PREFIX, DEPLOY_ROOT)
+            elif url.startswith(ZULIP_SERVER_GITHUB_DIRECTORY_URL_PREFIX):
+                dir_path = url.replace(ZULIP_SERVER_GITHUB_DIRECTORY_URL_PREFIX, DEPLOY_ROOT)
                 if not os.path.isdir(dir_path):
                     self.logger.error("There is no local directory associated with the GitHub URL: %s", url)
                 return


### PR DESCRIPTION
f82cc4e started checking all zulip/zulip GitHub links in CI. Instead, it should have checked only zulip/zulip file and directory links since checking for other links require making requests to GitHub servers.