### PR TITLE
frontend: display "user not found" for invalid user search query

### DIFF
--- a/static/js/buddy_list.js
+++ b/static/js/buddy_list.js
@@ -269,6 +269,12 @@ export class BuddyList extends BuddyListConf {
 
         // Add a fudge factor.
         height += 10;
+        
+        if (this.keys.length === 0) {
+            this.container = $(this.container_sel);
+            this.container.append('<div class="user-not-found"> User not found </div>');
+            return;
+        }
 
         while (this.render_count < this.keys.length) {
             const padding_height = $(this.padding_sel).height();

--- a/static/js/buddy_list.js
+++ b/static/js/buddy_list.js
@@ -269,7 +269,7 @@ export class BuddyList extends BuddyListConf {
 
         // Add a fudge factor.
         height += 10;
-        
+
         if (this.keys.length === 0) {
             this.container = $(this.container_sel);
             this.container.append('<div class="user-not-found"> User not found </div>');

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -22,7 +22,7 @@
         color: hsl(0, 0%, 67%);
         font-style: italic;
     }
-    
+
     li {
         overflow: hidden;
         white-space: nowrap;

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -17,6 +17,12 @@
     overflow-x: hidden;
     list-style-position: inside; /* Draw the bullets inside our box */
 
+    .user-not-found {
+        margin-left: 10px;
+        color: hsl(0, 0%, 67%);
+        font-style: italic;
+    }
+    
     li {
         overflow: hidden;
         white-space: nowrap;


### PR DESCRIPTION
#17842 


**Testing plan:** manual testing


**GIFs or screenshots:** 

Before:

![image](https://user-images.githubusercontent.com/44806328/112732440-47c68600-8f3a-11eb-8a51-642bda68c710.png)

After:

![image](https://user-images.githubusercontent.com/44806328/112732451-590f9280-8f3a-11eb-9232-262f7382564e.png)
