### PR TITLE
lint: Suppress Ruby warnings from puppet on Ubuntu 20.04

### DIFF
--- a/tools/lint
+++ b/tools/lint
@@ -67,7 +67,7 @@ def run() -> None:
     )
     linter_config.external_linter(
         "puppet",
-        ["puppet", "parser", "validate"],
+        ["env", "RUBYOPT=-W0", "puppet", "parser", "validate"],
         ["pp"],
         description="Runs the puppet parser validator, checking for syntax errors.",
     )


### PR DESCRIPTION
```
puppet    | /usr/lib/ruby/vendor_ruby/puppet/util.rb:461: warning: URI.escape is obsolete
puppet    | /usr/lib/ruby/vendor_ruby/puppet/util.rb:461: warning: URI.escape is obsolete
puppet    | /usr/lib/ruby/vendor_ruby/puppet/util.rb:461: warning: URI.escape is obsolete
puppet    | /usr/lib/ruby/vendor_ruby/puppet/util.rb:461: warning: URI.escape is obsolete
```

https://bugs.launchpad.net/ubuntu/+source/puppet/+bug/1875848
https://tickets.puppetlabs.com/browse/PUP-10247

See also commit 3971824d041850413fca3a3960a20b391cba9b3e (#14571).