### PR TITLE
Revert "stream-ui: Change view from 2-column to 1-column at width 992px."

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1789,7 +1789,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 
 /* This value needs to match with the same in subscriptions.css, as
    we have some shared styles declared there */
-@media (width < $lg_min) {
+@media (width < $md_min) {
     #settings_overlay_container {
         /* this variable allows JavaScript to detect this media query */
         --single-column: yes;

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -1119,7 +1119,7 @@ ul.grey-box {
 
    Longer-term we should extract this logic two-column-overlay class
    to read more naturally. */
-@media (width < $lg_min) {
+@media (width < $md_min) {
     .subscriptions-container {
         position: relative;
         overflow: hidden;


### PR DESCRIPTION
This reverts commit 34ada1144833ea7a15848428fec2913c36880f80 (#17343).

My most common browser width is 960px (1920dpx, half of my UHD laptop screen), at which the old stream management and settings pages were fully usable:

![Screenshot from 2021-02-25 21-38-41](https://user-images.githubusercontent.com/26471/109259877-ee8bfb00-77b1-11eb-9cd3-53f48e297fed.png)

But 34ada1144833ea7a15848428fec2913c36880f80 forced them both into the much less useful one-column mode to paper over a positioning bug that I didn’t even have:

![Screenshot from 2021-02-25 21-39-51](https://user-images.githubusercontent.com/26471/109259918-03688e80-77b2-11eb-842b-1d2150310b2e.png)

I’m happy to consider a solution other than a straight revert, but it should be one that fixes the actual bug, not one that cripples the UI on many devices to avoid exposing it.

Cc @ganpa3.