### PR TITLE
typeahead: Repositioned typeahead closer to cursor.

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "stacktrace-gps": "^3.0.4",
     "style-loader": "^2.0.0",
     "terser-webpack-plugin": "^4.1.0",
+    "textarea-caret": "^3.1.0",
     "turndown": "^7.0.0",
     "url-loader": "^4.1.1",
     "webfonts-loader": "^7.0.1",

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -1018,6 +1018,7 @@ exports.initialize_compose_typeahead = function (selector) {
         items: exports.max_num_items,
         dropup: true,
         fixed: true,
+        shift: true,
         // Performance note: We have trivial matcher/sorters to do
         // matching and sorting inside the `source` field to avoid
         // O(n) behavior in the number of users in the organization
@@ -1077,6 +1078,7 @@ exports.initialize = function () {
         },
         items: 3,
         fixed: true,
+        shift: true,
         highlighter(item) {
             return typeahead_helper.render_typeahead_item({primary: item});
         },
@@ -1095,6 +1097,7 @@ exports.initialize = function () {
         },
         items: 3,
         fixed: true,
+        shift: true,
         highlighter(item) {
             return typeahead_helper.render_typeahead_item({primary: item});
         },
@@ -1112,6 +1115,7 @@ exports.initialize = function () {
         items: exports.max_num_items,
         dropup: true,
         fixed: true,
+        shift: true,
         highlighter(item) {
             return typeahead_helper.render_person_or_user_group(item);
         },

--- a/version.py
+++ b/version.py
@@ -43,4 +43,4 @@ API_FEATURE_LEVEL = 36
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '120.0'
+PROVISION_VERSION = '121.0'

--- a/yarn.lock
+++ b/yarn.lock
@@ -12066,6 +12066,11 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+textarea-caret@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/textarea-caret/-/textarea-caret-3.1.0.tgz#5d5a35bb035fd06b2ff0e25d5359e97f2655087f"
+  integrity sha512-cXAvzO9pP5CGa6NKx0WYHl+8CHKZs8byMkt3PCJBCmq2a34YA9pO1NrQET5pzeqnBjBdToF5No4rrmkDUgQC2Q==
+
 through2-filter@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/through2-filter/-/through2-filter-3.0.0.tgz#700e786df2367c2c88cd8aa5be4cf9c1e7831254"


### PR DESCRIPTION
Added Typeahead feature to follow the cursor location when mentioning a user/group or a stream topic.

<strong>Known Issues : </strong>
There have been a few known issues with <code>textarea-caret</code> which are listed down <a href = 'https://github.com/component/textarea-caret-position#known-issues'>here</a>.

<strong>ScreenShots :</strong> 

![Screenshot from 2020-12-25 22-32-24](https://user-images.githubusercontent.com/53977614/103141628-ec0f1580-471c-11eb-93be-dfe9f8ea70cb.png)
<br/>
![Screenshot from 2020-12-25 22-33-38](https://user-images.githubusercontent.com/53977614/103141629-f0d3c980-471c-11eb-9eb4-5211cacd707e.png)

<strong>For devices with smaller narrows </strong> : 

![Screenshot from 2020-12-25 22-36-24](https://user-images.githubusercontent.com/53977614/103141631-f3362380-471c-11eb-94e1-a998c505f8be.png)

Fixes #15709