### PR TITLE
lint: Scrutinize jQuery .append() like .html()

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -128,8 +128,8 @@ js_rules = RuleList(
         },
         {"pattern": r"\+.*\$t\(.+\)", "description": "Do not concatenate i18n strings"},
         {
-            "pattern": "[.]html[(]",
-            "exclude_pattern": r"""\.html\(("|'|render_|html|message\.content|util\.clean_user_content_links|rendered_|$|\)|error_html|widget_elem|\$error|\$\("<p>"\))""",
+            "pattern": r"\.(append|html)\(",
+            "exclude_pattern": r"""\.(append|html)\(("|'|render_|html|message\.content|util\.clean_user_content_links|rendered_|$|\)|error_html|widget_elem|\$error|\$\("<p>"\))""",
             "exclude": {
                 "static/js/portico",
                 "static/js/lightbox.js",
@@ -137,7 +137,8 @@ js_rules = RuleList(
                 "static/js/dialog_widget.js",
                 "frontend_tests/",
             },
-            "description": "Setting HTML content with jQuery .html() can lead to XSS security bugs.  Consider .text() or using rendered_foo as a variable name if content comes from Handlebars and thus is already sanitized.",
+            "description": "Setting HTML content with jQuery .append() or .html() can lead to XSS security bugs.  Consider .text() or using rendered_foo as a variable name if content comes from Handlebars and thus is already sanitized.",
+            "bad_lines": ['$("#id").append(text)', '$("#id").html(text)'],
         },
         {
             "pattern": "[\"']json/",


### PR DESCRIPTION
`.append()` interprets a string argument as HTML code just like `.html()` does. While there are many other problems with this lint rule in terms of false positives and false negatives, at least this change removes the incentive to trivially bypass it using equivalently insecure code.