### PR TITLE
search: Add is:muted search filter where -is:muted is an alias for in:home

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -260,6 +260,14 @@ function assert_not_mark_read_with_is_operands(additional_operators_to_test) {
     is_operator = [{operator: "is", operand: "unread", negated: true}];
     filter = new Filter(additional_operators_to_test.concat(is_operator));
     assert(!filter.can_mark_messages_read());
+
+    is_operator = [{operator: "is", operand: "muted"}];
+    filter = new Filter(additional_operators_to_test.concat(is_operator));
+    assert(!filter.can_mark_messages_read());
+
+    is_operator = [{operator: "is", operand: "muted", negated: true}];
+    filter = new Filter(additional_operators_to_test.concat(is_operator));
+    assert(!filter.can_mark_messages_read());
 }
 
 function assert_not_mark_read_when_searching(additional_operators_to_test) {
@@ -600,6 +608,12 @@ test("predicate_basics", () => {
     assert(predicate({}));
 
     const unknown_stream_id = 999;
+    predicate = get_predicate([["is", "muted"]]);
+    assert(predicate({stream_id: unknown_stream_id, stream: "unknown"}));
+    assert(!predicate({type: "private"}));
+    page_params.narrow_stream = "kiosk";
+    assert(!predicate({stream: "kiosk"}));
+
     predicate = get_predicate([["in", "home"]]);
     assert(!predicate({stream_id: unknown_stream_id, stream: "unknown"}));
     assert(predicate({type: "private"}));

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -370,6 +370,7 @@ test("empty_query_suggestions", (override) => {
         "is:mentioned",
         "is:alerted",
         "is:unread",
+        "is:muted",
         "sender:myself@zulip.com",
         "stream:devel",
         "stream:office",
@@ -388,6 +389,7 @@ test("empty_query_suggestions", (override) => {
     assert.equal(describe("is:mentioned"), "@-mentions");
     assert.equal(describe("is:alerted"), "Alerted messages");
     assert.equal(describe("is:unread"), "Unread messages");
+    assert.equal(describe("is:muted"), "Muted messages");
     assert.equal(describe("sender:myself@zulip.com"), "Sent by me");
     assert.equal(describe("has:link"), "Messages with one or more link");
     assert.equal(describe("has:image"), "Messages with one or more image");
@@ -463,6 +465,7 @@ test("check_is_suggestions", (override) => {
         "is:mentioned",
         "is:alerted",
         "is:unread",
+        "is:muted",
         "sender:alice@zulip.com",
         "pm-with:alice@zulip.com",
         "group-pm-with:alice@zulip.com",
@@ -479,10 +482,19 @@ test("check_is_suggestions", (override) => {
     assert.equal(describe("is:mentioned"), "@-mentions");
     assert.equal(describe("is:alerted"), "Alerted messages");
     assert.equal(describe("is:unread"), "Unread messages");
+    assert.equal(describe("is:muted"), "Muted messages");
 
     query = "-i";
     suggestions = get_suggestions("", query);
-    expected = ["-i", "-is:private", "-is:starred", "-is:mentioned", "-is:alerted", "-is:unread"];
+    expected = [
+        "-i",
+        "-is:private",
+        "-is:starred",
+        "-is:mentioned",
+        "-is:alerted",
+        "-is:unread",
+        "-is:muted",
+    ];
     assert.deepEqual(suggestions.strings, expected);
 
     assert.equal(describe("-is:private"), "Exclude private messages");
@@ -490,6 +502,7 @@ test("check_is_suggestions", (override) => {
     assert.equal(describe("-is:mentioned"), "Exclude @-mentions");
     assert.equal(describe("-is:alerted"), "Exclude alerted messages");
     assert.equal(describe("-is:unread"), "Exclude unread messages");
+    assert.equal(describe("-is:muted"), "Exclude muted messages");
 
     query = "";
     suggestions = get_suggestions("", query);
@@ -501,6 +514,7 @@ test("check_is_suggestions", (override) => {
         "is:mentioned",
         "is:alerted",
         "is:unread",
+        "is:muted",
         "sender:myself@zulip.com",
         "stream:devel",
         "stream:office",
@@ -518,6 +532,7 @@ test("check_is_suggestions", (override) => {
         "is:mentioned",
         "is:alerted",
         "is:unread",
+        "is:muted",
         "sender:myself@zulip.com",
         "has:link",
         "has:image",
@@ -529,7 +544,7 @@ test("check_is_suggestions", (override) => {
 
     query = "is:";
     suggestions = get_suggestions("", query);
-    expected = ["is:private", "is:starred", "is:mentioned", "is:alerted", "is:unread"];
+    expected = ["is:private", "is:starred", "is:mentioned", "is:alerted", "is:unread", "is:muted"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "is:st";

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -373,6 +373,7 @@ test("empty_query_suggestions", (override) => {
         "is:mentioned",
         "is:alerted",
         "is:unread",
+        "is:muted",
         "sender:myself@zulip.com",
         "stream:devel",
         "stream:office",
@@ -391,6 +392,7 @@ test("empty_query_suggestions", (override) => {
     assert.equal(describe("is:mentioned"), "@-mentions");
     assert.equal(describe("is:alerted"), "Alerted messages");
     assert.equal(describe("is:unread"), "Unread messages");
+    assert.equal(describe("is:muted"), "Muted messages");
     assert.equal(describe("sender:myself@zulip.com"), "Sent by me");
     assert.equal(describe("has:link"), "Messages with one or more link");
     assert.equal(describe("has:image"), "Messages with one or more image");
@@ -469,6 +471,7 @@ test("check_is_suggestions", (override) => {
         "is:mentioned",
         "is:alerted",
         "is:unread",
+        "is:muted",
         "sender:alice@zulip.com",
         "pm-with:alice@zulip.com",
         "group-pm-with:alice@zulip.com",
@@ -485,10 +488,19 @@ test("check_is_suggestions", (override) => {
     assert.equal(describe("is:mentioned"), "@-mentions");
     assert.equal(describe("is:alerted"), "Alerted messages");
     assert.equal(describe("is:unread"), "Unread messages");
+    assert.equal(describe("is:muted"), "Muted messages");
 
     query = "-i";
     suggestions = get_suggestions("", query);
-    expected = ["-i", "-is:private", "-is:starred", "-is:mentioned", "-is:alerted", "-is:unread"];
+    expected = [
+        "-i",
+        "-is:private",
+        "-is:starred",
+        "-is:mentioned",
+        "-is:alerted",
+        "-is:unread",
+        "-is:muted",
+    ];
     assert.deepEqual(suggestions.strings, expected);
 
     assert.equal(describe("-is:private"), "Exclude private messages");
@@ -496,12 +508,13 @@ test("check_is_suggestions", (override) => {
     assert.equal(describe("-is:mentioned"), "Exclude @-mentions");
     assert.equal(describe("-is:alerted"), "Exclude alerted messages");
     assert.equal(describe("-is:unread"), "Exclude unread messages");
+    assert.equal(describe("-is:muted"), "Exclude muted messages");
 
     // operand suggestions follow.
 
     query = "is:";
     suggestions = get_suggestions("", query);
-    expected = ["is:private", "is:starred", "is:mentioned", "is:alerted", "is:unread"];
+    expected = ["is:private", "is:starred", "is:mentioned", "is:alerted", "is:unread", "is:muted"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "is:st";

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -88,6 +88,8 @@ function message_matches_search_term(message, operator, operand) {
                 return message.alerted;
             } else if (operand === "unread") {
                 return unread.message_unread(message);
+            } else if (operand === "muted") {
+                return !message_in_home(message);
             }
             return true; // is:whatever returns true
 
@@ -838,6 +840,7 @@ export class Filter {
             "is-private",
             "is-starred",
             "is-unread",
+            "is-muted",
             "has-link",
             "has-image",
             "has-attachment",
@@ -912,7 +915,7 @@ export class Filter {
     static describe_is_operator(operator) {
         const verb = operator.negated ? "exclude " : "";
         const operand = operator.operand;
-        const operand_list = ["private", "starred", "alerted", "unread"];
+        const operand_list = ["private", "starred", "alerted", "unread", "muted"];
         if (operand_list.includes(operand)) {
             return verb + operand + " messages";
         } else if (operand === "mentioned") {

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -478,6 +478,11 @@ function get_is_filter_suggestions(last, operators) {
             description: "unread messages",
             invalid: [{operator: "is", operand: "unread"}],
         },
+        {
+            search_string: "is:muted",
+            description: "muted messages",
+            invalid: [{operator: "is", operand: "muted"}],
+        },
     ];
     return get_special_filter_suggestions(last, operators, suggestions);
 }

--- a/templates/zerver/app/search_operators.html
+++ b/templates/zerver/app/search_operators.html
@@ -65,6 +65,10 @@
                 <td class="definition">{{ _('Narrow to unread messages.') }}</td>
             </tr>
             <tr>
+                <td class="operator">is:muted</td>
+                <td class="definition">{{ _('Narrow to muted messages.') }}</td>
+            </tr>
+            <tr>
                 <td class="operator">has:link</td>
                 <td class="definition">{{ _('Narrow to messages containing links.') }}</td>
             </tr>

--- a/zerver/lib/topic_mutes.py
+++ b/zerver/lib/topic_mutes.py
@@ -2,11 +2,13 @@ import datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from django.utils.timezone import now as timezone_now
-from sqlalchemy.sql import ClauseElement, and_, column, not_, or_
+from sqlalchemy.sql import ClauseElement, and_, column, or_
 
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import topic_match_sa
 from zerver.models import MutedTopic, UserProfile, get_stream
+
+ConditionTransform = Callable[[ClauseElement], ClauseElement]
 
 
 def get_topic_mutes(user_profile: UserProfile) -> List[Tuple[str, str, float]]:
@@ -85,8 +87,11 @@ def topic_is_muted(user_profile: UserProfile, stream_id: int, topic_name: str) -
     return is_muted
 
 
-def exclude_topic_mutes(
-    conditions: List[ClauseElement], user_profile: UserProfile, stream_id: Optional[int]
+def get_topic_mutes_conditions(
+    conditions: List[ClauseElement],
+    user_profile: UserProfile,
+    stream_id: Optional[int],
+    maybe_negate: ConditionTransform,
 ) -> List[ClauseElement]:
     query = MutedTopic.objects.filter(
         user_profile=user_profile,
@@ -113,7 +118,7 @@ def exclude_topic_mutes(
         topic_cond = topic_match_sa(topic_name)
         return and_(stream_cond, topic_cond)
 
-    condition = not_(or_(*list(map(mute_cond, rows))))
+    condition = maybe_negate(or_(*list(map(mute_cond, rows))))
     return [*conditions, condition]
 
 


### PR DESCRIPTION
Fixes: #16943 

**Testing plan:** <!-- How have you tested? -->
- Results of `-is:muted` should be same as `in:home`
- Try muting a stream, then search using `is:muted`, you will get messages muted streams only.


 <!-- **GIFs or screenshots:** If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
