### PR TITLE
docs: Remove "beta" mark from message-retention-policy.md.

### DIFF
--- a/templates/zerver/help/message-retention-policy.md
+++ b/templates/zerver/help/message-retention-policy.md
@@ -1,4 +1,4 @@
-# Message retention policy (beta)
+# Message retention policy
 
 {!owner-only.md!}
 


### PR DESCRIPTION
The retention policy has been sufficiently well tested at this point to
consider it stable.
