### PR TITLE
realm_emoji: Avoided overriding of custom emoji with default emojis

### DIFF
--- a/zerver/lib/emoji.py
+++ b/zerver/lib/emoji.py
@@ -23,6 +23,7 @@ if not os.path.exists(emoji_codes_path):  # nocoverage
 with open(emoji_codes_path, "rb") as fp:
     emoji_codes = orjson.loads(fp.read())
 
+all_emoji_names = emoji_codes["names"]
 name_to_codepoint = emoji_codes["name_to_codepoint"]
 codepoint_to_name = emoji_codes["codepoint_to_name"]
 EMOTICON_CONVERSIONS = emoji_codes["emoticon_conversions"]
@@ -107,10 +108,12 @@ def check_emoji_admin(user_profile: UserProfile, emoji_name: Optional[str]=None)
 
 def check_valid_emoji_name(emoji_name: str) -> None:
     if emoji_name:
-        if re.match(r'^[0-9a-z.\-_]+(?<![.\-_])$', emoji_name):
-            return
-        raise JsonableError(_("Invalid characters in emoji name"))
-    raise JsonableError(_("Emoji name is missing"))
+        if not re.match(r'^[0-9a-z.\-_]+(?<![.\-_])$', emoji_name):
+            raise JsonableError(_("Invalid characters in emoji name"))
+        elif emoji_name in all_emoji_names:
+            raise JsonableError(_("Default emoji exists with similar name"))
+    else:
+        raise JsonableError(_("Emoji name is missing"))
 
 def get_emoji_url(emoji_file_name: str, realm_id: int) -> str:
     return upload_backend.get_emoji_url(emoji_file_name, realm_id)


### PR DESCRIPTION
Realm custom emojis can override default emoji when the owner/admin adds an emoji with a name that already exists within emoji catalog.

<strong>Screenshots :</strong>

![fix](https://user-images.githubusercontent.com/53977614/102528166-2f85d600-40c4-11eb-8092-34270d2ce518.gif)


Fixes #16913
