### PR TITLE
docs: Make the color contrast of sidebar meet the WCAG standard

### DIFF
--- a/static/styles/portico/markdown.css
+++ b/static/styles/portico/markdown.css
@@ -188,7 +188,7 @@
     }
 
     a {
-        color: hsl(176, 46%, 41%);
+        color: hsl(176, 27%, 43%);
         font-weight: 600;
     }
 

--- a/static/styles/portico/markdown.css
+++ b/static/styles/portico/markdown.css
@@ -188,7 +188,6 @@
     }
 
     a {
-        color: hsl(176, 27%, 43%);
         font-weight: 600;
     }
 

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -153,7 +153,7 @@ html {
         border-right: 1px solid hsl(219, 10%, 97%);
         overflow: auto;
 
-        background-color: hsl(153, 32%, 55%);
+        background-color: hsl(153, 30%, 35%);
         color: hsl(0, 0%, 100%);
 
         -webkit-overflow-scrolling: touch;
@@ -246,7 +246,7 @@ html {
 
         a {
             &.highlighted {
-                background-color: hsl(152, 40%, 42%);
+                background-color: hsl(152, 37%, 23%);
 
                 /* Extend highlight to entire width of sidebar, not just link area */
                 /* This has been changed from "+" to "- -" because of issue #8403.
@@ -560,7 +560,7 @@ input.text-error {
             font-size: 1.2rem;
             font-weight: 400;
             color: hsl(0, 0%, 20%);
-            opacity: 0.5;
+            opacity: 0.7;
         }
     }
 
@@ -1645,7 +1645,7 @@ label.label-title {
 
 .documentation-footer {
     font-size: 0.85rem;
-    opacity: 0.8;
+    opacity: 0.9;
 }
 
 #devtools-wrapper {

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -1,3 +1,9 @@
+$dark-blue: hsl(209, 80%, 17%);
+$light-blue: hsl(212, 91%, 69%);
+$purple: hsl(238, 86%, 71%);
+$light-green: hsl(155, 62%, 71%);
+$purple-blue-gradient: linear-gradient(0deg, $purple, $light-blue);
+
 body {
     background-color: hsl(0, 0%, 98%);
     font-family: "Source Sans 3", sans-serif;
@@ -153,7 +159,7 @@ html {
         border-right: 1px solid hsl(219, 10%, 97%);
         overflow: auto;
 
-        background-color: hsl(153, 30%, 35%);
+        background: $purple-blue-gradient;
         color: hsl(0, 0%, 100%);
 
         -webkit-overflow-scrolling: touch;
@@ -246,7 +252,7 @@ html {
 
         a {
             &.highlighted {
-                background-color: hsl(152, 37%, 23%);
+                background-color: $dark-blue;
 
                 /* Extend highlight to entire width of sidebar, not just link area */
                 /* This has been changed from "+" to "- -" because of issue #8403.

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -1,8 +1,9 @@
-$dark-blue: hsl(209, 80%, 17%);
-$light-blue: hsl(212, 91%, 69%);
-$purple: hsl(238, 86%, 71%);
-$light-green: hsl(155, 62%, 71%);
-$purple-blue-gradient: linear-gradient(0deg, $purple, $light-blue);
+$blue1: #3a87ad;
+$text1: #23688a;
+$blue2: #04254e;
+$text2: hsl(209, 79%, 25%);
+$blue3: #0e3c91;
+$text3: #0c3074;
 
 body {
     background-color: hsl(0, 0%, 98%);
@@ -159,7 +160,7 @@ html {
         border-right: 1px solid hsl(219, 10%, 97%);
         overflow: auto;
 
-        background: $purple-blue-gradient;
+        background: $blue2;
         color: hsl(0, 0%, 100%);
 
         -webkit-overflow-scrolling: touch;
@@ -252,7 +253,7 @@ html {
 
         a {
             &.highlighted {
-                background-color: $dark-blue;
+                background-color: $text2;
 
                 /* Extend highlight to entire width of sidebar, not just link area */
                 /* This has been changed from "+" to "- -" because of issue #8403.

--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -238,7 +238,7 @@ html {
 
     .top-links a,
     .header-main .logo span {
-        color: hsl(0, 0%, 27%);
+        color: hsl(0, 0%, 15%);
     }
 }
 


### PR DESCRIPTION
This make the background color of sidebar a bit darker so that there is sufficient contrast between the text and background.
Also, the heading is made a bit darker with respect to white background.

Removes the warning in the accessibility section of developer section.
Related to issue #15948 1st one.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Yes, tested it properly. Also ran frontend and listing tests. Here are screenshots.
After vs before
![image](https://user-images.githubusercontent.com/56730716/104089087-e32c5100-5291-11eb-8827-12a6c3ef80f7.png)

Here are the lighthouse reports.
![image](https://user-images.githubusercontent.com/56730716/104089308-ee807c00-5293-11eb-869c-fe040d2b71db.png)


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
