### PR TITLE
markdown: Re-enable backslash escape inline pattern.

### DIFF
--- a/help/format-your-message-using-markdown.md
+++ b/help/format-your-message-using-markdown.md
@@ -28,6 +28,7 @@ whenever you need a reminder of the formatting syntax below.
 * [Tables](#tables)
 * [Collaborative to-do lists](#collaborative-to-do-lists)
 * [Paragraph and section formatting](#paragraph-and-section-formatting)
+* [Backslash escapes](#backslash-escapes)
 
 ## Text emphasis
 
@@ -123,6 +124,13 @@ whenever you need a reminder of the formatting syntax below.
 {!paragraphs-and-sections-intro.md!}
 
 {!paragraphs-and-sections-examples.md!}
+
+## Backslash escapes
+
+You can prevent a punctuation character from being interpreted as
+Markdown syntax by escaping it with a backslash. For example, you can
+surround a phrase with literal asterisks (instead of emphasizing it)
+like this: `\*literal asterisks\*`.
 
 ## Message formatting reference
 

--- a/web/src/info_overlay.js
+++ b/web/src/info_overlay.js
@@ -101,6 +101,10 @@ This text won't be visible until the user clicks.
         markdown: "Some inline `code`",
     },
     {
+        markdown: "\\*literal asterisks\\*",
+        output_html: "<p>*literal asterisks*</p>",
+    },
+    {
         markdown: `\
 \`\`\`
 def zulip():

--- a/web/third/marked/lib/marked.js
+++ b/web/third/marked/lib/marked.js
@@ -465,7 +465,7 @@ Lexer.prototype.token = function(src, top, bq) {
  */
 
 var inline = {
-  escape: /^\\([\\`*{}\[\]()#+\-.!_>])/,
+  escape: /^\\([!"#$%&'()*+,\-./:;<=>?@[\\^\]_`{|}~])/,
   autolink: /^<([^ >]+(@|:\/)[^ >]+)>/,
   url: noop,
   tag: /^<!--[\s\S]*?-->|^<\/?\w+(?:"[^"]*"|'[^']*'|[^'">])*?>/,
@@ -636,10 +636,17 @@ InlineLexer.prototype.output = function(src) {
     , cap;
 
   while (src) {
+    // tex
+    if (cap = this.rules.tex.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += this.tex(cap[2], cap[0]);
+      continue;
+    }
+
     // escape
     if (cap = this.rules.escape.exec(src)) {
       src = src.substring(cap[0].length);
-      out += cap[1];
+      out += escape(cap[1]);
       continue;
     }
 
@@ -821,13 +828,6 @@ InlineLexer.prototype.output = function(src) {
     if (cap = this.rules.timestamp.exec(src)) {
       src = src.substring(cap[0].length);
       out += this.timestamp(cap[1]);
-      continue;
-    }
-
-    // tex
-    if (cap = this.rules.tex.exec(src)) {
-      src = src.substring(cap[0].length);
-      out += this.tex(cap[2], cap[0]);
       continue;
     }
 

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2113,13 +2113,13 @@ class ZulipMarkdown(markdown.Markdown):
         # html_block - insecure
         # reference - references don't make sense in a chat context.
         preprocessors = markdown.util.Registry()
-        preprocessors.register(MarkdownListPreprocessor(self), "hanging_lists", 35)
+        preprocessors.register(MarkdownListPreprocessor(self), "hanging_lists", 40)
         preprocessors.register(
             markdown.preprocessors.NormalizeWhitespace(self), "normalize_whitespace", 30
         )
         preprocessors.register(fenced_code.FencedBlockPreprocessor(self), "fenced_code_block", 25)
         preprocessors.register(
-            AlertWordNotificationProcessor(self), "custom_text_notifications", 20
+            AlertWordNotificationProcessor(self), "custom_text_notifications", 10
         )
         return preprocessors
 
@@ -2133,22 +2133,21 @@ class ZulipMarkdown(markdown.Markdown):
         # quote - replaced by ours
         parser = BlockParser(self)
         parser.blockprocessors.register(
-            markdown.blockprocessors.EmptyBlockProcessor(parser), "empty", 95
+            markdown.blockprocessors.EmptyBlockProcessor(parser), "empty", 100
         )
         parser.blockprocessors.register(ListIndentProcessor(parser), "indent", 90)
         if not self.email_gateway:
             parser.blockprocessors.register(
-                markdown.blockprocessors.CodeBlockProcessor(parser), "code", 85
+                markdown.blockprocessors.CodeBlockProcessor(parser), "code", 80
             )
-        parser.blockprocessors.register(HashHeaderProcessor(parser), "hashheader", 80)
         # We get priority 75 from 'table' extension
-        parser.blockprocessors.register(markdown.blockprocessors.HRProcessor(parser), "hr", 70)
-        parser.blockprocessors.register(OListProcessor(parser), "olist", 65)
-        parser.blockprocessors.register(UListProcessor(parser), "ulist", 60)
-        parser.blockprocessors.register(BlockQuoteProcessor(parser), "quote", 55)
-        # We get priority 51 from our 'include' extension
+        parser.blockprocessors.register(HashHeaderProcessor(parser), "hashheader", 70)
+        parser.blockprocessors.register(markdown.blockprocessors.HRProcessor(parser), "hr", 50)
+        parser.blockprocessors.register(OListProcessor(parser), "olist", 40)
+        parser.blockprocessors.register(UListProcessor(parser), "ulist", 30)
+        parser.blockprocessors.register(BlockQuoteProcessor(parser), "quote", 20)
         parser.blockprocessors.register(
-            markdown.blockprocessors.ParagraphProcessor(parser), "paragraph", 50
+            markdown.blockprocessors.ParagraphProcessor(parser), "paragraph", 10
         )
         return parser
 
@@ -2188,39 +2187,39 @@ class ZulipMarkdown(markdown.Markdown):
         # rules, that preserves the order from upstream but leaves
         # space for us to add our own.
         reg = markdown.util.Registry()
-        reg.register(BacktickInlineProcessor(markdown.inlinepatterns.BACKTICK_RE), "backtick", 105)
-        reg.register(Tex(TEX_RE, self), "tex", 103)
+        reg.register(BacktickInlineProcessor(markdown.inlinepatterns.BACKTICK_RE), "backtick", 190)
+        reg.register(Tex(TEX_RE, self), "tex", 185)
         reg.register(
-            markdown.inlinepatterns.DoubleTagPattern(STRONG_EM_RE, "strong,em"), "strong_em", 100
+            markdown.inlinepatterns.DoubleTagPattern(STRONG_EM_RE, "strong,em"), "strong_em", 178
         )
-        reg.register(UserMentionPattern(mention.MENTIONS_RE, self), "usermention", 95)
-        reg.register(StreamTopicPattern(get_compiled_stream_topic_link_regex(), self), "topic", 87)
-        reg.register(StreamPattern(get_compiled_stream_link_regex(), self), "stream", 85)
-        reg.register(Timestamp(TIMESTAMP_RE), "timestamp", 75)
+        reg.register(UserMentionPattern(mention.MENTIONS_RE, self), "usermention", 175)
+        reg.register(StreamTopicPattern(get_compiled_stream_topic_link_regex(), self), "topic", 172)
+        reg.register(StreamPattern(get_compiled_stream_link_regex(), self), "stream", 169)
+        reg.register(Timestamp(TIMESTAMP_RE), "timestamp", 166)
         reg.register(
-            UserGroupMentionPattern(mention.USER_GROUP_MENTIONS_RE, self), "usergroupmention", 65
+            UserGroupMentionPattern(mention.USER_GROUP_MENTIONS_RE, self), "usergroupmention", 163
         )
-        reg.register(LinkInlineProcessor(markdown.inlinepatterns.LINK_RE, self), "link", 60)
-        reg.register(AutoLink(get_web_link_regex(), self), "autolink", 55)
-        # Reserve priority 45-54 for linkifiers
+        reg.register(LinkInlineProcessor(markdown.inlinepatterns.LINK_RE, self), "link", 160)
+        reg.register(AutoLink(get_web_link_regex(), self), "autolink", 120)
+        # Reserve priority 100-110 for linkifiers
         reg = self.register_linkifiers(reg)
         reg.register(
             markdown.inlinepatterns.HtmlInlineProcessor(markdown.inlinepatterns.ENTITY_RE, self),
             "entity",
-            40,
+            80,
         )
-        reg.register(markdown.inlinepatterns.SimpleTagPattern(STRONG_RE, "strong"), "strong", 35)
-        reg.register(markdown.inlinepatterns.SimpleTagPattern(EMPHASIS_RE, "em"), "emphasis", 30)
-        reg.register(markdown.inlinepatterns.SimpleTagPattern(DEL_RE, "del"), "del", 25)
+        reg.register(markdown.inlinepatterns.SimpleTagPattern(STRONG_RE, "strong"), "strong", 78)
+        reg.register(markdown.inlinepatterns.SimpleTagPattern(EMPHASIS_RE, "em"), "emphasis", 75)
+        reg.register(markdown.inlinepatterns.SimpleTagPattern(DEL_RE, "del"), "del", 73)
         reg.register(
             markdown.inlinepatterns.SimpleTextInlineProcessor(
                 markdown.inlinepatterns.NOT_STRONG_RE
             ),
             "not_strong",
-            20,
+            70,
         )
-        reg.register(Emoji(EMOJI_REGEX, self), "emoji", 15)
-        reg.register(EmoticonTranslation(EMOTICON_RE, self), "translate_emoticons", 10)
+        reg.register(Emoji(EMOJI_REGEX, self), "emoji", 60)
+        reg.register(EmoticonTranslation(EMOTICON_RE, self), "translate_emoticons", 50)
         # We get priority 5 from 'nl2br' extension
         reg.register(UnicodeEmoji(UNICODE_EMOJI_RE), "unicodeemoji", 0)
         return reg
@@ -2231,7 +2230,7 @@ class ZulipMarkdown(markdown.Markdown):
             registry.register(
                 LinkifierPattern(pattern, linkifier["url_template"], self),
                 f"linkifiers/{pattern}",
-                45,
+                100,
             )
         return registry
 
@@ -2239,22 +2238,21 @@ class ZulipMarkdown(markdown.Markdown):
         # Here we build all the processors from upstream, plus a few of our own.
         treeprocessors = markdown.util.Registry()
         # We get priority 30 from 'hilite' extension
-        treeprocessors.register(markdown.treeprocessors.InlineProcessor(self), "inline", 25)
-        treeprocessors.register(markdown.treeprocessors.PrettifyTreeprocessor(self), "prettify", 20)
-        treeprocessors.register(markdown.treeprocessors.UnescapeTreeprocessor(self), "unescape", 18)
-        treeprocessors.register(
-            InlineInterestingLinkProcessor(self), "inline_interesting_links", 15
-        )
+        treeprocessors.register(markdown.treeprocessors.InlineProcessor(self), "inline", 20)
+        treeprocessors.register(markdown.treeprocessors.PrettifyTreeprocessor(self), "prettify", 10)
+        treeprocessors.register(markdown.treeprocessors.UnescapeTreeprocessor(self), "unescape", 7)
+        treeprocessors.register(InlineInterestingLinkProcessor(self), "inline_interesting_links", 5)
         if settings.CAMO_URI:
-            treeprocessors.register(InlineImageProcessor(self), "rewrite_images_proxy", 10)
+            treeprocessors.register(InlineImageProcessor(self), "rewrite_images_proxy", 0)
         return treeprocessors
 
     def build_postprocessors(self) -> markdown.util.Registry:
-        # These are the default Python-Markdown processors, unmodified.
+        # `RawHtmlPostprocessor` and `AndSubstitutePostprocessor`
+        # are the default python-markdown processors, unmodified.
         postprocessors = markdown.util.Registry()
-        postprocessors.register(markdown.postprocessors.RawHtmlPostprocessor(self), "raw_html", 20)
+        postprocessors.register(markdown.postprocessors.RawHtmlPostprocessor(self), "raw_html", 30)
         postprocessors.register(
-            markdown.postprocessors.AndSubstitutePostprocessor(), "amp_substitute", 15
+            markdown.postprocessors.AndSubstitutePostprocessor(), "amp_substitute", 20
         )
         return postprocessors
 
@@ -2271,7 +2269,7 @@ class ZulipMarkdown(markdown.Markdown):
             # insert new 'inline' processor because we have changed self.inlinePatterns
             # but InlineProcessor copies md as self.md in __init__.
             self.treeprocessors.register(
-                markdown.treeprocessors.InlineProcessor(self), "inline", 25
+                markdown.treeprocessors.InlineProcessor(self), "inline", 20
             )
             self.preprocessors = get_sub_registry(self.preprocessors, ["custom_text_notifications"])
             self.parser.blockprocessors = get_sub_registry(

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2189,11 +2189,11 @@ class ZulipMarkdown(markdown.Markdown):
         # space for us to add our own.
         reg = markdown.util.Registry()
         reg.register(BacktickInlineProcessor(markdown.inlinepatterns.BACKTICK_RE), "backtick", 105)
+        reg.register(Tex(TEX_RE, self), "tex", 103)
         reg.register(
             markdown.inlinepatterns.DoubleTagPattern(STRONG_EM_RE, "strong,em"), "strong_em", 100
         )
         reg.register(UserMentionPattern(mention.MENTIONS_RE, self), "usermention", 95)
-        reg.register(Tex(TEX_RE, self), "tex", 90)
         reg.register(StreamTopicPattern(get_compiled_stream_topic_link_regex(), self), "topic", 87)
         reg.register(StreamPattern(get_compiled_stream_link_regex(), self), "stream", 85)
         reg.register(Timestamp(TIMESTAMP_RE), "timestamp", 75)

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -977,6 +977,148 @@
       "input": "```\n#!/usr/bin/python\nprint(\"Hello World\")\n```",
       "expected_output": "<div class=\"codehilite\"><pre><span></span><code><span class=\"ch\">#!/usr/bin/python</span>\n<span class=\"nb\">print</span><span class=\"p\">(</span><span class=\"s2\">&quot;Hello World&quot;</span><span class=\"p\">)</span>\n</code></pre></div>",
       "marked_expected_output": "<div class=\"codehilite\"><pre><span></span><code>#!/usr/bin/python\nprint(&quot;Hello World&quot;)\n</code></pre></div>"
+    },
+    {
+      "name": "backslash_backslash",
+      "input": "\\foo \\\\bar \\\\\\baz \\\\\\\\zar",
+      "expected_output": "<p>\\foo \\bar \\\\baz \\\\zar</p>"
+    },
+    {
+      "name": "backslash_backtick",
+      "input": "\\`Hello World`\n\n\\```python\ndef fib(n):\n    # TODO: base case\n    return fib(n-1) + fib(n-2)\n\\```",
+      "expected_output": "<p>`Hello World`</p>\n<p>```python<br>\ndef fib(n):<br>\n    # TODO: base case<br>\n    return fib(n-1) + fib(n-2)<br>\n```</p>"
+    },
+    {
+      "name": "backslash_asterisk",
+      "input": "\\*italic*\n*italic\\*\n\\**bold**\n\\*\\*bold**\n**bold\\**\n**bold\\*\\*\n**bold*\\*\n\\***~~All three at once~~***\n\\*\\**~~All three at once~~***\n\\*\\*\\*~~All three at once~~***\n\\*\\*\\*\\~~All three at once~~***\n\\*\\*\\*\\~\\~All three at once~~***\n***~~All three at once\\~~***\n***~~All three at once\\~\\~***\n***~~All three at once\\~\\~\\***\n***~~All three at once\\~\\~\\*\\**\n***~~All three at once\\~\\~\\*\\*\\*",
+      "expected_output": "<p>*italic*<br>\n*italic*<br>\n*<em>bold</em>*<br>\n**bold**<br>\n*<em>bold*</em><br>\n**bold**<br>\n*<em>bold</em>*<br>\n*<strong><del>All three at once</del></strong>*<br>\n**<em><del>All three at once</del></em>**<br>\n***<del>All three at once</del>***<br>\n***~~All three at once~~***<br>\n***~~All three at once~~***<br>\n<strong><em>~~All three at once~~</em></strong><br>\n<strong><em>~~All three at once~~</em></strong><br>\n<strong>*~~All three at once~~*</strong><br>\n**<em>~~All three at once~~**</em><br>\n***~~All three at once~~***</p>",
+      "marked_expected_output": "<p>*italic*<br>\n<em>italic\\</em><br>\n*<em>bold*</em><br>\n**bold<strong>\n</strong>bold**<br>\n<strong>bold**\n</strong>bold<em>*<br>\n*<strong><del>All three at once</del>*</strong><br>\n\\</em>*<em><del>All three at once</del>***<br>\n\\</em>**<del>All three at once</del><strong>*<br>\n***~~All three at once~~*</strong><br>\n***~~All three at once<del><strong>*<br>\n*</strong></del>All three at once~~<strong>*<br>\n*</strong>~~All three at once~~<strong>*<br>\n*</strong>~~All three at once~~*<strong><br>\n*</strong>~~All three at once~~***<br>\n<em>**~~All three at once~~\\</em>**</p>"
+    },
+    {
+      "name": "backslash_underscore",
+      "input": "\\_italic_\n_italic\\_\n\\__bold__\n\\_\\_bold__\n__bold\\__\n__bold\\_\\_\n__bold_\\_",
+      "expected_output": "<p>_italic_<br>\n_italic_<br>\n__bold__<br>\n__bold__<br>\n__bold__<br>\n__bold__<br>\n__bold__</p>"
+    },
+    {
+      "name": "backslash_links",
+      "input": "\\{foo}\n{foo\\}\n\\[link](url)\n[link\\](url)\n[link]\\(url)\n[link](url\\)\n\n[text1 \\`code span` text2](url)\n[text3 \\$\\$O(n^2)$$ text4](url)",
+      "expected_output": "<p>{foo}<br>\n{foo}<br>\n[link](url)<br>\n[link](url)<br>\n[link](url)<br>\n[link](url)</p>\n<p><a href=\"http://url\">text1 `code span` text2</a><br>\n<a href=\"http://url\">text3 $$O(n^2)$$ text4</a></p>",
+      "marked_expected_output": "<p>{foo}<br>\n{foo}<br>\n[link](url)<br>\n<a href=\"url\">link\\</a><br>\n[link](url)<br>\n<a href=\"url\\\">link</a></p>\n<p><a href=\"url\">text1 `code span` text2</a><br>\n<a href=\"url\">text3 $$O(n^2)$$ text4</a></p>"
+    },
+    {
+      "name": "backslash_lists",
+      "input": "1\\. item1\n1\\. item2\n\\!123\n\n\\+ item1\n\\- item2",
+      "expected_output": "<p>1. item1<br>\n1. item2<br>\n!123</p>\n<p>+ item1<br>\n- item2</p>"
+    },
+    {
+      "name": "fenced_code_no_backslash",
+      "input": "```\n\\foo \\\\bar \\\\\\baz \\\\\\\\zar\n```\n-\n```\n\\`Hello World`\n```\n-\n```\n\\*italic**italic\\*\\**bold**\\*\\*bold****bold\\****bold\\*\\***bold*\\*\n```",
+      "expected_output": "<div class=\"codehilite\"><pre><span></span><code>\\foo \\\\bar \\\\\\baz \\\\\\\\zar\n</code></pre></div>\n<p>-</p>\n<div class=\"codehilite\"><pre><span></span><code>\\`Hello World`\n</code></pre></div>\n<p>-</p>\n<div class=\"codehilite\"><pre><span></span><code>\\*italic**italic\\*\\**bold**\\*\\*bold****bold\\****bold\\*\\***bold*\\*\n</code></pre></div>"
+    },
+    {
+      "name": "fenced_code_no_backslash_2",
+      "input": "```\n\\_italic_\n_italic\\_\n\\__bold__\n\\_\\_bold__\n__bold\\__\n__bold\\_\\_\n__bold_\\_\n```\n-\n```\n\\{foo}\n{foo\\}\n```\n-\n```\n\\[link](url)\n[link\\](url)\n[link]\\(url)\n[link](url\\)\n```",
+      "expected_output": "<div class=\"codehilite\"><pre><span></span><code>\\_italic_\n_italic\\_\n\\__bold__\n\\_\\_bold__\n__bold\\__\n__bold\\_\\_\n__bold_\\_\n</code></pre></div>\n<p>-</p>\n<div class=\"codehilite\"><pre><span></span><code>\\{foo}\n{foo\\}\n</code></pre></div>\n<p>-</p>\n<div class=\"codehilite\"><pre><span></span><code>\\[link](url)\n[link\\](url)\n[link]\\(url)\n[link](url\\)\n</code></pre></div>"
+    },
+    {
+      "name": "fenced_code_no_backslash_3",
+      "input": "```\n\\#**announce>zulip**\n#\\**announce>zulip**\n#*\\*announce>zulip**\n#**announce\\>zulip**\n#**announce>zulip\\**\n#**announce>zulip*\\*\n\\#\\*\\*announce>zulip**\n\\#\\*\\*announce\\>zulip**\n```\n-\n```\n1\\. item1\n1\\. item2\n```\n-\n```\n\\!123\n\\+ item1\n\\- item2\n```",
+      "expected_output": "<div class=\"codehilite\"><pre><span></span><code>\\#**announce&gt;zulip**\n#\\**announce&gt;zulip**\n#*\\*announce&gt;zulip**\n#**announce\\&gt;zulip**\n#**announce&gt;zulip\\**\n#**announce&gt;zulip*\\*\n\\#\\*\\*announce&gt;zulip**\n\\#\\*\\*announce\\&gt;zulip**\n</code></pre></div>\n<p>-</p>\n<div class=\"codehilite\"><pre><span></span><code>1\\. item1\n1\\. item2\n</code></pre></div>\n<p>-</p>\n<div class=\"codehilite\"><pre><span></span><code>\\!123\n\\+ item1\n\\- item2\n</code></pre></div>"
+    },
+    {
+      "name": "code_span_no_backslash",
+      "input": "`\\foo` `\\\\bar` `\\\\\\baz` `\\\\\\\\zar`\n`\\*Italic*`\n`\\**Bold**`\n`\\_Italic_`\n`\\__Bold__`\n`\\{foo}`\n`{foo\\}`\n`\\[link](url)`\n`[link\\](url)`\n`[link]\\(url)`\n`[link](url\\)`",
+      "expected_output": "<p><code>\\foo</code> <code>\\\\bar</code> <code>\\\\\\baz</code> <code>\\\\\\\\zar</code><br>\n<code>\\*Italic*</code><br>\n<code>\\**Bold**</code><br>\n<code>\\_Italic_</code><br>\n<code>\\__Bold__</code><br>\n<code>\\{foo}</code><br>\n<code>{foo\\}</code><br>\n<code>\\[link](url)</code><br>\n<code>[link\\](url)</code><br>\n<code>[link]\\(url)</code><br>\n<code>[link](url\\)</code></p>"
+    },
+    {
+      "name": "code_span_no_backslash_2",
+      "input": "`\\#**announce>zulip**`\n`#\\**announce>zulip**`\n`#*\\*announce>zulip**`\n`#**announce\\>zulip**`\n`\\#\\*\\*announce>zulip**`\n`\\#\\*\\*announce\\>zulip**`\n`1\\. item1`\n`1\\. item2`\n`\\!123`\n`\\+ item1`\n`\\- item2`",
+      "expected_output": "<p><code>\\#**announce&gt;zulip**</code><br>\n<code>#\\**announce&gt;zulip**</code><br>\n<code>#*\\*announce&gt;zulip**</code><br>\n<code>#**announce\\&gt;zulip**</code><br>\n<code>\\#\\*\\*announce&gt;zulip**</code><br>\n<code>\\#\\*\\*announce\\&gt;zulip**</code><br>\n<code>1\\. item1</code><br>\n<code>1\\. item2</code><br>\n<code>\\!123</code><br>\n<code>\\+ item1</code><br>\n<code>\\- item2</code></p>"
+    },
+    {
+      "name": "backslash_punctuation",
+      "input": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\]\\^\\_\\`\\{\\|\\}\\~",
+      "expected_output": "<p>!\"#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>"
+    },
+    {
+      "name": "code_span_no_backslash_punctuation",
+      "input": "`\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\]\\^\\_\\{\\|\\}\\~`",
+      "expected_output": "<p><code>\\!\\\"\\#\\$\\%\\&amp;\\'\\(\\)\\*\\+\\,\\-\\.\/\\:\\;\\&lt;\\=\\&gt;\\?\\@\\[\\\\]\\^\\_\\{\\|\\}\\~</code></p>"
+    },
+    {
+      "name": "fenced_code_no_backslash_punctuation",
+      "input": "```\n\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\]\\^\\_\\`\\{\\|\\}\\~\n```",
+      "expected_output": "<div class=\"codehilite\"><pre><span></span><code>\\!\\&quot;\\#\\$\\%\\&amp;\\&#39;\\(\\)\\*\\+\\,\\-\\.\/\\:\\;\\&lt;\\=\\&gt;\\?\\@\\[\\\\]\\^\\_\\`\\{\\|\\}\\~\n</code></pre></div>"
+    },
+    {
+      "name": "no_backslash_non_punctuation",
+      "input": "\\→\\A\\a\\ \\3\\φ\\«",
+      "expected_output": "<p>\\→\\A\\a\\ \\3\\φ\\«</p>"
+    },
+    {
+      "name": "code_block_no_backslash",
+      "input": "    \\[\\]",
+      "expected_output": "<div class=\"codehilite\"><pre><span></span><code>\\[\\]\n</code></pre></div>"
+    },
+    {
+      "name": "backslash_safe_html",
+      "input": "\\<h1\\>stay normal\\<\/h1\\> thanks",
+      "expected_output": "<p>&lt;h1&gt;stay normal&lt;/h1&gt; thanks</p>",
+      "text_content": "<h1>stay normal<\/h1> thanks"
+    },
+    {
+      "name": "backslash_safe_html_script",
+      "input": "\\<script\\>alert(1)\\<\\/script\\>",
+      "expected_output": "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>",
+      "text_content": "<script>alert(1)<\/script>"
+    },
+    {
+      "name": "safe_html_in_code_with_no_backslash_escaping",
+      "input": "~~~\n\\<h1\\>stay normal\\<\/h1\\>",
+      "expected_output": "<div class=\"codehilite\"><pre><span></span><code>\\&lt;h1\\&gt;stay normal\\&lt;/h1\\&gt;\n</code></pre></div>",
+      "text_content": "\\<h1\\>stay normal\\</h1\\>\n"
+    },
+    {
+      "name": "timestamp_invalid_input_and_valid_input_with_backslash_escaping",
+      "input": "\\<time\\:\\<alert\\(1\\)\\>\\>\n\n\\<time:May 28 2020, 1:30 PM IST>",
+      "expected_output": "<p>&lt;time:&lt;alert(1)&gt;&gt;</p>\n<p>&lt;time:May 28 2020, 1:30 PM IST&gt;</p>"
+    },
+    {
+      "name": "spoilers_script_tags_with_backslash_escaping",
+      "input": "```spoiler \\<script\\>alert(1)\\<\/script\\>\n\\<script\\>alert(1)\\<\/script\\>\n```",
+      "expected_output": "<div class=\"spoiler-block\"><div class=\"spoiler-header\">\n<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>\n</div><div class=\"spoiler-content\" aria-hidden=\"true\">\n<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>\n</div></div>",
+      "text_content": "<script>alert(1)</script> (…)\n"
+    },
+    {
+      "name": "backslash_emoticons",
+      "input":  "\\:) :\\) foo \\:( bar \\<3 with real emoji \\:smile: with white space :smile\\:",
+      "expected_output": "<p>:) :) foo :( bar &lt;3 with real emoji :smile: with white space :smile:</p>",
+      "translate_emoticons": true
+    },
+    {
+      "name": "backslash_heading",
+      "input": "\\# Hello World\n\\#### New World\n\\####### Old World",
+      "expected_output": "<p># Hello World<br>\n#### New World<br>\n####### Old World</p>"
+    },
+    {
+      "name": "tex_inline_no_backslash",
+      "input": "$$\\{1, 2, 3\\}$$\n\n$$\\int_a^b f(t), dt = F(b) - F(a)$$",
+      "expected_output": "<p><span class=\"katex\"><span class=\"katex-mathml\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\"><semantics><mrow><mo stretchy=\"false\">{</mo><mn>1</mn><mo separator=\"true\">,</mo><mn>2</mn><mo separator=\"true\">,</mo><mn>3</mn><mo stretchy=\"false\">}</mo></mrow><annotation encoding=\"application/x-tex\">\\{1, 2, 3\\}</annotation></semantics></math></span><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:1em;vertical-align:-0.25em;\"></span><span class=\"mopen\">{</span><span class=\"mord\">1</span><span class=\"mpunct\">,</span><span class=\"mspace\" style=\"margin-right:0.1667em;\"></span><span class=\"mord\">2</span><span class=\"mpunct\">,</span><span class=\"mspace\" style=\"margin-right:0.1667em;\"></span><span class=\"mord\">3</span><span class=\"mclose\">}</span></span></span></span></p>\n<p><span class=\"katex\"><span class=\"katex-mathml\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\"><semantics><mrow><msubsup><mo>∫</mo><mi>a</mi><mi>b</mi></msubsup><mi>f</mi><mo stretchy=\"false\">(</mo><mi>t</mi><mo stretchy=\"false\">)</mo><mo separator=\"true\">,</mo><mi>d</mi><mi>t</mi><mo>=</mo><mi>F</mi><mo stretchy=\"false\">(</mo><mi>b</mi><mo stretchy=\"false\">)</mo><mo>−</mo><mi>F</mi><mo stretchy=\"false\">(</mo><mi>a</mi><mo stretchy=\"false\">)</mo></mrow><annotation encoding=\"application/x-tex\">\\int_a^b f(t), dt = F(b) - F(a)</annotation></semantics></math></span><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:1.3998em;vertical-align:-0.3558em;\"></span><span class=\"mop\"><span class=\"mop op-symbol small-op\" style=\"margin-right:0.19445em;position:relative;top:-0.0006em;\">∫</span><span class=\"msupsub\"><span class=\"vlist-t vlist-t2\"><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:1.044em;\"><span style=\"top:-2.3442em;margin-left:-0.1945em;margin-right:0.05em;\"><span class=\"pstrut\" style=\"height:2.7em;\"></span><span class=\"sizing reset-size6 size3 mtight\"><span class=\"mord mathnormal mtight\">a</span></span></span><span style=\"top:-3.2579em;margin-right:0.05em;\"><span class=\"pstrut\" style=\"height:2.7em;\"></span><span class=\"sizing reset-size6 size3 mtight\"><span class=\"mord mathnormal mtight\">b</span></span></span></span><span class=\"vlist-s\">\u200b</span></span><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:0.3558em;\"><span></span></span></span></span></span></span><span class=\"mspace\" style=\"margin-right:0.1667em;\"></span><span class=\"mord mathnormal\" style=\"margin-right:0.10764em;\">f</span><span class=\"mopen\">(</span><span class=\"mord mathnormal\">t</span><span class=\"mclose\">)</span><span class=\"mpunct\">,</span><span class=\"mspace\" style=\"margin-right:0.1667em;\"></span><span class=\"mord mathnormal\">d</span><span class=\"mord mathnormal\">t</span><span class=\"mspace\" style=\"margin-right:0.2778em;\"></span><span class=\"mrel\">=</span><span class=\"mspace\" style=\"margin-right:0.2778em;\"></span></span><span class=\"base\"><span class=\"strut\" style=\"height:1em;vertical-align:-0.25em;\"></span><span class=\"mord mathnormal\" style=\"margin-right:0.13889em;\">F</span><span class=\"mopen\">(</span><span class=\"mord mathnormal\">b</span><span class=\"mclose\">)</span><span class=\"mspace\" style=\"margin-right:0.2222em;\"></span><span class=\"mbin\">−</span><span class=\"mspace\" style=\"margin-right:0.2222em;\"></span></span><span class=\"base\"><span class=\"strut\" style=\"height:1em;vertical-align:-0.25em;\"></span><span class=\"mord mathnormal\" style=\"margin-right:0.13889em;\">F</span><span class=\"mopen\">(</span><span class=\"mord mathnormal\">a</span><span class=\"mclose\">)</span></span></span></span></p>"
+    },
+    {
+      "name": "backslash_blockquote",
+      "input": "\\> Hello World!\n\n\\> Hello Universe!",
+      "expected_output": "<p>&gt; Hello World!</p>\n<p>&gt; Hello Universe!</p>"
+    },
+    {
+      "name": "backslash_table",
+      "input": "\\|| yes | no | maybe\n\\|---|---|:---:|------:\n\\| A | left-aligned | centered | right-aligned\n\\| B |     extra      spaces      |  are |  ok\n\\| C | **bold** *italic* ~~strikethrough~~  \\:smile:  ||",
+      "expected_output": "<p>|| yes | no | maybe<br>\n|---|---|:---:|------:<br>\n| A | left-aligned | centered | right-aligned<br>\n| B |     extra      spaces      |  are |  ok<br>\n| C | <strong>bold</strong> <em>italic</em> <del>strikethrough</del>  :smile:  ||</p>"
+    },
+    {
+      "name": "backslash_time",
+      "input": "Our next meeting is scheduled for \\<time:2020-05-28T13:30:00+05:30\\>",
+      "expected_output": "<p>Our next meeting is scheduled for &lt;time:2020-05-28T13:30:00+05:30&gt;</p>"
     }
   ],
   "linkify_tests": [


### PR DESCRIPTION
This commit re-enables backslash escape inline pattern.

Fixes #18202.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
New test cases are added.