### PR TITLE
[WIP] Make user profile picture adjustable.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clean-css": "^4.2.1",
     "clipboard": "^2.0.4",
     "core-js": "^3.6.5",
+    "cropperjs": "^1.5.9",
     "css-loader": "^5.0.0",
     "css.escape": "^1.5.1",
     "date-fns": "^2.16.1",

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -11,6 +11,7 @@ import "spectrum-colorpicker";
 import "jquery-validation";
 import "flatpickr";
 import "flatpickr/dist/plugins/confirmDate/confirmDate";
+import "cropperjs/dist/cropper.min.css";
 
 // Import app JS
 import "../i18n";
@@ -227,6 +228,7 @@ import "../../styles/hotspots.css";
 import "../../styles/night_mode.css";
 import "../../styles/user_status.css";
 import "../../styles/widgets.css";
+import "../../styles/image_edit_modal.css";
 
 // This should be last.
 import "../ready";

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -639,6 +639,7 @@ exports.set_up = function () {
     });
 
     function upload_avatar(file_input) {
+        // here we can get the edited file as extra parameter sent from upload_Widget.js and then send to server.
         const form_data = new FormData();
 
         form_data.append("csrfmiddlewaretoken", csrf_token);

--- a/static/styles/image_edit_modal.css
+++ b/static/styles/image_edit_modal.css
@@ -1,0 +1,40 @@
+.canvas {
+    align-items: center;
+    height: calc(100vh - 300px);
+    justify-content: center;
+    & > img {
+        width: 100%;
+        height: 100%;
+    }
+}
+.image-edit-toolbar {
+    background-color: hsla(0, 0%, 0%, 0.5);
+    bottom: 1rem;
+    color: hsl(0, 0%, 100%);
+    height: 2rem;
+    left: 50%;
+    margin-left: -6rem;
+    position: absolute;
+    width: 12rem;
+    z-index: 500;
+    .edit__toolbar__button {
+        background-color: transparent;
+        border-width: 0;
+        color: #fff;
+        cursor: pointer;
+        display: flex;
+        float: left;
+        font-size: 0.875rem;
+        height: 2rem;
+        justify-content: center;
+        align-items: center;
+        width: 1.5rem;
+        &:focus {
+            outline: none;
+        }
+        &:hover {
+            background-color: hsl(208, 100%, 43%);
+            color: hsl(0, 0%, 100%);
+        }
+    }
+}

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -163,6 +163,7 @@
             <div id="user-avatar-source">
                 <a href="https://en.gravatar.com/" target="_blank" rel="noopener noreferrer">{{t "Avatar from Gravatar" }}</a>
             </div>
+            {{> image_edit_modal}}
         </div>
         <div class="clear-float"></div>
 

--- a/static/templates/settings/image_edit_modal.hbs
+++ b/static/templates/settings/image_edit_modal.hbs
@@ -1,0 +1,74 @@
+<div id="image_edit_modal" class="modal modal-bg hide fade image_edit_modal" tabindex="-1" role="dialog" aria-labelledby="image_edit_modal_label" aria-hidden="true">
+    <div class="modal-dialog image-edit-dialog" role="dialog-container">
+        <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+            <h3 id="image_edit_modal_label">{{t 'Edit Image' }}</h3>
+        </div>
+        <div class="modal-body image-edit-body">
+            <div class="canvas">
+                <img id="uploaded-image" src="" alt="uploaded-image" class="uploaded-image" >
+            </div>
+            <div class="image-edit-toolbar">
+                <button
+                    class="edit__toolbar__button"
+                    data-action="move"
+                    title="Move"
+                >
+                    <span class="fa fa-arrows" />
+                </button>
+                <button
+                    class="edit__toolbar__button"
+                    data-action="crop"
+                    title="Crop"
+                >
+                    <span class="fa fa-crop" />
+                </button>
+                <button
+                    class="edit__toolbar__button"
+                    data-action="zoom-in"
+                    title="Zoom In"
+                >
+                    <span class="fa fa-search-plus" />
+                </button>
+                <button
+                    class="edit__toolbar__button"
+                    data-action="zoom-out"
+                    title="Zoom Out"
+                >
+                    <span class="fa fa-search-minus" />
+                </button>
+                <button
+                    class="edit__toolbar__button"
+                    data-action="rotate-left"
+                    title="Rotate Left"
+                >
+                    <span class="fa fa-rotate-left" />
+                </button>
+                <button
+                    class="edit__toolbar__button"
+                    data-action="rotate-right"
+                    title="Rotate Right"
+                >
+                    <span class="fa fa-rotate-right" />
+                </button>
+                <button
+                    class="edit__toolbar__button"
+                    data-action="flip-horizontal"
+                    title="Flip Horizontal"
+                >
+                    <span class="fa fa-arrows-h" />
+                </button>
+                <button
+                    class="edit__toolbar__button"
+                    data-action="flip-vertical"
+                    title="Flip Vertical"
+                >
+                    <span class="fa fa-arrows-v" />
+                </button>
+            </div>
+        </div>
+        <div class="modal-footer">
+            <button id='confirm_edit_button' class="button rounded sea-green">{{t "Confirm" }}</button>
+        </div>
+    </div>
+</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3470,6 +3470,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cropperjs@^1.5.9:
+  version "1.5.9"
+  resolved "https://registry.yarnpkg.com/cropperjs/-/cropperjs-1.5.9.tgz#4ff9d31e02ad04d2fc5df0044207c2ad53d99da8"
+  integrity sha512-aPWlg43sLIcYN4GBXIdyvM09wNPgn1ug+vNVwV8jlb3dbgEX/B34Iw6hrjGSajkUDQBmaCi6uPOevFb7N0yUsw==
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -13039,8 +13044,10 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Related issue: #16579 .
I am done with most of the work related to this issue but I am blocked due to a problem:

I have made a modal for supporting this feature which opens when a user uploads a file and then it gives various options for editing the image. I had set the css rules so that uploaded image is properly positioned in the modal at all sizes of screen. But as soon as I initialize `Cropper` constructor then it hides the image element for which I set the style rules and creates it's own custom elements for which style is not proper and image displayed is quite small. I tried adding some css rules to set styles for elements created by cropper but it seems not working. I will update the pr as soon as I resolve this issue for elements created by cropper is solved.
Along with that I need to add frontend tests as soon as above issue is resolved.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![ezgif com-crop(1)](https://user-images.githubusercontent.com/63504956/107368251-541b8e80-6b06-11eb-935d-6c555e8bd99d.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
