### PR TITLE
hostpots: Add TUTORIAL_ENABLED setting to toggle INTRO_HOTSPOTS.

### DIFF
--- a/zerver/lib/hotspots.py
+++ b/zerver/lib/hotspots.py
@@ -71,6 +71,10 @@ def get_next_hotspots(user: UserProfile) -> List[Dict[str, object]]:
             for hotspot in ALL_HOTSPOTS
         ]
 
+    # If a Zulip server has disabled the tutorial, never send hotspots.
+    if not settings.TUTORIAL_ENABLED:
+        return []
+
     if user.tutorial_status == UserProfile.TUTORIAL_FINISHED:
         return []
 

--- a/zerver/tests/test_hotspots.py
+++ b/zerver/tests/test_hotspots.py
@@ -28,15 +28,20 @@ class TestGetNextHotspots(ZulipTestCase):
         self.assertEqual(hotspots[0]["name"], "intro_streams")
 
     def test_all_intro_hotspots_done(self) -> None:
-        self.assertNotEqual(self.user.tutorial_status, UserProfile.TUTORIAL_FINISHED)
-        for hotspot in INTRO_HOTSPOTS:
-            do_mark_hotspot_as_read(self.user, hotspot)
-        self.assertEqual(self.user.tutorial_status, UserProfile.TUTORIAL_FINISHED)
-        self.assertEqual(get_next_hotspots(self.user), [])
+        with self.settings(TUTORIAL_ENABLED=True):
+            self.assertNotEqual(self.user.tutorial_status, UserProfile.TUTORIAL_FINISHED)
+            for hotspot in INTRO_HOTSPOTS:
+                do_mark_hotspot_as_read(self.user, hotspot)
+            self.assertEqual(self.user.tutorial_status, UserProfile.TUTORIAL_FINISHED)
+            self.assertEqual(get_next_hotspots(self.user), [])
 
     def test_send_all(self) -> None:
         with self.settings(DEVELOPMENT=True, ALWAYS_SEND_ALL_HOTSPOTS=True):
             self.assertEqual(len(ALL_HOTSPOTS), len(get_next_hotspots(self.user)))
+
+    def test_tutorial_disabled(self) -> None:
+        with self.settings(TUTORIAL_ENABLED=False):
+            self.assertEqual(get_next_hotspots(self.user), [])
 
 
 class TestHotspots(ZulipTestCase):

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -100,8 +100,6 @@ else:
 
 # This is overridden in test_settings.py for the test suites
 TEST_SUITE = False
-# The new user tutorial is enabled by default, but disabled for client tests.
-TUTORIAL_ENABLED = True
 # This is overridden in test_settings.py for the test suites
 PUPPETEER_TESTS = False
 # This is overridden in test_settings.py for the test suites

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -190,6 +190,10 @@ TWO_FACTOR_AUTHENTICATION_ENABLED = False
 # in development mode.
 ALWAYS_SEND_ALL_HOTSPOTS = False
 
+# The new user tutorial is enabled by default, but can be disabled for
+# self-hosters who want to disable the tutorial entirely on their system.
+TUTORIAL_ENABLED = True
+
 # In-development search pills feature.
 SEARCH_PILLS_ENABLED = False
 

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -672,6 +672,9 @@ ENABLE_GRAVATAR = True
 ## to '' will disable the Camo integration.
 CAMO_URI = "/external_content/"
 
+## Controls the tutorial popups for new users.
+# TUTORIAL_ENABLED = True
+
 ## Controls whether Zulip will rate-limit user requests.
 # RATE_LIMITING = True
 

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -93,9 +93,6 @@ RATE_LIMITING_AUTHENTICATE = False
 # real app.
 USING_RABBITMQ = False
 
-# Disable the tutorial because it confuses the client tests.
-TUTORIAL_ENABLED = False
-
 # Disable use of memcached for caching
 CACHES["database"] = {
     "BACKEND": "django.core.cache.backends.dummy.DummyCache",


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is an extension to #17485, as suggested by @timabbott [here](https://github.com/zulip/zulip/pull/17485#issuecomment-792489478). Instead of removing the `TUTORIAL_ENABLED` setting altogether, we use it to toggle displaying `INTRO_HOTSPOTS`. This enabled self-hosters to disable the tutorial feature when onboarding new users.

**Testing plan:** <!-- How have you tested? -->
Tested manually, along with test cases added to `test_hotspots.py`


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

I have kept the commit from Anders in #17485 as is since the settings can now be placed in `default_settings.py`  with an entry added to `prod_settings_template.py` to overwrite it.
