### PR TITLE
users: Rename access_user_by_id to validate_and_access_user.

### DIFF
--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -382,29 +382,30 @@ class PermissionTest(ZulipTestCase):
 
         # Must be a valid user ID in the realm
         with self.assertRaises(JsonableError):
-            access_user_by_id(iago, 1234)
+            access_user_by_id(iago, 1234, for_admin=False)
         with self.assertRaises(JsonableError):
-            access_user_by_id(iago, self.mit_user("sipbtest").id)
+            access_user_by_id(iago, self.mit_user("sipbtest").id, for_admin=False)
 
-        # Can only access bot users if allow_deactivated is passed
+        # Can only access bot users if allow_bots is passed
         bot = self.example_user("default_bot")
-        access_user_by_id(iago, bot.id, allow_bots=True)
+        access_user_by_id(iago, bot.id, allow_bots=True, for_admin=True)
         with self.assertRaises(JsonableError):
-            access_user_by_id(iago, bot.id)
+            access_user_by_id(iago, bot.id, for_admin=True)
 
         # Can only access deactivated users if allow_deactivated is passed
         hamlet = self.example_user("hamlet")
         do_deactivate_user(hamlet)
         with self.assertRaises(JsonableError):
-            access_user_by_id(iago, hamlet.id)
-        access_user_by_id(iago, hamlet.id, allow_deactivated=True)
+            access_user_by_id(iago, hamlet.id, for_admin=False)
+        with self.assertRaises(JsonableError):
+            access_user_by_id(iago, hamlet.id, for_admin=True)
+        access_user_by_id(iago, hamlet.id, allow_deactivated=True, for_admin=True)
 
         # Non-admin user can't admin another user
         with self.assertRaises(JsonableError):
-            access_user_by_id(self.example_user("cordelia"), self.example_user("aaron").id)
+            access_user_by_id(self.example_user("cordelia"), self.example_user("aaron").id, for_admin=True)
         # But does have read-only access to it.
-        access_user_by_id(self.example_user("cordelia"), self.example_user("aaron").id,
-                          read_only=True)
+        access_user_by_id(self.example_user("cordelia"), self.example_user("aaron").id, for_admin=False)
 
     def test_change_regular_member_to_guest(self) -> None:
         iago = self.example_user("iago")


### PR DESCRIPTION

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This pr renames all the occurences of this function to use validate_and_access_user and also
use target_user_id instead of user_id as a parameter to solve the problem highlighted in the issue #17111 and [on CZO conversation](https://chat.zulip.org/#narrow/stream/49-development-help/topic/Admin.20Bot.20.20.2312424/near/1104966)
**Testing plan:** <!-- How have you tested? -->
Testing has been done mainly using `./tools/test-backend/test_user.py` and few manual checking from dev server.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
 fixes #17111 