### PR TITLE
edit_bot: Fixed dropdown username capitalization and other bugs.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -859,6 +859,11 @@ input[type="checkbox"] {
     .buttons {
         margin: 10px 0 5px 0;
     }
+
+    button.dropdown-toggle {
+        font-weight: 600;
+        color: hsl(0, 0%, 67%);
+    }
 }
 
 .edit_bot_email {

--- a/static/templates/admin_bot_form.hbs
+++ b/static/templates/admin_bot_form.hbs
@@ -12,8 +12,7 @@
                     {{> settings/dropdown_list_widget
                       widget_name="edit_bot_owner"
                       list_placeholder=(t 'Filter users')
-                      reset_button_text=(t '[Remove owner]')
-                      label="" }}
+                      reset_button_text=(t '[Remove owner]') }}
                 </div>
                 <div class="input-group name_change_container">
                     <label for="full_name">{{t "Full name" }}</label>

--- a/static/templates/edit_bot.hbs
+++ b/static/templates/edit_bot.hbs
@@ -12,12 +12,11 @@
         </div>
         <div class="edit-bot-form-box">
             <div class="edit-bot-owner">
-                <label for="bot_owner_select">{{t "Owner" }}</label>
+                <label>{{t "Owner" }}</label>
                 {{> settings/dropdown_list_widget
                   widget_name="bot_owner"
                   list_placeholder=(t 'Filter users')
-                  reset_button_text=(t '[Remove owner]')
-                  label="" }}
+                  reset_button_text=(t '[Remove owner]') }}
             </div>
             <div class="">
                 <label for="edit_bot_name">{{t "Full name" }}</label>

--- a/static/templates/settings/dropdown_list_widget.hbs
+++ b/static/templates/settings/dropdown_list_widget.hbs
@@ -1,22 +1,23 @@
 <div class="input-group dropdown-list-widget" id="{{widget_name}}_widget">
-    <label for="{{widget_name}}" id="{{widget_name}}_label" class="inline-block">
-        {{ label }}
-        <span class="{{widget_name}}_setting dropup actual-dropdown-menu prop-element" id="id_{{widget_name}}"
-          name="{{widget_name}}" aria-labelledby="{{widget_name}}_label">
-            <button class="button small rounded dropdown-toggle" data-toggle="dropdown">
-                <span id="{{widget_name}}_name"></span>
-                <i class="fa fa-pencil"></i>
-            </button>
-            <ul class="dropdown-menu modal-bg" role="menu">
-                <li class="dropdown-search" role="presentation">
-                    <input class="no-input-change-detection" type="text" role="menuitem" placeholder="{{list_placeholder}}" autofocus/>
-                </li>
-                <div class="dropdown-list-wrapper" data-simplebar>
-                    <span class="dropdown-list-body"></span>
-                </div>
-            </ul>
-        </span>
-    </label>
+    <span class="{{widget_name}}_setting dropup actual-dropdown-menu prop-element" id="id_{{widget_name}}" aria-labelledby="{{widget_name}}_label">
+        {{#if label}}
+        <label id="{{widget_name}}_label" class="inline-block">
+            {{ label }}
+        </label>
+        {{/if}}
+        <button class="button small rounded dropdown-toggle" data-toggle="dropdown">
+            <span id="{{widget_name}}_name"></span>
+            <i class="fa fa-pencil"></i>
+        </button>
+        <ul class="dropdown-menu modal-bg" role="menu">
+            <li class="dropdown-search" role="presentation">
+                <input class="no-input-change-detection" type="text" role="menuitem" placeholder="{{list_placeholder}}" autofocus/>
+            </li>
+            <div class="dropdown-list-wrapper" data-simplebar>
+                <span class="dropdown-list-body"></span>
+            </div>
+        </ul>
+    </span>
     <button class="button small dropdown_list_reset_button">
         <a>{{reset_button_text}}</a>
     </button>


### PR DESCRIPTION
Fixes the bugs listed within #17311, mainly as: 

<ul>
<li>Unwrapped the label tag from entire control group which also brings back the dropdown items to their default size.</li>
<li>Rectifies broken label tag having a misleading 'for' attribute.</li>
<li>Removed 'name' attribute from unlabelled span tag.</li>
</ul>

This is an updated pr for #17403 which was later reverted in #17468, due to issues found within organization notification settings.(Sorry about that)

<strong>Screenshots: </strong>

![Screenshot from 2021-03-04 15-11-48](https://user-images.githubusercontent.com/53977614/109947141-01955280-7cff-11eb-821d-f63b06646075.png)
![Screenshot from 2021-03-04 15-12-09](https://user-images.githubusercontent.com/53977614/109947149-02c67f80-7cff-11eb-9bf6-aefa2a34255a.png)
