### PR TITLE
Improve delete message warning #16426.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -2,6 +2,7 @@
 
 const ClipboardJS = require("clipboard");
 
+const render_delete_popover = require("../templates/message_delete_popover.hbs");
 const render_message_edit_form = require("../templates/message_edit_form.hbs");
 const render_topic_edit_form = require("../templates/topic_edit_form.hbs");
 
@@ -11,7 +12,9 @@ const currently_editing_messages = new Map();
 let currently_deleting_messages = [];
 let currently_topic_editing_messages = [];
 const currently_echoing_messages = new Map();
-
+let current_message_delete_popover_elem;
+const APPROX_HEIGHT = 208;
+const APPROX_WIDTH = 390;
 // These variables are designed to preserve the user's most recent
 // choices when editing a group of messages, to make it convenient to
 // move several topics in a row with the same settings.
@@ -31,7 +34,6 @@ const editability_types = {
     FULL: 4,
 };
 exports.editability_types = editability_types;
-
 function is_topic_editable(message, edit_limit_seconds_buffer = 0) {
     if (!page_params.realm_allow_message_editing) {
         // If message editing is disabled, so is topic editing.
@@ -860,15 +862,30 @@ function hide_delete_btn_show_spinner(deleting) {
     }
 }
 
-exports.delete_message = function (msg_id) {
-    $("#delete-message-error").html("");
-    $("#delete_message_modal").modal("show");
-    if (currently_deleting_messages.includes(msg_id)) {
-        hide_delete_btn_show_spinner(true);
-    } else {
-        hide_delete_btn_show_spinner(false);
+exports.delete_message = function (element, id) {
+    const msg_id = id;
+    // $("#delete-message-error").html("");
+    // $("#delete_message_modal").modal("show");
+    const last_popover_elem = current_message_delete_popover_elem;
+    popovers.hide_all();
+    if (last_popover_elem !== undefined && last_popover_elem.get()[0] === element) {
+        // We want it to be the case that a user can dismiss a popover
+        // by clicking on the same element that caused the popover.
+        return;
     }
-    $("#do_delete_message_button")
+    $(element).closest(".message_row").toggleClass("has_popover");
+    const elt = $(element);
+
+    if (elt.data("popover") === undefined) {
+        // Keep the element over which the popover is based off visible.
+        exports.build_delete_popover(elt);
+    }
+    // if (currently_deleting_messages.includes(msg_id)) {
+    //     hide_delete_btn_show_spinner(true);
+    // } else {
+    //     hide_delete_btn_show_spinner(false);
+    // }
+    $("#delete_message_button")
         .off()
         .on("click", (e) => {
             e.stopPropagation();
@@ -878,7 +895,7 @@ exports.delete_message = function (msg_id) {
             channel.del({
                 url: "/json/messages/" + msg_id,
                 success() {
-                    $("#delete_message_modal").modal("hide");
+                    // $("#delete_message_modal").modal("hide");
                     currently_deleting_messages = currently_deleting_messages.filter(
                         (id) => id !== msg_id,
                     );
@@ -966,6 +983,32 @@ exports.move_topic_containing_message_to_stream = function (
             ui_report.error(i18n.t("Error moving the topic"), xhr, $("#home-error"), 4000);
         },
     });
+};
+exports.build_delete_popover = function (elt) {
+    let placement = popovers.compute_placement(elt, APPROX_HEIGHT, APPROX_WIDTH, true);
+
+    if (placement === "viewport_center") {
+        // For legacy reasons `compute_placement` actually can
+        // return `viewport_center`, but bootstrap doesn't actually
+        // support that.
+        placement = "left";
+    }
+
+    const template = render_delete_popover();
+
+    // if the window is mobile sized, add the `.popover-flex` wrapper to the delete info
+    // popover so that it will be wrapped in flex and centered in the screen.
+
+    elt.popover({
+        // temporary patch for handling popover placement of `viewport_center`
+        fix_positions: true,
+        template,
+        content: "delete message",
+        title: "",
+        html: true,
+        trigger: "manual",
+    });
+    elt.popover("show");
 };
 
 window.message_edit = exports;

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1221,10 +1221,13 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $("body").on("click", ".delete_message", (e) => {
-        const message_id = $(e.currentTarget).data("message-id");
+    $("body").on("click", ".actions_popover .delete_message", (e) => {
+        // const message_id = $(e.currentTarget).data("message-id");
+        const msg_id = $(e.currentTarget).data("message-id");
         exports.hide_actions_popover();
-        message_edit.delete_message(message_id);
+        // message_edit.delete_message(message_id);
+        const elem = $(".actions_popover")[0];
+        message_edit.delete_message(elem, msg_id);
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -475,3 +475,8 @@ ul {
         margin-left: 5px !important;
     }
 }
+
+.message-delete-popover {
+margin-top:20px;
+margin-right:27px;
+}

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -477,6 +477,6 @@ ul {
 }
 
 .message-delete-popover {
-margin-top:20px;
-margin-right:27px;
+margin-top: 20px;
+margin-right: 27px;
 }

--- a/static/templates/message_delete_popover.hbs
+++ b/static/templates/message_delete_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover new-style" style="margin-top:20px;margin-right:27px">
+<div class="popover new-style message-delete-popover">
     <div  class="modal-header" >
         <button type="button" class="close"  aria-label="Close"><span
                 aria-hidden="true">&times;</span></button>

--- a/static/templates/message_delete_popover.hbs
+++ b/static/templates/message_delete_popover.hbs
@@ -1,0 +1,23 @@
+<div class="popover new-style" style="margin-top:20px;margin-right:27px">
+    <div  class="modal-header" >
+        <button type="button" class="close"  aria-label="Close"><span
+                aria-hidden="true">&times;</span></button>
+        <h3>
+            Delete message
+            <a href="/help/edit-or-delete-a-message#delete-a-message" target="_blank" rel="noopener noreferrer">
+                <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+            </a>
+        </h3>
+    </div>
+    <div class="modal-body">
+        <div class="content">
+            <p><strong>Are you sure you want to permanently delete this message?</strong></p>
+            <p>Deleting a message removes it for everyone.</p>
+        </div>
+        <div id="delete-message-error"></div>
+    </div>
+    <div class="modal-footer">
+        <button class="button rounded" data-dismiss="modal">Cancel</button>
+        <button class="button rounded btn-danger" id="delete_message_button">Yes, delete this message</button>
+    </div>
+</div>

--- a/static/templates/message_delete_popover.hbs
+++ b/static/templates/message_delete_popover.hbs
@@ -1,7 +1,6 @@
 <div class="popover new-style message-delete-popover">
     <div  class="modal-header" >
-        <button type="button" class="close"  aria-label="{{t 'Close' }}"><span
-                aria-hidden="true">&times;</span></button>
+        <button type="button" class="close"  aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <h3>
             Delete message
             <a href="/help/edit-or-delete-a-message#delete-a-message" target="_blank" rel="noopener noreferrer">

--- a/static/templates/message_delete_popover.hbs
+++ b/static/templates/message_delete_popover.hbs
@@ -1,6 +1,6 @@
 <div class="popover new-style message-delete-popover">
     <div  class="modal-header" >
-        <button type="button" class="close"  aria-label="Close"><span
+        <button type="button" class="close"  aria-label="{{t 'Close' }}"><span
                 aria-hidden="true">&times;</span></button>
         <h3>
             Delete message


### PR DESCRIPTION
replace the modal with a popover widget then message is visible.Added new template message_delete_popover to render popover and updated related static/js files.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

issue: #16426
**Testing plan:** <!-- How have you tested? -->
Did manual testing using browser.

- tested for different window sizes.

- tested for mobile screen

- ran .tools/test no error  

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot (15)](https://user-images.githubusercontent.com/57071700/109191084-d02afd00-77bb-11eb-8c5b-151084635038.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
