### PR TITLE
node tests: Add test() wrapper for reload_state.

### DIFF
--- a/frontend_tests/node_tests/reload_state.js
+++ b/frontend_tests/node_tests/reload_state.js
@@ -7,13 +7,20 @@ const {run_test} = require("../zjsunit/test");
 
 const reload_state = zrequire("reload_state");
 
-run_test("set_state_to_pending", () => {
+function test(label, f) {
+    run_test(label, (override) => {
+        reload_state.clear_for_testing();
+        f(override);
+    });
+}
+
+test("set_state_to_pending", () => {
     assert(!reload_state.is_pending());
     reload_state.set_state_to_pending();
     assert(reload_state.is_pending());
 });
 
-run_test("set_state_to_in_progress", () => {
+test("set_state_to_in_progress", () => {
     assert(!reload_state.is_in_progress());
     reload_state.set_state_to_in_progress();
     assert(reload_state.is_in_progress());


### PR DESCRIPTION
This is kinda overkill for such a tiny test, but
it should future-proof us from intra-test leaks.
