### PR TITLE
Fixed_Shift_in_User_Invite_copy_Icon

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -435,7 +435,7 @@ li,
     outline-color: hsl(0, 0%, 73%);
     height: 18px;
     width: 10px;
-    padding: 6px 6px;
+    padding: 7px 3px 0px 12px;
     display: block;
     /* The below two avoids the padded element from displaying
     it's own border and background color */

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -435,7 +435,7 @@ li,
     outline-color: hsl(0, 0%, 73%);
     height: 18px;
     width: 10px;
-    padding: 7px 3px 0px 12px;
+    padding: 7px 3px 0px 12px ;
     display: block;
     /* The below two avoids the padded element from displaying
     it's own border and background color */


### PR DESCRIPTION


<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/16868

**Front End : About changing the location of the Copy Icon {General Invite Link}**
Its about the position of the Copy icon in the General Invite link ;when we press it is dislocated .
So task is to adjust it when we click it.
Changed the CSS of the element , Now it working fine and I dropped an image below ;  showing how it looks now .

**Testing plan:** <!-- How have you tested? -->
Yes , all tests  succeeded .  
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot (37)](https://user-images.githubusercontent.com/60990123/102776788-63f3dd80-43b5-11eb-8a00-56589a902a32.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
