### PR TITLE
push_notifs: Log the number of devices notification was sent to.

### DIFF
--- a/zerver/lib/remote_server.py
+++ b/zerver/lib/remote_server.py
@@ -107,8 +107,10 @@ def send_to_push_bouncer(
     return orjson.loads(res.content)
 
 
-def send_json_to_push_bouncer(method: str, endpoint: str, post_data: Mapping[str, object]) -> None:
-    send_to_push_bouncer(
+def send_json_to_push_bouncer(
+    method: str, endpoint: str, post_data: Mapping[str, object]
+) -> Dict[str, object]:
+    return send_to_push_bouncer(
         method,
         endpoint,
         orjson.dumps(post_data),

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -196,7 +196,9 @@ def remote_server_notify_push(
 
     send_apple_push_notification(user_id, apple_devices, apns_payload, remote=True)
 
-    return json_success()
+    return json_success(
+        {"total_android_devices": len(android_devices), "total_apple_devices": len(apple_devices)}
+    )
 
 
 def validate_incoming_table_data(


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Mobile.20Notifications/near/1144748 for context

Missing tests, because this is a draft and It hasn't really been discussed  if this is exactly how we'll want the logging and API to work.