### PR TITLE
frontend: Show the timezone in the rendered text. Fixes #17731.

### DIFF
--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -178,7 +178,10 @@ export function render_markdown_timestamp(time, text) {
     const timestring = format(time, "E, MMM d yyyy, " + hourformat);
     const titlestring = "This time is in your timezone. Original text was '" + text + "'.";
     return {
-        text: timestring,
+        text:
+            timestring +
+            " " +
+            time.toLocaleTimeString("en-us", {timeZoneName: "short"}).split(" ")[2],
         title: titlestring,
     };
 }


### PR DESCRIPTION
Fixes 1st part of #17731.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="577" alt="Chennai_ Kolkata_Mumbai_New delhi" src="https://user-images.githubusercontent.com/59444243/112104468-4101e100-8bd1-11eb-82f7-7264136079dc.png">
<img width="580" alt="timzoneabbr" src="https://user-images.githubusercontent.com/59444243/112104521-524aed80-8bd1-11eb-8177-089659a429e1.png">




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
