### PR TITLE
Remove op field for the event custom_profile_fields.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -181,7 +181,7 @@ run_test("user groups", (override) => {
 });
 
 run_test("custom profile fields", (override) => {
-    const event = event_fixtures.custom_profile_fields__update;
+    const event = event_fixtures.custom_profile_fields;
     override(settings_profile_fields, "populate_profile_fields", noop);
     override(settings_account, "add_custom_profile_fields_to_settings", noop);
     dispatch(event);

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -111,12 +111,11 @@ exports.fixtures = {
         upload_space_used: 90000,
     },
 
-    custom_profile_fields__update: {
+    custom_profile_fields: {
         type: "custom_profile_fields",
-        op: "update",
         fields: [
-            {id: 1, name: "teams", type: 1},
-            {id: 2, name: "hobbies", type: 1},
+            {id: 1, name: "teams", type: 1, hint: "", field_data: "", order: 1},
+            {id: 2, name: "hobbies", type: 1, hint: "", field_data: "", order: 2},
         ],
     },
 

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,13 @@ below features are supported.
 
 ## Changes in Zulip 4.0
 
+**Feature level 45**
+
+* [`GET /events`](/api/get-events): Removed useless `op` field from
+  `custom_profile_fields` events.  These events contain the full set
+  of configured `custom_profile_fields` for the organization
+  regardless of what triggered the change.
+
 **Feature level 44**
 
 * [`POST /register`](/api/register-queue): extended the `unread_msgs`

--- a/version.py
+++ b/version.py
@@ -30,7 +30,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 44
+API_FEATURE_LEVEL = 45
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -6715,9 +6715,9 @@ def check_attachment_reference_change(message: Message) -> bool:
     return message.attachment_set.exists()
 
 
-def notify_realm_custom_profile_fields(realm: Realm, operation: str) -> None:
+def notify_realm_custom_profile_fields(realm: Realm) -> None:
     fields = custom_profile_fields_for_realm(realm.id)
-    event = dict(type="custom_profile_fields", op=operation, fields=[f.as_dict() for f in fields])
+    event = dict(type="custom_profile_fields", fields=[f.as_dict() for f in fields])
     send_event(realm, event, active_user_ids(realm.id))
 
 
@@ -6735,7 +6735,7 @@ def try_add_realm_default_custom_profile_field(
     field.save()
     field.order = field.id
     field.save(update_fields=["order"])
-    notify_realm_custom_profile_fields(realm, "add")
+    notify_realm_custom_profile_fields(realm)
     return field
 
 
@@ -6757,7 +6757,7 @@ def try_add_realm_custom_profile_field(
     field.save()
     field.order = field.id
     field.save(update_fields=["order"])
-    notify_realm_custom_profile_fields(realm, "add")
+    notify_realm_custom_profile_fields(realm)
     return field
 
 
@@ -6767,7 +6767,7 @@ def do_remove_realm_custom_profile_field(realm: Realm, field: CustomProfileField
     associated with it in CustomProfileFieldValue model.
     """
     field.delete()
-    notify_realm_custom_profile_fields(realm, "delete")
+    notify_realm_custom_profile_fields(realm)
 
 
 def do_remove_realm_custom_profile_fields(realm: Realm) -> None:
@@ -6789,7 +6789,7 @@ def try_update_realm_custom_profile_field(
     ):
         field.field_data = orjson.dumps(field_data or {}).decode()
     field.save()
-    notify_realm_custom_profile_fields(realm, "update")
+    notify_realm_custom_profile_fields(realm)
 
 
 def try_reorder_realm_custom_profile_fields(realm: Realm, order: List[int]) -> None:
@@ -6801,7 +6801,7 @@ def try_reorder_realm_custom_profile_fields(realm: Realm, order: List[int]) -> N
     for field in fields:
         field.order = order_mapping[field.id]
         field.save(update_fields=["order"])
-    notify_realm_custom_profile_fields(realm, "update")
+    notify_realm_custom_profile_fields(realm)
 
 
 def notify_user_update_custom_profile_data(

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -184,7 +184,6 @@ custom_profile_field_type = DictType(
 custom_profile_fields_event = event_dict_type(
     required_keys=[
         ("type", Equals("custom_profile_fields")),
-        ("op", Equals("add")),
         ("fields", ListType(custom_profile_field_type)),
     ]
 )

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -530,6 +530,16 @@ def apply_event(
         state["hotspots"] = event["hotspots"]
     elif event["type"] == "custom_profile_fields":
         state["custom_profile_fields"] = event["fields"]
+        custom_profile_field_ids = {field["id"] for field in state["custom_profile_fields"]}
+
+        if "raw_users" in state:
+            for user_dict in state["raw_users"].values():
+                if "profile_data" not in user_dict:
+                    continue
+                profile_data = user_dict["profile_data"]
+                for (field_id, field_data) in list(profile_data.items()):
+                    if int(field_id) not in custom_profile_field_ids:
+                        del profile_data[field_id]
     elif event["type"] == "realm_user":
         person = event["person"]
         person_user_id = person["user_id"]

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1390,10 +1390,6 @@ paths:
                                     - $ref: "#/components/schemas/EventTypeSchema"
                                     - enum:
                                         - custom_profile_fields
-                                op:
-                                  type: string
-                                  enum:
-                                    - add
                                 fields:
                                   type: array
                                   description: |
@@ -1405,7 +1401,6 @@ paths:
                               example:
                                 {
                                   "type": "custom_profile_fields",
-                                  "op": "add",
                                   "fields":
                                     [
                                       {


### PR DESCRIPTION
As Tim mentioned [here](https://github.com/zulip/zulip/pull/17709#discussion_r599836102) `op` (operation) field, added in f6fb88549f9, was never 
intended for `custom_profile_fields` event, and it should be removed.

As a part of cleanup, this also eliminates the schema check warnings
```
WARNING - NEED SCHEMA: custom_profile_fields__update
WARNING - NEED SCHEMA to match OpenAPI custom_profile_fields_add_event
```
for `custom_profile_fields` event, mentioned in #17568.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
