### PR TITLE
timestamp: Enhanced tooltip and added timezone to rendered text.

### DIFF
--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -180,7 +180,10 @@ run_test("timestamp", () => {
     rm.update_elements($content);
 
     // Final asserts
-    assert.equal($timestamp.html(), '<i class="fa fa-clock-o"></i>\nThu, Jan 1 1970, 12:00 AM\n');
+    assert.equal(
+        $timestamp.html(),
+        '<i class="fa fa-clock-o"></i>\nThu, Jan 1 1970, 12:00 AM UTC\n',
+    );
     assert.equal(
         $timestamp.attr("title"),
         "This time is in your timezone. Original text was 'never-been-set'.",
@@ -197,14 +200,17 @@ run_test("timestamp-twenty-four-hour-time", () => {
     // We will temporarily change the 24h setting for this test.
     with_field(page_params, "twenty_four_hour_time", true, () => {
         rm.update_elements($content);
-        assert.equal($timestamp.html(), '<i class="fa fa-clock-o"></i>\nWed, Jul 15 2020, 20:40\n');
+        assert.equal(
+            $timestamp.html(),
+            '<i class="fa fa-clock-o"></i>\nWed, Jul 15 2020, 20:40 UTC\n',
+        );
     });
 
     with_field(page_params, "twenty_four_hour_time", false, () => {
         rm.update_elements($content);
         assert.equal(
             $timestamp.html(),
-            '<i class="fa fa-clock-o"></i>\nWed, Jul 15 2020, 8:40 PM\n',
+            '<i class="fa fa-clock-o"></i>\nWed, Jul 15 2020, 8:40 PM UTC\n',
         );
     });
 });

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -218,7 +218,7 @@ run_test("timestamp", () => {
     );
 
     assert.equal(
-        $timestamp.attr("title"),
+        $timestamp.attr("data-title"),
         "This time is in your timezone. Original text was 'never-been-set'.",
     );
     assert.equal($timestamp_invalid.text(), "never-been-set");

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -1,3 +1,4 @@
+import {isValid, parseISO} from "date-fns";
 import $ from "jquery";
 import _ from "lodash";
 import WinChan from "winchan";
@@ -38,6 +39,7 @@ import * as settings_toggle from "./settings_toggle";
 import * as stream_edit from "./stream_edit";
 import * as stream_list from "./stream_list";
 import * as stream_popover from "./stream_popover";
+import * as timerender from "./timerender";
 import * as ui_util from "./ui_util";
 import * as unread_ops from "./unread_ops";
 import * as user_status_ui from "./user_status_ui";
@@ -267,6 +269,42 @@ export function initialize() {
     });
 
     $("#main_div").on("mouseleave", ".message_reaction", (e) => {
+        e.stopPropagation();
+        $(e.currentTarget).tooltip("destroy");
+    });
+
+    // TOOLTIP FOR TIMESTAMPS
+
+    $("#main_div").on("mouseenter", "time", (e) => {
+        e.stopPropagation();
+        const elem = $(e.currentTarget);
+        const time_str = elem.attr("datetime");
+        if (time_str === undefined) {
+            return;
+        }
+
+        const timestamp = parseISO(time_str);
+        if (isValid(timestamp)) {
+            const text = elem.attr("data-title");
+            const rendered_time = timerender.render_markdown_timestamp(timestamp, text);
+
+            elem.tooltip({
+                title: rendered_time.title,
+                trigger: "hover",
+                placement: "bottom",
+                animation: false,
+            });
+            elem.tooltip("show");
+            $(".tooltip, .tooltip-inner").css({
+                "margin-left": "15px",
+                "max-width": $(window).width() * 0.6,
+            });
+            // Remove the arrow from the tooltip.
+            $(".tooltip-arrow").remove();
+        }
+    });
+
+    $("#main_div").on("mouseleave", "time", (e) => {
         e.stopPropagation();
         $(e.currentTarget).tooltip("destroy");
     });

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -166,8 +166,9 @@ export const update_elements = (content) => {
         if (isValid(timestamp)) {
             const text = $(this).text();
             const rendered_time = timerender.render_markdown_timestamp(timestamp, text);
+            const rendered_text = rendered_time.text + ` ${timerender.get_abbreviated_timezone()}`;
             const rendered_timestamp = render_markdown_timestamp({
-                text: rendered_time.text,
+                text: rendered_text,
             });
             $(this).html(rendered_timestamp);
             $(this).attr("title", rendered_time.title);

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -171,7 +171,7 @@ export const update_elements = (content) => {
                 text: rendered_text,
             });
             $(this).html(rendered_timestamp);
-            $(this).attr("title", rendered_time.title);
+            $(this).attr("data-title", rendered_time.title);
         } else {
             // This shouldn't happen. If it does, we're very interested in debugging it.
             blueslip.error(`Could not parse datetime supplied by backend: ${time_str}`);

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -82,7 +82,7 @@ export function build_page() {
             page_params.enable_sounds || page_params.enable_stream_audible_notifications,
         zuliprc: "zuliprc",
         botserverrc: "botserverrc",
-        timezones: timezones.timezones,
+        timezones: Object.keys(timezones.timezones),
         can_create_new_bots: settings_bots.can_create_new_bots(),
         settings_label,
         demote_inactive_streams_values: settings_config.demote_inactive_streams_values,

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -10,6 +10,9 @@ import {
 } from "date-fns";
 import $ from "jquery";
 
+import timezones from "../generated/timezones.json";
+
+import * as blueslip from "./blueslip";
 import {i18n} from "./i18n";
 import {page_params} from "./page_params";
 
@@ -127,6 +130,17 @@ function maybe_add_update_list_entry(entry) {
     if (entry.needs_update) {
         update_list.push(entry);
     }
+}
+
+export function get_abbreviated_timezone() {
+    const tz_values = timezones.timezones;
+    const timezone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+    if (!Object.keys(timezones.timezones).includes(timezone)) {
+        blueslip.warn("Invalid browser timezone detected.");
+        return "";
+    }
+    return tz_values[timezone].abbreviation;
 }
 
 function render_date_span(elem, rendered_time, rendered_time_above) {

--- a/tools/setup/build_timezone_values
+++ b/tools/setup/build_timezone_values
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import datetime
 import json
 import os
 
@@ -7,5 +8,14 @@ import pytz
 ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
 OUT_PATH = os.path.join(ZULIP_PATH, "static", "generated", "timezones.json")
 
+timezone_values = {
+    timezone: {
+        "abbreviation": pytz.timezone(timezone)
+        .localize(datetime.datetime.now(), is_dst=False)
+        .tzname()
+    }
+    for timezone in pytz.all_timezones
+}
+
 with open(OUT_PATH, "w") as f:
-    json.dump({"timezones": pytz.all_timezones}, f)
+    json.dump({"timezones": timezone_values}, f)

--- a/version.py
+++ b/version.py
@@ -45,4 +45,4 @@ API_FEATURE_LEVEL = 45
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "135.0"
+PROVISION_VERSION = "135.1"


### PR DESCRIPTION
Added a couple of commits referencing issue: #17731 and [comments](https://github.com/zulip/zulip/pull/17593#discussion_r598413261) within #17593. 

<ul>
<li>Added an <code>abbreviated</code> timezone value to rendered timestamp text. The text will look like following: <code>Mon, Mar 29 2021, 12:00 AM IST</code>(A extra <code>IST</code> timezone value being appended).</li>
<li>Added a <code>bootstrap-tooltip</code> for timestamp so that the text is visible with more ease.</li>
</ul>



<strong>Screenshot: </strong>

![tooltip](https://user-images.githubusercontent.com/53977614/112203226-4fcfae80-8c38-11eb-941d-a3793fc2f52a.gif)
