### PR TITLE
ui: Remove warning for unsupported old Zulip desktop app

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -138,7 +138,6 @@
                 "avatar": false,
                 "blueslip": false,
                 "bot_data": false,
-                "bridge": false,
                 "buddy_data": false,
                 "buddy_list": false,
                 "channel": false,

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -13,8 +13,6 @@ const $ = require("../zjsunit/zjquery");
 
 const events = require("./lib/events");
 
-set_global("bridge", false);
-
 const noop = () => {};
 
 set_global("DOMParser", new JSDOM().window.DOMParser);
@@ -1029,7 +1027,6 @@ test_ui("initialize", () => {
         assert.equal("#compose-textarea", elem);
         resize_watch_manual_resize_checked = true;
     };
-    set_global("bridge", true);
     let xmlhttprequest_checked = false;
     set_global("XMLHttpRequest", function () {
         this.upload = true;

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -18,7 +18,6 @@ const page_params = set_global("page_params", {
     max_file_upload_size: 25,
 });
 set_global("csrf_token", "csrf_token");
-set_global("bridge", false);
 
 // Setting these up so that we can test that links to uploads within messages are
 // automatically converted to server relative links.

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -60,22 +60,6 @@ function update_message_in_all_views(message_id, callback) {
     }
 }
 
-exports.show_error_for_unsupported_platform = function () {
-    // Check if the user is using old desktop app
-    if (typeof bridge !== "undefined") {
-        // We don't internationalize this string because it is long,
-        // and few users will have both the old desktop app and an
-        // internationalized version of Zulip anyway.
-        const error =
-            "Hello! You're using the unsupported old Zulip desktop app," +
-            " which is no longer developed. We recommend switching to the new, " +
-            "modern desktop app, which you can download at " +
-            "<a href='https://zulip.com/apps'>zulip.com/apps</a>.";
-
-        ui_report.generic_embed_error(error);
-    }
-};
-
 exports.update_starred_view = function (message_id, new_value) {
     const starred = new_value;
 
@@ -183,7 +167,6 @@ exports.restore_compose_cursor = function () {
 
 exports.initialize = function () {
     exports.set_compose_textarea_handlers();
-    exports.show_error_for_unsupported_platform();
 };
 
 window.ui = exports;


### PR DESCRIPTION
This warning was added in #6551. It’s not for any version of the current Electron app, which we warn about on the server side with `DESKTOP_WARNING_VERSION`, but rather some pre-Electron app so ancient I don’t even know what it is. Apparently it communicated using the `window.bridge` global, so eradicate that too.