### PR TITLE
docs: Fix typo in setup-advanced.md

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -157,7 +157,7 @@ eventually eliminate this documentation section altogether).
 You can use
 [our provisioning tool](#installing-directly-on-ubuntu-debian-centos-or-fedora)
 to set up the Zulip development environment on current versions of
-these platforms reliably and easily, so we no long maintain manual
+these platforms reliably and easily, so we no longer maintain manual
 installation instructions for these platforms.
 
 If `tools/provision` doesn't yet support a newer release of Debian or


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

There was a grammatical typo in `setup-advanced.md`. I have fixed the typo by changing *long* to ***longer***

**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
