### PR TITLE
[WIP] Show Zulip version in menu

### DIFF
--- a/static/js/about_zulip.js
+++ b/static/js/about_zulip.js
@@ -1,0 +1,9 @@
+export function launch() {
+    overlays.open_overlay({
+        name: "about-zulip",
+        overlay: $("#about-zulip"),
+        on_close() {
+            hashchange.exit_overlay();
+        },
+    });
+}

--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -20,6 +20,7 @@ link:  Help center
 info:  Keyboard shortcuts
 info:  Message formatting
 info:  Search operators
+hash:  About Zulip
 ---
 link:  Desktop & mobile apps
 link:  Integrations
@@ -47,6 +48,7 @@ links:
     #streams
     #settings
     #organization
+    #about-zulip
     #invite
 
 When you click on the links there is a function

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const about_zulip = require("./about_zulip");
 const invite = require("./invite");
 
 // Read https://zulip.readthedocs.io/en/latest/subsystems/hashchange-system.html
@@ -80,6 +81,7 @@ function is_overlay_hash(hash) {
         "keyboard-shortcuts",
         "message-formatting",
         "search-operators",
+        "about-zulip",
     ];
     const main_hash = hash_util.get_hash_category(hash);
 
@@ -134,6 +136,7 @@ function do_hashchange_normal(from_reload) {
         case "#organization":
         case "#settings":
         case "#recent_topics":
+        case "#about-zulip":
             blueslip.error("overlay logic skipped for: " + hash);
             break;
     }
