### PR TITLE
node_test: Add clear_search tests for clear_search_stream_button.

### DIFF
--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -100,6 +100,17 @@ function test_ui(label, f) {
     });
 }
 
+test_ui("clear_search", (override) => {
+    stream_list.set_event_handlers();
+    override(stream_list, "update_streams_for_search", () => {});
+
+    $(".stream-list-filter").val("somevalue");
+    $("#clear_search_stream_button").trigger("click");
+    assert.equal($(".stream-list-filter").val(), "");
+    $("#clear_search_stream_button").trigger("click");
+    assert($(".stream_search_section").hasClass("notdisplayed"));
+});
+
 test_ui("create_sidebar_row", (override) => {
     // Make a couple calls to create_sidebar_row() and make sure they
     // generate the right markup as well as play nice with get_stream_li().


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) --> Missing clear_search node tests for clear_search_stream_button.


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
