### PR TITLE
node_tests: Revert wrong conversion of some functions to arrows

### DIFF
--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -39,7 +39,7 @@ function make_textbox(s) {
     widget.s = s;
     widget.focused = false;
 
-    widget.caret = (arg) => {
+    widget.caret = function (arg) {
         if (typeof arg === "number") {
             widget.pos = arg;
             return this;
@@ -58,7 +58,7 @@ function make_textbox(s) {
         return widget.pos;
     };
 
-    widget.val = (new_val) => {
+    widget.val = function (new_val) {
         if (new_val) {
             widget.s = new_val;
             return this;
@@ -66,7 +66,7 @@ function make_textbox(s) {
         return widget.s;
     };
 
-    widget.trigger = (type) => {
+    widget.trigger = function (type) {
         if (type === "focus") {
             widget.focused = true;
         } else if (type === "blur") {
@@ -95,7 +95,7 @@ run_test("autosize_textarea", (override) => {
 
 run_test("insert_syntax_and_focus", () => {
     $("#compose-textarea").val("xyz ");
-    $("#compose-textarea").caret = (syntax) => {
+    $("#compose-textarea").caret = function (syntax) {
         if (syntax !== undefined) {
             $("#compose-textarea").val($("#compose-textarea").val() + syntax);
             return this;

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -313,7 +313,7 @@ run_test("content_typeahead_selected", () => {
     };
     let caret_called1 = false;
     let caret_called2 = false;
-    fake_this.$element.caret = (...args) => {
+    fake_this.$element.caret = function (...args) {
         if (args.length === 0) {
             // .caret() used in split_at_cursor
             caret_called1 = true;


### PR DESCRIPTION
`function` and `=>` are not equivalent because they bind `this` differently. For these functions, the `function` semantics are intentional.

This reverts part of commit 1a241cef88e8fc43a137ffa47829dee659b36645 (#17388).

Cc @showell.