### PR TITLE
node tests: Use override instead of with_field wherever possible.

### DIFF
--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const autosize = require("autosize");
 
-const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -80,21 +80,19 @@ function make_textbox(s) {
     return widget;
 }
 
-run_test("autosize_textarea", () => {
+run_test("autosize_textarea", (override) => {
     const textarea_autosized = {};
 
-    function fake_autosize_update(textarea) {
+    override(autosize, "update", (textarea) => {
         textarea_autosized.textarea = textarea;
         textarea_autosized.autosized = true;
-    }
-
-    with_field(autosize, "update", fake_autosize_update, () => {
-        // Call autosize_textarea with an argument
-        const container = "container-stub";
-        compose_ui.autosize_textarea(container);
-        assert.equal(textarea_autosized.textarea, container);
-        assert(textarea_autosized.autosized);
     });
+
+    // Call autosize_textarea with an argument
+    const container = "container-stub";
+    compose_ui.autosize_textarea(container);
+    assert.equal(textarea_autosized.textarea, container);
+    assert(textarea_autosized.autosized);
 });
 
 run_test("insert_syntax_and_focus", () => {

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const markdown_test_cases = require("../../zerver/tests/fixtures/markdown_test_cases.json");
 const markdown_assert = require("../zjsunit/markdown_assert");
-const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -750,7 +750,7 @@ run_test("translate_emoticons_to_names", () => {
     }
 });
 
-run_test("missing unicode emojis", () => {
+run_test("missing unicode emojis", (override) => {
     const message = {raw_content: "\u{1F6B2}"};
 
     markdown.apply_markdown(message);
@@ -759,15 +759,11 @@ run_test("missing unicode emojis", () => {
         '<p><span aria-label="bike" class="emoji emoji-1f6b2" role="img" title="bike">:bike:</span></p>',
     );
 
-    // Now simulate that we don't know any emoji names.
-    function fake_get_emoji_name(codepoint) {
+    override(emoji, "get_emoji_name", (codepoint) => {
+        // Now simulate that we don't know any emoji names.
         assert.equal(codepoint, "1f6b2");
         // return undefined
-    }
-
-    with_field(emoji, "get_emoji_name", fake_get_emoji_name, () => {
-        markdown.apply_markdown(message);
     });
-
+    markdown.apply_markdown(message);
     assert.equal(message.content, "<p>\u{1F6B2}</p>");
 });

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
@@ -256,15 +256,7 @@ run_test("update_private_messages", (override) => {
         find();
     };
 
-    with_field(
-        pm_list,
-        "is_all_privates",
-        () => true,
-        () => {
-            pm_list.update_private_messages();
-        },
-    );
-
+    pm_list.update_private_messages();
     assert(html_updated);
     assert($(".top_left_private_messages").hasClass("active-filter"));
 });

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -229,54 +229,44 @@ run_test("is_all_privates", () => {
     assert.equal(pm_list.is_all_privates(), true);
 });
 
-function with_fake_list(f) {
-    with_field(pm_list, "_build_private_messages_list", () => "PM_LIST_CONTENTS", f);
-}
+run_test("expand", (override) => {
+    override(pm_list, "_build_private_messages_list", () => "PM_LIST_CONTENTS");
+    let html_updated;
+    vdom.update = () => {
+        html_updated = true;
+    };
 
-run_test("expand", () => {
-    with_fake_list(() => {
-        let html_updated;
-
-        vdom.update = () => {
-            html_updated = true;
-        };
-
-        pm_list.expand();
-
-        assert(html_updated);
-    });
+    pm_list.expand();
+    assert(html_updated);
 });
 
-run_test("update_private_messages", () => {
+run_test("update_private_messages", (override) => {
     narrow_state.active = () => true;
-
     $("#private-container").find = (sel) => {
         assert.equal(sel, "ul");
     };
+    override(pm_list, "_build_private_messages_list", () => "PM_LIST_CONTENTS");
 
-    with_fake_list(() => {
-        let html_updated;
+    let html_updated;
+    vdom.update = (replace_content, find) => {
+        html_updated = true;
 
-        vdom.update = (replace_content, find) => {
-            html_updated = true;
+        // get line coverage for simple one-liners
+        replace_content();
+        find();
+    };
 
-            // get line coverage for simple one-liners
-            replace_content();
-            find();
-        };
+    with_field(
+        pm_list,
+        "is_all_privates",
+        () => true,
+        () => {
+            pm_list.update_private_messages();
+        },
+    );
 
-        with_field(
-            pm_list,
-            "is_all_privates",
-            () => true,
-            () => {
-                pm_list.update_private_messages();
-            },
-        );
-
-        assert(html_updated);
-        assert($(".top_left_private_messages").hasClass("active-filter"));
-    });
+    assert(html_updated);
+    assert($(".top_left_private_messages").hasClass("active-filter"));
 });
 
 run_test("ensure coverage", () => {

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {stub_templates} = require("../zjsunit/handlebars");
-const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_stub} = require("../zjsunit/stub");
 const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
@@ -686,7 +686,7 @@ run_test("with_view_stubs", () => {
     });
 });
 
-run_test("error_handling", () => {
+run_test("error_handling", (override) => {
     message_store.get = function () {
         return;
     };
@@ -700,15 +700,8 @@ run_test("error_handling", () => {
         emoji_code: "991",
         user_id: 99,
     };
-
-    with_field(
-        reactions,
-        "current_user_has_reacted_to_emoji",
-        () => true,
-        () => {
-            reactions.toggle_emoji_reaction(55, bogus_event.emoji_name);
-        },
-    );
+    override(reactions, "current_user_has_reacted_to_emoji", () => true);
+    reactions.toggle_emoji_reaction(55, bogus_event.emoji_name);
 
     reactions.add_reaction(bogus_event);
     reactions.remove_reaction(bogus_event);


### PR DESCRIPTION
This replaces some `with_field` calls to use the `override` style.
The reason to do so is `override` makes sure the stubbed function gets called, while `with_field`
doesn't, making it difficult to spot dead code.

https://chat.zulip.org/#narrow/stream/92-learning/topic/node.20tests.3A.20When.20to.20run.20actual.20dependency.20code.3F/near/1117757