### PR TITLE
puppet: Use two location blocks, instead of nesting them.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -14,11 +14,17 @@ location /static/ {
 
     # Set a nonexistent path, so we just serve the nice Django 404 page.
     error_page 404 /django_static_404.html;
+}
 
-    # These files are hashed and thus immutable; cache them aggressively.
-    location /static/webpack-bundles {
-        add_header Cache-Control "public, max-age=31536000, immutable";
-    }
+# These files are hashed and thus immutable; cache them aggressively.
+location /static/webpack-bundles/ {
+    alias /home/zulip/prod-static/webpack-bundles/;
+    include /etc/nginx/zulip-include/headers;
+    add_header Access-Control-Allow-Origin *;
+    add_header Cache-Control "public, max-age=31536000, immutable";
+
+    # Set a nonexistent path, so we just serve the nice Django 404 page.
+    error_page 404 /django_static_404.html;
 }
 
 # Send longpoll requests to Tornado


### PR DESCRIPTION
Directives in `location` blocks may or may not inherit from
surrounding `location` blocks; specifically, `add_header` directives
do not[1]:

> There could be several add_header directives. These directives are
> inherited from the previous configuration level if and only if there
> are no add_header directives defined on the current level.

In order to maintain the same headers (including, critically,
`Access-Control-Allow-Origin`) as the surrounding block, all
`add_header` directives must thus be repeated (which includes the
`include`).

For clarity, un-nest and repeat the entire `location` block as was
used for `/static/`, but with the additional `add_header`.  This is
preferred to the of an `if $request_uri` statement to add the header,
as those can have unexpected or undefined results[2].

[1] http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
[2] https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/

**Testing plan:** 
```
ilwrath ~/src/zulip (static-webpack>) $ curl -I https://alexmv-prod.zulipdev.org/static/webpack-bundles/app.ce309377bdde3bcb713d.js
HTTP/2 200
server: nginx/1.18.0 (Ubuntu)
date: Thu, 11 Mar 2021 05:00:56 GMT
content-type: application/javascript
content-length: 89986
last-modified: Thu, 11 Mar 2021 04:55:56 GMT
vary: Accept-Encoding
etag: "6049a2dc-15f82"
strict-transport-security: max-age=15768000
x-frame-options: DENY
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
access-control-allow-origin: *
cache-control: public, max-age=31536000, immutable
accept-ranges: bytes

```