### PR TITLE
left-sidebar: Display ellipsis icon by default on touch-based devices.

### DIFF
--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -379,6 +379,17 @@ li.top_left_recent_topics {
     &:hover {
         color: hsl(0, 0%, 0%) !important;
     }
+
+    /*
+        Hover does not work for touch-based devices like mobile phones.
+        Hence the the icons does not appear, making the user unaware of its
+        presence on such devices. The following media property displays the
+        icon by default for such behaviour.
+    */
+
+    @media (hover: none) {
+        display: block;
+    }
 }
 
 /*


### PR DESCRIPTION
Hover does not work for touch-based devices like mobile phones. Hence the the ellipsis icons does not appear, making the user unaware of its presence on such devices. 

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
local server

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Default Behaviour (On desktop, pc):

![icon1](https://user-images.githubusercontent.com/55033316/109506573-cb1fc380-7ac3-11eb-950d-ada0385265b1.png)

On only-touch-based devices:

![icon2](https://user-images.githubusercontent.com/55033316/109506651-e4c10b00-7ac3-11eb-9a43-5e25ab736822.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
