### PR TITLE
message-screenshot: Update for removal of navigate global

### DIFF
--- a/tools/message-screenshot.js
+++ b/tools/message-screenshot.js
@@ -1,6 +1,6 @@
 "use strict";
 
-/* global $, CSS, navigate */
+/* global $, CSS */
 
 const path = require("path");
 
@@ -60,8 +60,8 @@ async function run() {
         // remove unread marker and don't select message
         const marker = `#zfilt${CSS.escape(options.messageId)} .unread_marker`;
         await page.evaluate((sel) => $(sel).remove(), marker);
-        await page.evaluate(() => navigate.up());
         const messageBox = await page.$(messageSelector);
+        await page.keyboard.press("KeyK");
         const messageGroup = (await messageBox.$x(".."))[0];
         // Compute screenshot area, with some padding around the message group
         const clip = {...(await messageGroup.boundingBox())};


### PR DESCRIPTION
Commit 0200f48a12ac25e148abf694e21174a90b30992b (#17407) removed the `navigate` global variable.  Use the K hotkey instead of evaluating `navigate.up()`.

**Testing plan:** Ran `./tools/generate-integration-docs-screenshot --integration zapier --fixture weather_update.json -H ''`. (No idea whether it’s intentional that `-H` is required.)

![001](https://user-images.githubusercontent.com/26471/112700764-196a7d00-8e4c-11eb-9d53-c61c517a5759.png)
