### PR TITLE
left-sidebar: Remove add-streams option out of scrollbar.

### DIFF
--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -40,6 +40,7 @@ function get_new_heights() {
     const viewport_height = message_viewport.height();
     const top_navbar_height = $("#top_navbar").safeOuterHeight(true);
     const invite_user_link_height = $("#invite-user-link").safeOuterHeight(true) || 0;
+    const add_streams_link_height = $("#add-stream-link").safeOuterHeight(true) || 0;
 
     res.bottom_whitespace_height = viewport_height * 0.4;
 
@@ -51,7 +52,8 @@ function get_new_heights() {
         Number.parseInt($(".narrows_panel").css("marginTop"), 10) -
         Number.parseInt($(".narrows_panel").css("marginBottom"), 10) -
         $("#global_filters").safeOuterHeight(true) -
-        $("#streams_header").safeOuterHeight(true);
+        $("#streams_header").safeOuterHeight(true) -
+        add_streams_link_height;
 
     // Don't let us crush the stream sidebar completely out of view
     res.stream_filters_max_height = Math.max(80, res.stream_filters_max_height);

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -78,7 +78,7 @@ li.show-more-topics {
 
 #stream_filters {
     overflow: visible;
-    margin-bottom: 10px;
+    margin-bottom: 5px;
     margin-right: 12px;
     padding: 0;
     font-weight: normal;
@@ -175,7 +175,6 @@ li.show-more-topics {
 #add-stream-link {
     text-decoration: none;
     margin-left: 10px;
-    margin-bottom: 18px;
     i {
         min-width: 19px;
         text-align: center;

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -82,12 +82,12 @@
             </div>
             <div id="stream-filters-container" class="scrolling_list" data-simplebar>
                 <ul id="stream_filters" class="filters"></ul>
-                {% if show_add_streams %}
-                <div id="add-stream-link">
-                    <a href="#streams/all"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Subscribe to more streams') }}</a>
-                </div>
-                {% endif %}
             </div>
+            {% if show_add_streams %}
+            <div id="add-stream-link">
+                <a href="#streams/all"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Subscribe to more streams') }}</a>
+            </div>
+            {% endif %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
This commit removes the option to add more streams out of scrollbar
as it is not visible on mobile devices or organizations with large number of
streams until scrolled down.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

local dev server.
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Zulip-Dev---Zulip-leftsidebar](https://user-images.githubusercontent.com/55033316/109489129-6e64de80-7aac-11eb-90e5-d1867f80dcf2.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
