### PR TITLE
Add moderators option in create_stream_policy, invite_to_stream_policy and stream_post_policy.

### DIFF
--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -604,6 +604,8 @@ def list_to_streams(
         if not user_profile.can_create_streams():
             if user_profile.realm.create_stream_policy == Realm.POLICY_ADMINS_ONLY:
                 raise JsonableError(_("Only administrators can create streams."))
+            if user_profile.realm.create_stream_policy == Realm.POLICY_MODERATORS_ONLY:
+                raise JsonableError(_("Only administrators and moderators can create streams."))
             if user_profile.realm.create_stream_policy == Realm.POLICY_FULL_MEMBERS_ONLY:
                 raise JsonableError(_("Your account is too new to create streams."))
             raise JsonableError(_("Not allowed for guest users"))

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -195,6 +195,13 @@ def check_stream_access_based_on_stream_post_policy(sender: UserProfile, stream:
         pass
     elif stream.stream_post_policy == Stream.STREAM_POST_POLICY_ADMINS:
         raise JsonableError(_("Only organization administrators can send to this stream."))
+    elif (
+        stream.stream_post_policy == Stream.STREAM_POST_POLICY_MODERATORS
+        and not sender.is_moderator
+    ):
+        raise JsonableError(
+            _("Only organization administrators and moderators can send to this stream.")
+        )
     elif stream.stream_post_policy != Stream.STREAM_POST_POLICY_EVERYONE and sender.is_guest:
         raise JsonableError(_("Guests cannot send to this stream."))
     elif (

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1699,6 +1699,7 @@ class Stream(models.Model):
     STREAM_POST_POLICY_EVERYONE = 1
     STREAM_POST_POLICY_ADMINS = 2
     STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS = 3
+    STREAM_POST_POLICY_MODERATORS = 4
     # TODO: Implement policy to restrict posting to a user group or admins.
 
     # Who in the organization has permission to send messages to this stream.
@@ -1707,6 +1708,7 @@ class Stream(models.Model):
         STREAM_POST_POLICY_EVERYONE,
         STREAM_POST_POLICY_ADMINS,
         STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS,
+        STREAM_POST_POLICY_MODERATORS,
     ]
 
     # The unique thing about Zephyr public streams is that we never list their

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1454,6 +1454,8 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
 
         if policy_value == Realm.POLICY_MEMBERS_ONLY:
             return True
+
+        assert policy_value == Realm.POLICY_FULL_MEMBERS_ONLY
         return not self.is_provisional_member
 
     def can_create_streams(self) -> bool:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -253,11 +253,13 @@ class Realm(models.Model):
     POLICY_MEMBERS_ONLY = 1
     POLICY_ADMINS_ONLY = 2
     POLICY_FULL_MEMBERS_ONLY = 3
+    POLICY_MODERATORS_ONLY = 4
 
     COMMON_POLICY_TYPES = [
         POLICY_MEMBERS_ONLY,
         POLICY_ADMINS_ONLY,
         POLICY_FULL_MEMBERS_ONLY,
+        POLICY_MODERATORS_ONLY,
     ]
 
     # Who in the organization is allowed to create streams.
@@ -1447,6 +1449,12 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
 
         policy_value = getattr(self.realm, policy_name)
         if policy_value == Realm.POLICY_ADMINS_ONLY:
+            return False
+
+        if self.is_moderator:
+            return True
+
+        if policy_value == Realm.POLICY_MODERATORS_ONLY:
             return False
 
         if self.is_guest:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9536,6 +9536,7 @@ components:
             * 1 => Any user can post.
             * 2 => Only administrators can post.
             * 3 => Only full members can post.
+            * 4 => Only moderators can post.
 
             **Changes**: New in Zulip 3.0, replacing the previous
             `is_announcement_only` boolean.
@@ -10082,6 +10083,7 @@ components:
             * 1 => Any user can post.
             * 2 => Only administrators can post.
             * 3 => Only full members can post.
+            * 4 => Only moderators can post.
 
             **Changes**: New in Zulip 3.0, replacing the previous
             `is_announcement_only` boolean.
@@ -10993,6 +10995,7 @@ components:
         * 1 => Any user can post.
         * 2 => Only administrators can post.
         * 3 => Only full members can post.
+        * 4 => Only moderators can post.
 
         **Changes**: New in Zulip 3.0, replacing the previous
         `is_announcement_only` boolean.

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -204,6 +204,26 @@ class MessagePOSTTest(ZulipTestCase):
             "Only organization administrators can send to this stream.",
         )
 
+        moderator_profile = self.example_user("shiva")
+        self.login_user(moderator_profile)
+
+        # Moderators and their owned bots cannot send to STREAM_POST_POLICY_ADMINS streams
+        self._send_and_verify_message(
+            moderator_profile,
+            stream_name,
+            "Only organization administrators can send to this stream.",
+        )
+        moderator_owned_bot = self.create_test_bot(
+            short_name="whatever3",
+            full_name="whatever3",
+            user_profile=moderator_profile,
+        )
+        self._send_and_verify_message(
+            moderator_owned_bot,
+            stream_name,
+            "Only organization administrators can send to this stream.",
+        )
+
         # Bots without owner (except cross realm bot) cannot send to announcement only streams
         bot_without_owner = do_create_user(
             email="free-bot@zulip.testserver",

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -514,6 +514,10 @@ def add_subscriptions_backend(
         if not user_profile.can_subscribe_other_users():
             if user_profile.realm.invite_to_stream_policy == Realm.POLICY_ADMINS_ONLY:
                 return json_error(_("Only administrators can modify other users' subscriptions."))
+            if user_profile.realm.invite_to_stream_policy == Realm.POLICY_MODERATORS_ONLY:
+                return json_error(
+                    _("Only administrators and moderators can modify other users' subscriptions.")
+                )
             # Realm.POLICY_MEMBERS_ONLY only fails if the
             # user is a guest, which happens in the decorator above.
             assert user_profile.realm.invite_to_stream_policy == Realm.POLICY_FULL_MEMBERS_ONLY


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR mainly addresses-
- Add moderators only option in `create_stream_policy`.
- Add moderators only option in `invite_to_stream_policy`.
- Add moderators only option in `stream_post_policy`.

This also contains some prep commits for fixing comments in tests, typo in api docs and one for
adding checks for moderators in `test_sending_message_as_stream_post_policy_admins`.

**Testing plan:** <!-- How have you tested? --> Updated existing tests and added new tests.


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
