### PR TITLE
markdown: Add support to shorten GitHub links.

### DIFF
--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -561,6 +561,58 @@ inline.zulip = merge({}, inline.breaks, {
     ()
 });
 
+function shorten_links(href) {
+  // This value must match what is used in the backend.
+  const COMMIT_ID_PREFIX_LENGTH = 12;
+  const url = new URL(href);
+  if (url.protocol === 'https:' && ['github.com'].includes(url.hostname)) {
+    // The following part of the code was necessary because unlike Python, str.split
+    // method in javascript does not return the remaining part of the string.
+    var parts = url.pathname.split('/').slice(1);
+    parts = parts.slice(0, 4)
+      .concat(parts.slice(4).join('/'))
+      .concat(Array(5).fill(''))
+      .slice(0, 5);
+
+    const organisation = parts[0]
+      , repository = parts[1]
+      , artifact = parts[2]
+      , value = parts[3]
+      , remaining_path = parts[4];
+
+    if (!organisation || !repository || !artifact || !value) {
+      return href;
+    }
+
+    const repo_short_text = organisation + '/' + repository;
+
+    if (remaining_path || url.hash) {
+      return href;
+    }
+
+    if (url.hostname === 'github.com') {
+      return shorten_github_links(href, artifact, repo_short_text,
+                                  value, COMMIT_ID_PREFIX_LENGTH);
+    }
+  }
+  return href;
+}
+
+/**
+ * Shorten GitHub Links
+ */
+
+function shorten_github_links(href, artifact, repo_short_text,
+                              value, commit_id_prefix_length) {
+  if (['pull', 'issues'].includes(artifact)) {
+    return repo_short_text + '#' + value;
+  }
+  if (artifact == 'commit') {
+    return repo_short_text + '@' + value.slice(0, commit_id_prefix_length);
+  }
+  return href;
+}
+
 /**
  * Inline Lexer & Compiler
  */
