### PR TITLE
invites: Fix bug revoking user invites in other realms than intended.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -501,23 +501,10 @@ def process_new_human_user(
                     user=f"{user_profile.full_name} <`{user_profile.email}`>"
                 ),
             )
-    # Mark any other PreregistrationUsers in the realm that are STATUS_ACTIVE as
-    # inactive so we can keep track of the PreregistrationUser we
-    # actually used for analytics.
-    # In the special case of realm creation, there can be no additional PreregistrationUser
-    # for us to want to modify.
-    if prereg_user is not None and not realm_creation:
-        PreregistrationUser.objects.filter(
-            email__iexact=user_profile.delivery_email, realm=user_profile.realm
-        ).exclude(id=prereg_user.id).update(status=confirmation_settings.STATUS_REVOKED)
 
-        if prereg_user.referred_by is not None:
-            notify_invites_changed(user_profile)
-    elif prereg_user is None:
-        assert not realm_creation
-        PreregistrationUser.objects.filter(
-            email__iexact=user_profile.delivery_email, realm=user_profile.realm
-        ).update(status=confirmation_settings.STATUS_REVOKED)
+    revoke_preregistration_users(user_profile, prereg_user, realm_creation)
+    if not realm_creation and prereg_user is not None and prereg_user.referred_by is not None:
+        notify_invites_changed(user_profile)
 
     notify_new_user(user_profile)
     # Clear any scheduled invitation emails to prevent them
@@ -531,6 +518,32 @@ def process_new_human_user(
     from zerver.lib.onboarding import send_initial_pms
 
     send_initial_pms(user_profile)
+
+
+def revoke_preregistration_users(
+    created_user_profile: UserProfile,
+    used_preregistration_user: Optional[PreregistrationUser],
+    realm_creation: bool,
+) -> None:
+    if realm_creation and used_preregistration_user is None:
+        raise AssertionError("realm_creation should only happen with a PreregistrationUser")
+
+    # Mark any other PreregistrationUsers in the realm that are STATUS_ACTIVE as
+    # inactive so we can keep track of the PreregistrationUser we
+    # actually used for analytics.
+    # In the special case of realm creation, there can be no additional PreregistrationUser
+    # for us to want to modify.
+    if used_preregistration_user is not None and not realm_creation:
+        PreregistrationUser.objects.filter(
+            email__iexact=created_user_profile.delivery_email, realm=created_user_profile.realm
+        ).exclude(id=used_preregistration_user.id).update(
+            status=confirmation_settings.STATUS_REVOKED
+        )
+    elif used_preregistration_user is None:
+        assert not realm_creation
+        PreregistrationUser.objects.filter(
+            email__iexact=created_user_profile.delivery_email, realm=created_user_profile.realm
+        ).update(status=confirmation_settings.STATUS_REVOKED)
 
 
 def notify_created_user(user_profile: UserProfile) -> None:

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -464,8 +464,6 @@ def process_new_human_user(
 
     mit_beta_user = realm.is_zephyr_mirror_realm
     if prereg_user is not None:
-        prereg_user.status = confirmation_settings.STATUS_ACTIVE
-        prereg_user.save(update_fields=["status"])
         streams = prereg_user.streams.all()
         acting_user: Optional[UserProfile] = prereg_user.referred_by
     else:
@@ -527,6 +525,10 @@ def revoke_preregistration_users(
 ) -> None:
     if realm_creation and used_preregistration_user is None:
         raise AssertionError("realm_creation should only happen with a PreregistrationUser")
+
+    if used_preregistration_user is not None:
+        used_preregistration_user.status = confirmation_settings.STATUS_ACTIVE
+        used_preregistration_user.save(update_fields=["status"])
 
     # Mark any other PreregistrationUsers in the realm that are STATUS_ACTIVE as
     # inactive so we can keep track of the PreregistrationUser we

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -445,8 +445,6 @@ class WorkerTest(ZulipTestCase):
             dict(prereg_id=prereg_alice.id, referrer_id=inviter.id, email_body=None),
             # Nonexistent prereg_id, as if the invitation was deleted
             dict(prereg_id=-1, referrer_id=inviter.id, email_body=None),
-            # Form with `email` is from versions up to Zulip 1.7.1
-            dict(email=self.nonreg_email("bob"), referrer_id=inviter.id, email_body=None),
         ]
         for element in data:
             fake_client.enqueue("invites", element)
@@ -458,7 +456,7 @@ class WorkerTest(ZulipTestCase):
                 "zerver.worker.queue_processors.send_future_email"
             ) as send_mock:
                 worker.start()
-                self.assertEqual(send_mock.call_count, 2)
+                self.assertEqual(send_mock.call_count, 1)
 
     def test_error_handling(self) -> None:
         processed = []

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -410,19 +410,12 @@ class LoopQueueProcessingWorker(QueueProcessingWorker):
 @assign_queue("invites")
 class ConfirmationEmailWorker(QueueProcessingWorker):
     def consume(self, data: Mapping[str, Any]) -> None:
-        if "email" in data:
-            # When upgrading from a version up through 1.7.1, there may be
-            # existing items in the queue with `email` instead of `prereg_id`.
-            invitee = filter_to_valid_prereg_users(
-                PreregistrationUser.objects.filter(email__iexact=data["email"].strip())
-            ).latest("invited_at")
-        else:
-            invitee = filter_to_valid_prereg_users(
-                PreregistrationUser.objects.filter(id=data["prereg_id"])
-            ).first()
-            if invitee is None:
-                # The invitation could have been revoked
-                return
+        invitee = filter_to_valid_prereg_users(
+            PreregistrationUser.objects.filter(id=data["prereg_id"])
+        ).first()
+        if invitee is None:
+            # The invitation could have been revoked
+            return
 
         referrer = get_user_profile_by_id(data["referrer_id"])
         logger.info(


### PR DESCRIPTION
Fixes #17238.
In process_new_human user, the queries were wrong, revoking all invites
sent to the email address, even in other realms than the one where the
new account just got created.
