### PR TITLE
Alert Words list only takes up half of the space provided on the page #17172

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -908,9 +908,22 @@ input[type="checkbox"] {
 #alert_words_list {
     margin: 0;
 
+    .alert-word-information-box {
+        min-width: 98%;
+        float: left;
+    }
+
+    .edit-alert-words-buttons{
+        float: left;
+    }
+
+    .remove-alert-word {
+        position: absolute;
+        margin-top: 0.5%;
+    }
+
     li {
         list-style-type: none;
-
         &.alert-word-item:first-child {
             background: none;
             margin-top: 8px;
@@ -918,7 +931,7 @@ input[type="checkbox"] {
     }
 
     .alert_word_listing .value {
-        display: block;
+        
         word-wrap: break-word;
         word-break: break-all;
         white-space: normal;
@@ -928,9 +941,7 @@ input[type="checkbox"] {
 #alert_words_list,
 #attachments_list {
     .edit-attachment-buttons {
-        position: absolute;
-        right: 20px;
-        top: 0;
+        display: inline-block;
     }
 }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -78,7 +78,7 @@ h3 .fa-question-circle-o {
         #pw_strength {
             width: 140px;
             height: 8px;
-            margin: 6px 0 0 0;
+            margin: 6px 0 0;
         }
     }
     .button {
@@ -231,7 +231,7 @@ td .button {
     .settings-section-title {
         font-size: 1.4em;
         font-weight: 500;
-        margin: 10px 0 10px 0;
+        margin: 10px 0;
 
         &.transparent {
             background-color: transparent;
@@ -269,7 +269,7 @@ td .button {
                 display: inline-block;
                 position: absolute;
                 padding-top: 3px;
-                font: normal normal normal 12px/1 FontAwesome;
+                font: normal normal normal 12px / 1 FontAwesome;
                 font-size: inherit;
             }
 
@@ -400,7 +400,7 @@ td .button {
 
 .button,
 .input-group {
-    margin: 0 0 20px 0;
+    margin: 0 0 20px;
 }
 
 .input-group {
@@ -432,7 +432,7 @@ input[type="checkbox"] {
     }
 
     .inline-block {
-        margin: -2px 0 0 0;
+        margin: -2px 0 0;
     }
 }
 
@@ -620,8 +620,7 @@ input[type="checkbox"] {
 #account-settings-status {
     text-align: center;
     width: 50%;
-    margin: auto;
-    margin-bottom: 20px;
+    margin: auto auto 20px;
 }
 
 .add-new-emoji-box,
@@ -691,7 +690,7 @@ input[type="checkbox"] {
 
 #admin-filter-pattern-status,
 #admin-filter-format-status {
-    margin: 20px 0 0 0;
+    margin: 20px 0 0;
 }
 
 .progressive-table-wrapper {
@@ -857,7 +856,7 @@ input[type="checkbox"] {
     }
 
     .buttons {
-        margin: 10px 0 5px 0;
+        margin: 10px 0 5px;
     }
 }
 
@@ -913,11 +912,9 @@ input[type="checkbox"] {
         float: left;
     }
 
-    .edit-alert-word-buttons{
+    .edit-alert-word-buttons {
         float: left;
     }
-
-
 
     .remove-alert-word {
         position: absolute;
@@ -933,7 +930,6 @@ input[type="checkbox"] {
     }
 
     .alert_word_listing .value {
-        
         word-wrap: break-word;
         word-break: break-all;
         white-space: normal;
@@ -958,7 +954,7 @@ input[type="checkbox"] {
 
     label {
         border-bottom: 1px solid hsla(0, 0%, 0%, 0.2);
-        padding: 8px 0 10px 0;
+        padding: 8px 0 10px;
 
         &:last-of-type {
             border-bottom: none;
@@ -1204,7 +1200,7 @@ input[type="checkbox"] {
 
     input.search {
         font-size: 0.9rem;
-        margin: 10px 0 20px 0;
+        margin: 10px 0 20px;
     }
 
     .form-sidebar {
@@ -1331,7 +1327,7 @@ input[type="checkbox"] {
             .icon {
                 width: 18px;
                 height: 18px;
-                margin: 10px 10px;
+                margin: 10px;
                 text-align: center;
 
                 font-size: 1.4em;
@@ -1694,7 +1690,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 @supports (-moz-appearance: none) {
     #settings_page select {
         appearance: none;
-        background: hsl(0, 0%, 100%) url(../images/dropdown.png) right / 20px
+        background: hsl(0, 0%, 100%) url("../images/dropdown.png") right / 20px
             no-repeat;
         padding-right: 20px;
     }
@@ -1791,7 +1787,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     }
 
     .subsection-failed-status p {
-        margin: 5px 0 0 0;
+        margin: 5px 0 0;
     }
 }
 
@@ -1857,10 +1853,9 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
         display: block;
         width: 120px;
         padding: 0;
-        padding-top: 0;
         text-align: center;
         margin: auto;
-        float: none;
+        margin: auto;
     }
 
     #filter-settings .new-filter-form .controls,
@@ -1871,7 +1866,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 
     #settings_page .save-button-controls {
         display: block;
-        margin: 10px 0 0 0;
+        margin: 10px 0 0;
     }
 }
 
@@ -1883,7 +1878,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     }
 }
 
-@media only screen and (max-width: $lg_max) {
+@media only screen and(max-width: $lg_max) {
     /* Show bot-information-box at full width on small
        screen sizes. Not having this media query breaks the
        information box */

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -913,9 +913,11 @@ input[type="checkbox"] {
         float: left;
     }
 
-    .edit-alert-words-buttons{
+    .edit-alert-word-buttons{
         float: left;
     }
+
+
 
     .remove-alert-word {
         position: absolute;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -486,6 +486,14 @@ input[type="checkbox"] {
     border-left: 0;
 }
 
+.alert-word {
+    width: 80%;
+}
+
+.alert-word.delete {
+    width: 10%;
+}
+
 .alert-word-information-box {
     position: relative;
     padding: 7px;
@@ -1854,7 +1862,6 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
         width: 120px;
         padding: 0;
         text-align: center;
-        margin: auto;
         margin: auto;
     }
 

--- a/static/templates/settings/alert_word_settings.hbs
+++ b/static/templates/settings/alert_word_settings.hbs
@@ -27,5 +27,15 @@
             </div>
         </div>
     </form>
-    <ul id="alert_words_list"></ul>
+    <!--<ul id="alert_words_list"></ul>-->
+    <div class="progressive-table-wrapper" data-simplebar>
+        <table class="table table-condensed table-striped wrapped-table">
+            <thead>
+                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Word" }}</th>
+                <th class="user_role" data-sort="role">{{t "Delete" }}</th>
+            </thead>
+            <tbody id="alert_words_list" class="alert_words_list required-text thick"
+              data-empty="{{t 'No users match your current filter.' }}"></tbody>
+        </table>
+    </div>
 </div>

--- a/static/templates/settings/alert_word_settings.hbs
+++ b/static/templates/settings/alert_word_settings.hbs
@@ -31,8 +31,13 @@
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped wrapped-table">
             <thead>
+<<<<<<< HEAD
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Word" }}</th>
                 <th class="user_role" data-sort="role">{{t "Delete" }}</th>
+=======
+                <th class="active alert-word" data-sort="alphabetic" data-sort-prop="full_name">{{t "Word" }}</th>
+                <th class="user_role alert-word-delete" data-sort="role">{{t "Delete" }}</th>
+>>>>>>> alertwords: Fix css in static/styles/settings.css.
             </thead>
             <tbody id="alert_words_list" class="alert_words_list required-text thick"
               data-empty="{{t 'No users match your current filter.' }}"></tbody>

--- a/static/templates/settings/alert_word_settings_item.hbs
+++ b/static/templates/settings/alert_word_settings_item.hbs
@@ -11,3 +11,4 @@
         </button>
     </div>
 </li>
+

--- a/static/templates/settings/alert_word_settings_item.hbs
+++ b/static/templates/settings/alert_word_settings_item.hbs
@@ -5,7 +5,7 @@
             <span class="value">{{word}}</span>
         </div>
     </div>
-    <div class="edit-alert-word-buttons" style="float: left">
+    <div class="edit-alert-word-buttons">
         <button type="submit" class="button small btn-danger remove-alert-word" title="{{t 'Delete alert word' }}" data-word="{{word}}">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>

--- a/static/templates/settings/alert_word_settings_item.hbs
+++ b/static/templates/settings/alert_word_settings_item.hbs
@@ -4,10 +4,10 @@
         <div class="alert_word_listing">
             <span class="value">{{word}}</span>
         </div>
-        <div class="edit-alert-word-buttons">
-            <button type="submit" class="button small btn-danger remove-alert-word" title="{{t 'Delete alert word' }}" data-word="{{word}}">
-                <i class="fa fa-trash-o" aria-hidden="true"></i>
-            </button>
-        </div>
+    </div>
+    <div class="edit-alert-word-buttons" style="float: left">
+        <button type="submit" class="button small btn-danger remove-alert-word" title="{{t 'Delete alert word' }}" data-word="{{word}}">
+            <i class="fa fa-trash-o" aria-hidden="true"></i>
+        </button>
     </div>
 </li>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/17172

**Testing plan:** <!-- How have you tested? -->
Consistent behavior with long words, shorts words, dynamic description label, delete word, mobile view

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screen Shot 2021-02-01 at 5 52 41 PM](https://user-images.githubusercontent.com/38388793/106665417-45683100-6574-11eb-9af4-3bdd98e69c9e.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
