### PR TITLE
ci: Upload puppeteer artifacts on failure.

### DIFF
--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -143,7 +143,8 @@ jobs:
           pip install codecov && codecov || echo "Error in uploading coverage reports to codecov.io."
 
       - name: Store Puppeteer artifacts
-        if: ${{ matrix.include_frontend_tests }}
+        # Upload these on failure, as well
+        if: ${{ always() && matrix.include_frontend_tests }}
         uses: actions/upload-artifact@v2
         with:
           name: puppeteer


### PR DESCRIPTION
Storing the puppeteer artifacts is useful for debugging failures in
CI.

Confusingly, `if: ${{ something }}` does not work out to be true like
`if: ${{ always() && something }}` does; the former has a silent
`success()` built into it.

**Testing plan:** https://github.com/zulip/zulip/pull/17528/checks?check_run_id=2060804667 is a failing test, https://github.com/zulip/zulip/suites/2208449287/artifacts/45666531 is the artifact.

**GIFs or screenshots:** 
![failure-0](https://user-images.githubusercontent.com/28347/110393294-20f1ef80-801f-11eb-88e6-c4a640b1d369.png)
