### PR TITLE
api docs: Fix non-rendering response parameter data types.

### DIFF
--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -77,7 +77,7 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
             # More correctly, we should be doing something that looks at the types;
             # print statements and test_api_doc_endpoint is useful for testing.
             arr = description.split(": ", 1)
-            if data_type != "object" or len(arr) == 1 or '\n' in arr[0]:
+            if len(arr) == 1 or '\n' in arr[0]:
                 return (spacing * " ") + "* " + description
             (key_name, key_description) = arr
             return (spacing * " ") + "* " + key_name + ": " + '<span class="api-response-datatype">' + data_type + "</span> "  + key_description


### PR DESCRIPTION
The current logic doesn't display data types when the additionalProperties are not object, but are array of strings, etc. Changed the if condition to allow rendering in such cases.  

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
**EARLIER**
![image](https://user-images.githubusercontent.com/56172924/107148923-db88c680-697b-11eb-9f2d-29ec22b2cebc.png)
**NOW**
![image](https://user-images.githubusercontent.com/56172924/107148959-083cde00-697c-11eb-9f1d-589646317dcf.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
