### PR TITLE
minor: Check if typeahead query exists.

### DIFF
--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -111,6 +111,22 @@ run_test("triage", () => {
             rest: [alice, alicia, steve, stephanie],
         },
     );
+
+    assert.deepEqual(
+        typeahead.triage(" ", names, (r) => r.name),
+        {
+            matches: [],
+            rest: [alice, alicia, joan, jo, steve, stephanie],
+        },
+    );
+
+    assert.deepEqual(
+        typeahead.triage(";", names, (r) => r.name),
+        {
+            matches: [],
+            rest: [alice, alicia, joan, jo, steve, stephanie],
+        },
+    );
 });
 
 run_test("sort_emojis th", () => {

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -129,7 +129,7 @@ export function triage(query, objs, get_item) {
     const beginswithCaseSensitive = [];
     const beginswithCaseInsensitive = [];
     const noMatch = [];
-    const lowerQuery = query.toLowerCase();
+    const lowerQuery = query ? query.toLowerCase() : "";
 
     for (const obj of objs) {
         const item = get_item(obj);


### PR DESCRIPTION
When a user entered an invalid character (whitespace or characters not present
in a name), the cleaned-up array, and hence the query,
would be empty which resulted in an error.

Fixes #17542