### PR TITLE
migrations: Enforce evaluation order in 0306 WHERE clause

### DIFF
--- a/zerver/migrations/0306_custom_profile_field_date_format.py
+++ b/zerver/migrations/0306_custom_profile_field_date_format.py
@@ -20,7 +20,10 @@ class Migration(migrations.Migration):
                 FROM zerver_customprofilefield AS f
                 WHERE f.id = field_id
                 AND f.field_type = 4
-                AND value <> to_char(to_date(value, 'YYYY-MM-DD'), 'YYYY-MM-DD');
+                AND CASE
+                        WHEN f.field_type = 4
+                        THEN value <> to_char(to_date(value, 'YYYY-MM-DD'), 'YYYY-MM-DD')
+                    END;
             """,
             reverse_sql="",
         ),


### PR DESCRIPTION
Depending on PostgreSQL’s query plan, it was [possible](https://chat.zulip.org/#narrow/stream/31-production-help/topic/Upgrading.20to.20Zulip.20Master.20%28a42f7a6%29/near/1110128) for the `value` condition to be evaluated before the `field_type` condition was checked, leading to errors like

```
psycopg2.errors.InvalidDatetimeFormat: invalid value "stri" for "YYYY"
DETAIL:  Value must be an integer.
```

**Testing plan:** Tested the new statement locally and verified with the original reporter.