### PR TITLE
Fix tab-complete in `manage shell`

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -12,7 +12,7 @@ Of the files, only dev, prod, and mypy have been used in the install
 scripts directly. The rest are implicit dependencies.
 
 Steps to update a lock file, e.g. to update ipython from 5.3.0 to latest version:
-0. Remove entry for `ipython==5.4.1` in dev.txt.
+0. Remove entry for `ipython==5.3.0` in dev.txt.
 1. Run `./tools/update-locked-requirements`, which will generate new entries, pinned to the latest version.
 2. Increase `PROVISION_VERSION` in `version.py`.
 3. Run `./tools/provision` to install the new deps and test them.

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -23,6 +23,11 @@ jsx-lexer
 # Needed for manage.py
 ipython
 
+# Needed for compatibility with ipython < 7.20, which we cannot
+# install on Python <3.7; see
+# https://github.com/ipython/ipython/issues/12740
+jedi<0.18.0
+
 # Needed for image processing
 Pillow
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,7 @@
 #
 # This file is GENERATED.  Don't edit directly.
 #
-# To update, edit the non-"lock" files in requirements/*.txt, then:
+# To update, edit the non-"lock" files in requirements/*.in, then:
 #
 #    tools/update-locked-requirements
 #

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -558,10 +558,12 @@ itemloaders==1.0.4 \
     --hash=sha256:1277cd8ca3e4c02dcdfbc1bcae9134ad89acfa6041bd15b4561c6290203a0c96 \
     --hash=sha256:4cb46a0f8915e910c770242ae3b60b1149913ed37162804f1e40e8535d6ec497
     # via scrapy
-jedi==0.18.0 \
-    --hash=sha256:18456d83f65f400ab0c2d3319e48520420ef43b23a086fdc05dff34132f0fb93 \
-    --hash=sha256:92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707
-    # via ipython
+jedi==0.17.2 \
+    --hash=sha256:86ed7d9b750603e4ba582ea8edc678657fb4007894a12bcf6f4bb97892f31d20 \
+    --hash=sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5
+    # via
+    #   -r requirements/common.in
+    #   ipython
 jinja2==2.11.3 \
     --hash=sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419 \
     --hash=sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6
@@ -880,9 +882,9 @@ parsel==1.6.0 \
     # via
     #   itemloaders
     #   scrapy
-parso==0.8.1 \
-    --hash=sha256:15b00182f472319383252c18d5913b69269590616c947747bc50bf4ac768f410 \
-    --hash=sha256:8519430ad07087d4c997fda3a7918f7cfa27cb58972a8c89c2a0295a1c940e9e
+parso==0.7.1 \
+    --hash=sha256:97218d9159b2520ff45eb78028ba8b50d2bc61dcc062a9682666f2dc4bd331ea \
+    --hash=sha256:caba44724b994a8a5e086460bb212abc5a8bc46951bf4a9a1210745953622eb9
     # via jedi
 pathspec==0.8.1 \
     --hash=sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd \

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 #
 # This file is GENERATED.  Don't edit directly.
 #
-# To update, edit the non-"lock" files in requirements/*.txt, then:
+# To update, edit the non-"lock" files in requirements/*.in, then:
 #
 #    tools/update-locked-requirements
 #

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -1,7 +1,7 @@
 #
 # This file is GENERATED.  Don't edit directly.
 #
-# To update, edit the non-"lock" files in requirements/*.txt, then:
+# To update, edit the non-"lock" files in requirements/*.in, then:
 #
 #    tools/update-locked-requirements
 #

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,7 +1,7 @@
 #
 # This file is GENERATED.  Don't edit directly.
 #
-# To update, edit the non-"lock" files in requirements/*.txt, then:
+# To update, edit the non-"lock" files in requirements/*.in, then:
 #
 #    tools/update-locked-requirements
 #

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,7 +1,7 @@
 #
 # This file is GENERATED.  Don't edit directly.
 #
