### PR TITLE
Improve the find my team page.

### DIFF
--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -50,6 +50,15 @@ html {
     font-size: 0.8em;
 }
 
+.disabled-submit-button {
+    background-color: hsl(0, 0%, 50%) !important;
+    cursor: not-allowed;
+}
+
+.invalid-error-text {
+    display: none;
+}
+
 .app-main {
     .login-page-header {
         font-size: 1.5em;

--- a/templates/zerver/find_account.html
+++ b/templates/zerver/find_account.html
@@ -40,7 +40,7 @@
                             <input type="text" autofocus id="emails" name="emails" required />
                             <label for="emails">{{ _('Email addresses') }}</label>
                         </div>
-                        <button type="submit">{{ _('Find accounts') }}</button>
+                        <button type="submit" id="submit_button">{{ _('Find accounts') }}</button>
                     </div>
                     <div><i>{{ form.emails.help_text }}</i></div>
                 </form>
@@ -50,6 +50,40 @@
                     <div class="alert alert-error">{{ error }}</div>
                     {% endfor %}
                 {% endif %}
+                <div class="alert alert-error invalid-error-text" id="invalid_emails_text">Enter a valid email address</div>
+                <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+                <script id="button_logic">
+                    $(document).ready(function(){
+                        $("#emails").on("change", function(){
+                            validateEmails(document.getElementById("emails").value);
+                        });
+                    });
+
+                    function validateEmails(val){
+                        if (val && validate(val.split(","))) {
+                            document.getElementById("submit_button").disabled = false;
+                            document.getElementById("submit_button").className = "";
+                            document.getElementById("invalid_emails_text").className = "alert alert-error invalid-error-text";
+                        } else {
+                            document.getElementById("submit_button").disabled = true;
+                            document.getElementById("submit_button").className = "disabled-submit-button";
+                            document.getElementById("invalid_emails_text").className = "alert alert-error";
+                        }
+                    }
+
+                    function validate(emailList){
+                        var re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+                        var valid = true;
+
+                        emailList.forEach(function(element) {
+                            if (!re.test(element.trim())) {
+                                valid = false;
+                            }
+                        });
+
+                        return valid;
+                    }
+                </script>
             </div>
             {% endif %}
         </div>

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -4154,9 +4154,7 @@ class TestFindMyTeam(ZulipTestCase):
         # We capitalize a letter in cordelia's email to test that the search is case-insensitive.
         result = self.client_post('/accounts/find/',
                                   dict(emails="iago@zulip.com,cordeliA@zulip.com"))
-        self.assertEqual(result.status_code, 302)
-        self.assertEqual(result.url, "/accounts/find/?emails=iago%40zulip.com%2CcordeliA%40zulip.com")
-        result = self.client_get(result.url)
+        self.assertEqual(result.status_code, 200)
         content = result.content.decode('utf8')
         self.assertIn("Emails sent! You will only receive emails", content)
         self.assertIn("iago@zulip.com", content)
@@ -4169,9 +4167,7 @@ class TestFindMyTeam(ZulipTestCase):
     def test_find_team_ignore_invalid_email(self) -> None:
         result = self.client_post('/accounts/find/',
                                   dict(emails="iago@zulip.com,invalid_email@zulip.com"))
-        self.assertEqual(result.status_code, 302)
-        self.assertEqual(result.url, "/accounts/find/?emails=iago%40zulip.com%2Cinvalid_email%40zulip.com")
-        result = self.client_get(result.url)
+        self.assertEqual(result.status_code, 200)
         content = result.content.decode('utf8')
         self.assertIn("Emails sent! You will only receive emails", content)
         self.assertIn(self.example_email("iago"), content)
@@ -4202,8 +4198,8 @@ class TestFindMyTeam(ZulipTestCase):
     def test_find_team_one_email(self) -> None:
         data = {'emails': self.example_email("hamlet")}
         result = self.client_post('/accounts/find/', data)
-        self.assertEqual(result.status_code, 302)
-        self.assertEqual(result.url, '/accounts/find/?emails=hamlet%40zulip.com')
+        self.assertIn('Emails sent! You will only receive emails', result.content.decode('utf8'))
+        self.assertEqual(result.status_code, 200)
         from django.core.mail import outbox
         self.assertEqual(len(outbox), 1)
 
@@ -4211,8 +4207,8 @@ class TestFindMyTeam(ZulipTestCase):
         do_deactivate_user(self.example_user("hamlet"))
         data = {'emails': self.example_email("hamlet")}
         result = self.client_post('/accounts/find/', data)
-        self.assertEqual(result.status_code, 302)
-        self.assertEqual(result.url, '/accounts/find/?emails=hamlet%40zulip.com')
+        self.assertIn('Emails sent! You will only receive emails', result.content.decode('utf8'))
+        self.assertEqual(result.status_code, 200)
         from django.core.mail import outbox
         self.assertEqual(len(outbox), 0)
 
@@ -4220,16 +4216,15 @@ class TestFindMyTeam(ZulipTestCase):
         do_deactivate_realm(get_realm("zulip"))
         data = {'emails': self.example_email("hamlet")}
         result = self.client_post('/accounts/find/', data)
-        self.assertEqual(result.status_code, 302)
-        self.assertEqual(result.url, '/accounts/find/?emails=hamlet%40zulip.com')
+        self.assertIn('Emails sent! You will only receive emails', result.content.decode('utf8'))
+        self.assertEqual(result.status_code, 200)
         from django.core.mail import outbox
         self.assertEqual(len(outbox), 0)
 
     def test_find_team_bot_email(self) -> None:
         data = {'emails': self.example_email("webhook_bot")}
         result = self.client_post('/accounts/find/', data)
-        self.assertEqual(result.status_code, 302)
-        self.assertEqual(result.url, '/accounts/find/?emails=webhook-bot%40zulip.com')
+        self.assertEqual(result.status_code, 200)
         from django.core.mail import outbox
         self.assertEqual(len(outbox), 0)
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -1,6 +1,5 @@
 import logging
 import smtplib
-import urllib
 from typing import Dict, List, Optional
 from urllib.parse import urlencode
 
@@ -618,26 +617,12 @@ def find_account(request: HttpRequest) -> HttpResponse:
                 )
                 send_email('zerver/emails/find_team', to_user_ids=[user.id], context=context,
                            from_address=FromAddress.SUPPORT)
-
-            # Note: Show all the emails in the result otherwise this
-            # feature can be used to ascertain which email addresses
-            # are associated with Zulip.
-            data = urllib.parse.urlencode({'emails': ','.join(emails)})
-            return redirect(add_query_to_redirect_url(url, data))
     else:
         form = FindMyTeamForm()
-        result = request.GET.get('emails')
-        # The below validation is perhaps unnecessary, in that we
-        # shouldn't get able to get here with an invalid email unless
-        # the user hand-edits the URLs.
-        if result:
-            for email in result.split(','):
-                try:
-                    validators.validate_email(email)
-                    emails.append(email)
-                except ValidationError:
-                    pass
 
+    # Note: Show all the emails in the result otherwise this
+    # feature can be used to ascertain which email addresses
+    # are associated with Zulip.
     return render(request,
                   'zerver/find_account.html',
                   context={'form': form, 'current_url': lambda: url,


### PR DESCRIPTION
Partially implemented #3128

- [x] You shouldn't be able to click "Find team" if you don't have a valid list of email addresses. Slack does this really nicely: https://slack.com/signin/find
- [ ] We should send an email regardless of whether they are in a Zulip org or not.
- [ ] The followup page should have links to resend the email or enter a different email address.
- [x] The URL of the followup page currently has the email as a URL parameter, which should be removed.

**Testing plan:**
Tried many invalid types of inputs to confirm that the user can not click the "Find Team" button unless the input has all valid emails.
Checked if the email list was still showing up on the URL on the follow-up page. Tested original functionality of the follow-up page as well by confirming that the emails still showed up in the content.

**GIFs or screenshots:**
Greyed out and disabled button when the user entered invalid input:
![image](https://user-images.githubusercontent.com/37922108/102697168-c3a98780-4201-11eb-8974-788561387bd1.png)