### PR TITLE
analytics: escape HTML correctly when generating links.

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -6,6 +6,7 @@ import urllib
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from html import escape
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Type, Union
 from urllib.parse import urlencode
 
@@ -1559,25 +1560,25 @@ def format_date_for_activity_reports(date: Optional[datetime]) -> str:
 
 def user_activity_link(email: str) -> mark_safe:
     url = reverse(get_user_activity, kwargs=dict(email=email))
-    email_link = f'<a href="{url}">{email}</a>'
+    email_link = f'<a href="{escape(url)}">{escape(email)}</a>'
     return mark_safe(email_link)
 
 
 def realm_activity_link(realm_str: str) -> mark_safe:
     url = reverse(get_realm_activity, kwargs=dict(realm_str=realm_str))
-    realm_link = f'<a href="{url}">{realm_str}</a>'
+    realm_link = f'<a href="{escape(url)}">{escape(realm_str)}</a>'
     return mark_safe(realm_link)
 
 
 def realm_stats_link(realm_str: str) -> mark_safe:
     url = reverse(stats_for_realm, kwargs=dict(realm_str=realm_str))
-    stats_link = f'<a href="{url}"><i class="fa fa-pie-chart"></i>{realm_str}</a>'
+    stats_link = f'<a href="{escape(url)}"><i class="fa fa-pie-chart"></i>{escape(realm_str)}</a>'
     return mark_safe(stats_link)
 
 
 def remote_installation_stats_link(server_id: int, hostname: str) -> mark_safe:
     url = reverse(stats_for_remote_installation, kwargs=dict(remote_server_id=server_id))
-    stats_link = f'<a href="{url}"><i class="fa fa-pie-chart"></i>{hostname}</a>'
+    stats_link = f'<a href="{escape(url)}"><i class="fa fa-pie-chart"></i>{escape(hostname)}</a>'
     return mark_safe(stats_link)
 
 


### PR DESCRIPTION
Added fix for codeql classifying server-side scripting
by wrapping the html text within html.escape function.

For more info: https://codeql.github.com/codeql-query-help/python/py-reflective-xss/