### PR TITLE
views/streams: Prepares deactivate stream for hard delete feature.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -685,9 +685,12 @@ export function change_stream_description(e) {
     });
 }
 
-export function delete_stream(stream_id, alert_element, stream_row) {
+export function archive_stream(stream_id, alert_element, stream_row) {
     channel.del({
         url: "/json/streams/" + stream_id,
+        data: {
+            is_archive: JSON.stringify(true),
+        },
         error(xhr) {
             ui_report.error(i18n.t("Failed"), xhr, alert_element);
         },
@@ -865,7 +868,7 @@ export function initialize() {
             return;
         }
         const row = $(".stream-row.active");
-        delete_stream(stream_id, $(".stream_change_property_info"), row);
+        archive_stream(stream_id, $(".stream_change_property_info"), row);
     });
 
     $("#subscriptions_table").on("hide.bs.modal", "#deactivation_stream_modal", () => {

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -407,20 +407,32 @@ def get_stream_id(client: Client) -> int:
 
 
 @openapi_test_function("/streams/{stream_id}:delete")
-def delete_stream(client: Client, stream_id: int) -> None:
+def archive_stream(client: Client, stream_id: int) -> None:
     result = client.add_subscriptions(
         streams=[
             {
-                "name": "stream to be deleted",
+                "name": "stream to be archived",
                 "description": "New stream for testing",
             },
         ],
     )
 
     # {code_example|start}
-    # Delete the stream named 'new stream'
-    stream_id = client.get_stream_id("stream to be deleted")["stream_id"]
-    result = client.delete_stream(stream_id)
+    # Archive the stream named 'new stream'
+
+    # Give the boolean flag to archive the stream
+    request = {
+        "is_archive": True,
+    }
+
+    stream_id = client.get_stream_id("stream to be archived")["stream_id"]
+
+    result = client.call_endpoint(
+        url=f"streams/{stream_id}",
+        method="DELETE",
+        request=request,
+    )
+
     # {code_example|end}
     validate_against_openapi_schema(result, "/streams/{stream_id}", "delete", "200")
 
@@ -1336,7 +1348,7 @@ def test_streams(client: Client, nonadmin_client: Client) -> None:
     update_subscription_settings(client)
     update_notification_settings(client)
     get_stream_topics(client, 1)
-    delete_stream(client, stream_id)
+    archive_stream(client, stream_id)
 
     test_user_not_authorized_error(nonadmin_client)
     test_authorization_errors_fatal(client, nonadmin_client)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8232,11 +8232,19 @@ paths:
       operationId: delete_stream
       tags: ["streams"]
       description: |
-        [Delete the stream](/help/delete-a-stream) with the ID `stream_id`.
+        [Archive/Delete the stream](/help/delete-a-stream) with the ID `stream_id`.
 
         `DELETE {{ api_url }}/v1/streams/{stream_id}`
       parameters:
         - $ref: "#/components/parameters/StreamIdInPath"
+        - name: is_archive
+          in: query
+          description: |
+            Change whether the stream shall be archived or deleted.
+          schema:
+            type: boolean
+          example: true
+          required: false
       responses:
         "200":
           description: Success.

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -521,7 +521,7 @@ class StreamAdminTest(ZulipTestCase):
         self.subscribe(user_profile, stream.name)
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
 
-        result = self.client_delete(f"/json/streams/{stream.id}")
+        result = self.client_delete(f"/json/streams/{stream.id}", {"is_archive": orjson.dumps(True).decode()})
         self.assert_json_success(result)
         subscription_exists = (
             get_active_subscriptions_for_stream_id(stream.id)
@@ -540,7 +540,7 @@ class StreamAdminTest(ZulipTestCase):
             user_profile, sub, stream, "role", Subscription.ROLE_STREAM_ADMINISTRATOR
         )
 
-        result = self.client_delete(f"/json/streams/{stream.id}")
+        result = self.client_delete(f"/json/streams/{stream.id}", {"is_archive": orjson.dumps(True).decode()})
         self.assert_json_success(result)
         subscription_exists = (
             get_active_subscriptions_for_stream_id(stream.id)
@@ -636,7 +636,7 @@ class StreamAdminTest(ZulipTestCase):
         sub = get_subscription("new_stream", user_profile)
         self.assertFalse(sub.is_stream_admin)
 
-        result = self.client_delete(f"/json/streams/{stream.id}")
+        result = self.client_delete(f"/json/streams/{stream.id}", {"is_archive": orjson.dumps(True).decode()})
         self.assert_json_error(result, "Must be an organization or stream administrator")
 
     def test_private_stream_live_updates(self) -> None:
@@ -946,7 +946,7 @@ class StreamAdminTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Invalid stream id")
 
-        result = self.client_delete(f"/json/streams/{stream_id}")
+        result = self.client_delete(f"/json/streams/{stream_id}", {"is_archive": orjson.dumps(True).decode()})
         self.assert_json_error(result, "Invalid stream id")
 
     def test_change_stream_description(self) -> None:
@@ -4174,7 +4174,7 @@ class SubscriptionAPITest(ZulipTestCase):
 
         def delete_stream(stream_name: str) -> None:
             stream_id = get_stream(stream_name, realm).id
-            result = self.client_delete(f"/json/streams/{stream_id}")
+            result = self.client_delete(f"/json/streams/{stream_id}", {"is_archive": orjson.dumps(True).decode()})
             self.assert_json_success(result)
 
         # Deleted/deactivated stream should not be returned in the helper results

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -132,12 +132,19 @@ def check_if_removing_someone_else(
     else:
         return principals[0] != user_profile.email
 
-
+@has_request_variables
 def deactivate_stream_backend(
-    request: HttpRequest, user_profile: UserProfile, stream_id: int
+    request: HttpRequest,
+    user_profile: UserProfile,
+    stream_id: int,
+    is_archive: Optional[bool] = REQ(validator=check_bool, default=None),
 ) -> HttpResponse:
     (stream, sub) = access_stream_for_delete_or_update(user_profile, stream_id)
-    do_deactivate_stream(stream, acting_user=user_profile)
+    if is_archive is None or is_archive:
+        do_deactivate_stream(stream, acting_user=user_profile)
+    if not is_archive:
+        # delete stream feature here
+        print("delete")
     return json_success()
 
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is the first part of pr #17405 broken up into a single pr.  

1) Renaming the current functions and methods related to 'deleting' a stream to properly describe their behavior of 'archiving' a stream.

2) Modifying the API and its docs to accommodate a boolean flag `is_archive` that allows the current behavior to exist and to also make room for adding a hard delete feature.

### Changes

`static/js/stream_edit` : Rename the functionality and to account for sending the new request data.  

`zerver/openapi/python_examples` :  Documents changes to API.

`zerver/openapi/openapi.yaml` : Changes and documents changes to API.

`zerver/tests/test_subs` : Modifies API calls according to addition of new parameters.

`zerver/views/streams` : Modifies deactivate_stream_backend to receive new `is_archive` parameter and prepares for hard delete feature addition. 

**Testing**
Used `tools/test-backend` , `tools/test-js-with-node`, and `run-mypy`.


