### PR TITLE
Dark Mode : Message_action : Fix background-color while selecting one of list using keyboard

### DIFF
--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -459,6 +459,12 @@ on a dark background, and don't change the dark labels dark either. */
         }
     }
 
+    .nav > li > a:hover,
+    .nav > li > a:focus {
+        text-decoration: none;
+        background-color: hsla(0, 0%, 0%, 0.2);
+    }
+
     thead,
     .drafts-container .drafts-header,
     .recent_topics_container .recent_topics_header,


### PR DESCRIPTION
When we want to select any list in Message actions from keyboard by keyup and keydown . Then we can not see the text clear except that one which the cursor is pointing

Screenshot
before:
![before](https://user-images.githubusercontent.com/56171689/106789721-a5e09680-6678-11eb-94b1-e7b4cbdd8b32.gif)

after:
![after](https://user-images.githubusercontent.com/56171689/106789783-b5f87600-6678-11eb-8a99-cdebf31cc21c.gif)

