### PR TITLE
js: Clean up typeof … === "undefined" checks

### DIFF
--- a/static/js/bot_data.js
+++ b/static/js/bot_data.js
@@ -48,7 +48,7 @@ export function update(bot_id, bot_update) {
 
     // We currently only support one service per bot.
     const service = services.get(bot_id)[0];
-    if (typeof bot_update.services !== "undefined" && bot_update.services.length > 0) {
+    if (bot_update.services !== undefined && bot_update.services.length > 0) {
         Object.assign(service, _.pick(bot_update.services[0], services_fields));
     }
 }

--- a/static/js/browser_history.js
+++ b/static/js/browser_history.js
@@ -5,7 +5,7 @@ import * as ui_util from "./ui_util";
 const state = {
     is_internal_change: false,
     hash_before_overlay: null,
-    old_hash: typeof window !== "undefined" ? window.location.hash : "#",
+    old_hash: window.location.hash,
 };
 
 export function clear_for_testing() {

--- a/static/js/local_message.js
+++ b/static/js/local_message.js
@@ -19,7 +19,7 @@ export const get_next_id_float = (function () {
     return function () {
         const local_id_increment = 0.01;
         let latest = page_params.max_message_id;
-        if (typeof message_list.all !== "undefined" && message_list.all.last() !== undefined) {
+        if (message_list.all.last() !== undefined) {
             latest = message_list.all.last().id;
         }
         latest = Math.max(0, latest);

--- a/static/js/localstorage.js
+++ b/static/js/localstorage.js
@@ -120,7 +120,7 @@ export const localstorage = function () {
         },
 
         set(name, data) {
-            if (typeof _data.VERSION !== "undefined") {
+            if (_data.VERSION !== undefined) {
                 ls.setData(_data.VERSION, name, data, _data.expires);
 
                 // if the expires attribute was not set as a global, then

--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -122,11 +122,8 @@ function do_revoke_invite() {
     });
 }
 
-export function set_up(initialize_event_handlers) {
+export function set_up(initialize_event_handlers = true) {
     meta.loaded = true;
-    if (typeof initialize_event_handlers === "undefined") {
-        initialize_event_handlers = true;
-    }
 
     // create loading indicators
     loading.make_indicator($("#admin_page_invites_loading_indicator"));

--- a/static/js/setup.js
+++ b/static/js/setup.js
@@ -64,12 +64,10 @@ $(() => {
         }
     });
 
-    if (typeof $ !== "undefined") {
-        $.fn.expectOne = function () {
-            if (blueslip && this.length !== 1) {
-                blueslip.error("Expected one element in jQuery set, " + this.length + " found");
-            }
-            return this;
-        };
-    }
+    $.fn.expectOne = function () {
+        if (blueslip && this.length !== 1) {
+            blueslip.error("Expected one element in jQuery set, " + this.length + " found");
+        }
+        return this;
+    };
 });

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -679,7 +679,7 @@ export function maybe_get_stream_name(stream_id) {
 
 export function is_user_subscribed(stream_id, user_id) {
     const sub = get_sub_by_id(stream_id);
-    if (typeof sub === "undefined" || !sub.can_access_subscribers) {
+    if (sub === undefined || !sub.can_access_subscribers) {
         // If we don't know about the stream, or we ourselves cannot access subscriber list,
         // so we return undefined (treated as falsy if not explicitly handled).
         blueslip.warn(
@@ -687,7 +687,7 @@ export function is_user_subscribed(stream_id, user_id) {
         );
         return undefined;
     }
-    if (typeof user_id === "undefined") {
+    if (user_id === undefined) {
         blueslip.warn("Undefined user_id passed to function is_user_subscribed");
         return undefined;
     }

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -112,7 +112,7 @@ export function get_active_data() {
 }
 
 function get_hash_safe() {
-    if (typeof window !== "undefined" && typeof window.location.hash === "string") {
+    if (typeof window.location.hash === "string") {
         return window.location.hash.slice(1);
     }
 

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -286,10 +286,7 @@ export const absolute_time = (function () {
         return str;
     };
 
-    return function (timestamp, today) {
-        if (typeof today === "undefined") {
-            today = new Date();
-        }
+    return function (timestamp, today = new Date()) {
         const date = new Date(timestamp);
         const is_older_year = today.getFullYear() - date.getFullYear() > 0;
         const H_24 = page_params.twenty_four_hour_time;

--- a/static/js/ui_util.js
+++ b/static/js/ui_util.js
@@ -11,14 +11,14 @@ export function change_tab_to(tabname) {
 export function place_caret_at_end(el) {
     el.focus();
 
-    if (typeof window.getSelection !== "undefined" && typeof document.createRange !== "undefined") {
+    if (window.getSelection !== undefined && document.createRange !== undefined) {
         const range = document.createRange();
         range.selectNodeContents(el);
         range.collapse(false);
         const sel = window.getSelection();
         sel.removeAllRanges();
         sel.addRange(range);
-    } else if (typeof document.body.createTextRange !== "undefined") {
+    } else if (document.body.createTextRange !== undefined) {
         const textRange = document.body.createTextRange();
         textRange.moveToElementText(el);
         textRange.collapse(false);


### PR DESCRIPTION
The only reason to use `typeof foo === "undefined"` is when `foo` is a global identifier that might not have been declared at all, so it might raise a `ReferenceError` if evaluated.  For a variable declared with `const` or `let` or `import`, a function argument, or a complex expression, simply `foo === undefined` is equivalent.

Some of these conditions have become impossible and can be removed entirely, and some can be replaced more idiomatically with default parameters (note that JavaScript does not share the Python misfeature of evaluating the default parameter at function declaration time).