### PR TITLE
events: Remove email field from update subscription events.

### DIFF
--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -562,7 +562,6 @@ exports.fixtures = {
     subscription__update: {
         type: "subscription",
         op: "update",
-        email: test_user.email,
         name: streams.devel.name,
         stream_id: streams.devel.stream_id,
         property: "pin_to_top",

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,11 @@ below features are supported.
 
 ## Changes in Zulip 4.0
 
+**Feature level 40**
+
+* [`GET /events`](/api/get-events): Remove email field from update
+  subscription events.
+
 **Feature level 39**
 
 * Added new [GET /users/{email}](/api/get-user-by-email) endpoint.

--- a/version.py
+++ b/version.py
@@ -30,7 +30,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 39
+API_FEATURE_LEVEL = 40
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3697,7 +3697,6 @@ def do_change_subscription_property(
     event = dict(
         type="subscription",
         op="update",
-        email=user_profile.email,
         property=event_property_name,
         value=event_value,
         stream_id=stream.id,

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1226,7 +1226,6 @@ subscription_update_event = event_dict_type(
         ("stream_id", int),
         ("value", value_type),
         ("name", str),
-        ("email", str),
     ]
 )
 _check_subscription_update = make_checker(subscription_update_event)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -601,14 +601,6 @@ paths:
                                     - type: integer
                                     - type: boolean
                                     - type: string
-                                email:
-                                  type: string
-                                  deprecated: true
-                                  description: |
-                                    The display email for the current user.
-
-                                    **Deprecated** and to be removed as it
-                                    serves no purpose to include this field here.
                               additionalProperties: false
                               example:
                                 {
@@ -616,7 +608,6 @@ paths:
                                   "type": "subscription",
                                   "property": "pin_to_top",
                                   "value": true,
-                                  "email": "user10@zulip.testserver",
                                   "stream_id": 11,
                                   "name": "test_stream",
                                   "id": 0,


### PR DESCRIPTION
This PR removes email field from update subscription
events, as email field is of no use in this case.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


 <!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
