### PR TITLE
scrollbar: Remove vertical scrollbar for alert box

### DIFF
--- a/static/styles/alerts.css
+++ b/static/styles/alerts.css
@@ -55,6 +55,12 @@ $alert-error-red: hsl(0, 80%, 40%);
     max-height: 100%;
     overflow-y: auto;
     overscroll-behavior: contain;
+    -ms-overflow-style: none; /* Internet Explorer 10+ */
+    scrollbar-width: none; /* Firefox */
+
+    &::-webkit-scrollbar {
+        display: none; /* Google Chrome */
+    }
 
     .stacktrace {
         @extend .alert-display, .alert-animations;


### PR DESCRIPTION
There was an unnecessary vertical scrollbar for the alert box during
the server reload. This was automatically inserted by browser due to
overflow-y: auto css rule on it. 

Fixes: #16911
**Testing plan:** <!-- How have you tested? -->
Testing has been done manually on `google chrome version: 87.0.4280.88` and `mozilla firefox version:83.0` by modifying the `event_register` so that alert box persists and then varying the screen width.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Following were the changes after fixing:

**Chrome**
![chrome](https://user-images.githubusercontent.com/63504956/102475613-13f8dc00-4080-11eb-806e-ae164c211f11.png)

**fire fox**
![mozilla](https://user-images.githubusercontent.com/63504956/102475655-2541e880-4080-11eb-85a9-cabeb1ef46cc.png)

Actually this was only a problem in google chrome browser and was already fine in mozilla firefox

