### PR TITLE
Add error codes in validate_account_and_subdomain 

### DIFF
--- a/templates/zerver/api/rest-error-handling.md
+++ b/templates/zerver/api/rest-error-handling.md
@@ -42,3 +42,9 @@ for a query:
 A typical failed json response for when user's account is deactivated:
 
 {generate_code_example|/rest-error-handling:post|fixture(403_0)}
+
+## Realm deactivated
+
+A typical failed json response for when user's organization is deactivated:
+
+{generate_code_example|/rest-error-handling:post|fixture(403_1)}

--- a/templates/zerver/api/rest-error-handling.md
+++ b/templates/zerver/api/rest-error-handling.md
@@ -36,3 +36,9 @@ A typical failed JSON response for when the user is not authorized
 for a query:
 
 {generate_code_example|/rest-error-handling:post|fixture(400_2)}
+
+## User account deactivated
+
+A typical failed json response for when user's account is deactivated:
+
+{generate_code_example|/rest-error-handling:post|fixture(403_0)}

--- a/tools/test-api
+++ b/tools/test-api
@@ -31,12 +31,16 @@ with test_server_running(
 ):
     # Zerver imports should happen after `django.setup()` is run
     # by the test_server_running decorator.
-    from zerver.lib.actions import do_create_user
+    from zerver.lib.actions import change_user_is_active, do_create_user, do_reactivate_user
     from zerver.lib.test_helpers import reset_emails_in_zulip_realm
     from zerver.lib.users import get_api_key
     from zerver.models import get_realm, get_user
     from zerver.openapi.javascript_examples import test_js_bindings
-    from zerver.openapi.python_examples import test_invalid_api_key, test_the_api
+    from zerver.openapi.python_examples import (
+        test_invalid_api_key,
+        test_the_api,
+        test_user_account_deactivated,
+    )
     from zerver.openapi.test_curl_examples import test_generated_curl_examples_for_success
 
     print("Running API tests...")
@@ -105,6 +109,18 @@ with test_server_running(
         site=site,
     )
     test_invalid_api_key(client)
+
+    # Test account deactivated error
+    # we deactivate user manually because do_deactivate_user removes user session
+    change_user_is_active(guest_user, False)
+    client = Client(
+        email=email,
+        api_key=api_key,
+        site=site,
+    )
+    test_user_account_deactivated(client)
+    # reactivate user to avoid any side-effects in other tests.
+    do_reactivate_user(guest_user, acting_user=None)
 
 
 print("API tests passed!")

--- a/tools/test-api
+++ b/tools/test-api
@@ -31,13 +31,20 @@ with test_server_running(
 ):
     # Zerver imports should happen after `django.setup()` is run
     # by the test_server_running decorator.
-    from zerver.lib.actions import change_user_is_active, do_create_user, do_reactivate_user
+    from zerver.lib.actions import (
+        change_user_is_active,
+        do_create_user,
+        do_deactivate_realm,
+        do_reactivate_realm,
+        do_reactivate_user,
+    )
     from zerver.lib.test_helpers import reset_emails_in_zulip_realm
     from zerver.lib.users import get_api_key
     from zerver.models import get_realm, get_user
     from zerver.openapi.javascript_examples import test_js_bindings
     from zerver.openapi.python_examples import (
         test_invalid_api_key,
+        test_realm_deactivated,
         test_the_api,
         test_user_account_deactivated,
     )
