### PR TITLE
[Fixed #17172] Alert Words styling issue 

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -908,9 +908,22 @@ input[type="checkbox"] {
 #alert_words_list {
     margin: 0;
 
+    .alert-word-information-box {
+        min-width: 98%;
+        float: left;
+    }
+
+    .edit-alert-words-buttons{
+        float: left;
+    }
+
+    .remove-alert-word {
+        position: absolute;
+        margin-top: 0.5%;
+    }
+
     li {
         list-style-type: none;
-
         &.alert-word-item:first-child {
             background: none;
             margin-top: 8px;
@@ -918,7 +931,7 @@ input[type="checkbox"] {
     }
 
     .alert_word_listing .value {
-        display: block;
+        
         word-wrap: break-word;
         word-break: break-all;
         white-space: normal;
@@ -928,9 +941,7 @@ input[type="checkbox"] {
 #alert_words_list,
 #attachments_list {
     .edit-attachment-buttons {
-        position: absolute;
-        right: 20px;
-        top: 0;
+        display: inline-block;
     }
 }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -913,9 +913,11 @@ input[type="checkbox"] {
         float: left;
     }
 
-    .edit-alert-words-buttons{
+    .edit-alert-word-buttons{
         float: left;
     }
+
+
 
     .remove-alert-word {
         position: absolute;

--- a/static/templates/settings/alert_word_settings.hbs
+++ b/static/templates/settings/alert_word_settings.hbs
@@ -27,5 +27,15 @@
             </div>
         </div>
     </form>
-    <ul id="alert_words_list"></ul>
+    <!--<ul id="alert_words_list"></ul>-->
+    <div class="progressive-table-wrapper" data-simplebar>
+        <table class="table table-condensed table-striped wrapped-table">
+            <thead>
+                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Word" }}</th>
+                <th class="user_role" data-sort="role">{{t "Delete" }}</th>
+            </thead>
+            <tbody id="alert_words_list" class="alert_words_list required-text thick"
+              data-empty="{{t 'No users match your current filter.' }}"></tbody>
+        </table>
+    </div>
 </div>

--- a/static/templates/settings/alert_word_settings_item.hbs
+++ b/static/templates/settings/alert_word_settings_item.hbs
@@ -5,7 +5,7 @@
             <span class="value">{{word}}</span>
         </div>
     </div>
-    <div class="edit-alert-word-buttons" style="float: left">
+    <div class="edit-alert-word-buttons">
         <button type="submit" class="button small btn-danger remove-alert-word" title="{{t 'Delete alert word' }}" data-word="{{word}}">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>

--- a/static/templates/settings/alert_word_settings_item.hbs
+++ b/static/templates/settings/alert_word_settings_item.hbs
@@ -4,10 +4,10 @@
         <div class="alert_word_listing">
             <span class="value">{{word}}</span>
         </div>
-        <div class="edit-alert-word-buttons">
-            <button type="submit" class="button small btn-danger remove-alert-word" title="{{t 'Delete alert word' }}" data-word="{{word}}">
-                <i class="fa fa-trash-o" aria-hidden="true"></i>
-            </button>
-        </div>
+    </div>
+    <div class="edit-alert-word-buttons" style="float: left">
+        <button type="submit" class="button small btn-danger remove-alert-word" title="{{t 'Delete alert word' }}" data-word="{{word}}">
+            <i class="fa fa-trash-o" aria-hidden="true"></i>
+        </button>
     </div>
 </li>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/17172

**Testing plan:** <!-- How have you tested? -->
- Consistent behavior with long words, short words, mobile view, dynamically shifting descriptions, many words, deleting words

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screen Shot 2021-02-01 at 5 52 41 PM](https://user-images.githubusercontent.com/38388793/106656816-3039d500-6569-11eb-9f54-d95fc0aeb7bb.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
