### PR TITLE
dark_mode: Message action popup button :focus fix.

### DIFF
--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -86,6 +86,11 @@ body.night-mode {
     .popover a {
         color: inherit;
     }
+    /* this one is because in the light-mode we have light-white overlay (bootstrap default)
+    and in night-mode it should be light-black overlay. */
+    .popover a:focus {
+        background-color: hsla(0, 0%, 0%, 0.2);
+    }
 
     .dark_background a,
     a.dark_background:hover,


### PR DESCRIPTION
This PR replaces the light
white overlay when message action popup
buttons are in focus with a light black
overlay in dark mode.
[Chat Reference](https://chat.zulip.org/#narrow/stream/6-frontend/topic/message.20action.20popup.20button.20issue/near/1121238)


<!-- What's this PR for?  (Just a link to an issue is fine.) -->



**Testing plan:** <!-- How have you tested? -->
Tested localy.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before | After
--- | ---
![Message Action Popup Issue](https://user-images.githubusercontent.com/63820270/108523160-9c4f6380-72f3-11eb-9566-1624588406ab.png) |  ![Screenshot 2021-02-19 at 7 53 13 PM](https://user-images.githubusercontent.com/63820270/108523178-a1acae00-72f3-11eb-8a52-c2a57b8ba0f4.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
