### PR TITLE
design: Show spinner icon only when click on topic_edit_save.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -175,6 +175,7 @@ exports.show_topic_edit_spinner = function (row) {
     spinner.css({height: ""});
     $(".topic_edit_save").hide();
     $(".topic_edit_cancel").hide();
+    $(".topic_edit_spinner").show();
 };
 
 exports.hide_topic_move_spinner = function () {
@@ -549,6 +550,7 @@ exports.start_topic_edit = function (recipient_row) {
     const form = $(render_topic_edit_form());
     current_msg_list.show_edit_topic_on_recipient_row(recipient_row, form);
     form.on("keydown", handle_inline_topic_edit_keydown);
+    $(".topic_edit_spinner").hide();
     const msg_id = rows.id_for_recipient_row(recipient_row);
     const message = current_msg_list.get(msg_id);
     let topic = message.topic;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
The spinner icon is not visible until the user edit the topic name and click `check-box` :check: . The space alloted to `spinner-icon` looks empty for rest of the time. 
Related [thread](https://chat.zulip.org/#narrow/stream/101-design/topic/Swap.20the.20position.20of.20spinner.20and.20bell-icon.2E).
**Testing plan:** <!-- How have you tested? --> Tested manually.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before: 
![Beforeswap](https://user-images.githubusercontent.com/59444243/105953805-d1241e00-6099-11eb-83cb-3bce24a6c833.png)
After: 
![Afterwsap](https://user-images.githubusercontent.com/59444243/105953825-d8e3c280-6099-11eb-9b0d-3f4130e6ce78.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
