### PR TITLE
api doc: Refactor hacky openAPI curl test.

### DIFF
--- a/tools/test-api
+++ b/tools/test-api
@@ -106,7 +106,7 @@ with test_server_running(
     )
 
     test_the_api(client, nonadmin_client, owner_client)
-    test_generated_curl_examples_for_success(client, owner_client)
+    test_generated_curl_examples_for_success(client)
     test_js_bindings(client)
 
     # Test error payloads

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -16,11 +16,14 @@ from zulip import Client
 
 from zerver.models import get_realm
 from zerver.openapi import markdown_extension
-from zerver.openapi.curl_param_value_generators import assert_all_helper_functions_called
+from zerver.openapi.curl_param_value_generators import (
+    AUTHENTICATION_LINE,
+    assert_all_helper_functions_called,
+)
 
 
-def test_generated_curl_examples_for_success(client: Client, owner_client: Client) -> None:
-    authentication_line = f"{client.email}:{client.api_key}"
+def test_generated_curl_examples_for_success(client: Client) -> None:
+    default_authentication_line = f"{client.email}:{client.api_key}"
     # A limited Markdown engine that just processes the code example syntax.
     realm = get_realm("zulip")
     md_engine = markdown.Markdown(
@@ -35,6 +38,10 @@ def test_generated_curl_examples_for_success(client: Client, owner_client: Clien
     for file_name in sorted(glob.glob("templates/zerver/api/*.md")):
         with open(file_name) as f:
             for line in f:
+                # Set AUTHENTICATION_LINE to default_authentication_line.
+                # Set this every iteration, because deactivate_own_user
+                # will override this for its test.
+                AUTHENTICATION_LINE[0] = default_authentication_line
                 # A typical example from the Markdown source looks like this:
                 #     {generate_code_example(curl, ...}
                 if not line.startswith("{generate_code_example(curl"):
@@ -47,20 +54,8 @@ def test_generated_curl_examples_for_success(client: Client, owner_client: Clien
                 unescaped_html = html.unescape(curl_command_html)
                 curl_command_text = unescaped_html[len("<p><code>curl\n") : -len("</code></p>")]
                 curl_command_text = curl_command_text.replace(
-                    "BOT_EMAIL_ADDRESS:BOT_API_KEY", authentication_line
+                    "BOT_EMAIL_ADDRESS:BOT_API_KEY", AUTHENTICATION_LINE[0]
                 )
-
-                # TODO: This needs_reactivation block is a hack.
-                # However, it's awkward to test the "deactivate
-                # myself" endpoint with how this system tries to use
-                # the same account for all tests without some special
-                # logic for that endpoint; and the hack is better than
-                # just not documenting the endpoint.
-                needs_reactivation = False
-                user_id = 0
-                if file_name == "templates/zerver/api/deactivate-own-user.md":
-                    needs_reactivation = True
-                    user_id = client.get_profile()["user_id"]
 
                 print("Testing {} ...".format(curl_command_text.split("\n")[0]))
 
@@ -77,8 +72,6 @@ def test_generated_curl_examples_for_success(client: Client, owner_client: Clien
                     )
                     response = json.loads(response_json)
                     assert response["result"] == "success"
-                    if needs_reactivation:
-                        owner_client.reactivate_user_by_id(user_id)
                 except (AssertionError, Exception):
                     error_template = """
 Error verifying the success of the API documentation curl example.


### PR DESCRIPTION
Fixes #17795
In PR #17014, we added support for deactivate-own-user. And while doing so, we first deactivated the client and then reactivated it. But this implementation is a bit hacky.

So, to fix this, we're now deactivating a test_user so that we don't have to reactivate it. I did so by changing the value of authentication_line in  test_curl_examples.py.

**Testing plan:** <!-- How have you tested? -->
Tested by running:
    1. ./tools/test-api
    2. ./tools/test-backend

CC @MSurfer20 
