### PR TITLE
puppet: Do not require a venv for zulip-puppet-apply.

### DIFF
--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -33,13 +33,18 @@ class zulip::profile::base {
         '20.04' => 'focal',
       }
       $base_packages = [
-        # Accurate time is essential
-        'ntp',
+        # Basics
+        'python3',
+        'puppet',
+        'git',
         # Used in scripts including install-yarn.sh
         'curl',
         'wget',
+        'jq',
         # Used to read /etc/zulip/zulip.conf for `zulipconf` Puppet function
         'crudini',
+        # Accurate time is essential
+        'ntp',
         # Used for tools like sponge
         'moreutils',
         # Nagios monitoring plugins
@@ -53,10 +58,14 @@ class zulip::profile::base {
     'redhat': {
       $release_name = "${::operatingsystem}${::operatingsystemmajrelease}"
       $base_packages = [
-        'ntp',
+        'python3',
+        'puppet',
+        'git',
         'curl',
         'wget',
+        'jq',
         'crudini',
+        'ntp',
         'moreutils',
         'nmap-ncat',
         'nagios-plugins',  # there is no dummy package on CentOS 7

--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -35,6 +35,7 @@ class zulip::profile::base {
       $base_packages = [
         # Basics
         'python3',
+        'python3-yaml',
         'puppet',
         'git',
         # Used in scripts including install-yarn.sh
@@ -59,6 +60,7 @@ class zulip::profile::base {
       $release_name = "${::operatingsystem}${::operatingsystemmajrelease}"
       $base_packages = [
         'python3',
+        'python3-pyyaml',
         'puppet',
         'git',
         'curl',

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -323,9 +323,11 @@ if [ -z "$NO_DIST_UPGRADE" ]; then
 fi
 
 if [ "$package_system" = apt ]; then
+    # Note that any additions to these lists must also be added to
+    # `zulip::profile::base` such that the new dependency is seen by
+    # upgrades, as well as new installs.
     if ! apt-get install -y \
-        puppet git curl wget jq \
-        python3 crudini \
+        python3 puppet git curl wget jq crudini \
         "${ADDITIONAL_PACKAGES[@]}"; then
         set +x
         echo -e '\033[0;31m' >&2
@@ -336,8 +338,7 @@ if [ "$package_system" = apt ]; then
     fi
 elif [ "$package_system" = yum ]; then
     if ! yum install -y \
-        puppet git curl wget jq \
-        python3 crudini \
+        python3 puppet git curl wget jq crudini \
         "${ADDITIONAL_PACKAGES[@]}"; then
         set +x
         echo -e '\033[0;31m' >&2

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -327,7 +327,7 @@ if [ "$package_system" = apt ]; then
     # `zulip::profile::base` such that the new dependency is seen by
     # upgrades, as well as new installs.
     if ! apt-get install -y \
-        python3 puppet git curl wget jq crudini \
+        python3 python3-yaml puppet git curl wget jq crudini \
         "${ADDITIONAL_PACKAGES[@]}"; then
         set +x
         echo -e '\033[0;31m' >&2
@@ -338,7 +338,7 @@ if [ "$package_system" = apt ]; then
     fi
 elif [ "$package_system" = yum ]; then
     if ! yum install -y \
-        python3 puppet git curl wget jq crudini \
+        python3 python3-pyyaml puppet git curl wget jq crudini \
         "${ADDITIONAL_PACKAGES[@]}"; then
         set +x
         echo -e '\033[0;31m' >&2

--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -7,14 +7,9 @@ import subprocess
 import sys
 import tempfile
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.append(BASE_DIR)
-from scripts.lib.setup_path import setup_path
-from scripts.lib.zulip_tools import assert_running_as_root, parse_os_release
-
-setup_path()
-
 import yaml
+
+from lib.zulip_tools import assert_running_as_root, parse_os_release
 
 assert_running_as_root()
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
0663b23d54dafe4911ef1b67fa64b2e18a82846d changed zulip-puppet-apply to
use the venv, because it began using `yaml` to parse the output of
puppet to determine if changes would happen.

However, not every install ends with a venv; notably, non-frontend
servers do not have one.  Attempting to run zulip-puppet-apply on them
hence now fails.

Remove this dependency on the venv, by installing a system
python3-yaml package -- though in reality, this package is already an
indirect dependency of the system.  Especially since pyyaml is quite
stable, we're not using it in any interesting way, and it does not
actually add to the dependencies, it is preferable to parsing the YAML
by hand in this instance.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
