### PR TITLE
tests: Refactor create_stream_policy and invite_to_stream_policy tests.

### DIFF
--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -602,7 +602,11 @@ def list_to_streams(
     else:
         # autocreate=True path starts here
         if not user_profile.can_create_streams():
-            raise JsonableError(_("User cannot create streams."))
+            if user_profile.realm.create_stream_policy == Realm.POLICY_ADMINS_ONLY:
+                raise JsonableError(_("Only administrators can create streams."))
+            if user_profile.realm.create_stream_policy == Realm.POLICY_FULL_MEMBERS_ONLY:
+                raise JsonableError(_("Your account is too new to create streams."))
+            raise JsonableError(_("Not allowed for guest users"))
         elif not autocreate:
             raise JsonableError(
                 _("Stream(s) ({}) do not exist").format(

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3204,34 +3204,34 @@ class SubscriptionAPITest(ZulipTestCase):
 
     def test_can_create_streams(self) -> None:
         othello = self.example_user("othello")
-        othello.role = UserProfile.ROLE_REALM_ADMINISTRATOR
+        do_change_user_role(othello, UserProfile.ROLE_REALM_ADMINISTRATOR)
         self.assertTrue(othello.can_create_streams())
 
-        othello.role = UserProfile.ROLE_MEMBER
-        othello.realm.create_stream_policy = Realm.POLICY_ADMINS_ONLY
+        do_change_user_role(othello, UserProfile.ROLE_MEMBER)
+        do_set_realm_property(othello.realm, "create_stream_policy", Realm.POLICY_ADMINS_ONLY)
         # Make sure that we are checking the permission with a full member,
         # as full member is the user just below admin in the role hierarchy.
         self.assertFalse(othello.is_provisional_member)
         self.assertFalse(othello.can_create_streams())
 
-        othello.realm.create_stream_policy = Realm.POLICY_MEMBERS_ONLY
-        othello.role = UserProfile.ROLE_GUEST
+        do_set_realm_property(othello.realm, "create_stream_policy", Realm.POLICY_MEMBERS_ONLY)
+        do_change_user_role(othello, UserProfile.ROLE_GUEST)
         self.assertFalse(othello.can_create_streams())
 
-        othello.role = UserProfile.ROLE_MEMBER
+        do_change_user_role(othello, UserProfile.ROLE_MEMBER)
         self.assertTrue(othello.can_create_streams())
 
-        othello.realm.waiting_period_threshold = 1000
-        othello.realm.create_stream_policy = Realm.POLICY_FULL_MEMBERS_ONLY
+        do_set_realm_property(othello.realm, "waiting_period_threshold", 1000)
+        do_set_realm_property(othello.realm, "create_stream_policy", Realm.POLICY_FULL_MEMBERS_ONLY)
         othello.date_joined = timezone_now() - timedelta(
             days=(othello.realm.waiting_period_threshold - 1)
         )
         self.assertFalse(othello.can_create_streams())
 
-        othello.role = UserProfile.ROLE_MODERATOR
+        do_change_user_role(othello, UserProfile.ROLE_MODERATOR)
         self.assertTrue(othello.can_create_streams())
 
-        othello.role = UserProfile.ROLE_MEMBER
+        do_change_user_role(othello, UserProfile.ROLE_MEMBER)
         othello.date_joined = timezone_now() - timedelta(
             days=(othello.realm.waiting_period_threshold + 1)
         )

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3285,7 +3285,6 @@ class SubscriptionAPITest(ZulipTestCase):
         do_change_user_role(othello, UserProfile.ROLE_REALM_ADMINISTRATOR)
         self.assertTrue(othello.can_subscribe_other_users())
 
-        do_change_user_role(othello, UserProfile.ROLE_MEMBER)
         do_change_user_role(othello, UserProfile.ROLE_GUEST)
         self.assertFalse(othello.can_subscribe_other_users())
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3256,7 +3256,22 @@ class SubscriptionAPITest(ZulipTestCase):
         )
         self.assert_json_error(result, "Only administrators can modify other users' subscriptions.")
 
+        do_change_user_role(self.test_user, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        self.common_subscribe_to_streams(
+            self.test_user, ["stream1"], {"principals": orjson.dumps([invitee_user_id]).decode()}
+        )
+
         do_set_realm_property(realm, "invite_to_stream_policy", Realm.POLICY_MEMBERS_ONLY)
+        do_change_user_role(self.test_user, UserProfile.ROLE_GUEST)
+        result = self.common_subscribe_to_streams(
+            self.test_user,
+            ["stream2"],
+            {"principals": orjson.dumps([invitee_user_id]).decode()},
+            allow_fail=True,
+        )
+        self.assert_json_error(result, "Not allowed for guest users")
+
+        do_change_user_role(self.test_user, UserProfile.ROLE_MEMBER)
         self.common_subscribe_to_streams(
             self.test_user,
             ["stream2"],


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR involves most of the commits for refactoring the tests related to `create_stream_policy` and
`invite_to_stream_policy` in `test_subs.py`.
- First commit is just a simple removal of unnecessary call to `do_change_user_role`.
- Second commit is to just follow a specific order and cases in `test_can_create_streams`
and `test_can_unsubscribe_other_users`. Explained more in the commit message.
- Third commit is to use `do_*` functions in `test_can_create_streams` instead of directly
changing role and policy value.
- Fourth commit is to cover all cases in `test_user_settings_for_subscrbing_other_users`.
- Fifth commit is to show different error messages based on `create_stream_policy`. Also added a test
for, which is basically to end-to-end tests similar to one we use for testing `invite_to_stream_policy` for
covering all cases of different error messages. Note that I am not sure what should be the name of this test
as similar test exists with mocking the `can_create_streams` function, would change the name based on
suggestions.



<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
