### PR TITLE
settings: Rework user_group save_discard widget

### DIFF
--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -111,9 +111,16 @@ export function populate_user_groups() {
                 .text()
                 .trim();
             const user_group_status = $(`#user-groups #${CSS.escape(data.id)} .user-group-status`);
-
             if (user_group_status.is(":visible")) {
+                reload();
                 return false;
+            }
+            // temporarily disables click-function on other user-groups
+            // and allows editing one user group at a time
+            for (const element of user_groups_array) {
+                if (group_data.id !== element.id) {
+                    $("#" + element.id).addClass("avoid-user-group-clicks");
+                }
             }
 
             if (
@@ -133,12 +140,17 @@ export function populate_user_groups() {
             const cancel_button = $(`#user-groups #${CSS.escape(data.id)} .save-status.btn-danger`);
             const saved_button = $(`#user-groups #${CSS.escape(data.id)} .save-status.sea-green`);
             const save_instructions = $(`#user-groups #${CSS.escape(data.id)} .save-instructions`);
+            const save_user_group_btn = $(
+                "#user-groups #" + data.id + " .save-discard-widget-button",
+            );
 
             if (is_user_group_changed() && !cancel_button.is(":visible")) {
                 saved_button.fadeOut(0);
+                save_user_group_btn.css({display: "inline-block", opacity: "0"}).fadeTo(400, 1);
                 cancel_button.css({display: "inline-block", opacity: "0"}).fadeTo(400, 1);
                 save_instructions.css({display: "block", opacity: "0"}).fadeTo(400, 1);
             } else if (!is_user_group_changed() && cancel_button.is(":visible")) {
+                reload();
                 cancel_button.fadeOut();
                 save_instructions.fadeOut();
             }
@@ -218,57 +230,23 @@ export function populate_user_groups() {
             });
         }
 
-        function do_not_blur(except_class, event) {
-            // Event generated from or inside the typeahead.
-            if ($(event.relatedTarget).closest(".typeahead").length) {
-                return true;
-            }
-
-            const blur_exceptions = _.without(
-                [".pill-container", ".name", ".description", ".input", ".delete"],
-                except_class,
-            );
-            if ($(event.relatedTarget).closest(`#user-groups #${CSS.escape(data.id)}`).length) {
-                return blur_exceptions.some(
-                    (class_name) => $(event.relatedTarget).closest(class_name).length,
-                );
-            }
-            return false;
-        }
-
-        function auto_save(class_name, event) {
-            if (!can_edit(data.id)) {
-                return;
-            }
-
-            if (do_not_blur(class_name, event)) {
-                return;
-            }
-            if (
-                $(event.relatedTarget).closest(`#user-groups #${CSS.escape(data.id)}`) &&
-                $(event.relatedTarget).closest(".save-status.btn-danger").length
-            ) {
-                reload();
-                return;
-            }
+        function auto_save() {
             save_name_desc();
             save_members();
         }
 
-        $(`#user-groups #${CSS.escape(data.id)}`).on("blur", ".input", (event) => {
-            auto_save(".input", event);
+        $(`#user-groups #${CSS.escape(data.id)}`).on("click", "#save-user-group", () => {
+            auto_save();
         });
 
-        $(`#user-groups #${CSS.escape(data.id)}`).on("blur", ".name", (event) => {
-            auto_save(".name", event);
+        $(`#user-groups #${CSS.escape(data.id)}`).on("click", ".save-status.btn-danger", () => {
+            reload();
         });
+
         $(`#user-groups #${CSS.escape(data.id)}`).on("input", ".name", () => {
             update_cancel_button();
         });
 
-        $(`#user-groups #${CSS.escape(data.id)}`).on("blur", ".description", (event) => {
-            auto_save(".description", event);
-        });
         $(`#user-groups #${CSS.escape(data.id)}`).on("input", ".description", () => {
             update_cancel_button();
         });
@@ -342,7 +320,6 @@ export function set_up() {
         }
         const user_group = user_groups.get_user_group_from_id(group_id);
         const btn = $(this);
-
         function delete_user_group() {
             channel.del({
                 url: "/json/user_groups/" + group_id,

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1050,6 +1050,10 @@ input[type="checkbox"] {
         }
     }
 
+    .avoid-user-group-clicks {
+        pointer-events: none;
+    }
+
     .save-status {
         background-color: transparent;
         padding: 2px 5px;

--- a/static/templates/admin_user_group_list.hbs
+++ b/static/templates/admin_user_group_list.hbs
@@ -9,8 +9,11 @@
             <img class="checkmark" src="/static/images/checkbox-green.svg" />
             {{t 'Saved' }}
         </button>
-        <button class="button save-status btn-danger small">
+        <button class="save-status btn-danger save-discard-widget-button button discard-button">
             {{t 'Discard changes' }}
+        </button>
+        <button class="save-discard-widget-button save-status button primary save-button" id='save-user-group'>
+            {{t 'Save changes' }}
         </button>
         <button class="button rounded small delete btn-danger">
             {{t 'Delete' }}
@@ -21,7 +24,7 @@
         <div class="input" contenteditable="true" data-placeholder="{{t 'Add member...' }}"></div>
     </div>
     <p class="save-instructions">
-        {{t "Click outside the input box to save. We'll automatically notify anyone that was added or removed."}}
+        {{t "We'll automatically notify anyone that was added or removed."}}
     </p>
 </div>
 {{/with}}


### PR DESCRIPTION
Added a consistent save/discard widget inside the
USER GROUP widget and replaces the inconsistent
"Click outside to save or click discard to discard" UI it had.
Allows users to edit user group-settings one user group at a time.

Fixes: #16453

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
![2020-12-08-16-33-39 (1)](https://user-images.githubusercontent.com/56171163/111036608-0b792d00-8446-11eb-8591-9db9bc457ddf.gif)
