### PR TITLE
[WIP]rendered_markdown: Let wide LaTeX equations scroll horizontally.

### DIFF
--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -78,6 +78,7 @@ const get_content_element = () => {
     $content.set_find_results(".emoji", $array([]));
     $content.set_find_results("div.spoiler-header", $array([]));
     $content.set_find_results("div.codehilite", $array([]));
+    $content.set_find_results("span.katex-display", $array([]));
     return $content;
 };
 
@@ -273,4 +274,17 @@ run_test("spoiler-header-empty-fill", () => {
     $header.html("");
     rm.update_elements($content);
     assert.equal(toggle_button_html + "<p>translated: Spoiler</p>", $header.html());
+});
+
+run_test("katex-display", () => {
+    // Setup
+    const $content = get_content_element();
+    const $katex = $.create("span.katex-display");
+    $content.set_find_results("span.katex-display", $array([$katex]));
+
+    // Test that span.katex-display is wrapped by an outer div element.
+    const outer_div_katex = '<div class="katex-outer"></div>';
+    $katex.set_parent(outer_div_katex);
+    rm.update_elements($content);
+    assert.equal(outer_div_katex, $katex.parent());
 });

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -414,6 +414,9 @@ function make_new_elem(selector, opts) {
         visible() {
             return shown;
         },
+        wrap() {
+            return self;
+        },
     };
 
     if (opts.children) {

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -237,4 +237,15 @@ export const update_elements = (content) => {
             return ":" + text + ":";
         });
     }
+
+    content.find("span.katex-display").each(function () {
+        // Long LaTeX equations gets cut off from right instead of scrolling horizontally.
+        // Also applying normal overflow css rule doesn't solve the problem of vertical cutoff of
+        // superscripts in integration upper limits.
+        // We do this by applying a div element wrapping katex.diplay span element and applying
+        // overflow css rule.
+        // Everything about this is discussed in the issue: https://github.com/zulip/zulip/issues/14422
+        const outer_div_katex = '<div class="katex-outer"></div>';
+        $(this).wrap(outer_div_katex);
+    });
 };

--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -155,8 +155,10 @@
     }
 
     /* LaTeX styling */
-    .katex-display {
-        margin: 0 0;
+    .katex-outer {
+        display: block;
+        overflow-x: auto;
+        text-align: center;
     }
 
     .tex-error {

--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -159,6 +159,21 @@
         display: block;
         overflow-x: auto;
         text-align: center;
+        &::-webkit-scrollbar {
+            height: 8px;
+            width: 10px;
+            background-color: hsla(0, 0%, 0%, 0.05);
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background-color: hsla(0, 0%, 0%, 0.3);
+            border-radius: 20px;
+            transition: all 0.2s ease;
+        }
+
+        &::-webkit-scrollbar-thumb:hover {
+            background-color: hsla(0, 0%, 0%, 0.6);
+        }
     }
 
     .tex-error {


### PR DESCRIPTION
Currently a wide LaTeX equation gets cut off horizontally instead of
scrolling.But simple addition of overflow css rule creates another
bug,i.e,the superscripts in integration upper limits gets cut off
vertically.

So,wrap a `div` element outside of `span.katex-display` element and
add overflow css rule to that `div` element.


**GIFs or screenshots:** 
![zulipAfter3](https://user-images.githubusercontent.com/42652941/112521180-3c504f00-8dc2-11eb-95d6-71e878aa402d.gif)


**Testing plan:**
Manually Tested 


Fixes: #14422
Signed-off-by: rajprakash00 <rajprakash1999@gmail.com>
