### PR TITLE
left-sidebar: Make the sidebar responsive and resizable to handle long stream names

### DIFF
--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -194,6 +194,7 @@ import "../search_pill_widget";
 import "../stream_ui_updates";
 import "../spoilers";
 import "../desktop_integration";
+import "../left_sidebar";
 
 // Import styles
 

--- a/static/js/left_sidebar.js
+++ b/static/js/left_sidebar.js
@@ -1,0 +1,37 @@
+"use strict";
+
+/* For the making the left sidebar resizable */
+const columnMiddle = $(".column-middle");
+const leftSidebar = $("#left-sidebar");
+const composeContent = $(".compose-content");
+const recipientBarMain = $(".recipient-bar-main");
+const floatingRecipientBar = $("#floating_recipient_bar");
+
+function leftSidebarResize(event) {
+    /*
+
+    This function resizes the sidebar and at the same time managing the other items
+        it increases the width of the left sidebar according to the mouse event,
+        Changes the margin-left of the column-middle class elements
+        Also changes the margin left of the compose box
+
+    */
+
+    leftSidebar.css("width", event.pageX - leftSidebar.offset().left - 8 + "px");
+    columnMiddle.css("margin-left", event.pageX - leftSidebar.offset().left + "px");
+    recipientBarMain.css(
+        "padding-left",
+        -Number.parseInt(floatingRecipientBar.css("left"), 10) + "px",
+    );
+    composeContent.css("margin-left", event.pageX - leftSidebar.offset().left + "px");
+}
+
+function stopResize() {
+    window.removeEventListener("mousemove", leftSidebarResize);
+}
+
+$("#left-sidebar-resizer").on("mousedown", (event) => {
+    event.preventDefault();
+    window.addEventListener("mousemove", leftSidebarResize);
+    window.addEventListener("mouseup", stopResize);
+});

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -506,7 +506,7 @@ a#undo_markdown_preview {
 @media (max-width: 775px) {
     .compose-content {
         margin-right: 7px;
-        margin-left: 7px;
+        margin-left: 7px !important;
     }
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2599,6 +2599,16 @@ select.inline_select_topic_edit {
     display: none;
 }
 
+#left-sidebar-resizer {
+    margin-left: -10px;
+    width: 10px;
+    height: 100%;
+    cursor: ew-resize;
+    float: left;
+    position: fixed;
+    z-index: 100;
+}
+
 /* This max-width must be synced with message_viewport.is_narrow */
 @media (max-width: 1165px) {
     .app-main,
@@ -2708,7 +2718,7 @@ select.inline_select_topic_edit {
 
                 height: 100%;
                 padding-left: 10px;
-                width: 250px;
+                width: 250px !important;
             }
         }
     }
@@ -2722,7 +2732,7 @@ select.inline_select_topic_edit {
 
     .column-middle,
     .app-main .column-middle {
-        margin-left: 7px;
+        margin-left: 7px !important;
         margin-right: 7px;
     }
 
@@ -2775,6 +2785,14 @@ select.inline_select_topic_edit {
         #searchbox .navbar-search.expanded {
             width: calc(100% - 90px);
         }
+    }
+
+    #left-sidebar-resizer {
+        display: none;
+    }
+
+    .recipient-bar-main {
+        padding-left: 0 !important;
     }
 }
 

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -93,6 +93,7 @@
             {% include "zerver/app/left_sidebar.html" %}
         </div>
         <div class="column-middle">
+            <div id="left-sidebar-resizer"></div>
             <div class="column-middle-inner tab-content">
                 <div class="tab-pane active" id="message_feed_container">
                     <div class="fixed-app" id="floating_recipient_bar">

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -69,6 +69,7 @@ EXEMPT_FILES = {
     'static/js/hotspots.js',
     'static/js/info_overlay.js',
     'static/js/invite.js',
+    'static/js/left_sidebar.js',
     'static/js/lightbox_canvas.js',
     'static/js/lightbox.js',
     'static/js/list_util.js',


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #16998 


**Testing plan:** <!-- How have you tested? -->
I have tested it on laptop, and different screen sizes using the developer tools. Ran local frontend tests also.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![Peek 2021-01-07 01-30](https://user-images.githubusercontent.com/56730716/103814674-1bf8da00-5088-11eb-80fe-8d7dc2715178.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
**Commits currently named temporarily just understandable**, once it get's ready to merge, I will squash and properly rename the commit message properly.

#### How it works
It actually first adds a strip and when you drag it as you resize a window on your desktop, it changes the css accordingly. It increases the margin right of middle columns and compose box, and increases the width of the left sidebar. Also added media rule so that it functions properly on all kind of devices.

#### What is left.
- [x] The javascript has been put in the `static/js/ui.js` for now as suggested, some tests are failing due to listener, to be fixed.
- [ ] Needs more comprehensive tests for this feature.
- [ ] Set a min and max width i.e. a limit to the the width of the left sidebar.
- [ ] Store the width in database at backend, so user need not change width everytime.

This PR aims to let a user adjust the width of left sidebar just like slack.
Relevant conversations are [here](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Stream.20name.20length.20issues/near/1092703)
