### PR TITLE
setup: Remove unused $.fn.within

### DIFF
--- a/static/js/setup.js
+++ b/static/js/setup.js
@@ -68,9 +68,5 @@ $(() => {
             }
             return this;
         };
-
-        $.fn.within = function (sel) {
-            return $(this).is(sel) || $(this).closest(sel).length;
-        };
     }
 });


### PR DESCRIPTION
It’s unused since commit 805ac2475b09c3e4c44d6484babf60fc9bcf3db4 (#14162).