### PR TITLE
Add typing indicators for streams.

### DIFF
--- a/docs/subsystems/typing-indicators.md
+++ b/docs/subsystems/typing-indicators.md
@@ -121,7 +121,7 @@ like the following:
 - `add_typist`
 - `remove_typist`
 - `get_group_typists`
-- `get_all_typists`
+- `get_all_pms_typists`
 
 One subtle thing that the client has to do here is to maintain
 timers for typing notifications. The constant

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -682,6 +682,37 @@ run_test("typing", ({override}) => {
     page_params.user_id = typing_person1.user_id;
     event = event_fixtures.typing__start;
     dispatch(event);
+    page_params.user_id = undefined; // above change shouldn't effect stream_typing tests below
+});
+
+run_test("stream_typing", ({override}) => {
+    const stream_typing_in_id = events.stream_typing_in_id;
+    const topic_typing_in = events.topic_typing_in;
+    let event = event_fixtures.stream_typing__start;
+    {
+        const stub = make_stub();
+        override(typing_events, "display_notification", stub.f);
+        dispatch(event);
+        assert.equal(stub.num_calls, 1);
+        const args = stub.get_args("event");
+        assert_same(args.event.sender.user_id, typing_person1.user_id);
+        assert_same(args.event.message_type, "stream");
+        assert_same(args.event.stream_id, stream_typing_in_id);
+        assert_same(args.event.topic, topic_typing_in);
+    }
+
+    event = event_fixtures.stream_typing__stop;
+    {
+        const stub = make_stub();
+        override(typing_events, "hide_notification", stub.f);
+        dispatch(event);
+        assert.equal(stub.num_calls, 1);
+        const args = stub.get_args("event");
+        assert_same(args.event.sender.user_id, typing_person1.user_id);
+        assert_same(args.event.message_type, "stream");
+        assert_same(args.event.stream_id, stream_typing_in_id);
+        assert_same(args.event.topic, topic_typing_in);
+    }
 });
 
 run_test("user_settings", ({override, override_rewire}) => {

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -32,6 +32,8 @@ const typing_person2 = {
 
 exports.typing_person1 = typing_person1;
 exports.typing_person2 = typing_person2;
+exports.stream_typing_in_id = 1;
+exports.topic_typing_in = "Typing topic";
 
 const fake_then = 1596710000;
 const fake_now = 1596713966;
@@ -582,6 +584,24 @@ exports.fixtures = {
         stream_id: 99,
         property: "color",
         value: "blue",
+    },
+
+    stream_typing__start: {
+        type: "typing",
+        op: "start",
+        message_type: "stream",
+        sender: typing_person1,
+        stream_id: this.stream_typing_in_id,
+        topic: this.topic_typing_in,
+    },
+
+    stream_typing__stop: {
+        type: "typing",
+        op: "stop",
+        message_type: "stream",
+        sender: typing_person1,
+        stream_id: this.stream_typing_in_id,
+        topic: this.topic_typing_in,
     },
 
     submessage: {

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -29,6 +29,7 @@ function test(label, f) {
 test("stream", () => {
     assert.equal(narrow_state.public_operators(), undefined);
     assert.ok(!narrow_state.active());
+    assert.equal(narrow_state.stream_id(), undefined);
 
     const test_stream = {name: "Test", stream_id: 15};
     stream_data.add_sub(test_stream);
@@ -43,6 +44,7 @@ test("stream", () => {
     assert.ok(narrow_state.active());
 
     assert.equal(narrow_state.stream(), "Test");
+    assert.equal(narrow_state.stream_id(), 15);
     assert.equal(narrow_state.stream_sub().stream_id, test_stream.stream_id);
     assert.equal(narrow_state.topic(), "Bar");
     assert.ok(narrow_state.is_for_stream_id(test_stream.stream_id));

--- a/frontend_tests/node_tests/typing_data.js
+++ b/frontend_tests/node_tests/typing_data.js
@@ -21,49 +21,65 @@ test("basics", () => {
     // user ids being in arbitrary sorting order and
     // possibly in string form instead of integer. So all
     // the apparent randomness in these tests has a purpose.
-    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), 15);
+
+    const stream_id = 1;
+    const topic = "typing notifications";
+    const topic_typing_key = typing_data.get_topic_key(stream_id, topic);
+
+    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), 15, "private");
     assert.deepEqual(typing_data.get_group_typists([15, 10, 5]), [15]);
 
+    typing_data.add_typist(topic_typing_key, 12, "stream");
+    assert.deepEqual(typing_data.get_stream_typists(stream_id, topic), [12]);
+
     // test that you can add twice
-    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), 15);
+    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), 15, "private");
 
     // add another id to our first group
-    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), "10");
+    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), "10", "private");
     assert.deepEqual(typing_data.get_group_typists([10, 15, 5]), [10, 15]);
 
