### PR TITLE
requirements: Upgrade python-zulip-api from Git

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -128,8 +128,8 @@ python-magic
 # the version from Git rather than a PyPI release. Keeping everything in
 # one repository simplifies the process of implementing and documenting
 # new bots for new contributors.
-https://github.com/zulip/python-zulip-api/archive/0.7.0.zip/#egg=zulip==0.7.0_git&subdirectory=zulip
-https://github.com/zulip/python-zulip-api/archive/0.7.0.zip/#egg=zulip_bots==0.7.0+git&subdirectory=zulip_bots
+https://github.com/zulip/python-zulip-api/archive/70f457f82ab3e2fa6fc489f950e46e105dc27ae3.zip#egg=zulip==0.7.1+git&subdirectory=zulip
+https://github.com/zulip/python-zulip-api/archive/70f457f82ab3e2fa6fc489f950e46e105dc27ae3.zip#egg=zulip_bots==0.7.1+git&subdirectory=zulip_bots
 
 # Used for Hesiod lookups, etc.
 py3dns

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1381,7 +1381,6 @@ six==1.15.0 \
     #   traitlets
     #   twilio
     #   w3lib
-    #   zulip
 snakeviz==2.1.0 \
     --hash=sha256:8ce375b18ae4a749516d7e6c6fbbf8be6177c53974f53534d8eadb646cd279b1 \
     --hash=sha256:92ad876fb6a201a7e23a6b85ea96d9643a51e285667c253a8653643804f7cb68
@@ -1603,6 +1602,7 @@ typing-extensions==3.7.4.3 \
     #   sqlalchemy-stubs
     #   typing-inspect
     #   zulint
+    #   zulip-bots
 typing-inspect==0.6.0 \
     --hash=sha256:3b98390df4d999a28cf5b35d8b333425af5da2ece8a4ea9e98f71e7591347b4f \
     --hash=sha256:8f1b1dd25908dbfd81d3bebc218011531e7ab614ba6e5bf7826d887c834afab7 \
@@ -1740,13 +1740,13 @@ zope.interface==5.3.0 \
 https://github.com/zulip/zulint/archive/20508eb8939e909806e6c8018fadfc24e854a02a.zip#egg=zulint==0.0.1 \
     --hash=sha256:d3fba0d7232c769b1aaff042315f1d9a92dcc5c522b907c744af457c6752fcd2
     # via -r requirements/dev.in
-https://github.com/zulip/python-zulip-api/archive/0.7.0.zip/#egg=zulip==0.7.0_git&subdirectory=zulip \
-    --hash=sha256:161e3f38a9d27bf76a30da3d3d81f5f1b71a8c2c8144e0c4a33cd15018606d9f
+https://github.com/zulip/python-zulip-api/archive/70f457f82ab3e2fa6fc489f950e46e105dc27ae3.zip#egg=zulip==0.7.1+git&subdirectory=zulip \
+    --hash=sha256:56efd8b260de2cd5cb80b1fa994c99eeda8d4d91d4b481115a615933a1c74761
     # via
     #   -r requirements/common.in
     #   zulip-bots
-https://github.com/zulip/python-zulip-api/archive/0.7.0.zip/#egg=zulip_bots==0.7.0+git&subdirectory=zulip_bots \
-    --hash=sha256:161e3f38a9d27bf76a30da3d3d81f5f1b71a8c2c8144e0c4a33cd15018606d9f
+https://github.com/zulip/python-zulip-api/archive/70f457f82ab3e2fa6fc489f950e46e105dc27ae3.zip#egg=zulip_bots==0.7.1+git&subdirectory=zulip_bots \
+    --hash=sha256:56efd8b260de2cd5cb80b1fa994c99eeda8d4d91d4b481115a615933a1c74761
     # via -r requirements/common.in
 zxcvbn==4.4.28 \
     --hash=sha256:151bd816817e645e9064c354b13544f85137ea3320ca3be1fb6873ea75ef7dc1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -919,7 +919,6 @@ six==1.15.0 \
     #   talon-core
     #   traitlets
     #   twilio
-    #   zulip
 social-auth-app-django==4.0.0 \
     --hash=sha256:2c69e57df0b30c9c1823519c5f1992cbe4f3f98fdc7d95c840e091a752708840 \
     --hash=sha256:567ad0e028311541d7dfed51d3bf2c60440a6fd236d5d4d06c5a618b3d6c57c5 \
@@ -1019,6 +1018,7 @@ typing-extensions==3.7.4.3 \
     # via
     #   -r requirements/common.in
     #   importlib-metadata
