### PR TITLE
eslint: Forbid CommonJS variables in ES6 modules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -209,7 +209,6 @@
             "files": ["static/**"],
             "env": {
                 "browser": true,
-                "commonjs": true,
                 "node": false
             },
             "rules": {
@@ -223,7 +222,6 @@
             "files": ["static/shared/**"],
             "env": {
                 "browser": false,
-                "commonjs": false,
                 "shared-node-browser": true
             },
             "rules": {

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const Module = require("module");
 const path = require("path");
 
 require("css.escape");
@@ -51,11 +50,6 @@ const window = new Proxy(global, {
 handlebars.hook_require();
 
 const noop = function () {};
-
-// Set up fake module.hot
-Module.prototype.hot = {
-    accept: noop,
-};
 
 function short_tb(tb) {
     const lines = tb.split("\n");

--- a/static/assets/icons/zulip-icons.font.js
+++ b/static/assets/icons/zulip-icons.font.js
@@ -1,3 +1,5 @@
+/* eslint-env commonjs */
+
 "use strict";
 
 module.exports = {

--- a/static/js/avatar.js
+++ b/static/js/avatar.js
@@ -1,11 +1,11 @@
 import $ from "jquery";
 
+import render_confirm_delete_user_avatar from "../templates/confirm_delete_user_avatar.hbs";
+
 import * as channel from "./channel";
 import * as confirm_dialog from "./confirm_dialog";
 import * as settings_data from "./settings_data";
 import * as upload_widget from "./upload_widget";
-
-const render_confirm_delete_user_avatar = require("../templates/confirm_delete_user_avatar.hbs");
 
 export function build_bot_create_widget() {
     // We have to do strange gyrations with the file input to clear it,

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1,10 +1,5 @@
 import $ from "jquery";
 
-// This reloads the module in development rather than refreshing the page
-if (module.hot) {
-    module.hot.accept();
-}
-
 export const status_classes = "alert-error alert-success alert-info alert-warning";
 
 // TODO: Move this to the portico codebase.

--- a/static/js/csrf.js
+++ b/static/js/csrf.js
@@ -1,3 +1,5 @@
+/* eslint-env commonjs */
+
 "use strict";
 
 const $ = require("jquery");

--- a/static/js/css_variables.js
+++ b/static/js/css_variables.js
@@ -1,3 +1,5 @@
+/* eslint-env commonjs */
+
 "use strict";
 
 // Media query breakpoints according to Bootstrap 4.5

--- a/static/js/page_params.js
+++ b/static/js/page_params.js
@@ -1,3 +1,5 @@
+/* eslint-env commonjs */
+
 "use strict";
 
 const $ = require("jquery");

--- a/static/js/zulip.js
+++ b/static/js/zulip.js
@@ -1,3 +1,5 @@
+/* eslint-env commonjs */
+
 "use strict";
 
 const {Filter} = require("./filter");


### PR DESCRIPTION
To prevent accidents like the one fixed by 1cc6f6158ef31b45a2bff5bbe65a08a7157962bc.