### PR TITLE
linkifiers: Add setting to edit linkifiers.

### DIFF
--- a/frontend_tests/puppeteer_tests/realm-linkifier.ts
+++ b/frontend_tests/puppeteer_tests/realm-linkifier.ts
@@ -35,11 +35,11 @@ async function test_add_linkifier(page: Page): Promise<void> {
 }
 
 async function test_delete_linkifier(page: Page): Promise<void> {
-    await page.click(".linkifier_row button");
+    await page.click(".linkifier_row .delete");
     await page.waitForSelector(".linkifier_row", {hidden: true});
 }
 
-async function test_invalid_linkifier_pattern(page: Page): Promise<void> {
+async function test_add_invalid_linkifier_pattern(page: Page): Promise<void> {
     await page.waitForSelector(".admin-linkifier-form", {visible: true});
     await common.fill_form(page, "form.admin-linkifier-form", {
         pattern: "a$",
@@ -54,14 +54,94 @@ async function test_invalid_linkifier_pattern(page: Page): Promise<void> {
     );
 }
 
+async function test_edit_linkifier(page: Page): Promise<void> {
+    await page.click(".linkifier_row .edit");
+    await page.waitForFunction(() => document.activeElement === $("#linkifier-edit-form-modal")[0]);
+    await common.fill_form(page, "form.linkifier-edit-form", {
+        pattern: "(?P<num>[0-9a-f]{40})",
+        url_format_string: "https://trac.example.com/commit/%(num)s",
+    });
+    await page.click(".submit-linkifier-info-change");
+
+    await page.waitForSelector("#linkifier-edit-form-modal", {hidden: true});
+    await page.waitForFunction(() => $(".edit-linkifier-status").text().trim() === "Saved");
+    await page.waitForSelector(".linkifier_row", {visible: true});
+    assert.strictEqual(
+        await common.get_text_from_selector(page, ".linkifier_row span.linkifier_pattern"),
+        "(?P<num>[0-9a-f]{40})",
+    );
+    assert.strictEqual(
+        await common.get_text_from_selector(
+            page,
+            ".linkifier_row span.linkifier_url_format_string",
+        ),
+        "https://trac.example.com/commit/%(num)s",
+    );
+}
+
+async function test_edit_invalid_linkifier(page: Page): Promise<void> {
+    await page.click(".linkifier_row .edit");
+    await page.waitForFunction(() => document.activeElement === $("#linkifier-edit-form-modal")[0]);
+    await common.fill_form(page, "form.linkifier-edit-form", {
+        pattern: "####",
+        url_format_string: "####",
+    });
+    await page.click(".submit-linkifier-info-change");
+
+    const edit_linkifier_pattern_status_selector = "div#edit-linkifier-pattern-status";
+    await page.waitForSelector(edit_linkifier_pattern_status_selector, {visible: true});
+    const edit_linkifier_pattern_status = await common.get_text_from_selector(
+        page,
+        edit_linkifier_pattern_status_selector,
+    );
+    assert.strictEqual(
+        edit_linkifier_pattern_status,
+        "Failed: Invalid linkifier pattern.  Valid characters are [ a-zA-Z_#=/:+!-].",
+    );
+
+    const edit_linkifier_format_status_selector = "div#edit-linkifier-format-status";
+    await page.waitForSelector(edit_linkifier_format_status_selector, {visible: true});
+    const edit_linkifier_format_status = await common.get_text_from_selector(
+        page,
+        edit_linkifier_format_status_selector,
+    );
+    assert.strictEqual(
+        edit_linkifier_format_status,
+        "Failed: Enter a valid URL.,Invalid URL format string.",
+    );
+
+    await page.click(".cancel-linkifier-info-change");
+    await page.waitForSelector("#linkifier-edit-form-modal", {hidden: true});
+
+    await page.waitForFunction(
+        () =>
+            $(".edit-linkifier-status").text().trim() ===
+            "Save failed: Invalid linkifier pattern.  Valid characters are [ a-zA-Z_#=/:+!-].",
+    );
+    await page.waitForSelector(".linkifier_row", {visible: true});
+    assert.strictEqual(
+        await common.get_text_from_selector(page, ".linkifier_row span.linkifier_pattern"),
+        "(?P<num>[0-9a-f]{40})",
+    );
+    assert.strictEqual(
+        await common.get_text_from_selector(
+            page,
+            ".linkifier_row span.linkifier_url_format_string",
+        ),
+        "https://trac.example.com/commit/%(num)s",
+    );
+}
+
 async function linkifier_test(page: Page): Promise<void> {
     await common.log_in(page);
     await common.manage_organization(page);
     await page.click("li[data-section='linkifier-settings']");
 
     await test_add_linkifier(page);
+    await test_edit_linkifier(page);
+    await test_edit_invalid_linkifier(page);
+    await test_add_invalid_linkifier_pattern(page);
     await test_delete_linkifier(page);
-    await test_invalid_linkifier_pattern(page);
 }
 
 common.run_test(linkifier_test);

--- a/static/js/settings_linkifiers.js
+++ b/static/js/settings_linkifiers.js
@@ -1,11 +1,14 @@
 import $ from "jquery";
 
+import render_admin_linkifier_edit_form from "../templates/settings/admin_linkifier_edit_form.hbs";
 import render_admin_linkifier_list from "../templates/settings/admin_linkifier_list.hbs";
 
 import * as channel from "./channel";
 import {$t_html} from "./i18n";
 import * as ListWidget from "./list_widget";
+import * as overlays from "./overlays";
 import {page_params} from "./page_params";
+import * as settings_ui from "./settings_ui";
 import * as ui from "./ui";
 import * as ui_report from "./ui_report";
 
@@ -38,6 +41,22 @@ function sort_pattern(a, b) {
 
 function sort_url(a, b) {
     return compare_values(a.url_format, b.url_format);
+}
+
+function open_linkifier_edit_form(linkifier_id) {
+    const linkifiers_list = page_params.realm_linkifiers;
+    const linkifier = linkifiers_list.find((linkifier) => linkifier.id === linkifier_id);
+    const edit_form_html = render_admin_linkifier_edit_form({
+        linkifier_id,
+        pattern: linkifier.pattern,
+        url_format_string: linkifier.url_format,
+    });
+    const $edit_form_div = $(edit_form_html);
+    const modal_container = $("#linkifier-edit-form-modal-container");
+    modal_container.empty().append($edit_form_div);
+    overlays.open_modal("#linkifier-edit-form-modal");
+
+    return $edit_form_div;
 }
 
 function handle_linkifier_api_error(xhr, pattern_status, format_status, linkifier_status) {
@@ -124,6 +143,58 @@ export function build_page() {
                 const row = btn.parents("tr");
                 row.remove();
             },
+        });
+    });
+
+    $(".admin_linkifiers_table").on("click", ".edit", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const btn = $(this);
+        const linkifier_id = Number.parseInt(btn.attr("data-linkifier-id"), 10);
+        const modal = open_linkifier_edit_form(linkifier_id);
+
+        modal.find(".submit-linkifier-info-change").on("click", (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            const change_linkifier_button = $(".submit-linkifier-info-change");
+            change_linkifier_button.prop("disabled", true);
+
+            const url = "/json/realm/filters/" + encodeURIComponent(linkifier_id);
+            const pattern = modal.find("#edit-linkifier-pattern").val().trim();
+            const url_format_string = modal.find("#edit-linkifier-url-format-string").val().trim();
+            const data = {pattern, url_format_string};
+            const pattern_status = modal.find("#edit-linkifier-pattern-status").expectOne();
+            const format_status = modal.find("#edit-linkifier-format-status").expectOne();
+            const linkifier_status = modal.find(".edit-linkifier-status").expectOne();
+            const opts = {
+                success_continuation() {
+                    change_linkifier_button.prop("disabled", false);
+                    overlays.close_modal("#linkifier-edit-form-modal");
+                },
+                error_continuation(xhr) {
+                    change_linkifier_button.prop("disabled", false);
+                    const response_text = JSON.parse(xhr.responseText);
+                    if (response_text.errors !== undefined) {
+                        handle_linkifier_api_error(
+                            xhr,
+                            pattern_status,
+                            format_status,
+                            linkifier_status,
+                        );
+                    } else {
+                        // This must be `Linkifier not found` error.
+                        ui_report.error($t_html({defaultMessage: "Failed"}), xhr, linkifier_status);
+                    }
+                },
+            };
+            settings_ui.do_settings_change(
+                channel.patch,
+                url,
+                data,
+                $("#linkifier-field-status"),
+                opts,
+            );
         });
     });
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1927,3 +1927,15 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
         max-height: unset;
     }
 }
