### PR TITLE
provision: Suppress exception chaining for CalledProcessError retries

### DIFF
--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -354,8 +354,12 @@ def do_setup_virtualenv(venv_path: str, requirements_file: str) -> None:
     try:
         install_venv_deps(pip, requirements_file)
     except subprocess.CalledProcessError:
-        # Might be a failure due to network connection issues. Retrying...
-        print(WARNING + "`pip install` failed; retrying..." + ENDC)
-        install_venv_deps(pip, requirements_file)
+        try:
+            # Might be a failure due to network connection issues. Retrying...
+            print(WARNING + "`pip install` failed; retrying..." + ENDC)
+            install_venv_deps(pip, requirements_file)
+        except BaseException as e:
+            # Suppress exception chaining
+            raise e from None
 
     run_as_root(["chmod", "-R", "a+rX", venv_path])

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -368,9 +368,13 @@ def main(options: argparse.Namespace) -> "NoReturn":
         try:
             install_system_deps()
         except subprocess.CalledProcessError:
-            # Might be a failure due to network connection issues. Retrying...
-            print(WARNING + "Installing system dependencies failed; retrying..." + ENDC)
-            install_system_deps()
+            try:
+                # Might be a failure due to network connection issues. Retrying...
+                print(WARNING + "Installing system dependencies failed; retrying..." + ENDC)
+                install_system_deps()
+            except BaseException as e:
+                # Suppress exception chaining
+                raise e from None
         with open(apt_hash_file_path, "w") as hash_file:
             hash_file.write(new_apt_dependencies_hash)
     else:


### PR DESCRIPTION
When exception is raised inside an exception handler, Python 3 helpfully prints both tracebacks separated by “During handling of the above exception, another exception occurred:”. But when we’re using an exception handler to retry the same operation, multiple tracebacks are just noise.  Suppress the earlier one using [PEP 409 syntax](https://docs.python.org/3/whatsnew/3.3.html#pep-409-suppressing-exception-context).

**Testing plan:** Added `"nonexistent"` to `COMMON_DEPENDENCIES`.