### PR TITLE
popovers: Added search typeahead to Move topic popover.

### DIFF
--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -119,7 +119,13 @@ export const DropdownListWidget = function ({
             // On opening a Bootstrap Dropdown, the parent element receives focus.
             // Here, we want our search input to have focus instead.
             e.preventDefault();
-            search_input.trigger("focus");
+            // This function gets called twice when focusing the
+            // dropdown, and only in the second call is the input
+            // field visible in the DOM; so the following visibility
+            // check ensures we wait for the second call to focus.
+            if (dropdown_list_body.is(":visible")) {
+                search_input.trigger("focus");
+            }
         });
 
         search_input.on("keydown", (e) => {

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -526,24 +526,37 @@ ul {
     padding: 2px 0 3px 0;
 }
 
-#topic_stream_edit_form_error {
-    background-color: hsla(0, 70%, 87%, 0.7);
-    color: hsl(0, 100%, 50%);
-}
-
-.topic_stream_edit_header {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-start;
-
-    #select_stream_id {
-        border-left: 0;
-        padding-left: 0;
-        border-radius: 3px;
-        margin: 0 5px 5px -10px;
-        text-indent: 10px;
+#move_topic_modal {
+    /* Ensure that the dropdown can overflow the modal. */
+    overflow: visible;
+    .modal-body {
+        overflow: visible;
     }
+
+    .stream_header_colorblock {
+        margin-bottom: 20px;
+    }
+
+    #topic_stream_edit_form_error {
+        background-color: hsla(0, 70%, 87%, 0.7);
+        color: hsl(0, 100%, 50%);
+    }
+
     .inline_topic_edit {
         margin-left: 5px !important;
+    }
+
+    .topic_stream_edit_header {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+
+        #select_stream_id {
+            border-left: 0;
+            padding-left: 0;
+            border-radius: 3px;
+            margin: 0 5px 5px -10px;
+            text-indent: 10px;
+        }
     }
 }

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -542,10 +542,6 @@ ul {
         color: hsl(0, 100%, 50%);
     }
 
-    .inline_topic_edit {
-        margin-left: 5px !important;
-    }
-
     .topic_stream_edit_header {
         display: flex;
         flex-wrap: wrap;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2357,18 +2357,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
     max-height: 60vh;
 }
 
-#move_topic_modal {
-    /* Ensure that the dropdown can overflow the modal. */
-    overflow: visible;
-    .modal-body {
-        overflow: visible;
-    }
-
-    .stream_header_colorblock {
-        margin-bottom: 20px;
-    }
-}
-
 #invitee_emails {
     min-height: 40px;
     max-height: 300px;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2357,6 +2357,12 @@ div.topic_edit_spinner .loading_indicator_spinner {
     max-height: 60vh;
 }
 
+#move_topic_modal {
+    .stream_header_colorblock {
+        margin-bottom: 20px;
+    }
+}
+
 #invitee_emails {
     min-height: 40px;
     max-height: 300px;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2358,6 +2358,12 @@ div.topic_edit_spinner .loading_indicator_spinner {
 }
 
 #move_topic_modal {
+    /* Ensure that the dropdown can overflow the modal. */
+    overflow: visible;
+    .modal-body {
+        overflow: visible;
+    }
+
     .stream_header_colorblock {
         margin-bottom: 20px;
     }

--- a/static/templates/move_topic_to_stream.hbs
+++ b/static/templates/move_topic_to_stream.hbs
@@ -42,7 +42,7 @@
     <div class="modal-footer">
         <button class="button" data-dismiss="modal">{{t "Cancel" }}</button>
         <button class="button btn-danger rounded" id="do_move_topic_button">
-            {{t "Move topic" }}
+            {{t "Confirm" }}
         </button>
     </div>
 </div>

--- a/static/templates/move_topic_to_stream.hbs
+++ b/static/templates/move_topic_to_stream.hbs
@@ -13,12 +13,11 @@
             <p>{{t "Select a stream below or change topic name." }}</p>
             <div class="topic_stream_edit_header">
                 <div class="stream_header_colorblock"></div>
-                <select name="select_stream_id" class="inline_select_topic_edit" id="select_stream_id">
-                    <option value="{{ current_stream_id }}">#{{ current_stream_name }}</option>
-                    {{#each available_streams}}
-                    <option value="{{ this.stream_id }}">#{{this.name}}</option>
-                    {{/each}}
-                </select>
+                <div class="move-topic-dropdown">
+                    {{> settings/dropdown_list_widget
+                      widget_name="select_stream"
+                      list_placeholder=(t 'Filter streams')}}
+                </div>
                 <i class="fa fa-angle-right" aria-hidden="true"></i>
                 <input name="new_topic_name" type="text" class="inline_topic_edit" value="{{topic_name}}" />
                 <input name="old_topic_name" type="hidden" class="inline_topic_edit" value="{{topic_name}}" />


### PR DESCRIPTION
Added an input typeahead within the `Move Topic` modal, for the user to select a desired stream to move a specific topic.
The purpose it to reduce users effort since a dropdown makes it time consuming to search for a stream (especially when dealing with a plenty of streams).

<strong>Screenshots :</strong>
![movefix](https://user-images.githubusercontent.com/53977614/108750109-a75dfa00-7566-11eb-9f3c-c0022f1ab965.gif)


Closes #14860.

Would appreciate a review @amanagr.