### PR TITLE
streams: Fix behavior of bots in STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS stream.

### DIFF
--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -205,7 +205,7 @@ def access_stream_for_send_message(
     elif stream.stream_post_policy != Stream.STREAM_POST_POLICY_EVERYONE and sender.is_guest:
         raise JsonableError(_("Guests cannot send to this stream."))
     elif stream.stream_post_policy == Stream.STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS:
-        if sender.is_bot and (sender.bot_owner is not None and sender.bot_owner.is_new_member):
+        if sender.is_bot and (sender.bot_owner is None or sender.bot_owner.is_new_member):
             raise JsonableError(_("New members cannot send to this stream."))
         elif sender.is_new_member:
             raise JsonableError(_("New members cannot send to this stream."))

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -207,7 +207,7 @@ def access_stream_for_send_message(
     elif stream.stream_post_policy == Stream.STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS:
         if sender.is_bot and (sender.bot_owner is None or sender.bot_owner.is_new_member):
             raise JsonableError(_("New members cannot send to this stream."))
-        elif sender.is_new_member:
+        elif not sender.is_bot and sender.is_new_member:
             raise JsonableError(_("New members cannot send to this stream."))
 
     if stream.is_web_public:

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -279,7 +279,8 @@ class MessagePOSTTest(ZulipTestCase):
             non_admin_owned_bot, stream_name, "New members cannot send to this stream."
         )
 
-        # Bots without owner (except cross realm bot) cannot send to announcement only stream
+        # Bots without owner (except cross realm bot) cannot send to STREAM_POST_POLICY_ADMINS_ONLY and
+        # STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS streams
         bot_without_owner = do_create_user(
             email="free-bot@zulip.testserver",
             password="",

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -279,6 +279,16 @@ class MessagePOSTTest(ZulipTestCase):
             non_admin_owned_bot, stream_name, "New members cannot send to this stream."
         )
 
+        non_admin_profile.date_joined = timezone_now() - datetime.timedelta(days=11)
+        non_admin_profile.save()
+        self.assertFalse(non_admin_profile.is_new_member)
+
+        self._send_and_verify_message(non_admin_profile, stream_name)
+        # We again set bot owner here, as date_joined of non_admin_profile is changed.
+        non_admin_owned_bot.bot_owner = non_admin_profile
+        non_admin_owned_bot.save()
+        self._send_and_verify_message(non_admin_owned_bot, stream_name)
+
         # Bots without owner (except cross realm bot) cannot send to STREAM_POST_POLICY_ADMINS_ONLY and
         # STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS streams
         bot_without_owner = do_create_user(


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR contains the following 3 commits - 
- The tests say that we should not allow bots without owners to send messages in streams
with post policy other than `STREAM_POST_POLICY_EVERYONE` but in the code the error
raised in test is due to bot being a new member.So, this commit fixes code to check the 
condition of bot not having an owner and raising error.
- This commit changes the code to allow even new bot with ots owner being full member to send 
message in `STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS` stream and this makes
 the behavior consistent with `STREAM_POST_POLICY_ADMINS_ONLY` stream.
- Add tests for messages being sent successfully by full members and bots owned by them
in `STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS` stream.

**Testing plan:** <!-- How have you tested? --> Modified the tests as needed.

Discussion here - https://chat.zulip.org/#narrow/stream/9-issues/topic/stream.20post.20policy.20for.20bots/near/1091346
 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
