### PR TITLE
puppet: Switch to more explicit variable rather than reuse a nagios one.

### DIFF
--- a/puppet/zulip_ops/manifests/app_frontend.pp
+++ b/puppet/zulip_ops/manifests/app_frontend.pp
@@ -9,7 +9,7 @@ class zulip_ops::app_frontend {
     'autossh',
   ]
   package { $app_packages: ensure => 'installed' }
-  $default_host_domain = zulipconf('nagios', 'default_host_domain', undef)
+  $redis_hostname = zulipconf('redis', 'hostname', undef)
 
   file { '/etc/logrotate.d/zulip':
     ensure => file,

--- a/puppet/zulip_ops/templates/supervisor/conf.d/redis_tunnel.conf.template.erb
+++ b/puppet/zulip_ops/templates/supervisor/conf.d/redis_tunnel.conf.template.erb
@@ -1,5 +1,5 @@
 [program:redis-tunnel]
-command=autossh -M 0 -N -L 127.0.0.1:6379:127.0.0.1:6379 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 redis0.<%= @default_host_domain %>
+command=autossh -M 0 -N -L 127.0.0.1:6379:127.0.0.1:6379 -o ServerAliveInterval=30 -o ServerAliveCountMax=3 <%= @redis_hostname %>
 priority=50
 user=zulip
 autostart=true


### PR DESCRIPTION
Redis is not nagios, and this only leads to confusion as to why there
is a nagios domain setting on frontend servers; it also leaves the
`redis0` part of the name buried in the template.

Switch to an explicit variable for the redis hostname.

----

The new settings have already been placed in `zulip.conf` on the relevant hosts.