### PR TITLE
Search: Bug fixed for topic-rename

### DIFF
--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -22,11 +22,7 @@
                 <a class="message_label_clickable narrows_by_topic"
                     href="{{topic_url}}"
                     title="{{#tr this}}Narrow to stream &quot;__display_recipient__&quot;, topic &quot;__topic__&quot;{{/tr}}">
-                    {{#if use_match_properties}}
-                    {{{match_topic}}}
-                    {{else}}
                     {{topic}}
-                    {{/if}}
                 </a>
                 <!-- The missing whitespace on the next line is a hack; ideally, would be user-select: none. -->
             </span><span class="recipient_bar_controls no-select">


### PR DESCRIPTION
This PR fixes issue #16956. The view was not updated if a user changed
the topic name after searching for a particular keyword. This PR solves
this bug.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
