### PR TITLE
[3.x] certbot: Explicitly apt-get update before installing certbot.

### DIFF
--- a/scripts/setup/setup-certbot
+++ b/scripts/setup/setup-certbot
@@ -97,6 +97,7 @@ set -x
 
 case " $os_id $os_id_like " in
     *' debian '*)
+        apt-get update
         apt-get install -y certbot
         ;;
     *' rhel '*)


### PR DESCRIPTION
Backport #16385 to 3.x.