### PR TITLE
user docs: Made the simplebar a bit wider on hover

### DIFF
--- a/static/styles/components.css
+++ b/static/styles/components.css
@@ -82,7 +82,7 @@ a.no-underline:hover {
         transition: width 0.2s ease 1s;
 
         &.simplebar-hover {
-            width: 15px;
+            width: 25px;
             transition: width 0.2s ease;
         }
     }
@@ -91,7 +91,7 @@ a.no-underline:hover {
         transition: height 0.2s ease 1s;
 
         &.simplebar-hover {
-            height: 15px;
+            height: 25px;
             transition: height 0.2s ease;
         }
 


### PR DESCRIPTION
This commit increases the width of simplebar that is used in /docs and /api. It does not affect the ones using mouse scrollbar, and helps those who find scrollbar a bit smaller for scrolling using mouse pointer. Makes css changes in simplebar hover in components.css

Fixes #10732

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested Manually and pretty small too.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Notice the width of the scrollbar
![simplebar](https://user-images.githubusercontent.com/56730716/105229093-6a7a9e00-5b89-11eb-812c-4a294fafd3de.gif)

It changes the width on hover for both the left and right simplebars.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
