### PR TITLE
Revert "Make sure Vagrant works with SELinux enabled"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -158,12 +158,6 @@ sudo dpkg --purge landscape-client landscape-common ubuntu-release-upgrader-core
 sudo dpkg-divert --add --rename /etc/default/motd-news
 sudo sh -c 'echo ENABLED=0 > /etc/default/motd-news'
 
-# If the host is running SELinux remount the /sys/fs/selinux directory as read only,
-# needed for apt-get to work.
-if [ -d "/sys/fs/selinux" ]; then
-    sudo mount -o remount,ro /sys/fs/selinux
-fi
-
 # Set default locale, this prevents errors if the user has another locale set.
 if ! grep -q 'LC_ALL=en_US.UTF-8' /etc/default/locale; then
     echo "LC_ALL=en_US.UTF-8" | sudo tee -a /etc/default/locale


### PR DESCRIPTION
This reverts commit 5ad831fdf0eebb22271e811e6e9124cf88f67842 (part of #2395).

This block is five years old and predates multiple Ubuntu upgrades and our switch from LXC to Docker; now it [reportedly](https://chat.zulip.org/#narrow/stream/21-provision-help/topic/Vagrant.20ssh.20fail.20%28selinux.3F%29/near/1107172) breaks provisioning on SELinux systems instead of fixing it.