### PR TITLE
alert-box: Fix scroll bar on alert-box.

### DIFF
--- a/static/styles/alerts.css
+++ b/static/styles/alerts.css
@@ -199,8 +199,9 @@ $alert-error-red: hsl(0, 80%, 40%);
             cursor: pointer;
 
             &::after {
-                padding: 10px;
+                padding-right: 10px;
                 content: "\d7";
+                font-size: 0.9em;
             }
         }
     }


### PR DESCRIPTION
There was a weird scroll bar appearing on the alert-box
for "Unable to connect to Zulip". It was happening due to the
big font-size of exit button.

To fix this issue, I reduced the font-size of exit button and
changed padding to padding-right as only right padding is
required for exit button.

Fixes #16911.

Before
![Screenshot from 2020-12-27 20-38-57](https://user-images.githubusercontent.com/39924567/103174723-70cb7200-488a-11eb-8a6d-ca27467a06a8.png)

Now
![Screenshot from 2020-12-27 20-39-16](https://user-images.githubusercontent.com/39924567/103174721-6f01ae80-488a-11eb-9823-03d805684447.png)