@@ -239,6 +242,10 @@ function do_hashchange_overlay(old_hash) {
     if (base === "search-operators") {
         info_overlay.show("search-operators");
         return;
+    }
+
+    if (base === "about-zulip") {
+        about_zulip.launch();
     }
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -632,12 +632,27 @@ li.actual-dropdown-menu > a:focus {
     outline: 0;
 }
 
-li.actual-dropdown-menu i {
+li.actual-dropdown-menu i,
+li.actual-dropdown-menu svg {
     /* In gear menu, make icons the same width so labels line up. */
     display: inline-block;
     width: 14px;
     text-align: center;
     margin-right: 3px;
+}
+
+li.actual-dropdown-menu svg {
+    fill: hsl(0, 0%, 27%);
+    transform: translateY(2px);
+}
+
+body.night-mode li.actual-dropdown-menu svg {
+    fill: hsl(0, 0%, 100%);
+}
+
+.menuitem-version:hover > svg,
+.menuitem-version:focus > svg {
+    fill: hsl(0, 0%, 100%);
 }
 
 .settings-dropdown-cog {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2614,6 +2614,40 @@ select.inline_select_topic_edit {
     display: none;
 }
 
+#about-zulip {
+    .exit {
+        font-size: 1.5rem;
+        font-weight: 600;
+        background-color: transparent;
+        border: none;
+        position: absolute;
+        right: 8px;
+        z-index: 1;
+        color: hsl(0, 0%, 67%);
+    }
+
+    .overlay-content {
+        position: relative;
+        width: 300px;
+        border-radius: 4px;
+    }
+
+    .modal-body {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    #zulip_logo {
+        height: 40px;
+    }
+
+    .zulip_title {
+        font-weight: 600;
+        padding-bottom: 10px;
+    }
+}
+
 /* This max-width must be synced with message_viewport.is_narrow */
 @media (width < $xl_min) {
     .app-main,

--- a/templates/zerver/app/about-zulip.html
+++ b/templates/zerver/app/about-zulip.html
@@ -1,0 +1,12 @@
+<div id="about-zulip" class="overlay flex new-style" tabindex="-1" role="dialog" data-overlay="about-zulip"
+  aria-labelledby="about-zulip-label" aria-hidden="true">
+    <div class="overlay-content modal-bg">
+        <button type="button" class="exit" aria-label="{{ _('Close') }}"><span aria-hidden="true">&times;</span></button>
+        <div class="modal-body">
+            <img id="zulip_logo" src="/static/images/favicon.png" alt="" />
+            <div class="zulip_title">Zulip</div>
+            <p>{{ _('Zulip ' + zulip_version)}}</p>
+            <p>Zulip is <a href="https://github.com/zulip/zulip">open-source software</a></p>
+        </div>
+    </div>
+</div>

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -170,6 +170,7 @@
     {% include "zerver/app/invite_user.html" %}
     {% include "zerver/app/logout.html" %}
     {% include "zerver/app/deprecation_notice.html" %}
+    {% include "zerver/app/about-zulip.html" %}
     <div id="user-profile-modal-holder"></div>
     <div class='notifications top-right'></div>
     <div id="delete-topic-modal-holder"></div>

--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -104,6 +104,12 @@
                                 </a>
                             </li>
                             {% endif %}
+                            <li role="presentation">
+                                <a href="https://zulip.readthedocs.io/en/latest/overview/changelog.html"  target="_blank" rel="noopener noreff" role="menuitem" class="menuitem-version">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="49.99 49.99 673.14 673.14"><path d="M688.52 150.67c0 33.91-15.23 64.04-38.44 82.31L424.79 434.17c-4.18 3.59-9.62-2.19-6.61-7.03l82.64-165.46c2.31-4.63-.69-10.33-5.44-10.33H174.86c-49.64 0-90.26-45.31-90.26-100.68 0-55.37 40.62-100.68 90.26-100.68h423.39c49.65 0 90.27 45.31 90.27 100.68zM174.86 723.13h423.39c49.64 0 90.26-45.31 90.26-100.68 0-55.37-40.62-100.68-90.26-100.68H277.73c-4.75 0-7.76-5.7-5.44-10.33l82.64-165.46c3.01-4.83-2.42-10.62-6.61-7.03L123.04 540.14c-23.21 18.27-38.44 48.4-38.44 82.31 0 55.37 40.62 100.68 90.26 100.68z" /></svg>
+                                    {{ _('Zulip ' + (zulip_version[:-4] if zulip_version.endswith('+git') else zulip_version) ) }}
+                                </a>
+                            </li>
                             <li class="divider" role="presentation"></li>
                             <li role="presentation">
                                 <a href="{{ apps_page_url }}" target="_blank" rel="noopener noreferrer" role="menuitem">

--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -105,9 +105,9 @@
                             </li>
                             {% endif %}
                             <li role="presentation">
-                                <a href="https://zulip.readthedocs.io/en/latest/overview/changelog.html"  target="_blank" rel="noopener noreff" role="menuitem" class="menuitem-version">
+                                <a href="#about-zulip" role="menuitem" class="menuitem-version">
                                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="49.99 49.99 673.14 673.14"><path d="M688.52 150.67c0 33.91-15.23 64.04-38.44 82.31L424.79 434.17c-4.18 3.59-9.62-2.19-6.61-7.03l82.64-165.46c2.31-4.63-.69-10.33-5.44-10.33H174.86c-49.64 0-90.26-45.31-90.26-100.68 0-55.37 40.62-100.68 90.26-100.68h423.39c49.65 0 90.27 45.31 90.27 100.68zM174.86 723.13h423.39c49.64 0 90.26-45.31 90.26-100.68 0-55.37-40.62-100.68-90.26-100.68H277.73c-4.75 0-7.76-5.7-5.44-10.33l82.64-165.46c3.01-4.83-2.42-10.62-6.61-7.03L123.04 540.14c-23.21 18.27-38.44 48.4-38.44 82.31 0 55.37 40.62 100.68 90.26 100.68z" /></svg>
-                                    {{ _('Zulip ' + (zulip_version[:-4] if zulip_version.endswith('+git') else zulip_version) ) }}
+                                    {{ _('About') + ' Zulip' }}
                                 </a>
                             </li>
                             <li class="divider" role="presentation"></li>


### PR DESCRIPTION
I've added the Zulip version number in the gear menu. Added a conditional for when version number ends in '+git' it omits that part.
Fixes #8005 

![Screenshot from 2021-02-09 15-26-50](https://user-images.githubusercontent.com/59016893/107350807-e7959500-6aef-11eb-9041-6df6e6810b73.png)
![Screenshot from 2021-02-09 15-28-29](https://user-images.githubusercontent.com/59016893/107350812-e8c6c200-6aef-11eb-8829-ebab8302825c.png)
