### PR TITLE
openapi: Fix schema for unread_msgs in /register.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6392,7 +6392,14 @@ paths:
                           the 50000 most recent unread messages the user has received.  This will usually
                           contain every unread message the user has received, but clients should support
                           users with even more unread messages (and not hardcode the number 50000).
+                        additionalProperties: false
                         properties:
+                          count:
+                            type: integer
+                            description: |
+                              The total number of unread messages to display; this includes private
+                              and group private messages, as well as all messags to unmuted topics
+                              on unmuted streams.
                           pms:
                             type: array
                             description: |


### PR DESCRIPTION
The schema for unread_msgs was missing additionalProperties: false
that was causing tests to pass even with undocumented parameters
which were validated as an additional property. Set
additionalProperties to false and added documentation for missing
count variable. Fixes #17728.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
On removing old_unreads_missing, the tests are failing as expected.
![image](https://user-images.githubusercontent.com/56172924/112337301-cbd30080-8ce3-11eb-8a68-f047f8fe4df0.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
