### PR TITLE
docs: Add a debugging tip for failure when typing on modal with puppeteer test.

### DIFF
--- a/docs/testing/testing-with-puppeteer.md
+++ b/docs/testing/testing-with-puppeteer.md
@@ -82,6 +82,17 @@ integration](../testing/continuous-integration.md):
   Integration (CI) services because small races are amplified in those
   environments; this often explains failures in CI that cannot be
   easily reproduced locally.
+* Does the test fail when you are typing (filling the form) on a modal
+  or other just-opened UI widget? Puppeteer starts typing after focusing on
+  the text field, sending keystrokes one after another. So, if
+  application code explicitly focuses the modal after it
+  appears/animates, this could cause the text field that Puppeteer is
+  trying to type into to lose focus, resulting in partially typed data.
+  The recommended fix for this is to wait until the modal is focused before
+  starting typing, like this:
+  ```JavaScript
+  await page.waitForFunction(":focus").attr("id") === modal_id);
+  ```
 
 These tools/features are often useful when debugging:
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
[Link to CZO conversation.](https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/puppeteer.20issue)


**Testing plan:** <!-- How have you tested? -->
Tested it manually on the local dev server by visiting `/docs/testing/testing-with-puppeteer.html`.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
![Screenshot 2021-03-29 at 10 23 14 PM](https://user-images.githubusercontent.com/63820270/112871942-6b760180-90dd-11eb-9d1f-176156f7e9b8.png)


