### PR TITLE
circleci: Resolve node installation error in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,14 +36,6 @@ aliases:
         # Install moreutils so we can use `ts` and `mispipe` in the following.
         sudo apt-get install -y moreutils
 
-        # CircleCI sets the following in Git config at clone time:
-        #   url.ssh://git@github.com.insteadOf https://github.com
-        # This breaks the Git clones in the NVM `install.sh` we run
-        # in `install-node`.
-        # TODO: figure out why that breaks, and whether we want it.
-        #   (Is it an optimization?)
-        rm -f /home/circleci/.gitconfig
-
         # This is the main setup job for the test suite
         mispipe "tools/ci/setup-backend --skip-dev-db-build" ts
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,16 +92,8 @@ aliases:
         mv /home/circleci/zulip/var/.coverage /home/circleci/zulip/.coverage
 
         . /srv/zulip-py3-venv/bin/activate
-        # TODO: Check that the next release of codecov doesn't
-        # throw find error.
-        # codecov==2.0.16 introduced a bug which uses "find"
-        # for locating files which is buggy on some platforms.
-        # It was fixed via https://github.com/codecov/codecov-python/pull/217
-        # and should get automatically fixed here once it's released.
-        # We cannot pin the version here because we need the latest version for uploading files.
-        # see https://community.codecov.io/t/http-400-while-uploading-to-s3-with-python-codecov-from-travis/1428/7
-        pip install codecov && codecov \
-          || echo "Error in uploading coverage reports to codecov.io."
+
+        pip install codecov && codecov
 
   - &build_production
     run:


### PR DESCRIPTION
The Git clones in 'install-node' were breaking because
we use CircleCI's special step, checkout, to clone source
code. It configures Git to use SSH while cloning.
More info:
https://circleci.com/docs/2.0/configuration-reference/#checkout
The error no longer occurs.

Codecov has released the new version which fixes the find error.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
