### PR TITLE
puppeteer_tests: Reset test database after each run.

### DIFF
--- a/tools/test-js-with-puppeteer
+++ b/tools/test-js-with-puppeteer
@@ -5,10 +5,13 @@ import shlex
 import subprocess
 import sys
 
+import requests
+
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from scripts.lib.zulip_tools import ENDC, FAIL, OKGREEN
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+from zerver.lib.test_fixtures import reset_zulip_test_database
 
 # Request the special webpack setup for frontend integration tests,
 # where webpack assets are compiled up front rather than running in
@@ -83,6 +86,13 @@ def run_tests(files: Iterable[str], external_host: str) -> None:
                 flush=True,
             )
             ret = subprocess.call(cmd)
+
+            # Resetting test environment.
+            reset_zulip_test_database()
+            # We are calling to /flush_caches to remove all the server-side caches.
+            response = requests.get("http://zulip.zulipdev.com:9981/flush_caches")
+            assert response.status_code == 200
+
             if ret != 0:
                 return ret, current_test_num
             current_test_num += 1

--- a/tools/test-js-with-puppeteer
+++ b/tools/test-js-with-puppeteer
@@ -90,7 +90,7 @@ def run_tests(files: Iterable[str], external_host: str) -> None:
             # Resetting test environment.
             reset_zulip_test_database()
             # We are calling to /flush_caches to remove all the server-side caches.
-            response = requests.get("http://zulip.zulipdev.com:9981/flush_caches")
+            response = requests.post("http://zulip.zulipdev.com:9981/flush_caches")
             assert response.status_code == 200
 
             if ret != 0:

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -495,6 +495,7 @@ def write_instrumentation_reports(full_suite: bool, include_webhooks: bool) -> N
             "docs/(?P<path>.+)",
             "casper/(?P<path>.+)",
             "static/(?P<path>.+)",
+            "flush_caches",
             *(webhook.url for webhook in WEBHOOK_INTEGRATIONS if not include_webhooks),
         }
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1821,6 +1821,11 @@ class Client(models.Model):
 get_client_cache: Dict[str, Client] = {}
 
 
+def clear_client_cache() -> None:  # nocoverage
+    global get_client_cache
+    get_client_cache = {}
+
+
 def get_client(name: str) -> Client:
     # Accessing KEY_PREFIX through the module is necessary
     # because we need the updated value of the variable.

--- a/zerver/views/development/cache.py
+++ b/zerver/views/development/cache.py
@@ -1,7 +1,9 @@
 import os
 
 from django.http import HttpRequest, HttpResponse
+from django.views.decorators.csrf import csrf_exempt
 
+from zerver.decorator import require_post
 from zerver.lib.cache import get_cache_backend
 from zerver.lib.response import json_success
 from zerver.models import clear_client_cache, flush_per_request_caches
@@ -9,6 +11,8 @@ from zerver.models import clear_client_cache, flush_per_request_caches
 ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../../")
 
 # This is used only by the Puppeteer Tests to clear all the cache after each run.
+@csrf_exempt
+@require_post
 def remove_caches(request: HttpRequest) -> HttpResponse:
     cache = get_cache_backend(None)
     cache.clear()

--- a/zerver/views/development/cache.py
+++ b/zerver/views/development/cache.py
@@ -1,0 +1,17 @@
+import os
+
+from django.http import HttpRequest, HttpResponse
+
+from zerver.lib.cache import get_cache_backend
+from zerver.lib.response import json_success
+from zerver.models import clear_client_cache, flush_per_request_caches
+
+ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../../")
+
+# This is used only by the Puppeteer Tests to clear all the cache after each run.
+def remove_caches(request: HttpRequest) -> HttpResponse:
+    cache = get_cache_backend(None)
+    cache.clear()
+    clear_client_cache()
+    flush_per_request_caches()
+    return json_success()

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -10,6 +10,7 @@ from django.views.generic import TemplateView
 from django.views.static import serve
 
 from zerver.views.auth import config_error, login_page
+from zerver.views.development.cache import remove_caches
 from zerver.views.development.email_log import clear_emails, email_page, generate_all_emails
 from zerver.views.development.integrations import (
     check_send_webhook_fixture_message,
@@ -73,6 +74,8 @@ urls = [
     path("devtools/integrations/<integration_name>/fixtures", get_fixtures),
     path("config-error/<error_category_name>", config_error, name="config_error"),
     path("config-error/remoteuser/<error_category_name>", config_error),
+    # Special endpoint to remove all the server-side caches.
+    path("flush_caches", remove_caches),
 ]
 
 # Serve static assets via the Django server


### PR DESCRIPTION
When running some tests multiple times in the same call,
were failing because of the data duplication.

This commit resolves that issue by resetting the test
environment (i.e: Re-cloning test database and clearing
cache) after each run.

It also works fine with Firefox.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #17607.


**Testing plan:** <!-- How have you tested? -->
Manually tested ✅ 


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
