### PR TITLE
run-dev: Fix dev url showing extra port when EXTERNAL_HOST is specified.

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -340,8 +340,8 @@ def shutdown_handler(*args: Any, **kwargs: Any) -> None:
         io_loop.stop()
 
 def print_listeners() -> None:
-    external_host = os.getenv('EXTERNAL_HOST', 'localhost')
-    print(f"\nStarting Zulip on:\n\n\t{CYAN}http://{external_host}:{proxy_port}/{ENDC}\n\nInternal ports:")
+    external_host = os.getenv('EXTERNAL_HOST', f'localhost:{proxy_port}')
+    print(f"\nStarting Zulip on:\n\n\t{CYAN}http://{external_host}/{ENDC}\n\nInternal ports:")
     ports = [
         (proxy_port, 'Development server proxy (connect here)'),
         (django_port, 'Django'),


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#17054


**Testing plan:** <!-- How have you tested? -->
Tested with linter and local tests.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