+    typing_data.add_typist(topic_typing_key, [12], "stream");
+
+    // add another typist to our stream/topic
+    typing_data.add_typist(topic_typing_key, "13", "stream");
+    assert.deepEqual(typing_data.get_stream_typists(stream_id, topic), [12, 13]);
+
     // start adding to a new group
-    typing_data.add_typist(typing_data.get_pms_key([7, 15]), 7);
-    typing_data.add_typist(typing_data.get_pms_key([7, "15"]), 15);
+    typing_data.add_typist(typing_data.get_pms_key([7, 15]), 7, "private");
+    typing_data.add_typist(typing_data.get_pms_key([7, "15"]), 15, "private");
 
     // test get_all_pms_typists
     assert.deepEqual(typing_data.get_all_pms_typists(), [7, 10, 15]);
 
     // test basic removal
-    assert.ok(typing_data.remove_typist(typing_data.get_pms_key([15, 7]), "7"));
+    assert.ok(typing_data.remove_typist(typing_data.get_pms_key([15, 7]), "7", "private"));
     assert.deepEqual(typing_data.get_group_typists([7, 15]), [15]);
+    assert.ok(typing_data.remove_typist(topic_typing_key, "12", "stream"));
+    assert.deepEqual(typing_data.get_stream_typists(stream_id, topic), [13]);
 
     // test removing an id that is not there
-    assert.ok(!typing_data.remove_typist(typing_data.get_pms_key([15, 7]), 7));
+    assert.ok(!typing_data.remove_typist(typing_data.get_pms_key([15, 7]), 7, "private"));
     assert.deepEqual(typing_data.get_group_typists([7, 15]), [15]);
     assert.deepEqual(typing_data.get_all_pms_typists(), [10, 15]);
 
     // remove user from one group, but "15" will still be among
     // "all typists"
-    assert.ok(typing_data.remove_typist(typing_data.get_pms_key(["15", 7]), "15"));
+    assert.ok(typing_data.remove_typist(typing_data.get_pms_key(["15", 7]), "15", "private"));
     assert.deepEqual(typing_data.get_all_pms_typists(), [10, 15]);
 
     // now remove from the other group
-    assert.ok(typing_data.remove_typist(typing_data.get_pms_key([5, 15, 10]), 15));
+    assert.ok(typing_data.remove_typist(typing_data.get_pms_key([5, 15, 10]), 15, "private"));
     assert.deepEqual(typing_data.get_all_pms_typists(), [10]);
 
     // test duplicate ids in a groups
-    typing_data.add_typist(typing_data.get_pms_key([20, 40, 20]), 20);
+    typing_data.add_typist(typing_data.get_pms_key([20, 40, 20]), 20, "private");
     assert.deepEqual(typing_data.get_group_typists([20, 40]), [20]);
 });
 
 test("muted_typists_excluded", () => {
-    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), 5);
-    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), 10);
+    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), 5, "private");
+    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), 10, "private");
 
     // Nobody is muted.
     assert.deepEqual(typing_data.get_group_typists([5, 10, 15]), [5, 10]);
