### PR TITLE
update-prod-static: Remove unused --prev-deploy option

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -27,7 +27,6 @@ os.environ["LANGUAGE"] = "en_US.UTF-8"
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 from scripts.lib.zulip_tools import (
-    DEPLOYMENTS_DIR,
     assert_running_as_root,
     get_config,
     get_config_file,
@@ -227,10 +226,7 @@ elif args.from_git:
     # update-prod-static with the Git upgrade process.  But it'll fail
     # safely; this seems like a worthwhile tradeoff to minimize downtime.
     logging.info("Building static assets...")
-    subprocess.check_call(
-        ["./tools/update-prod-static", "--prev-deploy=" + os.path.join(DEPLOYMENTS_DIR, "current")],
-        preexec_fn=su_to_zulip,
-    )
+    subprocess.check_call(["./tools/update-prod-static"], preexec_fn=su_to_zulip)
     logging.info("Caching Zulip Git version...")
     subprocess.check_call(["./tools/cache-zulip-git-version"], preexec_fn=su_to_zulip)
 else:

--- a/tools/update-prod-static
+++ b/tools/update-prod-static
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 # Updates static files for production.
-import argparse
 import os
 import sys
 
@@ -20,13 +19,6 @@ from scripts.lib.node_cache import setup_node_modules
 from scripts.lib.zulip_tools import run
 
 sanity_check.check_venv(__file__)
-
-parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--prev-deploy", metavar="DIR", help="a previous deploy from which to reuse files if possible"
-)
-args = parser.parse_args()
-prev_deploy = args.prev_deploy
 
 os.chdir(settings.DEPLOY_ROOT)
 


### PR DESCRIPTION
It’s unused since commit 079ddae4c84cabb3d51fd88b93e5afdfd76c8111 (#12676).

**Testing plan:** Ran `upgrade-zulip-from-git` on https://andersk.zulipdev.org.