### PR TITLE
email: Set an envelope-from which may be different from the From: field.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1422,7 +1422,8 @@ class StripeTest(StripeTestCase):
             self.assertEqual(message.to[0], "desdemona+admin@zulip.com")
             self.assertEqual(message.subject, "Sponsorship request (Open-source) for zulip")
             self.assertEqual(message.reply_to, ["hamlet@zulip.com"])
-            self.assertIn("Zulip sponsorship <noreply-", message.from_email)
+            self.assertEqual(self.email_envelope_from(message), settings.NOREPLY_EMAIL_ADDRESS)
+            self.assertIn("Zulip sponsorship <noreply-", self.email_display_from(message))
             self.assertIn("Requested by: King Hamlet (Member)", message.body)
             self.assertIn(
                 "Support URL: http://zulip.testserver/activity/support?q=zulip", message.body

--- a/templates/zerver/email.html
+++ b/templates/zerver/email.html
@@ -1,3 +1,6 @@
+{% if from_email != envelope_from %}
+<h4>Envelope-From: {{ envelope_from }}</h4>
+{% endif %}
 <h4>From: {{ from_email }}</h4>
 {% if reply_to %}
 <h4>Reply To:

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -148,7 +148,9 @@ def build_email(
     if from_address == FromAddress.support_placeholder:
         from_address = FromAddress.SUPPORT
 
-    from_email = str(Address(display_name=from_name, addr_spec=from_address))
+    # Set the "From" that is displayed separately from the envelope-from
+    extra_headers["From"] = str(Address(display_name=from_name, addr_spec=from_address))
+
     reply_to = None
     if reply_to_email is not None:
         reply_to = [reply_to_email]
@@ -158,8 +160,9 @@ def build_email(
     elif from_address == FromAddress.NOREPLY:
         reply_to = [FromAddress.NOREPLY]
 
+    envelope_from = FromAddress.NOREPLY
     mail = EmailMultiAlternatives(
-        email_subject, message, from_email, to_emails, reply_to=reply_to, headers=extra_headers
+        email_subject, message, envelope_from, to_emails, reply_to=reply_to, headers=extra_headers
     )
     if html_message is not None:
         mail.attach_alternative(html_message, "text/html")

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -13,6 +13,7 @@ import lxml.html
 import orjson
 from django.apps import apps
 from django.conf import settings
+from django.core.mail import EmailMessage
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
 from django.db.migrations.state import StateApps
@@ -1159,6 +1160,25 @@ Output:
 
     def ldap_password(self, uid: str) -> str:
         return f"{uid}_ldap_password"
+
+    def email_display_from(self, email_message: EmailMessage) -> str:
+        """
+        Returns the email address that will show in email clients as the
+        "From" field.
+        """
+        # The extra_headers field may contain a "From" which is used
+        # for display in email clients, and appears in the RFC822
+        # header as `From`.  The `.from_email` accessor is the
+        # "envelope from" address, used by mail transfer agents if
+        # the email bounces.
+        return email_message.extra_headers.get("From", email_message.from_email)
+
+    def email_envelope_from(self, email_message: EmailMessage) -> str:
+        """
+        Returns the email address that will be used if the email bounces.
+        """
+        # See email_display_from, above.
+        return email_message.from_email
 
 
 class WebhookTestCase(ZulipTestCase):

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.conf import settings
 from django.core import mail
 from django.utils.timezone import now
 
@@ -116,8 +117,9 @@ class EmailChangeTestCase(ZulipTestCase):
         )
         body = email_message.body
         self.assertIn("We received a request to change the email", body)
+        self.assertEqual(self.email_envelope_from(email_message), settings.NOREPLY_EMAIL_ADDRESS)
         self.assertRegex(
-            email_message.from_email,
+            self.email_display_from(email_message),
             fr"^Zulip Account Security <{self.TOKENIZED_NOREPLY_REGEX}>\Z",
         )
 

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -311,7 +311,8 @@ class TestMissedMessages(ZulipTestCase):
         self.assertEqual(len(mail.outbox), 1)
         if send_as_user:
             from_email = f'"{othello.full_name}" <{othello.email}>'
-        self.assertEqual(msg.from_email, from_email)
+        self.assertEqual(self.email_envelope_from(msg), settings.NOREPLY_EMAIL_ADDRESS)
+        self.assertEqual(self.email_display_from(msg), from_email)
         self.assertEqual(msg.subject, email_subject)
         self.assertEqual(len(msg.reply_to), 1)
         self.assertIn(msg.reply_to[0], reply_to_emails)

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -377,8 +377,9 @@ class TestPasswordRestEmail(ZulipTestCase):
         call_command(self.COMMAND_NAME, users=self.example_email("iago"))
         from django.core.mail import outbox
 
+        self.assertEqual(self.email_envelope_from(outbox[0]), settings.NOREPLY_EMAIL_ADDRESS)
         self.assertRegex(
-            outbox[0].from_email,
+            self.email_display_from(outbox[0]),
             fr"^Zulip Account Security <{self.TOKENIZED_NOREPLY_REGEX}>\Z",
         )
         self.assertIn("reset your password", outbox[0].body)

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -282,8 +282,9 @@ class RealmTest(ZulipTestCase):
         from django.core.mail import outbox
 
         self.assertEqual(len(outbox), 1)
+        self.assertEqual(self.email_envelope_from(outbox[0]), settings.NOREPLY_EMAIL_ADDRESS)
         self.assertRegex(
-            outbox[0].from_email,
+            self.email_display_from(outbox[0]),
             fr"^Zulip Account Security <{self.TOKENIZED_NOREPLY_REGEX}>\Z",
         )
         self.assertIn("Reactivate your Zulip organization", outbox[0].subject)

--- a/zproject/email_backends.py
+++ b/zproject/email_backends.py
@@ -39,7 +39,8 @@ class EmailLogBackEnd(EmailBackend):
 
         context = {
             "subject": email.subject,
-            "from_email": email.from_email,
+            "envelope_from": email.from_email,
+            "from_email": email.extra_headers.get("From", email.from_email),
             "reply_to": email.reply_to,
             "recipients": email.to,
             "body": email.body,


### PR DESCRIPTION
The envelope-from is used by the MTA if the destination address is not
deliverable.  Route all such mail to the noreply address, tokenized if
necessary.

-----

I don't have great ideas for how to end-to-end test this.  My plan is to deploy this toa test prod instance, and point the outgoing SMTP to a `socat` on localhost.

I'm also not thrilled with replacing all of the `.from_email` calls with `.extra_headers["From"]`, which seems like someone may be apt to "fix".  Using `.extra_headers.get("From", msg.from_email)` is my attempt to get aheaad of that, but I'm not thrilled with it.