### PR TITLE
recent_topics: Don't revive focus when RT is not in focus.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -94,6 +94,7 @@ mock_esm("../../static/js/hotspots", {
 
 mock_esm("../../static/js/recent_topics", {
     is_visible: () => false,
+    is_in_focus: () => false,
 });
 
 message_lists.current = {

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -530,14 +530,7 @@ export function process_hotkey(e, hotkey) {
         case "tab":
         case "shift_tab":
         case "open_recent_topics":
-            if (
-                hashchange.in_recent_topics_hash() &&
-                !popovers.any_active() &&
-                !overlays.is_active() &&
-                !$("#searchbox_form #search_query").is(":focus") &&
-                !$(".user-list-filter").is(":focus") &&
-                !$(".stream-list-filter").is(":focus")
-            ) {
+            if (recent_topics.is_in_focus()) {
                 return recent_topics.change_focused_element($(e.target), event_name);
             }
     }

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -7,6 +7,7 @@ import render_recent_topics_body from "../templates/recent_topics_table.hbs";
 import * as compose_actions from "./compose_actions";
 import * as drafts from "./drafts";
 import * as hash_util from "./hash_util";
+import * as hashchange from "./hashchange";
 import * as ListWidget from "./list_widget";
 import {localstorage} from "./localstorage";
 import * as message_store from "./message_store";
@@ -16,8 +17,10 @@ import * as muting from "./muting";
 import * as narrow from "./narrow";
 import * as narrow_state from "./narrow_state";
 import * as navigate from "./navigate";
+import * as overlays from "./overlays";
 import * as panels from "./panels";
 import * as people from "./people";
+import * as popovers from "./popovers";
 import * as recent_senders from "./recent_senders";
 import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
@@ -66,6 +69,17 @@ const ls = localstorage();
 
 let filters = new Set();
 
+export function is_in_focus() {
+    // Check if user is focused on
+    // recent topics.
+    return (
+        hashchange.in_recent_topics_hash() &&
+        !popovers.any_active() &&
+        !overlays.is_active() &&
+        !$(".home-page-input").is(":focus")
+    );
+}
+
 export function clear_for_tests() {
     filters.clear();
     topics.clear();
@@ -109,8 +123,9 @@ function revive_current_focus() {
     // to the focused element, this function attempts to revive the
     // link and focus to the element prior to the rerender.
 
-    // Don't change focus if user is trying to type anywhere.
-    if ($(".home-page-input").is(":focus")) {
+    // We try to avoid setting focus when user
+    // is not focused on recent topics.
+    if (!is_in_focus()) {
         return false;
     }
 


### PR DESCRIPTION
When there is any overlay or popover open or user is focused on
any other input, we don't revive focus within recent topics.

Fixes #17875
