### PR TITLE
UI: Fix redundant condense message appearing in edit message menu.

### DIFF
--- a/static/js/condense.js
+++ b/static/js/condense.js
@@ -170,9 +170,21 @@ export function hide_message_expander(row) {
     }
 }
 
+export function hide_message_condenser(row) {
+    if (row.find(".could-be-condensed").length !== 0) {
+        row.find(".message_condenser").hide();
+    }
+}
+
 export function show_message_expander(row) {
     if (row.find(".could-be-condensed").length !== 0) {
         row.find(".message_expander").show();
+    }
+}
+
+export function show_message_condenser(row) {
+    if (row.find(".could-be-condensed").length !== 0) {
+        row.find(".message_condenser").show();
     }
 }
 

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -291,6 +291,7 @@ function timer_text(seconds_left) {
 function edit_message(row, raw_content) {
     row.find(".message_reactions").hide();
     condense.hide_message_expander(row);
+    condense.hide_message_condenser(row);
     const content_top = row.find(".message_top_line")[0].getBoundingClientRect().top;
 
     const message = current_msg_list.get(rows.id(row));
@@ -591,7 +592,11 @@ export function end_message_row_edit(row) {
 
         compose.abort_video_callbacks(message.id);
     }
-    condense.show_message_expander(row);
+    if (row.find(".condensed").length !== 0) {
+        condense.show_message_expander(row);
+    } else {
+        condense.show_message_condenser(row);
+    }
     row.find(".message_reactions").show();
 
     // We have to blur out text fields, or else hotkeys.js


### PR DESCRIPTION
Added the handler functions which were previously missing
for when a user tries to `edit`/`view source` of a message
after expanding it.

Fixes #17478

Earlier:
![redundant-condense](https://user-images.githubusercontent.com/59016893/109949293-373b3b00-7d01-11eb-8604-97d8c43e8fcf.gif)

Now:
![fixed-issue-17478](https://user-images.githubusercontent.com/59016893/109949316-3dc9b280-7d01-11eb-871a-cc136d502ebf.gif)
