### PR TITLE
Fixes #17309: Added label to edit topic button in streams.

### DIFF
--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -42,7 +42,7 @@
                     <i class="fa fa-pencil always_visible_topic_edit recipient_bar_icon" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
                 {{else}}
                     {{#if on_hover_topic_edit}}
-                    <i class="fa fa-pencil on_hover_topic_edit recipient_bar_icon" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} title="{{t 'Edit' }}" role="button"  tabindex="0" aria-label="{{t 'Edit' }}"></i>
+                    <i class="fa fa-pencil on_hover_topic_edit recipient_bar_icon" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} title="{{t 'Edit' }}" role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
                     {{/if}}
                 {{/if}}
 

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -42,7 +42,7 @@
                     <i class="fa fa-pencil always_visible_topic_edit recipient_bar_icon" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
                 {{else}}
                     {{#if on_hover_topic_edit}}
-                    <i class="fa fa-pencil on_hover_topic_edit recipient_bar_icon" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} role="button" title="{{t 'Edit'}}" tabindex="0" aria-label="{{t 'Edit' }}"></i>
+                    <i class="fa fa-pencil on_hover_topic_edit recipient_bar_icon" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} title="{{t 'Edit' }}" role="button"  tabindex="0" aria-label="{{t 'Edit' }}"></i>
                     {{/if}}
                 {{/if}}
 

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -42,7 +42,7 @@
                     <i class="fa fa-pencil always_visible_topic_edit recipient_bar_icon" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
                 {{else}}
                     {{#if on_hover_topic_edit}}
-                    <i class="fa fa-pencil on_hover_topic_edit recipient_bar_icon" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
+                    <i class="fa fa-pencil on_hover_topic_edit recipient_bar_icon" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} role="button" title="{{t 'Edit'}}" tabindex="0" aria-label="{{t 'Edit' }}"></i>
                     {{/if}}
                 {{/if}}
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #17309 [https://github.com/zulip/zulip/issues/17309]

Added a Label for edit topic button in streams.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
     ###-->
![Screenshot 2021-02-21 144321](https://user-images.githubusercontent.com/63050765/108621619-b1de9d80-7459-11eb-9908-7da864ef8322.png)


  

