### PR TITLE
home: Add report-only content security policy

### DIFF
--- a/zerver/tests/test_report.py
+++ b/zerver/tests/test_report.py
@@ -204,6 +204,5 @@ class TestReport(ZulipTestCase):
         with self.assertLogs(level='WARNING') as warn_logs:
             result = self.client_post("/report/csp_violations", fixture_data, content_type="application/json")
         self.assert_json_success(result)
-        self.assertEqual(warn_logs.output, [
-            "WARNING:root:CSP Violation in Document(''). Blocked URI(''), Original Policy(''), Violated Directive(''), Effective Directive(''), Disposition(''), Referrer(''), Status Code(''), Script Sample('')"
-        ])
+        self.assertEqual(1, len(warn_logs.output))
+        self.assertTrue(warn_logs.output[0].startswith("WARNING:root:CSP Violation"))

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -232,6 +232,23 @@ def home_real(request: HttpRequest) -> HttpResponse:
                                'max_file_upload_size_mib': settings.MAX_FILE_UPLOAD_SIZE,
                                })
     patch_cache_control(response, no_cache=True, no_store=True, must_revalidate=True)
+
+    connect_src = "'self'"
+    if settings.DEVELOPMENT:
+        # Required for webpack-dev-server hot module replacement
+        connect_src = "http://localhost:9994/ ws://localhost:9994/ " + connect_src
+
+    response['Content-Security-Policy-Report-Only'] = (
+        "default-src 'self'; "
+        f"script-src 'nonce-{csp_nonce}' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'self'; "
+        f"connect-src {connect_src};"
+        "img-src 'self' data: blob: https:;"
+        "frame-src  https:; "
+        "style-src 'unsafe-inline' 'self'; "
+        "base-uri 'none'; "
+        "report-uri /report/csp_violations"
+    )
+
     return response
 
 @zulip_login_required

--- a/zerver/views/report.py
+++ b/zerver/views/report.py
@@ -153,22 +153,6 @@ def report_error(request: HttpRequest, user_profile: UserProfile, message: str=R
 @has_request_variables
 def report_csp_violations(request: HttpRequest,
                           csp_report: Dict[str, Any]=REQ(argument_type='body')) -> HttpResponse:
-    def get_attr(csp_report_attr: str) -> str:
-        return csp_report.get(csp_report_attr, '')
-
-    logging.warning("CSP Violation in Document('%s'). "
-                    "Blocked URI('%s'), Original Policy('%s'), "
-                    "Violated Directive('%s'), Effective Directive('%s'), "
-                    "Disposition('%s'), Referrer('%s'), "
-                    "Status Code('%s'), Script Sample('%s')",
-                    get_attr('document-uri'),
-                    get_attr('blocked-uri'),
-                    get_attr('original-policy'),
-                    get_attr('violated-directive'),
-                    get_attr('effective-directive'),
-                    get_attr('disposition'),
-                    get_attr('referrer'),
-                    get_attr('status-code'),
-                    get_attr('script-sample'))
+    logging.warning("CSP Violation: %s", csp_report)
 
     return json_success()


### PR DESCRIPTION
This adds a report-only CSP with a semi-conservative policy that uses
nonce for scripts and sets the default-src to self (requiring
whitelisting of third-party embeds). It could be locked down a bit more,
particularly the img-src rule, but that's something we can circle back
to at a later date.

It should also probably be applied to pages other than home (for
instance, the login page), but that can also be added later.

This also changes the /report/csp_violations endpoint to not assume that
a browser will provide a well-formed report, since current Chromium does
not conform to the format that it expected, and it's better to err on
the side of accepting some garbage that we filter later, rather than
missing real error reports.

This is based on, and hence supersedes #9065.

**Testing plan:** Clicked around in the dev server and checked the console for violations. Running this in prod will get us a much wider report of potential problems.