### PR TITLE
widgets: Prevent edits to widgets.

### DIFF
--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -68,6 +68,10 @@ run_test("get_editability", () => {
     // is true, we can edit the topic if there is one.
     message.type = "stream";
     assert.equal(get_editability(message, 45), editability_types.TOPIC_ONLY);
+    // Right now, we prevent users from editing widgets.
+    message.submessages = ["/poll"];
+    assert.equal(get_editability(message, 45), editability_types.TOPIC_ONLY);
+    delete message.submessages;
     message.type = "private";
     assert.equal(get_editability(message, 45), editability_types.NO_LONGER);
     // If we don't pass a second argument, treat it as 0

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -67,7 +67,8 @@
             {{#if has_been_editable}}
             <div class="message-edit-timer-control-group">
                 <span class="message_edit_countdown_timer"></span>
-                <span><i id="message_edit_tooltip" class="tippy-zulip-tooltip message_edit_tooltip fa fa-question-circle" aria-hidden="true" data-tippy-content="{{#tr}}This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.{{/tr}}"></i>
+                <span><i id="message_edit_tooltip" class="tippy-zulip-tooltip message_edit_tooltip fa fa-question-circle" aria-hidden="true"
+                    {{#if is_widget_message}} data-tippy-content="{{#tr}}Widgets cannot be edited.{{/tr}}" {{else}} data-tippy-content="{{#tr}}This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.{{/tr}}" {{/if}}></i>
                 </span>
             </div>
             {{/if}}

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -3,7 +3,7 @@ import re
 from typing import Any, Optional, Tuple
 
 from zerver.lib.message import SendMessageRequest
-from zerver.models import SubMessage
+from zerver.models import Message, SubMessage
 
 
 def get_widget_data(content: str) -> Tuple[Optional[str], Optional[str]]:
@@ -77,3 +77,8 @@ def do_widget_post_save_actions(send_request: SendMessageRequest) -> None:
         )
         submessage.save()
         send_request.submessages = SubMessage.get_raw_db_rows([message_id])
+
+
+def is_widget_message(message: Message) -> bool:
+    # Right now all messages that are widgetized use submessage, and vice versa.
+    return message.submessage_set.exists()

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -187,6 +187,24 @@ class EditMessageTest(ZulipTestCase):
         result = self.client_get("/json/messages/" + str(msg_id))
         self.assert_json_error(result, "Invalid message(s)")
 
+    # Right now, we prevent users from editing widgets.
+    def test_edit_submessage(self) -> None:
+        self.login("hamlet")
+        msg_id = self.send_stream_message(
+            self.example_user("hamlet"),
+            "Scotland",
+            topic_name="editing",
+            content="/poll Games?\nYES\nNO",
+        )
+        result = self.client_patch(
+            "/json/messages/" + str(msg_id),
+            {
+                "message_id": msg_id,
+                "content": "/poll Games?\nYES\nNO\nMaybe",
+            },
+        )
+        self.assert_json_error(result, "Widgets cannot be edited.")
+
     def test_edit_message_no_permission(self) -> None:
         self.login("hamlet")
         msg_id = self.send_stream_message(

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -24,6 +24,7 @@ from zerver.lib.streams import access_stream_by_id
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import LEGACY_PREV_TOPIC, REQ_topic
 from zerver.lib.validator import check_bool, check_string_in, to_non_negative_int
+from zerver.lib.widget import is_widget_message
 from zerver.models import Message, Realm, UserProfile
 
 
@@ -138,6 +139,10 @@ def update_message_backend(
         pass
     else:
         raise JsonableError(_("You don't have permission to edit this message"))
+
+    # Right now, we prevent users from editing widgets.
+    if content is not None and is_widget_message(message):
+        return json_error(_("Widgets cannot be edited."))
 
     # If there is a change to the content, check that it hasn't been too long
     # Allow an extra 20 seconds since we potentially allow editing 15 seconds


### PR DESCRIPTION
We currently don't support editing widgets.

Fixes #17156
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
