### PR TITLE
Add webhook tests

### DIFF
--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -48,6 +48,16 @@ class TestGenericOutgoingWebhookService(ZulipTestCase):
             )
         self.assertTrue(m.called)
 
+        response = make_response(text=json.dumps(dict(content="")))
+
+        with mock.patch("zerver.lib.outgoing_webhook.send_response_message") as m:
+            process_success_response(
+                event=event,
+                service_handler=service_handler,
+                response=response,
+            )
+        self.assertFalse(m.called)
+
         response = make_response(text="unparsable text")
 
         with mock.patch("zerver.lib.outgoing_webhook.fail_with_message") as m:

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -48,16 +48,6 @@ class TestGenericOutgoingWebhookService(ZulipTestCase):
             )
         self.assertTrue(m.called)
 
-        response = make_response(text=json.dumps(dict(content="")))
-
-        with mock.patch("zerver.lib.outgoing_webhook.send_response_message") as m:
-            process_success_response(
-                event=event,
-                service_handler=service_handler,
-                response=response,
-            )
-        self.assertFalse(m.called)
-
         response = make_response(text="unparsable text")
 
         with mock.patch("zerver.lib.outgoing_webhook.fail_with_message") as m:
@@ -237,6 +227,17 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
             message=dict(type="private"),
         )
         service_handler = self.handler
+
+        # verify we don't try to send a message with empty text/content
+        response = make_response(text=json.dumps(dict(text="")))
+
+        with mock.patch("zerver.lib.outgoing_webhook.send_response_message") as m:
+            process_success_response(
+                event=event,
+                service_handler=service_handler,
+                response=response,
+            )
+        self.assertFalse(m.called)
 
         # verify we don't try to send a message with no text/content
         response = make_response(text=json.dumps(dict(text=None)))


### PR DESCRIPTION
New tests added to cover the cases of the parsed response JSON
containing either an empty string or None in process_success_response() from
zerver/lib/outgoing_webhook.py

Tests set the text field in the received json to both an empty string "" and to None, then confirms that the
mock object is never called for either case, as process_success_response is expected
to return before attempting to send a response.

Fixes part of #7089.

Testing plan: Both tests were manually tested to confirm if the early return was
removed the test would then fail.

New PR as previous was mistakenly commit to master branch.
Previous PR: https://github.com/zulip/zulip/pull/17563

TODO: 
 - Add final test to bring file to 100 coverage%, posting as a draft simply as an update until this is complete
 - Investigate failing builds, will investigate when I can as fairly busy currently :)