### PR TITLE
copy_message: Remove weird white background displayed on hover.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -445,6 +445,11 @@ li,
     icon is clickable and is needed because of reduced
     opacity of readonly textarea */
     z-index: 2;
+    background: transparent;
+
+    &:hover {
+        background: transparent;
+    }
 
     &:hover svg path {
         fill: hsl(200, 100%, 40%);


### PR DESCRIPTION
The white background is coming from bootstrap, we override it
here.
<img width="352" alt="Screenshot 2021-02-02 at 6 55 27 PM" src="https://user-images.githubusercontent.com/25124304/106606693-6dfa2600-6588-11eb-85e0-38a9b54f1151.png">
<img width="352" alt="Screenshot 2021-02-02 at 7 17 12 PM" src="https://user-images.githubusercontent.com/25124304/106609581-ba933080-658b-11eb-8b3f-33a95c40e2ee.png">
<img width="352" alt="Screenshot 2021-02-02 at 7 17 16 PM" src="https://user-images.githubusercontent.com/25124304/106609584-bbc45d80-658b-11eb-9393-d57a14531c0c.png">
