### PR TITLE
Zulip as OAuth provider

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -188,3 +188,7 @@ pyuca
 
 # Handle connection retries with exponential backoff
 backoff
+
+# Needed to make Zulip server act as OAuth2 Provider
+django-oauth-toolkit
+

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -364,6 +364,10 @@ django-formtools==2.2 \
 django-otp==1.0.3 \
     --hash=sha256:381a15e65293b8b06d47b7d6b306e0b7af2e104137ac92f6c566d3b9b90b6244 \
     --hash=sha256:f4ab096b424c33ffe69453620356e1b7517f30dfb9ba13bfeaa1d1f20faddc13
+    # via -r requirements/common.in
+django-oauth-toolkit==1.3.3 \
+    --hash=sha256:48a45d9ec23b50646b14b4b93988bd0d35ad5cf933edfcb833a8527f86329f28 \
+    --hash=sha256:a67ab96089b96540e34dc8d1ee6e6305a80ee01a36f7688108cd94b77406bdd3 \
     # via django-two-factor-auth
 django-phonenumber-field==5.1.0 \
     --hash=sha256:48724ba235ee8248a474204faa0934c5baf9536f429859d05cb131fbd6b1c695 \
@@ -388,6 +392,7 @@ django[argon2]==3.1.8 \
     #   django-auth-ldap
     #   django-bitfield
     #   django-formtools
+    #   django-oauth-toolkit
     #   django-otp
     #   django-phonenumber-field
     #   django-sendfile2
@@ -1259,6 +1264,8 @@ requests[security]==2.25.1 \
     --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e
     # via
     #   -r requirements/common.in
+    #   django-oauth-toolkit
+    #   docker
     #   matrix-client
     #   moto
     #   premailer

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -228,6 +228,10 @@ django-formtools==2.2 \
 django-otp==1.0.3 \
     --hash=sha256:381a15e65293b8b06d47b7d6b306e0b7af2e104137ac92f6c566d3b9b90b6244 \
     --hash=sha256:f4ab096b424c33ffe69453620356e1b7517f30dfb9ba13bfeaa1d1f20faddc13
+    # via -r requirements/common.in
+django-oauth-toolkit==1.3.3 \
+    --hash=sha256:48a45d9ec23b50646b14b4b93988bd0d35ad5cf933edfcb833a8527f86329f28 \
+    --hash=sha256:a67ab96089b96540e34dc8d1ee6e6305a80ee01a36f7688108cd94b77406bdd3 \
     # via django-two-factor-auth
 django-phonenumber-field==5.1.0 \
     --hash=sha256:48724ba235ee8248a474204faa0934c5baf9536f429859d05cb131fbd6b1c695 \
@@ -252,6 +256,7 @@ django[argon2]==3.1.8 \
     #   django-auth-ldap
     #   django-bitfield
     #   django-formtools
+    #   django-oauth-toolkit
     #   django-otp
     #   django-phonenumber-field
     #   django-sendfile2
@@ -555,6 +560,7 @@ oauthlib==3.1.0 \
     --hash=sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889 \
     --hash=sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea
     # via
+    #   django-oauth-toolkit
     #   requests-oauthlib
     #   social-auth-core
 openapi-core==0.13.7 \
@@ -873,6 +879,7 @@ requests[security]==2.25.1 \
     --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e
     # via
     #   -r requirements/common.in
+    #   django-oauth-toolkit
     #   matrix-client
     #   premailer
     #   pyoembed

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -45,6 +45,7 @@ import * as settings_invites from "./settings_invites";
 import * as settings_linkifiers from "./settings_linkifiers";
 import * as settings_notifications from "./settings_notifications";
 import * as settings_org from "./settings_org";
+import * as settings_oauth from "./settings_oauth";
 import * as settings_playgrounds from "./settings_playgrounds";
 import * as settings_profile_fields from "./settings_profile_fields";
 import * as settings_streams from "./settings_streams";
