### PR TITLE
invite-new-users: Specify that the limit spans for the whole day.

### DIFF
--- a/templates/zerver/help/invite-new-users.md
+++ b/templates/zerver/help/invite-new-users.md
@@ -7,7 +7,7 @@ the article below describes each in more detail.
 
 * Allow people to join based on the **domain** of their email address.
 
-* Send **email invitations** to up to 100 addresses at a time.
+* Send **email invitations** to up to 100 addresses in a day.
 
 * Share a **reusable invitation link**.
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5317,7 +5317,7 @@ def estimate_recent_invites(realms: Iterable[Realm], *, days: int) -> int:
 
 def check_invite_limit(realm: Realm, num_invitees: int) -> None:
     '''Discourage using invitation emails as a vector for carrying spam.'''
-    msg = _("You do not have enough remaining invites. "
+    msg = _("You do not have enough remaining invites for today. "
             "Please contact {email} to have your limit raised. "
             "No invitations were sent.").format(email=settings.ZULIP_ADMINISTRATOR)
     if not settings.OPEN_REALM_CREATION:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1250,7 +1250,7 @@ earl-test@zulip.com""", ["Denmark"]))
         self.invite(invitee_emails, ["Denmark"])
         invitee_emails = ", ".join(str(i) for i in range(get_realm("zulip").max_invites - 1))
         self.assert_json_error(self.invite(invitee_emails, ["Denmark"]),
-                               "You do not have enough remaining invites. "
+                               "You do not have enough remaining invites for today. "
                                "Please contact desdemona+admin@zulip.com to have your limit raised. "
                                "No invitations were sent.")
 


### PR DESCRIPTION
Relevant conversation in https://chat.zulip.org/#narrow/stream/2-general/topic/number.20of.20invites