### PR TITLE
navbar: Replace gear menu with avatar and show status icon.

### DIFF
--- a/docs/subsystems/full-text-search.md
+++ b/docs/subsystems/full-text-search.md
@@ -8,7 +8,7 @@ full-text search for all languages.
 
 The user interface and feature set for Zulip's full-text search is
 documented in the "Search operators" documentation section in the Zulip
-app's gear menu.
+app's avatar menu.
 
 ## The default full-text search implementation
 

--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -273,7 +273,7 @@ Here are the things to test:
     - Compose (send a message to the stream)
     - Mark as read (scroll back and then have Hamlet send you a message)
     - Mute/unmute (do both)
-    - Unsubscribe (and then go to Stream settings in the gear menu to resubscribe)
+    - Unsubscribe (and then go to Stream settings in the avatar menu to resubscribe)
     - Choose custom color (play around with this)
 
 - Topic sidebar menus (click ellipsis when hovering over topics)
@@ -409,11 +409,11 @@ Miscellaneous:
 ### Stream settings ###
 
 Test various UI entry points into stream settings:
-- Use small gear menu in left sidebar, then filter to "devel".
+- Use small avatar menu in left sidebar, then filter to "devel".
 - Use popover menu in left sidebar next to "devel".
-- Use gear menu above buddy list and filter to "devel".
-- Use gear menu and click on "devel."
-- Use gear menu and then click on chevron menu next to "devel."
+- Use avatar menu above buddy list and filter to "devel".
+- Use avatar menu and click on "devel."
+- Use avatar menu and then click on chevron menu next to "devel."
   (I'm not sure why we still have the chevron at this writing.)
 
 Create new public stream "public1" and add Hamlet:
@@ -455,7 +455,7 @@ Test per-stream options:
 
 ### User settings ###
 
-You can modify per-user settings by choosing "Settings" in the gear menu.
+You can modify per-user settings by choosing "Settings" in the avatar menu.
 Do these tasks as Cordelia.
 
 - Your account
@@ -500,7 +500,7 @@ Here are the tasks for this section:
 - Use the "?" hotkey to open the keyboard help
 - Proofread the dialog for typos.
 - Close the dialog.
-- Re-open the keyboard help using the gear menu.
+- Re-open the keyboard help using the avatar menu.
 - Find a hotkey that you don't frequently use and experiment with its
   usage.
 
@@ -520,11 +520,11 @@ Make sure that these options launch appropriate help screens:
 Here are the tasks:
 - Invite ignore@zulip.com using the link beneath the buddy list but
   then don't take further action.
-- Fully invite foo@zulip.com using the gear menu.
+- Fully invite foo@zulip.com using the avatar menu.
 - Go to the development console to get the login link for foo@zulip.com.
 - Go through the signup flow.
 - Follow the tutorial.
-- Use the gear menu to log out.
+- Use the avatar menu to log out.
 - Log back in as Cordelia (admittedly, this step doesn't really QA
   much of our production code, since the login flow is customized for
   the development environment).

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -202,7 +202,7 @@ export function info_for(user_id) {
     };
 }
 
