### PR TITLE
[Wip]Message-actions: Fix css in static/styles/night_mode.css

### DIFF
--- a/static/third/bootstrap/css/bootstrap.css
+++ b/static/third/bootstrap/css/bootstrap.css
@@ -2497,7 +2497,7 @@ legend + .control-group {
 .nav > li > a:hover,
 .nav > li > a:focus {
   text-decoration: none;
-  background-color: #eeeeee;
+  background-color: hsla(0, 0%, 0%, 0.2);
 }
 .nav > li > a > img {
   max-width: none;


### PR DESCRIPTION
When we want to select any list in Message actions from keyboard by keyup and keydown . Then we can not see the text clear.

Before:
![before](https://user-images.githubusercontent.com/56171689/106773032-a708c800-6666-11eb-8976-cd47df2aab97.gif)

After:
![after](https://user-images.githubusercontent.com/56171689/106773064-af610300-6666-11eb-8eee-4b5bd7f313b9.gif)
