### PR TITLE
WIP: Archive and Delete Stream

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -689,6 +689,7 @@ export function delete_stream(stream_id, alert_element, stream_row) {
     channel.del({
         url: "/json/streams/" + stream_id,
         data: {
+            stream_id: stream_id,
             is_archive: JSON.stringify(true),
         },
         error(xhr) {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -688,6 +688,9 @@ export function change_stream_description(e) {
 export function delete_stream(stream_id, alert_element, stream_row) {
     channel.del({
         url: "/json/streams/" + stream_id,
+        data: {
+            is_archive: JSON.stringify(true),
+        },
         error(xhr) {
             ui_report.error(i18n.t("Failed"), xhr, alert_element);
         },

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -689,7 +689,6 @@ export function delete_stream(stream_id, alert_element, stream_row) {
     channel.del({
         url: "/json/streams/" + stream_id,
         data: {
-            stream_id: stream_id,
             is_archive: JSON.stringify(true),
         },
         error(xhr) {

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -421,19 +421,20 @@ def delete_stream(client: Client, stream_id: int) -> None:
     # Delete the stream named 'new stream'
 
     request = {
-        'is_archive': True,
+        "is_archive": True,
     }
 
-    stream_id = client.get_stream_id('stream to be deleted')['stream_id']
+    stream_id = client.get_stream_id("stream to be deleted")["stream_id"]
     # send request to archive stream
     result = client.call_endpoint(
-        url=f'streams/{stream_id}',
-        method='DELETE',
+        url=f"streams/{stream_id}",
+        method="DELETE",
         request=request,
     )
     # {code_example|end}
-    validate_against_openapi_schema(result, '/streams/{stream_id}', 'delete', '200')
-    assert result['result'] == 'success'
+    validate_against_openapi_schema(result, "/streams/{stream_id}", "delete", "200")
+    assert result["result"] == "success"
+
 
 @openapi_test_function("/streams:get")
 def get_streams(client: Client) -> None:

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -419,6 +419,7 @@ def delete_stream(client: Client, stream_id: int) -> None:
 
     # {code_example|start}
     # Delete the stream named 'new stream'
+<<<<<<< HEAD
     stream_id = client.get_stream_id("stream to be deleted")["stream_id"]
     result = client.delete_stream(stream_id)
     # {code_example|end}
@@ -426,6 +427,20 @@ def delete_stream(client: Client, stream_id: int) -> None:
 
     assert result["result"] == "success"
 
+=======
+
+    request = {
+        'stream_id': stream_id,
+        'is_archive': True
+    }
+
+    stream_id = client.get_stream_id('stream to be deleted')['stream_id']
+    # send request to archive stream
+    result = client.delete_stream(request)
+    # {code_example|end}
+    validate_against_openapi_schema(result, '/streams/{stream_id}', 'delete', '200')
+    assert result['result'] == 'success'
+>>>>>>> passing tests
 
 @openapi_test_function("/streams:get")
 def get_streams(client: Client) -> None:

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -419,19 +419,10 @@ def delete_stream(client: Client, stream_id: int) -> None:
 
     # {code_example|start}
     # Delete the stream named 'new stream'
-<<<<<<< HEAD
-    stream_id = client.get_stream_id("stream to be deleted")["stream_id"]
-    result = client.delete_stream(stream_id)
-    # {code_example|end}
-    validate_against_openapi_schema(result, "/streams/{stream_id}", "delete", "200")
-
-    assert result["result"] == "success"
-
-=======
 
     request = {
         'stream_id': stream_id,
-        'is_archive': True,
+        'is_archive': True
     }
 
     stream_id = client.get_stream_id('stream to be deleted')['stream_id']
@@ -444,7 +435,6 @@ def delete_stream(client: Client, stream_id: int) -> None:
     # {code_example|end}
     validate_against_openapi_schema(result, '/streams/{stream_id}', 'delete', '200')
     assert result['result'] == 'success'
->>>>>>> passing tests
 
 @openapi_test_function("/streams:get")
 def get_streams(client: Client) -> None:

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -431,12 +431,16 @@ def delete_stream(client: Client, stream_id: int) -> None:
 
     request = {
         'stream_id': stream_id,
-        'is_archive': True
+        'is_archive': True,
     }
 
     stream_id = client.get_stream_id('stream to be deleted')['stream_id']
     # send request to archive stream
-    result = client.delete_stream(request)
+    result = client.call_endpoint(
+        url=f'streams/{stream_id}',
+        method='DELETE',
+        request=request,
+    )
     # {code_example|end}
     validate_against_openapi_schema(result, '/streams/{stream_id}', 'delete', '200')
     assert result['result'] == 'success'

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -421,8 +421,7 @@ def delete_stream(client: Client, stream_id: int) -> None:
     # Delete the stream named 'new stream'
 
     request = {
-        'stream_id': stream_id,
-        'is_archive': True
+        'is_archive': True,
     }
 
     stream_id = client.get_stream_id('stream to be deleted')['stream_id']

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8232,11 +8232,19 @@ paths:
       operationId: delete_stream
       tags: ["streams"]
       description: |
-        [Delete the stream](/help/delete-a-stream) with the ID `stream_id`.
+        [Archive/Delete the stream](/help/delete-a-stream) with the ID `stream_id`.
 
         `DELETE {{ api_url }}/v1/streams/{stream_id}`
       parameters:
         - $ref: "#/components/parameters/StreamIdInPath"
+        - name: is_archive
+          in: query
+          description: |
+            Describes if command is to archive stream or delete it.
+          schema:
+            type: boolean
+          example: true
+          required: false
       responses:
         "200":
           description: Success.

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -550,6 +550,12 @@ class StreamAdminTest(ZulipTestCase):
             .exists()
         )
         self.assertFalse(subscription_exists)
+    
+    def test_destroy_stream_backend(self) -> None:
+        stream = self.make_stream("new_stream_1")
+        do_add_default_stream(stream)
+        self.assertEqual(1, DefaultStream.objects.filter(stream_id=stream.id).count())
+        self.assertEqual(0, DefaultStream.objects.filter(stream_id=stream.id).count())
 
     def test_deactivate_stream_removes_default_stream(self) -> None:
         stream = self.make_stream("new_stream")

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -552,10 +552,15 @@ class StreamAdminTest(ZulipTestCase):
         self.assertFalse(subscription_exists)
     
     def test_destroy_stream_backend(self) -> None:
+        user_profile = self.example_user("hamlet")
+        self.login_user(user_profile)
         stream = self.make_stream("new_stream_1")
-        do_add_default_stream(stream)
-        self.assertEqual(1, DefaultStream.objects.filter(stream_id=stream.id).count())
-        self.assertEqual(0, DefaultStream.objects.filter(stream_id=stream.id).count())
+
+        self.subscribe(user_profile, stream.name)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+
+        result = self.client_delete(f"/json/streams/{stream.id}", {"is_archive": orjson.dumps(False).decode()})
+        self.assert_json_success(result)
 
     def test_deactivate_stream_removes_default_stream(self) -> None:
         stream = self.make_stream("new_stream")

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -550,7 +550,7 @@ class StreamAdminTest(ZulipTestCase):
             .exists()
         )
         self.assertFalse(subscription_exists)
-    
+
     def test_destroy_stream_backend(self) -> None:
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
@@ -559,7 +559,9 @@ class StreamAdminTest(ZulipTestCase):
         self.subscribe(user_profile, stream.name)
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
 
-        result = self.client_delete(f"/json/streams/{stream.id}", {"is_archive": orjson.dumps(False).decode()})
+        result = self.client_delete(
+            f"/json/streams/{stream.id}", {"is_archive": orjson.dumps(False).decode()}
+        )
         self.assert_json_success(result)
 
     def test_deactivate_stream_removes_default_stream(self) -> None:

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -132,12 +132,22 @@ def check_if_removing_someone_else(
     else:
         return principals[0] != user_profile.email
 
+<<<<<<< HEAD
 
 def deactivate_stream_backend(
     request: HttpRequest, user_profile: UserProfile, stream_id: int
 ) -> HttpResponse:
+=======
+def deactivate_stream_backend(request: HttpRequest,
+                              user_profile: UserProfile,
+                              stream_id: int,
+                              is_archive: bool=True) -> HttpResponse:
+>>>>>>> passing tests
     (stream, sub) = access_stream_for_delete_or_update(user_profile, stream_id)
-    do_deactivate_stream(stream, acting_user=user_profile)
+
+    if (is_archive and is_archive is not None):
+        do_deactivate_stream(stream, acting_user=user_profile)
+
     return json_success()
 
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -145,7 +145,7 @@ def deactivate_stream_backend(request: HttpRequest,
 >>>>>>> passing tests
     (stream, sub) = access_stream_for_delete_or_update(user_profile, stream_id)
 
-    if (is_archive and is_archive is not None):
+    if (is_archive):
         do_deactivate_stream(stream, acting_user=user_profile)
 
     return json_success()

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -131,16 +131,20 @@ def check_if_removing_someone_else(
         return principals[0] != user_profile.id
     else:
         return principals[0] != user_profile.email
+
+
 @has_request_variables
-def deactivate_stream_backend(request: HttpRequest,
-                              user_profile: UserProfile,
-                              stream_id: int,
-                              is_archive: Optional[bool] = REQ(validator=check_bool, default=None)) -> HttpResponse:
+def deactivate_stream_backend(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    stream_id: int,
+    is_archive: Optional[bool] = REQ(validator=check_bool, default=None),
+) -> HttpResponse:
     (stream, sub) = access_stream_for_delete_or_update(user_profile, stream_id)
 
-    if (is_archive is None or is_archive):
+    if is_archive is None or is_archive:
         do_deactivate_stream(stream, acting_user=user_profile)
-    if (not is_archive):
+    if not is_archive:
         ## WIP: destroy stream
         return json_error(_("Trying to destroy stream"))
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -131,15 +131,19 @@ def check_if_removing_someone_else(
         return principals[0] != user_profile.id
     else:
         return principals[0] != user_profile.email
-
+@has_request_variables
 def deactivate_stream_backend(request: HttpRequest,
                               user_profile: UserProfile,
                               stream_id: int,
-                              is_archive: bool=True) -> HttpResponse:
+                              is_archive: Optional[bool] = REQ(validator=check_bool, default=None)) -> HttpResponse:
     (stream, sub) = access_stream_for_delete_or_update(user_profile, stream_id)
 
-    if (is_archive and is_archive is not None):
+    print(is_archive)
+    if (is_archive is None or is_archive):
         do_deactivate_stream(stream, acting_user=user_profile)
+    if (not is_archive):
+        ##destroy stream
+        return json_error(_("Trying to destroy stream"))
 
     return json_success()
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -132,20 +132,13 @@ def check_if_removing_someone_else(
     else:
         return principals[0] != user_profile.email
 
-<<<<<<< HEAD
-
-def deactivate_stream_backend(
-    request: HttpRequest, user_profile: UserProfile, stream_id: int
-) -> HttpResponse:
-=======
 def deactivate_stream_backend(request: HttpRequest,
                               user_profile: UserProfile,
                               stream_id: int,
                               is_archive: bool=True) -> HttpResponse:
->>>>>>> passing tests
     (stream, sub) = access_stream_for_delete_or_update(user_profile, stream_id)
 
-    if (is_archive):
+    if (is_archive and is_archive is not None):
         do_deactivate_stream(stream, acting_user=user_profile)
 
     return json_success()

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -138,11 +138,10 @@ def deactivate_stream_backend(request: HttpRequest,
                               is_archive: Optional[bool] = REQ(validator=check_bool, default=None)) -> HttpResponse:
     (stream, sub) = access_stream_for_delete_or_update(user_profile, stream_id)
 
-    print(is_archive)
     if (is_archive is None or is_archive):
         do_deactivate_stream(stream, acting_user=user_profile)
     if (not is_archive):
-        ##destroy stream
+        ## WIP: destroy stream
         return json_error(_("Trying to destroy stream"))
 
     return json_success()

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -32,6 +32,7 @@ from zerver.lib.actions import (
     do_create_default_stream_group,
     do_deactivate_stream,
     do_delete_messages,
+    do_destroy_stream,
     do_get_streams,
     do_remove_default_stream,
     do_remove_default_stream_group,
@@ -145,8 +146,10 @@ def deactivate_stream_backend(
     if is_archive is None or is_archive:
         do_deactivate_stream(stream, acting_user=user_profile)
     if not is_archive:
-        ## WIP: destroy stream
-        return json_error(_("Trying to destroy stream"))
+        result = do_destroy_stream(stream, acting_user=user_profile)
+
+        if result < 1:
+            return json_error(_("Did not delete stream"))
 
     return json_success()
 


### PR DESCRIPTION
#17202 
[issue on Zulip chat](https://chat.zulip.org/#narrow/stream/9-issues/topic/Deactivated.20streams.20searchable)

### WIP: Progress (Not in any particular order)

#### Back end
✅ Create failing test case for new "delete" stream functionality.
✅ Modify deactivate_stream_backend to differentiate "archive" from "delete".
🔲 Add true delete_stream functionality.
🔲 Rename current references to "delete_stream" to "archive_stream".


#### API
✅ Add request parameter for **delete_stream** in zulip.yaml for internal API documentation.
✅ Add request to **delete_stream** in python_examples.py for documentation.
🔲 Modify [python-zulip-api](https://github.com/zulip/python-zulip-api) for consistency in documentation.

#### Front end
🔲 Modify front end to accommodate new "delete".

### Testing <!-- How have you tested? -->
Relies on tools/test-backend
#### 1.  Testing for modifying deactivate_stream_backend
- Force failing of test cases that use deactivate_stream_backend.
- Implement modifications.
- Ensure implementation passes all tests.

#### 2. Testing for creating new "delete" stream
- Create new test case/s necessary and force failing.
- Implement new functionality.
- Ensure new test cases pass.
