### PR TITLE
zjsunit: Extract complain_about_unused_mocks.

### DIFF
--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -74,6 +74,7 @@ function run_one_module(file) {
     console.info("running test " + path.basename(file, ".js"));
     test.set_current_file_name(file);
     require(file);
+    namespace.complain_about_unused_mocks();
 }
 
 test.set_verbose(files.length === 1);

--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -136,6 +136,16 @@ exports.zrequire = function (short_fn) {
 const staticPath = path.resolve(__dirname, "../../static") + path.sep;
 const templatesPath = staticPath + "templates" + path.sep;
 
+exports.complain_about_unused_mocks = function () {
+    for (const filename of module_mocks.keys()) {
+        if (!used_module_mocks.has(filename)) {
+            throw new Error(
+                `You asked to mock ${filename} but we never saw it during compilation.`,
+            );
+        }
+    }
+};
+
 exports.finish = function () {
     /*
         Handle cleanup tasks after we've run one module.
@@ -151,13 +161,6 @@ exports.finish = function () {
     Module._load = actual_load;
     actual_load = undefined;
 
-    for (const filename of module_mocks.keys()) {
-        if (!used_module_mocks.has(filename)) {
-            throw new Error(
-                `You asked to mock ${filename} but we never saw it during compilation.`,
-            );
-        }
-    }
     module_mocks.clear();
     used_module_mocks.clear();
 


### PR DESCRIPTION
This is prep toward allowing individual tests
to fail while continuing to run the test suite.

Most of the steps in namespace.finish() could
be put in a `finally` block, but once a test
fails, there's no reason to complain about
unused mocks, since there are bigger things
to address.

