### PR TITLE
api docs: Sort response keys in /get-events.

### DIFF
--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -191,7 +191,7 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
             # This part is for adding examples of individual events
             text.append("**Example**")
             text.append("\n```json\n")
-            example = json.dumps(events["example"], indent=4)
+            example = json.dumps(events["example"], indent=4, sort_keys=True)
             text.append(example)
             text.append("```\n\n")
         return text


### PR DESCRIPTION
Currently, the keys were not sorted in example responses of events making them unreadable. Added sort_keys parameter to sort them.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
