### PR TITLE
mypy: Specify mypy_path and cache_dir relative to config path.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -4,8 +4,8 @@ scripts_are_modules = True
 show_traceback = True
 # See https://zulip.readthedocs.io/en/latest/testing/mypy.html#mypy-stubs-for-third-party-modules
 # for notes on how we manage mypy stubs.
-mypy_path = stubs/
-cache_dir = var/mypy-cache
+mypy_path = $MYPY_CONFIG_FILE_DIR/stubs
+cache_dir = $MYPY_CONFIG_FILE_DIR/var/mypy-cache
 
 # Options to make the checking stricter.
 check_untyped_defs = True


### PR DESCRIPTION
Previously, these were interpreted relative to the current directory. This was notably causing dozens of extra `var/mypy-cache` directories to be created in different places when mypy was run from Emacs Flycheck. Use the `$MYPY_CONFIG_FILE_DIR` variable added in mypy 0.800.

**Testing plan:** Verified that mypy still finds `stubs` (otherwise it would throw warnings about unused `type: ignore`) and `mypy-cache` (otherwise it wouldn’t create it).