### PR TITLE
message view: Show message source button by default.

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -95,14 +95,13 @@ function message_hover(message_row) {
     if (current_message_hover && rows.id(current_message_hover) === id) {
         return;
     }
-    // Don't allow on-hover editing for local-only messages
-    if (message_row.hasClass("local")) {
-        return;
-    }
+
     const message = current_msg_list.get(rows.id(message_row));
     message_unhover();
     current_message_hover = message_row;
 
+    // Locally echoed messages have !is_topic_editable and thus go
+    // through this code path.
     if (!message_edit.is_topic_editable(message)) {
         // The actions and reactions icon hover logic is handled entirely by CSS
         return;

--- a/static/templates/message_controls.hbs
+++ b/static/templates/message_controls.hbs
@@ -1,8 +1,6 @@
 <div class="message_controls{{#status_message}} sender-status-controls{{/status_message}} no-select">
     {{#if msg/sent_by_me}}
-        {{#unless msg/locally_echoed}}
-        <div class="edit_content"></div>
-        {{/unless}}
+    <div class="edit_content"></div>
     {{/if}}
 
     {{#unless msg/sent_by_me}}


### PR DESCRIPTION
This commit removes the unless msg/locally_echoed condition for the
edit content div to be shown. Also adds the View source button by
default to the edit_content div. This ensures that the message source
can be seen if a very long message has been sent and it fails due to
certain reasons.

Fixes #17650

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
[CZO Conversations here](https://chat.zulip.org/#narrow/stream/2-general/topic/View.20source.20for.20failed.20messages/near/1134083)

**Testing plan:** <!-- How have you tested? -->
Tested locally using the developer tools to fail the message sent.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
A screenshot of the source button coming for the failed message.
![image](https://user-images.githubusercontent.com/56730716/111402974-2e2f6e00-86f2-11eb-82cc-220c52fc00ee.png)

And it opens.
![image](https://user-images.githubusercontent.com/56730716/111403061-54eda480-86f2-11eb-982b-d75a8923e5d6.png)

Also when the message is successfully sent, the source changes to the edit button as what the default behavior is.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
