### PR TITLE
puppeteer: Update language_setting_status check for new language data.

### DIFF
--- a/frontend_tests/puppeteer_tests/16-settings.js
+++ b/frontend_tests/puppeteer_tests/16-settings.js
@@ -243,15 +243,10 @@ async function change_language(page, language_data_code) {
     await page.click(language_selector);
 }
 
-async function check_language_setting_status(page, current_lang_code) {
+async function check_language_setting_status(page) {
     const language_setting_status_selector = "#language-settings-status";
     await page.waitForSelector(language_setting_status_selector, {visible: true});
-    let status_text;
-    if (current_lang_code === "en") {
-        status_text = "Saved. Please reload for the change to take effect.";
-    } else if (current_lang_code === "de") {
-        status_text = "Gespeichert. Bitte lade die Seite neu um die Änderungen zu aktivieren.";
-    }
+    const status_text = "Saved. Please reload for the change to take effect.";
     await page.waitForFunction(
         (selector, status) => $(selector).text() === status,
         {},
@@ -284,7 +279,8 @@ async function test_default_language_setting(page) {
 
     const chinese_language_data_code = "zh-hans";
     await change_language(page, chinese_language_data_code);
-    await check_language_setting_status(page, "en");
+    // Check that the saved indicator appears
+    await check_language_setting_status(page);
     await page.click(".reload_link");
     await page.waitForSelector("#default_language", {visible: true});
     await assert_language_changed_to_chinese(page);
@@ -295,8 +291,8 @@ async function test_default_language_setting(page) {
     // Change the language back to English so that subsequent tests pass.
     await change_language(page, "en");
 
-    // As we've opened settings page in German the language status will be german.
-    await check_language_setting_status(page, "de");
+    // Check that the saved indicator appears
+    await check_language_setting_status(page);
     await page.goto("http://zulip.zulipdev.com:9981/#settings"); // get back to normal language.
     await page.waitForSelector(display_settings_section, {visible: true});
     await page.click(display_settings_section);


### PR DESCRIPTION
Commit f0f6138f01e09a99626ee9499966ad8188163194 deleted the
translation for "Saved. Please <a class='reload_link'>reload</a> for
the change to take effect." which caused puppeteer test 16-settings to
fail as it had hardcoded the translation for German. This commit
changes the expected text and hence fixes the failing puppeteer test.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Puppeteer tests on CI

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
