### PR TITLE
Make the pricing of Standard plan more explicit in plans page

### DIFF
--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -2567,7 +2567,7 @@ nav {
     display: inline-block;
     vertical-align: bottom;
     margin: 0;
-    width: 300px;
+    width: 325px;
     height: 500px;
 
     box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
@@ -2642,8 +2642,7 @@ nav {
     position: absolute;
     bottom: 0;
     width: 100%;
-    height: 150px;
-
+    height: 170px;
     background-color: hsl(0, 0%, 93%);
 }
 
@@ -2654,7 +2653,7 @@ nav {
     top: 4px;
     left: -3px;
 
-    font-size: 2rem;
+    font-size: 1.4rem;
     font-weight: 300;
     color: hsl(0, 0%, 53%);
 }
@@ -2663,7 +2662,7 @@ nav {
     display: inline-block;
     margin-right: 2px;
 
-    font-size: 3.5em;
+    font-size: 2.5em;
     font-weight: 600;
     line-height: 0.8;
 }
@@ -2672,8 +2671,7 @@ nav {
     display: inline-block;
     vertical-align: top;
     margin-left: 15px;
-    margin-top: 4px;
-
+    margin-top: -7px;
     font-size: 0.9em;
     font-weight: 400;
     color: hsl(0, 0%, 53%);
@@ -2682,7 +2680,7 @@ nav {
 }
 
 .pricing-model .pricing-container .bottom .button {
-    margin-top: 20px;
+    margin-top: 35px;
     display: block;
     text-align: center;
 

--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -2685,6 +2685,7 @@ nav {
     text-align: center;
 
     font-size: 0.9em;
+    font-weight: 600;
 
     transition: all 0.3s ease;
 }

--- a/templates/zerver/faq.html
+++ b/templates/zerver/faq.html
@@ -91,6 +91,19 @@
             </div>
             <div class="faq">
                 <div class="question">
+                    Are users that are not actively using Zulip billed?
+                </div>
+                <p class="answer">
+                    All users are billed until they are deactivated.
+                    Deactivated users would not be billed from the
+                    subsequent billing period. See the
+                    <a href="/help/deactivate-or-reactivate-a-user">user
+                    deactivation documentation</a> for more details on
+                    deactivating a user.
+                </p>
+            </div>
+            <div class="faq">
+                <div class="question">
                     How does the free plan message limit work?
                 </div>
                 <p class="answer">

--- a/templates/zerver/plans.html
+++ b/templates/zerver/plans.html
@@ -76,9 +76,9 @@
                                     <div class="standard-price-box">
                                         <div class="price">6<span class="price-cents">.67</span></div>
                                         <div class="details">
-                                            per user per month
+                                            per user, per month, when billed annually
                                             <br />
-                                            $8/month billed monthly
+                                            $8 per user, per month, when billed monthly
                                         </div>
                                     </div>
                                     {% if realm_plan_type in [3, 4] %}


### PR DESCRIPTION
The way we show the pricing of Standard plan in /plans page can be a bit confusing for users.

For example, see https://chat.zulip.org/#narrow/stream/2-general/topic/Pricing

> Does this mean $6.67 per user per month plus $8 per month billed monthly? For example, for 10 users it would be $74.70 per month or $896.40 for an entire year?

I have updated the plans page to make the pricing of the Standard plan more explicit.  See the screenshots below for more details

### Current version

![Screenshot from 2020-12-31 21-35-51](https://user-images.githubusercontent.com/7190633/103417298-2ad71c80-4bb0-11eb-8c91-a30dc8d82dcd.png)

### Proposed change

![Screenshot from 2020-12-31 21-31-41](https://user-images.githubusercontent.com/7190633/103417168-9d93c800-4baf-11eb-8e51-2c9ec8e15841.png)


I have also included an entry on inactive users to the FAQ. The question was raised in the same thread above.

![Screenshot from 2020-12-31 21-42-57](https://user-images.githubusercontent.com/7190633/103417573-3119c880-4bb1-11eb-8abe-d16e04ab7153.png)