@@ -140,6 +141,11 @@ export function dispatch_normal_event(event) {
         case "muted_users":
             muting_ui.handle_user_updates(event.muted_users);
             break;
+
+        case "oauth2":
+              page_params.oauth2 = event.oauth2;
+              settings_oauth.populate_oauth2(page_params.oauth2);
+              break;
 
         case "presence":
             activity.update_presence_info(event.user_id, event.presence, event.server_timestamp);

--- a/static/js/settings_sections.js
+++ b/static/js/settings_sections.js
@@ -12,6 +12,7 @@ import * as settings_muted_topics from "./settings_muted_topics";
 import * as settings_muted_users from "./settings_muted_users";
 import * as settings_notifications from "./settings_notifications";
 import * as settings_org from "./settings_org";
+import * as settings_oauth from "./settings_oauth";
 import * as settings_playgrounds from "./settings_playgrounds";
 import * as settings_profile_fields from "./settings_profile_fields";
 import * as settings_streams from "./settings_streams";
@@ -29,6 +30,7 @@ export function get_group(section) {
         case "organization-settings":
         case "organization-permissions":
         case "auth-methods":
+        case "oauth-application":
             return "org_misc";
 
         case "bot-list-admin":
@@ -49,6 +51,7 @@ export function initialize() {
     load_func_dict.set("display-settings", settings_display.set_up);
     load_func_dict.set("notifications", settings_notifications.set_up);
     load_func_dict.set("your-bots", settings_bots.set_up);
+    load_func_dict.set("oauth-application", settings_oauth.set_up);
     load_func_dict.set("alert-words", alert_words_ui.set_up_alert_words);
     load_func_dict.set("uploaded-files", attachments_ui.set_up_attachments);
     load_func_dict.set("muted-topics", settings_muted_topics.set_up);

--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -242,6 +242,26 @@ html {
     }
 }
 
+.oauth-account {
+    .terms-of-service .input-group,
+    .default-stream-groups .input-group,
+    .default-stream-groups p {
+        width: 330px;
+        margin: 0 auto 10px;
+    }
+
+    .terms-of-service .text-error {
+        position: relative;
+        display: block;
+        top: -5px;
+        padding: 0;
+        height: 0;
+
+        font-size: 0.7em;
+        font-weight: 600;
+    }
+}
+
 .register-form {
     &.new-style {
         text-align: left;
@@ -794,6 +814,16 @@ button#register_auth_button_gitlab {
         font-weight: normal !important;
     }
 
+    .oauth-button-box {
+        text-align: center;
+    }
+
+    .oauth-button {
+        margin: 25px auto 30px;
+        width: 330px;
+        border-radius: 4px;
+    }
+
     .register-button-box {
         text-align: center;
     }
@@ -918,6 +948,14 @@ button#register_auth_button_gitlab {
         font-size: 1.2rem;
         font-weight: 400;
     }
+}
+
+#client_type_section,
+#authorization_grant_type_section {
+    position: relative;
+    top: 15px;
+    margin-bottom: 20px;
+    font-size: 22px;
 }
 
 #source_realm_select_section {

--- a/templates/oauth2_provider/application_confirm_delete.html
+++ b/templates/oauth2_provider/application_confirm_delete.html
@@ -1,0 +1,22 @@
+{% extends "oauth2_provider/base.html" %}
+
+{% block portico_content %}
+<div class="oauth-account flex full-page">
+    <div class="center-block new-style">
+
+        <form class="white-box" method="post" action="{{ url('oauth2_provider:delete', args=[application.pk]) }}">
+            <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+
+            <h3 class="block-center-heading">{{_("Are you sure to delete the application")}} {{ application.name }}?</h3>
+
+            <div class="block-center">
+                <a class="oauth-button" href="{{ url('oauth2_provider:list') }}">{{ _("Cancel") }}</a>
+                <button type="submit" class="oauth-button" value="Delete">{{ _("Delete") }}</button>
+            </div>
+
+        </form>
+
+    </div>
+</div>
+
+{% endblock %}

