### PR TITLE
api docs: Fix blank line at end of Code Blocks.

### DIFF
--- a/static/styles/portico/markdown.css
+++ b/static/styles/portico/markdown.css
@@ -311,6 +311,7 @@
         code {
             font-size: 14px;
             white-space: pre-wrap;
+            padding: 0;
         }
     }
 


### PR DESCRIPTION
Added the missing padding: 0 to remove the blank line in code blocks as is done in Webapp code blocks CSS. Fixes part of #15967.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/56172924/108950803-dcfd0300-768c-11eb-90ad-92f5725fdefc.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
