### PR TITLE
Add a clear search button in the input field.

### DIFF
--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -90,6 +90,11 @@ function render_attachments_ui() {
     const uploaded_files_table = $("#uploaded_files_table").expectOne();
     const $search_input = $("#upload_file_search");
 
+    $("#clear_upload_file_search_button").on("click", () => {
+        $("#upload_file_search").val("");
+        render_attachments_ui();
+    });
+
     ListWidget.create(uploaded_files_table, attachments, {
         name: "uploaded-files-list",
         modifier(attachment) {

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -90,6 +90,11 @@ export function set_up_muted_topics_ui() {
     const muted_topics_table = $("#muted_topics_table");
     const $search_input = $("#muted_topics_search");
 
+    $("#clear_muted_topics_search_button").on("click", () => {
+        $("#muted_topics_search").val("");
+        set_up_muted_topics_ui();
+    });
+
     ListWidget.create(muted_topics_table, muted_topics, {
         name: "muted-topics-list",
         modifier(muted_topics) {

--- a/static/js/settings_emoji.js
+++ b/static/js/settings_emoji.js
@@ -88,6 +88,11 @@ export function populate_emoji() {
         }
     }
 
+    $("#clear_filter_emojis_search_button").on("click", () => {
+        $("#filter_emojis_search").val("");
+        populate_emoji();
+    });
+
     const emoji_table = $("#admin_emoji_table").expectOne();
     ListWidget.create(emoji_table, Object.values(emoji_data), {
         name: "emoji_list",

--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -86,6 +86,11 @@ function populate_invites(invites_data) {
     });
 
     loading.destroy_indicator($("#admin_page_invites_loading_indicator"));
+
+    $("#clear_invites_list_search_button").on("click", () => {
+        $("#invites_list_search").val("");
+        populate_invites(invites_data);
+    });
 }
 
 function do_revoke_invite() {

--- a/static/js/settings_linkifiers.js
+++ b/static/js/settings_linkifiers.js
@@ -75,6 +75,11 @@ export function populate_linkifiers(linkifiers_data) {
         },
         simplebar_container: $("#linkifier-settings .progressive-table-wrapper"),
     });
+
+    $("#clear_linkifier_settings_search_button").on("click", () => {
+        $("#linkifier_settings_search").val("");
+        populate_linkifiers(page_params.realm_filters);
+    });
 }
 
 export function set_up() {

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -57,6 +57,11 @@ export function build_default_stream_table() {
     });
 
     loading.destroy_indicator($("#admin_page_default_streams_loading_indicator"));
+
+    $("#clear_default_streams_list_search_button").on("click", () => {
+        $("#default_streams_list_search").val("");
+        build_default_stream_table();
+    });
 }
 
 export function update_default_streams_table() {

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -167,6 +167,16 @@ function populate_users() {
 
     section.active.create_table(active_user_ids);
     section.deactivated.create_table(deactivated_user_ids);
+
+<<<<<<< Updated upstream
+    $("#clear_user_list_search_button").on("click", () => {
+        $("#user_list_search").val("");
+=======
+    $("#clear_deactivated_user_list_search_button").on("click", () => {
+        $("#deactivated_user_list_search").val("");
+>>>>>>> Stashed changes
+        populate_users();
+    });
 }
 
 function reset_scrollbar($sel) {
@@ -327,6 +337,12 @@ section.active.create_table = (active_users) => {
 
     loading.destroy_indicator($("#admin_page_users_loading_indicator"));
     $("#admin_users_table").show();
+
+    
+    $("#clear_user_list_search_button").on("click", () => {
+        $("#user_list_search").val("");
+        section.active.create_table(active_users);
+    });
 };
 
 section.deactivated.create_table = (deactivated_users) => {

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -177,6 +177,11 @@ function populate_users() {
 >>>>>>> Stashed changes
         populate_users();
     });
+
+    $("#clear_deactivated_user_list_search_button").on("click", () => {
+        $("#deactivated_user_list_search").val("");
+        populate_users();
+    });
 }
 
 function reset_scrollbar($sel) {

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -314,6 +314,11 @@ section.bots.create_table = () => {
 
     loading.destroy_indicator($("#admin_page_bots_loading_indicator"));
     $bots_table.show();
+
+    $("#clear_bot_list_search_button").on("click", () => {
+        $("#bot_list_search").val("");
+        section.bots.create_table();
+    });
 };
 
 section.active.create_table = (active_users) => {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -392,6 +392,11 @@ function show_subscription_settings(sub) {
 
     const opts = {source: get_users_for_subscriber_typeahead, stream: true};
     pill_typeahead.set_up(sub_settings.find(".input"), pill_widget, opts);
+
+    $("#clear_subscriber_search_button").on("click", () => {
+        $("#subscriber_search").val("");
+        show_subscription_settings(sub);
+    });
 }
 
 export function is_notification_setting(setting_label) {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -301,8 +301,6 @@ td .button {
     }
 
     input[type="text"].search {
-        float: right;
-        margin: 2px 5px 2px 0;
         padding: 2px 5px;
         font-size: 0.9em;
     }
@@ -1182,7 +1180,6 @@ input[type="checkbox"] {
 
     input.search {
         font-size: 0.9rem;
-        margin: 10px 0 20px 0;
     }
 
     .form-sidebar {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1756,7 +1756,8 @@ div.focused_table {
 .user_list_search_section,
 .deactivated_user_search_section,
 .bot_list_search_section,
-.default_streams_list_search_section {
+.default_streams_list_search_section,
+.linkifier_settings_search_section {
     float: right;
     margin: 10px 0 20px 0;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1754,7 +1754,8 @@ div.focused_table {
 .muted_topics_search_section,
 .filter_emojis_search_section,
 .user_list_search_section,
-.deactivated_user_search_section {
+.deactivated_user_search_section,
+.bot_list_search_section {
     float: right;
     margin: 10px 0 20px 0;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1751,7 +1751,8 @@ div.focused_table {
 }
 
 .upload_file_search_section,
-.muted_topics_search_section {
+.muted_topics_search_section,
+.filter_emojis_search_section {
     float: right;
     margin: 10px 0 20px 0;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1757,7 +1757,8 @@ div.focused_table {
 .deactivated_user_search_section,
 .bot_list_search_section,
 .default_streams_list_search_section,
-.linkifier_settings_search_section {
+.linkifier_settings_search_section,
+.invites_list_search_section {
     float: right;
     margin: 10px 0 20px 0;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1750,7 +1750,8 @@ div.focused_table {
     }
 }
 
-.upload_file_search_section {
+.upload_file_search_section,
+.muted_topics_search_section {
     float: right;
     margin: 10px 0 20px 0;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1755,7 +1755,8 @@ div.focused_table {
 .filter_emojis_search_section,
 .user_list_search_section,
 .deactivated_user_search_section,
-.bot_list_search_section {
+.bot_list_search_section,
+.default_streams_list_search_section {
     float: right;
     margin: 10px 0 20px 0;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1750,6 +1750,11 @@ div.focused_table {
     }
 }
 
+.upload_file_search_section {
+    float: right;
+    margin: 10px 0 20px 0;
+}
+
 #searchbox,
 #searchbox_legacy {
     width: 100%;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1753,7 +1753,8 @@ div.focused_table {
 .upload_file_search_section,
 .muted_topics_search_section,
 .filter_emojis_search_section,
-.user_list_search_section {
+.user_list_search_section,
+.deactivated_user_search_section {
     float: right;
     margin: 10px 0 20px 0;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1752,7 +1752,8 @@ div.focused_table {
 
 .upload_file_search_section,
 .muted_topics_search_section,
-.filter_emojis_search_section {
+.filter_emojis_search_section,
+.user_list_search_section {
     float: right;
     margin: 10px 0 20px 0;
 }

--- a/static/templates/settings/attachments_settings.hbs
+++ b/static/templates/settings/attachments_settings.hbs
@@ -1,6 +1,11 @@
 <div id="attachments-settings" class="settings-section" data-name="uploaded-files">
     <div id="attachment-stats-holder"></div>
-    <input id="upload_file_search" class="search" type="text" placeholder="{{t 'Search uploads...' }}" aria-label="{{t 'Search uploads...' }}"/>
+    <div class="input-append upload_file_search_section">
+        <input class="search" id="upload_file_search" type="text" placeholder="{{t 'Search uploads...' }}" aria-label="{{t 'Search uploads...' }}">
+        <button type="button" class="btn clear_search_button" id="clear_upload_file_search_button">
+            <i class="fa fa-remove" aria-hidden="true"></i>
+        </button>
+    </div>
     <div class="clear-float"></div>
     <div class="alert" id="delete-upload-status"></div>
     <div class="progressive-table-wrapper" data-simplebar>

--- a/static/templates/settings/bot_list_admin.hbs
+++ b/static/templates/settings/bot_list_admin.hbs
@@ -1,7 +1,12 @@
 <div id="admin-bot-list" class="settings-section" data-name="bot-list-admin">
     <div class="tip bot-settings-tip"></div>
     <h3 class="inline-block">{{t "Bots" }}</h3>
-    <input type="text" class="search" placeholder="{{t 'Filter bots' }}" aria-label="{{t 'Filter bots' }}"/>
+    <div class="input-append bot_list_search_section">
+        <input class="search" id="bot_list_search" type="text" placeholder="{{t 'Filter bots' }}" aria-label="{{t 'Filter bots' }}">
+        <button type="button" class="btn clear_search_button" id="clear_bot_list_search_button">
+            <i class="fa fa-remove" aria-hidden="true"></i>
+        </button>
+    </div>
     <div class="alert-notification" id="bot-field-status"></div>
     <div class="clear-float"></div>
     <div class="progressive-table-wrapper" data-simplebar>

--- a/static/templates/settings/deactivated_users_admin.hbs
+++ b/static/templates/settings/deactivated_users_admin.hbs
@@ -2,7 +2,12 @@
     <h3 class="inline-block">{{t "Deactivated users" }}
         {{> ../help_link_widget link="/help/deactivate-or-reactivate-a-user" }}
     </h3>
-    <input type="text" class="search" placeholder="{{t 'Filter deactivated users' }}" aria-label="{{t 'Filter deactivated users' }}"/>
+    <div class="input-append deactivated_user_search_section">
+        <input class="search" id="deactivated_user_list_search" type="text" placeholder="{{t 'Filter deactivated users' }}" aria-label="{{t 'Filter deactivated users' }}">
+        <button type="button" class="btn clear_search_button" id="clear_deactivated_user_list_search_button">
+            <i class="fa fa-remove" aria-hidden="true"></i>
+        </button>
+    </div>
     <div class="alert-notification" id="deactivated-user-field-status"></div>
     <div class="clear-float"></div>
 

--- a/static/templates/settings/default_streams_list_admin.hbs
+++ b/static/templates/settings/default_streams_list_admin.hbs
@@ -21,7 +21,12 @@
     </form>
     {{/if}}
 
-    <input type="text" class="search" placeholder="{{t 'Filter streams' }}" aria-label="{{t 'Filter streams' }}"/>
+    <div class="input-append default_streams_list_search_section">
+        <input class="search" id="default_streams_list_search" type="text" placeholder="{{t 'Filter streams' }}" aria-label="{{t 'Filter streams' }}">
+        <button type="button" class="btn clear_search_button" id="clear_default_streams_list_search_button">
+            <i class="fa fa-remove" aria-hidden="true"></i>
+        </button>
+    </div>
     <div class="clear-float"></div>
 
     <div class="progressive-table-wrapper" data-simplebar>

--- a/static/templates/settings/emoji_settings_admin.hbs
+++ b/static/templates/settings/emoji_settings_admin.hbs
@@ -16,9 +16,10 @@
                 </div>
                 <div class="inline-block">
                     <span id="emoji-file-name"></span>
-                    <input type="file" name="emoji_file_input" class="notvisible"
-                      id="emoji_file_input" value="{{t 'Upload image or GIF' }}"/>
-                    <button class="button white rounded" style="display: none;" id="emoji_image_clear_button">{{t "Clear emoji image" }}</button>
+                    <input type="file" name="emoji_file_input" class="notvisible" id="emoji_file_input"
+                      value="{{t 'Upload image or GIF' }}" />
+                    <button class="button white rounded" style="display: none;" id="emoji_image_clear_button">{{t "Clear
+                        emoji image" }}</button>
                     <button class="button rounded" id="emoji_upload_button">{{t "Upload image or GIF" }}</button>
                 </div>
                 <button id="admin_emoji_submit" type="submit" class="button rounded sea-green">
@@ -32,8 +33,13 @@
         </div>
     </form>
 
-    <input type="text" class="search" placeholder="{{t 'Filter emojis' }}"
-      aria-label="{{t 'Filter emojis' }}"/>
+    <div class="input-append filter_emojis_search_section">
+        <input class="search" id="filter_emojis_search" type="text" placeholder="{{t 'Filter emojis' }}"
+          aria-label="{{t 'Filter emojis' }}">
+        <button type="button" class="btn clear_search_button" id="clear_filter_emojis_search_button">
+            <i class="fa fa-remove" aria-hidden="true"></i>
+        </button>
+    </div>
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped wrapped-table admin_emoji_table">
             <thead>

--- a/static/templates/settings/invites_list_admin.hbs
+++ b/static/templates/settings/invites_list_admin.hbs
@@ -5,7 +5,12 @@
     <a class="invite-user-link" href="#invite"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{t "Invite more users" }}</a>
     <div>
         <h3 class="inline-block">{{t "Invites" }}</h3>
-        <input type="text" class="search" placeholder="{{t 'Filter invites' }}" aria-label="{{t 'Filter invites' }}"/>
+        <div class="input-append invites_list_search_section">
+            <input class="search" id="invites_list_search" type="text" placeholder="{{t 'Filter invites' }}" aria-label="{{t 'Filter invites' }}">
+            <button type="button" class="btn clear_search_button" id="clear_invites_list_search_button">
+                <i class="fa fa-remove" aria-hidden="true"></i>
+            </button>
+        </div>
         <div class="alert-notification" id="invites-field-status"></div>
     </div>
     <div class="clear-float"></div>

--- a/static/templates/settings/linkifier_settings_admin.hbs
+++ b/static/templates/settings/linkifier_settings_admin.hbs
@@ -64,7 +64,12 @@
         </form>
         {{/if}}
 
-        <input type="text" class="search" placeholder="{{t 'Filter linkifiers' }}" aria-label="{{t 'Filter linkifiers' }}"/>
+        <div class="input-append linkifier_settings_search_section">
+            <input class="search" id="linkifier_settings_search" type="text" placeholder="{{t 'Filter linkifiers' }}" aria-label="{{t 'Filter linkifiers' }}">
+            <button type="button" class="btn clear_search_button" id="clear_linkifier_settings_search_button">
+                <i class="fa fa-remove" aria-hidden="true"></i>
+            </button>
+        </div>
         <div class="progressive-table-wrapper" data-simplebar>
             <table class="table table-condensed table-striped wrapped-table admin_linkifiers_table">
                 <thead>

--- a/static/templates/settings/muted_topics_settings.hbs
+++ b/static/templates/settings/muted_topics_settings.hbs
@@ -1,5 +1,10 @@
 <div id="muted-topic-settings" class="settings-section" data-name="muted-topics">
-    <input id="muted_topics_search" class="search" type="text" placeholder="{{t 'Search muted topics...' }}" aria-label="{{t 'Search muted topics...' }}"/>
+    <div class="input-append muted_topics_search_section">
+        <input class="search" id="muted_topics_search" type="text" placeholder="{{t 'Search muted topics...' }}" aria-label="{{t 'Search muted topics...' }}">
+        <button type="button" class="btn clear_search_button" id="clear_muted_topics_search_button">
+            <i class="fa fa-remove" aria-hidden="true"></i>
+        </button>
+    </div>
     <div class="progressive-table-wrapper" data-simplebar data-list-widget="muted-topics-list">
         <table class="table table-condensed table-striped wrapped-table">
             <thead>

--- a/static/templates/settings/user_list_admin.hbs
+++ b/static/templates/settings/user_list_admin.hbs
@@ -1,7 +1,12 @@
 <div id="admin-user-list" class="settings-section" data-name="user-list-admin">
     <h3 class="inline-block">{{t "Users" }}</h3>
 
-    <input type="text" class="search" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
+    <div class="input-append user_list_search_section">
+        <input class="search" id="user_list_search" type="text" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}">
+        <button type="button" class="btn clear_search_button" id="clear_user_list_search_button">
+            <i class="fa fa-remove" aria-hidden="true"></i>
+        </button>
+    </div>
     <div class="alert-notification" id="user-field-status"></div>
     <div class="clear-float"></div>
 

--- a/static/templates/subscription_members.hbs
+++ b/static/templates/subscription_members.hbs
@@ -5,7 +5,10 @@
             {{t "Stream membership" }}
         </label>
         <div class="subscriber-search float-right">
-            <input type="text" class="search" placeholder="{{t 'Search subscribers' }}" />
+            <input type="text" class="search" id="subscriber_search" placeholder="{{t 'Search subscribers' }}" />
+            <button type="button" class="btn clear_search_button" id="clear_subscriber_search_button">
+                <i class="fa fa-remove" aria-hidden="true"></i>
+            </button>
         </div>
         <div class="subscriber_list_add float-left">
             <form class="form-inline">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
The approach to implement the clear search button is very similar to other clear search button like `Search streams` and `Search people` and it is kept consistent in every commit.
Discussion : https://chat.zulip.org/#narrow/stream/101-design/topic/No.20close(cross).20button
Fixes #17263 
This is the list of the sections where the cross clear search button have to be implemented:
- [x] SETTINGS / UPLOADED FILES  0e42a7f12576290e1652209779730ced1768bd79
- [x] SETTINGS / MUTED TOPICS  7c0253a022c8cc462794e875a54b64c42ff8e54d
- [x] SETTINGS / CUSTOM EMOJI  a1de713a0fddd1a3dcf5f2cfb08130b1f653cff2
- [x] SETTINGS / USERS  e68b1fe2f8cd0641871bb2e73eaf0d5978393c00
- [x] SETTINGS / DEACTIVATED USERS  1c9476b49334f8d20f61b381b50729f0bf19773c
- [x] SETTINGS / BOTS  f862b232ceab520eb2ae31e4420ab9656e548e15
- [x] SETTINGS / DEFAULT STREAMS  a1c0e77f265d708c64a68c8e413112f5786d4dfb
- [x] SETTINGS / LINKIFIERS  72363056e9fab292ffd4424bdc5e44a7ceba8c06
- [x] SETTINGS / INVITATION  abbf982ec2b108ee46abab81ae227e637e440c47
- [x] Manage streams/Stream settings/Stream membership  488a186415cb4afeefa770f50461966d7a239817

**Testing plan:** <!-- How have you tested? -->

1. Run all the automated tests and it pass on all the commits.
2. Checked all the design factors for all the 10 clear search buttons window.
3. Checked working of clear search button :
      a. Clear search button should clear the input of the input box.
      b. After clearing the input the table should be reloaded.
4. Checked all the new classes names and id names spellings.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