-# To update, edit the non-"lock" files in requirements/*.txt, then:
+# To update, edit the non-"lock" files in requirements/*.in, then:
 #
 #    tools/update-locked-requirements
 #

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -378,10 +378,12 @@ isodate==0.6.0 \
     #   openapi-core
     #   openapi-schema-validator
     #   python3-saml
-jedi==0.18.0 \
-    --hash=sha256:18456d83f65f400ab0c2d3319e48520420ef43b23a086fdc05dff34132f0fb93 \
-    --hash=sha256:92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707
-    # via ipython
+jedi==0.17.2 \
+    --hash=sha256:86ed7d9b750603e4ba582ea8edc678657fb4007894a12bcf6f4bb97892f31d20 \
+    --hash=sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5
+    # via
+    #   -r requirements/common.in
+    #   ipython
 jinja2==2.11.3 \
     --hash=sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419 \
     --hash=sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6
@@ -600,9 +602,9 @@ orjson==3.5.0 \
 parse==1.19.0 \
     --hash=sha256:9ff82852bcb65d139813e2a5197627a94966245c897796760a3a2a8eb66f020b
     # via openapi-core
-parso==0.8.1 \
-    --hash=sha256:15b00182f472319383252c18d5913b69269590616c947747bc50bf4ac768f410 \
-    --hash=sha256:8519430ad07087d4c997fda3a7918f7cfa27cb58972a8c89c2a0295a1c940e9e
+parso==0.7.1 \
+    --hash=sha256:97218d9159b2520ff45eb78028ba8b50d2bc61dcc062a9682666f2dc4bd331ea \
+    --hash=sha256:caba44724b994a8a5e086460bb212abc5a8bc46951bf4a9a1210745953622eb9
     # via jedi
 pexpect==4.8.0 \
     --hash=sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937 \

--- a/requirements/thumbor-dev.txt
+++ b/requirements/thumbor-dev.txt
@@ -1,7 +1,7 @@
 #
 # This file is GENERATED.  Don't edit directly.
 #
-# To update, edit the non-"lock" files in requirements/*.txt, then:
+# To update, edit the non-"lock" files in requirements/*.in, then:
 #
 #    tools/update-locked-requirements
 #

--- a/requirements/thumbor.txt
+++ b/requirements/thumbor.txt
@@ -1,7 +1,7 @@
 #
 # This file is GENERATED.  Don't edit directly.
 #
-# To update, edit the non-"lock" files in requirements/*.txt, then:
+# To update, edit the non-"lock" files in requirements/*.in, then:
 #
 #    tools/update-locked-requirements
 #

