### PR TITLE
mobile_ui_fix: Made the Keyboard Shortcuts and Setting modals more responsive.

### DIFF
--- a/static/styles/informational_overlays.css
+++ b/static/styles/informational_overlays.css
@@ -89,7 +89,7 @@
         white-space: nowrap;
         background-color: hsl(0, 0%, 98%);
         color: hsl(0, 0%, 20%);
-        margin: 0 0.1em;
+        margin: 0.25em 0.1em;
         padding: 0.1em 0.4em;
         text-shadow: 0 1px 0 hsl(0, 0%, 100%);
         /* Prevent selection */
@@ -109,7 +109,7 @@
 
     td:not(.definition) {
         text-align: left;
-        white-space: nowrap;
+        white-space: normal;
         font-weight: bold;
 
         :not(kbd) {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1873,6 +1873,9 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
         flex-direction: column;
         margin-top: 5px;
     }
+    #settings_page .custom_user_field textarea {
+        width: calc(100% - 25px);
+    }
 }
 
 @media only screen and (width < $lg_min) {


### PR DESCRIPTION
The Keyboard Shortcuts Modal and Textarea in Settings/User Profile was overflowing in small width devices.  
This commit fixes that issue by adding appropriate media query and changes to existing CSS

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Partially Fixed #16817 (2/3)


**Testing plan:** <!-- How have you tested? -->
Ran it locally.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Keyboard Shortcuts Before (375 x 667):
![Before(375 x 667)](https://user-images.githubusercontent.com/63820270/102681770-49213d80-41ea-11eb-9b74-ba53479e873e.png)
Keyboard Shortcuts After (375 x 667):
![After(375 x 667)](https://user-images.githubusercontent.com/63820270/102963255-a0871c80-450e-11eb-889c-abaee5dce60e.png)
Keyboard Shortcuts Before (534 x 330):
![Before(534 x 330)](https://user-images.githubusercontent.com/63820270/102681772-50484b80-41ea-11eb-9ff9-1d1ac92b1d8e.png)
Keyboard Shortcuts After (534 x 330):
![After(534 x 330)](https://user-images.githubusercontent.com/63820270/102963270-a7ae2a80-450e-11eb-8437-4d2749a5bd0d.png)
Keyboard Shortcuts Before (438 x 669):
![Before(438 x 669)](https://user-images.githubusercontent.com/63820270/102681782-63f3b200-41ea-11eb-92db-33e622c7d524.png)
Keyboard Shortcuts After (438 x 669):
![After(438 x 669)](https://user-images.githubusercontent.com/63820270/102963277-ac72de80-450e-11eb-8993-bb3a943fb91a.png)


Settings Textarea Before
![Settings Textarea Before](https://user-images.githubusercontent.com/63820270/100886919-6364d700-34da-11eb-89fe-0821a1c3ff8d.png)
Settings Textarea After
![Settings Textarea After](https://user-images.githubusercontent.com/63820270/100886975-74ade380-34da-11eb-8b90-684c2720bad1.png)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
