### PR TITLE
Fix colorpicker stream settings.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -966,7 +966,9 @@ exports.initialize = function () {
         $(".right").removeClass("show");
         $(".subscriptions-header").removeClass("slide-left");
     });
-
+    $("#subscriptions_table").on("click", ".exit", () => {
+        $(".colorpicker").spectrum("hide");
+    });
     (function defocus_sub_settings() {
         const sel = ".search-container, .streams-list, .subscriptions-header";
 


### PR DESCRIPTION
Color picker not hiding even after exiting settings.

Fix by adding event listner to hide colorpicker when exiting settings.

issue: #17334

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

- Tested manually for different screen sizes.
- Tested for both mobile and desktop screen sizes.

**GIFs or screenshots:** <!-- If a UI change.  See:https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Before fix:

![108261834-28de1280-718a-11eb-89ab-33ff3cd65611](https://user-images.githubusercontent.com/57071700/110433107-0d559000-80d6-11eb-8df0-c4f95985b3f7.gif)

After fix:

![colorpicker_hide](https://user-images.githubusercontent.com/57071700/110432839-b18b0700-80d5-11eb-9b4a-c63c0e4a4613.gif)

  

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
