### PR TITLE
issue:On forget password it redirects with email

### DIFF
--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -1074,6 +1074,9 @@ def password_reset(request: HttpRequest) -> HttpResponse:
         template_name="zerver/reset.html",
         form_class=ZulipPasswordResetForm,
         success_url="/accounts/password/reset/done/",
+        initial={
+            "email": request.user.email
+        }
     )
     return view_func(request)
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![](https://user-images.githubusercontent.com/55244065/112095965-71428300-8bc3-11eb-90e5-3045e14f89f7.png)

On forgetting password it redirects with a registered user email address

so this also gives the user to confirm option for reset password


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
