### PR TITLE
lint: Re-enable imperative mood checking

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -3,7 +3,7 @@ ignore=title-trailing-punctuation, body-min-length, body-is-missing, title-imper
 
 extra-path=tools/lib/gitlint-rules.py
 
-[title-match-regex-allow-exception]
+[title-match-regex]
 regex=^(.+:\ )?[A-Z].+\.$
 
 [title-max-length]

--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,5 @@
 [general]
-ignore=title-trailing-punctuation, body-min-length, body-is-missing, title-imperative-mood
+ignore=title-trailing-punctuation, body-min-length, body-is-missing
 
 extra-path=tools/lib/gitlint-rules.py
 

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -45,7 +45,7 @@ pyinotify
 tblib
 
 # Needed to lint Git commit messages
-gitlint
+gitlint>=0.13.0
 
 # Needed for visualising cprofile reports
 snakeviz

--- a/tools/lib/gitlint-rules.py
+++ b/tools/lib/gitlint-rules.py
@@ -305,7 +305,9 @@ class ImperativeMood(LineRule):
             violation = RuleViolation(
                 self.id,
                 self.error_msg.format(
-                    word=first_word, imperative=imperative, title=commit.message.title,
+                    word=first_word,
+                    imperative=imperative,
+                    title=commit.message.title,
                 ),
             )
 

--- a/tools/lib/gitlint-rules.py
+++ b/tools/lib/gitlint-rules.py
@@ -1,8 +1,6 @@
-import re
 from typing import List
 
 from gitlint.git import GitCommit
-from gitlint.options import StrOption
 from gitlint.rules import CommitMessageTitle, LineRule, RuleViolation
 
 # Word list from https://github.com/m1foley/fit-commit
@@ -307,31 +305,10 @@ class ImperativeMood(LineRule):
             violation = RuleViolation(
                 self.id,
                 self.error_msg.format(
-                    word=first_word,
-                    imperative=imperative,
-                    title=commit.message.title,
+                    word=first_word, imperative=imperative, title=commit.message.title,
                 ),
             )
 
             violations.append(violation)
 
         return violations
-
-
-class TitleMatchRegexAllowException(LineRule):
-    """Allows revert commits contrary to the built-in title-match-regex rule"""
-
-    name = "title-match-regex-allow-exception"
-    id = "Z2"
-    target = CommitMessageTitle
-    options_spec = [StrOption("regex", ".*", "Regex the title should match")]
-
-    def validate(self, title: str, commit: GitCommit) -> List[RuleViolation]:
-
-        regex = self.options["regex"].value
-        pattern = re.compile(regex, re.UNICODE)
-        if not pattern.search(title) and not title.startswith('Revert "'):
-            violation_msg = f"Title does not match regex ({regex})"
-            return [RuleViolation(self.id, violation_msg, title)]
-
-        return []


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:**
```
ilwrath ~/src/zulip (lint) $ git commit --allow-empty -m 'foo: Cleans things.'
[lint c8b93683c1] foo: Cleans things.
(zulip-py3-venv) vagrant@vagrant:/srv/zulip$ ./tools/lint --only gitlint
gitlint   | Commit c8b93683c1:
gitlint   | 1: Z1 The first word in commit title should be in imperative mood ("cleans" -> "clean"): "foo: Cleans things."
```

vs on master:
```
ilwrath ~/src/zulip (master=) $ git commit --allow-empty -m 'foo: Cleans things.'
[master 364a7e0d76] foo: Cleans things.
(zulip-py3-venv) vagrant@vagrant:/srv/zulip$ ./tools/lint --only gitlint
(zulip-py3-venv) vagrant@vagrant:/srv/zulip$
```
