### PR TITLE
isort: Move configuration into pyproject.toml

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,0 @@
-[settings]
-src_paths = ., tools, tools/setup/emoji
-known_third_party = zulip
-profile = black
-line_length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 [tool.black]
 line-length = 100
-target-version = ['py36']
+target-version = ["py36"]
+
+[tool.isort]
+src_paths = [".", "tools", "tools/setup/emoji"]
+known_third_party = "zulip"
+profile = "black"
+line_length = 100


### PR DESCRIPTION
Since we already have one for Black, this saves a top-level file.