### PR TITLE
digest: Fix the structure that we enqueue across when digesting.

### DIFF
--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -88,7 +88,7 @@ def should_process_digest(realm_str: str) -> bool:
 def queue_digest_user_ids(user_ids: List[int], cutoff: datetime.datetime) -> None:
     # Convert cutoff to epoch seconds for transit.
     event = {
-        "user_profile_id": user_ids,
+        "user_ids": user_ids,
         "cutoff": cutoff.strftime('%s')
     }
     queue_json_publish("digest_emails", event)

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -313,7 +313,7 @@ class TestDigestEmailMessages(ZulipTestCase):
 
         # Check that all users without an a UserActivityInterval entry are considered
         # inactive users and get enqueued.
-        with mock.patch('zerver.lib.digest.queue_digest_user_ids') as queue_mock:
+        with mock.patch('zerver.worker.queue_processors.bulk_handle_digest_email') as queue_mock:
             _enqueue_emails_for_realm(realm, cutoff)
 
         num_queued_users = len(queue_mock.call_args[0][0])
@@ -328,7 +328,7 @@ class TestDigestEmailMessages(ZulipTestCase):
             )
 
         # Now we expect no users, due to recent activity.
-        with mock.patch('zerver.lib.digest.queue_digest_user_ids') as queue_mock:
+        with mock.patch('zerver.worker.queue_processors.bulk_handle_digest_email') as queue_mock:
             _enqueue_emails_for_realm(realm, cutoff)
 
         self.assertEqual(queue_mock.call_count, 0)
@@ -337,7 +337,7 @@ class TestDigestEmailMessages(ZulipTestCase):
         last_visit = timezone_now() - datetime.timedelta(days=7)
         UserActivityInterval.objects.all().update(start=last_visit, end=last_visit)
 
-        with mock.patch('zerver.lib.digest.queue_digest_user_ids') as queue_mock:
+        with mock.patch('zerver.worker.queue_processors.bulk_handle_digest_email') as queue_mock:
             _enqueue_emails_for_realm(realm, cutoff)
 
         num_queued_users = len(queue_mock.call_args[0][0])

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -612,7 +612,6 @@ class DigestWorker(QueueProcessingWorker):  # nocoverage
     # Who gets a digest is entirely determined by the enqueue_digest_emails
     # management command, not here.
     def consume(self, event: Mapping[str, Any]) -> None:
-        logging.info("Received digest event: %s", event)
         if "user_ids" in event:
             user_ids = event["user_ids"]
         else:


### PR DESCRIPTION
This rename was missed in bfa0bdf3d665cb2d5ac7bebda83c6db9b56ee08e.
Without this fix, digest messages fail to send.

**Testing plan:** Added a test, verified it failed before and passed after.