### PR TITLE
static: Add support for JS exception popups in portico pages

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -112,7 +112,6 @@ def render_stats(
         data_url_suffix=data_url_suffix,
         for_installation=for_installation,
         remote=remote,
-        debug_mode=False,
     )
 
     request_language = get_and_set_request_language(

--- a/static/js/alert_popup.ts
+++ b/static/js/alert_popup.ts
@@ -1,0 +1,16 @@
+import $ from "jquery";
+
+export function initialize(): void {
+    // this will hide the alerts that you click "x" on.
+    $("body").on("click", ".alert-box > div .exit", function () {
+        const $alert = $(this).closest(".alert-box > div");
+        $alert.addClass("fade-out");
+        setTimeout(() => {
+            $alert.removeClass("fade-out show");
+        }, 300);
+    });
+
+    $(".alert-box").on("click", ".stackframe .expand", function () {
+        $(this).parent().siblings(".code-context").toggle("fast");
+    });
+}

--- a/static/js/bundles/portico.js
+++ b/static/js/bundles/portico.js
@@ -1,5 +1,6 @@
 import "./common";
 import "../i18n";
+import "../portico/alert_popup";
 import "../portico/header";
 import "../portico/google-analytics";
 import "../../styles/portico/portico_styles.css";

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -643,25 +643,12 @@ export function initialize() {
         server_events.restart_get_events({dont_block: true});
     });
 
-    // this will hide the alerts that you click "x" on.
-    $("body").on("click", ".alert-box > div .exit", function () {
-        const $alert = $(this).closest(".alert-box > div");
-        $alert.addClass("fade-out");
-        setTimeout(() => {
-            $alert.removeClass("fade-out show");
-        }, 300);
-    });
-
     $("#settings_page").on("click", ".collapse-settings-btn", () => {
         settings_toggle.toggle_org_setting_collapse();
     });
 
     $(".organization-box").on("show.bs.modal", () => {
         popovers.hide_all();
-    });
-
-    $(".alert-box").on("click", ".stackframe .expand", function () {
-        $(this).parent().siblings(".code-context").toggle("fast");
     });
 
     // COMPOSE

--- a/static/js/portico/alert_popup.js
+++ b/static/js/portico/alert_popup.js
@@ -1,0 +1,7 @@
+import $ from "jquery";
+
+import * as alert_popup from "../alert_popup";
+
+$(() => {
+    alert_popup.initialize();
+});

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -8,6 +8,7 @@ import * as fenced_code from "../shared/js/fenced_code";
 import render_edit_content_button from "../templates/edit_content_button.hbs";
 
 import * as activity from "./activity";
+import * as alert_popup from "./alert_popup";
 import * as alert_words from "./alert_words";
 import * as blueslip from "./blueslip";
 import * as bot_data from "./bot_data";
@@ -473,6 +474,7 @@ export function initialize_everything() {
 
     const user_status_params = pop_fields("user_status");
 
+    alert_popup.initialize();
     alert_words.initialize(alert_words_params);
     emojisets.initialize();
     people.initialize(page_params.user_id, people_params);

--- a/static/styles/portico/portico_styles.css
+++ b/static/styles/portico/portico_styles.css
@@ -2,3 +2,4 @@
 @import "portico.css";
 @import "portico_signin.css";
 @import "markdown.css";
+@import "../alerts.css";

--- a/templates/zerver/integrations/development/dev_panel.html
+++ b/templates/zerver/integrations/development/dev_panel.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 
-{% block content %}
+{% block portico_content %}
 <div class="header portico-header">
     <div class="header-main top-navbar">
         <div>

--- a/templates/zerver/portico.html
+++ b/templates/zerver/portico.html
@@ -20,6 +20,7 @@
             </div>
         </div>
     </div>
+    <div class="alert-box"></div>
     {% if not isolated_page %}
     {% include 'zerver/footer.html' %}
     {% endif %}

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -36,6 +36,7 @@ USAGE = """
 # We do not yet require 100% line coverage for these files:
 EXEMPT_FILES = {
     "static/js/admin.js",
+    "static/js/alert_popup.ts",
     "static/js/archive.js",
     "static/js/attachments_ui.js",
     "static/js/avatar.js",

--- a/zerver/views/development/integrations.py
+++ b/zerver/views/development/integrations.py
@@ -30,7 +30,12 @@ def get_valid_integration_name(name: str) -> Optional[str]:
 def dev_panel(request: HttpRequest) -> HttpResponse:
     integrations = get_webhook_integrations()
     bots = UserProfile.objects.filter(is_bot=True, bot_type=UserProfile.INCOMING_WEBHOOK_BOT)
-    context = {"integrations": integrations, "bots": bots}
+    context = {
+        "integrations": integrations,
+        "bots": bots,
+        # We set isolated_page to avoid clutter from footer/header.
+        "isolated_page": True,
+    }
     return render(request, "zerver/integrations/development/dev_panel.html", context)
 
 

--- a/zproject/jinja2/__init__.py
+++ b/zproject/jinja2/__init__.py
@@ -16,7 +16,7 @@ def environment(**options: Any) -> Environment:
     env = Environment(**options)
     env.globals.update(
         default_page_params={
-            "debug_mode": False,
+            "debug_mode": settings.DEBUG,
             "webpack_public_path": staticfiles_storage.url(
                 settings.WEBPACK_LOADER["DEFAULT"]["BUNDLE_DIR_NAME"],
             ),


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
The details are addressed in https://github.com/zulip/zulip/issues/17540
It adds supports to blueslip exception popups in portico pages in development.

**Testing plan:** <!-- How have you tested? -->
It has been tested on portico pages, but the click events are not working.
The reason might be that the click handlers for alert-box are integrated into ui_init, which is only loaded in app.js.
Planning to migrate the two handlers that are responsible for animations of alert-box in a separate js file.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
The alert box can be properly displayed:
<img width="720" alt="sample" src="https://user-images.githubusercontent.com/39874143/112499393-630e8580-8dc2-11eb-8e26-6931c649e1a9.png">

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
