### PR TITLE
Move copyright notice from LICENSE to NOTICE; bump copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-Copyright 2011-2020 Dropbox, Inc., Kandra Labs, Inc., and contributors
 
                                  Apache License
                            Version 2.0, January 2004

--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,5 @@
+Copyright 2011-2020 Dropbox, Inc., Kandra Labs, Inc., and contributors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this project except in compliance with the License.
 You may obtain a copy of the License at

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2011-2020 Dropbox, Inc., Kandra Labs, Inc., and contributors
+Copyright 2012–2015 Dropbox, Inc., 2015–2021 Kandra Labs, Inc., and contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this project except in compliance with the License.

--- a/docs/THIRDPARTY
+++ b/docs/THIRDPARTY
@@ -17,7 +17,7 @@ Comment:
  information or errors found in these notices.
 
 Files: *
-Copyright: 2011-2015 Dropbox, Inc., 2015-2019 Kandra Labs, Inc., and contributors
+Copyright: 2012–2015 Dropbox, Inc., 2015–2021 Kandra Labs, Inc., and contributors
 License: Apache-2.0
 
 Files: confirmation/*

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Zulip'
-copyright = '2015–2020, The Zulip Team'
+copyright = '2012–2015 Dropbox, Inc., 2015–2021 Kandra Labs, Inc., and contributors'
 author = 'The Zulip Team'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
A `LICENSE` file is supposed to be an unmodified copy of the license, and the license appendix explains that the copyright line should be included with the notice.

**Testing plan:**

```console
$ licensee
License:        Apache-2.0
Matched files:  LICENSE, package.json
LICENSE:
  Content hash:  ab3901051663cb8ee5dea9ebdff406ad136910e3
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       Apache-2.0
package.json:
  Confidence:  90.00%
  Matcher:     Licensee::Matchers::NpmBower
  License:     Apache-2.0
```