### PR TITLE
zjsunit: Truncate the stack trace only at run_one_module.

### DIFF
--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -60,7 +60,7 @@ Module.prototype.hot = {
 function short_tb(tb) {
     const lines = tb.split("\n");
 
-    const i = lines.findIndex((line) => line.includes("Module._compile"));
+    const i = lines.findIndex((line) => line.includes("run_one_module"));
 
     if (i === -1) {
         return tb;


### PR DESCRIPTION
Commit 5bd73ce1909b46078b9576101be250fda639a826 (#17367) unintentionally truncated more of the traceback rather than less when there’s more than one `Module._compile` frame.

[Discussion on CZO](https://chat.zulip.org/#narrow/stream/92-learning/topic/Node.20tests.20for.20clear.20search.20buttons/near/1131880).

**Testing plan:** Before:

```
test failed: /srv/zulip/frontend_tests/node_tests/stream_list.js > clear_search

TypeError: $(...).width is not a function
    at Object.<anonymous> (/srv/zulip/static/js/resize.js:217:28)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
(...)


** Tests failed, PLEASE FIX! **
```

After:

```
test failed: /srv/zulip/frontend_tests/node_tests/stream_list.js > clear_search

TypeError: $(...).width is not a function
    at Object.<anonymous> (/srv/zulip/static/js/resize.js:217:28)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Module._compile (/srv/zulip/node_modules/pirates/lib/index.js:99:24)
    at Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Object.newLoader [as .js] (/srv/zulip/node_modules/pirates/lib/index.js:104:7)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.load [as _load] (/srv/zulip/frontend_tests/zjsunit/namespace.js:20:12)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at resize (/srv/zulip/static/js/stream_list.js:12:1)
    at _get_original__ (/srv/zulip/static/js/stream_list.js:1306:38)
    at _get__ (/srv/zulip/static/js/stream_list.js:1201:12)
    at hide_search_section (/srv/zulip/static/js/stream_list.js:608:5)
    at clear_and_hide_search (/srv/zulip/static/js/stream_list.js:638:5)
    at Object.clear_search (/srv/zulip/static/js/stream_list.js:593:9)
    at Object.trigger (/srv/zulip/frontend_tests/zjsunit/zjquery.js:155:22)
    at Proxy.trigger (/srv/zulip/frontend_tests/zjsunit/zjquery.js:404:25)
    at /srv/zulip/frontend_tests/node_tests/stream_list.js:110:38
    at /srv/zulip/frontend_tests/node_tests/stream_list.js:99:9
    at Object.exports.with_overrides (/srv/zulip/frontend_tests/zjsunit/namespace.js:229:9)
    at exports.run_test (/srv/zulip/frontend_tests/zjsunit/test.js:29:19)
    at test_ui (/srv/zulip/frontend_tests/node_tests/stream_list.js:96:5)
    at Object.<anonymous> (/srv/zulip/frontend_tests/node_tests/stream_list.js:103:1)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Module._compile (/srv/zulip/node_modules/pirates/lib/index.js:99:24)
    at Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Object.newLoader [as .js] (/srv/zulip/node_modules/pirates/lib/index.js:104:7)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.load [as _load] (/srv/zulip/frontend_tests/zjsunit/namespace.js:20:12)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at run_one_module (/srv/zulip/frontend_tests/zjsunit/index.js:77:5)
(...)


** Tests failed, PLEASE FIX! **
```