### PR TITLE
compose-box: Insert quoted content at the cursor position.

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -358,9 +358,7 @@ test("quote_and_reply", ({override}) => {
         reply_type: "personal",
     };
 
-    $("#compose-textarea").caret = (pos) => {
-        assert.equal(pos, 0);
-    };
+    $("#compose-textarea").caret = noop;
 
     replaced = false;
     expected_replacement =

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -453,20 +453,18 @@ export function quote_and_reply(opts) {
         // are prone to glitches where you select the
         // text, plus it's a complicated codepath that
         // can have other unintended consequences.)
-        //
-        // Note also that we always put the quoted text
-        // above the current text, which explains us
-        // moving the caret below.  I think this is what
-        // most users will want, and it's consistent with
-        // the behavior we had on FF before this change
-        // (which may have been an accident of
-        // implementation).  If we change this decision,
-        // we'll need to make `insert_syntax_and_focus`
-        // smarter about newlines.
-        textarea.caret(0);
+
+        if (textarea.caret() !== 0) {
+            // Insert a newline before quoted message if there is
+            // already some content in the compose box and quoted
+            // message is not being inserted at the beginning.
+            textarea.caret("\n");
+        }
     } else {
         respond_to_message(opts);
     }
+
+    const prev_caret = textarea.caret();
 
     compose_ui.insert_syntax_and_focus("[Quoting…]\n", textarea);
 
@@ -488,6 +486,8 @@ export function quote_and_reply(opts) {
         content += `${fence}quote\n${message.raw_content}\n${fence}`;
         compose_ui.replace_syntax("[Quoting…]", content, textarea);
         compose_ui.autosize_textarea($("#compose-textarea"));
+        // Update textarea caret to point to the new line after quoted message.
+        textarea.caret(prev_caret + content.length + 1);
     }
 
     if (message && message.raw_content) {


### PR DESCRIPTION
Right now, on clicking `quote and reply` on any message, the quoted
message is always inserted at the top of compose-box irrespective of
the current cursor position. Also, after insertion of the quoted
message, the cursor is shifted at the end of the compose box.

This commit changes this behaviour to insertion of quoted message
at the current cursor position with a newline at the end of quote
and moving the cursor position to that newline after insertion.
A newline is added at the beginning of quoted message only if there
was some content already present in compose box before the previous
cursor position.

Tested on Google Chrome and Firefox browsers on Ubuntu dev environment.

Fixes: #16836


![quote-reply (1)](https://user-images.githubusercontent.com/39924567/103410773-d7a2a100-4b92-11eb-8593-2f9086ad6064.gif)
