### PR TITLE
default_stream_groups: Keep list of streams sorted by stream name.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3001,7 +3001,7 @@ class DefaultStreamGroup(models.Model):
             name=self.name,
             id=self.id,
             description=self.description,
-            streams=[stream.to_dict() for stream in self.streams.all()],
+            streams=[stream.to_dict() for stream in self.streams.all().order_by("name")],
         )
 
 


### PR DESCRIPTION
Since the list of streams returned by a query which is not sorted
can vary, the tests which use it become flaky.
`NormalActionsTest.test_default_stream_groups_events` became
flaky due to this and hopefully sorting the streams should
fix it.

Flaky test proof - https://github.com/zulip/zulip/pull/16425/checks?check_run_id=2190443935#step:14:1421 
discussion - https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/Backend.20test.20flake