### PR TITLE
Change outline color of close button at notifications header.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -276,6 +276,10 @@ p.n-margin {
             right: 18px;
             top: 50%;
             transform: translateY(-50%);
+
+            &:focus {
+                outline: hsl(200, 100%, 25%) solid 5px;
+            }
         }
 
         .alert-link {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
**Remove the odd outline appearing on close button.**

Before:
![WhatsApp Image 2021-01-24 at 14 12 25](https://user-images.githubusercontent.com/55033316/105625657-ae52f900-5e50-11eb-8eab-34029468a64a.jpeg)

After:
![image](https://user-images.githubusercontent.com/55033316/105625607-721f9880-5e50-11eb-97fb-d3e960083538.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
