### PR TITLE
node_tests: Fixed failing rendered_markdown tests.

### DIFF
--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -172,7 +172,7 @@ run_test("timestamp", () => {
     const $timestamp_invalid = $.create("timestamp(invalid)");
     $timestamp_invalid.attr("datetime", "invalid");
     $content.set_find_results("time", $array([$timestamp, $timestamp_invalid]));
-    blueslip.expect("error", "Moment could not parse datetime supplied by backend: invalid");
+    blueslip.expect("error", "Could not parse datetime supplied by backend: invalid");
 
     // Initial asserts
     assert.equal($timestamp.text(), "never-been-set");


### PR DESCRIPTION
Follow up of #16451, since the changes in <code>blueslip.error</code> were still referring to Moment as a library within <code>rendered_markdown</code> node tests.