### PR TITLE
message_edit: Stop stream_header_colorblock from overlapping others.

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -412,7 +412,7 @@
 .stream_header_colorblock {
     @extend .stream-selection-header-colorblock;
     margin-bottom: 5px;
-    z-index: 1000;
+    z-index: 1;
 }
 
 .edit-controls .fa-angle-right,


### PR DESCRIPTION
<img width="386" alt="Screenshot 2021-01-16 at 8 06 24 PM" src="https://user-images.githubusercontent.com/25124304/104835966-32950180-58d0-11eb-978f-e379d6f08da6.png">
<img width="386" alt="Screenshot 2021-01-16 at 8 06 32 PM" src="https://user-images.githubusercontent.com/25124304/104835974-3a54a600-58d0-11eb-9b82-46f280b5a88c.png">
