### PR TITLE
message-view: Increase spacing for lists coming after paragraphs.

### DIFF
--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -37,7 +37,7 @@
     /* Reduce top-margin when a paragraph is followed by an ordered or bulleted list */
     p + ul,
     p + ol {
-        margin-top: -3px;
+        margin-top: 0;
     }
 
     /* Headings: We need to make sure our headings are less prominent than our sender names styling. */


### PR DESCRIPTION
Lists that were followed by a paragraph in messages had negative
top margin of -3px. This reduced spaces between paragraph and list
such that there was no clearly visible separation between the two.

There has been some complains regarding this an example of which is
issue #17284 .

This commit addresses this issue by specifying margin-top: 0px; for
list that come after paragraphs. We have default margin-top as 2px
for lists in messages but due to concerns expressed here:

https://chat.zulip.org/#narrow/stream/9-issues/topic/issue.20.2317284.20%28bulleted.20lists%29/near/1116936

it was decided to keep it 0px.

This was discussed here:
https://chat.zulip.org/#narrow/stream/9-issues/topic/issue.20.2317284.20(bulleted.20lists)

**Testing plan:** Changes have been tested in development server by also using developer tools by trying out different values for `p+ul` and `p+ol` combinaition.

Fixes: #17284

