### PR TITLE
missedmessage_hook: Fix inaccurate docstring.

### DIFF
--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -693,7 +693,7 @@ def missedmessage_hook(
     """The receiver_is_off_zulip logic used to determine whether a user
     has no active client suffers from a somewhat fundamental race
     condition.  If the client is no longer on the Internet,
-    receiver_is_off_zulip will still return true for
+    receiver_is_off_zulip will still return False for
     DEFAULT_EVENT_QUEUE_TIMEOUT_SECS, until the queue is
     garbage-collected.  This would cause us to reliably miss
     push/email notifying users for messages arriving during the


### PR DESCRIPTION
If the client is no longer on the Internet (Hard Disconnect Problem) then `receiver_is_off_zulip` returns False, not True, for `DEFAULT_EVENT_QUEUE_TIMEOUT_SECS`, until the queue is garbage-collected.

https://chat.zulip.org/#narrow/stream/2-general/topic/missedmessage_hook.20docstring

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
