### PR TITLE
test-js-with-puppeteer: Propagate --skip-provision-check to test server

### DIFF
--- a/tools/test-js-with-puppeteer
+++ b/tools/test-js-with-puppeteer
@@ -88,7 +88,7 @@ def run_tests(files: Iterable[str], external_host: str) -> None:
             current_test_num += 1
         return 0, -1
 
-    with test_server_running(False, external_host):
+    with test_server_running(options.skip_provision_check, external_host):
         # Important: do this next call inside the `with` block, when Django
         #            will be pointing at the test database.
         subprocess.check_call("tools/setup/generate-test-credentials")


### PR DESCRIPTION
**Testing plan:** `tools/test-js-with-puppeteer --skip-provision-check`