### PR TITLE
compose: Add support for full-screen compose box

### DIFF
--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -406,3 +406,19 @@ run_test("quote_and_reply", ({override}) => {
         "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n```quote\nTesting with compose-box containing whitespaces and newlines only.\n```\n%",
     );
 });
+
+run_test("test_compose_height_changes", ({override}) => {
+    let autosize_destroyed = false;
+    override(autosize, "destroy", () => {
+        autosize_destroyed = true;
+    });
+
+    compose_ui.make_compose_box_full_size();
+    assert.ok($("#compose").hasClass("compose-fullscreen"));
+    assert.ok(compose_ui.is_full_size());
+    assert.ok(autosize_destroyed);
+
+    compose_ui.make_compose_box_original_size();
+    assert.ok(!$("#compose").hasClass("compose-fullscreen"));
+    assert.ok(!compose_ui.is_full_size());
+});

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -830,6 +830,16 @@ export function initialize() {
         clear_preview_area();
     });
 
+    $("#compose").on("click", ".expand_composebox_button", (e) => {
+        e.preventDefault();
+        compose_ui.make_compose_box_full_size();
+    });
+
+    $("#compose").on("click", ".collapse_composebox_button", (e) => {
+        e.preventDefault();
+        compose_ui.make_compose_box_original_size();
+    });
+
     uppy = upload.setup_upload({
         mode: "compose",
     });

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -120,11 +120,13 @@ function clear_box() {
 }
 
 export function autosize_message_content() {
-    autosize($("#compose-textarea"), {
-        callback() {
-            maybe_scroll_up_selected_message();
-        },
-    });
+    if (!compose_ui.is_full_size()) {
+        autosize($("#compose-textarea"), {
+            callback() {
+                maybe_scroll_up_selected_message();
+            },
+        });
+    }
 }
 
 export function expand_compose_box() {
@@ -281,6 +283,9 @@ export function start(msg_type, opts) {
 }
 
 export function cancel() {
+    // As user closes the compose box, restore the compose box max height
+    compose_ui.make_compose_box_original_size();
+
     $("#compose-textarea").height(40 + "px");
 
     if (page_params.narrow !== undefined) {

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -5,10 +5,23 @@ import {$t} from "./i18n";
 import * as people from "./people";
 import * as user_status from "./user_status";
 
+let full_size_status = false; // true or false
+
+// Some functions to handle the full size status explicitly
+export function set_full_size(is_full) {
+    full_size_status = is_full;
+}
+
+export function is_full_size() {
+    return full_size_status;
+}
+
 export function autosize_textarea(textarea) {
     // Since this supports both compose and file upload, one must pass
     // in the text area to autosize.
-    autosize.update(textarea);
+    if (!is_full_size()) {
+        autosize.update(textarea);
+    }
 }
 
 export function smart_insert(textarea, syntax) {
@@ -129,4 +142,32 @@ export function wrap_text_with_markdown(textarea, prefix, suffix) {
     if (!document.execCommand("insertText", false, prefix + range.text + suffix)) {
         textarea.range(range.start, range.end).range(prefix + range.text + suffix);
     }
+}
+
+export function make_compose_box_full_size() {
+    set_full_size(true);
+
+    // The autosize should be destroyed for the full size compose
+    // box else it will interfare and shrink its size accordingly.
+    autosize.destroy($("#compose-textarea"));
+
+    $("#compose").addClass("compose-fullscreen");
+
+    $(".collapse_composebox_button").show();
+    $(".expand_composebox_button").hide();
+    $("#compose-textarea").trigger("focus");
+}
+
+export function make_compose_box_original_size() {
+    set_full_size(false);
+
+    $("#compose").removeClass("compose-fullscreen");
+
+    // Again initialise the compose textarea as it was destroyed
+    // when compose box was made full screen
+    autosize($("#compose-textarea"));
+
+    $(".collapse_composebox_button").hide();
+    $(".expand_composebox_button").show();
+    $("#compose-textarea").trigger("focus");
 }

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -65,6 +65,9 @@
     padding: 4px 4px 8px 4px;
     border-left: 1px solid hsl(0, 0%, 93%);
     border-right: 1px solid hsl(0, 0%, 93%);
+    height: 100%;
+    display: flex;
+    flex-flow: column;
 }
 
 .ztable_comp_col1 {
@@ -85,6 +88,10 @@
 }
 
 .compose_table {
+    height: 100%;
+    display: flex;
+    flex-flow: column;
+
     .stream-selection-header-colorblock {
         &.message_header_private_message {
             border-radius: 3px 0 0 3px;
@@ -147,6 +154,11 @@
 
 #send_message_form {
     margin: 0;
+    height: 100%;
+
+    .messagebox-wrapper {
+        flex: 1;
+    }
 
     .messagebox {
         /* normally 5px 14px; pull in the right and bottom a bit */
@@ -155,6 +167,9 @@
         background: none;
         box-shadow: none;
         border: none;
+        height: 100%;
+        display: flex;
+        flex-flow: column;
     }
 
     .message_content {
@@ -198,11 +213,30 @@
     margin: auto;
 }
 
-#compose_close {
-    display: none;
+#compose_top_right {
     position: absolute;
     right: 0;
-    opacity: 0.7;
+    float: right;
+
+    button {
+        background: transparent;
+        font-size: 20px;
+        font-weight: bold;
+        line-height: 20px;
+        opacity: 0.6;
+        border: 0;
+        padding: 0;
+        margin-left: 4px;
+
+        &:hover {
+            opacity: 1;
+        }
+    }
+}
+
+.collapse_composebox_button,
+#compose_close {
+    display: none;
 }
 
 .compose_invite_user,
@@ -306,6 +340,7 @@ div[id^="message-edit-send-status"],
 
 .composition-area {
     position: relative;
+    flex: 1;
 }
 
 textarea.new_message_textarea {
@@ -541,5 +576,26 @@ a.compose_control_button.hide {
     #compose-content {
         margin-right: 5px;
         margin-left: 5px;
+    }
+}
+
+#compose.compose-fullscreen {
+    height: 100%;
+    z-index: 99;
+
+    #compose-container {
+        margin-top: 50px;
+        height: calc(100% - 50px);
+    }
+
+    .message_comp {
+        flex: 1;
+        display: flex !important;
+        flex-flow: column;
+    }
+
+    #compose-textarea {
+        max-height: none !important;
+        flex: 1;
     }
 }

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -55,7 +55,11 @@
         <div id="compose_private_stream_alert" class="alert home-error-bar"></div>
         <div id="out-of-view-notification" class="notification-alert"></div>
         <div class="composition-area">
-            <button type="button" class="close" id='compose_close' title="{{t 'Cancel compose' }} (Esc)">&times;</button>
+            <div id="compose_top_right">
+                <button type="button" class="expand_composebox_button fa fa-angle-up" aria-label="{{t 'Expand compose' }}" tabindex=0 title="{{t 'Expand compose' }}"></button>
+                <button type="button" class="collapse_composebox_button fa fa-angle-down" aria-label="{{t 'Collapse compose' }}" tabindex=0 title="{{t 'Collapse compose' }}"></button>
+                <button type="button" class="close" id='compose_close' title="{{t 'Cancel compose' }} (Esc)">&times;</button>
+            </div>
             <form id="send_message_form" action="/json/messages" method="post">
                 {{ csrf_input }}
                 <div class="compose_table">
@@ -82,7 +86,7 @@
                             </div>
                         </div>
                     </div>
-                    <div>
+                    <div class="messagebox-wrapper">
                         <div class="messagebox">
                             <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
                             <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area" style="display:none;">

--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -69,6 +69,11 @@
  *   so that the `Backspace` key is free to interact with the other elements.
  *
  *   Our custom changes include all mentions of `helpOnEmptyStrings` and `hideOnEmpty`.
+ *
+ * 6. Prevent typeahead going off top of screen:
+ *   If typeahead would go off the top of the screen, we set its top to 0 instead.
+ *   This patch should be replaced with something more flexible.
+ *
  * ============================================================ */
 
 !function($){
@@ -172,6 +177,11 @@
       var top_pos = pos.top + pos.height
       if (this.dropup) {
         top_pos = pos.top - this.$container.outerHeight()
+      }
+
+      // Zulip patch: Avoid typeahead going off top of screen.
+      if (top_pos < 0) {
+          top_pos = 0;
       }
 
       this.$container.css({


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #17660

- [x] Adds a default max-height which will facilitate scrolling.
- [x] Add a expansion/collapsing button for toggling full-screen view.
- [x] Make the CSS needed for making textarea occupy full height.
- [x] Find a way to handle auto-resize properly.
- [x] Test properly for different use cases.
- [x] On the close of the compose box, it should be restored to its original width.
- [x] Add tests once we are ready that the intended behaviour is correct. (Also make the CI tests pass)

**Testing plan:** <!-- How have you tested? -->
Tested manually:
Open the compose box, toggle the height using the toggler button added just below the compose area.
To check autosize doesnot interfare is that when the compose height state is true, it is destroyed as this is the way to stop all the listeners added by it (check on docs of autosize) and particularly checked for changing messages and drafts while having full size compose box.
The save and copy also doesn't not have any problems as the autosize has been destroyed.
For node tests, I think for the compose_height file some basic tests needs to be defined.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
The design of full height text-area currently.
![image](https://user-images.githubusercontent.com/56730716/111416298-a3f30400-8709-11eb-8fdd-70adf7e45de4.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
