### PR TITLE
user_status: Fix the revoking of away status on setting status text.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -205,7 +205,6 @@ from zerver.models import (
     UserMessage,
     UserPresence,
     UserProfile,
-    UserStatus,
     active_non_guest_user_ids,
     active_user_ids,
     custom_profile_fields_for_realm,
@@ -4104,10 +4103,11 @@ def do_update_user_status(user_profile: UserProfile,
                           away: Optional[bool],
                           status_text: Optional[str],
                           client_id: int) -> None:
-    if away:
-        status = UserStatus.AWAY
+
+    if away is not None:
+        status = away
     else:
-        status = UserStatus.NORMAL
+        status = None
 
     realm = user_profile.realm
 


### PR DESCRIPTION
Fixes #17071
On setting the status text whilst the status is set to unavailable leads to revoking of the away status setting it to normal.
This commit fixes the problem by passing the previous status along the new status text to the endpoint.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested on dev server.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Zulip-Dev---Zulip](https://user-images.githubusercontent.com/55033316/105079882-0fc44200-5ab6-11eb-8700-127e91918829.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
