### PR TITLE
Eliminate check_schemas warnings in tools/check-schemas.

### DIFF
--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -479,6 +479,7 @@ exports.fixtures = {
 
     restart: {
         type: "restart",
+        server_generation: 2,
         immediate: true,
     },
 

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -216,6 +216,7 @@ exports.fixtures = {
     realm__deactivated: {
         type: "realm",
         op: "deactivated",
+        realm_id: 2,
     },
 
     realm__update__bot_creation_policy: {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -249,6 +249,13 @@ export function dispatch_normal_event(event) {
                 page_params.realm_night_logo_source = event.data.night_logo_source;
                 realm_logo.rerender();
             } else if (event.op === "deactivated") {
+                // This handler is likely unnecessary, in that if we
+                // did nothing here, we'd reload and end up at the
+                // same place when we attempt the next `GET /events`
+                // and get an error.  Some clients will do that even
+                // with this code, if they didn't have an active
+                // longpoll waiting at the moment the realm was
+                // deactivated.
                 window.location.href = "/accounts/deactivated/";
             }
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1010,6 +1010,12 @@ def do_deactivate_realm(realm: Realm, acting_user: Optional[UserProfile] = None)
         # notice when they try to log in.
         delete_user_sessions(user)
 
+    # This event will only ever be received by clients with an active
+    # longpoll connection, because by this point clients will be
+    # unable to authenticate again to their event queue (triggering an
+    # immediate reload into the page explaining the realm was
+    # deactivated). So the purpose of sending this is to flush all
+    # active longpoll connections for the realm.
     event = dict(type="realm", op="deactivated", realm_id=realm.id)
     send_event(realm, event, active_user_ids(realm.id))
 

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -458,6 +458,14 @@ reaction_remove_event = event_dict_type(
 )
 check_reaction_remove = make_checker(reaction_remove_event)
 
+realm_deactivated_event = event_dict_type(
+    required_keys=[
+        ("type", Equals("realm")),
+        ("op", Equals("deactivated")),
+        ("realm_id", int),
+    ]
+)
+check_realm_deactivated = make_checker(realm_deactivated_event)
 
 bot_services_outgoing_type = DictType(
     required_keys=[

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1085,6 +1085,11 @@ def check_realm_user_update(
     )
 
 
+restart_event = event_dict_type(
+    required_keys=[("type", Equals("restart")), ("server_generation", int), ("immediate", bool)]
+)
+check_restart_event = make_checker(restart_event)
+
 stream_create_event = event_dict_type(
     required_keys=[
         ("type", Equals("stream")),

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -742,6 +742,15 @@ def apply_event(
                 if key == "authentication_methods":
                     state["realm_password_auth_enabled"] = value["Email"] or value["LDAP"]
                     state["realm_email_auth_enabled"] = value["Email"]
+        elif event["op"] == "deactivated":
+            # The realm has just been deactivated.  If our request had
+            # arrived a moment later, we'd have rendered the
+            # deactivation UI; if it'd been a moment sooner, we've
+            # have rendered the app and then immediately got this
+            # event (or actually, more likely, an auth error on GET
+            # /events) and immediately reloaded into the same
+            # deactivation UI. Passing achieves the same result.
+            pass
         else:
             raise AssertionError("Unexpected event type {type}/{op}".format(**event))
     elif event["type"] == "subscription":

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -625,23 +625,21 @@ def apply_event(
                             p["profile_data"][str(custom_field_id)] = {
                                 "value": custom_field_new_value,
                             }
-
+        else:
+            raise AssertionError("Unexpected event type {type}/{op}".format(**event))
     elif event["type"] == "realm_bot":
         if event["op"] == "add":
             state["realm_bots"].append(event["bot"])
-
-        if event["op"] == "remove":
+        elif event["op"] == "remove":
             user_id = event["bot"]["user_id"]
             for bot in state["realm_bots"]:
                 if bot["user_id"] == user_id:
                     bot["is_active"] = False
-
-        if event["op"] == "delete":
+        elif event["op"] == "delete":
             state["realm_bots"] = [
                 item for item in state["realm_bots"] if item["user_id"] != event["bot"]["user_id"]
             ]
-
-        if event["op"] == "update":
+        elif event["op"] == "update":
             for bot in state["realm_bots"]:
                 if bot["user_id"] == event["bot"]["user_id"]:
                     if "owner_id" in event["bot"]:
@@ -649,7 +647,8 @@ def apply_event(
                         bot["owner_id"] = bot_owner_id
                     else:
                         bot.update(event["bot"])
-
+        else:
+            raise AssertionError("Unexpected event type {type}/{op}".format(**event))
     elif event["type"] == "stream":
         if event["op"] == "create":
             for stream in event["streams"]:
@@ -743,6 +742,8 @@ def apply_event(
                 if key == "authentication_methods":
                     state["realm_password_auth_enabled"] = value["Email"] or value["LDAP"]
                     state["realm_email_auth_enabled"] = value["Email"]
+        else:
+            raise AssertionError("Unexpected event type {type}/{op}".format(**event))
     elif event["type"] == "subscription":
         if event["op"] == "add":
             added_stream_ids = {sub["stream_id"] for sub in event["subscriptions"]}
@@ -813,6 +814,8 @@ def apply_event(
                         if sub["stream_id"] in stream_ids:
                             subscribers = set(sub["subscribers"]) - user_ids
                             sub["subscribers"] = sorted(list(subscribers))
+        else:
+            raise AssertionError("Unexpected event type {type}/{op}".format(**event))
     elif event["type"] == "presence":
         if slim_presence:
             user_key = str(event["user_id"])
@@ -923,6 +926,8 @@ def apply_event(
                 for realm_domain in state["realm_domains"]
                 if realm_domain["domain"] != event["domain"]
             ]
+        else:
+            raise AssertionError("Unexpected event type {type}/{op}".format(**event))
     elif event["type"] == "realm_emoji":
         state["realm_emoji"] = event["realm_emoji"]
     elif event["type"] == "realm_export":
@@ -966,6 +971,8 @@ def apply_event(
             state["realm_user_groups"] = [
                 ug for ug in state["realm_user_groups"] if ug["id"] != event["group_id"]
             ]
+        else:
+            raise AssertionError("Unexpected event type {type}/{op}".format(**event))
     elif event["type"] == "user_status":
         user_id_str = str(event["user_id"])
         user_status = state["user_status"]

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2777,6 +2777,47 @@ paths:
                               additionalProperties: false
                               description: |
                                 Event sent to all users in a Zulip organization when the
+                                organization (realm) is deactivated.  Its main purpose is to
+                                flush active longpolling connections so clients can immediately
+                                show the organization as deactivated.
+
+                                Clients cannot rely on receiving this event, because they will
+                                no longer be able to authenticate to the Zulip API due to the
+                                deactivation, and thus can miss it if they did not have an active
+                                longpolling connection at the moment of deactivation.
+
+                                Correct handling of realm deactivations requires that clients
+                                parse authentication errors from GET /events; if that is done
+                                correctly, the client can ignore this event type and rely on its
+                                handling of the `GET /events` request it will do immediately
+                                after processing this batch of events.
+                              properties:
+                                id:
+                                  $ref: "#/components/schemas/EventIdSchema"
+                                type:
+                                  allOf:
+                                    - $ref: "#/components/schemas/EventTypeSchema"
+                                    - enum:
+                                        - realm
+                                op:
+                                  type: string
+                                  enum:
+                                    - deactivated
+                                realm_id:
+                                  type: integer
+                                  description: |
+                                    The ID of the deactivated realm.
+                              example:
+                                {
+                                  "type": "realm",
+                                  "op": "deactivated",
+                                  "realm_id": 2,
+                                  "id": 0,
+                                }
+                            - type: object
+                              additionalProperties: false
+                              description: |
+                                Event sent to all users in a Zulip organization when the
                                 configuration of the organization (realm) has changed.
 
                                 Unlike realm / update, supports multiple properties being changed

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 
 from zerver.lib.actions import check_send_message, do_change_user_role, do_set_realm_property
+from zerver.lib.event_schema import check_restart_event
 from zerver.lib.events import fetch_initial_state_data, get_raw_user_data
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import HostRequestMock, queries_captured, stub_event_queue_user_events
@@ -816,9 +817,7 @@ class RestartEventsTest(ZulipTestCase):
         self.assertEqual(len(virtual_events), 1)
         restart_event = virtual_events["restart"]
 
-        # TODO: add a schema checker for this to event_schema.py
-        # and exercise it here (as well as the more concrete
-        # check)
+        check_restart_event("restart_event", restart_event)
         self.assertEqual(
             restart_event,
             dict(

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -52,6 +52,7 @@ from zerver.lib.actions import (
     do_create_default_stream_group,
     do_create_multiuse_invite_link,
     do_create_user,
+    do_deactivate_realm,
     do_deactivate_stream,
     do_deactivate_user,
     do_delete_messages,
@@ -114,6 +115,7 @@ from zerver.lib.event_schema import (
     check_realm_bot_delete,
     check_realm_bot_remove,
     check_realm_bot_update,
+    check_realm_deactivated,
     check_realm_domains_add,
     check_realm_domains_change,
     check_realm_domains_remove,
@@ -1476,6 +1478,19 @@ class NormalActionsTest(BaseAction):
         action = lambda: do_reactivate_user(bot)
         events = self.verify_action(action, num_events=2)
         check_realm_bot_add("events[1]", events[1])
+
+    def test_do_deactivate_realm(self) -> None:
+        realm = self.user_profile.realm
+        action = lambda: do_deactivate_realm(realm)
+
+        # We delete sessions of all active users when a realm is
+        # deactivated, and redirect them to a deactivated page in
+        # order to inform that realm/organization has been
+        # deactivated.  state_change_expected is False is kinda
+        # correct because were one to somehow compute page_params (as
+        # this test does), but that's not actually possible.
+        events = self.verify_action(action, state_change_expected=False)
+        check_realm_deactivated("events[0]", events[0])
 
     def test_do_mark_hotspot_as_read(self) -> None:
         self.user_profile.tutorial_status = UserProfile.TUTORIAL_WAITING


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#17568 
This eliminates the following check_schemas warnings.
```
WARNING - NEED SCHEMA: realm__deactivated
WARNING - NEED SCHEMA: restart
WARNING - NEED SCHEMA to match OpenAPI stream_add_event
WARNING - NEED SCHEMA to match OpenAPI update_message_flags_add_add_event
WARNING - NEED SCHEMA to match OpenAPI update_message_flags_remove_remove_event
```
**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
