### PR TITLE
refactor: Lift out log-out call from individual tests to `common.ts`.

### DIFF
--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -581,6 +581,7 @@ class CommonUtils {
 
         try {
             await test_function(page);
+            await this.log_out(page);
 
             if (page_errored) {
                 throw new Error("Page threw an error");

--- a/frontend_tests/puppeteer_tests/00-realm-creation.ts
+++ b/frontend_tests/puppeteer_tests/00-realm-creation.ts
@@ -68,7 +68,6 @@ async function realm_creation_tests(page: Page): Promise<void> {
 
     // Updating common.realm_url because we are redirecting to it when logging out.
     common.realm_url = page.url();
-    await common.log_out(page);
 }
 
 common.run_test(realm_creation_tests);

--- a/frontend_tests/puppeteer_tests/01-login.ts
+++ b/frontend_tests/puppeteer_tests/01-login.ts
@@ -5,7 +5,6 @@ import common from "../puppeteer_lib/common";
 
 async function login_tests(page: Page): Promise<void> {
     await common.log_in(page, test_credentials.default_user);
-    await common.log_out(page);
 }
 
 common.run_test(login_tests);

--- a/frontend_tests/puppeteer_tests/02-message-basics.ts
+++ b/frontend_tests/puppeteer_tests/02-message-basics.ts
@@ -458,8 +458,6 @@ async function message_basic_tests(page: Page): Promise<void> {
     await test_narrow_by_clicking_the_left_sidebar(page);
     await test_stream_search_filters_stream_list(page);
     await test_users_search(page);
-
-    await common.log_out(page);
 }
 
 common.run_test(message_basic_tests);

--- a/frontend_tests/puppeteer_tests/03-compose.ts
+++ b/frontend_tests/puppeteer_tests/03-compose.ts
@@ -227,7 +227,6 @@ async function compose_tests(page: Page): Promise<void> {
     await test_narrow_to_private_messages_with_cordelia(page);
     await test_send_multirecipient_pm_from_cordelia_pm_narrow(page);
     await test_markdown_preview(page);
-    await common.log_out(page);
 }
 
 common.run_test(compose_tests);

--- a/frontend_tests/puppeteer_tests/04-subscriptions.ts
+++ b/frontend_tests/puppeteer_tests/04-subscriptions.ts
@@ -255,7 +255,6 @@ async function subscriptions_tests(page: Page): Promise<void> {
     await test_subscription_button_verona_stream(page);
     await test_stream_creation(page);
     await test_streams_search_feature(page);
-    await common.log_out(page);
 }
 
 common.run_test(subscriptions_tests);

--- a/frontend_tests/puppeteer_tests/05-stars.ts
+++ b/frontend_tests/puppeteer_tests/05-stars.ts
@@ -64,7 +64,6 @@ async function stars_test(page: Page): Promise<void> {
 
     await toggle_test_star_message(page);
     assert.strictEqual(await stars_count(page), 0, "Message was not unstarred correctly.");
-    await common.log_out(page);
 }
 
 common.run_test(stars_test);

--- a/frontend_tests/puppeteer_tests/06-edit.ts
+++ b/frontend_tests/puppeteer_tests/06-edit.ts
@@ -80,7 +80,6 @@ async function edit_tests(page: Page): Promise<void> {
     await test_stream_message_edit(page);
     await test_edit_message_with_slash_me(page);
     await test_edit_private_message(page);
-    await common.log_out(page);
 }
 
 common.run_test(edit_tests);

--- a/frontend_tests/puppeteer_tests/07-navigation.ts
+++ b/frontend_tests/puppeteer_tests/07-navigation.ts
@@ -100,8 +100,6 @@ async function navigation_tests(page: Page): Promise<void> {
     await page.waitForXPath(
         '//*[@id="message_view_header"]//*[@class="stream" and normalize-space()="Verona"]',
     );
-
-    await common.log_out(page);
 }
 
 common.run_test(navigation_tests);

--- a/frontend_tests/puppeteer_tests/08-admin.ts
+++ b/frontend_tests/puppeteer_tests/08-admin.ts
@@ -396,7 +396,6 @@ async function admin_test(page: Page): Promise<void> {
     }
     await test_default_streams(page);
     await test_authentication_methods(page);
-    await common.log_out(page);
 }
 
 common.run_test(admin_test);

--- a/frontend_tests/puppeteer_tests/09-mention.ts
+++ b/frontend_tests/puppeteer_tests/09-mention.ts
@@ -37,7 +37,6 @@ async function test_mention(page: Page): Promise<void> {
     await page.waitForSelector("#compose-send-status", {hidden: true});
 
     await common.check_messages_sent(page, "zhome", [["Verona > Test mention all", ["@all"]]]);
-    await common.log_out(page);
 }
 
 common.run_test(test_mention);

--- a/frontend_tests/puppeteer_tests/10-custom-profile.ts
+++ b/frontend_tests/puppeteer_tests/10-custom-profile.ts
@@ -67,8 +67,6 @@ async function test_custom_profile(page: Page): Promise<void> {
     await test_add_new_profile_field(page);
     await test_edit_profile_field(page);
     await test_delete_custom_profile_field(page);
-
-    await common.log_out(page);
 }
 
 common.run_test(test_custom_profile);

--- a/frontend_tests/puppeteer_tests/11-user-deactivation.ts
+++ b/frontend_tests/puppeteer_tests/11-user-deactivation.ts
@@ -94,7 +94,6 @@ async function user_deactivation_test(page: Page): Promise<void> {
     await test_reactivate_user(page);
     await test_deactivated_users_section(page);
     await test_bot_deactivation_and_reactivation(page);
-    await common.log_out(page);
 }
 
 common.run_test(user_deactivation_test);

--- a/frontend_tests/puppeteer_tests/12-drafts.ts
+++ b/frontend_tests/puppeteer_tests/12-drafts.ts
@@ -277,7 +277,6 @@ async function drafts_test(page: Page): Promise<void> {
     await test_delete_draft(page);
     await test_save_draft_by_reloading(page);
     await test_delete_draft_on_sending(page);
-    await common.log_out(page);
 }
 
 common.run_test(drafts_test);

--- a/frontend_tests/puppeteer_tests/13-delete-message.ts
+++ b/frontend_tests/puppeteer_tests/13-delete-message.ts
@@ -35,7 +35,6 @@ async function delete_message_test(page: Page): Promise<void> {
     await page.waitForSelector("#do_delete_message_spinner .loading_indicator_spinner", {
         hidden: true,
     });
-    await common.log_out(page);
 }
 
 common.run_test(delete_message_test);

--- a/frontend_tests/puppeteer_tests/14-copy-and-paste.ts
+++ b/frontend_tests/puppeteer_tests/14-copy-and-paste.ts
@@ -160,7 +160,6 @@ async function copy_paste_test(page: Page): Promise<void> {
     await test_copying_last_from_prev_all_from_next(page);
     await test_copying_all_from_prev_first_from_next(page);
     await test_copying_messages_from_several_topics(page);
-    await common.log_out(page);
 }
 
 common.run_test(copy_paste_test);

--- a/frontend_tests/puppeteer_tests/15-realm-linkifier.ts
+++ b/frontend_tests/puppeteer_tests/15-realm-linkifier.ts
@@ -62,8 +62,6 @@ async function linkifier_test(page: Page): Promise<void> {
     await test_add_linkifier(page);
     await test_delete_linkifier(page);
     await test_invalid_linkifier_pattern(page);
-
-    await common.log_out(page);
 }
 
 common.run_test(linkifier_test);

--- a/frontend_tests/puppeteer_tests/16-settings.ts
+++ b/frontend_tests/puppeteer_tests/16-settings.ts
@@ -362,7 +362,6 @@ async function settings_tests(page: Page): Promise<void> {
     await test_your_bots_section(page);
     await test_default_language_setting(page);
     await test_notifications_section(page);
-    await common.log_out(page);
 }
 
 common.run_test(settings_tests);


### PR DESCRIPTION
We recently added the commit to add the log-out call
after each test (52706908b).

This PR cleans that approach by using
just one log-out call after the test is executed at
`common.ts`

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested it by running puppeteer tests in chrome and firefox ✅.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
