### PR TITLE
blueslip: Pass through the return value in measure_time

### DIFF
--- a/frontend_tests/zjsunit/zblueslip.js
+++ b/frontend_tests/zjsunit/zblueslip.js
@@ -119,9 +119,7 @@ exports.make_zblueslip = function () {
         return ex.message;
     };
 
-    lib.measure_time = (label, f) => {
-        f();
-    };
+    lib.measure_time = (label, f) => f();
 
     lib.preview_node = (node) => "node:" + node;
 

--- a/static/js/blueslip.js
+++ b/static/js/blueslip.js
@@ -253,10 +253,11 @@ exports.timings = new Map();
 
 exports.measure_time = function (label, f) {
     const t1 = performance.now();
-    f();
+    const ret = f();
     const t2 = performance.now();
     const elapsed = t2 - t1;
     exports.timings.set(label, elapsed);
+    return ret;
 };
 
 // Produces an easy-to-read preview on an HTML element.  Currently

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -257,13 +257,11 @@ exports.show_new_stream_modal = function () {
     $("#stream-creation").removeClass("hide");
     $(".right .settings").hide();
 
-    let html;
-
-    blueslip.measure_time("render new stream users", () => {
+    const html = blueslip.measure_time("render new stream users", () => {
         const all_users = people.get_people_for_stream_create();
         // Add current user on top of list
         all_users.unshift(people.get_by_user_id(page_params.user_id));
-        html = render_new_stream_users({
+        return render_new_stream_users({
             users: all_users,
             streams: stream_data.get_streams_for_settings_page(),
             is_admin: page_params.is_admin,

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -400,15 +400,14 @@ function get_stream_id_buckets(stream_ids, query) {
 }
 
 exports.populate_stream_settings_left_panel = function () {
-    let html;
-    blueslip.measure_time("render left panel", () => {
+    const html = blueslip.measure_time("render left panel", () => {
         const sub_rows = stream_data.get_updated_unsorted_subs();
 
         const template_data = {
             subscriptions: sub_rows,
         };
 
-        html = render_subscriptions(template_data);
+        return render_subscriptions(template_data);
     });
 
     ui.get_content_element($("#subscriptions_table .streams-list")).html(html);


### PR DESCRIPTION
Avoids the `const` to `let` conversions in #17165—not that `let` is a big deal, but this seems nicer and makes it easier to wrap `measure_time` around an existing expression. Cc @showell.