### PR TITLE
account_settings: Change the position of the custom-profile-fields-form.

### DIFF
--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -142,14 +142,6 @@
                     </div>
                 </form>
             </div>
-
-            <h3 class="inline-block" id="custom-field-header" {{#unless page_params.custom_profile_fields}}style="display: none"{{/unless}}>{{t "Profile" }}</h3>
-            <form class="form-horizontal custom-profile-fields-form grid"></form>
-            <button class="button rounded sea-green w-200 block" id="show_my_user_profile_modal">
-                {{t 'Preview profile' }}
-                <i class="fa fa-external-link" aria-hidden="true" title="{{t 'Preview profile' }}"></i>
-            </button>
-
         </div>
 
         <div class="inline-block user-avatar-section">
@@ -165,6 +157,13 @@
             </div>
         </div>
         <div class="clear-float"></div>
+
+        <h3 class="inline-block" id="custom-field-header" {{#unless page_params.custom_profile_fields}}style="display: none"{{/unless}}>{{t "Profile" }}</h3>
+        <form class="form-horizontal custom-profile-fields-form grid"></form>
+        <button class="button rounded sea-green w-200 block" id="show_my_user_profile_modal">
+            {{t 'Preview profile' }}
+            <i class="fa fa-external-link" aria-hidden="true" title="{{t 'Preview profile' }}"></i>
+        </button>
 
         <div id="deactivate_self_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="deactivation_self_modal_label" aria-hidden="true">
             <div class="modal-header">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) --> Fixes #17617.


**Testing plan:** <!-- How have you tested? --> Tested manually.
One drawback from this fix: When the screen size is reduced, the Avatar widget is placed between `Deactivate account` button and `Profile` field, though I think this new placements is better than the current placements.
(FYI The current placement is, when the screen size is reduced, the Avatar widget is placed at the bottom between `Preview Profile` button and `API` key field. )

For more clear visual of the above drawback, check GIF.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![avatar_widget_bug](https://user-images.githubusercontent.com/59444243/111474766-649cd580-8752-11eb-8894-9ef8263f8fc8.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
