### PR TITLE
typeahead: Eliminate render caches.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -690,25 +690,6 @@ test("initialize", (override) => {
         ];
         assert.deepEqual(actual_value, expected_value);
 
-        // Even though the items passed to .highlighter() are the full
-        // objects of the users matching the query, it only returns the
-        // HTML string with the "User_name <email>" format, with the
-        // corresponding parts in bold.
-        options.query = "oth";
-        actual_value = options.highlighter(othello);
-        expected_value = `        <span class="user_circle_empty user_circle"></span>\n        <img class="typeahead-image" src="/avatar/${othello.user_id}&amp;s&#x3D;50" />\n<strong>Othello, the Moor of Venice</strong>`;
-        assert.equal(actual_value, expected_value);
-
-        options.query = "Lear";
-        actual_value = options.highlighter(cordelia);
-        expected_value = `        <span class="user_circle_empty user_circle"></span>\n        <img class="typeahead-image" src="/avatar/${cordelia.user_id}&amp;s&#x3D;50" />\n<strong>Cordelia Lear</strong>`;
-        assert.equal(actual_value, expected_value);
-
-        options.query = "othello@zulip.com, co";
-        actual_value = options.highlighter(cordelia);
-        expected_value = `        <span class="user_circle_empty user_circle"></span>\n        <img class="typeahead-image" src="/avatar/${cordelia.user_id}&amp;s&#x3D;50" />\n<strong>Cordelia Lear</strong>`;
-        assert.equal(actual_value, expected_value);
-
         function matcher(query, person) {
             query = typeahead.clean_query_lowercase(query);
             return ct.query_matches_person(query, person);
@@ -872,7 +853,11 @@ test("initialize", (override) => {
         // content_highlighter.
         fake_this = {completing: "mention", token: "othello"};
         actual_value = options.highlighter.call(fake_this, othello);
-        expected_value = `        <span class="user_circle_empty user_circle"></span>\n        <img class="typeahead-image" src="/avatar/${othello.user_id}&amp;s&#x3D;50" />\n<strong>Othello, the Moor of Venice</strong>`;
+        expected_value =
+            `        <span class="user_circle_empty user_circle"></span>\n` +
+            `        <img class="typeahead-image" src="/avatar/${othello.user_id}&amp;s&#x3D;50" />\n` +
+            `<strong>Othello, the Moor of Venice</strong>&nbsp;&nbsp;\n` +
+            `<small class="autocomplete_secondary">othello@zulip.com</small>\n`;
         assert.equal(actual_value, expected_value);
 
         fake_this = {completing: "mention", token: "hamletcharacters"};

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -591,7 +591,6 @@ test("render_person when emails hidden", () => {
         rendered = true;
         return "typeahead-item-stub";
     });
-    th.clear_rendered_person(b_user_1.user_id);
     assert.equal(th.render_person(b_user_1), "typeahead-item-stub");
     assert(rendered);
 });
@@ -607,7 +606,6 @@ test("render_person", () => {
         rendered = true;
         return "typeahead-item-stub";
     });
-    th.clear_rendered_person(a_user.user_id);
     assert.equal(th.render_person(a_user), "typeahead-item-stub");
     assert(rendered);
 });
