### PR TITLE
UI: Adjust messaging for users who have 50K unread messages.

### DIFF
--- a/templates/zerver/app/navbar_alerts.html
+++ b/templates/zerver/app/navbar_alerts.html
@@ -47,9 +47,17 @@
     </div>
     <div data-process="bankruptcy" class="alert alert-info brankruptcy">
         <div data-step="1">
-            {% trans count=page_params.unread_msgs.count %}
-            Welcome back!  You have <span class="bankruptcy_unread_count">{{ count }}</span> unread messages.  Do you want to mark them all as read?
-            {% endtrans %}
+            {% with old_unreads_missing=page_params.unread_msgs.old_unreads_missing, count=page_params.unread_msgs.count %}
+                {% if old_unreads_missing %}
+                    {% trans %}
+                    Welcome back!  You have <a href="/help/unread-messages">more than <span class="bankruptcy_unread_count">{{ count }}</span></a> unread messages. Do you want to mark them all as read?
+                    {% endtrans %}
+                {% else %}
+                    {% trans %}
+                    Welcome back!  You have <span class="bankruptcy_unread_count">{{ count }}</span> unread messages. Do you want to mark them all as read?
+                    {% endtrans %}
+                {% endif %}
+            {% endwith %}
             <span class="buttons">
                 <a class="alert-link accept-bankruptcy" role="button" tabindex=0>{{ _("Yes, please!") }}</a>
                 &bull;

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -50,6 +50,7 @@
 * [Link to a message or conversation](/help/link-to-a-message-or-conversation)
 * [Advanced search](/help/search-for-messages)
 * [View a message's edit history](/help/view-a-messages-edit-history)
+* [Unread messages](/help/unread-messages)
 
 ## People
 * [Status and availability](/help/status-and-availability)

--- a/templates/zerver/help/unread-messages.md
+++ b/templates/zerver/help/unread-messages.md
@@ -1,0 +1,3 @@
+# Unread Messages
+
+Zulip only shows the first 50,000 unread messages. A user won't be able to read more than 50,000 unread messages.


### PR DESCRIPTION
Fixes: #17469

**GIFs or screenshots:**
![50k_unread](https://user-images.githubusercontent.com/42413316/111133195-3f686580-85a0-11eb-8bba-5ba79456a01f.gif)
