### PR TITLE
[FIX] AlertWords: Consecutive words are not being highlighted

### DIFF
--- a/frontend_tests/node_tests/alert_words.js
+++ b/frontend_tests/node_tests/alert_words.js
@@ -67,6 +67,12 @@ const question_word_message = {
     alerted: true,
 };
 
+const typo_word_message = {
+    sender_email: "another@zulip.com",
+    content: "<p>alertones alerttwo alerttwo alertthreez</p>",
+    alerted: true,
+};
+
 const alert_domain_message = {
     sender_email: "another@zulip.com",
     content:
@@ -135,6 +141,11 @@ run_test("munging", () => {
     assert_transform(
         question_word_message,
         "<p>still <span class='alert-word'>alertone</span>? me</p>",
+    );
+
+    assert_transform(
+        typo_word_message,
+        "<p>alertones <span class='alert-word'>alerttwo</span> <span class='alert-word'>alerttwo</span> alertthreez</p>",
     );
 
     assert_transform(

--- a/static/js/alert_words.js
+++ b/static/js/alert_words.js
@@ -32,8 +32,8 @@ export function process_message(message) {
 
     for (const word of my_alert_words) {
         const clean = _.escapeRegExp(word);
-        const before_punctuation = "\\s|^|>|[\\(\\\".,';\\[]";
-        const after_punctuation = "\\s|$|<|[\\)\\\"\\?!:.,';\\]!]";
+        const before_punctuation = "(?<=\\s)|^|>|[\\(\\\".,';\\[]";
+        const after_punctuation = "(?=\\s)|$|<|[\\)\\\"\\?!:.,';\\]!]";
 
         const regex = new RegExp(`(${before_punctuation})(${clean})(${after_punctuation})`, "ig");
         message.content = message.content.replace(

--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -192,6 +192,11 @@ class AlertWordTests(ZulipTestCase):
         self.assertFalse(self.message_does_alert(user, "Don't alert on http://t.co/one/ URLs"))
         self.assertFalse(self.message_does_alert(user, "Don't alert on http://t.co/one URLs"))
 
+        # We don't cause alerts for matches within a word.
+        self.assertFalse(
+            self.message_does_alert(user, "Don't alert on clone, twofold or seventytwofold")
+        )
+
     def test_update_alert_words(self) -> None:
         user = self.get_user()
         self.login_user(user)


### PR DESCRIPTION
This makes the regex accept alert words separated by spaces.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR closes #17320 

**Testing plan:** <!-- How have you tested? -->
Used the tests in react-native mobile repo

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
