### PR TITLE
Replace lists with tuples to improve type-inferrence

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1887,11 +1887,11 @@ class Markdown(markdown.Markdown):
     ) -> None:
         # define default configs
         self.config = {
-            "realm_filters": [realm_filters,
-                              f"Realm-specific filters for realm_filters_key {realm_filters_key}"],
-            "realm": [realm_filters_key, "Realm id"],
-            "code_block_processor_disabled": [email_gateway,
-                                              "Disabled for email gateway"],
+            "realm_filters": (realm_filters,
+                              f"Realm-specific filters for realm_filters_key {realm_filters_key}"),
+            "realm": (realm_filters_key, "Realm id"),
+            "code_block_processor_disabled": (email_gateway,
+                                              "Disabled for email gateway"),
         }
 
         super().__init__(


### PR DESCRIPTION
I recently submitted a PR to mypy, which improves handling of generic types. This PR, if accepted, would lead to a type-error being reported in your code which was previously not reported.
I described it in detail here in the mypy PR: https://github.com/python/mypy/pull/9994#issuecomment-772497568


**Testing plan:** I ran mypy, both the current version and the version with my PR against the source code