### PR TITLE
refactor: Replace local Request object with HostRequestMock in test_REQ_aliases function.

### DIFF
--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -131,11 +131,7 @@ class DecoratorTestCase(ZulipTestCase):
         ) -> int:
             return x + x
 
-        class Request:
-            GET: Dict[str, str] = {}
-            POST: Dict[str, str] = {}
-
-        request = Request()
+        request = HostRequestMock()
 
         request.POST = dict(bogus="5555")
         with self.assertRaises(RequestVariableMissingError):


### PR DESCRIPTION
Replaced local Request class and object with HostRequestMock inside class DecoratorTestCase(ZulipTestCase)'s test_REQ_aliases(self) function.

Fixes part of #1211 

Local backend tests passed.




