### PR TITLE
[WIP] Show users in left sidebar

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -124,6 +124,9 @@ exports.initialize_kitchen_sink_stuff = function () {
 
     if (!page_params.left_side_userlist) {
         $("#navbar-buttons").addClass("right-userlist");
+    } else {
+        $("#userlist-toggle").hide();
+        $("#navbar-buttons").removeClass("right-userlist");
     }
 
     if (page_params.high_contrast_mode) {


### PR DESCRIPTION
Hide the user toggle icon when the setting "show users on left when the screen is narrower" is checked

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/17247

**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/28783073/107355005-e450d800-6af4-11eb-824c-8c3380c1644f.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
