### PR TITLE
retention: Eliminate redundant JOIN from cross-realm query.

### DIFF
--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -256,8 +256,7 @@ def move_expired_personal_and_huddle_messages_to_archive(realm: Realm,
         FROM zerver_message
         INNER JOIN zerver_recipient ON zerver_recipient.id = zerver_message.recipient_id
         INNER JOIN zerver_userprofile recipient_profile ON recipient_profile.id = zerver_recipient.type_id
-        INNER JOIN zerver_userprofile sender_profile ON sender_profile.id = zerver_message.sender_id
-        WHERE sender_profile.id IN {cross_realm_bot_ids}
+        WHERE zerver_message.sender_id IN {cross_realm_bot_ids}
             AND recipient_profile.realm_id = {realm_id}
             AND zerver_recipient.type = {recipient_personal}
             AND zerver_message.date_sent < {check_date}

--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -254,11 +254,9 @@ def move_expired_personal_and_huddle_messages_to_archive(realm: Realm,
     INSERT INTO zerver_archivedmessage ({dst_fields}, archive_transaction_id)
         SELECT {src_fields}, {archive_transaction_id}
         FROM zerver_message
-        INNER JOIN zerver_recipient ON zerver_recipient.id = zerver_message.recipient_id
-        INNER JOIN zerver_userprofile recipient_profile ON recipient_profile.id = zerver_recipient.type_id
+        INNER JOIN zerver_userprofile recipient_profile ON recipient_profile.recipient_id = zerver_message.recipient_id
         WHERE zerver_message.sender_id IN {cross_realm_bot_ids}
             AND recipient_profile.realm_id = {realm_id}
-            AND zerver_recipient.type = {recipient_personal}
             AND zerver_message.date_sent < {check_date}
         LIMIT {chunk_size}
     ON CONFLICT (id) DO UPDATE SET archive_transaction_id = {archive_transaction_id}
@@ -270,7 +268,6 @@ def move_expired_personal_and_huddle_messages_to_archive(realm: Realm,
         realm=realm,
         cross_realm_bot_ids=Literal(tuple(cross_realm_bot_ids)),
         realm_id=Literal(realm.id),
-        recipient_personal=Literal(Recipient.PERSONAL),
         check_date=Literal(check_date.isoformat()),
         chunk_size=chunk_size,
     )


### PR DESCRIPTION
The query for archiving cross-realm messages takes a lot of time, raising nagios alerts. Removing this useless JOIN should improve the situation, hopefully to a sufficient extent.

Query plans: (in the dev environment, not sure how representative they are of what happens on zulipchat)

Old query:
```
zulip=>     EXPLAIN ANALYZE
zulip->     INSERT INTO zerver_archivedmessage ("id","sender_id","recipient_id","subject","content","rendered_content","rendered_content_version","date_sent","sending_client_id","last_edit_time","edit_history","has_attachment","has_image","has_link", archive_transaction_id)
zulip->         SELECT "zerver_message"."id","zerver_message"."sender_id","zerver_message"."recipient_id","zerver_message"."subject","zerver_message"."content","zerver_message"."rendered_content","zerver_message"."rendered_content_version","zerver_message"."date_sent","zerver_message"."sending_client_id","zerver_message"."last_edit_time","zerver_message"."edit_history","zerver_message"."has_attachment","zerver_message"."has_image","zerver_message"."has_link", 34
zulip->         FROM zerver_message
zulip->         INNER JOIN zerver_recipient ON zerver_recipient.id = zerver_message.recipient_id
zulip->         INNER JOIN zerver_userprofile recipient_profile ON recipient_profile.id = zerver_recipient.type_id
zulip->         INNER JOIN zerver_userprofile sender_profile ON sender_profile.id = zerver_message.sender_id
zulip->         WHERE sender_profile.id IN (1, 4, 5)
zulip->             AND recipient_profile.realm_id = 2
zulip->             AND zerver_recipient.type = 1
zulip->             AND zerver_message.date_sent < '2021-01-16T12:55:51.920577+00:00'
zulip->         LIMIT 1000
zulip->     ON CONFLICT (id) DO UPDATE SET archive_transaction_id = 34
zulip->     RETURNING id
zulip-> ;
                                                                                      QUERY PLAN                                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Insert on zerver_archivedmessage  (cost=6.85..26.17 rows=1 width=460) (actual time=0.092..0.094 rows=0 loops=1)
   Conflict Resolution: UPDATE
   Conflict Arbiter Indexes: zerver_archivedmessage_pkey
   Tuples Inserted: 0
   Conflicting Tuples: 0
   ->  Subquery Scan on "*SELECT*"  (cost=6.85..26.17 rows=1 width=460) (actual time=0.091..0.092 rows=0 loops=1)
         ->  Limit  (cost=6.85..26.16 rows=1 width=452) (actual time=0.090..0.092 rows=0 loops=1)
               ->  Nested Loop  (cost=6.85..26.16 rows=1 width=452) (actual time=0.089..0.091 rows=0 loops=1)
                     Join Filter: (zerver_message.sender_id = sender_profile.id)
                     ->  Nested Loop  (cost=6.85..23.82 rows=1 width=448) (actual time=0.089..0.090 rows=0 loops=1)
                           ->  Hash Join  (cost=6.72..17.42 rows=1 width=4) (actual time=0.064..0.071 rows=16 loops=1)
                                 Hash Cond: (zerver_recipient.type_id = recipient_profile.id)
                                 ->  Bitmap Heap Scan on zerver_recipient  (cost=4.24..14.91 rows=11 width=8) (actual time=0.017..0.020 rows=22 loops=1)
                                       Recheck Cond: (type = 1)
                                       Heap Blocks: exact=1
                                       ->  Bitmap Index Scan on zerver_recipient_type_139dd891  (cost=0.00..4.24 rows=11 width=0) (actual time=0.013..0.013 rows=22 loops=1)
                                             Index Cond: (type = 1)
                                 ->  Hash  (cost=2.27..2.27 rows=16 width=4) (actual time=0.022..0.023 rows=16 loops=1)
                                       Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                       ->  Seq Scan on zerver_userprofile recipient_profile  (cost=0.00..2.27 rows=16 width=4) (actual time=0.008..0.016 rows=16 loops=1)
                                             Filter: (realm_id = 2)
                                             Rows Removed by Filter: 6
                           ->  Index Scan using zerver_message_recipient_id_5a7b6f03 on zerver_message  (cost=0.13..6.37 rows=3 width=448) (actual time=0.001..0.001 rows=0 loops=16)
                                 Index Cond: (recipient_id = zerver_recipient.id)
                                 Filter: (date_sent < '2021-01-16 12:55:51.920577+00'::timestamp with time zone)
                     ->  Seq Scan on zerver_userprofile sender_profile  (cost=0.00..2.30 rows=3 width=4) (never executed)
                           Filter: (id = ANY ('{1,4,5}'::integer[]))
 Planning time: 66.806 ms
 Execution time: 0.214 ms
(29 rows)
```

New query:
```
zulip=>     EXPLAIN ANALYZE      
    INSERT INTO zerver_archivedmessage ("id","sender_id","recipient_id","subject","content","rendered_content","rendered_content_version","date_sent","sending_client_id","last_edit_time","edit_history","has_attachment","has_image","has_link", archive_transaction_id)
        SELECT "zerver_message"."id","zerver_message"."sender_id","zerver_message"."recipient_id","zerver_message"."subject","zerver_message"."content","zerver_message"."rendered_content","zerver_message"."rendered_content_version","zerver_message"."date_sent","zerver_message"."sending_client_id","zerver_message"."last_edit_time","zerver_message"."edit_history","zerver_message"."has_attachment","zerver_message"."has_image","zerver_message"."has_link", 34
        FROM zerver_message
        INNER JOIN zerver_recipient ON zerver_recipient.id = zerver_message.recipient_id
        INNER JOIN zerver_userprofile recipient_profile ON recipient_profile.id = zerver_recipient.type_id
        WHERE zerver_message.sender_id IN (1, 4, 5)
            AND recipient_profile.realm_id = 2
            AND zerver_recipient.type = 1
            AND zerver_message.date_sent < '2021-01-16T12:55:51.920577+00:00'
        LIMIT 1000
    ON CONFLICT (id) DO UPDATE SET archive_transaction_id = 34
    RETURNING id;
                                                                           QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
 Insert on zerver_archivedmessage  (cost=0.29..19.93 rows=1 width=557) (actual time=0.054..0.056 rows=0 loops=1)
   Conflict Resolution: UPDATE
   Conflict Arbiter Indexes: zerver_archivedmessage_pkey
   Tuples Inserted: 0
   Conflicting Tuples: 0
   ->  Subquery Scan on "*SELECT*"  (cost=0.29..19.93 rows=1 width=557) (actual time=0.053..0.054 rows=0 loops=1)
         ->  Limit  (cost=0.29..19.92 rows=1 width=549) (actual time=0.053..0.053 rows=0 loops=1)
               ->  Nested Loop  (cost=0.29..19.92 rows=1 width=549) (actual time=0.052..0.052 rows=0 loops=1)
                     ->  Nested Loop  (cost=0.15..18.14 rows=1 width=549) (actual time=0.051..0.052 rows=0 loops=1)
                           ->  Seq Scan on zerver_message  (cost=0.00..8.62 rows=1 width=545) (actual time=0.051..0.051 rows=0 loops=1)
                                 Filter: ((date_sent < '2021-01-16 12:55:51.920577+00'::timestamp with time zone) AND (sender_id = ANY ('{1,4,5}'::integer[])))
                                 Rows Removed by Filter: 100
                           ->  Index Scan using zerver_recipient_pkey on zerver_recipient  (cost=0.15..8.17 rows=1 width=8) (never executed)
                                 Index Cond: (id = zerver_message.recipient_id)
                                 Filter: (type = 1)
                     ->  Index Scan using zerver_userprofile_pkey on zerver_userprofile recipient_profile  (cost=0.14..1.61 rows=1 width=4) (never executed)
                           Index Cond: (id = zerver_recipient.type_id)
                           Filter: (realm_id = 2)
 Planning time: 64.730 ms
 Execution time: 0.160 ms
(20 rows)
```