### PR TITLE
right-sidebar: Display ellipsis icon by default on touch-based devices.

### DIFF
--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -48,6 +48,17 @@
                 cursor: pointer;
                 color: hsl(0, 0%, 0%) !important;
             }
+
+            /*
+            Hover does not work for touch-based devices like mobile phones.
+            Hence the the icons does not appear, making the user unaware of its
+            presence on such devices. The following media property displays the
+            icon by default for such behaviour.
+            */
+
+            @media (hover: none) {
+                display: inline;
+            }
         }
 
         &:hover {


### PR DESCRIPTION
Hover does not work for touch-based devices like mobile phones. Hence the icons on the right sidebar do not appear, making the user unaware of its presence on such devices.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
local dev server

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![icon3](https://user-images.githubusercontent.com/55033316/109639068-bf400a00-7b74-11eb-83cf-c2cf3a44324c.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
