### PR TITLE
user docs: Replace right simplebar with browser scrollbar

### DIFF
--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -37,7 +37,7 @@
         {% endblock %}
     </head>
 
-    <body class="{% if noscroll %}noscroll{% endif %}">
+    <body>
         {% block content %}
         {% endblock %}
 

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -1,6 +1,5 @@
 {% extends "zerver/portico-help.html" %}
 {% set entrypoint = "help" %}
-{% set noscroll = true %}
 
 {# Zulip user and API documentation. #}
 {% block title %}

--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -94,7 +94,6 @@ function render_code_sections() {
     });
 }
 
-new SimpleBar($(".markdown")[0]);
 new SimpleBar($(".sidebar")[0]);
 
 // Scroll to anchor link when clicked. Note that landing-page.js has a

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -2,7 +2,6 @@
     font-weight: 400;
     font-size: 1rem;
     line-height: 1.5;
-    overflow: auto;
 
     & h1[id],
     h2[id],

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -98,7 +98,6 @@ html {
     display: inline-flex;
 
     box-shadow: 0 -20px 50px hsl(0deg 0% 0% / 4%);
-    overflow: auto;
 
     color: hsl(0deg 0% 27%);
 
@@ -125,7 +124,7 @@ html {
         height: calc(100vh - 59px);
 
         border-right: 1px solid hsl(219deg 10% 97%);
-        overflow: auto;
+        position: fixed;
 
         background-color: hsl(153deg 32% 55%);
         color: hsl(0deg 0% 100%);
@@ -252,10 +251,10 @@ html {
     background-color: hsl(0deg 0% 100%);
     width: calc(100vw - 300px);
     height: calc(100vh - 59px);
+    margin-left: 300px;
 
     & :target {
-        /* Match to where simplebar scrolls */
-        scroll-margin-top: 20px;
+        scroll-margin-top: 59px;
     }
     /* Highlight the headings as well as the first child
       of any targeted div, as in the API documentation. */
@@ -1061,6 +1060,7 @@ input.new-organization-button {
     .app.help {
         .markdown {
             width: 100vw;
+            margin-left: 0;
 
             .content {
                 max-width: none;
@@ -1072,7 +1072,7 @@ input.new-organization-button {
             display: block;
             position: fixed;
             top: 70px;
-            left: 9px;
+            right: calc(100% - 40px);
             fill: hsl(0deg 0% 100%);
             z-index: 2;
             transition: all 0.3s ease;
@@ -1082,7 +1082,7 @@ input.new-organization-button {
         .sidebar {
             position: fixed;
             top: 59px;
-            right: calc(100vw - 50px);
+            right: calc(100% - 50px);
             width: 100%;
             min-width: unset;
             height: calc(100vh - 59px);
@@ -1102,7 +1102,7 @@ input.new-organization-button {
             }
 
             + .hamburger {
-                transform: translateX(calc(100vw - 50px));
+                right: 12px;
             }
 
             ~ .markdown {


### PR DESCRIPTION
This commit removes the simplebar implementation for the right.
Thus using the default browser scrollbar. Removes simplebar class
and functions scrollToHash with this commit.

Fixes #10732 

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested manually and with node-tests.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
How it looks now
![image](https://user-images.githubusercontent.com/56730716/107115928-fed94600-6895-11eb-8b12-d6d2051fb7ad.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
