### PR TITLE
left-sidebar: Add the new topic button in stream popover

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -965,7 +965,9 @@ export function initialize() {
 
         if (compose_state.composing()) {
             if ($(e.target).closest("a").length > 0) {
-                // Refocus compose message text box if link is clicked
+                // Refocus compose message text box if one clicks an external
+                // link/url to view something else while composing a message
+                // See issue #4331 for more details
                 $("#compose-textarea").trigger("focus");
                 return;
             } else if (

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -10,6 +10,7 @@ import render_topic_sidebar_actions from "../templates/topic_sidebar_actions.hbs
 import * as blueslip from "./blueslip";
 import * as browser_history from "./browser_history";
 import * as channel from "./channel";
+import * as compose_actions from "./compose_actions";
 import * as hash_util from "./hash_util";
 import * as message_edit from "./message_edit";
 import * as muting from "./muting";
@@ -468,6 +469,16 @@ export function register_stream_handlers() {
         const sub = stream_popover_sub(e);
         hide_stream_popover();
         subs.set_muted(sub, !sub.is_muted);
+        e.stopPropagation();
+    });
+
+    // New topic in stream menu
+    $("body").on("click", ".popover_new_topic_button", (e) => {
+        const sub = stream_popover_sub(e);
+        hide_stream_popover();
+
+        compose_actions.start("stream", {trigger: "popover new topic button", stream: sub.name});
+        e.preventDefault();
         e.stopPropagation();
     });
 

--- a/static/templates/stream_sidebar_actions.hbs
+++ b/static/templates/stream_sidebar_actions.hbs
@@ -48,6 +48,12 @@
         </a>
     </li>
     <li>
+        <a tabindex="0" class="popover_new_topic_button">
+            <i class="fa fa-plus" aria-hidden="true"></i>
+            {{t "New topic" }}
+        </a>
+    </li>
+    <li>
         <a tabindex="0" class="popover_sub_unsub_button" data-name="{{stream.name}}">
             <i class='fa fa-envelope' aria-hidden="true"></i>
             {{t "Unsubscribe" }}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #13480 

This PR adds an option to create new topic in stream popovers. It adds a click listener on them which triggers the compose start function with the stream specified.
**Testing plan:** <!-- How have you tested? -->
I tested in manually on different browsers like Firefox and chromium.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![net-topic](https://user-images.githubusercontent.com/56730716/105049343-8c452980-5a92-11eb-96dc-c8f734ed8c25.gif)
[Edit] In this gif, the focus is coming to the compose text area, this has been fixed after a discussion.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
