### PR TITLE
Smokescreen camo

### DIFF
--- a/puppet/zulip_ops/manifests/profile/smokescreen.pp
+++ b/puppet/zulip_ops/manifests/profile/smokescreen.pp
@@ -3,6 +3,7 @@
 class zulip_ops::profile::smokescreen {
   include zulip_ops::profile::base
   include zulip::supervisor
+  include zulip::camo
 
   $golang_version = '1.14.10'
   zulip::sha256_tarball_to { 'golang':

--- a/puppet/zulip_ops/manifests/profile/smokescreen.pp
+++ b/puppet/zulip_ops/manifests/profile/smokescreen.pp
@@ -39,6 +39,7 @@ class zulip_ops::profile::smokescreen {
     ensure  => 'link',
     target  => "/usr/local/bin/smokescreen-${version}",
     require => Exec['compile smokescreen'],
+    notify  => Service[supervisor],
   }
 
   file { '/etc/supervisor/conf.d/smokescreen.conf':
@@ -50,7 +51,7 @@ class zulip_ops::profile::smokescreen {
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    source  => 'puppet:///modules/zulip_ops/supervisor/conf.d/smokescreen.conf',
+    content => template('zulip_ops/supervisor/conf.d/smokescreen.conf.erb'),
     notify  => Service[supervisor],
   }
 }

--- a/puppet/zulip_ops/templates/supervisor/conf.d/smokescreen.conf.erb
+++ b/puppet/zulip_ops/templates/supervisor/conf.d/smokescreen.conf.erb
@@ -1,5 +1,5 @@
 [program:smokescreen]
-command=/usr/local/bin/smokescreen
+command=/usr/local/bin/smokescreen-<%= @version %>
 priority=15
 autostart=true
 autorestart=true


### PR DESCRIPTION
Adjust supervisorctl to make smokescreen upgrade itself correctly on new releases, and add camo to the profile.

**Testing plan:** Stood up a new smokescreen host.