### PR TITLE
frontend: Fix shifted user invite copy icon

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -460,6 +460,7 @@ li,
     position: relative;
     margin-right: -32px;
     margin-top: -1px;
+    padding: 8px 3px 0 13px;
 }
 
 #clipboard_image {


### PR DESCRIPTION
This issue adds the appropriate padding to the
copy_generate_invite_link class. This fixes the copy link icon which
seemed to be shifted when clicked.

Fixes #16868

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before
![image](https://user-images.githubusercontent.com/56730716/108584842-787b3480-736a-11eb-89b0-6c89437fc005.png)

After
![image](https://user-images.githubusercontent.com/56730716/108584890-d576ea80-736a-11eb-8510-dc1c02f1647d.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
