### PR TITLE
Additional nagious checks

### DIFF
--- a/puppet/zulip_ops/files/nagios3/commands.cfg
+++ b/puppet/zulip_ops/files/nagios3/commands.cfg
@@ -192,6 +192,11 @@ define command{
 }
 
 define command{
+       command_name     check_ssl_certificate
+       command_line     /usr/lib/nagios/plugins/check_http --ssl -H '$HOSTADDRESS$' -I '$HOSTADDRESS$' --expect=200,302,401 -C30,14
+}
+
+define command{
        command_name     check_proxy_status
        command_line     /usr/lib/nagios/plugins/check_http --ssl -H 'www.google.com' -u 'https://www.google.com/' -j CONNECT -I '$HOSTADDRESS$' -p 4750 --expect=200,302,401 -s Search
 }

--- a/puppet/zulip_ops/files/nagios3/commands.cfg
+++ b/puppet/zulip_ops/files/nagios3/commands.cfg
@@ -200,3 +200,8 @@ define command{
        command_name     check_proxy_status
        command_line     /usr/lib/nagios/plugins/check_http --ssl -H 'www.google.com' -u 'https://www.google.com/' -j CONNECT -I '$HOSTADDRESS$' -p 4750 --expect=200,302,401 -s Search
 }
+
+define command{
+       command_name     check_apt_repo_status
+       command_line     /usr/lib/nagios/plugins/check_http --sni --ssl -H '$ARG1$' -u 'https://$ARG1$$ARG2$/dists/stable/Release' --expect=200 -s Contents-amd64
+}

--- a/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
+++ b/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
@@ -488,3 +488,10 @@ define service {
         hostgroup_name                  smokescreen
         contact_groups                  page_admins
 }
+define service {
+        use                             generic-service
+        service_description             Check chat.fhir.org cert
+        host_name                       nagios
+        check_command                   check_ssl_certificate!chat.fhir.org
+        contact_groups                  admins
+}

--- a/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
+++ b/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
@@ -488,6 +488,15 @@ define service {
         hostgroup_name                  smokescreen
         contact_groups                  page_admins
 }
+
+define service {
+        use                             generic-service
+        service_description             Check desktop APT repository
+        host_name                       nagios
+        check_command                   check_apt_repo_status!download.zulip.com!/desktop/apt
+        contact_groups                  admins
+}
+
 define service {
         use                             generic-service
         service_description             Check chat.fhir.org cert


### PR DESCRIPTION
These are for abstract health of systems, not hosts; they're placed on the `nagios` host to centralize.

**Testing plan:** Test-deployed.
