### PR TITLE
Split out `starred_messages_ui.js` from `starred_messages.js`.

### DIFF
--- a/static/js/starred_messages.js
+++ b/static/js/starred_messages.js
@@ -1,10 +1,3 @@
-import $ from "jquery";
-
-import render_confirm_unstar_all_messages from "../templates/confirm_unstar_all_messages.hbs";
-import render_confirm_unstar_all_messages_in_topic from "../templates/confirm_unstar_all_messages_in_topic.hbs";
-
-import * as confirm_dialog from "./confirm_dialog";
-import * as message_flags from "./message_flags";
 import * as message_store from "./message_store";
 import * as stream_popover from "./stream_popover";
 import * as top_left_corner from "./top_left_corner";
@@ -82,36 +75,4 @@ export function rerender_ui() {
     stream_popover.hide_topic_popover();
     top_left_corner.update_starred_count(count);
     stream_popover.hide_starred_messages_popover();
-}
-
-export function confirm_unstar_all_messages() {
-    const modal_parent = $(".left-sidebar-modal-holder");
-    const html_body = render_confirm_unstar_all_messages();
-
-    confirm_dialog.launch({
-        parent: modal_parent,
-        html_heading: i18n.t("Unstar all messages"),
-        html_body,
-        html_yes_button: i18n.t("Unstar messages"),
-        on_click: message_flags.unstar_all_messages,
-    });
-}
-
-export function confirm_unstar_all_messages_in_topic(stream_id, topic) {
-    function on_click() {
-        message_flags.unstar_all_messages_in_topic(stream_id, topic);
-    }
-
-    const modal_parent = $(".left-sidebar-modal-holder");
-    const html_body = render_confirm_unstar_all_messages_in_topic({
-        topic,
-    });
-
-    confirm_dialog.launch({
-        parent: modal_parent,
-        html_heading: i18n.t("Unstar messages in topic"),
-        html_body,
-        html_yes_button: i18n.t("Unstar messages"),
-        on_click,
-    });
 }

--- a/static/js/starred_messages_ui.js
+++ b/static/js/starred_messages_ui.js
@@ -1,0 +1,39 @@
+import $ from "jquery";
+
+import render_confirm_unstar_all_messages from "../templates/confirm_unstar_all_messages.hbs";
+import render_confirm_unstar_all_messages_in_topic from "../templates/confirm_unstar_all_messages_in_topic.hbs";
+
+import * as confirm_dialog from "./confirm_dialog";
+import * as message_flags from "./message_flags";
+
+export function confirm_unstar_all_messages() {
+    const modal_parent = $(".left-sidebar-modal-holder");
+    const html_body = render_confirm_unstar_all_messages();
+
+    confirm_dialog.launch({
+        parent: modal_parent,
+        html_heading: i18n.t("Unstar all messages"),
+        html_body,
+        html_yes_button: i18n.t("Unstar messages"),
+        on_click: message_flags.unstar_all_messages,
+    });
+}
+
+export function confirm_unstar_all_messages_in_topic(stream_id, topic) {
+    function on_click() {
+        message_flags.unstar_all_messages_in_topic(stream_id, topic);
+    }
+
+    const modal_parent = $(".left-sidebar-modal-holder");
+    const html_body = render_confirm_unstar_all_messages_in_topic({
+        topic,
+    });
+
+    confirm_dialog.launch({
+        parent: modal_parent,
+        html_heading: i18n.t("Unstar messages in topic"),
+        html_body,
+        html_yes_button: i18n.t("Unstar messages"),
+        on_click,
+    });
+}

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -18,6 +18,7 @@ import * as narrow from "./narrow";
 import * as popovers from "./popovers";
 import * as resize from "./resize";
 import * as starred_messages from "./starred_messages";
+import * as starred_messages_ui from "./starred_messages_ui";
 import * as stream_bar from "./stream_bar";
 import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
@@ -432,7 +433,7 @@ export function register_stream_handlers() {
         hide_starred_messages_popover();
         e.preventDefault();
         e.stopPropagation();
-        starred_messages.confirm_unstar_all_messages();
+        starred_messages_ui.confirm_unstar_all_messages();
     });
 
     // Unstar all messages in topic
@@ -442,7 +443,7 @@ export function register_stream_handlers() {
         const topic_name = $(".sidebar-popover-unstar-all-in-topic").attr("data-topic-name");
         const stream_id = $(".sidebar-popover-unstar-all-in-topic").attr("data-stream-id");
         hide_topic_popover();
-        starred_messages.confirm_unstar_all_messages_in_topic(
+        starred_messages_ui.confirm_unstar_all_messages_in_topic(
             Number.parseInt(stream_id, 10),
             topic_name,
         );

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -132,7 +132,7 @@ EXEMPT_FILES = {
     "static/js/settings_users.js",
     "static/js/setup.js",
     "static/js/spoilers.js",
-    "static/js/starred_messages.js",
+    "static/js/starred_messages_ui.js",
     "static/js/stream_bar.js",
     "static/js/stream_color.js",
     "static/js/stream_create.js",


### PR DESCRIPTION
This is a direct code move which will allow us
to enforce 100% coverage on the data handling
parts of `starred_messages.js`.

Follow up for #17440.
Tested in dev server that both confirm modals work correctly.