### PR TITLE
compose: only show "new topic" when in stream or topic narrow.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1724,7 +1724,7 @@ test_ui("nonexistent_stream_reply_error", () => {
 test_ui("narrow_button_titles", () => {
     util.is_mobile = () => false;
 
-    compose.update_closed_compose_buttons_for_private();
+    compose.update_closed_compose_buttons_outside_stream();
     assert.equal(
         $("#left_bar_compose_stream_button_big").text(),
         $t({defaultMessage: "New stream message"}),

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -93,7 +93,7 @@ function test_helper() {
     stub(ui_util, "change_tab_to");
     stub(unread_ops, "process_visible");
     stub(compose, "update_closed_compose_buttons_for_stream");
-    stub(compose, "update_closed_compose_buttons_for_private");
+    stub(compose, "update_closed_compose_buttons_outside_stream");
 
     return {
         clear: () => {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -177,7 +177,7 @@ function update_conversation_button(btn_text, title) {
     $("#left_bar_compose_private_button_big").prop("title", title);
 }
 
-export function update_closed_compose_buttons_for_private() {
+export function update_closed_compose_buttons_outside_stream() {
     const text_stream = $t({defaultMessage: "New stream message"});
     const title_stream = text_stream + " (c)";
     const text_conversation = $t({defaultMessage: "New private message"});

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -379,10 +379,10 @@ export function activate(raw_operators, opts) {
         }
     }
 
-    if (filter.contains_only_private_messages()) {
-        compose.update_closed_compose_buttons_for_private();
-    } else {
+    if (filter.has_operator("stream")) {
         compose.update_closed_compose_buttons_for_stream();
+    } else {
+        compose.update_closed_compose_buttons_outside_stream();
     }
 
     search.update_button_visibility();
@@ -800,7 +800,7 @@ function handle_post_narrow_deactivate_processes() {
 
     top_left_corner.handle_narrow_deactivated();
     stream_list.handle_narrow_deactivated();
-    compose.update_closed_compose_buttons_for_stream();
+    compose.update_closed_compose_buttons_outside_stream();
     message_edit.handle_narrow_deactivated();
     widgetize.set_widgets_for_list();
     typing_events.render_notifications_for_narrow();


### PR DESCRIPTION
Fixes #12496

This PR makes the "new topic" button to be named as "new stream message" when the user is not any stream or topic narrow. Previously this was only for pm, but this adds it to other places also.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Ran node tests and tested manually.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![button_label](https://user-images.githubusercontent.com/56730716/108589773-13cdd300-7386-11eb-95ba-c90c504ebd44.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
