### PR TITLE
[3.x] email_notifications: Fix HTML injection bug

### DIFF
--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -67,14 +67,14 @@ run_test("get_and_set_muted_topics", () => {
     assert.deepEqual(muting.get_muted_topics().sort(), [
         {
             date_muted: 1577836800000,
-            date_muted_str: "Jan 01",
+            date_muted_str: "Jan\u00A001,\u00A02020",
             stream: devel.name,
             stream_id: devel.stream_id,
             topic: "java",
         },
         {
             date_muted: 1577836800000,
-            date_muted_str: "Jan 01",
+            date_muted_str: "Jan\u00A001,\u00A02020",
             stream: office.name,
             stream_id: office.stream_id,
             topic: "gossip",
@@ -93,14 +93,14 @@ run_test("get_and_set_muted_topics", () => {
     assert.deepEqual(muting.get_muted_topics().sort(), [
         {
             date_muted: 1577836800000,
-            date_muted_str: "Jan 01",
+            date_muted_str: "Jan\u00A001,\u00A02020",
             stream: social.name,
             stream_id: social.stream_id,
             topic: "breakfast",
         },
         {
             date_muted: 1577836800000,
-            date_muted_str: "Jan 01",
+            date_muted_str: "Jan\u00A001,\u00A02020",
             stream: design.name,
             stream_id: design.stream_id,
             topic: "typography",

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -23,7 +23,7 @@ run_test("settings", () => {
         assert.deepEqual(opts, [
             {
                 date_muted: 1577836800000,
-                date_muted_str: "Jan 01",
+                date_muted_str: "Jan\u00A001,\u00A02020",
                 stream: frontend.name,
                 stream_id: frontend.stream_id,
                 topic: "js",

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -75,11 +75,15 @@ def relative_to_full_url(base_url: str, content: str) -> str:
     # entire message body will be that image element; here, we need a
     # more drastic edit to the content.
     if fragment.get('class') == 'message_inline_image':
-        content_template = '<p><a href="%s" target="_blank" title="%s">%s</a></p>'
         image_link = fragment.find('a').get('href')
         image_title = fragment.find('a').get('title')
-        new_content = (content_template % (image_link, image_title, image_link))
-        fragment = lxml.html.fromstring(new_content)
+        fragment = lxml.html.Element('p')
+        a = lxml.html.Element('a')
+        a.set('href', image_link)
+        a.set('target', '_blank')
+        a.set('title', image_title)
+        a.text = image_link
+        fragment.append(a)
 
     fragment.make_links_absolute(base_url)
     content = lxml.html.tostring(fragment).decode("utf-8")


### PR DESCRIPTION
This is unlikely to be exploitable for XSS since this is only used in emails, but still worth fixing.

Cherry-picked from commit c0ad59585534a27a60eda26298d4122b45d2168d (#17130).