@@ -82,6 +98,9 @@ test("timers", () => {
     const stub_group = [5, 10, 15];
     const stub_delay = 99;
     const stub_f = "function";
+    const stub_stream_id = 1;
+    const stub_topic = "typing notifications";
+    const topic_typing_key = typing_data.get_topic_key(stub_stream_id, stub_topic);
 
     function set_timeout(f, delay) {
         assert.equal(delay, stub_delay);
@@ -113,6 +132,16 @@ test("timers", () => {
     function clear() {
         reset_events();
         typing_data.clear_inbound_timer(typing_data.get_pms_key(stub_group));
+    }
+
+    function streams_kickstart() {
+        reset_events();
+        typing_data.kickstart_inbound_timer(topic_typing_key, stub_delay, stub_f);
+    }
+
+    function streams_clear() {
+        reset_events();
+        typing_data.clear_inbound_timer(topic_typing_key);
     }
 
     set_global("setTimeout", set_timeout);
@@ -148,5 +177,45 @@ test("timers", () => {
         f: undefined,
         timer_cleared: false,
         timer_set: false,
+    });
+
+    // first time, we set
+    streams_kickstart();
+    assert.deepEqual(events, {
+        f: stub_f,
+        timer_cleared: false,
+        timer_set: true,
+    });
+
+    // second time we clear and set
+    streams_kickstart();
+    assert.deepEqual(events, {
+        f: stub_f,
+        timer_cleared: true,
+        timer_set: true,
+    });
+
+    // first time clearing, we clear
+    streams_clear();
+    assert.deepEqual(events, {
+        f: undefined,
+        timer_cleared: true,
+        timer_set: false,
+    });
+
+    // second time clearing, we noop
+    streams_clear();
+    assert.deepEqual(events, {
+        f: undefined,
+        timer_cleared: false,
+        timer_set: false,
+    });
+});
+
+test("get_typist_dict throws error", () => {
+    /* Adding this just for coverage. */
+    assert.throws(() => typing_data.get_typist_dict("neither stream nor private"), {
+        name: "Error",
+        message: "Unknown message_type: neither stream nor private",
     });
 });

--- a/frontend_tests/node_tests/typing_data.js
+++ b/frontend_tests/node_tests/typing_data.js
@@ -35,8 +35,8 @@ test("basics", () => {
     typing_data.add_typist([7, 15], 7);
     typing_data.add_typist([7, "15"], 15);
 
-    // test get_all_typists
-    assert.deepEqual(typing_data.get_all_typists(), [7, 10, 15]);
+    // test get_all_pms_typists
+    assert.deepEqual(typing_data.get_all_pms_typists(), [7, 10, 15]);
 
     // test basic removal
     assert.ok(typing_data.remove_typist([15, 7], "7"));
@@ -45,16 +45,16 @@ test("basics", () => {
     // test removing an id that is not there
     assert.ok(!typing_data.remove_typist([15, 7], 7));
     assert.deepEqual(typing_data.get_group_typists([7, 15]), [15]);
-    assert.deepEqual(typing_data.get_all_typists(), [10, 15]);
+    assert.deepEqual(typing_data.get_all_pms_typists(), [10, 15]);
 
     // remove user from one group, but "15" will still be among
     // "all typists"
     assert.ok(typing_data.remove_typist(["15", 7], "15"));
-    assert.deepEqual(typing_data.get_all_typists(), [10, 15]);
+    assert.deepEqual(typing_data.get_all_pms_typists(), [10, 15]);
 
     // now remove from the other group
     assert.ok(typing_data.remove_typist([5, 15, 10], 15));
-    assert.deepEqual(typing_data.get_all_typists(), [10]);
+    assert.deepEqual(typing_data.get_all_pms_typists(), [10]);
 
     // test duplicate ids in a groups
     typing_data.add_typist([20, 40, 20], 20);
@@ -67,12 +67,12 @@ test("muted_typists_excluded", () => {
 
     // Nobody is muted.
     assert.deepEqual(typing_data.get_group_typists([5, 10, 15]), [5, 10]);
-    assert.deepEqual(typing_data.get_all_typists(), [5, 10]);
+    assert.deepEqual(typing_data.get_all_pms_typists(), [5, 10]);
 
     // Mute a user, and test that the get_* functions exclude that user.
     muted_users.add_muted_user(10);
     assert.deepEqual(typing_data.get_group_typists([5, 10, 15]), [5]);
-    assert.deepEqual(typing_data.get_all_typists(), [5]);
+    assert.deepEqual(typing_data.get_all_pms_typists(), [5]);
 });
 
 test("timers", () => {

--- a/frontend_tests/node_tests/typing_data.js
+++ b/frontend_tests/node_tests/typing_data.js
@@ -78,17 +78,26 @@ test("basics", () => {
 });
 
 test("muted_typists_excluded", () => {
+    const stream_id = 1;
+    const topic = "typing notifications";
+    const topic_typing_key = typing_data.get_topic_key(stream_id, topic);
+
     typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), 5, "private");
     typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), 10, "private");
+    typing_data.add_typist(topic_typing_key, 7, "stream");
+    typing_data.add_typist(topic_typing_key, 12, "stream");
 
     // Nobody is muted.
     assert.deepEqual(typing_data.get_group_typists([5, 10, 15]), [5, 10]);
     assert.deepEqual(typing_data.get_all_pms_typists(), [5, 10]);
+    assert.deepEqual(typing_data.get_stream_typists(stream_id, topic), [7, 12]);
 
     // Mute a user, and test that the get_* functions exclude that user.
     muted_users.add_muted_user(10);
+    muted_users.add_muted_user(7);
     assert.deepEqual(typing_data.get_group_typists([5, 10, 15]), [5]);
     assert.deepEqual(typing_data.get_all_pms_typists(), [5]);
+    assert.deepEqual(typing_data.get_stream_typists(stream_id, topic), [12]);
 });
 
 test("timers", () => {

--- a/frontend_tests/node_tests/typing_data.js
+++ b/frontend_tests/node_tests/typing_data.js
@@ -21,49 +21,49 @@ test("basics", () => {
     // user ids being in arbitrary sorting order and
     // possibly in string form instead of integer. So all
     // the apparent randomness in these tests has a purpose.
-    typing_data.add_typist([5, 10, 15], 15);
+    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), 15);
     assert.deepEqual(typing_data.get_group_typists([15, 10, 5]), [15]);
 
     // test that you can add twice
-    typing_data.add_typist([5, 10, 15], 15);
+    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), 15);
 
     // add another id to our first group
-    typing_data.add_typist([5, 10, 15], "10");
+    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), "10");
     assert.deepEqual(typing_data.get_group_typists([10, 15, 5]), [10, 15]);
 
     // start adding to a new group
-    typing_data.add_typist([7, 15], 7);
-    typing_data.add_typist([7, "15"], 15);
+    typing_data.add_typist(typing_data.get_pms_key([7, 15]), 7);
+    typing_data.add_typist(typing_data.get_pms_key([7, "15"]), 15);
 
     // test get_all_pms_typists
     assert.deepEqual(typing_data.get_all_pms_typists(), [7, 10, 15]);
 
     // test basic removal
-    assert.ok(typing_data.remove_typist([15, 7], "7"));
+    assert.ok(typing_data.remove_typist(typing_data.get_pms_key([15, 7]), "7"));
     assert.deepEqual(typing_data.get_group_typists([7, 15]), [15]);
 
     // test removing an id that is not there
-    assert.ok(!typing_data.remove_typist([15, 7], 7));
+    assert.ok(!typing_data.remove_typist(typing_data.get_pms_key([15, 7]), 7));
     assert.deepEqual(typing_data.get_group_typists([7, 15]), [15]);
     assert.deepEqual(typing_data.get_all_pms_typists(), [10, 15]);
 
     // remove user from one group, but "15" will still be among
     // "all typists"
-    assert.ok(typing_data.remove_typist(["15", 7], "15"));
+    assert.ok(typing_data.remove_typist(typing_data.get_pms_key(["15", 7]), "15"));
     assert.deepEqual(typing_data.get_all_pms_typists(), [10, 15]);
 
     // now remove from the other group
-    assert.ok(typing_data.remove_typist([5, 15, 10], 15));
+    assert.ok(typing_data.remove_typist(typing_data.get_pms_key([5, 15, 10]), 15));
     assert.deepEqual(typing_data.get_all_pms_typists(), [10]);
 
     // test duplicate ids in a groups
-    typing_data.add_typist([20, 40, 20], 20);
+    typing_data.add_typist(typing_data.get_pms_key([20, 40, 20]), 20);
     assert.deepEqual(typing_data.get_group_typists([20, 40]), [20]);
 });
 
 test("muted_typists_excluded", () => {
-    typing_data.add_typist([5, 10, 15], 5);
-    typing_data.add_typist([5, 10, 15], 10);
+    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), 5);
+    typing_data.add_typist(typing_data.get_pms_key([5, 10, 15]), 10);
 
     // Nobody is muted.
     assert.deepEqual(typing_data.get_group_typists([5, 10, 15]), [5, 10]);
@@ -103,12 +103,16 @@ test("timers", () => {
 
     function kickstart() {
         reset_events();
-        typing_data.kickstart_inbound_timer(stub_group, stub_delay, stub_f);
+        typing_data.kickstart_inbound_timer(
+            typing_data.get_pms_key(stub_group),
+            stub_delay,
+            stub_f,
+        );
     }
 
     function clear() {
         reset_events();
-        typing_data.clear_inbound_timer(stub_group);
+        typing_data.clear_inbound_timer(typing_data.get_pms_key(stub_group));
     }
 
     set_global("setTimeout", set_timeout);

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -7,6 +7,7 @@ const {run_test} = require("../zjsunit/test");
 
 const typing = zrequire("typing");
 const compose_pm_pill = zrequire("compose_pm_pill");
+const compose_state = zrequire("compose_state");
 const typing_status = zrequire("../shared/js/typing_status");
 
 function make_time(secs) {
@@ -264,6 +265,7 @@ run_test("basics", ({override_rewire}) => {
     // and typing_status.state.current_recipient are the same
 
     override_rewire(compose_pm_pill, "get_user_ids_string", () => "1,2,3");
+    override_rewire(compose_state, "get_message_type", () => "private");
     typing_status.state.current_recipient = typing.get_recipient();
 
     const call_count = {

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -114,6 +114,14 @@ export function stream() {
     return undefined;
 }
 
+export function stream_id() {
+    const stream_name = stream();
+    if (stream_name === undefined) {
+        return undefined;
+    }
+    return stream_data.get_stream_id(stream_name);
+}
+
 export function stream_sub() {
     if (current_filter === undefined) {
         return undefined;

--- a/static/js/typing_data.js
+++ b/static/js/typing_data.js
@@ -51,7 +51,7 @@ export function get_group_typists(group) {
     return muted_users.filter_muted_user_ids(user_ids);
 }
 
-export function get_all_typists() {
+export function get_all_pms_typists() {
     let typists = Array.from(typist_dct.values()).flat();
     typists = util.sorted_ids(typists);
     return muted_users.filter_muted_user_ids(typists);

--- a/static/js/typing_data.js
+++ b/static/js/typing_data.js
@@ -3,11 +3,13 @@ import * as util from "./util";
 
 // See docs/subsystems/typing-indicators.md for details on typing indicators.
 
-const typist_dct = new Map();
+const pm_typists_dict = new Map();
+const stream_typists_dict = new Map();
 const inbound_timer_dict = new Map();
 
 export function clear_for_testing() {
-    typist_dct.clear();
+    pm_typists_dict.clear();
+    stream_typists_dict.clear();
     inbound_timer_dict.clear();
 }
 
@@ -20,17 +22,35 @@ export function get_pms_key(group) {
     return ids.join(",");
 }
 
-export function add_typist(key, typist) {
-    const current = typist_dct.get(key) || [];
+export function get_topic_key(stream_id, topic) {
+    topic = topic.toLowerCase(); // Topics are case-insensitive
+    return JSON.stringify({stream_id, topic});
+}
+
+export function get_typist_dict(message_type) {
+    if (message_type === "stream") {
+        return stream_typists_dict;
+    }
+
+    if (message_type === "private") {
+        return pm_typists_dict;
+    }
+    throw new Error(`Unknown message_type: ${message_type}`);
+}
+
+export function add_typist(key, typist, message_type) {
+    const typist_dict = get_typist_dict(message_type);
+    const current = typist_dict.get(key) || [];
     typist = to_int(typist);
     if (!current.includes(typist)) {
         current.push(typist);
     }
-    typist_dct.set(key, util.sorted_ids(current));
+    typist_dict.set(key, util.sorted_ids(current));
 }
 
-export function remove_typist(key, typist) {
-    let current = typist_dct.get(key) || [];
+export function remove_typist(key, typist, message_type) {
+    const typist_dict = get_typist_dict(message_type);
+    let current = typist_dict.get(key) || [];
 
     typist = to_int(typist);
     if (!current.includes(typist)) {
@@ -39,20 +59,24 @@ export function remove_typist(key, typist) {
 
     current = current.filter((user_id) => to_int(user_id) !== to_int(typist));
 
-    typist_dct.set(key, current);
+    typist_dict.set(key, current);
     return true;
 }
 
 export function get_group_typists(group) {
     const key = get_pms_key(group);
-    const user_ids = typist_dct.get(key) || [];
+    const user_ids = pm_typists_dict.get(key) || [];
     return muted_users.filter_muted_user_ids(user_ids);
 }
 
 export function get_all_pms_typists() {
-    let typists = Array.from(typist_dct.values()).flat();
+    let typists = Array.from(pm_typists_dict.values()).flat();
     typists = util.sorted_ids(typists);
     return muted_users.filter_muted_user_ids(typists);
+}
+
+export function get_stream_typists(stream_id, topic) {
+    return stream_typists_dict.get(get_topic_key(stream_id, topic)) || [];
 }
 
 // The next functions aren't pure data, but it is easy

--- a/static/js/typing_data.js
+++ b/static/js/typing_data.js
@@ -76,7 +76,8 @@ export function get_all_pms_typists() {
 }
 
 export function get_stream_typists(stream_id, topic) {
-    return stream_typists_dict.get(get_topic_key(stream_id, topic)) || [];
+    const typists = stream_typists_dict.get(get_topic_key(stream_id, topic)) || [];
+    return muted_users.filter_muted_user_ids(typists);
 }
 
 // The next functions aren't pure data, but it is easy

--- a/static/js/typing_data.js
+++ b/static/js/typing_data.js
@@ -15,13 +15,12 @@ function to_int(s) {
     return Number.parseInt(s, 10);
 }
 
-function get_key(group) {
+export function get_pms_key(group) {
     const ids = util.sorted_ids(group);
     return ids.join(",");
 }
 
-export function add_typist(group, typist) {
-    const key = get_key(group);
+export function add_typist(key, typist) {
     const current = typist_dct.get(key) || [];
     typist = to_int(typist);
     if (!current.includes(typist)) {
@@ -30,8 +29,7 @@ export function add_typist(group, typist) {
     typist_dct.set(key, util.sorted_ids(current));
 }
 
-export function remove_typist(group, typist) {
-    const key = get_key(group);
+export function remove_typist(key, typist) {
     let current = typist_dct.get(key) || [];
 
     typist = to_int(typist);
@@ -46,7 +44,7 @@ export function remove_typist(group, typist) {
 }
 
 export function get_group_typists(group) {
-    const key = get_key(group);
+    const key = get_pms_key(group);
     const user_ids = typist_dct.get(key) || [];
     return muted_users.filter_muted_user_ids(user_ids);
 }
@@ -59,8 +57,7 @@ export function get_all_pms_typists() {
 
 // The next functions aren't pure data, but it is easy
 // enough to mock the setTimeout/clearTimeout functions.
-export function clear_inbound_timer(group) {
-    const key = get_key(group);
+export function clear_inbound_timer(key) {
     const timer = inbound_timer_dict.get(key);
     if (timer) {
         clearTimeout(timer);
@@ -68,9 +65,8 @@ export function clear_inbound_timer(group) {
     }
 }
 
-export function kickstart_inbound_timer(group, delay, callback) {
-    const key = get_key(group);
-    clear_inbound_timer(group);
+export function kickstart_inbound_timer(key, delay, callback) {
+    clear_inbound_timer(key);
     const timer = setTimeout(callback, delay);
     inbound_timer_dict.set(key, timer);
 }

--- a/static/js/typing_events.js
+++ b/static/js/typing_events.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 
 import render_typing_notifications from "../templates/typing_notifications.hbs";
 
+import * as blueslip from "./blueslip";
 import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as people from "./people";
@@ -27,8 +28,12 @@ const MAX_USERS_TO_DISPLAY_NAME = 3;
 // that make typing indicators work.
 
 function get_users_typing_for_narrow() {
+    if (narrow_state.narrowed_to_topic()) {
+        return typing_data.get_stream_typists(narrow_state.stream_id(), narrow_state.topic());
+    }
+
     if (!narrow_state.narrowed_to_pms()) {
-        // Narrow is neither pm-with nor is: private
+        // Narrow is neither pm-with nor is: private nor topic
         return [];
     }
 
@@ -69,14 +74,31 @@ export function render_notifications_for_narrow() {
     }
 }
 
+function get_key(event) {
+    let key;
+    let recipients;
+    switch (event.message_type) {
+        case "stream":
+            key = typing_data.get_topic_key(event.stream_id, event.topic);
+            break;
+        case "private":
+            recipients = event.recipients.map((user) => user.user_id);
+            recipients.sort();
+
+            key = typing_data.get_pms_key(recipients);
+            break;
+        default:
+            blueslip.error("Unexpected message_type in typing event: " + event.message_type);
+            break;
+    }
+    return key;
+}
+
 export function hide_notification(event) {
-    const recipients = event.recipients.map((user) => user.user_id);
-    recipients.sort();
+    const key = get_key(event);
+    typing_data.clear_inbound_timer(key);
 
-    const pms_typing_key = typing_data.get_pms_key(recipients);
-    typing_data.clear_inbound_timer(pms_typing_key);
-
-    const removed = typing_data.remove_typist(pms_typing_key, event.sender.user_id);
+    const removed = typing_data.remove_typist(key, event.sender.user_id, event.message_type);
 
     if (removed) {
         render_notifications_for_narrow();
@@ -84,18 +106,15 @@ export function hide_notification(event) {
 }
 
 export function display_notification(event) {
-    const recipients = event.recipients.map((user) => user.user_id);
-    recipients.sort();
-
     const sender_id = event.sender.user_id;
     event.sender.name = people.get_by_user_id(sender_id).full_name;
 
-    const pms_typing_key = typing_data.get_pms_key(recipients);
-    typing_data.add_typist(pms_typing_key, sender_id);
+    const key = get_key(event);
+    typing_data.add_typist(key, sender_id, event.message_type);
 
     render_notifications_for_narrow();
 
-    typing_data.kickstart_inbound_timer(pms_typing_key, TYPING_STARTED_EXPIRY_PERIOD, () => {
+    typing_data.kickstart_inbound_timer(key, TYPING_STARTED_EXPIRY_PERIOD, () => {
         hide_notification(event);
     });
 }

--- a/static/js/typing_events.js
+++ b/static/js/typing_events.js
@@ -48,7 +48,7 @@ function get_users_typing_for_narrow() {
         return typing_data.get_group_typists(group);
     }
     // Get all users typing (in all private conversations with current user)
-    return typing_data.get_all_typists();
+    return typing_data.get_all_pms_typists();
 }
 
 export function render_notifications_for_narrow() {

--- a/static/js/typing_events.js
+++ b/static/js/typing_events.js
@@ -73,9 +73,10 @@ export function hide_notification(event) {
     const recipients = event.recipients.map((user) => user.user_id);
     recipients.sort();
 
-    typing_data.clear_inbound_timer(recipients);
+    const pms_typing_key = typing_data.get_pms_key(recipients);
+    typing_data.clear_inbound_timer(pms_typing_key);
 
-    const removed = typing_data.remove_typist(recipients, event.sender.user_id);
+    const removed = typing_data.remove_typist(pms_typing_key, event.sender.user_id);
 
     if (removed) {
         render_notifications_for_narrow();
@@ -89,11 +90,12 @@ export function display_notification(event) {
     const sender_id = event.sender.user_id;
     event.sender.name = people.get_by_user_id(sender_id).full_name;
 
-    typing_data.add_typist(recipients, sender_id);
+    const pms_typing_key = typing_data.get_pms_key(recipients);
+    typing_data.add_typist(pms_typing_key, sender_id);
 
     render_notifications_for_narrow();
 
-    typing_data.kickstart_inbound_timer(recipients, TYPING_STARTED_EXPIRY_PERIOD, () => {
+    typing_data.kickstart_inbound_timer(pms_typing_key, TYPING_STARTED_EXPIRY_PERIOD, () => {
         hide_notification(event);
     });
 }

--- a/static/shared/js/typing_status.js
+++ b/static/shared/js/typing_status.js
@@ -74,10 +74,6 @@ export function maybe_ping_server(worker, recipient) {
  * rate, and keeps a timer to send a "stopped typing" notice when the user
  * hasn't typed for a few seconds.
  *
- * Zulip supports typing notifications only for PMs (both 1:1 and group); so
- * composing a stream message should be treated like composing no message at
- * all.
- *
  * Call with `new_recipient` of `null` when the user actively stops
  * composing a message.  If the user switches from one set of recipients to
  * another, there's no need to call with `null` in between; the
@@ -88,9 +84,11 @@ export function maybe_ping_server(worker, recipient) {
  *
  * @param {*} worker Callbacks for reaching the real world.  See typing.js
  *   for implementations.
- * @param {*} new_recipient The users the PM being composed is addressed to,
- *   as a sorted array of user IDs; or `null` if no PM is being composed
- *   anymore.
+ * @param {*} new_recipient Depends on type of message being composed. If
+ *   * Private message: The users the PM being composed is addressed to,
+ *     as a sorted array of user IDs
+ *   * Stream message: An Object containing the stream_id and topic
+ *   * No meesage is being composed: `null`
  */
 export function update(worker, new_recipient) {
     const current_recipient = state.current_recipient;

--- a/static/shared/js/typing_status.js.flow
+++ b/static/shared/js/typing_status.js.flow
@@ -5,14 +5,15 @@
 "use strict";
 
 type RecipientUserIds<UserId: number> = $ReadOnlyArray<UserId>;
+type StreamTopicObject = {|stream_id: number, topic: string|};
 
 type Worker<UserId> = {|
     get_current_time: () => number, // as ms since epoch
-    notify_server_start: (RecipientUserIds<UserId>) => void,
-    notify_server_stop: (RecipientUserIds<UserId>) => void,
+    notify_server_start: (RecipientUserIds<UserId> | StreamTopicObject) => void,
+    notify_server_stop: (RecipientUserIds<UserId> | StreamTopicObject) => void,
 |};
 
 declare export function update<UserId>(
     worker: Worker<UserId>,
-    new_recipient: RecipientUserIds<UserId> | null,
+    new_recipient: RecipientUserIds<UserId> | StreamTopicObject | null,
 ): void;

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -134,7 +134,7 @@ def build_page_params_for_home_page_load(
         "notification_settings_null": True,
         "bulk_message_deletion": True,
         "user_avatar_url_field_optional": True,
-        "stream_typing_notifications": False,  # Set this to True when frontend support is implemented.
+        "stream_typing_notifications": True,
         "user_settings_object": True,
     }
 


### PR DESCRIPTION
Fixes #11152

This is almost done. Things left to be done are

- [x] Fix and add few frontend tests.
- [x] Document the new arguments `stream_id` and `topic` for `api/v1/typing` in `zerver/openapi/zulip.yaml`.
- [x] Send typing notification only if the topic already exists as we want to show typing notification only in a topic narrow.

Sending a request to streams with 0 or 1 subscriber(only sender) won't throw any error. Do we want to return any error for that?

