### PR TITLE
scroll_bar: Fix incorrectly converted breakpoint

### DIFF
--- a/static/js/scroll_bar.js
+++ b/static/js/scroll_bar.js
@@ -64,7 +64,7 @@ exports.initialize = function () {
                 (7 + sbWidth) +
                 "px !important; } } " +
                 "@media (max-width: " +
-                media_breakpoints.xl_max +
+                media_breakpoints.md_max +
                 ") { .fixed-app .column-middle { margin-left: " +
                 (7 + sbWidth) +
                 "px !important; } } " +


### PR DESCRIPTION
Commit e941ee4a15a0d5e2514882cce24770a02e02829d (#16680) incorrectly converted this from 775px to xl-max = 1199px instead of md-max = 767px, causing misplacement of the FRB for browser widths between these values.

Cc @amanagr.