### PR TITLE
fix invalid typescript

### DIFF
--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -495,7 +495,7 @@ class CommonUtils {
         const page = await this.get_page();
         try {
             await test_function(page);
-        } catch (error: unknown) {
+        } catch (error) {
             console.log(error);
 
             // Take a screenshot, and increment the screenshot_id.


### PR DESCRIPTION
catch(error: unknown) is not valid typescript removing 'unknown'

We regularly scan zulip as part of Semgrep QA testing and we noticed this recent change
meant zulip had some unparsable typescript.