### PR TITLE
custom_emojis: Fix unresponsiveness after submitting without a name.

### DIFF
--- a/static/js/settings_emoji.js
+++ b/static/js/settings_emoji.js
@@ -175,13 +175,22 @@ exports.set_up = function () {
             e.preventDefault();
             e.stopPropagation();
             const emoji_status = $("#admin-emoji-status");
-            $("#admin_emoji_submit").prop("disabled", true);
             const emoji = {};
             const formData = new FormData();
 
             for (const obj of $(this).serializeArray()) {
                 emoji[obj.name] = obj.value;
             }
+
+            if (emoji.name.trim() === "") {
+                ui_report.message(
+                    i18n.t("Failed: Emoji name is required."),
+                    emoji_status,
+                    "alert-error",
+                );
+                return;
+            }
+            $("#admin_emoji_submit").prop("disabled", true);
 
             for (const [i, file] of Array.prototype.entries.call($("#emoji_file_input")[0].files)) {
                 formData.append("file-" + i, file);


### PR DESCRIPTION
While adding custom emojis, when a user clicks on the submit
button without providing a name to the emoji, the submit button
becomes unresponsive. This commit fixes that.

Fixes #16921

Sorry for the inconvenience. My fork got deleted so sending the PR again.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![zulip](https://user-images.githubusercontent.com/58626718/102692921-cc6b7f00-423c-11eb-8ba1-356336dddca6.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
