### PR TITLE
middleware: Do not trust X-Forwarded-For; use X-Real-Ip, set from nginx.

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -368,7 +368,6 @@ place to start.
 backend zulip
     mode http
     balance leastconn
-    http-request set-header X-Client-IP %[src]
     reqadd X-Forwarded-Proto:\ https
     server zulip 10.10.10.10:80 check
 ```

--- a/puppet/zulip/files/nginx/zulip-include-common/proxy
+++ b/puppet/zulip/files/nginx/zulip-include-common/proxy
@@ -4,5 +4,6 @@ proxy_http_version 1.1;
 proxy_set_header Connection "";
 proxy_set_header Host $host;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Real-Ip $remote_addr;
 proxy_next_upstream off;
 proxy_redirect off;

--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -52,6 +52,7 @@ location /api/v1/events {
 # Send everything else to Django via uWSGI
 location / {
     include uwsgi_params;
+    uwsgi_param HTTP_X_REAL_IP $remote_addr;
     uwsgi_pass django;
 }
 
@@ -65,12 +66,14 @@ location /thumbnail {
     include /etc/nginx/zulip-include/api_headers;
 
     include uwsgi_params;
+    uwsgi_param HTTP_X_REAL_IP $remote_addr;
     uwsgi_pass django;
 }
 location /avatar {
     include /etc/nginx/zulip-include/api_headers;
 
     include uwsgi_params;
+    uwsgi_param HTTP_X_REAL_IP $remote_addr;
     uwsgi_pass django;
 }
 
@@ -79,6 +82,7 @@ location /api/ {
     include /etc/nginx/zulip-include/api_headers;
 
     include uwsgi_params;
+    uwsgi_param HTTP_X_REAL_IP $remote_addr;
     uwsgi_pass django;
 }
 

--- a/puppet/zulip/templates/accept-loadbalancer.conf.template.erb
+++ b/puppet/zulip/templates/accept-loadbalancer.conf.template.erb
@@ -1,7 +1,11 @@
 # Configuration for making Zulip app frontends accept the
-# X-Forwarded-For header used by the Zulip proxy.  The accepted IP
-# addresses here are set in /etc/zulip/zulip.conf.
+# X-Forwarded-For header used by proxies.  The trusted IP addresses
+# here are set by `loadbalancer.ips` in /etc/zulip/zulip.conf.
+#
+# This causes us to update $remote_addr, which we use in logging, and
+# also pass down to Zulip as X-Real-Ip.
 real_ip_header X-Forwarded-For;
+real_ip_recursive on;
 <% @loadbalancers.each do |host| -%>
 set_real_ip_from <%= host %>;
 <%

--- a/zerver/management/commands/runtornado.py
+++ b/zerver/management/commands/runtornado.py
@@ -49,20 +49,6 @@ class Command(BaseCommand):
             "(use multiple ports to start multiple servers)",
         )
 
-        parser.add_argument(
-            "--nokeepalive",
-            action="store_true",
-            dest="no_keep_alive",
-            help="Tells Tornado to NOT keep alive http connections.",
-        )
-
-        parser.add_argument(
-            "--noxheaders",
-            action="store_false",
-            dest="xheaders",
-            help="Tells Tornado to NOT override remote IP with X-Real-IP.",
-        )
-
     def handle(self, addrport: str, **options: bool) -> None:
         interactive_debug_listen()
 
@@ -79,9 +65,6 @@ class Command(BaseCommand):
 
         if not addr:
             addr = "127.0.0.1"
-
-        xheaders = options.get("xheaders", True)
-        no_keep_alive = options.get("no_keep_alive", False)
 
         if settings.DEBUG:
             logging.basicConfig(
@@ -115,9 +98,7 @@ class Command(BaseCommand):
                     zulip_autoreload_start()
 
                 # start tornado web server in single-threaded mode
-                http_server = httpserver.HTTPServer(
-                    application, xheaders=xheaders, no_keep_alive=no_keep_alive
-                )
+                http_server = httpserver.HTTPServer(application, xheaders=True)
                 http_server.listen(port, address=addr)
 
                 from zerver.tornado.ioloop_logging import logging_data

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -174,7 +174,7 @@ MIDDLEWARE = (
     # With the exception of it's dependencies,
     # our logging middleware should be the top middleware item.
     "zerver.middleware.TagRequests",
-    "zerver.middleware.SetRemoteAddrFromForwardedFor",
+    "zerver.middleware.SetRemoteAddrFromRealIpHeader",
     "zerver.middleware.RequestContext",
     "zerver.middleware.LogRequests",
     "zerver.middleware.JsonErrorHandler",


### PR DESCRIPTION
The `X-Forwarded-For` header is a list of proxies' IP addresses; each
proxy appends the remote address of the host it received its request
from to the list, as it passes the request down.  A naïve parsing, as
SetRemoteAddrFromForwardedFor did, would thus interpret the first
address in the list as the client's IP.

However, clients can pass in arbitrary `X-Forwarded-For` headers,
which would allow them to spoof their IP address.  `nginx`'s behavior
is to treat the addresses as untrusted unless they match an allowlist
of known proxies.  By setting `real_ip_recursive on`, it also allows
this behavior to be applied repeatedly, moving from right to left down
the `X-Forwarded-For` list, stopping at the right-most that is
untrusted.

Rather than re-implement this logic in Django, pass the first
untrusted value that `nginx` computer down into Django via `X-Real-Ip`
header.  This allows consistent IP addresses in logs between `nginx`
and Django.

Calls into Tornado already passed this header, as Tornado logging
respects it.

**Testing plan:** Deployed to test prod, made requests from an IP that was marked "trusted" as well as not.  Tested lists of IPs, with some trusted and not.  Passed in `X-Real-IP` headers from client and ensured they were ignored.