### PR TITLE
[WIP]refactor: Integrate POSTRequestMock into HostRequestMock.

### DIFF
--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -7,7 +7,7 @@ from django.http import HttpRequest, HttpResponse
 
 from zerver.lib.actions import do_change_subscription_property, do_mute_topic
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import POSTRequestMock, mock_queue_publish
+from zerver.lib.test_helpers import HostRequestMock, mock_queue_publish
 from zerver.models import Recipient, Stream, Subscription, UserProfile, get_stream
 from zerver.tornado.event_queue import (
     ClientDescriptor,
@@ -288,7 +288,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         user_profile: UserProfile,
         post_data: Dict[str, Any],
     ) -> HttpResponse:
-        request = POSTRequestMock(post_data, user_profile)
+        request = HostRequestMock(post_data, user_profile)
         return view_func(request, user_profile)
 
     def test_stream_watchers(self) -> None:

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -9,7 +9,7 @@ from django.http import HttpRequest, HttpResponse
 from zerver.lib.actions import check_send_message, do_change_user_role, do_set_realm_property
 from zerver.lib.events import fetch_initial_state_data, get_raw_user_data
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import POSTRequestMock, queries_captured, stub_event_queue_user_events
+from zerver.lib.test_helpers import HostRequestMock, queries_captured, stub_event_queue_user_events
 from zerver.lib.users import get_api_key
 from zerver.models import (
     Realm,
@@ -145,13 +145,13 @@ class EventsEndpointTest(ZulipTestCase):
                 ),
             ).decode(),
         )
-        req = POSTRequestMock(post_data, user_profile=None)
+        req = HostRequestMock(post_data, user_profile=None)
         req.META["REMOTE_ADDR"] = "127.0.0.1"
         result = self.client_post_request("/notify_tornado", req)
         self.assert_json_error(result, "Access denied", status_code=403)
 
         post_data["secret"] = settings.SHARED_SECRET
-        req = POSTRequestMock(post_data, user_profile=None)
+        req = HostRequestMock(post_data, user_profile=None)
         req.META["REMOTE_ADDR"] = "127.0.0.1"
         result = self.client_post_request("/notify_tornado", req)
         self.assert_json_success(result)
@@ -164,7 +164,7 @@ class GetEventsTest(ZulipTestCase):
         user_profile: UserProfile,
         post_data: Dict[str, Any],
     ) -> HttpResponse:
-        request = POSTRequestMock(post_data, user_profile)
+        request = HostRequestMock(post_data, user_profile)
         return view_func(request, user_profile)
 
     def test_get_events(self) -> None:

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -33,7 +33,7 @@ from zerver.lib.request import JsonableError
 from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
 from zerver.lib.streams import StreamDict, create_streams_if_needed, get_public_streams_queryset
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import POSTRequestMock, get_user_messages, queries_captured
+from zerver.lib.test_helpers import HostRequestMock, get_user_messages, queries_captured
 from zerver.lib.topic import MATCH_TOPIC, TOPIC_NAME
 from zerver.lib.topic_mutes import set_topic_mutes
 from zerver.lib.types import DisplayRecipientT
@@ -2927,7 +2927,7 @@ class GetOldMessagesTest(ZulipTestCase):
         self, query_params: Dict[str, object], expected: str
     ) -> None:
         user_profile = self.example_user("hamlet")
-        request = POSTRequestMock(query_params, user_profile)
+        request = HostRequestMock(query_params, user_profile)
         with queries_captured() as queries:
             get_messages_backend(request, user_profile)
 
@@ -2986,7 +2986,7 @@ class GetOldMessagesTest(ZulipTestCase):
             num_after=10,
             narrow='[["stream", "England"]]',
         )
-        request = POSTRequestMock(query_params, user_profile)
+        request = HostRequestMock(query_params, user_profile)
 
         payload = get_messages_backend(request, user_profile)
         result = orjson.loads(payload.content)
@@ -3023,7 +3023,7 @@ class GetOldMessagesTest(ZulipTestCase):
             num_after=10,
             narrow="[]",
         )
-        request = POSTRequestMock(query_params, user_profile)
+        request = HostRequestMock(query_params, user_profile)
 
         payload = get_messages_backend(request, user_profile)
         result = orjson.loads(payload.content)
@@ -3036,7 +3036,7 @@ class GetOldMessagesTest(ZulipTestCase):
             num_after=10,
             narrow="[]",
         )
-        request = POSTRequestMock(query_params, user_profile)
+        request = HostRequestMock(query_params, user_profile)
 
         payload = get_messages_backend(request, user_profile)
         result = orjson.loads(payload.content)
@@ -3050,7 +3050,7 @@ class GetOldMessagesTest(ZulipTestCase):
             num_after=10,
             narrow="[]",
         )
-        request = POSTRequestMock(query_params, user_profile)
+        request = HostRequestMock(query_params, user_profile)
 
         payload = get_messages_backend(request, user_profile)
         result = orjson.loads(payload.content)
@@ -3064,7 +3064,7 @@ class GetOldMessagesTest(ZulipTestCase):
             num_after=10,
             narrow="[]",
         )
-        request = POSTRequestMock(query_params, user_profile)
+        request = HostRequestMock(query_params, user_profile)
 
         payload = get_messages_backend(request, user_profile)
         result = orjson.loads(payload.content)
@@ -3078,7 +3078,7 @@ class GetOldMessagesTest(ZulipTestCase):
             num_after=10,
             narrow="[]",
         )
-        request = POSTRequestMock(query_params, user_profile)
+        request = HostRequestMock(query_params, user_profile)
 
         payload = get_messages_backend(request, user_profile)
         result = orjson.loads(payload.content)
@@ -3106,7 +3106,7 @@ class GetOldMessagesTest(ZulipTestCase):
             num_after=10,
             narrow="[]",
         )
-        request = POSTRequestMock(query_params, user_profile)
+        request = HostRequestMock(query_params, user_profile)
 
         with queries_captured() as all_queries:
             get_messages_backend(request, user_profile)
@@ -3151,7 +3151,7 @@ class GetOldMessagesTest(ZulipTestCase):
             num_after=10,
             narrow="[]",
         )
-        request = POSTRequestMock(query_params, user_profile)
+        request = HostRequestMock(query_params, user_profile)
 
         first_visible_message_id = first_unread_message_id + 2
         with first_visible_id_as(first_visible_message_id):
@@ -3177,7 +3177,7 @@ class GetOldMessagesTest(ZulipTestCase):
             num_after=10,
             narrow="[]",
         )
-        request = POSTRequestMock(query_params, user_profile)
+        request = HostRequestMock(query_params, user_profile)
 
         with queries_captured() as all_queries:
             get_messages_backend(request, user_profile)
@@ -3229,7 +3229,7 @@ class GetOldMessagesTest(ZulipTestCase):
             num_after=0,
             narrow='[["stream", "Scotland"]]',
         )
-        request = POSTRequestMock(query_params, user_profile)
+        request = HostRequestMock(query_params, user_profile)
 
         with queries_captured() as all_queries:
             get_messages_backend(request, user_profile)


### PR DESCRIPTION
Minimized code duplication by integrating POSTRequestMock into
HostRequestMock and then updating the required files with
HostRequestMock.

Fixes part of #1211.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Local tests ran.
Current failing:  ./tools/test-backend --include-webhooks --ban-console-output
CircleCI tests passed!



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
