### PR TITLE
recent_topics: Remove beta label.

### DIFF
--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -22,7 +22,7 @@ function make_message_view_header(filter) {
     const message_view_header = {};
     if (recent_topics.is_visible()) {
         return {
-            title: i18n.t("Recent topics (beta)"),
+            title: i18n.t("Recent topics"),
             icon: "clock-o",
         };
     }


### PR DESCRIPTION
Since recent topics is now the default view and all of the
known bugs have been fixed, we remove the beta label from it.
