### PR TITLE
Make acting_user mandatory kwargs and transitions log to RealmAuditLog.

### DIFF
--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -1322,7 +1322,7 @@ class TestLoggingCountStats(AnalyticsTestCase):
                 "value__sum"
             ],
         )
-        do_deactivate_user(user)
+        do_deactivate_user(user, acting_user=None)
         self.assertEqual(
             0,
             RealmCount.objects.filter(property=property, subgroup=False).aggregate(Sum("value"))[
@@ -1336,7 +1336,7 @@ class TestLoggingCountStats(AnalyticsTestCase):
                 "value__sum"
             ],
         )
-        do_deactivate_user(user)
+        do_deactivate_user(user, acting_user=None)
         self.assertEqual(
             0,
             RealmCount.objects.filter(property=property, subgroup=False).aggregate(Sum("value"))[
@@ -1662,7 +1662,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
         user4 = do_create_user(
             "email4", "password", self.default_realm, "full_name", acting_user=None
         )
-        do_deactivate_user(user2)
+        do_deactivate_user(user2, acting_user=None)
         do_activate_user(user3, acting_user=None)
         do_reactivate_user(user4, acting_user=None)
         end_time = floor_to_day(timezone_now()) + self.DAY
@@ -1785,7 +1785,7 @@ class TestRealmActiveHumans(AnalyticsTestCase):
         time_zero = floor_to_day(timezone_now()) + self.DAY
         update_user_activity_interval(user1, time_zero)
         update_user_activity_interval(user2, time_zero)
-        do_deactivate_user(user2)
+        do_deactivate_user(user2, acting_user=None)
         for property in [
             "active_users_audit:is_bot:day",
             "15day_actives::day",

--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -1343,7 +1343,7 @@ class TestLoggingCountStats(AnalyticsTestCase):
                 "value__sum"
             ],
         )
-        do_reactivate_user(user)
+        do_reactivate_user(user, acting_user=None)
         self.assertEqual(
             1,
             RealmCount.objects.filter(property=property, subgroup=False).aggregate(Sum("value"))[
@@ -1664,7 +1664,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
         )
         do_deactivate_user(user2)
         do_activate_user(user3, acting_user=None)
-        do_reactivate_user(user4)
+        do_reactivate_user(user4, acting_user=None)
         end_time = floor_to_day(timezone_now()) + self.DAY
         do_fill_count_stat_at_hour(self.stat, end_time)
         for user in [user1, user3, user4]:

--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -723,7 +723,10 @@ class TestSupportEndpoint(ZulipTestCase):
         self.login("iago")
 
         do_set_realm_property(
-            get_realm("zulip"), "email_address_visibility", Realm.EMAIL_ADDRESS_VISIBILITY_NOBODY
+            get_realm("zulip"),
+            "email_address_visibility",
+            Realm.EMAIL_ADDRESS_VISIBILITY_NOBODY,
+            acting_user=None,
         )
 
         customer = Customer.objects.create(realm=get_realm("lear"), stripe_customer_id="cus_123")

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -2720,7 +2720,7 @@ class LicenseLedgerTest(StripeTestCase):
         self.local_upgrade(self.seat_count, True, CustomerPlan.ANNUAL, "token")
         user = do_create_user("email", "password", get_realm("zulip"), "name", acting_user=None)
         do_deactivate_user(user)
-        do_reactivate_user(user)
+        do_reactivate_user(user, acting_user=None)
         # Not a proper use of do_activate_user, but fine for this test
         do_activate_user(user, acting_user=None)
         ledger_entries = list(

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1531,7 +1531,7 @@ class StripeTest(StripeTestCase):
         self.assertEqual(get_latest_seat_count(realm), initial_count + 1)
 
         # Test that inactive users aren't counted
-        do_deactivate_user(user2)
+        do_deactivate_user(user2, acting_user=None)
         self.assertEqual(get_latest_seat_count(realm), initial_count)
 
         # Test guests
@@ -2719,7 +2719,7 @@ class LicenseLedgerTest(StripeTestCase):
     def test_user_changes(self) -> None:
         self.local_upgrade(self.seat_count, True, CustomerPlan.ANNUAL, "token")
         user = do_create_user("email", "password", get_realm("zulip"), "name", acting_user=None)
-        do_deactivate_user(user)
+        do_deactivate_user(user, acting_user=None)
         do_reactivate_user(user, acting_user=None)
         # Not a proper use of do_activate_user, but fine for this test
         do_activate_user(user, acting_user=None)

--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -293,8 +293,9 @@ active users in a realm.
 
     # zerver/lib/actions.py
 
-    def do_set_realm_property(realm: Realm, name: str, value: bool,
-                              acting_user: Optional[UserProfile]=None) -> None:
+    def do_set_realm_property(
+        realm: Realm, name: str, value: Any, *, acting_user: Optional[UserProfile]
+    ) -> None:
       """Takes in a realm object, the name of an attribute to update, the
          value to update and and the user who initiated the update.
       """

--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -321,7 +321,9 @@ field and send an event. For example:
 
     # zerver/lib/actions.py
 
-    def do_set_realm_authentication_methods(realm: Realm, authentication_methods: Dict[str, bool]) -> None:
+    def do_set_realm_authentication_methods(
+        realm: Realm, authentication_methods: Dict[str, bool], *, acting_user: Optional[UserProfile]
+    ) -> None:
         for key, value in list(authentication_methods.items()):
             index = getattr(realm.authentication_methods, key).number
             realm.authentication_methods.set_bit(index, int(value))

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -769,7 +769,7 @@ def active_humans_in_realm(realm: Realm) -> Sequence[UserProfile]:
 
 
 def do_set_realm_property(
-    realm: Realm, name: str, value: Any, acting_user: Optional[UserProfile] = None
+    realm: Realm, name: str, value: Any, *, acting_user: Optional[UserProfile]
 ) -> None:
     """Takes in a realm object, the name of an attribute to update, the
     value to update and and the user who initiated the update.

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -728,9 +728,7 @@ def do_activate_user(user_profile: UserProfile, *, acting_user: Optional[UserPro
     notify_created_user(user_profile)
 
 
-def do_reactivate_user(
-    user_profile: UserProfile, acting_user: Optional[UserProfile] = None
-) -> None:
+def do_reactivate_user(user_profile: UserProfile, *, acting_user: Optional[UserProfile]) -> None:
     # Unlike do_activate_user, this is meant for re-activating existing users,
     # so it doesn't reset their password, etc.
     user_profile.is_active = True

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -824,7 +824,7 @@ def do_set_realm_property(
 
 
 def do_set_realm_authentication_methods(
-    realm: Realm, authentication_methods: Dict[str, bool], acting_user: Optional[UserProfile] = None
+    realm: Realm, authentication_methods: Dict[str, bool], *, acting_user: Optional[UserProfile]
 ) -> None:
     old_value = realm.authentication_methods_dict()
     for key, value in list(authentication_methods.items()):

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -859,7 +859,8 @@ def do_set_realm_message_editing(
     allow_message_editing: bool,
     message_content_edit_limit_seconds: int,
     allow_community_topic_editing: bool,
-    acting_user: Optional[UserProfile] = None,
+    *,
+    acting_user: Optional[UserProfile],
 ) -> None:
     old_values = dict(
         allow_message_editing=realm.allow_message_editing,

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1090,7 +1090,7 @@ def do_delete_user(user_profile: UserProfile) -> None:
     if user_profile.realm.is_zephyr_mirror_realm:
         raise AssertionError("Deleting zephyr mirror users is not supported")
 
-    do_deactivate_user(user_profile)
+    do_deactivate_user(user_profile, acting_user=None)
 
     subscribed_huddle_recipient_ids = set(
         Subscription.objects.filter(
@@ -1122,7 +1122,7 @@ def do_delete_user(user_profile: UserProfile) -> None:
 
 
 def do_deactivate_user(
-    user_profile: UserProfile, acting_user: Optional[UserProfile] = None, _cascade: bool = True
+    user_profile: UserProfile, _cascade: bool = True, *, acting_user: Optional[UserProfile]
 ) -> None:
     if not user_profile.is_active:
         return
@@ -1184,7 +1184,7 @@ def do_deactivate_user(
             is_bot=True, is_active=True, bot_owner=user_profile
         )
         for profile in bot_profiles:
-            do_deactivate_user(profile, acting_user=acting_user, _cascade=False)
+            do_deactivate_user(profile, _cascade=False, acting_user=acting_user)
 
 
 def do_deactivate_stream(

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4188,7 +4188,7 @@ def do_change_default_all_public_streams(
 
 
 def do_change_user_role(
-    user_profile: UserProfile, value: int, acting_user: Optional[UserProfile] = None
+    user_profile: UserProfile, value: int, *, acting_user: Optional[UserProfile]
 ) -> None:
     old_value = user_profile.role
     user_profile.role = value

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -232,7 +232,10 @@ def stdout_suppressed() -> Iterator[IO[str]]:
 def reset_emails_in_zulip_realm() -> None:
     realm = get_realm("zulip")
     do_set_realm_property(
-        realm, "email_address_visibility", Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE
+        realm,
+        "email_address_visibility",
+        Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
+        acting_user=None,
     )
 
 

--- a/zerver/management/commands/deactivate_user.py
+++ b/zerver/management/commands/deactivate_user.py
@@ -45,5 +45,5 @@ class Command(ZulipBaseCommand):
         if not options["for_real"]:
             raise CommandError("This was a dry run. Pass -f to actually deactivate.")
 
-        do_deactivate_user(user_profile)
+        do_deactivate_user(user_profile, acting_user=None)
         print("Sessions deleted, user deactivated.")

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1515,7 +1515,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase):
     def test_social_auth_registration_without_is_signup_closed_realm(self) -> None:
         """If the user doesn't exist yet in closed realm, give an error"""
         realm = get_realm("zulip")
-        do_set_realm_property(realm, "emails_restricted_to_domains", True)
+        do_set_realm_property(realm, "emails_restricted_to_domains", True, acting_user=None)
         email = "nonexisting@phantom.com"
         name = "Full Name"
         account_data_dict = self.get_account_data_dict(email=email, name=name)
@@ -5292,7 +5292,10 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
         hamlet = self.example_user("hamlet")
         realm = get_realm("zulip")
         do_set_realm_property(
-            realm, "email_address_visibility", Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS
+            realm,
+            "email_address_visibility",
+            Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+            acting_user=None,
         )
         hamlet.refresh_from_db()
 
@@ -5855,7 +5858,7 @@ class EmailValidatorTestCase(ZulipTestCase):
         cordelia = self.example_user("cordelia")
 
         realm = inviter.realm
-        do_set_realm_property(realm, "emails_restricted_to_domains", True)
+        do_set_realm_property(realm, "emails_restricted_to_domains", True, acting_user=None)
         inviter.realm.refresh_from_db()
         error = validate_email_is_valid(
             "fred+5555@zulip.com",

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -176,7 +176,7 @@ class AuthBackendTest(ZulipTestCase):
             self.assertIsNone(result)
 
         # Reactivate the user and verify auth works again
-        do_reactivate_user(user_profile)
+        do_reactivate_user(user_profile, acting_user=None)
         result = backend.authenticate(**good_kwargs)
         self.assertEqual(user_profile, result)
 

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -777,7 +777,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         bot_email = "hambot-bot@zulip.testserver"
         bot_user = get_user(bot_email, bot_realm)
-        do_deactivate_user(bot_user)
+        do_deactivate_user(bot_user, acting_user=None)
 
         # A regular user cannot reactivate a generic bot
         self.assert_num_bots_equal(0)
@@ -963,7 +963,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_num_bots_equal(1)
 
         target_user_profile = self.example_user("othello")
-        do_deactivate_user(target_user_profile)
+        do_deactivate_user(target_user_profile, acting_user=None)
         target_user_profile = self.example_user("othello")
         self.assertFalse(target_user_profile.is_active)
         bot_info = {

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -327,7 +327,10 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         # email_address_visiblity limited to admins
         user = self.example_user("hamlet")
         do_set_realm_property(
-            user.realm, "email_address_visibility", Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS
+            user.realm,
+            "email_address_visibility",
+            Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+            acting_user=None,
         )
         user.refresh_from_db()
 

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1184,7 +1184,7 @@ class InactiveUserTest(ZulipTestCase):
         """
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
-        do_deactivate_user(user_profile)
+        do_deactivate_user(user_profile, acting_user=None)
 
         result = self.client_post(
             "/json/messages",
@@ -1249,7 +1249,7 @@ class InactiveUserTest(ZulipTestCase):
 
         """
         user_profile = self.example_user("hamlet")
-        do_deactivate_user(user_profile)
+        do_deactivate_user(user_profile, acting_user=None)
 
         result = self.login_with_return(self.example_email("hamlet"))
         self.assert_in_response("Your account is no longer active.", result)
@@ -1278,7 +1278,7 @@ class InactiveUserTest(ZulipTestCase):
             self.assertTrue(form.is_valid())
 
         # Test a mirror-dummy deactivated user.
-        do_deactivate_user(user_profile)
+        do_deactivate_user(user_profile, acting_user=None)
         user_profile.save()
 
         form = OurAuthenticationForm(request, payload)
@@ -1301,7 +1301,7 @@ class InactiveUserTest(ZulipTestCase):
 
         """
         user_profile = self.example_user("hamlet")
-        do_deactivate_user(user_profile)
+        do_deactivate_user(user_profile, acting_user=None)
 
         api_key = get_api_key(user_profile)
         url = f"/api/v1/external/jira?api_key={api_key}&stream=jira_custom"

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1134,7 +1134,7 @@ class LoginRequiredTest(ZulipTestCase):
         self.assertEqual(result.status_code, 302)
 
         # Verify succeeds if user reactivated
-        do_reactivate_user(user_profile)
+        do_reactivate_user(user_profile, acting_user=None)
         self.login_user(user_profile)
         result = self.client_get("/accounts/accept_terms/")
         self.assert_in_response("I agree to the", result)
@@ -1198,7 +1198,7 @@ class InactiveUserTest(ZulipTestCase):
         self.assert_json_error_contains(result, "Not logged in", status_code=401)
 
         # Even if a logged-in session was leaked, it still wouldn't work
-        do_reactivate_user(user_profile)
+        do_reactivate_user(user_profile, acting_user=None)
         self.login_user(user_profile)
         user_profile.is_active = False
         user_profile.save()
@@ -1656,7 +1656,7 @@ class TestAuthenticatedJsonPostViewDecorator(ZulipTestCase):
         user_profile.is_active = False
         user_profile.save()
         self.assert_json_error_contains(self._do_test(user_profile), "Account is deactivated")
-        do_reactivate_user(user_profile)
+        do_reactivate_user(user_profile, acting_user=None)
 
     def test_authenticated_json_post_view_if_user_realm_is_deactivated(self) -> None:
         user_profile = self.example_user("hamlet")

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1158,7 +1158,10 @@ class FetchAPIKeyTest(ZulipTestCase):
     def test_fetch_api_key_email_address_visibility(self) -> None:
         user = self.example_user("cordelia")
         do_set_realm_property(
-            user.realm, "email_address_visibility", Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS
+            user.realm,
+            "email_address_visibility",
+            Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+            acting_user=None,
         )
 
         self.login_user(user)

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -66,6 +66,7 @@ class EmailChangeTestCase(ZulipTestCase):
             user_profile.realm,
             "email_address_visibility",
             Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
+            acting_user=None,
         )
 
         old_email = user_profile.delivery_email
@@ -138,7 +139,12 @@ class EmailChangeTestCase(ZulipTestCase):
         data = {"email": "hamlet-new@zulip.com"}
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
-        do_set_realm_property(user_profile.realm, "email_changes_disabled", True)
+        do_set_realm_property(
+            user_profile.realm,
+            "email_changes_disabled",
+            True,
+            acting_user=None,
+        )
         url = "/json/settings"
         result = self.client_patch(url, data)
         self.assertEqual(len(mail.outbox), 0)
@@ -179,7 +185,12 @@ class EmailChangeTestCase(ZulipTestCase):
         body = email_message.body
         self.assertIn("We received a request to change the email", body)
 
-        do_set_realm_property(user_profile.realm, "email_changes_disabled", True)
+        do_set_realm_property(
+            user_profile.realm,
+            "email_changes_disabled",
+            True,
+            acting_user=None,
+        )
 
         activation_url = [s for s in body.split("\n") if s][2]
         response = self.client_get(activation_url)
@@ -207,7 +218,10 @@ class EmailChangeTestCase(ZulipTestCase):
     def test_change_delivery_email_end_to_end_with_admins_visibility(self) -> None:
         user_profile = self.example_user("hamlet")
         do_set_realm_property(
-            user_profile.realm, "email_address_visibility", Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS
+            user_profile.realm,
+            "email_address_visibility",
+            Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+            acting_user=None,
         )
 
         self.login_user(user_profile)

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1041,7 +1041,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
 
         mm_address = create_missed_message_address(user_profile, message)
 
-        do_deactivate_user(user_profile)
+        do_deactivate_user(user_profile, acting_user=None)
 
         incoming_valid_message = EmailMessage()
         incoming_valid_message.set_content("TestMissedMessageEmailMessages Body")

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -124,7 +124,7 @@ class TestCustomEmails(ZulipTestCase):
 
     def test_send_custom_email_admins_only(self) -> None:
         admin_user = self.example_user("hamlet")
-        do_change_user_role(admin_user, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(admin_user, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
 
         non_admin_user = self.example_user("cordelia")
 

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -409,7 +409,10 @@ class FetchInitialStateDataTest(ZulipTestCase):
         self.assertFalse(user_profile.is_realm_admin)
 
         do_set_realm_property(
-            user_profile.realm, "email_address_visibility", Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE
+            user_profile.realm,
+            "email_address_visibility",
+            Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
+            acting_user=None,
         )
         result = fetch_initial_state_data(user_profile)
 
@@ -417,7 +420,10 @@ class FetchInitialStateDataTest(ZulipTestCase):
             self.assertNotIn("delivery_email", value)
 
         do_set_realm_property(
-            user_profile.realm, "email_address_visibility", Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS
+            user_profile.realm,
+            "email_address_visibility",
+            Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+            acting_user=None,
         )
         result = fetch_initial_state_data(user_profile)
 
@@ -429,14 +435,20 @@ class FetchInitialStateDataTest(ZulipTestCase):
         self.assertTrue(user_profile.is_realm_admin)
 
         do_set_realm_property(
-            user_profile.realm, "email_address_visibility", Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE
+            user_profile.realm,
+            "email_address_visibility",
+            Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
+            acting_user=None,
         )
         result = fetch_initial_state_data(user_profile)
         for key, value in result["raw_users"].items():
             self.assertNotIn("delivery_email", value)
 
         do_set_realm_property(
-            user_profile.realm, "email_address_visibility", Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS
+            user_profile.realm,
+            "email_address_visibility",
+            Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+            acting_user=None,
         )
         result = fetch_initial_state_data(user_profile)
         for key, value in result["raw_users"].items():

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -392,7 +392,7 @@ class FetchInitialStateDataTest(ZulipTestCase):
     # Admin users have access to all bots in the realm_bots field
     def test_realm_bots_admin(self) -> None:
         user_profile = self.example_user("hamlet")
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         self.assertTrue(user_profile.is_realm_admin)
         result = fetch_initial_state_data(user_profile)
         self.assertTrue(len(result["realm_bots"]) > 2)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -965,7 +965,7 @@ class NormalActionsTest(BaseAction):
         do_create_default_stream_group(self.user_profile.realm, "group1", "This is group1", streams)
         group = lookup_default_stream_groups(["group1"], self.user_profile.realm)[0]
 
-        do_change_user_role(self.user_profile, UserProfile.ROLE_GUEST)
+        do_change_user_role(self.user_profile, UserProfile.ROLE_GUEST, acting_user=None)
         venice_stream = get_stream("Venice", self.user_profile.realm)
         self.verify_action(
             lambda: do_add_streams_to_default_stream_group(
@@ -983,7 +983,7 @@ class NormalActionsTest(BaseAction):
         check_default_streams("events[0]", events[0])
 
     def test_default_streams_events_guest(self) -> None:
-        do_change_user_role(self.user_profile, UserProfile.ROLE_GUEST)
+        do_change_user_role(self.user_profile, UserProfile.ROLE_GUEST, acting_user=None)
         stream = get_stream("Scotland", self.user_profile.realm)
         self.verify_action(
             lambda: do_add_default_stream(stream), state_change_expected=False, num_events=0
@@ -1180,9 +1180,11 @@ class NormalActionsTest(BaseAction):
         # for email being passed into this next function.
         self.user_profile.refresh_from_db()
 
-        do_change_user_role(self.user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(self.user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         for role in [UserProfile.ROLE_REALM_ADMINISTRATOR, UserProfile.ROLE_MEMBER]:
-            events = self.verify_action(lambda: do_change_user_role(self.user_profile, role))
+            events = self.verify_action(
+                lambda: do_change_user_role(self.user_profile, role, acting_user=None)
+            )
             check_realm_user_update("events[0]", events[0], "role")
             self.assertEqual(events[0]["person"]["role"], role)
 
@@ -1194,9 +1196,11 @@ class NormalActionsTest(BaseAction):
         # for email being passed into this next function.
         self.user_profile.refresh_from_db()
 
-        do_change_user_role(self.user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(self.user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         for role in [UserProfile.ROLE_REALM_OWNER, UserProfile.ROLE_MEMBER]:
-            events = self.verify_action(lambda: do_change_user_role(self.user_profile, role))
+            events = self.verify_action(
+                lambda: do_change_user_role(self.user_profile, role, acting_user=None)
+            )
             check_realm_user_update("events[0]", events[0], "role")
             self.assertEqual(events[0]["person"]["role"], role)
 
@@ -1208,9 +1212,11 @@ class NormalActionsTest(BaseAction):
         # for email being passed into this next function.
         self.user_profile.refresh_from_db()
 
-        do_change_user_role(self.user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(self.user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         for role in [UserProfile.ROLE_GUEST, UserProfile.ROLE_MEMBER]:
-            events = self.verify_action(lambda: do_change_user_role(self.user_profile, role))
+            events = self.verify_action(
+                lambda: do_change_user_role(self.user_profile, role, acting_user=None)
+            )
             check_realm_user_update("events[0]", events[0], "role")
             self.assertEqual(events[0]["person"]["role"], role)
 
@@ -1705,7 +1711,9 @@ class NormalActionsTest(BaseAction):
         self.assertEqual(events[0]["upload_space_used"], 0)
 
     def test_notify_realm_export(self) -> None:
-        do_change_user_role(self.user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(
+            self.user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None
+        )
         self.login_user(self.user_profile)
 
         with mock.patch(
@@ -1757,7 +1765,9 @@ class NormalActionsTest(BaseAction):
         )
 
     def test_notify_realm_export_on_failure(self) -> None:
-        do_change_user_role(self.user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(
+            self.user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None
+        )
         self.login_user(self.user_profile)
 
         with mock.patch(

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1140,6 +1140,7 @@ class NormalActionsTest(BaseAction):
                     allow_message_editing,
                     message_content_edit_limit_seconds,
                     False,
+                    acting_user=None,
                 )
             )
             check_realm_update_dict("events[0]", events[0])

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1488,7 +1488,7 @@ class NormalActionsTest(BaseAction):
     def test_do_reactivate_user(self) -> None:
         bot = self.create_bot("test")
         do_deactivate_user(bot)
-        action = lambda: do_reactivate_user(bot)
+        action = lambda: do_reactivate_user(bot, acting_user=None)
         events = self.verify_action(action, num_events=2)
         check_realm_bot_add("events[1]", events[1])
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1480,14 +1480,14 @@ class NormalActionsTest(BaseAction):
 
     def test_do_deactivate_user(self) -> None:
         bot = self.create_bot("test")
-        action = lambda: do_deactivate_user(bot)
+        action = lambda: do_deactivate_user(bot, acting_user=None)
         events = self.verify_action(action, num_events=2)
         check_realm_user_remove("events[0]", events[0])
         check_realm_bot_remove("events[1]", events[1])
 
     def test_do_reactivate_user(self) -> None:
         bot = self.create_bot("test")
-        do_deactivate_user(bot)
+        do_deactivate_user(bot, acting_user=None)
         action = lambda: do_reactivate_user(bot, acting_user=None)
         events = self.verify_action(action, num_events=2)
         check_realm_bot_add("events[1]", events[1])

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -819,6 +819,7 @@ class NormalActionsTest(BaseAction):
             self.user_profile.realm,
             "email_address_visibility",
             Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+            acting_user=None,
         )
 
         events = self.verify_action(lambda: self.register("test1@zulip.com", "test1"))
@@ -1029,6 +1030,7 @@ class NormalActionsTest(BaseAction):
             self.user_profile.realm,
             "email_address_visibility",
             Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+            acting_user=None,
         )
         # Important: We need to refresh from the database here so that
         # we don't have a stale UserProfile object with an old value

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1068,7 +1068,7 @@ class NormalActionsTest(BaseAction):
             with fake_backends():
                 events = self.verify_action(
                     lambda: do_set_realm_authentication_methods(
-                        self.user_profile.realm, auth_method_dict
+                        self.user_profile.realm, auth_method_dict, acting_user=None
                     )
                 )
 

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1706,25 +1706,25 @@ class MarkdownTest(ZulipTestCase):
         msg_with_none = markdown_convert_wrapper(text.format("none"))
 
         # Render with default=javascript
-        do_set_realm_property(realm, "default_code_block_language", "javascript")
+        do_set_realm_property(realm, "default_code_block_language", "javascript", acting_user=None)
         msg_without_language_default_js = markdown_convert_wrapper(text.format(""))
         msg_with_python_default_js = markdown_convert_wrapper(text.format("python"))
 
         # Render with default=python
-        do_set_realm_property(realm, "default_code_block_language", "python")
+        do_set_realm_property(realm, "default_code_block_language", "python", acting_user=None)
         msg_without_language_default_py = markdown_convert_wrapper(text.format(""))
         msg_with_none_default_py = markdown_convert_wrapper(text.format("none"))
 
         # Render with default=quote
-        do_set_realm_property(realm, "default_code_block_language", "quote")
+        do_set_realm_property(realm, "default_code_block_language", "quote", acting_user=None)
         msg_without_language_default_quote = markdown_convert_wrapper(text.format(""))
 
         # Render with default=math
-        do_set_realm_property(realm, "default_code_block_language", "math")
+        do_set_realm_property(realm, "default_code_block_language", "math", acting_user=None)
         msg_without_language_default_math = markdown_convert_wrapper(text.format(""))
 
         # Render without default language
-        do_set_realm_property(realm, "default_code_block_language", None)
+        do_set_realm_property(realm, "default_code_block_language", None, acting_user=None)
         msg_without_language_final = markdown_convert_wrapper(text.format(""))
 
         self.assertTrue(msg_with_js == msg_without_language_default_js)
@@ -1738,12 +1738,12 @@ class MarkdownTest(ZulipTestCase):
 
         # Test checking inside nested quotes
         nested_text = "````quote\n\n{}\n\n{}````".format(text.format("js"), text.format(""))
-        do_set_realm_property(realm, "default_code_block_language", "javascript")
+        do_set_realm_property(realm, "default_code_block_language", "javascript", acting_user=None)
         rendered = markdown_convert_wrapper(nested_text)
         with_language, without_language = re.findall(r"<pre>(.*?)$", rendered, re.MULTILINE)
         self.assertTrue(with_language == without_language)
 
-        do_set_realm_property(realm, "default_code_block_language", None)
+        do_set_realm_property(realm, "default_code_block_language", None, acting_user=None)
         rendered = markdown_convert_wrapper(nested_text)
         with_language, without_language = re.findall(r"<pre>(.*?)$", rendered, re.MULTILINE)
         self.assertFalse(with_language == without_language)

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -246,7 +246,7 @@ class EditMessageTest(ZulipTestCase):
 
     def test_edit_message_history_disabled(self) -> None:
         user_profile = self.example_user("hamlet")
-        do_set_realm_property(user_profile.realm, "allow_edit_history", False)
+        do_set_realm_property(user_profile.realm, "allow_edit_history", False, acting_user=None)
         self.login("hamlet")
 
         # Single-line edit

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -1639,7 +1639,10 @@ class GetOldMessagesTest(ZulipTestCase):
         self.login_user(hamlet)
 
         do_set_realm_property(
-            hamlet.realm, "email_address_visibility", Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE
+            hamlet.realm,
+            "email_address_visibility",
+            Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
+            acting_user=None,
         )
 
         self.send_personal_message(hamlet, self.example_user("iago"))
@@ -1654,7 +1657,10 @@ class GetOldMessagesTest(ZulipTestCase):
 
         # Now verify client_gravatar doesn't run with EMAIL_ADDRESS_VISIBILITY_ADMINS
         do_set_realm_property(
-            hamlet.realm, "email_address_visibility", Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS
+            hamlet.realm,
+            "email_address_visibility",
+            Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+            acting_user=None,
         )
         result = self.get_and_check_messages(dict(client_gravatar=orjson.dumps(True).decode()))
         message = result["messages"][0]

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -1697,7 +1697,7 @@ class GetOldMessagesTest(ZulipTestCase):
             [self.example_user("iago"), self.example_user("aaron")],
         )
         aaron = self.example_user("aaron")
-        do_deactivate_user(aaron)
+        do_deactivate_user(aaron, acting_user=None)
         self.assertFalse(aaron.is_active)
 
         personals = [

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -239,7 +239,7 @@ class MessagePOSTTest(ZulipTestCase):
         admin_profile = self.example_user("iago")
         self.login_user(admin_profile)
 
-        do_set_realm_property(admin_profile.realm, "waiting_period_threshold", 10)
+        do_set_realm_property(admin_profile.realm, "waiting_period_threshold", 10, acting_user=None)
         admin_profile.date_joined = timezone_now() - datetime.timedelta(days=9)
         admin_profile.save()
         self.assertTrue(admin_profile.is_provisional_member)
@@ -1629,12 +1629,18 @@ class StreamMessagesTest(ZulipTestCase):
         self.subscribe(shiva, stream_name)
 
         do_set_realm_property(
-            realm, "wildcard_mention_policy", Realm.WILDCARD_MENTION_POLICY_EVERYONE
+            realm,
+            "wildcard_mention_policy",
+            Realm.WILDCARD_MENTION_POLICY_EVERYONE,
+            acting_user=None,
         )
         self.send_and_verify_wildcard_mention_message("polonius")
 
         do_set_realm_property(
-            realm, "wildcard_mention_policy", Realm.WILDCARD_MENTION_POLICY_MEMBERS
+            realm,
+            "wildcard_mention_policy",
+            Realm.WILDCARD_MENTION_POLICY_MEMBERS,
+            acting_user=None,
         )
         self.send_and_verify_wildcard_mention_message("polonius", test_fails=True)
         # There is no restriction on small streams.
@@ -1642,9 +1648,12 @@ class StreamMessagesTest(ZulipTestCase):
         self.send_and_verify_wildcard_mention_message("cordelia")
 
         do_set_realm_property(
-            realm, "wildcard_mention_policy", Realm.WILDCARD_MENTION_POLICY_FULL_MEMBERS
+            realm,
+            "wildcard_mention_policy",
+            Realm.WILDCARD_MENTION_POLICY_FULL_MEMBERS,
+            acting_user=None,
         )
-        do_set_realm_property(realm, "waiting_period_threshold", 10)
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
         iago.date_joined = timezone_now()
         iago.save()
         shiva.date_joined = timezone_now()
@@ -1662,7 +1671,10 @@ class StreamMessagesTest(ZulipTestCase):
         self.send_and_verify_wildcard_mention_message("cordelia")
 
         do_set_realm_property(
-            realm, "wildcard_mention_policy", Realm.WILDCARD_MENTION_POLICY_STREAM_ADMINS
+            realm,
+            "wildcard_mention_policy",
+            Realm.WILDCARD_MENTION_POLICY_STREAM_ADMINS,
+            acting_user=None,
         )
         # TODO: Change this when we implement stream administrators
         self.send_and_verify_wildcard_mention_message("cordelia", test_fails=True)
@@ -1673,7 +1685,7 @@ class StreamMessagesTest(ZulipTestCase):
         cordelia.date_joined = timezone_now()
         cordelia.save()
         do_set_realm_property(
-            realm, "wildcard_mention_policy", Realm.WILDCARD_MENTION_POLICY_ADMINS
+            realm, "wildcard_mention_policy", Realm.WILDCARD_MENTION_POLICY_ADMINS, acting_user=None
         )
         self.send_and_verify_wildcard_mention_message("cordelia", test_fails=True)
         # There is no restriction on small streams.
@@ -1681,7 +1693,7 @@ class StreamMessagesTest(ZulipTestCase):
         self.send_and_verify_wildcard_mention_message("iago")
 
         do_set_realm_property(
-            realm, "wildcard_mention_policy", Realm.WILDCARD_MENTION_POLICY_NOBODY
+            realm, "wildcard_mention_policy", Realm.WILDCARD_MENTION_POLICY_NOBODY, acting_user=None
         )
         self.send_and_verify_wildcard_mention_message("iago", test_fails=True)
         self.send_and_verify_wildcard_mention_message("iago", sub_count=10)
@@ -1691,7 +1703,7 @@ class StreamMessagesTest(ZulipTestCase):
         self.login_user(cordelia)
 
         self.subscribe(cordelia, "test_stream")
-        do_set_realm_property(cordelia.realm, "wildcard_mention_policy", 10)
+        do_set_realm_property(cordelia.realm, "wildcard_mention_policy", 10, acting_user=None)
         content = "@**all** test wildcard mention"
         with mock.patch("zerver.lib.message.num_subscribers_for_stream_id", return_value=16):
             with self.assertRaisesRegex(AssertionError, "Invalid wildcard mention policy"):
@@ -1865,7 +1877,10 @@ class PersonalMessageSendTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
         do_set_realm_property(
-            user_profile.realm, "private_message_policy", Realm.PRIVATE_MESSAGE_POLICY_DISABLED
+            user_profile.realm,
+            "private_message_policy",
+            Realm.PRIVATE_MESSAGE_POLICY_DISABLED,
+            acting_user=None,
         )
         with self.assertRaises(JsonableError):
             self.send_personal_message(user_profile, self.example_user("cordelia"))
@@ -2116,7 +2131,7 @@ class InternalPrepTest(ZulipTestCase):
 class TestCrossRealmPMs(ZulipTestCase):
     def make_realm(self, domain: str) -> Realm:
         realm = do_create_realm(string_id=domain, name=domain)
-        do_set_realm_property(realm, "invite_required", False)
+        do_set_realm_property(realm, "invite_required", False, acting_user=None)
         RealmDomain.objects.create(realm=realm, domain=domain)
         return realm
 

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -546,7 +546,7 @@ class MessagePOSTTest(ZulipTestCase):
         """
         othello = self.example_user("othello")
         cordelia = self.example_user("cordelia")
-        do_deactivate_user(othello)
+        do_deactivate_user(othello, acting_user=None)
         self.login("hamlet")
 
         result = self.client_post(

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -468,7 +468,7 @@ class SingleUserPresenceTests(ZulipTestCase):
         result = self.client_get(f"/json/users/{cordelia.id}/presence")
         self.assert_json_error(result, f"No presence data for {cordelia.id}")
 
-        do_deactivate_user(self.example_user("cordelia"))
+        do_deactivate_user(self.example_user("cordelia"), acting_user=None)
         result = self.client_get("/json/users/cordelia@zulip.com/presence")
         self.assert_json_error(result, "No such user")
 

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -59,10 +59,9 @@ class RealmTest(ZulipTestCase):
         """The main complicated thing about setting realm names is fighting the
         cache, and we start by populating the cache for Hamlet, and we end
         by checking the cache to ensure that the new value is there."""
-        self.example_user("hamlet")
         realm = get_realm("zulip")
         new_name = "Zed You Elle Eye Pea"
-        do_set_realm_property(realm, "name", new_name)
+        do_set_realm_property(realm, "name", new_name, acting_user=None)
         self.assertEqual(get_realm(realm.string_id).name, new_name)
         self.assert_user_profile_cache_gets_new_name(self.example_user("hamlet"), new_name)
 
@@ -71,7 +70,7 @@ class RealmTest(ZulipTestCase):
         new_name = "Puliz"
         events: List[Mapping[str, Any]] = []
         with tornado_redirected_to_list(events):
-            do_set_realm_property(realm, "name", new_name)
+            do_set_realm_property(realm, "name", new_name, acting_user=None)
         event = events[0]["event"]
         self.assertEqual(
             event,
@@ -88,7 +87,7 @@ class RealmTest(ZulipTestCase):
         new_description = "zulip dev group"
         events: List[Mapping[str, Any]] = []
         with tornado_redirected_to_list(events):
-            do_set_realm_property(realm, "description", new_description)
+            do_set_realm_property(realm, "description", new_description, acting_user=None)
         event = events[0]["event"]
         self.assertEqual(
             event,
@@ -159,7 +158,7 @@ class RealmTest(ZulipTestCase):
         data = {"full_name": "Sir Hamlet"}
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
-        do_set_realm_property(user_profile.realm, "name_changes_disabled", True)
+        do_set_realm_property(user_profile.realm, "name_changes_disabled", True, acting_user=None)
         url = "/json/settings"
         result = self.client_patch(url, data)
         self.assertEqual(result.status_code, 200)

--- a/zerver/tests/test_realm_domains.py
+++ b/zerver/tests/test_realm_domains.py
@@ -72,7 +72,9 @@ class RealmDomainTest(ZulipTestCase):
         mit_user_profile = self.mit_user("sipbtest")
         self.login_user(mit_user_profile)
 
-        do_change_user_role(mit_user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(
+            mit_user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None
+        )
 
         result = self.client_post(
             "/json/realm/domains", info=data, HTTP_HOST=mit_user_profile.realm.host

--- a/zerver/tests/test_realm_domains.py
+++ b/zerver/tests/test_realm_domains.py
@@ -18,7 +18,7 @@ from zerver.models import DomainNotAllowedForRealmError, RealmDomain, UserProfil
 class RealmDomainTest(ZulipTestCase):
     def setUp(self) -> None:
         realm = get_realm("zulip")
-        do_set_realm_property(realm, "emails_restricted_to_domains", True)
+        do_set_realm_property(realm, "emails_restricted_to_domains", True, acting_user=None)
 
     def test_list_realm_domains(self) -> None:
         self.login("iago")

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -953,16 +953,20 @@ class TestGetRealmAndStreamsForArchiving(ZulipTestCase):
         archiving_enabled_zephyr_stream.save()
 
         no_archiving_realm = do_create_realm(string_id="no_archiving", name="no_archiving")
-        do_set_realm_property(no_archiving_realm, "invite_required", False)
-        do_set_realm_property(no_archiving_realm, "message_retention_days", -1)
+        do_set_realm_property(no_archiving_realm, "invite_required", False, acting_user=None)
+        do_set_realm_property(no_archiving_realm, "message_retention_days", -1, acting_user=None)
 
         # Realm for testing the edge case where it has a default retention policy,
         # but all streams disable it.
         realm_all_streams_archiving_disabled = do_create_realm(
             string_id="with_archiving", name="with_archiving"
         )
-        do_set_realm_property(realm_all_streams_archiving_disabled, "invite_required", False)
-        do_set_realm_property(realm_all_streams_archiving_disabled, "message_retention_days", 1)
+        do_set_realm_property(
+            realm_all_streams_archiving_disabled, "invite_required", False, acting_user=None
+        )
+        do_set_realm_property(
+            realm_all_streams_archiving_disabled, "message_retention_days", 1, acting_user=None
+        )
         Stream.objects.filter(realm=realm_all_streams_archiving_disabled).update(
             message_retention_days=-1
         )

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1362,7 +1362,7 @@ earl-test@zulip.com""",
         Tests inviting with various missing or invalid parameters.
         """
         realm = get_realm("zulip")
-        do_set_realm_property(realm, "emails_restricted_to_domains", True)
+        do_set_realm_property(realm, "emails_restricted_to_domains", True, acting_user=None)
 
         self.login("hamlet")
         invitee_emails = "foo@zulip.com"
@@ -3052,7 +3052,7 @@ class UserSignUpTest(InviteUserBase):
         password = "newpassword"
         timezone = "US/Mountain"
         realm = get_realm("zulip")
-        do_set_realm_property(realm, "default_language", "de")
+        do_set_realm_property(realm, "default_language", "de", acting_user=None)
 
         result = self.client_post("/accounts/home/", {"email": email})
         self.assertEqual(result.status_code, 302)
@@ -3084,7 +3084,7 @@ class UserSignUpTest(InviteUserBase):
         email = self.nonreg_email("newguy")
         password = "newpassword"
         realm = get_realm("zulip")
-        do_set_realm_property(realm, "default_twenty_four_hour_time", True)
+        do_set_realm_property(realm, "default_twenty_four_hour_time", True, acting_user=None)
 
         result = self.client_post("/accounts/home/", {"email": email})
         self.assertEqual(result.status_code, 302)
@@ -3595,8 +3595,8 @@ class UserSignUpTest(InviteUserBase):
 
     def test_failed_signup_due_to_restricted_domain(self) -> None:
         realm = get_realm("zulip")
-        do_set_realm_property(realm, "invite_required", False)
-        do_set_realm_property(realm, "emails_restricted_to_domains", True)
+        do_set_realm_property(realm, "invite_required", False, acting_user=None)
+        do_set_realm_property(realm, "emails_restricted_to_domains", True, acting_user=None)
 
         email = "user@acme.com"
         form = HomepageForm({"email": email}, realm=realm)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -4611,11 +4611,11 @@ class DeactivateUserTest(ZulipTestCase):
         user = self.example_user("desdemona")
         self.assertTrue(user.is_active)
         self.assertTrue(user.is_realm_owner)
-        do_change_user_role(user_2, UserProfile.ROLE_REALM_OWNER)
+        do_change_user_role(user_2, UserProfile.ROLE_REALM_OWNER, acting_user=None)
         self.assertTrue(user_2.is_realm_owner)
         result = self.client_delete("/json/users/me")
         self.assert_json_success(result)
-        do_change_user_role(user, UserProfile.ROLE_REALM_OWNER)
+        do_change_user_role(user, UserProfile.ROLE_REALM_OWNER, acting_user=None)
 
     def test_do_not_deactivate_final_user(self) -> None:
         realm = get_realm("zulip")

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -443,7 +443,7 @@ class PasswordResetTest(ZulipTestCase):
     def test_password_reset_for_deactivated_user(self) -> None:
         user_profile = self.example_user("hamlet")
         email = user_profile.delivery_email
-        do_deactivate_user(user_profile)
+        do_deactivate_user(user_profile, acting_user=None)
 
         # start the password reset process by supplying an email address
         result = self.client_post("/accounts/password/reset/", {"email": email})
@@ -654,7 +654,7 @@ class LoginTest(ZulipTestCase):
 
     def test_login_deactivated_user(self) -> None:
         user_profile = self.example_user("hamlet")
-        do_deactivate_user(user_profile)
+        do_deactivate_user(user_profile, acting_user=None)
         result = self.login_with_return(self.example_email("hamlet"), "xxx")
         self.assertEqual(result.status_code, 200)
         self.assert_in_response("Your account is no longer active.", result)
@@ -4768,7 +4768,7 @@ class TestFindMyTeam(ZulipTestCase):
         self.assertEqual(len(outbox), 1)
 
     def test_find_team_deactivated_user(self) -> None:
-        do_deactivate_user(self.example_user("hamlet"))
+        do_deactivate_user(self.example_user("hamlet"), acting_user=None)
         data = {"emails": self.example_email("hamlet")}
         result = self.client_post("/accounts/find/", data)
         self.assertEqual(result.status_code, 302)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3922,7 +3922,7 @@ class SubscriptionAPITest(ZulipTestCase):
         )
         self.common_subscribe_to_streams(self.test_user, "Verona", post_data)
 
-        do_deactivate_user(target_profile)
+        do_deactivate_user(target_profile, acting_user=None)
         result = self.common_subscribe_to_streams(
             self.test_user, "Denmark", post_data, allow_fail=True
         )

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -360,7 +360,7 @@ class StreamAdminTest(ZulipTestCase):
         self.make_stream("private_stream_1", invite_only=True)
         self.make_stream("private_stream_2", invite_only=True)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         params = {
             "stream_name": orjson.dumps("private_stream_1").decode(),
             "is_private": orjson.dumps(False).decode(),
@@ -372,7 +372,7 @@ class StreamAdminTest(ZulipTestCase):
         stream = self.subscribe(user_profile, "private_stream_1")
         self.assertFalse(stream.is_in_zephyr_realm)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         params = {
             "stream_name": orjson.dumps("private_stream_1").decode(),
             "is_private": orjson.dumps(False).decode(),
@@ -385,7 +385,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertFalse(stream.invite_only)
         self.assertTrue(stream.history_public_to_subscribers)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         params = {
             "stream_name": orjson.dumps("private_stream_2").decode(),
             "is_private": orjson.dumps(False).decode(),
@@ -413,7 +413,7 @@ class StreamAdminTest(ZulipTestCase):
         self.make_stream("public_stream_1", realm=realm)
         self.make_stream("public_stream_2")
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         params = {
             "stream_name": orjson.dumps("public_stream_1").decode(),
             "is_private": orjson.dumps(True).decode(),
@@ -435,7 +435,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_json_error(result, "Default streams cannot be made private.")
         self.assertFalse(default_stream.invite_only)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         params = {
             "stream_name": orjson.dumps("public_stream_2").decode(),
             "is_private": orjson.dumps(True).decode(),
@@ -463,7 +463,7 @@ class StreamAdminTest(ZulipTestCase):
         self.make_stream("target_stream", realm=realm, invite_only=True)
         self.subscribe(user_profile, "target_stream")
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         params = {
             "stream_name": orjson.dumps("target_stream").decode(),
             "is_private": orjson.dumps(False).decode(),
@@ -481,7 +481,7 @@ class StreamAdminTest(ZulipTestCase):
         realm = user_profile.realm
         self.make_stream("public_history_stream", realm=realm)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         params = {
             "stream_name": orjson.dumps("public_history_stream").decode(),
             "is_private": orjson.dumps(True).decode(),
@@ -500,7 +500,7 @@ class StreamAdminTest(ZulipTestCase):
         realm = user_profile.realm
         self.make_stream("public_stream", realm=realm)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         params = {
             "stream_name": orjson.dumps("public_stream").decode(),
             "is_private": orjson.dumps(False).decode(),
@@ -518,7 +518,7 @@ class StreamAdminTest(ZulipTestCase):
         self.login_user(user_profile)
         stream = self.make_stream("new_stream_1")
         self.subscribe(user_profile, stream.name)
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
 
         result = self.client_delete(f"/json/streams/{stream.id}")
         self.assert_json_success(result)
@@ -531,7 +531,7 @@ class StreamAdminTest(ZulipTestCase):
         )
         self.assertFalse(subscription_exists)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         stream = self.make_stream("new_stream_2")
         self.subscribe(user_profile, stream.name)
         sub = get_subscription(stream.name, user_profile)
@@ -623,7 +623,7 @@ class StreamAdminTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
         self.make_stream("new_stream")
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
 
         result = self.client_delete("/json/streams/999999999")
         self.assert_json_error(result, "Invalid stream id")
@@ -642,7 +642,7 @@ class StreamAdminTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
 
         self.make_stream("private_stream", invite_only=True)
         self.subscribe(user_profile, "private_stream")
@@ -695,7 +695,7 @@ class StreamAdminTest(ZulipTestCase):
         self.login_user(user_profile)
         realm = user_profile.realm
         stream = self.subscribe(user_profile, "stream_name1")
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
 
         result = self.client_patch(
             f"/json/streams/{stream.id}", {"new_name": orjson.dumps("stream_name1").decode()}
@@ -818,7 +818,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertNotIn(self.example_user("prospero").id, notified_user_ids)
 
         # Test renaming of stream by stream admin.
-        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         new_stream = self.make_stream("new_stream", realm=user_profile.realm)
         self.subscribe(user_profile, "new_stream")
         sub = get_subscription("new_stream", user_profile)
@@ -858,7 +858,7 @@ class StreamAdminTest(ZulipTestCase):
         self.make_stream("stream_name1")
 
         stream = self.subscribe(user_profile, "stream_name1")
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         result = self.client_patch(
             f"/json/streams/{stream.id}", {"new_name": orjson.dumps("stream_name2").decode()}
         )
@@ -1016,7 +1016,7 @@ class StreamAdminTest(ZulipTestCase):
         )
 
         # Test changing stream description by stream admin.
-        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         sub = get_subscription("stream_name1", user_profile)
         do_change_subscription_property(
             user_profile, sub, stream, "role", Subscription.ROLE_STREAM_ADMINISTRATOR
@@ -1039,7 +1039,7 @@ class StreamAdminTest(ZulipTestCase):
         stream = self.subscribe(user_profile, "stream_name1")
         sub = get_subscription("stream_name1", user_profile)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         do_change_subscription_property(user_profile, sub, stream, "role", Subscription.ROLE_MEMBER)
 
         stream_id = get_stream("stream_name1", user_profile.realm).id
@@ -1053,7 +1053,7 @@ class StreamAdminTest(ZulipTestCase):
         self.login_user(user_profile)
 
         self.subscribe(user_profile, "stream_name1")
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
 
         stream_id = get_stream("stream_name1", user_profile.realm).id
         result = self.client_patch(
@@ -1070,7 +1070,7 @@ class StreamAdminTest(ZulipTestCase):
         stream = self.subscribe(user_profile, "stream_name1")
         sub = get_subscription("stream_name1", user_profile)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         do_change_subscription_property(user_profile, sub, stream, "role", Subscription.ROLE_MEMBER)
 
         do_set_realm_property(user_profile.realm, "waiting_period_threshold", 10, acting_user=None)
@@ -1107,7 +1107,7 @@ class StreamAdminTest(ZulipTestCase):
             stream = get_stream("stream_name1", user_profile.realm)
             self.assertEqual(stream.stream_post_policy, policy)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
 
         for policy in policies:
             stream_id = get_stream("stream_name1", user_profile.realm).id
@@ -1231,7 +1231,7 @@ class StreamAdminTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Must be an organization owner")
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_OWNER)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_OWNER, acting_user=None)
         result = self.client_patch(
             f"/json/streams/{stream.id}", {"message_retention_days": orjson.dumps(2).decode()}
         )
@@ -1315,7 +1315,7 @@ class StreamAdminTest(ZulipTestCase):
         if subscribed:
             self.subscribe(user_profile, stream_name)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
 
         return stream
 
@@ -1387,7 +1387,7 @@ class StreamAdminTest(ZulipTestCase):
 
         # Even becoming a realm admin doesn't help us for an out-of-realm
         # stream.
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         result = self.client_delete("/json/streams/" + str(stream.id))
         self.assert_json_error(result, "Invalid stream id")
 
@@ -1693,7 +1693,7 @@ class StreamAdminTest(ZulipTestCase):
         user_profile.date_joined = timezone_now()
         user_profile.save()
         self.login_user(user_profile)
-        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
 
         # Allow all members to create streams.
         do_set_realm_property(
@@ -1725,7 +1725,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_json_error(result, "Only administrators can create streams.")
 
         # Make current user an admin.
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
 
         # Can successfully create stream as user is now an admin.
         stream_name = ["admins_only"]
@@ -1744,7 +1744,7 @@ class StreamAdminTest(ZulipTestCase):
         self.common_subscribe_to_streams(user_profile, stream_name)
 
         # Make current user no longer an admin.
-        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
 
         # Cannot create stream because user is not an admin and is not older than the waiting
         # period.
@@ -1782,14 +1782,14 @@ class StreamAdminTest(ZulipTestCase):
         cordelia_user_id = cordelia_user.id
 
         self.login_user(hamlet_user)
-        do_change_user_role(hamlet_user, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(hamlet_user, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
 
         # Hamlet creates a stream as an admin..
         stream_name = ["waitingperiodtest"]
         self.common_subscribe_to_streams(hamlet_user, stream_name)
 
         # Can only invite users to stream if their account is ten days old..
-        do_change_user_role(hamlet_user, UserProfile.ROLE_MEMBER)
+        do_change_user_role(hamlet_user, UserProfile.ROLE_MEMBER, acting_user=None)
         do_set_realm_property(hamlet_user.realm, "waiting_period_threshold", 10, acting_user=None)
 
         # Attempt and fail to invite Cordelia to the stream..
@@ -1891,7 +1891,7 @@ class DefaultStreamTest(ZulipTestCase):
 
     def test_api_calls(self) -> None:
         user_profile = self.example_user("hamlet")
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         self.login_user(user_profile)
 
         stream_name = "stream ADDED via api"
@@ -2034,7 +2034,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
         self.login("hamlet")
         user_profile = self.example_user("hamlet")
         realm = user_profile.realm
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
 
         # Test creating new default stream group
         stream_names = ["stream1", "stream2", "stream3"]
@@ -3223,13 +3223,13 @@ class SubscriptionAPITest(ZulipTestCase):
         )
         self.assert_json_error(result, "Only administrators can create streams.")
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         self.common_subscribe_to_streams(user_profile, ["new_stream1"])
 
         do_set_realm_property(
             realm, "create_stream_policy", Realm.POLICY_MEMBERS_ONLY, acting_user=None
         )
-        do_change_user_role(user_profile, UserProfile.ROLE_GUEST)
+        do_change_user_role(user_profile, UserProfile.ROLE_GUEST, acting_user=None)
         result = self.common_subscribe_to_streams(
             user_profile,
             ["new_stream2"],
@@ -3237,7 +3237,7 @@ class SubscriptionAPITest(ZulipTestCase):
         )
         self.assert_json_error(result, "Not allowed for guest users")
 
-        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         self.common_subscribe_to_streams(
             self.test_user,
             ["new_stream2"],
@@ -3259,10 +3259,10 @@ class SubscriptionAPITest(ZulipTestCase):
 
     def test_can_create_streams(self) -> None:
         othello = self.example_user("othello")
-        do_change_user_role(othello, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(othello, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         self.assertTrue(othello.can_create_streams())
 
-        do_change_user_role(othello, UserProfile.ROLE_MEMBER)
+        do_change_user_role(othello, UserProfile.ROLE_MEMBER, acting_user=None)
         do_set_realm_property(
             othello.realm, "create_stream_policy", Realm.POLICY_ADMINS_ONLY, acting_user=None
         )
@@ -3274,10 +3274,10 @@ class SubscriptionAPITest(ZulipTestCase):
         do_set_realm_property(
             othello.realm, "create_stream_policy", Realm.POLICY_MEMBERS_ONLY, acting_user=None
         )
-        do_change_user_role(othello, UserProfile.ROLE_GUEST)
+        do_change_user_role(othello, UserProfile.ROLE_GUEST, acting_user=None)
         self.assertFalse(othello.can_create_streams())
 
-        do_change_user_role(othello, UserProfile.ROLE_MEMBER)
+        do_change_user_role(othello, UserProfile.ROLE_MEMBER, acting_user=None)
         self.assertTrue(othello.can_create_streams())
 
         do_set_realm_property(othello.realm, "waiting_period_threshold", 1000, acting_user=None)
@@ -3289,10 +3289,10 @@ class SubscriptionAPITest(ZulipTestCase):
         )
         self.assertFalse(othello.can_create_streams())
 
-        do_change_user_role(othello, UserProfile.ROLE_MODERATOR)
+        do_change_user_role(othello, UserProfile.ROLE_MODERATOR, acting_user=None)
         self.assertTrue(othello.can_create_streams())
 
-        do_change_user_role(othello, UserProfile.ROLE_MEMBER)
+        do_change_user_role(othello, UserProfile.ROLE_MEMBER, acting_user=None)
         othello.date_joined = timezone_now() - timedelta(
             days=(othello.realm.waiting_period_threshold + 1)
         )
@@ -3321,7 +3321,7 @@ class SubscriptionAPITest(ZulipTestCase):
         )
         self.assert_json_error(result, "Only administrators can modify other users' subscriptions.")
 
-        do_change_user_role(self.test_user, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(self.test_user, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         self.common_subscribe_to_streams(
             self.test_user, ["stream1"], {"principals": orjson.dumps([invitee_user_id]).decode()}
         )
@@ -3329,7 +3329,7 @@ class SubscriptionAPITest(ZulipTestCase):
         do_set_realm_property(
             realm, "invite_to_stream_policy", Realm.POLICY_MEMBERS_ONLY, acting_user=None
         )
-        do_change_user_role(self.test_user, UserProfile.ROLE_GUEST)
+        do_change_user_role(self.test_user, UserProfile.ROLE_GUEST, acting_user=None)
         result = self.common_subscribe_to_streams(
             self.test_user,
             ["stream2"],
@@ -3338,7 +3338,7 @@ class SubscriptionAPITest(ZulipTestCase):
         )
         self.assert_json_error(result, "Not allowed for guest users")
 
-        do_change_user_role(self.test_user, UserProfile.ROLE_MEMBER)
+        do_change_user_role(self.test_user, UserProfile.ROLE_MEMBER, acting_user=None)
         self.common_subscribe_to_streams(
             self.test_user,
             ["stream2"],
@@ -3374,13 +3374,13 @@ class SubscriptionAPITest(ZulipTestCase):
         enough.
         """
         othello = self.example_user("othello")
-        do_change_user_role(othello, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(othello, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         self.assertTrue(othello.can_subscribe_other_users())
 
         do_set_realm_property(
             othello.realm, "invite_to_stream_policy", Realm.POLICY_ADMINS_ONLY, acting_user=None
         )
-        do_change_user_role(othello, UserProfile.ROLE_MEMBER)
+        do_change_user_role(othello, UserProfile.ROLE_MEMBER, acting_user=None)
         # Make sure that we are checking the permission with a full member,
         # as full member is the user just below admin in the role hierarchy.
         self.assertFalse(othello.is_provisional_member)
@@ -3389,10 +3389,10 @@ class SubscriptionAPITest(ZulipTestCase):
         do_set_realm_property(
             othello.realm, "invite_to_stream_policy", Realm.POLICY_MEMBERS_ONLY, acting_user=None
         )
-        do_change_user_role(othello, UserProfile.ROLE_GUEST)
+        do_change_user_role(othello, UserProfile.ROLE_GUEST, acting_user=None)
         self.assertFalse(othello.can_subscribe_other_users())
 
-        do_change_user_role(othello, UserProfile.ROLE_MEMBER)
+        do_change_user_role(othello, UserProfile.ROLE_MEMBER, acting_user=None)
         self.assertTrue(othello.can_subscribe_other_users())
 
         do_set_realm_property(othello.realm, "waiting_period_threshold", 1000, acting_user=None)
@@ -3407,10 +3407,10 @@ class SubscriptionAPITest(ZulipTestCase):
         )
         self.assertFalse(othello.can_subscribe_other_users())
 
-        do_change_user_role(othello, UserProfile.ROLE_MODERATOR)
+        do_change_user_role(othello, UserProfile.ROLE_MODERATOR, acting_user=None)
         self.assertTrue(othello.can_subscribe_other_users())
 
-        do_change_user_role(othello, UserProfile.ROLE_MEMBER)
+        do_change_user_role(othello, UserProfile.ROLE_MEMBER, acting_user=None)
         othello.date_joined = timezone_now() - timedelta(
             days=(othello.realm.waiting_period_threshold + 1)
         )

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -568,7 +568,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         user3_email = "other-user@uploadtest.example.com"
 
         r1 = do_create_realm(string_id=test_subdomain, name=test_subdomain)
-        do_set_realm_property(r1, "invite_required", False)
+        do_set_realm_property(r1, "invite_required", False, acting_user=None)
         RealmDomain.objects.create(realm=r1, domain=test_subdomain)
 
         user_1 = create_user(user1_email, test_subdomain)
@@ -969,7 +969,12 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
         Attempting to upload avatar on a realm with avatar changes disabled should fail.
         """
         self.login("cordelia")
-        do_set_realm_property(self.example_user("cordelia").realm, "avatar_changes_disabled", True)
+        do_set_realm_property(
+            self.example_user("cordelia").realm,
+            "avatar_changes_disabled",
+            True,
+            acting_user=None,
+        )
 
         with get_test_image_file("img.png") as fp1:
             result = self.client_post("/json/users/me/avatar", {"f1": fp1})
@@ -1214,11 +1219,11 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
         cordelia.avatar_source = UserProfile.AVATAR_FROM_USER
         cordelia.save()
 
-        do_set_realm_property(cordelia.realm, "avatar_changes_disabled", True)
+        do_set_realm_property(cordelia.realm, "avatar_changes_disabled", True, acting_user=None)
         result = self.client_delete("/json/users/me/avatar")
         self.assert_json_error(result, "Avatar changes are disabled in this organization.", 400)
 
-        do_set_realm_property(cordelia.realm, "avatar_changes_disabled", False)
+        do_set_realm_property(cordelia.realm, "avatar_changes_disabled", False, acting_user=None)
         result = self.client_delete("/json/users/me/avatar")
         user_profile = self.example_user("cordelia")
 

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -443,7 +443,10 @@ class UserGroupAPITestCase(ZulipTestCase):
         cordelia = self.example_user("cordelia")
         self.login_user(iago)
         do_set_realm_property(
-            iago.realm, "user_group_edit_policy", Realm.USER_GROUP_EDIT_POLICY_ADMINS
+            iago.realm,
+            "user_group_edit_policy",
+            Realm.USER_GROUP_EDIT_POLICY_ADMINS,
+            acting_user=None,
         )
 
         params = {

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -108,21 +108,21 @@ class PermissionTest(ZulipTestCase):
 
     def test_get_admin_users(self) -> None:
         user_profile = self.example_user("hamlet")
-        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         self.assertFalse(user_profile.is_realm_owner)
         admin_users = user_profile.realm.get_human_admin_users()
         self.assertFalse(user_profile in admin_users)
         admin_users = user_profile.realm.get_admin_users_and_bots()
         self.assertFalse(user_profile in admin_users)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         self.assertFalse(user_profile.is_realm_owner)
         admin_users = user_profile.realm.get_human_admin_users()
         self.assertTrue(user_profile in admin_users)
         admin_users = user_profile.realm.get_admin_users_and_bots()
         self.assertTrue(user_profile in admin_users)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_REALM_OWNER)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_OWNER, acting_user=None)
         self.assertTrue(user_profile.is_realm_owner)
         admin_users = user_profile.realm.get_human_admin_users()
         self.assertTrue(user_profile in admin_users)
@@ -136,7 +136,7 @@ class PermissionTest(ZulipTestCase):
     def test_updating_non_existent_user(self) -> None:
         self.login("hamlet")
         admin = self.example_user("hamlet")
-        do_change_user_role(admin, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(admin, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
 
         invalid_user_id = 1000
         result = self.client_patch(f"/json/users/{invalid_user_id}", {})
@@ -150,7 +150,7 @@ class PermissionTest(ZulipTestCase):
         iago = self.example_user("iago")
         realm = iago.realm
 
-        do_change_user_role(iago, UserProfile.ROLE_REALM_OWNER)
+        do_change_user_role(iago, UserProfile.ROLE_REALM_OWNER, acting_user=None)
 
         result = self.client_get("/json/users")
         self.assert_json_success(result)
@@ -200,7 +200,7 @@ class PermissionTest(ZulipTestCase):
             result, "The owner permission cannot be removed from the only organization owner."
         )
 
-        do_change_user_role(iago, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(iago, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         self.login("iago")
         with tornado_redirected_to_list([]):
             result = self.client_patch(f"/json/users/{desdemona.id}", req)
@@ -464,7 +464,7 @@ class PermissionTest(ZulipTestCase):
         iago = self.example_user("iago")
         self.login_user(iago)
         hamlet = self.example_user("hamlet")
-        do_change_user_role(hamlet, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(hamlet, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         self.assertFalse(hamlet.is_guest)
         self.assertTrue(hamlet.is_realm_admin)
 
@@ -512,7 +512,7 @@ class PermissionTest(ZulipTestCase):
     def test_change_owner_to_guest(self) -> None:
         self.login("desdemona")
         iago = self.example_user("iago")
-        do_change_user_role(iago, UserProfile.ROLE_REALM_OWNER)
+        do_change_user_role(iago, UserProfile.ROLE_REALM_OWNER, acting_user=None)
         self.assertFalse(iago.is_guest)
         self.assertTrue(iago.is_realm_owner)
 
@@ -584,7 +584,7 @@ class PermissionTest(ZulipTestCase):
         desdemona = self.example_user("desdemona")
         self.login_user(desdemona)
         iago = self.example_user("iago")
-        do_change_user_role(iago, UserProfile.ROLE_REALM_OWNER)
+        do_change_user_role(iago, UserProfile.ROLE_REALM_OWNER, acting_user=None)
         self.assertTrue(iago.is_realm_owner)
 
         # Test changing a user from admin to owner and revoking admin status
@@ -888,7 +888,7 @@ class AdminCreateUserTest(ZulipTestCase):
         admin = self.example_user("hamlet")
         realm = admin.realm
         self.login_user(admin)
-        do_change_user_role(admin, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(admin, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         valid_params = dict(
             email="romeo@zulip.net",
             password="xxxx",
@@ -901,11 +901,11 @@ class AdminCreateUserTest(ZulipTestCase):
 
         do_change_can_create_users(admin, True)
         # can_create_users is insufficient without being a realm administrator:
-        do_change_user_role(admin, UserProfile.ROLE_MEMBER)
+        do_change_user_role(admin, UserProfile.ROLE_MEMBER, acting_user=None)
         result = self.client_post("/json/users", valid_params)
         self.assert_json_error(result, "Must be an organization administrator")
 
-        do_change_user_role(admin, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(admin, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
 
         result = self.client_post("/json/users", {})
         self.assert_json_error(result, "Missing 'email' argument")
@@ -1333,7 +1333,7 @@ class ActivateTest(ZulipTestCase):
 
     def test_api(self) -> None:
         admin = self.example_user("othello")
-        do_change_user_role(admin, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(admin, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         self.login("othello")
 
         user = self.example_user("hamlet")
@@ -1358,7 +1358,7 @@ class ActivateTest(ZulipTestCase):
 
         iago = self.example_user("iago")
         desdemona = self.example_user("desdemona")
-        do_change_user_role(iago, UserProfile.ROLE_REALM_OWNER)
+        do_change_user_role(iago, UserProfile.ROLE_REALM_OWNER, acting_user=None)
 
         # Cannot deactivate a user with the bot api
         result = self.client_delete("/json/bots/{}".format(self.example_user("hamlet").id))
@@ -1385,7 +1385,7 @@ class ActivateTest(ZulipTestCase):
 
     def test_api_with_insufficient_permissions(self) -> None:
         non_admin = self.example_user("othello")
-        do_change_user_role(non_admin, UserProfile.ROLE_MEMBER)
+        do_change_user_role(non_admin, UserProfile.ROLE_MEMBER, acting_user=None)
         self.login("othello")
 
         # Cannot deactivate a user with the users api

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -405,7 +405,7 @@ class PermissionTest(ZulipTestCase):
 
         # Can only access deactivated users if allow_deactivated is passed
         hamlet = self.example_user("hamlet")
-        do_deactivate_user(hamlet)
+        do_deactivate_user(hamlet, acting_user=None)
         with self.assertRaises(JsonableError):
             access_user_by_id(iago, hamlet.id, for_admin=False)
         with self.assertRaises(JsonableError):
@@ -1158,7 +1158,7 @@ class UserProfileTest(ZulipTestCase):
 
         # We verify that get_accounts_for_email don't return deactivated users accounts
         user = self.example_user("hamlet")
-        do_deactivate_user(user)
+        do_deactivate_user(user, acting_user=None)
         email = self.example_email("hamlet")
         accounts = get_accounts_for_email(email)
         with self.assertRaises(AssertionError):
@@ -1326,7 +1326,7 @@ class UserProfileTest(ZulipTestCase):
 class ActivateTest(ZulipTestCase):
     def test_basics(self) -> None:
         user = self.example_user("hamlet")
-        do_deactivate_user(user)
+        do_deactivate_user(user, acting_user=None)
         self.assertFalse(user.is_active)
         do_reactivate_user(user, acting_user=None)
         self.assertTrue(user.is_active)
@@ -1407,7 +1407,7 @@ class ActivateTest(ZulipTestCase):
             delay=datetime.timedelta(hours=1),
         )
         self.assertEqual(ScheduledEmail.objects.count(), 1)
-        do_deactivate_user(user)
+        do_deactivate_user(user, acting_user=None)
         self.assertEqual(ScheduledEmail.objects.count(), 0)
 
     def test_send_future_email_with_multiple_recipients(self) -> None:

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1328,7 +1328,7 @@ class ActivateTest(ZulipTestCase):
         user = self.example_user("hamlet")
         do_deactivate_user(user)
         self.assertFalse(user.is_active)
-        do_reactivate_user(user)
+        do_reactivate_user(user, acting_user=None)
         self.assertTrue(user.is_active)
 
     def test_api(self) -> None:

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -282,7 +282,10 @@ class PermissionTest(ZulipTestCase):
         # Now, switch email address visibility, check client_gravatar
         # is automatically disabled for the user.
         do_set_realm_property(
-            user.realm, "email_address_visibility", Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS
+            user.realm,
+            "email_address_visibility",
+            Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+            acting_user=None,
         )
         result = self.client_get("/json/users", {"client_gravatar": "true"})
         self.assert_json_success(result)
@@ -946,7 +949,7 @@ class AdminCreateUserTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Bad name or username")
 
-        do_set_realm_property(realm, "emails_restricted_to_domains", True)
+        do_set_realm_property(realm, "emails_restricted_to_domains", True, acting_user=None)
         result = self.client_post(
             "/json/users",
             dict(

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -911,7 +911,7 @@ class ZulipLDAPUserPopulator(ZulipLDAPAuthBackendBase):
                     "Reactivating user %s because they are not disabled in LDAP.",
                     user.delivery_email,
                 )
-                do_reactivate_user(user)
+                do_reactivate_user(user, acting_user=None)
 
         self.sync_avatar_from_ldap(user, ldap_user)
         self.sync_full_name_from_ldap(user, ldap_user)

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -903,7 +903,7 @@ class ZulipLDAPUserPopulator(ZulipLDAPAuthBackendBase):
                         "Deactivating user %s because they are disabled in LDAP.",
                         user.delivery_email,
                     )
-                    do_deactivate_user(user)
+                    do_deactivate_user(user, acting_user=None)
                 # Do an early return to avoid trying to sync additional data.
                 return (user, built)
             elif not user.is_active:
@@ -949,7 +949,7 @@ def sync_user_from_ldap(user_profile: UserProfile, logger: logging.Logger) -> bo
             if settings.LDAP_DEACTIVATE_NON_MATCHING_USERS is None
             else settings.LDAP_DEACTIVATE_NON_MATCHING_USERS
         ):
-            do_deactivate_user(user_profile)
+            do_deactivate_user(user_profile, acting_user=None)
             logger.info("Deactivated non-matching user: %s", user_profile.delivery_email)
             return True
         elif user_profile.is_active:


### PR DESCRIPTION
https://github.com/zulip/zulip/issues/14808#issuecomment-663700003.
