### PR TITLE
[WIP] Make acting_user a mandatory kwarg.

### DIFF
--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -1325,7 +1325,7 @@ class TestLoggingCountStats(AnalyticsTestCase):
                 "value__sum"
             ],
         )
-        do_activate_user(user)
+        do_activate_user(user, acting_user=None)
         self.assertEqual(
             1,
             RealmCount.objects.filter(property=property, subgroup=False).aggregate(Sum("value"))[
@@ -1659,7 +1659,7 @@ class TestActiveUsersAudit(AnalyticsTestCase):
             "email4", "password", self.default_realm, "full_name", acting_user=None
         )
         do_deactivate_user(user2)
-        do_activate_user(user3)
+        do_activate_user(user3, acting_user=None)
         do_reactivate_user(user4)
         end_time = floor_to_day(timezone_now()) + self.DAY
         do_fill_count_stat_at_hour(self.stat, end_time)

--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -1309,7 +1309,9 @@ class TestLoggingCountStats(AnalyticsTestCase):
 
     def test_active_users_log_by_is_bot(self) -> None:
         property = "active_users_log:is_bot:day"
-        user = do_create_user("email", "password", self.default_realm, "full_name")
+        user = do_create_user(
+            "email", "password", self.default_realm, "full_name", acting_user=None
+        )
         self.assertEqual(
             1,
             RealmCount.objects.filter(property=property, subgroup=False).aggregate(Sum("value"))[
@@ -1644,10 +1646,18 @@ class TestActiveUsersAudit(AnalyticsTestCase):
         self.assertTableState(UserCount, ["user", "subgroup"], [[user1, "false"], [user2, "false"]])
 
     def test_end_to_end_with_actions_dot_py(self) -> None:
-        user1 = do_create_user("email1", "password", self.default_realm, "full_name")
-        user2 = do_create_user("email2", "password", self.default_realm, "full_name")
-        user3 = do_create_user("email3", "password", self.default_realm, "full_name")
-        user4 = do_create_user("email4", "password", self.default_realm, "full_name")
+        user1 = do_create_user(
+            "email1", "password", self.default_realm, "full_name", acting_user=None
+        )
+        user2 = do_create_user(
+            "email2", "password", self.default_realm, "full_name", acting_user=None
+        )
+        user3 = do_create_user(
+            "email3", "password", self.default_realm, "full_name", acting_user=None
+        )
+        user4 = do_create_user(
+            "email4", "password", self.default_realm, "full_name", acting_user=None
+        )
         do_deactivate_user(user2)
         do_activate_user(user3)
         do_reactivate_user(user4)
@@ -1761,9 +1771,13 @@ class TestRealmActiveHumans(AnalyticsTestCase):
         )
 
     def test_end_to_end(self) -> None:
-        user1 = do_create_user("email1", "password", self.default_realm, "full_name")
-        user2 = do_create_user("email2", "password", self.default_realm, "full_name")
-        do_create_user("email3", "password", self.default_realm, "full_name")
+        user1 = do_create_user(
+            "email1", "password", self.default_realm, "full_name", acting_user=None
+        )
+        user2 = do_create_user(
+            "email2", "password", self.default_realm, "full_name", acting_user=None
+        )
+        do_create_user("email3", "password", self.default_realm, "full_name", acting_user=None)
         time_zero = floor_to_day(timezone_now()) + self.DAY
         update_user_activity_interval(user1, time_zero)
         update_user_activity_interval(user2, time_zero)

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -2713,7 +2713,7 @@ class LicenseLedgerTest(StripeTestCase):
         do_deactivate_user(user)
         do_reactivate_user(user)
         # Not a proper use of do_activate_user, but fine for this test
-        do_activate_user(user)
+        do_activate_user(user, acting_user=None)
         ledger_entries = list(
             LicenseLedger.objects.values_list(
                 "is_renewal", "licenses", "licenses_at_next_renewal"

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -2709,7 +2709,7 @@ class LicenseLedgerTest(StripeTestCase):
 
     def test_user_changes(self) -> None:
         self.local_upgrade(self.seat_count, True, CustomerPlan.ANNUAL, "token")
-        user = do_create_user("email", "password", get_realm("zulip"), "name")
+        user = do_create_user("email", "password", get_realm("zulip"), "name", acting_user=None)
         do_deactivate_user(user)
         do_reactivate_user(user)
         # Not a proper use of do_activate_user, but fine for this test

--- a/tools/test-api
+++ b/tools/test-api
@@ -73,10 +73,7 @@ with test_server_running(force=options.force, external_host="zulipdev.com:9981")
     # Prepare the non-admin client
     email = "guest@zulip.com"  # guest is not an admin
     guest_user = do_create_user(
-        "guest@zulip.com",
-        "secret",
-        get_realm("zulip"),
-        "Mr. Guest",
+        "guest@zulip.com", "secret", get_realm("zulip"), "Mr. Guest", acting_user=None
     )
     api_key = get_api_key(guest_user)
     nonadmin_client = Client(

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -616,7 +616,8 @@ def do_create_user(
     default_stream_groups: Sequence[DefaultStreamGroup] = [],
     source_profile: Optional[UserProfile] = None,
     realm_creation: bool = False,
-    acting_user: Optional[UserProfile] = None,
+    *,
+    acting_user: Optional[UserProfile],
 ) -> UserProfile:
 
     user_profile = create_user(

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -674,7 +674,7 @@ def do_create_user(
     return user_profile
 
 
-def do_activate_user(user_profile: UserProfile, acting_user: Optional[UserProfile] = None) -> None:
+def do_activate_user(user_profile: UserProfile, *, acting_user: Optional[UserProfile]) -> None:
     user_profile.is_active = True
     user_profile.is_mirror_dummy = False
     user_profile.set_unusable_password()

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -271,6 +271,10 @@ def upload_custom_emoji() -> Dict[str, object]:
 @openapi_param_value_generator(["/users/{user_id}:delete"])
 def deactivate_user() -> Dict[str, object]:
     user_profile = do_create_user(
-        email="testuser@zulip.com", password=None, full_name="test_user", realm=get_realm("zulip")
+        email="testuser@zulip.com",
+        password=None,
+        full_name="test_user",
+        realm=get_realm("zulip"),
+        acting_user=None,
     )
     return {"user_id": user_profile.id}

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3245,7 +3245,9 @@ class GitHubAuthBackendTest(SocialAuthBase):
         # Now we create the user account with the noreply email and verify that it's
         # possible to sign in to it.
         realm = get_realm("zulip")
-        do_create_user(noreply_email, "password", realm, account_data_dict["name"])
+        do_create_user(
+            noreply_email, "password", realm, account_data_dict["name"], acting_user=None
+        )
         result = self.social_auth_test(
             account_data_dict,
             subdomain="zulip",
@@ -5349,12 +5351,7 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
         test_realm = do_create_realm("test", "test", False)
         hamlet = self.example_user("hamlet")
         email = hamlet.delivery_email
-        hamlet2 = do_create_user(
-            email,
-            None,
-            test_realm,
-            hamlet.full_name,
-        )
+        hamlet2 = do_create_user(email, None, test_realm, hamlet.full_name, acting_user=None)
 
         self.change_ldap_user_attr("hamlet", "cn", "Second Hamlet")
         expected_call_args = [hamlet2, "Second Hamlet", None]

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -384,6 +384,7 @@ class TestDigestEmailMessages(ZulipTestCase):
             realm,
             "some_bot",
             bot_type=UserProfile.DEFAULT_BOT,
+            acting_user=None,
         )
 
         # Check that bots are not sent emails

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -667,6 +667,7 @@ class NormalActionsTest(BaseAction):
                 self.user_profile.realm,
                 "full name",
                 prereg_user=prereg_user,
+                acting_user=None,
             ),
             state_change_expected=True,
             num_events=4,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -487,15 +487,13 @@ class HomeTest(ZulipTestCase):
             full_name=bot_name,
             bot_type=UserProfile.DEFAULT_BOT,
             bot_owner=owner,
+            acting_user=None,
         )
         return user
 
     def create_non_active_user(self, realm: Realm, email: str, name: str) -> UserProfile:
         user = do_create_user(
-            email=email,
-            password="123",
-            realm=realm,
-            full_name=name,
+            email=email, password="123", realm=realm, full_name=name, acting_user=None
         )
 
         # Doing a full-stack deactivation would be expensive here,

--- a/zerver/tests/test_hotspots.py
+++ b/zerver/tests/test_hotspots.py
@@ -12,10 +12,7 @@ class TestGetNextHotspots(ZulipTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.user = do_create_user(
-            "user@zulip.com",
-            "password",
-            get_realm("zulip"),
-            "user",
+            "user@zulip.com", "password", get_realm("zulip"), "user", acting_user=None
         )
 
     def test_first_hotspot(self) -> None:

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -818,6 +818,7 @@ class ImportExportTest(ZulipTestCase):
             full_name="bot",
             bot_type=UserProfile.EMBEDDED_BOT,
             bot_owner=sample_user,
+            acting_user=None,
         )
         storage = StateHandler(bot_profile)
         storage.put("some key", "some value")

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -78,7 +78,7 @@ class TestZulipBaseCommand(ZulipTestCase):
         with self.assertRaisesRegex(CommandError, "server does not contain a user with email"):
             self.command.get_user("invalid_email@example.com", None)
 
-        do_create_user(email, "password", mit_realm, "full_name")
+        do_create_user(email, "password", mit_realm, "full_name", acting_user=None)
 
         with self.assertRaisesRegex(CommandError, "server contains multiple users with that email"):
             self.command.get_user(email, None)

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -210,6 +210,7 @@ class MessagePOSTTest(ZulipTestCase):
             realm=non_admin_profile.realm,
             full_name="freebot",
             bot_type=UserProfile.DEFAULT_BOT,
+            acting_user=None,
         )
         self._send_and_verify_message(
             bot_without_owner,
@@ -286,6 +287,7 @@ class MessagePOSTTest(ZulipTestCase):
             realm=non_admin_profile.realm,
             full_name="freebot",
             bot_type=UserProfile.DEFAULT_BOT,
+            acting_user=None,
         )
         self._send_and_verify_message(
             bot_without_owner, stream_name, "New members cannot send to this stream."
@@ -1549,6 +1551,7 @@ class StreamMessagesTest(ZulipTestCase):
             full_name="Normal Bot",
             bot_type=UserProfile.DEFAULT_BOT,
             bot_owner=cordelia,
+            acting_user=None,
         )
 
         content = "test @**Normal Bot** rules"
@@ -2290,6 +2293,7 @@ class CheckMessageTest(ZulipTestCase):
             full_name="",
             bot_type=UserProfile.DEFAULT_BOT,
             bot_owner=parent,
+            acting_user=None,
         )
         bot.last_reminder = None
 

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -245,6 +245,7 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
             email="whatever",
             realm=bot_owner.realm,
             password=None,
+            acting_user=None,
         )
 
         add_service(

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -268,10 +268,7 @@ class RealmEmojiTest(ZulipTestCase):
         # having same name can be administered independently.
         realm_1 = do_create_realm("test_realm", "test_realm")
         emoji_author_1 = do_create_user(
-            "abc@example.com",
-            password="abc",
-            realm=realm_1,
-            full_name="abc",
+            "abc@example.com", password="abc", realm=realm_1, full_name="abc", acting_user=None
         )
         self.create_test_emoji("test_emoji", emoji_author_1)
 

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -30,6 +30,7 @@ class TestServiceBotBasics(ZulipTestCase):
             full_name="BarBot",
             bot_type=UserProfile.OUTGOING_WEBHOOK_BOT,
             bot_owner=self.example_user("cordelia"),
+            acting_user=None,
         )
 
         return outgoing_bot
@@ -178,6 +179,7 @@ class TestServiceBotStateHandler(ZulipTestCase):
             full_name="EmbeddedBo1",
             bot_type=UserProfile.EMBEDDED_BOT,
             bot_owner=self.user_profile,
+            acting_user=None,
         )
         self.second_bot_profile = do_create_user(
             email="embedded-bot-2@zulip.com",
@@ -186,6 +188,7 @@ class TestServiceBotStateHandler(ZulipTestCase):
             full_name="EmbeddedBot2",
             bot_type=UserProfile.EMBEDDED_BOT,
             bot_owner=self.user_profile,
+            acting_user=None,
         )
 
     def test_basic_storage_and_retrieval(self) -> None:
@@ -433,6 +436,7 @@ class TestServiceBotEventTriggers(ZulipTestCase):
             full_name="FooBot",
             bot_type=UserProfile.OUTGOING_WEBHOOK_BOT,
             bot_owner=self.user_profile,
+            acting_user=None,
         )
         self.second_bot_profile = do_create_user(
             email="bar-bot@zulip.com",
@@ -441,6 +445,7 @@ class TestServiceBotEventTriggers(ZulipTestCase):
             full_name="BarBot",
             bot_type=UserProfile.OUTGOING_WEBHOOK_BOT,
             bot_owner=self.user_profile,
+            acting_user=None,
         )
 
     @for_all_bot_types

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1781,6 +1781,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
             self.user_profile.realm,
             "full name",
             prereg_user=prereg_user,
+            acting_user=None,
         )
 
         accepted_invite = PreregistrationUser.objects.filter(

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -808,6 +808,7 @@ class QueryCountTest(ZulipTestCase):
                         realm=realm,
                         full_name="Fred Flintstone",
                         prereg_user=prereg_user,
+                        acting_user=None,
                     )
 
         self.assert_length(queries, 68)
@@ -1658,6 +1659,7 @@ class RecipientInfoTest(ZulipTestCase):
             realm=realm,
             full_name="",
             bot_type=UserProfile.EMBEDDED_BOT,
+            acting_user=None,
         )
 
         info = get_recipient_info(
@@ -1680,6 +1682,7 @@ class RecipientInfoTest(ZulipTestCase):
             realm=realm,
             full_name="",
             bot_type=UserProfile.DEFAULT_BOT,
+            acting_user=None,
         )
 
         info = get_recipient_info(


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR makes `acting_user` a mandatory kwarg for functions in `zerver/lib/actions.py`.

https://github.com/zulip/zulip/issues/14808#issuecomment-663700003
(https://github.com/zulip/zulip/pull/17025#issuecomment-774279320)
