### PR TITLE
composebox_typeahead: Increase max typeahead box size

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -25,7 +25,7 @@ const settings_data = require("./settings_data");
 
 // This is what we use for PM/compose typeaheads.
 // We export it to allow tests to mock it.
-exports.max_num_items = 5;
+exports.max_num_items = 8;
 
 exports.emoji_collection = [];
 


### PR DESCRIPTION
On realms with large numbers of custom emoji, the typeahead emoji picker
often isn't useful. This is exacerbated by the fact the picker prefers
longer matches, so if there are five emoji that share a prefix, and an
emoji that is just the prefix, the only-prefix emoji will never show in
the typeahead emoji picker. This means that if someone thinks that there
is an emoji that shares a prefix with many other emoji, but they don't
remember for sure, they cannot use the typeahead emoji picker to check
that the emoji that they are entering exists.

There are two "real" fixes to this, neither of which this commit
addresses:

First, we should adjust the emoji ranking code such that exact string
matches for existing emojis are always shown in the picker. This would
be an improvement overall (the current behaviour is surprising and
frustrating), but it doesn't fundamentally solve the problem - if there
are many matching emoji, some of them will be pushed off the list.

Second, we should allow scrolling through the entire list of matching
entries in a typeahead, instead of only looping through the top N
matches. This will completely fix the problem (although there is some
UI/UX consideration in how to make it clear that the box is scrollable),
but seems like significantly more work to implement.

However, increasing the typeahead box size should improve the user
experience here independently of either of those changes.

I've chosen 8 as the max size for no particularly principled reason -
the fact that it's larger than 5 makes it more useful, but it's not so
large that it covers an obnoxious amount of the screen. Possibly it
would make sense to make it a bit bigger, but 8 seems like a good place
to start.

I've tested this on my laptop, which has a Intel i5-7200U CPU (~4.5 years
old, middle of the line when it was released) on a test instance with
5000 users, as well as on chat.zulip.org, and didn't see any noticeable
performance regression in completing @-mentions or emoji on either.

**GIFs or screenshots:** 

![typeahead-5](https://user-images.githubusercontent.com/5001092/109008698-9a691400-76e8-11eb-8aa7-4bc1018524d3.png)


![typeahead-8](https://user-images.githubusercontent.com/5001092/109008694-9937e700-76e8-11eb-8cb2-d8ab236cdadd.png)