### PR TITLE
[WIP] Improve Accessibility and UX in Recent Topics

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -430,6 +430,11 @@ exports.initialize = function () {
         recent_topics.update_filters_view();
     });
 
+    $("body").on("click", "td.recent_topic_stream", (e) => {
+        e.stopPropagation();
+        window.location.href = $(e.currentTarget).find("a").attr("href");
+    });
+
     $("body").on("click", "td.recent_topic_name", (e) => {
         e.stopPropagation();
         window.location.href = $(e.currentTarget).find("a").attr("href");

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -351,7 +351,8 @@ function show_selected_filters() {
         for (const filter of filters) {
             $("#recent_topics_filter_buttons")
                 .find(`[data-filter="${CSS.escape(filter)}"]`)
-                .addClass("btn-recent-selected");
+                .addClass("btn-recent-selected")
+                .attr("aria-checked", "true");
         }
     }
 }

--- a/static/templates/recent_topics_filters.hbs
+++ b/static/templates/recent_topics_filters.hbs
@@ -1,5 +1,5 @@
 <button data-filter="all" type="button" class="btn btn-default btn-recent-filters">{{t 'All' }}</button>
-<button data-filter="include_muted" type="button" class="btn btn-default btn-recent-filters">
+<button data-filter="include_muted" type="button" class="btn btn-default btn-recent-filters" role="checkbox" aria-checked="false">
     {{#if filter_muted }}
     <i class="fa fa-check-square-o"></i>
     {{else}}
@@ -7,7 +7,7 @@
     {{/if}}
     {{t 'Include muted' }}
 </button>
-<button data-filter="unread" type="button" class="btn btn-default btn-recent-filters">
+<button data-filter="unread" type="button" class="btn btn-default btn-recent-filters" role="checkbox" aria-checked="false">
     {{#if filter_unread}}
     <i class="fa fa-check-square-o"></i>
     {{else}}
@@ -15,7 +15,7 @@
     {{/if}}
     {{t 'Unread' }}
 </button>
-<button data-filter="participated" type="button" class="btn btn-default btn-recent-filters">
+<button data-filter="participated" type="button" class="btn btn-default btn-recent-filters" role="checkbox" aria-checked="false">
     {{#if filter_participated}}
     <i class="fa fa-check-square-o"></i>
     {{else}}


### PR DESCRIPTION
I added the 'role=checkbox' and 'aria-checked' labels in the recent topics filter buttons
and made the whole stream cell clickable. Improving accessibility through 'Tab' requires more discussion.
Hence, fixes part of #15826
**GIFs or screenshots:** 
![recent_topics-2021-02-13_12 02 44](https://user-images.githubusercontent.com/59016893/107843888-dea90a00-6df4-11eb-9fc5-705bc66f71fa.gif)
