### PR TITLE
Add organization moderator role.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1337,6 +1337,8 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
 
     @property
     def is_provisional_member(self) -> bool:
+        if self.is_moderator:
+            return False
         diff = (timezone_now() - self.date_joined).days
         if diff < self.realm.waiting_period_threshold:
             return True
@@ -1378,6 +1380,10 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
             # We need to be careful to not accidentally change
             # ROLE_REALM_ADMINISTRATOR to ROLE_MEMBER here.
             self.role = UserProfile.ROLE_MEMBER
+
+    @property
+    def is_moderator(self) -> bool:
+        return self.role == UserProfile.ROLE_MODERATOR
 
     @property
     def is_incoming_webhook(self) -> bool:

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -304,6 +304,24 @@ class MessagePOSTTest(ZulipTestCase):
             bot_without_owner, stream_name, "New members cannot send to this stream."
         )
 
+        moderator_profile = self.example_user("shiva")
+        moderator_profile.date_joined = timezone_now() - datetime.timedelta(days=9)
+        moderator_profile.save()
+        self.assertTrue(moderator_profile.is_moderator)
+        self.assertFalse(moderator_profile.is_provisional_member)
+
+        # Moderators and their owned bots can send to STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS
+        # streams, even if the admin is a new user
+        self._send_and_verify_message(moderator_profile, stream_name)
+        moderator_owned_bot = self.create_test_bot(
+            short_name="whatever3",
+            full_name="whatever3",
+            user_profile=moderator_profile,
+        )
+        moderator_owned_bot.date_joined = timezone_now() - datetime.timedelta(days=11)
+        moderator_owned_bot.save()
+        self._send_and_verify_message(moderator_owned_bot, stream_name)
+
         # Cross realm bots should be allowed
         notification_bot = get_system_bot("notification-bot@zulip.com")
         internal_send_stream_message(
@@ -1600,12 +1618,14 @@ class StreamMessagesTest(ZulipTestCase):
         cordelia = self.example_user("cordelia")
         iago = self.example_user("iago")
         polonius = self.example_user("polonius")
+        shiva = self.example_user("shiva")
         realm = cordelia.realm
 
         stream_name = "test_stream"
         self.subscribe(cordelia, stream_name)
         self.subscribe(iago, stream_name)
         self.subscribe(polonius, stream_name)
+        self.subscribe(shiva, stream_name)
 
         do_set_realm_property(
             realm, "wildcard_mention_policy", Realm.WILDCARD_MENTION_POLICY_EVERYONE
@@ -1626,12 +1646,15 @@ class StreamMessagesTest(ZulipTestCase):
         do_set_realm_property(realm, "waiting_period_threshold", 10)
         iago.date_joined = timezone_now()
         iago.save()
+        shiva.date_joined = timezone_now()
+        shiva.save()
         cordelia.date_joined = timezone_now()
         cordelia.save()
         self.send_and_verify_wildcard_mention_message("cordelia", test_fails=True)
         self.send_and_verify_wildcard_mention_message("cordelia", sub_count=10)
-        # Administrators can use wildcard mentions even if they are new.
+        # Administrators and moderators can use wildcard mentions even if they are new.
         self.send_and_verify_wildcard_mention_message("iago")
+        self.send_and_verify_wildcard_mention_message("shiva")
 
         cordelia.date_joined = timezone_now() - datetime.timedelta(days=11)
         cordelia.save()

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3223,6 +3223,10 @@ class SubscriptionAPITest(ZulipTestCase):
         )
         self.assertFalse(othello.can_create_streams())
 
+        othello.role = UserProfile.ROLE_MODERATOR
+        self.assertTrue(othello.can_create_streams())
+
+        othello.role = UserProfile.ROLE_MEMBER
         othello.date_joined = timezone_now() - timedelta(
             days=(othello.realm.waiting_period_threshold + 1)
         )
@@ -3295,6 +3299,10 @@ class SubscriptionAPITest(ZulipTestCase):
         )
         self.assertFalse(othello.can_subscribe_other_users())
 
+        do_change_user_role(othello, UserProfile.ROLE_MODERATOR)
+        self.assertTrue(othello.can_subscribe_other_users())
+
+        do_change_user_role(othello, UserProfile.ROLE_MEMBER)
         othello.date_joined = timezone_now() - timedelta(
             days=(othello.realm.waiting_period_threshold + 1)
         )


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- [x] Add moderator role in `models.py`. (merged)
- [x] Add new user in development environment as moderator. (merged)
- [x] Give moderator all the permissions that full members has.
- [ ] Modify the permissions which moderator has such that moderator is between admin and full member.
- [ ] Allow to create moderators from API.
- [ ] Modify UI to display user role as moderator (including development environment)
- [ ] Add moderator options in settings accordingly.
- [ ] Add frontend for adding and modifying moderator roles.
- [ ] Allow user to be invited as moderator.
- [ ] Add help documentation for moderator role and update docs in other relevant places.



**Testing plan:** <!-- How have you tested? --> Added and updated existing tests.


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