+
+.linkifier-edit-form {
+    #edit-linkifier-pattern,
+    #edit-linkifier-url-format-string {
+        width: 400px;
+    }
+
+    #edit-linkifier-pattern-status,
+    #edit-linkifier-format-status {
+        margin-top: 10px;
+    }
+}

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -85,9 +85,6 @@ h3 .fa-question-circle-o {
         ul {
             text-align: left;
         }
-        &.button i.fa.fa-pencil {
-            margin-left: 3px;
-        }
     }
     /* this is because the input[type=text] is also 200px wide but has
     12px of padding and 2px worth of borders. These don't apply to
@@ -365,6 +362,14 @@ td .button {
 
     .inline {
         display: inline !important;
+    }
+
+    /* Messy implementation of buttons with text and a pencil icon in them
+       having spacing before the pencil icon. */
+    button.btn-link i.fa-pencil,
+    button[data-dismiss="modal"] i.fa-pencil,
+    .dropdown-toggle i.fa-pencil {
+        margin-left: 3px;
     }
 }
 

--- a/static/templates/copy_code_button.hbs
+++ b/static/templates/copy_code_button.hbs
@@ -1,3 +1,3 @@
-<button class="btn pull-left copy_button_base copy_codeblock tippy-zulip-tooltip" data-tippy-content="{{t "Copy code" }}" aria-label="{{t "Copy code" }}">
+<button class="btn pull-left copy_button_base copy_codeblock tippy-zulip-tooltip" data-tippy-content="{{t 'Copy code' }}" aria-label="{{t 'Copy code' }}">
     {{> copy_to_clipboard_svg }}
 </button>

