### PR TITLE
docs: Add about Remote - SSH for remote dev.

### DIFF
--- a/docs/development/remote.md
+++ b/docs/development/remote.md
@@ -181,6 +181,7 @@ you prefer for development in general.
 
 If you use [TextMate](https://macromates.com), Atom, VS Code, or a
 similar GUI editor, tools like
+[VSCode Remote - SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) and
 [rmate](https://github.com/textmate/rmate) that are designed to
 integrate that editor with remote development over SSH allow you to
 develop remotely from the comfort of your local machine.
@@ -188,7 +189,13 @@ develop remotely from the comfort of your local machine.
 Similar packages/extensions exist for other popular code editors as
 well; contributions of precise documentation for them are welcome!
 
-To set up [rmate](https://github.com/textmate/rmate) for VS Code:
+- [VSCode Remote - SSH][vscode-remote-ssh]: Lets you use Visual Studio
+Code against a remote repository with a similar user experience to
+developing locally.
+
+[vscode-remote-ssh]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh
+
+- [rmate](https://github.com/textmate/rmate) for TextMate + VS Code:
 1. Install the extension
 [Remote VSCode](https://marketplace.visualstudio.com/items?itemName=rafaelmaiolla.remote-vscode).
 2. On your remote machine, run:

--- a/docs/development/remote.md
+++ b/docs/development/remote.md
@@ -197,23 +197,24 @@ developing locally.
 
 - [rmate](https://github.com/textmate/rmate) for TextMate + VS Code:
 1. Install the extension
-[Remote VSCode](https://marketplace.visualstudio.com/items?itemName=rafaelmaiolla.remote-vscode).
+   [Remote VSCode](https://marketplace.visualstudio.com/items?itemName=rafaelmaiolla.remote-vscode).
 2. On your remote machine, run:
-```
-$ mkdir -p ~/bin
-$ curl -Lo ~/bin/rmate https://raw.githubusercontent.com/textmate/rmate/master/bin/rmate
-$ chmod a+x ~/bin/rmate
-```
-3. Make sure the remote server is running in VS Code (you can force-start through the Command Palette).
+   ```
+   $ mkdir -p ~/bin
+   $ curl -Lo ~/bin/rmate https://raw.githubusercontent.com/textmate/rmate/master/bin/rmate
+   $ chmod a+x ~/bin/rmate
+   ```
+3. Make sure the remote server is running in VS Code (you can
+   force-start through the Command Palette).
 4. SSH to your remote machine using
-```
-$ ssh -R 52698:localhost:52698 user@example.org
-```
+   ```
+   $ ssh -R 52698:localhost:52698 user@example.org
+   ```
 5. On your remote machine, run
-```
-$ rmate [options] file
-```
-and the file should open up in VS Code. Any changes you make now will be saved remotely.
+   ```
+   $ rmate [options] file
+   ```
+   and the file should open up in VS Code. Any changes you make now will be saved remotely.
 
 ##### Command line editors
 


### PR DESCRIPTION
This PR adds about Remote - SSH extension (in VS Code),
which helps us develop remotely by providing a
similar interface as if we are developing locally.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested Localy

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
