### PR TITLE
right-sidebar: Fix design bugs with keyboard-shortcuts.

### DIFF
--- a/static/js/scroll_bar.js
+++ b/static/js/scroll_bar.js
@@ -56,7 +56,7 @@ export function initialize() {
 
         $("#compose").css("left", "-" + sbWidth + "px");
         $(".compose-content").css({left: sbWidth + "px", "margin-right": 7 + sbWidth + "px"});
-        $("#keyboard-icon").css({right: sbWidth + 35 + "px"});
+        $("#keyboard-icon").css({"margin-right": sbWidth + "px"});
 
         $("head").append(
             "<style> @media (min-width: " +

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -201,8 +201,7 @@
 }
 
 #keyboard-icon {
-    position: fixed;
-    bottom: 8px; /* bottom padding of .compose-content */
+    position: relative;
     cursor: pointer;
     font-size: 20px;
 }
@@ -211,16 +210,14 @@
     color: inherit;
 }
 
+.right-sidebar-shortcuts {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
 /* This max-width must be synced with message_viewport.is_narrow */
 @media (width < $xl_min) {
-    #sidebar-keyboard-shortcuts {
-        /* This is supposed to fix this appearing improperly in narrow
-        windows.  It's likely the wrong solution; a proper fix likely
-        involves replacing `position: fixed` in #keyboard-icon so that
-        it still appears in the right sidebar overlay. */
-        display: none;
-    }
-
     #userlist-toggle {
         display: block;
     }

--- a/templates/zerver/app/right_sidebar.html
+++ b/templates/zerver/app/right_sidebar.html
@@ -16,11 +16,13 @@
                 <div id="buddy_list_wrapper_padding"></div>
             </div>
         </div>
-        {% if show_invites %}
-        <a id="invite-user-link" href="#invite"><i class="fa fa-user-plus" aria-hidden="true"></i>{{ _('Invite more users') }}</a>
-        {% endif %}
-        <a id="sidebar-keyboard-shortcuts" data-overlay-trigger="keyboard-shortcuts">
-            <i class="fa fa-keyboard-o fa-2x" id="keyboard-icon" data-html="true" data-toggle="tooltip" title="{{ _('Keyboard shortcuts') }} <span class='hotkey-hint'>(?)</span>"></i>
-        </a>
+        <div class="right-sidebar-shortcuts">
+            {% if show_invites %}
+            <a id="invite-user-link" href="#invite"><i class="fa fa-user-plus" aria-hidden="true"></i>{{ _('Invite more users') }}</a>
+            {% endif %}
+            <a id="sidebar-keyboard-shortcuts" data-overlay-trigger="keyboard-shortcuts">
+                <i class="fa fa-keyboard-o fa-2x" id="keyboard-icon" data-html="true" data-toggle="tooltip" title="{{ _('Keyboard shortcuts') }} <span class='hotkey-hint'>(?)</span>"></i>
+            </a>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
The keyboard-shortcuts icon currently has a fix position causing design related bugs such as overlapping with userlist in the sidebar.
The fix wraps the invite-more-users link and keyboard icon inside
a div with display property as flex instead of just using the anchor
tags inside the side-bar items.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![sb-1](https://user-images.githubusercontent.com/55033316/112047633-914a5600-8b73-11eb-9c04-4e8eb74e2aa1.png)

![sb-2](https://user-images.githubusercontent.com/55033316/112047701-a0310880-8b73-11eb-8b3b-59a5fb8d05eb.png)

![sb-3](https://user-images.githubusercontent.com/55033316/112047721-a2936280-8b73-11eb-9d7e-3c8c076da461.png)

![sb-4](https://user-images.githubusercontent.com/55033316/112047733-a6bf8000-8b73-11eb-8fe2-6c2ff0daef21.png)

![sb-5](https://user-images.githubusercontent.com/55033316/112047743-a8894380-8b73-11eb-877f-5192d582adb8.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
