### PR TITLE
style: Fix the vertical alignment in message controls.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -852,6 +852,7 @@ td.pointer {
         font-weight: bold;
         color: hsl(0, 100%, 50%);
         position: relative;
+        vertical-align: middle;
 
         .rotating {
             display: inline-block;


### PR DESCRIPTION
This commit adds translateY to .message_failed in zulip.css which was
necessary as the alignment of .message_failed wasn't matching with rest
of the message controls like .edit_content. The translateY makes it
align properly, so that it doesn't look shifted.

Follow up #17666

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested manually.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before
![image](https://user-images.githubusercontent.com/56730716/111709579-dc135780-886d-11eb-8bdc-cc149d3a66e1.png)

After
![image](https://user-images.githubusercontent.com/56730716/111709615-ef262780-886d-11eb-9667-e36e1c1405e4.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
