### PR TITLE
[WIP] edit_history: Clean up in preparation for further work.

### DIFF
--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -799,6 +799,16 @@ class EditMessageTest(EditMessageTestCase):
         history = orjson.loads(Message.objects.get(id=msg_id).edit_history)
         self.assertEqual(history[0]["prev_content"], "content 3")
         self.assertEqual(history[0]["user_id"], hamlet.id)
+        self.assertEqual(
+            set(history[0].keys()),
+            {
+                "timestamp",
+                "prev_content",
+                "user_id",
+                "prev_rendered_content",
+                "prev_rendered_content_version",
+            },
+        )
 
         self.login("iago")
         result = self.client_patch(
@@ -812,6 +822,7 @@ class EditMessageTest(EditMessageTestCase):
         history = orjson.loads(Message.objects.get(id=msg_id).edit_history)
         self.assertEqual(history[0][LEGACY_PREV_TOPIC], "topic 3")
         self.assertEqual(history[0]["user_id"], self.example_user("iago").id)
+        self.assertEqual(set(history[0].keys()), {"timestamp", LEGACY_PREV_TOPIC, "user_id"})
 
         history = orjson.loads(Message.objects.get(id=msg_id).edit_history)
         self.assertEqual(history[0][LEGACY_PREV_TOPIC], "topic 3")

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -843,6 +843,7 @@ class EditMessageTest(EditMessageTestCase):
         self.assert_length(message_history, 6)
         self.assertEqual(message_history[0]["prev_topic"], "topic 3")
         self.assertEqual(message_history[0]["topic"], "topic 4")
+        self.assertEqual(message_history[0]["prev_topic"], "topic 3")
         self.assertEqual(message_history[1]["topic"], "topic 3")
         self.assertEqual(message_history[2]["topic"], "topic 3")
         self.assertEqual(message_history[2]["prev_topic"], "topic 2")

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -53,6 +53,14 @@ def fill_edit_history_entries(message_history: List[Dict[str, Any]], message: Me
             del entry["prev_rendered_content_version"]
             prev_content = entry["prev_content"]
             prev_rendered_content = entry["prev_rendered_content"]
+            # mypy infers that prev_rendered_content is of type Optional[str]
+            # based on the assignment near the top of this function, because
+            # message.rendered_content is of that type, as of the writing of
+            # this comment. However, after the assignment immediately above,
+            # prev_rendered_content will always be a string (barring bad data
+            # in the database). The assertion below is necessary because mypy
+            # will otherwise complain that an Optional[str] variable is being
+            # used where a str variable is required.
             assert prev_rendered_content is not None
             entry["content_html_diff"] = highlight_html_differences(
                 prev_rendered_content, entry["rendered_content"], message.id


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
These commits are doing some clean up around `fill_edit_history_entries()`, in preparation for adding to that function support for stream edits and filtering of past no-op edits.

**Testing plan:** <!-- How have you tested? -->
There was a preexisting test. I've refactored it in preparation for adding stream edit-related tests, but did so carefully, and in a separate commit from any changes to product code.

**WIP:**

There's still some polish that needs to be applied, but it's a good time to get some review and make sure I'm not going off the rails.