### PR TITLE
dropdown_list_widget: Display default_text for invalid values. 

### DIFF
--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -58,6 +58,12 @@ run_test("basic_functions", () => {
     assert.equal(widget.value(), "");
     assert.equal(updated_value, null);
     assert(!reset_button.visible());
+
+    widget.update("four");
+    assert.equal($widget.text(), "translated: not set");
+    assert.equal(widget.value(), "four");
+    assert.equal(updated_value, "four");
+    assert(!reset_button.visible());
 });
 
 run_test("no_default_value", () => {

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -20,20 +20,30 @@ const DropdownListWidget = function (opts) {
     };
     init();
 
+    const render_default_text = (elem) => {
+        elem.text(opts.default_text);
+        elem.addClass("text-warning");
+        elem.closest(".input-group").find(".dropdown_list_reset_button:enabled").hide();
+    };
+
     const render = (value) => {
         $(`#${CSS.escape(opts.container_id)} #${CSS.escape(opts.value_id)}`).data("value", value);
 
         const elem = $(`#${CSS.escape(opts.container_id)} #${CSS.escape(opts.widget_name)}_name`);
 
         if (!value || value === opts.null_value) {
-            elem.text(opts.default_text);
-            elem.addClass("text-warning");
-            elem.closest(".input-group").find(".dropdown_list_reset_button:enabled").hide();
+            render_default_text(elem);
             return;
         }
 
         // Happy path
         const item = opts.data.find((x) => x.value === value.toString());
+
+        if (item === undefined) {
+            render_default_text(elem);
+            return;
+        }
+
         const text = opts.render_text(item.name);
         elem.text(text);
         elem.removeClass("text-warning");


### PR DESCRIPTION
Fixes #16946.

Made this PR as an alternative approach for #17260 as per discussion [here](https://chat.zulip.org/#narrow/stream/91-code-review/topic/.2317260/near/1115988).

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
