### PR TITLE
Add <time> mention markdown parsing to polls

### DIFF
--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -315,7 +315,12 @@ function handleTimestamp(time) {
     // Use html5 <time> tag for valid timestamps.
     // render time without milliseconds.
     const escaped_isotime = _.escape(timeobject.toISOString().split(".")[0] + "Z");
-    return `<time datetime="${escaped_isotime}">${escaped_time}</time>`;
+    //const humanReadableTime = timeobject.toString();
+    const timeOptions = {weekday: 'short', year: 'numeric', month: 'short', 
+                        day: 'numeric', hour12: 'true', hour: '2-digit', minute: '2-digit'};
+    const humanReadableTime = timeobject.toLocaleString(undefined, timeOptions);
+    //return `<time datetime="${escaped_isotime}">${escaped_time}</time>`;
+    return `<time datetime="${escaped_isotime}">${humanReadableTime}</time>`;
 }
 
 function handleStream(stream_name) {

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -96,7 +96,6 @@ exports.contains_backend_only_syntax = function (content) {
 };
 
 exports.apply_markdown = function (message) {
-    console.trace();
     message_store.init_booleans(message);
 
     const options = {
@@ -315,11 +314,18 @@ function handleTimestamp(time) {
     // Use html5 <time> tag for valid timestamps.
     // render time without milliseconds.
     const escaped_isotime = _.escape(timeobject.toISOString().split(".")[0] + "Z");
-    //const humanReadableTime = timeobject.toString();
-    const timeOptions = {weekday: 'short', year: 'numeric', month: 'short', 
-                        day: 'numeric', hour12: 'true', hour: '2-digit', minute: '2-digit'};
+
+    // Options set so that time is rendered similarly to the backend parser
+    const timeOptions = {
+        weekday: "short",
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour12: "true",
+        hour: "2-digit",
+        minute: "2-digit",
+    };
     const humanReadableTime = timeobject.toLocaleString(undefined, timeOptions);
-    //return `<time datetime="${escaped_isotime}">${escaped_time}</time>`;
     return `<time datetime="${escaped_isotime}">${humanReadableTime}</time>`;
 }
 

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -96,6 +96,7 @@ exports.contains_backend_only_syntax = function (content) {
 };
 
 exports.apply_markdown = function (message) {
+    console.trace();
     message_store.init_booleans(message);
 
     const options = {

--- a/static/js/poll_widget.js
+++ b/static/js/poll_widget.js
@@ -3,9 +3,8 @@
 const render_widgets_poll_widget = require("../templates/widgets/poll_widget.hbs");
 const render_widgets_poll_widget_results = require("../templates/widgets/poll_widget_results.hbs");
 
-const people = require("./people");
 const markdown = require("./markdown");
-const timerender = require("./timerender");
+const people = require("./people");
 
 class PollData {
     // This object just holds data for a poll, although it
@@ -62,33 +61,10 @@ class PollData {
             const voters = Array.from(obj.votes.keys());
             const current_user_vote = voters.includes(this.me);
 
-            /*
             obj.raw_content = obj.option;
             markdown.apply_markdown(obj);
-            */
-
-            
-
-            //console.log('Option: ' + obj.option);
-            //const rendered_option  = markdown.apply_markdown({raw_content: obj.option});
-            //const rendered_option = {raw_content: obj.option};
-            //markdown.apply_markdown(rendered_option);
-            //console.log('Option rendered: ' + raw_content);
-            //console.log('Rendered option: ' + rendered_option);
-            //rendered_option  = timerender.render_markdown_timestamp({content: obj.option});
-            //console.log(rendered_option);
-            obj.raw_content = obj.option;
-            markdown.apply_markdown(obj);
-            //timerender.render_markdown_timestamp(obj);
-            console.log("obj.content: " + obj.content);
-            console.log("obj.raw_content: " + obj.raw_content);
-            
-
             options.push({
                 option: obj.content,
-                //rendered_option: rendered_option,
-                //option: rendered_option,
-                //option: markdown.apply_markdown({raw_content: obj.option}),
                 names: people.safe_full_names(voters),
                 count: voters.length,
                 key,

--- a/static/js/poll_widget.js
+++ b/static/js/poll_widget.js
@@ -78,8 +78,8 @@ class PollData {
             //rendered_option  = timerender.render_markdown_timestamp({content: obj.option});
             //console.log(rendered_option);
             obj.raw_content = obj.option;
-            //markdown.apply_markdown(obj);
-            timerender.render_markdown_timestamp(obj);
+            markdown.apply_markdown(obj);
+            //timerender.render_markdown_timestamp(obj);
             console.log("obj.content: " + obj.content);
             console.log("obj.raw_content: " + obj.raw_content);
             

--- a/static/js/poll_widget.js
+++ b/static/js/poll_widget.js
@@ -4,6 +4,8 @@ const render_widgets_poll_widget = require("../templates/widgets/poll_widget.hbs
 const render_widgets_poll_widget_results = require("../templates/widgets/poll_widget_results.hbs");
 
 const people = require("./people");
+const markdown = require("./markdown");
+const timerender = require("./timerender");
 
 class PollData {
     // This object just holds data for a poll, although it
@@ -60,8 +62,31 @@ class PollData {
             const voters = Array.from(obj.votes.keys());
             const current_user_vote = voters.includes(this.me);
 
+            /*
+            obj.raw_content = obj.option;
+            markdown.apply_markdown(obj);
+            */
+
+            
+
+            //console.log('Option: ' + obj.option);
+            //const rendered_option  = markdown.apply_markdown({raw_content: obj.option});
+            //const rendered_option = {raw_content: obj.option};
+            //markdown.apply_markdown(rendered_option);
+            //console.log('Option rendered: ' + raw_content);
+            //console.log('Rendered option: ' + rendered_option);
+            //rendered_option  = timerender.render_markdown_timestamp({content: obj.option});
+            //console.log(rendered_option);
+            obj.raw_content = obj.option;
+            markdown.apply_markdown(obj);
+            console.log(obj.content);
+            
+
             options.push({
-                option: obj.option,
+                option: obj.content,
+                //rendered_option: rendered_option,
+                //option: rendered_option,
+                //option: markdown.apply_markdown({raw_content: obj.option}),
                 names: people.safe_full_names(voters),
                 count: voters.length,
                 key,

--- a/static/js/poll_widget.js
+++ b/static/js/poll_widget.js
@@ -78,8 +78,10 @@ class PollData {
             //rendered_option  = timerender.render_markdown_timestamp({content: obj.option});
             //console.log(rendered_option);
             obj.raw_content = obj.option;
-            markdown.apply_markdown(obj);
-            console.log(obj.content);
+            //markdown.apply_markdown(obj);
+            timerender.render_markdown_timestamp(obj);
+            console.log("obj.content: " + obj.content);
+            console.log("obj.raw_content: " + obj.raw_content);
             
 
             options.push({

--- a/static/templates/widgets/poll_widget_results.hbs
+++ b/static/templates/widgets/poll_widget_results.hbs
@@ -3,7 +3,7 @@
     <button class="poll-vote {{#if current_user_vote}}current-user-vote{{/if}}" data-key="{{ key }}">
         {{ count }}
     </button>
-    <span class="poll-option">{{ option }}</span>
+    <span class="poll-option">{{{ option }}}</span>
     {{#if names}}
     <span class="poll-names">({{ names }})</span>
     {{/if}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #16821 

**Testing plan:** <!-- How have you tested? -->
Manual testing, use of ./tools/lint and ./tools/lint --fix, as well as use of CI testing upon pushing changes


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Original time poll (time not rendered):
<img width="264" alt="timeTestPoll" src="https://user-images.githubusercontent.com/56456094/109371055-0c6c6500-7871-11eb-8125-78045182980a.png"> <br>

New time poll:
<img width="474" alt="timePollComplete2" src="https://user-images.githubusercontent.com/56456094/109371117-610fe000-7871-11eb-84bb-4e189dfbdb21.png">




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
