### PR TITLE
css: Change close button outline to none on focus.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -278,6 +278,10 @@ p.n-margin {
             transform: translateY(-50%);
         }
 
+        .close:focus {
+            outline: none;
+        }
+
         .alert-link {
             color: hsl(169, 100%, 88%);
             font-weight: 600;


### PR DESCRIPTION
Change close-button border focus outline to none


**Testing plan:** I've tested the both branch and on multiple browsers.


**GIFs or screenshots:**
Before
<img width="828" alt="before" src="https://user-images.githubusercontent.com/44085033/103610681-b6e99b00-4f46-11eb-98ec-793592f8989a.png">

After
<img width="828" alt="after" src="https://user-images.githubusercontent.com/44085033/103610697-c1a43000-4f46-11eb-9d76-6bce10e06562.png">