@@ -682,8 +734,8 @@ InlineLexer.prototype.output = function(src) {
     // url (gfm)
     if (!this.inLink && (cap = this.rules.url.exec(src))) {
       src = src.substring(cap[0].length);
-      text = escape(cap[1]);
-      href = text;
+      href = escape(cap[1]);
+      text = shorten_links(href)
       out += this.renderer.link(href, null, text);
       continue;
     }

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -932,6 +932,121 @@
       "input": "<h1>*<h1>[<h2>Static types in Python</h2>](https://blog.zulip.com/2016/10/13/static-types-in-python-oh-mypy)</h1>*</h1>",
       "expected_output": "<p>&lt;h1&gt;<em>&lt;h1&gt;<a href=\"https://blog.zulip.com/2016/10/13/static-types-in-python-oh-mypy\">&lt;h2&gt;Static types in Python&lt;/h2&gt;</a>&lt;/h1&gt;</em>&lt;/h1&gt;</p>",
       "marked_expected_output": "<p>&lt;h1&gt;<em>&lt;h1&gt;<a href=\"https://blog.zulip.com/2016/10/13/static-types-in-python-oh-mypy\">&lt;h2&gt;Static types in Python&lt;/h2&gt;</a>&lt;/h1&gt;</em>&lt;/h1&gt;\n\n</p>"
+    },
+    {
+      "name": "auto_shorten_github_repo_link",
+      "input": "https://github.com/zulip/zulip-mobile",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile\">https://github.com/zulip/zulip-mobile</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_issues_link",
+      "input": "https://github.com/zulip/zulip-mobile/issues/11895",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/issues/11895\">zulip/zulip-mobile#11895</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_pull_link",
+      "input": "https://github.com/zulip/zulip-mobile/pull/16665",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/pull/16665\">zulip/zulip-mobile#16665</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_commit_link",
+      "input": "https://github.com/zulip/zulip-mobile/commit/620e9cbf72ca729534aba41693d7ab2872caa394",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/commit/620e9cbf72ca729534aba41693d7ab2872caa394\">zulip/zulip-mobile@620e9cbf72ca</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_commits_link",
+      "input": "https://github.com/zulip/zulip-mobile/pull/16860/commits/19e96bcea616e6e9b1a3c10f25930ac1f75d4f92",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/pull/16860/commits/19e96bcea616e6e9b1a3c10f25930ac1f75d4f92\">https://github.com/zulip/zulip-mobile/pull/16860/commits/19e96bcea616e6e9b1a3c10f25930ac1f75d4f92</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_pull_initial_comment_link",
+      "input": "https://github.com/zulip/zulip-mobile/pull/16665#issue-513297835",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/pull/16665#issue-513297835\">https://github.com/zulip/zulip-mobile/pull/16665#issue-513297835</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_pull_comment_link",
+      "input": "https://github.com/zulip/zulip-mobile/pull/16665#issuecomment-719814618",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/pull/16665#issuecomment-719814618\">https://github.com/zulip/zulip-mobile/pull/16665#issuecomment-719814618</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_issues_initial_comment_link",
+      "input": "https://github.com/zulip/zulip-mobile/issues/16579#issue-725908927",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/issues/16579#issue-725908927\">https://github.com/zulip/zulip-mobile/issues/16579#issue-725908927</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_issues_comment_link",
+      "input": "https://github.com/zulip/zulip-mobile/issues/16482#issuecomment-726354516",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/issues/16482#issuecomment-726354516\">https://github.com/zulip/zulip-mobile/issues/16482#issuecomment-726354516</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_files_link",
+      "input": "https://github.com/zulip/zulip-mobile/pull/16860/files",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/pull/16860/files\">https://github.com/zulip/zulip-mobile/pull/16860/files</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_files_comment_link",
+      "input": "https://github.com/zulip/zulip-mobile/pull/16860/files#r539133612",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/pull/16860/files#r539133612\">https://github.com/zulip/zulip-mobile/pull/16860/files#r539133612</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_repo_issues_link",
+      "input": "https://github.com/zulip/zulip-mobile/issues",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/issues\">https://github.com/zulip/zulip-mobile/issues</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_repo_pull_link",
+      "input": "https://github.com/zulip/zulip-mobile/pull",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/pull\">https://github.com/zulip/zulip-mobile/pull</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_repo_commit_link",
+      "input": "https://github.com/zulip/zulip-mobile/commit",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/commit\">https://github.com/zulip/zulip-mobile/commit</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_repo_clone_link",
+      "input": "https://github.com/zulip/zulip-mobile.git",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile.git\">https://github.com/zulip/zulip-mobile.git</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_repo_labels_link",
+      "input": "https://github.com/zulip/zulip-mobile/labels",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/labels\">https://github.com/zulip/zulip-mobile/labels</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_labels_link",
+      "input": "https://github.com/zulip/zulip-mobile/labels/area%3A%20markdown",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/labels/area%3A%20markdown\">https://github.com/zulip/zulip-mobile/labels/area%3A%20markdown</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_tree_link",
+      "input": "https://github.com/zulip/zulip-mobile/tree/chat.zulip.org",
+      "expected_output": "<p><a href=\"https://github.com/zulip/zulip-mobile/tree/chat.zulip.org\">https://github.com/zulip/zulip-mobile/tree/chat.zulip.org</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_marketplace_circleci_link",
+      "input": "https://github.com/marketplace/circleci",
+      "expected_output": "<p><a href=\"https://github.com/marketplace/circleci\">https://github.com/marketplace/circleci</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_foo_bar_baz_link",
+      "input": "https://github.com/foo/bar/baz",
+      "expected_output": "<p><a href=\"https://github.com/foo/bar/baz\">https://github.com/foo/bar/baz</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_foo_bar_baz_zar_link",
+      "input": "https://github.com/foo/bar/baz/zar",
+      "expected_output": "<p><a href=\"https://github.com/foo/bar/baz/zar\">https://github.com/foo/bar/baz/zar</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_marketplace_link",
+      "input": "https://github.com/marketplace",
+      "expected_output": "<p><a href=\"https://github.com/marketplace\">https://github.com/marketplace</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_link",
+      "input": "https://github.com",
+      "expected_output": "<p><a href=\"https://github.com\">https://github.com</a></p>"
     }
   ],
   "linkify_tests": [


### PR DESCRIPTION
Support added to shorten GitHub links.

Logic added in frontend and backend Markdown Processor are identical.
This makes easy upgradation for other services like gitlab.

Fixes zulip#11895.


**Testing plan:** <!-- How have you tested? -->
New test cases are added.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
| Before | After |
| --- | --- |
| `https://github.com/zulip/zulip/issues/11895` | `zulip/zulip#11895` |
| `https://github.com/zulip/zulip/pull/16665` | `zulip/zulip#16665` |
| `https://github.com/zulip/zulip/commit/620e9cbf72ca729534aba41693d7ab2872caa394` | `zulip/zulip@620e9cbf72` |
| `https://github.com/zulip/zulip/issues/11895#issuecomment-476370010` | `zulip/zulip#11895#issuecomment-476370010` |
| `https://github.com/zulip/zulip/pull/16665#issuecomment-719814618` | `zulip/zulip#16665#issuecomment-719814618` |
| `https://github.com/zulip/zulip/pull/16860/files#r539133612` | `zulip/zulip#16860/files#r539133612` |