### PR TITLE
help: Clarify the number of invites one can send

### DIFF
--- a/templates/zerver/help/invite-new-users.md
+++ b/templates/zerver/help/invite-new-users.md
@@ -7,7 +7,7 @@ the article below describes each in more detail.
 
 * Allow people to join based on the **domain** of their email address.
 
-* Send **email invitations** to up to 100 addresses in a day.
+* Send **email invitations**.
 
 * Share a **reusable invitation link**.
 
@@ -88,8 +88,11 @@ and reusable invitation links expire 10 days after they are sent.
 1. Click **Invite**.
 
 !!! warn ""
-    You will only see **Invite users** in the gear menu if you have
+    * You will only see **Invite users** in the gear menu if you have
     permission to invite users.
+    * The number of email invites you can send in a day is limited in
+    the free plan. [Contact us](/help/contact-support) if you hit the
+    limit and want to invite more users.
 
 {tab|share-an-invite-link}
 


### PR DESCRIPTION
The 100 invite per day restriction is only for the free plan. Also, the value 100 comes from settings.INVITES_DEFAULT_REALM_DAILY_MAX is something that can be changed. On top of this, newly created realms
on free plan combined can only send INVITES_NEW_REALM_LIMIT_DAYS number of invites. So it's better not to hardcode 100 in the doc.

![Screenshot from 2021-02-03 22-43-17](https://user-images.githubusercontent.com/7190633/106783364-3ca95500-6671-11eb-9dfd-d79cd7eee954.png)

Ready for review.