### PR TITLE
puppeteer_tests: Log-out at the end of every test.

### DIFF
--- a/frontend_tests/puppeteer_tests/00-realm-creation.ts
+++ b/frontend_tests/puppeteer_tests/00-realm-creation.ts
@@ -65,6 +65,10 @@ async function realm_creation_tests(page: Page): Promise<void> {
     // Check if realm is created and user is logged in by checking if
     // element of id `lightbox_overlay` exists.
     await page.waitForSelector("#lightbox_overlay"); // if element doesn't exist,timeout error raises
+
+    // Updating common.realm_url because we are redirecting to it when logging out.
+    common.realm_url = page.url();
+    await common.log_out(page);
 }
 
 common.run_test(realm_creation_tests);

--- a/frontend_tests/puppeteer_tests/04-subscriptions.ts
+++ b/frontend_tests/puppeteer_tests/04-subscriptions.ts
@@ -255,6 +255,7 @@ async function subscriptions_tests(page: Page): Promise<void> {
     await test_subscription_button_verona_stream(page);
     await test_stream_creation(page);
     await test_streams_search_feature(page);
+    await common.log_out(page);
 }
 
 common.run_test(subscriptions_tests);

--- a/frontend_tests/puppeteer_tests/05-stars.ts
+++ b/frontend_tests/puppeteer_tests/05-stars.ts
@@ -64,6 +64,7 @@ async function stars_test(page: Page): Promise<void> {
 
     await toggle_test_star_message(page);
     assert.strictEqual(await stars_count(page), 0, "Message was not unstarred correctly.");
+    await common.log_out(page);
 }
 
 common.run_test(stars_test);

--- a/frontend_tests/puppeteer_tests/06-edit.ts
+++ b/frontend_tests/puppeteer_tests/06-edit.ts
@@ -80,6 +80,7 @@ async function edit_tests(page: Page): Promise<void> {
     await test_stream_message_edit(page);
     await test_edit_message_with_slash_me(page);
     await test_edit_private_message(page);
+    await common.log_out(page);
 }
 
 common.run_test(edit_tests);

--- a/frontend_tests/puppeteer_tests/08-admin.ts
+++ b/frontend_tests/puppeteer_tests/08-admin.ts
@@ -396,6 +396,7 @@ async function admin_test(page: Page): Promise<void> {
     }
     await test_default_streams(page);
     await test_authentication_methods(page);
+    await common.log_out(page);
 }
 
 common.run_test(admin_test);

--- a/frontend_tests/puppeteer_tests/12-drafts.ts
+++ b/frontend_tests/puppeteer_tests/12-drafts.ts
@@ -277,6 +277,7 @@ async function drafts_test(page: Page): Promise<void> {
     await test_delete_draft(page);
     await test_save_draft_by_reloading(page);
     await test_delete_draft_on_sending(page);
+    await common.log_out(page);
 }
 
 common.run_test(drafts_test);

--- a/frontend_tests/puppeteer_tests/13-delete-message.ts
+++ b/frontend_tests/puppeteer_tests/13-delete-message.ts
@@ -35,6 +35,7 @@ async function delete_message_test(page: Page): Promise<void> {
     await page.waitForSelector("#do_delete_message_spinner .loading_indicator_spinner", {
         hidden: true,
     });
+    await common.log_out(page);
 }
 
 common.run_test(delete_message_test);

--- a/frontend_tests/puppeteer_tests/14-copy-and-paste.ts
+++ b/frontend_tests/puppeteer_tests/14-copy-and-paste.ts
@@ -160,6 +160,7 @@ async function copy_paste_test(page: Page): Promise<void> {
     await test_copying_last_from_prev_all_from_next(page);
     await test_copying_all_from_prev_first_from_next(page);
     await test_copying_messages_from_several_topics(page);
+    await common.log_out(page);
 }
 
 common.run_test(copy_paste_test);

--- a/frontend_tests/puppeteer_tests/16-settings.ts
+++ b/frontend_tests/puppeteer_tests/16-settings.ts
@@ -353,6 +353,7 @@ async function settings_tests(page: Page): Promise<void> {
     await test_your_bots_section(page);
     await test_default_language_setting(page);
     await test_notifications_section(page);
+    await common.log_out(page);
 }
 
 common.run_test(settings_tests);


### PR DESCRIPTION
When migrating from Casper to Puppeteer, some tests
were missed for adding log-out calls at the end.

This PR adds log-out calls to those missed tests.

Also, As we are resetting the test database after each
run (from 99f8be6a1298e9) it will better to log out because we are
not resting Tornado's internal state. It'd help us prevent
any future flakes.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
[Link to CZO conversation](https://chat.zulip.org/#narrow/stream/92-learning/topic/Why.20we.20do.20not.20log.20out.20in.20some.20puppeteer.20tests.3F/near/1146290).


**Testing plan:** <!-- How have you tested? -->
Tested it by running puppeteer tests multiple times in Chrome and Firefox ✅.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
