### PR TITLE
Email address visibility: Display current value of setting during account creation.

### DIFF
--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -657,6 +657,31 @@ html {
     }
 }
 
+
+.email-vis-tooltip:hover .email-vis-tooltip-text{
+    visibility: visible;
+}
+
+.email-vis-tooltip {
+    position: relative;
+    display: inline-block;
+    border-radius: 100%; 
+}
+
+.email-vis-tooltip .email-vis-tooltip-text {
+    visibility: hidden;
+    width: max-content;
+    background-color: rgba(0, 0, 0, 0.7);
+    color: #fff;
+    text-align: center;
+    padding: 2px 10px;
+    border-radius: 6px;
+    position: absolute;
+    z-index: 1;
+    font-weight: 300;
+}
+
+
 .confirm-email-change-page .white-box {
     max-width: 500px;
 }

--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -657,30 +657,29 @@ html {
     }
 }
 
-
-.email-vis-tooltip:hover .email-vis-tooltip-text{
+.email-vis-tooltip:hover .email-vis-tooltip-text {
     visibility: visible;
 }
 
 .email-vis-tooltip {
     position: relative;
     display: inline-block;
-    border-radius: 100%; 
+    border-radius: 100%;
 }
 
 .email-vis-tooltip .email-vis-tooltip-text {
     visibility: hidden;
     width: max-content;
-    background-color: rgba(0, 0, 0, 0.7);
-    color: #fff;
+    background-color: hsla(0, 100%, 0%, 0.7);
+    color: hsl(0, 100%, 100%);
     text-align: center;
     padding: 2px 10px;
     border-radius: 6px;
     position: absolute;
     z-index: 1;
     font-weight: 300;
+    margin-left: 10px;
 }
-
 
 .confirm-email-change-page .white-box {
     max-width: 500px;

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -101,11 +101,20 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                 <div class="input-box no-validation">
                     <input type='hidden' name='key' value='{{ key }}' />
                     <input type='hidden' name='timezone' id='timezone'/>
-                    <label for="id_email" class="inline-block label-title">{{ _('Email') }} 
+                    <label for="id_email" class="inline-block label-title">
+                        {{ _('Email') }}
                         <span class="email-vis-tooltip">
-                            <span class="fa fa-question-circle"></span>
+                            <span class="fa fa-question-circle-o"></span>
                             <span class="email-vis-tooltip-text">
-                                Only Administrators in the Zulip organization will be able to see this email address.
+                                {% if EMAIL_ADDRESS_VISIBILITY == "1" %}
+                                All the admins, members and guests will be able to see this email address.
+                                {% elif EMAIL_ADDRESS_VISIBILITY == "3" %}
+                                Only admins will be able to see this email address.
+                                {% elif EMAIL_ADDRESS_VISIBILITY == "4" %}
+                                Nobody will be able to see this email address.
+                                {% else %}
+                                Everyone will be able to see this email address.
+                                {% endif %}
                             </span>
                         </span>
                     </label>

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -101,7 +101,14 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                 <div class="input-box no-validation">
                     <input type='hidden' name='key' value='{{ key }}' />
                     <input type='hidden' name='timezone' id='timezone'/>
-                    <label for="id_email" class="inline-block label-title">{{ _('Email') }}</label>
+                    <label for="id_email" class="inline-block label-title">{{ _('Email') }} 
+                        <span class="email-vis-tooltip">
+                            <span class="fa fa-question-circle"></span>
+                            <span class="email-vis-tooltip-text">
+                                Only Administrators in the Zulip organization will be able to see this email address.
+                            </span>
+                        </span>
+                    </label>
                     <div id="id_email">{{ email }}</div>
                 </div>
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -433,6 +433,7 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
                  'MAX_NAME_LENGTH': str(UserProfile.MAX_NAME_LENGTH),
                  'MAX_PASSWORD_LENGTH': str(form.MAX_PASSWORD_LENGTH),
                  'MAX_REALM_SUBDOMAIN_LENGTH': str(Realm.MAX_REALM_SUBDOMAIN_LENGTH),
+                 'EMAIL_ADDRESS_VISIBILITY': "0" if realm is None else str(realm.email_address_visibility),
                  },
     )
 


### PR DESCRIPTION
Fixes: #16920

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds a question mark(?) beside the Email text which on hovering displays the tooltip displaying the message about email address visibility.


<!-- **Testing plan:**  How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Email visibility tooltip](https://user-images.githubusercontent.com/57018360/102612893-94d6d700-4157-11eb-9d38-796fc31cf640.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
