### PR TITLE
compose_buttons: Add JS tooltip to drafts, new message, new topic, ne…

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -1169,6 +1169,12 @@ exports.initialize = function () {
         },
     );
 
+    $(".compose_drafts_button").tooltip();
+    $(".compose_mobile_button").tooltip();
+    $(".compose_stream_button").tooltip();
+    $(".compose_private_button").tooltip();
+    $(".compose_reply_button").tooltip();
+
     // Click event binding for "Attach files" button
     // Triggers a click on a hidden file input field
 


### PR DESCRIPTION
Issue: Implementing all titles using JS tooltip as discussed [here](https://chat.zulip.org/#narrow/stream/9-issues/topic/Different.20styles.20of.20title)

Testing plan: Tested by hovering over it.

GIF or Screenshot:
Before:
![composeouterbefore](https://user-images.githubusercontent.com/59444243/102990575-9cbebe80-453d-11eb-9c8d-b41e7b9f7ce1.gif)

After:
![composeouterafter](https://user-images.githubusercontent.com/59444243/102990603-a9431700-453d-11eb-95f9-3fb35972bdf3.gif)
