### PR TITLE
Improve delete message warning.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1221,10 +1221,13 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $("body").on("click", ".delete_message", (e) => {
-        const message_id = $(e.currentTarget).data("message-id");
+    $("body").on("click", ".actions_popover .delete_message", (e) => {
+        // const message_id = $(e.currentTarget).data("message-id");
+        const msg_id = $(e.currentTarget).data("message-id");
         exports.hide_actions_popover();
-        message_edit.delete_message(message_id);
+        // message_edit.delete_message(message_id);
+        const elem = $(".actions_popover")[0];
+        message_edit.delete_message(elem, msg_id);
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -475,3 +475,8 @@ ul {
         margin-left: 5px !important;
     }
 }
+
+.message-delete-popover {
+    margin-top: 20px;
+    margin-right: 27px;
+}

--- a/static/templates/message_delete_popover.hbs
+++ b/static/templates/message_delete_popover.hbs
@@ -1,0 +1,23 @@
+<div class="popover new-style message-delete-popover" >
+    <div  class="modal-header" >
+        <button type="button" class="close"  aria-label="{{t 'Close' }}"><span
+                aria-hidden="true">&times;</span></button>
+        <h3>
+            Delete message
+            <a href="/help/edit-or-delete-a-message#delete-a-message" target="_blank" rel="noopener noreferrer">
+                <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+            </a>
+        </h3>
+    </div>
+    <div class="modal-body">
+        <div class="content">
+            <p><strong>Are you sure you want to permanently delete this message?</strong></p>
+            <p>Deleting a message removes it for everyone.</p>
+        </div>
+        <div id="delete-message-error"></div>
+    </div>
+    <div class="modal-footer">
+        <button class="button rounded" data-dismiss="modal">Cancel</button>
+        <button class="button rounded btn-danger" id="delete_message_button">Yes, delete this message</button>
+    </div>
+</div>

--- a/static/templates/message_delete_popover.hbs
+++ b/static/templates/message_delete_popover.hbs
@@ -20,4 +20,6 @@
         <button class="button rounded" data-dismiss="modal">Cancel</button>
         <button class="button rounded btn-danger" id="delete_message_button">Yes, delete this message</button>
     </div>
+
 </div>
+


### PR DESCRIPTION
replaced the modal with a popover widget then message is visible. Added new frontend template message_delete_popover.hbs to render popover and updated related static/js files.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
issue:#16426

**Testing plan:** <!-- How have you tested? -->
Did manual testing using browser.

tested for different window sizes.

tested for mobile screen

ran .tools/test no error

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![Screenshot (15)](https://user-images.githubusercontent.com/57071700/109394411-e6b48e00-794c-11eb-824e-475ba40eda34.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
