### PR TITLE
production_suite: Add debian production install to production suite.

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -120,6 +120,11 @@ jobs:
             is_focal: true
             os: focal
 
+          - docker_image: ligmitz/actions:buster
+            name: Buster production install
+            is_buster: true
+            os: buster
+
     name: ${{ matrix.name  }}
     container: ${{ matrix.docker_image }}
     runs-on: ubuntu-latest

--- a/tools/ci/images.yml
+++ b/tools/ci/images.yml
@@ -3,3 +3,6 @@ bionic:
 
 focal:
   base_image: buildpack-deps:focal-scm
+
+buster:
+  base_image: buildpack-deps:buster-scm

--- a/tools/ci/production-build
+++ b/tools/ci/production-build
@@ -34,6 +34,7 @@ mkdir /tmp/production-build
 mv /tmp/tmp.*/zulip-server-test.tar.gz /tmp/production-build
 cp -a \
     tools/ci/success-http-headers.template.txt \
+    tools/ci/success-http-headers.template.debian.txt \
     tools/ci/production-install \
     tools/ci/production-verify \
     tools/ci/production-upgrade-pg \

--- a/tools/ci/production-verify
+++ b/tools/ci/production-verify
@@ -12,6 +12,31 @@ NOREPLY_EMAIL_ADDRESS = 'noreply@circleci.example.com'
 ALLOWED_HOSTS = []
 EOF
 
+if [ -f /etc/os-release ]; then
+    os_info="$(
+        . /etc/os-release
+        printf '%s\n' "$VERSION_CODENAME"
+    )"
+    { read -r os_version_codename || true; } <<<"$os_info"
+fi
+
+check_header() {
+    sed -i -e 's|Length: [0-9]\+\( [(][0-9]\+[.][0-9]K[)]\)\?|Length: <Length>|' -e "s|{nginx_version_string}|$nginx_version|g" "$success_header_file"
+    if ! diff -ur /tmp/http-headers-processed "$success_header_file"; then
+        set +x
+        echo
+        echo "FAILURE: The HTTP Headers returned from loading the homepage on the server do not match the contents of tools/ci/success-http-headers.template.txt.  Typically, this means that the server threw a 500 when trying to load the homepage."
+        echo "Displaying the contents of the server's error log:"
+        echo
+        cat /var/log/zulip/errors.log
+        echo
+        echo "Displaying the contents of the main server log:"
+        echo
+        cat /var/log/zulip/server.log
+        exit 1
+    fi
+}
+
 echo
 echo "Now testing that the supervisord jobs are running properly"
 echo
@@ -42,23 +67,16 @@ echo
 wget https://localhost -O /tmp/index.html --no-check-certificate -S 2>/tmp/wget-output || true # || true so we see errors.log if this 500s
 grep -vi '\(Vary\|Content-Language\|expires\|issued by\|modified\|saved\|[.][.][.]\|Date\|[-][-]\)' /tmp/wget-output >/tmp/http-headers-processed
 
-nginx_version="$(nginx -v 2>&1 | awk '{print $3, $4}')"
+nginx_version="$(nginx -v 2>&1 | awk '{print $3, $4}' | xargs)"
 
 # Simplify the diff by getting replacing 4-5 digit length numbers with <Length>.
 sed -i 's|Length: [0-9]\+\( [(][0-9]\+[.][0-9]K[)]\)\?|Length: <Length>|' /tmp/http-headers-processed
-sed -i -e 's|Length: [0-9]\+\( [(][0-9]\+[.][0-9]K[)]\)\?|Length: <Length>|' -e "s|{nginx_version_string}|$nginx_version|g" /tmp/success-http-headers.template.txt
-if ! diff -ur /tmp/http-headers-processed /tmp/success-http-headers.template.txt; then
-    set +x
-    echo
-    echo "FAILURE: The HTTP Headers returned from loading the homepage on the server do not match the contents of tools/ci/success-http-headers.template.txt.  Typically, this means that the server threw a 500 when trying to load the homepage."
-    echo "Displaying the contents of the server's error log:"
-    echo
-    cat /var/log/zulip/errors.log
-    echo
-    echo "Displaying the contents of the main server log:"
-    echo
-    cat /var/log/zulip/server.log
-    exit 1
+if [ "$os_version_codename" = "buster" ]; then
+    success_header_file="/tmp/success-http-headers.template.debian.txt"
+    check_header
+else
+    success_header_file="/tmp/success-http-headers.template.txt"
+    check_header
 fi
 
 # Start the RabbitMQ queue worker related section

--- a/tools/ci/success-http-headers.template.debian.txt
+++ b/tools/ci/success-http-headers.template.debian.txt
@@ -1,0 +1,29 @@
+WARNING: The certificate of ‘localhost’ is not trusted.
+WARNING: The certificate of ‘localhost’ doesn't have a known issuer.
+The certificate's owner does not match hostname ‘localhost’
+  HTTP/1.1 302 Found
+  Server: {nginx_version_string}
+  Content-Type: text/html; charset=utf-8
+  Content-Length: 0
+  Connection: keep-alive
+  Location: /login/
+  Strict-Transport-Security: max-age=15768000
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  X-XSS-Protection: 1; mode=block
+Location: /login/ [following]
+Reusing existing connection to localhost:443.
+  HTTP/1.1 200 OK
+  Server: {nginx_version_string}
+  Content-Type: text/html; charset=utf-8
+  Content-Length: 6361
+  Connection: keep-alive
+  Strict-Transport-Security: max-age=15768000
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  X-XSS-Protection: 1; mode=block
+Length: 6361 (6.2K) [text/html]
+Saving to: ‘/tmp/index.html’
+
+
+

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -68,7 +68,10 @@ whitespace_rules: List["Rule"] = [
     {
         "pattern": "\t",
         "strip": "\n",
-        "exclude": {"tools/ci/success-http-headers.template.txt"},
+        "exclude": {
+            "tools/ci/success-http-headers.template.txt",
+            "tools/ci/success-http-headers.template.debian.txt",
+        },
         "description": "Fix tab-based whitespace",
     },
 ]


### PR DESCRIPTION
We support Debian as an OS for setting up the Zulip server. But the CI
does not run on pull request to test the setting up of the server on
Debian. Hence, add the check to CI.

