### PR TITLE
i18n: Use browser locale to set default language of user and realm

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -164,6 +164,13 @@ def require_billing_access(func: ViewFuncT) -> ViewFuncT:
     return cast(ViewFuncT, wrapper)  # https://github.com/python/mypy/issues/1927
 
 
+def get_browser_locale(request: HttpRequest) -> Optional[str]:
+    browser_locale = request.META.get("HTTP_ACCEPT_LANGUAGE")
+    if not browser_locale:
+        return None
+    return browser_locale.split(",")[0]
+
+
 def process_client(
     request: HttpRequest,
     user_profile: UserProfile,

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1053,6 +1053,10 @@ def do_change_realm_subdomain(
     do_deactivate_realm(placeholder_realm, acting_user=None)
     do_add_deactivated_redirect(placeholder_realm, realm.uri)
 
+def do_set_realm_default_language(realm: Realm, default_language: str) -> None:
+    realm.default_language = default_language
+    realm.save(update_fields=["default_language"])
+
 
 def do_add_deactivated_redirect(realm: Realm, redirect_url: str) -> None:
     realm.deactivated_redirect = redirect_url

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -610,6 +610,7 @@ def do_create_user(
     tos_version: Optional[str] = None,
     timezone: str = "",
     avatar_source: str = UserProfile.AVATAR_FROM_GRAVATAR,
+    default_language: str = "en",
     default_sending_stream: Optional[Stream] = None,
     default_events_register_stream: Optional[Stream] = None,
     default_all_public_streams: Optional[bool] = None,
@@ -632,6 +633,7 @@ def do_create_user(
         tos_version=tos_version,
         timezone=timezone,
         avatar_source=avatar_source,
+        default_language=default_language,
         default_sending_stream=default_sending_stream,
         default_events_register_stream=default_events_register_stream,
         default_all_public_streams=default_all_public_streams,
@@ -1067,6 +1069,7 @@ def do_change_realm_subdomain(
     placeholder_realm = do_create_realm(old_subdomain, "placeholder-realm")
     do_deactivate_realm(placeholder_realm, acting_user=None)
     do_add_deactivated_redirect(placeholder_realm, realm.uri)
+
 
 def do_set_realm_default_language(realm: Realm, default_language: str) -> None:
     realm.default_language = default_language

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -121,6 +121,7 @@ def create_user(
     tos_version: Optional[str] = None,
     timezone: str = "",
     avatar_source: str = UserProfile.AVATAR_FROM_GRAVATAR,
+    default_language: Optional[str] = None,
     is_mirror_dummy: bool = False,
     default_sending_stream: Optional[Stream] = None,
     default_events_register_stream: Optional[Stream] = None,
@@ -145,6 +146,10 @@ def create_user(
     user_profile.timezone = timezone
     user_profile.default_sending_stream = default_sending_stream
     user_profile.default_events_register_stream = default_events_register_stream
+    user_profile.default_language = (
+        default_language if default_language is not None else realm.default_language
+    )
+
     if role is not None:
         user_profile.role = role
     # Allow the ORM default to be used if not provided

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -76,6 +76,12 @@ def get_available_language_codes() -> List[str]:
     return codes
 
 
+def get_available_language_locales() -> List[str]:
+    language_list = get_language_list()
+    locales = [language["locale"] for language in language_list]
+    return locales
+
+
 def get_language_translation_data(language: str) -> Dict[str, str]:
     if language == "en":
         return {}

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -125,52 +125,53 @@ def send_initial_realm_messages(realm: Realm) -> None:
     # Make sure each stream created in the realm creation process has at least one message below
     # Order corresponds to the ordering of the streams on the left sidebar, to make the initial Home
     # view slightly less overwhelming
-    content_of_private_streams_topic = (
-        _("This is a private stream, as indicated by the lock icon next to the stream name.")
-        + " "
-        + _("Private streams are only visible to stream members.")
-        + "\n"
-        "\n"
-        + _(
-            "To manage this stream, go to [Stream settings]({stream_settings_url}) "
-            "and click on `{initial_private_stream_name}`."
+    with override_language(realm.default_language):
+        content_of_private_streams_topic = (
+            _("This is a private stream, as indicated by the lock icon next to the stream name.")
+            + " "
+            + _("Private streams are only visible to stream members.")
+            + "\n"
+            "\n"
+            + _(
+                "To manage this stream, go to [Stream settings]({stream_settings_url}) "
+                "and click on `{initial_private_stream_name}`."
+            )
+        ).format(
+            stream_settings_url="#streams/subscribed",
+            initial_private_stream_name=Realm.INITIAL_PRIVATE_STREAM_NAME,
         )
-    ).format(
-        stream_settings_url="#streams/subscribed",
-        initial_private_stream_name=Realm.INITIAL_PRIVATE_STREAM_NAME,
-    )
 
-    content1_of_topic_demonstration_topic = (
-        _(
-            "This is a message on stream #**{default_notification_stream_name}** with the "
-            "topic `topic demonstration`."
-        )
-    ).format(default_notification_stream_name=Realm.DEFAULT_NOTIFICATION_STREAM_NAME)
+        content1_of_topic_demonstration_topic = (
+            _(
+                "This is a message on stream #**{default_notification_stream_name}** with the "
+                "topic `topic demonstration`."
+            )
+        ).format(default_notification_stream_name=Realm.DEFAULT_NOTIFICATION_STREAM_NAME)
 
-    content2_of_topic_demonstration_topic = (
-        _("Topics are a lightweight tool to keep conversations organized.")
-        + " "
-        + _("You can learn more about topics at [Streams and topics]({about_topics_help_url}).")
-    ).format(about_topics_help_url="/help/about-streams-and-topics")
+        content2_of_topic_demonstration_topic = (
+            _("Topics are a lightweight tool to keep conversations organized.")
+            + " "
+            + _("You can learn more about topics at [Streams and topics]({about_topics_help_url}).")
+        ).format(about_topics_help_url="/help/about-streams-and-topics")
 
-    content_of_swimming_turtles_topic = (
-        _(
-            "This is a message on stream #**{default_notification_stream_name}** with the "
-            "topic `swimming turtles`."
+        content_of_swimming_turtles_topic = (
+            _(
+                "This is a message on stream #**{default_notification_stream_name}** with the "
+                "topic `swimming turtles`."
+            )
+            + "\n"
+            "\n"
+            "[](/static/images/cute/turtle.png)"
+            "\n"
+            "\n"
+            + _(
+                "[Start a new topic]({start_topic_help_url}) any time you're not replying to a \
+            previous message."
+            )
+        ).format(
+            default_notification_stream_name=Realm.DEFAULT_NOTIFICATION_STREAM_NAME,
+            start_topic_help_url="/help/start-a-new-topic",
         )
-        + "\n"
-        "\n"
-        "[](/static/images/cute/turtle.png)"
-        "\n"
-        "\n"
-        + _(
-            "[Start a new topic]({start_topic_help_url}) any time you're not replying to a \
-        previous message."
-        )
-    ).format(
-        default_notification_stream_name=Realm.DEFAULT_NOTIFICATION_STREAM_NAME,
-        start_topic_help_url="/help/start-a-new-topic",
-    )
 
     welcome_messages: List[Dict[str, str]] = [
         {

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -3,6 +3,7 @@ from typing import Dict, List
 from django.conf import settings
 from django.db.models import Count
 from django.utils.translation import gettext as _
+from django.utils.translation import override as override_language
 
 from zerver.lib.actions import (
     create_users,
@@ -69,32 +70,35 @@ def send_initial_pms(user: UserProfile) -> None:
             + "\n"
         ).format(help_url=help_url)
 
-    content = (
-        _("Hello, and welcome to Zulip!") + "\n"
-        "\n"
-        + _("This is a private message from me, Welcome Bot.")
-        + " "
-        + _("Here are some tips to get you started:")
-        + "\n"
-        "* " + _("Download our [Desktop and mobile apps]({apps_url})") + "\n"
-        "* "
-        + _("Customize your account and notifications on your [Settings page]({settings_url})")
-        + "\n"
-        "* " + _("Type `?` to check out Zulip's keyboard shortcuts") + "\n"
-        "{organization_setup_text}"
-        "\n" + _("The most important shortcut is `r` to reply.") + "\n"
-        "\n"
-        + _("Practice sending a few messages by replying to this conversation.")
-        + " "
-        + _(
-            "If you're not into keyboards, that's okay too; "
-            "clicking anywhere on this message will also do the trick!"
+    with override_language(user.default_language):
+        content = (
+            _("Hello, and welcome to Zulip!") + "\n"
+            "\n"
+            + _("This is a private message from me, Welcome Bot.")
+            + " "
+            + _("Here are some tips to get you started:")
+            + "\n"
+            "* " + _("Download our [Desktop and mobile apps]({apps_url})") + "\n"
+            "* "
+            + _("Customize your account and notifications on your [Settings page]({settings_url})")
+            + "\n"
+            "* " + _("Type `?` to check out Zulip's keyboard shortcuts") + "\n"
+            "{organization_setup_text}"
+            "\n" + _("The most important shortcut is `r` to reply.") + "\n"
+            "\n"
+            + _("Practice sending a few messages by replying to this conversation.")
+            + " "
+            + _(
+                "If you're not into keyboards, that's okay too; "
+                "clicking anywhere on this message will also do the trick!"
+            )
         )
-    )
 
-    content = content.format(
-        apps_url="/apps", settings_url="#settings", organization_setup_text=organization_setup_text
-    )
+        content = content.format(
+            apps_url="/apps",
+            settings_url="#settings",
+            organization_setup_text=organization_setup_text,
+        )
 
     internal_send_private_message(get_system_bot(settings.WELCOME_BOT), user, content)
 

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -636,6 +636,7 @@ Output:
             "from_confirmation": from_confirmation,
             "default_stream_group": default_stream_groups,
             "source_realm_id": source_realm_id,
+            "default_language": "en",
         }
         if realm_in_root_domain is not None:
             payload["realm_in_root_domain"] = realm_in_root_domain

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -18,6 +18,7 @@ from zerver.decorator import (
     authenticated_rest_api_view,
     authenticated_uploads_api_view,
     cachify,
+    get_browser_locale,
     internal_notify_view,
     is_local_addr,
     rate_limit,
@@ -124,6 +125,20 @@ class DecoratorTestCase(ZulipTestCase):
             "HTTP_USER_AGENT"
         ] = "Mozilla/5.0 (Linux; Android 8.0.0; SM-G930F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36"
         self.assertEqual(parse_client(req), ("Mozilla", None))
+
+    def test_get_browser_locale(self) -> None:
+        req = HostRequestMock()
+        req.META["HTTP_ACCEPT_LANGUAGE"] = "fr,en,de"
+        self.assertEqual(get_browser_locale(req), "fr")
+
+        req.META["HTTP_ACCEPT_LANGUAGE"] = "en-us"
+        self.assertEqual(get_browser_locale(req), "en-us")
+
+        req.META["HTTP_ACCEPT_LANGUAGE"] = "en-us,fr,zh-cn"
+        self.assertEqual(get_browser_locale(req), "en-us")
+
+        req.META["HTTP_ACCEPT_LANGUAGE"] = ""
+        self.assertIsNone(get_browser_locale(req))
 
     def test_REQ_aliases(self) -> None:
         @has_request_variables

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -16,6 +16,7 @@ from zerver.lib.actions import (
     do_deactivate_stream,
     do_scrub_realm,
     do_send_realm_reactivation_email,
+    do_set_realm_default_language,
     do_set_realm_property,
 )
 from zerver.lib.realm_description import get_realm_rendered_description, get_realm_text_description
@@ -263,6 +264,13 @@ class RealmTest(ZulipTestCase):
         do_add_deactivated_redirect(realm, new_redirect_url)
         self.assertEqual(realm.deactivated_redirect, new_redirect_url)
         self.assertNotEqual(realm.deactivated_redirect, redirect_url)
+
+    def test_do_set_realm_default_language(self) -> None:
+        realm = get_realm("zulip")
+        self.assertTrue(realm.default_language, "en")
+        do_set_realm_default_language(realm, "de")
+        realm.refresh_from_db()
+        self.assertEqual(realm.default_language, "de")
 
     def test_realm_reactivation_link(self) -> None:
         realm = get_realm("zulip")


### PR DESCRIPTION
### What this PR for
This PR aims to solve the issue https://github.com/zulip/zulip/issues/16288 and https://github.com/zulip/zulip/issues/16221
#### During New Organization Creation:
- [x] Use browser locale to set the `default_language` of a user while user registration.
- [x] Use browser locale to set the `default_language` of the realm while realm registration.
- [x] Create a function to fetch the browser locale.
#### During New User signup:
- [x] Check weather the browser locale is among the locale we support or else set default to `realm.default_language` during user creation.
#### Inconsistency with Welcome Bot:
- [x] Fix the inconsistant translations of the `Welcome Bot`. 
- [x] Create separate commits for welcome bot personal messages and messages to the streams.
- [x] Complete test coverage.

Link to the conversation: https://chat.zulip.org/#narrow/stream/2-general/topic/Set.20language.20.20same.20as.20browser.20locale.2E/near/1082710

https://user-images.githubusercontent.com/53316982/113515692-acfe2500-9593-11eb-9c6b-77eb65f49187.mp4