### PR TITLE
Incorrect "topics_header" text.

### DIFF
--- a/static/js/topic_zoom.js
+++ b/static/js/topic_zoom.js
@@ -56,7 +56,7 @@ exports.initialize = function () {
         e.stopPropagation();
     });
 
-    $(".show-all-streams").on("click", (e) => {
+    $(".show-all-topics").on("click", (e) => {
         exports.zoom_out();
 
         e.preventDefault();

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -450,7 +450,7 @@ li.expanded_private_message {
     }
 }
 
-.show-all-streams {
+.show-all-topics {
     a {
         color: hsl(0, 0%, 20%);
     }

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -78,7 +78,7 @@
                 </div>
             </div>
             <div id="topics_header">
-                <a href="" class="show-all-streams"> <i class="fa fa-chevron-left" aria-hidden="true"></i>{{ _('All streams') }}</a>
+                <a href="" class="show-all-topics"> <i class="fa fa-chevron-left" aria-hidden="true"></i>{{ _('All topics') }}</a>
             </div>
             <div id="stream-filters-container" class="scrolling_list" data-simplebar>
                 <ul id="stream_filters" class="filters"></ul>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->Issue: The topics_header section shows incorrect text when click on "more topics". The text displays "ALL STREAMS" while that should be "ALL TOPICS".


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before: 
![before_topicsheader](https://user-images.githubusercontent.com/59444243/107196407-99619280-6a18-11eb-9717-d9ce1b6615d8.png)
After:
![after_topicsheader](https://user-images.githubusercontent.com/59444243/107196423-9d8db000-6a18-11eb-91bf-c349b93eef19.png)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
