### PR TITLE
frontend_tests: Don’t read from most deprecated global variables

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -105,7 +105,15 @@
     },
     "overrides": [
         {
-            "files": ["frontend_tests/**", "static/js/**"],
+            "files": ["frontend_tests/puppeteer_lib/**", "frontend_tests/puppeteer_tests/**"],
+            "globals": {
+                "$": false,
+                "current_msg_list": false,
+                "page_params": false
+            }
+        },
+        {
+            "files": ["frontend_tests/node_tests/**", "frontend_tests/zjsunit/**", "static/js/**"],
             "globals": {
                 "$": false,
                 "FetchStatus": false,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -105,6 +105,18 @@
     },
     "overrides": [
         {
+            "files": ["frontend_tests/node_tests/**"],
+            "globals": {
+                "$": false,
+                "blueslip": false,
+                "current_msg_list": false,
+                "home_msg_list": false,
+                "i18n": false,
+                "location": false,
+                "page_params": false
+            }
+        },
+        {
             "files": ["frontend_tests/puppeteer_lib/**", "frontend_tests/puppeteer_tests/**"],
             "globals": {
                 "$": false,
@@ -113,7 +125,7 @@
             }
         },
         {
-            "files": ["frontend_tests/node_tests/**", "frontend_tests/zjsunit/**", "static/js/**"],
+            "files": ["static/js/**"],
             "globals": {
                 "$": false,
                 "FetchStatus": false,

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -26,7 +26,7 @@ const _document = {
     },
 };
 
-const _channel = {};
+const channel = {};
 
 const _ui = {
     get_content_element: (element) => element,
@@ -38,7 +38,7 @@ const _keydown_util = {
     },
 };
 
-const _compose_state = {};
+const compose_state = {};
 
 const _scroll_util = {
     scroll_element_into_container: () => {},
@@ -66,8 +66,8 @@ const _resize = {
 set_global("padded_widget", {
     update_padding: () => {},
 });
-set_global("channel", _channel);
-set_global("compose_state", _compose_state);
+set_global("channel", channel);
+set_global("compose_state", compose_state);
 set_global("document", _document);
 set_global("keydown_util", _keydown_util);
 set_global("page_params", _page_params);
@@ -78,18 +78,18 @@ set_global("scroll_util", _scroll_util);
 set_global("stream_popover", _stream_popover);
 set_global("ui", _ui);
 
-zrequire("compose_fade");
+const compose_fade = zrequire("compose_fade");
 zrequire("unread");
 zrequire("hash_util");
-zrequire("narrow");
-zrequire("presence");
+const narrow = zrequire("narrow");
+const presence = zrequire("presence");
 const people = zrequire("people");
-zrequire("buddy_data");
-zrequire("buddy_list");
+const buddy_data = zrequire("buddy_data");
+const buddy_list = zrequire("buddy_list");
 zrequire("user_search");
-zrequire("user_status");
+const user_status = zrequire("user_status");
 zrequire("list_cursor");
-zrequire("activity");
+const activity = zrequire("activity");
 
 const me = {
     email: "me@zulip.com",

--- a/frontend_tests/node_tests/alert_words.js
+++ b/frontend_tests/node_tests/alert_words.js
@@ -10,7 +10,7 @@ const params = {
 };
 
 const people = zrequire("people");
-zrequire("alert_words");
+const alert_words = zrequire("alert_words");
 
 alert_words.initialize(params);
 

--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -9,10 +9,10 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());
 
-set_global("channel", {});
+const channel = set_global("channel", {});
 
-zrequire("alert_words");
-zrequire("alert_words_ui");
+const alert_words = zrequire("alert_words");
+const alert_words_ui = zrequire("alert_words_ui");
 
 alert_words.initialize({
     alert_words: ["foo", "bar"],

--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -14,10 +14,10 @@ const template = fs.readFileSync("templates/corporate/billing.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});
 const document = dom.window.document;
 
-set_global("helpers", {
+const helpers = set_global("helpers", {
     set_tab: noop,
 });
-set_global("StripeCheckout", {
+const StripeCheckout = set_global("StripeCheckout", {
     configure: noop,
 });
 

--- a/frontend_tests/node_tests/billing_helpers.js
+++ b/frontend_tests/node_tests/billing_helpers.js
@@ -16,8 +16,8 @@ const jquery = jQueryFactory(dom.window);
 
 set_global("$", make_zjquery());
 set_global("page_params", {});
-set_global("loading", {});
-set_global("history", {});
+const loading = set_global("loading", {});
+const history = set_global("history", {});
 set_global("document", {
     title: "Zulip",
 });
@@ -27,7 +27,7 @@ set_global("location", {
     hash: "#billing",
 });
 
-zrequire("helpers", "js/billing/helpers");
+const helpers = zrequire("helpers", "js/billing/helpers");
 
 run_test("create_ajax_request", () => {
     const form_loading_indicator = "#autopay_loading_indicator";

--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -11,7 +11,7 @@ const _settings_bots = {
 
 set_global("settings_bots", _settings_bots);
 
-zrequire("bot_data");
+const bot_data = zrequire("bot_data");
 const people = zrequire("people");
 
 const me = {

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -13,11 +13,11 @@ const _page_params = {};
 set_global("page_params", _page_params);
 set_global("$", make_zjquery());
 const people = zrequire("people");
-zrequire("presence");
-zrequire("user_status");
+const presence = zrequire("presence");
+const user_status = zrequire("user_status");
 
-zrequire("buddy_data");
-set_global("timerender", {});
+const buddy_data = zrequire("buddy_data");
+const timerender = set_global("timerender", {});
 
 // The buddy_data module is mostly tested indirectly through
 // activity.js, but we should feel free to add direct tests

--- a/frontend_tests/node_tests/buddy_list.js
+++ b/frontend_tests/node_tests/buddy_list.js
@@ -11,7 +11,7 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 set_global("$", make_zjquery());
 const people = zrequire("people");
 zrequire("buddy_data");
-zrequire("buddy_list");
+const buddy_list = zrequire("buddy_list");
 zrequire("ui");
 
 set_global("padded_widget", {

--- a/frontend_tests/node_tests/channel.js
+++ b/frontend_tests/node_tests/channel.js
@@ -9,9 +9,9 @@ const {run_test} = require("../zjsunit/test");
 
 set_global("$", {});
 
-set_global("reload", {});
+const reload = set_global("reload", {});
 zrequire("reload_state");
-zrequire("channel");
+const channel = zrequire("channel");
 
 const default_stub_xhr = "default-stub-xhr";
 

--- a/frontend_tests/node_tests/color_data.js
+++ b/frontend_tests/node_tests/color_data.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("color_data");
+const color_data = zrequire("color_data");
 
 run_test("pick_color", () => {
     color_data.colors = ["blue", "orange", "red", "yellow"];

--- a/frontend_tests/node_tests/colorspace.js
+++ b/frontend_tests/node_tests/colorspace.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("colorspace");
+const colorspace = zrequire("colorspace");
 
 run_test("sRGB_to_linear", () => {
     let srgb_color = 0.0042;

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -25,7 +25,7 @@ $(input).val = (arg) => {
     };
 };
 
-zrequire("common");
+const common = zrequire("common");
 
 run_test("basics", () => {
     common.autofocus("#home");

--- a/frontend_tests/node_tests/components.js
+++ b/frontend_tests/node_tests/components.js
@@ -8,7 +8,7 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 zrequire("keydown_util");
-zrequire("components");
+const components = zrequire("components");
 
 const noop = function () {};
 

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -38,14 +38,14 @@ const _drafts = {
     delete_draft_after_send: noop,
 };
 
-const _sent_messages = {
+const sent_messages = {
     start_tracking_message: noop,
 };
 const _notifications = {
     notify_above_composebox: noop,
     clear_compose_notifications: noop,
 };
-const _reminder = {
+const reminder = {
     is_deferred_delivery: noop,
 };
 
@@ -53,19 +53,19 @@ set_global("document", _document);
 set_global("drafts", _drafts);
 set_global("navigator", _navigator);
 set_global("notifications", _notifications);
-set_global("reminder", _reminder);
-set_global("sent_messages", _sent_messages);
+set_global("reminder", reminder);
+set_global("sent_messages", sent_messages);
 
-set_global("local_message", {});
-set_global("transmit", {});
-set_global("channel", {});
-set_global("stream_edit", {});
-set_global("markdown", {});
-set_global("loading", {});
+const local_message = set_global("local_message", {});
+const transmit = set_global("transmit", {});
+const channel = set_global("channel", {});
+const stream_edit = set_global("stream_edit", {});
+const markdown = set_global("markdown", {});
+const loading = set_global("loading", {});
 set_global("page_params", {});
-set_global("resize", {});
-set_global("subs", {});
-set_global("ui_util", {});
+const resize = set_global("resize", {});
+const subs = set_global("subs", {});
+const ui_util = set_global("ui_util", {});
 
 // Setting these up so that we can test that links to uploads within messages are
 // automatically converted to server relative links.
@@ -76,25 +76,25 @@ const fake_now = 555;
 MockDate.set(new Date(fake_now * 1000));
 
 zrequire("zcommand");
-zrequire("compose_ui");
+const compose_ui = zrequire("compose_ui");
 const peer_data = zrequire("peer_data");
 const util = zrequire("util");
-zrequire("rtl");
+const rtl = zrequire("rtl");
 zrequire("common");
-zrequire("stream_data");
-zrequire("compose_state");
+const stream_data = zrequire("stream_data");
+const compose_state = zrequire("compose_state");
 const people = zrequire("people");
 zrequire("input_pill");
 zrequire("user_pill");
-zrequire("compose_pm_pill");
-zrequire("echo");
-rewiremock.proxy(() => zrequire("compose"), {
+const compose_pm_pill = zrequire("compose_pm_pill");
+const echo = zrequire("echo");
+const compose = rewiremock.proxy(() => zrequire("compose"), {
     "../../static/js/rendered_markdown": {
         update_elements: () => {},
     },
 });
-zrequire("upload");
-zrequire("server_events_dispatch");
+const upload = zrequire("upload");
+const server_events_dispatch = zrequire("server_events_dispatch");
 const settings_config = zrequire("settings_config");
 
 people.small_avatar_url_for_person = function () {

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -22,16 +22,16 @@ set_global("page_params", {});
 
 set_global("$", make_zjquery());
 
-set_global("compose_pm_pill", {});
+const compose_pm_pill = set_global("compose_pm_pill", {});
 
-set_global("hash_util", {});
+const hash_util = set_global("hash_util", {});
 
 const people = zrequire("people");
-zrequire("compose_ui");
-zrequire("compose");
-zrequire("compose_state");
-zrequire("compose_actions");
-zrequire("stream_data");
+const compose_ui = zrequire("compose_ui");
+const compose = zrequire("compose");
+const compose_state = zrequire("compose_state");
+const compose_actions = zrequire("compose_actions");
+const stream_data = zrequire("stream_data");
 
 set_global("document", "document-stub");
 
@@ -65,7 +65,7 @@ set_global("notifications", {
     clear_compose_notifications: noop,
 });
 
-set_global("compose_fade", {
+const compose_fade = set_global("compose_fade", {
     clear_compose: noop,
 });
 
@@ -73,7 +73,7 @@ set_global("drafts", {
     update_draft: noop,
 });
 
-set_global("narrow_state", {
+const narrow_state = set_global("narrow_state", {
     set_compose_defaults: noop,
 });
 
@@ -367,9 +367,11 @@ run_test("quote_and_reply", () => {
         };
     };
 
-    channel.get = function () {
-        assert.fail("channel.get should not be used if raw_content is present");
-    };
+    set_global("channel", {
+        get() {
+            assert.fail("channel.get should not be used if raw_content is present");
+        },
+    });
 
     quote_and_reply(opts);
 

--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -5,10 +5,10 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("stream_data");
+const stream_data = zrequire("stream_data");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
-zrequire("compose_fade");
+const compose_fade = zrequire("compose_fade");
 
 const me = {
     email: "me@example.com",

--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -10,8 +10,8 @@ set_global("$", make_zjquery());
 
 const people = zrequire("people");
 
-zrequire("compose_pm_pill");
-zrequire("input_pill");
+const compose_pm_pill = zrequire("compose_pm_pill");
+const input_pill = zrequire("input_pill");
 zrequire("user_pill");
 
 let pills = {

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -8,9 +8,9 @@ const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
-zrequire("compose_ui");
+const compose_ui = zrequire("compose_ui");
 const people = zrequire("people");
-zrequire("user_status");
+const user_status = zrequire("user_status");
 
 set_global("document", {
     execCommand() {

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -8,15 +8,15 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 
 const emoji = zrequire("emoji", "shared/js/emoji");
 const typeahead = zrequire("typeahead", "shared/js/typeahead");
-zrequire("compose_state");
+const compose_state = zrequire("compose_state");
 zrequire("templates");
-zrequire("typeahead_helper");
+const typeahead_helper = zrequire("typeahead_helper");
 const people = zrequire("people");
-zrequire("user_groups");
-zrequire("stream_data");
-zrequire("user_pill");
-zrequire("compose_pm_pill");
-zrequire("composebox_typeahead");
+const user_groups = zrequire("user_groups");
+const stream_data = zrequire("stream_data");
+const user_pill = zrequire("user_pill");
+const compose_pm_pill = zrequire("compose_pm_pill");
+const composebox_typeahead = zrequire("composebox_typeahead");
 zrequire("recent_senders");
 zrequire("settings_org");
 const settings_config = zrequire("settings_config");
@@ -25,9 +25,9 @@ const settings_config = zrequire("settings_config");
 stream_data.update_calculated_fields = () => {};
 stream_data.set_filter_out_inactives = () => false;
 
-set_global("stream_topic_history", {});
+const stream_topic_history = set_global("stream_topic_history", {});
 
-set_global("message_store", {
+const message_store = set_global("message_store", {
     user_ids: () => [],
 });
 
@@ -174,8 +174,8 @@ stream_data.add_sub(netherland_stream);
 set_global("$", make_zjquery());
 
 set_global("page_params", {});
-set_global("channel", {});
-set_global("compose", {
+const channel = set_global("channel", {});
+const compose = set_global("compose", {
     finish: noop,
 });
 

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -9,7 +9,6 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 const emoji = zrequire("emoji", "shared/js/emoji");
 const typeahead = zrequire("typeahead", "shared/js/typeahead");
 zrequire("compose_state");
-zrequire("pm_conversations");
 zrequire("templates");
 zrequire("typeahead_helper");
 const people = zrequire("people");

--- a/frontend_tests/node_tests/copy_and_paste.js
+++ b/frontend_tests/node_tests/copy_and_paste.js
@@ -10,7 +10,7 @@ const {run_test} = require("../zjsunit/test");
 set_global("page_params", {
     development_environment: true,
 });
-set_global("compose_ui", {});
+const compose_ui = set_global("compose_ui", {});
 
 const {window} = new JSDOM("<!DOCTYPE html><p>Hello world</p>");
 const {DOMParser, document} = window;

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -35,9 +35,9 @@ set_global("hotspots", {});
 set_global("markdown", {});
 set_global("message_edit", {});
 set_global("message_events", {});
-set_global("message_list", {});
+const message_list = set_global("message_list", {});
 set_global("muting_ui", {});
-set_global("narrow_state", {});
+const narrow_state = set_global("narrow_state", {});
 set_global("night_mode", {});
 set_global("notifications", {});
 set_global("overlays", {});
@@ -76,20 +76,20 @@ set_global("page_params", {
 });
 
 // For data-oriented modules, just use them, don't stub them.
-zrequire("alert_words");
+const alert_words = zrequire("alert_words");
 zrequire("unread");
 zrequire("stream_topic_history");
 zrequire("stream_list");
 zrequire("message_flags");
-zrequire("message_store");
+const message_store = zrequire("message_store");
 const people = zrequire("people");
 zrequire("starred_messages");
-zrequire("user_status");
+const user_status = zrequire("user_status");
 zrequire("subs");
 
 const emoji = zrequire("emoji", "shared/js/emoji");
 
-zrequire("server_events_dispatch");
+const server_events_dispatch = zrequire("server_events_dispatch");
 zrequire("panels");
 
 function dispatch(ev) {

--- a/frontend_tests/node_tests/dispatch_subs.js
+++ b/frontend_tests/node_tests/dispatch_subs.js
@@ -18,8 +18,8 @@ set_global("subs", {});
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 
-zrequire("stream_data");
-zrequire("server_events_dispatch");
+const stream_data = zrequire("stream_data");
+const server_events_dispatch = zrequire("server_events_dispatch");
 
 people.add_active_user(test_user);
 

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -9,9 +9,9 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());
 
-zrequire("localstorage");
-zrequire("drafts");
-zrequire("timerender");
+const localstorage = zrequire("localstorage");
+const drafts = zrequire("drafts");
+const timerender = zrequire("timerender");
 zrequire("stream_color");
 zrequire("colorspace");
 
@@ -20,7 +20,7 @@ const noop = function () {
     return;
 };
 
-set_global("localStorage", {
+const localStorage = set_global("localStorage", {
     getItem(key) {
         return ls_container.get(key);
     },
@@ -35,7 +35,7 @@ set_global("localStorage", {
     },
 });
 set_global("compose", {});
-set_global("compose_state", {});
+const compose_state = set_global("compose_state", {});
 set_global("stream_data", {
     get_color() {
         return "#FFFFFF";

--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -6,7 +6,7 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
-zrequire("dropdown_list_widget");
+const dropdown_list_widget = zrequire("dropdown_list_widget");
 zrequire("scroll_util");
 set_global("$", make_zjquery());
 

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -9,14 +9,14 @@ const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());
-set_global("local_message", {});
-set_global("markdown", {});
+const local_message = set_global("local_message", {});
+const markdown = set_global("markdown", {});
 set_global("page_params", {});
 
 const fake_now = 555;
 MockDate.set(new Date(fake_now * 1000));
 
-zrequire("echo");
+const echo = zrequire("echo");
 const people = zrequire("people");
 
 let disparities = [];

--- a/frontend_tests/node_tests/emoji_picker.js
+++ b/frontend_tests/node_tests/emoji_picker.js
@@ -8,7 +8,7 @@ const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 const emoji = zrequire("emoji", "shared/js/emoji");
-zrequire("emoji_picker");
+const emoji_picker = zrequire("emoji_picker");
 
 const emoji_codes = zrequire("emoji_codes", "generated/emoji/emoji_codes.json");
 

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -7,13 +7,13 @@ const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("unread");
-zrequire("stream_data");
+const stream_data = zrequire("stream_data");
 const people = zrequire("people");
 set_global("$", make_zjquery());
 zrequire("message_util", "js/message_util");
-zrequire("Filter", "js/filter");
+const Filter = zrequire("Filter", "js/filter");
 
-set_global("message_store", {});
+const message_store = set_global("message_store", {});
 set_global("page_params", {});
 
 const me = {

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -80,7 +80,7 @@ const denmark_stream = {
 
 set_global("page_params", {});
 
-zrequire("stream_data");
+const stream_data = zrequire("stream_data");
 
 run_test("verify stream_data persists stream color", () => {
     assert.equal(stream_data.get_sub_by_name("Denmark"), undefined);
@@ -114,19 +114,19 @@ const messages = {
 
 const noop = () => undefined;
 
-set_global("alert_words", {});
+const alert_words = set_global("alert_words", {});
 
 alert_words.process_message = noop;
 
 // We can also bring in real code:
 zrequire("recent_senders");
-zrequire("unread");
-zrequire("stream_topic_history");
+const unread = zrequire("unread");
+const stream_topic_history = zrequire("stream_topic_history");
 zrequire("recent_topics");
 zrequire("overlays");
 
 // And finally require the module that we will test directly:
-zrequire("message_store");
+const message_store = zrequire("message_store");
 
 run_test("message_store", () => {
     const in_message = {...messages.isaac_to_denmark_stream};
@@ -170,7 +170,7 @@ run_test("unread", () => {
 
 // We use the second argument of zrequire to find the location of the
 // Filter class.
-zrequire("Filter", "js/filter");
+const Filter = zrequire("Filter", "js/filter");
 
 run_test("filter", () => {
     const filter_terms = [
@@ -210,7 +210,7 @@ run_test("filter", () => {
 // "filter" abstraction.  If you are in a narrow, we track the
 // state with the narrow_state module.
 
-zrequire("narrow_state");
+const narrow_state = zrequire("narrow_state");
 
 run_test("narrow_state", () => {
     // As we often do, first make assertions about the starting
@@ -308,7 +308,7 @@ run_test("narrow_state", () => {
 
 */
 
-zrequire("server_events_dispatch");
+const server_events_dispatch = zrequire("server_events_dispatch");
 
 // We will use Bob in several tests.
 const bob = {
@@ -429,16 +429,16 @@ function test_helper() {
 
 */
 
-set_global("home_msg_list", {});
-set_global("message_list", {});
+const home_msg_list = set_global("home_msg_list", {});
+const message_list = set_global("message_list", {});
 set_global("message_util", {});
-set_global("notifications", {});
+const notifications = set_global("notifications", {});
 set_global("resize", {});
 set_global("stream_list", {});
 set_global("unread_ops", {});
 set_global("unread_ui", {});
 
-zrequire("message_events");
+const message_events = zrequire("message_events");
 
 run_test("insert_message", (override) => {
     override("pm_list.update_private_messages", noop);
@@ -522,13 +522,11 @@ run_test("insert_message", (override) => {
 
 */
 
-set_global("channel", {});
-set_global("home_msg_list", {});
-set_global("message_list", {});
-set_global("message_viewport", {});
+const channel = set_global("channel", {});
+const message_viewport = set_global("message_viewport", {});
 zrequire("message_flags");
 
-zrequire("unread_ops");
+const unread_ops = zrequire("unread_ops");
 
 run_test("unread_ops", () => {
     (function set_up() {
@@ -608,10 +606,10 @@ run_test("unread_ops", () => {
 
 */
 
-set_global("topic_list", {});
+const topic_list = set_global("topic_list", {});
 
 zrequire("stream_sort");
-zrequire("stream_list");
+const stream_list = zrequire("stream_list");
 
 const social_stream = {
     color: "red",

--- a/frontend_tests/node_tests/hash_util.js
+++ b/frontend_tests/node_tests/hash_util.js
@@ -6,11 +6,11 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
-zrequire("hash_util");
-zrequire("stream_data");
+const hash_util = zrequire("hash_util");
+const stream_data = zrequire("stream_data");
 const people = zrequire("people");
-zrequire("Filter", "js/filter");
-zrequire("narrow_state");
+const Filter = zrequire("Filter", "js/filter");
+const narrow_state = zrequire("narrow_state");
 
 set_global(
     "$",
@@ -18,7 +18,7 @@ set_global(
         silent: true,
     }),
 );
-set_global("ui_report", {
+const ui_report = set_global("ui_report", {
     displayed_error: false,
     error: () => {
         ui_report.displayed_error = true;

--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -15,28 +15,28 @@ set_global("location", {
 set_global("to_$", () => window_stub);
 
 const people = zrequire("people");
-zrequire("hash_util");
-zrequire("hashchange");
-zrequire("stream_data");
+const hash_util = zrequire("hash_util");
+const hashchange = zrequire("hashchange");
+const stream_data = zrequire("stream_data");
 zrequire("navigate");
 
 set_global("search", {
     update_button_visibility: () => {},
 });
 set_global("document", "document-stub");
-set_global("history", {});
+const history = set_global("history", {});
 
 set_global("admin", {});
 set_global("drafts", {});
 set_global("favicon", {});
 set_global("floating_recipient_bar", {});
-set_global("info_overlay", {});
+const info_overlay = set_global("info_overlay", {});
 set_global("message_viewport", {});
-set_global("narrow", {});
+const narrow = set_global("narrow", {});
 set_global("overlays", {});
 set_global("settings", {});
 set_global("subs", {});
-set_global("ui_util", {});
+const ui_util = set_global("ui_util", {});
 
 run_test("operators_round_trip", () => {
     let operators;

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -28,7 +28,7 @@ set_global("navigator", {
 
 set_global("page_params", {});
 
-set_global("overlays", {});
+let overlays = set_global("overlays", {});
 
 // jQuery stuff should go away if we make an initialize() method.
 set_global("document", "document-stub");
@@ -51,7 +51,7 @@ set_global("drafts", {});
 set_global("hashchange", {});
 set_global("info_overlay", {});
 set_global("lightbox", {});
-set_global("list_util", {});
+const list_util = set_global("list_util", {});
 set_global("message_edit", {});
 set_global("muting_ui", {});
 set_global("narrow", {});
@@ -225,7 +225,7 @@ run_test("basic_chars", () => {
         all_messages_popped: return_false,
         starred_messages_popped: return_false,
     });
-    set_global("emoji_picker", {
+    const emoji_picker = set_global("emoji_picker", {
         reactions_popped: return_false,
     });
     set_global("hotspots", {
@@ -249,7 +249,7 @@ run_test("basic_chars", () => {
     for (const settings_open of [return_true, return_false]) {
         for (const is_active of [return_true, return_false]) {
             for (const info_overlay_open of [return_true, return_false]) {
-                set_global("overlays", {
+                overlays = set_global("overlays", {
                     is_active,
                     settings_open,
                     info_overlay_open,

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -7,7 +7,7 @@ const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());
-zrequire("input_pill");
+const input_pill = zrequire("input_pill");
 
 zrequire("templates");
 

--- a/frontend_tests/node_tests/keydown_util.js
+++ b/frontend_tests/node_tests/keydown_util.js
@@ -6,7 +6,7 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());
 
-zrequire("keydown_util");
+const keydown_util = zrequire("keydown_util");
 
 run_test("test_early_returns", () => {
     const stub = $.create("stub");

--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -6,10 +6,10 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
-zrequire("rows");
-zrequire("lightbox");
+const rows = zrequire("rows");
+const lightbox = zrequire("lightbox");
 
-set_global("message_store", {});
+const message_store = set_global("message_store", {});
 set_global("Image", class Image {});
 set_global("overlays", {
     close_overlay: () => {},

--- a/frontend_tests/node_tests/list_cursor.js
+++ b/frontend_tests/node_tests/list_cursor.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("list_cursor");
+const ListCursor = zrequire("list_cursor");
 
 run_test("config errors", () => {
     blueslip.expect("error", "Programming error");

--- a/frontend_tests/node_tests/list_widget.js
+++ b/frontend_tests/node_tests/list_widget.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("list_widget");
+const ListWidget = zrequire("list_widget");
 
 // We need these stubs to get by instanceof checks.
 // The ListWidget library allows you to insert objects
@@ -16,7 +16,7 @@ function Element() {
     return {};
 }
 set_global("Element", Element);
-set_global("ui", {});
+const ui = set_global("ui", {});
 
 // We only need very simple jQuery wrappers for when the
 // "real" code wraps html or sets up click handlers.

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -17,11 +17,11 @@ const fenced_code = zrequire("fenced_code", "shared/js/fenced_code");
 const markdown_config = zrequire("markdown_config");
 const marked = zrequire("marked", "third/marked/lib/marked");
 
-zrequire("markdown");
+const markdown = zrequire("markdown");
 zrequire("message_store");
 const people = zrequire("people");
-zrequire("stream_data");
-zrequire("user_groups");
+const stream_data = zrequire("stream_data");
+const user_groups = zrequire("user_groups");
 
 set_global("location", {
     origin: "http://zulip.zulipdev.com",

--- a/frontend_tests/node_tests/markdown_katex.js
+++ b/frontend_tests/node_tests/markdown_katex.js
@@ -18,7 +18,6 @@ set_global("page_params", {});
 
 zrequire("hash_util");
 zrequire("message_store");
-zrequire("people");
 zrequire("stream_data");
 zrequire("user_groups");
 

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -12,7 +12,7 @@ set_global("page_params", {
 
 stub_out_jquery();
 
-zrequire("message_edit");
+const message_edit = zrequire("message_edit");
 
 const get_editability = message_edit.get_editability;
 const editability_types = message_edit.editability_types;

--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -6,21 +6,21 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
-zrequire("message_events");
-zrequire("message_store");
+const message_events = zrequire("message_events");
+const message_store = zrequire("message_store");
 zrequire("muting");
 const people = zrequire("people");
 zrequire("recent_senders");
-zrequire("stream_data");
-zrequire("stream_topic_history");
-zrequire("unread");
+const stream_data = zrequire("stream_data");
+const stream_topic_history = zrequire("stream_topic_history");
+const unread = zrequire("unread");
 
 set_global("$", make_zjquery());
-set_global("alert_words", {});
+const alert_words = set_global("alert_words", {});
 set_global("condense", {});
 set_global("current_msg_list", {});
 set_global("message_edit", {});
-set_global("message_list", {});
+const message_list = set_global("message_list", {});
 set_global("notifications", {});
 set_global("page_params", {});
 set_global("pm_list", {});

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -11,7 +11,7 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 set_global("$", make_zjquery());
 set_global("document", "document-stub");
 
-zrequire("message_fetch");
+const message_fetch = zrequire("message_fetch");
 
 const noop = () => {};
 
@@ -21,9 +21,9 @@ function MessageListView() {
 set_global("MessageListView", MessageListView);
 
 zrequire("FetchStatus", "js/fetch_status");
-zrequire("Filter", "js/filter");
+const Filter = zrequire("Filter", "js/filter");
 zrequire("MessageListData", "js/message_list_data");
-zrequire("message_list");
+const message_list = zrequire("message_list");
 const people = zrequire("people");
 
 set_global("recent_topics", {
@@ -35,7 +35,7 @@ set_global("ui_report", {
     hide_error: noop,
 });
 
-set_global("channel", {});
+const channel = set_global("channel", {});
 set_global("document", "document-stub");
 set_global("message_scroll", {
     show_loading_older: noop,
@@ -44,12 +44,12 @@ set_global("message_scroll", {
     hide_loading_newer: noop,
     update_top_of_narrow_notices: () => {},
 });
-set_global("message_util", {});
-set_global("message_store", {});
-set_global("narrow_state", {});
-set_global("pm_list", {});
-set_global("server_events", {});
-set_global("stream_list", {
+const message_util = set_global("message_util", {});
+const message_store = set_global("message_store", {});
+const narrow_state = set_global("narrow_state", {});
+const pm_list = set_global("pm_list", {});
+const server_events = set_global("server_events", {});
+const stream_list = set_global("stream_list", {
     maybe_scroll_narrow_into_view: () => {},
 });
 

--- a/frontend_tests/node_tests/message_flags.js
+++ b/frontend_tests/node_tests/message_flags.js
@@ -7,10 +7,10 @@ const {run_test} = require("../zjsunit/test");
 
 zrequire("unread");
 zrequire("unread_ops");
-zrequire("message_flags");
+const message_flags = zrequire("message_flags");
 
-set_global("ui", {});
-set_global("channel", {});
+const ui = set_global("ui", {});
+const channel = set_global("channel", {});
 set_global("starred_messages", {
     add: () => {},
     remove: () => {},

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -18,7 +18,7 @@ set_global("narrow_state", {});
 set_global("stream_data", {});
 
 zrequire("FetchStatus", "js/fetch_status");
-zrequire("muting");
+const muting = zrequire("muting");
 zrequire("MessageListData", "js/message_list_data");
 zrequire("MessageListView", "js/message_list_view");
 const {MessageList} = zrequire("message_list");

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -2,16 +2,15 @@
 
 const {strict: assert} = require("assert");
 
-const MessageListData = require("../../static/js/message_list_data");
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("muting");
+const muting = zrequire("muting");
 zrequire("unread");
 
 zrequire("Filter", "js/filter");
 zrequire("FetchStatus", "js/fetch_status");
-zrequire("MessageListData", "js/message_list_data");
+const MessageListData = zrequire("MessageListData", "js/message_list_data");
 
 set_global("page_params", {});
 

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -11,11 +11,11 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 set_global("$", make_zjquery());
 set_global("document", "document-stub");
 
-zrequire("Filter", "js/filter");
+const Filter = zrequire("Filter", "js/filter");
 zrequire("FetchStatus", "js/fetch_status");
 zrequire("MessageListData", "js/message_list_data");
-zrequire("MessageListView", "js/message_list_view");
-zrequire("message_list");
+const MessageListView = zrequire("MessageListView", "js/message_list_view");
+const message_list = zrequire("message_list");
 
 const noop = function () {};
 

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -8,7 +8,6 @@ const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 const util = zrequire("util");
-zrequire("pm_conversations");
 const people = zrequire("people");
 zrequire("message_store");
 

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -9,7 +9,7 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 
 const util = zrequire("util");
 const people = zrequire("people");
-zrequire("message_store");
+const message_store = zrequire("message_store");
 
 const noop = function () {};
 

--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -6,8 +6,8 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 zrequire("timerender");
-zrequire("muting");
-zrequire("stream_data");
+const muting = zrequire("muting");
+const stream_data = zrequire("stream_data");
 set_global("page_params", {});
 
 run_test("edge_cases", () => {

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -7,12 +7,12 @@ const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());
-zrequire("hash_util");
+const hash_util = zrequire("hash_util");
 zrequire("hashchange");
-zrequire("narrow_state");
+const narrow_state = zrequire("narrow_state");
 const people = zrequire("people");
-zrequire("stream_data");
-zrequire("Filter", "js/filter");
+const stream_data = zrequire("stream_data");
+const Filter = zrequire("Filter", "js/filter");
 set_global("page_params", {
     stop_words: ["what", "about"],
 });
@@ -21,7 +21,7 @@ set_global("resize", {
     resize_stream_filters_container: () => {},
 });
 
-zrequire("narrow");
+const narrow = zrequire("narrow");
 
 function set_filter(operators) {
     operators = operators.map((op) => ({
@@ -249,8 +249,8 @@ run_test("show_invalid_narrow_message", () => {
 });
 
 run_test("narrow_to_compose_target", () => {
-    set_global("compose_state", {});
-    set_global("stream_topic_history", {});
+    const compose_state = set_global("compose_state", {});
+    const stream_topic_history = set_global("stream_topic_history", {});
     const args = {called: false};
     const activate_backup = narrow.activate;
     narrow.activate = function (operators, opts) {

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -9,26 +9,26 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 const util = zrequire("util");
 set_global("$", make_zjquery());
 
-zrequire("narrow_state");
+const narrow_state = zrequire("narrow_state");
 set_global("resize", {
     resize_stream_filters_container: () => {},
 });
-zrequire("stream_data");
+const stream_data = zrequire("stream_data");
 zrequire("Filter", "js/filter");
 zrequire("FetchStatus", "js/fetch_status");
 zrequire("MessageListData", "js/message_list_data");
 zrequire("unread");
-zrequire("narrow");
+const narrow = zrequire("narrow");
 zrequire("search_pill");
 
-set_global("channel", {});
+const channel = set_global("channel", {});
 set_global("compose", {});
 set_global("compose_actions", {});
 set_global("current_msg_list", {});
 set_global("hashchange", {});
 set_global("home_msg_list", {});
-set_global("message_fetch", {});
-set_global("message_list", {
+const message_fetch = set_global("message_fetch", {});
+const message_list = set_global("message_list", {
     set_narrowed(value) {
         this.narrowed = value;
     },

--- a/frontend_tests/node_tests/narrow_local.js
+++ b/frontend_tests/node_tests/narrow_local.js
@@ -5,14 +5,14 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("Filter", "js/filter");
+const Filter = zrequire("Filter", "js/filter");
 zrequire("FetchStatus", "js/fetch_status");
-zrequire("MessageListData", "js/message_list_data");
-zrequire("narrow_state");
-zrequire("narrow");
+const MessageListData = zrequire("MessageListData", "js/message_list_data");
+const narrow_state = zrequire("narrow_state");
+const narrow = zrequire("narrow");
 zrequire("stream_data");
 
-set_global("message_list", {});
+const message_list = set_global("message_list", {});
 set_global("muting", {
     is_topic_muted: () => false,
 });

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -6,9 +6,9 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 const people = zrequire("people");
-zrequire("Filter", "js/filter");
-zrequire("stream_data");
-zrequire("narrow_state");
+const Filter = zrequire("Filter", "js/filter");
+const stream_data = zrequire("stream_data");
+const narrow_state = zrequire("narrow_state");
 
 set_global("page_params", {});
 

--- a/frontend_tests/node_tests/narrow_unread.js
+++ b/frontend_tests/node_tests/narrow_unread.js
@@ -5,12 +5,12 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("Filter", "js/filter");
+const Filter = zrequire("Filter", "js/filter");
 const people = zrequire("people");
-zrequire("stream_data");
-zrequire("unread");
+const stream_data = zrequire("stream_data");
+const unread = zrequire("unread");
 
-set_global("message_store", {});
+const message_store = set_global("message_store", {});
 set_global("page_params", {});
 
 set_global("muting", {
@@ -18,7 +18,7 @@ set_global("muting", {
 });
 
 // The main code we are testing lives here.
-zrequire("narrow_state");
+const narrow_state = zrequire("narrow_state");
 
 const alice = {
     email: "alice@example.com",

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -33,13 +33,13 @@ const _navigator = {
 set_global("navigator", _navigator);
 
 zrequire("alert_words");
-zrequire("muting");
-zrequire("stream_data");
+const muting = zrequire("muting");
+const stream_data = zrequire("stream_data");
 zrequire("ui");
-zrequire("spoilers");
+const spoilers = zrequire("spoilers");
 spoilers.hide_spoilers_in_notification = () => {};
 
-rewiremock.proxy(() => zrequire("notifications"), {
+const notifications = rewiremock.proxy(() => zrequire("notifications"), {
     "../../static/js/favicon": {},
 });
 

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -35,7 +35,6 @@ set_global("navigator", _navigator);
 zrequire("alert_words");
 zrequire("muting");
 zrequire("stream_data");
-zrequire("people");
 zrequire("ui");
 zrequire("spoilers");
 spoilers.hide_spoilers_in_notification = () => {};

--- a/frontend_tests/node_tests/password.js
+++ b/frontend_tests/node_tests/password.js
@@ -6,7 +6,7 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 set_global("zxcvbn", zrequire("zxcvbn", "zxcvbn"));
-zrequire("common");
+const common = zrequire("common");
 
 run_test("basics", () => {
     let accepted;

--- a/frontend_tests/node_tests/peer_data.js
+++ b/frontend_tests/node_tests/peer_data.js
@@ -14,7 +14,7 @@ const {run_test} = require("../zjsunit/test");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 zrequire("hash_util");
-zrequire("stream_data");
+const stream_data = zrequire("stream_data");
 
 set_global("page_params", {
     is_admin: false,

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -9,7 +9,7 @@ const MockDate = require("mockdate");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-set_global("message_store", {});
+const message_store = set_global("message_store", {});
 set_global("page_params", {});
 set_global("settings_data", {});
 

--- a/frontend_tests/node_tests/people_errors.js
+++ b/frontend_tests/node_tests/people_errors.js
@@ -13,7 +13,7 @@ const return_false = function () {
 const return_true = function () {
     return true;
 };
-set_global("reload_state", {
+const reload_state = set_global("reload_state", {
     is_in_progress: return_false,
 });
 

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -8,19 +8,19 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());
 
-set_global("narrow_state", {});
+const narrow_state = set_global("narrow_state", {});
 set_global("ui", {
     get_content_element: (element) => element,
 });
 set_global("stream_popover", {
     hide_topic_popover() {},
 });
-set_global("unread", {});
-set_global("unread_ui", {});
-set_global("vdom", {
+const unread = set_global("unread", {});
+const unread_ui = set_global("unread_ui", {});
+const vdom = set_global("vdom", {
     render: () => "fake-dom-for-pm-list",
 });
-set_global("pm_list_dom", {});
+const pm_list_dom = set_global("pm_list_dom", {});
 
 zrequire("user_status");
 zrequire("presence");
@@ -28,7 +28,7 @@ zrequire("buddy_data");
 zrequire("hash_util");
 const people = zrequire("people");
 const pm_conversations = zrequire("pm_conversations");
-zrequire("pm_list");
+const pm_list = zrequire("pm_list");
 
 const alice = {
     email: "alice@zulip.com",

--- a/frontend_tests/node_tests/poll_widget.js
+++ b/frontend_tests/node_tests/poll_widget.js
@@ -7,7 +7,7 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
-zrequire("poll_widget");
+const poll_widget = zrequire("poll_widget");
 
 set_global("$", make_zjquery());
 

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -17,9 +17,9 @@ zrequire("narrow_state");
 const people = zrequire("people");
 zrequire("presence");
 zrequire("buddy_data");
-zrequire("user_status");
+const user_status = zrequire("user_status");
 zrequire("feature_flags");
-zrequire("message_edit");
+const message_edit = zrequire("message_edit");
 
 const noop = function () {};
 $.fn.popover = noop; // this will get wrapped by our code
@@ -30,7 +30,7 @@ set_global("page_params", {
     realm_email_address_visibility: 3,
     custom_profile_fields: [],
 });
-set_global("rows", {});
+const rows = set_global("rows", {});
 
 set_global("message_viewport", {
     height: () => 500,
@@ -48,11 +48,11 @@ set_global("stream_popover", {
     hide_streamlist_sidebar: noop,
 });
 
-set_global("stream_data", {});
+const stream_data = set_global("stream_data", {});
 
 const ClipboardJS = noop;
 
-rewiremock.proxy(() => zrequire("popovers"), {
+const popovers = rewiremock.proxy(() => zrequire("popovers"), {
     clipboard: ClipboardJS,
 });
 

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -6,14 +6,14 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 const people = zrequire("people");
-zrequire("presence");
+const presence = zrequire("presence");
 
 const return_false = function () {
     return false;
 };
 
-set_global("server_events", {});
-set_global("reload_state", {
+const server_events = set_global("server_events", {});
+const reload_state = set_global("reload_state", {
     is_in_progress: return_false,
 });
 

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -15,7 +15,7 @@ const emoji_codes = zrequire("emoji_codes", "generated/emoji/emoji_codes.json");
 const emoji = zrequire("emoji", "shared/js/emoji");
 
 const people = zrequire("people");
-zrequire("reactions");
+const reactions = zrequire("reactions");
 
 set_global("page_params", {
     user_id: 5,
@@ -47,8 +47,8 @@ const emoji_params = {
 
 emoji.initialize(emoji_params);
 
-set_global("channel", {});
-set_global("emoji_picker", {
+const channel = set_global("channel", {});
+const emoji_picker = set_global("emoji_picker", {
     hide_emoji_popover() {},
 });
 
@@ -108,7 +108,7 @@ const message = {
     ],
 };
 
-set_global("message_store", {
+const message_store = set_global("message_store", {
     get(message_id) {
         assert.equal(message_id, 1001);
         return message;

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -19,7 +19,7 @@ set_global(
 set_global("hashchange", {
     exit_overlay: noop,
 });
-set_global("overlays", {
+const overlays = set_global("overlays", {
     open_overlay: (opts) => {
         overlays.close_callback = opts.on_close;
     },
@@ -55,7 +55,7 @@ set_global("hash_util", {
 set_global("recent_senders", {
     get_topic_recent_senders: () => [1, 2],
 });
-set_global("ListWidget", {
+const ListWidget = set_global("ListWidget", {
     modifier: noop,
     create: (container, mapped_topic_values, opts) => {
         const formatted_topics = [];

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -8,8 +8,8 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 
 const rm = zrequire("rendered_markdown");
 const people = zrequire("people");
-zrequire("user_groups");
-zrequire("stream_data");
+const user_groups = zrequire("user_groups");
+const stream_data = zrequire("stream_data");
 zrequire("timerender");
 set_global("$", make_zjquery());
 

--- a/frontend_tests/node_tests/schema.js
+++ b/frontend_tests/node_tests/schema.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("schema");
+const schema = zrequire("schema");
 
 run_test("basics", () => {
     assert.equal(schema.check_string("x", "fred"), undefined);

--- a/frontend_tests/node_tests/scroll_util.js
+++ b/frontend_tests/node_tests/scroll_util.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("scroll_util");
+const scroll_util = zrequire("scroll_util");
 set_global("ui", {
     get_scroll_element: (element) => element,
 });

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -9,9 +9,9 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 set_global("page_params", {
     search_pills_enabled: true,
 });
-zrequire("search");
-zrequire("search_pill");
-zrequire("Filter", "js/filter");
+const search = zrequire("search");
+const search_pill = zrequire("search_pill");
+const Filter = zrequire("Filter", "js/filter");
 zrequire("message_view_header");
 
 const noop = () => {};
@@ -19,13 +19,13 @@ const return_true = () => true;
 const return_false = () => false;
 
 set_global("$", make_zjquery());
-set_global("narrow_state", {filter: return_false});
-set_global("search_suggestion", {});
+const narrow_state = set_global("narrow_state", {filter: return_false});
+const search_suggestion = set_global("search_suggestion", {});
 set_global("ui_util", {
     change_tab_to: noop,
     place_caret_at_end: noop,
 });
-set_global("narrow", {});
+const narrow = set_global("narrow", {});
 set_global("search_pill_widget", {
     widget: {
         getByID: return_true,

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -9,7 +9,7 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 set_global("page_params", {
     search_pills_enabled: false,
 });
-zrequire("search");
+const search = zrequire("search");
 zrequire("message_view_header");
 
 const noop = () => {};
@@ -17,13 +17,13 @@ const return_true = () => true;
 const return_false = () => false;
 
 set_global("$", make_zjquery());
-set_global("narrow_state", {});
-set_global("search_suggestion", {});
+const narrow_state = set_global("narrow_state", {});
+const search_suggestion = set_global("search_suggestion", {});
 set_global("ui_util", {
     change_tab_to: noop,
 });
-set_global("narrow", {});
-set_global("Filter", {});
+const narrow = set_global("narrow", {});
+const Filter = set_global("Filter", {});
 
 set_global("setTimeout", (func) => func());
 

--- a/frontend_tests/node_tests/search_pill.js
+++ b/frontend_tests/node_tests/search_pill.js
@@ -5,8 +5,8 @@ const {strict: assert} = require("assert");
 const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("search_pill");
-zrequire("input_pill");
+const search_pill = zrequire("search_pill");
+const input_pill = zrequire("input_pill");
 zrequire("Filter", "js/filter");
 
 const is_starred_item = {

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -21,9 +21,9 @@ const huddle_data = zrequire("huddle_data");
 
 zrequire("typeahead_helper");
 zrequire("Filter", "js/filter");
-zrequire("narrow_state");
-zrequire("stream_data");
-zrequire("stream_topic_history");
+const narrow_state = zrequire("narrow_state");
+const stream_data = zrequire("stream_data");
+const stream_topic_history = zrequire("stream_topic_history");
 const people = zrequire("people");
 zrequire("unread");
 zrequire("common");

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -20,9 +20,9 @@ const huddle_data = zrequire("huddle_data");
 
 zrequire("typeahead_helper");
 zrequire("Filter", "js/filter");
-zrequire("narrow_state");
-zrequire("stream_data");
-zrequire("stream_topic_history");
+const narrow_state = zrequire("narrow_state");
+const stream_data = zrequire("stream_data");
+const stream_topic_history = zrequire("stream_topic_history");
 const people = zrequire("people");
 zrequire("unread");
 zrequire("common");

--- a/frontend_tests/node_tests/server_events.js
+++ b/frontend_tests/node_tests/server_events.js
@@ -13,10 +13,10 @@ stub_out_jquery();
 
 zrequire("message_store");
 zrequire("server_events_dispatch");
-zrequire("server_events");
+const server_events = zrequire("server_events");
 zrequire("sent_messages");
 
-set_global("channel", {});
+const channel = set_global("channel", {});
 set_global("home_msg_list", {
     select_id: noop,
     selected_id() {

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -29,17 +29,17 @@ const bot_data_params = {
     ],
 };
 
-set_global("avatar", {});
+const avatar = set_global("avatar", {});
 
 set_global("$", make_zjquery());
 
-zrequire("bot_data");
+const bot_data = zrequire("bot_data");
 
 function ClipboardJS(sel) {
     assert.equal(sel, "#copy_zuliprc");
 }
 
-rewiremock.proxy(() => zrequire("settings_bots"), {
+const settings_bots = rewiremock.proxy(() => zrequire("settings_bots"), {
     clipboard: ClipboardJS,
 });
 

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -34,7 +34,6 @@ set_global("avatar", {});
 set_global("$", make_zjquery());
 
 zrequire("bot_data");
-zrequire("people");
 
 function ClipboardJS(sel) {
     assert.equal(sel, "#copy_zuliprc");

--- a/frontend_tests/node_tests/settings_emoji.js
+++ b/frontend_tests/node_tests/settings_emoji.js
@@ -7,8 +7,8 @@ const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());
-set_global("upload_widget", {});
-zrequire("settings_emoji");
+const upload_widget = set_global("upload_widget", {});
+const settings_emoji = zrequire("settings_emoji");
 
 run_test("build_emoji_upload_widget", () => {
     let build_widget_stub = false;

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -9,10 +9,10 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 set_global("$", make_zjquery());
 
 zrequire("timerender");
-zrequire("settings_muting");
-zrequire("stream_data");
-zrequire("muting");
-set_global("muting_ui", {});
+const settings_muting = zrequire("settings_muting");
+const stream_data = zrequire("stream_data");
+const muting = zrequire("muting");
+const muting_ui = set_global("muting_ui", {});
 
 const noop = function () {};
 

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -41,8 +41,8 @@ const _page_params = {
     realm_authentication_methods: {},
 };
 
-const _realm_icon = {};
-const _channel = {};
+const realm_icon = set_global("realm_icon", {});
+const channel = set_global("channel", {});
 
 stub_templates((name, data) => {
     if (name === "settings/admin_realm_domains_list") {
@@ -52,7 +52,7 @@ stub_templates((name, data) => {
     throw new Error(`Unknown template ${name}`);
 });
 
-const _overlays = {};
+const overlays = set_global("overlays", {});
 
 const _ui_report = {
     success(msg, elem) {
@@ -72,29 +72,26 @@ const _ListWidget = {
     create: () => ({init: noop}),
 };
 
-set_global("channel", _channel);
 set_global("csrf_token", "token-stub");
 set_global("FormData", _FormData);
 set_global("jQuery", _jQuery);
 set_global("loading", _loading);
-set_global("overlays", _overlays);
 set_global("page_params", _page_params);
-set_global("realm_icon", _realm_icon);
 set_global("realm_logo", _realm_logo);
 set_global("ui_report", _ui_report);
 set_global("ListWidget", _ListWidget);
 
 const settings_config = zrequire("settings_config");
 const settings_bots = zrequire("settings_bots");
-zrequire("stream_data");
-rewiremock.proxy(() => zrequire("settings_account"), {
+const stream_data = zrequire("stream_data");
+const settings_account = rewiremock.proxy(() => zrequire("settings_account"), {
     // Setup is only imported to set the
     // setup.password_change_in_progress flag.
     "../../static/js/setup": {},
 });
-zrequire("settings_org");
+const settings_org = zrequire("settings_org");
 zrequire("settings_ui");
-zrequire("dropdown_list_widget");
+const dropdown_list_widget = zrequire("dropdown_list_widget");
 
 run_test("unloaded", () => {
     // This test mostly gets us line coverage, and makes

--- a/frontend_tests/node_tests/settings_profile_fields.js
+++ b/frontend_tests/node_tests/settings_profile_fields.js
@@ -11,7 +11,7 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("page_params", {});
 set_global("$", make_zjquery());
-set_global("loading", {});
+const loading = set_global("loading", {});
 
 const SHORT_TEXT_ID = 1;
 const CHOICE_ID = 3;
@@ -39,7 +39,7 @@ page_params.custom_profile_field_types = {
     },
 };
 
-rewiremock.proxy(() => zrequire("settings_profile_fields"), {
+const settings_profile_fields = rewiremock.proxy(() => zrequire("settings_profile_fields"), {
     sortablejs: {default: {create: () => {}}},
 });
 

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -9,12 +9,12 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
-zrequire("user_pill");
+const user_pill = zrequire("user_pill");
 zrequire("pill_typeahead");
-zrequire("settings_user_groups");
+const settings_user_groups = zrequire("settings_user_groups");
 
 set_global("$", make_zjquery());
-set_global("confirm_dialog", {});
+const confirm_dialog = set_global("confirm_dialog", {});
 
 const noop = function () {};
 
@@ -25,14 +25,14 @@ const settings_config = zrequire("settings_config");
 
 let create_item_handler;
 
-set_global("channel", {});
-set_global("typeahead_helper", {});
-set_global("user_groups", {
+const channel = set_global("channel", {});
+const typeahead_helper = set_global("typeahead_helper", {});
+const user_groups = set_global("user_groups", {
     get_user_group_from_id: noop,
     remove: noop,
     add: noop,
 });
-set_global("ui_report", {});
+const ui_report = set_global("ui_report", {});
 
 const people = zrequire("people");
 

--- a/frontend_tests/node_tests/spoilers.js
+++ b/frontend_tests/node_tests/spoilers.js
@@ -7,7 +7,7 @@ const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());
-zrequire("spoilers");
+const spoilers = zrequire("spoilers");
 
 // This function is taken from rendered_markdown.js and slightly modified.
 const $array = (array) => {

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -13,17 +13,17 @@ set_global("page_params", {
     is_guest: false,
 });
 
-zrequire("color_data");
+const color_data = zrequire("color_data");
 zrequire("hash_util");
-zrequire("stream_topic_history");
+const stream_topic_history = zrequire("stream_topic_history");
 const people = zrequire("people");
-zrequire("stream_color");
-zrequire("stream_data");
+const stream_color = zrequire("stream_color");
+const stream_data = zrequire("stream_data");
 zrequire("FetchStatus", "js/fetch_status");
 zrequire("Filter", "js/filter");
 zrequire("MessageListData", "js/message_list_data");
 zrequire("MessageListView", "js/message_list_view");
-zrequire("message_list");
+const message_list = zrequire("message_list");
 const settings_config = zrequire("settings_config");
 
 const me = {

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -29,8 +29,8 @@ set_global("stream_color", {
 set_global("stream_ui_updates", {
     update_add_subscriptions_elements: noop,
 });
-set_global("typeahead_helper", {});
-set_global("ui", {
+const typeahead_helper = set_global("typeahead_helper", {});
+const ui = set_global("ui", {
     get_scroll_element: noop,
 });
 set_global("$", make_zjquery());
@@ -40,10 +40,10 @@ const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 zrequire("pill_typeahead");
 zrequire("subs");
-zrequire("stream_edit");
-zrequire("stream_data");
-zrequire("stream_pill");
-zrequire("user_pill");
+const stream_edit = zrequire("stream_edit");
+const stream_data = zrequire("stream_data");
+const stream_pill = zrequire("stream_pill");
+const user_pill = zrequire("user_pill");
 
 stream_edit.sort_but_pin_current_user_on_top = noop;
 

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -19,18 +19,18 @@ set_global("settings_notifications", _settings_notifications);
 
 set_global("color_data", {});
 set_global("current_msg_list", {});
-set_global("message_util", {});
+const message_util = set_global("message_util", {});
 set_global("stream_color", {});
-set_global("stream_list", {});
+const stream_list = set_global("stream_list", {});
 set_global("stream_muting", {});
-set_global("subs", {});
+let subs = set_global("subs", {});
 
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
-zrequire("stream_data");
-zrequire("stream_events");
-zrequire("Filter", "js/filter");
-zrequire("narrow_state");
+const stream_data = zrequire("stream_data");
+const stream_events = zrequire("stream_events");
+const Filter = zrequire("Filter", "js/filter");
+const narrow_state = zrequire("narrow_state");
 zrequire("message_view_header");
 
 const george = {
@@ -243,7 +243,7 @@ run_test("marked_subscribed", (override) => {
         },
     });
 
-    set_global("subs", {update_settings_for_subscribed: noop});
+    subs = set_global("subs", {update_settings_for_subscribed: noop});
     set_global("overlays", {streams_open: return_true});
 
     // Test basic dispatching and updating stream color

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -11,16 +11,16 @@ set_global("document", "document-stub");
 set_global("$", make_zjquery());
 
 zrequire("unread_ui");
-zrequire("Filter", "js/filter");
-zrequire("stream_sort");
+const Filter = zrequire("Filter", "js/filter");
+const stream_sort = zrequire("stream_sort");
 zrequire("colorspace");
-zrequire("stream_color");
+const stream_color = zrequire("stream_color");
 zrequire("hash_util");
-zrequire("unread");
-zrequire("stream_data");
-zrequire("scroll_util");
+const unread = zrequire("unread");
+const stream_data = zrequire("stream_data");
+const scroll_util = zrequire("scroll_util");
 zrequire("list_cursor");
-zrequire("stream_list");
+const stream_list = zrequire("stream_list");
 zrequire("topic_zoom");
 zrequire("ui");
 set_global("page_params", {
@@ -38,7 +38,7 @@ const return_true = function () {
     return true;
 };
 
-set_global("topic_list", {});
+const topic_list = set_global("topic_list", {});
 set_global("overlays", {});
 set_global("popovers", {});
 
@@ -387,10 +387,11 @@ run_test("zoom_in_and_zoom_out", () => {
 
 set_global("$", make_zjquery());
 
+let narrow_state;
 run_test("narrowing", () => {
     initialize_stream_data();
 
-    set_global("narrow_state", {
+    narrow_state = set_global("narrow_state", {
         stream() {
             return "devel";
         },

--- a/frontend_tests/node_tests/stream_pill.js
+++ b/frontend_tests/node_tests/stream_pill.js
@@ -6,8 +6,8 @@ const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 const peer_data = zrequire("peer_data");
-zrequire("stream_data");
-zrequire("stream_pill");
+const stream_data = zrequire("stream_data");
+const stream_pill = zrequire("stream_pill");
 
 const denmark = {
     stream_id: 1,

--- a/frontend_tests/node_tests/stream_search.js
+++ b/frontend_tests/node_tests/stream_search.js
@@ -9,7 +9,7 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 // lives in stream_list.js.
 
 set_global("$", make_zjquery());
-zrequire("stream_list");
+const stream_list = zrequire("stream_list");
 
 const noop = () => {};
 
@@ -18,8 +18,8 @@ set_global("resize", {
     resize_stream_filters_container: noop,
 });
 
-set_global("popovers", {});
-set_global("stream_popover", {});
+const popovers = set_global("popovers", {});
+const stream_popover = set_global("stream_popover", {});
 
 function expand_sidebar() {
     $(".app-main .column-left").addClass("expanded");

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -5,8 +5,8 @@ const {strict: assert} = require("assert");
 const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("stream_data");
-zrequire("stream_sort");
+const stream_data = zrequire("stream_data");
+const stream_sort = zrequire("stream_sort");
 
 run_test("no_subscribed_streams", () => {
     assert.equal(stream_sort.sort_groups([]), undefined);

--- a/frontend_tests/node_tests/stream_topic_history.js
+++ b/frontend_tests/node_tests/stream_topic_history.js
@@ -5,12 +5,12 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("unread");
-zrequire("stream_data");
-zrequire("stream_topic_history");
+const unread = zrequire("unread");
+const stream_data = zrequire("stream_data");
+const stream_topic_history = zrequire("stream_topic_history");
 
-set_global("channel", {});
-set_global("message_list", {});
+const channel = set_global("channel", {});
+const message_list = set_global("message_list", {});
 
 run_test("basics", () => {
     const stream_id = 55;

--- a/frontend_tests/node_tests/submessage.js
+++ b/frontend_tests/node_tests/submessage.js
@@ -5,11 +5,11 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("submessage");
+const submessage = zrequire("submessage");
 
-set_global("channel", {});
-set_global("widgetize", {});
-set_global("message_store", {});
+const channel = set_global("channel", {});
+const widgetize = set_global("widgetize", {});
+const message_store = set_global("message_store", {});
 
 run_test("get_message_events", () => {
     let msg = {};

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -7,11 +7,11 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("ui", {
+const ui = set_global("ui", {
     get_content_element: (element) => element,
     get_scroll_element: (element) => element,
 });
-zrequire("stream_data");
+const stream_data = zrequire("stream_data");
 zrequire("search_util");
 set_global("page_params", {});
 
@@ -21,7 +21,7 @@ set_global("location", {
     hash: `#streams/${denmark_stream_id}/announce`,
 });
 
-zrequire("subs");
+const subs = zrequire("subs");
 
 set_global("$", make_zjquery());
 set_global("hash_util", {

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -14,7 +14,7 @@ set_global("page_params", {
     twenty_four_hour_time: true,
 });
 
-zrequire("timerender");
+const timerender = zrequire("timerender");
 
 run_test("render_now_returns_today", () => {
     const today = new Date(1555091573000); // Friday 4/12/2019 5:52:53 PM (UTC+0)

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -8,11 +8,11 @@ const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());
 
-zrequire("Filter", "js/filter");
+const Filter = zrequire("Filter", "js/filter");
 zrequire("unread_ui");
 const people = zrequire("people");
 
-zrequire("top_left_corner");
+const top_left_corner = zrequire("top_left_corner");
 
 run_test("narrowing", () => {
     // activating narrow

--- a/frontend_tests/node_tests/topic_generator.js
+++ b/frontend_tests/node_tests/topic_generator.js
@@ -8,11 +8,11 @@ const {run_test} = require("../zjsunit/test");
 const pm_conversations = zrequire("pm_conversations");
 pm_conversations.recent = {};
 
-zrequire("muting");
-zrequire("unread");
-zrequire("stream_data");
-zrequire("stream_topic_history");
-zrequire("stream_sort");
+const muting = zrequire("muting");
+const unread = zrequire("unread");
+const stream_data = zrequire("stream_data");
+const stream_topic_history = zrequire("stream_topic_history");
+const stream_sort = zrequire("stream_sort");
 const tg = zrequire("topic_generator");
 
 run_test("streams", () => {

--- a/frontend_tests/node_tests/topic_list_data.js
+++ b/frontend_tests/node_tests/topic_list_data.js
@@ -7,15 +7,15 @@ const _ = require("lodash");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-set_global("narrow_state", {});
+const narrow_state = set_global("narrow_state", {});
 set_global("unread", {});
-set_global("muting", {});
+const muting = set_global("muting", {});
 set_global("message_list", {});
 
 zrequire("hash_util");
-zrequire("stream_data");
-zrequire("unread");
-zrequire("stream_topic_history");
+const stream_data = zrequire("stream_data");
+const unread = zrequire("unread");
+const stream_topic_history = zrequire("stream_topic_history");
 const topic_list_data = zrequire("topic_list_data");
 
 const general = {

--- a/frontend_tests/node_tests/transmit.js
+++ b/frontend_tests/node_tests/transmit.js
@@ -10,16 +10,16 @@ const noop = function () {};
 
 set_global("$", make_zjquery());
 set_global("page_params", {});
-set_global("channel", {});
-set_global("reload", {});
-set_global("reload_state", {});
-set_global("sent_messages", {
+const channel = set_global("channel", {});
+const reload = set_global("reload", {});
+const reload_state = set_global("reload_state", {});
+const sent_messages = set_global("sent_messages", {
     start_tracking_message: noop,
     report_server_ack: noop,
 });
 
 const people = zrequire("people");
-zrequire("transmit");
+const transmit = zrequire("transmit");
 
 run_test("transmit_message_ajax", () => {
     let success_func_called;

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -14,10 +14,10 @@ const pm_conversations = zrequire("pm_conversations");
 page_params.realm_email_address_visibility =
     settings_config.email_address_visibility_values.admins_only.code;
 
-zrequire("recent_senders");
+const recent_senders = zrequire("recent_senders");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
-zrequire("stream_data");
+const stream_data = zrequire("stream_data");
 zrequire("narrow");
 zrequire("hash_util");
 

--- a/frontend_tests/node_tests/typing_data.js
+++ b/frontend_tests/node_tests/typing_data.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("typing_data");
+const typing_data = zrequire("typing_data");
 
 run_test("basics", () => {
     // The typing_data needs to be robust with lists of

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -5,8 +5,8 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("typing");
-zrequire("compose_pm_pill");
+const typing = zrequire("typing");
+const compose_pm_pill = zrequire("compose_pm_pill");
 const typing_status = zrequire("typing_status", "shared/js/typing_status");
 
 function make_time(secs) {

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -6,7 +6,6 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 zrequire("typing");
-zrequire("people");
 zrequire("compose_pm_pill");
 const typing_status = zrequire("typing_status", "shared/js/typing_status");
 

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -95,7 +95,6 @@ zrequire("overlays");
 zrequire("invite");
 zrequire("message_view_header");
 zrequire("narrow_state");
-zrequire("people");
 zrequire("presence");
 zrequire("search_pill_widget");
 zrequire("user_groups");
@@ -112,7 +111,6 @@ zrequire("tutorial");
 rewiremock.proxy(() => zrequire("notifications"), {
     "../../static/js/favicon": {},
 });
-zrequire("pm_conversations");
 zrequire("pm_list");
 zrequire("list_cursor");
 zrequire("keydown_util");

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -38,7 +38,7 @@ set_global("document", {
 set_global("csrf_token", "whatever");
 
 set_global("$", () => {});
-set_global("resize", {});
+const resize = set_global("resize", {});
 set_global("page_params", {});
 
 const ignore_modules = [
@@ -69,11 +69,14 @@ const ignore_modules = [
     "unread_ui",
 ];
 
-for (const mod of ignore_modules) {
-    set_global(mod, {
-        initialize: () => {},
-    });
-}
+const {server_events, ui} = Object.fromEntries(
+    ignore_modules.map((mod) => [
+        mod,
+        set_global(mod, {
+            initialize: () => {},
+        }),
+    ]),
+);
 
 util.is_mobile = () => false;
 stub_templates(() => "some-html");
@@ -101,8 +104,8 @@ zrequire("user_groups");
 zrequire("unread");
 zrequire("bot_data");
 zrequire("markdown");
-zrequire("upload");
-zrequire("compose");
+const upload = zrequire("upload");
+const compose = zrequire("compose");
 zrequire("composebox_typeahead");
 zrequire("narrow");
 zrequire("search_suggestion");

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -7,10 +7,10 @@ const _ = require("lodash");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("muting");
+const muting = zrequire("muting");
 const people = zrequire("people");
-zrequire("stream_data");
-zrequire("unread");
+const stream_data = zrequire("stream_data");
+const unread = zrequire("unread");
 
 set_global("page_params", {
     realm_push_notifications_enabled: false,
@@ -22,7 +22,7 @@ const {FoldDict} = zrequire("fold_dict");
 set_global("narrow_state", {});
 set_global("current_msg_list", {});
 set_global("home_msg_list", {});
-set_global("message_store", {});
+const message_store = set_global("message_store", {});
 
 const me = {
     email: "me@example.com",

--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -14,11 +14,7 @@ const template = fs.readFileSync("templates/corporate/upgrade.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});
 const document = dom.window.document;
 
-set_global("helpers", {
-    set_tab: noop,
-});
-
-set_global("StripeCheckout", {
+const StripeCheckout = set_global("StripeCheckout", {
     configure: noop,
 });
 
@@ -29,7 +25,7 @@ set_global("page_params", {
     percent_off: 20,
 });
 
-zrequire("helpers", "js/billing/helpers");
+const helpers = zrequire("helpers", "js/billing/helpers");
 set_global("$", make_zjquery());
 
 run_test("initialize", () => {

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -26,10 +26,10 @@ set_global("bridge", false);
 document.location.protocol = "https:";
 document.location.host = "foo.com";
 
-zrequire("compose_ui");
+const compose_ui = zrequire("compose_ui");
 zrequire("compose_state");
 zrequire("compose");
-zrequire("compose_actions");
+const compose_actions = zrequire("compose_actions");
 
 const plugin_stub = {
     prototype: {
@@ -37,7 +37,7 @@ const plugin_stub = {
     },
 };
 
-zrequire("upload");
+let upload = zrequire("upload");
 
 run_test("make_upload_absolute", () => {
     let uri = "/user_uploads/5/d4/6lSlfIPIg9nDI2Upj0Mq_EbE/kerala.png";
@@ -358,7 +358,7 @@ run_test("uppy_config", () => {
         };
     }
     uppy_stub.Plugin = plugin_stub;
-    rewiremock.proxy(() => require("../../static/js/upload"), {"@uppy/core": uppy_stub});
+    upload = rewiremock.proxy(() => require("../../static/js/upload"), {"@uppy/core": uppy_stub});
     upload.setup_upload({mode: "compose"});
 
     assert.equal(uppy_stub_called, true);
@@ -502,7 +502,7 @@ run_test("uppy_events", () => {
         };
     }
     uppy_stub.Plugin = plugin_stub;
-    rewiremock.proxy(() => require("../../static/js/upload"), {"@uppy/core": uppy_stub});
+    upload = rewiremock.proxy(() => require("../../static/js/upload"), {"@uppy/core": uppy_stub});
     upload.setup_upload({mode: "compose"});
     assert.equal(Object.keys(callbacks).length, 5);
 

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -10,7 +10,7 @@ set_global("$", make_zjquery());
 
 const people = zrequire("people");
 const settings_config = zrequire("settings_config");
-zrequire("user_events");
+const user_events = zrequire("user_events");
 
 set_global("activity", {
     redraw() {},
@@ -51,12 +51,12 @@ set_global("compose", {
     update_email() {},
 });
 
-set_global("settings_account", {
+const settings_account = set_global("settings_account", {
     update_email() {},
     update_full_name() {},
 });
 
-set_global("message_live_update", {});
+const message_live_update = set_global("message_live_update", {});
 
 const me = {
     email: "me@example.com",

--- a/frontend_tests/node_tests/user_groups.js
+++ b/frontend_tests/node_tests/user_groups.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("user_groups");
+const user_groups = zrequire("user_groups");
 
 run_test("user_groups", () => {
     const students = {

--- a/frontend_tests/node_tests/user_pill.js
+++ b/frontend_tests/node_tests/user_pill.js
@@ -6,7 +6,7 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 const people = zrequire("people");
-zrequire("user_pill");
+const user_pill = zrequire("user_pill");
 zrequire("pill_typeahead");
 
 set_global("page_params", {});

--- a/frontend_tests/node_tests/user_status.js
+++ b/frontend_tests/node_tests/user_status.js
@@ -5,8 +5,8 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-set_global("channel", {});
-zrequire("user_status");
+const channel = set_global("channel", {});
+const user_status = zrequire("user_status");
 
 function initialize() {
     const params = {

--- a/frontend_tests/node_tests/vdom.js
+++ b/frontend_tests/node_tests/vdom.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-zrequire("vdom");
+const vdom = zrequire("vdom");
 
 run_test("basics", () => {
     const opts = {

--- a/frontend_tests/node_tests/widgetize.js
+++ b/frontend_tests/node_tests/widgetize.js
@@ -7,7 +7,7 @@ const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 set_global("$", make_zjquery());
-set_global("poll_widget", {});
+const poll_widget = set_global("poll_widget", {});
 set_global("todo_widget", {});
 set_global("zform", {});
 set_global("document", "document-stub");
@@ -15,9 +15,9 @@ set_global("document", "document-stub");
 const return_true = () => true;
 const return_false = () => false;
 
-zrequire("widgetize");
+const widgetize = zrequire("widgetize");
 
-set_global("narrow_state", {});
+const narrow_state = set_global("narrow_state", {});
 set_global("current_msg_list", {});
 
 run_test("activate", () => {

--- a/frontend_tests/puppeteer_lib/common.js
+++ b/frontend_tests/puppeteer_lib/common.js
@@ -39,9 +39,10 @@ class CommonUtils {
             },
 
             async expect(page, expected) {
-                const actual_recipients = await page.evaluate(() =>
-                    compose_state.private_message_recipient(),
-                );
+                const actual_recipients = await page.evaluate(() => {
+                    const compose_state = window.require("./static/js/compose_state");
+                    return compose_state.private_message_recipient();
+                });
                 assert.equal(actual_recipients, expected);
             },
         };
@@ -171,10 +172,10 @@ class CommonUtils {
     }
 
     async get_stream_id(page, stream_name) {
-        return await page.evaluate(
-            (stream_name) => stream_data.get_stream_id(stream_name),
-            stream_name,
-        );
+        return await page.evaluate((stream_name) => {
+            const stream_data = window.require("./static/js/stream_data");
+            return stream_data.get_stream_id(stream_name);
+        }, stream_name);
     }
 
     async get_user_id_from_name(page, name) {
@@ -279,6 +280,7 @@ class CommonUtils {
                     - does it look to have been
                       re-rendered based on server info?
             */
+                const rows = window.require("./static/js/rows");
                 const last_msg = current_msg_list.last();
                 if (last_msg === undefined) {
                     return false;
@@ -359,6 +361,7 @@ class CommonUtils {
 
         // Close the compose box after sending the message.
         await page.evaluate(() => {
+            const compose_actions = window.require("./static/js/compose_actions");
             compose_actions.cancel();
         });
         // Make sure the compose box is closed.

--- a/frontend_tests/puppeteer_tests/07-navigation.js
+++ b/frontend_tests/puppeteer_tests/07-navigation.js
@@ -57,7 +57,10 @@ async function test_reload_hash(page) {
 
     const initial_hash = await page.evaluate(() => window.location.hash);
 
-    await page.evaluate(() => reload.initiate({immediate: true}));
+    await page.evaluate(() => {
+        const reload = window.require("./static/js/reload");
+        reload.initiate({immediate: true});
+    });
     await page.waitForSelector("#zfilt", {visible: true});
 
     const page_load_time = await page.evaluate(() => page_params.page_load_time);
@@ -72,7 +75,10 @@ async function navigation_tests(page) {
 
     await navigate_to_settings(page);
 
-    const verona_id = await page.evaluate(() => stream_data.get_stream_id("Verona"));
+    const verona_id = await page.evaluate(() => {
+        const stream_data = window.require("./static/js/stream_data");
+        return stream_data.get_stream_id("Verona");
+    });
     const verona_narrow = `narrow/stream/${verona_id}-Verona`;
 
     await navigate_to(page, verona_narrow, "message_feed_container");

--- a/frontend_tests/puppeteer_tests/09-mention.js
+++ b/frontend_tests/puppeteer_tests/09-mention.js
@@ -17,10 +17,12 @@ async function test_mention(page) {
     await common.ensure_enter_does_not_send(page);
 
     console.log("Checking for all everyone warning");
-    const stream_size = await page.evaluate(() =>
-        stream_data.get_subscriber_count(stream_data.get_sub("Verona").stream_id),
-    );
+    const stream_size = await page.evaluate(() => {
+        const stream_data = window.require("./static/js/stream_data");
+        return stream_data.get_subscriber_count(stream_data.get_sub("Verona").stream_id);
+    });
     const threshold = await page.evaluate(() => {
+        const compose = window.require("./static/js/compose");
         compose.wildcard_mention_large_stream_threshold = 5;
         return compose.wildcard_mention_large_stream_threshold;
     });

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -87,7 +87,7 @@ try {
         _.throttle = immediate;
         _.debounce = immediate;
 
-        namespace.set_global("blueslip", make_zblueslip());
+        const blueslip = namespace.set_global("blueslip", make_zblueslip());
         namespace.set_global("i18n", stub_i18n);
         namespace.clear_zulip_refs();
 

--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -73,7 +73,7 @@ exports.restore = function () {
 };
 
 exports.stub_out_jquery = function () {
-    exports.set_global("$", () => ({
+    const $ = exports.set_global("$", () => ({
         on() {},
         trigger() {},
         hide() {},

--- a/frontend_tests/zjsunit/test.js
+++ b/frontend_tests/zjsunit/test.js
@@ -26,5 +26,5 @@ exports.run_test = (label, f) => {
         throw error;
     }
     // defensively reset blueslip after each test.
-    blueslip.reset();
+    window.blueslip.reset();
 };

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -142,4 +142,5 @@ const DropdownListWidget = function (opts) {
     };
 };
 
+module.exports = DropdownListWidget;
 window.dropdown_list_widget = DropdownListWidget;


### PR DESCRIPTION
This should allow us to convert 14 additional modules to ES6 modules using the strategy of #17259.