### PR TITLE
Support creating production droplets from create.py

### DIFF
--- a/tools/droplets/README.md
+++ b/tools/droplets/README.md
@@ -210,3 +210,12 @@ They can remove your SSH keys by running:
 ```
 $ python3 ~/zulip/tools/droplets/add_mentor.py <your username> --remove
 ```
+
+
+# Creating a production droplet
+
+`create.py` can also create a production droplet quickly for testing purposes.
+
+```
+$ python3 create.py <username> --production
+```

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -86,7 +86,7 @@ def fork_exists(username: str) -> bool:
         sys.exit(1)
 
 
-def exit_if_droplet_exists(my_token: str, username: str, recreate: bool) -> None:
+def assert_droplet_does_not_exist(my_token: str, username: str, recreate: bool) -> None:
     print(f"Checking to see if droplet for {username} already exists...")
     manager = digitalocean.Manager(token=my_token)
     my_droplets = manager.get_all_droplets()
@@ -269,8 +269,7 @@ if __name__ == "__main__":
     fork_exists(username=username)
 
     api_token = config["digitalocean"]["api_token"]
-    # does the droplet already exist?
-    exit_if_droplet_exists(my_token=api_token, username=username, recreate=args.recreate)
+    assert_droplet_does_not_exist(my_token=api_token, username=username, recreate=args.recreate)
 
     # set user_data
     user_data = set_user_data(username=username, userkey_dicts=public_keys)

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -41,9 +41,9 @@ def get_config() -> configparser.ConfigParser:
     return config
 
 
-def user_exists(username: str) -> bool:
-    print(f"Checking to see if GitHub user {username} exists...")
-    user_api_url = f"https://api.github.com/users/{username}"
+def assert_github_user_exists(github_username: str) -> bool:
+    print(f"Checking to see if GitHub user {github_username} exists...")
+    user_api_url = f"https://api.github.com/users/{github_username}"
     try:
         response = urllib.request.urlopen(user_api_url)
         json.load(response)
@@ -51,7 +51,7 @@ def user_exists(username: str) -> bool:
         return True
     except urllib.error.HTTPError as err:
         print(err)
-        print(f"Does the GitHub user {username} exist?")
+        print(f"Does the GitHub user {github_username} exist?")
         sys.exit(1)
 
 
@@ -260,8 +260,7 @@ if __name__ == "__main__":
     # get config details
     config = get_config()
 
-    # see if droplet already exists for this user
-    user_exists(username=username)
+    assert_github_user_exists(github_username=username)
 
     # grab user's public keys
     public_keys = get_keys(username=username)

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -86,20 +86,20 @@ def fork_exists(username: str) -> bool:
         sys.exit(1)
 
 
-def assert_droplet_does_not_exist(my_token: str, username: str, recreate: bool) -> None:
-    print(f"Checking to see if droplet for {username} already exists...")
+def assert_droplet_does_not_exist(my_token: str, droplet_name: str, recreate: bool) -> None:
+    print(f"Checking to see if droplet {droplet_name} already exists...")
     manager = digitalocean.Manager(token=my_token)
     my_droplets = manager.get_all_droplets()
     for droplet in my_droplets:
-        if droplet.name.lower() == f"{username}.zulipdev.org":
+        if droplet.name.lower() == droplet_name:
             if not recreate:
                 print(
-                    "Droplet for user {} already exists. Pass --recreate if you "
-                    "need to recreate the droplet.".format(username)
+                    "Droplet {} already exists. Pass --recreate if you "
+                    "need to recreate the droplet.".format(droplet_name)
                 )
                 sys.exit(1)
             else:
-                print(f"Deleting existing droplet for {username}.")
+                print(f"Deleting existing droplet {droplet_name}.")
                 droplet.destroy()
                 return
     print("...No droplet found...proceeding.")
@@ -270,7 +270,9 @@ if __name__ == "__main__":
     fork_exists(username=username)
 
     api_token = config["digitalocean"]["api_token"]
