### PR TITLE
click_handlers: Improve the pencil icon behaviour.

### DIFF
--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -331,6 +331,7 @@ export class MessageList {
         recipient_row.find(".edit_content_button").hide();
         recipient_row.find(".stream_topic").hide();
         recipient_row.find(".topic_edit").show();
+        recipient_row.find(".always_visible_topic_edit").hide();
     }
 
     hide_edit_topic_on_recipient_row(recipient_row) {
@@ -339,6 +340,7 @@ export class MessageList {
         recipient_row.find(".edit_content_button").show();
         recipient_row.find(".topic_edit_form").empty();
         recipient_row.find(".topic_edit").hide();
+        recipient_row.find(".always_visible_topic_edit").show();
     }
 
     show_message_as_read(message, options) {


### PR DESCRIPTION
Fixes #17813.
Discussion: https://chat.zulip.org/#narrow/stream/49-development-help/topic/No.20topic.20bug.20.2317813

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? --> I have tested the behaviour of topic edit button after this fix manually and everything works as expected.



**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![no_topic_bug_resolved](https://user-images.githubusercontent.com/59444243/112841813-93a23800-90be-11eb-9168-ea9db68dac02.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
