### PR TITLE
drafts: Fix racy computation that gets current time twice

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const {subDays} = require("date-fns");
 const Handlebars = require("handlebars/runtime");
 const XDate = require("xdate");
 
@@ -208,7 +209,7 @@ exports.restore_draft = function (draft_id) {
 const DRAFT_LIFETIME = 30;
 
 exports.remove_old_drafts = function () {
-    const old_date = new Date().setDate(new Date().getDate() - DRAFT_LIFETIME);
+    const old_date = subDays(new Date(), DRAFT_LIFETIME).getTime();
     const drafts = draft_model.get();
     for (const [id, draft] of Object.entries(drafts)) {
         if (draft.updatedAt < old_date) {


### PR DESCRIPTION
The result could have been off by a month if the two calls to `new Date()` straddled a month boundary.

**Testing plan:** Checked manually that the computation is equivalent in the normal case.