### PR TITLE
node tests: Fix zjquery leaks.

### DIFF
--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -18,7 +18,12 @@ alert_words.initialize({
     alert_words: ["foo", "bar"],
 });
 
-run_test("render_alert_words_ui", () => {
+function test_ui(label, f) {
+    $.clear_all_elements();
+    run_test(label, f);
+}
+
+test_ui("render_alert_words_ui", () => {
     const word_list = $("#alert_words_list");
     const appended = [];
     word_list.append = (rendered) => {
@@ -42,8 +47,8 @@ run_test("render_alert_words_ui", () => {
     assert(new_alert_word.is_focused());
 });
 
-run_test("add_alert_word", () => {
-    alert_words_ui.render_alert_words_ui = () => {}; // we've already tested this above
+test_ui("add_alert_word", (override) => {
+    override(alert_words_ui, "render_alert_words_ui", () => {}); // we've already tested this above
 
     alert_words_ui.set_up_alert_words();
 
@@ -97,7 +102,10 @@ run_test("add_alert_word", () => {
     assert(alert_word_status.visible());
 });
 
-run_test("add_alert_word_keypress", () => {
+test_ui("add_alert_word_keypress", (override) => {
+    override(alert_words_ui, "render_alert_words_ui", () => {});
+    alert_words_ui.set_up_alert_words();
+
     const create_form = $("#create_alert_word_form");
     const keypress_func = create_form.get_on_handler("keypress", "#create_alert_word_name");
 
@@ -120,7 +128,10 @@ run_test("add_alert_word_keypress", () => {
     assert(called);
 });
 
-run_test("remove_alert_word", () => {
+test_ui("remove_alert_word", (override) => {
+    override(alert_words_ui, "render_alert_words_ui", () => {});
+    alert_words_ui.set_up_alert_words();
+
     const word_list = $("#alert_words_list");
     const remove_func = word_list.get_on_handler("click", ".remove-alert-word");
 
@@ -164,7 +175,10 @@ run_test("remove_alert_word", () => {
     assert(alert_word_status.visible());
 });
 
-run_test("close_status_message", () => {
+test_ui("close_status_message", (override) => {
+    override(alert_words_ui, "render_alert_words_ui", () => {});
+    alert_words_ui.set_up_alert_words();
+
     const alert_word_settings = $("#alert-word-settings");
     const close = alert_word_settings.get_on_handler("click", ".close-alert-word-status");
 

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1850,17 +1850,9 @@ run_test("create_message_object", () => {
     };
     stream_data.add_sub(sub);
 
-    const page = {
-        "#stream_message_recipient_stream": "social",
-        "#stream_message_recipient_topic": "lunch",
-        "#compose-textarea": "burrito",
-    };
-
-    set_global("$", (selector) => ({
-        val() {
-            return page[selector];
-        },
-    }));
+    $("#stream_message_recipient_stream").val("social");
+    $("#stream_message_recipient_topic").val("lunch");
+    $("#compose-textarea").val("burrito");
 
     compose_state.get_message_type = function () {
         return "stream";
@@ -1873,7 +1865,7 @@ run_test("create_message_object", () => {
 
     blueslip.expect("error", "Trying to send message with bad stream name: BOGUS STREAM");
 
-    page["#stream_message_recipient_stream"] = "BOGUS STREAM";
+    $("#stream_message_recipient_stream").val("BOGUS STREAM");
     message = compose.create_message_object();
     assert.equal(message.to, "BOGUS STREAM");
     assert.equal(message.topic, "lunch");

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -113,7 +113,7 @@ function stub_out_video_calls() {
 
 function reset_jquery() {
     // Avoid leaks.
-    set_global("$", make_zjquery());
+    $.clear_all_elements();
 }
 
 const new_user = {
@@ -206,7 +206,7 @@ run_test("validate_stream_message_address_info", () => {
 
 run_test("validate", () => {
     function initialize_pm_pill() {
-        set_global("$", make_zjquery());
+        reset_jquery();
 
         $("#compose-send-button").prop("disabled", false);
         $("#compose-send-button").trigger("focus");
@@ -1891,7 +1891,7 @@ run_test("create_message_object", () => {
 });
 
 run_test("nonexistent_stream_reply_error", () => {
-    set_global("$", make_zjquery());
+    reset_jquery();
 
     const actions = [];
     $("#nonexistent_stream_reply_error").show = () => {

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -112,13 +112,18 @@ function assert_hidden(sel) {
     assert(!$(sel).visible());
 }
 
-run_test("initial_state", () => {
+function test_ui(label, f) {
+    $.clear_all_elements();
+    run_test(label, f);
+}
+
+test_ui("initial_state", () => {
     assert.equal(compose_state.composing(), false);
     assert.equal(compose_state.get_message_type(), false);
     assert.equal(compose_state.has_message_content(), false);
 });
 
-run_test("start", () => {
+test_ui("start", () => {
     compose_actions.autosize_message_content = noop;
     compose_actions.expand_compose_box = noop;
     compose_actions.set_focus = noop;
@@ -234,7 +239,7 @@ run_test("start", () => {
     assert(!compose_state.composing());
 });
 
-run_test("respond_to_message", () => {
+test_ui("respond_to_message", () => {
     // Test PM
     const person = {
         user_id: 22,
@@ -271,7 +276,7 @@ run_test("respond_to_message", () => {
     assert.equal($("#stream_message_recipient_stream").val(), "devel");
 });
 
-run_test("reply_with_mention", () => {
+test_ui("reply_with_mention", (override) => {
     const msg = {
         type: "stream",
         stream: "devel",
@@ -283,16 +288,15 @@ run_test("reply_with_mention", () => {
     stub_selected_message(msg);
 
     let syntax_to_insert;
-    compose_ui.insert_syntax_and_focus = function (syntax) {
+    override(compose_ui, "insert_syntax_and_focus", (syntax) => {
         syntax_to_insert = syntax;
-    };
+    });
 
     const opts = {};
 
     reply_with_mention(opts);
     assert.equal($("#stream_message_recipient_stream").val(), "devel");
     assert.equal(syntax_to_insert, "@**Bob Roberts**");
-    assert(compose_state.has_message_content());
 
     // Test for extended mention syntax
     const bob_1 = {
@@ -311,10 +315,9 @@ run_test("reply_with_mention", () => {
     reply_with_mention(opts);
     assert.equal($("#stream_message_recipient_stream").val(), "devel");
     assert.equal(syntax_to_insert, "@**Bob Roberts|40**");
-    assert(compose_state.has_message_content());
 });
 
-run_test("quote_and_reply", () => {
+test_ui("quote_and_reply", () => {
     const msg = {
         type: "stream",
         stream: "devel",
@@ -396,7 +399,7 @@ run_test("quote_and_reply", () => {
     quote_and_reply(opts);
 });
 
-run_test("get_focus_area", () => {
+test_ui("get_focus_area", () => {
     assert.equal(get_focus_area("private", {}), "#private_message_recipient");
     assert.equal(
         get_focus_area("private", {
@@ -413,7 +416,7 @@ run_test("get_focus_area", () => {
     );
 });
 
-run_test("focus_in_empty_compose", () => {
+test_ui("focus_in_empty_compose", () => {
     $("#compose-textarea").is = function (attr) {
         assert.equal(attr, ":focus");
         return $("#compose-textarea").is_focused;
@@ -434,7 +437,7 @@ run_test("focus_in_empty_compose", () => {
     assert(!compose_state.focus_in_empty_compose());
 });
 
-run_test("on_narrow", () => {
+test_ui("on_narrow", () => {
     let cancel_called = false;
     compose_actions.cancel = function () {
         cancel_called = true;

--- a/frontend_tests/node_tests/hash_util.js
+++ b/frontend_tests/node_tests/hash_util.js
@@ -12,12 +12,8 @@ const people = zrequire("people");
 const Filter = zrequire("Filter", "js/filter");
 const narrow_state = zrequire("narrow_state");
 
-set_global(
-    "$",
-    make_zjquery({
-        silent: true,
-    }),
-);
+set_global("$", make_zjquery());
+
 const ui_report = set_global("ui_report", {
     displayed_error: false,
     error: () => {

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -93,7 +93,7 @@ run_test("basics", () => {
 });
 
 function set_up() {
-    set_global("$", make_zjquery());
+    $.clear_all_elements();
     const items = {
         blue: {
             display_value: "BLUE",

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -9,12 +9,7 @@ const {run_test} = require("../zjsunit/test");
 const {make_zjquery} = require("../zjsunit/zjquery");
 
 // Dependencies
-set_global(
-    "$",
-    make_zjquery({
-        silent: true,
-    }),
-);
+set_global("$", make_zjquery());
 set_global("document", {
     hasFocus() {
         return true;
@@ -34,7 +29,7 @@ set_global("navigator", _navigator);
 
 const muting = zrequire("muting");
 const stream_data = zrequire("stream_data");
-zrequire("ui");
+const ui = zrequire("ui");
 const spoilers = zrequire("spoilers");
 spoilers.hide_spoilers_in_notification = () => {};
 
@@ -262,7 +257,9 @@ run_test("message_is_notifiable", () => {
     assert.equal(notifications.message_is_notifiable(message), true);
 });
 
-run_test("basic_notifications", () => {
+run_test("basic_notifications", (override) => {
+    override(ui, "replace_emoji_with_text", () => {});
+
     let n; // Object for storing all notification data for assertions.
     let last_closed_message_id = null;
     let last_shown_message_id = null;

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -71,11 +71,6 @@ const me = {
     timezone: "America/Los_Angeles",
 };
 
-const target = $.create("click target");
-target.offset = () => ({
-    top: 10,
-});
-
 const e = {
     stopPropagation: noop,
 };
@@ -111,9 +106,15 @@ function make_image_stubber() {
     };
 }
 
-popovers.register_click_handlers();
+function test_ui(label, f) {
+    $.clear_all_elements();
+    run_test(label, (override) => {
+        popovers.register_click_handlers();
+        f(override);
+    });
+}
 
-run_test("sender_hover", (override) => {
+test_ui("sender_hover", (override) => {
     override(popovers, "hide_user_profile", noop);
 
     const selection = ".sender_name, .sender_name-in-status, .inline_profile_picture";
@@ -139,6 +140,8 @@ run_test("sender_hover", (override) => {
     current_msg_list.select_id = (msg_id) => {
         assert.equal(msg_id, message.id);
     };
+
+    const target = $.create("click target");
 
     target.closest = (sel) => {
         assert.equal(sel, ".message_row");
@@ -206,7 +209,9 @@ run_test("sender_hover", (override) => {
     // todo: load image
 });
 
-run_test("actions_popover", (override) => {
+test_ui("actions_popover", (override) => {
+    const target = $.create("click target");
+
     override(popovers, "hide_user_profile", noop);
 
     const handler = $("#main_div").get_on_handler("click", ".actions_hover");

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -121,7 +121,7 @@ function test_create_bot_type_input_box_toggle(f) {
 }
 
 function set_up() {
-    set_global("$", make_zjquery());
+    $.clear_all_elements();
 
     // bunch of stubs
 

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -393,7 +393,7 @@ run_test("with_external_user", () => {
     };
 
     // Reset zjquery to test stuff with user who cannot edit
-    set_global("$", make_zjquery());
+    $.clear_all_elements();
 
     let user_group_find_called = 0;
     const user_group_stub = $(`div.user-group[id="${CSS.escape(1)}"]`);

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -91,34 +91,40 @@ for (const sub of subs) {
     stream_data.add_sub(sub);
 }
 
-const subscriptions_table_selector = "#subscriptions_table";
-const input_field_stub = $.create(".input");
+function test_ui(label, f) {
+    $.clear_all_elements();
+    run_test(label, (override) => {
+        stream_edit.initialize();
+        f(override);
+    });
+}
 
-const sub_settings_selector = `#subscription_overlay .subscription_settings[data-stream-id='${CSS.escape(
-    denmark.stream_id,
-)}']`;
-const $sub_settings_container = $.create(sub_settings_selector);
-$sub_settings_container.find = noop;
-$sub_settings_container.find = function () {
-    return input_field_stub;
-};
+test_ui("subscriber_pills", () => {
+    const subscriptions_table_selector = "#subscriptions_table";
+    const input_field_stub = $.create(".input");
 
-const pill_container_stub = $.create(sub_settings_selector + " .pill-container");
-pill_container_stub.find = function () {
-    return input_field_stub;
-};
+    const sub_settings_selector = `#subscription_overlay .subscription_settings[data-stream-id='${CSS.escape(
+        denmark.stream_id,
+    )}']`;
+    const $sub_settings_container = $.create(sub_settings_selector);
+    $sub_settings_container.find = noop;
+    $sub_settings_container.find = function () {
+        return input_field_stub;
+    };
 
-const $subscription_settings = $.create(".subscription_settings");
-$subscription_settings.addClass = noop;
-$subscription_settings.closest = () => $subscription_settings;
-$subscription_settings.attr("data-stream-id", denmark.stream_id);
-$subscription_settings.length = 0;
+    const pill_container_stub = $.create(sub_settings_selector + " .pill-container");
+    pill_container_stub.find = function () {
+        return input_field_stub;
+    };
 
-const $add_subscribers_form = $.create(".subscriber_list_add form");
-$add_subscribers_form.closest = () => $subscription_settings;
+    const $subscription_settings = $.create(".subscription_settings");
+    $subscription_settings.addClass = noop;
+    $subscription_settings.closest = () => $subscription_settings;
+    $subscription_settings.attr("data-stream-id", denmark.stream_id);
+    $subscription_settings.length = 0;
 
-run_test("subscriber_pills", () => {
-    stream_edit.initialize();
+    const $add_subscribers_form = $.create(".subscriber_list_add form");
+    $add_subscribers_form.closest = () => $subscription_settings;
 
     let template_rendered = false;
     ui.get_content_element = () => {

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -77,10 +77,6 @@ const {server_events, ui} = Object.fromEntries(
     ]),
 );
 
-util.is_mobile = () => false;
-stub_templates(() => "some-html");
-ui.get_scroll_element = (element) => element;
-
 zrequire("hash_util");
 zrequire("stream_color");
 zrequire("stream_edit");
@@ -124,67 +120,71 @@ const ui_init = rewiremock.proxy(() => zrequire("ui_init"), {
 
 set_global("$", make_zjquery());
 
-const document_stub = $.create("document-stub");
-document.to_$ = () => document_stub;
-document_stub.idle = () => {};
-
-const window_stub = $.create("window-stub");
-set_global("to_$", () => window_stub);
-window_stub.idle = () => {};
-
-ui_init.initialize_kitchen_sink_stuff = () => {};
-
-page_params.realm_default_streams = [];
-page_params.subscriptions = [];
-page_params.unsubscribed = [];
-page_params.never_subscribed = [];
-page_params.realm_notifications_stream_id = -1;
-page_params.unread_msgs = {
-    huddles: [],
-    pms: [],
-    streams: [],
-    mentions: [],
-};
-page_params.recent_private_conversations = [];
-page_params.user_status = {};
-page_params.realm_emoji = {};
-page_params.realm_users = [];
-page_params.realm_non_active_users = [];
-page_params.cross_realm_bots = [];
-page_params.muted_topics = [];
-page_params.realm_user_groups = [];
-page_params.realm_bots = [];
-page_params.realm_filters = [];
-page_params.starred_messages = [];
-page_params.presences = [];
-
-const $message_view_header = $.create("#message_view_header");
-$message_view_header.append = () => {};
-upload.setup_upload = () => {};
-
-server_events.home_view_loaded = () => true;
-
-resize.watch_manual_resize = () => {};
-
-$("#stream_message_recipient_stream").typeahead = () => {};
-$("#stream_message_recipient_topic").typeahead = () => {};
-$("#private_message_recipient").typeahead = () => {};
-$("#compose-textarea").typeahead = () => {};
-$("#search_query").typeahead = () => {};
-
-const value_stub = $.create("value");
-const count_stub = $.create("count");
-count_stub.set_find_results(".value", value_stub);
-$(".top_left_starred_messages").set_find_results(".count", count_stub);
-
-$("#message_view_header .stream").length = 0;
-
-// set find results doesn't work here since we call .empty() in the code.
-$message_view_header.find = () => false;
-
-compose.compute_show_video_chat_button = () => {};
-$("#below-compose-content .video_link").toggle = () => {};
-
 run_test("initialize_everything", () => {
+    util.is_mobile = () => false;
+    stub_templates(() => "some-html");
+    ui.get_scroll_element = (element) => element;
+
+    const document_stub = $.create("document-stub");
+    document.to_$ = () => document_stub;
+    document_stub.idle = () => {};
+
+    const window_stub = $.create("window-stub");
+    set_global("to_$", () => window_stub);
+    window_stub.idle = () => {};
+
+    ui_init.initialize_kitchen_sink_stuff = () => {};
+
+    page_params.realm_default_streams = [];
+    page_params.subscriptions = [];
+    page_params.unsubscribed = [];
+    page_params.never_subscribed = [];
+    page_params.realm_notifications_stream_id = -1;
+    page_params.unread_msgs = {
+        huddles: [],
+        pms: [],
+        streams: [],
+        mentions: [],
+    };
+    page_params.recent_private_conversations = [];
+    page_params.user_status = {};
+    page_params.realm_emoji = {};
+    page_params.realm_users = [];
+    page_params.realm_non_active_users = [];
+    page_params.cross_realm_bots = [];
+    page_params.muted_topics = [];
+    page_params.realm_user_groups = [];
+    page_params.realm_bots = [];
+    page_params.realm_filters = [];
+    page_params.starred_messages = [];
+    page_params.presences = [];
+
+    const $message_view_header = $.create("#message_view_header");
+    $message_view_header.append = () => {};
+    upload.setup_upload = () => {};
+
+    server_events.home_view_loaded = () => true;
+
+    resize.watch_manual_resize = () => {};
+
+    $("#stream_message_recipient_stream").typeahead = () => {};
+    $("#stream_message_recipient_topic").typeahead = () => {};
+    $("#private_message_recipient").typeahead = () => {};
+    $("#compose-textarea").typeahead = () => {};
+    $("#search_query").typeahead = () => {};
+
+    const value_stub = $.create("value");
+    const count_stub = $.create("count");
+    count_stub.set_find_results(".value", value_stub);
+    $(".top_left_starred_messages").set_find_results(".count", count_stub);
+
+    $("#message_view_header .stream").length = 0;
+
+    // set find results doesn't work here since we call .empty() in the code.
+    $message_view_header.find = () => false;
+
+    compose.compute_show_video_chat_button = () => {};
+    $("#below-compose-content .video_link").toggle = () => {};
+
     ui_init.initialize_everything();
 });

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -368,7 +368,7 @@ run_test("uppy_config", () => {
 });
 
 run_test("file_input", () => {
-    set_global("$", make_zjquery());
+    $.clear_all_elements();
 
     upload.setup_upload({mode: "compose"});
 
@@ -391,8 +391,7 @@ run_test("file_input", () => {
 });
 
 run_test("file_drop", () => {
-    set_global("$", make_zjquery());
-
+    $.clear_all_elements();
     upload.setup_upload({mode: "compose"});
 
     let prevent_default_counter = 0;
@@ -431,7 +430,7 @@ run_test("file_drop", () => {
 });
 
 run_test("copy_paste", () => {
-    set_global("$", make_zjquery());
+    $.clear_all_elements();
 
     upload.setup_upload({mode: "compose"});
 
@@ -472,7 +471,7 @@ run_test("copy_paste", () => {
 });
 
 run_test("uppy_events", () => {
-    set_global("$", make_zjquery());
+    $.clear_all_elements();
     const callbacks = {};
     let uppy_cancel_all_called = false;
     let state = {};

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -227,9 +227,6 @@ exports.make_new_elem = function (selector, opts) {
                 // if ($.find().length) { //success }
                 return [];
             }
-            if (opts.silent) {
-                return self;
-            }
             throw new Error("Cannot find " + child_selector + " in " + selector);
         },
         get_on_handler(name, child_selector) {
@@ -407,19 +404,14 @@ exports.make_new_elem = function (selector, opts) {
     return self;
 };
 
-exports.make_zjquery = function (opts) {
-    opts = opts || {};
-
+exports.make_zjquery = function () {
     const elems = new Map();
 
     // Our fn structure helps us simulate extending jQuery.
     const fn = {};
 
     function new_elem(selector, create_opts) {
-        const elem = exports.make_new_elem(selector, {
-            silent: opts.silent,
-            ...create_opts,
-        });
+        const elem = exports.make_new_elem(selector, {...create_opts});
         Object.assign(elem, fn);
 
         // Create a proxy handler to detect missing stubs.


### PR DESCRIPTION
Just to be clear, the leaks here are within files.

For almost all modules, it's pretty easy to keep `$(...)` stubs contained to single `run_test(...)` blocks.

The two remaining beasts are compose.js and settings_user_groups.