### PR TITLE
left-sidebar: Fix 3-points-menu responsive bug.

### DIFF
--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -254,6 +254,7 @@ function build_all_messages_popover(e) {
     }
 
     popovers.hide_all();
+    exports.show_streamlist_sidebar();
 
     const content = render_all_messages_sidebar_actions();
 
@@ -279,6 +280,7 @@ function build_starred_messages_popover(e) {
     }
 
     popovers.hide_all();
+    exports.show_streamlist_sidebar();
 
     const content = render_starred_messages_sidebar_actions({
         starred_message_counts: page_params.starred_message_counts,


### PR DESCRIPTION
When the window narrow down,by clicking
3-points of 'All messages' and 'Starred messages'
left navigation bar disappear and
3-points-menu display badly.

To fix the issue,avoid disappearance of left sidebar.

Fixes: #17537

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

- manual testing 

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![left-sidebar](https://user-images.githubusercontent.com/57071700/111194662-6abf7480-85e1-11eb-9d77-005c9a0b7217.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
