### PR TITLE
Revert "starred_messages: Add support to unstar all messages in a topic."

### DIFF
--- a/static/js/message_flags.js
+++ b/static/js/message_flags.js
@@ -111,13 +111,8 @@ exports.toggle_starred_and_update_server = function (message) {
     }
 };
 
-exports.unstar_messages = function (topic_name, stream_id) {
-    let starred_msg_ids;
-    if (topic_name && stream_id) {
-        starred_msg_ids = starred_messages.get_topic_starred_msg_ids(topic_name, stream_id);
-    } else {
-        starred_msg_ids = starred_messages.get_starred_msg_ids();
-    }
+exports.unstar_all_messages = function () {
+    const starred_msg_ids = starred_messages.get_starred_msg_ids();
     channel.post({
         url: "/json/messages/flags",
         idempotent: true,

--- a/static/js/starred_messages.js
+++ b/static/js/starred_messages.js
@@ -36,16 +36,6 @@ exports.get_starred_msg_ids = function () {
     return Array.from(exports.starred_ids);
 };
 
-exports.get_topic_starred_msg_ids = function (topic_name, stream_id) {
-    return Array.from(exports.starred_ids).filter((id) => {
-        const message = message_store.get(id);
-        return (
-            message.stream_id === stream_id &&
-            message.topic.toLowerCase() === topic_name.toLowerCase()
-        );
-    });
-};
-
 exports.rerender_ui = function () {
     let count = exports.get_count();
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -218,8 +218,6 @@ function build_topic_popover(opts) {
     const is_muted = muting.is_topic_muted(sub.stream_id, topic_name);
     const can_mute_topic = !is_muted;
     const can_unmute_topic = is_muted;
-    const starred_ids = starred_messages.get_topic_starred_msg_ids(topic_name, sub.stream_id);
-    const has_starred = starred_ids.length > 0;
 
     const content = render_topic_sidebar_actions({
         stream_name: sub.name,
@@ -229,7 +227,6 @@ function build_topic_popover(opts) {
         can_unmute_topic,
         is_realm_admin: sub.is_realm_admin,
         color: sub.color,
-        has_starred,
     });
 
     $(elt).popover({
@@ -407,26 +404,19 @@ exports.register_stream_handlers = function () {
         e.stopPropagation();
     });
 
-    // Unstar all messages, or all messages in a topic
-    $("body").on("click", "#unstar_all_messages, .sidebar-popover-unstar-all-in-topic", (e) => {
+    // Unstar all messages
+    $("body").on("click", "#unstar_all_messages", (e) => {
         exports.hide_starred_messages_popover();
         e.preventDefault();
         e.stopPropagation();
         $(".left-sidebar-modal-holder").empty();
-        const topic_name = $(".sidebar-popover-unstar-all-in-topic").attr("data-topic-name");
-        const args = {
-            topic_name,
-        };
-        $(".left-sidebar-modal-holder").html(render_unstar_messages_modal(args));
-        exports.hide_topic_popover();
+        $(".left-sidebar-modal-holder").html(render_unstar_messages_modal());
         $("#unstar-messages-modal").modal("show");
     });
 
     $("body").on("click", "#do_unstar_messages_button", (e) => {
         $("#unstar-messages-modal").modal("hide");
-        const topic_name = $(".sidebar-popover-unstar-all-in-topic").attr("data-topic-name");
-        const stream_id = $(".sidebar-popover-unstar-all-in-topic").attr("data-stream-id");
-        message_flags.unstar_messages(topic_name, Number.parseInt(stream_id, 10));
+        message_flags.unstar_all_messages();
         e.stopPropagation();
     });
 

--- a/static/templates/topic_sidebar_actions.hbs
+++ b/static/templates/topic_sidebar_actions.hbs
@@ -34,15 +34,6 @@
         </a>
     </li>
     {{/if}}
-
-    {{#if has_starred}}
-    <li>
-        <a href="#" class="sidebar-popover-unstar-all-in-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
-            <i class="fa fa-star-o" aria-hidden="true"></i>
-            {{#tr this}}Unstar all messages in topic{{/tr}}
-        </a>
-    </li>
-    {{/if}}
     <li>
         <a tabindex="0" class="sidebar-popover-mark-topic-read" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-book" aria-hidden="true"></i>

--- a/static/templates/unstar_messages_modal.hbs
+++ b/static/templates/unstar_messages_modal.hbs
@@ -1,18 +1,10 @@
 <div id="unstar-messages-modal" class="modal new-style modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="unstar_messages_modal_label" aria-hidden="true">
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-        {{#if topic_name}}
-        <h3 id="unstar_messages_modal_label">{{t "Unstar all messages in this topic" }}</h3>
-        {{else}}
         <h3 id="unstar_messages_modal_label">{{t "Unstar all messages" }}</h3>
-        {{/if}}
     </div>
     <div class="modal-body">
-        {{#if topic_name}}
-        <p>{{#tr this}}Would you like to unstar all starred messages in <b>__topic_name__</b>?  This action cannot be undone.{{/tr}}</p>
-        {{else}}
         <p>{{t "Would you like to unstar all starred messages?  This action cannot be undone." }}</p>
-        {{/if}}
     </div>
     <div class="modal-footer">
         <button type="button" class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>


### PR DESCRIPTION
This reverts commit 6fba17599f7ff728b5671fb1008cdcee3c69ec69 (#16898).

@chrisbobbe [reported](https://chat.zulip.org/#narrow/stream/6-frontend/topic/topic.20ellipsis.20not.20responding.20to.20clicks.3F/near/1124684) this crash:

```
Uncaught TypeError: Cannot read property 'stream_id' of undefined
    at starred_messages.js:43
    at Array.filter (<anonymous>)
    at Object.e.get_topic_starred_msg_ids (starred_messages.js:40)
    at stream_popover.js:221
    at HTMLSpanElement.<anonymous> (stream_popover.js:358)
    at HTMLUListElement.dispatch (jquery.js:5429)
    at HTMLUListElement.v.handle (jquery.js:5233)
```

Cc @abhijeetbodas2001.