### PR TITLE
middleware: Add client version to log and other logging improvements.

### DIFF
--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -14,7 +14,6 @@ from version import (
     LATEST_RELEASE_VERSION,
     ZULIP_VERSION,
 )
-from zerver.decorator import get_client_name
 from zerver.lib.exceptions import InvalidSubdomainError
 from zerver.lib.realm_description import get_realm_rendered_description, get_realm_text_description
 from zerver.lib.realm_icon import get_realm_icon_url
@@ -131,11 +130,6 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
         f'<a href="mailto:{escape(support_email)}">{escape(support_email)}</a>'
     )
 
-    # We can't use request.client here because we might not be using
-    # an auth decorator that sets it, but we can call its helper to
-    # get the same result.
-    platform = get_client_name(request)
-
     default_page_params = {
         **DEFAULT_PAGE_PARAMS,
         "request_language": get_language(),
@@ -170,7 +164,7 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
         "settings_path": settings_path,
         "secrets_path": secrets_path,
         "settings_comments_path": settings_comments_path,
-        "platform": platform,
+        "platform": request.client_name,
         "allow_search_engine_indexing": allow_search_engine_indexing,
         "landing_page_navbar_message": settings.LANDING_PAGE_NAVBAR_MESSAGE,
         "default_page_params": default_page_params,

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -196,7 +196,7 @@ def process_client(
     query: Optional[str] = None,
 ) -> None:
     if client_name is None:
-        client_name = get_client_name(request)
+        client_name = request.client_name
 
     # We could check for a browser's name being "Mozilla", but
     # e.g. Opera and MobileSafari don't set that, and it seems

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -43,7 +43,6 @@ from zerver.lib.response import json_error, json_method_not_allowed, json_succes
 from zerver.lib.subdomains import get_subdomain, user_matches_subdomain
 from zerver.lib.timestamp import datetime_to_timestamp, timestamp_to_datetime
 from zerver.lib.types import ViewFuncT
-from zerver.lib.user_agent import parse_user_agent
 from zerver.lib.utils import has_api_key_format, statsd
 from zerver.models import Realm, UserProfile, get_client, get_user_profile_by_api_key
 
@@ -163,27 +162,6 @@ def require_billing_access(func: ViewFuncT) -> ViewFuncT:
         return func(request, user_profile, *args, **kwargs)
 
     return cast(ViewFuncT, wrapper)  # https://github.com/python/mypy/issues/1927
-
-
-def get_client_name(request: HttpRequest) -> str:
-    # If the API request specified a client in the request content,
-    # that has priority.  Otherwise, extract the client from the
-    # User-Agent.
-    if "client" in request.GET:  # nocoverage
-        return request.GET["client"]
-    if "client" in request.POST:
-        return request.POST["client"]
-    if "HTTP_USER_AGENT" in request.META:
-        user_agent: Optional[Dict[str, str]] = parse_user_agent(request.META["HTTP_USER_AGENT"])
-    else:
-        user_agent = None
-    if user_agent is not None:
-        return user_agent["name"]
-
-    # In the future, we will require setting USER_AGENT, but for
-    # now we just want to tag these requests so we can review them
-    # in logs and figure out the extent of the problem
-    return "Unspecified"
 
 
 def process_client(

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -352,6 +352,7 @@ class HostRequestMock:
         self.user = user_profile
         self.body = ""
         self.content_type = ""
+        self.client_name = ""
 
     def get_host(self) -> str:
         return self.host

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -32,6 +32,7 @@ from zerver.lib.request import set_request, unset_request
 from zerver.lib.response import json_error, json_response_from_error, json_unauthorized
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.types import ViewFuncT
+from zerver.lib.user_agent import parse_user_agent
 from zerver.lib.utils import statsd
 from zerver.models import Realm, flush_per_request_caches, get_realm
 
@@ -291,6 +292,9 @@ class LogRequests(MiddlewareMixin):
     # method here too
     def process_user_agent(self, request: HttpRequest) -> None:
         request.client_name = get_client_name(request)
+        request.client_version = None
+        if request.client_name.startswith("Zulip"):
+            request.client_version = parse_user_agent(request.META["HTTP_USER_AGENT"])["version"]
 
     def process_request(self, request: HttpRequest) -> None:
         maybe_tracemalloc_listen()

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -140,6 +140,7 @@ def write_log_line(
     remote_ip: str,
     requestor_for_logs: str,
     client_name: str,
+    client_version: Optional[str] = None,
     status_code: int = 200,
     error_content: Optional[AnyStr] = None,
     error_content_iter: Optional[Iterable[AnyStr]] = None,
@@ -246,7 +247,10 @@ def write_log_line(
         extra_request_data = " {}".format(log_data["extra"])
     else:
         extra_request_data = ""
-    logger_client = f"({requestor_for_logs} via {client_name})"
+    if client_version is None:
+        logger_client = f"({requestor_for_logs} via {client_name})"
+    else:
+        logger_client = f"({requestor_for_logs} via {client_name}/{client_version})"
     logger_timing = f"{format_timedelta(time_delta):>5}{optional_orig_delta}{remote_cache_output}{markdown_output}{db_time_output}{startup_output} {path}"
     logger_line = f"{remote_ip:<15} {method:<7} {status_code:3} {logger_timing}{extra_request_data} {logger_client}"
     if status_code in [200, 304] and method == "GET" and path.startswith("/static"):
@@ -368,6 +372,7 @@ class LogRequests(MiddlewareMixin):
             remote_ip,
             requestor_for_logs,
             client,
+            client_version=request.client_version,
             status_code=response.status_code,
             error_content=content,
             error_content_iter=content_iter,

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1748,6 +1748,7 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
         request.META["PATH_INFO"] = ""
         request.user = hamlet = self.example_user("hamlet")
         request.user.is_verified = lambda: False
+        request.client_name = ""
         self.login_user(hamlet)
         request.session = self.client.session
         request.get_host = lambda: "zulip.testserver"
@@ -1763,6 +1764,7 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
             request.META["PATH_INFO"] = ""
             request.user = hamlet = self.example_user("hamlet")
             request.user.is_verified = lambda: False
+            request.client_name = ""
             self.login_user(hamlet)
             request.session = self.client.session
             request.get_host = lambda: "zulip.testserver"
@@ -1789,6 +1791,7 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
             request.META["PATH_INFO"] = ""
             request.user = hamlet = self.example_user("hamlet")
             request.user.is_verified = lambda: True
+            request.client_name = ""
             self.login_user(hamlet)
             request.session = self.client.session
             request.get_host = lambda: "zulip.testserver"

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -231,6 +231,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
             request._requestor_for_logs = old_request._requestor_for_logs
         request.user = old_request.user
         request.client = old_request.client
+        request.client_name = old_request.client_name
 
         # The saved_response attribute, if present, causes
         # rest_dispatch to return the response immediately before

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -232,6 +232,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         request.user = old_request.user
         request.client = old_request.client
         request.client_name = old_request.client_name
+        request.client_version = old_request.client_version
 
         # The saved_response attribute, if present, causes
         # rest_dispatch to return the response immediately before


### PR DESCRIPTION
The first commit uses get_client_name in LogRequests's process_request and removes its usage in process_client.
The second commit adds request.client_version to LogRequest's process_request.
The third commit changes write_log_line so that it now shows client version if available.
The fourth commit uses client id instead of client name for logging.

Fixes #14067 .
[This is the cleaned up version of #14139]