### PR TITLE
bots: Avoid strange debounce code for bot updates.

### DIFF
--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -2,12 +2,9 @@
 
 const {strict: assert} = require("assert");
 
-const {mock_esm, zrequire} = require("../zjsunit/namespace");
+const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-mock_esm("../../static/js/settings_bots", {
-    render_bots: () => {},
-});
 const bot_data = zrequire("bot_data");
 
 const people = zrequire("people");

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -401,6 +401,7 @@ run_test("realm_bot add", (override) => {
     const bot_stub = make_stub();
     const admin_stub = make_stub();
     override(bot_data, "add", bot_stub.f);
+    override(settings_bots, "eventually_render_bots", () => {});
     override(settings_users, "update_bot_data", admin_stub.f);
     dispatch(event);
 
@@ -416,6 +417,7 @@ run_test("realm_bot remove", (override) => {
     const bot_stub = make_stub();
     const admin_stub = make_stub();
     override(bot_data, "deactivate", bot_stub.f);
+    override(settings_bots, "eventually_render_bots", () => {});
     override(settings_users, "update_bot_data", admin_stub.f);
     dispatch(event);
 
@@ -437,6 +439,7 @@ run_test("realm_bot update", (override) => {
     const bot_stub = make_stub();
     const admin_stub = make_stub();
     override(bot_data, "update", bot_stub.f);
+    override(settings_bots, "eventually_render_bots", () => {});
     override(settings_users, "update_bot_data", admin_stub.f);
 
     dispatch(event);

--- a/static/js/bot_data.js
+++ b/static/js/bot_data.js
@@ -1,7 +1,6 @@
 import _ from "lodash";
 
 import * as people from "./people";
-import * as settings_bots from "./settings_bots";
 
 const bots = new Map();
 
@@ -23,10 +22,6 @@ const bot_fields = [
 const services = new Map();
 const services_fields = ["base_url", "interface", "config_data", "service_name", "token"];
 
-const send_change_event = _.debounce(() => {
-    settings_bots.render_bots();
-}, 50);
-
 export function all_user_ids() {
     return Array.from(bots.keys());
 }
@@ -36,19 +31,15 @@ export function add(bot) {
     bots.set(bot.user_id, clean_bot);
     const clean_services = bot.services.map((service) => _.pick(service, services_fields));
     services.set(bot.user_id, clean_services);
-
-    send_change_event();
 }
 
 export function deactivate(bot_id) {
     bots.get(bot_id).is_active = false;
-    send_change_event();
 }
 
 export function del(bot_id) {
     bots.delete(bot_id);
     services.delete(bot_id);
-    send_change_event();
 }
 
 export function update(bot_id, bot_update) {
@@ -60,8 +51,6 @@ export function update(bot_id, bot_update) {
     if (typeof bot_update.services !== "undefined" && bot_update.services.length > 0) {
         Object.assign(service, _.pick(bot_update.services[0], services_fields));
     }
-
-    send_change_event();
 }
 
 export function get_all_bots_for_current_user() {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -272,6 +272,7 @@ export function dispatch_normal_event(event) {
             } else if (event.op === "update") {
                 bot_data.update(event.bot.user_id, event.bot);
             }
+            settings_bots.eventually_render_bots();
             settings_users.update_bot_data(event.bot.user_id);
             break;
 

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -1,5 +1,6 @@
 import ClipboardJS from "clipboard";
 import $ from "jquery";
+import _ from "lodash";
 
 import render_bot_avatar_row from "../templates/bot_avatar_row.hbs";
 import render_edit_bot from "../templates/edit_bot.hbs";
@@ -82,7 +83,7 @@ export function type_id_to_string(type_id) {
     return page_params.bot_types.find((bot_type) => bot_type.type_id === type_id).name;
 }
 
-export function render_bots() {
+function render_bots() {
     $("#active_bots_list").empty();
     $("#inactive_bots_list").empty();
 
@@ -122,6 +123,15 @@ export function render_bots() {
         $("#inactive_bots_list").show();
     }
 }
+
+// The reason we debounce this call is very wonky. I just moved it
+// from bot_data.js as part of breaking dependencies. Basically, it
+// allows the server response to win the race against events.
+// TODO: Organize the code so that we clear loading spinners and
+//       switch tabs within the UI when the event comes in.
+export const eventually_render_bots = _.debounce(() => {
+    render_bots();
+}, 50);
 
 export function generate_zuliprc_uri(bot_id) {
     const bot = bot_data.get(bot_id);


### PR DESCRIPTION
This is a bit more than a refactoring, as we eliminate O(N)
debounced calls to render bots during the initialization of
bot_data.

We break the dependency of bot_data on settings_bots by just lifting
the call (un-debounced) to the dispatch code.

We don't need to explicitly render bots during
bot_data.initialize(), which you can verify by loading
"#settings/your-bots" as the home page.  It was just an artifact of
how add() was implemented.

Note that for the **admin** screen, we did not and
still do not do live updates for add/remove; we only
do it for updates.  Fixing that is out of the scope
of this change.  The code that was moved here affects
**personal** bot settings.
