### PR TITLE
WIP:Add a clear search button.

### DIFF
--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -113,6 +113,13 @@ function render_attachments_ui() {
     });
 
     ui.reset_scrollbar(uploaded_files_table.closest(".progressive-table-wrapper"));
+
+    // Clear the input field when clicked on cross icon and
+    // render the uploaded_files_table again.
+    $("#clear_upload_file_search_button").on("click", () => {
+        $("#upload_file_search").val("");
+        render_attachments_ui();
+    });
 }
 
 function format_attachment_data(new_attachments) {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -301,8 +301,6 @@ td .button {
     }
 
     input[type="text"].search {
-        float: right;
-        margin: 2px 5px 2px 0;
         padding: 2px 5px;
         font-size: 0.9em;
     }
@@ -1182,7 +1180,6 @@ input[type="checkbox"] {
 
     input.search {
         font-size: 0.9rem;
-        margin: 10px 0 20px 0;
     }
 
     .form-sidebar {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1751,6 +1751,11 @@ div.focused_table {
     }
 }
 
+.upload_file_search_section {
+    float: right;
+    margin: 10px 0 20px 0;
+}
+
 #searchbox,
 #searchbox_legacy {
     width: 100%;

--- a/static/templates/settings/attachments_settings.hbs
+++ b/static/templates/settings/attachments_settings.hbs
@@ -1,6 +1,11 @@
 <div id="attachments-settings" class="settings-section" data-name="uploaded-files">
     <div id="attachment-stats-holder"></div>
-    <input id="upload_file_search" class="search" type="text" placeholder="{{t 'Search uploads...' }}" aria-label="{{t 'Search uploads...' }}"/>
+    <div class="input-append upload_file_search_section">
+        <input class="search" id="upload_file_search" type="text" placeholder="{{t 'Search uploads...' }}" aria-label="{{t 'Search uploads...' }}">
+        <button type="button" class="btn clear_search_button" id="clear_upload_file_search_button">
+            <i class="fa fa-remove" aria-hidden="true"></i>
+        </button>
+    </div>
     <div class="clear-float"></div>
     <div class="alert" id="delete-upload-status"></div>
     <div class="progressive-table-wrapper" data-simplebar>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
The approach to implement the clear search button is very similar to other clear search button like `Search streams` and `Search people` and it is kept consistent in every commit.
Discussion : https://chat.zulip.org/#narrow/stream/101-design/topic/No.20close(cross).20button
Fixes #17263 
This is the list of the sections where the cross clear search button have to be implemented:
- [x] SETTINGS / UPLOADED FILES  0e42a7f12576290e1652209779730ced1768bd79
- [x] SETTINGS / MUTED TOPICS  7c0253a022c8cc462794e875a54b64c42ff8e54d
- [x] SETTINGS / CUSTOM EMOJI  a1de713a0fddd1a3dcf5f2cfb08130b1f653cff2
- [x] SETTINGS / USERS  e68b1fe2f8cd0641871bb2e73eaf0d5978393c00
- [x] SETTINGS / DEACTIVATED USERS  1c9476b49334f8d20f61b381b50729f0bf19773c
- [x] SETTINGS / BOTS  f862b232ceab520eb2ae31e4420ab9656e548e15
- [x] SETTINGS / DEFAULT STREAMS  a1c0e77f265d708c64a68c8e413112f5786d4dfb
- [x] SETTINGS / LINKIFIERS  72363056e9fab292ffd4424bdc5e44a7ceba8c06
- [x] SETTINGS / INVITATION  abbf982ec2b108ee46abab81ae227e637e440c47
- [x] Manage streams/Stream settings/Stream membership  488a186415cb4afeefa770f50461966d7a239817

**Testing plan:** <!-- How have you tested? -->

1. Run all the automated tests and it pass on all the commits.
2. Checked all the design factors for all the 10 clear search buttons window.
3. Checked working of clear search button :
      a. Clear search button should clear the input of the input box.
      b. After clearing the input the table should be reloaded.
4. Checked all the new classes names and id names spellings.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
