### PR TITLE
mobile web: Fix overlap b/w message content and message options

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -786,6 +786,11 @@ td.pointer {
         width: 16px;
         text-align: center;
 
+        @media (max-width: 500px) {
+            opacity: 1;
+            visibility: visible;
+        }
+
         > i {
             vertical-align: middle;
         }
@@ -2880,6 +2885,7 @@ select.inline_select_topic_edit {
 
     .message_content {
         padding-right: 50px;
+        margin-top: 20px;
     }
 }
 


### PR DESCRIPTION
For mobiles, the message options are not visible but when
they become visible they overlap with the message content.
The commit solves this by making the options always visible
in mobile view and giving some padding so that message
content does not overlap.

Part of #16488

More detailed conversations are [here](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Overlap.20in.20Mobile.20View/near/1103240)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested manually on various device widths.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Before | After
-- | --
![image](https://user-images.githubusercontent.com/56730716/105325952-3045e680-5bf3-11eb-9018-43ec502634b8.png) | ![image](https://user-images.githubusercontent.com/56730716/105325857-12788180-5bf3-11eb-9586-97c7800bd32b.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
