### PR TITLE
documentation: Update upload_file python api documentation.

### DIFF
--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -1055,12 +1055,9 @@ def upload_file(client: Client) -> None:
     # {code_example|start}
     # Upload a file
     with open(path_to_file, "rb") as fp:
-        result = client.call_endpoint(
-            "user_uploads",
-            method="POST",
-            files=[fp],
-        )
+        result = client.upload_file(fp)
 
+    # send file uri as a message
     client.send_message(
         {
             "type": "stream",


### PR DESCRIPTION
According to the current api documentation
have to use call_endpoint to
upload a file.

According to the example of python-zulip-api
repo can use specific upload_file
endpoint to upload a file.

Update the documentation using
upload_file endpoint.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

- manual testing

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Before update:

![Screenshot (26)](https://user-images.githubusercontent.com/57071700/112867139-2c917d00-90d8-11eb-962f-c30908a7ea59.png)

After update:

![Screenshot (25)](https://user-images.githubusercontent.com/57071700/112867180-3adf9900-90d8-11eb-82c3-6f04a8009e27.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
