### PR TITLE
compose: Fix presence circle in mention typeahead.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -868,7 +868,7 @@ run_test("initialize", (override) => {
         fake_this = {completing: "mention", token: "hamletcharacters"};
         actual_value = options.highlighter.call(fake_this, hamletcharacters);
         expected_value =
-            '        <i class="typeahead-image icon fa fa-group" aria-hidden="true"></i>\n<strong>hamletcharacters</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">Characters of Hamlet</small>\n';
+            '        <i class="typeahead-image icon fa fa-group no-presence-circle" aria-hidden="true"></i>\n<strong>hamletcharacters</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">Characters of Hamlet</small>\n';
         assert.equal(actual_value, expected_value);
 
         // matching

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -80,7 +80,6 @@ export function render_person(person) {
     if (person.special_item_text) {
         return render_typeahead_item({
             primary: person.special_item_text,
-            user_circle_class,
             is_person: true,
         });
     }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2053,7 +2053,8 @@ div.focused_table {
     font-size: 19px;
     text-align: center;
 
-    &.fa-group {
+    &.fa-group,
+    &.fa-bullhorn {
         margin-left: 9px;
         top: 3px;
     }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2053,8 +2053,7 @@ div.focused_table {
     font-size: 19px;
     text-align: center;
 
-    &.fa-group,
-    &.fa-bullhorn {
+    &.no-presence-circle {
         margin-left: 9px;
         top: 3px;
     }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -630,7 +630,7 @@ strong {
                 margin: 0 5px 0 -6px;
                 position: relative;
                 top: 6px;
-                right: 7px;
+                right: 8px;
                 display: inline-block;
             }
         }

--- a/static/templates/typeahead_list_item.hbs
+++ b/static/templates/typeahead_list_item.hbs
@@ -13,11 +13,11 @@
         {{#if has_image}}
         <img class="typeahead-image" src="{{ img_src }}" />
         {{else}}
-        <span class='typeahead-image fa fa-bullhorn'></span>
+        <span class='typeahead-image fa fa-bullhorn no-presence-circle'></span>
         {{/if}}
     {{else}}
         {{#if is_user_group}}
-        <i class="typeahead-image icon fa fa-group" aria-hidden="true"></i>
+        <i class="typeahead-image icon fa fa-group no-presence-circle" aria-hidden="true"></i>
         {{/if}}
     {{/if}}
 {{/if}}


### PR DESCRIPTION
This pr makes following changes after discussion on
[ #design>Presence circles in typeahead](https://chat.zulip.org/#narrow/stream/101-design/topic/Presence.20circles.20in.20typeahead/near/1128531) circles in typeahead.

* Remove presence circle for special wildcard users like(all, stream).
* Fix spacing between presence circles and user avatar.

I used 1px space that was on the left of the circles so these changes does not interfere with alignments of other items.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** Tested manually in development server.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/63504956/110370906-4b20cd00-8072-11eb-9ee2-82e63f25b823.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
