### PR TITLE
email: Modify followup day1 email if user already has an account.

### DIFF
--- a/templates/zerver/emails/followup_day1.source.html
+++ b/templates/zerver/emails/followup_day1.source.html
@@ -27,14 +27,18 @@
     {% else %}
         <li>{% trans email=macros.email_tag(email) %}Email: {{ email }}{% endtrans %}<br></li>
     {% endif %}
-    {% trans apps_page_link="https://zulip.com/apps" %}(you'll need these to sign in to the <a href="{{ apps_page_link }}">mobile and desktop</a> apps){% endtrans %}
+    {% if not other_account %}
+        {% trans apps_page_link="https://zulip.com/apps" %}(you'll need these to sign in to the <a href="{{ apps_page_link }}">mobile and desktop</a> apps){% endtrans %}
+    {% endif %}
 </p>
 
 <p>
-    {% if is_realm_admin %}
-        {% trans %}Check out our <a href="{{ getting_started_link }}">guide for admins</a>, become a Zulip pro with a few <a href="{{ keyboard_shortcuts_link }}">keyboard shortcuts</a>, or <a href="{{ realm_uri }}">dive right in</a>!{% endtrans %}
-    {% else %}
-        {% trans %}<a href="{{ getting_started_link }}">Learn more</a> about Zulip, become a pro with a few <a href="{{ keyboard_shortcuts_link }}">keyboard shortcuts</a>, or <a href="{{ realm_uri }}">dive right in</a>!{% endtrans %}
+    {% if not other_account %}
+        {% if is_realm_admin %}
+            {% trans %}Check out our <a href="{{ getting_started_link }}">guide for admins</a>, become a Zulip pro with a few <a href="{{ keyboard_shortcuts_link }}">keyboard shortcuts</a>, or <a href="{{ realm_uri }}">dive right in</a>!{% endtrans %}
+        {% else %}
+            {% trans %}<a href="{{ getting_started_link }}">Learn more</a> about Zulip, become a pro with a few <a href="{{ keyboard_shortcuts_link }}">keyboard shortcuts</a>, or <a href="{{ realm_uri }}">dive right in</a>!{% endtrans %}
+        {% endif %}
     {% endif %}
 </p>
 

--- a/templates/zerver/emails/followup_day1.txt
+++ b/templates/zerver/emails/followup_day1.txt
@@ -18,13 +18,17 @@
 {% else %}
 * {% trans %}Email: {{ email }}{% endtrans %}
 {% endif %}
+{% if not other_account %}
 {% trans apps_page_link="https://zulip.com/apps" %}(you'll need these to sign in to the mobile and desktop apps ({{ apps_page_link }})){% endtrans %}
+{% endif %}
 
 
+{% if not other_account %}
 {% if is_realm_admin %}
 {% trans %}Check out our guide ({{ getting_started_link }}) for admins, become a Zulip pro with a few keyboard shortcuts ({{ keyboard_shortcuts_link }}), or dive right in to {{ realm_uri }}!{% endtrans %}
 {% else %}
 {% trans %}Learn more ({{ getting_started_link }}) about Zulip, become a pro with a few keyboard shortcuts ({{ keyboard_shortcuts_link }}), or dive right in to {{ realm_uri }}!{% endtrans %}
+{% endif %}
 {% endif %}
 
 

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -618,6 +618,9 @@ def enqueue_welcome_emails(user: UserProfile, realm_creation: bool=False) -> Non
                 context["ldap_username"] = backend.django_to_ldap_username(user.delivery_email)
                 break
 
+    if other_account_count != 0:
+        context['other_account'] = True
+
     send_future_email(
         "zerver/emails/followup_day1", user.realm, to_user_ids=[user.id], from_name=from_name,
         from_address=from_address, context=context)


### PR DESCRIPTION
Modifies the content of the followup day1 email so that a user that already has one or more accounts on the same server gets a shorter version of that email.
<img width="524" alt="grafik" src="https://user-images.githubusercontent.com/74138733/104948061-f8555e00-59bc-11eb-8cf3-76f09eda71a1.png">

@timabbott, could you have a look at this and give me feedback if this is how the email should look?

Manually tested by creating users with the same email address on different realms.

Fixes part of: #9220
