### PR TITLE
puppeteer: Make subscribe/unsubscribe test more robust.

### DIFF
--- a/frontend_tests/puppeteer_tests/04-subscriptions.js
+++ b/frontend_tests/puppeteer_tests/04-subscriptions.js
@@ -47,17 +47,33 @@ async function open_streams_modal(page) {
 }
 
 async function test_subscription_button_verona_stream(page) {
-    const verona_subscribed_selector = "[data-stream-name='Verona'] .sub_unsub_button.checked";
-    const verona_unsubscribed_selector =
-        "[data-stream-name='Verona'] .sub_unsub_button:not(.checked)";
-    // assert it's already checked.
-    await page.waitForSelector(verona_subscribed_selector, {visible: true});
-    // get subscribe/unsubscribe button element.
-    const subscription_checkmark = await page.$("[data-stream-name='Verona'] .sub_unsub_button");
-    await subscription_checkmark.click(); // Unsubscribe.
-    await page.waitForSelector(verona_unsubscribed_selector); // Unsubscribed.
-    await subscription_checkmark.click(); // Subscribe again now.
-    await page.waitForSelector(verona_subscribed_selector, {visible: true}); // Subscribed.
+    const button_selector = "[data-stream-name='Verona'] .sub_unsub_button";
+    const subscribed_selector = `${button_selector}.checked`;
+    const unsubscribed_selector = `${button_selector}:not(.checked)`;
+
+    async function subscribed() {
+        return await page.waitForSelector(subscribed_selector, {visible: true});
+    }
+
+    async function unsubscribed() {
+        return await page.waitForSelector(unsubscribed_selector, {visible: true});
+    }
+
+    // Note that we intentionally re-find the button after each click, since
+    // the live-update code may replace the whole row.
+    let button;
+
+    // We assume Verona is already subscribed, so the first line here
+    // should happen immediately.
+    button = await subscribed();
+    button.click();
+    button = await unsubscribed();
+    button.click();
+    button = await subscribed();
+    button.click();
+    button = await unsubscribed();
+    button.click();
+    button = await subscribed();
 }
 
 async function click_create_new_stream(page, cordelia_checkbox, othello_checkbox) {


### PR DESCRIPTION
We generally want to avoid clicking on DOM elements
that may not actually be visible due to the prior
operation.  Instead, we can just find the visible
element after each step.

I also introduce a couple helper functions to
de-clutter the click/unclick/click steps, and I do
a couple extra clicks for good measure.

You can verify that the test will fail if you
add an early return to update_check_button_for_sub.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
