### PR TITLE
Increase opacity when we  hover on the "filter user" on the right-sidebar.

### DIFF
--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -181,6 +181,11 @@
         font-size: 13px;
         opacity: 0.5;
         margin-right: 5px;
+
+        &:hover {
+            opacity: 1;
+            cursor: pointer;
+        }
     }
 }
 


### PR DESCRIPTION
Issue: Usually we increase the opacity of an icon on hover, but the search-icon on right sidebar at top miss this functionality.
**Testing plan:** tested locally.
 **GIFS and Screenshot:**
![icon](https://user-images.githubusercontent.com/56171689/108390321-8fb90580-7236-11eb-8609-5b208663f798.gif)
