### PR TITLE
FIX STREAM HELP TOOlTIP.

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -443,14 +443,38 @@ export function set_up_handlers() {
             html: true,
             trigger: "manual",
         });
-        announce_stream_docs.popover("show");
-        announce_stream_docs.data("popover").tip().css("z-index", 2000);
         announce_stream_docs
             .data("popover")
             .tip()
             .find(".popover-content")
             .css("margin", "9px 14px");
+        announce_stream_docs.popover("show");
+        announce_stream_docs.data("popover").tip().css("z-index", 2000);
         e.stopPropagation();
+        // simple hack to fix the issue
+        // for 2 lines
+        let mul = 0;
+        const popover_height = Number.parseFloat(
+            announce_stream_docs.data("popover").tip().css("height"),
+        );
+        // for 3 lines
+        if (popover_height > 66.5) {
+            mul = 0.1;
+        }
+        // for 4 lines
+        if (popover_height > 105) {
+            mul = 0.15;
+        }
+        // TODO n lines
+        announce_stream_docs
+            .data("popover")
+            .tip()
+            .css(
+                "top",
+                announce_stream_docs.data("popover").tip().position().top -
+                    Number.parseFloat(announce_stream_docs.data("popover").tip().css("height")) *
+                        mul,
+            );
     });
     container.on("mouseout", "#announce-stream-docs", (e) => {
         $("#announce-stream-docs").popover("hide");


### PR DESCRIPTION
fix issue tooltip not correctly positioning for different screen sizes.

fix issue After the refresh initial tooltip position was wrong.

issue: #17349.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

- Tested manually for different screen sizes. 
- Tested for both mobile and desktop screen sizes.
 

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

screenshot 1:

![Screenshot (17)](https://user-images.githubusercontent.com/57071700/109433337-ddebb700-7a35-11eb-82d3-dd83af78128d.png)

screenshot 2:

![Screenshot (18)](https://user-images.githubusercontent.com/57071700/109433342-e47a2e80-7a35-11eb-9c23-f5b6f4f003e4.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
