### PR TITLE
topic-typeahead: Add autocomplete suggestions for topic editing.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -990,6 +990,28 @@ export function compose_trigger_selection(event) {
     return false;
 }
 
+export function initialize_topic_edit_typeahead(form_field, stream_name, dropup) {
+    const options = {
+        fixed: true,
+        dropup,
+        highlighter(item) {
+            return typeahead_helper.render_typeahead_item({primary: item});
+        },
+        sorter(items) {
+            const sorted = typeahead_helper.sorter(this.query, items, (x) => x);
+            if (sorted.length > 0 && !sorted.includes(this.query)) {
+                sorted.unshift(this.query);
+            }
+            return sorted;
+        },
+        source() {
+            return topics_seen_for(stream_name);
+        },
+        items: 5,
+    };
+    form_field.typeahead(options);
+}
+
 function get_header_html() {
     let tip_text = "";
     switch (this.completing) {

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -17,7 +17,7 @@
                     {{/each}}
                 </select>
                 <i class="fa fa-angle-right" aria-hidden="true" {{#unless is_stream_editable}}style="display:none"{{/unless}}></i>
-                <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" />
+                <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" autocomplete="off" />
                 <div class="message_edit_breadcrumb_messages"  style='display:none;'>
                     <label class="checkbox">
                         <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />


### PR DESCRIPTION
It addresses the autocompeletion feature asked in issue #16368.

It extends composebox_typeahead to support autocompletion
suggestions on editing the topic of a message. As topic can be edited
for a message in following ways:
(i). Inline topic edit.
(ii). Editing topic through message edit form.

The changes made in the handle_message_row_edit_keydown in
message_edit.js handle proper selection of suggestions by modifying
the way we handle pressing of enter key while one edits the topic
through message edit form. This ensures that typeahead for topic
works properly with message edit form too.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
It addresses the issue #16368.
**Testing plan:** <!-- How have you tested? -->
Testing has been done manually in development mode by editing the topics through topic edit form as well as through message edit UI.
`composebox_typeahead` tests have also been used.
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
**Inline Topic edit**
![inline-edit](https://user-images.githubusercontent.com/63504956/103087853-de6b6a00-460e-11eb-941b-801399f231a3.gif)

**Editing topic using message edit UI:**

![using message-edit](https://user-images.githubusercontent.com/63504956/103088013-749f9000-460f-11eb-9ea5-b81af05df4e7.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
