### PR TITLE
docs: Replace A icon with help in format using markdown

### DIFF
--- a/templates/zerver/help/format-your-message-using-markdown.md
+++ b/templates/zerver/help/format-your-message-using-markdown.md
@@ -273,7 +273,7 @@ A summary of the formatting syntax is available in-app.
 
 {!start-composing.md!}
 
-1. Click the A (<i class="fa fa-font"></i>) icon at the bottom of the compose box.
+1. Click help at the bottom of the compose box.
 
 {end_tabs}
 


### PR DESCRIPTION
Relevant conversations are [here](https://chat.zulip.org/#narrow/stream/19-documentation/topic/Help.20needed/near/1104200)

As suggested by @timabbott, the A icon was replaced by help in the compose box. This updates that in the docs.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
#### Before
![image](https://user-images.githubusercontent.com/56730716/107111748-8ca63880-6878-11eb-88a3-c233db1f9e85.png)

#### The change
![image](https://user-images.githubusercontent.com/56730716/107111761-ab0c3400-6878-11eb-8e16-a4678bfbd72e.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
