### PR TITLE
css: Hide copy-paste button for codeblocks in formatting help overlay.

### DIFF
--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -460,6 +460,10 @@
     display: none;
 }
 
+.informational-overlays .copy_codeblock {
+    display: none;
+}
+
 .preview_content .code_external_link {
     right: 12px;
 }


### PR DESCRIPTION
Fixes the issue raised by @akshatdalton regarding the buggy copy-paste icon for codeblocks in the `Message Formatting Help` section (https://chat.zulip.org/#narrow/stream/6-frontend/topic/buggy.20copy.20button/near/1142479)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