@@ -624,7 +622,6 @@ test("render_person special_item_text", () => {
         user_id: 7,
         special_item_text: "special_text",
     };
-    th.clear_rendered_person(special_person.user_id);
 
     rendered = false;
     stub_templates((template_name, args) => {
@@ -637,34 +634,6 @@ test("render_person special_item_text", () => {
     assert(rendered);
 });
 
-test("clear_rendered_person", () => {
-    page_params.is_admin = true;
-    th.clear_rendered_person(b_bot.user_id);
-
-    let rendered = false;
-    stub_templates((template_name, args) => {
-        assert.equal(template_name, "typeahead_list_item");
-        assert.equal(args.primary, b_bot.full_name);
-        assert.equal(args.secondary, b_bot.email);
-        rendered = true;
-        return "typeahead-item-stub";
-    });
-    assert.equal(th.render_person(b_bot), "typeahead-item-stub");
-    assert(rendered);
-
-    // Bot once rendered won't be rendered again until clear_rendered_person
-    // function is called. clear_rendered_person is used to clear rendered
-    // data once bot name is modified.
-    rendered = false;
-    assert.equal(th.render_person(b_bot), "typeahead-item-stub");
-    assert.equal(rendered, false);
-
-    // Here rendered will be true as it is being rendered again.
-    th.clear_rendered_person(b_bot.user_id);
-    assert.equal(th.render_person(b_bot), "typeahead-item-stub");
-    assert(rendered);
-});
-
 test("render_stream", () => {
     // Test render_stream with short description
     let rendered = false;
@@ -673,7 +642,6 @@ test("render_stream", () => {
         stream_id: 42,
         name: "Short Description",
     };
-    th.clear_rendered_stream(stream.stream_id);
 
     stub_templates((template_name, args) => {
         assert.equal(template_name, "typeahead_list_item");
@@ -694,7 +662,6 @@ test("render_stream w/long description", () => {
         stream_id: 43,
         name: "Long Description",
     };
-    th.clear_rendered_stream(stream.stream_id);
 
     stub_templates((template_name, args) => {
         assert.equal(template_name, "typeahead_list_item");
@@ -704,35 +671,6 @@ test("render_stream w/long description", () => {
         rendered = true;
         return "typeahead-item-stub";
     });
-    assert.equal(th.render_stream(stream), "typeahead-item-stub");
-    assert(rendered);
-});
-
-test("clear_rendered_stream", () => {
-    let rendered = false;
-    const stream = {
-        description: "This is a description.",
-        stream_id: 44,
-        name: "Stream To Be Cleared",
-    };
-
-    th.clear_rendered_stream(stream.stream_id);
-    stub_templates((template_name, args) => {
-        assert.equal(template_name, "typeahead_list_item");
-        assert.equal(args.primary, stream.name);
-        assert.equal(args.secondary, stream.description);
-        rendered = true;
-        return "typeahead-item-stub";
-    });
-    assert.equal(th.render_stream(stream), "typeahead-item-stub");
-    assert(rendered);
-
-    rendered = false;
-    assert.equal(th.render_stream(stream), "typeahead-item-stub");
-    assert.equal(rendered, false);
-
-    // Here rendered will be true as it is being rendered again.
-    th.clear_rendered_stream(stream.stream_id);
     assert.equal(th.render_stream(stream), "typeahead-item-stub");
     assert(rendered);
 });

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -14,7 +14,6 @@ import {DropdownListWidget as dropdown_list_widget} from "./dropdown_list_widget
 import * as loading from "./loading";
 import * as overlays from "./overlays";
 import * as people from "./people";
-import * as typeahead_helper from "./typeahead_helper";
 
 export function hide_errors() {
     $("#bot_table_error").hide();
@@ -525,7 +524,6 @@ export function set_up() {
                         errors.hide();
                         edit_button.show();
                         avatar_widget.clear();
-                        typeahead_helper.clear_rendered_person(bot_id);
                         if (data.avatar_url) {
                             // Note that the avatar_url won't actually change on the backend
                             // when the user had a previous uploaded avatar.  Only the content

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -25,7 +25,6 @@ import * as stream_edit from "./stream_edit";
 import * as stream_list from "./stream_list";
 import * as stream_muting from "./stream_muting";
 import * as stream_ui_updates from "./stream_ui_updates";
-import * as typeahead_helper from "./typeahead_helper";
 import * as ui from "./ui";
 import * as ui_report from "./ui_report";
 import * as util from "./util";
@@ -193,9 +192,6 @@ export function update_stream_name(sub, new_name) {
 
     // Update the message feed.
     message_live_update.update_stream_name(stream_id, new_name);
-
-    // Clear rendered typeahead cache
-    typeahead_helper.clear_rendered_stream(stream_id);
 
     // Update compose_state if needed
     if (compose_state.stream_name() === old_name) {

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -73,8 +73,6 @@ export function render_typeahead_item(args) {
     return render_typeahead_list_item(args);
 }
 
-const rendered = {persons: new Map(), streams: new Map(), user_groups: new Map()};
-
 export function render_person(person) {
     const user_circle_class = buddy_data.get_user_circle_class(person.user_id);
     if (person.special_item_text) {
@@ -84,39 +82,24 @@ export function render_person(person) {
         });
     }
 
-    let html = rendered.persons.get(person.user_id);
-    if (html === undefined) {
-        const avatar_url = people.small_avatar_url_for_person(person);
+    const avatar_url = people.small_avatar_url_for_person(person);
 
-        const typeahead_arguments = {
-            primary: person.full_name,
-            img_src: avatar_url,
-            user_circle_class,
-            is_person: true,
-        };
-        typeahead_arguments.secondary = settings_data.email_for_user_settings(person);
-        html = render_typeahead_item(typeahead_arguments);
-        rendered.persons.set(person.user_id, html);
-    }
-    return html;
-}
-
-export function clear_rendered_person(user_id) {
-    rendered.persons.delete(user_id);
+    const typeahead_arguments = {
+        primary: person.full_name,
+        img_src: avatar_url,
+        user_circle_class,
+        is_person: true,
+    };
+    typeahead_arguments.secondary = settings_data.email_for_user_settings(person);
+    return render_typeahead_item(typeahead_arguments);
 }
 
 export function render_user_group(user_group) {
-    let html = rendered.user_groups.get(user_group.id);
-    if (html === undefined) {
-        html = render_typeahead_item({
-            primary: user_group.name,
-            secondary: user_group.description,
-            is_user_group: true,
-        });
-        rendered.user_groups.set(user_group.id, html);
-    }
-
-    return html;
+    return render_typeahead_item({
+        primary: user_group.name,
+        secondary: user_group.description,
+        is_user_group: true,
+    });
 }
 
 export function render_person_or_user_group(item) {
@@ -127,12 +110,6 @@ export function render_person_or_user_group(item) {
     return render_person(item);
 }
 
-export function clear_rendered_stream(stream_id) {
-    if (rendered.streams.has(stream_id)) {
-        rendered.streams.delete(stream_id);
-    }
-}
-
 export function render_stream(stream) {
     let desc = stream.description;
     const short_desc = desc.slice(0, 35);
@@ -141,17 +118,11 @@ export function render_stream(stream) {
         desc = short_desc + "...";
     }
 
-    let html = rendered.streams.get(stream.stream_id);
-    if (html === undefined) {
-        html = render_typeahead_item({
-            primary: stream.name,
-            secondary: desc,
-            is_unsubscribed: !stream.subscribed,
-        });
-        rendered.streams.set(stream.stream_id, html);
-    }
-
-    return html;
+    return render_typeahead_item({
+        primary: stream.name,
+        secondary: desc,
+        is_unsubscribed: !stream.subscribed,
+    });
 }
 
 export function render_emoji(item) {


### PR DESCRIPTION
These were introduced in ff9a929d7a7ffc2f7058c1934f27ae4351535b1f
with no explanation of why they were necessary.

Generally you only render a few things, and it's
important that they're up to date.

We weren't doing a good job of invalidating the cache.

Eliminating the cache will fix bugs (like presence circles
being out of date) and break some dependencies.

I removed some very fragile test code that was relying
on invalid values taken out of the cache.  (We now have
less line coverage, but if we want to test our rendering,
there are much cleaner ways to do it.)

As part of testing this, I renamed Hamlet to "aaron", so
that there are two aarons, and then I logged on as Iago
to see the "secondary" code in action that shows their
emails to distinguish them.
