### PR TITLE
tooltip: Fix stream help tooltip.

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -454,14 +454,38 @@ export function set_up_handlers() {
             html: true,
             trigger: "manual",
         });
-        announce_stream_docs.popover("show");
-        announce_stream_docs.data("popover").tip().css("z-index", 2000);
         announce_stream_docs
             .data("popover")
             .tip()
             .find(".popover-content")
             .css("margin", "9px 14px");
+        announce_stream_docs.popover("show");
+        announce_stream_docs.data("popover").tip().css("z-index", 2000);
         e.stopPropagation();
+        // simple hack to fix the issue
+        // for 2 lines
+        let mul = 0;
+        const popover_height = Number.parseFloat(
+            announce_stream_docs.data("popover").tip().css("height"),
+        );
+        // for 3 lines
+        if (popover_height > 66.5) {
+            mul = 0.1;
+        }
+        // for 4 lines
+        if (popover_height > 105) {
+            mul = 0.15;
+        }
+        // TODO n lines
+        announce_stream_docs
+            .data("popover")
+            .tip()
+            .css(
+                "top",
+                announce_stream_docs.data("popover").tip().position().top -
+                    Number.parseFloat(announce_stream_docs.data("popover").tip().css("height")) *
+                        mul,
+            );
     });
     container.on("mouseout", "#announce-stream-docs", (e) => {
         $("#announce-stream-docs").popover("hide");


### PR DESCRIPTION
Announce stream help tooltip arrow
not align with help icon for small window sizes.

Fix the issues by handling the issue
for different screen sizes.
Grouped the screen sizes and
implemented different logics per group.

Fixes: #17349

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

- manual testing 

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

For further understanding refer the linked issue.

screenshot 1:

![109433337-ddebb700-7a35-11eb-82d3-dd83af78128d](https://user-images.githubusercontent.com/57071700/111918192-f5084c80-8aa9-11eb-9630-edd4f8ab8713.png)

screenshot 2:

![109433342-e47a2e80-7a35-11eb-9c23-f5b6f4f003e4](https://user-images.githubusercontent.com/57071700/111918200-fe91b480-8aa9-11eb-9bfe-bd2eb346601f.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

