### PR TITLE
docs: Improve documentation for changing a realm's subdomain.

### DIFF
--- a/templates/zerver/help/change-organization-url.md
+++ b/templates/zerver/help/change-organization-url.md
@@ -21,13 +21,26 @@ for paid plans.
 
 ## Self-hosting
 
-If you're self-hosting, you can change the root domain of your server
-by changing the `EXTERNAL_HOST` [setting][zulip-settings].  If you're
-[hosting multiple organizations][zulip-multiple-organizations] and
-want to change the subdomain for one of them, you can use
-`do_change_realm_subdomain(realm, "new_subdomain")` in a [management
-shell][management-shell].
+If you're self-hosting, you can change the root domain of your Zulip
+server by changing the `EXTERNAL_HOST` [setting][zulip-settings].  If
+you're [hosting multiple organizations][zulip-multiple-organizations]
+and want to change the subdomain for one of them, you can follow these
+steps:
+
+{start_tabs}
+
+1. Get the `string_id` for your organization as [described here][find-string-id]
+
+2. Run the following commands in a [management shell][management-shell]:
+
+    ```
+    realm = get_realm("string_id")
+    do_change_realm_subdomain(realm, "new_subdomain")
+    ```
+
+{end_tabs}
 
 [zulip-settings]: https://zulip.readthedocs.io/en/stable/production/settings.html
 [zulip-multiple-organizations]: https://zulip.readthedocs.io/en/stable/production/multiple-organizations.html
 [management-shell]: https://zulip.readthedocs.io/en/stable/production/management-commands.html#manage-py-shell
+[find-string-id]: https://zulip.readthedocs.io/en/stable/production/management-commands.html#accessing-an-organization-s-string-id


### PR DESCRIPTION
## What is this PR for
The PR aims to solve the issue https://github.com/zulip/zulip/issues/17857

The current documentation doesn't clearly explain the process of
changing the organization's subdomain.
This commit adds instructions for user to get the string_id of their
organization and then lists the commands to be executed in the
management shell to change the subdomain.

I have manually tested in my development environment that the links are working and pointing to correct places.

Here is the screenshot of the modified page:

![image](https://user-images.githubusercontent.com/53316982/113585971-8f3fc700-964a-11eb-85de-9bd190e04a09.png)