-function get_last_seen(active_status, last_seen) {
+export function get_last_seen(active_status, last_seen) {
     if (active_status === "active") {
         return last_seen;
     }

--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -93,13 +93,14 @@ export function update_org_settings_menu_item() {
 
 export function initialize() {
     update_org_settings_menu_item();
+    set_avatar();
 
-    $('#gear-menu a[data-toggle="tab"]').on("show", (e) => {
+    $('#avatar-menu a[data-toggle="tab"]').on("show", (e) => {
         // Save the position of our old tab away, before we switch
         const old_tab = $(e.relatedTarget).attr("href");
         scroll_positions.set(old_tab, message_viewport.scrollTop());
     });
-    $('#gear-menu a[data-toggle="tab"]').on("shown", (e) => {
+    $('#avatar-menu a[data-toggle="tab"]').on("shown", (e) => {
         const target_tab = $(e.target).attr("href");
         // Hide all our error messages when switching tabs
         $(".alert").removeClass("show");
@@ -130,7 +131,7 @@ export function initialize() {
 export function open() {
     $("#settings-dropdown").trigger("click");
     // there are invisible li tabs, which should not be clicked.
-    $("#gear-menu").find("li:not(.invisible) a").eq(0).trigger("focus");
+    $("#avatar-menu").find("li:not(.invisible) a").eq(0).trigger("focus");
 }
 
 export function is_open() {
@@ -141,4 +142,10 @@ export function close() {
     if (is_open()) {
         $(".dropdown").removeClass("open");
     }
+}
+
+export function set_avatar() {
+    const avatar_url = page_params.avatar_url;
+
+    $(".settings-dropdown-avatar").attr("src", avatar_url);
 }

--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -1,10 +1,12 @@
 import $ from "jquery";
 
+import * as buddy_data from "./buddy_data";
 import * as hashchange from "./hashchange";
 import {$t} from "./i18n";
 import * as message_viewport from "./message_viewport";
 import * as navigate from "./navigate";
 import {page_params} from "./page_params";
+import * as presence from "./presence";
 
 /*
 For various historical reasons there isn't one
@@ -146,6 +148,18 @@ export function close() {
 
 export function set_avatar() {
     const avatar_url = page_params.avatar_url;
+    const user_id = page_params.user_id;
+    const full_name = page_params.full_name;
+    const active_status = presence.get_status(user_id);
+    const last_seen = buddy_data.user_last_seen_time_status(user_id);
+    const user_circle_class = buddy_data.get_user_circle_class(user_id);
 
     $(".settings-dropdown-avatar").attr("src", avatar_url);
+    $(".dropdown-user-fullname").append(full_name);
+    $(".dropdown-user-presence").append(
+        "<span class='" +
+            user_circle_class +
+            " user_circle'></span>" +
+            buddy_data.get_last_seen(active_status, last_seen),
+    );
 }

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -379,7 +379,7 @@ function handle_popover_events(event_name) {
 // Returns true if we handled it, false if the browser should.
 export function process_enter_key(e) {
     if ($(".dropdown.open").length && $(e.target).attr("role") === "menuitem") {
-        // on #gear-menu li a[tabindex] elements, force a click and prevent default.
+        // on #avatar-menu li a[tabindex] elements, force a click and prevent default.
         // this is because these links do not have an href and so don't force a
         // default action.
         e.target.click();

--- a/static/js/ui_util.js
+++ b/static/js/ui_util.js
@@ -4,7 +4,7 @@ import $ from "jquery";
 // dependencies other than jQuery.
 
 export function change_tab_to(tabname) {
-    $(`#gear-menu a[href="${CSS.escape(tabname)}"]`).tab("show");
+    $(`#avatar-menu a[href="${CSS.escape(tabname)}"]`).tab("show");
 }
 
 // https://stackoverflow.com/questions/4233265/contenteditable-set-caret-at-the-end-of-the-text-cross-browser

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -678,8 +678,11 @@ li.actual-dropdown-menu i {
     margin-right: 3px;
 }
 
-.settings-dropdown-cog {
-    padding: 6px 12px;
+.settings-dropdown-avatar {
+    margin-top: -6px;
+    padding: 10px;
+    border-radius: 12px;
+    width: 25px;
 }
 
 .message_area_padder {
@@ -1929,7 +1932,7 @@ div.focused_table {
             box-shadow: inherit;
             display: block;
             position: absolute;
-            right: 6px;
+            right: 4px;
             top: -3px;
         }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -685,6 +685,46 @@ li.actual-dropdown-menu i {
     width: 25px;
 }
 
+.settings-dropdown-profile {
+    display: flex;
+    justify-content: left;
+    flex-direction: row;
+    padding-left: 10px;
+
+    .avatar-medium {
+        min-width: 35px;
+    }
+
+    > div {
+        display: flex;
+        justify-content: space-evenly;
+        flex-direction: column;
+        margin-left: 5px;
+        margin-top: 2px;
+        line-height: 15px;
+        padding-right: 5px;
+
+        .dropdown-user-fullname {
+            font-weight: 600;
+            max-width: 75px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .dropdown-user-presence {
+            display: flex;
+            flex-direction: row;
+
+            .user_circle {
+                height: 6px;
+                width: 6px;
+                margin: 3px 3px 3px 0;
+                position: inherit;
+            }
+        }
+    }
+}
+
 .message_area_padder {
     /* The height of the header and the message_view_header plus a small gap */
     margin-top: 57px;

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -282,7 +282,7 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{% trans %}Toggle the gear menu{% endtrans %}</td>
+                    <td class="definition">{% trans %}Toggle the avatar menu{% endtrans %}</td>
                     <td><span class="hotkey"><kbd>G</kbd></span></td>
                 </tr>
                 <tr>

--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -49,9 +49,9 @@
             </div>
             <div id="navbar-buttons" {%if embedded %} style="visibility: hidden"{% endif %}>
                 <ul class="nav" role="navigation">
-                    <li class="dropdown actual-dropdown-menu" id="gear-menu">
-                        <a id="settings-dropdown" href="#" role="button" class="dropdown-toggle" data-target="nada" data-toggle="dropdown" title="{{ _('Menu') }} (g)">
-                            <i class="fa fa-cog settings-dropdown-cog" aria-hidden="true"></i>
+                    <li class="dropdown actual-dropdown-menu" id="avatar-menu">
+                        <a id="settings-dropdown" href="#" role="button" class="dropdown-toggle" data-target="#avatar-menu" data-toggle="dropdown" title="{{ _('Menu') }} (g)">
+                            <img id="menu-avatar" class="settings-dropdown-avatar">
                         </a>
                         <ul class="dropdown-menu" role="menu" aria-labelledby="settings-dropdown">
                             {#

--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -60,6 +60,18 @@
                             anymore
                             #}
                             <li class="invisible" style="display:none;" role="presentation"><a href="#message_feed_container" data-toggle="tab"></a></li>
+                            <div class="settings-dropdown-profile">
+                                <div>
+                                    <img class="settings-dropdown-avatar avatar-medium" alt="{{ _('User avatar') }}">
+                                </div>
+                                <div>
+                                    <div class="dropdown-user-fullname">
+                                    </div>
+                                    <div class="dropdown-user-presence">
+                                    </div>
+                                </div>
+                            </div>
+                            <li class="divider"></li>
                             <li role="presentation">
                                 <a href="#streams/subscribed" role="menuitem">
                                     <i class="fa fa-exchange" aria-hidden="true"></i> {{ _('Manage streams') }}

--- a/templates/zerver/help/invite-new-users.md
+++ b/templates/zerver/help/invite-new-users.md
@@ -88,7 +88,7 @@ and reusable invitation links expire 10 days after they are sent.
 1. Click **Invite**.
 
 !!! warn ""
-    * You will only see **Invite users** in the gear menu if you have
+    * You will only see **Invite users** in the avatar menu if you have
     permission to invite users.
     * The number of email invites you can send in a day is limited in
     the free plan. [Contact us](/help/contact-support) if you hit the
@@ -112,7 +112,7 @@ and reusable invitation links expire 10 days after they are sent.
 1. Copy the link, and send it to anyone you'd like to invite.
 
 !!! warn ""
-    * You will only see **Invite users** in the gear menu if you have
+    * You will only see **Invite users** in the avatar menu if you have
     permission to invite users.
     * Only organization administrators can create these reusable invitation links.
 

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -165,7 +165,7 @@ Keyboard navigation (e.g. arrow keys) works as expected.
 
 * **Toggle shortcuts help**: `?`
 
-* **Toggle gear menu**: `g`
+* **Toggle avatar menu**: `g`
 
 ### For a selected message (outlined in blue)
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
commit 1: Replace gear-menu with user avatar.
commit 2: Display status icon beside user avatar only when user has a valid user_status.

**Testing plan:** <!-- How have you tested? -->
local dev env

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![menu](https://user-images.githubusercontent.com/55033316/107699149-a95cc900-6cdb-11eb-82cf-eb7fbbcab86a.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
