### PR TITLE
frontend: add padding to usernames in private messages on left-sidebar.

### DIFF
--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -40,6 +40,7 @@ $topic_indent: calc($far_left_gutter_size + $left_col_size + 4px);
 
 .pm_left_col {
     min-width: $left_col_size;
+    padding-left: 15px;
 }
 
 #stream_filters,


### PR DESCRIPTION
I think that sort of indentation there could be helpful for consistency with how we do topics within a stream. As the username in private message are vertically aligned (to all messages,Mentions etc.) which does not give a good idea.

**Testing plan:** Tested locally.


**GIFs or screenshots:**
Before:
![screencapture-chat-zulip-org-1614334495233](https://user-images.githubusercontent.com/56171689/109287681-e97a8a80-7849-11eb-9aeb-2aa5759dabb2.png)

After:
![screencapture-localhost-9991-1614333849994](https://user-images.githubusercontent.com/56171689/109287718-f7301000-7849-11eb-9f9d-0f07f04634a1.png)
