### PR TITLE
Set up puppeteer tests with Firefox.

### DIFF
--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -104,6 +104,14 @@ class CommonUtils {
         return await page.evaluate("location.href");
     }
 
+    // This function will clear the existing value of the element and
+    // replace it with the text.
+    async clear_and_type(page: Page, selector: string, text: string): Promise<void> {
+        // Select all text currently in the element.
+        await page.click(selector, {clickCount: 3});
+        await page.type(selector, text);
+    }
+
     /**
      * This function takes a params object whose fields
      * are referenced by name attribute of an input field and

--- a/frontend_tests/puppeteer_tests/02-message-basics.ts
+++ b/frontend_tests/puppeteer_tests/02-message-basics.ts
@@ -316,9 +316,7 @@ async function test_stream_search_filters_stream_list(page: Page): Promise<void>
     await page.waitForSelector(await get_stream_li(page, "Verona"), {visible: true});
 
     // Enter the search box and test highlighted suggestion
-    await page.evaluate(() =>
-        $(".stream-list-filter").expectOne().trigger("focus").trigger("click"),
-    );
+    await page.click(".stream-list-filter");
 
     await page.waitForSelector("#stream_filters .highlighted_stream", {visible: true});
     // First stream in list gets highlihted on clicking search.
@@ -351,9 +349,8 @@ async function test_stream_search_filters_stream_list(page: Page): Promise<void>
     await test_search_venice(page);
 
     // Search for brginning of "Verona".
-    await page.evaluate(() =>
-        $(".stream-list-filter").expectOne().trigger("focus").val("ver").trigger("input"),
-    );
+    await page.click("#streams_header .sidebar-title");
+    await page.type(".stream-list-filter", "ver");
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {hidden: true});
     await page.click(await get_stream_li(page, "Verona"));
     await expect_verona_stream(page);
@@ -393,7 +390,7 @@ async function test_users_search(page: Page): Promise<void> {
     await assert_in_list(page, "aaron");
 
     // Enter the search box and test selected suggestion navigation
-    await page.evaluate(() => $("#user_filter_icon").expectOne().trigger("focus").trigger("click"));
+    await page.click("#user_filter_icon");
     await page.waitForSelector("#user_presences .highlighted_user", {visible: true});
     await assert_selected(page, "Desdemona");
     await assert_not_selected(page, "Cordelia Lear");

--- a/frontend_tests/puppeteer_tests/03-compose.ts
+++ b/frontend_tests/puppeteer_tests/03-compose.ts
@@ -59,9 +59,9 @@ async function test_keyboard_shortcuts(page: Page): Promise<void> {
 }
 
 async function test_reply_by_click_prepopulates_stream_topic_names(page: Page): Promise<void> {
-    const stream_message = get_last_element(
-        await page.$x(get_message_xpath("Compose stream reply test")),
-    );
+    const stream_message_xpath = get_message_xpath("Compose stream reply test");
+    await page.waitForXPath(stream_message_xpath, {visible: true});
+    const stream_message = get_last_element(await page.$x(stream_message_xpath));
     // we chose only the last element make sure we don't click on any duplicates.
     await stream_message.click();
     await common.check_form_contents(page, "#send_message_form", {

--- a/frontend_tests/puppeteer_tests/06-edit.ts
+++ b/frontend_tests/puppeteer_tests/06-edit.ts
@@ -14,11 +14,8 @@ async function trigger_edit_last_message(page: Page): Promise<void> {
 async function edit_stream_message(page: Page, topic: string, content: string): Promise<void> {
     await trigger_edit_last_message(page);
 
-    await page.evaluate(() => $(".message_edit_topic").val(""));
-    await page.evaluate(() => $(".message_edit_content").val(""));
-
-    await page.type(".message_edit_topic", topic);
-    await page.type(".message_edit_content", content);
+    await common.clear_and_type(page, ".message_edit_topic", topic);
+    await common.clear_and_type(page, ".message_edit_content", content);
     await page.click(".message_edit_save");
 
     await common.wait_for_fully_processed_message(page, content);
@@ -66,8 +63,7 @@ async function test_edit_private_message(page: Page): Promise<void> {
     });
     await trigger_edit_last_message(page);
 
-    await page.evaluate(() => $(".message_edit_content").val(""));
-    await page.type(".message_edit_content", "test edited pm");
+    await common.clear_and_type(page, ".message_edit_content", "test edited pm");
     await page.click(".message_edit_save");
     await common.wait_for_fully_processed_message(page, "test edited pm");
 

--- a/frontend_tests/puppeteer_tests/07-navigation.ts
+++ b/frontend_tests/puppeteer_tests/07-navigation.ts
@@ -34,6 +34,8 @@ async function navigate_to_settings(page: Page): Promise<void> {
     await page.waitForSelector("#settings_page", {visible: true});
 
     await page.click("#settings_page .content-wrapper .exit");
+    // Wait until the overlay is completely closed.
+    await page.waitForSelector("#settings_overlay_container", {hidden: true});
 }
 
 async function navigate_to_subscriptions(page: Page): Promise<void> {
@@ -49,6 +51,8 @@ async function navigate_to_subscriptions(page: Page): Promise<void> {
     await page.waitForSelector("#subscriptions_table", {visible: true});
 
     await page.click("#subscription_overlay .exit");
+    // Wait until the overlay is completely closed.
+    await page.waitForSelector("#settings_overlay_container", {hidden: true});
 }
 
 async function test_reload_hash(page: Page): Promise<void> {

--- a/frontend_tests/puppeteer_tests/16-settings.ts
+++ b/frontend_tests/puppeteer_tests/16-settings.ts
@@ -53,7 +53,11 @@ async function test_change_password(page: Page): Promise<void> {
     const change_password_button_selector = "#change_password_button";
     await page.waitForSelector(change_password_button_selector, {visible: true});
 
-    await page.waitForFunction(() => $(":focus").attr("id") === "change_password_modal");
+    // For some strange reason #change_password_modal:focus is not working with Firefox.
+    // The below line is an alternative to that.
+    // TODO: Replace the below line with `await page.waitForSelector("#change_password_modal:focus", {visible: true})`
+    // when the above issue is resolved.
+    await page.waitForFunction(() => document.activeElement!.id === "change_password_modal");
     await page.type("#old_password", test_credentials.default_user.password);
     await page.type("#new_password", "new_password");
     await page.click(change_password_button_selector);

--- a/frontend_tests/puppeteer_tests/16-settings.ts
+++ b/frontend_tests/puppeteer_tests/16-settings.ts
@@ -76,6 +76,12 @@ async function test_get_api_key(page: Page): Promise<void> {
     await common.fill_form(page, "#api_key_form", {
         password: test_credentials.default_user.password,
     });
+
+    // When typing the password in Firefox, it shows "Not Secure" warning
+    // which was hiding the Get API Key button.
+    // You can see the screenshot of it in https://github.com/zulip/zulip/pull/17136.
+    // Focusing on it will remove the warning.
+    await page.focus(get_api_key_button_selector);
     await page.click(get_api_key_button_selector);
 
     await page.waitForSelector("#show_api_key", {visible: true});

--- a/tools/lib/test_script.py
+++ b/tools/lib/test_script.py
@@ -121,8 +121,10 @@ def find_js_test_files(test_dir: str, files: Iterable[str]) -> List[str]:
     return test_files
 
 
-def prepare_puppeteer_run() -> None:
+def prepare_puppeteer_run(is_firefox: bool = False) -> None:
     os.chdir(ZULIP_PATH)
+    # This will determine if the browser will be firefox or chrome.
+    os.environ["PUPPETEER_PRODUCT"] = "firefox" if is_firefox else "chrome"
     subprocess.check_call(["node", "node_modules/puppeteer/install.js"])
     os.makedirs("var/puppeteer", exist_ok=True)
     for f in glob.glob("var/puppeteer/puppeteer-failure*.png"):

--- a/tools/test-js-with-puppeteer
+++ b/tools/test-js-with-puppeteer
@@ -51,6 +51,7 @@ parser = argparse.ArgumentParser(usage)
 
 parser.add_argument("--interactive", action="store_true", help="Run tests interactively")
 add_provision_check_override_param(parser)
+parser.add_argument("--firefox", action="store_true", help="Run tests with firefox.")
 parser.add_argument(
     "tests", nargs=argparse.REMAINDER, help="Specific tests to run; by default, runs all tests"
 )
@@ -127,7 +128,7 @@ or report and ask for help in chat.zulip.org""",
 
 external_host = "zulipdev.com:9981"
 assert_provisioning_status_ok(options.skip_provision_check)
-prepare_puppeteer_run()
+prepare_puppeteer_run(is_firefox=options.firefox)
 run_tests(options.tests, external_host)
 print(f"{OKGREEN}All tests passed!{ENDC}")
 sys.exit(0)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#16240


**Testing plan:** <!-- How have you tested? -->
Tested locally.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Here is the screenshot of "Not Secure Warning" hiding the Get API Key button.
Refer this [commit](https://github.com/zulip/zulip/pull/17136/commits/428f55bb3964be9dcea4a91dbf46b629a8f500ce)
![Screenshot 2021-02-17 at 12 25 13 AM](https://user-images.githubusercontent.com/63820270/108224108-8e1d0e00-7160-11eb-9ce8-b6229992398e.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
