### PR TITLE
landing_page: Add label for next and previous arrow buttons.

### DIFF
--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -3863,3 +3863,17 @@ nav {
     font-size: 13px;
     padding-left: 10px;
 }
+
+.carousel-control.left:hover #prev {
+    display:block;
+}
+
+.carousel-control.right:hover #next {
+    display: block;
+}
+
+.carousel-label {
+    display: none;
+    font-family: inherit;
+    font-size: 14px;
+}

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -141,8 +141,8 @@
                         </div>
                     </div>
 
-                    <a class="carousel-control left visibility-control hide" href="#tour-carousel" data-slide="prev"><i class="fa fa-chevron-left" aria-hidden="true"></i></a>
-                    <a class="carousel-control right visibility-control" href="#tour-carousel" data-slide="next"><i class="fa fa-chevron-right" aria-hidden="true"></i></a>
+                    <a class="carousel-control left visibility-control hide" href="#tour-carousel" data-slide="prev"><i class="fa fa-chevron-left" aria-hidden="true"></i><label class="carousel-label" id="prev">Previous</label></a>
+                    <a class="carousel-control right visibility-control" href="#tour-carousel" data-slide="next"><i class="fa fa-chevron-right" aria-hidden="true"></i><label class="carousel-label" id="next">Next</label></a>
                     <ol class="carousel-indicators">
                         <li data-target="#tour-carousel" data-slide-to="0" class="active"></li>
                         <li data-target="#tour-carousel" data-slide-to="1"></li>


### PR DESCRIPTION
[#17467](https://github.com/zulip/zulip/issues/17467)

**Testing plan:** Manually tested as this is a small feature update, haven't written Puppeteer tests, need guidance here if tests are required


**GIFs or screenshots:** 

Labels appear upon hover.

![prev_label](https://user-images.githubusercontent.com/36158530/112723960-097b9780-8f37-11eb-81c4-e87d9605d5fe.png)

![next_label](https://user-images.githubusercontent.com/36158530/112723957-0680a700-8f37-11eb-8d4f-e7191619a3d6.png)
