### PR TITLE
static: Fix setting gear to be not active when app loads

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1933,7 +1933,7 @@ div.focused_table {
             top: -3px;
         }
 
-        .dropdown-toggle,
+        .dropdown-toggle:hover,
         li.active .dropdown-toggle:hover {
             opacity: 1;
         }


### PR DESCRIPTION
[issue-17476](https://github.com/zulip/zulip/issues/17476)

Since it's a UI change, I have tested it manually


Before:
![issue-17476-fixed](https://user-images.githubusercontent.com/49791933/110419978-5a2e6c00-80c0-11eb-8c4e-edc1b065d3bf.gif)

After:
![issue-17476](https://user-images.githubusercontent.com/49791933/110420010-6a464b80-80c0-11eb-98e4-36e709c221ce.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
