### PR TITLE
node tests: Clean up node tests.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -105,6 +105,7 @@ function assert_same(actual, expected) {
 }
 
 run_test("alert_words", (override) => {
+    alert_words.initialize({alert_words: []});
     assert(!alert_words.has_alert_word("fire"));
     assert(!alert_words.has_alert_word("lunch"));
 
@@ -194,6 +195,7 @@ run_test("default_streams", (override) => {
 });
 
 run_test("hotspots", (override) => {
+    page_params.hotspots = [];
     const event = event_fixtures.hotspots;
     override(hotspots, "load_new", noop);
     dispatch(event);
@@ -467,6 +469,7 @@ run_test("realm_emoji", (override) => {
     }
 
     // Make sure we start with nothing...
+    emoji.update_emojis([]);
     assert.equal(emoji.get_realm_emoji_url("spain"), undefined);
 
     dispatch(event);
@@ -568,6 +571,9 @@ run_test("submessage", (override) => {
 // For subscriptions, see dispatch_subs.js
 
 run_test("typing", (override) => {
+    // Simulate that we are not typing.
+    page_params.user_id = typing_person1.user_id + 1;
+
     let event = event_fixtures.typing__start;
     {
         const stub = make_stub();
@@ -588,9 +594,10 @@ run_test("typing", (override) => {
         assert_same(args.event.sender.user_id, typing_person1.user_id);
     }
 
+    // Get line coverage--we ignore our own typing events.
     page_params.user_id = typing_person1.user_id;
     event = event_fixtures.typing__start;
-    dispatch(event); // get line coverage
+    dispatch(event);
 });
 
 run_test("update_display_settings", (override) => {

--- a/frontend_tests/node_tests/dispatch_subs.js
+++ b/frontend_tests/node_tests/dispatch_subs.js
@@ -42,9 +42,8 @@ people.initialize_current_user(me.user_id);
 const dispatch = server_events_dispatch.dispatch_normal_event;
 
 function test(label, f) {
-    stream_data.clear_subscriptions();
-
     run_test(label, (override) => {
+        stream_data.clear_subscriptions();
         f(override);
     });
 }

--- a/frontend_tests/node_tests/message_flags.js
+++ b/frontend_tests/node_tests/message_flags.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {mock_module, set_global, zrequire} = require("../zjsunit/namespace");
+const {mock_module, set_global, with_field, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 const channel = mock_module("channel");
@@ -16,7 +16,7 @@ mock_module("starred_messages", {
 
 const message_flags = zrequire("message_flags");
 
-run_test("starred", () => {
+run_test("starred", (override) => {
     const message = {
         id: 50,
     };
@@ -32,10 +32,10 @@ run_test("starred", () => {
 
     let posted_data;
 
-    channel.post = (opts) => {
+    override(channel, "post", (opts) => {
         assert.equal(opts.url, "/json/messages/flags");
         posted_data = opts.data;
-    };
+    });
 
     message_flags.toggle_starred_and_update_server(message);
 
@@ -69,15 +69,20 @@ run_test("starred", () => {
         starred: false,
     });
 });
-run_test("read", () => {
+run_test("read", (override) => {
     // Way to capture posted info in every request
     let channel_post_opts;
-    channel.post = (opts) => {
+    override(channel, "post", (opts) => {
         channel_post_opts = opts;
-    };
+    });
 
     // For testing purpose limit the batch size value to 5 instead of 1000
-    message_flags.__Rewire__("_unread_batch_size", 5);
+    function send_read(messages) {
+        with_field(message_flags, "_unread_batch_size", 5, () => {
+            message_flags.send_read(messages);
+        });
+    }
+
     let msgs_to_flag_read = [
         {locally_echoed: false, id: 1},
         {locally_echoed: false, id: 2},
@@ -87,7 +92,7 @@ run_test("read", () => {
         {locally_echoed: false, id: 6},
         {locally_echoed: false, id: 7},
     ];
-    message_flags.send_read(msgs_to_flag_read);
+    send_read(msgs_to_flag_read);
     assert.deepEqual(channel_post_opts, {
         url: "/json/messages/flags",
         idempotent: true,
@@ -131,7 +136,7 @@ run_test("read", () => {
         {locally_echoed: false, id: 6},
         {locally_echoed: false, id: 7},
     ];
-    message_flags.send_read(msgs_to_flag_read);
+    send_read(msgs_to_flag_read);
     assert.deepEqual(channel_post_opts, {
         url: "/json/messages/flags",
         idempotent: true,

--- a/frontend_tests/node_tests/password.js
+++ b/frontend_tests/node_tests/password.js
@@ -2,14 +2,29 @@
 
 const {strict: assert} = require("assert");
 
-const {set_global, zrequire} = require("../zjsunit/namespace");
+const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 set_global("zxcvbn", require("zxcvbn"));
 
 const common = zrequire("common");
 
-run_test("basics", () => {
+function password_field(min_length, min_guesses) {
+    const self = {};
+
+    self.data = (field) => {
+        if (field === "minLength") {
+            return min_length;
+        } else if (field === "minGuesses") {
+            return min_guesses;
+        }
+        throw new Error(`Unknown field ${field}`);
+    };
+
+    return self;
+}
+
+run_test("basics w/progress bar", () => {
     let accepted;
     let password;
     let warning;
@@ -35,21 +50,6 @@ run_test("basics", () => {
         return self;
     })();
 
-    function password_field(min_length, min_guesses) {
-        const self = {};
-
-        self.data = (field) => {
-            if (field === "minLength") {
-                return min_length;
-            } else if (field === "minGuesses") {
-                return min_guesses;
-            }
-            throw new Error(`Unknown field ${field}`);
-        };
-
-        return self;
-    }
-
     password = "z!X4@S_&";
     accepted = common.password_quality(password, bar, password_field(10, 80000));
     assert(!accepted);
@@ -72,11 +72,20 @@ run_test("basics", () => {
     assert.equal(bar.added_class, "bar-danger");
     warning = common.password_warning(password, password_field(6));
     assert.equal(warning, 'Repeats like "aaa" are easy to guess');
+});
 
-    set_global("zxcvbn", undefined);
-    password = "aaaaaaaa";
-    accepted = common.password_quality(password, bar, password_field(6, 1e100));
-    assert(accepted === undefined);
-    warning = common.password_warning(password, password_field(6));
-    assert(warning === undefined);
+run_test("zxcvbn undefined", () => {
+    // According to common.js, we load zxcvbn.js asynchronously, so the
+    // variable might not be set.  This just gets line coverage on the
+    // defensive code.
+
+    const password = "aaaaaaaa";
+    const progress_bar = undefined;
+
+    with_field(global, "zxcvbn", undefined, () => {
+        const accepted = common.password_quality(password, progress_bar, password_field(6, 1e100));
+        assert(accepted === undefined);
+        const warning = common.password_warning(password, password_field(6));
+        assert(warning === undefined);
+    });
 });

--- a/frontend_tests/node_tests/people_errors.js
+++ b/frontend_tests/node_tests/people_errors.js
@@ -22,12 +22,12 @@ people.init();
 people.add_active_user(me);
 people.initialize_current_user(me.user_id);
 
-run_test("report_late_add", () => {
+run_test("report_late_add", (override) => {
     blueslip.expect("error", "Added user late: user_id=55 email=foo@example.com");
     people.report_late_add(55, "foo@example.com");
 
     blueslip.expect("log", "Added user late: user_id=55 email=foo@example.com");
-    reload_state.is_in_progress = () => true;
+    override(reload_state, "is_in_progress", () => true);
     people.report_late_add(55, "foo@example.com");
 });
 

--- a/frontend_tests/node_tests/pm_conversations.js
+++ b/frontend_tests/node_tests/pm_conversations.js
@@ -5,7 +5,13 @@ const {strict: assert} = require("assert");
 const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
+const people = zrequire("people");
 const pmc = zrequire("pm_conversations");
+
+function initialize_recents(params) {
+    pmc.recent.clear_for_testing();
+    pmc.recent.initialize(params);
+}
 
 run_test("partners", () => {
     const user1_id = 1;
@@ -20,8 +26,6 @@ run_test("partners", () => {
     assert.equal(pmc.is_partner(user3_id), true);
 });
 
-const people = zrequire("people");
-
 run_test("insert_recent_private_message", () => {
     const params = {
         recent_private_conversations: [
@@ -31,7 +35,7 @@ run_test("insert_recent_private_message", () => {
         ],
     };
     people.initialize_current_user(15);
-    pmc.recent.initialize(params);
+    initialize_recents(params);
 
     assert.deepEqual(pmc.recent.get(), [
         {user_ids_string: "2,11", max_message_id: 150},

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -110,14 +110,23 @@ run_test("robust_uri_decode", () => {
     assert.equal(util.robust_uri_decode("xxx%3Ayyy"), "xxx:yyy");
     assert.equal(util.robust_uri_decode("xxx%3"), "xxx");
 
-    set_global("decodeURIComponent", () => {
-        throw new Error("foo");
-    });
-    try {
-        util.robust_uri_decode("%E0%A4%A");
-    } catch (error) {
-        assert.equal(error.message, "foo");
-    }
+    let error_message;
+    with_field(
+        global,
+        "decodeURIComponent",
+        () => {
+            throw new Error("foo");
+        },
+        () => {
+            try {
+                util.robust_uri_decode("%E0%A4%A");
+            } catch (error) {
+                error_message = error.message;
+            }
+        },
+    );
+
+    assert.equal(error_message, "foo");
 });
 
 run_test("dumb_strcmp", () => {

--- a/static/js/pm_conversations.js
+++ b/static/js/pm_conversations.js
@@ -18,6 +18,12 @@ class RecentPrivateMessages {
     recent_message_ids = new FoldDict(); // key is user_ids_string
     recent_private_messages = [];
 
+    clear_for_testing() {
+        // Because we only export the singleton, we need this for tests.
+        this.recent_message_ids.clear();
+        this.recent_private_messages.length = 0;
+    }
+
     insert(user_ids, message_id) {
         if (user_ids.length === 0) {
             // The server sends [] for self-PMs.


### PR DESCRIPTION
I have a branch where I have the node tests runner run all the `run_test` blocks forward, then reverse, and then forward again, in order to detect tests that rely on state leaking from the previous tests.  There are some false positives with that technique, but there are plenty of true negatives.

I've been going through the list and trying to cherry-pick modules that I know to be mostly sane and cleaning them up a bit.