### PR TITLE
[WIP] message_edit: Restrict editing/deleting in deactivated streams.

### DIFF
--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -206,6 +206,17 @@ class InvalidJSONError(JsonableError):
         return _("Malformed JSON")
 
 
+class DeactivatedStreamError(JsonableError):
+    code: ErrorCode = ErrorCode.UNAUTHORIZED_PRINCIPAL
+
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    def msg_format() -> str:
+        return _("Cannot edit content in deactivated stream.")
+
+
 class OrganizationMemberRequired(JsonableError):
     code: ErrorCode = ErrorCode.UNAUTHORIZED_PRINCIPAL
 

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -7,8 +7,15 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
-from zerver.lib.actions import check_update_message, do_delete_messages
-from zerver.lib.exceptions import JsonableError
+from zerver.decorator import REQ, has_request_variables
+from zerver.lib.actions import (
+    check_update_message,
+    do_delete_messages,
+    do_update_message,
+    get_user_info_for_message_updates,
+    render_incoming_message,
+)
+from zerver.lib.exceptions import DeactivatedStreamError, JsonableError
 from zerver.lib.html_diff import highlight_html_differences
 from zerver.lib.message import access_message
 from zerver.lib.request import REQ, RequestNotes, has_request_variables
@@ -105,7 +112,113 @@ def update_message_backend(
     send_notification_to_new_thread: bool = REQ(default=True, json_validator=check_bool),
     content: Optional[str] = REQ(default=None),
 ) -> HttpResponse:
