### PR TITLE
zjquery: Make zjquery a singleton.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -108,7 +108,6 @@
         {
             "files": ["frontend_tests/node_tests/**"],
             "globals": {
-                "$": false,
                 "blueslip": false,
                 "current_msg_list": false,
                 "home_msg_list": false,

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -4,9 +4,8 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
-set_global("$", make_zjquery());
 const window_stub = $.create("window-stub");
 set_global("to_$", () => window_stub);
 $(window).idle = () => {};

--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -5,9 +5,7 @@ const {strict: assert} = require("assert");
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
-
-set_global("$", make_zjquery());
+const $ = require("../zjsunit/zjquery");
 
 const channel = set_global("channel", {});
 

--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -7,7 +7,7 @@ const {JSDOM} = require("jsdom");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const noop = () => {};
 const template = fs.readFileSync("templates/corporate/billing.html", "utf-8");
@@ -20,8 +20,6 @@ const helpers = set_global("helpers", {
 const StripeCheckout = set_global("StripeCheckout", {
     configure: noop,
 });
-
-set_global("$", make_zjquery());
 
 run_test("initialize", () => {
     let token_func;

--- a/frontend_tests/node_tests/billing_helpers.js
+++ b/frontend_tests/node_tests/billing_helpers.js
@@ -8,13 +8,12 @@ const {JSDOM} = require("jsdom");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const template = fs.readFileSync("templates/corporate/upgrade.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});
 const jquery = jQueryFactory(dom.window);
 
-set_global("$", make_zjquery());
 set_global("page_params", {});
 const loading = set_global("loading", {});
 const history = set_global("history", {});

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -6,12 +6,10 @@ const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
 
 const _page_params = {};
 
 set_global("page_params", _page_params);
-set_global("$", make_zjquery());
 const people = zrequire("people");
 const presence = zrequire("presence");
 const user_status = zrequire("user_status");

--- a/frontend_tests/node_tests/buddy_list.js
+++ b/frontend_tests/node_tests/buddy_list.js
@@ -6,9 +6,8 @@ const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
-set_global("$", make_zjquery());
 const people = zrequire("people");
 zrequire("buddy_data");
 const buddy_list = zrequire("buddy_list");

--- a/frontend_tests/node_tests/channel.js
+++ b/frontend_tests/node_tests/channel.js
@@ -6,8 +6,7 @@ const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-
-set_global("$", {});
+const $ = require("../zjsunit/zjquery");
 
 const reload = set_global("reload", {});
 zrequire("reload_state");

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -4,11 +4,10 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const noop = () => {};
 
-set_global("$", make_zjquery());
 set_global("document", {});
 
 const common = zrequire("common");

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -9,7 +9,7 @@ const rewiremock = require("rewiremock/node");
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const events = require("./lib/events");
 
@@ -17,7 +17,6 @@ set_global("bridge", false);
 
 const noop = function () {};
 
-set_global("$", make_zjquery());
 set_global("DOMParser", new JSDOM().window.DOMParser);
 set_global("compose_actions", {
     update_placeholder_text: noop,

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const noop = function () {};
 const return_false = function () {
@@ -19,8 +19,6 @@ set_global("document", {
 });
 
 set_global("page_params", {});
-
-set_global("$", make_zjquery());
 
 const compose_pm_pill = set_global("compose_pm_pill", {});
 

--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -2,11 +2,9 @@
 
 const {strict: assert} = require("assert");
 
-const {set_global, zrequire} = require("../zjsunit/namespace");
+const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
-
-set_global("$", make_zjquery());
+const $ = require("../zjsunit/zjquery");
 
 const people = zrequire("people");
 

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -6,7 +6,7 @@ const autosize = require("autosize");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const compose_ui = zrequire("compose_ui");
 const people = zrequire("people");
@@ -17,8 +17,6 @@ set_global("document", {
         return false;
     },
 });
-
-set_global("$", make_zjquery());
 
 const alice = {
     email: "alice@zulip.com",

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const emoji = zrequire("emoji", "shared/js/emoji");
 const typeahead = zrequire("typeahead", "shared/js/typeahead");
@@ -170,8 +170,6 @@ const netherland_stream = {
 stream_data.add_sub(sweden_stream);
 stream_data.add_sub(denmark_stream);
 stream_data.add_sub(netherland_stream);
-
-set_global("$", make_zjquery());
 
 set_global("page_params", {});
 const channel = set_global("channel", {});

--- a/frontend_tests/node_tests/copy_and_paste.js
+++ b/frontend_tests/node_tests/copy_and_paste.js
@@ -2,6 +2,7 @@
 
 const {strict: assert} = require("assert");
 
+const jquery = require("jquery");
 const {JSDOM} = require("jsdom");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
@@ -14,7 +15,7 @@ const compose_ui = set_global("compose_ui", {});
 
 const {window} = new JSDOM("<!DOCTYPE html><p>Hello world</p>");
 const {DOMParser, document} = window;
-set_global("$", require("jquery")(window));
+const $ = set_global("$", jquery(window));
 
 set_global("DOMParser", DOMParser);
 set_global("document", document);

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_stub} = require("../zjsunit/stub");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const noop = function () {};
 
@@ -15,8 +15,6 @@ const event_fixtures = events.fixtures;
 const test_message = events.test_message;
 const test_user = events.test_user;
 const typing_person1 = events.typing_person1;
-
-set_global("$", make_zjquery());
 
 set_global("setTimeout", (func) => func());
 

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -5,9 +5,7 @@ const {strict: assert} = require("assert");
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire, with_overrides} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
-
-set_global("$", make_zjquery());
+const $ = require("../zjsunit/zjquery");
 
 const localstorage = zrequire("localstorage");
 const drafts = zrequire("drafts");

--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -4,11 +4,10 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const dropdown_list_widget = zrequire("dropdown_list_widget");
 zrequire("scroll_util");
-set_global("$", make_zjquery());
 
 const noop = () => {};
 const _ListWidget = {

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -6,9 +6,7 @@ const MockDate = require("mockdate");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", make_zjquery());
 const local_message = set_global("local_message", {});
 const markdown = set_global("markdown", {});
 set_global("page_params", {});

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -4,12 +4,11 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 zrequire("unread");
 const stream_data = zrequire("stream_data");
 const people = zrequire("people");
-set_global("$", make_zjquery());
 zrequire("message_util", "js/message_util");
 const Filter = zrequire("Filter", "js/filter");
 

--- a/frontend_tests/node_tests/hash_util.js
+++ b/frontend_tests/node_tests/hash_util.js
@@ -4,15 +4,12 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
 
 const hash_util = zrequire("hash_util");
 const stream_data = zrequire("stream_data");
 const people = zrequire("people");
 const Filter = zrequire("Filter", "js/filter");
 const narrow_state = zrequire("narrow_state");
-
-set_global("$", make_zjquery());
 
 const ui_report = set_global("ui_report", {
     displayed_error: false,

--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -4,9 +4,8 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
-set_global("$", make_zjquery());
 const window_stub = $.create("window-stub");
 set_global("location", {
     protocol: "http:",

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -5,7 +5,6 @@ const {strict: assert} = require("assert");
 const {set_global, with_overrides, zrequire} = require("../zjsunit/namespace");
 const {make_stub} = require("../zjsunit/stub");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
 
 // Important note on these tests:
 //
@@ -32,7 +31,6 @@ let overlays = set_global("overlays", {});
 
 // jQuery stuff should go away if we make an initialize() method.
 set_global("document", "document-stub");
-set_global("$", make_zjquery());
 
 const emoji = zrequire("emoji", "shared/js/emoji");
 

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -4,9 +4,8 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
-set_global("$", make_zjquery());
 const input_pill = zrequire("input_pill");
 
 zrequire("templates");

--- a/frontend_tests/node_tests/keydown_util.js
+++ b/frontend_tests/node_tests/keydown_util.js
@@ -1,10 +1,8 @@
 "use strict";
 
-const {set_global, zrequire} = require("../zjsunit/namespace");
+const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
-
-set_global("$", make_zjquery());
+const $ = require("../zjsunit/zjquery");
 
 const keydown_util = zrequire("keydown_util");
 

--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const rows = zrequire("rows");
 const lightbox = zrequire("lightbox");
@@ -21,8 +21,6 @@ set_global("popovers", {
 });
 
 rows.is_draft_row = () => false;
-
-set_global("$", make_zjquery());
 
 run_test("pan_and_zoom", () => {
     $.clear_all_elements();

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -6,7 +6,6 @@ const markdown_test_cases = require("../../zerver/tests/fixtures/markdown_test_c
 const markdown_assert = require("../zjsunit/markdown_assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
 
 zrequire("hash_util");
 
@@ -61,8 +60,6 @@ fenced_code.initialize(pygments_data);
 
 const doc = "";
 set_global("document", doc);
-
-set_global("$", make_zjquery());
 
 const cordelia = {
     full_name: "Cordelia Lear",

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -2,15 +2,13 @@
 
 const {strict: assert} = require("assert");
 
-const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 set_global("document", null);
 set_global("page_params", {
     realm_community_topic_editing_limit_seconds: 259200,
 });
-
-stub_out_jquery();
 
 const message_edit = zrequire("message_edit");
 

--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -4,7 +4,6 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
 
 const message_events = zrequire("message_events");
 const message_store = zrequire("message_store");
@@ -15,7 +14,6 @@ const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const unread = zrequire("unread");
 
-set_global("$", make_zjquery());
 const condense = set_global("condense", {});
 set_global("current_msg_list", {});
 const message_edit = set_global("message_edit", {});

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -6,9 +6,8 @@ const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
-set_global("$", make_zjquery());
 set_global("document", "document-stub");
 
 const message_fetch = zrequire("message_fetch");

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
 const {make_stub} = require("../zjsunit/stub");
 const {run_test} = require("../zjsunit/test");
+
 // These unit tests for static/js/message_list.js emphasize the model-ish
 // aspects of the MessageList class.  We have to stub out a few functions
 // related to views and events to get the tests working.
@@ -31,7 +32,7 @@ function accept_all_filter() {
     return filter;
 }
 
-run_test("basics", () => {
+run_test("basics", (override) => {
     const filter = accept_all_filter();
 
     const list = new MessageList({
@@ -74,9 +75,9 @@ run_test("basics", () => {
 
     assert.deepEqual(list.all_messages(), messages);
 
-    $.Event = function (ev) {
+    override(global.$, "Event", (ev) => {
         assert.equal(ev, "message_selected.zulip");
-    };
+    });
     list.select_id(50);
 
     assert.equal(list.selected_id(), 50);

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -2,9 +2,10 @@
 
 const {strict: assert} = require("assert");
 
-const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_stub} = require("../zjsunit/stub");
 const {run_test} = require("../zjsunit/test");
+const $ = require("../zjsunit/zjquery");
 
 // These unit tests for static/js/message_list.js emphasize the model-ish
 // aspects of the MessageList class.  We have to stub out a few functions
@@ -13,8 +14,14 @@ const {run_test} = require("../zjsunit/test");
 const noop = function () {};
 
 set_global("Filter", noop);
-stub_out_jquery();
-set_global("document", null);
+set_global("document", {
+    to_$() {
+        return {
+            trigger() {},
+        };
+    },
+});
+
 const narrow_state = set_global("narrow_state", {});
 const stream_data = set_global("stream_data", {});
 
@@ -75,7 +82,7 @@ run_test("basics", (override) => {
 
     assert.deepEqual(list.all_messages(), messages);
 
-    override(global.$, "Event", (ev) => {
+    override($, "Event", (ev) => {
         assert.equal(ev, "message_selected.zulip");
     });
     list.select_id(50);

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -6,9 +6,7 @@ const _ = require("lodash");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", make_zjquery());
 set_global("document", "document-stub");
 
 const Filter = zrequire("Filter", "js/filter");

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -5,7 +5,6 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_stub} = require("../zjsunit/stub");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
 
 const util = zrequire("util");
 const people = zrequire("people");
@@ -13,7 +12,6 @@ const message_store = zrequire("message_store");
 
 const noop = function () {};
 
-set_global("$", make_zjquery());
 set_global("document", "document-stub");
 
 set_global("stream_topic_history", {

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -4,9 +4,8 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
-set_global("$", make_zjquery());
 const hash_util = zrequire("hash_util");
 zrequire("hashchange");
 const narrow_state = zrequire("narrow_state");

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -4,10 +4,8 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
 
 const util = zrequire("util");
-set_global("$", make_zjquery());
 
 const narrow_state = zrequire("narrow_state");
 set_global("resize", {

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -6,10 +6,9 @@ const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
 
 // Dependencies
-set_global("$", make_zjquery());
+
 set_global("document", {
     hasFocus() {
         return true;

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -4,9 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
-
-set_global("$", make_zjquery());
+const $ = require("../zjsunit/zjquery");
 
 const narrow_state = set_global("narrow_state", {});
 set_global("ui", {

--- a/frontend_tests/node_tests/poll_widget.js
+++ b/frontend_tests/node_tests/poll_widget.js
@@ -3,13 +3,11 @@
 const {strict: assert} = require("assert");
 
 const {stub_templates} = require("../zjsunit/handlebars");
-const {set_global, zrequire} = require("../zjsunit/namespace");
+const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const poll_widget = zrequire("poll_widget");
-
-set_global("$", make_zjquery());
 
 const people = zrequire("people");
 

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -7,9 +7,7 @@ const rewiremock = require("rewiremock/node");
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
-
-set_global("$", make_zjquery());
+const $ = require("../zjsunit/zjquery");
 
 zrequire("hash_util");
 zrequire("narrow");

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -6,10 +6,9 @@ const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_stub} = require("../zjsunit/stub");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 set_global("document", "document-stub");
-set_global("$", make_zjquery());
 
 const emoji_codes = zrequire("emoji_codes", "generated/emoji/emoji_codes.json");
 const emoji = zrequire("emoji", "shared/js/emoji");

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -5,12 +5,12 @@ const {strict: assert} = require("assert");
 const {stub_templates} = require("../zjsunit/handlebars");
 const {reset_module, set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 zrequire("message_util");
 
 const noop = () => {};
-set_global("$", make_zjquery());
+
 set_global("hashchange", {
     exit_overlay: noop,
 });

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -4,14 +4,13 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const rm = zrequire("rendered_markdown");
 const people = zrequire("people");
 const user_groups = zrequire("user_groups");
 const stream_data = zrequire("stream_data");
 zrequire("timerender");
-set_global("$", make_zjquery());
 
 set_global("rtl", {
     get_direction: () => "ltr",

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 set_global("page_params", {
     search_pills_enabled: true,
@@ -18,7 +18,6 @@ const noop = () => {};
 const return_true = () => true;
 const return_false = () => false;
 
-set_global("$", make_zjquery());
 const narrow_state = set_global("narrow_state", {filter: return_false});
 const search_suggestion = set_global("search_suggestion", {});
 set_global("ui_util", {

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 set_global("page_params", {
     search_pills_enabled: false,
@@ -16,7 +16,6 @@ const noop = () => {};
 const return_true = () => true;
 const return_false = () => false;
 
-set_global("$", make_zjquery());
 const narrow_state = set_global("narrow_state", {});
 const search_suggestion = set_global("search_suggestion", {});
 set_global("ui_util", {

--- a/frontend_tests/node_tests/server_events.js
+++ b/frontend_tests/node_tests/server_events.js
@@ -2,18 +2,31 @@
 
 const {strict: assert} = require("assert");
 
-const {set_global, stub_out_jquery, zrequire} = require("../zjsunit/namespace");
+const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
+const $ = require("../zjsunit/zjquery");
 
 const noop = function () {};
 
-set_global("document", {});
+set_global("document", {
+    to_$() {
+        return {
+            trigger() {},
+        };
+    },
+});
 set_global("addEventListener", noop);
-stub_out_jquery();
+
+// Turn off $.now so we can import server_events.
+set_global("$", {
+    now() {},
+});
 
 zrequire("message_store");
 const server_events = zrequire("server_events");
 zrequire("sent_messages");
+
+set_global("$", $);
 
 const channel = set_global("channel", {});
 set_global("home_msg_list", {

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -6,7 +6,7 @@ const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 set_global("page_params", {
     realm_uri: "https://chat.example.com",
@@ -30,8 +30,6 @@ const bot_data_params = {
 };
 
 const avatar = set_global("avatar", {});
-
-set_global("$", make_zjquery());
 
 const bot_data = zrequire("bot_data");
 

--- a/frontend_tests/node_tests/settings_emoji.js
+++ b/frontend_tests/node_tests/settings_emoji.js
@@ -4,9 +4,8 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
-set_global("$", make_zjquery());
 const upload_widget = set_global("upload_widget", {});
 const settings_emoji = zrequire("settings_emoji");
 

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -4,9 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
-
-set_global("$", make_zjquery());
+const $ = require("../zjsunit/zjquery");
 
 zrequire("timerender");
 const settings_muting = zrequire("settings_muting");

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -7,9 +7,7 @@ const rewiremock = require("rewiremock/node");
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
-
-set_global("$", make_zjquery());
+const $ = require("../zjsunit/zjquery");
 
 const noop = () => {};
 

--- a/frontend_tests/node_tests/settings_profile_fields.js
+++ b/frontend_tests/node_tests/settings_profile_fields.js
@@ -7,10 +7,9 @@ const rewiremock = require("rewiremock/node");
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 set_global("page_params", {});
-set_global("$", make_zjquery());
 const loading = set_global("loading", {});
 
 const SHORT_TEXT_ID = 1;

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -7,12 +7,11 @@ const _ = require("lodash");
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const user_pill = zrequire("user_pill");
 const settings_user_groups = zrequire("settings_user_groups");
 
-set_global("$", make_zjquery());
 const confirm_dialog = set_global("confirm_dialog", {});
 
 const noop = function () {};

--- a/frontend_tests/node_tests/spoilers.js
+++ b/frontend_tests/node_tests/spoilers.js
@@ -2,11 +2,10 @@
 
 const {strict: assert} = require("assert");
 
-const {set_global, zrequire} = require("../zjsunit/namespace");
+const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
-set_global("$", make_zjquery());
 const spoilers = zrequire("spoilers");
 
 // This function is taken from rendered_markdown.js and slightly modified.

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const noop = () => {};
 stub_templates(() => noop);
@@ -30,7 +30,6 @@ const typeahead_helper = set_global("typeahead_helper", {});
 const ui = set_global("ui", {
     get_scroll_element: noop,
 });
-set_global("$", make_zjquery());
 
 zrequire("input_pill");
 const peer_data = zrequire("peer_data");

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -5,13 +5,12 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {make_stub} = require("../zjsunit/stub");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const noop = function () {};
 const return_true = function () {
     return true;
 };
-set_global("$", make_zjquery());
 const _settings_notifications = {
     update_page: () => {},
 };

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -5,10 +5,9 @@ const {strict: assert} = require("assert");
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 set_global("document", "document-stub");
-set_global("$", make_zjquery());
 
 zrequire("unread_ui");
 const Filter = zrequire("Filter", "js/filter");

--- a/frontend_tests/node_tests/stream_search.js
+++ b/frontend_tests/node_tests/stream_search.js
@@ -4,11 +4,10 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
-// This tests the stream searching functionality which currently
+const $ = require("../zjsunit/zjquery");
+
 // lives in stream_list.js.
 
-set_global("$", make_zjquery());
 const stream_list = zrequire("stream_list");
 
 const noop = () => {};

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const ui = set_global("ui", {
     get_content_element: (element) => element,
@@ -22,7 +22,6 @@ set_global("location", {
 
 const subs = zrequire("subs");
 
-set_global("$", make_zjquery());
 set_global("hash_util", {
     by_stream_uri: () => {},
 });

--- a/frontend_tests/node_tests/support.js
+++ b/frontend_tests/node_tests/support.js
@@ -5,15 +5,13 @@ const fs = require("fs");
 
 const {JSDOM} = require("jsdom");
 
-const {set_global, zrequire} = require("../zjsunit/namespace");
+const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const template = fs.readFileSync("templates/analytics/realm_details.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});
 const document = dom.window.document;
-
-set_global("$", make_zjquery());
 
 run_test("scrub_realm", () => {
     zrequire("support", "js/analytics/support");

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -7,9 +7,8 @@ const MockDate = require("mockdate");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
-set_global("$", make_zjquery());
 set_global("page_params", {
     twenty_four_hour_time: true,
 });

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -4,9 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
-
-set_global("$", make_zjquery());
+const $ = require("../zjsunit/zjquery");
 
 const Filter = zrequire("Filter", "js/filter");
 zrequire("unread_ui");

--- a/frontend_tests/node_tests/transmit.js
+++ b/frontend_tests/node_tests/transmit.js
@@ -4,11 +4,9 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
 
 const noop = function () {};
 
-set_global("$", make_zjquery());
 set_global("page_params", {});
 const channel = set_global("channel", {});
 const reload = set_global("reload", {});

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -5,7 +5,7 @@ const rewiremock = require("rewiremock/node");
 const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 /*
     This test suite is designed to find errors
@@ -27,6 +27,7 @@ const {make_zjquery} = require("../zjsunit/zjquery");
     some things can happen later in a `launch` method.
 
 */
+
 const util = zrequire("util");
 
 set_global("document", {
@@ -118,7 +119,7 @@ const ui_init = rewiremock.proxy(() => zrequire("ui_init"), {
     },
 });
 
-set_global("$", make_zjquery());
+set_global("$", $);
 
 run_test("initialize_everything", () => {
     util.is_mobile = () => false;

--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -7,7 +7,7 @@ const {JSDOM} = require("jsdom");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 const noop = () => {};
 const template = fs.readFileSync("templates/corporate/upgrade.html", "utf-8");
@@ -26,7 +26,6 @@ set_global("page_params", {
 });
 
 const helpers = zrequire("helpers", "js/billing/helpers");
-set_global("$", make_zjquery());
 
 run_test("initialize", () => {
     let token_func;

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -6,9 +6,8 @@ const rewiremock = require("rewiremock/node");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
-set_global("$", make_zjquery());
 set_global("document", {
     location: {},
 });

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -4,9 +4,6 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
-
-set_global("$", make_zjquery());
 
 const people = zrequire("people");
 const settings_config = zrequire("settings_config");

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -7,9 +7,7 @@ const _ = require("lodash");
 
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
 
-set_global("$", make_zjquery());
 set_global("DOMParser", new JSDOM().window.DOMParser);
 set_global("document", {});
 const util = zrequire("util");

--- a/frontend_tests/node_tests/widgetize.js
+++ b/frontend_tests/node_tests/widgetize.js
@@ -4,9 +4,8 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
-set_global("$", make_zjquery());
 const poll_widget = set_global("poll_widget", {});
 set_global("document", "document-stub");
 

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -2,9 +2,8 @@
 
 const {strict: assert} = require("assert");
 
-const {set_global} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
-const {make_zjquery} = require("../zjsunit/zjquery");
+const $ = require("../zjsunit/zjquery");
 
 /*
 
@@ -29,12 +28,6 @@ The code we are testing lives here:
     https://github.com/zulip/zulip/blob/master/frontend_tests/zjsunit/zjquery.js
 
 */
-
-// The first thing we do to use zjquery is patch our global namespace
-// with zjquery as follows.  This call gives us our own instance of a
-// zjquery stub variable.  Like with real jQuery, the '$' function will
-// be the gateway to a bigger API.
-set_global("$", make_zjquery());
 
 run_test("basics", () => {
     // Let's create a sample piece of code to test:

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -13,6 +13,8 @@ const namespace = require("./namespace");
 const test = require("./test");
 const {make_zblueslip} = require("./zblueslip");
 
+global.$ = require("./zjquery");
+
 require("@babel/register")({
     extensions: [".es6", ".es", ".jsx", ".js", ".mjs", ".ts"],
     only: [
@@ -66,6 +68,7 @@ function short_tb(tb) {
 }
 
 function run_one_module(file) {
+    global.$.clear_all_elements();
     console.info("running test " + path.basename(file, ".js"));
     test.set_current_file_name(file);
     require(file);

--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -72,17 +72,6 @@ exports.restore = function () {
     new_globals.clear();
 };
 
-exports.stub_out_jquery = function () {
-    const $ = exports.set_global("$", () => ({
-        on() {},
-        trigger() {},
-        hide() {},
-        removeClass() {},
-    }));
-    $.fn = {};
-    $.now = function () {};
-};
-
 exports.with_field = function (obj, field, val, f) {
     const old_val = obj[field];
     obj[field] = val;

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -16,7 +16,7 @@ class Event {
     stopPropagation() {}
 }
 
-exports.make_event_store = (selector) => {
+function make_event_store(selector) {
     /*
 
        This function returns an event_store object that
@@ -144,9 +144,9 @@ exports.make_event_store = (selector) => {
     };
 
     return self;
-};
+}
 
-exports.make_new_elem = function (selector, opts) {
+function make_new_elem(selector, opts) {
     let html = "never-been-set";
     let text = "never-been-set";
     let value;
@@ -160,7 +160,7 @@ exports.make_new_elem = function (selector, opts) {
     const properties = new Map();
     const attrs = new Map();
     const classes = new Map();
-    const event_store = exports.make_event_store(selector);
+    const event_store = make_event_store(selector);
 
     const self = {
         addClass(class_name) {
@@ -402,16 +402,16 @@ exports.make_new_elem = function (selector, opts) {
     self.length = 1;
 
     return self;
-};
+}
 
-exports.make_zjquery = function () {
+function make_zjquery() {
     const elems = new Map();
 
     // Our fn structure helps us simulate extending jQuery.
     const fn = {};
 
     function new_elem(selector, create_opts) {
-        const elem = exports.make_new_elem(selector, {...create_opts});
+        const elem = make_new_elem(selector, {...create_opts});
         Object.assign(elem, fn);
 
         // Create a proxy handler to detect missing stubs.
@@ -550,4 +550,6 @@ exports.make_zjquery = function () {
     };
 
     return zjquery;
-};
+}
+
+module.exports = make_zjquery();


### PR DESCRIPTION
We no longer export make_zjquery().

We now instead have a singleton zjquery instance
that we attach to global.$ in index.js.

We call $.clear_all_elements() before each module.
(We will soon get even more aggressive about doing
it in run_test.)

Test functions can still override $ with set_global.
A good example of this is copy_and_paste using the
real jquery module.

We no longer exempt $ as a global variable, so
test modules that use the zjquery $ need to do:

    const $ = require("../zjsunit/zjquery");

