### PR TITLE
The side-bar name overlapping with setting

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1958,7 +1958,7 @@ div.focused_table {
     left: auto;
     right: 0;
     top: 30px;
-    min-width: 180px;
+    min-width: 233px;
     box-shadow: 0 0 5px hsla(0, 0%, 0%, 0.2);
 
     &::after {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->The PR is for issue #17169


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot (97)](https://user-images.githubusercontent.com/43277445/107656156-e3ad7280-6ca9-11eb-8702-67490077873c.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
