### PR TITLE
static/templates: change of wording and icon from delete/deactivate stream to archive stream

### DIFF
--- a/docs/documentation/user.md
+++ b/docs/documentation/user.md
@@ -169,6 +169,8 @@ class="fa fa-bars"></i>) icon`
 `smiley face (<i class="fa fa-smile-o"></i>) icon`
 * star (<i class="fa fa-star-o"></i>) icon —
 `star (<i class="fa fa-star-o"></i>) icon`
+* archive <i class="fa fa-archive" aria-hidden="true"></i> icon —
+`archive <i class="fa fa-archive" aria-hidden="true"></i> icon`
 * trash (<i class="fa fa-trash-o"></i>) icon —
 `trash (<i class="fa fa-trash-o"></i>) icon`
 * video-camera (<i class="fa fa-video-camera"></i>) icon —

--- a/static/templates/settings/deactivation_stream_modal.hbs
+++ b/static/templates/settings/deactivation_stream_modal.hbs
@@ -1,13 +1,13 @@
 <div id="deactivation_stream_modal" class="modal modal-bg hide fade new-style" tabindex="-1" role="dialog" aria-labelledby="deactivation_stream_modal_label" aria-hidden="true">
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-        <h3 id="deactivation_stream_modal_label">{{t "Delete stream" }} <span class="stream_name">{{stream_name}}</span></h3>
+        <h3 id="deactivation_stream_modal_label">{{t "Archive stream" }} <span class="stream_name">{{stream_name}}</span></h3>
     </div>
     <div class="modal-body">
-        <p>{{t "Deleting this stream will immediately unsubscribe everyone, and the stream's content will not be recoverable." }} <strong>{{t "Are you sure you want to do this?" }}</strong></p>
+        <p>{{t "Archiving this stream will immediately unsubscribe everyone and remove it from active streams." }} <strong>{{t "Are you sure you want to do this?" }}</strong></p>
     </div>
     <div class="modal-footer">
         <button class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
-        <button class="button rounded btn-danger" id="do_deactivate_stream_button" data-stream-id="{{stream_id}}">{{t "Yes, delete this stream" }}</button>
+        <button class="button rounded btn-danger" id="do_deactivate_stream_button" data-stream-id="{{stream_id}}">{{t "Yes, archive this stream" }}</button>
     </div>
 </div>

--- a/static/templates/settings/deactivation_stream_modal.hbs
+++ b/static/templates/settings/deactivation_stream_modal.hbs
@@ -4,7 +4,7 @@
         <h3 id="deactivation_stream_modal_label">{{t "Archive stream" }} <span class="stream_name">{{stream_name}}</span></h3>
     </div>
     <div class="modal-body">
-        <p>{{t "Archiving this stream will immediately unsubscribe everyone and remove it from active streams." }} <strong>{{t "Are you sure you want to do this?" }}</strong></p>
+        <p>{{t "Archiving this stream will immediately unsubscribe everyone and remove it from active streams." }} <strong>{{t "Are you sure you want to do this?" }}</strong> {{> ../help_link_widget link="?" }}</p>
     </div>
     <div class="modal-footer">
         <button class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -16,7 +16,7 @@
             </div>
             <div class="button-group">
                 {{#if is_realm_admin}}
-                <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Delete stream'}}"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
+                <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Archive stream'}}"> <i class="fa fa-archive" aria-hidden="true"></i></button>
                 {{/if}}
                 <div class="sub_unsub_button_wrapper inline-block">
                     <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}}title="{{t 'Toggle subscription'}} (S)" {{else}}disabled="disabled"{{/if}}>


### PR DESCRIPTION

#17240  
Wording change in /settings/deactivation_stream_modal & subscription_settings to better describe current behavior to the user.
More related discussion here: [Deactivated Streams Searchable](https://chat.zulip.org/#narrow/stream/9-issues/topic/Deactivated.20streams.20searchable)
Documentation of Font Awesome's archive icon being used is added as well.

## Manual Testing ##
Go through the delete stream flow and verify that the archive stream flow follows the same behavior. Screenshot comparisons below.

### Current UI: ###

Before Delete:
![BeforeDelete](https://user-images.githubusercontent.com/38027049/107112269-50e18380-6824-11eb-89f0-e3df2856454f.PNG)

Delete Modal:
![DeleteModal](https://user-images.githubusercontent.com/38027049/107112274-58a12800-6824-11eb-9d04-8430246e93a3.PNG)

After Delete:
![AfterDelete](https://user-images.githubusercontent.com/38027049/107112276-5b9c1880-6824-11eb-8c9f-beb698dd80b1.PNG)

### Proposed UI: ###

Before Archive:
![BeforeArchive](https://user-images.githubusercontent.com/38027049/107112282-6c4c8e80-6824-11eb-96d5-29baf0b5fe57.PNG)

Archive Modal:
![ArchiveModal](https://user-images.githubusercontent.com/38027049/107112284-7078ac00-6824-11eb-86b9-c5d3ef61d168.PNG)

After Archive:
![AfterArchive](https://user-images.githubusercontent.com/38027049/107112285-73739c80-6824-11eb-9757-a88ca3bd77b5.PNG)
