### PR TITLE
puppet: Add a nagios alert configuration for smokescreen.

### DIFF
--- a/puppet/zulip_ops/files/nagios3/commands.cfg
+++ b/puppet/zulip_ops/files/nagios3/commands.cfg
@@ -190,3 +190,8 @@ define command{
        command_name     check_https_status
        command_line     /usr/lib/nagios/plugins/check_http --ssl -H '$HOSTADDRESS$' -I '$HOSTADDRESS$' --expect=200,302,401
 }
+
+define command{
+       command_name     check_proxy_status
+       command_line     /usr/lib/nagios/plugins/check_http --ssl -H 'www.google.com' -u 'https://www.google.com/' -j CONNECT -I '$HOSTADDRESS$' -p 4750 --expect=200,302,401 -s Search
+}

--- a/puppet/zulip_ops/files/nagios3/conf.d/hostgroups.cfg
+++ b/puppet/zulip_ops/files/nagios3/conf.d/hostgroups.cfg
@@ -81,3 +81,8 @@ define hostgroup {
        hostgroup_name     has_swap
        alias              Servers that are expected to have swap
        }
+
+define hostgroup {
+       hostgroup_name     smokescreen
+       alias              Servers that run the Smokescreen HTTP proxy
+}

--- a/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
+++ b/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
@@ -480,3 +480,11 @@ define service {
         check_command                   check_email_deliverer_backlog
         contact_groups                  admins
 }
+
+define service {
+        use                             generic-service
+        service_description             Check Smokescreen proxy
+        check_command                   check_proxy_status
+        hostgroup_name                  smokescreen
+        contact_groups                  page_admins
+}

--- a/puppet/zulip_ops/manifests/profile/nagios.pp
+++ b/puppet/zulip_ops/manifests/profile/nagios.pp
@@ -29,6 +29,7 @@ class zulip_ops::profile::nagios {
   $hosts_redis = split(zulipconf('nagios', 'hosts_redis', undef), ',')
   $hosts_stats = split(zulipconf('nagios', 'hosts_stats', undef), ',')
   $hosts_fullstack = split(zulipconf('nagios', 'hosts_fullstack', undef), ',')
+  $hosts_smokescreen = split(zulipconf('nagios', 'hosts_smokescreen', undef), ',')
 
   file { '/etc/nagios3/':
     recurse => true,

--- a/puppet/zulip_ops/templates/nagios3/hosts.cfg.template.erb
+++ b/puppet/zulip_ops/templates/nagios3/hosts.cfg.template.erb
@@ -87,3 +87,13 @@ define host{
        hostgroups       all,not_pageable_servers, redis
        }
 <% end -%>
+
+<% @hosts_smokescreen.each do |host| -%>
+define host{
+       use              generic-host
+       host_name        <%= host %>
+       alias            <%= host %>
+       address          <%= host %>.<%= @default_host_domain %>
+       hostgroups       all,pageable_servers,smokescreen
+       }
+<% end -%>


### PR DESCRIPTION
This verifies that the proxy is working by accessing a
highly-available website through it.

**Testing plan:** Configured and test deployed.

