### PR TITLE
api docs: Removed duplicacy in CSS.

### DIFF
--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -1693,6 +1693,12 @@ label.label-title {
         }
     }
 
+    .api-field-type {
+        text-transform: lowercase;
+        font-weight: 600;
+        font-size: 14px;
+    }
+
     .api-argument-example-label {
         font-style: italic;
     }
@@ -1717,16 +1723,9 @@ label.label-title {
         font-size: 12px;
         color: hsl(0, 50%, 60%);
     }
-
-    .api-argument-datatype {
-        text-transform: lowercase;
-        font-weight: 600;
-        font-size: 14px;
-        color: hsl(176, 46.4%, 41%);
-    }
 }
 
-.api-response-datatype {
+.api-field-type {
     color: hsl(176, 46.4%, 41%);
 }
 

--- a/zerver/lib/markdown/api_arguments_table_generator.py
+++ b/zerver/lib/markdown/api_arguments_table_generator.py
@@ -92,7 +92,7 @@ class APIArgumentsTablePreprocessor(Preprocessor):
         table = []
         argument_template = """
 <div class="api-argument" id="parameter-{argument}">
-    <p class="api-argument-name"><strong>{argument}</strong> <span class="api-argument-datatype">{type}</span> {required} {deprecated} <a href="#parameter-{argument}" class="api-argument-hover-link"><i class="fa fa-chain"></i></a></p>
+    <p class="api-argument-name"><strong>{argument}</strong> <span class="api-field-type">{type}</span> {required} {deprecated} <a href="#parameter-{argument}" class="api-argument-hover-link"><i class="fa fa-chain"></i></a></p>
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>{example}</code>
     </div>

--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -80,8 +80,8 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
             if data_type != "object" or len(arr) == 1 or '\n' in arr[0]:
                 return (spacing * " ") + "* " + description
             (key_name, key_description) = arr
-            return (spacing * " ") + "* " + key_name + ": " + '<span class="api-response-datatype">' + data_type + "</span> "  + key_description
-        return (spacing * " ") + "* `" + return_value + "`: " + '<span class="api-response-datatype">' + data_type + "</span> "  + description
+            return (spacing * " ") + "* " + key_name + ": " + '<span class="api-field-type">' + data_type + "</span> "  + key_description
+        return (spacing * " ") + "* `" + return_value + "`: " + '<span class="api-field-type">' + data_type + "</span> "  + description
 
     def render_table(self, return_values: Dict[str, Any], spacing: int) -> List[str]:
         IGNORE = ["result", "msg"]


### PR DESCRIPTION
Deduplicate CSS for coloration of data types of response and
request parameters in API Documentation.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