--- a/static/templates/copy_invite_link.hbs
+++ b/static/templates/copy_invite_link.hbs
@@ -1,7 +1,7 @@
 {{t "Link:" }}
 <a href="{{ invite_link }}" id="multiuse_invite_link">{{ invite_link }}</a>
 &nbsp;
-<a class="btn pull-right copy_button_base tippy-zulip-tooltip" data-tippy-content="{{t "Copy link" }}" aria-label="{{t "Copy link" }}"
+<a class="btn pull-right copy_button_base tippy-zulip-tooltip" data-tippy-content="{{t 'Copy link' }}" aria-label="{{t 'Copy link' }}"
   id='copy_generated_invite_link' data-clipboard-text="{{ invite_link }}">
     {{> copy_to_clipboard_svg }}
 </a>

--- a/static/templates/copy_message_button.hbs
+++ b/static/templates/copy_message_button.hbs
@@ -1,3 +1,3 @@
-<button class="btn pull-right copy_button_base copy_message tippy-zulip-tooltip" data-tippy-content="{{t "Copy and close" }}" aria-label="{{t "Copy and close" }}" >
+<button class="btn pull-right copy_button_base copy_message tippy-zulip-tooltip" data-tippy-content="{{t 'Copy and close' }}" aria-label="{{t 'Copy and close' }}" >
     {{> copy_to_clipboard_svg }}
 </button>

