### PR TITLE
node tests: Remove unnecessary zjquery stubs.

### DIFF
--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -257,19 +257,8 @@ function generate_topic_data(topic_info_array) {
     // with non common fields.
     $.clear_all_elements();
     const data = [];
-    const selectors = [];
 
     for (const [stream_id, topic, unread_count, muted, participated] of topic_info_array) {
-        const topic_selector = $.create("#recent_topic:" + get_topic_key(stream_id, topic));
-        topic_selector.data = function () {
-            return {
-                participated,
-                muted,
-                unreadCount: unread_count,
-            };
-        };
-
-        selectors.push(topic_selector);
         data.push({
             other_senders_count: 0,
             invite_only: false,
@@ -371,8 +360,6 @@ run_test("test_filter_all", () => {
     // Test search
     expected.search_val = "topic-1";
     row_data = generate_topic_data([[1, "topic-1", 0, false, true]]);
-    const search_element = $.create("#recent_topics_search");
-    search_element.val("topic-3");
     i = row_data.length;
     assert.equal(rt.inplace_rerender("1:topic-1"), true);
 });
@@ -714,14 +701,6 @@ run_test("test_topic_edit", () => {
     verify_topic_data(all_topics, stream1, topic6, messages[8].id, true);
     assert.equal(all_topics.get(get_topic_key(stream1, topic8)), undefined);
 
-    let topic_selector = $.create("#recent_topic:" + get_topic_key(stream1, topic8));
-    topic_selector.data = function () {
-        return {
-            participated: true,
-            muted: false,
-            unreadCount: 1,
-        };
-    };
     // change topic of topic6 to topic8
     messages[7].topic = topic8;
     messages[8].topic = topic8;
@@ -735,14 +714,6 @@ run_test("test_topic_edit", () => {
     verify_topic_data(all_topics, stream1, topic1, messages[0].id, true);
     assert.equal(all_topics.get(get_topic_key(stream2, topic1)), undefined);
 
-    topic_selector = $.create("#recent_topic:" + get_topic_key(stream2, topic1));
-    topic_selector.data = function () {
-        return {
-            participated: true,
-            muted: false,
-            unreadCount: 0,
-        };
-    };
     messages[0].stream_id = stream2;
     rt.process_topic_edit(stream1, topic1, topic1, stream2);
     all_topics = rt.get();
@@ -754,14 +725,6 @@ run_test("test_topic_edit", () => {
     verify_topic_data(all_topics, stream2, topic1, messages[0].id, true);
     assert.equal(all_topics.get(get_topic_key(stream3, topic9)), undefined);
 
-    topic_selector = $.create("#recent_topic:" + get_topic_key(stream3, topic9));
-    topic_selector.data = function () {
-        return {
-            participated: false,
-            muted: false,
-            unreadCount: 1,
-        };
-    };
     messages[0].stream_id = stream3;
     messages[0].topic = topic9;
     rt.process_topic_edit(stream2, topic1, topic9, stream3);


### PR DESCRIPTION
It's not clear to me why this code was necessary,
and I assume it was either originally written
with a bit of misunderstanding of how zjquery
works or it became unnecessary with some refactoring
of the "real" code.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
