### PR TITLE
ci: Regenerate bionic and focal containers.

### DIFF
--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -19,7 +19,7 @@ jobs:
           # This docker image was created by a generated Dockerfile at:
           #   tools/ci/images/bionic/Dockerfile
           # Bionic ships with Python 3.6.
-          - docker_image: mepriyank/actions:bionic
+          - docker_image: amanagr/actions:bionic
             name: Ubuntu 18.04 Bionic (Python 3.6, backend + frontend)
             os: bionic
             is_bionic: true
@@ -28,7 +28,7 @@ jobs:
           # This docker image was created by a generated Dockerfile at:
           #   tools/ci/images/focal/Dockerfile
           # Focal ships with Python 3.8.2.
-          - docker_image: mepriyank/actions:focal
+          - docker_image: amanagr/actions:focal
             name: Ubuntu 20.04 Focal (Python 3.8, backend)
             os: focal
             is_focal: true


### PR DESCRIPTION
This helps us reduce time to update dependencies on every CI
build since the previous containers used to take about 1 minute.

`sudo` had a bug due to which we were not able to create directories.
See https://github.com/sudo-project/sudo/issues/42.
We used these directories to restore caches.
Upgrading the focus dependencies via this commit naturally fixes that
bug.

Fixes #17854