### PR TITLE
code cleanup: Clean up subs.js code (including tests).

### DIFF
--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -105,7 +105,7 @@ run_test("filter_table", () => {
         populated_subs = data.subscriptions;
     });
 
-    subs.populate_stream_settings_left_panel();
+    subs.render_left_panel_superset();
 
     const sub_stubs = [];
 

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -28,18 +28,6 @@ set_global("hash_util", {
 });
 
 run_test("filter_table", () => {
-    const stream_list = $(".streams-list");
-
-    let scrolltop_called = false;
-    stream_list.scrollTop = function (set) {
-        scrolltop_called = true;
-        if (!set) {
-            return 10;
-        }
-        assert.equal(set, 10);
-        return this;
-    };
-
     // set-up sub rows stubs
     const sub_row_data = [
         {
@@ -167,7 +155,6 @@ run_test("filter_table", () => {
 
     // assert these once and call it done
     assert(ui_called);
-    assert(scrolltop_called);
     assert(tooltip_called);
     assert.deepEqual(sub_table_append, [
         ".stream-row-poland",

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -31,58 +31,58 @@ run_test("filter_table", (override) => {
     override(subs, "add_tooltips_to_left_panel", () => {});
 
     // set-up sub rows stubs
-    const sub_row_data = [
-        {
-            elem: "denmark",
-            subscribed: false,
-            name: "Denmark",
-            stream_id: denmark_stream_id,
-            description: "Copenhagen",
-            subscribers: [1],
-            stream_weekly_traffic: null,
-            color: "red",
-        },
-        {
-            elem: "poland",
-            subscribed: true,
-            name: "Poland",
-            stream_id: 102,
-            description: "monday",
-            subscribers: [1, 2, 3],
-            stream_weekly_traffic: 13,
-            color: "red",
-        },
-        {
-            elem: "pomona",
-            subscribed: true,
-            name: "Pomona",
-            stream_id: 103,
-            description: "college",
-            subscribers: [],
-            stream_weekly_traffic: 0,
-            color: "red",
-        },
-        {
-            elem: "cpp",
-            subscribed: true,
-            name: "C++",
-            stream_id: 104,
-            description: "programming lang",
-            subscribers: [1, 2],
-            stream_weekly_traffic: 6,
-            color: "red",
-        },
-        {
-            elem: "zzyzx",
-            subscribed: true,
-            name: "Zzyzx",
-            stream_id: 105,
-            description: "california town",
-            subscribers: [1, 2],
-            stream_weekly_traffic: 6,
-            color: "red",
-        },
-    ];
+    const denmark = {
+        elem: "denmark",
+        subscribed: false,
+        name: "Denmark",
+        stream_id: denmark_stream_id,
+        description: "Copenhagen",
+        subscribers: [1],
+        stream_weekly_traffic: null,
+        color: "red",
+    };
+    const poland = {
+        elem: "poland",
+        subscribed: true,
+        name: "Poland",
+        stream_id: 102,
+        description: "monday",
+        subscribers: [1, 2, 3],
+        stream_weekly_traffic: 13,
+        color: "red",
+    };
+    const pomona = {
+        elem: "pomona",
+        subscribed: true,
+        name: "Pomona",
+        stream_id: 103,
+        description: "college",
+        subscribers: [],
+        stream_weekly_traffic: 0,
+        color: "red",
+    };
+    const cpp = {
+        elem: "cpp",
+        subscribed: true,
+        name: "C++",
+        stream_id: 104,
+        description: "programming lang",
+        subscribers: [1, 2],
+        stream_weekly_traffic: 6,
+        color: "red",
+    };
+    const zzyzx = {
+        elem: "zzyzx",
+        subscribed: true,
+        name: "Zzyzx",
+        stream_id: 105,
+        description: "california town",
+        subscribers: [1, 2],
+        stream_weekly_traffic: 6,
+        color: "red",
+    };
+
+    const sub_row_data = [denmark, poland, pomona, cpp, zzyzx];
 
     for (const sub of sub_row_data) {
         stream_data.create_sub_from_server_data(sub);

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -27,7 +27,9 @@ set_global("hash_util", {
     by_stream_uri: () => {},
 });
 
-run_test("filter_table", () => {
+run_test("filter_table", (override) => {
+    override(subs, "add_tooltips_to_left_panel", () => {});
+
     // set-up sub rows stubs
     const sub_row_data = [
         {
@@ -102,23 +104,10 @@ run_test("filter_table", () => {
         sub_stubs.push(sub_row);
 
         $(sub_row).attr("data-stream-id", data.stream_id);
-        $(sub_row).set_find_results(
-            '.sub-info-box [class$="-bar"] [class$="-count"]',
-            $(".tooltip"),
-        );
         $(sub_row).detach = function () {
             return sub_row;
         };
     }
-
-    let tooltip_called = false;
-    $(".tooltip").tooltip = function (obj) {
-        tooltip_called = true;
-        assert.deepEqual(obj, {
-            placement: "left",
-            animation: false,
-        });
-    };
 
     $.stub_selector("#subscriptions_table .stream-row", sub_stubs);
 
@@ -155,7 +144,6 @@ run_test("filter_table", () => {
 
     // assert these once and call it done
     assert(ui_called);
-    assert(tooltip_called);
     assert.deepEqual(sub_table_append, [
         ".stream-row-poland",
         ".stream-row-pomona",

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -477,6 +477,9 @@ exports.filter_table = function (left_panel_params) {
     }
 
     exports.maybe_reset_right_panel();
+
+    // return this for test convenience
+    return [...buckets.name, ...buckets.desc];
 };
 
 let sort_order = "by-stream-name";

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -529,7 +529,6 @@ exports.switch_stream_tab = function (tab_name) {
     stream_edit.setup_subscriptions_tab_hash(tab_name);
 };
 
-exports.sort_toggler = undefined;
 exports.switch_stream_sort = function (tab_name) {
     if (
         tab_name === "by-stream-name" ||
@@ -560,7 +559,7 @@ exports.setup_page = function (callback) {
     function initialize_components() {
         // Sort by name by default when opening "Manage streams".
         sort_order = "by-stream-name";
-        exports.sort_toggler = components.toggle({
+        const sort_toggler = components.toggle({
             values: [
                 {
                     label_html: `<i class="fa fa-sort-alpha-asc" title="${i18n.t(
@@ -586,7 +585,7 @@ exports.setup_page = function (callback) {
                 exports.switch_stream_sort(key);
             },
         });
-        $("#subscriptions_table .search-container").prepend(exports.sort_toggler.get());
+        $("#subscriptions_table .search-container").prepend(sort_toggler.get());
 
         // Reset our internal state to reflect that we're initially in
         // the "Subscribed" tab if we're reopening "Manage streams".

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -350,13 +350,13 @@ exports.update_settings_for_unsubscribed = function (sub) {
     stream_ui_updates.update_stream_row_in_settings_tab(sub);
 };
 
-function triage_stream(query, sub) {
-    if (query.subscribed_only && !sub.subscribed) {
+function triage_stream(left_panel_params, sub) {
+    if (left_panel_params.subscribed_only && !sub.subscribed) {
         // reject non-subscribed streams
         return "rejected";
     }
 
-    const search_terms = search_util.get_search_terms(query.input);
+    const search_terms = search_util.get_search_terms(left_panel_params.input);
 
     function match(attr) {
         const val = sub[attr];
@@ -378,7 +378,7 @@ function triage_stream(query, sub) {
     return "rejected";
 }
 
-function get_stream_id_buckets(stream_ids, query) {
+function get_stream_id_buckets(stream_ids, left_panel_params) {
     // When we simplify the settings UI, we can get
     // rid of the "others" bucket.
 
@@ -390,7 +390,7 @@ function get_stream_id_buckets(stream_ids, query) {
 
     for (const stream_id of stream_ids) {
         const sub = stream_data.get_sub_by_id(stream_id);
-        const match_status = triage_stream(query, sub);
+        const match_status = triage_stream(left_panel_params, sub);
 
         if (match_status === "name_match") {
             buckets.name.push(stream_id);
@@ -401,8 +401,8 @@ function get_stream_id_buckets(stream_ids, query) {
         }
     }
 
-    stream_data.sort_for_stream_settings(buckets.name, query.sort_order);
-    stream_data.sort_for_stream_settings(buckets.desc, query.sort_order);
+    stream_data.sort_for_stream_settings(buckets.name, left_panel_params.sort_order);
+    stream_data.sort_for_stream_settings(buckets.desc, left_panel_params.sort_order);
 
     return buckets;
 }
@@ -424,9 +424,8 @@ exports.render_left_panel_superset = function () {
     ui.get_content_element($("#subscriptions_table .streams-list")).html(html);
 };
 
-// query is now an object rather than a string.
-// Query { input: String, subscribed_only: Boolean, sort_order: String }
-exports.filter_table = function (query) {
+// LeftPanelParams { input: String, subscribed_only: Boolean, sort_order: String }
+exports.filter_table = function (left_panel_params) {
     exports.show_active_stream_in_left_panel();
 
     function stream_id_for_row(row) {
@@ -443,7 +442,7 @@ exports.filter_table = function (query) {
         stream_ids.push(stream_id);
     }
 
-    const buckets = get_stream_id_buckets(stream_ids, query);
+    const buckets = get_stream_id_buckets(stream_ids, left_panel_params);
 
     // If we just re-built the DOM from scratch we wouldn't need
     // all this hidden/notdisplayed logic.
@@ -486,7 +485,7 @@ exports.filter_table = function (query) {
 
 let sort_order = "by-stream-name";
 
-exports.get_search_params = function () {
+exports.get_left_panel_params = function () {
     const search_box = $("#stream_filter input[type='text']");
     const input = search_box.expectOne().val().trim();
     const params = {
@@ -506,8 +505,8 @@ exports.maybe_reset_right_panel = function () {
 };
 
 exports.redraw_left_panel = function () {
-    const search_params = exports.get_search_params();
-    exports.filter_table(search_params);
+    const left_panel_params = exports.get_left_panel_params();
+    exports.filter_table(left_panel_params);
 };
 
 // Make it explicit that our toggler is not created right away.

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -433,7 +433,6 @@ exports.filter_table = function (left_panel_params) {
     }
 
     const widgets = new Map();
-    const streams_list_scrolltop = ui.get_scroll_element($(".streams-list")).scrollTop();
 
     const stream_ids = [];
 
@@ -478,9 +477,6 @@ exports.filter_table = function (left_panel_params) {
     }
 
     exports.maybe_reset_right_panel();
-
-    // this puts the scrollTop back to what it was before the list was updated again.
-    ui.get_scroll_element($(".streams-list")).scrollTop(streams_list_scrolltop);
 };
 
 let sort_order = "by-stream-name";


### PR DESCRIPTION
This is indirect prep for changing how we send subscriber payloads.