### PR TITLE
streams: Use "archive stream" phrasing instead of "delete stream".

### DIFF
--- a/docs/production/security-model.md
+++ b/docs/production/security-model.md
@@ -139,7 +139,7 @@ strength allowed is controlled by two settings in
   and bots.
 
 * Owners and administrators have the ability to deactivate and
-  reactivate other human and bot users, delete streams, add/remove
+  reactivate other human and bot users, archive streams, add/remove
   administrator privileges, as well as change configuration for the
   organization.
 

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -418,7 +418,7 @@ test("delete_sub", () => {
     assert(!stream_data.get_sub("Canada"));
     assert(!stream_data.get_sub_by_id(canada.stream_id));
 
-    blueslip.expect("warn", "Failed to delete stream 99999");
+    blueslip.expect("warn", "Failed to archive stream 99999");
     stream_data.delete_sub(99999);
 });
 

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -356,7 +356,7 @@ export function slug_to_name(slug) {
 export function delete_sub(stream_id) {
     const sub = subs_by_stream_id.get(stream_id);
     if (!sub) {
-        blueslip.warn("Failed to delete stream " + stream_id);
+        blueslip.warn("Failed to archive stream " + stream_id);
         return;
     }
     subs_by_stream_id.delete(stream_id);

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -688,7 +688,7 @@ export function change_stream_description(e) {
     });
 }
 
