### PR TITLE
Use tippyjs for showing tooltips.

### DIFF
--- a/static/js/css_variables.js
+++ b/static/js/css_variables.js
@@ -25,4 +25,15 @@ module.exports = {
         mm_min: mm + "px",
         ms_min: ms + "px",
     },
+
+    media_breakpoints_num: {
+        xs,
+        sm,
+        md,
+        lg,
+        xl,
+        ml,
+        mm,
+        ms,
+    },
 };

--- a/static/js/message_viewport.js
+++ b/static/js/message_viewport.js
@@ -1,7 +1,7 @@
 import $ from "jquery";
 
 import * as blueslip from "./blueslip";
-import {media_breakpoints} from "./css_variables";
+import {media_breakpoints_num} from "./css_variables";
 import * as message_lists from "./message_lists";
 import * as message_scroll from "./message_scroll";
 import * as rows from "./rows";
@@ -314,7 +314,7 @@ export function is_narrow() {
     // This basically returns true when we hide the right sidebar for
     // the left_side_userlist skinny mode.  It would be nice to have a less brittle
     // test for this.
-    return window.innerWidth < Number(media_breakpoints.xl_min.slice(0, -2));
+    return window.innerWidth < media_breakpoints_num.xl;
 }
 
 export function system_initiated_animate_scroll(scroll_amount) {

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -45,6 +45,7 @@ export function initialize() {
     // message reaction tooltip showing who reacted.
     delegate("body", {
         target: ".message_reaction",
+        placement: "bottom",
         onShow(instance) {
             const elem = $(instance.reference);
             const local_id = elem.attr("data-reaction-id");

--- a/static/templates/buddy_list_tooltip.hbs
+++ b/static/templates/buddy_list_tooltip.hbs
@@ -1,6 +1,0 @@
-<div class="tooltip">
-    <div class="tooltip-inner">
-        <div class="tooltip-content">
-        </div>
-    </div>
-</div>

--- a/static/templates/copy_invite_link.hbs
+++ b/static/templates/copy_invite_link.hbs
@@ -1,8 +1,7 @@
 {{t "Link:" }}
 <a href="{{ invite_link }}" id="multiuse_invite_link">{{ invite_link }}</a>
 &nbsp;
-<a class="btn pull-right copy_button_base" data-toggle="tooltip"
-  title="{{t "Copy link" }}" aria-label="{{t "Copy link" }}"
+<a class="btn pull-right copy_button_base tippy-zulip-tooltip" data-tippy-content="{{t "Copy link" }}" aria-label="{{t "Copy link" }}"
   id='copy_generated_invite_link' data-clipboard-text="{{ invite_link }}">
     {{> copy_to_clipboard_svg }}
 </a>

--- a/static/templates/draft.hbs
+++ b/static/templates/draft.hbs
@@ -32,11 +32,11 @@
                 <div class="messagebox-content">
                     <div class="message_top_line">
                         <div class="draft_controls">
-                            <i class="fa fa-pencil fa-lg restore-draft" aria-hidden="true" data-toggle="tooltip" title="{{t 'Restore draft' }}"></i>
-                            <i class="fa fa-trash-o fa-lg delete-draft" aria-hidden="true" data-toggle="tooltip" title="{{t 'Delete draft' }} (Backspace)"></i>
+                            <i class="fa fa-pencil fa-lg edit-draft tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Restore draft' }}"></i>
+                            <i class="fa fa-trash-o fa-lg delete-draft tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Delete draft' }} (Backspace)"></i>
                         </div>
                     </div>
-                    <div class="message_content rendered_markdown restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }}">{{rendered_markdown content}}</div>
+                    <div class="message_content rendered_markdown restore-draft tippy-zulip-tooltip" data-tippy-content="{{t 'Restore draft' }}">{{rendered_markdown content}}</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Split out from #17244

Tippyjs docs - https://atomiks.github.io/tippyjs/ 

Tippyjs is a library wrapped around popper library. Popper was also used for bootstrap-tooltip, so we are basically upgrading our positioning library too. This upgrade also fixes our tooltip arrow alignment issues, so I have made arrows visible on all the tooltips. They look nice to me.

Tooltips are darker. The default font size was 14px set by Tippyjs but I changed it to 12px.

I have left emoji tooltips as they are part of emoji_picker library which I am doing separately with the popover. There are some mentions of $('tooltip').hide which I have left because of this.