### PR TITLE
[WIP] Getting rid of cross-realm bots

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -395,7 +395,7 @@ class StripeTestCase(ZulipTestCase):
         # sure relevant queries restrict on realm).
         self.assertEqual(
             UserProfile.objects.exclude(realm=realm).filter(is_active=True).count(),
-            10,
+            16,
         )
 
         # Our seat count excludes our guest user and bot, and

--- a/frontend_tests/puppeteer_tests/compose.ts
+++ b/frontend_tests/puppeteer_tests/compose.ts
@@ -151,8 +151,8 @@ async function test_send_multirecipient_pm_from_cordelia_pm_narrow(page: Page): 
     }, pm_selector);
     await page.waitForSelector("#compose-textarea", {visible: true});
     const recipient_internal_emails = [
-        await common.get_internal_email_from_name(page, "othello"),
         await common.get_internal_email_from_name(page, "cordelia"),
+        await common.get_internal_email_from_name(page, "othello"),
     ].join(",");
     await common.pm_recipient.expect(page, recipient_internal_emails);
 }

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -254,7 +254,11 @@ python_rules = RuleList(
                     "user_profile.save()  # Can't use update_fields because of how the foreign key works.",
                 ),
             },
-            "exclude": {"zerver/tests", "zerver/lib/create_user.py"},
+            "exclude": {
+                "zerver/tests",
+                "zerver/lib/create_user.py",
+                "zerver/migrations/0341_put_system_bots_in_all_realms.py",
+            },
             "good_lines": ['user_profile.save(update_fields=["pointer"])'],
             "bad_lines": ["user_profile.save()"],
         },

