### PR TITLE
slugs: Fix regex for legacy stream slugs.

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -116,7 +116,12 @@ run_test("basics", () => {
     assert.equal(stream_data.slug_to_name("2-whatever"), "social");
     assert.equal(stream_data.slug_to_name("2"), "social");
 
+    // legacy
     assert.equal(stream_data.slug_to_name("25-or-6-to-4"), "25-or-6-to-4");
+    assert.equal(stream_data.slug_to_name("2something"), "2something");
+
+    assert.equal(stream_data.slug_to_name("99-whatever"), "99-whatever");
+    assert.equal(stream_data.slug_to_name("99whatever"), "99whatever");
 });
 
 run_test("renames", () => {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -328,7 +328,7 @@ exports.slug_to_name = function (slug) {
     GitHub conversations.  We migrated to modern slugs in
     early 2018.
     */
-    const m = /^(\d+)(-.*)?/.exec(slug);
+    const m = /^(\d+)(-.*)?$/.exec(slug);
     if (m) {
         const stream_id = Number.parseInt(m[1], 10);
         const sub = subs_by_stream_id.get(stream_id);


### PR DESCRIPTION
This prevents a bug where we interpret "2something"
as a modern slug instead of a legacy stream name.

The bug was probably somewhat unlikely to happen in
practice, since it only manifests if 2 is an actual
stream_id.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
