### PR TITLE
stream_sidebar_row: Show full stream name on hover.

### DIFF
--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -73,14 +73,14 @@ run_test("get_and_set_muted_topics", () => {
     assert.deepEqual(muting.get_muted_topics().sort(), [
         {
             date_muted: 1577836800000,
-            date_muted_str: "Jan 01",
+            date_muted_str: "Jan\u00A001,\u00A02020",
             stream: devel.name,
             stream_id: devel.stream_id,
             topic: "java",
         },
         {
             date_muted: 1577836800000,
-            date_muted_str: "Jan 01",
+            date_muted_str: "Jan\u00A001,\u00A02020",
             stream: office.name,
             stream_id: office.stream_id,
             topic: "gossip",
@@ -99,14 +99,14 @@ run_test("get_and_set_muted_topics", () => {
     assert.deepEqual(muting.get_muted_topics().sort(), [
         {
             date_muted: 1577836800000,
-            date_muted_str: "Jan 01",
+            date_muted_str: "Jan\u00A001,\u00A02020",
             stream: social.name,
             stream_id: social.stream_id,
             topic: "breakfast",
         },
         {
             date_muted: 1577836800000,
-            date_muted_str: "Jan 01",
+            date_muted_str: "Jan\u00A001,\u00A02020",
             stream: design.name,
             stream_id: design.stream_id,
             topic: "typography",

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -31,7 +31,7 @@ run_test("settings", () => {
         assert.deepEqual(opts, [
             {
                 date_muted: 1577836800000,
-                date_muted_str: "Jan 01",
+                date_muted_str: "Jan\u00A001,\u00A02020",
                 stream: frontend.name,
                 stream_id: frontend.stream_id,
                 topic: "js",

--- a/static/templates/stream_sidebar_row.hbs
+++ b/static/templates/stream_sidebar_row.hbs
@@ -8,7 +8,7 @@
                 {{> stream_privacy }}
             </span>
 
-            <a href="{{uri}}" class="stream-name">{{name}}</a>
+            <a href="{{uri}}" title="{{name}}" class="stream-name">{{name}}</a>
 
             <div class="count"><div class="value"></div></div>
         </div>


### PR DESCRIPTION
This will help users see the full stream name for truncated
stream names in the left sidebar more easily.