-    assert_droplet_does_not_exist(my_token=api_token, username=username, recreate=args.recreate)
+    assert_droplet_does_not_exist(
+        my_token=api_token, droplet_name=droplet_domain_name, recreate=args.recreate
+    )
 
     # set user_data
     user_data = set_user_data(username=username, userkey_dicts=public_keys)

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -147,11 +147,11 @@ su -c 'git config --global pull.rebase true' zulipdev
 
 
 def create_droplet(
-    my_token: str, template_id: str, username: str, tags: List[str], user_data: str
+    my_token: str, template_id: str, name: str, tags: List[str], user_data: str
 ) -> str:
     droplet = digitalocean.Droplet(
         token=my_token,
-        name=f"{username}.zulipdev.org",
+        name=name,
         region="nyc3",
         image=template_id,
         size_slug="s-1vcpu-2gb",
@@ -255,6 +255,8 @@ if __name__ == "__main__":
     username = args.username.lower()
     print(f"Creating Zulip developer environment for GitHub user {username}...")
 
+    droplet_domain_name = f"{username}.zulipdev.org"
+
     # get config details
     config = get_config()
 
@@ -278,7 +280,7 @@ if __name__ == "__main__":
     ip_address = create_droplet(
         my_token=api_token,
         template_id=template_id,
-        username=username,
+        name=droplet_domain_name,
         tags=args.tags,
         user_data=user_data,
     )

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -105,13 +105,14 @@ def exit_if_droplet_exists(my_token: str, username: str, recreate: bool) -> None
     print("...No droplet found...proceeding.")
 
 
-def set_user_data(username: str, userkey_dicts: List[Dict[str, Any]]) -> str:
-    print("Setting cloud-config data, populated with GitHub user's public keys...")
-    userkeys = [userkey_dict["key"] for userkey_dict in userkey_dicts]
-    ssh_keys = "\n".join(userkeys)
+def get_ssh_keys_string_from_github_ssh_key_dicts(userkey_dicts: List[Dict[str, Any]]) -> str:
+    return "\n".join([userkey_dict["key"] for userkey_dict in userkey_dicts])
 
-    setup_root_ssh_keys = f"printf '{ssh_keys}' > /root/.ssh/authorized_keys"
-    setup_zulipdev_ssh_keys = f"printf '{ssh_keys}' > /home/zulipdev/.ssh/authorized_keys"
+
+def set_user_data(username: str, userkey_dicts: List[Dict[str, Any]]) -> str:
+    ssh_keys_string = get_ssh_keys_string_from_github_ssh_key_dicts(userkey_dicts)
+    setup_root_ssh_keys = f"printf '{ssh_keys_string}' > /root/.ssh/authorized_keys"
+    setup_zulipdev_ssh_keys = f"printf '{ssh_keys_string}' > /home/zulipdev/.ssh/authorized_keys"
 
     # We pass the hostname as username.zulipdev.org to the DigitalOcean API.
     # But some droplets (eg on 18.04) are created with with hostname set to just username.

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -76,7 +76,7 @@ def get_keys(username: str) -> List[Dict[str, Any]]:
         sys.exit(1)
 
 
-def fork_exists(username: str) -> bool:
+def assert_user_forked_zulip_server_repo(username: str) -> bool:
     print("Checking to see GitHub user has forked zulip/zulip...")
     apiurl_fork = f"https://api.github.com/repos/{username}/zulip"
     try:
@@ -318,8 +318,7 @@ if __name__ == "__main__":
         user_data = generate_prod_droplet_user_data(username=username, userkey_dicts=public_keys)
 
     else:
-        # now make sure the user has forked zulip/zulip
-        fork_exists(username=username)
+        assert_user_forked_zulip_server_repo(username=username)
 
         subdomain = username
         droplet_domain_name = f"{subdomain}.zulipdev.org"

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -190,18 +190,18 @@ def delete_existing_records(records: List[digitalocean.Record], record_name: str
         print(f"Deleted {count} existing A records for {record_name}.zulipdev.org.")
 
 
-def create_dns_record(my_token: str, username: str, ip_address: str) -> None:
+def create_dns_record(my_token: str, record_name: str, ip_address: str) -> None:
     domain = digitalocean.Domain(token=my_token, name="zulipdev.org")
     domain.load()
     records = domain.get_records()
 
-    delete_existing_records(records, username)
-    wildcard_name = "*." + username
+    delete_existing_records(records, record_name)
+    wildcard_name = "*." + record_name
     delete_existing_records(records, wildcard_name)
 
-    print(f"Creating new A record for {username}.zulipdev.org that points to {ip_address}.")
-    domain.create_new_domain_record(type="A", name=username, data=ip_address)
-    print(f"Creating new A record for *.{username}.zulipdev.org that points to {ip_address}.")
+    print(f"Creating new A record for {record_name}.zulipdev.org that points to {ip_address}.")
+    domain.create_new_domain_record(type="A", name=record_name, data=ip_address)
+    print(f"Creating new A record for *.{record_name}.zulipdev.org that points to {ip_address}.")
     domain.create_new_domain_record(type="A", name=wildcard_name, data=ip_address)
 
 
@@ -255,7 +255,8 @@ if __name__ == "__main__":
     username = args.username.lower()
     print(f"Creating Zulip developer environment for GitHub user {username}...")
 
-    droplet_domain_name = f"{username}.zulipdev.org"
+    subdomain = username
+    droplet_domain_name = f"{subdomain}.zulipdev.org"
 
     # get config details
     config = get_config()
@@ -283,8 +284,7 @@ if __name__ == "__main__":
         user_data=user_data,
     )
 
-    # create dns entry
-    create_dns_record(my_token=api_token, username=username, ip_address=ip_address)
+    create_dns_record(my_token=api_token, record_name=subdomain, ip_address=ip_address)
 
     # print completion message
     print_completion(username=username)

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -4,9 +4,6 @@
 # Particularly useful for sprints/hackathons, interns, and other
 # situation where one wants to quickly onboard new contributors.
 #
-# This script takes one argument: the name of the GitHub user for whom you want
-# to create a Zulip developer environment. Requires Python 3.
-#
 # Requires python-digitalocean library:
 # https://github.com/koalalorenzo/python-digitalocean
 #
@@ -14,8 +11,6 @@
 # https://cloud.digitalocean.com/settings/api/tokens
 #
 # Copy conf.ini-template to conf.ini and populate with your API token.
-#
-# usage: python3 create.py <username>
 import argparse
 import configparser
 import json
@@ -29,7 +24,6 @@ from typing import Any, Dict, List
 import digitalocean
 import requests
 
-# initiation argument parser
 parser = argparse.ArgumentParser(description="Create a Zulip devopment VM DigitalOcean droplet.")
 parser.add_argument(
     "username", help="GitHub username for whom you want to create a Zulip dev droplet"
@@ -295,7 +289,6 @@ def get_zulip_oneclick_app_slug(api_token: str) -> str:
 
 
 if __name__ == "__main__":
-    # get command line arguments
     args = parser.parse_args()
     username = args.username.lower()
 
@@ -304,7 +297,6 @@ if __name__ == "__main__":
     else:
         print(f"Creating Zulip developer environment for GitHub user {username}...")
 
-    # get config details
     config = get_config()
     api_token = config["digitalocean"]["api_token"]
 
@@ -336,7 +328,6 @@ if __name__ == "__main__":
         my_token=api_token, droplet_name=droplet_domain_name, recreate=args.recreate
     )
 
-    # create droplet
     ip_address = create_droplet(
         my_token=api_token,
         template_id=template_id,

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -59,20 +59,22 @@ def assert_github_user_exists(github_username: str) -> bool:
         sys.exit(1)
 
 
-def get_keys(username: str) -> List[Dict[str, Any]]:
+def get_ssh_public_keys_from_github(github_username: str) -> List[Dict[str, Any]]:
     print("Checking to see that GitHub user has available public keys...")
-    apiurl_keys = f"https://api.github.com/users/{username}/keys"
+    apiurl_keys = f"https://api.github.com/users/{github_username}/keys"
     try:
         response = urllib.request.urlopen(apiurl_keys)
         userkeys = json.load(response)
         if not userkeys:
-            print(f"No keys found. Has user {username} added SSH keys to their GitHub account?")
+            print(
+                f"No keys found. Has user {github_username} added SSH keys to their GitHub account?"
+            )
             sys.exit(1)
         print("...public keys found!")
         return userkeys
     except urllib.error.HTTPError as err:
         print(err)
-        print(f"Has user {username} added SSH keys to their GitHub account?")
+        print(f"Has user {github_username} added SSH keys to their GitHub account?")
         sys.exit(1)
 
 
@@ -308,8 +310,7 @@ if __name__ == "__main__":
 
     assert_github_user_exists(github_username=username)
 
-    # grab user's public keys
-    public_keys = get_keys(username=username)
+    public_keys = get_ssh_public_keys_from_github(github_username=username)
 
     if args.production:
         subdomain = f"{username}-prod"

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -205,7 +205,7 @@ def create_dns_record(my_token: str, record_name: str, ip_address: str) -> None:
     domain.create_new_domain_record(type="A", name=wildcard_name, data=ip_address)
 
 
-def print_completion(username: str) -> None:
+def print_completion(droplet_domain_name: str) -> None:
     print(
         """
 COMPLETE! Droplet for GitHub user {0} is available at {0}.zulipdev.org.
@@ -216,15 +216,15 @@ Instructions for use are below. (copy and paste to the user)
 Your remote Zulip dev server has been created!
 
 - Connect to your server by running
-  `ssh zulipdev@{0}.zulipdev.org` on the command line
+  `ssh zulipdev@{0}` on the command line
   (Terminal for macOS and Linux, Bash for Git on Windows).
 - There is no password; your account is configured to use your SSH keys.
 - Once you log in, you should see `(zulip-py3-venv) ~$`.
 - To start the dev server, `cd zulip` and then run `./tools/run-dev.py`.
 - While the dev server is running, you can see the Zulip server in your browser at
-  http://{0}.zulipdev.org:9991.
+  http://{0}:9991.
 """.format(
-            username
+            droplet_domain_name
         )
     )
 
@@ -286,7 +286,6 @@ if __name__ == "__main__":
 
     create_dns_record(my_token=api_token, record_name=subdomain, ip_address=ip_address)
 
-    # print completion message
-    print_completion(username=username)
+    print_completion(droplet_domain_name=droplet_domain_name)
 
     sys.exit(1)


### PR DESCRIPTION
Useful for quickly creating production droplets for testing purposes. Takes GitHub username as an argument just like how we create dev droplets.

Except for the 1 commit that adds the creating production droplet functionality rest of the commits are prep commits or cleanup commits,

Related discussion https://chat.zulip.org/#narrow/stream/9-issues/topic/outgoing.20webhook.20should.20catch.20407.20error.20more.20gracefully/near/1131419