### PR TITLE
puppet: Check in defensive restart-camo cron job.

### DIFF
--- a/puppet/zulip_ops/files/cron.d/camo
+++ b/puppet/zulip_ops/files/cron.d/camo
@@ -1,0 +1,1 @@
+* * * * * root /bin/bash -c '(pgrep -u nobody -f camo || /etc/init.d/camo restart) 2>&1 >>/var/log/camo/restart-log'

--- a/puppet/zulip_ops/manifests/camo.pp
+++ b/puppet/zulip_ops/manifests/camo.pp
@@ -1,0 +1,11 @@
+class zulip_ops::camo {
+  include zulip::camo
+
+  file { '/etc/cron.d/camo':
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    source => 'puppet:///modules/zulip_ops/cron.d/camo',
+  }
+}

--- a/puppet/zulip_ops/manifests/profile/smokescreen.pp
+++ b/puppet/zulip_ops/manifests/profile/smokescreen.pp
@@ -3,7 +3,7 @@
 class zulip_ops::profile::smokescreen {
   include zulip_ops::profile::base
   include zulip::supervisor
-  include zulip::camo
+  include zulip_ops::camo
 
   $golang_version = '1.14.10'
   zulip::sha256_tarball_to { 'golang':


### PR DESCRIPTION
This was found on lb1; add it to the camo install on smokescreen.

**Testing plan:** Test-applied on smokescreen.

----

This is a hack documented in our internal docs; I'd much rather clean it up and clean it out, but for now, putting it in puppet means it won't get lost.