### PR TITLE
settings css: Only allow to resize the textarea vertically.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1400,6 +1400,7 @@ input[type="checkbox"] {
         textarea {
             width: 320px;
             height: 80px;
+            resize: vertical;
         }
 
         &:hover .remove_date {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) --> Fixes #17617 


**Testing plan:** <!-- How have you tested? --> Tested manually.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![textareaverticallyonly](https://user-images.githubusercontent.com/59444243/111068996-002f0b80-84f1-11eb-95e2-0cf5d597967e.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
