### PR TITLE
eslint: Re-enable no-undef for TypeScript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -115,6 +115,15 @@
             }
         },
         {
+            "files": ["frontend_tests/puppeteer_lib/**", "frontend_tests/puppeteer_tests/**"],
+            "globals": {
+                "$": false,
+                "current_msg_list": false,
+                "page_params": false,
+                "zulip_test": false
+            }
+        },
+        {
             "files": ["static/js/**"],
             "globals": {
                 "$": false,
@@ -161,7 +170,8 @@
                 "@typescript-eslint/prefer-regexp-exec": "error",
                 "@typescript-eslint/prefer-string-starts-ends-with": "error",
                 "@typescript-eslint/promise-function-async": "error",
-                "@typescript-eslint/unified-signatures": "error"
+                "@typescript-eslint/unified-signatures": "error",
+                "no-undef": "error"
             }
         },
         {


### PR DESCRIPTION
@typescript-eslint/recommended disables no-undef on the theory that TypeScript knows which globals are in scope. However, some TypeScript definitions include declarations for globals that may or may not actually be available depending on the environment.  So we will need to prohibit some globals that TypeScript knows about, and enforce that they are properly imported.