--- a/templates/oauth2_provider/application_detail.html
+++ b/templates/oauth2_provider/application_detail.html
@@ -1,0 +1,64 @@
+{% extends "oauth2_provider/base.html" %}
+
+{% block portico_content %}
+<div class="oauth-account flex full-page">
+    <div class="center-block new-style">
+
+        <div class="pitch">
+            <h1>{{ application.name }}</h1>
+        </div>
+
+        <div class="block-center white-box">
+            <ul class="unstyled">
+                <li>
+                    <div class="block-center input-box">
+                        <input class=required  type="text" value="{{ application.client_id }}" readonly />
+                        <label class="inline-block label-title" for="id_client_id">{{ _('Client ID') }}</label>
+                    </div>
+                </li>
+
+                <li>
+                    <div class="block-center input-box">
+                        <input class=required  type="text" value="{{ application.client_secret }}" readonly />
+                        <label class="inline-block label-title" for="id_client_secret">{{ _('Client Secret') }}</label>
+                    </div>
+                </li>
+
+                <li>
+                    <div class="block-center input-box">
+                        <input class=required  type="text" value="{{ application.client_type }}" readonly />
+                        <label class="inline-block label-title" for="id_client_type">{{ _('Client Type') }}</label>
+                    </div>
+                </li>
+
+                <li>
+                    <div class="block-center input-box">
+                        <input class=required  type="text" value="{{ application.authorization_grant_type }}" readonly />
+                        <label class="inline-block label-title" for="id_authorization_grant_type">{{ _('Authorization Grant Type') }}</label>
+                    </div>
+                </li>
+
+                <li>
+                    <div class="block-center input-box">
+                        <input class=required  type="text" value="{{ application.redirect_uris }}" readonly />
+                        <label class="inline-block label-title" for="id_redirect_uris">{{ _('Redirect uris') }}</label>
+                    </div>
+                </li>
+            </ul>
+
+            <a class="oauth-button" href="{{ url('oauth2_provider:list') }}">
+                <button type="submit">{{ _("Go Back") }}</button>
+            </a>
+            <a class="oauth-button" href="{{ url('oauth2_provider:update', args=[application.id]) }}">
+                <button type="submit">{{ _("Edit") }}</button>
+            </a>
+            <a class="oauth-button" href="{{ url('oauth2_provider:delete', args=[application.id]) }}">
+                <button type="submit">{{ _("Delete") }}</button>
+            </a>
+
+        </div>
+
+    </div>
+</div>
+
+{% endblock %}

