### PR TITLE
tests: Use do_create_realm where possible.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -55,6 +55,7 @@ from corporate.models import (
 )
 from zerver.lib.actions import (
     do_activate_user,
+    do_create_realm,
     do_create_user,
     do_deactivate_realm,
     do_deactivate_user,
@@ -1543,7 +1544,7 @@ class StripeTest(StripeTestCase):
         )
         self.assertEqual(get_latest_seat_count(realm), initial_count)
         # Test 1 member and 5 guests
-        realm = Realm.objects.create(string_id="second", name="second")
+        realm = do_create_realm(string_id="second", name="second")
         UserProfile.objects.create(
             realm=realm, email="member@second.com", delivery_email="member@second.com"
         )

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -5125,7 +5125,7 @@ class TestLDAP(ZulipLDAPTestCase):
     def test_login_success_with_different_subdomain(self) -> None:
         ldap_user_attr_map = {"full_name": "cn"}
 
-        Realm.objects.create(string_id="acme")
+        do_create_realm(string_id="acme", name="acme")
         with self.settings(
             LDAP_APPEND_DOMAIN="zulip.com", AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map
         ):

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -12,6 +12,7 @@ from markdown import Markdown
 
 from zerver.lib.actions import (
     do_add_alert_words,
+    do_create_realm,
     do_remove_realm_emoji,
     do_set_realm_property,
     do_set_user_display_setting,
@@ -47,7 +48,6 @@ from zerver.lib.user_groups import create_user_group
 from zerver.models import (
     MAX_MESSAGE_LENGTH,
     Message,
-    Realm,
     RealmEmoji,
     RealmFilter,
     Stream,
@@ -472,7 +472,7 @@ class MarkdownTest(ZulipTestCase):
 
         clear_state_for_testing()
         with self.settings(ENABLE_FILE_LINKS=False):
-            realm = Realm.objects.create(string_id="file_links_test")
+            realm = do_create_realm(string_id="file_links_test", name="file_links_test")
             maybe_update_markdown_engines(realm.id, False)
             converted = markdown_convert(msg, message_realm=realm)
             self.assertEqual(
@@ -2377,7 +2377,9 @@ class MarkdownTest(ZulipTestCase):
         )
         self.assertEqual(converted, expected_output)
 
-        realm = Realm.objects.create(string_id="code_block_processor_test")
+        realm = do_create_realm(
+            string_id="code_block_processor_test", name="code_block_processor_test"
+        )
         maybe_update_markdown_engines(realm.id, True)
         converted = markdown_convert(msg, message_realm=realm, email_gateway=True)
         expected_output = (

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -17,6 +17,7 @@ from zerver.lib.actions import (
     check_send_stream_message,
     do_change_can_forge_sender,
     do_change_stream_post_policy,
+    do_create_realm,
     do_create_user,
     do_deactivate_user,
     do_send_messages,
@@ -2091,7 +2092,9 @@ class InternalPrepTest(ZulipTestCase):
 
 class TestCrossRealmPMs(ZulipTestCase):
     def make_realm(self, domain: str) -> Realm:
-        realm = Realm.objects.create(string_id=domain, invite_required=False)
+        realm = do_create_realm(string_id=domain, name=domain)
+        realm.invite_required = False
+        realm.save(update_fields=["invite_required"])
         RealmDomain.objects.create(realm=realm, domain=domain)
         return realm
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1380,7 +1380,7 @@ class StreamAdminTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
 
-        other_realm = Realm.objects.create(string_id="other")
+        other_realm = do_create_realm(string_id="other", name="other")
         stream = self.make_stream("other_realm_stream", realm=other_realm)
 
         result = self.client_delete("/json/streams/" + str(stream.id))

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -21,6 +21,7 @@ from zerver.lib.actions import (
     do_change_icon_source,
     do_change_logo_source,
     do_change_plan_type,
+    do_create_realm,
     do_delete_old_unclaimed_attachments,
     do_set_realm_property,
     internal_send_private_message,
@@ -566,7 +567,9 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         user2_email = "test-og-bot@zulip.com"
         user3_email = "other-user@uploadtest.example.com"
 
-        r1 = Realm.objects.create(string_id=test_subdomain, invite_required=False)
+        r1 = do_create_realm(string_id=test_subdomain, name=test_subdomain)
+        r1.invite_required = False
+        r1.save(update_fields=["invite_required"])
         RealmDomain.objects.create(realm=r1, domain=test_subdomain)
 
         user_1 = create_user(user1_email, test_subdomain)


### PR DESCRIPTION
This is also a prerequisite for the migration of cross realm bots into each realm - it will break things in tests to have isolated `Realm` objects with their bots missing - thus full `do_create_realm` procedure is needed.

Using do_create_realm should be preferred over manual creation where
possible, as it creates more realistic data. We don't change how things
are done in analytics tests, as those are more fiddly, and work fine
with the manually created and adjusted Realms.