### PR TITLE
node_tests: Don’t read page_params from deprecated global variable.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -112,16 +112,14 @@
                 "current_msg_list": false,
                 "home_msg_list": false,
                 "i18n": false,
-                "location": false,
-                "page_params": false
+                "location": false
             }
         },
         {
             "files": ["frontend_tests/puppeteer_lib/**", "frontend_tests/puppeteer_tests/**"],
             "globals": {
                 "$": false,
-                "current_msg_list": false,
-                "page_params": false
+                "current_msg_list": false
             }
         },
         {

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -14,10 +14,10 @@ let filter_key_handlers;
 
 const huddle_data = zrequire("huddle_data");
 
-const _page_params = {
+let page_params = set_global("page_params", {
     realm_users: [],
     user_id: 999,
-};
+});
 
 const _document = {
     hasFocus() {
@@ -69,7 +69,6 @@ set_global("channel", channel);
 set_global("compose_state", compose_state);
 set_global("document", _document);
 set_global("keydown_util", _keydown_util);
-set_global("page_params", _page_params);
 set_global("pm_list", _pm_list);
 set_global("popovers", _popovers);
 set_global("resize", _resize);
@@ -749,7 +748,7 @@ test_ui("electron_bridge", () => {
 });
 
 test_ui("test_send_or_receive_no_presence_for_web_public_visitor", () => {
-    set_global("page_params", {
+    page_params = set_global("page_params", {
         is_web_public_visitor: true,
     });
     activity.send_presence_to_server();

--- a/frontend_tests/node_tests/billing_helpers.js
+++ b/frontend_tests/node_tests/billing_helpers.js
@@ -14,7 +14,7 @@ const template = fs.readFileSync("templates/corporate/upgrade.html", "utf-8");
 const dom = new JSDOM(template, {pretendToBeVisual: true});
 const jquery = jQueryFactory(dom.window);
 
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 const loading = set_global("loading", {});
 const history = set_global("history", {});
 set_global("document", {

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -7,9 +7,8 @@ const _ = require("lodash");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-const _page_params = {};
+const page_params = set_global("page_params", {});
 
-set_global("page_params", _page_params);
 const people = zrequire("people");
 const presence = zrequire("presence");
 const user_status = zrequire("user_status");

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -61,7 +61,7 @@ const channel = set_global("channel", {});
 const stream_edit = set_global("stream_edit", {});
 const markdown = set_global("markdown", {});
 const loading = set_global("loading", {});
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 const resize = set_global("resize", {});
 const subs = set_global("subs", {});
 const ui_util = set_global("ui_util", {});

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -171,7 +171,7 @@ stream_data.add_sub(sweden_stream);
 stream_data.add_sub(denmark_stream);
 stream_data.add_sub(netherland_stream);
 
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 const channel = set_global("channel", {});
 const compose = set_global("compose", {
     finish: noop,

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -63,7 +63,7 @@ const user_events = set_global("user_events", {});
 const user_groups = set_global("user_groups", {});
 
 // page_params is highly coupled to dispatching now
-set_global("page_params", {
+const page_params = set_global("page_params", {
     test_suite: false,
     is_admin: true,
     realm_description: "already set description",

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -9,7 +9,7 @@ const {run_test} = require("../zjsunit/test");
 
 const local_message = set_global("local_message", {});
 const markdown = set_global("markdown", {});
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 
 const fake_now = 555;
 MockDate.set(new Date(fake_now * 1000));

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -13,7 +13,7 @@ zrequire("message_util", "js/message_util");
 const Filter = zrequire("Filter", "js/filter");
 
 const message_store = set_global("message_store", {});
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 
 const me = {
     email: "me@example.com",

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -25,7 +25,7 @@ set_global("navigator", {
     platform: "",
 });
 
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 
 let overlays = set_global("overlays", {});
 

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -38,7 +38,7 @@ const emoji_params = {
     emoji_codes,
 };
 
-set_global("page_params", {
+const page_params = set_global("page_params", {
     realm_users: [],
     realm_filters: [
         ["#(?P<id>[0-9]{2,8})", "https://trac.example.com/ticket/%(id)s"],

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-set_global("page_params", {
+let page_params = set_global("page_params", {
     realm_community_topic_editing_limit_seconds: 259200,
 });
 
@@ -51,19 +51,19 @@ run_test("get_editability", () => {
         sent_by_me: true,
     };
 
-    set_global("page_params", {
+    page_params = set_global("page_params", {
         realm_allow_message_editing: false,
     });
     assert.equal(get_editability(message), editability_types.NO);
 
-    set_global("page_params", {
+    page_params = set_global("page_params", {
         realm_allow_message_editing: true,
         // Limit of 0 means no time limit on editing messages
         realm_message_content_edit_limit_seconds: 0,
     });
     assert.equal(get_editability(message), editability_types.FULL);
 
-    set_global("page_params", {
+    page_params = set_global("page_params", {
         realm_allow_message_editing: true,
         realm_message_content_edit_limit_seconds: 10,
     });
@@ -85,7 +85,7 @@ run_test("get_editability", () => {
         sent_by_me: false,
         type: "stream",
     };
-    set_global("page_params", {
+    page_params = set_global("page_params", {
         realm_allow_community_topic_editing: true,
         realm_allow_message_editing: true,
         realm_message_content_edit_limit_seconds: 0,
@@ -116,7 +116,7 @@ run_test("get_editability", () => {
 });
 
 run_test("get_deletability", () => {
-    set_global("page_params", {
+    page_params = set_global("page_params", {
         is_admin: true,
         realm_allow_message_deleting: false,
         realm_message_content_delete_limit_seconds: 0,

--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -19,7 +19,7 @@ set_global("current_msg_list", {});
 const message_edit = set_global("message_edit", {});
 const message_list = set_global("message_list", {});
 const notifications = set_global("notifications", {});
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 const pm_list = set_global("pm_list", {});
 const stream_list = set_global("stream_list", {});
 const unread_ui = set_global("unread_ui", {});

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -17,7 +17,7 @@ const message_list = zrequire("message_list");
 
 const noop = function () {};
 
-set_global("page_params", {
+const page_params = set_global("page_params", {
     twenty_four_hour_time: false,
 });
 set_global("home_msg_list", "stub");

--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -8,7 +8,7 @@ const {run_test} = require("../zjsunit/test");
 zrequire("timerender");
 const muting = zrequire("muting");
 const stream_data = zrequire("stream_data");
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 
 run_test("edge_cases", () => {
     // private messages

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -14,7 +14,7 @@ set_global("document", {
         return true;
     },
 });
-set_global("page_params", {
+const page_params = set_global("page_params", {
     is_admin: false,
     realm_users: [],
     enable_desktop_notifications: true,

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -10,7 +10,7 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 const message_store = set_global("message_store", {});
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 
 const people = zrequire("people");
 const settings_config = zrequire("settings_config");

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -65,7 +65,7 @@ const $array = (array) => {
     return {each};
 };
 
-set_global("page_params", {emojiset: "apple"});
+let page_params = set_global("page_params", {emojiset: "apple"});
 
 const get_content_element = () => {
     $.clear_all_elements();
@@ -197,16 +197,16 @@ run_test("timestamp-twenty-four-hour-time", () => {
     // We will temporarily change the 24h setting for this test.
     const old_page_params = page_params;
 
-    set_global("page_params", {...old_page_params, twenty_four_hour_time: true});
+    page_params = set_global("page_params", {...old_page_params, twenty_four_hour_time: true});
     rm.update_elements($content);
     assert.equal($timestamp.text(), "Wed, Jul 15 2020, 20:40");
 
-    set_global("page_params", {...old_page_params, twenty_four_hour_time: false});
+    page_params = set_global("page_params", {...old_page_params, twenty_four_hour_time: false});
     rm.update_elements($content);
     assert.equal($timestamp.text(), "Wed, Jul 15 2020, 8:40 PM");
 
     // Set page_params back to its original value.
-    set_global("page_params", old_page_params);
+    page_params = set_global("page_params", old_page_params);
 });
 
 run_test("timestamp-error", () => {

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-set_global("page_params", {
+const page_params = set_global("page_params", {
     search_pills_enabled: true,
 });
 

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-set_global("page_params", {
+const page_params = set_global("page_params", {
     search_pills_enabled: false,
 });
 set_global("message_store", {

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -8,7 +8,7 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 
-set_global("page_params", {
+const page_params = set_global("page_params", {
     realm_uri: "https://chat.example.com",
     realm_embedded_bots: [
         {name: "converter", config: {}},

--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -8,7 +8,7 @@ const {run_test} = require("../zjsunit/test");
 const settings_data = zrequire("settings_data");
 const settings_config = zrequire("settings_config");
 
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 
 /*
     Some methods in settings_data are fairly

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -30,14 +30,14 @@ const _loading = {
     destroy_indicator: noop,
 };
 
-const _page_params = {
+const page_params = set_global("page_params", {
     is_admin: false,
     realm_domains: [
         {domain: "example.com", allow_subdomains: true},
         {domain: "example.org", allow_subdomains: false},
     ],
     realm_authentication_methods: {},
-};
+});
 
 const realm_icon = set_global("realm_icon", {});
 const channel = set_global("channel", {});
@@ -74,7 +74,6 @@ set_global("csrf_token", "token-stub");
 set_global("FormData", _FormData);
 set_global("jQuery", _jQuery);
 set_global("loading", _loading);
-set_global("page_params", _page_params);
 set_global("realm_logo", _realm_logo);
 set_global("ui_report", _ui_report);
 set_global("ListWidget", _ListWidget);

--- a/frontend_tests/node_tests/settings_profile_fields.js
+++ b/frontend_tests/node_tests/settings_profile_fields.js
@@ -9,7 +9,7 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 const loading = set_global("loading", {});
 
 const SHORT_TEXT_ID = 1;

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -34,7 +34,7 @@ const ui_report = set_global("ui_report", {});
 
 const people = zrequire("people");
 
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 
 function reset_test_setup(pill_container_stub) {
     function input_pill_stub(opts) {

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -7,7 +7,7 @@ const _ = require("lodash");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-set_global("page_params", {
+const page_params = set_global("page_params", {
     is_admin: false,
     realm_users: [],
     is_guest: false,

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -19,7 +19,7 @@ set_global("hash_util", {
 set_global("ListWidget", {
     create: () => ({init: noop}),
 });
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 set_global("settings_notifications", {
     get_notifications_table_row_data: noop,
 });

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -20,7 +20,7 @@ const scroll_util = zrequire("scroll_util");
 zrequire("list_cursor");
 const stream_list = zrequire("stream_list");
 zrequire("ui");
-set_global("page_params", {
+const page_params = set_global("page_params", {
     is_admin: false,
     realm_users: [],
 });

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -9,7 +9,7 @@ const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 
-set_global("page_params", {
+let page_params = set_global("page_params", {
     twenty_four_hour_time: true,
 });
 
@@ -158,7 +158,7 @@ run_test("get_timestamp_for_flatpickr", () => {
 });
 
 run_test("absolute_time_12_hour", () => {
-    set_global("page_params", {
+    page_params = set_global("page_params", {
         twenty_four_hour_time: false,
     });
 
@@ -190,7 +190,7 @@ run_test("absolute_time_12_hour", () => {
 });
 
 run_test("absolute_time_24_hour", () => {
-    set_global("page_params", {
+    page_params = set_global("page_params", {
         twenty_four_hour_time: true,
     });
 

--- a/frontend_tests/node_tests/transmit.js
+++ b/frontend_tests/node_tests/transmit.js
@@ -7,7 +7,7 @@ const {run_test} = require("../zjsunit/test");
 
 const noop = function () {};
 
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 const channel = set_global("channel", {});
 const reload = set_global("reload", {});
 const reload_state = set_global("reload_state", {});

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -6,7 +6,7 @@ const {stub_templates} = require("../zjsunit/handlebars");
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-set_global("page_params", {realm_is_zephyr_mirror_realm: false});
+const page_params = set_global("page_params", {realm_is_zephyr_mirror_realm: false});
 
 const settings_config = zrequire("settings_config");
 const pm_conversations = zrequire("pm_conversations");

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -40,7 +40,7 @@ set_global("csrf_token", "whatever");
 
 set_global("$", () => {});
 const resize = set_global("resize", {});
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 
 const ignore_modules = [
     "activity",

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -12,7 +12,7 @@ const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 const unread = zrequire("unread");
 
-set_global("page_params", {
+let page_params = set_global("page_params", {
     realm_push_notifications_enabled: false,
 });
 zrequire("settings_notifications");
@@ -49,17 +49,17 @@ function assert_zero_counts(counts) {
 }
 
 function test_notifiable_count(home_unread_messages, expected_notifiable_count) {
-    set_global("page_params", {
+    page_params = set_global("page_params", {
         desktop_icon_count_display: 1,
     });
     let notifiable_counts = unread.get_notifiable_count();
     assert.deepEqual(notifiable_counts, home_unread_messages);
-    set_global("page_params", {
+    page_params = set_global("page_params", {
         desktop_icon_count_display: 2,
     });
     notifiable_counts = unread.get_notifiable_count();
     assert.deepEqual(notifiable_counts, expected_notifiable_count);
-    set_global("page_params", {
+    page_params = set_global("page_params", {
         desktop_icon_count_display: 3,
     });
     notifiable_counts = unread.get_notifiable_count();

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -14,7 +14,7 @@ set_global("document", {
 set_global("navigator", {
     userAgent: "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)",
 });
-set_global("page_params", {
+const page_params = set_global("page_params", {
     max_file_upload_size: 25,
 });
 set_global("csrf_token", "csrf_token");

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -32,7 +32,7 @@ set_global("settings_users", {
 set_global("gear_menu", {
     update_org_settings_menu_item() {},
 });
-set_global("page_params", {
+const page_params = set_global("page_params", {
     is_admin: true,
 });
 

--- a/frontend_tests/node_tests/user_pill.js
+++ b/frontend_tests/node_tests/user_pill.js
@@ -8,7 +8,7 @@ const {run_test} = require("../zjsunit/test");
 const people = zrequire("people");
 const user_pill = zrequire("user_pill");
 
-set_global("page_params", {});
+const page_params = set_global("page_params", {});
 
 const alice = {
     email: "alice@example.com",


### PR DESCRIPTION
Follow up to commit 89aa3155a97f9cd7977766a530787e2a14219091 (#17262).