### PR TITLE
i18n: Translate quote and reply mention text.

### DIFF
--- a/docs/translating/internationalization.md
+++ b/docs/translating/internationalization.md
@@ -257,7 +257,7 @@ i18n.t('keyWithCount', {count: 100}); // output: '100 items'
 For further reading on plurals, read the [official] documentation.
 
 By default, all text is escaped by i18next. To unescape a text you can use
-double-underscores followed by a dash `__-` like this:
+double-underscores followed by a dash and space `__- ` like this:
 
 ```
 i18n.t('English text with a __- variable__', {'variable': 'Variable value'});

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -333,7 +333,8 @@ test("quote_and_reply", (override) => {
         sender_full_name: "Steve Stephenson",
         sender_id: 90,
     };
-    hash_util.by_conversation_and_time_uri = () => "link_to_message";
+    hash_util.by_conversation_and_time_uri = () =>
+        "https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado";
 
     let success_function;
     override(channel, "get", (opts) => {
@@ -356,7 +357,7 @@ test("quote_and_reply", (override) => {
 
     replaced = false;
     expected_replacement =
-        "@_**Steve Stephenson|90** [said](link_to_message):\n```quote\nTesting.\n```";
+        "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n```quote\nTesting.\n```";
 
     quote_and_reply(opts);
 
@@ -395,7 +396,7 @@ test("quote_and_reply", (override) => {
 
     replaced = false;
     expected_replacement =
-        "@_**Steve Stephenson|90** [said](link_to_message):\n````quote\n```\nmultiline code block\nshoudln't mess with quotes\n```\n````";
+        "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n````quote\n```\nmultiline code block\nshoudln't mess with quotes\n```\n````";
     quote_and_reply(opts);
     assert(replaced);
 });

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -456,8 +456,11 @@ export function quote_and_reply(opts) {
         //     ```quote
         //     message content
         //     ```
-        let content = `@_**${message.sender_full_name}|${message.sender_id}** `;
-        content += `[said](${hash_util.by_conversation_and_time_uri(message)}):\n`;
+        let content = i18n.t("__username__ [said](__- link_to_message__):", {
+            username: `@_**${message.sender_full_name}|${message.sender_id}**`,
+            link_to_message: `${hash_util.by_conversation_and_time_uri(message)}`,
+        });
+        content += "\n";
         const fence = fenced_code.get_unused_fence(message.raw_content);
         content += `${fence}quote\n${message.raw_content}\n${fence}`;
         compose_ui.replace_syntax("[Quoting…]", content, textarea);


### PR DESCRIPTION
Related discussion: https://chat.zulip.org/#narrow/stream/58-translation/topic/SAID.20translation.20.2317479

I think we should also probably update the i18n.js zjsunit implementation to handle the case of `__variable__`(escape) and `__- variable__`(no escape) separately. At the moment there is no distinction.

Related issue https://github.com/zulip/zulip/issues/17479