### PR TITLE
run-dev: Suppress the notices by third-party tools.

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -341,7 +341,7 @@ def shutdown_handler(*args: Any, **kwargs: Any) -> None:
 
 def print_listeners() -> None:
     external_host = os.getenv('EXTERNAL_HOST', 'localhost')
-    print(f"\nStarting Zulip on {CYAN}http://{external_host}:{proxy_port}/{ENDC}.  Internal ports:")
+    print(f"\nStarting Zulip on:\n\n\t{CYAN}http://{external_host}:{proxy_port}/{ENDC}\n\nInternal ports:")
     ports = [
         (proxy_port, 'Development server proxy (connect here)'),
         (django_port, 'Django'),

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -224,6 +224,16 @@ export default (_env: unknown, argv: {mode?: string}): webpack.Configuration[] =
             },
         },
         plugins: [
+            new webpack.ProgressPlugin({
+                handler(percentage) {
+                    if (percentage === 1) {
+                        console.log(
+                            "\u001B[34mi ｢wdm｣\u001B[0m:",
+                            "Webpack compilation successful.",
+                        );
+                    }
+                },
+            }),
             new DebugRequirePlugin(),
             new BundleTracker({
                 filename: production
@@ -256,6 +266,7 @@ export default (_env: unknown, argv: {mode?: string}): webpack.Configuration[] =
             },
             publicPath: "/webpack/",
             stats: "errors-only",
+            noInfo: true,
         },
     };
 


### PR DESCRIPTION
Suppress notices made by third-party tools such as
webpack to limit the `run-dev.py` startup output.
And made the terminal message a bit more clear about
accessing the server.

Fixes #16846

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Ran ```./tools/test-all```

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![webpack](https://user-images.githubusercontent.com/58626718/105514920-0fb48400-5cfa-11eb-82dc-ed5e6b37259d.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
