### PR TITLE
puppet: Set aggressive caching headers on immutable webpack files.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -14,6 +14,11 @@ location /static/ {
 
     # Set a nonexistent path, so we just serve the nice Django 404 page.
     error_page 404 /django_static_404.html;
+
+    # These files are hashed and thus immutable; cache them aggressively.
+    location /static/webpack-bundles {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
 }
 
 # Send longpoll requests to Tornado


### PR DESCRIPTION
A partial fix for #3470.

**Testing plan:** Deployed to a test prod environment:
```
$ curl -I https://alexmv-prod.zulipdev.org/static/webpack-bundles/0dbc0b059e4fcf36b2f2.css
HTTP/2 200
server: nginx/1.18.0 (Ubuntu)
date: Tue, 02 Mar 2021 23:53:38 GMT
content-type: text/css
content-length: 24708
last-modified: Tue, 27 Oct 2020 00:23:20 GMT
vary: Accept-Encoding
etag: "5f976878-6084"
cache-control: public, max-age=31536000, immutable
accept-ranges: bytes
```