### PR TITLE
email: Open a single SMTP connection to send email batches.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -185,3 +185,6 @@ tlds
 
 # Unicode Collation Algorithm for sorting multilingual strings
 pyuca
+
+# Handle connection retries with exponential backoff
+backoff

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -73,6 +73,10 @@ backcall==0.2.0 \
     --hash=sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e \
     --hash=sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255
     # via ipython
+backoff==1.10.0 \
+    --hash=sha256:5e73e2cbe780e1915a204799dba0a01896f45f4385e636bcca7a0614d879d0cd \
+    --hash=sha256:b8fba021fac74055ac05eb7c7bfce4723aedde6cd0a504e5326bcb0bdd6d19a4
+    # via -r requirements/common.in
 beautifulsoup4==4.9.3 \
     --hash=sha256:4c98143716ef1cb40bf7f39a8e3eec8f8b009509e74904ba3a7b315431577e35 \
     --hash=sha256:84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25 \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -45,6 +45,10 @@ backcall==0.2.0 \
     --hash=sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e \
     --hash=sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255
     # via ipython
+backoff==1.10.0 \
+    --hash=sha256:5e73e2cbe780e1915a204799dba0a01896f45f4385e636bcca7a0614d879d0cd \
+    --hash=sha256:b8fba021fac74055ac05eb7c7bfce4723aedde6cd0a504e5326bcb0bdd6d19a4
+    # via -r requirements/common.in
 beautifulsoup4==4.9.3 \
     --hash=sha256:4c98143716ef1cb40bf7f39a8e3eec8f8b009509e74904ba3a7b315431577e35 \
     --hash=sha256:84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25 \

--- a/version.py
+++ b/version.py
@@ -45,4 +45,4 @@ API_FEATURE_LEVEL = 57
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "141.2"
+PROVISION_VERSION = "141.3"

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -690,6 +690,9 @@ def mock_queue_publish(
 ) -> Iterator[mock.MagicMock]:
     inner = mock.MagicMock(**kwargs)
 
+    # This helper ensures that events published to the queues are
+    # serializable as JSON; unserializable events would make RabbitMQ
+    # crash in production.
     def verify_serialize(
         queue_name: str,
         event: Dict[str, object],


### PR DESCRIPTION
Previously the outgoing emails were sent over several SMTP
connections through the EmailSendingWorker. In order to improve
the efficiency of this process the EmailSendingWorker worker is
now defined based on the LoopQueueProcessingWorker which allows to
handle batches of events from the queue workers. This permits to
open a single SMTP connection to send the whole batch of emails.

This was implemented directly in the consume_batch function
inherited from the LoopQueueProcessingWorker's abstract method.
This concrete implementation first creates and opens a new SMTP
connection from the default Django SMTP server then sends each
email of the batch through this connection and finally closes the
connection.

A first retry mechanism is used to redo the opening of the
connection until it works or until three attempts failed. A second
retry mechanism tackles errors that could happen when sending a
particular email from the batch and for which the process is
retriable (e.g. an SMTPServerDisconnected error). If the error
doesn't fall in this category then the particular email is just
dropped (e.g. an SMTPRecipientsRejected).

**Help/Feedback required**

This second part about the retry mechanisms is trickier than what
I first thought and I must say I am a bit confused about how I
could adapt the "retry_send_email_failures" decorator to be able
to use it in the new consume_batch function. I'm then open to any
suggestions to improve the current workaround that I tried to
implement but that still makes the backend tests fail.

**Testing plan:** <!-- How have you tested? -->

Automatic tests.

Fixes: #17672.
