### PR TITLE
recent_topics: Display compose box & enable compose hotkeys.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -429,6 +429,15 @@ export function initialize() {
 
     $("body").on("keydown", ".on_hover_topic_read", ui_util.convert_enter_to_click);
 
+    $("body").on("click", "#recent_topics_table .on_hover_topic_reply", (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        recent_topics.focus_clicked_element($(e.target), recent_topics.COLUMNS.reply);
+        compose_actions.respond_to_message({trigger: "hotkey"});
+    });
+
+    $("body").on("keydown", ".on_hover_topic_reply", ui_util.convert_enter_to_click);
+
     $("body").on("click", ".btn-recent-filters", (e) => {
         e.stopPropagation();
         recent_topics.change_focused_element($(e.target), "click");

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -456,11 +456,14 @@ export function process_enter_key(e) {
         return true;
     }
 
-    // If we got this far, then we're presumably in the message
-    // view, so in that case "Enter" is the hotkey to respond to a message.
-    // Note that "r" has same effect, but that is handled in process_hotkey().
-    compose_actions.respond_to_message({trigger: "hotkey enter"});
-    return true;
+    if (!recent_topics.is_visible()) {
+        // If we got this far, then we're presumably in the message
+        // view, so in that case "Enter" is the hotkey to respond to a message.
+        // Note that "r" has same effect, but that is handled in process_hotkey().
+        compose_actions.respond_to_message({trigger: "hotkey enter"});
+        return true;
+    }
+    return false;
 }
 
 export function process_tab_key() {

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -55,15 +55,16 @@ let col_focus = 1;
 export const COLUMNS = {
     stream: 0,
     topic: 1,
-    mute: 2,
-    read: 3,
+    reply: 2,
+    mute: 3,
+    read: 4,
 };
 
 // The number of selectable actions in a recent_topics.  Used to
 // implement wraparound of elements with the right/left keys.  Must be
 // increased when we add new actions, or rethought if we add optional
 // actions that only appear in some rows.
-const MAX_SELECTABLE_COLS = 4;
+const MAX_SELECTABLE_COLS = 5;
 
 // we use localstorage to persist the recent topic filters
 const ls_key = "recent_topic_filters";

--- a/static/js/ui_util.js
+++ b/static/js/ui_util.js
@@ -35,6 +35,8 @@ export function convert_enter_to_click(e) {
     const key = e.which;
     if (key === 13) {
         // Enter
+        e.preventDefault();
+        e.stopPropagation();
         $(e.currentTarget).trigger("click");
     }
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1316,6 +1316,7 @@ td.pointer {
 }
 
 .on_hover_topic_edit,
+.on_hover_topic_reply,
 .on_hover_topic_read {
     opacity: 0.2;
 }
@@ -1343,6 +1344,7 @@ td.pointer {
 
 .on_hover_topic_edit,
 .always_visible_topic_edit,
+.on_hover_topic_reply,
 .on_hover_topic_read {
     &:hover {
         cursor: pointer;

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -16,6 +16,9 @@
                 {{#if unread_count}}<span class="unread_count">{{unread_count}}</span>{{/if}}
                 <div class="recent_topic_actions">
                     <div class="recent_topics_focusable">
+                        <i class="fa fa-reply on_hover_topic_reply" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Message topic' }}" role="button" tabindex="0" aria-label="{{t 'Message topic' }}"></i>
+                    </div>
+                    <div class="recent_topics_focusable">
                         {{#if topic_muted}}
                         <i class="fa fa-bell-slash on_hover_topic_unmute recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Unmute topic' }}" role="button" tabindex="0" aria-label="{{t 'Unmute topic' }}"></i>
                         {{else}}


### PR DESCRIPTION
We move compose from being a part of message feed to
being a part of  middle column which is a common parent of recent
topics and message feed. This allows us to use a common compose
box for both the views. Fortunately, compose actions were
independent of this change so there weren't any evident
side effects.

We hide reply button in recent topics view for now. We may
bring it back with the ability to reply to selected topic / stream
after we are confident with bringing compose to recent topics.

We also enable compose hotkeys except for reply.

Fixes #17543
