### PR TITLE
encoding: Reduce the number of replace calls while encoding URL.

### DIFF
--- a/static/js/hash_util.js
+++ b/static/js/hash_util.js
@@ -27,13 +27,12 @@ export function get_hash_section(hash) {
 // by replacing % with . (like MediaWiki).
 export function encodeHashComponent(str) {
     const characterToBeReplaced = {
+        ".": ".2E",
         "%": ".",
         "(": ".28",
         ")": ".29",
     };
-    return encodeURIComponent(str)
-        .replace(/\./g, "%2E")
-        .replace(/[%()]/g, (matched) => characterToBeReplaced[matched]);
+    return encodeURIComponent(str).replace(/[%().]/g, (matched) => characterToBeReplaced[matched]);
 }
 
 export function encode_operand(operator, operand) {


### PR DESCRIPTION
Follow up for the PR #17572 
We are making two calls to replace function while encoding the URL. But we can optimize it to make only one.
https://github.com/zulip/zulip/pull/17572#discussion_r596580824
**Testing plan:** <!-- How have you tested? -->
Automated Testing

CC @gnprice 

