### PR TITLE
landing_page: Add label for next and previous arrow buttons.

### DIFF
--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -1563,7 +1563,6 @@ nav {
     &:hover {
         color: hsl(220, 23%, 33%);
     }
-
     &.right {
         right: 40px;
     }

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -42,7 +42,6 @@
                         <div class="item-container">
                             <div class="item active">
                                 <div class="item-inner">
-
                                     <button data-target="#tour-carousel" data-slide="next" type="button" name="button" class="start-button">Take the tour</button>
                                     <img src="/static/images/story-tutorial/zulip-topic-blurred.png" alt="" class="start-image">
                                 </div>
@@ -141,13 +140,15 @@
                         </div>
                     </div>
 
-                    <a class="carousel-control left visibility-control hide" href="#tour-carousel" data-slide="prev"><i class="fa fa-chevron-left" aria-hidden="true"></i></a>
-                    <a class="carousel-control right visibility-control" href="#tour-carousel" data-slide="next"><i class="fa fa-chevron-right" aria-hidden="true"></i></a>
+                    <a class="carousel-control left visibility-control hide" href="#tour-carousel" data-slide="prev" aria-labelledby="previous" title="{{ _('Previous') }}"><i id="previous" class="fa fa-chevron-left" aria-hidden="true"></i></a>
+                    <a class="carousel-control right visibility-control" href="#tour-carousel" data-slide="next"  aria-labelledby="next" title="{{ _('Next') }}"><i id="next" class="fa fa-chevron-right" aria-hidden="true"></i></a>
+
                     <ol class="carousel-indicators">
                         <li data-target="#tour-carousel" data-slide-to="0" class="active"></li>
                         <li data-target="#tour-carousel" data-slide-to="1"></li>
                         <li data-target="#tour-carousel" data-slide-to="2"></li>
                         <li data-target="#tour-carousel" data-slide-to="3"></li>
+
                         <li data-target="#tour-carousel" data-slide-to="4"></li>
                         <li data-target="#tour-carousel" data-slide-to="5"></li>
                         <li data-target="#tour-carousel" data-slide-to="6"></li>


### PR DESCRIPTION
[#17467](https://github.com/zulip/zulip/issues/17467)

**Testing plan:**  Manually tested as this is a small feature update, haven't written Puppeteer tests, need guidance here if tests are required

**GIFs or screenshots:** 
Labels appear upon hover.

![next_label](https://user-images.githubusercontent.com/36158530/112732655-3e9cdf80-8f61-11eb-8969-566a928924a9.png)

![prev_label](https://user-images.githubusercontent.com/36158530/112732657-4066a300-8f61-11eb-9273-e6c122bcf16a.png)

