### PR TITLE
subscribers: Move more logic into peer_data.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1018,7 +1018,9 @@ run_test("warn_if_private_stream_is_linked", () => {
     denmark = {
         invite_only: true,
         name: "Denmark",
+        stream_id: 22,
     };
+    stream_data.add_sub(denmark);
 
     compose.warn_if_private_stream_is_linked(denmark);
     assert.equal($("#compose_private_stream_alert").visible(), true);

--- a/frontend_tests/node_tests/dispatch_subs.js
+++ b/frontend_tests/node_tests/dispatch_subs.js
@@ -71,10 +71,14 @@ test("peer add/remove", (override) => {
     assert.equal(compose_fade_stub.num_calls, 1);
     assert.equal(subs_stub.num_calls, 1);
 
+    assert(peer_data.is_user_subscribed(event.stream_ids[0], event.user_ids[0]));
+
     event = event_fixtures.subscription__peer_remove;
     dispatch(event);
     assert.equal(compose_fade_stub.num_calls, 2);
     assert.equal(subs_stub.num_calls, 2);
+
+    assert(!peer_data.is_user_subscribed(event.stream_ids[0], event.user_ids[0]));
 });
 
 test("remove", (override) => {

--- a/frontend_tests/node_tests/peer_data.js
+++ b/frontend_tests/node_tests/peer_data.js
@@ -1,0 +1,298 @@
+"use strict";
+
+/*
+    This mostly tests the peer_data module, but it
+    also tests some stream_data functions that are
+    glorified wrappers for peer_data functions.
+*/
+
+const {strict: assert} = require("assert");
+
+const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
+
+const peer_data = zrequire("peer_data");
+const people = zrequire("people");
+zrequire("hash_util");
+zrequire("stream_data");
+
+set_global("page_params", {
+    is_admin: false,
+    realm_users: [],
+    is_guest: false,
+});
+
+const me = {
+    email: "me@zulip.com",
+    full_name: "Current User",
+    user_id: 100,
+};
+
+// set up user data
+people.add_active_user(me);
+people.initialize_current_user(me.user_id);
+
+function contains_sub(subs, sub) {
+    return subs.some((s) => s.name === sub.name);
+}
+
+run_test("unsubscribe", () => {
+    stream_data.clear_subscriptions();
+
+    let sub = {name: "devel", subscribed: false, stream_id: 1};
+
+    // set up our subscription
+    stream_data.add_sub(sub);
+    sub.subscribed = true;
+    peer_data.set_subscribers(sub.stream_id, [me.user_id]);
+
+    // ensure our setup is accurate
+    assert(stream_data.is_subscribed("devel"));
+
+    // DO THE UNSUBSCRIBE HERE
+    stream_data.unsubscribe_myself(sub);
+    assert(!sub.subscribed);
+    assert(!stream_data.is_subscribed("devel"));
+    assert(!contains_sub(stream_data.subscribed_subs(), sub));
+    assert(contains_sub(stream_data.unsubscribed_subs(), sub));
+
+    // make sure subsequent calls work
+    sub = stream_data.get_sub("devel");
+    assert(!sub.subscribed);
+});
+
+run_test("subscribers", () => {
+    stream_data.clear_subscriptions();
+    let sub = {name: "Rome", subscribed: true, stream_id: 1001};
+
+    stream_data.add_sub(sub);
+
+    const fred = {
+        email: "fred@zulip.com",
+        full_name: "Fred",
+        user_id: 101,
+    };
+    const not_fred = {
+        email: "not_fred@zulip.com",
+        full_name: "Not Fred",
+        user_id: 102,
+    };
+    const george = {
+        email: "george@zulip.com",
+        full_name: "George",
+        user_id: 103,
+    };
+    people.add_active_user(fred);
+    people.add_active_user(not_fred);
+    people.add_active_user(george);
+
+    function potential_subscriber_ids() {
+        const users = peer_data.potential_subscribers(sub.stream_id);
+        return users.map((u) => u.user_id).sort();
+    }
+
+    assert.deepEqual(potential_subscriber_ids(), [
+        me.user_id,
+        fred.user_id,
+        not_fred.user_id,
+        george.user_id,
+    ]);
+
+    peer_data.set_subscribers(sub.stream_id, [me.user_id, fred.user_id, george.user_id]);
+    stream_data.update_calculated_fields(sub);
+    assert(stream_data.is_user_subscribed(sub.stream_id, me.user_id));
+    assert(stream_data.is_user_subscribed(sub.stream_id, fred.user_id));
+    assert(stream_data.is_user_subscribed(sub.stream_id, george.user_id));
+    assert(!stream_data.is_user_subscribed(sub.stream_id, not_fred.user_id));
+
+    assert.deepEqual(potential_subscriber_ids(), [not_fred.user_id]);
+
+    peer_data.set_subscribers(sub.stream_id, []);
+
+    const brutus = {
+        email: "brutus@zulip.com",
+        full_name: "Brutus",
+        user_id: 104,
+    };
+    people.add_active_user(brutus);
+    assert(!stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
+
+    // add
+    let ok = peer_data.add_subscriber(sub.stream_id, brutus.user_id);
+    assert(ok);
+    assert(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
+    sub = stream_data.get_sub("Rome");
+    assert.equal(peer_data.get_subscriber_count(sub.stream_id), 1);
+    const sub_email = "Rome:214125235@zulipdev.com:9991";
+    stream_data.update_stream_email_address(sub, sub_email);
+    assert.equal(sub.email_address, sub_email);
+
+    // verify that adding an already-added subscriber is a noop
+    peer_data.add_subscriber(sub.stream_id, brutus.user_id);
+    assert(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
+    sub = stream_data.get_sub("Rome");
+    assert.equal(peer_data.get_subscriber_count(sub.stream_id), 1);
+
+    // remove
+    ok = peer_data.remove_subscriber(sub.stream_id, brutus.user_id);
+    assert(ok);
+    assert(!stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
+    sub = stream_data.get_sub("Rome");
+    assert.equal(peer_data.get_subscriber_count(sub.stream_id), 0);
+
+    // verify that checking subscription with undefined user id
+
+    blueslip.expect("warn", "Undefined user_id passed to function is_user_subscribed");
+    assert.equal(stream_data.is_user_subscribed(sub.stream_id, undefined), undefined);
+
+    // Verify noop for bad stream when removing subscriber
+    const bad_stream_id = 999999;
+    blueslip.expect(
+        "warn",
+        "We got a remove_subscriber call for an untracked stream " + bad_stream_id,
+    );
+    ok = peer_data.remove_subscriber(bad_stream_id, brutus.user_id);
+    assert(!ok);
+
+    // verify that removing an already-removed subscriber is a noop
+    blueslip.expect("warn", "We tried to remove invalid subscriber: 104");
+    ok = peer_data.remove_subscriber(sub.stream_id, brutus.user_id);
+    assert(!ok);
+    assert(!stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
+    sub = stream_data.get_sub("Rome");
+    assert.equal(peer_data.get_subscriber_count(sub.stream_id), 0);
+
+    // Verify defensive code in set_subscribers, where the second parameter
+    // can be undefined.
+    stream_data.add_sub(sub);
+    peer_data.add_subscriber(sub.stream_id, brutus.user_id);
+    sub.subscribed = true;
+    assert(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
+
+    // Verify that we noop and don't crash when unsubscribed.
+    sub.subscribed = false;
+    stream_data.update_calculated_fields(sub);
+    ok = peer_data.add_subscriber(sub.stream_id, brutus.user_id);
+    assert(ok);
+    assert.equal(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id), true);
+    peer_data.remove_subscriber(sub.stream_id, brutus.user_id);
+    assert.equal(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id), false);
+    peer_data.add_subscriber(sub.stream_id, brutus.user_id);
+    assert.equal(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id), true);
+
+    blueslip.expect(
+        "warn",
+        "We got a is_user_subscribed call for a non-existent or inaccessible stream.",
+        2,
+    );
+    sub.invite_only = true;
+    stream_data.update_calculated_fields(sub);
+    assert.equal(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id), undefined);
+    peer_data.remove_subscriber(sub.stream_id, brutus.user_id);
+    assert.equal(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id), undefined);
+
+    // Verify that we don't crash and return false for a bad stream.
+    blueslip.expect("warn", "We got an add_subscriber call for an untracked stream: 9999999");
+    ok = peer_data.add_subscriber(9999999, brutus.user_id);
+    assert(!ok);
+
+    // Verify that we don't crash and return false for a bad user id.
+    blueslip.expect("error", "Unknown user_id in get_by_user_id: 9999999");
+    blueslip.expect("error", "We tried to add invalid subscriber: 9999999");
+    ok = peer_data.add_subscriber(sub.stream_id, 9999999);
+    assert(!ok);
+});
+
+run_test("get_subscriber_count", () => {
+    const india = {
+        stream_id: 102,
+        name: "India",
+        subscribed: true,
+    };
+    stream_data.clear_subscriptions();
+
+    blueslip.expect("warn", "We got a get_subscriber_count call for an untracked stream: 102");
+    assert.equal(peer_data.get_subscriber_count(india.stream_id), undefined);
+
+    stream_data.add_sub(india);
+    assert.equal(peer_data.get_subscriber_count(india.stream_id), 0);
+
+    const fred = {
+        email: "fred@zulip.com",
+        full_name: "Fred",
+        user_id: 101,
+    };
+    people.add_active_user(fred);
+    peer_data.add_subscriber(india.stream_id, 102);
+    assert.equal(peer_data.get_subscriber_count(india.stream_id), 1);
+    const george = {
+        email: "george@zulip.com",
+        full_name: "George",
+        user_id: 103,
+    };
+    people.add_active_user(george);
+    peer_data.add_subscriber(india.stream_id, 103);
+    assert.equal(peer_data.get_subscriber_count(india.stream_id), 2);
+
+    peer_data.remove_subscriber(india.stream_id, 103);
+    assert.deepStrictEqual(peer_data.get_subscriber_count(india.stream_id), 1);
+});
+
+run_test("is_subscriber_subset", () => {
+    function make_sub(stream_id, user_ids) {
+        const sub = {stream_id};
+        peer_data.set_subscribers(sub.stream_id, user_ids);
+        return sub;
+    }
+
+    const sub_a = make_sub(301, [1, 2]);
+    const sub_b = make_sub(302, [2, 3]);
+    const sub_c = make_sub(303, [1, 2, 3]);
+
+    // The bogus case should not come up in normal
+    // use.
+    // We simply punt on any calculation if
+    // a stream has no subscriber info (like
+    // maybe Zephyr?).
+    const bogus = {}; // no subscribers
+
+    const matrix = [
+        [sub_a, sub_a, true],
+        [sub_a, sub_b, false],
+        [sub_a, sub_c, true],
+        [sub_b, sub_a, false],
+        [sub_b, sub_b, true],
+        [sub_b, sub_c, true],
+        [sub_c, sub_a, false],
+        [sub_c, sub_b, false],
+        [sub_c, sub_c, true],
+        [bogus, bogus, false],
+    ];
+
+    for (const row of matrix) {
+        assert.equal(peer_data.is_subscriber_subset(row[0].stream_id, row[1].stream_id), row[2]);
+    }
+});
+
+run_test("warn if subscribers are missing", () => {
+    // This should only happen in this contrived test situation.
+    stream_data.clear_subscriptions();
+    const sub = {
+        name: "test",
+        stream_id: 3,
+        can_access_subscribers: true,
+    };
+
+    with_field(
+        stream_data,
+        "get_sub_by_id",
+        () => sub,
+        () => {
+            blueslip.expect("warn", "We called is_user_subscribed for an untracked stream: 3");
+            stream_data.is_user_subscribed(sub.stream_id, me.user_id);
+
+            blueslip.expect("warn", "We called get_subscribers for an untracked stream: 3");
+            assert.deepEqual(peer_data.get_subscribers(sub.stream_id), []);
+        },
+    );
+});

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -239,8 +239,7 @@ run_test("subscribers", () => {
     assert(ok);
     assert(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
     sub = stream_data.get_sub("Rome");
-    stream_data.update_subscribers_count(sub);
-    assert.equal(sub.subscriber_count, 1);
+    assert.equal(peer_data.get_subscriber_count(sub.stream_id), 1);
     const sub_email = "Rome:214125235@zulipdev.com:9991";
     stream_data.update_stream_email_address(sub, sub_email);
     assert.equal(sub.email_address, sub_email);
@@ -249,16 +248,14 @@ run_test("subscribers", () => {
     peer_data.add_subscriber(sub.stream_id, brutus.user_id);
     assert(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
     sub = stream_data.get_sub("Rome");
-    stream_data.update_subscribers_count(sub);
-    assert.equal(sub.subscriber_count, 1);
+    assert.equal(peer_data.get_subscriber_count(sub.stream_id), 1);
 
     // remove
     ok = peer_data.remove_subscriber(sub.stream_id, brutus.user_id);
     assert(ok);
     assert(!stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
     sub = stream_data.get_sub("Rome");
-    stream_data.update_subscribers_count(sub);
-    assert.equal(sub.subscriber_count, 0);
+    assert.equal(peer_data.get_subscriber_count(sub.stream_id), 0);
 
     // verify that checking subscription with undefined user id
 
@@ -280,8 +277,7 @@ run_test("subscribers", () => {
     assert(!ok);
     assert(!stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
     sub = stream_data.get_sub("Rome");
-    stream_data.update_subscribers_count(sub);
-    assert.equal(sub.subscriber_count, 0);
+    assert.equal(peer_data.get_subscriber_count(sub.stream_id), 0);
 
     // Verify defensive code in set_subscribers, where the second parameter
     // can be undefined.

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
-const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 set_global("page_params", {
@@ -12,9 +12,6 @@ set_global("page_params", {
     realm_users: [],
     is_guest: false,
 });
-
-set_global("document", null);
-stub_out_jquery();
 
 zrequire("color_data");
 zrequire("hash_util");

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
-const {set_global, stub_out_jquery, with_field, zrequire} = require("../zjsunit/namespace");
+const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 set_global("page_params", {
@@ -19,7 +19,6 @@ stub_out_jquery();
 zrequire("color_data");
 zrequire("hash_util");
 zrequire("stream_topic_history");
-const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 zrequire("stream_color");
 zrequire("stream_data");
@@ -151,173 +150,6 @@ run_test("renames", () => {
 
     const actual_id = stream_data.get_stream_id("Denmark");
     assert.equal(actual_id, 42);
-});
-
-run_test("unsubscribe", () => {
-    stream_data.clear_subscriptions();
-
-    let sub = {name: "devel", subscribed: false, stream_id: 1};
-
-    // set up our subscription
-    stream_data.add_sub(sub);
-    sub.subscribed = true;
-    peer_data.set_subscribers(sub.stream_id, [me.user_id]);
-
-    // ensure our setup is accurate
-    assert(stream_data.is_subscribed("devel"));
-
-    // DO THE UNSUBSCRIBE HERE
-    stream_data.unsubscribe_myself(sub);
-    assert(!sub.subscribed);
-    assert(!stream_data.is_subscribed("devel"));
-    assert(!contains_sub(stream_data.subscribed_subs(), sub));
-    assert(contains_sub(stream_data.unsubscribed_subs(), sub));
-
-    // make sure subsequent calls work
-    sub = stream_data.get_sub("devel");
-    assert(!sub.subscribed);
-});
-
-run_test("subscribers", () => {
-    stream_data.clear_subscriptions();
-    let sub = {name: "Rome", subscribed: true, stream_id: 1001};
-
-    stream_data.add_sub(sub);
-
-    const fred = {
-        email: "fred@zulip.com",
-        full_name: "Fred",
-        user_id: 101,
-    };
-    const not_fred = {
-        email: "not_fred@zulip.com",
-        full_name: "Not Fred",
-        user_id: 102,
-    };
-    const george = {
-        email: "george@zulip.com",
-        full_name: "George",
-        user_id: 103,
-    };
-    people.add_active_user(fred);
-    people.add_active_user(not_fred);
-    people.add_active_user(george);
-
-    function potential_subscriber_ids() {
-        const users = peer_data.potential_subscribers(sub.stream_id);
-        return users.map((u) => u.user_id).sort();
-    }
-
-    assert.deepEqual(potential_subscriber_ids(), [
-        me.user_id,
-        fred.user_id,
-        not_fred.user_id,
-        george.user_id,
-    ]);
-
-    peer_data.set_subscribers(sub.stream_id, [me.user_id, fred.user_id, george.user_id]);
-    stream_data.update_calculated_fields(sub);
-    assert(stream_data.is_user_subscribed(sub.stream_id, me.user_id));
-    assert(stream_data.is_user_subscribed(sub.stream_id, fred.user_id));
-    assert(stream_data.is_user_subscribed(sub.stream_id, george.user_id));
-    assert(!stream_data.is_user_subscribed(sub.stream_id, not_fred.user_id));
-
-    assert.deepEqual(potential_subscriber_ids(), [not_fred.user_id]);
-
-    peer_data.set_subscribers(sub.stream_id, []);
-
-    const brutus = {
-        email: "brutus@zulip.com",
-        full_name: "Brutus",
-        user_id: 104,
-    };
-    people.add_active_user(brutus);
-    assert(!stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
-
-    // add
-    let ok = peer_data.add_subscriber(sub.stream_id, brutus.user_id);
-    assert(ok);
-    assert(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
-    sub = stream_data.get_sub("Rome");
-    assert.equal(peer_data.get_subscriber_count(sub.stream_id), 1);
-    const sub_email = "Rome:214125235@zulipdev.com:9991";
-    stream_data.update_stream_email_address(sub, sub_email);
-    assert.equal(sub.email_address, sub_email);
-
-    // verify that adding an already-added subscriber is a noop
-    peer_data.add_subscriber(sub.stream_id, brutus.user_id);
-    assert(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
-    sub = stream_data.get_sub("Rome");
-    assert.equal(peer_data.get_subscriber_count(sub.stream_id), 1);
-
-    // remove
-    ok = peer_data.remove_subscriber(sub.stream_id, brutus.user_id);
-    assert(ok);
-    assert(!stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
-    sub = stream_data.get_sub("Rome");
-    assert.equal(peer_data.get_subscriber_count(sub.stream_id), 0);
-
-    // verify that checking subscription with undefined user id
-
-    blueslip.expect("warn", "Undefined user_id passed to function is_user_subscribed");
-    assert.equal(stream_data.is_user_subscribed(sub.stream_id, undefined), undefined);
-
-    // Verify noop for bad stream when removing subscriber
-    const bad_stream_id = 999999;
-    blueslip.expect(
-        "warn",
-        "We got a remove_subscriber call for an untracked stream " + bad_stream_id,
-    );
-    ok = peer_data.remove_subscriber(bad_stream_id, brutus.user_id);
-    assert(!ok);
-
-    // verify that removing an already-removed subscriber is a noop
-    blueslip.expect("warn", "We tried to remove invalid subscriber: 104");
-    ok = peer_data.remove_subscriber(sub.stream_id, brutus.user_id);
-    assert(!ok);
-    assert(!stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
-    sub = stream_data.get_sub("Rome");
-    assert.equal(peer_data.get_subscriber_count(sub.stream_id), 0);
-
-    // Verify defensive code in set_subscribers, where the second parameter
-    // can be undefined.
-    stream_data.add_sub(sub);
-    peer_data.add_subscriber(sub.stream_id, brutus.user_id);
-    sub.subscribed = true;
-    assert(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id));
-
-    // Verify that we noop and don't crash when unsubscribed.
-    sub.subscribed = false;
-    stream_data.update_calculated_fields(sub);
-    ok = peer_data.add_subscriber(sub.stream_id, brutus.user_id);
-    assert(ok);
-    assert.equal(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id), true);
-    peer_data.remove_subscriber(sub.stream_id, brutus.user_id);
-    assert.equal(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id), false);
-    peer_data.add_subscriber(sub.stream_id, brutus.user_id);
-    assert.equal(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id), true);
-
-    blueslip.expect(
-        "warn",
-        "We got a is_user_subscribed call for a non-existent or inaccessible stream.",
-        2,
-    );
-    sub.invite_only = true;
-    stream_data.update_calculated_fields(sub);
-    assert.equal(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id), undefined);
-    peer_data.remove_subscriber(sub.stream_id, brutus.user_id);
-    assert.equal(stream_data.is_user_subscribed(sub.stream_id, brutus.user_id), undefined);
-
-    // Verify that we don't crash and return false for a bad stream.
-    blueslip.expect("warn", "We got an add_subscriber call for an untracked stream: 9999999");
-    ok = peer_data.add_subscriber(9999999, brutus.user_id);
-    assert(!ok);
-
-    // Verify that we don't crash and return false for a bad user id.
-    blueslip.expect("error", "Unknown user_id in get_by_user_id: 9999999");
-    blueslip.expect("error", "We tried to add invalid subscriber: 9999999");
-    ok = peer_data.add_subscriber(sub.stream_id, 9999999);
-    assert(!ok);
 });
 
 run_test("is_active", () => {
@@ -593,41 +425,6 @@ run_test("delete_sub", () => {
 
     blueslip.expect("warn", "Failed to delete stream 99999");
     stream_data.delete_sub(99999);
-});
-
-run_test("get_subscriber_count", () => {
-    const india = {
-        stream_id: 102,
-        name: "India",
-        subscribed: true,
-    };
-    stream_data.clear_subscriptions();
-
-    blueslip.expect("warn", "We got a get_subscriber_count call for an untracked stream: 102");
-    assert.equal(peer_data.get_subscriber_count(india.stream_id), undefined);
-
-    stream_data.add_sub(india);
-    assert.equal(peer_data.get_subscriber_count(india.stream_id), 0);
-
-    const fred = {
-        email: "fred@zulip.com",
-        full_name: "Fred",
-        user_id: 101,
-    };
-    people.add_active_user(fred);
-    peer_data.add_subscriber(india.stream_id, 102);
-    assert.equal(peer_data.get_subscriber_count(india.stream_id), 1);
-    const george = {
-        email: "george@zulip.com",
-        full_name: "George",
-        user_id: 103,
-    };
-    people.add_active_user(george);
-    peer_data.add_subscriber(india.stream_id, 103);
-    assert.equal(peer_data.get_subscriber_count(india.stream_id), 2);
-
-    peer_data.remove_subscriber(india.stream_id, 103);
-    assert.deepStrictEqual(peer_data.get_subscriber_count(india.stream_id), 1);
 });
 
 run_test("notifications", () => {
@@ -970,42 +767,6 @@ run_test("filter inactives", () => {
     assert(stream_data.is_filtering_inactives());
 });
 
-run_test("is_subscriber_subset", () => {
-    function make_sub(stream_id, user_ids) {
-        const sub = {stream_id};
-        peer_data.set_subscribers(sub.stream_id, user_ids);
-        return sub;
-    }
-
-    const sub_a = make_sub(301, [1, 2]);
-    const sub_b = make_sub(302, [2, 3]);
-    const sub_c = make_sub(303, [1, 2, 3]);
-
-    // The bogus case should not come up in normal
-    // use.
-    // We simply punt on any calculation if
-    // a stream has no subscriber info (like
-    // maybe Zephyr?).
-    const bogus = {}; // no subscribers
-
-    const matrix = [
-        [sub_a, sub_a, true],
-        [sub_a, sub_b, false],
-        [sub_a, sub_c, true],
-        [sub_b, sub_a, false],
-        [sub_b, sub_b, true],
-        [sub_b, sub_c, true],
-        [sub_c, sub_a, false],
-        [sub_c, sub_b, false],
-        [sub_c, sub_c, true],
-        [bogus, bogus, false],
-    ];
-
-    for (const row of matrix) {
-        assert.equal(peer_data.is_subscriber_subset(row[0].stream_id, row[1].stream_id), row[2]);
-    }
-});
-
 run_test("edge_cases", () => {
     const bad_stream_ids = [555555, 99999];
 
@@ -1082,27 +843,4 @@ run_test("all_topics_in_cache", () => {
 
     sub.first_message_id = 2;
     assert.equal(stream_data.all_topics_in_cache(sub), true);
-});
-
-run_test("warn if subscribers are missing", () => {
-    // This should only happen in this contrived test situation.
-    stream_data.clear_subscriptions();
-    const sub = {
-        name: "test",
-        stream_id: 3,
-        can_access_subscribers: true,
-    };
-
-    with_field(
-        stream_data,
-        "get_sub_by_id",
-        () => sub,
-        () => {
-            blueslip.expect("warn", "We called is_user_subscribed for an untracked stream: 3");
-            stream_data.is_user_subscribed(sub.stream_id, me.user_id);
-
-            blueslip.expect("warn", "We called get_subscribers for an untracked stream: 3");
-            assert.deepEqual(peer_data.get_subscribers(sub.stream_id), []);
-        },
-    );
 });

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -420,7 +420,7 @@ run_test("remove_deactivated_user_from_all_streams", () => {
     assert(!stream_data.is_user_subscribed(dev_help.stream_id, george.user_id));
 
     // verify that deactivating user should unsubscribe user from all streams
-    assert(peer_data.add_subscriber(dev_help.stream_id, george.user_id));
+    peer_data.add_subscriber(dev_help.stream_id, george.user_id);
     assert(stream_data.is_user_subscribed(dev_help.stream_id, george.user_id));
 
     stream_events.remove_deactivated_user_from_all_streams(george.user_id);

--- a/frontend_tests/node_tests/stream_pill.js
+++ b/frontend_tests/node_tests/stream_pill.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
+const peer_data = zrequire("peer_data");
 zrequire("stream_data");
 zrequire("stream_pill");
 
@@ -12,24 +13,25 @@ const denmark = {
     stream_id: 1,
     name: "Denmark",
     subscribed: true,
-    subscriber_count: 10,
 };
 const sweden = {
     stream_id: 2,
     name: "Sweden",
     subscribed: false,
-    subscriber_count: 30,
 };
+
+peer_data.set_subscribers(denmark.stream_id, [1, 2, 3]);
+peer_data.set_subscribers(sweden.stream_id, [1, 2, 3, 4, 5]);
 
 const denmark_pill = {
     stream_name: denmark.name,
     stream_id: denmark.stream_id,
-    display_value: "#" + denmark.name + ": " + denmark.subscriber_count + " users",
+    display_value: "#Denmark: 3 users",
 };
 const sweden_pill = {
     stream_name: sweden.name,
     stream_id: sweden.stream_id,
-    display_value: "#" + sweden.name + ": " + sweden.subscriber_count + " users",
+    display_value: "#Sweden: 5 users",
 };
 
 const subs = [denmark, sweden];

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -42,27 +42,43 @@ stream_data.create_streams([
 ]);
 
 run_test("sort_streams", () => {
-    const popular = [1, 2, 3, 4, 5, 6];
-
-    const unpopular = [1];
-
     let test_streams = [
-        {stream_id: 101, name: "Dev", pin_to_top: false, subscribers: unpopular, subscribed: true},
-        {stream_id: 102, name: "Docs", pin_to_top: false, subscribers: popular, subscribed: true},
-        {stream_id: 103, name: "Derp", pin_to_top: false, subscribers: unpopular, subscribed: true},
-        {stream_id: 104, name: "Denmark", pin_to_top: true, subscribers: popular, subscribed: true},
-        {stream_id: 105, name: "dead", pin_to_top: false, subscribers: unpopular, subscribed: true},
+        {
+            stream_id: 101,
+            name: "Dev",
+            pin_to_top: false,
+            stream_weekly_traffic: 0,
+            subscribed: true,
+        },
+        {
+            stream_id: 102,
+            name: "Docs",
+            pin_to_top: false,
+            stream_weekly_traffic: 100,
+            subscribed: true,
+        },
+        {
+            stream_id: 103,
+            name: "Derp",
+            pin_to_top: false,
+            stream_weekly_traffic: 0,
+            subscribed: true,
+        },
+        {
+            stream_id: 104,
+            name: "Denmark",
+            pin_to_top: true,
+            stream_weekly_traffic: 100,
+            subscribed: true,
+        },
+        {
+            stream_id: 105,
+            name: "dead",
+            pin_to_top: false,
+            stream_weekly_traffic: 0,
+            subscribed: true,
+        },
     ];
-
-    function process_test_streams() {
-        for (const test_stream of test_streams) {
-            peer_data.set_subscribers(test_stream.stream_id, test_stream.subscribers);
-            delete test_stream.subscribers;
-            stream_data.update_calculated_fields(test_stream);
-        }
-    }
-
-    process_test_streams();
 
     stream_data.is_active = function (sub) {
         return sub.name !== "dead";
@@ -81,43 +97,34 @@ run_test("sort_streams", () => {
             stream_id: 201,
             name: "Dev",
             description: "development help",
-            subscribers: unpopular,
             subscribed: true,
         },
         {
             stream_id: 202,
             name: "Docs",
             description: "writing docs",
-            subscribers: popular,
             subscribed: true,
         },
         {
             stream_id: 203,
             name: "Derp",
             description: "derping around",
-            subscribers: unpopular,
             subscribed: true,
         },
         {
             stream_id: 204,
             name: "Denmark",
             description: "visiting Denmark",
-            subscribers: popular,
             subscribed: true,
         },
         {
             stream_id: 205,
             name: "dead",
             description: "dead stream",
-            subscribers: unpopular,
             subscribed: true,
         },
     ];
-    process_test_streams();
 
-    for (const sub of test_streams) {
-        stream_data.update_calculated_fields(sub);
-    }
     test_streams = th.sort_streams(test_streams, "wr");
     assert.deepEqual(test_streams[0].name, "Docs"); // Description match
     assert.deepEqual(test_streams[1].name, "Denmark"); // Popular stream
@@ -132,45 +139,38 @@ run_test("sort_streams", () => {
             name: "Dev",
             description: "Some devs",
             subscribed: true,
-            subscribers: popular,
         },
         {
             stream_id: 302,
             name: "East",
             description: "Developing east",
             subscribed: true,
-            subscribers: popular,
         },
         {
             stream_id: 303,
             name: "New",
             description: "No match",
             subscribed: true,
-            subscribers: popular,
         },
         {
             stream_id: 304,
             name: "Derp",
             description: "Always Derping",
             subscribed: false,
-            subscribers: popular,
         },
         {
             stream_id: 305,
             name: "Ether",
             description: "Destroying ether",
             subscribed: false,
-            subscribers: popular,
         },
         {
             stream_id: 306,
             name: "Mew",
             description: "Cat mews",
             subscribed: false,
-            subscribers: popular,
         },
     ];
-    process_test_streams();
 
     test_streams = th.sort_streams(test_streams, "d");
     assert.deepEqual(test_streams[0].name, "Dev"); // Subscribed and stream name starts with query

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -980,11 +980,15 @@ exports.warn_if_private_stream_is_linked = function (linked_stream) {
         return;
     }
 
-    if (peer_data.is_subscriber_subset(compose_stream.stream_id, linked_stream.stream_id)) {
-        // Don't warn if subscribers list of current compose_stream is
-        // a subset of linked_stream's subscribers list, because
-        // everyone will be subscribed to the linked stream and so
-        // knows it exists.
+    // Don't warn if subscribers list of current compose_stream is
+    // a subset of linked_stream's subscribers list, because
+    // everyone will be subscribed to the linked stream and so
+    // knows it exists.  (But always warn Zephyr users, since
+    // we may not know their stream's subscribers.)
+    if (
+        peer_data.is_subscriber_subset(compose_stream.stream_id, linked_stream.stream_id) &&
+        !page_params.realm_is_zephyr_mirror_realm
+    ) {
         return;
     }
 

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -415,12 +415,4 @@ exports.all = new MessageList({
     muting_enabled: false,
 });
 
-// We stop autoscrolling when the user is clearly in the middle of
-// doing something.  Be careful, though, if you try to capture
-// mousemove, then you will have to contend with the autoscroll
-// itself generating mousemove events.
-$(document).on("message_selected.zulip wheel", () => {
-    message_viewport.stop_auto_scrolling();
-});
-
 window.message_list = exports;

--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -2,15 +2,10 @@
 
 const render_message_view_header = require("../templates/message_view_header.hbs");
 
+const peer_data = require("./peer_data");
 const rendered_markdown = require("./rendered_markdown");
 
-function get_sub_count(current_stream) {
-    const sub_count = current_stream.subscriber_count;
-    return sub_count;
-}
-
-function get_formatted_sub_count(current_stream) {
-    let sub_count = get_sub_count(current_stream);
+function get_formatted_sub_count(sub_count) {
     if (sub_count >= 1000) {
         // parseInt() is used to floor the value of division to an integer
         sub_count = Number.parseInt(sub_count / 1000, 10) + "k";
@@ -42,8 +37,9 @@ function make_message_view_header(filter) {
         // the current user can access.
         const current_stream = filter._sub;
         message_view_header.rendered_narrow_description = current_stream.rendered_description;
-        message_view_header.sub_count = get_sub_count(current_stream);
-        message_view_header.formatted_sub_count = get_formatted_sub_count(current_stream);
+        const sub_count = peer_data.get_subscriber_count(current_stream.stream_id);
+        message_view_header.sub_count = sub_count;
+        message_view_header.formatted_sub_count = get_formatted_sub_count(sub_count);
         // the "title" is passed as a variable and doesn't get translated (nor should it)
         message_view_header.sub_count_tooltip_text = i18n.t(
             "__count__ users are subscribed to #__title__",

--- a/static/js/message_viewport.js
+++ b/static/js/message_viewport.js
@@ -457,6 +457,14 @@ exports.initialize = function () {
     $(document).on("compose_started compose_canceled compose_finished", () => {
         bottom_of_feed.reset();
     });
+
+    // We stop autoscrolling when the user is clearly in the middle of
+    // doing something.  Be careful, though, if you try to capture
+    // mousemove, then you will have to contend with the autoscroll
+    // itself generating mousemove events.
+    $(document).on("message_selected.zulip wheel", () => {
+        exports.stop_auto_scrolling();
+    });
 };
 
 window.message_viewport = exports;

--- a/static/js/peer_data.js
+++ b/static/js/peer_data.js
@@ -94,6 +94,7 @@ export function get_subscribers(stream_id) {
 export function set_subscribers(stream_id, user_ids) {
     const subscribers = new LazySet(user_ids || []);
     stream_subscribers.set(stream_id, subscribers);
+    return subscribers;
 }
 
 export function add_subscriber(stream_id, user_id) {
@@ -126,6 +127,26 @@ export function remove_subscriber(stream_id, user_id) {
     subscribers.delete(user_id);
 
     return true;
+}
+
+export function bulk_add_subscribers({stream_ids, user_ids}) {
+    // We rely on our callers to validate stream_ids and user_ids.
+    for (const stream_id of stream_ids) {
+        const subscribers = stream_subscribers.get(stream_id) || set_subscribers(stream_id);
+        for (const user_id of user_ids) {
+            subscribers.add(user_id);
+        }
+    }
+}
+
+export function bulk_remove_subscribers({stream_ids, user_ids}) {
+    // We rely on our callers to validate stream_ids and user_ids.
+    for (const stream_id of stream_ids) {
+        const subscribers = stream_subscribers.get(stream_id) || set_subscribers(stream_id);
+        for (const user_id of user_ids) {
+            subscribers.delete(user_id);
+        }
+    }
 }
 
 export function is_user_subscribed(stream_id, user_id) {

--- a/static/js/peer_data.js
+++ b/static/js/peer_data.js
@@ -1,13 +1,6 @@
 const {LazySet} = require("./lazy_set");
 const people = require("./people");
 
-/*
-
-For legacy reasons this module is mostly tested
-by frontend_tests/node_tests/stream_data.js.
-
-*/
-
 // This maps a stream_id to a LazySet of user_ids who are subscribed.
 // We maintain the invariant that this has keys for all all stream_ids
 // that we track in the other data structures.  We intialize it during

--- a/static/js/peer_data.js
+++ b/static/js/peer_data.js
@@ -7,6 +7,28 @@ const people = require("./people");
 // clear_subscriptions.
 let stream_subscribers;
 
+function assert_number(id) {
+    if (typeof id !== "number") {
+        blueslip.error(`You must pass ids as numbers to peer_data. id = ${id}`);
+    }
+}
+
+function get_user_set(stream_id) {
+    assert_number(stream_id);
+
+    // This is an internal function to get the LazySet of users.
+    // We create one on the fly as necessary, but we warn in that case.
+    let subscribers = stream_subscribers.get(stream_id);
+
+    if (subscribers === undefined) {
+        blueslip.warn("We called get_user_set for an untracked stream: " + stream_id);
+        subscribers = new LazySet([]);
+        stream_subscribers.set(stream_id, subscribers);
+    }
+
+    return subscribers;
+}
+
 export function clear() {
     stream_subscribers = new Map();
 }
@@ -18,14 +40,10 @@ export function maybe_clear_subscribers(stream_id) {
 }
 
 export function is_subscriber_subset(stream_id1, stream_id2) {
-    const sub1_set = stream_subscribers.get(stream_id1);
-    const sub2_set = stream_subscribers.get(stream_id2);
+    const sub1_set = get_user_set(stream_id1);
+    const sub2_set = get_user_set(stream_id2);
 
-    if (sub1_set && sub2_set) {
-        return Array.from(sub1_set.keys()).every((key) => sub2_set.has(key));
-    }
-
-    return false;
+    return Array.from(sub1_set.keys()).every((key) => sub2_set.has(key));
 }
 
 export function potential_subscribers(stream_id) {
@@ -63,23 +81,14 @@ export function potential_subscribers(stream_id) {
 }
 
 export function get_subscriber_count(stream_id) {
-    const subscribers = stream_subscribers.get(stream_id);
-
-    if (!subscribers) {
-        blueslip.warn("We got a get_subscriber_count call for an untracked stream: " + stream_id);
-        return undefined;
-    }
-
+    const subscribers = get_user_set(stream_id);
     return subscribers.size;
 }
 
 export function get_subscribers(stream_id) {
-    const subscribers = stream_subscribers.get(stream_id);
-
-    if (typeof subscribers === "undefined") {
-        blueslip.warn("We called get_subscribers for an untracked stream: " + stream_id);
-        return [];
-    }
+    // This is our external interface for callers who just
+    // want an array of user_ids who are subscribed to a stream.
+    const subscribers = get_user_set(stream_id);
 
     return Array.from(subscribers.keys());
 }
@@ -91,27 +100,18 @@ export function set_subscribers(stream_id, user_ids) {
 }
 
 export function add_subscriber(stream_id, user_id) {
-    const subscribers = stream_subscribers.get(stream_id);
-    if (typeof subscribers === "undefined") {
-        blueslip.warn("We got an add_subscriber call for an untracked stream: " + stream_id);
-        return false;
-    }
+    // If stream_id/user_id are unknown to us, we will
+    // still track it, but we will warn.
+    const subscribers = get_user_set(stream_id);
     const person = people.get_by_user_id(user_id);
     if (person === undefined) {
-        blueslip.error("We tried to add invalid subscriber: " + user_id);
-        return false;
+        blueslip.warn("We tried to add invalid subscriber: " + user_id);
     }
     subscribers.add(user_id);
-
-    return true;
 }
 
 export function remove_subscriber(stream_id, user_id) {
-    const subscribers = stream_subscribers.get(stream_id);
-    if (typeof subscribers === "undefined") {
-        blueslip.warn("We got a remove_subscriber call for an untracked stream " + stream_id);
-        return false;
-    }
+    const subscribers = get_user_set(stream_id);
     if (!subscribers.has(user_id)) {
         blueslip.warn("We tried to remove invalid subscriber: " + user_id);
         return false;
@@ -125,7 +125,7 @@ export function remove_subscriber(stream_id, user_id) {
 export function bulk_add_subscribers({stream_ids, user_ids}) {
     // We rely on our callers to validate stream_ids and user_ids.
     for (const stream_id of stream_ids) {
-        const subscribers = stream_subscribers.get(stream_id) || set_subscribers(stream_id);
+        const subscribers = get_user_set(stream_id);
         for (const user_id of user_ids) {
             subscribers.add(user_id);
         }
@@ -135,7 +135,7 @@ export function bulk_add_subscribers({stream_ids, user_ids}) {
 export function bulk_remove_subscribers({stream_ids, user_ids}) {
     // We rely on our callers to validate stream_ids and user_ids.
     for (const stream_id of stream_ids) {
-        const subscribers = stream_subscribers.get(stream_id) || set_subscribers(stream_id);
+        const subscribers = get_user_set(stream_id);
         for (const user_id of user_ids) {
             subscribers.delete(user_id);
         }
@@ -146,11 +146,6 @@ export function is_user_subscribed(stream_id, user_id) {
     // Most callers should call stream_data.is_user_subscribed,
     // which does additional checks.
 
-    const subscribers = stream_subscribers.get(stream_id);
-    if (typeof subscribers === "undefined") {
-        blueslip.warn("We called is_user_subscribed for an untracked stream: " + stream_id);
-        return false;
-    }
-
+    const subscribers = get_user_set(stream_id);
     return subscribers.has(user_id);
 }

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -56,6 +56,25 @@ export function get_by_user_id(user_id, ignore_missing) {
     return people_by_user_id_dict.get(user_id);
 }
 
+export function validate_user_ids(user_ids) {
+    const good_ids = [];
+    const bad_ids = [];
+
+    for (const user_id of user_ids) {
+        if (people_by_user_id_dict.has(user_id)) {
+            good_ids.push(user_id);
+        } else {
+            bad_ids.push(user_id);
+        }
+    }
+
+    if (bad_ids.length > 0) {
+        blueslip.warn(`We have untracked user_ids: ${bad_ids}`);
+    }
+
+    return good_ids;
+}
+
 export function get_by_email(email) {
     const person = people_dict.get(email);
 

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -345,42 +345,28 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                     }
                 }
             } else if (event.op === "peer_add") {
-                for (const stream_id of event.stream_ids) {
+                const stream_ids = stream_data.validate_stream_ids(event.stream_ids);
+                const user_ids = people.validate_user_ids(event.user_ids);
+
+                peer_data.bulk_add_subscribers({stream_ids, user_ids});
+
+                for (const stream_id of stream_ids) {
                     const sub = stream_data.get_sub_by_id(stream_id);
-
-                    if (!sub) {
-                        blueslip.warn("Cannot find stream for peer_add: " + stream_id);
-                        continue;
-                    }
-
-                    for (const user_id of event.user_ids) {
-                        if (!peer_data.add_subscriber(stream_id, user_id)) {
-                            blueslip.warn("Cannot process peer_add event");
-                            continue;
-                        }
-                    }
-
                     subs.update_subscribers_ui(sub);
                 }
+
                 compose_fade.update_faded_users();
             } else if (event.op === "peer_remove") {
-                for (const stream_id of event.stream_ids) {
+                const stream_ids = stream_data.validate_stream_ids(event.stream_ids);
+                const user_ids = people.validate_user_ids(event.user_ids);
+
+                peer_data.bulk_remove_subscribers({stream_ids, user_ids});
+
+                for (const stream_id of stream_ids) {
                     const sub = stream_data.get_sub_by_id(stream_id);
-
-                    if (!sub) {
-                        blueslip.warn("Cannot find stream for peer_remove: " + stream_id);
-                        continue;
-                    }
-
-                    for (const user_id of event.user_ids) {
-                        if (!peer_data.remove_subscriber(sub.stream_id, user_id)) {
-                            blueslip.warn("Cannot process peer_remove event.");
-                            continue;
-                        }
-                    }
-
                     subs.update_subscribers_ui(sub);
                 }
+
                 compose_fade.update_faded_users();
             } else if (event.op === "remove") {
                 for (const rec of event.subscriptions) {

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -258,6 +258,7 @@ exports.show_new_stream_modal = function () {
     $("#stream-creation").removeClass("hide");
     $(".right .settings").hide();
 
+    const finish = blueslip.start_timing("render new stream users");
     const all_users = people.get_people_for_stream_create();
     // Add current user on top of list
     all_users.unshift(people.get_by_user_id(page_params.user_id));
@@ -266,6 +267,7 @@ exports.show_new_stream_modal = function () {
         streams: stream_data.get_streams_for_settings_page(),
         is_admin: page_params.is_admin,
     });
+    finish();
 
     const container = $("#people_to_add");
     container.html(html);

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -225,6 +225,25 @@ exports.get_sub_by_id = function (stream_id) {
     return subs_by_stream_id.get(stream_id);
 };
 
+exports.validate_stream_ids = function (stream_ids) {
+    const good_ids = [];
+    const bad_ids = [];
+
+    for (const stream_id of stream_ids) {
+        if (subs_by_stream_id.has(stream_id)) {
+            good_ids.push(stream_id);
+        } else {
+            bad_ids.push(stream_id);
+        }
+    }
+
+    if (bad_ids.length > 0) {
+        blueslip.warn(`We have untracked stream_ids: ${bad_ids}`);
+    }
+
+    return good_ids;
+};
+
 exports.get_stream_id = function (name) {
     // Note: Only use this function for situations where
     // you are comfortable with a user dealing with an

--- a/static/js/stream_pill.js
+++ b/static/js/stream_pill.js
@@ -3,7 +3,8 @@
 const peer_data = require("./peer_data");
 
 function display_pill(sub) {
-    return "#" + sub.name + ": " + sub.subscriber_count + " users";
+    const sub_count = peer_data.get_subscriber_count(sub.stream_id);
+    return "#" + sub.name + ": " + sub_count + " users";
 }
 
 exports.create_item_from_stream_name = function (stream_name, current_items) {

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -174,16 +174,22 @@ exports.update_subscribers_count = function (sub, just_subscribed) {
         // If the streams overlay isn't open, we don't need to rerender anything.
         return;
     }
+
     const stream_row = subs.row_for_stream_id(sub.stream_id);
+    const sub_count = peer_data.get_subscriber_count(sub.stream_id);
+
     if (
         !sub.can_access_subscribers ||
         (just_subscribed && sub.invite_only) ||
         page_params.is_guest
     ) {
-        const rendered_sub_count = render_subscription_count(sub);
+        const rendered_sub_count = render_subscription_count({
+            can_access_subscribers: sub.can_access_subscribers,
+            subscriber_count: sub_count,
+        });
         stream_row.find(".subscriber-count").expectOne().html(rendered_sub_count);
     } else {
-        stream_row.find(".subscriber-count-text").expectOne().text(sub.subscriber_count);
+        stream_row.find(".subscriber-count-text").expectOne().text(sub_count);
     }
 };
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -213,7 +213,6 @@ exports.rerender_subscriptions_settings = function (sub) {
         blueslip.error("Undefined sub passed to function rerender_subscriptions_settings");
         return;
     }
-    stream_data.update_subscribers_count(sub);
     stream_ui_updates.update_subscribers_count(sub);
     stream_ui_updates.update_subscribers_list(sub);
 };
@@ -237,8 +236,10 @@ exports.add_sub_to_table = function (sub) {
         return;
     }
 
-    const html = render_subscription(sub);
+    const setting_sub = stream_data.get_sub_for_settings(sub);
+    const html = render_subscription(setting_sub);
     const settings_html = render_subscription_settings(sub);
+
     if (stream_create.get_name() === sub.name) {
         ui.get_content_element($(".streams-list")).prepend(html);
         ui.reset_scrollbar($(".streams-list"));
@@ -287,7 +288,6 @@ exports.update_settings_for_subscribed = function (sub) {
     ).show();
 
     if (exports.is_sub_already_present(sub)) {
-        stream_data.update_subscribers_count(sub);
         stream_ui_updates.update_stream_row_in_settings_tab(sub);
         stream_ui_updates.update_subscribers_count(sub, true);
         stream_ui_updates.update_check_button_for_sub(sub);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -400,13 +400,13 @@ function get_stream_id_buckets(stream_ids, query) {
 }
 
 exports.populate_stream_settings_left_panel = function () {
+    const finish = blueslip.start_timing("render left panel");
     const sub_rows = stream_data.get_updated_unsorted_subs();
 
     const template_data = {
         subscriptions: sub_rows,
     };
 
-    const finish = blueslip.start_timing("render_subscriptions");
     const html = render_subscriptions(template_data);
     finish();
 

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -8,7 +8,6 @@ const emoji = require("../shared/js/emoji");
 const typeahead = require("../shared/js/typeahead");
 const render_typeahead_list_item = require("../templates/typeahead_list_item.hbs");
 
-const peer_data = require("./peer_data");
 const people = require("./people");
 const pm_conversations = require("./pm_conversations");
 const settings_data = require("./settings_data");
@@ -384,15 +383,14 @@ function activity_score(sub) {
 }
 
 // Sort streams by ranking them by activity. If activity is equal,
-// as defined bv activity_score, decide based on subscriber count.
+// as defined bv activity_score, decide based on our weekly traffic
+// stats.
 exports.compare_by_activity = function (stream_a, stream_b) {
     let diff = activity_score(stream_b) - activity_score(stream_a);
     if (diff !== 0) {
         return diff;
     }
-    diff =
-        peer_data.get_subscriber_count(stream_b.stream_id) -
-        peer_data.get_subscriber_count(stream_a.stream_id);
+    diff = (stream_b.stream_weekly_traffic || 0) - (stream_a.stream_weekly_traffic || 0);
     if (diff !== 0) {
         return diff;
     }


### PR DESCRIPTION
I'm basically trying to make it so that not matter we change how we represent subscriber data, we will basically be able to update just peer_data.js.

This is mostly refactoring and a very tiny user-facing change.