### PR TITLE
apidocs: Display data type of responses in API Documentation and minor API Documentation fixes.

### DIFF
--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -1726,6 +1726,10 @@ label.label-title {
     }
 }
 
+.api-response-datatype {
+    color: hsl(176, 46.4%, 41%);
+}
+
 .desktop-redirect-box {
     text-align: center;
 

--- a/templates/zerver/api/update-subscription-settings.md
+++ b/templates/zerver/api/update-subscription-settings.md
@@ -41,8 +41,7 @@ The possible values for each `property` and `value` pairs are:
 
 #### Return values
 
-* `subscription_data`: The same `subscription_data` object sent by the client
-    for the request, confirming the changes made.
+{generate_return_values_table|zulip.yaml|/users/me/subscriptions/properties:post}
 
 #### Example response
 

--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -9,6 +9,8 @@ from markdown.preprocessors import Preprocessor
 
 from zerver.openapi.openapi import get_openapi_return_values, likely_deprecated_parameter
 
+from .api_arguments_table_generator import generate_data_type
+
 REGEXP = re.compile(r'\{generate_return_values_table\|\s*(.+?)\s*\|\s*(.+)\s*\}')
 
 class MarkdownReturnValuesTableGenerator(Extension):
@@ -59,11 +61,27 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
                 done = True
         return lines
 
-    def render_desc(self, description: str, spacing: int, return_value: Optional[str]=None) -> str:
+    def render_desc(self, description: str, spacing: int, data_type: str,
+                    return_value: Optional[str]=None) -> str:
         description = description.replace('\n', '\n' + ((spacing + 4) * ' '))
         if return_value is None:
-            return (spacing * " ") + "* " + description
-        return (spacing * " ") + "* `" + return_value + "`: " + description
+            # HACK: It's not clear how to use OpenAPI data to identify
+            # the `key` fields for objects where e.g. the keys are
+            # user/stream IDs being mapped to data associated with
+            # those IDs.  We hackily describe those fields by
+            # requiring that the descriptions be written as `key_name:
+            # key_description` and parsing for that pattern; we need
+            # to be careful to skip cases where we'd have `Note: ...`
+            # on a later line.
+            #
+            # More correctly, we should be doing something that looks at the types;
+            # print statements and test_api_doc_endpoint is useful for testing.
+            arr = description.split(": ", 1)
+            if data_type != "object" or len(arr) == 1 or '\n' in arr[0]:
+                return (spacing * " ") + "* " + description
+            (key_name, key_description) = arr
+            return (spacing * " ") + "* " + key_name + ": " + '<span class="api-response-datatype">' + data_type + "</span> "  + key_description
+        return (spacing * " ") + "* `" + return_value + "`: " + '<span class="api-response-datatype">' + data_type + "</span> "  + description
 
     def render_table(self, return_values: Dict[str, Any], spacing: int) -> List[str]:
         IGNORE = ["result", "msg"]
@@ -77,28 +95,32 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
                 # description of the endpoint. Then for each element of oneOf there is a
                 # specialized description for that particular case. The description used
                 # right below is the main description.
+                data_type = generate_data_type(return_values[return_value])
                 ans.append(self.render_desc(return_values[return_value]['description'],
-                                            spacing, return_value))
+                                            spacing, data_type, return_value))
                 for element in return_values[return_value]['oneOf']:
                     if 'description' not in element:
                         continue
                     # Add the specialized description of the oneOf element.
-                    ans.append(self.render_desc(element['description'], spacing + 4))
+                    data_type = generate_data_type(element)
+                    ans.append(self.render_desc(element['description'], spacing + 4, data_type))
                     # If the oneOf element is an object schema then render the documentation
                     # of its keys.
                     if 'properties' in element:
                         ans += self.render_table(element['properties'], spacing + 8)
                 continue
             description = return_values[return_value]['description']
+            data_type = generate_data_type(return_values[return_value])
             # Test to make sure deprecated keys are marked appropriately.
             if likely_deprecated_parameter(description):
                 assert(return_values[return_value]['deprecated'])
-            ans.append(self.render_desc(description, spacing, return_value))
+            ans.append(self.render_desc(description, spacing, data_type, return_value))
             if 'properties' in return_values[return_value]:
                 ans += self.render_table(return_values[return_value]['properties'], spacing + 4)
             if return_values[return_value].get('additionalProperties', False):
+                data_type = generate_data_type(return_values[return_value]['additionalProperties'])
                 ans.append(self.render_desc(return_values[return_value]['additionalProperties']
-                                            ['description'], spacing + 4))
+                                            ['description'], spacing + 4, data_type))
                 if 'properties' in return_values[return_value]['additionalProperties']:
                     ans += self.render_table(return_values[return_value]['additionalProperties']
                                              ['properties'], spacing + 8)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4694,6 +4694,24 @@ paths:
             exist a new stream is created. The description of the stream created can
             be specified by setting the dictionary key `description` with an
             appropriate value.
