### PR TITLE
computed_settings: Remove unused TUTORIAL_ENABLED setting

### DIFF
--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -100,8 +100,6 @@ else:
 
 # This is overridden in test_settings.py for the test suites
 TEST_SUITE = False
-# The new user tutorial is enabled by default, but disabled for client tests.
-TUTORIAL_ENABLED = True
 # This is overridden in test_settings.py for the test suites
 PUPPETEER_TESTS = False
 # This is overridden in test_settings.py for the test suites

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -93,9 +93,6 @@ RATE_LIMITING_AUTHENTICATE = False
 # real app.
 USING_RABBITMQ = False
 
-# Disable the tutorial because it confuses the client tests.
-TUTORIAL_ENABLED = False
-
 # Disable use of memcached for caching
 CACHES["database"] = {
     "BACKEND": "django.core.cache.backends.dummy.DummyCache",


### PR DESCRIPTION
It’s unused as of commit 88bec164523033e4ae218c2e0087f57a83c0f08f (#6621).