### PR TITLE
components: Allow passing labels as HTML (but explicitly)

### DIFF
--- a/frontend_tests/node_tests/components.js
+++ b/frontend_tests/node_tests/components.js
@@ -51,6 +51,17 @@ run_test("basics", () => {
             return i;
         };
 
+        self.text = function (text) {
+            assert.equal(
+                text,
+                [
+                    "translated: Keyboard shortcuts",
+                    "translated: Message formatting",
+                    "translated: Search operators",
+                ][i],
+            );
+        };
+
         self.trigger = function (type) {
             if (type === "focus") {
                 focused_tab = i;
@@ -154,19 +165,7 @@ run_test("basics", () => {
                         },
                     ][tab_id],
                 );
-                return {
-                    text: (text) => {
-                        assert.equal(
-                            text,
-                            [
-                                "translated: Keyboard shortcuts",
-                                "translated: Message formatting",
-                                "translated: Search operators",
-                            ][tab_id],
-                        );
-                        return make_tab(tab_id);
-                    },
-                };
+                return make_tab(tab_id);
             }
             default:
                 throw new Error("unknown selector: " + sel);

--- a/static/js/components.js
+++ b/static/js/components.js
@@ -28,7 +28,15 @@ exports.toggle = function (opts) {
                 "data-tab-key": value.key,
                 "data-tab-id": i,
                 tabindex: 0,
-            }).text(value.label);
+            });
+
+            /* istanbul ignore if */
+            if (value.label_html !== undefined) {
+                const html = value.label_html;
+                tab.html(html);
+            } else {
+                tab.text(value.label);
+            }
 
             // add proper classes for styling in CSS.
             if (i === 0) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -559,17 +559,19 @@ exports.setup_page = function (callback) {
         exports.sort_toggler = components.toggle({
             values: [
                 {
-                    label: `<i class="fa fa-sort-alpha-asc" title="${i18n.t("Sort by name")}"></i>`,
+                    label_html: `<i class="fa fa-sort-alpha-asc" title="${i18n.t(
+                        "Sort by name",
+                    )}"></i>`,
                     key: "by-stream-name",
                 },
                 {
-                    label: `<i class="fa fa-user-o" title="${i18n.t(
+                    label_html: `<i class="fa fa-user-o" title="${i18n.t(
                         "Sort by number of subscribers",
                     )}"></i>`,
                     key: "by-subscriber-count",
                 },
                 {
-                    label: `<i class="fa fa-bar-chart" title="${i18n.t(
+                    label_html: `<i class="fa fa-bar-chart" title="${i18n.t(
                         "Sort by estimated weekly traffic",
                     )}"></i>`,
                     key: "by-weekly-traffic",


### PR DESCRIPTION
Fixes the sorting button labels in stream settings, which were regressed by commit f8fbae4d8ed16cceabc23806aa421e1481e14e8d (because the HTML was not marked as being HTML).