-export function delete_stream(stream_id, alert_element, stream_row) {
+export function archive_stream(stream_id, alert_element, stream_row) {
     channel.del({
         url: "/json/streams/" + stream_id,
         error(xhr) {
@@ -874,7 +874,7 @@ export function initialize() {
             return;
         }
         const row = $(".stream-row.active");
-        delete_stream(stream_id, $(".stream_change_property_info"), row);
+        archive_stream(stream_id, $(".stream_change_property_info"), row);
     });
 
     $("#subscriptions_table").on("click", ".stream-row", function (e) {

--- a/static/templates/settings/deactivation_stream_modal.hbs
+++ b/static/templates/settings/deactivation_stream_modal.hbs
@@ -1,13 +1,13 @@
 <div id="deactivation_stream_modal" class="modal modal-bg hide fade new-style" tabindex="-1" role="dialog" aria-labelledby="deactivation_stream_modal_label" aria-hidden="true">
     <div class="modal-header">
         <button type="button" class="close close-modal-btn" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-        <h3 id="deactivation_stream_modal_label">{{t "Delete stream" }} <span class="stream_name">{{stream_name}}</span></h3>
+        <h3 id="deactivation_stream_modal_label">{{t "Archive stream" }} <span class="stream_name">{{stream_name}}</span></h3>
     </div>
     <div class="modal-body">
-        <p>{{t "Deleting this stream will immediately unsubscribe everyone, and the stream's content will not be recoverable." }} <strong>{{t "Are you sure you want to do this?" }}</strong></p>
+        <p>{{t "Archiving this stream will immediately unsubscribe everyone, and the stream's content will not be recoverable." }} <strong>{{t "Are you sure you want to do this?" }}</strong></p>
     </div>
     <div class="modal-footer">
         <button class="button rounded close-modal-btn" data-dismiss="modal">{{t "Cancel" }}</button>
-        <button class="button rounded btn-danger" id="do_deactivate_stream_button" data-stream-id="{{stream_id}}">{{t "Yes, delete this stream" }}</button>
+        <button class="button rounded btn-danger" id="do_deactivate_stream_button" data-stream-id="{{stream_id}}">{{t "Yes, archive this stream" }}</button>
     </div>
 </div>

--- a/static/templates/settings/deactivation_stream_modal.hbs
+++ b/static/templates/settings/deactivation_stream_modal.hbs
@@ -4,7 +4,7 @@
         <h3 id="deactivation_stream_modal_label">{{t "Archive stream" }} <span class="stream_name">{{stream_name}}</span></h3>
     </div>
     <div class="modal-body">
-        <p>{{t "Archiving this stream will immediately unsubscribe everyone, and the stream's content will not be recoverable." }} <strong>{{t "Are you sure you want to do this?" }}</strong></p>
+        <p>{{t "Archiving this stream will immediately unsubscribe everyone, and this action cannot be undone." }} <strong>{{t "Are you sure you want to do this?" }}</strong></p>
     </div>
     <div class="modal-footer">
         <button class="button rounded close-modal-btn" data-dismiss="modal">{{t "Cancel" }}</button>

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -16,7 +16,7 @@
             </div>
             <div class="button-group">
                 {{#if is_realm_admin}}
-                <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Delete stream'}}"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
+                <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Archive stream'}}"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
                 {{/if}}
                 <div class="sub_unsub_button_wrapper inline-block">
                     <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}}title="{{t 'Toggle subscription'}} (S)" {{else}}disabled="disabled"{{/if}}>

--- a/templates/zerver/api/archive-stream.md
+++ b/templates/zerver/api/archive-stream.md
@@ -1,4 +1,4 @@
-# Delete a stream
+# Archive a stream
 
 {generate_api_description(/streams/{stream_id}:delete)}
 

--- a/templates/zerver/help/archive-a-stream.md
+++ b/templates/zerver/help/archive-a-stream.md
@@ -28,7 +28,8 @@ than archiving them.
 {end_tabs}
 
 !!! warn ""
-    Archiving a stream is irreversible.
+    Archiving a stream is currently irreversible, but we plan to add support
+    for unarchiving streams in the future.
 
 ## Related articles
 

--- a/templates/zerver/help/archive-a-stream.md
+++ b/templates/zerver/help/archive-a-stream.md
@@ -1,19 +1,19 @@
-# Delete a stream
+# Archive a stream
 
 {!admin-only.md!}
 
-Deleting a stream will immediately unsubscribe all users from the stream,
+Archiving a stream will immediately unsubscribe all users from the stream,
 remove the stream from search and other typeaheads, and remove the stream's
 messages from **All messages**.
 
-Deleting a stream does not delete a stream's messages. Users will still be
+Archiving a stream does not delete a stream's messages. Users will still be
 able to find any given message by searching for it. However, links to
 messages and topics in the stream may or may not continue to work.
 
 In most cases, we recommend [renaming streams](/help/rename-a-stream) rather
-than deleting them.
+than archiving them.
 
-### Delete a stream
+### Archive a stream
 
 {start_tabs}
 
@@ -21,14 +21,14 @@ than deleting them.
 
 1. Select a stream.
 
-1. On the right, click **Delete**.
+1. On the right, click **Archive**.
 
-1. Click **Yes, delete this stream**.
+1. Click **Yes, archive this stream**.
 
 {end_tabs}
 
 !!! warn ""
-    Deleting a stream is irreversible.
+    Archiving a stream is irreversible.
 
 ## Related articles
 

--- a/templates/zerver/help/delete-a-topic.md
+++ b/templates/zerver/help/delete-a-topic.md
@@ -16,7 +16,7 @@ better idea, or just leaving the topic as is. Deleting a topic can confuse
 users who come to the topic later via an email notification.
 
 Note that deleting a topic also deletes every message with that topic,
-whereas [deleting a stream](/help/delete-a-stream) does not.
+whereas [archiving a stream](/help/archive-a-stream) does not.
 
 ### Delete a topic
 
@@ -39,5 +39,5 @@ attribute of messages in Zulip.
 ## Related articles
 
 * [Edit or delete a message](/help/edit-or-delete-a-message)
-* [Delete a stream](/help/delete-a-stream)
+* [Archive a stream](/help/archive-a-stream)
 * [Message retention policy](/help/message-retention-policy)

--- a/templates/zerver/help/edit-or-delete-a-message.md
+++ b/templates/zerver/help/edit-or-delete-a-message.md
@@ -92,6 +92,6 @@ permissions to delete that message.
 ## Related articles
 
 * [Delete a topic](/help/delete-a-topic)
-* [Delete a stream](/help/delete-a-stream)
+* [Archive a stream](/help/archive-a-stream)
 * [Message retention policy](/help/message-retention-policy)
 * [Configure editing and deletion policies](/help/configure-message-editing-and-deletion)

--- a/templates/zerver/help/include/rest-endpoints.md
+++ b/templates/zerver/help/include/rest-endpoints.md
@@ -26,7 +26,7 @@
 * [Get stream ID](/api/get-stream-id)
 * [Create a stream](/api/create-stream)
 * [Update a stream](/api/update-stream)
-* [Delete a stream](/api/delete-stream)
+* [Archive a stream](/api/archive-stream)
 * [Get topics in a stream](/api/get-stream-topics)
 * [Topic muting](/api/mute-topic)
 

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -157,7 +157,7 @@
 
 ## Stream management
 * [Stream permissions](/help/stream-permissions)
-* [Delete or archive a stream](/help/delete-a-stream)
+* [Delete or archive a stream](/help/archive-a-stream)
 * [Delete a topic](/help/delete-a-topic)
 * [Set default streams for new users](/help/set-default-streams-for-new-users)
 * [Rename a stream](/help/rename-a-stream)

--- a/templates/zerver/help/message-retention-policy.md
+++ b/templates/zerver/help/message-retention-policy.md
@@ -69,4 +69,4 @@ more details on precisely how message deletion works in Zulip.
 
 * [Edit or delete a message](/help/edit-or-delete-a-message)
 * [Delete a topic](/help/delete-a-topic)
-* [Delete a stream](/help/delete-a-stream)
+* [Archive a stream](/help/archive-a-stream)

--- a/templates/zerver/help/moderating-open-organizations.md
+++ b/templates/zerver/help/moderating-open-organizations.md
@@ -33,7 +33,7 @@ Zulip has many features designed to simplify moderation:
   bad faith. You can reactivate them later if they repent.
 * Use the `streams:public sender:user@example.com`
   [search operators](/help/search-for-messages) to find all messages sent by a user.
-* Delete messages, [delete streams](/help/delete-a-stream), and
+* Delete messages, [archive streams](/help/archive-a-stream), and
   [unsubscribe users from streams](/help/add-or-remove-users-from-a-stream).
 * [Rename topics](/help/rename-a-topic).
 * [Change users' names](/help/change-a-users-name) (e.g. to "Spammer")

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -496,6 +496,8 @@ def write_instrumentation_reports(full_suite: bool, include_webhooks: bool) -> N
             "confirmation_key/",
             "node-coverage/(?P<path>.+)",
             "docs/(?P<path>.+)",
+            "help/delete-a-stream",
+            "api/delete-stream",
             "casper/(?P<path>.+)",
             "static/(?P<path>.+)",
             "flush_caches",

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -424,19 +424,19 @@ def get_stream_id(client: Client) -> int:
 
 
 @openapi_test_function("/streams/{stream_id}:delete")
-def delete_stream(client: Client, stream_id: int) -> None:
+def archive_stream(client: Client, stream_id: int) -> None:
     result = client.add_subscriptions(
         streams=[
             {
-                "name": "stream to be deleted",
+                "name": "stream to be archived",
                 "description": "New stream for testing",
             },
         ],
     )
 
     # {code_example|start}
-    # Delete the stream named 'stream to be deleted'
-    stream_id = client.get_stream_id("stream to be deleted")["stream_id"]
+    # Archive the stream named 'stream to be archived'
+    stream_id = client.get_stream_id("stream to be archived")["stream_id"]
     result = client.delete_stream(stream_id)
     # {code_example|end}
     validate_against_openapi_schema(result, "/streams/{stream_id}", "delete", "200")
@@ -1368,7 +1368,7 @@ def test_streams(client: Client, nonadmin_client: Client) -> None:
     update_subscription_settings(client)
     update_notification_settings(client)
     get_stream_topics(client, 1)
-    delete_stream(client, stream_id)
+    archive_stream(client, stream_id)
 
     test_user_not_authorized_error(nonadmin_client)
     test_authorization_errors_fatal(client, nonadmin_client)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8810,10 +8810,10 @@ paths:
                       }
   /streams/{stream_id}:
     delete:
-      operationId: delete_stream
+      operationId: archive_stream
       tags: ["streams"]
       description: |
-        [Delete the stream](/help/delete-a-stream) with the ID `stream_id`.
+        [Archive the stream](/help/archive-a-stream) with the ID `stream_id`.
 
         `DELETE {{ api_url }}/v1/streams/{stream_id}`
       parameters:

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1305,17 +1305,17 @@ class StreamAdminTest(ZulipTestCase):
         self.assertEqual(result[1][2].name, "new_stream3")
         self.assertEqual(result[1][2].message_retention_days, None)
 
-    def set_up_stream_for_deletion(
+    def set_up_stream_for_archiving(
         self, stream_name: str, invite_only: bool = False, subscribed: bool = True
     ) -> Stream:
         """
-        Create a stream for deletion by an administrator.
+        Create a stream for archiving by an administrator.
         """
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
         stream = self.make_stream(stream_name, invite_only=invite_only)
 
-        # For testing deleting streams you aren't on.
+        # For testing archiving streams you aren't on.
         if subscribed:
             self.subscribe(user_profile, stream_name)
 
@@ -1323,9 +1323,9 @@ class StreamAdminTest(ZulipTestCase):
 
         return stream
 
-    def delete_stream(self, stream: Stream) -> None:
+    def archive_stream(self, stream: Stream) -> None:
         """
-        Delete the stream and assess the result.
+        Archive the stream and assess the result.
         """
         active_name = stream.name
         realm = stream.realm
@@ -1402,28 +1402,28 @@ class StreamAdminTest(ZulipTestCase):
         When an administrator deletes a public stream, that stream is not
         visible to users at all anymore.
         """
-        stream = self.set_up_stream_for_deletion("newstream")
-        self.delete_stream(stream)
+        stream = self.set_up_stream_for_archiving("newstream")
+        self.archive_stream(stream)
 
     def test_delete_private_stream(self) -> None:
         """
         Administrators can delete private streams they are on.
         """
-        stream = self.set_up_stream_for_deletion("newstream", invite_only=True)
-        self.delete_stream(stream)
+        stream = self.set_up_stream_for_archiving("newstream", invite_only=True)
+        self.archive_stream(stream)
 
-    def test_delete_streams_youre_not_on(self) -> None:
+    def test_archive_streams_youre_not_on(self) -> None:
         """
         Administrators can delete public streams they aren't on, including
         private streams in their realm.
         """
-        pub_stream = self.set_up_stream_for_deletion("pubstream", subscribed=False)
-        self.delete_stream(pub_stream)
+        pub_stream = self.set_up_stream_for_archiving("pubstream", subscribed=False)
+        self.archive_stream(pub_stream)
 
-        priv_stream = self.set_up_stream_for_deletion(
+        priv_stream = self.set_up_stream_for_archiving(
             "privstream", subscribed=False, invite_only=True
         )
-        self.delete_stream(priv_stream)
+        self.archive_stream(priv_stream)
 
     def attempt_unsubscribe_of_principal(
         self,
@@ -4369,7 +4369,7 @@ class SubscriptionAPITest(ZulipTestCase):
             self.subscribe(non_admin_user, stream_name)
             self.subscribe(self.example_user("othello"), stream_name)
 
-        def delete_stream(stream_name: str) -> None:
+        def archive_stream(stream_name: str) -> None:
             stream_id = get_stream(stream_name, realm).id
             result = self.client_delete(f"/json/streams/{stream_id}")
             self.assert_json_success(result)
@@ -4379,7 +4379,7 @@ class SubscriptionAPITest(ZulipTestCase):
         non_admin_before_delete = gather_subscriptions_helper(non_admin_user)
 
         # Delete our stream
-        delete_stream("stream1")
+        archive_stream("stream1")
 
         # Get subs after delete
         admin_after_delete = gather_subscriptions_helper(admin_user)

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -764,6 +764,11 @@ api_documentation_view = MarkdownDirectoryView.as_view(
     template_name="zerver/documentation_main.html", path_template="/zerver/api/%s.md"
 )
 urls += [
+    # Redirects due to us having moved the docs:
+    path(
+        "help/delete-a-stream", RedirectView.as_view(url="/help/archive-a-stream", permanent=True)
+    ),
+    path("api/delete-stream", RedirectView.as_view(url="/api/archive-stream", permanent=True)),
     path("help/", help_documentation_view),
     path("help/<path:article>", help_documentation_view),
     path("api/", api_documentation_view),


### PR DESCRIPTION
The previous phrasing was misleading in relation to what the action
actually does.

Discussed in https://chat.zulip.org/#narrow/stream/9-issues/topic/.2316971.20starred.20messages.20view and https://chat.zulip.org/#narrow/stream/2-general/topic/topics.20don't.20get.20deleted.20if.20you.20delete.20all.20messages.20in.20topic/near/1138690 Fixing this phrasing will probably also let us close #16971