### PR TITLE
api docs: Add missing ID fields for event responses.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -245,6 +245,7 @@ paths:
                                   "type": "update_display_settings",
                                   "setting_name": "high_contrast_mode",
                                   "setting": false,
+                                  "id": 0,
                                 }
                             - type: object
                               description: |
@@ -275,6 +276,7 @@ paths:
                                   "type": "update_global_notifications",
                                   "notification_name": "enable_sounds",
                                   "setting": true,
+                                  "id": 0,
                                 }
                             - type: object
                               description: |


### PR DESCRIPTION
Some event responses were missing the id field. Added the ID at appropriate places.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
