### PR TITLE
search: Add streams:all search operand.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -147,6 +147,25 @@ run_test("basics", () => {
     assert(filter.includes_full_stream_history());
     assert(!filter.is_personal_filter());
 
+    operators = [{operator: "streams", operand: "all", negated: true}];
+    filter = new Filter(operators);
+    assert(!filter.contains_only_private_messages());
+    assert(!filter.has_operator("streams"));
+    assert(!filter.can_mark_messages_read());
+    assert(filter.has_negated_operand("streams", "all"));
+    assert(!filter.can_apply_locally());
+    assert(!filter.is_personal_filter());
+
+    operators = [{operator: "streams", operand: "all"}];
+    filter = new Filter(operators);
+    assert(!filter.contains_only_private_messages());
+    assert(filter.has_operator("streams"));
+    assert(!filter.can_mark_messages_read());
+    assert(!filter.has_negated_operand("streams", "all"));
+    assert(!filter.can_apply_locally());
+    assert(filter.includes_full_stream_history());
+    assert(!filter.is_personal_filter());
+
     operators = [{operator: "is", operand: "private"}];
     filter = new Filter(operators);
     assert(filter.contains_only_private_messages());
@@ -578,6 +597,9 @@ run_test("predicate_basics", () => {
     predicate = get_predicate([["streams", "public"]]);
     assert(predicate({}));
 
+    predicate = get_predicate([["streams", "all"]]);
+    assert(predicate({}));
+
     predicate = get_predicate([["is", "starred"]]);
     assert(predicate({starred: true}));
     assert(!predicate({starred: false}));
@@ -914,12 +936,27 @@ run_test("parse", () => {
     ];
     _test();
 
+    string = "text streams:all more text";
+    operators = [
+        {operator: "streams", operand: "all"},
+        {operator: "search", operand: "text more text"},
+    ];
+    _test();
+
     string = "streams:public";
     operators = [{operator: "streams", operand: "public"}];
     _test();
 
     string = "-streams:public";
     operators = [{operator: "streams", operand: "public", negated: true}];
+    _test();
+
+    string = "streams:all";
+    operators = [{operator: "streams", operand: "all"}];
+    _test();
+
+    string = "-streams:all";
+    operators = [{operator: "streams", operand: "all", negated: true}];
     _test();
 
     string = "stream:foo :emoji: are cool";
@@ -983,6 +1020,22 @@ run_test("unparse", () => {
     string = "-streams:public";
     assert.deepEqual(Filter.unparse(operators), string);
 
+    operators = [
+        {operator: "streams", operand: "all"},
+        {operator: "search", operand: "text"},
+    ];
+
+    string = "streams:all text";
+    assert.deepEqual(Filter.unparse(operators), string);
+
+    operators = [{operator: "streams", operand: "all"}];
+    string = "streams:all";
+    assert.deepEqual(Filter.unparse(operators), string);
+
+    operators = [{operator: "streams", operand: "all", negated: true}];
+    string = "-streams:all";
+    assert.deepEqual(Filter.unparse(operators), string);
+
     operators = [{operator: "id", operand: 50}];
     string = "id:50";
     assert.deepEqual(Filter.unparse(operators), string);
@@ -1006,6 +1059,14 @@ run_test("describe", () => {
 
     narrow = [{operator: "streams", operand: "public", negated: true}];
     string = "exclude streams public";
+    assert.equal(Filter.describe(narrow), string);
+
+    narrow = [{operator: "streams", operand: "all"}];
+    string = "streams all";
+    assert.equal(Filter.describe(narrow), string);
+
+    narrow = [{operator: "streams", operand: "all", negated: true}];
+    string = "exclude streams all";
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
@@ -1341,6 +1402,7 @@ run_test("navbar_helpers", () => {
     const is_private = [{operator: "is", operand: "private"}];
     const is_mentioned = [{operator: "is", operand: "mentioned"}];
     const streams_public = [{operator: "streams", operand: "public"}];
+    const streams_all = [{operator: "streams", operand: "all"}];
     const stream_topic_operators = [
         {operator: "stream", operand: "foo"},
         {operator: "topic", operand: "bar"},
@@ -1411,6 +1473,13 @@ run_test("navbar_helpers", () => {
             icon: undefined,
             title: "translated: Public stream messages in organization",
             redirect_url_with_search: "/#narrow/streams/public",
+        },
+        {
+            operator: streams_all,
+            is_common_narrow: true,
+            icon: undefined,
+            title: "translated: All stream messages with shared history in organization",
+            redirect_url_with_search: "/#narrow/streams/all",
         },
         {
             operator: stream_operator,

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -381,6 +381,7 @@ run_test("empty_query_suggestions", () => {
     const expected = [
         "",
         "streams:public",
+        "streams:all",
         "is:private",
         "is:starred",
         "is:mentioned",
@@ -512,6 +513,7 @@ run_test("check_is_suggestions", () => {
     expected = [
         "",
         "streams:public",
+        "streams:all",
         "is:private",
         "is:starred",
         "is:mentioned",
@@ -560,7 +562,7 @@ run_test("check_is_suggestions", () => {
 
     query = "st";
     suggestions = get_suggestions("", query);
-    expected = ["st", "streams:public", "is:starred", "stream:"];
+    expected = ["st", "streams:public", "streams:all", "is:starred", "stream:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "is:sta";
@@ -902,7 +904,7 @@ run_test("operator_suggestions", () => {
 
     query = "st";
     suggestions = get_suggestions("", query);
-    expected = ["st", "streams:public", "is:starred", "stream:"];
+    expected = ["st", "streams:public", "streams:all", "is:starred", "stream:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "group-";
@@ -912,7 +914,14 @@ run_test("operator_suggestions", () => {
 
     query = "-s";
     suggestions = get_suggestions("", query);
-    expected = ["-s", "-streams:public", "-sender:myself@zulip.com", "-stream:", "-sender:"];
+    expected = [
+        "-s",
+        "-streams:public",
+        "-streams:all",
+        "-sender:myself@zulip.com",
+        "-stream:",
+        "-sender:",
+    ];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-f";

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -383,6 +383,7 @@ run_test("empty_query_suggestions", () => {
     const expected = [
         "",
         "streams:public",
+        "streams:all",
         "is:private",
         "is:starred",
         "is:mentioned",
@@ -531,7 +532,7 @@ run_test("check_is_suggestions", () => {
 
     query = "st";
     suggestions = get_suggestions("", query);
-    expected = ["st", "streams:public", "is:starred", "stream:"];
+    expected = ["st", "streams:public", "streams:all", "is:starred", "stream:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "stream:Denmark has:link is:sta";
@@ -837,7 +838,7 @@ run_test("operator_suggestions", () => {
 
     query = "st";
     suggestions = get_suggestions("", query);
-    expected = ["st", "streams:public", "is:starred", "stream:"];
+    expected = ["st", "streams:public", "streams:all", "is:starred", "stream:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "group-";
@@ -847,7 +848,14 @@ run_test("operator_suggestions", () => {
 
     query = "-s";
     suggestions = get_suggestions("", query);
-    expected = ["-s", "-streams:public", "-sender:myself@zulip.com", "-stream:", "-sender:"];
+    expected = [
+        "-s",
+        "-streams:public",
+        "-streams:all",
+        "-sender:myself@zulip.com",
+        "-stream:",
+        "-sender:",
+    ];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "stream:Denmark is:alerted -f";

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -492,6 +492,9 @@ class Filter {
         if (_.isEqual(term_types, ["streams-public"])) {
             return true;
         }
+        if (_.isEqual(term_types, ["streams-all"])) {
+            return true;
+        }
         return false;
     }
 
@@ -542,6 +545,8 @@ class Filter {
                     return "/#narrow/is/mentioned";
                 case "streams-public":
                     return "/#narrow/streams/public";
+                case "streams-all":
+                    return "/#narrow/streams/all";
                 case "pm-with":
                     // join is used to transform the array to a comma separated string
                     return (
@@ -608,6 +613,8 @@ class Filter {
                     return i18n.t("All messages including muted streams");
                 case "streams-public":
                     return i18n.t("Public stream messages in organization");
+                case "streams-all":
+                    return i18n.t("All stream messages with shared history in organization");
                 case "stream":
                     if (!this._sub) {
                         return i18n.t("Unknown stream");
@@ -684,7 +691,11 @@ class Filter {
             return false;
         }
 
-        if (this.has_operator("streams") || this.has_negated_operand("streams", "public")) {
+        if (
+            this.has_operator("streams") ||
+            this.has_negated_operand("streams", "public") ||
+            this.has_negated_operand("streams", "all")
+        ) {
             return false;
         }
 
@@ -830,6 +841,7 @@ class Filter {
         const levels = [
             "in",
             "streams-public",
+            "streams-all",
             "stream",
             "topic",
             "pm-with",

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -438,7 +438,20 @@ function get_streams_filter_suggestions(last, operators) {
                 {operator: "streams"},
             ],
         },
+        {
+            search_string: "streams:all",
+            description: "All public and private streams with shared history in organisation",
+            invalid: [
+                {operator: "is", operand: "private"},
+                {operator: "stream"},
+                {operator: "group-pm-with"},
+                {operator: "pm-with"},
+                {operator: "in"},
+                {operator: "streams"},
+            ],
+        },
     ];
+
     return get_special_filter_suggestions(last, operators, suggestions);
 }
 function get_is_filter_suggestions(last, operators) {

--- a/templates/zerver/app/search_operators.html
+++ b/templates/zerver/app/search_operators.html
@@ -45,6 +45,10 @@
                 <td class="definition">{{ _('Search all public streams in the organization.') }}</td>
             </tr>
             <tr>
+                <td class="operator">streams:all</td>
+                <td class="definition">{{ _('Search all public and private streams with shared history in the organization.') }}</td>
+            </tr>
+            <tr>
                 <td class="operator">is:alerted</td>
                 <td class="definition">{{ _('Narrow to messages with alert words.') }}</td>
             </tr>

--- a/templates/zerver/help/search-for-messages.md
+++ b/templates/zerver/help/search-for-messages.md
@@ -33,7 +33,8 @@ Here is the **full list of search operators**.
 * `id:12345`: Show only message `12345`.
 * `streams:public`: Search the history of all [public
   streams](/help/change-the-privacy-of-a-stream) in the organization.
-
+* `streams:all`: Search the history of [public and private streams
+  with shared history](/help/change-the-privacy-of-a-stream) in the organization.
 * `is:alerted`: See [alert words](/help/add-an-alert-word).
 * `is:mentioned`: See [mentions](/help/mention-a-user-or-group).
 * `is:starred`: See [starred messages](/help/star-a-message).

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -364,6 +364,10 @@ def get_public_streams_queryset(realm: Realm) -> "QuerySet[Stream]":
     return Stream.objects.filter(realm=realm, invite_only=False, history_public_to_subscribers=True)
 
 
+def get_history_public_streams_queryset(realm: Realm) -> "QuerySet[Stream]":
+    return Stream.objects.filter(realm=realm, history_public_to_subscribers=True)
+
+
 def get_web_public_streams_queryset(realm: Realm) -> "QuerySet[Stream]":
     # In theory, is_web_public=True implies invite_only=False and
     # history_public_to_subscribers=True, but it's safer to include


### PR DESCRIPTION
Fixes #17183 

I have added a new search operand streams:all to search 
the entire history of public as well as private streams with
 shared history.

Tested manually as well as using tools/test-all.