### PR TITLE
puppet: Only match incoming gateway address on our mail domain.

### DIFF
--- a/puppet/zulip/files/postfix/access
+++ b/puppet/zulip/files/postfix/access
@@ -4,6 +4,6 @@
 
 /\+.*@/         OK
 /\..*@/         OK
-/^mm/           OK
+/^mm.{32}@/     OK
 
 /^postmaster@/  OK

--- a/puppet/zulip/manifests/postfix_localmail.pp
+++ b/puppet/zulip/manifests/postfix_localmail.pp
@@ -45,7 +45,7 @@ class zulip::postfix_localmail {
     mode    => '0644',
     owner   => root,
     group   => root,
-    source  => 'puppet:///modules/zulip/postfix/virtual',
+    content => template('zulip/postfix/virtual.erb'),
     require => Package[postfix],
     notify  => Service['postfix'],
   }

--- a/puppet/zulip/templates/postfix/virtual.erb
+++ b/puppet/zulip/templates/postfix/virtual.erb
@@ -1,7 +1,7 @@
 if /@<%= Regexp.escape(@postfix_mailname) %>\.?$/
 # Changes to this list require a corresponding change to `access` as
 # well.
-/\+.*@/  zulip@localhost
-/\..*@/  zulip@localhost
-/^mm/    zulip@localhost
+/\+.*@/     zulip@localhost
+/\..*@/     zulip@localhost
+/^mm.{32}@/ zulip@localhost
 endif

--- a/puppet/zulip/templates/postfix/virtual.erb
+++ b/puppet/zulip/templates/postfix/virtual.erb
@@ -1,6 +1,7 @@
+if /@<%= Regexp.escape(@postfix_mailname) %>\.?$/
 # Changes to this list require a corresponding change to `access` as
 # well.
-
 /\+.*@/  zulip@localhost
 /\..*@/  zulip@localhost
 /^mm/    zulip@localhost
+endif


### PR DESCRIPTION
79931051bd27b60887aeb9c85b3ed92fa21df9ac allows outgoing emails from
localhost, but outgoing recipients are still subjected to virtualmaps.
This caused all outgoing email from Zulip with destination addresses
containing `.`, `+`, or starting with `mm`, to be redirected back
through the email gateway.

Bracket the virualmap addresses used for local delivery to the mail
gateway with a restriction on the domain matching the
`postfix.mailname` configuration, regex-escaped, so those only apply
to email destined for that domain.

The hostname is _not_ moved from `mydestination` to
`virtual_alias_domains`, as that would preclude delivery to
actually-local addresses, like `postmaster@`.

**Testing plan:** Deployed to a test prod instance.  Verified that MAIL FROM `noreply@alexmv-prod` RCPT `alex.testing@example.com` went into the outgoing path, and that MAIL FROM `test@example.com` RCPT TO `some.test@alexmv-prod` was directed into the email gateway.