### PR TITLE
Increase the opacity of an icon on hover.

### DIFF
--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -181,6 +181,11 @@
         font-size: 13px;
         opacity: 0.5;
         margin-right: 5px;
+
+        &:hover {
+            opacity: 1;
+            cursor: pointer;
+        }
     }
 }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->Issue: Usually we increase the opacity of an icon on hover, but the search-icon on right sidebar at top miss this functionality.

**Testing plan:** <!-- How have you tested? --> Tested manually.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->After this fix, it will look like this:
![icon-hover](https://user-images.githubusercontent.com/59444243/108357153-10fea100-7213-11eb-9259-9673a67754ec.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
