### PR TITLE
statuspage: Properly detect whether the update is for component or incident

### DIFF
--- a/zerver/webhooks/statuspage/fixtures/incident_created.json
+++ b/zerver/webhooks/statuspage/fixtures/incident_created.json
@@ -6,7 +6,7 @@
     },
     "page": {
         "id": "jb7j80lkgqvb",
-        "status_indicator": "none",
+        "status_indicator": "critical",
         "status_description": "All Systems Operational"
     },
     "incident": {


### PR DESCRIPTION
The value of "status_indicator" can be "none" for both the component and incident updates[1]. Also, it is not at all necessary that the value of "status_indicator" is always "none" for incident updates[2][3]. So our previous logic of using the value of "status_indicator" to determine whether the update is that of a component or incident was incorrect. Instead, we should use "incident" or "component" keys to determine the type of update.

This commit fixes issues [1] and [2] in sentry.

1. https://sentry.io/organizations/zulip/issues/2303217561
2. https://sentry.io/organizations/zulip/issues/2303197407
3. https://support.atlassian.com/statuspage/docs/enable-webhook-notifications/