### PR TITLE
hotspots: Add "Restart Tutorial" option to gear menu.

### DIFF
--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -22,6 +22,7 @@ link:  Help center
 info:  Keyboard shortcuts
 info:  Message formatting
 info:  Search operators
+hotspot:  Restart tutorial
 ---
 link:  Desktop & mobile apps
 link:  Integrations
@@ -70,6 +71,8 @@ using a click handler in static/js/click_handlers.js.
 The click handler uses "[data-overlay-trigger]" as
 the selector and then calls hash_change.go_to_location.
 
+The "hotspot" item uses a click handler in static/js/hotspots.js
+to call a server API endpoint which restarts the tutorial.
 */
 
 // We want to remember how far we were scrolled on each 'tab'.

--- a/static/js/hotspots.js
+++ b/static/js/hotspots.js
@@ -5,6 +5,7 @@ import render_hotspot_overlay from "../templates/hotspot_overlay.hbs";
 import render_intro_reply_hotspot from "../templates/intro_reply_hotspot.hbs";
 
 import * as channel from "./channel";
+import * as gear_menu from "./gear_menu";
 import * as popovers from "./popovers";
 
 // popover orientations
@@ -69,6 +70,15 @@ export function post_hotspot_as_read(hotspot_name) {
     channel.post({
         url: "/json/users/me/hotspots",
         data: {hotspot: JSON.stringify(hotspot_name)},
+        error(err) {
+            blueslip.error(err.responseText);
+        },
+    });
+}
+
+function reset_tutorial_hotspots() {
+    channel.post({
+        url: "/json/users/me/hotspots/reset",
         error(err) {
             blueslip.error(err.responseText);
         },
@@ -285,4 +295,11 @@ export function load_new(new_hotspots) {
 
 export function initialize() {
     load_new(page_params.hotspots);
+
+    $("body").on("click", "#restart_tutorial", (e) => {
+        e.stopPropagation();
+        page_params.hotspots = [];
+        reset_tutorial_hotspots();
+        gear_menu.close();
+    });
 }

--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -97,6 +97,11 @@
                                     <i class="fa fa-search" aria-hidden="true"></i> {{ _('Search operators') }}
                                 </a>
                             </li>
+                            <li role="presentation">
+                                <a tabindex="0" role="menuitem" id="restart_tutorial">
+                                    <i class="fa fa-info-circle" aria-hidden="true"></i> {{ _('Restart tutorial') }}
+                                </a>
+                            </li>
                             {% if corporate_enabled %}
                             <li role="presentation">
                                 <a href="/help/contact-support" target="_blank" rel="noopener noreferrer" role="menuitem">

--- a/zerver/tests/test_hotspots.py
+++ b/zerver/tests/test_hotspots.py
@@ -1,6 +1,6 @@
 import orjson
 
-from zerver.lib.actions import do_create_user, do_mark_hotspot_as_read
+from zerver.lib.actions import do_create_user, do_mark_hotspot_as_read, do_reset_tutorial_hotspots
 from zerver.lib.hotspots import ALL_HOTSPOTS, INTRO_HOTSPOTS, get_next_hotspots
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import UserHotspot, UserProfile, get_realm
@@ -48,6 +48,14 @@ class TestHotspots(ZulipTestCase):
             ["intro_compose"],
         )
 
+    def test_do_reset_tutorial_hotspots(self) -> None:
+        user = self.example_user("hamlet")
+        do_reset_tutorial_hotspots(user)
+        self.assertEqual(user.tutorial_status, UserProfile.TUTORIAL_STARTED)
+        self.assertEqual(
+            len(list(UserHotspot.objects.filter(user=user, hotspot__in=INTRO_HOTSPOTS.keys()))), 0
+        )
+
     def test_hotspots_url_endpoint(self) -> None:
         user = self.example_user("hamlet")
         self.login_user(user)
@@ -68,3 +76,9 @@ class TestHotspots(ZulipTestCase):
             list(UserHotspot.objects.filter(user=user).values_list("hotspot", flat=True)),
             ["intro_reply"],
         )
+
+    def test_reset_all_hotspots_endpoint(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        result = self.client_post("/json/users/me/hotspots/reset")
+        self.assert_json_success(result)

--- a/zerver/views/hotspots.py
+++ b/zerver/views/hotspots.py
@@ -2,7 +2,7 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
 from zerver.decorator import human_users_only
-from zerver.lib.actions import do_mark_hotspot_as_read
+from zerver.lib.actions import do_mark_hotspot_as_read, do_reset_tutorial_hotspots
 from zerver.lib.hotspots import ALL_HOTSPOTS
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_error, json_success
@@ -18,4 +18,10 @@ def mark_hotspot_as_read(
     if hotspot not in ALL_HOTSPOTS:
         return json_error(_("Unknown hotspot: {}").format(hotspot))
     do_mark_hotspot_as_read(user, hotspot)
+    return json_success()
+
+
+@human_users_only
+def reset_tutorial_hotspots(request: HttpRequest, user: UserProfile) -> HttpResponse:
+    do_reset_tutorial_hotspots(user)
     return json_success()

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -57,7 +57,7 @@ from zerver.views.drafts import create_drafts, delete_draft, edit_draft, fetch_d
 from zerver.views.email_mirror import email_mirror_message
 from zerver.views.events_register import events_register_backend
 from zerver.views.home import accounts_accept_terms, desktop_home, home
-from zerver.views.hotspots import mark_hotspot_as_read
+from zerver.views.hotspots import mark_hotspot_as_read, reset_tutorial_hotspots
 from zerver.views.invite import (
     generate_multiuse_invite_backend,
     get_user_invites,
@@ -391,14 +391,12 @@ v1_api_and_json_patterns = [
     ),
     rest_path("users/me/avatar", POST=set_avatar_backend, DELETE=delete_avatar_backend),
     # users/me/hotspots -> zerver.views.hotspots
+    #
+    # These endpoints are low priority for documentation as they
+    # are a part of the webapp-specific tutorial.
+    rest_path("users/me/hotspots", POST=(mark_hotspot_as_read, {"intentionally_undocumented"})),
     rest_path(
-        "users/me/hotspots",
-        POST=(
-            mark_hotspot_as_read,
-            # This endpoint is low priority for documentation as
-            # it is part of the webapp-specific tutorial.
-            {"intentionally_undocumented"},
-        ),
+        "users/me/hotspots/reset", POST=(reset_tutorial_hotspots, {"intentionally_undocumented"})
     ),
     # users/me/tutorial_status -> zerver.views.tutorial
     rest_path(


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR contains a series of commits adding a gear menu to restart the hotspots tutorial. The commits are organized as follows:
* The first commit contains small typo fixes.
* The second introduces the backend API to reset the hotspots, and backend tests for the same.
* The third introduces the button and links it to call the API (I went with the `fa-info-circle` icon for the option).
* The last includes a bugfix (which can be reproduced easily with the steps mentioned in the commit description).

**Testing plan:** <!-- How have you tested? -->
Manually testing performed. Backend tests added as well.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
Fixes: #6050 