### PR TITLE
edit_bot: Fixed dropdown username capitalization and other bugs.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -849,11 +849,16 @@ input[type="checkbox"] {
     margin: 0;
     padding: 0;
 
-    label {
+    label,
+    button.dropdown-toggle {
         text-transform: uppercase;
         font-weight: 600;
         color: hsl(0, 0%, 67%);
         margin-top: 5px;
+    }
+
+    button.dropdown-toggle {
+        text-transform: none;
     }
 
     .buttons {

--- a/static/templates/edit_bot.hbs
+++ b/static/templates/edit_bot.hbs
@@ -12,12 +12,12 @@
         </div>
         <div class="edit-bot-form-box">
             <div class="edit-bot-owner">
-                <label for="bot_owner_select">{{t "Owner" }}</label>
+                <label>{{t "Owner" }}</label>
                 {{> settings/dropdown_list_widget
                   widget_name="bot_owner"
                   list_placeholder=(t 'Filter users')
                   reset_button_text=(t '[Remove owner]')
-                  label="" }}
+                  }}
             </div>
             <div class="">
                 <label for="edit_bot_name">{{t "Full name" }}</label>

--- a/static/templates/settings/dropdown_list_widget.hbs
+++ b/static/templates/settings/dropdown_list_widget.hbs
@@ -1,9 +1,5 @@
 <div class="input-group dropdown-list-widget" id="{{widget_name}}_widget">
-    <label for="{{widget_name}}" id="{{widget_name}}_label" class="inline-block">
-        {{ label }}
-    </label>
-    <span class="{{widget_name}}_setting dropup actual-dropdown-menu prop-element" id="id_{{widget_name}}"
-        name="{{widget_name}}" aria-labelledby="{{widget_name}}_label">
+    <span class="{{widget_name}}_setting dropup actual-dropdown-menu prop-element" id="id_{{widget_name}}" aria-labelledby="{{widget_name}}_label">
         <button class="button small rounded dropdown-toggle" data-toggle="dropdown">
             <span id="{{widget_name}}_name"></span>
             <i class="fa fa-pencil"></i>

--- a/static/templates/settings/dropdown_list_widget.hbs
+++ b/static/templates/settings/dropdown_list_widget.hbs
@@ -1,22 +1,22 @@
 <div class="input-group dropdown-list-widget" id="{{widget_name}}_widget">
     <label for="{{widget_name}}" id="{{widget_name}}_label" class="inline-block">
         {{ label }}
-        <span class="{{widget_name}}_setting dropup actual-dropdown-menu prop-element" id="id_{{widget_name}}"
-          name="{{widget_name}}" aria-labelledby="{{widget_name}}_label">
-            <button class="button small rounded dropdown-toggle" data-toggle="dropdown">
-                <span id="{{widget_name}}_name"></span>
-                <i class="fa fa-pencil"></i>
-            </button>
-            <ul class="dropdown-menu modal-bg" role="menu">
-                <li class="dropdown-search" role="presentation">
-                    <input class="no-input-change-detection" type="text" role="menuitem" placeholder="{{list_placeholder}}" autofocus/>
-                </li>
-                <div class="dropdown-list-wrapper" data-simplebar>
-                    <span class="dropdown-list-body"></span>
-                </div>
-            </ul>
-        </span>
     </label>
+    <span class="{{widget_name}}_setting dropup actual-dropdown-menu prop-element" id="id_{{widget_name}}"
+        name="{{widget_name}}" aria-labelledby="{{widget_name}}_label">
+        <button class="button small rounded dropdown-toggle" data-toggle="dropdown">
+            <span id="{{widget_name}}_name"></span>
+            <i class="fa fa-pencil"></i>
+        </button>
+        <ul class="dropdown-menu modal-bg" role="menu">
+            <li class="dropdown-search" role="presentation">
+                <input class="no-input-change-detection" type="text" role="menuitem" placeholder="{{list_placeholder}}" autofocus/>
+            </li>
+            <div class="dropdown-list-wrapper" data-simplebar>
+                <span class="dropdown-list-body"></span>
+            </div>
+        </ul>
+    </span>
     <button class="button small dropdown_list_reset_button">
         <a>{{reset_button_text}}</a>
     </button>


### PR DESCRIPTION
Added a fix to transform dropdown elements to their default size and few other bugs listed in #17311 mainly as:
<ul>
<li>Rectifies broken label tag having a misleading 'for' attribute.</li>
<li>Removed 'name' attribute from unlabelled span tag.</li>
<li>Removed label expression from DropdownListWidget to built an
  abstraction for control group only.</li>
</ul>

<strong>Screenshot:</strong>

![Screenshot from 2021-02-24 23-54-55](https://user-images.githubusercontent.com/53977614/109053159-6ac70580-7702-11eb-9f53-b56e90218736.png)

Fixes #17311.

Would appreciate if @andersk can have a look at it.