### PR TITLE
Ignore non-delimiter '--' in email mirror `filter_footer`

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -323,7 +323,7 @@ def filter_footer(text: str) -> str:
         # isn't a trivial footer structure.
         return text
 
-    return text.partition("--")[0].strip()
+    return re.split(r"^\s*--\s*$", text, 1, flags=re.MULTILINE)[0].strip()
 
 
 def extract_and_upload_attachments(message: EmailMessage, realm: Realm) -> str:

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -211,10 +211,15 @@ class TestGetMissedMessageToken(ZulipTestCase):
 class TestFilterFooter(ZulipTestCase):
     def test_filter_footer(self) -> None:
         text = """Test message
+        --Not a delimiter--
+        More message
         --
         Footer"""
+        expected_output = """Test message
+        --Not a delimiter--
+        More message"""
         result = filter_footer(text)
-        self.assertEqual(result, "Test message")
+        self.assertEqual(result, expected_output)
 
     def test_filter_footer_many_parts(self) -> None:
         text = """Test message


### PR DESCRIPTION
#17502 is caused by `filter_footer` splitting the message at the first `--` encountered, instead of the `line.strip() == "--"` it looks for earlier.

This PR changes the email mirror test case to account for #17502, and fixes `filter_footer` by splitting using a regex equivalent to the condition used when counting delimiter candidates.

There was a suggestion by @andersk to use `talon.signature.bruteforce.extract_signature` which would have been better, but the bundled talon doesn't include it.