### PR TITLE
UI: Fix redundant more option in edit box of collapsed messages.

### DIFF
--- a/static/js/condense.js
+++ b/static/js/condense.js
@@ -165,7 +165,7 @@ function get_message_height(elem, message_id) {
 }
 
 export function hide_message_expander(row) {
-    if (row.find(".could-be-condensed").length !== 0) {
+    if (row.find(".could-be-condensed").length !== 0 || row.find(".collapsed").length !== 0) {
         row.find(".message_expander").hide();
     }
 }
@@ -177,7 +177,7 @@ export function hide_message_condenser(row) {
 }
 
 export function show_message_expander(row) {
-    if (row.find(".could-be-condensed").length !== 0) {
+    if (row.find(".could-be-condensed").length !== 0 || row.find(".collapsed").length !== 0) {
         row.find(".message_expander").show();
     }
 }

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -594,7 +594,7 @@ export function end_message_row_edit(row) {
 
         compose.abort_video_callbacks(message.id);
     }
-    if (row.find(".condensed").length !== 0) {
+    if (row.find(".condensed").length !== 0 || row.find(".collapsed").length !== 0) {
         condense.show_message_expander(row);
     } else {
         condense.show_message_condenser(row);


### PR DESCRIPTION
Added the necessary handler functions to hide the 'More...'
option which is visible when a user edits a collapsed
message.

Fixes #17564.

Now:
![removed-redundant-more-option](https://user-images.githubusercontent.com/59016893/110779079-23578200-8289-11eb-8eef-3e668d5dedc3.gif)
