### PR TITLE
left_sidebar: Place the <title> at private_messages_header div.

### DIFF
--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -15,8 +15,8 @@
                 </a>
                 <span class="arrow all-messages-sidebar-menu-icon"><i class="zulip-icon ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_private_messages"  title="{{ _('Private messages') }} (P)">
-                <div class="private_messages_header top_left_row">
+            <li class="top_left_private_messages">
+                <div class="private_messages_header top_left_row" title="{{ _('Private messages') }} (P)">
                     <a href="#narrow/is/private">
                         <span class="filter-icon">
                             <i class="fa fa-envelope" aria-hidden="true"></i>


### PR DESCRIPTION
Issue: The `<title>` tag in **li.top_left_private_messages** applies the
title to **private-container** too. Therefore, Private messages list elements shows two titles when hover. 

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? --> Tested manually.


**GIFs or screenshots:** <!-- If a UI change.  See:
Before:

![IMG20210315173805](https://user-images.githubusercontent.com/59444243/111151616-b5c39280-85b5-11eb-8dd1-4a60a1830d49.jpg)

After:
![aftertitlepositionchange](https://user-images.githubusercontent.com/59444243/111151767-ea374e80-85b5-11eb-8b3e-d3680c7ab038.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
