### PR TITLE
ready: Wait for other ready callbacks before marking app loaded

### DIFF
--- a/static/js/ready.js
+++ b/static/js/ready.js
@@ -1,3 +1,5 @@
 import $ from "jquery";
 
-$("#app-loading").addClass("loaded");
+$(() => {
+    $("#app-loading").addClass("loaded");
+});


### PR DESCRIPTION
This is needed not because the DOM isn’t ready here (we’re in a `<script defer>`), but because we want to wait an asynchronous tick until after all the other callbacks that waited an asynchronous tick for the DOM to be ready.

~~This is a potential fix for the ``TimeoutError: waiting for selector `a[href^='#settings']` failed`` Puppeteer flake in `07-navigation.ts`.~~ Edit: @Riken-Shah’s [diagnosis](https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/master.20failing/near/1131271) of that flake might be more plausible.