### PR TITLE
markdown: Clean up markdown_help.html with frontend markdown processor

### DIFF
--- a/static/js/info_overlay.js
+++ b/static/js/info_overlay.js
@@ -2,15 +2,31 @@ import * as common from "./common";
 import * as components from "./components";
 import * as hashchange from "./hashchange";
 import * as keydown_util from "./keydown_util";
+import * as markdown from "./markdown";
 import * as overlays from "./overlays";
 import * as popovers from "./popovers";
+import * as rendered_markdown from "./rendered_markdown";
 import * as ui from "./ui";
 
 // Make it explicit that our toggler is undefined until
 // set_up_toggler is called.
 export let toggler;
 
+function render_markdown () {
+    $.each($("#markdown-instructions .apply_markdown"), (id, element) => {
+        const rendering_object = {
+            raw_content: element.textContent,
+        };
+        markdown.apply_markdown(rendering_object);
+        const rendered_element = $('<td class="rendered_markdown">');
+        rendered_element.html(rendering_object.content);
+        rendered_markdown.update_elements(rendered_element);
+        rendered_element.insertAfter(element);
+    });
+};
+
 export function set_up_toggler() {
+    render_markdown();
     const opts = {
         selected: 0,
         child_wants_focus: true,

--- a/templates/zerver/app/markdown_help.html
+++ b/templates/zerver/app/markdown_help.html
@@ -12,7 +12,6 @@
 
                 <tbody>
                     <tr>
-
                         <td>*italic* (or <kbd>Ctrl + I</kbd>)</td>
                         <td class="rendered_markdown"><i>italic</i></td>
                     </tr>
@@ -21,44 +20,24 @@
                         <td class="rendered_markdown"><b>bold</b></td>
                     </tr>
                     <tr>
-                        <td>~~strikethrough~~</td>
-                        <td class="rendered_markdown"><del>strikethrough</del></td>
+                        <td class="apply_markdown">~~strikethrough~~</td>
                     </tr>
                     <tr>
                         <td>[Zulip website](https://zulip.org) (or <kbd>Ctrl + Shift + L</kbd>)</td>
                         <td class="rendered_markdown"><a href="https://zulip.org" target="_blank" rel="noopener noreferrer">Zulip website</a></td>
                     </tr>
                     <tr>
-                        <td>* Milk<br>
-                            * Tea<br>
-                            &nbsp;&nbsp;* Green tea<br>
-                            &nbsp;&nbsp;* Black tea<br>
-                            &nbsp;&nbsp;* Oolong tea<br>
-                            * Coffee
-                        </td>
-                        <td class="rendered_markdown">
-                            <ul>
-                                <li>Milk</li>
-                                <li>Tea
-                                    <ul>
-                                        <li>Green tea</li>
-                                        <li>Black tea</li>
-                                        <li>Oolong tea</li>
-                                    </ul>
-                                </li>
-                                <li>Coffee</li>
-                            </ul>
-                        </td>
+                        <td class="preserve_spaces apply_markdown">* Milk
+* Tea
+  * Green tea
+  * Black tea
+  * Oolong tea
+* Coffee</td>
                     </tr>
                     <tr>
-                        <td>1. Milk<br>
-                            1. Tea<br>
-                            1. Coffee
-                        </td>
-                        <td class="rendered_markdown">1. Milk<br>
-                            2. Tea<br>
-                            3. Coffee
-                        </td>
+                        <td class="preserve_spaces apply_markdown">1. Milk
+1. Tea
+1. Coffee</td>
                     </tr>
                     <tr>
                         <td>:heart: (and <a href="https://www.webfx.com/tools/emoji-cheat-sheet/" target="_blank" rel="noopener noreferrer">many others</a>, from the <a href="https://code.google.com/p/noto/" target="_blank" rel="noopener noreferrer">Noto Project</a>)</td>
@@ -88,18 +67,13 @@
                         <td class="rendered_markdown"><span class="sender_name-in-status">Iago</span> is busy working</td>
                     </tr>
                     <tr>
-                        <td>Some inline `code`</td>
-                        <td class="rendered_markdown">Some inline <code>code</code></td>
+                        <td class="apply_markdown">Some inline `code`</td>
                     </tr>
                     <tr>
-                    <td class="preserve_spaces">```
+                    <td class="preserve_spaces apply_markdown">```
 def zulip():
     print "Zulip"
 ```</td>
-                    <td class="rendered_markdown">
-                        <div class="codehilite"><pre>def zulip():
-    print "Zulip"</pre></div>
-                    </td>
                     </tr>
                     <tr>
                     <td class="preserve_spaces">```python
@@ -123,40 +97,22 @@ def zulip():
 
                     </tr>
                     <tr>
-                    <td class="preserve_spaces">```quote
+                    <td class="preserve_spaces apply_markdown">```quote
 Quoted block
 ```</td>
-                    <td class="rendered_markdown"><blockquote><p>Quoted block</p></blockquote></td>
                     </tr>
                     <tr>
-                        <td class="preserve_spaces">```spoiler Always visible heading
+                        <td class="preserve_spaces apply_markdown">```spoiler Always visible heading
 This text won't be visible until the user clicks.
 ```</td>
-                        <td class="rendered_markdown">
-                            <div class="spoiler-block">
-                                <div class="spoiler-header"><span class="spoiler-button"><span class="spoiler-arrow"></span></span>
-                                    <p>Always visible heading</p>
-                                </div>
-
-                                <div class="spoiler-content">
-                                    <p>This text won't be visible until the user clicks.</p>
-                                </div>
-                            </div>
-                        </td>
                     </tr>
                     <tr>
-                        <td>Some inline math $$ e^{i \pi } + 1 = 0 $$</td>
-                        <td class="rendered_markdown">
-                            Some inline math <span class="katex"><span class="katex-mathml"><math><semantics><mrow><msup><mi>e</mi><mrow><mi>i</mi><mi>π</mi></mrow></msup><mo>+</mo><mn>1</mn><mo>=</mo><mn>0</mn></mrow><annotation encoding="application/x-tex">e^{i\pi} + 1 = 0</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="strut" style="height: 0.874664em;"></span><span class="strut bottom" style="height: 0.957994em; vertical-align: -0.08333em;"></span><span class="base"><span class="mord"><span class="mord mathit">e</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height: 0.874664em;"><span class="" style="top: -3.113em; margin-right: 0.05em;"><span class="pstrut" style="height: 2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mathit mtight">i</span><span class="mord mathit mtight" style="margin-right: 0.03588em;">π</span></span></span></span></span></span></span></span></span><span class="mbin">+</span><span class="mord mathrm">1</span><span class="mrel">=</span><span class="mord mathrm">0</span></span></span></span>
-                        </td>
+                        <td class="apply_markdown">Some inline math $$ e^{i \pi } + 1 = 0 $$</td>
                     </tr>
                     <tr>
-                        <td class="preserve_spaces">```math
+                        <td class="preserve_spaces apply_markdown">```math
 \int_{0}^{1} f(x) dx
 ```</td>
-                        <td>
-                            <span class="katex-display"><span class="katex"><span class="katex-mathml"><math><semantics><mrow><msubsup><mo>∫</mo><mn>0</mn><mn>1</mn></msubsup><mi>f</mi><mo>(</mo><mi>x</mi><mo>)</mo><mi>d</mi><mi>x</mi></mrow><annotation encoding="application/x-tex">\int_{0}^{1} f(x) dx</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="strut" style="height: 1.56401em;"></span><span class="strut bottom" style="height: 2.47596em; vertical-align: -0.91195em;"></span><span class="base"><span class="mop"><span class="mop op-symbol large-op" style="margin-right: 0.44445em; position: relative; top: -0.001125em;">∫</span><span class="msupsub"><span class="vlist-t vlist-t2"><span class="vlist-r"><span class="vlist" style="height: 1.56401em;"><span class="" style="top: -1.78805em; margin-left: -0.44445em; margin-right: 0.05em;"><span class="pstrut" style="height: 2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mathrm mtight">0</span></span></span></span><span class="" style="top: -3.8129em; margin-right: 0.05em;"><span class="pstrut" style="height: 2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mathrm mtight">1</span></span></span></span></span><span class="vlist-s">​</span></span><span class="vlist-r"><span class="vlist" style="height: 0.91195em;"></span></span></span></span></span><span class="mord mathit" style="margin-right: 0.10764em;">f</span><span class="mopen">(</span><span class="mord mathit">x</span><span class="mclose">)</span><span class="mord mathit">d</span><span class="mord mathit">x</span></span></span></span></span>
-                        </td>
                     </tr>
                     <tr>
                         <td class="rendered_markdown" colspan="2">{% trans %}You can also make <a target="_blank" rel="noopener noreferrer"


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is a follow-up PR for #16891 
Done the changes as suggested by @timabbott in the review.

Checklist for changes requested:
- [x] Rebased and solved conflicts
- [x] Used a more direct selector instead of next
- [x] Removed empty `td` tags
- [x] Used the frontend parser wherever possible

Fixes #15375 
**Testing plan:** <!-- How have you tested? -->
Tested manually and still checking in progress.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
