### PR TITLE
test_settings: Use TEST_EXTERNAL_HOST to override ‘testserver’ default

### DIFF
--- a/tools/lib/test_server.py
+++ b/tools/lib/test_server.py
@@ -25,7 +25,7 @@ from zerver.lib.test_fixtures import update_test_databases_if_required
 
 def set_up_django(external_host: str) -> None:
     os.environ['FULL_STACK_ZULIP_TEST'] = '1'
-    os.environ['EXTERNAL_HOST'] = external_host
+    os.environ['TEST_EXTERNAL_HOST'] = external_host
     os.environ["LOCAL_UPLOADS_DIR"] = get_or_create_dev_uuid_var_path(
         'test-backend/test_uploads')
     os.environ['DJANGO_SETTINGS_MODULE'] = 'zproject.test_settings'

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -15,8 +15,7 @@ import os
 # transmitting the value of EXTERNAL_HOST to dev_settings.py so that
 # it can be set there, at the right place in the settings.py flow.
 # Ick.
-if os.getenv("EXTERNAL_HOST") is None:
-    os.environ["EXTERNAL_HOST"] = "testserver"
+os.environ["EXTERNAL_HOST"] = os.getenv("TEST_EXTERNAL_HOST", "testserver")
 
 from .settings import *  # noqa: F401,F403 isort: skip
 from .test_extra_settings import *  # noqa: F401,F403 isort: skip


### PR DESCRIPTION
This allows `test-backend` to work even if the user has `EXTERNAL_HOST` set to something else.

https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/backend.20test.20failing.20with.20no.20changes/near/1082250