+    #   zulip-bots
 uhashring==2.0 \
     --hash=sha256:c44c53e88ab01222d3a14346af6aac72a5b3b8ea1a1ddc8d102d0c893bf3e249
     # via python-binary-memcached
@@ -1067,13 +1067,13 @@ zipp==3.4.1 \
     --hash=sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76 \
     --hash=sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098
     # via importlib-metadata
-https://github.com/zulip/python-zulip-api/archive/0.7.0.zip/#egg=zulip==0.7.0_git&subdirectory=zulip \
-    --hash=sha256:161e3f38a9d27bf76a30da3d3d81f5f1b71a8c2c8144e0c4a33cd15018606d9f
+https://github.com/zulip/python-zulip-api/archive/70f457f82ab3e2fa6fc489f950e46e105dc27ae3.zip#egg=zulip==0.7.1+git&subdirectory=zulip \
+    --hash=sha256:56efd8b260de2cd5cb80b1fa994c99eeda8d4d91d4b481115a615933a1c74761
     # via
     #   -r requirements/common.in
     #   zulip-bots
-https://github.com/zulip/python-zulip-api/archive/0.7.0.zip/#egg=zulip_bots==0.7.0+git&subdirectory=zulip_bots \
-    --hash=sha256:161e3f38a9d27bf76a30da3d3d81f5f1b71a8c2c8144e0c4a33cd15018606d9f
+https://github.com/zulip/python-zulip-api/archive/70f457f82ab3e2fa6fc489f950e46e105dc27ae3.zip#egg=zulip_bots==0.7.1+git&subdirectory=zulip_bots \
+    --hash=sha256:56efd8b260de2cd5cb80b1fa994c99eeda8d4d91d4b481115a615933a1c74761
     # via -r requirements/common.in
 zxcvbn==4.4.28 \
     --hash=sha256:151bd816817e645e9064c354b13544f85137ea3320ca3be1fb6873ea75ef7dc1

--- a/version.py
+++ b/version.py
@@ -45,4 +45,4 @@ API_FEATURE_LEVEL = 44
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "134.3"
+PROVISION_VERSION = "135.0"

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -1207,12 +1207,11 @@ def update_user_group_members(client: Client, user_group_id: int) -> None:
     ensure_users([8, 10, 11], ["cordelia", "hamlet", "iago"])
     # {code_example|start}
     request = {
-        "group_id": user_group_id,
         "delete": [8, 10],
         "add": [11],
     }
 
-    result = client.update_user_group_members(request)
+    result = client.update_user_group_members(user_group_id, request)
     # {code_example|end}
     validate_against_openapi_schema(result, "/user_groups/{group_id}/members", "post", "200")
 

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -31,7 +31,6 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
-    cast,
 )
 
 import orjson
@@ -43,7 +42,7 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import override as override_language
 from django.utils.translation import ugettext as _
 from sentry_sdk import add_breadcrumb, configure_scope
-from zulip_bots.lib import ExternalBotHandler, extract_query_without_mention
+from zulip_bots.lib import extract_query_without_mention
 
 from zerver.context_processors import common_context
 from zerver.lib.actions import (
@@ -776,7 +775,7 @@ class EmbeddedBotWorker(QueueProcessingWorker):
                 if event["trigger"] == "mention":
                     message["content"] = extract_query_without_mention(
                         message=message,
-                        client=cast(ExternalBotHandler, self.get_bot_api_client(user_profile)),
+                        client=self.get_bot_api_client(user_profile),
                     )
                     assert message["content"] is not None
                 bot_handler.handle_message(


### PR DESCRIPTION
In order to pass tests and to satisfy the `BotHandler` protocol codified in zulip/python-zulip-api#656, our `EmbeddedBotHandler` class needs updates for:

* zulip/python-zulip-api@45e0f77298b153a382ea57e68136d9e610acfcc8 (#4967)
  bots: Allow bots to update messages.
* zulip/python-zulip-api@56c59d915a01550becaca430622a7c7927dad934 (zulip/python-zulip-api#369)
  bots: Support determining bot runtime identity.
* zulip/python-zulip-api@fcd39204a982a0033860e8731dc0ae72332dc081 (zulip/python-zulip-api#419)
  bots: Pass through widget_content if passed in.
* zulip/python-zulip-api@3b1ef57694ab519455a0b2a8ab8aa4e9e5261292 (zulip/python-zulip-api#593)
  bots: Support adding reactions to message for a bot.

I’ve stubbed the class to ignore the new methods and parameters (except `identity`, which is easy, although I suspect that should have been a helper function instead). Do we need a more complete implementation?

Cc @iishiishii @LoopThrough-i-j @neiljp @showell