### PR TITLE
stream settings: Clean up live-update code (and misc)

### DIFF
--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -28,7 +28,7 @@ set_global("hash_util", {
 });
 
 run_test("filter_table", (override) => {
-    override(subs, "add_tooltips_to_left_panel", () => {});
+    override(subs, "add_tooltip_to_left_panel_row", () => {});
 
     // set-up sub rows stubs
     const denmark = {

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -27,7 +27,7 @@ set_global("hash_util", {
     by_stream_uri: () => {},
 });
 
-run_test("filter_table", (override) => {
+run_test("redraw_left_panel", (override) => {
     override(subs, "add_tooltip_to_left_panel_row", () => {});
 
     // set-up sub rows stubs
@@ -124,7 +124,7 @@ run_test("filter_table", (override) => {
     assert(!denmark_row.hasClass("active"));
 
     function test_filter(params, expected_streams) {
-        const stream_ids = subs.filter_table(params);
+        const stream_ids = subs.redraw_left_panel(params);
         assert.deepEqual(
             stream_ids,
             expected_streams.map((sub) => sub.stream_id),

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -1,27 +1,6 @@
-import render_subscription_count from "../templates/subscription_count.hbs";
-import render_subscription_setting_icon from "../templates/subscription_setting_icon.hbs";
 import render_subscription_type from "../templates/subscription_type.hbs";
 
 import * as peer_data from "./peer_data";
-
-export function update_check_button_for_sub(sub) {
-    /*
-        TODO: remove update_check_button_for_sub
-
-        <div class="check {{#if subscribed }}checked{{/if}} sub_unsub_button {{#unless should_display_subscription_button}}disabled{{/unless}}">
-    */
-    const button = subs.check_button_for_sub(sub);
-    if (sub.subscribed) {
-        button.addClass("checked");
-    } else {
-        button.removeClass("checked");
-    }
-    if (sub.should_display_subscription_button) {
-        button.removeClass("disabled");
-    } else {
-        button.addClass("disabled");
-    }
-}
 
 export function initialize_disable_btn_hint_popover(
     btn_wrapper,
@@ -143,39 +122,6 @@ export function update_stream_row_in_settings_tab(sub) {
     }
 }
 
-export function update_stream_privacy_type_icon(sub) {
-    /*
-        TODO: remove update_stream_privacy_type_icon
-
-        {{#if invite_only}}
-        <i class="fa fa-lock" aria-hidden="true"></i>
-        {{else if is_web_public}}
-        <i class="fa fa-globe fa-lg" aria-hidden="true"></i>
-        {{else}}
-        <span class="hashtag">#</span>
-        {{/if}}
-
-    */
-    const stream_settings = stream_edit.settings_for_sub(sub);
-    const sub_row = subs.row_for_stream_id(sub.stream_id);
-    const html = render_subscription_setting_icon(sub);
-
-    if (overlays.streams_open()) {
-        sub_row.find(".icon").expectOne().replaceWith($(html));
-    }
-    if (stream_edit.is_sub_settings_active(sub)) {
-        const large_icon = stream_settings.find(".large-icon").expectOne();
-        if (sub.invite_only) {
-            large_icon
-                .removeClass("hash")
-                .addClass("lock")
-                .html("<i class='fa fa-lock' aria-hidden='true'></i>");
-        } else {
-            large_icon.addClass("hash").removeClass("lock").html("");
-        }
-    }
-}
-
 export function update_stream_subscription_type_text(sub) {
     // This is in the right panel.
     const stream_settings = stream_edit.settings_for_sub(sub);
@@ -187,45 +133,6 @@ export function update_stream_subscription_type_text(sub) {
     const html = render_subscription_type(template_data);
     if (stream_edit.is_sub_settings_active(sub)) {
         stream_settings.find(".subscription-type-text").expectOne().html(html);
-    }
-}
-
-export function update_subscribers_count(sub, just_subscribed) {
-    /*
-        TODO: remove update_subscribers_count
-
-            <div class="subscriber-count" data-toggle="tooltip" title="{{t 'Subscriber count' }}">
-                {{> subscription_count}}
-            </div>
-
-            <i class="fa fa-user-o" aria-hidden="true"></i>
-            {{#if can_access_subscribers}}
-            <span class="subscriber-count-text">{{numberFormat subscriber_count}}</span>
-            {{else}}
-            <i class="subscriber-count-lock fa fa-lock" aria-hidden="true"></i>
-            {{/if}}
-    */
-
-    if (!overlays.streams_open()) {
-        // If the streams overlay isn't open, we don't need to rerender anything.
-        return;
-    }
-
-    const stream_row = subs.row_for_stream_id(sub.stream_id);
-    const sub_count = peer_data.get_subscriber_count(sub.stream_id);
-
-    if (
-        !sub.can_access_subscribers ||
-        (just_subscribed && sub.invite_only) ||
-        page_params.is_guest
-    ) {
-        const rendered_sub_count = render_subscription_count({
-            can_access_subscribers: sub.can_access_subscribers,
-            subscriber_count: sub_count,
-        });
-        stream_row.find(".subscriber-count").expectOne().html(rendered_sub_count);
-    } else {
-        stream_row.find(".subscriber-count-text").expectOne().text(sub_count);
     }
 }
 

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -5,6 +5,11 @@ import render_subscription_type from "../templates/subscription_type.hbs";
 import * as peer_data from "./peer_data";
 
 export function update_check_button_for_sub(sub) {
+    /*
+        TODO: remove update_check_button_for_sub
+
+        <div class="check {{#if subscribed }}checked{{/if}} sub_unsub_button {{#unless should_display_subscription_button}}disabled{{/unless}}">
+    */
     const button = subs.check_button_for_sub(sub);
     if (sub.subscribed) {
         button.addClass("checked");
@@ -59,6 +64,7 @@ export function initialize_cant_subscribe_popover(sub) {
 }
 
 export function update_settings_button_for_sub(sub) {
+    // This is for the Subscribe/Unsubscribe button in the right panel.
     const settings_button = subs.settings_button_for_sub(sub);
     if (sub.subscribed) {
         settings_button.text(i18n.t("Unsubscribe")).removeClass("unsubscribed");
@@ -77,6 +83,7 @@ export function update_settings_button_for_sub(sub) {
 }
 
 export function update_regular_sub_settings(sub) {
+    // These are in the right panel.
     if (!stream_edit.is_sub_settings_active(sub)) {
         return;
     }
@@ -96,6 +103,7 @@ export function update_regular_sub_settings(sub) {
 }
 
 export function update_change_stream_privacy_settings(sub) {
+    // This is in the right panel.
     const stream_privacy_btn = $(".change-stream-privacy");
 
     if (sub.can_change_stream_permissions) {
@@ -106,6 +114,7 @@ export function update_change_stream_privacy_settings(sub) {
 }
 
 export function update_notification_setting_checkbox(notification_name) {
+    // This is in the right panel (Personal settings).
     const stream_row = $("#subscriptions_table .stream-row.active");
     if (!stream_row.length) {
         return;
@@ -118,6 +127,7 @@ export function update_notification_setting_checkbox(notification_name) {
 }
 
 export function update_stream_row_in_settings_tab(sub) {
+    // This is in the left panel.
     // This function display/hide stream row in stream settings tab,
     // used to display immediate effect of add/removal subscription event.
     // If user is subscribed to stream, it will show sub row under
@@ -134,6 +144,18 @@ export function update_stream_row_in_settings_tab(sub) {
 }
 
 export function update_stream_privacy_type_icon(sub) {
+    /*
+        TODO: remove update_stream_privacy_type_icon
+
+        {{#if invite_only}}
+        <i class="fa fa-lock" aria-hidden="true"></i>
+        {{else if is_web_public}}
+        <i class="fa fa-globe fa-lg" aria-hidden="true"></i>
+        {{else}}
+        <span class="hashtag">#</span>
+        {{/if}}
+
+    */
     const stream_settings = stream_edit.settings_for_sub(sub);
     const sub_row = subs.row_for_stream_id(sub.stream_id);
     const html = render_subscription_setting_icon(sub);
@@ -155,6 +177,7 @@ export function update_stream_privacy_type_icon(sub) {
 }
 
 export function update_stream_subscription_type_text(sub) {
+    // This is in the right panel.
     const stream_settings = stream_edit.settings_for_sub(sub);
     const template_data = {
         ...sub,
@@ -168,6 +191,21 @@ export function update_stream_subscription_type_text(sub) {
 }
 
 export function update_subscribers_count(sub, just_subscribed) {
+    /*
+        TODO: remove update_subscribers_count
+
+            <div class="subscriber-count" data-toggle="tooltip" title="{{t 'Subscriber count' }}">
+                {{> subscription_count}}
+            </div>
+
+            <i class="fa fa-user-o" aria-hidden="true"></i>
+            {{#if can_access_subscribers}}
+            <span class="subscriber-count-text">{{numberFormat subscriber_count}}</span>
+            {{else}}
+            <i class="subscriber-count-lock fa fa-lock" aria-hidden="true"></i>
+            {{/if}}
+    */
+
     if (!overlays.streams_open()) {
         // If the streams overlay isn't open, we don't need to rerender anything.
         return;
@@ -192,6 +230,7 @@ export function update_subscribers_count(sub, just_subscribed) {
 }
 
 export function update_subscribers_list(sub) {
+    // This is for the "Stream membership" section of the right panel.
     // Render subscriptions only if stream settings is open
     if (!stream_edit.is_sub_settings_active(sub)) {
         return;

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -30,6 +30,7 @@ exports.show_subs_pane = {
 };
 
 exports.check_button_for_sub = function (sub) {
+    // TODO: remove check_button_for_sub
     return $(`.stream-row[data-stream-id='${CSS.escape(sub.stream_id)}'] .check`);
 };
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -216,21 +216,9 @@ exports.set_color = function (stream_id, color) {
     stream_edit.set_stream_property(sub, "color", color);
 };
 
-exports.rerender_subscriptions_settings = function (sub) {
-    // This rerendes the subscriber data for a given sub object
-    // where it might have already been rendered in the subscriptions UI.
-    if (typeof sub === "undefined") {
-        blueslip.error("Undefined sub passed to function rerender_subscriptions_settings");
-        return;
-    }
+exports.update_subscribers_ui = function (sub) {
     stream_ui_updates.update_subscribers_count(sub);
     stream_ui_updates.update_subscribers_list(sub);
-};
-
-exports.update_subscribers_ui = function (sub) {
-    // We rely on rerender_subscriptions_settings to complete the
-    // stream_data subscribers count update
-    exports.rerender_subscriptions_settings(sub);
     message_view_header.maybe_rerender_title_area_for_stream(sub);
 };
 
@@ -325,7 +313,8 @@ exports.add_tooltip_to_left_panel_row = (row) => {
 };
 
 exports.update_settings_for_unsubscribed = function (sub) {
-    exports.rerender_subscriptions_settings(sub);
+    stream_ui_updates.update_subscribers_count(sub);
+    stream_ui_updates.update_subscribers_list(sub);
     stream_ui_updates.update_check_button_for_sub(sub);
     stream_ui_updates.update_settings_button_for_sub(sub);
     stream_ui_updates.update_regular_sub_settings(sub);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -37,6 +37,10 @@ exports.row_for_stream_id = function (stream_id) {
     return $(`.stream-row[data-stream-id='${CSS.escape(stream_id)}']`);
 };
 
+exports.is_sub_already_present = function (sub) {
+    return exports.row_for_stream_id(sub.stream_id).length > 0;
+};
+
 exports.settings_button_for_sub = function (sub) {
     // We don't do expectOne() here, because this button is only
     // visible if the user has that stream selected in the streams UI.
@@ -264,16 +268,6 @@ exports.add_sub_to_table = function (sub) {
         exports.row_for_stream_id(sub.stream_id).trigger("click");
         stream_create.reset_created_stream();
     }
-};
-
-exports.is_sub_already_present = function (sub) {
-    // This checks if a stream is already listed the "Manage streams"
-    // UI, by checking for its subscribe/unsubscribe checkmark button.
-    const button = exports.check_button_for_sub(sub);
-    if (button.length !== 0) {
-        return true;
-    }
-    return false;
 };
 
 exports.remove_stream = function (stream_id) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -429,7 +429,13 @@ exports.render_left_panel_superset = function () {
 };
 
 // LeftPanelParams { input: String, subscribed_only: Boolean, sort_order: String }
-exports.filter_table = function (left_panel_params) {
+exports.redraw_left_panel = function (left_panel_params) {
+    // We only get left_panel_params passed in from tests.  Real
+    // code calls get_left_panel_params().
+    if (left_panel_params === undefined) {
+        left_panel_params = exports.get_left_panel_params();
+    }
+
     exports.show_active_stream_in_left_panel();
 
     function stream_id_for_row(row) {
@@ -506,11 +512,6 @@ exports.maybe_reset_right_panel = function () {
         $(".nothing-selected").show();
         $(".stream-row.active").removeClass("active");
     }
-};
-
-exports.redraw_left_panel = function () {
-    const left_panel_params = exports.get_left_panel_params();
-    exports.filter_table(left_panel_params);
 };
 
 // Make it explicit that our toggler is not created right away.

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -248,14 +248,17 @@ exports.add_sub_to_table = function (sub) {
 
     const setting_sub = stream_data.get_sub_for_settings(sub);
     const html = render_subscription(setting_sub);
-    const settings_html = render_subscription_settings(sub);
+    const new_row = $(html);
+    exports.add_tooltip_to_left_panel_row(new_row);
 
     if (stream_create.get_name() === sub.name) {
-        ui.get_content_element($(".streams-list")).prepend(html);
+        ui.get_content_element($(".streams-list")).prepend(new_row);
         ui.reset_scrollbar($(".streams-list"));
     } else {
-        ui.get_content_element($(".streams-list")).append(html);
+        ui.get_content_element($(".streams-list")).append(new_row);
     }
+
+    const settings_html = render_subscription_settings(sub);
     ui.get_content_element($(".subscriptions .settings")).append($(settings_html));
 
     if (stream_create.get_name() === sub.name) {
@@ -314,13 +317,11 @@ exports.show_active_stream_in_left_panel = function () {
     }
 };
 
-exports.add_tooltips_to_left_panel = function () {
-    for (const row of $("#subscriptions_table .stream-row")) {
-        $(row).find('.sub-info-box [class$="-bar"] [class$="-count"]').tooltip({
-            placement: "left",
-            animation: false,
-        });
-    }
+exports.add_tooltip_to_left_panel_row = (row) => {
+    row.find('.sub-info-box [class$="-bar"] [class$="-count"]').tooltip({
+        placement: "left",
+        animation: false,
+    });
 };
 
 exports.update_settings_for_unsubscribed = function (sub) {
@@ -458,8 +459,6 @@ exports.filter_table = function (left_panel_params) {
         widgets.set(stream_id, $(row).detach());
     }
 
-    exports.add_tooltips_to_left_panel();
-
     ui.reset_scrollbar($("#subscription_overlay .streams-list"));
 
     const all_stream_ids = [...buckets.name, ...buckets.desc, ...buckets.other];
@@ -469,8 +468,11 @@ exports.filter_table = function (left_panel_params) {
             widgets.get(stream_id),
         );
     }
-
     exports.maybe_reset_right_panel();
+
+    for (const row of $("#subscriptions_table .stream-row")) {
+        exports.add_tooltip_to_left_panel_row($(row));
+    }
 
     // return this for test convenience
     return [...buckets.name, ...buckets.desc];


### PR DESCRIPTION
This sets us up to finally remove all the move-DOM-in-place complexity.  (I have that on a local branch, but it still needs a bit of cleanup.)

I tried to manually test all I could here, but there are probably blind spots.  Basically you want to open up a few different windows with Manage Streams and do a bunch of stuff.  I would play with things like having Iago modify "Verona" when Hamlet is in all three of these states:

* in normal chat
* in Manage Stream with Verona showing in the list
* in Manage Stream but with Verona missing due to some filter
