### PR TITLE
Outgoing webhooks should catch 407 error more gracefully

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -236,10 +236,11 @@ def notify_bot_owner(
 ) -> None:
     message_url = get_message_url(event)
     bot_id = event["user_profile_id"]
-    bot_owner = get_user_profile_by_id(bot_id).bot_owner
+    bot = get_user_profile_by_id(bot_id)
+    bot_owner = bot.bot_owner
     assert bot_owner is not None
 
-    notification_message = f"[A message]({message_url}) triggered an outgoing webhook."
+    notification_message = f"[A message]({message_url}) to your bot @_**{bot.full_name}** triggered an outgoing webhook."
     if failure_message:
         notification_message += "\n" + failure_message
     if status_code:

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -241,23 +241,23 @@ def notify_bot_owner(
     assert bot_owner is not None
 
     notification_message = f"[A message]({message_url}) to your bot @_**{bot.full_name}** triggered an outgoing webhook."
-    if failure_message:
-        notification_message += "\n" + failure_message
-    if status_code == 407:
-        notification_message += (
-            "\nThe URL configured for the webhook is for a private or disallowed network."
-        )
-    elif status_code:
-        notification_message += f"\nThe webhook got a response with status code *{status_code}*."
-    if response_content and status_code != 407:
-        notification_message += (
-            f"\nThe response contains the following payload:\n```\n{response_content!r}\n```"
-        )
     if exception:
         notification_message += (
             "\nWhen trying to send a request to the webhook service, an exception "
             f"of type {type(exception).__name__} occurred:\n```\n{exception}\n```"
         )
+    elif failure_message:
+        notification_message += "\n" + failure_message
+    elif status_code == 407:
+        notification_message += (
+            "\nThe URL configured for the webhook is for a private or disallowed network."
+        )
+    elif status_code:
+        notification_message += f"\nThe webhook got a response with status code *{status_code}*."
+        if response_content:
+            notification_message += (
+                f"\nThe response contains the following payload:\n```\n{response_content!r}\n```"
+            )
 
     message_info = dict(
         type="private",

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -243,9 +243,13 @@ def notify_bot_owner(
     notification_message = f"[A message]({message_url}) to your bot @_**{bot.full_name}** triggered an outgoing webhook."
     if failure_message:
         notification_message += "\n" + failure_message
-    if status_code:
+    if status_code == 407:
+        notification_message += (
+            "\nThe URL configured for the webhook is for a private or disallowed network."
+        )
+    elif status_code:
         notification_message += f"\nThe webhook got a response with status code *{status_code}*."
-    if response_content:
+    if response_content and status_code != 407:
         notification_message += (
             f"\nThe response contains the following payload:\n```\n{response_content!r}\n```"
         )

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -99,7 +99,7 @@ class DoRestCallTests(ZulipTestCase):
         bot_owner_notification = self.get_last_message()
         self.assertEqual(
             bot_owner_notification.content,
-            """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) triggered an outgoing webhook.
+            """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
 The webhook got a response with status code *500*.""",
         )
 
@@ -131,7 +131,7 @@ The webhook got a response with status code *500*.""",
         bot_owner_notification = self.get_last_message()
         self.assertEqual(
             bot_owner_notification.content,
-            """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) triggered an outgoing webhook.
+            """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
 The webhook got a response with status code *400*.""",
         )
 
@@ -215,7 +215,7 @@ The webhook got a response with status code *400*.""",
         bot_owner_notification = self.get_last_message()
         self.assertEqual(
             bot_owner_notification.content,
-            """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) triggered an outgoing webhook.
+            """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
 When trying to send a request to the webhook service, an exception of type RequestException occurred:
 ```
 I'm a generic exception :(


### PR DESCRIPTION
## What is this PR for

This PR aims to solve the issue: https://github.com/zulip/zulip/issues/17555 

According to the current implementation, the message from the bot which triggered the 407 error message notifies the bot owner about the exception in the error message. 

I have done the following changes for this issue:
- [x] Modifies the 407 error message.
- [x] clear out the exception when 407 error message is triggered.
- [x] Add bot name when a outgoing_webhook is triggered.