### PR TITLE
puppet: Create new nginx logfiles as the zulip user, not as www-data.

### DIFF
--- a/puppet/zulip/files/logrotate/nginx
+++ b/puppet/zulip/files/logrotate/nginx
@@ -1,0 +1,18 @@
+/var/log/nginx/*.log {
+	daily
+	missingok
+	rotate 14
+	compress
+	delaycompress
+	notifempty
+	create 0640 zulip adm
+	sharedscripts
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+			run-parts /etc/logrotate.d/httpd-prerotate; \
+		fi \
+	endscript
+	postrotate
+		invoke-rc.d nginx rotate >/dev/null 2>&1
+	endscript
+}

--- a/puppet/zulip/manifests/nginx.pp
+++ b/puppet/zulip/manifests/nginx.pp
@@ -93,6 +93,14 @@ class zulip::nginx {
     group  => 'adm',
     mode   => '0650',
   }
+  file { '/etc/logrotate.d/nginx':
+    ensure  => file,
+    require => Package[$zulip::common::nginx],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    source  => 'puppet:///modules/zulip/logrotate/nginx',
+  }
 
   $certbot_auto_renew = zulipconf('certbot', 'auto_renew', '')
   if $certbot_auto_renew == 'yes' {


### PR DESCRIPTION
All of `/var/log/nginx/` is chown'd to `zulip` and the nginx processes
themselves run as `nginx`, and would thus (on their own) create new
logfiles as `zulip`.  Having `logrotate` create them as the package
default of `www-data` means that they are momentarily unreadable by
the `zulip` user just after rotation, which can cause problems with
logtail scripts.

Commit the standard `nginx` logrotate configuration, but with the
`zulip` user instead of the `www-data` user.