### PR TITLE
vagrant: Add a setting to downgrade VirtualBox Guest Additions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,6 +58,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   vm_memory = "2048"
 
   ubuntu_mirror = ""
+  vboxadd_version = nil
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/srv/zulip"
@@ -77,6 +78,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       when "GUEST_CPUS"; vm_num_cpus = value
       when "GUEST_MEMORY_MB"; vm_memory = value
       when "UBUNTU_MIRROR"; ubuntu_mirror = value
+      when "VBOXADD_VERSION"; vboxadd_version = value
       end
     end
   end
@@ -118,6 +120,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # It's possible we can get away with just 1.5GB; more testing needed
     vb.memory = vm_memory
     vb.cpus = vm_num_cpus
+
+    if !vboxadd_version.nil?
+      override.vbguest.installer = Class.new(VagrantVbguest::Installers::Ubuntu) do
+        define_method(:host_version) do |reload = false|
+          VagrantVbguest::Version(vboxadd_version)
+        end
+      end
+      override.vbguest.allow_downgrade = true
+      override.vbguest.iso_path = "https://download.virtualbox.org/virtualbox/#{vboxadd_version}/VBoxGuestAdditions_#{vboxadd_version}.iso"
+    end
   end
 
   config.vm.provider "parallels" do |prl, override|

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -894,12 +894,19 @@ This error is caused by a
 [bug](https://www.virtualbox.org/ticket/19004) in recent versions of
 the VirtualBox Guest Additions for Linux on Windows hosts.  It has not
 been fixed upstream as of this writing, but you may be able to work
-around it by removing the plugin that upgrades Guest Additions:
+around it by downgrading VirtualBox Guest Additions to 6.0.4.  To do
+this, create a `~/.zulip-vagrant-config` file and add this line:
 
 ```
-vagrant destroy
-vagrant plugin uninstall vagrant-vbguest
-vagrant up --provider=virtualbox
+VBOXADD_VERSION 6.0.4
+```
+
+Then run these commands (yes, reload is needed twice):
+
+```
+vagrant plugin install vagrant-vbguest
+vagrant reload
+vagrant reload --provision
 ```
 
 ### Specifying an Ubuntu mirror


### PR DESCRIPTION
It seems our Ubuntu base image now has a new enough VirtualBox Guest Additions to trigger the ETXTBSY bug even when it’s not upgraded by the vagrant-vbguest plugin. Provide and document a way to downgrade it.

**Testing plan:** Provisioned on Windows.