### PR TITLE
stream-ui: Fix oddly spaced elements in streams tab.

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -267,10 +267,6 @@
 
     .stream_sorter_toggle {
         margin-left: auto;
-
-        @media (width < $lg_min) {
-            margin-left: unset;
-        }
     }
 }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1784,7 +1784,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 
 /* This value needs to match with the same in subscriptions.css, as
    we have some shared styles declared there */
-@media (width < $md_min) {
+@media (width < $lg_min) {
     #settings_overlay_container {
         /* this variable allows JavaScript to detect this media query */
         --single-column: yes;

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -1106,7 +1106,6 @@ ul.grey-box {
 @media (width < $lg_min) {
     .subscriptions-container .left .search-container {
         flex-wrap: wrap;
-        justify-content: space-evenly;
     }
 
     .search-container {

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -1119,7 +1119,7 @@ ul.grey-box {
 
    Longer-term we should extract this logic two-column-overlay class
    to read more naturally. */
-@media (width < $md_min) {
+@media (width < $lg_min) {
     .subscriptions-container {
         position: relative;
         overflow: hidden;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This reverts most of the changes made in commit a5f0379.

Relevant conversation:
https://chat.zulip.org/#narrow/stream/6-frontend/topic/Oddly.20spaced.20elements.20in.20streams.20tab

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![flex1-2021-02-18_18 10 48](https://user-images.githubusercontent.com/58626718/108358951-5de37700-7215-11eb-975d-78b9a5f9f601.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
