### PR TITLE
import/export: Fix deprecated authentication method for Slack.

### DIFF
--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1349,7 +1349,9 @@ def check_token_access(token: str) -> None:
     if token.startswith("xoxp-"):
         logging.info("This is a Slack user token, which grants all rights the user has!")
     elif token.startswith("xoxb-"):
-        data = requests.get("https://slack.com/api/team.info", {"token": token})
+        data = requests.get(
+            "https://slack.com/api/team.info", headers={"Authorization": "Bearer {}".format(token)}
+        )
         has_scopes = set(data.headers.get("x-oauth-scopes", "").split(","))
         required_scopes = set(["emoji:read", "users:read", "users:read.email", "team:read"])
         missing_scopes = required_scopes - has_scopes
@@ -1366,7 +1368,10 @@ def check_token_access(token: str) -> None:
 def get_slack_api_data(slack_api_url: str, get_param: str, **kwargs: Any) -> Any:
     if not kwargs.get("token"):
         raise AssertionError("Slack token missing in kwargs")
-    data = requests.get(slack_api_url, kwargs)
+    token = kwargs.pop("token")
+    data = requests.get(
+        slack_api_url, headers={"Authorization": "Bearer {}".format(token)}, **kwargs
+    )
 
     if data.status_code == requests.codes.ok:
         result = data.json()

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -60,10 +60,16 @@ class MockResponse:
 
 
 # This method will be used by the mock to replace requests.get
-def mocked_requests_get(*args: str) -> MockResponse:
-    if args == ("https://slack.com/api/users.list", {"token": "xoxp-valid-token"}):
+def mocked_requests_get(*args: str, headers: Dict[str, str]) -> MockResponse:
+    if (
+        args == ("https://slack.com/api/users.list",)
+        and headers.get("Authorization") == "Bearer xoxp-valid-token"
+    ):
         return MockResponse({"ok": True, "members": "user_data"}, 200)
-    elif args == ("https://slack.com/api/users.list", {"token": "xoxp-invalid-token"}):
+    elif (
+        args == ("https://slack.com/api/users.list",)
+        and headers.get("Authorization") == "Bearer xoxp-invalid-token"
+    ):
         return MockResponse({"ok": False, "error": "invalid_auth"}, 200)
     else:
         return MockResponse(None, 404)


### PR DESCRIPTION
The query string parameter authentication method
is now deprecated for newly created Slack applications
since the 24th of February
(https://api.slack.com/changelog/2020-11-no-more-tokens-in-
querystrings-for-newly-created-apps).
This was causing Slack imports to fail.

Two methods can be used to solve this problem : either include the
authentication token in the header of an HTTP GET request or include
it in the body of an HTTP POST request. The former was prefered to
solve the issue as the code previously written was already using
HTTP GET requests to connect to the Slack API. The changes that were
made simply involved to change the way the parameters were passed to
the "requests.get" method calls.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

The fix was tested manually by creating a new Slack application and
importing it onto a new Zulip realm. Screenshots of this test can
be provided if necessary to prove that it is working as intended.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

Fixes: #17408.
