### PR TITLE
docs: Mention custom domains are not supported on Zulip Cloud.

### DIFF
--- a/templates/zerver/help/change-organization-url.md
+++ b/templates/zerver/help/change-organization-url.md
@@ -14,7 +14,10 @@ in an announcement stream to notify users that they need to update
 their clients.
 
 If you're using Zulip Cloud (E.g. `https://example.zulipchat.com`),
-you can request a change by emailing support@zulip.com.
+you can request a change by emailing support@zulip.com. Custom domains
+(i.e. those that do not have the form `example.zulipchat.com`) have a
+maintenance cost for our operational team and thus are only available
+for paid plans.
 
 ## Self-hosting
 


### PR DESCRIPTION
https://zulip.com/help/change-organization-url is not explicit enough about what's supported, which can sometimes lead to folks assuming they can request a custom domain.