### PR TITLE
dependencies: Upgrade clean-css 5.0.1 to 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "babel-loader": "^8.0.6",
     "blueimp-md5": "^2.10.0",
     "cache-loader": "^4.0.0",
-    "clean-css": "^5.0.1",
+    "clean-css": "^5.1.0",
     "clipboard": "^2.0.4",
     "core-js": "^3.6.5",
     "css-loader": "^5.0.0",

--- a/version.py
+++ b/version.py
@@ -45,4 +45,4 @@ API_FEATURE_LEVEL = 39
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "128.0"
+PROVISION_VERSION = "128.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2922,10 +2922,10 @@ clean-css@^4.2.3:
   dependencies:
     source-map "~0.6.0"
 
-clean-css@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.0.1.tgz#f84c6ad82c5a8246a680206da8bceef483ccc0b6"
-  integrity sha512-F1zAGOowUCg8yxT0O4UR+nmbMauf3YwbiUS60CPxpzJU7ulpamGzQomFrJSK4w/HqHtMmQKSHJUNue+dQQYQdg==
+clean-css@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.1.0.tgz#f3cc8ba900ab23b316e753330d15425149be36f1"
+  integrity sha512-98ALLW4NOhZpvUEoSc2dJO23xE4S4SXc4mLieCVFGo8DNLTFQ3gzi7msW1lqSYJeGZSF5r5+W3KF6cEnkILnFQ==
   dependencies:
     source-map "~0.6.0"
 


### PR DESCRIPTION
This [fixes](https://github.com/jakubpawlowicz/clean-css/commit/d9ab4b47b736738637092389734e00cb46c0c36d) a minification issue affecting our orange user circles.

**Testing plan:** Checked an orange user circle in the dev server.