### PR TITLE
frontend: Add the clock-icon before the timestamp.

### DIFF
--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -178,7 +178,7 @@ run_test("timestamp", () => {
     rm.update_elements($content);
 
     // Final asserts
-    assert.equal($timestamp.text(), "Thu, Jan 1 1970, 12:00 AM");
+    assert.equal($timestamp.html(), '<i class="fa fa-clock-o"></i>\nThu, Jan 1 1970, 12:00 AM\n');
     assert.equal(
         $timestamp.attr("title"),
         "This time is in your timezone. Original text was 'never-been-set'.",
@@ -195,12 +195,15 @@ run_test("timestamp-twenty-four-hour-time", () => {
     // We will temporarily change the 24h setting for this test.
     with_field(page_params, "twenty_four_hour_time", true, () => {
         rm.update_elements($content);
-        assert.equal($timestamp.text(), "Wed, Jul 15 2020, 20:40");
+        assert.equal($timestamp.html(), '<i class="fa fa-clock-o"></i>\nWed, Jul 15 2020, 20:40\n');
     });
 
     with_field(page_params, "twenty_four_hour_time", false, () => {
         rm.update_elements($content);
-        assert.equal($timestamp.text(), "Wed, Jul 15 2020, 8:40 PM");
+        assert.equal(
+            $timestamp.html(),
+            '<i class="fa fa-clock-o"></i>\nWed, Jul 15 2020, 8:40 PM\n',
+        );
     });
 });
 

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -3,6 +3,7 @@ import {parseISO, isValid} from "date-fns";
 import $ from "jquery";
 
 import copy_code_button from "../templates/copy_code_button.hbs";
+import render_markdown_timestamp from "../templates/markdown_timestamp.hbs";
 import view_code_in_playground from "../templates/view_code_in_playground.hbs";
 
 import * as people from "./people";
@@ -162,7 +163,10 @@ export const update_elements = (content) => {
         if (isValid(timestamp)) {
             const text = $(this).text();
             const rendered_time = timerender.render_markdown_timestamp(timestamp, text);
-            $(this).text(rendered_time.text);
+            const rendered_timestamp = render_markdown_timestamp({
+                text: rendered_time.text,
+            });
+            $(this).html(rendered_timestamp);
             $(this).attr("title", rendered_time.title);
         } else {
             // This shouldn't happen. If it does, we're very interested in debugging it.

--- a/static/templates/markdown_timestamp.hbs
+++ b/static/templates/markdown_timestamp.hbs
@@ -1,0 +1,2 @@
+<i class="fa fa-clock-o"></i>
+{{ text }}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) --> Add the clock-icon before the timestamp. Solves one of the part of issue #17293.

Related thread : https://chat.zulip.org/#narrow/stream/6-frontend/topic/time.20widget


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![clock-icon](https://user-images.githubusercontent.com/59444243/108059422-7cae0600-707b-11eb-9077-2d8447154c96.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
