### PR TITLE
sent_messages: Pass correct reference of this in setTimeout.

### DIFF
--- a/static/js/sent_messages.js
+++ b/static/js/sent_messages.js
@@ -110,7 +110,7 @@ class MessageState {
         // wrong with our event loop.
 
         if (!this.received) {
-            setTimeout(this.maybe_restart_event_loop, 5000);
+            setTimeout(this.maybe_restart_event_loop.bind(this), 5000);
         }
     }
 


### PR DESCRIPTION
We explicitly bind `this` to MessageState class which otherwise
was defaulting to `window`.

This resulted in variables like `this.received` and `this.local_id`
being incorrectly interpreted by called function
as `window.(received | local_id)` which are `undefined`.
Hence, frontend thinks that the message was never received.

It was noticed since this was the common log message when
a double message send bug was observed. This change in no
was indicates fixing of the double send bug, but is hopefully
one step forward in that direction.
