### PR TITLE
message view: Fix the wrong time shown for message locally echoed.

### DIFF
--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -230,6 +230,17 @@ export class MessageListView {
         }
     }
 
+    set_calculated_message_container_variables(message_container) {
+        set_timestr(message_container);
+
+        // Make sure the right thing happens if the message was edited to mention us.
+        message_container.contains_mention = message_container.msg.mentioned;
+
+        this._maybe_format_me_message(message_container);
+        // Once all other variables are updated
+        this._add_msg_edited_vars(message_container);
+    }
+
     add_subscription_marker(group, last_msg_container, first_msg_container) {
         if (last_msg_container === undefined) {
             return;
@@ -333,8 +344,6 @@ export class MessageListView {
                 }
             }
 
-            set_timestr(message_container);
-
             message_container.include_sender = true;
             if (
                 !message_container.include_recipient &&
@@ -355,10 +364,7 @@ export class MessageListView {
                 );
             }
 
-            message_container.contains_mention = message_container.msg.mentioned;
-            this._maybe_format_me_message(message_container);
-            // Once all other variables are updated
-            this._add_msg_edited_vars(message_container);
+            this.set_calculated_message_container_variables(message_container);
 
             prev = message_container;
         }
@@ -1130,19 +1136,7 @@ export class MessageListView {
         const row = this.get_row(message_container.msg.id);
         const was_selected = this.list.selected_message() === message_container.msg;
 
-        // Re-render just this one message
-        this._maybe_format_me_message(message_container);
-        this._add_msg_edited_vars(message_container);
-
-        // The timestr of message_container can be outdated if locally
-        // echoed. When the server sends the new timestamp, though the
-        // timestamp gets updated in echo.js, the timestr does not.
-        // This updates the timestr which will be then be used to
-        // update the message_time during rerender.
-        set_timestr(message_container);
-
-        // Make sure the right thing happens if the message was edited to mention us.
-        message_container.contains_mention = message_container.msg.mentioned;
+        this.set_calculated_message_container_variables(message_container);
 
         const rendered_msg = $(this._get_message_template(message_container));
         if (message_content_edited) {

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -1134,6 +1134,13 @@ export class MessageListView {
         this._maybe_format_me_message(message_container);
         this._add_msg_edited_vars(message_container);
 
+        // The timestr of message_container can be outdated if locally
+        // echoed. When the server sends the new timestamp, though the
+        // timestamp gets updated in echo.js, the timestr does not.
+        // This updates the timestr which will be then be used to
+        // update the message_time during rerender.
+        set_timestr(message_container);
+
         // Make sure the right thing happens if the message was edited to mention us.
         message_container.contains_mention = message_container.msg.mentioned;
 


### PR DESCRIPTION
Related [CZO conversations](https://chat.zulip.org/#narrow/stream/2-general/topic/Wrong.20time.20of.20message.20sent/near/1133986).

Fixes #17655

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
First, in the dev tools, make the network offline and then sent a message let's say at 6:32 AM. 
Waited till 6:33 AM, to reconnect to the internet and resend the message.
As the message got sent, now the time is coming 6:33 AM. Before this change, it would have been 6:32 AM as the `message_time` is now being updated on rerender of the message.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
