### PR TITLE
refactor: Move suspect_offline logic into watchdog.

### DIFF
--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -2,16 +2,16 @@
 
 const {strict: assert} = require("assert");
 
-const {mock_esm, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, with_field, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
 
 const reload_state = mock_esm("../../static/js/reload_state", {
     is_in_progress: () => false,
 });
-const server_events = mock_esm("../../static/js/server_events");
 
 const people = zrequire("people");
+const watchdog = zrequire("watchdog");
 const presence = zrequire("presence");
 
 const OFFLINE_THRESHOLD_SECS = 140;
@@ -98,9 +98,14 @@ test("unknown user", (override) => {
     // If the server is suspected to be offline or reloading,
     // then we suppress errors.  The use case here is that we
     // haven't gotten info for a brand new user yet.
-    server_events.suspect_offline = true;
-    presence.set_info(presences, now);
-    server_events.suspect_offline = false;
+    with_field(
+        watchdog,
+        "suspects_user_is_offline",
+        () => true,
+        () => {
+            presence.set_info(presences, now);
+        },
+    );
 
     override(reload_state, "is_in_progress", () => true);
     presence.set_info(presences, now);

--- a/frontend_tests/node_tests/watchdog.js
+++ b/frontend_tests/node_tests/watchdog.js
@@ -60,4 +60,12 @@ run_test("basics", () => {
     assert.equal(num_times_called_back, 1);
 });
 
+run_test("suspect_offline", () => {
+    watchdog.set_suspect_offline(true);
+    assert(watchdog.suspects_user_is_offline());
+
+    watchdog.set_suspect_offline(false);
+    assert(!watchdog.suspects_user_is_offline());
+});
+
 MockDate.reset();

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -183,7 +183,7 @@ export function send_presence_to_server(want_redraw) {
     // don't appear in people.js.  We handle this in 2 stages.  First,
     // here, we trigger an extra run of the clock-jump check that
     // detects whether this device just resumed from suspend.  This
-    // ensures that server_events.suspect_offline is always up-to-date
+    // ensures that watchdog.suspect_offline is always up-to-date
     // before we initiate a presence request.
     //
     // If we did just resume, it will also trigger an immediate

--- a/static/js/presence.js
+++ b/static/js/presence.js
@@ -1,7 +1,7 @@
 import * as blueslip from "./blueslip";
 import * as people from "./people";
 import * as reload_state from "./reload_state";
-import * as server_events from "./server_events";
+import * as watchdog from "./watchdog";
 
 // This module just manages data.  See activity.js for
 // the UI of our buddy list.
@@ -181,7 +181,7 @@ export function set_info(presences, server_timestamp) {
         // system are common in both situations.
         const person = people.get_by_user_id(user_id, true);
         if (person === undefined) {
-            if (!(server_events.suspect_offline || reload_state.is_in_progress())) {
+            if (!(watchdog.suspects_user_is_offline() || reload_state.is_in_progress())) {
                 // If we're online, and we get a user who we don't
                 // know about in the presence data, throw an error.
                 blueslip.error("Unknown user ID in presence data: " + user_id);

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -24,12 +24,6 @@ let get_events_timeout;
 let get_events_failures = 0;
 const get_events_params = {};
 
-// This field keeps track of whether we are attempting to
-// force-reconnect to the events server due to suspecting we are
-// offline.  It is important for avoiding races with the presence
-// system when coming back from unsuspend.
-export let suspect_offline = false;
-
 function get_events_success(events) {
     let messages = [];
     const update_message_events = [];
@@ -195,7 +189,7 @@ function get_events(options) {
         // that means it's fairly likely that this client has been off
         // the Internet and thus may have stale state (which is
         // important for potential presence issues).
-        suspect_offline = true;
+        watchdog.set_suspect_offline(true);
     }
     if (get_events_params.queue_id === undefined) {
         get_events_params.queue_id = page_params.queue_id;
@@ -219,7 +213,7 @@ function get_events(options) {
         idempotent: true,
         timeout: page_params.poll_timeout,
         success(data) {
-            suspect_offline = false;
+            watchdog.set_suspect_offline(false);
             try {
                 get_events_xhr = undefined;
                 get_events_failures = 0;

--- a/static/js/watchdog.js
+++ b/static/js/watchdog.js
@@ -1,6 +1,20 @@
 const unsuspend_callbacks = [];
 let watchdog_time = Date.now();
 
+// This field keeps track of whether we are attempting to
+// force-reconnect to the events server due to suspecting we are
+// offline.  It is important for avoiding races with the presence
+// system when coming back from unsuspend.
+let suspect_offline = false;
+
+export function set_suspect_offline(suspected) {
+    suspect_offline = suspected;
+}
+
+export function suspects_user_is_offline() {
+    return suspect_offline;
+}
+
 /*
     Our watchdog code checks every 5 seconds to make sure that we
     haven't gone 20 seconds since the last "5-second-ago" check.


### PR DESCRIPTION
This breaks some indirect dependencies in presense.js.