--- a/tools/update-locked-requirements
+++ b/tools/update-locked-requirements
@@ -17,7 +17,7 @@ compile_requirements() {
 #
 # This file is GENERATED.  Don't edit directly.
 #
-# To update, edit the non-"lock" files in requirements/*.txt, then:
+# To update, edit the non-"lock" files in requirements/*.in, then:
 #
 #    tools/update-locked-requirements
 #

--- a/version.py
+++ b/version.py
@@ -45,4 +45,4 @@ API_FEATURE_LEVEL = 40
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "131.0"
+PROVISION_VERSION = "131.1"


### PR DESCRIPTION
**Testing plan:**
```
$ ./manage.py shell
Python 3.6.9 (default, Jul 17 2020, 12:50:27)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

Successfully imported Zulip settings, models, and actions functions.

In [1]: u = get_user<TAB><TAB><ENTER>
Traceback (most recent call last):
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/IPython/terminal/ptutils.py", line 113, in get_completions
    yield from self._get_completions(body, offset, cursor_position, self.ipy_completer)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/IPython/terminal/ptutils.py", line 126, in _get_completions
    for c in completions:
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/IPython/core/completer.py", line 438, in _deduplicate_completions
    completions = list(completions)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/IPython/core/completer.py", line 1818, in completions
    for c in self._completions(text, offset, _timeout=self.jedi_compute_type_timeout/1000):
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/IPython/core/completer.py", line 1862, in _completions
    full_text=full_text, cursor_line=cursor_line, cursor_pos=cursor_column)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/IPython/core/completer.py", line 2030, in _complete
    cursor_pos, cursor_line, full_text)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/IPython/core/completer.py", line 1374, in _jedi_matches
    text[:offset], namespaces, column=cursor_column, line=cursor_line + 1)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/jedi/api/__init__.py", line 726, in __init__
    project=Project(Path.cwd()), **kwds)
TypeError: __init__() got an unexpected keyword argument 'column'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./manage.py", line 52, in <module>
    execute_from_command_line(sys.argv)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/django/core/management/__init__.py", line 395, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/django/core/management/base.py", line 330, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/django/core/management/base.py", line 371, in execute
    output = self.handle(*args, **options)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/django/core/management/commands/shell.py", line 100, in handle
    return getattr(self, shell)(options)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/django/core/management/commands/shell.py", line 36, in ipython
    start_ipython(argv=[])
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/IPython/__init__.py", line 126, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/traitlets/config/application.py", line 664, in launch_instance
    app.start()
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/IPython/terminal/ipapp.py", line 356, in start
    self.shell.mainloop()
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/IPython/terminal/interactiveshell.py", line 563, in mainloop
    self.interact()
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/IPython/terminal/interactiveshell.py", line 546, in interact
    code = self.prompt_for_code()
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/IPython/terminal/interactiveshell.py", line 474, in prompt_for_code
    **self._extra_prompt_options())
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/prompt_toolkit/shortcuts/prompt.py", line 1013, in prompt
    return self.app.run(set_exception_handler=set_exception_handler)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/prompt_toolkit/application/application.py", line 826, in run
    self.run_async(pre_run=pre_run, set_exception_handler=set_exception_handler)
  File "/usr/lib/python3.6/asyncio/base_events.py", line 484, in run_until_complete
    return future.result()
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/prompt_toolkit/application/application.py", line 792, in run_async
    return await _run_async2()
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/prompt_toolkit/application/application.py", line 780, in _run_async2
    await self.cancel_and_wait_for_background_tasks()
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/prompt_toolkit/application/application.py", line 881, in cancel_and_wait_for_background_tasks
    await task
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/prompt_toolkit/buffer.py", line 1909, in new_coroutine
    await coroutine(*a, **kw)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/prompt_toolkit/buffer.py", line 1739, in async_completer
    document, complete_event
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/prompt_toolkit/completion/base.py", line 270, in get_completions_async
    document, complete_event
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/prompt_toolkit/completion/base.py", line 196, in get_completions_async
    for item in self.get_completions(document, complete_event):
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/IPython/terminal/ptutils.py", line 116, in get_completions
    print_tb(e)
  File "/usr/lib/python3.6/traceback.py", line 53, in print_tb
    print_list(extract_tb(tb, limit=limit), file=file)
  File "/usr/lib/python3.6/traceback.py", line 72, in extract_tb
    return StackSummary.extract(walk_tb(tb), limit=limit)
  File "/usr/lib/python3.6/traceback.py", line 345, in extract
    for f, lineno in frame_gen:
  File "/usr/lib/python3.6/traceback.py", line 310, in walk_tb
    yield tb.tb_frame, tb.tb_lineno
AttributeError: 'TypeError' object has no attribute 'tb_frame'

If you suspect this is an IPython 7.16.1 bug, please report it at:
    https://github.com/ipython/ipython/issues
or send an email to the mailing list at ipython-dev@python.org

You can print a more detailed traceback right now with "%tb", or use "%debug"
to interactively debug it.

Extra-detailed tracebacks for bug-reporting purposes can be enabled via:
    %config Application.verbose_crash=True
```

After:
```
vagrant@vagrant:/srv/zulip$ ./manage.py shell
Python 3.6.9 (default, Jul 17 2020, 12:50:27)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

Successfully imported Zulip settings, models, and actions functions.

In [1]: u = get_user
                      get_user()                                    get_user_info_for_message_updates
                      get_user_by_delivery_email                    get_user_profile_by_api_key
                      get_user_by_id_in_realm_including_cross_realm get_user_profile_by_email                     >
                      get_user_including_cross_realm                get_user_profile_by_id
                     function(email: str, realm: zerver.models.Realm)
```


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
