### PR TITLE
default_stream: Refactored code for better error handling.

### DIFF
--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -125,10 +125,24 @@ exports.build_page = function () {
     $(".default-stream-form").on("click", "#do_submit_stream", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        const default_stream_input = $(".create_default_stream");
-        make_stream_default(stream_data.get_stream_id(default_stream_input.val()));
+        const default_stream_input = $(".create_default_stream").val().trim();
+        const default_stream_status = $("#admin-default-stream-status");
+        const stream_id = stream_data.get_stream_id(default_stream_input);
+
+        if (!(stream_id === undefined)) {
+            if (stream_data.get_default_stream_ids().includes(stream_id)) {
+                ui_report.client_error(
+                    i18n.t("Failed: Default Stream already exists."),
+                    default_stream_status,
+                );
+            } else {
+                make_stream_default(stream_id);
+            }
+        } else {
+            ui_report.client_error(i18n.t("Failed: Stream doesn't exists."), default_stream_status);
+        }
         // Clear value inside input box
-        default_stream_input[0].value = "";
+        $(".create_default_stream").val("");
     });
 
     $("body").on("click", ".default_stream_row .remove-default-stream", function (e) {


### PR DESCRIPTION
Refactored the <code>default_stream</code> realm setting to handle a few client-side errors through <code>ui_report</code>.

The restructuring includes :- 
<ul>
<li>Report an error, when the user enters an invalid stream name.</li>
<li>Trimmed the user input, to accept a valid stream name(Before, if a valid stream name is entered having an extra spaces, the ui used to throw an error claiming the stream_id parameter to be missing, since it wasn't a valid stream name).</li>
<li>Shows an error if the user, by chance, attempts to add an stream which has already been added to the default stream list.</li>
</ul>

<strong>Before :</strong>   (When adding a stream name with extra leading/lagging spaces)

![error1](https://user-images.githubusercontent.com/53977614/106642171-08209500-65ae-11eb-9e54-cb4cd2b4baf1.gif)

<strong>After :</strong>

![fix](https://user-images.githubusercontent.com/53977614/106642221-153d8400-65ae-11eb-8cd8-d23a87b511b6.gif)
