### PR TITLE
puppeteer_tests: Use more stable selectors.

### DIFF
--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -252,7 +252,7 @@ class CommonUtils {
     async log_out(page: Page): Promise<void> {
         await page.goto(this.realm_url);
         const menu_selector = "#settings-dropdown";
-        const logout_selector = 'a[href="#logout"]';
+        const logout_selector = '.dropdown-menu a[href="#logout"]';
         console.log("Logging out");
         await page.waitForSelector(menu_selector, {visible: true});
         await page.click(menu_selector);
@@ -468,7 +468,7 @@ class CommonUtils {
         await page.waitForSelector(menu_selector, {visible: true});
         await page.click(menu_selector);
 
-        const organization_settings = 'a[href="#organization"]';
+        const organization_settings = '.dropdown-menu a[href="#organization"]';
         await page.click(organization_settings);
         await page.waitForSelector("#settings_overlay_container.show", {visible: true});
 

--- a/frontend_tests/puppeteer_tests/04-subscriptions.ts
+++ b/frontend_tests/puppeteer_tests/04-subscriptions.ts
@@ -39,7 +39,7 @@ async function stream_name_error(page: Page): Promise<string> {
 }
 
 async function open_streams_modal(page: Page): Promise<void> {
-    const all_streams_selector = 'a[href="#streams/all"]';
+    const all_streams_selector = "#add-stream-link";
     await page.waitForSelector(all_streams_selector, {visible: true});
     await page.click(all_streams_selector);
 

--- a/frontend_tests/puppeteer_tests/05-stars.ts
+++ b/frontend_tests/puppeteer_tests/05-stars.ts
@@ -27,7 +27,7 @@ async function toggle_test_star_message(page: Page): Promise<void> {
 }
 
 async function test_narrow_to_starred_messages(page: Page): Promise<void> {
-    await page.click('a[href^="#narrow/is/starred"]');
+    await page.click('#global_filters a[href^="#narrow/is/starred"]');
     await common.check_messages_sent(page, "zfilt", [["Verona > stars", [message]]]);
 
     // Go back to all messages narrow.

--- a/frontend_tests/puppeteer_tests/07-navigation.ts
+++ b/frontend_tests/puppeteer_tests/07-navigation.ts
@@ -9,9 +9,13 @@ async function wait_for_tab(page: Page, tab: string): Promise<void> {
     await page.waitForSelector(tab_slector, {visible: true});
 }
 
-async function navigate_to(page: Page, click_target: string, tab: string): Promise<void> {
+async function navigate_using_left_sidebar(
+    page: Page,
+    click_target: string,
+    tab: string,
+): Promise<void> {
     console.log("Visiting #" + click_target);
-    await page.click(`a[href='#${CSS.escape(click_target)}']`);
+    await page.click(`#left-sidebar a[href='#${CSS.escape(click_target)}']`);
 
     await wait_for_tab(page, tab);
 }
@@ -80,7 +84,7 @@ async function navigation_tests(page: Page): Promise<void> {
     const verona_id = await page.evaluate(() => zulip_test.get_stream_id("Verona"));
     const verona_narrow = `narrow/stream/${verona_id}-Verona`;
 
-    await navigate_to(page, verona_narrow, "message_feed_container");
+    await navigate_using_left_sidebar(page, verona_narrow, "message_feed_container");
 
     // Hardcoded this instead of using `navigate_to`
     // as Puppeteer cannot click hidden elements.
@@ -88,11 +92,11 @@ async function navigation_tests(page: Page): Promise<void> {
     await wait_for_tab(page, "message_feed_container");
 
     await navigate_to_subscriptions(page);
-    await navigate_to(page, "all_messages", "message_feed_container");
+    await navigate_using_left_sidebar(page, "all_messages", "message_feed_container");
     await navigate_to_settings(page);
-    await navigate_to(page, "narrow/is/private", "message_feed_container");
+    await navigate_using_left_sidebar(page, "narrow/is/private", "message_feed_container");
     await navigate_to_subscriptions(page);
-    await navigate_to(page, verona_narrow, "message_feed_container");
+    await navigate_using_left_sidebar(page, verona_narrow, "message_feed_container");
 
     await test_reload_hash(page);
 

--- a/frontend_tests/puppeteer_tests/07-navigation.ts
+++ b/frontend_tests/puppeteer_tests/07-navigation.ts
@@ -31,7 +31,7 @@ async function navigate_to_settings(page: Page): Promise<void> {
 
     await open_menu(page);
 
-    const settings_selector = "a[href^='#settings']";
+    const settings_selector = ".dropdown-menu a[href^='#settings']";
     await page.waitForSelector(settings_selector, {visible: true});
     await page.click(settings_selector);
 
@@ -47,7 +47,7 @@ async function navigate_to_subscriptions(page: Page): Promise<void> {
 
     await open_menu(page);
 
-    const manage_streams_selector = 'a[href^="#streams"]';
+    const manage_streams_selector = '.dropdown-menu a[href^="#streams"]';
     await page.waitForSelector(manage_streams_selector, {visible: true});
     await page.click(manage_streams_selector);
 

--- a/frontend_tests/puppeteer_tests/11-user-deactivation.ts
+++ b/frontend_tests/puppeteer_tests/11-user-deactivation.ts
@@ -8,7 +8,7 @@ async function navigate_to_user_list(page: Page): Promise<void> {
     const menu_selector = "#settings-dropdown";
     await page.waitForSelector(menu_selector, {visible: true});
     await page.click(menu_selector);
-    await page.click('a[href="#organization"]');
+    await page.click('.dropdown-menu a[href="#organization"]');
     await page.waitForSelector("#settings_overlay_container.show", {visible: true});
     await page.click("li[data-section='user-list-admin']");
 }

--- a/frontend_tests/puppeteer_tests/16-settings.ts
+++ b/frontend_tests/puppeteer_tests/16-settings.ts
@@ -22,7 +22,7 @@ async function open_settings(page: Page): Promise<void> {
     await page.waitForSelector(menu_selector, {visible: true});
     await page.click(menu_selector);
 
-    const settings_selector = 'a[href="#settings"]';
+    const settings_selector = '.dropdown-menu a[href="#settings"]';
     await page.waitForSelector(settings_selector, {visible: true});
     await page.click(settings_selector);
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR changes some fragile selectors (like `a[href=#link]`) to more stable selectors because they are more prone to break from doing something normal like adding another link in the app.

[Link to CZO conversation](https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/Replacing.20fragile.20selectors.20to.20more.20stable.20selectors.2E/near/1146037).


**Testing plan:** <!-- How have you tested? -->
Tested it by running the puppeteer tests with chrome and firefox ✅.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
