### PR TITLE
Email address visibility: Display current setting during account creation

### DIFF
--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -739,6 +739,13 @@ button#register_auth_button_gitlab {
     }
 }
 
+.email-visibility-text {
+    font-size: small;
+    float: left;
+    font-style: italic;
+    margin-top: 20px;
+}
+
 #registration {
     width: auto;
     padding: 0;
@@ -834,8 +841,8 @@ button#register_auth_button_gitlab {
 
     #id_email {
         font-weight: normal;
-        margin: 2px;
-        padding-top: 25px;
+        margin-top: 2px;
+        padding: auto;
         text-align: left;
         overflow-wrap: break-word;
     }

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -103,11 +103,11 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                     <input type='hidden' name='timezone' id='timezone'/>
                     <label for="id_email" class="inline-block label-title">{{ _('Email') }}</label>
                     <div class="email-visibility-text">
-                        {% if EMAIL_ADDRESS_VISIBILITY == "1" %}
-                        All the admins, members and guests will be able to see this email address.
-                        {% elif EMAIL_ADDRESS_VISIBILITY == "3" %}
+                        {% if EMAIL_ADDRESS_VISIBILITY == EMAIL_ADDRESS_VISIBILITY_EVERYONE %}
+                        Everyone will be able to see this email address.
+                        {% elif EMAIL_ADDRESS_VISIBILITY == EMAIL_ADDRESS_VISIBILITY_ADMINS %}
                         Only admins will be able to see this email address.
-                        {% elif EMAIL_ADDRESS_VISIBILITY == "4" %}
+                        {% elif EMAIL_ADDRESS_VISIBILITY == EMAIL_ADDRESS_VISIBILITY_NOBODY %}
                         Nobody will be able to see this email address.
                         {% else %}
                         Everyone will be able to see this email address.

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -102,7 +102,20 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                     <input type='hidden' name='key' value='{{ key }}' />
                     <input type='hidden' name='timezone' id='timezone'/>
                     <label for="id_email" class="inline-block label-title">{{ _('Email') }}</label>
-                    <div id="id_email">{{ email }}</div>
+                    <div class="email-visibility-text">
+                        {% if EMAIL_ADDRESS_VISIBILITY == "1" %}
+                        All the admins, members and guests will be able to see this email address.
+                        {% elif EMAIL_ADDRESS_VISIBILITY == "3" %}
+                        Only admins will be able to see this email address.
+                        {% elif EMAIL_ADDRESS_VISIBILITY == "4" %}
+                        Nobody will be able to see this email address.
+                        {% else %}
+                        Everyone will be able to see this email address.
+                        {% endif %}
+                    </div>
+                    <div class="input-box">
+                        <input id="id_email" type="text" value="{{ email }}" disabled />
+                    </div>
                 </div>
 
                 {% if accounts %}

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -431,10 +431,10 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
                  'MAX_NAME_LENGTH': str(UserProfile.MAX_NAME_LENGTH),
                  'MAX_PASSWORD_LENGTH': str(form.MAX_PASSWORD_LENGTH),
                  'MAX_REALM_SUBDOMAIN_LENGTH': str(Realm.MAX_REALM_SUBDOMAIN_LENGTH),
-                 'EMAIL_ADDRESS_VISIBILITY': str(realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE) if realm is None else str(realm.email_address_visibility),
-                 'EMAIL_ADDRESS_VISIBILITY_EVERYONE': str(realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE),
-                 'EMAIL_ADDRESS_VISIBILITY_ADMINS': str(realm.EMAIL_ADDRESS_VISIBILITY_ADMINS),
-                 'EMAIL_ADDRESS_VISIBILITY_NOBODY': str(realm.EMAIL_ADDRESS_VISIBILITY_NOBODY),
+                 'EMAIL_ADDRESS_VISIBILITY': str(Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE) if realm is None else str(realm.email_address_visibility),
+                 'EMAIL_ADDRESS_VISIBILITY_EVERYONE': str(Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE),
+                 'EMAIL_ADDRESS_VISIBILITY_ADMINS': str(Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS),
+                 'EMAIL_ADDRESS_VISIBILITY_NOBODY': str(Realm.EMAIL_ADDRESS_VISIBILITY_NOBODY),
                  },
     )
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -431,6 +431,7 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
                  'MAX_NAME_LENGTH': str(UserProfile.MAX_NAME_LENGTH),
                  'MAX_PASSWORD_LENGTH': str(form.MAX_PASSWORD_LENGTH),
                  'MAX_REALM_SUBDOMAIN_LENGTH': str(Realm.MAX_REALM_SUBDOMAIN_LENGTH),
+                 'EMAIL_ADDRESS_VISIBILITY': "0" if realm is None else str(realm.email_address_visibility),
                  },
     )
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -431,7 +431,10 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
                  'MAX_NAME_LENGTH': str(UserProfile.MAX_NAME_LENGTH),
                  'MAX_PASSWORD_LENGTH': str(form.MAX_PASSWORD_LENGTH),
                  'MAX_REALM_SUBDOMAIN_LENGTH': str(Realm.MAX_REALM_SUBDOMAIN_LENGTH),
-                 'EMAIL_ADDRESS_VISIBILITY': "0" if realm is None else str(realm.email_address_visibility),
+                 'EMAIL_ADDRESS_VISIBILITY': str(realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE) if realm is None else str(realm.email_address_visibility),
+                 'EMAIL_ADDRESS_VISIBILITY_EVERYONE': str(realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE),
+                 'EMAIL_ADDRESS_VISIBILITY_ADMINS': str(realm.EMAIL_ADDRESS_VISIBILITY_ADMINS),
+                 'EMAIL_ADDRESS_VISIBILITY_NOBODY': str(realm.EMAIL_ADDRESS_VISIBILITY_NOBODY),
                  },
     )
 


### PR DESCRIPTION
This commit displays a line of text of email visibility according
to the email_address_visibility setting. It also includes a change
regarding the styling of the actual email address.

Fixes: #16920

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


<!--**Testing plan:** How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![In small text below title email](https://user-images.githubusercontent.com/57018360/102672079-ec0b9480-41b5-11eb-8f61-4f07c1c4567a.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
