### PR TITLE
js: Don't escape "Just now" in timerenderer

### DIFF
--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -200,7 +200,7 @@ function get_last_seen(active_status, last_seen) {
         return last_seen;
     }
 
-    const last_seen_text = i18n.t("Last active: __last_seen__", {last_seen});
+    const last_seen_text = i18n.t("Last active: __- last_seen__", {last_seen});
     return last_seen_text;
 }
 


### PR DESCRIPTION
This breaks the French translation, and is incorrect in general.

https://chat.zulip.org/#narrow/stream/58-translation/topic/French.20translations/near/1121376

**Testing plan:** untested, but i trust the test suite ¯\\_(ツ)_/¯ (i18n docs say this should work https://www.i18next.com/translation-function/interpolation)