### PR TITLE
ci: Remove 2>&1 redirection

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -90,7 +90,7 @@ jobs:
           sudo sed -i '/^bind/s/bind.*/bind 0.0.0.0/' /etc/redis/redis.conf
 
       - name: Build production tarball
-        run: ./tools/ci/production-build 2>&1
+        run: ./tools/ci/production-build
 
       - name: Upload production build artifacts for install jobs
         uses: actions/upload-artifact@v2
@@ -176,23 +176,23 @@ jobs:
           sudo sed -i '/^bind/s/bind.*/bind 0.0.0.0/' /etc/redis/redis.conf
 
       - name: Production extract tarball
-        run: /tmp/production-extract-tarball 2>&1
+        run: /tmp/production-extract-tarball
 
       - name: Install production
         run: |
           sudo service rabbitmq-server restart
-          sudo /tmp/production-install 2>&1
+          sudo /tmp/production-install
 
       - name: Verify install
-        run: sudo /tmp/production-verify 2>&1
+        run: sudo /tmp/production-verify
 
       - name: Upgrade postgresql
         if: ${{ matrix.is_bionic }}
-        run: sudo /tmp/production-upgrade-pg 2>&1
+        run: sudo /tmp/production-upgrade-pg
 
       - name: Verify install after upgrading postgresql
         if: ${{ matrix.is_bionic }}
-        run: sudo /tmp/production-verify 2>&1
+        run: sudo /tmp/production-verify
 
       - name: Report status
         if: failure()

--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -106,18 +106,16 @@ jobs:
 
           # Cleaning caches is mostly unnecessary in GitHub Actions, because
           # most builds don't get to write to the cache.
-          # scripts/lib/clean-unused-caches --verbose --threshold 0 2>&1
+          # scripts/lib/clean-unused-caches --verbose --threshold 0
 
       - name: Run tools test
         run: |
           source tools/ci/activate-venv
-          exec 2>&1
           ./tools/test-tools
 
       - name: Run backend lint
         run: |
           source tools/ci/activate-venv
-          exec 2>&1
           echo "Test suite is running under $(python --version)."
           ./tools/lint --groups=backend --skip=gitlint,mypy # gitlint disabled because flaky
 
@@ -125,19 +123,16 @@ jobs:
         if: ${{ matrix.include_frontend_tests }}
         run: |
           source tools/ci/activate-venv
-          exec 2>&1
           ./tools/lint --groups=frontend --skip=gitlint # gitlint disabled because flaky
 
       - name: Run backend tests
         run: |
           source tools/ci/activate-venv
-          exec 2>&1
           ./tools/test-backend --coverage --include-webhooks --no-cov-cleanup --ban-console-output
 
       - name: Run mypy
         run: |
           source tools/ci/activate-venv
-          exec 2>&1
           # We run mypy after the backend tests so we get output from the
           # backend tests, which tend to uncover more serious problems, first.
           ./tools/run-mypy --version
@@ -146,7 +141,6 @@ jobs:
       - name: Run miscellaneous tests
         run: |
           source tools/ci/activate-venv
-          exec 2>&1
 
           # Currently our compiled requirements files will differ for different python versions
           # so we will run test-locked-requirements only for Bionic.
@@ -164,7 +158,6 @@ jobs:
       - name: Run documentation and api tests
         run: |
           source tools/ci/activate-venv
-          exec 2>&1
           # In CI, we only test links we control in test-documentation to avoid flakes
           ./tools/test-documentation --skip-external-links
           ./tools/test-help-documentation --skip-external-links
@@ -174,7 +167,6 @@ jobs:
         if: ${{ matrix.include_frontend_tests }}
         run: |
           source tools/ci/activate-venv
-          exec 2>&1
           # Run the node tests first, since they're fast and deterministic
           ./tools/test-js-with-node --coverage
 
@@ -182,7 +174,6 @@ jobs:
         if: ${{ matrix.include_frontend_tests }}
         run: |
           source tools/ci/activate-venv
-          exec 2>&1
           # Check that various schemas are consistent. (is fast)
           ./tools/check-schemas
 
@@ -190,7 +181,6 @@ jobs:
         if: ${{ matrix.include_frontend_tests }}
         run: |
           source tools/ci/activate-venv
-          exec 2>&1
           ./manage.py makemessages --locale en
           PYTHONWARNINGS=ignore ./tools/check-capitalization --no-generate
           PYTHONWARNINGS=ignore ./tools/check-frontend-i18n --no-generate
@@ -199,13 +189,11 @@ jobs:
         if: ${{ matrix.include_frontend_tests }}
         run: |
           source tools/ci/activate-venv
-          exec 2>&1
           ./tools/test-js-with-puppeteer
 
       - name: Check for untracked files
         run: |
           source tools/ci/activate-venv
-          exec 2>&1
           # This final check looks for untracked files that may have been
           # created by test-backend or provision.
           untracked="$(git ls-files --exclude-standard --others)"
@@ -218,7 +206,7 @@ jobs:
         if: ${{ matrix.is_bionic }}
         run: |
           . /srv/zulip-py3-venv/bin/activate && \
-          ./tools/test-locked-requirements 2>&1
+          ./tools/test-locked-requirements
 
       - name: Upload coverage reports
 

--- a/tools/ci/setup-backend
+++ b/tools/ci/setup-backend
@@ -6,7 +6,7 @@ set -x
 # Provisioning may fail due to many issues but most of the times a network
 # connection issue is the reason. So we are going to retry entire provisioning
 # once again if that fixes our problem.
-tools/provision "$@" 2>&1 || {
+tools/provision "$@" || {
     ret=$?
     if [ "$ret" = 1 ]; then
         echo "\`provision\`: Something went wrong with the provisioning, might be a network issue, Retrying to provision..."


### PR DESCRIPTION
We had used `2>&1` to redirect stderr to stdout so it could be piped into `ts`, but commit dd3cdd6ec5085c25b6a9491b7e9b672ae99af442 (#17611) removed `ts`, so we no longer need the redirection.

Cc @amanagr.