### PR TITLE
Install script assumes useradd to be available 

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -376,7 +376,7 @@ has_class() {
 # files to exists; https://tickets.puppetlabs.com/browse/PUP-3907
 #
 # The home directory here should match what's declared in base.pp.
-id -u zulip &>/dev/null || useradd -m zulip --home-dir /home/zulip
+id -u zulip &>/dev/null || /usr/sbin/useradd -m zulip --home-dir /home/zulip
 if [ -n "$NO_OVERWRITE_SETTINGS" ] && [ -e "/etc/zulip/zulip.conf" ]; then
     "$ZULIP_PATH"/scripts/zulip-puppet-apply --noop \
         --write-catalog-summary \


### PR DESCRIPTION
This PR addresses the issue #17441 where the path of the command useradd is sometimes not configured in the $PATH variable

**Testing plan:**  
First, we tested to see if a Debian 10 machine recognizes the command useradd using "which useradd" command, which printed nothing, meaning that useradd is not recognized. Just to be sure, we made this test with bash command, and we got the path to bash as expected.

![Screenshot 2021-03-01 003405](https://user-images.githubusercontent.com/44806328/109437972-fb198900-7a27-11eb-917f-dd4b889a2f77.png)

To make sure useradd is present on the system, we run the following command:

![Screenshot 2021-03-01 003446](https://user-images.githubusercontent.com/44806328/109437983-07054b00-7a28-11eb-8dfb-3f085849838f.png)

This is a common issue that some Linux users encountered: 
https://www.toolbox.com/tech/operating-systems/question/useradd-command-not-found-102906/
http://pkgs.loginroot.com/errors/notFound/useradd

We managed to reproduce the mentioned issue:

![image](https://user-images.githubusercontent.com/44806328/109438419-387f1600-7a2a-11eb-8afe-ebcbb4e68924.png)

**Solution:**
To solve this issue, we updated the scripts/lib/install script to use the full path to useradd instead.

After applying the suggested fix, the installation no longer fails on the useradd step as shown below:

![image](https://user-images.githubusercontent.com/44806328/109438742-7f214000-7a2b-11eb-9c8a-fa64e1aad063.png)
