### PR TITLE
event_queue: Remove internal fields being leaked to the API.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -705,50 +705,6 @@ paths:
                                     The user's [message flags][message-flags] for the message.
                                   items:
                                     type: string
-                                email_notified:
-                                  type: boolean
-                                  deprecated: true
-                                  description: |
-                                    Whether the user receiving the event has already been
-                                    notified via email.
-
-                                    **Deprecated**: This field is present only due to a bug and
-                                    will be removed from the API.
-                                push_notified:
-                                  type: boolean
-                                  deprecated: true
-                                  description: |
-                                    Whether the user receiving the event has already been
-                                    notified via mobile notification.
-
-                                    **Deprecated**: This field is present only due to a bug and
-                                    will be removed from the API.
-                                stream_push_notify:
-                                  type: boolean
-                                  deprecated: true
-                                  description: |
-                                    Whether the user receiving the event has to be notified
-                                    via mobile notification for stream message.
-
-                                    **Deprecated**: This field is present only due to a bug and
-                                    will be removed from the API.
-                                stream_email_notify:
-                                  type: boolean
-                                  deprecated: true
-                                  description: |
-                                    Whether the user receiving the event has to be notified
-                                    via email for stream message.
-
-                                    **Deprecated**: This field is present only due to a bug and
-                                    will be removed from the API.
-                                wildcard_mention_notify:
-                                  type: boolean
-                                  deprecated: true
-                                  description: |
-                                    Whether the user has to be notified due to wildcard mention.
-
-                                    **Deprecated**: This field is present only due to a bug and
-                                    will be removed from the API.
                               additionalProperties: false
                               example:
                                 {
@@ -2820,13 +2776,6 @@ paths:
                         type: string
                         description: |
                           The ID of the registered queue.
-                      handler_id:
-                        type: integer
-                        description: |
-                          An internal field that should not be present in these API responses.
-
-                          **Deprecated**: This will be removed in a future release.
-                        deprecated: true
                     example:
                       {
                         "queue_id": "1375801870:2942",


### PR DESCRIPTION
Few internal fields, like `hander_id` and `push_notified`
bundle of fields, in the message event handling system were
being incorrectly leaked to clients. These fields can be
exposed to clients as useful hints but we have no guarantee
of a value of False correct as push notifications could be
triggered later on via `missedmessage_hook` so they should
just be removed from the API.

This commit move these extended event field on a `internal_data`
dataclass withing the event object and delete this field late
in the process of sending events.

Fixes: #15947.

