### PR TITLE
hash_util: Convert object characterToBeReplaced object to map

### DIFF
--- a/static/js/hash_util.js
+++ b/static/js/hash_util.js
@@ -22,17 +22,18 @@ export function get_hash_section(hash) {
     return parts[1] || "";
 }
 
+const hashReplacements = new Map([
+    ["%", "."],
+    ["(", ".28"],
+    [")", ".29"],
+    [".", ".2E"],
+]);
+
 // Some browsers zealously URI-decode the contents of
 // window.location.hash.  So we hide our URI-encoding
 // by replacing % with . (like MediaWiki).
 export function encodeHashComponent(str) {
-    const characterToBeReplaced = {
-        ".": ".2E",
-        "%": ".",
-        "(": ".28",
-        ")": ".29",
-    };
-    return encodeURIComponent(str).replace(/[%().]/g, (matched) => characterToBeReplaced[matched]);
+    return encodeURIComponent(str).replace(/[%().]/g, (matched) => hashReplacements.get(matched));
 }
 
 export function encode_operand(operator, operand) {


### PR DESCRIPTION
Computed indexing into an object, especially with a user-provided key, can be dangerous in JavaScript because of nonsense features like `obj["__proto__"]`.  In this case there’s no vulnerability because the possible keys are strictly limited by the regex, but it’s always better practice to use a `Map` for computed indexing.