### PR TITLE
test_home: Fix wrong bot references in test_people.

### DIFF
--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -615,7 +615,7 @@ class HomeTest(ZulipTestCase):
                         is_guest=False,
                     ),
                     dict(
-                        avatar_version=email_gateway_bot.avatar_version,
+                        avatar_version=notification_bot.avatar_version,
                         bot_owner_id=None,
                         bot_type=1,
                         email=notification_bot.email,
@@ -629,7 +629,7 @@ class HomeTest(ZulipTestCase):
                         is_guest=False,
                     ),
                     dict(
-                        avatar_version=email_gateway_bot.avatar_version,
+                        avatar_version=welcome_bot.avatar_version,
                         bot_owner_id=None,
                         bot_type=1,
                         email=welcome_bot.email,


### PR DESCRIPTION
These are all referring to email_gateway_bot, when they're supposed to
refer to the notification and welcome bots, respectively. The values are
the same though, so the tests were passing anyway.