### PR TITLE
zjsunit: Use clear_zulip_refs as the main way to undo zrequire

### DIFF
--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -90,7 +90,6 @@ try {
 
         const blueslip = namespace.set_global("blueslip", make_zblueslip());
         namespace.set_global("i18n", stub_i18n);
-        namespace.clear_zulip_refs();
 
         run_one_module(file);
 


### PR DESCRIPTION
Move `clear_zulip_refs` into `restore`, and rewrite it without lodash. We no longer need the `requires` array, and `zrequire` is now nothing more than a wrapper around `require`.

Cc @showell.