### PR TITLE
puppet: Explicitly use the snakeoil certificates for nginx.

### DIFF
--- a/puppet/zulip_ops/files/nginx/sites-available/zulip
+++ b/puppet/zulip_ops/files/nginx/sites-available/zulip
@@ -3,12 +3,15 @@ include /etc/nginx/zulip-include/upstreams;
 server {
     listen 443;
 
-    # While a proper wildcard cert is recommended, because nginx
-    # doesn't actually check SSL certificates when reverse proxying
-    # :(, one can get away with a snake-oil cert if one wants.
+    # This server is behind an ALB, which does not check the
+    # certificate validity:
+    # https://kevin.burke.dev/kevin/aws-alb-validation-tls-reply/
+    #
+    # Snakeoil verts are good for 10 years after initial creation, but
+    # the ALBs don't even check expiration. ¯\_(ツ)_/¯
     ssl on;
-    ssl_certificate /etc/ssl/certs/wildcard-zulipchat.com.combined-chain.crt;
-    ssl_certificate_key /etc/ssl/private/wildcard-zulipchat.com.key;
+    ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem
+    ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key
 
     server_name zulipchat.com *.zulipchat.com;
 


### PR DESCRIPTION
In production, the `wildcard-zulipchat.com.combined-chain.crt` file is
just a symlink to the snakeoil certificates; but we do not puppet that
symlink, which makes new hosts fail to start cleanly.  Instead, point
explicitly to the snakeoil certificate, and explain why.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
