### PR TITLE
Recent Topics: Improved the working of bell-icon when topic is mute and

### DIFF
--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -17,7 +17,7 @@
                 <div class="recent_topic_actions">
                     <div class="recent_topics_focusable">
                         {{#if topic_muted}}
-                        <i class="fa fa-bell-slash on_hover_topic_unmute recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Unmute topic' }}" role="button" tabindex="0" aria-label="{{t 'Unmute topic' }}"></i>
+                        <i class="fa fa-bell on_hover_topic_unmute recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Unmute topic' }}" role="button" tabindex="0" aria-label="{{t 'Unmute topic' }}"></i>
                         {{else}}
                         <i class="fa fa-bell-slash on_hover_topic_mute recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mute topic' }}" role="button" tabindex="0" aria-label="{{t 'Mute topic' }}"></i>
                         {{/if}}


### PR DESCRIPTION
previously when we mute or unmute topic there is no change in bell-icon (only the opacity changes).


**GIFs or screenshots:** 


---
![00](https://user-images.githubusercontent.com/56171689/116967204-6a815280-accf-11eb-8729-a95de048dc13.gif)
