### PR TITLE
eslint: Enable @typescript-eslint/consistent-type-imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -142,17 +142,20 @@
             },
             "rules": {
                 // Disable base rule to avoid conflict
+                "no-duplicate-imports": "off",
                 "no-unused-vars": "off",
                 "no-useless-constructor": "off",
 
                 "@typescript-eslint/array-type": "error",
                 "@typescript-eslint/await-thenable": "error",
                 "@typescript-eslint/consistent-type-assertions": "error",
+                "@typescript-eslint/consistent-type-imports": "error",
                 "@typescript-eslint/explicit-function-return-type": [
                     "error",
                     {"allowExpressions": true}
                 ],
                 "@typescript-eslint/member-ordering": "error",
+                "@typescript-eslint/no-duplicate-imports": "off",
                 "@typescript-eslint/no-explicit-any": "off",
                 "@typescript-eslint/no-extraneous-class": "error",
                 "@typescript-eslint/no-non-null-assertion": "off",

--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -2,7 +2,8 @@ import {strict as assert} from "assert";
 import "css.escape";
 import path from "path";
 
-import {Browser, ElementHandle, Page, launch} from "puppeteer";
+import type {Browser, ElementHandle, Page} from "puppeteer";
+import {launch} from "puppeteer";
 
 import {test_credentials} from "../../var/puppeteer/test_credentials";
 

--- a/static/js/blueslip_stacktrace.ts
+++ b/static/js/blueslip_stacktrace.ts
@@ -1,6 +1,6 @@
 import ErrorStackParser from "error-stack-parser";
 import $ from "jquery";
-import StackFrame from "stackframe";
+import type StackFrame from "stackframe";
 import StackTraceGPS from "stacktrace-gps";
 
 import render_blueslip_stacktrace from "../templates/blueslip_stacktrace.hbs";

--- a/static/js/types/stacktrace-gps/index.d.ts
+++ b/static/js/types/stacktrace-gps/index.d.ts
@@ -1,5 +1,5 @@
-import SourceMap from "source-map";
-import StackFrame from "stackframe";
+import type SourceMap from "source-map";
+import type StackFrame from "stackframe";
 
 declare namespace StackTraceGPS {
     type StackTraceGPSOptions = {

--- a/tools/debug-require-webpack-plugin.ts
+++ b/tools/debug-require-webpack-plugin.ts
@@ -4,7 +4,8 @@
 
 import path from "path";
 
-import webpack, {Template} from "webpack";
+import type webpack from "webpack";
+import {Template} from "webpack";
 
 export default class DebugRequirePlugin {
     apply(compiler: webpack.Compiler): void {


### PR DESCRIPTION
TypeScript [type-only imports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
) will probably become important eventually for reducing our circular import problem.