### PR TITLE
puppet: Set APT::Periodic::Unattended-Upgrade in apt config.

### DIFF
--- a/puppet/zulip_ops/files/apt/apt.conf.d/02periodic
+++ b/puppet/zulip_ops/files/apt/apt.conf.d/02periodic
@@ -1,6 +1,7 @@
-# Every day, update package lists and download (but do not install) packages
+# Every day, update package lists and install upgrades; see 50unattended-upgrades
 
 APT::Periodic::Enable "1";
 APT::Periodic::Update-Package-Lists "1";
 APT::Periodic::Download-Upgradeable-Packages "1";
 APT::Periodic::AutocleanInterval "7";
+APT::Periodic::Unattended-Upgrade "1";


### PR DESCRIPTION
This is required for unattended upgrades to actually run regularly.
In some distributions, it may be found in 20auto-upgrades, but placing
it here makes it more discoverable.
