### PR TITLE
puppet: Make the expected result of `zulip-puppet-apply` be empty, with no prompt.

### DIFF
--- a/puppet/zulip/manifests/apt_repository.pp
+++ b/puppet/zulip/manifests/apt_repository.pp
@@ -2,5 +2,6 @@ class zulip::apt_repository {
   $setup_apt_repo_file = "${::zulip_scripts_path}/lib/setup-apt-repo"
   exec{'setup_apt_repo':
     command => "bash -c '${setup_apt_repo_file}'",
+    unless  => "bash -c '${setup_apt_repo_file} --verify'",
   }
 }

--- a/scripts/lib/setup-apt-repo
+++ b/scripts/lib/setup-apt-repo
@@ -4,6 +4,22 @@ set -e
 set -u
 set -o pipefail
 
+verify=false
+args="$(getopt -o '' --long verify -- "$@")"
+eval "set -- $args"
+while true; do
+    case "$1" in
+        --verify)
+            verify=true
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+    esac
+done
+
 # Ensure the directory for LAST_DEPENDENCIES_HASH exists
 mkdir -p /var/lib/zulip
 
@@ -21,6 +37,8 @@ LAST_DEPENDENCIES_HASH="$(cat "$DEPENDENCIES_HASH_FILE")"
 # (apt keys, code, etc.)  changed.
 if [ "$DEPENDENCIES_HASH" = "$LAST_DEPENDENCIES_HASH" ]; then
     exit 0
+elif [ "$verify" == true ]; then
+    exit 1
 fi
 
 # Ensure that the sources file exists

--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -5,8 +5,16 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 
-from lib.zulip_tools import assert_running_as_root, parse_os_release
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(BASE_DIR)
+from scripts.lib.setup_path import setup_path
+from scripts.lib.zulip_tools import assert_running_as_root, parse_os_release
+
+setup_path()
+
+import yaml
 
 assert_running_as_root()
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -48,7 +56,20 @@ if (distro_info["ID"], distro_info["VERSION_ID"]) in [("ubuntu", "20.04")]:
     puppet_env["RUBYOPT"] = "-W0"
 
 if not args.noop and not args.force:
-    subprocess.check_call([*puppet_cmd, "--noop", "--show_diff"], env=puppet_env)
+    # --noop does not work with --detailed-exitcodes; see https://tickets.puppetlabs.com/browse/PUP-686
+    try:
+        lastrun_file = tempfile.NamedTemporaryFile()
+        subprocess.check_call(
+            [*puppet_cmd, "--noop", "--show_diff", "--lastrunfile", lastrun_file.name],
+            env=puppet_env,
+        )
+
+        with open(lastrun_file.name, "r") as lastrun:
+            lastrun_data = yaml.safe_load(lastrun)
+            if lastrun_data.get("resources", {}).get("out_of_sync", 0) == 0:
+                sys.exit(0)
+    finally:
+        lastrun_file.close()
 
     do_apply = None
     while do_apply != "y":


### PR DESCRIPTION
#1589 is tangentially relevant here.

**Testing plan:** 
```
root@alexmv-prod:/home/zulip/deployments/current# ~zulip/deployments/current/scripts/zulip-puppet-apply
Notice: Compiled catalog for alexmv-prod.zulipdev.org in environment production in 6.73 seconds
Notice: /Stage[main]/Zulip::Apt_repository/Exec[setup_apt_repo]/returns: current_value 'notrun', should be ['0'] (noop)
Notice: Class[Zulip::Apt_repository]: Would have triggered 'refresh' from 1 event
Notice: Stage[main]: Would have triggered 'refresh' from 1 event
Notice: Applied catalog in 1.07 seconds
Apply changes? [y/N] y

Notice: Compiled catalog for alexmv-prod.zulipdev.org in environment production in 3.39 seconds
Notice: /Stage[main]/Zulip::Apt_repository/Exec[setup_apt_repo]/returns: executed successfully
Notice: Applied catalog in 4.36 seconds

root@alexmv-prod:/home/zulip/deployments/current# ~zulip/deployments/current/scripts/zulip-puppet-apply
Notice: Compiled catalog for alexmv-prod.zulipdev.org in environment production in 3.36 seconds
Notice: Applied catalog in 1.09 seconds

root@alexmv-prod:/home/zulip/deployments/current#
```
