### PR TITLE
api docs: Expand condition for deprecated fields.

### DIFF
--- a/zerver/lib/markdown/api_arguments_table_generator.py
+++ b/zerver/lib/markdown/api_arguments_table_generator.py
@@ -8,7 +8,7 @@ from django.utils.html import escape as escape_html
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
 
-from zerver.openapi.openapi import get_openapi_parameters, likely_deprecated_parameter
+from zerver.openapi.openapi import check_deprecated_consistency, get_openapi_parameters
 
 REGEXP = re.compile(r"\{generate_api_arguments_table\|\s*(.+?)\s*\|\s*(.+)\s*\}")
 
@@ -139,9 +139,7 @@ class APIArgumentsTablePreprocessor(Preprocessor):
             else:
                 required_block = '<span class="api-argument-optional">optional</span>'
 
-            # Test to make sure deprecated parameters are marked so.
-            if likely_deprecated_parameter(description):
-                assert argument["deprecated"]
+            check_deprecated_consistency(argument, description)
             if argument.get("deprecated", False):
                 deprecated_block = '<span class="api-argument-deprecated">Deprecated</span>'
             else:

--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -7,7 +7,7 @@ import markdown
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
 
-from zerver.openapi.openapi import get_openapi_return_values, likely_deprecated_parameter
+from zerver.openapi.openapi import check_deprecated_consistency, get_openapi_return_values
 
 from .api_arguments_table_generator import generate_data_type
 
@@ -134,9 +134,7 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
                 continue
             description = return_values[return_value]["description"]
             data_type = generate_data_type(return_values[return_value])
-            # Test to make sure deprecated keys are marked appropriately.
-            if likely_deprecated_parameter(description):
-                assert return_values[return_value]["deprecated"]
+            check_deprecated_consistency(return_values[return_value], description)
             ans.append(self.render_desc(description, spacing, data_type, return_value))
             if "properties" in return_values[return_value]:
                 ans += self.render_table(return_values[return_value]["properties"], spacing + 4)

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -402,6 +402,14 @@ def likely_deprecated_parameter(parameter_description: str) -> bool:
     return "**Deprecated**" in parameter_description
 
 
+def check_deprecated_consistency(argument: Dict[str, Any], description: str) -> None:
+    # Test to make sure deprecated parameters are marked so.
+    if likely_deprecated_parameter(description):
+        assert argument["deprecated"]
+    if "deprecated" in argument:
+        assert likely_deprecated_parameter(description)
+
+
 # Skip those JSON endpoints whose query parameters are different from
 # their `/api/v1` counterpart.  This is a legacy code issue that we
 # plan to fix by changing the implementation.


### PR DESCRIPTION
Added assertion to check that if a deprecated flag is in a field's
schema, then it should have deprecated mentioned in description
as well. Fixes part of #15967.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
