### PR TITLE
Implement mute user feature.

### DIFF
--- a/frontend_tests/node_tests/compose_closed_ui.js
+++ b/frontend_tests/node_tests/compose_closed_ui.js
@@ -14,6 +14,7 @@ const message_lists = mock_esm("../../static/js/message_lists");
 
 // Code we're actually using/testing
 const compose_closed_ui = zrequire("compose_closed_ui");
+const {Filter} = zrequire("filter");
 const {MessageList} = zrequire("message_list");
 
 // Helper test function
@@ -24,9 +25,7 @@ function test_reply_label(expected_label) {
 
 run_test("reply_label", () => {
     // Mocking up a test message list
-    const filter = {
-        predicate: () => () => true,
-    };
+    const filter = new Filter();
     const list = new MessageList({
         filter,
     });

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -301,10 +301,7 @@ run_test("initialize", () => {
 });
 
 function simulate_narrow() {
-    const filter = {
-        predicate: () => () => false,
-        public_operators: () => [{operator: "pm-with", operand: alice.email}],
-    };
+    const filter = new Filter([{operator: "pm-with", operand: alice.email}]);
 
     const msg_list = new message_list.MessageList({
         table_name: "zfilt",
@@ -372,7 +369,7 @@ run_test("loading_newer", () => {
                 anchor: "444",
                 num_before: 0,
                 num_after: 100,
-                narrow: `[{"operator":"pm-with","operand":[${alice.user_id}]}]`,
+                narrow: `[{"negated":false,"operator":"pm-with","operand":[${alice.user_id}]}]`,
                 client_gravatar: true,
             },
             resp: {

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -16,9 +16,6 @@ const {page_params} = require("../zjsunit/zpage_params");
 const noop = function () {};
 
 mock_cjs("jquery", $);
-mock_esm("../../static/js/filter", {
-    Filter: noop,
-});
 set_global("document", {
     to_$() {
         return {
@@ -31,17 +28,10 @@ const narrow_state = mock_esm("../../static/js/narrow_state");
 const stream_data = mock_esm("../../static/js/stream_data");
 
 const {MessageList} = zrequire("message_list");
-
-function accept_all_filter() {
-    const filter = {
-        predicate: () => () => true,
-    };
-
-    return filter;
-}
+const {Filter} = zrequire("filter");
 
 run_test("basics", (override) => {
-    const filter = accept_all_filter();
+    const filter = new Filter();
 
     const list = new MessageList({
         filter,
@@ -384,9 +374,10 @@ run_test("bookend", (override) => {
 });
 
 run_test("add_remove_rerender", () => {
-    const filter = accept_all_filter();
-
-    const list = new MessageList({filter});
+    const filter = new Filter();
+    const list = new MessageList({
+        filter,
+    });
 
     const messages = [{id: 1}, {id: 2}, {id: 3}];
 

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -73,7 +73,7 @@ run_test("basics", () => {
     mld.remove([50]);
     assert_contents(mld, [10, 15, 20, 25, 30, 35, 40, 45, 60, 70]);
 
-    mld.update_items_for_topic_muting();
+    mld.update_items_for_muting();
     assert_contents(mld, [10, 15, 20, 25, 30, 35, 40, 45, 60, 70]);
 
     mld.reset_select_to_closest();

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -114,6 +114,14 @@ run_test("muting", () => {
         {id: 1, type: "stream", stream_id: 1, topic: "muted"},
         {id: 2, type: "stream", stream_id: 1, topic: "whatever"},
         {id: 3, type: "stream", stream_id: 1, topic: "muted", mentioned: true}, // mentions override muting
+
+        // 10 = muted user, 9 = non-muted user, 11 = you
+        {id: 4, type: "private", to_user_ids: "9,10,11", sender_id: 10}, // muted to huddle
+        {id: 5, type: "private", to_user_ids: "9,10,11", sender_id: 9}, // non-muted to huddle
+        {id: 6, type: "private", to_user_ids: "11", sender_id: 10}, // muted to 1:1 PM
+        {id: 7, type: "private", to_user_ids: "11", sender_id: 9}, // non-muted to 1:1 PM
+        {id: 8, type: "private", to_user_ids: "10", sender_id: 11}, // 1:1 PM to muted
+        {id: 9, type: "private", to_user_ids: "9", sender_id: 11}, // 1:1 PM to non-muted
     ];
 
     // `messages_filtered_for_topic_mutes` should skip filtering
@@ -132,42 +140,84 @@ run_test("muting", () => {
         },
     );
 
-    // Test actual behaviour of `messages_filtered_for_topic_mutes`
+    // Test actual behaviour of `messages_filtered_for_*` methods.
     mld.excludes_muted_topics = true;
     muting.add_muted_topic(1, "muted");
     const res = mld.messages_filtered_for_topic_mutes(msgs);
     assert.deepEqual(res, [
         {id: 2, type: "stream", stream_id: 1, topic: "whatever"},
         {id: 3, type: "stream", stream_id: 1, topic: "muted", mentioned: true}, // mentions override muting
+
+        // `messages_filtered_for_topic_mutes` does not affect private messages
+        {id: 4, type: "private", to_user_ids: "9,10,11", sender_id: 10},
+        {id: 5, type: "private", to_user_ids: "9,10,11", sender_id: 9},
+        {id: 6, type: "private", to_user_ids: "11", sender_id: 10},
+        {id: 7, type: "private", to_user_ids: "11", sender_id: 9},
+        {id: 8, type: "private", to_user_ids: "10", sender_id: 11},
+        {id: 9, type: "private", to_user_ids: "9", sender_id: 11},
     ]);
 
+    muting.add_muted_user(10);
+    const res_user = mld.messages_filtered_for_user_mutes(msgs);
+    assert.deepEqual(res_user, [
+        // `messages_filtered_for_user_mutes` does not affect stream messages
+        {id: 1, type: "stream", stream_id: 1, topic: "muted"},
+        {id: 2, type: "stream", stream_id: 1, topic: "whatever"},
+        {id: 3, type: "stream", stream_id: 1, topic: "muted", mentioned: true},
+
+        {id: 4, type: "private", to_user_ids: "9,10,11", sender_id: 10}, // muted to huddle
+        {id: 5, type: "private", to_user_ids: "9,10,11", sender_id: 9}, // non-muted to huddle
+        {id: 7, type: "private", to_user_ids: "11", sender_id: 9}, // non-muted to 1:1 PM
+        {id: 9, type: "private", to_user_ids: "9", sender_id: 11}, // 1:1 PM to non-muted
+    ]);
+
+    // Output filtered based on both topic and user muting.
+    mld._all_items = msgs;
+    const filtered_messages = mld.unmuted_messages(mld._all_items);
+    assert.deepEqual(filtered_messages, [
+        {id: 2, type: "stream", stream_id: 1, topic: "whatever"},
+        {id: 3, type: "stream", stream_id: 1, topic: "muted", mentioned: true},
+        {id: 4, type: "private", to_user_ids: "9,10,11", sender_id: 10},
+        {id: 5, type: "private", to_user_ids: "9,10,11", sender_id: 9},
+        {id: 7, type: "private", to_user_ids: "11", sender_id: 9},
+        {id: 9, type: "private", to_user_ids: "9", sender_id: 11},
+    ]);
+
+    // Also verify that, the correct set of messages is stored in `_items`
+    // once we update the list for muting.
+    mld.update_items_for_muting();
+    assert.deepEqual(filtered_messages, mld._items);
+
     // MessageListData methods should always attempt to filter messages,
-    // and update `_all_items` when `excludes_muted_topics` is true.
+    // and keep `_all_items` up-to-date.
     mld = new MessageListData({
         excludes_muted_topics: true,
     });
     assert.deepEqual(mld._all_items, []);
 
-    let messages_filtered_for_topic_mutes_calls = 0;
-    mld.messages_filtered_for_topic_mutes = (messages) => {
-        messages_filtered_for_topic_mutes_calls = messages_filtered_for_topic_mutes_calls + 1;
+    let unmuted_messages_calls = 0;
+    mld.unmuted_messages = (messages) => {
+        unmuted_messages_calls = unmuted_messages_calls + 1;
         return messages;
     };
 
-    mld.add_anywhere([{id: 10}]);
-    assert.equal(messages_filtered_for_topic_mutes_calls, 1);
-    assert_msg_ids(mld._all_items, [10]);
+    mld.add_anywhere([{id: 10}, {id: 20}]);
+    assert.equal(unmuted_messages_calls, 1);
+    assert_msg_ids(mld._all_items, [10, 20]);
 
-    mld.prepend([{id: 9}]);
-    assert.equal(messages_filtered_for_topic_mutes_calls, 2);
-    assert_msg_ids(mld._all_items, [9, 10]);
+    mld.prepend([{id: 9}, {id: 19}]);
+    assert.equal(unmuted_messages_calls, 2);
+    assert_msg_ids(mld._all_items, [9, 19, 10, 20]);
 
-    mld.append([{id: 11}]);
-    assert.equal(messages_filtered_for_topic_mutes_calls, 3);
-    assert_msg_ids(mld._all_items, [9, 10, 11]);
+    mld.append([{id: 11}, {id: 21}]);
+    assert.equal(unmuted_messages_calls, 3);
+    assert_msg_ids(mld._all_items, [9, 19, 10, 20, 11, 21]);
 
     mld.remove([9]);
-    assert_msg_ids(mld._all_items, [10, 11]);
+    assert_msg_ids(mld._all_items, [19, 10, 20, 11, 21]);
+
+    mld.reorder_messages(20);
+    assert_msg_ids(mld._all_items, [10, 11, 19, 20, 21]);
 
     mld.clear();
     assert_msg_ids(mld._all_items, []);

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -42,7 +42,6 @@ function assert_msg_ids(messages, msg_ids) {
 run_test("basics", () => {
     const mld = new MessageListData({
         excludes_muted_topics: false,
-        filter: undefined,
     });
 
     assert.equal(mld.is_search(), false);
@@ -109,7 +108,6 @@ run_test("basics", () => {
 run_test("muting", () => {
     let mld = new MessageListData({
         excludes_muted_topics: false,
-        filter: undefined,
     });
 
     const msgs = [
@@ -147,7 +145,6 @@ run_test("muting", () => {
     // and update `_all_items` when `excludes_muted_topics` is true.
     mld = new MessageListData({
         excludes_muted_topics: true,
-        filter: undefined,
     });
     assert.deepEqual(mld._all_items, []);
 
@@ -179,7 +176,6 @@ run_test("muting", () => {
     // filtering the messages.
     mld = new MessageListData({
         excludes_muted_topics: true,
-        filter: undefined,
     });
 
     const orig_messages = [
@@ -227,7 +223,6 @@ run_test("muting", () => {
 run_test("errors", () => {
     const mld = new MessageListData({
         excludes_muted_topics: false,
-        filter: undefined,
     });
     assert.equal(mld.get("bogus-id"), undefined);
 

--- a/frontend_tests/node_tests/narrow_local.js
+++ b/frontend_tests/node_tests/narrow_local.js
@@ -179,9 +179,9 @@ run_test("is private with no target", () => {
         },
         has_found_newest: true,
         all_messages: [
-            {id: 450, type: "private"},
-            {id: 500, type: "private"},
-            {id: 550, type: "private"},
+            {id: 450, type: "private", to_user_ids: "1,2"},
+            {id: 500, type: "private", to_user_ids: "1,2"},
+            {id: 550, type: "private", to_user_ids: "1,2"},
         ],
         expected_id_info: {
             target_id: undefined,
@@ -244,9 +244,9 @@ run_test("is:private with target and no unreads", () => {
         empty: false,
         all_messages: [
             {id: 350},
-            {id: 400, type: "private"},
-            {id: 450, type: "private"},
-            {id: 500, type: "private"},
+            {id: 400, type: "private", to_user_ids: "1,2"},
+            {id: 450, type: "private", to_user_ids: "1,2"},
+            {id: 500, type: "private", to_user_ids: "1,2"},
         ],
         expected_id_info: {
             target_id: 450,

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -411,18 +411,18 @@ export function update_messages(events) {
     // propagated edits to be updated (since the topic edits can have
     // changed the correct grouping of messages).
     if (topic_edited || stream_changed) {
-        message_lists.home.update_topic_muting_and_rerender();
+        message_lists.home.update_muting_and_rerender();
         // However, we don't need to rerender message_list.narrowed if
         // we just changed the narrow earlier in this function.
         //
         // TODO: We can potentially optimize this logic to avoid
-        // calling `update_topic_muting_and_rerender` if the muted
+        // calling `update_muting_and_rerender` if the muted
         // messages would not match the view before or after this
         // edit.  Doing so could save significant work, since most
         // topic edits will not match the current topic narrow in
         // large organizations.
         if (!changed_narrow && message_lists.current === message_list.narrowed) {
-            message_list.narrowed.update_topic_muting_and_rerender();
+            message_list.narrowed.update_muting_and_rerender();
         }
     } else {
         // If the content of the message was edited, we do a special animation.

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -395,6 +395,9 @@ export class MessageList {
         // to do this is in the message_events.js code path for
         // processing topic edits, since that's the only place we'll
         // call this frequently anyway.
+        //
+        // But in any case, we need to rerender the list for user muting,
+        // to make sure only the right messages are hidden.
         this.rerender();
     }
 

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -383,8 +383,8 @@ export class MessageList {
         }
     }
 
-    update_topic_muting_and_rerender() {
-        this.data.update_items_for_topic_muting();
+    update_muting_and_rerender() {
+        this.data.update_items_for_muting();
         // We need to rerender whether or not the narrow hides muted
         // topics, because we need to update recipient bars for topics
         // we've muted when we are displaying those topics.

--- a/static/js/message_list_data.js
+++ b/static/js/message_list_data.js
@@ -178,6 +178,11 @@ export class MessageListData {
     }
 
     messages_filtered_for_user_mutes(messages) {
+        if (this.filter.is_non_huddle_pm()) {
+            // We are in a 1:1 PM narrow, so do not do any filtering.
+            return [...messages];
+        }
+
         return messages.filter((message) => {
             if (message.type !== "private") {
                 return true;

--- a/static/js/message_list_data.js
+++ b/static/js/message_list_data.js
@@ -186,7 +186,7 @@ export class MessageListData {
         return this.messages_filtered_for_topic_mutes(messages);
     }
 
-    update_items_for_topic_muting() {
+    update_items_for_muting() {
         if (!this.excludes_muted_topics) {
             return;
         }

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -25,9 +25,9 @@ import * as unread_ui from "./unread_ui";
 
 export function rerender_for_muted_topic(old_muted_topics) {
     stream_list.update_streams_sidebar();
-    message_lists.current.update_topic_muting_and_rerender();
+    message_lists.current.update_muting_and_rerender();
     if (message_lists.current !== message_lists.home) {
-        message_lists.home.update_topic_muting_and_rerender();
+        message_lists.home.update_muting_and_rerender();
     }
     if (overlays.settings_open() && settings_muted_topics.loaded) {
         settings_muted_topics.populate_list();

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -157,9 +157,9 @@ export function unmute_user(user_id) {
 }
 
 export function rerender_for_muted_user() {
-    message_lists.current.rerender();
+    message_lists.current.update_muting_and_rerender();
     if (message_lists.current !== message_lists.home) {
-        message_lists.home.rerender();
+        message_lists.home.update_muting_and_rerender();
     }
 
     if (overlays.settings_open() && settings_muted_users.loaded) {


### PR DESCRIPTION
#8040

Implementation plan at https://chat.zulip.org/api/mute-user

### Remaining tasks
- [ ] Hide 1:1 PMs from muted user everywhere
- [x] Stream messages and huddle - tuck away under "Click to reveal" dialogue
- [x] Exclude muted users from typeaheads
- [x] Exclude muted users from typing status
- [ ] Make UI for muting/unmuting users available in production, and add a /help document.


<details><summary>PRs and commits which were merged as parts of this feature</summary>

- Commits for API work → 89f61395059788fe7c43bfd023b285441ee22370, 3bfcaa39689c9996cb7eb0ec65bd37f727074f6e, 1de9444242950d0f54e1e554aeb6e400ef8ad474
- Follow up work from 3bfcaa39689c9996cb7eb0ec65bd37f727074f6e → #18045
- All backend commits → #18086
- Buddy list work → #18218
- UI work (dev-only) → #18233 

</details>
