### PR TITLE
settings_ui: Use `overlays.open_modal` in user deactivation settings.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -538,11 +538,10 @@ function confirm_deactivation(row, user_id, status_field) {
         settings_ui.do_settings_change(channel.del, url, {}, status_field, opts);
     }
 
-    modal_elem.modal("hide");
     modal_elem.off("click", ".do_deactivate_button");
     set_fields();
     modal_elem.on("click", ".do_deactivate_button", handle_confirm);
-    modal_elem.modal("show");
+    overlays.open_modal("#deactivation_user_modal");
 }
 
 function handle_deactivation(tbody, status_field) {


### PR DESCRIPTION
This fixes the bug when, if the user clicks on another deactivate
user button, the modal blinks.

Fixes #17297 

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/58626718/113884956-0d33d780-97dd-11eb-9187-cab5ff225f28.gif)
