### PR TITLE
Setup: Add /usr/sbin to PATH variable

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -173,6 +173,10 @@ export LC_ALL="en_US.UTF-8"
 export LANG="en_US.UTF-8"
 export LANGUAGE="en_US.UTF-8"
 
+# Force a known path; this fixes problems on Debian where `su` from
+# non-root may not adjust `$PATH` to root's.
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 # Check for a supported OS release.
 if [ -f /etc/os-release ]; then
     os_info="$(

--- a/scripts/lib/install-node
+++ b/scripts/lib/install-node
@@ -45,8 +45,8 @@ if [ "$current_node_version" != "v$node_version" ] || ! [ -L "$node_wrapper_path
         . "$NVM_DIR/nvm.sh"
     fi
 
-    nvm install "$node_version" && nvm alias default "$node_version"
-    NODE_BIN="$(nvm which default)"
+    nvm install "$node_version"
+    NODE_BIN="$(nvm which $node_version)"
 
     # Fix messed-up uid=500 and group write bits produced by nvm
     n=${NODE_BIN%/bin/node}
@@ -57,6 +57,12 @@ if [ "$current_node_version" != "v$node_version" ] || ! [ -L "$node_wrapper_path
     ln -nsf "$NODE_BIN" /usr/local/bin/node
     ln -nsf "$(dirname "$NODE_BIN")/npm" /usr/local/bin/npm
     ln -nsf "$(dirname "$NODE_BIN")/npx" /usr/local/bin/npx
+
+    # Tell NVM that we don't want it messing around with $PATH, which
+    # can get us into trouble, if we've just upgraded but our parent
+    # env still has the old version first in its PATH.  Tell it to use
+    # the newly-symlinked one that it will find in /usr/local/bin
+    nvm alias default system
 fi
 
 # Work around the fact that apparently sudo doesn't clear the HOME

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -37,6 +37,9 @@ from scripts.lib.zulip_tools import (
 
 assert_running_as_root()
 
+# Set a known, reliable PATH
+os.environ["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s upgrade-zulip-stage-2: %(message)s", level=logging.INFO)
 


### PR DESCRIPTION
This addreses the issue #17441

The path of the command useradd (/usr/sbin) is sometimes not configured in the $PATH variable.
To solve this issue, we updated the scripts/setup/install script to add /usr/sbin to $PATH if it's not already included.

For more details on how to reproduce this bug, you can refer to a previous PR that addresses the same issue #17444

**Testing plan:** manual
