### PR TITLE
recent_topics: Load filters from localstorage before rendering.

### DIFF
--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -400,7 +400,6 @@ export function set_filter(filter) {
 function show_selected_filters() {
     // Add `btn-selected-filter` to the buttons to show
     // which filters are applied.
-    load_filters();
     if (filters.size === 0) {
         $("#recent_topics_filter_buttons")
             .find('[data-filter="all"]')
@@ -455,6 +454,7 @@ export function complete_rerender() {
         return;
     }
     // Prepare header
+    load_filters();
     const rendered_body = render_recent_topics_body({
         filter_participated: filters.has("participated"),
         filter_unread: filters.has("unread"),


### PR DESCRIPTION
We were loading filters from localstorage after rendering the
filters block which caused the incorrect icons being displayed
for filters.

Since usually recent_topics renders a couple times when it
is loaded directly and the filters were being loaded as part of
show_selected_filters after we rendered recent_topics filters,
it meant the correct filters were being displayed in the
second render.

But, when user loads any other narrow directly when Zulip is loaded,
and opens recent_topics, recent_topics is only rendered once,
hence the bug gets noticed.

Fixes #17496
