### PR TITLE
zerver/openapi/python_examples.py: Fix `message_id` type.

### DIFF
--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -783,10 +783,11 @@ def send_message(client: Client) -> int:
 
 @openapi_test_function("/messages/{message_id}/reactions:post")
 def add_reaction(client: Client, message_id: int) -> None:
+    request: Dict[str, Any] = {}
     # {code_example|start}
     # Add an emoji reaction
     request = {
-        "message_id": str(message_id),
+        "message_id": message_id,
         "emoji_name": "octopus",
     }
 
@@ -797,10 +798,11 @@ def add_reaction(client: Client, message_id: int) -> None:
 
 @openapi_test_function("/messages/{message_id}/reactions:delete")
 def remove_reaction(client: Client, message_id: int) -> None:
+    request: Dict[str, Any] = {}
     # {code_example|start}
     # Remove an emoji reaction
     request = {
-        "message_id": str(message_id),
+        "message_id": message_id,
         "emoji_name": "octopus",
     }
 


### PR DESCRIPTION
The `message_id` was made an `str` object because the request expected `Dict[str, str]`.
The request is now casted to `Dict[str, Any]` to fix the issue and removed typecast of `message_id` to str.

Part to be changed in [zulip/python-zulip-api](https://github.com/zulip/python-zulip-api/pull/653)
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

<!--
**Testing plan:**  How have you tested? -->

 <!-- 
**GIFs or screenshots:**If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
