### PR TITLE
custom_emojis: Fix unresponsiveness after submitting without a name.

### DIFF
--- a/static/js/settings_emoji.js
+++ b/static/js/settings_emoji.js
@@ -183,6 +183,16 @@ exports.set_up = function () {
                 emoji[obj.name] = obj.value;
             }
 
+            if (emoji.name === "") {
+                ui_report.message(
+                    i18n.t("Failed: You must provide a name to the emoji."),
+                    emoji_status,
+                    "alert-error",
+                );
+                $("#admin_emoji_submit").prop("disabled", false);
+                return;
+            }
+
             for (const [i, file] of Array.prototype.entries.call($("#emoji_file_input")[0].files)) {
                 formData.append("file-" + i, file);
             }


### PR DESCRIPTION
While adding custom emojis, when a user clicks on the submit
button without providing a name to the emoji, the submit button
becomes unresponsive. This commit fixes that.

NOTE: I have changed the error message to
"Failed: You must provide a name to the emoji."

Fixes #16921

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested manually.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![zulip](https://user-images.githubusercontent.com/58626718/102692921-cc6b7f00-423c-11eb-8ba1-356336dddca6.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
