### PR TITLE
apps: Advertise zulip-terminal on apps page.

### DIFF
--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -2144,7 +2144,7 @@ nav {
     vertical-align: top;
 
     width: 50px;
-    padding: 20px 30px;
+    padding: 18px 30px;
     border-radius: 70px;
 
     color: hsl(0, 0%, 80%);
@@ -2162,7 +2162,11 @@ nav {
 
 .portico-landing.apps .other-apps .apps .icon.fa-mobile-phone {
     font-size: 4em;
-    padding: 11.5px 27px;
+    padding: 14px 30px;
+}
+
+.portico-landing.apps .other-apps .apps .icon.fa-terminal {
+    padding: 12px 30px;
 }
 
 .portico-landing.apps .other-apps .apps .icon.fa-mobile-phone::after {

--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -57,6 +57,9 @@
             <a class="" href="/apps/ios">
                 <i class="icon fa fa-mobile-phone" data-label="iOS"></i>
             </a>
+            <a href="https://github.com/zulip/zulip-terminal#zulip-terminal---zulips-official-terminal-client">
+                <i class="icon fa fa-terminal" data-label="Terminal (alpha)"></i>
+            </a>
         </div>
         <div id="third-party-apps">
             Zulip also works great in pinned browser tabs and


### PR DESCRIPTION
Link to zulip-terminal's README which contains installation
instructions.

It is marked alpha to indicate that user may not find all
the features that zulip support in the client and may
run into unexpected errors.
<img width="959" alt="Screenshot 2021-03-26 at 3 44 47 PM" src="https://user-images.githubusercontent.com/25124304/112617299-ccd27200-8e4a-11eb-8964-aa638c41e07c.png">
