### PR TITLE
iptables: Limit smokescreen port 4750, add camo port.

### DIFF
--- a/puppet/zulip_ops/templates/iptables/rules.v4.erb
+++ b/puppet/zulip_ops/templates/iptables/rules.v4.erb
@@ -40,8 +40,13 @@
 -A INPUT -p tcp --dport https      -j ACCEPT
 -A INPUT -p tcp --dport postgresql -j ACCEPT
 
+<% if @fqdn.include? "smokescreen" -%>
 #                       Smokescreen proxy
 -A INPUT -p tcp --dport 4750       -j ACCEPT
+
+#                       Camo proxy
+-A INPUT -p tcp --dport 9292       -j ACCEPT
+<% end -%>
 
 #                       statsd
 -A INPUT -p udp --dport 8125       -j ACCEPT


### PR DESCRIPTION
Limit incoming connections to port 4750 to only the smokescreen host,
and also allow access to the Camo server on that host, on port 9292.
