### PR TITLE
password_change: Avoid unnecessary redirect to the login page.

### DIFF
--- a/static/js/setup.js
+++ b/static/js/setup.js
@@ -7,9 +7,13 @@ import * as util from "./util";
 
 // Miscellaneous early setup.
 export let password_change_in_progress = false;
+export let last_password_change_start_time = null;
 
 export function set_password_change_in_progress(value) {
     password_change_in_progress = value;
+    if (value) {
+        last_password_change_start_time = new Date();
+    }
 }
 
 $(() => {
@@ -42,9 +46,21 @@ $(() => {
         return this.outerWidth(...args) || 0;
     };
 
+    // Attach the time when the request was initiated to its XHR
+    // object.  This allows us to detect race situations where a
+    // password change completed before we got a response that failed
+    // due to the ongoing password change.
+    $(document).ajaxSend((event, xhr) => {
+        xhr.initiatedTime = new Date();
+    });
+
     // For some reason, jQuery wants this to be attached to an element.
     $(document).ajaxError((event, xhr) => {
-        if (password_change_in_progress) {
+        if (
+            password_change_in_progress ||
+            (last_password_change_start_time &&
+                xhr.initiatedTime <= last_password_change_start_time)
+        ) {
             // The backend for handling password change API requests
             // will replace the user's session; this results in a
             // brief race where any API request will fail with a 401


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds on to 9884226f, which was added to
handle a rare race condition that occurs when the
session hash is not updated by the backend during the
password change process.

It handles a situation where the request was initiated
before/during the password change event and
completed after it was completed. Hence, forcing the
page to redirect to the login page.



**Testing plan:** <!-- How have you tested? -->
Tested it by running node tests and puppeteer tests in chrome and firefox. ✅ 

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
