### PR TITLE
outgoing_webhooks: Catch JsonableError in do_rest_call. 

### DIFF
--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import orjson
 import requests
+import responses
 
 from version import ZULIP_VERSION
 from zerver.lib.actions import do_create_user
@@ -222,6 +223,34 @@ When trying to send a request to the webhook service, an exception of type Reque
 I'm a generic exception :(
 ```""",
         )
+        assert bot_user.bot_owner is not None
+        self.assertEqual(bot_owner_notification.recipient_id, bot_user.bot_owner.recipient_id)
+
+    def test_jsonable_exception(self) -> None:
+        bot_user = self.example_user("outgoing_webhook_bot")
+        mock_event = self.mock_event(bot_user)
+        service_handler = GenericOutgoingWebhookService("token", bot_user, "service")
+
+        # Widget content is being decoded twice, once in process_success_response along with response
+        # and again in check_messages leading to always cause an error
+        response_body = orjson.dumps(dict(content="whatever", widget_content="test"))
+        expect_logging_info = self.assertLogs(level="INFO")
+        expect_fail = mock.patch("zerver.lib.outgoing_webhook.fail_with_message")
+
+        with responses.RequestsMock(assert_all_requests_are_fired=True) as requests_mock:
+            requests_mock.add(
+                requests_mock.POST, "https://example.zulip.com", status=200, body=response_body
+            )
+            with expect_logging_info, expect_fail as mock_fail:
+                do_rest_call("https://example.zulip.com", None, mock_event, service_handler)
+            self.assertTrue(mock_fail.called)
+            bot_owner_notification = self.get_last_message()
+            self.assertEqual(
+                bot_owner_notification.content,
+                """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
+The outgoing webhook server attempted to send a message in Zulip, but that request resulted in the following error:
+> Widgets: API programmer sent invalid JSON content""",
+            )
         assert bot_user.bot_owner is not None
         self.assertEqual(bot_owner_notification.recipient_id, bot_user.bot_owner.recipient_id)
 


### PR DESCRIPTION
Added an except clause to catch JsonableError caused when parsing widget_content.

Logs the error and notifies bot owner.

Fixes #16850.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
We can prevent the `JsonableError` from being raised if we encode (json.dumps) `widget_content` in [`process_success_response`](https://github.com/zulip/zulip/blob/c693ae8982c12962e2fb510a18a947f16b9af640/zerver/lib/outgoing_webhook.py#L270), as this error is being raised only because `widget_content` is being decoded twice, once in [`process_success_response`](https://github.com/zulip/zulip/blob/c693ae8982c12962e2fb510a18a947f16b9af640/zerver/lib/outgoing_webhook.py#L270) and once more in [`check_message`](https://github.com/zulip/zulip/blob/c693ae8982c12962e2fb510a18a947f16b9af640/zerver/lib/actions.py#L2448).

**Testing plan:** <!-- How have you tested? -->
I added tests using `responses` library as @timabbott suggested. Please let me know if this is what was expected and if I can change the other tests for this module to use `responses`. 

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