+            The possible values for each `property` and `value` pairs are:
+
+            * `color` (string): the hex value of the user's display color for the stream.
+            * `is_muted` (boolean): whether the stream is
+              [muted](/help/mute-a-stream).  Prior to Zulip 2.1, this feature was
+              represented by the more confusingly named `in_home_view` (with the
+              opposite value, `in_home_view=!is_muted`); for
+              backwards-compatibility, modern Zulip still accepts that value.
+            * `pin_to_top` (boolean): whether to pin the stream at the top of the stream list.
+            * `desktop_notifications` (boolean): whether to show desktop notifications
+                for all messages sent to the stream.
+            * `audible_notifications` (boolean): whether to play a sound
+              notification for all messages sent to the stream.
+            * `push_notifications` (boolean): whether to trigger a mobile push
+                notification for all messages sent to the stream.
+            * `email_notifications` (boolean): whether to trigger an email
+                notification for all messages sent to the stream.
+
           content:
             application/json:
               schema:
@@ -5418,38 +5436,30 @@ paths:
                               type: string
                               description: |
                                 The property to be changed. It is one of:
-                                    *`color`: The hex value of the user's personal display color for the stream.
 
-                                    *`is_muted`: Whether the stream is [muted](/help/mute-a-stream).
+                                * `color`: The hex value of the user's personal display color for the stream.<br>
+                                * `is_muted`: Whether the stream is [muted](/help/mute-a-stream).<br>
+                                **Changes**: Prior to Zulip 2.1, this feature was
+                                represented by the more confusingly named `in_home_view` (with the
+                                opposite value, `in_home_view=!is_muted`); for
+                                backwards-compatibility, modern Zulip still accepts that value.<br>
+                                * `pin_to_top`: Whether to pin the stream at the top of the stream list.
+                                * `desktop_notifications`: Whether to show desktop notifications for all
+                                messages sent to the stream.<br>
+                                * `audible_notifications`: Whether to play a sound notification for all
+                                messages sent to the stream.<br>
+                                * `push_notifications`: Whether to trigger a mobile push notification for
+                                all messages sent to the stream.<br>
+                                * `email_notifications`: Whether to trigger an email notification for all
+                                messages sent to the stream.<br>
+                                * `in_home_view`: Whether to mute the stream (legacy property)<br>
+                                * `wildcard_mentions_notify`: whether wildcard mentions trigger notifications
+                                as though they were personal mentions in this stream.<br>
+                                A null value means the value of this setting
+                                should be inherited from the user-level default
+                                setting, wildcard_mentions_notify, for
+                                this stream.
 
-                                    **Changes**: Prior to Zulip 2.1, this feature was
-                                    represented by the more confusingly named `in_home_view` (with the
-                                    opposite value, `in_home_view=!is_muted`); for
-                                    backwards-compatibility, modern Zulip still accepts that value.
-
-                                    *`pin_to_top`: Whether to pin the stream at the top of the stream list.
-
-                                    *`desktop_notifications`: Whether to show desktop notifications for all
-                                    messages sent to the stream.
-
-                                    *`audible_notifications`: Whether to play a sound notification for all
-                                    messages sent to the stream.
-
-                                    *`push_notifications`: Whether to trigger a mobile push notification for
-                                    all messages sent to the stream.
-
-                                    *`email_notifications`: Whether to trigger an email notification for all
-                                    messages sent to the stream.
-
-                                    *`in_home_view`: Whether to mute the stream (legacy property)
-
-                                    *`wildcard_mentions_notify`: whether wildcard mentions trigger notifications
-                                    as though they were personal mentions in this stream.
-
-                                    A null value means the value of this setting
-                                    should be inherited from the user-level default
-                                    setting, wildcard_mentions_notify, for
-                                    this stream.
                               enum:
                                 - color
                                 - push_notifications

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3795,7 +3795,7 @@ paths:
                                 narrow is a search narrow, `<span class="highlight">` elements
                                 will be included wrapping the matches for the search keywords.
                           description: |
-                            The ID of the message that matches the narrow.  No record will be returned
+                            `message_id`: The ID of the message that matches the narrow.  No record will be returned
                             for queried messages that do not match the narrow.
                     example:
                       {
@@ -6430,6 +6430,7 @@ paths:
                           description: |
                             `{user_id}`: Object containing the status details of a user
                             with the key of the object being the id of the user.
+                          type: object
                           properties:
                             away:
                               type: boolean
@@ -7105,6 +7106,7 @@ paths:
                             `{provider_name}`: Dictionary containing the details of the
                             video chat provider with the name of the chat provider as
                             the key.
+                          type: object
                           properties:
                             name:
                               type: string
@@ -7217,6 +7219,7 @@ paths:
                             `{site_name}`: Dictionary containing the details of the
                             default external account provider with the name of the
                             website as the key.
+                          type: object
                           properties:
                             name:
                               type: string
@@ -9915,7 +9918,7 @@ components:
         type: object
         additionalProperties: false
         description: |
-          '{id}': Object with data about what value user filled in the custom
+          `{id}`: Object with data about what value user filled in the custom
                       profile field with id `id`.
         properties:
           value:
@@ -10101,7 +10104,7 @@ components:
                 subscribed to.
               additionalProperties:
                 description: |
-                  {email_address}`: List of the names of the streams that the user is
+                  `{email_address}`: List of the names of the streams that the user is
                   already subscribed to.
                 type: array
                 items:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes part of #15967


**Testing plan:** <!-- How have you tested? -->
Tested manually on Localhost

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/56172924/106049096-c0ac8b80-610b-11eb-9723-3fa9db79621e.png)
![image](https://user-images.githubusercontent.com/56172924/106049295-fcdfec00-610b-11eb-864b-213da3c07011.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