--- a/static/templates/edit_content_button.hbs
+++ b/static/templates/edit_content_button.hbs
@@ -1,5 +1,5 @@
 {{#if is_editable}}
-<i class="fa fa-pencil edit_content_button" role="button" tabindex="0" aria-label="{{t "Edit" }} (e)" title="{{t "Edit" }} (e)"></i>
+<i class="fa fa-pencil edit_content_button" role="button" tabindex="0" aria-label="{{t 'Edit' }} (e)" title="{{t 'Edit' }} (e)"></i>
 {{else}}
-<i class="fa fa-file-code-o edit_content_button" role="button" tabindex="0" aria-label="{{t "View source" }} (e)" title="{{t "View source" }} (e)" data-message-id="{{msg_id}}"></i>
+<i class="fa fa-file-code-o edit_content_button" role="button" tabindex="0" aria-label="{{t 'View source' }} (e)" title="{{t 'View source' }} (e)" data-message-id="{{msg_id}}"></i>
 {{/if}}

--- a/static/templates/markdown_help.hbs
+++ b/static/templates/markdown_help.hbs
@@ -1,5 +1,5 @@
 <div class="overlay-modal hide" id="message-formatting" tabindex="-1" role="dialog"
-  aria-label="{{t "Message formatting" }}">
+  aria-label="{{t 'Message formatting' }}">
     <div class="modal-body" data-simplebar data-simplebar-auto-hide="false">
         <div id="markdown-instructions">
             <table class="table table-striped table-condensed table-rounded table-bordered help-table">

--- a/static/templates/new_stream_users.hbs
+++ b/static/templates/new_stream_users.hbs
@@ -19,7 +19,7 @@
 
 <br />
 <input class="add-user-list-filter" name="user_list_filter" type="text"
-  autocomplete="off" placeholder="{{t "Filter" }}" />
+  autocomplete="off" placeholder="{{t 'Filter' }}" />
 
 
 <div>

--- a/static/templates/settings/admin_linkifier_edit_form.hbs
+++ b/static/templates/settings/admin_linkifier_edit_form.hbs
@@ -1,0 +1,27 @@
+<div id="linkifier-edit-form-modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="linkifier-edit-form-modal-label" aria-hidden="true">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        <h3 id="linkifier-edit-form-modal-label">{{t "Edit linkifiers" }}</h3>
+        <div class="alert-notification edit-linkifier-status"></div>
+    </div>
+    <div class="modal-body">
+        <div id="edit-linkifier-form">
+            <form class="form-horizontal linkifier-edit-form">
+                <div class="input-group name_change_container">
+                    <label for="edit-linkifier-pattern" >{{t "Pattern" }}</label>
+                    <input type="text" autocomplete="off" id="edit-linkifier-pattern" name="pattern" placeholder="#(?P<id>[0-9]+)" value="{{ pattern }}" />
+                    <div class="alert" id="edit-linkifier-pattern-status"></div>
+                </div>
+                <div class="input-group name_change_container">
+                    <label for="edit-linkifier-url-format-string" >{{t "URL format string" }}</label>
+                    <input type="text" autocomplete="off" id="edit-linkifier-url-format-string" name="url_format_string" placeholder="https://github.com/zulip/zulip/issues/%(id)s" value="{{ url_format_string }}" />
+                    <div class="alert" id="edit-linkifier-format-status"></div>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button type="submit" class="button rounded sea-green submit-linkifier-info-change">{{t "Save changes" }}</button>
+        <button type="button" class="button rounded cancel-linkifier-info-change" data-dismiss="modal">{{t "Cancel" }}</button>
+    </div>
+</div>

--- a/static/templates/settings/admin_linkifier_list.hbs
+++ b/static/templates/settings/admin_linkifier_list.hbs
@@ -8,6 +8,9 @@
     </td>
     {{#if ../can_modify}}
     <td class="no-select actions">
+        <button class="button small edit btn-warning" data-linkifier-id="{{id}}" title="{{t 'Edit' }}" aria-label="{{t 'Edit' }}">
+            <i class="fa fa-pencil"></i>
+        </button>
         <button class="button small delete btn-danger" data-linkifier-id="{{id}}" title="{{t 'Delete' }}" aria-label="{{t 'Delete' }}">
             <i class="fa fa-trash-o"></i>
         </button>

--- a/static/templates/settings/admin_linkifier_list.hbs
+++ b/static/templates/settings/admin_linkifier_list.hbs
@@ -8,8 +8,8 @@
     </td>
     {{#if ../can_modify}}
     <td class="no-select actions">
-        <button class="button small delete btn-danger" data-linkifier-id="{{id}}">
-            <i class="fa fa-trash-o" aria-hidden="true"></i>
+        <button class="button small delete btn-danger" data-linkifier-id="{{id}}" title="{{t 'Delete' }}" aria-label="{{t 'Delete' }}">
+            <i class="fa fa-trash-o"></i>
         </button>
     </td>
     {{/if}}

--- a/static/templates/settings/admin_settings_modals.hbs
+++ b/static/templates/settings/admin_settings_modals.hbs
@@ -5,3 +5,4 @@
 {{> resend_invite_modal }}
 
 <div id="user-info-form-modal-container"></div>
+<div id="linkifier-edit-form-modal-container"></div>

--- a/static/templates/settings/default_streams_list_admin.hbs
+++ b/static/templates/settings/default_streams_list_admin.hbs
@@ -11,7 +11,7 @@
                 <div class="settings-section-title">{{t "Add new default stream" }}</div>
                 <div class="inline-block" id="default_stream_inputs">
                     <label for="default_stream_name">{{t "Stream name" }}</label>
-                    <input class="create_default_stream" type="text" placeholder="{{t "Stream name" }}" name="stream_name" autocomplete="off" aria-label="{{t "Stream name" }}" />
+                    <input class="create_default_stream" type="text" placeholder="{{t 'Stream name' }}" name="stream_name" autocomplete="off" />
                 </div>
                 <div class="inline-block">
                     <button type="submit" id="do_submit_stream" class="button rounded sea-green">{{t "Add stream" }}</button>

--- a/static/templates/settings/linkifier_settings_admin.hbs
+++ b/static/templates/settings/linkifier_settings_admin.hbs
@@ -66,6 +66,7 @@
         {{/if}}
 
         <input type="text" class="search" placeholder="{{t 'Filter linkifiers' }}" aria-label="{{t 'Filter linkifiers' }}"/>
+        <div class="alert-notification edit-linkifier-status" id="linkifier-field-status"></div>
         <div class="progressive-table-wrapper" data-simplebar>
             <table class="table table-condensed table-striped wrapped-table admin_linkifiers_table">
                 <thead class="table-sticky-headers">

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -745,6 +745,10 @@ handlebars_rules = RuleList(
             "pattern": '{{t "[^"]+ " }}',
             "description": "Translatable strings should not have trailing spaces.",
         },
+        {
+            "pattern": r'"{{t "',
+            "description": "Invalid quoting for HTML element with translated string.",
+        },
     ],
 )
 


### PR DESCRIPTION
This commit adds a setting to edit realm filters. A new API is added in zproject/urls.py.Modal, added to edit realm filters, supports ui_report error.

Fixes #10830.

**Testing plan:** 
New test cases are added for this new setting.

**GIFs or screenshots:** 
#### Modal to Edit Linkifiers:
![Screenshot from 2021-01-12 21-31-31](https://user-images.githubusercontent.com/67277428/104345600-8e543900-5524-11eb-813a-64d249dffe4b.png)
-----------------------------------------------
#### Edit Linkifiers:
![Screenshot from 2021-01-12 21-33-30](https://user-images.githubusercontent.com/67277428/104345611-9318ed00-5524-11eb-834a-7c7e18d707e1.png)

