### PR TITLE
emails: Truncate overly-long sender addresses for SES compatibility

### DIFF
--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -2,6 +2,7 @@ import datetime
 import hashlib
 import logging
 import os
+import smtplib
 from email.headerregistry import Address
 from email.parser import Parser
 from email.policy import default
@@ -246,9 +247,14 @@ def send_email(
 
     if connection is None:
         connection = get_connection()
-    # This will call .open() for us, which is a no-op if it's already open;
-    # it will only call .close() if it was not open to begin with
-    if connection.send_messages([mail]) == 0:
+
+    try:
+        # This will call .open() for us, which is a no-op if it's already open;
+        # it will only call .close() if it was not open to begin with
+        if connection.send_messages([mail]) == 0:
+            logger.error("Error sending %s email to %s", template, mail.to)
+            raise EmailNotDeliveredException
+    except smtplib.SMTPException:
         logger.error("Error sending %s email to %s", template, mail.to)
         raise EmailNotDeliveredException
 

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -8,7 +8,6 @@ import functools
 import logging
 import os
 import signal
-import smtplib
 import socket
 import tempfile
 import time
@@ -182,7 +181,6 @@ def retry_send_email_failures(
         try:
             func(worker, data)
         except (
-            smtplib.SMTPServerDisconnected,
             socket.gaierror,
             socket.timeout,
             EmailNotDeliveredException,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Address issue #17558.

The second commit is a side commit to replace SMTPExceptions by an EmailNotDeliveredException as discussed in the linked issue above. Ready for a review.

**Testing plan:** <!-- How have you tested? -->
Automated tests.

Fixes: #17558.