### PR TITLE
puppet: Configure nginx for long keep-alives when behind a loadbalancer.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-app.d/keepalive-loadbalancer.conf
+++ b/puppet/zulip/files/nginx/zulip-include-app.d/keepalive-loadbalancer.conf
@@ -1,0 +1,17 @@
+# This file should be used if the nginx is behind a dedicated
+# loadbalancer.  This allows nginx to be configured for long
+# keep-alive timeouts, to keep connections open to the loadbalancer.
+#
+# All timeouts here should be _longer_ than those on the loadbalancer.
+# This ensures that there cannot be a race condition between nginx
+# deciding to shut down the connection, and the load-balancer sending
+# a request, resulting in a 502 from the loadbalancer.
+#
+# The timeouts on the loadbalancer are assumed to be 20min (1200s);
+# these timeouts are hence for 21min.
+
+keepalive_timeout     1260;
+client_header_timeout 1260;
+client_body_timeout   1260;
+
+keepalive_requests     500;

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -50,6 +50,14 @@ class zulip::app_frontend_base {
       content => template('zulip/accept-loadbalancer.conf.template.erb'),
       notify  => Service['nginx'],
     }
+    file { '/etc/nginx/zulip-include/app.d/keepalive-loadbalancer.conf':
+      require => File['/etc/nginx/zulip-include/app.d'],
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      source  => 'puppet:///modules/zulip/nginx/zulip-include-app.d/keepalive-loadbalancer.conf',
+      notify  => Service['nginx'],
+    }
   }
 
   file { '/etc/nginx/zulip-include/upstreams':


### PR DESCRIPTION
These optimizations only makes sense when all connections at a TCP
level are coming from the same host or set of hosts; as such, they
are only enabled if `loadbalancer.ips` is set in the `zulip.conf`.

**Testing plan:** Test-deployed to staging.
