### PR TITLE
settings: Move LDAP configuration together, in the same order.

### DIFF
--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -39,10 +39,19 @@ EMAIL_HOST: Optional[str] = None
 
 # LDAP auth
 AUTH_LDAP_SERVER_URI = ""
+AUTH_LDAP_BIND_DN = ""
+AUTH_LDAP_USER_SEARCH: Optional["LDAPSearch"] = None
 LDAP_APPEND_DOMAIN: Optional[str] = None
 LDAP_EMAIL_ATTR: Optional[str] = None
-AUTH_LDAP_USERNAME_ATTR: Optional[str] = None
 AUTH_LDAP_REVERSE_EMAIL_SEARCH: Optional["LDAPSearch"] = None
+AUTH_LDAP_USERNAME_ATTR: Optional[str] = None
+# AUTH_LDAP_USER_ATTR_MAP is uncommented in prod_settings_template.py,
+# so the value here mainly serves to help document the default.
+AUTH_LDAP_USER_ATTR_MAP: Dict[str, str] = {
+    "full_name": "cn",
+}
+# Automatically deactivate users not found by the AUTH_LDAP_USER_SEARCH query.
+LDAP_DEACTIVATE_NON_MATCHING_USERS: Optional[bool] = None
 # AUTH_LDAP_CONNECTION_OPTIONS: we set ldap.OPT_REFERRALS in settings.py if unset.
 AUTH_LDAP_CONNECTION_OPTIONS: Dict[int, object] = {}
 # Disable django-auth-ldap caching, to prevent problems with OU changes.
@@ -423,9 +432,6 @@ IS_DEV_DROPLET = False
 
 # Used by puppet/zulip_ops/files/cron.d/check_send_receive_time.
 NAGIOS_BOT_HOST = EXTERNAL_HOST
-
-# Automatically deactivate users not found by the AUTH_LDAP_USER_SEARCH query.
-LDAP_DEACTIVATE_NON_MATCHING_USERS: Optional[bool] = None
 
 # Use half of the available CPUs for data import purposes.
 DEFAULT_DATA_EXPORT_IMPORT_PARALLELISM = (len(os.sched_getaffinity(0)) // 2) or 1

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -142,12 +142,11 @@ from django_auth_ldap.config import LDAPSearch
 
 # The LDAP server to connect to.  Setting this enables Zulip
 # automatically fetching each new user's name from LDAP.
-# Example: "ldaps://ldap.example.com"
-AUTH_LDAP_SERVER_URI = ""
+#AUTH_LDAP_SERVER_URI = "ldaps://ldap.example.com"
 
 # The DN of the user to bind as (i.e., authenticate as) in order to
 # query LDAP.  If unset, Zulip does an anonymous bind.
-AUTH_LDAP_BIND_DN = ""
+#AUTH_LDAP_BIND_DN = ""
 
 # Passwords and secrets are not stored in this file.  The password
 # corresponding to AUTH_LDAP_BIND_DN goes in `/etc/zulip/zulip-secrets.conf`.


### PR DESCRIPTION
Match the order of the variables between `default_settings.py` and
`settings.py`, and move the defaults into `default_settings.py` so
the section does not require any uncommented lines in `settings.py` if
LDAP is not in use.

**Testing plan:** Existing tests.