-    number_changed = check_update_message(
+    if not user_profile.realm.allow_message_editing:
+        return json_error(_("Your organization has turned off message editing"))
+
+    if propagate_mode != "change_one" and topic_name is None and stream_id is None:
+        return json_error(_("Invalid propagate_mode without topic edit"))
+
+    message, ignored_user_message = access_message(user_profile, message_id)
+    is_no_topic_msg = message.topic_name() == "(no topic)"
+
+    # You only have permission to edit a message if:
+    # you change this value also change those two parameters in message_edit.js.
+    # 1. You sent it, OR:
+    # 2. This is a topic-only edit for a (no topic) message, OR:
+    # 3. This is a topic-only edit and you are an admin, OR:
+    # 4. This is a topic-only edit and your realm allows users to edit topics.
+    if message.sender == user_profile:
+        pass
+    elif (content is None) and (
+        is_no_topic_msg
+        or user_profile.is_realm_admin
+        or user_profile.realm.allow_community_topic_editing
+    ):
+        pass
+    else:
+        raise JsonableError(_("You don't have permission to edit this message"))
+
+    # Disallow editing of messages in deactivated streams unless you are an admin.
+    if message.is_stream_message() and not user_profile.is_realm_admin:
+        message_stream = get_stream_by_id(message.recipient.type_id)
+        if message_stream.deactivated:
+            raise DeactivatedStreamError()
+
+    # If there is a change to the content, check that it hasn't been too long
+    # Allow an extra 20 seconds since we potentially allow editing 15 seconds
+    # past the limit, and in case there are network issues, etc. The 15 comes
+    # from (min_seconds_to_edit + seconds_left_buffer) in message_edit.js; if
+    # you change this value also change those two parameters in message_edit.js.
+    edit_limit_buffer = 20
+    if content is not None and user_profile.realm.message_content_edit_limit_seconds > 0:
+        deadline_seconds = user_profile.realm.message_content_edit_limit_seconds + edit_limit_buffer
+        if (timezone_now() - message.date_sent) > datetime.timedelta(seconds=deadline_seconds):
+            raise JsonableError(_("The time limit for editing this message has passed"))
+
+    # If there is a change to the topic, check that the user is allowed to
+    # edit it and that it has not been too long. If this is not the user who
+    # sent the message, they are not the admin, and the time limit for editing
+    # topics is passed, raise an error.
+    if (
+        content is None
+        and message.sender != user_profile
+        and not user_profile.is_realm_admin
+        and not is_no_topic_msg
+    ):
+        deadline_seconds = Realm.DEFAULT_COMMUNITY_TOPIC_EDITING_LIMIT_SECONDS + edit_limit_buffer
+        if (timezone_now() - message.date_sent) > datetime.timedelta(seconds=deadline_seconds):
+            raise JsonableError(_("The time limit for editing this message has passed"))
+
+    if topic_name is None and content is None and stream_id is None:
+        return json_error(_("Nothing to change"))
+    if topic_name is not None:
+        topic_name = topic_name.strip()
+        if topic_name == "":
+            raise JsonableError(_("Topic can't be empty"))
+    rendered_content = None
+    links_for_embed: Set[str] = set()
+    prior_mention_user_ids: Set[int] = set()
+    mention_user_ids: Set[int] = set()
+    mention_data: Optional[MentionData] = None
+    if content is not None:
+        if content.rstrip() == "":
+            content = "(deleted)"
+        content = normalize_body(content)
+
+        mention_data = MentionData(
+            realm_id=user_profile.realm.id,
+            content=content,
+        )
+        user_info = get_user_info_for_message_updates(message.id)
+        prior_mention_user_ids = user_info["mention_user_ids"]
+
+        # We render the message using the current user's realm; since
+        # the cross-realm bots never edit messages, this should be
+        # always correct.
+        # Note: If rendering fails, the called code will raise a JsonableError.
+        rendered_content = render_incoming_message(
+            message,
+            content,
+            user_info["message_user_ids"],
+            user_profile.realm,
+            mention_data=mention_data,
+        )
+        links_for_embed |= message.links_for_preview
+
+        mention_user_ids = message.mentions_user_ids
+
+    new_stream = None
+    number_changed = 0
+
+    if stream_id is not None:
+        if not user_profile.is_realm_admin:
+            raise JsonableError(_("You don't have permission to move this message"))
+        if content is not None:
+            raise JsonableError(_("Cannot change message content while changing stream"))
+
+        new_stream = get_stream_by_id(stream_id)
+
+    number_changed = do_update_message(
         user_profile,
         message_id,
         stream_id,
@@ -134,6 +247,11 @@ def validate_can_delete_message(user_profile: UserProfile, message: Message) -> 
     if not user_profile.realm.allow_message_deleting:
         # User can not delete message, if message deleting is not allowed in realm.
         raise JsonableError(_("You don't have permission to delete this message"))
+    if message.is_stream_message():
+        message_stream = get_stream_by_id(message.recipient.type_id)
+        if message_stream.deactivated:
+            # Users can not delete messages in deactivated streams.
+            raise DeactivatedStreamError()
 
     deadline_seconds = user_profile.realm.message_content_delete_limit_seconds
     if deadline_seconds == 0:

--- a/zerver/views/reactions.py
+++ b/zerver/views/reactions.py
@@ -4,13 +4,28 @@ from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
-from zerver.lib.actions import check_add_reaction, do_remove_reaction
-from zerver.lib.emoji import emoji_name_to_emoji_code
-from zerver.lib.exceptions import JsonableError
+from zerver.decorator import REQ, has_request_variables
+from zerver.lib.actions import check_add_reaction, do_add_reaction, do_remove_reaction
+from zerver.lib.emoji import check_emoji_request, emoji_name_to_emoji_code
+from zerver.lib.exceptions import DeactivatedStreamError, JsonableError
 from zerver.lib.message import access_message
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
-from zerver.models import Reaction, UserProfile
+from zerver.lib.streams import get_stream_by_id
+from zerver.models import Message, Reaction, UserMessage, UserProfile
+
+
+def create_historical_message(user_profile: UserProfile, message: Message) -> None:
+    # Users can see and react to messages sent to streams they
+    # were not a subscriber to; in order to receive events for
+    # those, we give the user a `historical` UserMessage objects
+    # for the message.  This is the same trick we use for starring
+    # messages.
+    UserMessage.objects.create(
+        user_profile=user_profile,
+        message=message,
+        flags=UserMessage.flags.historical | UserMessage.flags.read,
+    )
 
 
 # transaction.atomic is required since we use FOR UPDATE queries in access_message
@@ -24,7 +39,63 @@ def add_reaction(
     emoji_code: Optional[str] = REQ(default=None),
     reaction_type: Optional[str] = REQ(default=None),
 ) -> HttpResponse:
-    check_add_reaction(user_profile, message_id, emoji_name, emoji_code, reaction_type)
+    message, user_message = access_message(user_profile, message_id)
+
+    if message.is_stream_message():
+        message_stream = get_stream_by_id(message.recipient.type_id)
+        if message_stream.deactivated:
+            raise DeactivatedStreamError()
+
+    if emoji_code is None:
+        # The emoji_code argument is only required for rare corner
+        # cases discussed in the long block comment below.  For simple
+        # API clients, we allow specifying just the name, and just
+        # look up the code using the current name->code mapping.
+        emoji_code = emoji_name_to_emoji_code(message.sender.realm, emoji_name)[0]
+
+    if reaction_type is None:
+        reaction_type = emoji_name_to_emoji_code(message.sender.realm, emoji_name)[1]
+
+    if Reaction.objects.filter(
+        user_profile=user_profile,
+        message=message,
+        emoji_code=emoji_code,
+        reaction_type=reaction_type,
+    ).exists():
+        raise JsonableError(_("Reaction already exists."))
+
+    query = Reaction.objects.filter(
+        message=message, emoji_code=emoji_code, reaction_type=reaction_type
+    )
+    if query.exists():
+        # If another user has already reacted to this message with
+        # same emoji code, we treat the new reaction as a vote for the
+        # existing reaction.  So the emoji name used by that earlier
+        # reaction takes precedence over whatever was passed in this
+        # request.  This is necessary to avoid a message having 2
+        # "different" emoji reactions with the same emoji code (and
+        # thus same image) on the same message, which looks ugly.
+        #
+        # In this "voting for an existing reaction" case, we shouldn't
+        # check whether the emoji code and emoji name match, since
+        # it's possible that the (emoji_type, emoji_name, emoji_code)
+        # triple for this existing rection xmay not pass validation
+        # now (e.g. because it is for a realm emoji that has been
+        # since deactivated).  We still want to allow users to add a
+        # vote any old reaction they see in the UI even if that is a
+        # deactivated custom emoji, so we just use the emoji name from
+        # the existing reaction with no further validation.
+        emoji_name = query.first().emoji_name
+    else:
+        # Otherwise, use the name provided in this request, but verify
+        # it is valid in the user's realm (e.g. not a deactivated
+        # realm emoji).
+        check_emoji_request(user_profile.realm, emoji_name, emoji_code, reaction_type)
+
+    if user_message is None:
+        create_historical_message(user_profile, message)
+
+    do_add_reaction(user_profile, message, emoji_name, emoji_code, reaction_type)
 
     return json_success()
 
@@ -41,6 +112,11 @@ def remove_reaction(
     reaction_type: str = REQ(default="unicode_emoji"),
 ) -> HttpResponse:
     message, user_message = access_message(user_profile, message_id, lock_message=True)
+
+    if message.is_stream_message():
+        message_stream = get_stream_by_id(message.recipient.type_id)
+        if message_stream.deactivated:
+            raise DeactivatedStreamError()
 
     if emoji_code is None:
         if emoji_name is None:


### PR DESCRIPTION
Users were able to edit/delete their messages in deactivated streams.
Added checks to see if a message is part of a deactivated stream before allowing these actions by non admin users.
If a user attempts to edit or delete a message in a deactivated stream an error is now displayed to the user.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Fixes #17231.

**Testing plan:** <!-- How have you tested? -->

Passed existing automated testing locally, tested new restrictions manually.
Added/modified automating testing to cover new changes.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![Edit](https://media.giphy.com/media/uNpEKpZvUShxH9rorr/giphy.gif)

![Delete](https://media.giphy.com/media/Jgimmzn9cQrF9GT9GQ/giphy.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
