### PR TITLE
api docs: Fix documentation of update-subscription-settings.

### DIFF
--- a/templates/zerver/api/update-subscription-settings.md
+++ b/templates/zerver/api/update-subscription-settings.md
@@ -19,24 +19,6 @@
 
 {generate_api_arguments_table|zulip.yaml|/users/me/subscriptions/properties:post}
 
-The possible values for each `property` and `value` pairs are:
-
-* `color` (string): the hex value of the user's display color for the stream.
-* `is_muted` (boolean): whether the stream is
-  [muted](/help/mute-a-stream).  Prior to Zulip 2.1, this feature was
-  represented by the more confusingly named `in_home_view` (with the
-  opposite value, `in_home_view=!is_muted`); for
-  backwards-compatibility, modern Zulip still accepts that value.
-* `pin_to_top` (boolean): whether to pin the stream at the top of the stream list.
-* `desktop_notifications` (boolean): whether to show desktop notifications
-    for all messages sent to the stream.
-* `audible_notifications` (boolean): whether to play a sound
-  notification for all messages sent to the stream.
-* `push_notifications` (boolean): whether to trigger a mobile push
-    notification for all messages sent to the stream.
-* `email_notifications` (boolean): whether to trigger an email
-    notification for all messages sent to the stream.
-
 ## Response
 
 #### Return values

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4645,24 +4645,6 @@ paths:
             exist a new stream is created. The description of the stream created can
             be specified by setting the dictionary key `description` with an
             appropriate value.
-            The possible values for each `property` and `value` pairs are:
-
-            * `color` (string): the hex value of the user's display color for the stream.
-            * `is_muted` (boolean): whether the stream is
-              [muted](/help/mute-a-stream).  Prior to Zulip 2.1, this feature was
-              represented by the more confusingly named `in_home_view` (with the
-              opposite value, `in_home_view=!is_muted`); for
-              backwards-compatibility, modern Zulip still accepts that value.
-            * `pin_to_top` (boolean): whether to pin the stream at the top of the stream list.
-            * `desktop_notifications` (boolean): whether to show desktop notifications
-                for all messages sent to the stream.
-            * `audible_notifications` (boolean): whether to play a sound
-              notification for all messages sent to the stream.
-            * `push_notifications` (boolean): whether to trigger a mobile push
-                notification for all messages sent to the stream.
-            * `email_notifications` (boolean): whether to trigger an email
-                notification for all messages sent to the stream.
-
           content:
             application/json:
               schema:
@@ -5353,6 +5335,24 @@ paths:
             each subscription. Each object represents a subscription, and must have
             a `stream_id` key that identifies the stream, as well as the `property`
             being modified and its new `value`.
+
+            The possible values for each `property` and `value` pairs are:
+
+            * `color` (string): the hex value of the user's display color for the stream.
+            * `is_muted` (boolean): whether the stream is
+              [muted](/help/mute-a-stream).  Prior to Zulip 2.1, this feature was
+              represented by the more confusingly named `in_home_view` (with the
+              opposite value, `in_home_view=!is_muted`); for
+              backwards-compatibility, modern Zulip still accepts that value.
+            * `pin_to_top` (boolean): whether to pin the stream at the top of the stream list.
+            * `desktop_notifications` (boolean): whether to show desktop notifications
+                for all messages sent to the stream.
+            * `audible_notifications` (boolean): whether to play a sound
+              notification for all messages sent to the stream.
+            * `push_notifications` (boolean): whether to trigger a mobile push
+                notification for all messages sent to the stream.
+            * `email_notifications` (boolean): whether to trigger an email
+                notification for all messages sent to the stream.
           content:
             application/json:
               schema:


### PR DESCRIPTION
The description of request parameter of update-subscription-settings was wrongly pasted in yaml and wasn't completely removed from the md file. Made appropriate fixes in yaml and md file.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
