### PR TITLE
compose: Fix message lost during server downtime.

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -26,7 +26,6 @@ const localStorage = set_global("localStorage", {
     },
 });
 mock_cjs("jquery", $);
-const compose_state = mock_esm("../../static/js/compose_state");
 mock_esm("../../static/js/markdown", {
     apply_markdown: noop,
 });
@@ -37,6 +36,7 @@ mock_esm("../../static/js/stream_data", {
 });
 page_params.twenty_four_hour_time = false;
 
+const compose_state = zrequire("compose_state");
 const {localstorage} = zrequire("localstorage");
 const drafts = zrequire("drafts");
 const timerender = zrequire("timerender");

--- a/frontend_tests/node_tests/unsent_messages.js
+++ b/frontend_tests/node_tests/unsent_messages.js
@@ -1,0 +1,294 @@
+"use strict";
+
+const {strict: assert} = require("assert");
+
+const {stub_templates} = require("../zjsunit/handlebars");
+const {mock_cjs, mock_esm, set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
+const $ = require("../zjsunit/zjquery");
+
+const compose = mock_esm("../../static/js/compose");
+
+const ls_container = new Map();
+const noop = () => {};
+
+const localStorage = set_global("localStorage", {
+    getItem(key) {
+        return ls_container.get(key);
+    },
+    setItem(key, val) {
+        ls_container.set(key, val);
+    },
+    removeItem(key) {
+        ls_container.delete(key);
+    },
+    clear() {
+        ls_container.clear();
+    },
+});
+mock_cjs("jquery", $);
+
+const compose_actions = zrequire("compose_actions");
+const compose_state = zrequire("compose_state");
+const {localstorage} = zrequire("localstorage");
+const unsent_messages = zrequire("unsent_messages");
+
+const KEY = "unsent_messages";
+
+const unsent_message_1 = {
+    type: "stream",
+    content: "An important meeting at 5 P.M.",
+    stream: "Denmark",
+    topic: "New topic",
+    createdAt: 1,
+};
+
+const unsent_message_2 = {
+    type: "private",
+    content: "foo **bar**",
+    reply_to: "aaron@zulip.com",
+    private_message_recipient: "aaron@zulip.com",
+    createdAt: 2,
+};
+
+const unsent_message_3 = {
+    type: "stream",
+    content: "Let's take a lunch break",
+    stream: "Rome",
+    topic: "bar",
+    createdAt: 3,
+};
+
+const unsent_message_4 = {
+    type: "private",
+    content: "We need to discuss about the project",
+    reply_to: "aaron@zulip.com",
+    private_message_recipient: "aaron@zulip.com",
+    createdAt: 4,
+};
+
+function setup_parents_and_mock_remove(container_sel, target_sel, parent) {
+    const container = $.create("fake " + container_sel);
+    let container_removed = false;
+
+    container.remove = () => {
+        container_removed = true;
+    };
+
+    const target = $.create("fake click target (" + target_sel + ")");
+
+    target.set_parents_result(parent, container);
+
+    const event = {
+        preventDefault: noop,
+        target,
+    };
+
+    const helper = {
+        event,
+        container,
+        target,
+        container_was_removed: () => container_removed,
+    };
+
+    return helper;
+}
+
+run_test("store_and_get_unsent_messages", (override) => {
+    const ls = localstorage();
+    assert.equal(ls.get(KEY), undefined);
+
+    let curr_unsent_msg;
+    function map(field, f) {
+        override(compose_state, field, f);
+    }
+
+    map("get_message_type", () => curr_unsent_msg.type);
+    map("stream_name", () => curr_unsent_msg.stream);
+    map("topic", () => curr_unsent_msg.topic);
+    map("private_message_recipient", () => curr_unsent_msg.private_message_recipient);
+
+    const expected = [];
+    function assert_unsent_messages() {
+        expected.push(curr_unsent_msg);
+        override(Date, "now", () => curr_unsent_msg.createdAt);
+        unsent_messages.store_unsent_message(curr_unsent_msg.content);
+        assert.deepEqual(unsent_messages.get_unsent_messages(), expected);
+    }
+
+    curr_unsent_msg = unsent_message_1;
+    assert_unsent_messages();
+
+    curr_unsent_msg = unsent_message_3;
+    assert_unsent_messages();
+
+    curr_unsent_msg = unsent_message_2;
+    assert_unsent_messages();
+});
+
+run_test("initialize_and_send_unsent_messages", (override) => {
+    // Unsent messages stored in the previous test will be used here.
+    const ls = localstorage();
+    const unsent_msg = unsent_messages.unsent_messages;
+
+    stub_templates((template_name) => {
+        assert.equal(template_name, "compose_unsent_message");
+        return "compose_unsent_message_stub";
+    });
+
+    $("#compose-unsent-message").append = (data) => {
+        assert.equal(data, "compose_unsent_message_stub");
+    };
+
+    let actual_msg_type;
+    let actual_opts;
+    override(compose_actions, "start", (msg_type, opts) => {
+        actual_msg_type = msg_type;
+        actual_opts = opts;
+    });
+
+    let compose_finish_called = false;
+    compose.finish = () => {
+        compose_finish_called = true;
+    };
+
+    let clear_compose_box_called = false;
+    compose.clear_compose_box = () => {
+        clear_compose_box_called = true;
+    };
+
+    unsent_messages.initialize();
+
+    const confirm_handler = $("#compose-unsent-message").get_on_handler(
+        "click",
+        ".compose-unsent-message-confirm",
+    );
+
+    const cancel_handler = $("#compose-unsent-message").get_on_handler(
+        "click",
+        ".compose-unsent-message-cancel",
+    );
+
+    const helper = setup_parents_and_mock_remove(
+        "compose-unsent-message",
+        "compose-unsent-message",
+        ".compose-unsent-message",
+    );
+
+    // At this point we must remove all the unsent messages from the
+    // localStorage and stage them to be acknowledged by the user.
+    assert.deepEqual(ls.get(KEY), []);
+
+    // We should send these unsent messages in the order they were created at.
+    assert.equal(actual_msg_type, unsent_message_1.type);
+    assert.deepEqual(actual_opts, {
+        stream: "Denmark",
+        topic: "New topic",
+        private_message_recipient: "",
+        content: "An important meeting at 5 P.M.",
+    });
+    assert($("#compose-unsent-message").is(":visible"));
+    assert($("#compose-send-button").prop("disabled"));
+
+    confirm_handler(helper.event);
+    assert(compose_finish_called);
+    compose_finish_called = false; // Reset
+    assert(!unsent_msg.is_empty());
+    assert(!helper.container_was_removed());
+
+    assert.equal(actual_msg_type, unsent_message_2.type);
+    assert.deepEqual(actual_opts, {
+        stream: "",
+        topic: "",
+        content: "foo **bar**",
+        private_message_recipient: "aaron@zulip.com",
+    });
+
+    cancel_handler(helper.event);
+    assert(!compose_finish_called);
+    assert(clear_compose_box_called);
+
+    assert.equal(actual_msg_type, unsent_message_3.type);
+    assert.deepEqual(actual_opts, {
+        stream: "Rome",
+        topic: "bar",
+        content: "Let's take a lunch break",
+        private_message_recipient: "",
+    });
+
+    confirm_handler(helper.event);
+    assert(compose_finish_called);
+    assert(unsent_msg.is_empty());
+    assert(helper.container_was_removed());
+    assert(!$("#compose-unsent-message").is(":visible"));
+    assert(!$("#compose-send-status").is(":visible"));
+    assert(!$("#compose-send-button").prop("disabled"));
+});
+
+run_test("initialize_and_send_no_unsent_message", (override) => {
+    // This specific test is added to cover a necessary area (Node coverage).
+    override(compose_state, "construct_message_data", () => unsent_message_4);
+    unsent_messages.store_unsent_message();
+
+    const ls = localstorage();
+    const unsent_msg = unsent_messages.unsent_messages;
+
+    stub_templates((template_name) => {
+        assert.equal(template_name, "compose_unsent_message");
+        return "compose_unsent_message_stub";
+    });
+
+    $("#compose-unsent-message").append = (data) => {
+        assert.equal(data, "compose_unsent_message_stub");
+    };
+
+    let actual_msg_type;
+    let actual_opts;
+    override(compose_actions, "start", (msg_type, opts) => {
+        actual_msg_type = msg_type;
+        actual_opts = opts;
+    });
+
+    unsent_messages.initialize();
+    assert.deepEqual(ls.get(KEY), []);
+
+    const cancel_handler = $("#compose-unsent-message").get_on_handler(
+        "click",
+        ".compose-unsent-message-cancel",
+    );
+
+    const helper = setup_parents_and_mock_remove(
+        "compose-unsent-message",
+        "compose-unsent-message",
+        ".compose-unsent-message",
+    );
+
+    assert.equal(actual_msg_type, unsent_message_4.type);
+    assert.deepEqual(actual_opts, {
+        stream: "",
+        topic: "",
+        content: "We need to discuss about the project",
+        private_message_recipient: "aaron@zulip.com",
+    });
+
+    cancel_handler(helper.event);
+    assert(unsent_msg.is_empty());
+    assert(helper.container_was_removed());
+    assert(!$("#compose-unsent-message").is(":visible"));
+    assert(!$("#compose-send-status").is(":visible"));
+    assert(!$("#compose-send-button").prop("disabled"));
+});
+
+run_test("initialize_no_unsent_message_available", () => {
+    const ls = localstorage();
+    localStorage.clear();
+    assert.equal(ls.get(KEY), undefined);
+
+    unsent_messages.initialize();
+    assert.deepEqual(ls.get(KEY), []);
+
+    const unsent_msg = unsent_messages.unsent_messages;
+    assert(unsent_msg.is_empty());
+    assert(!$("#compose-unsent-message").is(":visible"));
+    assert(!$("#compose-send-button").prop("disabled"));
+});

--- a/frontend_tests/puppeteer_tests/unsent-messages.ts
+++ b/frontend_tests/puppeteer_tests/unsent-messages.ts
@@ -1,0 +1,134 @@
+import {strict as assert} from "assert";
+
+import type {Page} from "puppeteer";
+
+import common from "../puppeteer_lib/common";
+
+type Message = {
+    stream_message_recipient_stream: string;
+    stream_message_recipient_topic: string;
+    content: string;
+};
+
+async function _send_stream_message(
+    page: Page,
+    id_ends_with: string,
+    params: Message,
+): Promise<void> {
+    await page.keyboard.press("KeyC");
+    await common.fill_form(page, 'form[action^="/json/messages"]', params);
+    await common.assert_compose_box_content(page, params.content);
+    await common.ensure_enter_does_not_send(page);
+    await page.waitForSelector("#compose-send-button", {visible: true});
+    await page.click("#compose-send-button");
+
+    // Here we do a cross-check that message is not acknowledged by the server
+    // when we are offline with the following two conditions:
+    // 1. star icon should not appear, as we don't add it until the server responds.
+    // 2. message `zid` must be equal to the local id which is highest message ID with 0.01 added to it.
+
+    assert(
+        await page.evaluate(() => {
+            const row = zulip_test.last_visible_row();
+            return row.find(".star").length === 0;
+        }),
+    );
+
+    const zid = await page.evaluate(() => {
+        const row = zulip_test.last_visible_row();
+        return row.attr("zid");
+    });
+
+    const pattern = new RegExp(`\\d+\\.${id_ends_with}`);
+    assert(pattern.test(zid));
+}
+
+async function _send_message_when_server_unreachable(page: Page): Promise<void> {
+    await _send_stream_message(page, "01", {
+        stream_message_recipient_stream: "Denmark",
+        stream_message_recipient_topic: "1st topic",
+        content: "1st message in Denmark",
+    });
+
+    await _send_stream_message(page, "02", {
+        stream_message_recipient_stream: "Venice",
+        stream_message_recipient_topic: "2nd topic",
+        content: "2nd message in Venice",
+    });
+
+    await _send_stream_message(page, "03", {
+        stream_message_recipient_stream: "Verona",
+        stream_message_recipient_topic: "3rd topic",
+        content: "3rd message in Verona",
+    });
+}
+
+async function send_unsent_messages(
+    page: Page,
+    content: string,
+    send_this_msg: boolean,
+): Promise<void> {
+    await page.waitForXPath(
+        '//*[@class="compose-unsent-message-msg" and contains(text(), "Following message was not sent to the server.")]',
+    );
+
+    await common.assert_compose_box_content(page, content);
+
+    if (send_this_msg) {
+        await page.click(".compose-unsent-message-confirm");
+        await common.wait_for_fully_processed_message(page, content);
+    } else {
+        await page.click(".compose-unsent-message-cancel");
+        const last_msg_content = await page.evaluate(() => {
+            const last_msg = zulip_test.current_msg_list.last();
+            return last_msg.raw_content;
+        });
+        assert(last_msg_content !== content);
+    }
+}
+
+async function set_throttling_property(page: Page, is_offline: boolean): Promise<void> {
+    // Connect to Chrome DevTools
+    const client = await page.target().createCDPSession();
+    // Set throttling property
+    await client.send("Network.emulateNetworkConditions", {
+        offline: is_offline,
+        downloadThroughput: (200 * 1024) / 8,
+        uploadThroughput: (200 * 1024) / 8,
+        latency: 20,
+    });
+}
+
+async function test_unsent_messages(page: Page): Promise<void> {
+    await common.log_in(page);
+    await page.click(".top_left_all_messages");
+    await page.waitForSelector("#zhome .message_row", {visible: true});
+
+    // Going offline to send messages which won't be responded by the server.
+    await set_throttling_property(page, true);
+    await _send_message_when_server_unreachable(page);
+
+    // Going online to send the last unsent messages.
+    await set_throttling_property(page, false);
+    await page.reload();
+    await page.waitForSelector("#zhome .message_row", {visible: true});
+    await page.waitForSelector("#compose-textarea", {visible: true});
+
+    // Unsent messages must pop up in the order they were sent earlier.
+    await send_unsent_messages(page, "1st message in Denmark", true);
+    await send_unsent_messages(page, "2nd message in Venice", false);
+    await send_unsent_messages(page, "3rd message in Verona", true);
+    // After all the unsent messages are acknowledged, compose_unsent_messages
+    // template should be no longer visible.
+    await page.waitForSelector("#compose-unsent-message", {hidden: true});
+
+    // Here we ensure that we don't get any other/older unsent messages on another reload.
+    await page.reload();
+    await page.waitForSelector("#zhome .message_row", {visible: true});
+    await page.keyboard.press("KeyR");
+    await page.waitForSelector("#compose-textarea", {visible: true});
+    await common.assert_compose_box_content(page, "");
+    await page.waitForSelector("#compose-unsent-message", {hidden: true});
+}
+
+common.run_test(test_unsent_messages);

--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -145,3 +145,15 @@ export function xhr_error_message(message, xhr) {
     }
     return message;
 }