--- a/templates/oauth2_provider/application_form.html
+++ b/templates/oauth2_provider/application_form.html
@@ -1,0 +1,86 @@
+{% extends "oauth2_provider/base.html" %}
+
+
+{% block portico_content %}
+<div class="oauth-account flex full-page">
+    <div class="center-block new-style">
+
+        <h1 class="block-center-heading">
+            {% block app_form_title %}
+            {{ _("Edit application") }} {{ application.name }}
+            {% endblock %}
+        </h1>
+
+        <form class="form-horizontal white-box" method="post" id="registration"
+          action="{% block app_form_action_url %}{{ url('oauth2_provider:update', args=[application.id])}}{% endblock %}">
+            <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+
+            <fieldset class="oauth-registration">
+                {% for field in form %}
+                <div class="controls">
+                    {% for error in field.errors %}
+                    <span class="help-inline">{{ error }}</span>
+                    {% endfor %}
+                </div>
+                {% endfor %}
+
+                <div class="block-center input-box">
+                    <div class="inline-block relative">
+                        <input id="id_name" class="required" type="text"
+                          value="{% if form.name.value() %}{{ form.name.value() }}{% endif %}"
+                          name="name" maxlength = 255 required />
+                    </div>
+                    <label class="inline-block label-title" for="id_name">{{ _('Organization name') }}</label>
+                </div>
+
+                <div class="block-center input-box">
+                    <div class="inline-block relative">
+                        <input id="oauth_id_client_id" class=required type="text"
+                          value="{{ form.client_id.value() }}" name="client_id" required  />
+                        <input id="initial-id_client_id" class=required type="hidden"
+                          value="{{ form.client_id.value() }}" name="initial-client_id" required  />
+                    </div>
+                    <label class="inline-block label-title" for="oauth_id_client_id">{{ _('Client ID') }}</label>
+                </div>
+
+                <div class="block-center input-box">
+                    <div class="inline-block relative">
+                        <input id="id_client_secret" class=required type="text"
+                          value="{{ form.client_secret.value() }}" name="client_secret" required  />
+                        <input id="initial-id_client_secret" class=required type="hidden"
+                          value="{{ form.client_secret.value() }}" name="initial-client_secret" required  />
+                    </div>
+                    <label class="inline-block label-title" for="id_client_secret">{{ _('Client Secret') }}</label>
+                </div>
+
+                <div class="block-center input-box">
+                    <div id="client_type_section">
+                        <input class=required  type="text" name="client_type" value="confidential" readonly />
+                    </div>
+                    <label class="inline-block label-title" for="client_type">{{ _('Client type') }}</label>
+                </div>
+
+                <div class="block-center input-box">
+                    <div id="authorization_grant_type_section">
+                        <input class="required" type="text" name="authorization_grant_type" value="authorization-code" readonly />
+                    </div>
+                    <label class="inline-block label-title" for="id_authorization_grant_type">{{ _('Authorization grant type') }}</label>
+                </div>
+
+                <div class="block-center input-box">
+                    <div class="inline-block relative">
+                        <input id="id_redirect_uris" class="required" type="text"
+                          name="redirect_uris"
+                          value="{% if form.redirect_uris.value() %}{{ form.redirect_uris.value() }}{% endif %}" required />
+                    </div>
+                    <label class="inline-block label-title" for="id_redirect_uris">{{ _('Redirect uris') }}</label>
+                </div>
+            </fieldset>
+
+            <div class="oauth-button-box">
+                <button class="oauth-button" type="submit">{{ _('Save') }}</button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/templates/oauth2_provider/application_list.html
+++ b/templates/oauth2_provider/application_list.html
@@ -1,0 +1,26 @@
+{% extends "oauth2_provider/base.html" %}
+
+{% block portico_content %}
+<div class="oauth-account flex full-page">
+    <div class="center-block new-style">
+
+        <div class="pitch">
+            <h1>{{ _("Your applications") }}</h1>
+        </div>
+
+        <div class="white-box">
+            <ul>
+                {% for application in applications %}
+                <li><a href="/o/applications/{{ application.id }}">{{ application.name }}</a></li>
+                {% endfor %}
+            </ul>
+
+            <a href="{{ 'register' }}">
+                <div class="oauth-button-box">
+                    <button class="oauth-button" type="submit">{{ _('Create New Applcation') }}</button>
+                </div>
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/oauth2_provider/application_registration_form.html
+++ b/templates/oauth2_provider/application_registration_form.html
@@ -1,0 +1,7 @@
+{% extends "oauth2_provider/application_form.html" %}
+
+{% block app_form_title %}{{ _("Register a new application") }} {% endblock %}
+
+{% block app_form_action_url %}{{ url('oauth2_provider:register') }}{% endblock %}
+
+{% block app_form_back_url %}{{ url('oauth2_provider:list') }}{% endblock %}

--- a/templates/oauth2_provider/authorize.html
+++ b/templates/oauth2_provider/authorize.html
@@ -1,0 +1,47 @@
+{% extends "oauth2_provider/base.html" %}
+
+{% block portico_content %}
+<div class="oauth-account flex full-page">
+    <div class="center-block new-style">
+
+        <h1 class="block-center">
+            {% block app_form_title %}
+            {{ _("Authorize") }} {{ application.name }}
+            {% endblock %}
+        </h1>
+
+        {% if not error %}
+        <form class="form-horizontal white-box" method="post" id="authorizationForm">
+
+            <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+
+            {% for field in form %}
+                {% if field.is_hidden %}
+                {{ field }}
+                {% endif %}
+            {% endfor %}
+
+            <p>{{ _("Application requires following permissions") }}</p>
+            <ul>
+                {% for scope in scopes_descriptions %}
+                <li>{{ scope }}</li>
+                {% endfor %}
+            </ul>
+
+            <div class="block-center">
+                <button class="oauth-button" type="submit" value="Cancle">{{ _('Cancel') }}</button>
+                <button class="oauth-button" type="submit" name="allow" value="Authorize">{{ _('Authorize') }}</button>
+            </div>
+
+        </form>
+
+        {% else %}
+        <h2>Error: {{ error.error }}</h2>
+        <p> {{ error.description }} </p>
+        {% endif %}
+
+    </div>
+
+</div>
+
+{% endblock %}

