### PR TITLE
doc: Correct the location of `Make a Zap` button.

### DIFF
--- a/zerver/webhooks/zapier/doc.md
+++ b/zerver/webhooks/zapier/doc.md
@@ -11,7 +11,7 @@ sent by Zapier directly in Zulip.
 1. [Click here](https://zapier.com/developer/public-invite/8304/bb0e9784d171eb44762c1bef4fcba2df/)
    and then click **Accept Invite & Build a Zap**.
 
-1. Click **Make a Zap!** in the upper right.
+1. Click **Make a Zap!** in the upper left.
 
 1. Follow the instructions to select a Trigger App and Event (**When this happens ...** (Step 1)).
    This could be an app like Trello, Gmail, Calendar, or anything else.


### PR DESCRIPTION

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
While working #16185 i came the documentation of Zapier integration. 
In the documentation, it's mentioned that the location of the "Make a Zap" button is in the upper right, but it's in the upper left. Maybe it's a typo or Zapier changed the location of the button.

**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot 2021-03-20 at 21 54 46](https://user-images.githubusercontent.com/70478296/111877034-5efbf580-89c7-11eb-9172-aa5bee37f490.png)
![Screenshot 2021-03-20 at 21 55 07](https://user-images.githubusercontent.com/70478296/111877038-63c0a980-89c7-11eb-9880-f0f7fcf1f1a6.png)
