### PR TITLE
notifications: Simplify sound playing

### DIFF
--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -90,7 +90,7 @@ export function set_up() {
     });
 
     $("#play_notification_sound").on("click", () => {
-        $("#notifications-area").find("audio")[0].play();
+        $("#notification-sound-audio")[0].play();
     });
 
     const notification_sound_dropdown = $("#notification_sound");

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2365,15 +2365,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
     top: 1px;
 }
 
-#notifications-area {
-    position: fixed;
-    z-index: 10;
-    bottom: 0;
-    right: 20px;
-    width: 200px;
-    height: auto;
-}
-
 .notifications-gravatar img {
     max-width: 25px;
     max-height: 25px;

--- a/templates/zerver/app/home.html
+++ b/templates/zerver/app/home.html
@@ -157,5 +157,7 @@
 {% include "zerver/app/message_history.html" %}
 {% include "zerver/app/delete_message.html" %}
 {% include "zerver/app/compose.html" %}
-<div id="notifications-area">
-</div>
+<audio id="notification-sound-audio">
+    <source id="notification-sound-source-ogg" type="audio/ogg">
+    <source id="notification-sound-source-mp3" type="audio/mpeg">
+</audio>


### PR DESCRIPTION
Remove the unused `notifications-area` wrapper.  Remove the feature detection code as all browsers recognize the `<audio>` element. Create the `<audio>` statically with the page template. Use multiple `<source>`s to let the browser detect the appropriate format instead of trying to do its job for it. Remove the absurd `loop="yes"` attribute, which had fortunately been specified on the wrong element.

**Testing plan:** Tested playing the sound and sending test notifications in notification settings.