--- a/templates/oauth2_provider/authorized-token-delete.html
+++ b/templates/oauth2_provider/authorized-token-delete.html
@@ -1,0 +1,8 @@
+{% extends "oauth2_provider/base.html" %}
+
+{% block portico_content %}
+<form action="" method="post">{% csrf_token %}
+    <p>{{ ("Are you sure you want to delete this token?") }}</p>
+    <input type="submit" value="{{ ("Delete") }}" />
+</form>
+{% endblock %}

--- a/templates/oauth2_provider/authorized-tokens.html
+++ b/templates/oauth2_provider/authorized-tokens.html
@@ -1,0 +1,30 @@
+{% extends "oauth2_provider/base.html" %}
+
+{% block portico_content %}
+<div class="oauth-account flex full-page">
+    <div class="center-block new-style">
+
+        <form class="form-horizontal white-box" id="registration" method="post">
+            <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+
+            <div class="pitch">
+                <h1>{{ Tokens.client_id }}</h1>
+            </div>
+
+            <div class="block-center white-box">
+                <ul class="unstyled">
+                    <li>
+                        {{ authorized_token.application }}
+                        <a href="/o/applications/{{ application.id }}/delete"><b>{{ ("Go Back") }}</b>revoke</a>
+                    </li>
+                    <ul>
+                        <li>{{ scope_name }}: {{ scope_description }}</li>
+                    </ul>
+                    <li>{{ ("There are no authorized tokens yet.") }}</li>
+                </ul>
+            </div>
+        </form>
+
+    </div>
+</div>
+{% endblock %}

--- a/templates/oauth2_provider/base.html
+++ b/templates/oauth2_provider/base.html
@@ -1,0 +1,1 @@
+{% extends "zerver/portico_signup.html" %}

--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -29,6 +29,10 @@
                     <div class="text">{{ _('Your bots') }}</div>
                 </li>
                 {% endif %}