--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -389,7 +389,6 @@ def build_realm(
         zerver_useractivity=[],
         zerver_realm=zerver_realm,
         zerver_huddle=[],
-        zerver_userprofile_crossrealm=[],
         zerver_useractivityinterval=[],
         zerver_reaction=[],
         zerver_realmemoji=[],

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2604,12 +2604,8 @@ def validate_recipient_user_profiles(
 ) -> Sequence[UserProfile]:
     recipient_profiles_map: Dict[int, UserProfile] = {}
 
-    # We exempt cross-realm bots from the check that all the recipients
-    # are in the same realm.
     realms = set()
-    if not is_system_bot_email(sender.email):
-        realms.add(sender.realm_id)
-
+    realms.add(sender.realm_id)
     for user_profile in user_profiles:
         if (
             not user_profile.is_active
@@ -2620,8 +2616,7 @@ def validate_recipient_user_profiles(
                 _("'{email}' is no longer using Zulip.").format(email=user_profile.email)
             )
         recipient_profiles_map[user_profile.id] = user_profile
-        if not is_system_bot_email(user_profile.email):
-            realms.add(user_profile.realm_id)
+        realms.add(user_profile.realm_id)
 
     if len(realms) > 1:
         raise ValidationError(_("You can't send private messages outside of your organization."))

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -249,7 +249,7 @@ from zerver.models import (
     get_user_by_delivery_email,
     get_user_by_id_in_realm_including_cross_realm,
     get_user_profile_by_id,
-    is_cross_realm_bot_email,
+    is_system_bot_email,
     linkifiers_for_realm,
     query_for_ids,
     realm_filters_for_realm,
@@ -2607,7 +2607,7 @@ def validate_recipient_user_profiles(
     # We exempt cross-realm bots from the check that all the recipients
     # are in the same realm.
     realms = set()
-    if not is_cross_realm_bot_email(sender.email):
+    if not is_system_bot_email(sender.email):
         realms.add(sender.realm_id)
 
     for user_profile in user_profiles:
@@ -2620,7 +2620,7 @@ def validate_recipient_user_profiles(
                 _("'{email}' is no longer using Zulip.").format(email=user_profile.email)
             )
         recipient_profiles_map[user_profile.id] = user_profile
-        if not is_cross_realm_bot_email(user_profile.email):
+        if not is_system_bot_email(user_profile.email):
             realms.add(user_profile.realm_id)
 
     if len(realms) > 1:
@@ -6806,7 +6806,7 @@ def do_send_confirmation_email(
 
 
 def email_not_system_bot(email: str) -> None:
-    if is_cross_realm_bot_email(email):
+    if is_system_bot_email(email):
         msg = email_reserved_for_system_bots_error(email)
         code = msg
         raise ValidationError(

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -247,7 +247,7 @@ from zerver.models import (
     get_stream_by_id_in_realm,
     get_system_bot,
     get_user_by_delivery_email,
-    get_user_by_id_in_realm_including_cross_realm,
+    get_user_by_id_in_realm,
     get_user_profile_by_id,
     is_system_bot_email,
     linkifiers_for_realm,
@@ -2506,10 +2506,7 @@ def check_send_typing_notification(sender: UserProfile, user_ids: List[int], ope
     user_profiles = []
     for user_id in user_ids:
         try:
-            # We include cross-bot realms as possible recipients,
-            # so that clients can know which huddle conversation
-            # is relevant here.
-            user_profile = get_user_by_id_in_realm_including_cross_realm(user_id, sender.realm)
+            user_profile = get_user_by_id_in_realm(user_id, sender.realm)
         except UserProfile.DoesNotExist:
             raise JsonableError(_("Invalid user ID {}").format(user_id))
         user_profiles.append(user_profile)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -124,7 +124,11 @@ from zerver.lib.send_email import (
     send_email,
     send_email_to_admins,
 )
-from zerver.lib.server_initialization import create_internal_realm, server_initialized
+from zerver.lib.server_initialization import (
+    create_internal_realm,
+    server_initialized,
+    setup_realm_internal_bots,
+)
 from zerver.lib.sessions import delete_user_sessions
 from zerver.lib.storage import static_path
 from zerver.lib.stream_subscription import (
@@ -4967,6 +4971,8 @@ def do_create_realm(
         RealmAuditLog.objects.create(
             realm=realm, event_type=RealmAuditLog.REALM_CREATED, event_time=realm.date_created
         )
+
+    setup_realm_internal_bots(realm)
 
     # Create stream once Realm object has been saved
     notifications_stream = ensure_stream(

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -7,7 +7,7 @@ from zerver.models import (
     Realm,
     Stream,
     UserProfile,
-    get_user_by_id_in_realm_including_cross_realm,
+    get_user_by_id_in_realm,
     get_user_including_system_bots,
 )
 
@@ -27,7 +27,7 @@ def get_user_profiles_by_ids(user_ids: Iterable[int], realm: Realm) -> List[User
     user_profiles: List[UserProfile] = []
     for user_id in user_ids:
         try:
-            user_profile = get_user_by_id_in_realm_including_cross_realm(user_id, realm)
+            user_profile = get_user_by_id_in_realm(user_id, realm)
         except UserProfile.DoesNotExist:
             raise JsonableError(_("Invalid user ID {}").format(user_id))
         user_profiles.append(user_profile)

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -8,7 +8,7 @@ from zerver.models import (
     Stream,
     UserProfile,
     get_user_by_id_in_realm_including_cross_realm,
-    get_user_including_cross_realm,
+    get_user_including_system_bots,
 )
 
 
@@ -16,7 +16,7 @@ def get_user_profiles(emails: Iterable[str], realm: Realm) -> List[UserProfile]:
     user_profiles: List[UserProfile] = []
     for email in emails:
         try:
-            user_profile = get_user_including_cross_realm(email, realm)
+            user_profile = get_user_including_system_bots(email, realm)
         except UserProfile.DoesNotExist:
             raise JsonableError(_("Invalid email '{}'").format(email))
         user_profiles.append(user_profile)

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -579,7 +579,7 @@ def get_stream_cache_key(stream_name: str, realm_id: int) -> str:
 def delete_user_profile_caches(user_profiles: Iterable["UserProfile"]) -> None:
     # Imported here to avoid cyclic dependency.
     from zerver.lib.users import get_all_api_keys
-    from zerver.models import is_cross_realm_bot_email
+    from zerver.models import is_system_bot_email
 
     keys = []
     for user_profile in user_profiles:
@@ -590,7 +590,7 @@ def delete_user_profile_caches(user_profiles: Iterable["UserProfile"]) -> None:
         keys.append(
             user_profile_delivery_email_cache_key(user_profile.delivery_email, user_profile.realm)
         )
-        if user_profile.is_bot and is_cross_realm_bot_email(user_profile.email):
+        if user_profile.is_bot and is_system_bot_email(user_profile.email):
             # Handle clearing system bots from their special cache.
             keys.append(bot_profile_cache_key(user_profile.email, user_profile.realm_id))
 

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -499,8 +499,8 @@ def user_profile_delivery_email_cache_key(delivery_email: str, realm: "Realm") -
     return f"user_profile_by_delivery_email:{make_safe_digest(delivery_email.strip())}:{realm.id}"
 
 
-def bot_profile_cache_key(email: str, realm_id: Optional[int] = None) -> str:
-    return f"bot_profile:{make_safe_digest(email.strip())}"
+def bot_profile_cache_key(email: str, realm_id: int) -> str:
+    return f"bot_profile:{make_safe_digest(email.strip())}:{realm_id}"
 
 
 def user_profile_by_id_cache_key(user_profile_id: int) -> str:
@@ -592,7 +592,7 @@ def delete_user_profile_caches(user_profiles: Iterable["UserProfile"]) -> None:
         )
         if user_profile.is_bot and is_cross_realm_bot_email(user_profile.email):
             # Handle clearing system bots from their special cache.
-            keys.append(bot_profile_cache_key(user_profile.email))
+            keys.append(bot_profile_cache_key(user_profile.email, user_profile.realm_id))
 
     cache_delete_many(keys)
 

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -345,7 +345,6 @@ def extract_and_upload_attachments(message: EmailMessage, realm: Realm) -> str:
                     content_type,
                     attachment,
                     user_profile,
-                    target_realm=realm,
                 )
                 formatted_link = f"[{filename}]({s3_url})"
                 attachment_links.append(formatted_link)

--- a/zerver/lib/email_validation.py
+++ b/zerver/lib/email_validation.py
@@ -16,7 +16,7 @@ from zerver.models import (
     email_to_domain,
     email_to_username,
     get_users_by_delivery_email,
-    is_cross_realm_bot_email,
+    is_system_bot_email,
 )
 
 
@@ -148,7 +148,7 @@ def get_existing_user_errors(
     user_dict = {user.delivery_email.lower(): user for user in users}
 
     def process_email(email: str) -> None:
-        if is_cross_realm_bot_email(email):
+        if is_system_bot_email(email):
             if verbose:
                 msg = email_reserved_for_system_bots_error(email)
             else:

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -67,8 +67,6 @@ from zerver.models import (
     UserProfile,
     UserTopic,
     get_huddle_hash,
-    get_realm,
-    get_system_bot,
     get_user_profile_by_id,
 )
 
@@ -928,20 +926,6 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
     realm.notifications_stream_id = notifications_stream_id
     realm.signup_notifications_stream_id = signup_notifications_stream_id
     realm.save()
-
-    # Remap the user IDs for notification_bot and friends to their
-    # appropriate IDs on this server
-    internal_realm = get_realm(settings.SYSTEM_BOT_REALM)
-    for item in data["zerver_userprofile_crossrealm"]:
-        logging.info(
-            "Adding to ID map: %s %s",
-            item["id"],
-            get_system_bot(item["email"], internal_realm.id).id,
-        )
-        new_user_id = get_system_bot(item["email"], internal_realm.id).id
-        update_id_map(table="user_profile", old_id=item["id"], new_id=new_user_id)
-        new_recipient_id = Recipient.objects.get(type=Recipient.PERSONAL, type_id=new_user_id).id
-        update_id_map(table="recipient", old_id=item["recipient_id"], new_id=new_recipient_id)
 
     # Merge in zerver_userprofile_mirrordummy
     data["zerver_userprofile"] = data["zerver_userprofile"] + data["zerver_userprofile_mirrordummy"]

--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -53,8 +53,6 @@ from zerver.models import (
     Stream,
     SubMessage,
     UserMessage,
-    get_realm,
-    get_user_including_cross_realm,
 )
 
 logger = logging.getLogger("zulip.retention")
@@ -223,17 +221,9 @@ def move_expired_personal_and_huddle_messages_to_archive(
     assert message_retention_days != -1
     check_date = timezone_now() - timedelta(days=message_retention_days)
 
-    # This function will archive appropriate messages and their related objects.
-    internal_realm = get_realm(settings.SYSTEM_BOT_REALM)
-    cross_realm_bot_ids = [
-        get_user_including_cross_realm(email, internal_realm).id
-        for email in settings.CROSS_REALM_BOT_EMAILS
-    ]
     recipient_types = (Recipient.PERSONAL, Recipient.HUDDLE)
 
-    # Archive expired personal and huddle Messages in the realm, except cross-realm messages.
-    # The condition zerver_userprofile.realm_id = {realm_id} assures the row won't be
-    # a message sent by a cross-realm bot, because cross-realm bots have their own separate realm.
+    # Archive expired personal and huddle Messages in the realm.
     query = SQL(
         """
     INSERT INTO zerver_archivedmessage ({dst_fields}, archive_transaction_id)
@@ -254,38 +244,8 @@ def move_expired_personal_and_huddle_messages_to_archive(
         query,
         type=ArchiveTransaction.RETENTION_POLICY_BASED,
         realm=realm,
-        cross_realm_bot_ids=Literal(tuple(cross_realm_bot_ids)),
         realm_id=Literal(realm.id),
         recipient_types=Literal(recipient_types),
-        check_date=Literal(check_date.isoformat()),
-        chunk_size=chunk_size,
-    )
-
-    # Archive cross-realm personal messages to users in the realm.  We
-    # don't archive cross-realm huddle messages via retention policy,
-    # as we don't support them as a feature in Zulip, and the query to
-    # find and delete them would be a lot of complexity and potential
-    # performance work for a case that doesn't actually happen.
-    query = SQL(
-        """
-    INSERT INTO zerver_archivedmessage ({dst_fields}, archive_transaction_id)
-        SELECT {src_fields}, {archive_transaction_id}
-        FROM zerver_message
-        INNER JOIN zerver_userprofile recipient_profile ON recipient_profile.recipient_id = zerver_message.recipient_id
-        WHERE zerver_message.sender_id IN {cross_realm_bot_ids}
-            AND recipient_profile.realm_id = {realm_id}
-            AND zerver_message.date_sent < {check_date}
-        LIMIT {chunk_size}
-    ON CONFLICT (id) DO UPDATE SET archive_transaction_id = {archive_transaction_id}
-    RETURNING id
-    """
-    )
-    message_count += run_archiving_in_chunks(
-        query,
-        type=ArchiveTransaction.RETENTION_POLICY_BASED,
-        realm=realm,
-        cross_realm_bot_ids=Literal(tuple(cross_realm_bot_ids)),
-        realm_id=Literal(realm.id),
         check_date=Literal(check_date.isoformat()),
         chunk_size=chunk_size,
     )

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -21,7 +21,7 @@ from zerver.models import (
     get_realm_stream,
     get_stream,
     get_stream_by_id_in_realm,
-    is_cross_realm_bot_email,
+    is_system_bot_email,
 )
 from zerver.tornado.django_api import send_event
 
@@ -190,7 +190,7 @@ def subscribed_to_stream(user_profile: UserProfile, stream_id: int) -> bool:
 
 
 def check_stream_access_based_on_stream_post_policy(sender: UserProfile, stream: Stream) -> None:
-    if sender.is_realm_admin or is_cross_realm_bot_email(sender.delivery_email):
+    if sender.is_realm_admin or is_system_bot_email(sender.delivery_email):
         pass
     elif stream.stream_post_policy == Stream.STREAM_POST_POLICY_ADMINS:
         raise JsonableError(_("Only organization administrators can send to this stream."))
@@ -236,7 +236,7 @@ def access_stream_for_send_message(
         else:
             raise JsonableError(_("User not authorized for this query"))
 
-    if is_cross_realm_bot_email(sender.delivery_email):
+    if is_system_bot_email(sender.delivery_email):
         return
 
     if stream.realm_id != sender.realm_id:

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -236,13 +236,12 @@ def access_stream_for_send_message(
         else:
             raise JsonableError(_("User not authorized for this query"))
 
+    if stream.realm_id != sender.realm_id:
+        # Sending to other realm's streams is always disallowed.
+        raise JsonableError(_("User not authorized for this query"))
+
     if is_system_bot_email(sender.delivery_email):
         return
-
-    if stream.realm_id != sender.realm_id:
-        # Sending to other realm's streams is always disallowed,
-        # with the exception of cross-realm bots.
-        raise JsonableError(_("User not authorized for this query"))
 
     if stream.is_web_public:
         # Even guest users can write to web-public streams.

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -227,7 +227,6 @@ class ZulipUploadBackend:
         content_type: Optional[str],
         file_data: bytes,
         user_profile: UserProfile,
-        target_realm: Optional[Realm] = None,
     ) -> str:
         raise NotImplementedError()
 
@@ -468,13 +467,10 @@ class S3UploadBackend(ZulipUploadBackend):
         content_type: Optional[str],
         file_data: bytes,
         user_profile: UserProfile,
-        target_realm: Optional[Realm] = None,
     ) -> str:
-        if target_realm is None:
-            target_realm = user_profile.realm
         s3_file_name = "/".join(
             [
-                str(target_realm.id),
+                str(user_profile.realm_id),
                 secrets.token_urlsafe(18),
                 sanitize_name(uploaded_file_name),
             ]
@@ -795,7 +791,6 @@ class LocalUploadBackend(ZulipUploadBackend):
         content_type: Optional[str],
         file_data: bytes,
         user_profile: UserProfile,
-        target_realm: Optional[Realm] = None,
     ) -> str:
         # Split into 256 subdirectories to prevent directories from getting too big
         path = "/".join(
@@ -1018,7 +1013,6 @@ def upload_message_file(
     content_type: Optional[str],
     file_data: bytes,
     user_profile: UserProfile,
-    target_realm: Optional[Realm] = None,
 ) -> str:
     return upload_backend.upload_message_file(
         uploaded_file_name,
@@ -1026,7 +1020,6 @@ def upload_message_file(
         content_type,
         file_data,
         user_profile,
-        target_realm=target_realm,
     )
 
 

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -428,7 +428,7 @@ def format_user_row(
 
     if is_bot:
         result["bot_type"] = row["bot_type"]
-        if row["email"] in settings.CROSS_REALM_BOT_EMAILS:
+        if row["email"] in settings.SYSTEM_BOTS_EMAILS:
             result["is_system_bot"] = True
 
         # Note that bot_owner_id can be None with legacy data.
@@ -462,7 +462,7 @@ def user_profile_to_user_row(user_profile: UserProfile) -> Dict[str, Any]:
 
 def get_cross_realm_dicts() -> List[Dict[str, Any]]:
     users = bulk_get_users(
-        list(settings.CROSS_REALM_BOT_EMAILS),
+        list(settings.SYSTEM_BOTS_EMAILS),
         None,
         base_query=UserProfile.objects.filter(realm__string_id=settings.SYSTEM_BOT_REALM),
     ).values()

--- a/zerver/migrations/0341_put_system_bots_in_all_realms.py
+++ b/zerver/migrations/0341_put_system_bots_in_all_realms.py
@@ -1,0 +1,122 @@
+import secrets
+from typing import Any, Optional
+
+import orjson
+from django.conf import settings
+from django.contrib.auth.hashers import make_password
+from django.db import migrations
+from django.db.backends.postgresql.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from django.utils.timezone import now as timezone_now
+
+USERPROFILE_DEFAULT_BOT = 1
+USERPROFILE_AVATAR_FROM_GRAVATAR = "G"
+USERPROFILE_TUTORIAL_WAITING = "W"
+RECIPIENT_PERSONAL = 1
+
+
+def generate_api_key() -> str:
+    api_key = ""
+    while len(api_key) < 32:
+        # One iteration suffices 99.4992% of the time.
+        api_key += secrets.token_urlsafe(3 * 9).replace("_", "").replace("-", "")
+    return api_key[:32]
+
+
+def create_bots(apps: StateApps, schema_editor: DatabaseSchemaEditor) -> None:
+    UserProfile = apps.get_model("zerver", "UserProfile")
+    Realm = apps.get_model("zerver", "Realm")
+    Recipient = apps.get_model("zerver", "Recipient")
+    Subscription = apps.get_model("zerver", "Subscription")
+
+    """
+    Helper functions, copy-pasted from production code and adjusted
+    to work in a migration, for system bot-creating purposes.
+    """
+
+    def create_user(
+        realm: Any,
+        email: str,
+        full_name: str,
+        bot_type: Optional[int] = None,
+    ) -> Any:
+        active = True
+        bot_owner = None
+        tos_version = None
+        timezone = ""
+        avatar_source = USERPROFILE_AVATAR_FROM_GRAVATAR
+        is_mirror_dummy = False
+        default_sending_stream = None
+        default_events_register_stream = None
+
+        now = timezone_now()
+
+        user_profile = UserProfile(
+            password=make_password(None),  # This sets an unusable password.
+            is_staff=False,
+            is_active=active,
+            full_name=full_name,
+            last_login=now,
+            date_joined=now,
+            realm=realm,
+            is_bot=bool(bot_type),
+            bot_type=bot_type,
+            bot_owner=bot_owner,
+            is_mirror_dummy=is_mirror_dummy,
+            tos_version=tos_version,
+            timezone=timezone,
+            tutorial_status=USERPROFILE_TUTORIAL_WAITING,
+            enter_sends=False,
+            onboarding_steps=orjson.dumps([]).decode(),
+            default_language=realm.default_language,
+            twenty_four_hour_time=realm.default_twenty_four_hour_time,
+            delivery_email=email,
+        )
+
+        user_profile.email = email
+        user_profile.api_key = generate_api_key()
+        user_profile.avatar_source = avatar_source
+        user_profile.timezone = timezone
+        user_profile.default_sending_stream = default_sending_stream
+        user_profile.default_events_register_stream = default_events_register_stream
+
+        user_profile.save()
+
+        recipient = Recipient.objects.create(type_id=user_profile.id, type=RECIPIENT_PERSONAL)
+        user_profile.recipient = recipient
+        user_profile.save(update_fields=["recipient"])
+
+        Subscription.objects.create(user_profile=user_profile, recipient=recipient)
+        return user_profile
+
+    def create_system_bots_in_realm(realm: Any) -> None:
+        internal_bots = [
+            (bot["name"], bot["email_template"] % (settings.INTERNAL_BOT_DOMAIN,))
+            for bot in settings.REALM_INTERNAL_BOTS
+        ]
+        for full_name, email in internal_bots:
+            create_user(realm, email, full_name, bot_type=USERPROFILE_DEFAULT_BOT)
+        # Set the owners for these bots to the bots themselves
+        bots = UserProfile.objects.filter(email__in=[bot_info[1] for bot_info in internal_bots])
+        for bot in bots:
+            bot.bot_owner = bot
+            bot.save()
+
+        # Initialize the email gateway bot as able to forge senders.
+        email_gateway_bot = UserProfile.objects.get(email=settings.EMAIL_GATEWAY_BOT, realm=realm)
+        email_gateway_bot.can_forge_sender = True
+        email_gateway_bot.save(update_fields=["can_forge_sender"])
+
+    for realm in Realm.objects.exclude(string_id=settings.SYSTEM_BOT_REALM):
+        create_system_bots_in_realm(realm)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("zerver", "0340_rename_mutedtopic_to_usertopic"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_bots),
+    ]

--- a/zerver/migrations/0342_migrate_old_crossrealm_messages.py
+++ b/zerver/migrations/0342_migrate_old_crossrealm_messages.py
@@ -1,0 +1,219 @@
+import hashlib
+from typing import Any, List
+
+from django.conf import settings
+from django.db import migrations, transaction
+from django.db.backends.postgresql.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+CROSS_REALM_BOT_EMAILS = {
+    "notification-bot@zulip.com",
+    "welcome-bot@zulip.com",
+    "emailgateway@zulip.com",
+}
+
+
+def get_huddle_hash(id_list: List[int]) -> str:
+    id_list = sorted(set(id_list))
+    hash_key = ",".join(str(x) for x in id_list)
+    return hashlib.sha1(hash_key.encode("utf-8")).hexdigest()
+
+
+def migrate_cross_realm_messages(apps: StateApps, schema_editor: DatabaseSchemaEditor) -> None:
+    Message = apps.get_model("zerver", "Message")
+    UserProfile = apps.get_model("zerver", "UserProfile")
+    UserMessage = apps.get_model("zerver", "UserMessage")
+    Huddle = apps.get_model("zerver", "Huddle")
+    Realm = apps.get_model("zerver", "Realm")
+    Subscription = apps.get_model("zerver", "Subscription")
+    Stream = apps.get_model("zerver", "Stream")
+    RECIPIENT_HUDDLE = 3
+
+    cross_realm_bots = list(
+        UserProfile.objects.filter(
+            email__in=settings.CROSS_REALM_BOT_EMAILS, realm__string_id=settings.SYSTEM_BOT_REALM
+        ).select_related("recipient")
+    )
+    cross_realm_bot_ids = [bot.id for bot in cross_realm_bots]
+    cross_realm_bot_recipients = [bot.recipient for bot in cross_realm_bots]
+
+    all_cross_realm_huddle_ids = set(
+        Subscription.objects.filter(
+            user_profile__in=cross_realm_bots,
+            recipient__type=RECIPIENT_HUDDLE,
+        ).values_list("recipient__type_id", flat=True)
+    )
+
+    def migrate_cross_realm_messages_for_realm(realm: Any) -> None:
+        realm_bots_dict = {
+            bot.id: UserProfile.objects.get(email__iexact=bot.email, realm=realm)
+            for bot in cross_realm_bots
+        }
+        cross_realm_bot_recipient_id_to_realm_bot_recipient = {
+            bot.recipient_id: realm_bots_dict[bot.id].recipient for bot in cross_realm_bots
+        }
+
+        """
+        Personal messages block
+        """
+
+        realm_users_query = UserProfile.objects.filter(realm=realm)
+        personal_recipient_ids = realm_users_query.values_list("recipient_id", flat=True)
+
+        personal_messages_from_cross_realm_bots = Message.objects.filter(
+            sender__in=cross_realm_bots, recipient_id__in=personal_recipient_ids
+        )
+        usermessages = UserMessage.objects.filter(
+            message__in=personal_messages_from_cross_realm_bots, user_profile__in=cross_realm_bots
+        )
+        message_id_to_usermessage = {
+            usermessage.message_id: usermessage for usermessage in usermessages
+        }
+        usermessages_to_add = []
+        for message in personal_messages_from_cross_realm_bots:
+            new_sender = realm_bots_dict[message.sender_id]
+            message.sender = new_sender
+            try:
+                message_id_to_usermessage[message.id].user_profile = new_sender
+            except KeyError:
+                # flags = 2048 means setting the is_private flag.
+                usermessages_to_add.append(
+                    UserMessage(user_profile=new_sender, message=message, flags=2048)
+                )
+
+        with transaction.atomic():
+            Message.objects.bulk_update(personal_messages_from_cross_realm_bots, fields=["sender"])
+            UserMessage.objects.bulk_update(
+                message_id_to_usermessage.values(), fields=["user_profile"]
+            )
+            UserMessage.objects.bulk_create(usermessages_to_add)
+        # Message lists can be relatively large, so we don't want to keep them in memory longer than needed.
+        del personal_messages_from_cross_realm_bots
+
+        personal_messages_to_cross_realm_bots = Message.objects.filter(
+            sender__realm=realm, recipient__in=cross_realm_bot_recipients
+        )
+        usermessages = UserMessage.objects.filter(
+            message__in=personal_messages_to_cross_realm_bots, user_profile__in=cross_realm_bots
+        )
+        message_id_to_usermessage = {
+            usermessage.message_id: usermessage for usermessage in usermessages
+        }
+        usermessages_to_add = []
+        for message in personal_messages_to_cross_realm_bots:
+            new_recipient = cross_realm_bot_recipient_id_to_realm_bot_recipient[
+                message.recipient_id
+            ]
+            message.recipient = new_recipient
+            try:
+                message_id_to_usermessage[message.id].user_profile_id = new_recipient.type_id
+            except KeyError:
+                usermessages_to_add.append(
+                    UserMessage(user_profile_id=new_recipient.type_id, message=message, flags=2048)
+                )
+
+        with transaction.atomic():
+            Message.objects.bulk_update(personal_messages_to_cross_realm_bots, fields=["recipient"])
+            UserMessage.objects.bulk_update(
+                message_id_to_usermessage.values(), fields=["user_profile_id"]
+            )
+            UserMessage.objects.bulk_create(usermessages_to_add)
+        del personal_messages_to_cross_realm_bots
+
+        """
+        Stream messages block.
+        This block doesn't involve UserMessages, as cross-realm bots
+        don't get UserMessages for the cross-realm messages they send.
+        """
+        stream_recipient_ids = Stream.objects.filter(realm=realm).values_list(
+            "recipient_id", flat=True
+        )
+        stream_messages_from_cross_realm_bots = Message.objects.filter(
+            sender__in=cross_realm_bots, recipient_id__in=stream_recipient_ids
+        )
+        for message in stream_messages_from_cross_realm_bots:
+            new_sender = realm_bots_dict[message.sender_id]
+            message.sender = new_sender
+
+        with transaction.atomic():
+            Message.objects.bulk_update(stream_messages_from_cross_realm_bots, fields=["sender"])
+        del stream_messages_from_cross_realm_bots
+
+        """
+        Huddle messages block
+        The queries and loops are not well-optimized but cross-realm huddles
+        should be extremely rare (if they exist at all), so it shouldn't pose a problem.
+        """
+        recipient_ids_of_huddles_with_cross_realm_bots = set(
+            Subscription.objects.filter(
+                user_profile__realm=realm,
+                recipient__type=RECIPIENT_HUDDLE,
+                recipient__type_id__in=all_cross_realm_huddle_ids,
+            ).values_list("recipient_id", flat=True)
+        )
+        subscriptions_to_huddles_with_cross_realm_bots = Subscription.objects.filter(
+            recipient_id__in=recipient_ids_of_huddles_with_cross_realm_bots,
+        ).select_related("recipient")
+
+        huddles_with_cross_realm_bots = Huddle.objects.filter(
+            id__in=set(
+                sub.recipient.type_id for sub in subscriptions_to_huddles_with_cross_realm_bots
+            )
+        )
+
+        if Message.objects.filter(
+            recipient_id__in=recipient_ids_of_huddles_with_cross_realm_bots,
+            sender__in=cross_realm_bots,
+        ).exists():
+            raise AssertionError(
+                "Cross-realm huddle messages where the sender is a cross-realm bot should't exist"
+            )
+
+        # Now we need to fix Huddle objects and their Subscriptions so that they stop being cross-realm.
+        # That's done by swapping the bots' Subscriptions to belong to the corresponding in-realm bots,
+        # and adjusting the huddle_hash of the Huddle.
+        subs_to_update = []
+        for huddle in huddles_with_cross_realm_bots:
+            subs = [
+                sub
+                for sub in subscriptions_to_huddles_with_cross_realm_bots
+                if sub.recipient.type_id == huddle.id
+            ]
+            if huddle.huddle_hash != get_huddle_hash([sub.user_profile_id for sub in subs]):
+                raise AssertionError(
+                    f"Cross-realm huddle {huddle.id} hash mismatching its subscribers"
+                )
+
+            bots_subs = [sub for sub in subs if sub.user_profile_id in cross_realm_bot_ids]
+            for sub in bots_subs:
+                corresponding_realm_bot = realm_bots_dict[sub.user_profile_id]
+                sub.user_profile_id = corresponding_realm_bot.id
+                subs_to_update.append(sub)
+            huddle.huddle_hash = get_huddle_hash([sub.user_profile_id for sub in subs])
+
+        with transaction.atomic():
+            Subscription.objects.bulk_update(subs_to_update, fields=["user_profile_id"])
+            Huddle.objects.bulk_update(huddles_with_cross_realm_bots, fields=["huddle_hash"])
+            for cross_realm_bot_id in cross_realm_bot_ids:
+                UserMessage.objects.filter(
+                    user_profile_id=cross_realm_bot_id,
+                    message__recipient_id__in=recipient_ids_of_huddles_with_cross_realm_bots,
+                ).update(user_profile_id=realm_bots_dict[cross_realm_bot_id].id)
+
+    for realm in Realm.objects.exclude(string_id=settings.SYSTEM_BOT_REALM):
+        migrate_cross_realm_messages_for_realm(realm)
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("zerver", "0341_put_system_bots_in_all_realms"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_cross_realm_messages,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/zerver/migrations/0342_migrate_old_crossrealm_messages.py
+++ b/zerver/migrations/0342_migrate_old_crossrealm_messages.py
@@ -6,7 +6,7 @@ from django.db import migrations, transaction
 from django.db.backends.postgresql.schema import DatabaseSchemaEditor
 from django.db.migrations.state import StateApps
 
-CROSS_REALM_BOT_EMAILS = {
+SYSTEM_BOTS_EMAILS = {
     "notification-bot@zulip.com",
     "welcome-bot@zulip.com",
     "emailgateway@zulip.com",
@@ -31,7 +31,7 @@ def migrate_cross_realm_messages(apps: StateApps, schema_editor: DatabaseSchemaE
 
     cross_realm_bots = list(
         UserProfile.objects.filter(
-            email__in=settings.CROSS_REALM_BOT_EMAILS, realm__string_id=settings.SYSTEM_BOT_REALM
+            email__in=settings.SYSTEM_BOTS_EMAILS, realm__string_id=settings.SYSTEM_BOT_REALM
         ).select_related("recipient")
     )
     cross_realm_bot_ids = [bot.id for bot in cross_realm_bots]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3089,7 +3089,7 @@ def get_active_user_profile_by_id_in_realm(uid: int, realm: Realm) -> UserProfil
     return user_profile
 
 
-def get_user_including_cross_realm(email: str, realm: Realm) -> UserProfile:
+def get_user_including_system_bots(email: str, realm: Realm) -> UserProfile:
     if is_system_bot_email(email):
         return get_system_bot(email, realm.id)
     return get_user(email, realm)

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1647,6 +1647,11 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
 
     def can_admin_user(self, target_user: "UserProfile") -> bool:
         """Returns whether this user has permission to modify target_user"""
+
+        if is_system_bot_email(target_user.delivery_email):
+            # We don't support modifying system bots.
+            return False
+
         if target_user.bot_owner == self:
             return True
         elif self.is_realm_admin and self.realm == target_user.realm:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3090,7 +3090,7 @@ def get_active_user_profile_by_id_in_realm(uid: int, realm: Realm) -> UserProfil
 
 
 def get_user_including_cross_realm(email: str, realm: Realm) -> UserProfile:
-    if is_cross_realm_bot_email(email):
+    if is_system_bot_email(email):
         return get_system_bot(email, realm.id)
     return get_user(email, realm)
 
@@ -3154,7 +3154,7 @@ def get_bot_dicts_in_realm(realm: Realm) -> List[Dict[str, Any]]:
     return UserProfile.objects.filter(realm=realm, is_bot=True).values(*bot_dict_fields)
 
 
-def is_cross_realm_bot_email(email: str) -> bool:
+def is_system_bot_email(email: str) -> bool:
     return email.lower() in settings.SYSTEM_BOTS_EMAILS
 
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3155,7 +3155,7 @@ def get_bot_dicts_in_realm(realm: Realm) -> List[Dict[str, Any]]:
 
 
 def is_cross_realm_bot_email(email: str) -> bool:
-    return email.lower() in settings.CROSS_REALM_BOT_EMAILS
+    return email.lower() in settings.SYSTEM_BOTS_EMAILS
 
 
 # The Huddle class represents a group of individuals who have had a

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3102,11 +3102,13 @@ def get_system_bot(email: str, realm_id: int) -> UserProfile:
     )
 
 
-def get_user_by_id_in_realm_including_cross_realm(
+def get_user_by_id_in_realm(
     uid: int,
     realm: Realm,
 ) -> UserProfile:
     user_profile = get_user_profile_by_id(uid)
+    if user_profile.realm_id != realm.id:
+        raise UserProfile.DoesNotExist()
 
     return user_profile
 

--- a/zerver/openapi/javascript_examples.js
+++ b/zerver/openapi/javascript_examples.js
@@ -114,7 +114,7 @@ add_example("send_message", "/messages:post", 200, async (client, console) => {
     console.log(await client.messages.send(params));
 
     // Send a private message
-    const user_id = 9;
+    const user_id = 18;
     params = {
         to: [user_id],
         type: "private",
@@ -244,8 +244,8 @@ add_example("render_message", "/messages/render:post", 200, async (client, conso
 
 add_example("set_typing_status", "/typing:post", 200, async (client, console) => {
     // {code_example|start}
-    const user_id1 = 9;
-    const user_id2 = 10;
+    const user_id1 = 18;
+    const user_id2 = 19;
 
     const typingParams = {
         op: "start",
@@ -267,7 +267,7 @@ add_example("add_subscriptions", "/users/me/subscriptions:post", 200, async (cli
 
     // To subscribe another user to a stream, you may pass in
     // the `principals` parameter, like so:
-    const user_id = 7;
+    const user_id = 16;
     const anotherUserParams = {
         subscriptions: JSON.stringify([{name: "Verona"}, {name: "Denmark"}]),
         principals: JSON.stringify([user_id]),
@@ -288,7 +288,7 @@ add_example(
         };
         console.log(await client.users.me.subscriptions.remove(meParams));
 
-        const user_id = 7;
+        const user_id = 16;
         // Unsubscribe Zoe from the stream "Denmark"
         const zoeParams = {
             subscriptions: JSON.stringify(["Denmark"]),

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -81,11 +81,11 @@ def add_subscriptions(client: Client) -> None:
 
     validate_against_openapi_schema(result, "/users/me/subscriptions", "post", "200_0")
 
-    ensure_users([26], ["newbie"])
+    ensure_users([35], ["newbie"])
     # {code_example|start}
     # To subscribe other users to a stream, you may pass
     # the `principals` argument, like so:
-    user_id = 26
+    user_id = 35
     result = client.add_subscriptions(
         streams=[
             {"name": "new stream", "description": "New stream for testing"},
@@ -239,11 +239,11 @@ def get_user_by_email(client: Client) -> None:
 
 @openapi_test_function("/users/{user_id}:get")
 def get_single_user(client: Client) -> None:
-    ensure_users([8], ["cordelia"])
+    ensure_users([17], ["cordelia"])
 
     # {code_example|start}
     # Fetch details on a user given a user ID
-    user_id = 8
+    user_id = 17
     result = client.get_user_by_id(user_id)
     # {code_example|end}
     validate_against_openapi_schema(result, "/users/{user_id}", "get", "200")
@@ -257,11 +257,11 @@ def get_single_user(client: Client) -> None:
 
 @openapi_test_function("/users/{user_id}:delete")
 def deactivate_user(client: Client) -> None:
-    ensure_users([8], ["cordelia"])
+    ensure_users([17], ["cordelia"])
 
     # {code_example|start}
     # Deactivate a user
-    user_id = 8
+    user_id = 17
     result = client.deactivate_user_by_id(user_id)
     # {code_example|end}
     validate_against_openapi_schema(result, "/users/{user_id}", "delete", "200")
@@ -269,9 +269,11 @@ def deactivate_user(client: Client) -> None:
 
 @openapi_test_function("/users/{user_id}/reactivate:post")
 def reactivate_user(client: Client) -> None:
+    ensure_users([17], ["cordelia"])
+
     # {code_example|start}
     # Reactivate a user
-    user_id = 8
+    user_id = 17
     result = client.reactivate_user_by_id(user_id)
     # {code_example|end}
     validate_against_openapi_schema(result, "/users/{user_id}/reactivate", "post", "200")
@@ -279,18 +281,18 @@ def reactivate_user(client: Client) -> None:
 
 @openapi_test_function("/users/{user_id}:patch")
 def update_user(client: Client) -> None:
-    ensure_users([8, 10], ["cordelia", "hamlet"])
+    ensure_users([17, 19], ["cordelia", "hamlet"])
 
     # {code_example|start}
     # Change a user's full name.
-    user_id = 10
+    user_id = 19
     result = client.update_user_by_id(user_id, full_name="New Name")
     # {code_example|end}
     validate_against_openapi_schema(result, "/users/{user_id}", "patch", "200")
 
     # {code_example|start}
     # Change value of the custom profile field with ID 9.
-    user_id = 8
+    user_id = 17
     result = client.update_user_by_id(user_id, profile_data=[{"id": 9, "value": "some data"}])
     # {code_example|end}
     validate_against_openapi_schema(result, "/users/{user_id}", "patch", "400")
@@ -298,11 +300,11 @@ def update_user(client: Client) -> None:
 
 @openapi_test_function("/users/{user_id}/subscriptions/{stream_id}:get")
 def get_subscription_status(client: Client) -> None:
-    ensure_users([7], ["zoe"])
+    ensure_users([16], ["zoe"])
 
     # {code_example|start}
     # Check whether a user is a subscriber to a given stream.
-    user_id = 7
+    user_id = 16
     stream_id = 1
     result = client.call_endpoint(
         url=f"/users/{user_id}/subscriptions/{stream_id}",
@@ -580,14 +582,14 @@ def test_user_not_authorized_error(nonadmin_client: Client) -> None:
 
 @openapi_test_function("/streams/{stream_id}/members:get")
 def get_subscribers(client: Client) -> None:
-    ensure_users([11, 26], ["iago", "newbie"])
+    ensure_users([20, 35], ["iago", "newbie"])
 
     # {code_example|start}
     # Get the subscribers to a stream
     result = client.get_subscribers(stream="new stream")
     print(result)
     # {code_example|end}
-    assert result["subscribers"] == [11, 26]
+    assert result["subscribers"] == [20, 35]
 
 
 def get_user_agent(client: Client) -> None:
@@ -681,10 +683,10 @@ def toggle_mute_topic(client: Client) -> None:
 
 @openapi_test_function("/users/me/muted_users/{muted_user_id}:post")
 def add_user_mute(client: Client) -> None:
-    ensure_users([10], ["hamlet"])
+    ensure_users([19], ["hamlet"])
     # {code_example|start}
-    # Mute user with ID 10
-    muted_user_id = 10
+    # Mute user with ID 13
+    muted_user_id = 19
     result = client.call_endpoint(url=f"/users/me/muted_users/{muted_user_id}", method="POST")
     # {code_example|end}
 
@@ -693,10 +695,10 @@ def add_user_mute(client: Client) -> None:
 
 @openapi_test_function("/users/me/muted_users/{muted_user_id}:delete")
 def remove_user_mute(client: Client) -> None:
-    ensure_users([10], ["hamlet"])
+    ensure_users([19], ["hamlet"])
     # {code_example|start}
-    # Unmute user with ID 10
-    muted_user_id = 10
+    # Unmute user with ID 13
+    muted_user_id = 19
     result = client.call_endpoint(url=f"/users/me/muted_users/{muted_user_id}", method="DELETE")
     # {code_example|end}
 
@@ -874,11 +876,11 @@ def send_message(client: Client) -> int:
     assert result["result"] == "success"
     assert result["raw_content"] == request["content"]
 
-    ensure_users([10], ["hamlet"])
+    ensure_users([19], ["hamlet"])
 
     # {code_example|start}
     # Send a private message
-    user_id = 10
+    user_id = 19
     request = {
         "type": "private",
         "to": [user_id],
@@ -1200,12 +1202,12 @@ def get_stream_topics(client: Client, stream_id: int) -> None:
 
 @openapi_test_function("/typing:post")
 def set_typing_status(client: Client) -> None:
-    ensure_users([10, 11], ["hamlet", "iago"])
+    ensure_users([19, 20], ["hamlet", "iago"])
 
     # {code_example|start}
     # The user has started to type in the group PM with Iago and Polonius
-    user_id1 = 10
-    user_id2 = 11
+    user_id1 = 19
+    user_id2 = 20
 
     request = {
         "op": "start",
@@ -1219,8 +1221,8 @@ def set_typing_status(client: Client) -> None:
 
     # {code_example|start}
     # The user has finished typing in the group PM with Iago and Polonius
-    user_id1 = 10
-    user_id2 = 11
+    user_id1 = 19
+    user_id2 = 20
 
     request = {
         "op": "stop",
@@ -1312,13 +1314,13 @@ def remove_alert_words(client: Client) -> None:
 
 @openapi_test_function("/user_groups/create:post")
 def create_user_group(client: Client) -> None:
-    ensure_users([6, 7, 8, 10], ["aaron", "zoe", "cordelia", "hamlet"])
+    ensure_users([15, 16, 17, 19], ["aaron", "zoe", "cordelia", "hamlet"])
 
     # {code_example|start}
     request = {
         "name": "marketing",
         "description": "The marketing team.",
-        "members": [6, 7, 8, 10],
+        "members": [15, 16, 17, 19],
     }
 
     result = client.create_user_group(request)
@@ -1354,11 +1356,11 @@ def remove_user_group(client: Client, user_group_id: int) -> None:
 
 @openapi_test_function("/user_groups/{user_group_id}/members:post")
 def update_user_group_members(client: Client, user_group_id: int) -> None:
-    ensure_users([8, 10, 11], ["cordelia", "hamlet", "iago"])
+    ensure_users([17, 19, 20], ["cordelia", "hamlet", "iago"])
     # {code_example|start}
     request = {
-        "delete": [8, 10],
-        "add": [11],
+        "delete": [17, 19],
+        "add": [20],
     }
 
     result = client.update_user_group_members(user_group_id, request)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -497,7 +497,7 @@ paths:
                                       "avatar_url": "https://secure.gravatar.com/avatar/6d8cad0fd00256e7b40691d27ddfd466?d=identicon&version=3",
                                       "avatar_url_medium": "https://secure.gravatar.com/avatar/6d8cad0fd00256e7b40691d27ddfd466?d=identicon&s=500&version=3",
                                       "avatar_version": 3,
-                                      "user_id": 10,
+                                      "user_id": 19,
                                     },
                                   "id": 0,
                                 }
@@ -687,7 +687,7 @@ paths:
                                   "type": "subscription",
                                   "op": "peer_add",
                                   "stream_id": 9,
-                                  "user_id": 12,
+                                  "user_id": 21,
                                   "id": 0,
                                 }
                             - type: object
@@ -726,7 +726,7 @@ paths:
                                   "type": "subscription",
                                   "op": "peer_remove",
                                   "stream_id": 9,
-                                  "user_id": 12,
+                                  "user_id": 21,
                                   "id": 0,
                                 }
                             - type: object
@@ -854,7 +854,7 @@ paths:
                                   "person":
                                     {
                                       "email": "foo@zulip.com",
-                                      "user_id": 38,
+                                      "user_id": 47,
                                       "avatar_version": 1,
                                       "is_admin": false,
                                       "is_owner": false,
@@ -910,7 +910,7 @@ paths:
                                   "type": "realm_user",
                                   "op": "remove",
                                   "person":
-                                    {"user_id": 35, "full_name": "Foo Bot"},
+                                    {"user_id": 44, "full_name": "Foo Bot"},
                                   "id": 0,
                                 }
                             - type: object
@@ -956,7 +956,7 @@ paths:
                               example:
                                 {
                                   "type": "presence",
-                                  "user_id": 10,
+                                  "user_id": 19,
                                   "email": "user10@zulip.testserver",
                                   "server_timestamp": 1594825445.320078373,
                                   "presence":
@@ -1183,10 +1183,10 @@ paths:
                                     {
                                       "type": "reaction",
                                       "op": "add",
-                                      "user_id": 10,
+                                      "user_id": 19,
                                       "user":
                                         {
-                                          "user_id": 10,
+                                          "user_id": 19,
                                           "email": "user10@zulip.testserver",
                                           "full_name": "King Hamlet",
                                         },
@@ -1228,10 +1228,10 @@ paths:
                                     {
                                       "type": "reaction",
                                       "op": "remove",
-                                      "user_id": 10,
+                                      "user_id": 19,
                                       "user":
                                         {
-                                          "user_id": 10,
+                                          "user_id": 19,
                                           "email": "user10@zulip.testserver",
                                           "full_name": "King Hamlet",
                                         },
@@ -1455,7 +1455,7 @@ paths:
                               example:
                                 {
                                   "type": "user_status",
-                                  "user_id": 10,
+                                  "user_id": 19,
                                   "away": true,
                                   "status_text": "out to lunch",
                                   "emoji_name": "car",
@@ -2063,7 +2063,7 @@ paths:
                               example:
                                 {
                                   "type": "update_message",
-                                  "user_id": 10,
+                                  "user_id": 19,
                                   "edit_timestamp": 1594825451,
                                   "message_id": 58,
                                   "stream_name": "Verona",
@@ -2181,17 +2181,17 @@ paths:
                                   "op": "start",
                                   "sender":
                                     {
-                                      "user_id": 10,
+                                      "user_id": 19,
                                       "email": "user10@zulip.testserver",
                                     },
                                   "recipients":
                                     [
                                       {
-                                        "user_id": 8,
+                                        "user_id": 17,
                                         "email": "user8@zulip.testserver",
                                       },
                                       {
-                                        "user_id": 10,
+                                        "user_id": 19,
                                         "email": "user10@zulip.testserver",
                                       },
                                     ],
@@ -2297,17 +2297,17 @@ paths:
                                   "op": "stop",
                                   "sender":
                                     {
-                                      "user_id": 10,
+                                      "user_id": 19,
                                       "email": "user10@zulip.testserver",
                                     },
                                   "recipients":
                                     [
                                       {
-                                        "user_id": 8,
+                                        "user_id": 17,
                                         "email": "user8@zulip.testserver",
                                       },
                                       {
-                                        "user_id": 10,
+                                        "user_id": 19,
                                         "email": "user10@zulip.testserver",
                                       },
                                     ],
@@ -2971,7 +2971,7 @@ paths:
                                   "bot":
                                     {
                                       "email": "test-bot@zulip.testserver",
-                                      "user_id": 36,
+                                      "user_id": 45,
                                       "full_name": "Foo Bot",
                                       "bot_type": 1,
                                       "is_active": true,
@@ -3024,7 +3024,7 @@ paths:
                                   "op": "update",
                                   "bot":
                                     {
-                                      "user_id": 37,
+                                      "user_id": 46,
                                       "services":
                                         [
                                           {
@@ -3071,7 +3071,7 @@ paths:
                                   "type": "realm_bot",
                                   "op": "remove",
                                   "bot":
-                                    {"user_id": 35, "full_name": "Foo Bot"},
+                                    {"user_id": 44, "full_name": "Foo Bot"},
                                   "id": 1,
                                 }
                             - type: object
@@ -3107,7 +3107,7 @@ paths:
                                   "type": "realm_bot",
                                   "op": "delete",
                                   "bot":
-                                    {"user_id": 35, "full_name": "Foo Bot"},
+                                    {"user_id": 44, "full_name": "Foo Bot"},
                                   "id": 1,
                                 }
                             - type: object
@@ -4389,7 +4389,7 @@ paths:
                 type: array
                 items:
                   type: integer
-              example: [9, 10]
+              example: [18, 19]
           required: true
         - $ref: "#/components/parameters/RequiredContent"
         - name: topic
@@ -4573,14 +4573,14 @@ paths:
                               "topic": "party at my houz",
                               "rendered_content": "<p>Hello!</p>",
                               "timestamp": 1530129122,
-                              "user_id": 5,
+                              "user_id": 14,
                             },
                             {
                               "topic": "party at my house",
                               "content": "Howdy!",
                               "prev_content": "Hello!",
                               "rendered_content": "<p>Howdy!</p>",
-                              "user_id": 5,
+                              "user_id": 14,
                               "prev_rendered_content": "<p>Hello!</p>",
                               "content_html_diff": '<div><p><span class="highlight_text_inserted">Howdy!</span></p> <p><span class="highlight_text_deleted">Hello!</span></p></div>',
                               "prev_topic": "party at my houz",
@@ -5374,7 +5374,7 @@ paths:
                               "bot_type": null,
                               "timezone": "",
                               "is_bot": false,
-                              "user_id": 7,
+                              "user_id": 16,
                               "profile_data": {},
                               "is_guest": false,
                               "date_joined": "2019-10-20T07:50:53.728864+00:00",
@@ -5407,7 +5407,7 @@ paths:
                                       "value": "Dark chocolate",
                                     },
                                 },
-                              "user_id": 10,
+                              "user_id": 19,
                               "is_bot": false,
                               "bot_type": null,
                               "timezone": "",
@@ -5420,7 +5420,7 @@ paths:
                               "email": "hamlet@zulip.com",
                             },
                             {
-                              "bot_owner_id": 11,
+                              "bot_owner_id": 20,
                               "is_guest": false,
                               "date_joined": "2019-10-20T12:52:17.862053+00:00",
                               "full_name": "Iago's Bot",
@@ -5431,7 +5431,7 @@ paths:
                               "is_owner": false,
                               "is_billing_admin": false,
                               "role": 400,
-                              "user_id": 23,
+                              "user_id": 32,
                               "bot_type": 1,
                               "timezone": "",
                               "is_bot": true,
@@ -5493,7 +5493,7 @@ paths:
                           The ID assigned to the newly created user.
 
                           **Changes**: New in Zulip 4.0 (feature level 30).
-                    example: {"msg": "", "result": "success", "user_id": 25}
+                    example: {"msg": "", "result": "success", "user_id": 44}
         "400":
           description: Bad request.
           content:
@@ -5790,7 +5790,7 @@ paths:
                         "max_message_id": 30,
                         "msg": "",
                         "result": "success",
-                        "user_id": 5,
+                        "user_id": 14,
                         "profile_data":
                           {
                             "5": {"value": "2000-01-01"},
@@ -7123,7 +7123,7 @@ paths:
                                     "value": "Dark chocolate",
                                   },
                               },
-                            "user_id": 10,
+                            "user_id": 19,
                             "is_bot": false,
                             "bot_type": null,
                             "timezone": "",
@@ -7213,7 +7213,7 @@ paths:
                                     "value": "Dark chocolate",
                                   },
                               },
-                            "user_id": 10,
+                            "user_id": 19,
                             "is_bot": false,
                             "bot_type": null,
                             "timezone": "",
@@ -10974,7 +10974,7 @@ paths:
                 type: array
                 items:
                   type: integer
-              example: [9, 10]
+              example: [18, 19]
           required: true
         - name: topic
           in: query
@@ -11098,7 +11098,7 @@ paths:
                 type: array
                 items:
                   type: integer
-              example: [10]
+              example: [19]
           required: false
         - name: add
           in: query
@@ -11110,7 +11110,7 @@ paths:
                 type: array
                 items:
                   type: integer
-              example: [12, 13]
+              example: [21, 22]
           required: false
       responses:
         "200":
@@ -13200,7 +13200,7 @@ components:
         The target user's ID.
       schema:
         type: integer
-      example: 12
+      example: 21
       required: true
     MutedUserId:
       name: muted_user_id
@@ -13209,7 +13209,7 @@ components:
         The ID of the user to mute/un-mute.
       schema:
         type: integer
-      example: 10
+      example: 19
       required: true
     StreamPostPolicy:
       name: stream_post_policy

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12600,6 +12600,7 @@ components:
           properties:
             email: {}
             is_bot: {}
+            is_system_bot: {}
             avatar_url: {}
             avatar_version: {}
             full_name: {}
@@ -12632,6 +12633,10 @@ components:
           type: boolean
           description: |
             A boolean specifying whether the user is a bot or full account.
+        is_system_bot:
+          type: boolean
+          description: |
+            A boolean specifying whether the user is a system bot.
         avatar_url:
           type: string
           nullable: true

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -1584,7 +1584,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertTrue(is_cross_realm_bot_email("notification-BOT@zulip.com"))
         self.assertFalse(is_cross_realm_bot_email("random-bot@zulip.com"))
 
-        with self.settings(CROSS_REALM_BOT_EMAILS={"random-bot@zulip.com"}):
+        with self.settings(SYSTEM_BOTS_EMAILS={"random-bot@zulip.com"}):
             self.assertTrue(is_cross_realm_bot_email("random-bot@zulip.com"))
             self.assertFalse(is_cross_realm_bot_email("notification-bot@zulip.com"))
 

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -26,7 +26,7 @@ from zerver.models import (
     get_realm,
     get_stream,
     get_user,
-    is_cross_realm_bot_email,
+    is_system_bot_email,
 )
 
 
@@ -1579,14 +1579,14 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             result = self.client_post("/json/bots", bot_info)
         self.assert_json_error(result, "Invalid configuration data!")
 
-    def test_is_cross_realm_bot_email(self) -> None:
-        self.assertTrue(is_cross_realm_bot_email("notification-bot@zulip.com"))
-        self.assertTrue(is_cross_realm_bot_email("notification-BOT@zulip.com"))
-        self.assertFalse(is_cross_realm_bot_email("random-bot@zulip.com"))
+    def test_is_system_bot_email(self) -> None:
+        self.assertTrue(is_system_bot_email("notification-bot@zulip.com"))
+        self.assertTrue(is_system_bot_email("notification-BOT@zulip.com"))
+        self.assertFalse(is_system_bot_email("random-bot@zulip.com"))
 
         with self.settings(SYSTEM_BOTS_EMAILS={"random-bot@zulip.com"}):
-            self.assertTrue(is_cross_realm_bot_email("random-bot@zulip.com"))
-            self.assertFalse(is_cross_realm_bot_email("notification-bot@zulip.com"))
+            self.assertTrue(is_system_bot_email("random-bot@zulip.com"))
+            self.assertFalse(is_system_bot_email("notification-bot@zulip.com"))
 
     @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
     def test_create_incoming_webhook_bot_with_service_name_and_with_keys(self) -> None:

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -529,7 +529,6 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
                 "image/png",
                 image_bytes,
                 get_system_bot(settings.EMAIL_GATEWAY_BOT, stream.realm_id),
-                target_realm=user_profile.realm,
             )
 
         message = most_recent_message(user_profile)
@@ -572,7 +571,6 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
                 "image/png",
                 image_bytes,
                 get_system_bot(settings.EMAIL_GATEWAY_BOT, stream.realm_id),
-                target_realm=user_profile.realm,
             )
 
         message = most_recent_message(user_profile)
@@ -618,7 +616,6 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
                 "image/png",
                 image_bytes,
                 get_system_bot(settings.EMAIL_GATEWAY_BOT, stream.realm_id),
-                target_realm=user_profile.realm,
             )
 
         message = most_recent_message(user_profile)

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -1118,7 +1118,7 @@ class TestGetRawUserDataSystemBotRealm(ZulipTestCase):
             user_avatar_url_field_optional=True,
         )
 
-        for bot_email in settings.CROSS_REALM_BOT_EMAILS:
+        for bot_email in settings.SYSTEM_BOTS_EMAILS:
             bot_profile = get_system_bot(bot_email, realm.id)
             self.assertTrue(bot_profile.id in result)
             self.assertTrue(result[bot_profile.id]["is_system_bot"])

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -467,7 +467,7 @@ class ImportExportTest(ZulipTestCase):
         realm_emoji.save()
 
         data = full_data["realm"]
-        self.assert_length(data["zerver_userprofile_crossrealm"], 3)
+        self.assertNotIn("zerver_userprofile_crossrealm", data)
         self.assert_length(data["zerver_userprofile_mirrordummy"], 0)
 
         exported_user_emails = self.get_set(data["zerver_userprofile"], "delivery_email")
@@ -628,7 +628,7 @@ class ImportExportTest(ZulipTestCase):
 
         data = full_data["realm"]
 
-        self.assert_length(data["zerver_userprofile_crossrealm"], 3)
+        self.assertNotIn("zerver_userprofile_crossrealm", data)
         self.assert_length(data["zerver_userprofile_mirrordummy"], 0)
 
         exported_user_emails = self.get_set(data["zerver_userprofile"], "delivery_email")

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2329,8 +2329,10 @@ class TestCrossRealmPMs(ZulipTestCase):
             messages = get_user_messages(to_user)
             self.assertEqual(messages[-1].sender.id, from_user.id)
 
-        def assert_invalid_user() -> Any:
-            return self.assertRaisesRegex(JsonableError, "Invalid user ID ")
+        def assert_cant_send_outside_realm() -> Any:
+            return self.assertRaisesRegex(
+                JsonableError, "You can't send private messages outside of your organization."
+            )
 
         user1_email = "user1@1.example.com"
         user1a_email = "user1a@1.example.com"
@@ -2399,27 +2401,27 @@ class TestCrossRealmPMs(ZulipTestCase):
 
         # Prevent old loophole where I could send PMs to other users as long
         # as I copied a cross-realm bot from the same realm.
-        with assert_invalid_user():
+        with assert_cant_send_outside_realm():
             self.send_huddle_message(user1, [user3, support_bot])
 
         # Users on three different realms can't PM each other,
         # even if one of the users is a cross-realm bot.
-        with assert_invalid_user():
+        with assert_cant_send_outside_realm():
             self.send_huddle_message(user1, [user2, notification_bot])
 
-        with assert_invalid_user():
+        with assert_cant_send_outside_realm():
             self.send_huddle_message(notification_bot, [user1, user2])
 
         # Users on the different realms cannot PM each other
-        with assert_invalid_user():
+        with assert_cant_send_outside_realm():
             self.send_personal_message(user1, user2)
 
         # Users on non-zulip realms can't PM "ordinary" Zulip users
-        with assert_invalid_user():
+        with assert_cant_send_outside_realm():
             self.send_personal_message(user1, self.example_user("hamlet"))
 
         # Users on three different realms cannot PM each other
-        with assert_invalid_user():
+        with assert_cant_send_outside_realm():
             self.send_huddle_message(user1, [user2, user3])
 
 

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2314,7 +2314,7 @@ class TestCrossRealmPMs(ZulipTestCase):
         return get_user(email, get_realm(subdomain))
 
     @override_settings(
-        CROSS_REALM_BOT_EMAILS=[
+        SYSTEM_BOTS_EMAILS=[
             "notification-bot@zulip.com",
             "welcome-bot@zulip.com",
             "support@3.example.com",
@@ -2349,7 +2349,7 @@ class TestCrossRealmPMs(ZulipTestCase):
         internal_realm = get_realm(settings.SYSTEM_BOT_REALM)
         notification_bot = get_system_bot(notification_bot_email, internal_realm.id)
         with self.settings(
-            CROSS_REALM_BOT_EMAILS=["notification-bot@zulip.com", "welcome-bot@zulip.com"]
+            SYSTEM_BOTS_EMAILS=["notification-bot@zulip.com", "welcome-bot@zulip.com"]
         ):
             # HACK: We should probably be creating this "bot" user another
             # way, but since you can't register a user with a

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2330,10 +2330,8 @@ class TestCrossRealmPMs(ZulipTestCase):
             messages = get_user_messages(to_user)
             self.assertEqual(messages[-1].sender.id, from_user.id)
 
-        def assert_cant_send_outside_realm() -> Any:
-            return self.assertRaisesRegex(
-                JsonableError, "You can't send private messages outside of your organization."
-            )
+        def assert_invalid_user_id() -> Any:
+            return self.assertRaisesRegex(JsonableError, r"Invalid user ID \d+")
 
         @contextmanager
         def assert_cant_send_outside_realm_error_logged() -> Any:
@@ -2386,7 +2384,7 @@ class TestCrossRealmPMs(ZulipTestCase):
             )
 
         # All users can PM cross-realm bots in the zulip.com realm
-        with assert_cant_send_outside_realm():
+        with assert_invalid_user_id():
             self.send_personal_message(user1, notification_bot)
 
         # Verify that internal_send_private_message can also successfully
@@ -2401,7 +2399,7 @@ class TestCrossRealmPMs(ZulipTestCase):
         # Users can PM cross-realm bots on non-zulip realms.
         # (The support bot represents some theoretical bot that we may
         # create in the future that does not have zulip.com as its realm.)
-        with assert_cant_send_outside_realm():
+        with assert_invalid_user_id():
             self.send_personal_message(user1, support_bot)
 
         # Allow sending PMs to two different cross-realm bots simultaneously.
@@ -2409,32 +2407,32 @@ class TestCrossRealmPMs(ZulipTestCase):
         # already individually send PMs to cross-realm bots, we shouldn't
         # prevent them from sending multiple bots at once.  We may revisit
         # this if it's a nuisance for huddles.)
-        with assert_cant_send_outside_realm():
+        with assert_invalid_user_id():
             self.send_huddle_message(user1, [notification_bot, support_bot])
 
         # Prevent old loophole where I could send PMs to other users as long
         # as I copied a cross-realm bot from the same realm.
-        with assert_cant_send_outside_realm():
+        with assert_invalid_user_id():
             self.send_huddle_message(user1, [user3, support_bot])
 
         # Users on three different realms can't PM each other,
         # even if one of the users is a cross-realm bot.
-        with assert_cant_send_outside_realm():
+        with assert_invalid_user_id():
             self.send_huddle_message(user1, [user2, notification_bot])
 
-        with assert_cant_send_outside_realm():
+        with assert_invalid_user_id():
             self.send_huddle_message(notification_bot, [user1, user2])
 
         # Users on the different realms cannot PM each other
-        with assert_cant_send_outside_realm():
+        with assert_invalid_user_id():
             self.send_personal_message(user1, user2)
 
         # Users on non-zulip realms can't PM "ordinary" Zulip users
-        with assert_cant_send_outside_realm():
+        with assert_invalid_user_id():
             self.send_personal_message(user1, self.example_user("hamlet"))
 
         # Users on three different realms cannot PM each other
-        with assert_cant_send_outside_realm():
+        with assert_invalid_user_id():
             self.send_huddle_message(user1, [user2, user3])
 
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -780,7 +780,7 @@ class LoginTest(ZulipTestCase):
         # seem to be any O(N) behavior.  Some of the cache hits are related
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
-        self.assert_length(cache_tries, 21)
+        self.assert_length(cache_tries, 20)
 
         user_profile = self.nonreg_user("test")
         self.assert_logged_in_user_id(user_profile.id)

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -658,7 +658,7 @@ class SlackImporter(ZulipTestCase):
             passed_realm["zerver_realm"][0]["description"], "Organization imported from Slack!"
         )
         self.assertEqual(passed_realm["zerver_userpresence"], [])
-        self.assert_length(passed_realm.keys(), 15)
+        self.assert_length(passed_realm.keys(), 14)
 
         self.assertEqual(realm["zerver_stream"], [])
         self.assertEqual(realm["zerver_userprofile"], [])

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -909,7 +909,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertEqual(message.recipient.type, Recipient.STREAM)
         self.assertEqual(message.content, message_content)
         self.assertEqual(message.sender.email, "notification-bot@zulip.com")
-        self.assertEqual(message.sender.realm, get_realm(settings.SYSTEM_BOT_REALM))
+        self.assertEqual(message.sender.realm, stream.realm)
 
     def test_realm_admin_can_update_unsub_private_stream(self) -> None:
         iago = self.example_user("iago")
@@ -3425,7 +3425,7 @@ class SubscriptionAPITest(ZulipTestCase):
         )
 
         self.assertNotIn(self.example_user("polonius").id, add_peer_event["users"])
-        self.assert_length(add_peer_event["users"], 12)
+        self.assert_length(add_peer_event["users"], 15)
         self.assertEqual(add_peer_event["event"]["type"], "subscription")
         self.assertEqual(add_peer_event["event"]["op"], "peer_add")
         self.assertEqual(add_peer_event["event"]["user_ids"], [self.user_profile.id])
@@ -3456,7 +3456,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # We don't send a peer_add event to othello
         self.assertNotIn(user_profile.id, add_peer_event["users"])
         self.assertNotIn(self.example_user("polonius").id, add_peer_event["users"])
-        self.assert_length(add_peer_event["users"], 12)
+        self.assert_length(add_peer_event["users"], 15)
         self.assertEqual(add_peer_event["event"]["type"], "subscription")
         self.assertEqual(add_peer_event["event"]["op"], "peer_add")
         self.assertEqual(add_peer_event["event"]["user_ids"], [user_profile.id])

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -586,7 +586,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         uri = result.json()["uri"]
         fp_path_id = re.sub("/user_uploads/", "", uri)
         body = f"First message ...[zulip.txt](http://{host}/user_uploads/" + fp_path_id + ")"
-        with self.settings(CROSS_REALM_BOT_EMAILS={user_2.email, user_3.email}):
+        with self.settings(SYSTEM_BOTS_EMAILS={user_2.email, user_3.email}):
             user_2.is_bot = True
             user_2.save(update_fields=["is_bot"])
             internal_send_private_message(

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1205,34 +1205,6 @@ class UserProfileTest(ZulipTestCase):
         hotspots = list(UserHotspot.objects.filter(user=iago).values_list("hotspot", flat=True))
         self.assertEqual(hotspots, hotspots_completed)
 
-    def test_get_user_by_id_in_realm_including_cross_realm(self) -> None:
-        realm = get_realm("zulip")
-        internal_realm = get_realm(settings.SYSTEM_BOT_REALM)
-        hamlet = self.example_user("hamlet")
-        othello = self.example_user("othello")
-        bot = get_system_bot(settings.WELCOME_BOT, internal_realm.id)
-
-        # Pass in the ID of a cross-realm bot and a valid realm
-        cross_realm_bot = get_user_by_id_in_realm_including_cross_realm(bot.id, realm)
-        self.assertEqual(cross_realm_bot.email, bot.email)
-        self.assertEqual(cross_realm_bot.id, bot.id)
-
-        # Pass in the ID of a cross-realm bot but with a invalid realm,
-        # note that the realm should be irrelevant here
-        cross_realm_bot = get_user_by_id_in_realm_including_cross_realm(bot.id, None)
-        self.assertEqual(cross_realm_bot.email, bot.email)
-        self.assertEqual(cross_realm_bot.id, bot.id)
-
-        # Pass in the ID of a non-cross-realm user with a realm
-        user_profile = get_user_by_id_in_realm_including_cross_realm(othello.id, realm)
-        self.assertEqual(user_profile.email, othello.email)
-        self.assertEqual(user_profile.id, othello.id)
-
-        # If the realm doesn't match, or if the ID is not that of a
-        # cross-realm bot, UserProfile.DoesNotExist is raised
-        with self.assertRaises(UserProfile.DoesNotExist):
-            get_user_by_id_in_realm_including_cross_realm(hamlet.id, None)
-
     def test_get_user_subscription_status(self) -> None:
         self.login("hamlet")
         iago = self.example_user("iago")

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, TypeVar, Union
 from unittest import mock
 
 import orjson
-from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.test import override_settings
@@ -66,10 +65,8 @@ from zerver.models import (
     get_realm,
     get_source_profile,
     get_stream,
-    get_system_bot,
     get_user,
     get_user_by_delivery_email,
-    get_user_by_id_in_realm_including_cross_realm,
 )
 
 K = TypeVar("K")
@@ -772,7 +769,7 @@ class QueryCountTest(ZulipTestCase):
                     )
 
         self.assert_length(queries, 84)
-        self.assert_length(cache_tries, 27)
+        self.assert_length(cache_tries, 26)
 
         peer_add_events = [event for event in events if event["event"].get("op") == "peer_add"]
 

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -77,7 +77,7 @@ from zerver.models import (
     UserProfile,
     get_active_streams,
     get_user_by_id_in_realm_including_cross_realm,
-    get_user_including_cross_realm,
+    get_user_including_system_bots,
 )
 
 LARGER_THAN_MAX_MESSAGE_ID = 10000000000000000
@@ -372,7 +372,7 @@ class NarrowBuilder:
     ) -> Select:
         try:
             if isinstance(operand, str):
-                sender = get_user_including_cross_realm(operand, self.realm)
+                sender = get_user_including_system_bots(operand, self.realm)
             else:
                 sender = get_user_by_id_in_realm_including_cross_realm(operand, self.realm)
         except UserProfile.DoesNotExist:
@@ -476,7 +476,7 @@ class NarrowBuilder:
 
         try:
             if isinstance(operand, str):
-                narrow_profile = get_user_including_cross_realm(operand, self.realm)
+                narrow_profile = get_user_including_system_bots(operand, self.realm)
             else:
                 narrow_profile = get_user_by_id_in_realm_including_cross_realm(operand, self.realm)
         except UserProfile.DoesNotExist:

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -76,7 +76,7 @@ from zerver.models import (
     UserMessage,
     UserProfile,
     get_active_streams,
-    get_user_by_id_in_realm_including_cross_realm,
+    get_user_by_id_in_realm,
     get_user_including_system_bots,
 )
 
@@ -374,7 +374,7 @@ class NarrowBuilder:
             if isinstance(operand, str):
                 sender = get_user_including_system_bots(operand, self.realm)
             else:
-                sender = get_user_by_id_in_realm_including_cross_realm(operand, self.realm)
+                sender = get_user_by_id_in_realm(operand, self.realm)
         except UserProfile.DoesNotExist:
             raise BadNarrowOperator("unknown user " + str(operand))
 
@@ -478,7 +478,7 @@ class NarrowBuilder:
             if isinstance(operand, str):
                 narrow_profile = get_user_including_system_bots(operand, self.realm)
             else:
-                narrow_profile = get_user_by_id_in_realm_including_cross_realm(operand, self.realm)
+                narrow_profile = get_user_by_id_in_realm(operand, self.realm)
         except UserProfile.DoesNotExist:
             raise BadNarrowOperator("unknown user " + str(operand))
 

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -32,7 +32,7 @@ from zerver.models import (
     RealmDomain,
     UserProfile,
     email_to_domain,
-    get_user_including_cross_realm,
+    get_user_including_system_bots,
 )
 
 
@@ -76,7 +76,7 @@ def create_mirrored_message_users(
     for email in referenced_users:
         create_mirror_user_if_needed(user_profile.realm, email, fullname_function)
 
-    sender = get_user_including_cross_realm(sender_email, user_profile.realm)
+    sender = get_user_including_system_bots(sender_email, user_profile.realm)
     return sender
 
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -46,7 +46,7 @@ from zerver.lib.actions import (
 )
 from zerver.lib.email_validation import email_allowed_for_realm, validate_email_not_already_in_realm
 from zerver.lib.exceptions import RateLimited
-from zerver.lib.onboarding import send_initial_realm_messages, setup_realm_internal_bots
+from zerver.lib.onboarding import send_initial_realm_messages
 from zerver.lib.pysa import mark_sanitized
 from zerver.lib.send_email import EmailNotDeliveredException, FromAddress, send_email
 from zerver.lib.sessions import get_expirable_session_var
@@ -313,7 +313,6 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
             realm_name = form.cleaned_data["realm_name"]
             realm_type = form.cleaned_data["realm_type"]
             realm = do_create_realm(string_id, realm_name, org_type=realm_type)
-            setup_realm_internal_bots(realm)
         assert realm is not None
 
         full_name = form.cleaned_data["full_name"]

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -82,7 +82,7 @@ from zerver.models import (
     get_user,
     get_user_by_delivery_email,
     get_user_by_id_in_realm_including_cross_realm,
-    get_user_including_cross_realm,
+    get_user_including_system_bots,
     get_user_profile_by_id_in_realm,
 )
 from zproject.backends import check_password_strength
@@ -229,7 +229,7 @@ def avatar(
     try:
         realm = user_profile.realm
         if is_email:
-            avatar_user_profile = get_user_including_cross_realm(email_or_id, realm)
+            avatar_user_profile = get_user_including_system_bots(email_or_id, realm)
         else:
             avatar_user_profile = get_user_by_id_in_realm_including_cross_realm(
                 int(email_or_id), realm

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -81,7 +81,7 @@ from zerver.models import (
     UserProfile,
     get_user,
     get_user_by_delivery_email,
-    get_user_by_id_in_realm_including_cross_realm,
+    get_user_by_id_in_realm,
     get_user_including_system_bots,
     get_user_profile_by_id_in_realm,
 )
@@ -231,9 +231,7 @@ def avatar(
         if is_email:
             avatar_user_profile = get_user_including_system_bots(email_or_id, realm)
         else:
-            avatar_user_profile = get_user_by_id_in_realm_including_cross_realm(
-                int(email_or_id), realm
-            )
+            avatar_user_profile = get_user_by_id_in_realm(int(email_or_id), realm)
         # If there is a valid user account passed in, use its avatar
         url = avatar_url(avatar_user_profile, medium=medium)
     except UserProfile.DoesNotExist:

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -486,6 +486,20 @@ TWITTER_ACCESS_TOKEN_SECRET = get_secret("twitter_access_token_secret")
 # These are the bots that Zulip sends automated messages as.
 INTERNAL_BOTS = [
     {
+        "var_name": "NAGIOS_RECEIVE_BOT",
+        "email_template": "nagios-receive-bot@%s",
+        "name": "Nagios Receive Bot",
+    },
+    {
+        "var_name": "NAGIOS_SEND_BOT",
+        "email_template": "nagios-send-bot@%s",
+        "name": "Nagios Send Bot",
+    },
+]
+
+# Bots that are created for each realm like the reminder-bot goes here.
+REALM_INTERNAL_BOTS: List[Dict[str, str]] = [
+    {
         "var_name": "NOTIFICATION_BOT",
         "email_template": "notification-bot@%s",
         "name": "Notification Bot",
@@ -496,24 +510,11 @@ INTERNAL_BOTS = [
         "name": "Email Gateway",
     },
     {
-        "var_name": "NAGIOS_SEND_BOT",
-        "email_template": "nagios-send-bot@%s",
-        "name": "Nagios Send Bot",
-    },
-    {
-        "var_name": "NAGIOS_RECEIVE_BOT",
-        "email_template": "nagios-receive-bot@%s",
-        "name": "Nagios Receive Bot",
-    },
-    {
         "var_name": "WELCOME_BOT",
         "email_template": "welcome-bot@%s",
         "name": "Welcome Bot",
     },
 ]
-
-# Bots that are created for each realm like the reminder-bot goes here.
-REALM_INTERNAL_BOTS: List[Dict[str, str]] = []
 # These are realm-internal bots that may exist in some organizations,
 # so configure power the setting, but should not be auto-created at this time.
 DISABLED_REALM_INTERNAL_BOTS = [

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -1176,7 +1176,7 @@ if PRODUCTION:
 # This is a debugging option only
 PROFILE_ALL_REQUESTS = False
 
-CROSS_REALM_BOT_EMAILS = {
+SYSTEM_BOTS_EMAILS = {
     "notification-bot@zulip.com",
     "welcome-bot@zulip.com",
     "emailgateway@zulip.com",


### PR DESCRIPTION
This depends on #17452 and #17516, so it has a bunch of initial commit from those PRs, will rebase appropriately when those get reviewed/fixed and merged. New commits begin with `test_webhooks_common: Compare users by id not email.`

What this does right now: Finishes the first logical part of the migration - adds the bots to every realm, makes `get_system_bots` take a realm (realm_id strictly speaking, to avoid fetching `.realm` attribute of objects just to call this function) argument and adjusts production code and all tests accordingly to make things work and the CI pass. I don't think this should be considered for merging without the follow-up parts. The main commit is `bots: Put system bots in each realm. `, the remaining are just follow-up adjustments to the changes this commit introduces.

What's left to be done:
1. Actually killing cross-realm messages - clean up all the code for handling those (and make sure they can't be sent anymore), rename/remove the various `cross_realm` named concepts.
2. Migrating existing cross-realm messages to use the in-realm bot instead of the `zulipinternal` bot as recipient/sender.