### PR TITLE
sponsorships: Don't translate the subject of support emails

### DIFF
--- a/templates/zerver/emails/sponsorship_request.subject.txt
+++ b/templates/zerver/emails/sponsorship_request.subject.txt
@@ -1,1 +1,1 @@
-{% trans %}Sponsorship request ({{ organization_type }}) for {{ string_id }}{% endtrans %}
+Sponsorship request ({{ organization_type }}) for {{ string_id }}


### PR DESCRIPTION
The email subject used to be translated to the language of the user who requested the sponsorship. This was a bug since
the recipient of the emails are Zulip's support staff and not the user who requested the sponsorship.

