### PR TITLE
events: Remove name field from update subscription events.

### DIFF
--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -562,7 +562,6 @@ exports.fixtures = {
     subscription__update: {
         type: "subscription",
         op: "update",
-        name: streams.devel.name,
         stream_id: streams.devel.stream_id,
         property: "pin_to_top",
         value: true,

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,11 @@ below features are supported.
 
 ## Changes in Zulip 4.0
 
+**Feature level 41**
+
+* [`GET /events`](/api/get-events): Remove name field from update
+  subscription events.
+
 **Feature level 40**
 
 * [`GET /events`](/api/get-events): Remove email field from update

--- a/version.py
+++ b/version.py
@@ -30,7 +30,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 40
+API_FEATURE_LEVEL = 41
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3700,7 +3700,6 @@ def do_change_subscription_property(
         property=event_property_name,
         value=event_value,
         stream_id=stream.id,
-        name=stream.name,
     )
     send_event(user_profile.realm, event, [user_profile.id])
 

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1225,7 +1225,6 @@ subscription_update_event = event_dict_type(
         ("property", str),
         ("stream_id", int),
         ("value", value_type),
-        ("name", str),
     ]
 )
 _check_subscription_update = make_checker(subscription_update_event)

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -783,7 +783,7 @@ def apply_event(
 
         elif event["op"] == "update":
             for sub in state["subscriptions"]:
-                if sub["name"].lower() == event["name"].lower():
+                if sub["stream_id"] == event["stream_id"]:
                     sub[event["property"]] = event["value"]
         elif event["op"] == "peer_add":
             if include_subscribers:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -580,10 +580,6 @@ paths:
                                   type: integer
                                   description: |
                                     The ID of the stream whose subscription details have changed.
-                                name:
-                                  type: string
-                                  description: |
-                                    The name of the stream whose subscription details have changed.
                                 property:
                                   type: string
                                   description: |
@@ -609,7 +605,6 @@ paths:
                                   "property": "pin_to_top",
                                   "value": true,
                                   "stream_id": 11,
-                                  "name": "test_stream",
                                   "id": 0,
                                 }
                             - type: object


### PR DESCRIPTION
This PR removes name field from update subscription
events, as it is not used by any of the clients.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


<!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
