### PR TITLE
puppet: Add access time and host to nginx access logs.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -1,4 +1,4 @@
-access_log /var/log/nginx/access.log;
+access_log /var/log/nginx/access.log combined_with_host_and_time;
 error_log /var/log/nginx/error.log;
 
 include /etc/nginx/zulip-include/headers;


### PR DESCRIPTION
2e20ab1658fdc169cc6ed00020444231aa586d61 attempted to add this; but
there are multiple locations that access logs are set, and the most
specific wins.

**Testing plan:** Deployed to a test prod instance, saw hostname and duration in logs:
```
135.180.41.241 - - [04/Mar/2021:19:27:25 +0000] "POST /json/users/me/presence HTTP/2.0" 200 110 "https://alexmv-prod.zulipdev.org/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.192 Safari/537.36" alexmv-prod.zulipdev.org 0.023
```
