### PR TITLE
openapi: Fix non-checking of /events and /register schema and yaml fixes.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1281,6 +1281,7 @@ paths:
                                   type: object
                                   description: |
                                     Dictionary containing the id of the deleted attachment.
+                                  additionalProperties: false
                                   properties:
                                     id:
                                       type: integer
@@ -2667,6 +2668,7 @@ paths:
                                   type: object
                                   description: |
                                     Object containing details about the deactivated bot.
+                                  additionalProperties: false
                                   properties:
                                     user_id:
                                       type: integer
@@ -2706,6 +2708,7 @@ paths:
                                   type: object
                                   description: |
                                     Object containing details about the deactivated bot.
+                                  additionalProperties: false
                                   properties:
                                     user_id:
                                       type: integer
@@ -2838,6 +2841,506 @@ paths:
                                   type: object
                                   description: |
                                     An object containing the properties that have changed.
+                                  properties:
+                                    add_emoji_by_admins_only:
+                                      type: boolean
+                                      description: |
+                                        Whether the organization is configured to only allow administrators
+                                        to upload new custom emoji.
+                                    allow_edit_history:
+                                      type: boolean
+                                      description: |
+                                        Whether this organization is configured to allow users to access
+                                        [message edit history](/help/view-a-messages-edit-history).
+                                    allow_message_deleting:
+                                      type: boolean
+                                      description: |
+                                        Whether messages can be deleted in this Zulip organization.
+                                    bot_creation_policy:
+                                      type: integer
+                                      description: |
+                                        The policy for which users can create bot users in this organization.
+                                    create_stream_policy:
+                                      type: integer
+                                      description: |
+                                        The policy for which users can create streams in this organization.
+                                    invite_to_stream_policy:
+                                      type: integer
+                                      description: |
+                                        The policy for which users can add other users to streams in this
+                                        organization.
+                                    wildcard_mention_policy:
+                                      type: integer
+                                      description: |
+                                        The policy for who can use wildcard mentions in large streams.
+
+                                        * 1 => Any user can use wildcard mentions in large streams.
+                                        * 2 => Only members can use wildcard mentions in large streams.
+                                        * 3 => Only full members can use wildcard mentions in large streams.
+                                        * 4 => Only stream and organization administrators can use wildcard mentions in large streams.
+                                        * 5 => Only organization administrators can use wildcard mentions in large streams.
+                                        * 6 => Nobody can use wildcard mentions in large streams.
+
+                                        All users will receive a warning/reminder when using
+                                        mentions in large streams, even when permitted to do so.
+
+                                        **Changes**: New in Zulip 4.0 (feature level 33).
+                                    default_language:
+                                      type: string
+                                      description: |
+                                        The default UI language for new users joining this organization.
+                                    default_twenty_four_hour_time:
+                                      type: boolean
+                                      description: |
+                                        Whether new members of this organization will see times displayed in
+                                        24-hour time (true) or 12-hour time (false).
+                                    description:
+                                      type: string
+                                      description: |
+                                        The description of the organization, used on login and registration pages.
+                                    digest_emails_enabled:
+                                      type: boolean
+                                      description: |
+                                        Whether the organization has enabled [weekly digest emails](/help/digest-emails).
+                                    disallow_disposable_email_addresses:
+                                      type: boolean
+                                      description: |
+                                        Whether the organization disallows disposable email
+                                        addresses.
+                                    email_address_visibility:
+                                      type: integer
+                                      description: |
+                                        The policy for which users in this organization can see the
+                                        real email addresses of other users.
+
+                                        * 1 = everyone
+                                        * 2 = members only
+                                        * 3 = administrators only
+                                        * 4 = nobody (though note that administrators can change this setting).
+                                    email_changes_disabled:
+                                      type: boolean
+                                      description: |
+                                        Whether users are allowed to change their own email address in this
+                                        organization.  This is typically disabled for organizations that
+                                        synchronize accounts from LDAP or a similar corporate database.
+                                    invite_required:
+                                      type: boolean
+                                      description: |
+                                        Whether an invitation is required to join this organization.
+                                    invite_by_admins_only:
+                                      type: boolean
+                                      description: |
+                                        If true, only organization administrators can invite new users to join.
+                                        If false, any [Member](/help/roles-and-permissions) can invite new users
+                                        to join the organization.  [Help center article](/help/invite-new-users#change-who-can-send-invitations).
+                                    inline_image_preview:
+                                      type: boolean
+                                      description: |
+                                        Whether this organization has been configured to enable
+                                        [previews of linked images](/help/allow-image-link-previews).
+                                    inline_url_embed_preview:
+                                      type: boolean
+                                      description: |
+                                        Whether this organization has been configured to enable
+                                        [previews of linked websites](/help/allow-image-link-previews).
+                                    mandatory_topics:
+                                      type: boolean
+                                      description: |
+                                        Whether [topics are required](/help/require-topics) for messages in this organization.
+                                    message_retention_days:
+                                      type: integer
+                                      description: |
+                                        The default [message retention policy](/help/message-retention-policy)
+                                        for this organization.  Pass `"forever"` to request that messages
+                                        by retained forever (the default).
+                                    realm_name:
+                                      type: string
+                                      description: |
+                                        The name of the organization, used in login pages etc.
+                                    name_changes_disabled:
+                                      type: boolean
+                                      description: |
+                                        Indicates whether users are
+                                        [allowed to change](/help/restrict-name-and-email-changes) their name
+                                        via the Zulip UI in this organization.  Typically disabled
+                                        in organizations syncing this this type of account information
+                                        an external user database like LDAP.
+                                    avatar_changes_disabled:
+                                      type: boolean
+                                      description: |
+                                        Indicates whether users are
+                                        [allowed to change](/help/restrict-name-and-email-changes) their avatar
+                                        via the Zulip UI in this organization.  Typically disabled
+                                        in organizations syncing this this type of account information
+                                        an external user database like LDAP.
+                                    emails_restricted_to_domains:
+                                      type: boolean
+                                      description: |
+                                        Whether [new users joining](/help/allow-anyone-to-join-without-an-invitation)
+                                        this organization are required to have an email
+                                        address in one of the `realm_domains` configured for the organization.
+                                    send_welcome_emails:
+                                      type: boolean
+                                      description: |
+                                        Whether or not this organization is configured to send the standard Zulip
+                                        [welcome emails](/help/disable-welcome-emails) to new users joining the organization.
+                                    ? message_content_allowed_in_email_notifications
+                                    : type: boolean
+                                      description: |
+                                        Whether notification emails in this organization are allowed to
+                                        contain Zulip the message content, or simply indicate that a new
+                                        message was sent.
+                                    video_chat_provider:
+                                      type: integer
+                                      description: |
+                                        The configured video call provider for the organization.
+                                    waiting_period_threshold:
+                                      type: integer
+                                      description: |
+                                        Members whose accounts have been created at least this many days ago
+                                        will be treated as [full members](/help/restrict-permissions-of-new-members)
+                                        for the purpose of settings that restrict access to new members.
+                                    digest_weekday:
+                                      type: integer
+                                      description: |
+                                        The day of the week when the organization will send
+                                        its weekly digest email to inactive users.
+                                    private_message_policy:
+                                      type: integer
+                                      description: |
+                                        Policy for [who can send private messages](/help/restrict-private-messages)
+                                        in this organization.
+
+                                        * 1 = Everyone
+                                        * 2 = Nobody
+                                    user_group_edit_policy:
+                                      type: integer
+                                      description: |
+                                        The organization's policy for [who can manage user groups
+                                        ](/help/restrict-user-group-management).
+
+                                        * 1 = All members can create and edit user groups
+                                        * 2 = Only organization administrators can create and edit user groups
+                                    default_code_block_language:
+                                      type: string
+                                      nullable: true
+                                      description: |
+                                        The default pygments language code to be used for a code blocks
+                                        in this organization.  Null if no default has been set.
+                                    message_content_delete_limit_seconds:
+                                      type: integer
+                                      description: |
+                                        Messages sent more than this many seconds ago cannot be deleted
+                                        with this organization's
+                                        [message deletion policy](/help/configure-message-editing-and-deletion).
+                                    authentication_methods:
+                                      type: object
+                                      additionalProperties:
+                                        description: |
+                                          Boolean describing whether the authentication method (i.e its key)
+                                          is enabled in this organization.
+                                        type: boolean
+                                      description: |
+                                        Dictionary of 'authentication_method_name': 'boolean' with each
+                                        entry describing whether the authentication name can be used for
+                                        authenticating into the organization.
+                                    allow_message_editing:
+                                      type: boolean
+                                      description: |
+                                        Whether this organizations [message edit policy](/help/configure-message-editing-and-deletion)
+                                        allows editing the content of messages.
+                                    allow_community_topic_editing:
+                                      type: boolean
+                                      description: |
+                                        Whether [community topic editing](/help/community-topic-edits) is enabled
+                                        in this organization.
+                                    message_content_edit_limit_seconds:
+                                      type: integer
+                                      description: |
+                                        Messages sent more than this many seconds ago cannot be edited
+                                        with this organization's
+                                        [message edit policy](/help/configure-message-editing-and-deletion).
+                                    community_topic_editing_limit_seconds:
+                                      type: integer
+                                      description: |
+                                        Messages sent more than this many seconds ago cannot have
+                                        their topics edited by other users with this organization's
+                                        [message edit policy](/help/configure-message-editing-and-deletion).
+
+                                        **Changes**: New in Zulip 3.0 (feature level 11).  Previously this
+                                        value was hardcoded to 86400 seconds (1 day).
+                                    icon_url:
+                                      type: string
+                                      description: |
+                                        The URL of the organization's [profile icon](/help/create-your-organization-profile).
+                                    icon_source:
+                                      type: string
+                                      description: |
+                                        String indicating whether the organization's
+                                        [profile icon](/help/create-your-organization-profile) was uploaded
+                                        by a user or is the default.  Useful for UI allowing editing the organization's icon.
+
+                                        * "G" means generated by Gravatar (the default).
+                                        * "U" means uploaded by an organization administrator.
+                                    icon_file_size:
+                                      type: integer
+                                      description: |
+                                        The maximum file size allowed for the organization's
+                                        icon.  Useful for UI allowing editing the organization's icon.
+                                    logo_url:
+                                      type: string
+                                      description: |
+                                        The URL of the organization's wide logo configured in the
+                                        [organization profile](/help/create-your-organization-profile).
+                                    logo_source:
+                                      type: string
+                                      description: |
+                                        String indicating whether the organization's
+                                        [profile wide logo](/help/create-your-organization-profile) was uploaded
+                                        by a user or is the default.  Useful for UI allowing editing the
+                                        organization's wide logo.
+
+                                        * "D" means the logo is the default Zulip logo.
+                                        * "U" means uploaded by an organization administrator.
+                                    night_logo_url:
+                                      type: string
+                                      description: |
+                                        The URL of the organization's night theme wide-format logo configured in the
+                                        [organization profile](/help/create-your-organization-profile).
+                                    night_logo_source:
+                                      type: string
+                                      description: |
+                                        String indicating whether the organization's night theme
+                                        [profile wide logo](/help/create-your-organization-profile) was uploaded
+                                        by a user or is the default.  Useful for UI allowing editing the
+                                        organization's wide logo.
+
+                                        * "D" means the logo is the default Zulip logo.
+                                        * "U" means uploaded by an organization administrator.
+                                    max_logo_file_size:
+                                      type: integer
+                                      description: |
+                                        The maximum file size allowed for the uploaded organization logos.
+                                    bot_domain:
+                                      type: string
+                                      description: |
+                                        The fake email domain that will be used for new bots created this
+                                        organization.  Useful for UI for creating bots.
+                                    realm_uri:
+                                      type: string
+                                      description: |
+                                        The URL for the organization.
+                                    available_video_chat_providers:
+                                      type: object
+                                      description: |
+                                        Dictionary where each entry describes a supported
+                                        [video call provider](/help/start-a-call)
+                                        that is configured on this server and could be selected by an
+                                        organization administrator.
+
+                                        Useful for administrative settings UI that allows changing the
+                                        video chat provider.
+                                      additionalProperties:
+                                        description: |
+                                          `{provider_name}`: Dictionary containing the details of the
+                                          video chat provider with the name of the chat provider as
+                                          the key.
+                                        type: object
+                                        additionalProperties: false
+                                        properties:
+                                          name:
+                                            type: string
+                                            description: |
+                                              The name of the video chat provider.
+                                          id:
+                                            type: integer
+                                            description: |
+                                              The ID of the video chat provider.
+                                    presence_disabled:
+                                      type: boolean
+                                      description: |
+                                        Whether online presence of other users is shown in this
+                                        organization.
+                                    settings_send_digest_emails:
+                                      type: boolean
+                                      description: |
+                                        Whether this Zulip server is configured to allow organizations to
+                                        enable [digest emails](/help/digest-emails).
+
+                                        Relevant for administrative settings UI that can change the digest
+                                        email settings.
+                                    is_zephyr_mirror_realm:
+                                      type: boolean
+                                      description: |
+                                        Whether the organization is a Zephyr mirror realm.
+                                    email_auth_enabled:
+                                      type: boolean
+                                      description: |
+                                        Whether the organization has enabled Zulip's default email and password
+                                        authentication feature.  Determines whether Zulip stores a password
+                                        for the user and clients should offer any UI for changing the user's
+                                        Zulip password.
+                                    password_auth_enabled:
+                                      type: boolean
+                                      description: |
+                                        Whether the organization allows any sort of password-based
+                                        authentication (whether via EmailAuthBackend or LDAP passwords).
+
+                                        Determines whether a client might ever need to display a password prompt
+                                        (clients will primarily look at this attribute in [server_settings](/api/get-server-settings)
+                                        before presenting a login page).
+                                    push_notifications_enabled:
+                                      type: boolean
+                                      description: |
+                                        Whether push notifications are enabled for this organization.  Typically
+                                        `false` for self-hosted servers that have not configured the
+                                        [Mobile push notifications service](https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html).
+                                    upload_quota:
+                                      type: integer
+                                      nullable: true
+                                      description: |
+                                        The total quota for uploaded files in this organization.
+
+                                        Clients are not responsible for checking this quota; it is included
+                                        in the API only for display purposes.
+
+                                        Null if there is no limit.
+                                    plan_type:
+                                      type: integer
+                                      description: |
+                                        The plan type of the organization.
+
+                                        * 1 = Self-hosted organization (SELF_HOSTED)
+                                        * 2 = Zulip Cloud free plan (LIMITED)
+                                        * 3 = Zulip Cloud Standard plan (STANDARD)
+                                        * 4 = Zulip Cloud Standard plan, sponsored for free (STANDARD_FREE)
+                                    zulip_plan_is_not_limited:
+                                      type: boolean
+                                      description: |
+                                        Whether the organization is using a limited (Zulip Cloud Free) plan.
+                                    upgrade_text_for_wide_organization_logo:
+                                      type: string
+                                      description: |
+                                        Text to use when displaying UI for wide organization logos, a feature
+                                        that is currently not available on the Zulip Cloud Free plan.
+
+                                        Useful only for clients supporting administrative UI for uploading
+                                        a new wide organization logo to brand the organization.
+                                    default_external_accounts:
+                                      type: object
+                                      description: |
+                                        Dictionary where each entry describes a default external
+                                        account type that can be configured with Zulip's custom
+                                        profile fields feature.
+                                      additionalProperties:
+                                        description: |
+                                          `{site_name}`: Dictionary containing the details of the
+                                          default external account provider with the name of the
+                                          website as the key.
+                                        type: object
+                                        additionalProperties: false
+                                        properties:
+                                          name:
+                                            type: string
+                                            description: |
+                                              The name of the external account provider
+                                          text:
+                                            type: string
+                                            description: |
+                                              The text describing the external account.
+                                          hint:
+                                            type: string
+                                            description: |
+                                              The help text to be displayed for the
+                                              custom profile field in user-facing
+                                              settings UI for configuring custom
+                                              profile fields for this account.
+                                          url_pattern:
+                                            type: string
+                                            description: |
+                                              The regex pattern of the URL of a profile page
+                                              on the external site.
+                                    jitsi_server_url:
+                                      type: string
+                                      description: |
+                                        The base URL the organization uses to create Jitsi video calls.
+                                    development_environment:
+                                      type: boolean
+                                      description: |
+                                        Whether this Zulip server is a development environment.  Used
+                                        to control certain features or UI (such as error popups)
+                                        that should only apply when connected to a Zulip development
+                                        environment.
+                                    server_generation:
+                                      type: integer
+                                      description: |
+                                        A timestamp indicating when the process hosting this
+                                        event queue was started.  Clients will likely only find
+                                        this value useful for inclusion in detailed error reports.
+                                    password_min_length:
+                                      type: integer
+                                      description: |
+                                        This Zulip server's configured minimum required length for passwords.
+                                        Necessary for password change UI to show whether the password
+                                        will be accepted.
+                                    password_min_guesses:
+                                      type: integer
+                                      description: |
+                                        This Zulip server's configured minimum `zxcvbn` minimum guesses.
+                                        Necessary for password change UI to show whether the password
+                                        will be accepted.
+                                    max_file_upload_size_mib:
+                                      type: integer
+                                      description: |
+                                        The maximum file size that can be uploaded to this Zulip server.
+                                    max_avatar_file_size_mib:
+                                      type: integer
+                                      description: |
+                                        The maximum avatar size that can be uploaded to this Zulip server.
+                                    server_inline_image_preview:
+                                      type: boolean
+                                      description: |
+                                        Whether the server is configured with support for inline image previews.
+                                        Clients containing administrative UI for changing
+                                        `realm_inline_image_preview` should consult this field before offering
+                                        that feature.
+                                    server_inline_url_embed_preview:
+                                      type: boolean
+                                      description: |
+                                        Whether the server is configured with support for inline URL previews.
+                                        Clients containing administrative UI for changing
+                                        `realm_inline_url_embed_preview` should consult this field before offering
+                                        that feature.
+                                    server_avatar_changes_disabled:
+                                      type: boolean
+                                      description: |
+                                        Whether the server allows avatar changes.  Similar to
+                                        `realm_avatar_changes_disabled` but based on the `AVATAR_CHANGES_DISABLED`
+                                        Zulip server level setting.
+                                    server_name_changes_disabled:
+                                      type: boolean
+                                      description: |
+                                        Whether the server allows name changes.  Similar to
+                                        `realm_name_changes_disabled` but based on the `NAME_CHANGES_DISABLED`
+                                        Zulip server level setting.
+                                    notifications_stream_id:
+                                      type: integer
+                                      description: |
+                                        The ID of the stream to which notifications announcing the
+                                        creation of new streams are sent. -1 if such notifications are disabled.
+
+                                        Since these notifications are sent by the server, this field is
+                                        primarily relevant to clients containing UI for changing it.
+                                    signup_notifications_stream_id:
+                                      type: integer
+                                      description: |
+                                        The ID of the stream to which notifications announcing
+                                        that new users have joined the organization are sent.
+                                        -1 if such notifications are disabled.
+
+                                        Since these notifications are sent by the server, this field is
+                                        primarily relevant to clients containing UI for changing it.
+                                  additionalProperties: false
                               example:
                                 {
                                   "type": "realm",
@@ -2875,7 +3378,6 @@ paths:
                                   "sender_full_name": "Othello Bot",
                                   "sender_id": 13215,
                                   "sender_realm_str": "example",
-                                  "topic": "Castle",
                                   "topic_links": [],
                                   "timestamp": 1375978403,
                                   "type": "stream",
@@ -6105,6 +6607,7 @@ paths:
                             * `URL` for links.
                             * `EXTERNAL_ACCOUNT` for external accounts.
                             * `USER` for selecting a user for the field.
+                          additionalProperties: false
                           properties:
                             id:
                               type: integer
@@ -6410,6 +6913,7 @@ paths:
                               description: |
                                 Object containing the details of a unread private
                                 message with a specific user.
+                              additionalProperties: false
                               properties:
                                 sender_id:
                                   type: integer
@@ -6432,6 +6936,7 @@ paths:
                               description: |
                                 `{message_id}`: Object containing the details of a unread stream
                                 message with the message_id as the key.
+                              additionalProperties: false
                               properties:
                                 sender_ids:
                                   type: array
@@ -6448,7 +6953,7 @@ paths:
                                   type: integer
                                   description: |
                                     The id of the stream to which the message was sent.
-                                message_ids:
+                                unread_message_ids:
                                   type: array
                                   description: |
                                     The message ids of the recent unread messages sent in this stream.
@@ -6465,6 +6970,7 @@ paths:
                               description: |
                                 Object containing the details of a unread group PM
                                 messages of a single group.
+                              additionalProperties: false
                               properties:
                                 user_ids_string:
                                   type: string
@@ -6579,6 +7085,7 @@ paths:
                             `{user_id}`: Object containing the status details of a user
                             with the key of the object being the id of the user.
                           type: object
+                          additionalProperties: false
                           properties:
                             away:
                               type: boolean
@@ -6852,6 +7359,7 @@ paths:
                           type: object
                           description: |
                             Object describing a emojiset.
+                          additionalProperties: false
                           properties:
                             key:
                               type: string
@@ -7264,6 +7772,7 @@ paths:
                             video chat provider with the name of the chat provider as
                             the key.
                           type: object
+                          additionalProperties: false
                           properties:
                             name:
                               type: string
@@ -7377,6 +7886,7 @@ paths:
                             default external account provider with the name of the
                             website as the key.
                           type: object
+                          additionalProperties: false
                           properties:
                             name:
                               type: string
@@ -7515,7 +8025,7 @@ paths:
                           key, as all the users present in this array have active accounts.
 
                           See also `cross_realm_bots` and `realm_non_active_users`.
-                        additionalProperties:
+                        items:
                           $ref: "#/components/schemas/User"
                       realm_non_active_users:
                         type: array
@@ -7527,7 +8037,7 @@ paths:
                           the usual User dictionary this does not contain the `is_active`
                           key as all the users present in this array have deactivated
                           accounts.
-                        additionalProperties:
+                        items:
                           $ref: "#/components/schemas/User"
                       avatar_source:
                         type: string
@@ -8975,6 +9485,7 @@ components:
       type: object
       description: |
         Object containing basic details about the stream.
+      additionalProperties: false
       properties:
         stream_id:
           type: integer
@@ -9620,6 +10131,7 @@ components:
       description: |
         Dictionary containing details of a default stream
         group.
+      additionalProperties: false
       properties:
         name:
           type: string

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -1007,7 +1007,7 @@ class OpenAPIAttributesTest(ZulipTestCase):
         * All example responses match their schema.
         * That no opaque object exists.
         """
-        EXCLUDE = ["/real-time", "/register", "/events"]
+        EXCLUDE = ["/real-time"]
         VALID_TAGS = [
             "users",
             "server_and_organizations",


### PR DESCRIPTION
The /events and /register endpoints were excluded from schema validations,
because they were earlier not completely documented. However, they can
now be added for proper checking. Removed them from excluded endpoints list
and fixed the documentation for /register and /events after the checking.
Fixes #17796.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
