### PR TITLE
registration: Stop enqueueing to the signups queue.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -421,10 +421,8 @@ def add_new_user_history(user_profile: UserProfile, streams: Iterable[Stream]) -
 # * Fills in some recent historical messages
 # * Notifies other users in realm and Zulip about the signup
 # * Deactivates PreregistrationUser objects
-# * subscribe the user to newsletter if newsletter_data is specified
 def process_new_human_user(user_profile: UserProfile,
                            prereg_user: Optional[PreregistrationUser]=None,
-                           newsletter_data: Optional[Mapping[str, str]]=None,
                            default_stream_groups: Sequence[DefaultStreamGroup]=[],
                            realm_creation: bool=False) -> None:
     realm = user_profile.realm
@@ -491,23 +489,6 @@ def process_new_human_user(user_profile: UserProfile,
     from zerver.lib.onboarding import send_initial_pms
     send_initial_pms(user_profile)
 
-    if newsletter_data is not None:
-        # If the user was created automatically via the API, we may
-        # not want to register them for the newsletter
-        queue_json_publish(
-            "signups",
-            {
-                'email_address': user_profile.delivery_email,
-                'user_id': user_profile.id,
-                'merge_fields': {
-                    'NAME': user_profile.full_name,
-                    'REALM_ID': user_profile.realm_id,
-                    'OPTIN_IP': newsletter_data["IP"],
-                    'OPTIN_TIME': datetime.datetime.isoformat(timezone_now().replace(microsecond=0)),
-                },
-            },
-            lambda event: None)
-
 def notify_created_user(user_profile: UserProfile) -> None:
     user_row = user_profile_to_user_row(user_profile)
     person = format_user_row(user_profile.realm, user_profile, user_row,
@@ -573,7 +554,6 @@ def do_create_user(email: str, password: Optional[str], realm: Realm, full_name:
                    default_events_register_stream: Optional[Stream]=None,
                    default_all_public_streams: Optional[bool]=None,
                    prereg_user: Optional[PreregistrationUser]=None,
-                   newsletter_data: Optional[Dict[str, str]]=None,
                    default_stream_groups: Sequence[DefaultStreamGroup]=[],
                    source_profile: Optional[UserProfile]=None,
                    realm_creation: bool=False,
@@ -607,7 +587,6 @@ def do_create_user(email: str, password: Optional[str], realm: Realm, full_name:
     notify_created_user(user_profile)
     if bot_type is None:
         process_new_human_user(user_profile, prereg_user=prereg_user,
-                               newsletter_data=newsletter_data,
                                default_stream_groups=default_stream_groups,
                                realm_creation=realm_creation)
     return user_profile

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -377,7 +377,6 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
                                           role=role,
                                           tos_version=settings.TOS_VERSION,
                                           timezone=timezone,
-                                          newsletter_data={"IP": request.META['REMOTE_ADDR']},
                                           default_stream_groups=default_stream_groups,
                                           source_profile=source_profile,
                                           realm_creation=realm_creation,


### PR DESCRIPTION
c2526844e9d66774526a16e43fff0f0c1981d9bd removed the `signups` queue
worker, and the command-line tool that enqueues to it -- but not the
automated process that enqueues during signups itself.

Remove the signup, since it is no longer in use.