### PR TITLE
ci: Notify in zulip when a build fails in GitHub Actions.

### DIFF
--- a/.github/workflows/legacy-os.yml
+++ b/.github/workflows/legacy-os.yml
@@ -16,3 +16,9 @@ jobs:
         run: |
           { { ! sudo scripts/lib/upgrade-zulip-stage-2 2>&1 >&3; } | tee upgrade.err; } 3>&1 >&2
           grep -Fq 'upgrade-zulip-stage-2: Unsupported platform: ubuntu 16.04' upgrade.err
+
+      - name: Report status
+        if: failure()
+        env:
+          ZULIP_BOT_KEY: ${{ secrets.ZULIP_BOT_KEY }}
+        run: tools/ci/send-failure-message

--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -99,6 +99,12 @@ jobs:
           path: /tmp/production-build
           retention-days: 14
 
+      - name: Report status
+        if: failure()
+        env:
+          ZULIP_BOT_KEY: ${{ secrets.ZULIP_BOT_KEY }}
+        run: tools/ci/send-failure-message
+
   production_install:
     strategy:
       fail-fast: false
@@ -142,6 +148,7 @@ jobs:
           chmod +x /tmp/production-upgrade-pg
           chmod +x /tmp/production-install
           chmod +x /tmp/production-verify
+          chmod +x /tmp/send-failure-message
 
       - name: Create cache directories
         run: |
@@ -181,3 +188,9 @@ jobs:
       - name: Verify install after upgrading postgresql
         if: ${{ matrix.is_bionic }}
         run: sudo mispipe "/tmp/production-verify 2>&1" ts
+
+      - name: Report status
+        if: failure()
+        env:
+          ZULIP_BOT_KEY: ${{ secrets.ZULIP_BOT_KEY }}
+        run: /tmp/send-failure-message

--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -153,7 +153,9 @@ jobs:
       - name: Check development database build
         if: ${{ matrix.is_focal }}
         run: mispipe "tools/ci/setup-backend" ts
-      # TODO: We need to port the notify_failure step from CircleCI
-      # config, however, it might be the case that GitHub notifications
-      # make this unnecessary. More details on settings to configure it:
-      # https://help.github.com/en/github/managing-subscriptions-and-notifications-on-github/configuring-notifications#github-actions-notification-options
+
+      - name: Report status
+        if: failure()
+        env:
+          ZULIP_BOT_KEY: ${{ secrets.ZULIP_BOT_KEY }}
+        run: tools/ci/send-failure-message

--- a/tools/ci/production-build
+++ b/tools/ci/production-build
@@ -38,6 +38,7 @@ cp -a \
     tools/ci/production-verify \
     tools/ci/production-upgrade-pg \
     tools/ci/production-extract-tarball \
+    tools/ci/send-failure-message \
     package.json yarn.lock \
     \
     /tmp/production-build

--- a/tools/ci/send-failure-message
+++ b/tools/ci/send-failure-message
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+if [[ "$ZULIP_BOT_KEY" != "" && "$GITHUB_REPOSITORY" == "zulip/zulip" ]]; then
+    BRANCH="$(python3 -c 'import sys; print(sys.argv[1].split("/")[-1])' "$GITHUB_REF")"
+    URI_ESCAPED_TOPIC="$(python3 -c 'import sys; import urllib.parse; print(urllib.parse.quote(sys.argv[1]))' "$BRANCH failing")"
+    curl -H "Content-Type: application/json" \
+        -X POST -i 'https://chat.zulip.org/api/v1/external/circleci?api_key='"$ZULIP_BOT_KEY"'&stream=automated%20testing&topic='"$URI_ESCAPED_TOPIC" \
+        -d '{"payload": { "branch": "'"$BRANCH"'", "reponame": "'"$GITHUB_REPOSITORY"'", "status": "failed", "build_url": "'"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"'", "username": "'"$GITHUB_ACTOR"'"}}'
+fi


### PR DESCRIPTION
Using the CURL command similar to CircleCI process.

<img width="519" alt="Screenshot 2021-02-16 at 2 06 39 PM" src="https://user-images.githubusercontent.com/25124304/108037893-3303f200-7060-11eb-8e39-c9d5953206af.png">

Output - https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/ci_actions.20failing