### PR TITLE
drafts: Allow failed messages to be converted into drafts for easy access.

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -141,6 +141,13 @@ function draft_notify() {
     $(".alert-draft").delay(1000).fadeOut(500);
 }
 
+export function save_draft(draft) {
+    // Save the draft and notify the user
+    const new_draft_id = draft_model.addDraft(draft);
+    $("#compose-textarea").data("draft-id", new_draft_id);
+    draft_notify();
+}
+
 export function update_draft() {
     const draft = snapshot_message();
 
@@ -165,9 +172,7 @@ export function update_draft() {
 
     // We have never saved a draft for this message, so add
     // one.
-    const new_draft_id = draft_model.addDraft(draft);
-    $("#compose-textarea").data("draft-id", new_draft_id);
-    draft_notify();
+    save_draft(draft);
 }
 
 export function delete_draft_after_send() {

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -4,6 +4,7 @@ import * as alert_words from "./alert_words";
 import {all_messages_data} from "./all_messages_data";
 import * as blueslip from "./blueslip";
 import * as compose from "./compose";
+import * as drafts from "./drafts";
 import * as local_message from "./local_message";
 import * as markdown from "./markdown";
 import * as message_events from "./message_events";
@@ -75,6 +76,18 @@ function resend_message(message, row) {
 
     sent_messages.start_resend(local_id);
     transmit.send_message(message, on_success, on_error);
+}
+
+function save_failed_message_as_draft(message) {
+    // Pass the message object of the failed message in parameters
+
+    // The message content has been applied markdown, but we need
+    // to save the draft with raw_content
+    message.content = message.raw_content;
+
+    // Finally save the new draft and abort current message
+    drafts.save_draft(message);
+    abort_message(message);
 }
 
 export function build_display_recipient(message) {
@@ -436,4 +449,5 @@ export function initialize() {
 
     on_failed_action(".remove-failed-message", abort_message);
     on_failed_action(".refresh-failed-message", resend_message);
+    on_failed_action(".failed-convert-to-draft", save_failed_message_as_draft);
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -803,6 +803,16 @@ td.pointer {
     top: 8px !important;
 }
 
+.failed-convert-to-draft {
+    position: absolute;
+    right: -59px;
+
+    .button {
+        /* Needs important as preference of app_components.css is higher than zulip.css */
+        padding: 1px 10px !important;
+    }
+}
+
 .message_controls {
     display: inline-block;
     position: absolute;

--- a/static/templates/message_controls.hbs
+++ b/static/templates/message_controls.hbs
@@ -18,6 +18,9 @@
     <div class="message_failed {{#unless msg.failed_request}}notvisible{{/unless}}">
         <i class="fa fa-refresh refresh-failed-message tippy-zulip-tooltip" data-tippy-content="{{t 'Retry' }}" aria-label="{{t 'Retry' }}" role="button" tabindex="0"></i>
         <i class="fa fa-times-circle remove-failed-message tippy-zulip-tooltip" data-tippy-content="{{t 'Cancel' }}" aria-label="{{t 'Cancel' }}" role="button" tabindex="0"></i>
+        <span class="new-style failed-convert-to-draft">
+            <span class="button sea-green tippy-zulip-tooltip" data-tippy-content="{{t 'Convert to draft' }}" aria-label="{{t 'Convert to draft' }}" role="button" tabindex="0">Draft</span>
+        </span>
     </div>
 
     {{#unless msg/locally_echoed}}


### PR DESCRIPTION
Fixes #17697

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
In the developer tools, in the network panel. Make the user offline and now send a message.
The message then send gets failed and various options come. Click the draft in the message option of the failed message. This will store the message in the form of a draft and cancels the message.
Working properly tested manually.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Will add soon, work in progress in improving it.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
