### PR TITLE
manage: Quote commands correctly in log_management_command

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
 
     from scripts.lib.zulip_tools import log_management_command
 
-    log_management_command(" ".join(sys.argv), settings.MANAGEMENT_LOG_PATH)
+    log_management_command(sys.argv, settings.MANAGEMENT_LOG_PATH)
 
     os.environ.setdefault("PYTHONSTARTUP", os.path.join(BASE_DIR, "scripts/lib/pythonrc.py"))
     if "--no-traceback" not in sys.argv and len(sys.argv) > 1:

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -203,7 +203,7 @@ def run(args: Sequence[str], **kwargs: Any) -> None:
         print()
         raise
 
-def log_management_command(cmd: str, log_path: str) -> None:
+def log_management_command(cmd: Sequence[str], log_path: str) -> None:
     log_dir = os.path.dirname(log_path)
     if not os.path.exists(log_dir):
         os.makedirs(log_dir)
@@ -215,7 +215,7 @@ def log_management_command(cmd: str, log_path: str) -> None:
     logger.addHandler(file_handler)
     logger.setLevel(logging.INFO)
 
-    logger.info("Ran '%s'", cmd)
+    logger.info("Ran %s", " ".join(map(shlex.quote, cmd)))
 
 def get_environment() -> str:
     if os.path.exists(DEPLOYMENTS_DIR):


### PR DESCRIPTION
**Testing plan:** Ran some `manage.py` commands, looked at `var/log/manage.log`.