### PR TITLE
tooltip: Hide tooltip for touch events on touch-enabled devices.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -536,6 +536,23 @@ strong {
         background-color: hsla(0, 0%, 7%, 0.8);
         padding: 3px 5px;
     }
+
+    /*
+    Since hover and click are activated together on touchscreen
+    devices, the hover state persists until the next click, creating
+    awkward UI where the tooltip sticks around forever :(.
+
+    To resolve this, we just hide the tooltip for touch-events on
+    touch-enabled devices resolving the above problem.  This means
+    that tooltips will never appear on touchscreen devices, but that's
+    probably a reasoanble tradeoff here.
+
+    Source: https://drafts.csswg.org/mediaqueries-4/#mf-interaction
+    */
+
+    @media (hover: none) {
+        visibility: hidden !important;
+    }
 }
 
 .buddy_list_tooltip_content {


### PR DESCRIPTION
Fixes #16674.
An another approach as mentioned in #16710 
The commit hides the tooltip for touch events on touch enabled device. Touch events trigger both click and hover action, leaving the hover action sustained until next click. Hence it is better to hide the tooltip to avoid the clutter in UI.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

Tested locally

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


![Mentioned-messages--Zulip](https://user-images.githubusercontent.com/55033316/102526360-8a69fe00-40c1-11eb-9e6a-ed85ac84763a.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
