### PR TITLE
docs: Document integration request process.

### DIFF
--- a/static/styles/portico/integrations.css
+++ b/static/styles/portico/integrations.css
@@ -433,6 +433,19 @@ $category-text: hsl(219, 23%, 33%);
         }
     }
 
+    .integration-request {
+        font-size: 1em;
+        padding: 10px 0;
+
+        p {
+            padding-bottom: 10px;
+        }
+
+        .button {
+            padding: 11px 25px 11px 25px;
+        }
+    }
+
     /* -- integration instructions -- */
 
     #integration-instructions-group {

--- a/static/styles/portico/integrations.css
+++ b/static/styles/portico/integrations.css
@@ -443,7 +443,13 @@ $category-text: hsl(219, 23%, 33%);
 
         .button {
             padding: 11px 25px 11px 25px;
+            margin: 5px;
+            font-size: 0.9em;
         }
+    }
+
+    .integration-divider {
+        padding: 11px 15px 0 15px;
     }
 
     /* -- integration instructions -- */

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -86,6 +86,7 @@
 ## Tools & customization
 * [Bots and integrations](/help/bots-and-integrations)
 * [Add a bot or integration](/help/add-a-bot-or-integration)
+* [Request an integration](/help/request-an-integration)
 * [Create a poll](/help/create-a-poll)
 * [Night mode](/help/night-mode)
 * [Enable emoticon translations](/help/enable-emoticon-translations)

--- a/templates/zerver/help/request-an-integration.md
+++ b/templates/zerver/help/request-an-integration.md
@@ -1,0 +1,26 @@
+# Request an integration
+
+Zulip provides its user over 100 native integrations. Several hundred more are
+available through [Hubot](https://hubot.github.com/), [Zapier](https://zapier.com/home),
+and [IFTTT](https://ifttt.com/) but there can be times where you don’t find an integration
+or bot you need.
+
+In such cases, you can request the integration by filing a feature request on our
+GitHub issues page. While filing a feature request please provide as much detail
+and context as possible.
+
+## Filing an issue
+
+{start_tabs}
+
+1. Go to [Zulip's Issue page](https://github.com/zulip/zulip/issues).
+
+2. Click **New issue**.
+
+3. Fill out the fields, and click **Submit new issue**.
+
+!!! warn ""
+    Make sure no issue exists for the same integration request or feature
+    and once you are sure you can file an issue for the integration you want.
+
+{end_tabs}

--- a/templates/zerver/help/request-an-integration.md
+++ b/templates/zerver/help/request-an-integration.md
@@ -1,26 +1,17 @@
 # Request an integration
 
-Zulip provides its user over 100 native integrations. Several hundred more are
-available through [Hubot](https://hubot.github.com/), [Zapier](https://zapier.com/home),
-and [IFTTT](https://ifttt.com/) but there can be times where you don’t find an integration
-or bot you need.
+Zulip comes with over 100 native integrations. Hundreds more are
+available through [Hubot](https://hubot.github.com/),
+[Zapier](https://zapier.com/home), [IFTTT](https://ifttt.com/), and
+the [Slack compatible webhook](/integrations/doc/slack_incoming).
 
-In such cases, you can request the integration by filing a feature request on our
-GitHub issues page. While filing a feature request please provide as much detail
-and context as possible.
+However, sometimes there is no integration for a tool you use, or an
+existing integration doesn't do what you need. If that's the case for
+a third-party product you use, we'd love to [hear about
+it](/help/contact-support)!
 
-## Filing an issue
+Or if you're familiar with GitHub, you can [browse open integrations
+issues][integrations-issues], and if none exists, [open a new
+issue](https://github.com/zulip/zulip/issues/new).
 
-{start_tabs}
-
-1. Go to [Zulip's Issue page](https://github.com/zulip/zulip/issues).
-
-2. Click **New issue**.
-
-3. Fill out the fields, and click **Submit new issue**.
-
-!!! warn ""
-    Make sure no issue exists for the same integration request or feature
-    and once you are sure you can file an issue for the integration you want.
-
-{end_tabs}
+[integrations-issues]: https://github.com/zulip/zulip/issues?q=is%3Aopen+label%3A%22area%3A+integrations%22+is%3Aissue

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -133,6 +133,12 @@
                                 <h3 class="integration-name create-your-own">{% trans %}Create your own!{% endtrans %}</h3>
                             </div>
                         </a>
+                        <div class="integration-request center">
+                            <p>Don't see an integration you use? Learn how you can request it.</p>
+                            <a href="/help/request-an-integration" class="button green">
+                                Request an Integration
+                            </a>
+                        </div>
                     </div>
                 </div>
 

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -125,18 +125,17 @@
                             </a>
                             {% endif %}
                         {% endfor %}
-                        <a href="/api/integrations-overview">
-                            <div class="integration-lozenge integration-create-your-own">
-                                <div class="integration-logo">
-                                    <i class="fa fa-plus" aria-hidden="true"></i>
-                                </div>
-                                <h3 class="integration-name create-your-own">{% trans %}Create your own!{% endtrans %}</h3>
-                            </div>
-                        </a>
+                        <hr>
                         <div class="integration-request center">
-                            <p>Don't see an integration you use? Learn how you can request it.</p>
+                            <p>Don't see an integration you need? We'd love to help.</p>
+                            <a href="/api/integrations-overview" class="button green">
+                                Create your own
+                            </a>
+                            <span class="integration-divider">
+                                or
+                            </span>
                             <a href="/help/request-an-integration" class="button green">
-                                Request an Integration
+                                Request an integration
                             </a>
                         </div>
                     </div>


### PR DESCRIPTION
## What is this PR for
This PR aims to solve the issue: https://github.com/zulip/zulip/issues/7935

This PR adds the documentation for requesting an integration on `/help/request-an-integration` and `\integration\` page.
Most of this work is done by @majordwarf in https://github.com/zulip/zulip/pull/14515 
I fetched it, rebased it with the current master. 

### Screenshot:
<details><summary>/help/request-an-integration</summary><p> 

![image](https://user-images.githubusercontent.com/53316982/113476938-40542f00-949c-11eb-95d4-5a08cc0ea74c.png)

</p></details>

<details><summary> /integrations/</summary><p>

![image](https://user-images.githubusercontent.com/53316982/113476918-21559d00-949c-11eb-8ebc-22690c57ae7f.png)

</p></details>