### PR TITLE
design: Make thead content fix at the top.

### DIFF
--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -10,6 +10,14 @@ body.night-mode {
         color: inherit;
     }
 
+    table.table-striped thead.table-sticky-headers th {
+        background-color: hsl(0, 0%, 0%);
+
+        &:hover {
+            background-color: hsl(211, 29%, 14%);
+        }
+    }
+
     .app-main,
     .header-main,
     #message_view_header_underpadding,

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -249,16 +249,22 @@ td .button {
         }
     }
 
+    .table-sticky-headers th {
+        position: sticky;
+        top: 0;
+    }
+
     .table-striped {
         table-layout: auto;
+        border-collapse: separate;
 
         tbody {
             border-bottom: none;
         }
 
         thead th {
-            background-color: inherit;
             color: inherit;
+            background-color: hsl(0, 0%, 100%);
             border-top: 1px solid hsla(0, 0%, 0%, 0.2) !important;
             border-bottom: 1px solid hsla(0, 0%, 0%, 0.2) !important;
 
@@ -284,7 +290,7 @@ td .button {
 
             &[data-sort]:hover {
                 cursor: pointer;
-                background-color: hsla(0, 0%, 0%, 0.05);
+                background-color: hsla(0, 0%, 95%);
                 transition: background-color 100ms ease-in-out;
 
                 &:not(.active)::after {

--- a/static/templates/settings/attachments_settings.hbs
+++ b/static/templates/settings/attachments_settings.hbs
@@ -5,7 +5,7 @@
     <div class="alert" id="delete-upload-status"></div>
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped wrapped-table">
-            <thead>
+            <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="name" class="upload-file-name">{{t "File" }}</th>
                 <th class="active" data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
                 <th data-sort="mentioned_in">{{t "Mentioned in" }}</th>

--- a/static/templates/settings/bot_list_admin.hbs
+++ b/static/templates/settings/bot_list_admin.hbs
@@ -6,7 +6,7 @@
     <div class="clear-float"></div>
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped wrapped-table">
-            <thead>
+            <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 <th data-sort="email">{{t "Email" }}</th>
                 <th data-sort="bot_owner">{{t "Owner" }}</th>

--- a/static/templates/settings/data_exports_admin.hbs
+++ b/static/templates/settings/data_exports_admin.hbs
@@ -30,7 +30,7 @@
       aria-label="{{t 'Filter exports' }}"/>
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped wrapped-table admin_exports_table">
-            <thead>
+            <thead class="table-sticky-headers">
                 <th class="active" data-sort="user">{{t "Requesting user" }}</th>
                 <th data-sort="numeric" data-sort-prop="export_time">{{t "Time" }}</th>
                 <th>{{t "Status" }}</th>

--- a/static/templates/settings/deactivated_users_admin.hbs
+++ b/static/templates/settings/deactivated_users_admin.hbs
@@ -8,7 +8,7 @@
 
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped wrapped-table">
-            <thead>
+            <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 {{#if show_email}}
                 <th data-sort="email">{{t "Email" }}</th>

--- a/static/templates/settings/default_streams_list_admin.hbs
+++ b/static/templates/settings/default_streams_list_admin.hbs
@@ -26,7 +26,7 @@
 
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped wrapped-table">
-            <thead>
+            <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="name">{{t "Name" }}</th>
                 {{#if is_admin}}
                 <th class="actions">{{t "Actions" }}</th>

--- a/static/templates/settings/emoji_settings_admin.hbs
+++ b/static/templates/settings/emoji_settings_admin.hbs
@@ -36,7 +36,7 @@
       aria-label="{{t 'Filter emojis' }}"/>
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped wrapped-table admin_emoji_table">
-            <thead>
+            <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="name">{{t "Name" }}</th>
                 <th class="image">{{t "Image" }}</th>
                 <th class="image" data-sort="author_full_name">{{t "Author" }}</th>

--- a/static/templates/settings/invites_list_admin.hbs
+++ b/static/templates/settings/invites_list_admin.hbs
@@ -12,7 +12,7 @@
 
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped">
-            <thead>
+            <thead class="table-sticky-headers">
                 <th class="active" data-sort="invitee">{{t "Invitee" }}</th>
                 {{#if is_admin }}
                 <th data-sort="alphabetic" data-sort-prop="ref">{{t "Invited by" }}</th>

--- a/static/templates/settings/linkifier_settings_admin.hbs
+++ b/static/templates/settings/linkifier_settings_admin.hbs
@@ -67,7 +67,7 @@
         <input type="text" class="search" placeholder="{{t 'Filter linkifiers' }}" aria-label="{{t 'Filter linkifiers' }}"/>
         <div class="progressive-table-wrapper" data-simplebar>
             <table class="table table-condensed table-striped wrapped-table admin_linkifiers_table">
-                <thead>
+                <thead class="table-sticky-headers">
                     <th class="active" data-sort="pattern">{{t "Pattern" }}</th>
                     <th data-sort="url">{{t "URL format string" }}</th>
                     {{#if is_admin}}

--- a/static/templates/settings/muted_topics_settings.hbs
+++ b/static/templates/settings/muted_topics_settings.hbs
@@ -2,7 +2,7 @@
     <input id="muted_topics_search" class="search" type="text" placeholder="{{t 'Search muted topics...' }}" aria-label="{{t 'Search muted topics...' }}"/>
     <div class="progressive-table-wrapper" data-simplebar data-list-widget="muted-topics-list">
         <table class="table table-condensed table-striped wrapped-table">
-            <thead>
+            <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="stream">{{t "Stream" }}</th>
                 <th data-sort="alphabetic" data-sort-prop="topic">{{t "Topic" }}</th>
                 <th data-sort="numeric" data-sort-prop="date_muted">{{t "Date muted" }}</th>

--- a/static/templates/settings/user_list_admin.hbs
+++ b/static/templates/settings/user_list_admin.hbs
@@ -7,7 +7,7 @@
 
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped wrapped-table">
-            <thead>
+            <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 {{#if show_email}}
                 <th data-sort="email">{{t "Email" }}</th>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->Issue: The table thead content in settings/organisation settings tables are not fixed at the top, that results in moving them with the tbody content.
Related [thread](https://chat.zulip.org/#narrow/stream/101-design/topic/Thead.20fix.20at.20top.2E).

**Testing plan:** <!-- How have you tested? -->Checked all tables manually in dark-mode as well as night-mode, and running tests.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
  Before: 
![before_thead-fix](https://user-images.githubusercontent.com/59444243/106379464-3e092200-63d2-11eb-992e-77646430053e.gif)
After:
![after_thead-fix](https://user-images.githubusercontent.com/59444243/106379468-45c8c680-63d2-11eb-869b-587e45e4e2f1.gif)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
