### PR TITLE
frontend: Fix right margin in stream description

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -712,6 +712,7 @@ form#add_new_subscription {
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+            margin-right: 12px;
         }
 
         .top-bar .subscriber-count,


### PR DESCRIPTION
Relevent conversations are [here](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Not.20enough.20space/near/1113792)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
Tested locally and manually.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before
![image](https://user-images.githubusercontent.com/56730716/107111469-5a93d700-6876-11eb-9ee8-633cfe7a852b.png)

After
![image](https://user-images.githubusercontent.com/56730716/107111502-9464dd80-6876-11eb-9b14-fed0b5e3d58d.png)


#### One more example
Before
![image](https://user-images.githubusercontent.com/56730716/107111562-0ccb9e80-6877-11eb-96e2-fb7728a8bcab.png)


After
![image](https://user-images.githubusercontent.com/56730716/107111548-f7ef0b00-6876-11eb-91f4-52ef17b98b19.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
