### PR TITLE
docs: updated uninstallation wsl url

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -62,8 +62,7 @@ We will be using Microsoft's new feature [WSL
 2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-about) for
 installation.
 
-WSL2 can be uninstalled by following the instructions [here from Microsoft]
-(https://docs.microsoft.com/en-us/windows/wsl/faq#how-do-i-uninstall-a-wsl-distribution).
+WSL 2 can be uninstalled by following the instructions [here from Microsoft](https://docs.microsoft.com/en-us/windows/wsl/faq#how-do-i-uninstall-a-wsl-distribution-).
 
 1. Install WSL 2 by following the instructions provided by Microsoft
 [here](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install).

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -20,14 +20,14 @@ that's running one of:
 
 You can just run the Zulip provision script on your machine.
 
-**Note**: you should not use the `root` user to run the installation.
+**Note**: You should not use the `root` user to run the installation.
 If you are using a [remote server](../development/remote.md), see
 the
 [section on creating appropriate user accounts](../development/remote.html#setting-up-user-accounts).
 
 ```eval_rst
 .. warning::
-    there is no supported uninstallation process with this
+    There is no supported uninstallation process with this
     method.  If you want that, use the Vagrant environment, where you can
     just do `vagrant destroy` to clean up the development environment.
 ```
@@ -168,7 +168,8 @@ likely only a few lines of changes to `tools/lib/provision.py` and
 `scripts/lib/setup-apt-repo` if you'd like to do it yourself and
 submit a pull request, or you can ask for help in
 [#development help](https://chat.zulip.org/#narrow/stream/49-development-help)
-on chat.zulip.org, and a core team member can help add support for you.
+on chat.zulip.org, and a core team member can help guide you through
+adding support for the platform.
 
 ### On OpenBSD 5.8 (experimental):
 
@@ -312,7 +313,7 @@ you can sign up [here](https://aws.amazon.com/cloud9/).
 
 #### Install zulip-cloud9
 
-There's an NPM package, `zulip-cloud9`, that provides a wrapper around
+There's a NPM package, `zulip-cloud9`, that provides a wrapper around
 the Zulip development server for use in the Cloud9 environment.
 
 Note: `npm i -g zulip-cloud9` does not work in zulip's virtual


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
  Updated correct link to uninstall WSL 2 and fixed typos in the development environment.

**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Advanced setup (non-Vagrant) — Zulip 4 0-dev+git documentation - Google Chrome 24-03-2021 18_35_07 (2)](https://user-images.githubusercontent.com/77020164/112331341-d63ecb80-8cde-11eb-932d-3f78fe84134b.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
