### PR TITLE
puppeteer_lib: Remove jQuery dependency

### DIFF
--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -197,15 +197,6 @@ class CommonUtils {
         return texts.join("").trim();
     }
 
-    async wait_for_text(page: Page, selector: string, text: string): Promise<void> {
-        await page.waitForFunction(
-            (selector: string, text: string) => $(selector).text().includes(text),
-            {},
-            selector,
-            text,
-        );
-    }
-
     async get_stream_id(page: Page, stream_name: string): Promise<number> {
         return await page.evaluate(
             (stream_name: string) => zulip_test.get_stream_id(stream_name),

--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -22,20 +22,16 @@ class CommonUtils {
             // a flake where the typeahead doesn't show up.
             await page.type("#private_message_recipient", recipient, {delay: 100});
 
-            // We use jQuery here because we need to use it's :visible
-            // pseudo selector to actually wait for typeahead item that
-            // is visible; there can be typeahead item with this selector
-            // that is invisible because it is meant for something else
-            // e.g. private message input typeahead is different from topic
-            // input typeahead but both can be present in the dom.
-            await page.waitForFunction(() => {
-                const selector = ".typeahead-menu .active a:visible";
-                return $(selector).length !== 0;
-            });
-
-            await page.evaluate(() => {
-                $(".typeahead-menu .active a:visible").trigger("click");
-            });
+            // We use [style*="display: block"] here to distinguish
+            // the visible typeahead menu from the invisible ones
+            // meant for something else; e.g., the private message
+            // input typeahead is different from the topic input
+            // typeahead but both can be present in the DOM.
+            const entry = await page.waitForSelector(
+                '.typeahead[style*="display: block"] .active a',
+                {visible: true},
+            );
+            await entry!.click();
         },
 
         async expect(page: Page, expected: string): Promise<void> {

--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -2,7 +2,7 @@ import {strict as assert} from "assert";
 import "css.escape";
 import path from "path";
 
-import {Browser, Page, launch} from "puppeteer";
+import {Browser, ElementHandle, Page, launch} from "puppeteer";
 
 import {test_credentials} from "../../var/puppeteer/test_credentials";
 
@@ -185,8 +185,16 @@ class CommonUtils {
         }
     }
 
+    async get_element_text(element: ElementHandle<Element>): Promise<string> {
+        return (await element.getProperty("textContent"))!.jsonValue();
+    }
+
     async get_text_from_selector(page: Page, selector: string): Promise<string> {
-        return await page.evaluate((selector: string) => $(selector).text().trim(), selector);
+        const elements = await page.$$(selector);
+        const texts = await Promise.all(
+            elements.map(async (element) => this.get_element_text(element)),
+        );
+        return texts.join("").trim();
     }
 
     async wait_for_text(page: Page, selector: string, text: string): Promise<void> {

--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -479,29 +479,11 @@ class CommonUtils {
         item: string,
     ): Promise<void> {
         console.log(`Looking in ${field_selector} to select ${str}, ${item}`);
-        await page.evaluate(
-            (field_selector: string, str: string, item: string) => {
-                // Set the value and then send a bogus keyup event to trigger
-                // the typeahead.
-                $(field_selector)
-                    .trigger("focus")
-                    .val(str)
-                    .trigger(new $.Event("keyup", {which: 0}));
-
-                // Trigger the typeahead.
-                // Reaching into the guts of Bootstrap Typeahead like this is not
-                // great, but I found it very hard to do it any other way.
-
-                const tah = $(field_selector).data().typeahead;
-                tah.mouseenter({
-                    currentTarget: $(`.typeahead:visible li:contains("${CSS.escape(item)}")`)[0],
-                });
-                tah.select();
-            },
-            field_selector,
-            str,
-            item,
+        await this.clear_and_type(page, field_selector, str);
+        const entry = await page.waitForXPath(
+            `//*[@class="typeahead dropdown-menu" and contains(@style, "display: block")]//li[contains(normalize-space(), "${item}")]//a`,
         );
+        await entry!.click();
     }
 
     async run_test(test_function: (page: Page) => Promise<void>): Promise<void> {

--- a/frontend_tests/puppeteer_tests/02-message-basics.ts
+++ b/frontend_tests/puppeteer_tests/02-message-basics.ts
@@ -131,6 +131,8 @@ async function search_and_check(
     check: (page: Page) => Promise<void>,
     expected_narrow_title: string,
 ): Promise<void> {
+    await page.click(".search_icon");
+    await page.waitForSelector("#search_query", {visible: true});
     await common.select_item_via_typeahead(page, "#search_query", search_str, item_to_select);
     await check(page);
     assert.strictEqual(await page.title(), expected_narrow_title);
@@ -139,6 +141,8 @@ async function search_and_check(
 }
 
 async function search_silent_user(page: Page, str: string, item: string): Promise<void> {
+    await page.click(".search_icon");
+    await page.waitForSelector("#search_query", {visible: true});
     await common.select_item_via_typeahead(page, "#search_query", str, item);
     await page.waitForSelector("#silent_user", {visible: true});
     const expect_message = "You haven't received any messages sent by this user yet!";
@@ -165,6 +169,8 @@ async function expect_non_existing_users(page: Page): Promise<void> {
 }
 
 async function search_non_existing_user(page: Page, str: string, item: string): Promise<void> {
+    await page.click(".search_icon");
+    await page.waitForSelector("#search_query", {visible: true});
     await common.select_item_via_typeahead(page, "#search_query", str, item);
     await expect_non_existing_user(page);
     await un_narrow(page);

--- a/frontend_tests/puppeteer_tests/07-navigation.ts
+++ b/frontend_tests/puppeteer_tests/07-navigation.ts
@@ -97,7 +97,9 @@ async function navigation_tests(page: Page): Promise<void> {
     await test_reload_hash(page);
 
     // Verify that we're narrowed to the target stream
-    await common.wait_for_text(page, "#message_view_header .stream", "Verona");
+    await page.waitForXPath(
+        '//*[@id="message_view_header"]//*[@class="stream" and normalize-space()="Verona"]',
+    );
 
     await common.log_out(page);
 }

--- a/frontend_tests/puppeteer_tests/08-admin.ts
+++ b/frontend_tests/puppeteer_tests/08-admin.ts
@@ -36,12 +36,11 @@ async function test_change_new_stream_notifications_setting(page: Page): Promise
         "verona",
     );
 
-    const verona_in_dropdown =
-        "#realm_notifications_stream_id_widget .dropdown-list-body > li:nth-of-type(1)";
-
-    await common.wait_for_text(page, verona_in_dropdown, "Verona");
-    await page.waitForSelector(verona_in_dropdown, {visible: true});
-    await page.evaluate((selector: string) => $(selector).trigger("click"), verona_in_dropdown);
+    const verona_in_dropdown = await page.waitForXPath(
+        '//*[@id="realm_notifications_stream_id_widget"]//*[@class="dropdown-list-body"]/li[1]',
+        {visible: true},
+    );
+    await verona_in_dropdown!.click();
 
     await submit_notifications_stream_settings(page);
 

--- a/frontend_tests/puppeteer_tests/09-mention.ts
+++ b/frontend_tests/puppeteer_tests/09-mention.ts
@@ -29,10 +29,8 @@ async function test_mention(page: Page): Promise<void> {
     assert(stream_size > threshold);
     await page.click("#compose-send-button");
 
-    await common.wait_for_text(
-        page,
-        ".compose-all-everyone-msg",
-        "Are you sure you want to mention all",
+    await page.waitForXPath(
+        '//*[@class="compose-all-everyone-msg" and contains(text(), "Are you sure you want to mention all")]',
     );
     await page.click(".compose-all-everyone-confirm");
     await page.waitForSelector(".compose-all-everyone-msg", {hidden: true});

--- a/frontend_tests/puppeteer_tests/09-mention.ts
+++ b/frontend_tests/puppeteer_tests/09-mention.ts
@@ -15,7 +15,7 @@ async function test_mention(page: Page): Promise<void> {
         stream_message_recipient_stream: "Verona",
         stream_message_recipient_topic: "Test mention all",
     });
-    await common.select_item_via_typeahead(page, "#compose-textarea", "@**all**", "all");
+    await common.select_item_via_typeahead(page, "#compose-textarea", "@**all", "all");
     await common.ensure_enter_does_not_send(page);
 
     console.log("Checking for all everyone warning");

--- a/frontend_tests/puppeteer_tests/10-custom-profile.ts
+++ b/frontend_tests/puppeteer_tests/10-custom-profile.ts
@@ -21,7 +21,9 @@ async function test_add_new_profile_field(page: Page): Promise<void> {
         await common.get_text_from_selector(page, "div#admin-add-profile-field-status"),
         "Saved",
     );
-    await common.wait_for_text(page, `${profile_field_row} span.profile_field_name`, "Teams");
+    await page.waitForXPath(
+        '//*[@id="admin_profile_fields_table"]//tr[last()-1]/td[normalize-space()="Teams"]',
+    );
     assert.strictEqual(
         await common.get_text_from_selector(page, `${profile_field_row} span.profile_field_type`),
         "Short text",
@@ -37,7 +39,9 @@ async function test_edit_profile_field(page: Page): Promise<void> {
     await page.click(`${profile_field_form} button.submit`);
 
     await page.waitForSelector("#admin-profile-field-status img", {visible: true});
-    await common.wait_for_text(page, `${profile_field_row} span.profile_field_name`, "team");
+    await page.waitForXPath(
+        '//*[@id="admin_profile_fields_table"]//tr[last()-1]/td[normalize-space()="team"]',
+    );
     assert.strictEqual(
         await common.get_text_from_selector(page, `${profile_field_row} span.profile_field_type`),
         "Short text",

--- a/frontend_tests/puppeteer_tests/12-drafts.ts
+++ b/frontend_tests/puppeteer_tests/12-drafts.ts
@@ -93,7 +93,10 @@ async function test_previously_created_drafts_rendered(page: Page): Promise<void
         "tests",
     );
     assert.strictEqual(
-        await common.get_text_from_selector(page, ".rendered_markdown.restore-draft:first"),
+        await common.get_text_from_selector(
+            page,
+            ".draft-row:nth-last-child(2) .rendered_markdown.restore-draft",
+        ),
         "Test private message.",
     );
     assert.strictEqual(
@@ -104,7 +107,10 @@ async function test_previously_created_drafts_rendered(page: Page): Promise<void
         "You and Cordelia Lear, King Hamlet",
     );
     assert.strictEqual(
-        await common.get_text_from_selector(page, ".rendered_markdown.restore-draft:last"),
+        await common.get_text_from_selector(
+            page,
+            ".draft-row:last-child .rendered_markdown.restore-draft",
+        ),
         "Test stream message.",
     );
 }
@@ -156,7 +162,10 @@ async function test_edited_draft_message(page: Page): Promise<void> {
         "tests",
     );
     assert.strictEqual(
-        await common.get_text_from_selector(page, ".rendered_markdown.restore-draft:first"),
+        await common.get_text_from_selector(
+            page,
+            ".draft-row:nth-last-child(2) .rendered_markdown.restore-draft",
+        ),
         "Updated Stream Message",
     );
 }
@@ -224,7 +233,10 @@ async function test_save_draft_by_reloading(page: Page): Promise<void> {
         "You and Cordelia Lear",
     );
     assert.strictEqual(
-        await common.get_text_from_selector(page, ".rendered_markdown.restore-draft:first"),
+        await common.get_text_from_selector(
+            page,
+            ".draft-row:nth-last-child(2) .rendered_markdown.restore-draft",
+        ),
         "Test private message draft.",
     );
 }

--- a/frontend_tests/puppeteer_tests/16-settings.ts
+++ b/frontend_tests/puppeteer_tests/16-settings.ts
@@ -172,13 +172,9 @@ async function test_edit_bot_form(page: Page): Promise<void> {
     // The form gets closed on saving. So, assert it's closed by waiting for it to be hidden.
     await page.waitForSelector("#edit_bot_modal", {hidden: true});
 
-    const bot1_name_selector = `.details:has(${bot1_edit_btn}) .name`;
-    await page.waitForFunction(
-        (bot1_name_selector: string) => $(bot1_name_selector).text() !== "Bot 1",
-        {},
-        bot1_name_selector,
+    await page.waitForXPath(
+        `//*[@class="btn open_edit_bot_form" and @data-email="${bot1_email}"]/ancestor::*[@class="details"]/*[@class="name" and text()="Bot one"]`,
     );
-    assert.strictEqual(await common.get_text_from_selector(page, bot1_name_selector), "Bot one");
 }
 
 async function test_your_bots_section(page: Page): Promise<void> {


### PR DESCRIPTION
We use jQuery internally as a module now (#17544), so we don’t want the tests to pull it out of the page’s global variables: that’s an abstraction violation, and it also causes flakes during early page load when jQuery might not yet be available. Instead, the tests should ideally interact with the page using external interfaces that correspond as closely as possible to the ways a human interacts with the page.

This work was started in @Riken-Shah’s #17136. There are still uses of jQuery in the individual tests in `puppeteer_tests`, to be removed in the future.