@@ -121,6 +128,17 @@ with test_server_running(
     test_user_account_deactivated(client)
     # reactivate user to avoid any side-effects in other tests.
     do_reactivate_user(guest_user, acting_user=None)
+
+    # Test realm deactivated error
+    do_deactivate_realm(guest_user.realm, acting_user=None)
+
+    client = Client(
+        email=email,
+        api_key=api_key,
+        site=site,
+    )
+    test_realm_deactivated(client)
+    do_reactivate_realm(guest_user.realm)
 
 
 print("API tests passed!")

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -33,6 +33,7 @@ from zerver.lib.exceptions import (
     OrganizationMemberRequired,
     OrganizationOwnerRequired,
     UnsupportedWebhookEventType,
+    UserDeactivatedError,
 )
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.rate_limiter import RateLimitedUser
@@ -270,7 +271,7 @@ def validate_account_and_subdomain(request: HttpRequest, user_profile: UserProfi
     if user_profile.realm.deactivated:
         raise JsonableError(_("This organization has been deactivated"))
     if not user_profile.is_active:
-        raise JsonableError(_("Account is deactivated"))
+        raise UserDeactivatedError()
 
     # Either the subdomain matches, or we're accessing Tornado from
     # and to localhost (aka spoofing a request as the user).

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -32,6 +32,7 @@ from zerver.lib.exceptions import (
     OrganizationAdministratorRequired,
     OrganizationMemberRequired,
     OrganizationOwnerRequired,
+    RealmDeactivatedError,
     UnsupportedWebhookEventType,
     UserDeactivatedError,
 )
@@ -269,7 +270,7 @@ def validate_api_key(
 
 def validate_account_and_subdomain(request: HttpRequest, user_profile: UserProfile) -> None:
     if user_profile.realm.deactivated:
-        raise JsonableError(_("This organization has been deactivated"))
+        raise RealmDeactivatedError()
     if not user_profile.is_active:
         raise UserDeactivatedError()
 

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -50,6 +50,7 @@ class ErrorCode(AbstractEnum):
     UNAUTHENTICATED_USER = ()
     NONEXISTENT_SUBDOMAIN = ()
     RATE_LIMIT_HIT = ()
+    USER_DEACTIVATED = ()
 
 
 class JsonableError(Exception):
@@ -269,6 +270,18 @@ class StreamAdministratorRequired(JsonableError):
     @staticmethod
     def msg_format() -> str:
         return _("Must be an organization or stream administrator")
+
+
+class UserDeactivatedError(JsonableError):
+    code: ErrorCode = ErrorCode.USER_DEACTIVATED
+    http_status_code = 403
+
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    def msg_format() -> str:
+        return _("Account is deactivated")
 
 
 class MarkdownRenderingException(Exception):

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -51,6 +51,7 @@ class ErrorCode(AbstractEnum):
     NONEXISTENT_SUBDOMAIN = ()
     RATE_LIMIT_HIT = ()
     USER_DEACTIVATED = ()
+    REALM_DEACTIVATED = ()
 
 
 class JsonableError(Exception):
@@ -282,6 +283,18 @@ class UserDeactivatedError(JsonableError):
     @staticmethod
     def msg_format() -> str:
         return _("Account is deactivated")
+
+
+class RealmDeactivatedError(JsonableError):
+    code: ErrorCode = ErrorCode.REALM_DEACTIVATED
+    http_status_code = 403
+
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    def msg_format() -> str:
+        return _("This organization has been deactivated")
 
 
 class MarkdownRenderingException(Exception):

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -1224,6 +1224,15 @@ def test_missing_request_argument(client: Client) -> None:
     validate_against_openapi_schema(result, "/rest-error-handling", "post", "400_1")
 
 
+def test_user_account_deactivated(client: Client) -> None:
+    request = {
+        "content": "**foo**",
+    }
+    result = client.render_message(request)
+
+    validate_against_openapi_schema(result, "/rest-error-handling", "post", "403_0")
+
+
 def test_invalid_stream_error(client: Client) -> None:
     result = client.get_stream_id("nonexistent")
 

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -1233,6 +1233,15 @@ def test_user_account_deactivated(client: Client) -> None:
     validate_against_openapi_schema(result, "/rest-error-handling", "post", "403_0")
 
 
+def test_realm_deactivated(client: Client) -> None:
+    request = {
+        "content": "**foo**",
+    }
+    result = client.render_message(request)
+
+    validate_against_openapi_schema(result, "/rest-error-handling", "post", "403_1")
+
+
 def test_invalid_stream_error(client: Client) -> None:
     result = client.get_stream_id("nonexistent")
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9266,6 +9266,14 @@ paths:
                   - $ref: "#/components/schemas/InvalidApiKeyError"
                   - $ref: "#/components/schemas/MissingArgumentError"
                   - $ref: "#/components/schemas/UserNotAuthorizedError"
+        "403":
+          description: |
+            Forbidden
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/UserDeactivatedError"
   /zulip-outgoing-webhook:
     post:
       operationId: zulip_outgoing_webhooks
@@ -10853,6 +10861,15 @@ components:
             {
               "code": "BAD_REQUEST",
               "msg": "User not authorized for this query",
+              "result": "error",
+            }
+    UserDeactivatedError:
+      allOf:
+        - $ref: "#/components/schemas/CodedError"
+        - example:
+            {
+              "code": "USER_DEACTIVATED",
+              "msg": "Account is deactivated",
               "result": "error",
             }
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9274,6 +9274,7 @@ paths:
               schema:
                 oneOf:
                   - $ref: "#/components/schemas/UserDeactivatedError"
+                  - $ref: "#/components/schemas/RealmDeactivatedError"
   /zulip-outgoing-webhook:
     post:
       operationId: zulip_outgoing_webhooks
@@ -10870,6 +10871,15 @@ components:
             {
               "code": "USER_DEACTIVATED",
               "msg": "Account is deactivated",
+              "result": "error",
+            }
+    RealmDeactivatedError:
+      allOf:
+        - $ref: "#/components/schemas/CodedError"
+        - example:
+            {
+              "code": "REALM_DEACTIVATED",
+              "msg": "This organization is deactivated",
               "result": "error",
             }
 

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1209,7 +1209,7 @@ class InactiveUserTest(ZulipTestCase):
                 "to": self.example_email("othello"),
             },
         )
-        self.assert_json_error_contains(result, "Account is deactivated", status_code=400)
+        self.assert_json_error_contains(result, "Account is deactivated", status_code=403)
 
         result = self.api_post(
             self.example_user("hamlet"),
@@ -1238,7 +1238,7 @@ class InactiveUserTest(ZulipTestCase):
         change_user_is_active(user_profile, False)
 
         result = self.client_post("/json/fetch_api_key", {"password": test_password})
-        self.assert_json_error_contains(result, "Account is deactivated", status_code=400)
+        self.assert_json_error_contains(result, "Account is deactivated", status_code=403)
 
     def test_login_deactivated_user(self) -> None:
         """
@@ -1304,7 +1304,7 @@ class InactiveUserTest(ZulipTestCase):
         url = f"/api/v1/external/jira?api_key={api_key}&stream=jira_custom"
         data = self.webhook_fixture_data("jira", "created_v2")
         result = self.client_post(url, data, content_type="application/json")
-        self.assert_json_error_contains(result, "Account is deactivated", status_code=400)
+        self.assert_json_error_contains(result, "Account is deactivated", status_code=403)
 
 
 class TestIncomingWebhookBot(ZulipTestCase):
@@ -1647,7 +1647,9 @@ class TestAuthenticatedJsonPostViewDecorator(ZulipTestCase):
         self.login_user(user_profile)
         # we deactivate user manually because do_deactivate_user removes user session
         change_user_is_active(user_profile, False)
-        self.assert_json_error_contains(self._do_test(user_profile), "Account is deactivated")
+        self.assert_json_error_contains(
+            self._do_test(user_profile), "Account is deactivated", status_code=403
+        )
         do_reactivate_user(user_profile, acting_user=None)
 
     def test_authenticated_json_post_view_if_user_realm_is_deactivated(self) -> None:

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1066,7 +1066,9 @@ class DeactivatedRealmTest(ZulipTestCase):
                 "to": self.example_email("othello"),
             },
         )
-        self.assert_json_error_contains(result, "has been deactivated", status_code=400)
+        self.assert_json_error_contains(
+            result, "This organization has been deactivated", status_code=403
+        )
 
         result = self.api_post(
             self.example_user("hamlet"),
@@ -1078,7 +1080,9 @@ class DeactivatedRealmTest(ZulipTestCase):
                 "to": self.example_email("othello"),
             },
         )
-        self.assert_json_error_contains(result, "has been deactivated", status_code=401)
+        self.assert_json_error_contains(
+            result, "This organization has been deactivated", status_code=401
+        )
 
     def test_fetch_api_key_deactivated_realm(self) -> None:
         """
@@ -1094,7 +1098,9 @@ class DeactivatedRealmTest(ZulipTestCase):
         realm.deactivated = True
         realm.save()
         result = self.client_post("/json/fetch_api_key", {"password": test_password})
-        self.assert_json_error_contains(result, "has been deactivated", status_code=400)
+        self.assert_json_error_contains(
+            result, "This organization has been deactivated", status_code=403
+        )
 
     def test_webhook_deactivated_realm(self) -> None:
         """
@@ -1107,7 +1113,9 @@ class DeactivatedRealmTest(ZulipTestCase):
         url = f"/api/v1/external/jira?api_key={api_key}&stream=jira_custom"
         data = self.webhook_fixture_data("jira", "created_v2")
         result = self.client_post(url, data, content_type="application/json")
-        self.assert_json_error_contains(result, "has been deactivated", status_code=400)
+        self.assert_json_error_contains(
+            result, "This organization has been deactivated", status_code=403
+        )
 
 
 class LoginRequiredTest(ZulipTestCase):
@@ -1659,7 +1667,9 @@ class TestAuthenticatedJsonPostViewDecorator(ZulipTestCase):
         user_profile.realm.deactivated = True
         user_profile.realm.save()
         self.assert_json_error_contains(
-            self._do_test(user_profile), "This organization has been deactivated"
+            self._do_test(user_profile),
+            "This organization has been deactivated",
+            status_code=403,
         )
         do_reactivate_realm(user_profile.realm)
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
issue: #17763 

It defines two new error codes `REALM_DEACTIVATED` and `USER_DEACTIVATED` and uses them in `validate_account_and_subdomain`.

I have not changed error code and message we sent earlier with `JsonableError` , as I was not sure about them also changing them would have required updating many tests just for error message, so I thought of getting reviews over this after creating pr.

**Testing plan:** <!-- How have you tested? -->
Using backend tests.

Fixes: #17763.