+
+export function is_server_unreachable(xhr) {
+    // There is no HTTP status code 0. Status 0 is
+    // returned by the library when the API is unreachable.
+    // The possible cases when status 0 is returned are:
+    // 1. user is offline.
+    // 2. server is down.
+    if (xhr.status === 0) {
+        return true;
+    }
+    return false;
+}

--- a/static/js/compose_state.js
+++ b/static/js/compose_state.js
@@ -56,3 +56,27 @@ export function private_message_recipient(value) {
 export function has_message_content() {
     return message_content() !== "";
 }
+
+export function construct_message_data() {
+    let content;
+    const msg_type = get_message_type();
+    if (msg_type) {
+        // message type may not be valid in some cases when it is called in
+        // `reload.js` in such case we wish not to send any message there.
+        content = message_content();
+    }
+
+    const message = {
+        type: msg_type,
+        content,
+    };
+    if (msg_type === "private") {
+        const recipient = private_message_recipient();
+        message.reply_to = recipient;
+        message.private_message_recipient = recipient;
+    } else if (msg_type === "stream") {
+        message.stream = stream_name();
+        message.topic = topic();
+    }
+    return message;
+}

--- a/static/js/compose_state.js
+++ b/static/js/compose_state.js
@@ -57,10 +57,15 @@ export function has_message_content() {
     return message_content() !== "";
 }
 
-export function construct_message_data() {
+export function construct_message_data(saved_message_content) {
     let content;
     const msg_type = get_message_type();
-    if (msg_type) {
+    if (saved_message_content !== undefined) {
+        // If we have `saved_message_content` then this implies that
+        // `message_content()` is empty and this value was saved
+        // at a point back in time.
+        content = saved_message_content;
+    } else if (msg_type) {
         // message type may not be valid in some cases when it is called in
         // `reload.js` in such case we wish not to send any message there.
         content = message_content();

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -96,18 +96,7 @@ export function snapshot_message() {
     }
 
     // Save what we can.
-    const message = {
-        type: compose_state.get_message_type(),
-        content: compose_state.message_content(),
-    };
-    if (message.type === "private") {
-        const recipient = compose_state.private_message_recipient();
-        message.reply_to = recipient;
-        message.private_message_recipient = recipient;
-    } else {
-        message.stream = compose_state.stream_name();
-        message.topic = compose_state.topic();
-    }
+    const message = compose_state.construct_message_data();
     return message;
 }
 

--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -36,19 +36,7 @@ function preserve_state(send_after_reload, save_pointer, save_narrow, save_compo
     saved_data.csrf_token = csrf_token;
 
     if (save_compose) {
-        const msg_type = compose_state.get_message_type();
-        const message = {type: msg_type};
-        if (msg_type === "stream") {
-            message.stream = compose_state.stream_name();
-            message.topic = compose_state.topic();
-        } else if (msg_type === "private") {
-            message.recipient = compose_state.private_message_recipient();
-        }
-
-        if (msg_type) {
-            message.content = compose_state.message_content();
-        }
-        saved_data.message = message;
+        saved_data.message = compose_state.construct_message_data();
     }
 
     if (save_pointer) {
@@ -134,7 +122,7 @@ export function initialize() {
             compose_actions.start(message.type, {
                 stream: message.stream || "",
                 topic: topic || "",
-                private_message_recipient: message.recipient || "",
+                private_message_recipient: message.private_message_recipient || "",
                 content: message.content || "",
             });
             if (saved_data.send_after_reload) {

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -74,6 +74,7 @@ import * as typing from "./typing";
 import * as ui from "./ui";
 import * as unread from "./unread";
 import * as unread_ui from "./unread_ui";
+import * as unsent_messages from "./unsent_messages";
 import * as user_groups from "./user_groups";
 import * as user_status from "./user_status";
 import * as user_status_ui from "./user_status_ui";
@@ -529,6 +530,7 @@ export function initialize_everything() {
     starred_messages.initialize();
     user_status_ui.initialize();
     fenced_code.initialize(generated_pygments_data);
+    unsent_messages.initialize();
 }
 
 $(() => {

--- a/static/js/unsent_messages.js
+++ b/static/js/unsent_messages.js
@@ -1,0 +1,141 @@
+import $ from "jquery";
+
+import render_compose_unsent_message from "../templates/compose_unsent_message.hbs";
+
+import * as compose from "./compose";
+import * as compose_actions from "./compose_actions";
+import * as compose_state from "./compose_state";
+import {localstorage} from "./localstorage";
+
+export const unsent_messages = (function () {
+    let messages_to_send = [];
+    const exports = {};
+
+    // the key that the unsent messages are stored under.
+    const KEY = "unsent_messages";
+    const ls = localstorage();
+    ls.version = 1;
+
+    function getTimestamp() {
+        return Date.now();
+    }
+
+    function save(unsent_messages) {
+        ls.set(KEY, unsent_messages);
+    }
+
+    exports.getUnsentMessages = function () {
+        messages_to_send = ls.get(KEY) || [];
+        return messages_to_send;
+    };
+
+    exports.addUnsentMessage = function (unsent_message) {
+        const unsent_messages = exports.getUnsentMessages();
+        unsent_message.createdAt = getTimestamp();
+        unsent_messages.push(unsent_message);
+        save(unsent_messages);
+    };
+
+    exports.removeUnsentMessages = function () {
+        const unsent_messages = [];
+        save(unsent_messages);
+    };
+
+    exports.sort_messages = function () {
+        messages_to_send.sort((msg_a, msg_b) => msg_b.createdAt - msg_a.createdAt);
+    };
+
+    exports.next = function () {
+        return messages_to_send.pop();
+    };
+
+    exports.is_empty = function () {
+        if (messages_to_send.length === 0) {
+            return true;
+        }
+        return false;
+    };
+
+    return exports;
+})();
+
+export function store_unsent_message(message_content) {
+    const message = compose_state.construct_message_data(message_content);
+    unsent_messages.addUnsentMessage(message);
+}
+
+function start_compose_actions() {
+    const message = unsent_messages.next();
+    if (message === undefined) {
+        // This implies that we have no unsent messages left.
+        return;
+    }
+
+    compose_actions.start(message.type, {
+        stream: message.stream || "",
+        topic: message.topic || "",
+        private_message_recipient: message.private_message_recipient || "",
+        content: message.content || "",
+    });
+
+    const unsent_message_template = render_compose_unsent_message();
+    const unsent_message_warning_area = $("#compose-unsent-message");
+
+    // Show only one warning message for any unsent messages.
+    if (!unsent_message_warning_area.is(":visible")) {
+        unsent_message_warning_area.append(unsent_message_template);
+    }
+
+    unsent_message_warning_area.show();
+    // We want the user to acknowledge these messages through the template.
+    $("#compose-send-button").prop("disabled", true);
+}
+
+function clear_unsent_message_warning(event) {
+    $(event.target).parents(".compose-unsent-message").remove();
+    $("#compose-unsent-message").hide();
+    $("#compose-unsent-message").empty();
+    $("#compose-send-status").hide();
+    $("#compose-send-button").prop("disabled", false);
+}
+
+export function send_unsent_messages() {
+    // We sent these messages in the order they were created.
+    unsent_messages.sort_messages();
+
+    start_compose_actions();
+
+    $("#compose-unsent-message").on("click", ".compose-unsent-message-confirm", (event) => {
+        event.preventDefault();
+
+        compose.finish();
+        if (unsent_messages.is_empty()) {
+            clear_unsent_message_warning(event);
+        } else {
+            start_compose_actions();
+        }
+    });
+
+    $("#compose-unsent-message").on("click", ".compose-unsent-message-cancel", (event) => {
+        event.preventDefault();
+
+        compose.clear_compose_box();
+        if (unsent_messages.is_empty()) {
+            clear_unsent_message_warning(event);
+        } else {
+            start_compose_actions();
+        }
+    });
+}
+
+export function get_unsent_messages() {
+    return unsent_messages.getUnsentMessages();
+}
+
+export function initialize() {
+    get_unsent_messages();
+    // We remove the unsent messages so that the old unsent
+    // messages don't clutter up in the localStorage.
+    unsent_messages.removeUnsentMessages();
+    send_unsent_messages();
+}

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -208,6 +208,7 @@
     margin-right: 10px;
 }
 
+.compose-unsent-message,
 .compose_invite_user,
 .compose_private_stream_alert,
 .compose-all-everyone,
@@ -232,6 +233,7 @@
     width: 10px;
 }
 
+.compose-unsent-message-controls,
 .compose-all-everyone-controls,
 .compose-announce-controls,
 .compose_invite_user_controls,

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -391,6 +391,11 @@ input.recipient_box {
     &:focus {
         box-shadow: 0 0 10px hsl(170, 48%, 54%), 0 0 5px hsl(170, 48%, 54%);
     }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
 }
 
 #send_controls {

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -58,6 +58,7 @@
         <div id="compose-announce" class="alert home-error-bar"></div>
         <div id="compose_not_subscribed" class="alert home-error-bar"></div>
         <div id="compose_private_stream_alert" class="alert home-error-bar"></div>
+        <div id="compose-unsent-message" class="alert home-error-bar"></div>
         <div id="out-of-view-notification" class="notification-alert"></div>
         <div class="composition-area">
             <button type="button" class="close" id='compose_close' title="{{t 'Cancel compose' }} (Esc)">&times;</button>

--- a/static/templates/compose_unsent_message.hbs
+++ b/static/templates/compose_unsent_message.hbs
@@ -1,0 +1,13 @@
+<div class="compose-unsent-message">
+    <span class="compose-unsent-message-msg">
+        {{#tr}}
+        Following message was not sent to the server.
+        <br />
+        Do you still wish to send this message?
+        {{/tr}}
+    </span>
+    <span class="compose-unsent-message-controls">
+        <button type="button" class="btn btn-warning compose-unsent-message-confirm">{{t "Yes, send" }}</button>
+        <button type="button" class="btn btn-warning compose-unsent-message-cancel">{{t "No" }}</button>
+    </span>
+</div>


### PR DESCRIPTION
This commit fixes the bug: web app loses the messages sent during the server downtime.

Fixes #15692.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Added new test case.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


https://user-images.githubusercontent.com/67277428/108834488-40872200-75f4-11eb-8596-1d3a9f719ce1.mp4

You can skip to `3:45` when the localhost restarts.