+                <li tabindex="0" data-section="oauth-application">
+                    <i class="icon fa fa-key" aria-hidden="true"></i>
+                    <div class="text">{{ _('OAuth') }}</div>
+                </li>
                 <li tabindex="0" data-section="alert-words">
                     <i class="icon fa fa-book" aria-hidden="true"></i>
                     <div class="text">{{ _('Alert words') }}</div>

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -675,8 +675,6 @@ def authenticated_rest_api_view(
                     role, api_key = base64.b64decode(credentials).decode("utf-8").split(":")
                 except ValueError:
                     return json_unauthorized(_("Invalid authorization header for basic auth"))
-                except KeyError:
-                    return json_unauthorized(_("Missing authorization header for basic auth"))
 
                 # Now we try to do authentication or die
                 try:

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -21,6 +21,7 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
 from django_otp import user_has_device
+from oauth2_provider.oauth2_backends import get_oauthlib_core
 from two_factor.utils import default_device
 
 from zerver.lib.exceptions import (
@@ -227,6 +228,28 @@ class InvalidZulipServerKeyError(InvalidZulipServerError):
     @staticmethod
     def msg_format() -> str:
         return "Zulip server auth failure: key does not match role {role}"
+
+
+def validate_oauth_key(request: HttpRequest) -> UserProfile:
+    access_token = request.META.get("HTTP_BEARER")
+    request.META["Authorization"] = f"bearer {access_token}"
+    (ok, req) = get_oauthlib_core().verify_request(request, [])
+    if not ok:
+        raise JsonableError(_("oauth failed"))
+
+    # convert from AnonymousUser
+    user_profile = UserProfile.objects.get(id=req.user.id)
+    request.user = user_profile
+
+    validate_account_and_subdomain(request, user_profile)
+
+    # Using oauth for webhooks might make sense some day, but we punt for now.
+    if user_profile.is_incoming_webhook:
+        raise JsonableError(_("This API is not available to incoming webhook bots."))
+
+    client_name = "beta oauth"
+    process_client(request, user_profile, client_name=client_name)
+    return user_profile
 
 
 def validate_api_key(
@@ -639,32 +662,43 @@ def authenticated_rest_api_view(
         def _wrapped_func_arguments(
             request: HttpRequest, *args: object, **kwargs: object
         ) -> HttpResponse:
-            # First try block attempts to get the credentials we need to do authentication
-            try:
-                # Grab the base64-encoded authentication string, decode it, and split it into
-                # the email and API key
-                auth_type, credentials = request.META["HTTP_AUTHORIZATION"].split()
-                # case insensitive per RFC 1945
-                if auth_type.lower() != "basic":
-                    return json_error(_("This endpoint requires HTTP basic authentication."))
-                role, api_key = base64.b64decode(credentials).decode("utf-8").split(":")
-            except ValueError:
-                return json_unauthorized(_("Invalid authorization header for basic auth"))
-            except KeyError:
-                return json_unauthorized(_("Missing authorization header for basic auth"))
 
-            # Now we try to do authentication or die
-            try:
-                # profile is a Union[UserProfile, RemoteZulipServer]
-                profile = validate_api_key(
-                    request,
-                    role,
-                    api_key,
-                    allow_webhook_access=allow_webhook_access,
-                    client_name=full_webhook_client_name(webhook_client_name),
-                )
-            except JsonableError as e:
-                return json_unauthorized(e.msg)
+            if request.META.get("HTTP_AUTHORIZATION"):
+                # First try block attempts to get the credentials we need to do authentication
+                try:
+                    # Grab the base64-encoded authentication string, decode it, and split it into
+                    # the email and API key
+                    auth_type, credentials = request.META["HTTP_AUTHORIZATION"].split()
+                    # case insensitive per RFC 1945
+                    if auth_type.lower() != "basic":
+                        return json_error(_("This endpoint requires HTTP basic authentication."))
+                    role, api_key = base64.b64decode(credentials).decode("utf-8").split(":")
+                except ValueError:
+                    return json_unauthorized(_("Invalid authorization header for basic auth"))
+                except KeyError:
+                    return json_unauthorized(_("Missing authorization header for basic auth"))
+
+                # Now we try to do authentication or die
+                try:
+                    # profile is a Union[UserProfile, RemoteZulipServer]
+                    profile = validate_api_key(
+                        request,
+                        role,
+                        api_key,
+                        allow_webhook_access=allow_webhook_access,
+                        client_name=full_webhook_client_name(webhook_client_name),
+                    )
+                except JsonableError as e:
+                    return json_unauthorized(e.msg)
+            elif request.META.get("HTTP_BEARER"):
+                try:
+                    profile = validate_oauth_key(request)
+                except JsonableError as e:
+                    return json_unauthorized(e.msg)
+            else:
+                # our caller should defend against missing headers, not us
+                raise AssertionError("expected some kind of header")
+
             try:
                 if not skip_rate_limiting:
                     # Apply rate limiting

--- a/zerver/lib/oauth2.py
+++ b/zerver/lib/oauth2.py
@@ -1,0 +1,15 @@
+import oauth2_provider.views as oauth2_views
+from django.urls import path
+
+oauth2_endpoint_views = [
+    # OAuth2 Application Management endpoints
+    path("applications/", oauth2_views.ApplicationList.as_view(), name="list"),
+    path("applications/register/", oauth2_views.ApplicationRegistration.as_view(), name="register"),
+    path("applications/<pk>/", oauth2_views.ApplicationDetail.as_view(), name="detail"),
+    path("applications/<pk>/delete/", oauth2_views.ApplicationDelete.as_view(), name="delete"),
+    path("applications/<pk>/update/", oauth2_views.ApplicationUpdate.as_view(), name="update"),
+    # tokens
+    path("authorize/", oauth2_views.AuthorizationView.as_view(), name="authorize"),
+    path("token/", oauth2_views.TokenView.as_view(), name="token"),
+    path("revoke-token/", oauth2_views.RevokeTokenView.as_view(), name="revoke-token"),
+]

--- a/zerver/lib/oauth2.py
+++ b/zerver/lib/oauth2.py
@@ -1,5 +1,26 @@
 import oauth2_provider.views as oauth2_views
 from django.urls import path
+from oauth2_provider.models import get_application_model
+
+from zerver.lib.response import json_success
+from zerver.models import UserProfile
+
+
+def get_oauth_backend(request, y, oauth_id):
+    user = UserProfile.objects.filter(id=oauth_id).first()
+    # print(user)
+    applications_list = get_application_model().objects.filter(user=user).first()
+    print(applications_list)
+    json_result = dict(
+        user_id=applications_list.user.id,
+        application_name=applications_list.name,
+        client_id=applications_list.client_id,
+        client_secret=applications_list.client_secret,
+        redirect_uri=applications_list.redirect_uris,
+    )
+    print(json_result)
+    return json_success(json_result)
+
 
 oauth2_endpoint_views = [
     # OAuth2 Application Management endpoints

--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -141,7 +141,7 @@ def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
 
         # most clients (mobile, bots, etc) use HTTP basic auth and REST calls, where instead of
         # username:password, we use email:apiKey
-        elif request.META.get("HTTP_AUTHORIZATION", None):
+        elif request.META.get("HTTP_AUTHORIZATION") or request.META.get("HTTP_BEARER"):
             # Wrap function with decorator to authenticate the user before
             # proceeding
             target_function = authenticated_rest_api_view(

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -663,6 +663,20 @@ class OAuthTest(ZulipTestCase):
         self.assertEqual(hamlet.email, result["email"])
         self.assertEqual(result["result"], "success")
 
+    def test_oauth_fails_on_invalid_access_token(self) -> None:
+        hamlet = self.example_user("hamlet")
+        self.start_oauth_code_flow()
+        self.login_user(hamlet)
+
+        code = self.authorize_the_web_app()
+        access_token = self.get_access_token(code=code)
+        access_token = access_token + "somejunk"
+        # Now use the access token to verify the login
+        result = self.client_get("/api/v1/users/me", {}, HTTP_BEARER=access_token)
+        # assert that hamlet has logged in!
+        result = json.loads(result.content.decode("utf-8"))
+        self.assertEqual(result["msg"], "oauth failed")
+
 
 class RateLimitTestCase(ZulipTestCase):
     def errors_disallowed(self) -> Any:

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -281,6 +281,7 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/bots",
         "/bots/{bot_id}",
         "/bots/{bot_id}/api_key/regenerate",
+        "/oauth/{oauth_id}",
         #### These "organization settings" endpoints have low value to document:
         "/realm/profile_fields/{field_id}",
         "/realm/icon",

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -168,6 +168,12 @@ class TwoFactorLoader(app_directories.Loader):
         return [d for d in dirs if d.match("two_factor/*")]
 
 
+class OauthLoader(app_directories.Loader):
+    def get_dirs(self) -> List[str]:
+        dirs = super().get_dirs()
+        return [d for d in dirs if "oauth2_provider" in str(d)]
+
+
 MIDDLEWARE = (
     # With the exception of it's dependencies,
     # our logging middleware should be the top middleware item.
@@ -210,6 +216,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.staticfiles",
     "confirmation",
+    "oauth2_provider",
     "zerver",
     "social_django",
     # 2FA related apps.
@@ -650,12 +657,25 @@ two_factor_template_engine_settings = {
     "OPTIONS": two_factor_template_options,
 }
 
+oauth_template_options = deepcopy(default_template_engine_settings["OPTIONS"])
+del oauth_template_options["environment"]
+del oauth_template_options["extensions"]
+oauth_template_options["loaders"] = ["zproject.settings.OauthLoader"]
+oauth_engine_settings = {
+    "NAME": "Oauth_Server",
+    "BACKEND": "django.template.backends.django.DjangoTemplates",
+    "DIRS": [],
+    "APP_DIRS": False,
+    "OPTIONS": oauth_template_options,
+}
+
 # The order here is important; get_template and related/parent functions try
 # the template engines in order until one succeeds.
 TEMPLATES = [
     default_template_engine_settings,
     non_html_template_engine_settings,
     two_factor_template_engine_settings,
+    oauth_engine_settings,
 ]
 ########################################################################
 # LOGGING SETTINGS

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -15,7 +15,7 @@ from django.views.generic import RedirectView, TemplateView
 
 from zerver.forms import LoggingSetPasswordForm
 from zerver.lib.integrations import WEBHOOK_INTEGRATIONS
-from zerver.lib.oauth2 import oauth2_endpoint_views
+from zerver.lib.oauth2 import get_oauth_backend, oauth2_endpoint_views
 from zerver.lib.rest import rest_path
 from zerver.tornado.views import cleanup_event_queue, get_events, get_events_internal, notify
 from zerver.views.alert_words import add_alert_words, list_alert_words, remove_alert_words
@@ -314,6 +314,8 @@ v1_api_and_json_patterns = [
     rest_path("mark_stream_as_read", POST=mark_stream_as_read),
     rest_path("mark_topic_as_read", POST=mark_topic_as_read),
     rest_path("zcommand", POST=zcommand_backend),
+    # oauth
+    rest_path("oauth/<oauth_id>", GET=get_oauth_backend),
     # Endpoints for syncing drafts.
     rest_path(
         "drafts",

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -15,6 +15,7 @@ from django.views.generic import RedirectView, TemplateView
 
 from zerver.forms import LoggingSetPasswordForm
 from zerver.lib.integrations import WEBHOOK_INTEGRATIONS
+from zerver.lib.oauth2 import oauth2_endpoint_views
 from zerver.lib.rest import rest_path
 from zerver.tornado.views import cleanup_event_queue, get_events, get_events_internal, notify
 from zerver.views.alert_words import add_alert_words, list_alert_words, remove_alert_words
@@ -773,7 +774,17 @@ urls += [
     path("api/<slug:article>", api_documentation_view),
 ]
 
-# Two-factor URLs
+# Experimental oauth provider support.
+urls += [
+    path(
+        "o/",
+        include(
+            (oauth2_endpoint_views, "oauth2_provider"),
+        ),
+    ),
+]
+
+# Two Factor urls
 if settings.TWO_FACTOR_AUTHENTICATION_ENABLED:
     urls += [path("", include(tf_urls)), path("", include(tf_twilio_urls))]
 


### PR DESCRIPTION
This PR is the continuation of the work already done by @showell and @aero31aero in the following PR:
https://github.com/zulip/zulip/pull/16529

The aim is to enable Zulip to work as an OAuth provider. This is the issue: https://github.com/zulip/zulip/issues/17042

- [x] Refine read/write scopes
- [x] complete test coverage
- [x] add functionality to display errors made during form filling on registration page
- [x] Lock the views and only allow admin to create applications
- [ ] Swap the models to give the migrations a meaningful name. (ERROR with migration name -- 0002_auto_20190406_1805)  
- [ ] Move the views to the `settings page` of the Zulip application.
- [ ]  Investigate more and Add more in Zulip OAuth scopes (Currently - Read, Write)
- [ ] Build a configuration UI (like the Bots UI).


https://user-images.githubusercontent.com/53316982/113919646-762d4680-9801-11eb-8233-84db7e2c6df3.mp4


https://user-images.githubusercontent.com/53316982/113920927-0d46ce00-9803-11eb-98cf-026fca9fb249.mp4



