### PR TITLE
markdown_help: Change "a" tag to "span" tag for spoiler-button class.

### DIFF
--- a/templates/zerver/app/markdown_help.html
+++ b/templates/zerver/app/markdown_help.html
@@ -134,7 +134,7 @@ This text won't be visible until the user clicks.
 ```</td>
                         <td class="rendered_markdown">
                             <div class="spoiler-block">
-                                <div class="spoiler-header"><a class="spoiler-button"><span class="spoiler-arrow"></span></a>
+                                <div class="spoiler-header"><span class="spoiler-button"><span class="spoiler-arrow"></span></span>
                                     <p>Always visible heading</p>
                                 </div>
 


### PR DESCRIPTION
Issue: The spoiler button present in the `Keyboard shortcut > Message formatting` page does not work. Related [thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/Spoiler.20button.20not.20working).

Testing plan: Tested manually.

GIFs or screenshots:
Before:
![spoiler-button before](https://user-images.githubusercontent.com/59444243/105014620-a5d07c00-5a66-11eb-86f4-a806f3fd7ac9.gif)

After:
![spoiler-button after](https://user-images.githubusercontent.com/59444243/105014643-aec14d80-5a66-11eb-9ecf-961109f5e23b.gif)
