### PR TITLE
populate_db : Add non-ASCII and non-BMP characters to usernames and stream names.

### DIFF
--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -425,14 +425,32 @@ class Command(BaseCommand):
                     "Towns",
                     "Wall",
                 ]
+                non_ascii_names = [
+                    "Günter",
+                    "أحمد",
+                    "Magnús",
+                    "आशी",
+                    "イツキ",
+                    "语嫣",
+                    "அருண்",
+                    "Александр",
+                    "José",
+                ]
+                # to imitate emoji insertions in usernames
+                raw_emojis = ["😎", "😂", "🐱‍👤"]
 
             for i in range(num_boring_names, num_names):
                 fname = random.choice(fnames) + str(i)
                 full_name = fname
                 if random.random() < 0.7:
-                    if random.random() < 0.5:
+                    if random.random() < 0.3:
+                        full_name += " " + random.choice(non_ascii_names)
+                    else:
                         full_name += " " + random.choice(mnames)
-                    full_name += " " + random.choice(lnames)
+                    if random.random() < 0.1:
+                        full_name += " {} ".format(random.choice(raw_emojis))
+                    else:
+                        full_name += " " + random.choice(lnames)
                 email = fname.lower() + "@zulip.com"
                 names.append((full_name, email))
 

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -770,17 +770,44 @@ class Command(BaseCommand):
                     "sales": {"description": "For sales discussion"},
                 }
 
-                # Calculate the maximum number of digits in any extra stream's
-                # number, since a stream with name "Extra Stream 3" could show
-                # up after "Extra Stream 29". (Used later to pad numbers with
-                # 0s).
-                maximum_digits = len(str(options["extra_streams"] - 1))
+                extra_stream_names = [
+                    "802.11a",
+                    "Ad Hoc Network",
+                    "Augmented Reality",
+                    "Cycling",
+                    "DPI",
+                    "FAQ",
+                    "FiFo",
+                    "commits",
+                    "Control panel",
+                    "desktop",
+                    "компьютеры",
+                    "Data security",
+                    "desktop",
+                    "काम",
+                    "discussions",
+                    "Cloud storage",
+                    "GCI",
+                    "Vaporware",
+                    "Recent Trends",
+                    "issues",
+                    "live",
+                    "Health",
+                    "mobile",
+                    "空間",
+                    "provision",
+                    "hidrógeno",
+                    "HR",
+                    "アニメ",
+                ]
 
+                # Add stream names and stream descriptions
                 for i in range(options["extra_streams"]):
-                    # Pad the number with 0s based on `maximum_digits`.
-                    number_str = str(i).zfill(maximum_digits)
+                    extra_stream_name = random.choice(extra_stream_names) + " " + str(i)
 
-                    extra_stream_name = "Extra Stream " + number_str
+                    # to imitate emoji insertions in stream names
+                    if random.random() <= 0.15:
+                        extra_stream_name += random.choice(raw_emojis)
 
                     zulip_stream_dict[extra_stream_name] = {
                         "description": "Auto-generated extra stream.",


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Previously, we had only plain text for our user and stream names
on `populate_db`.  with this PR, `populate_db` will have non-ASCII and
non-BMP characters on both stream names and user names.

Related issue: #14991

**Testing plan:** <!-- How have you tested? -->
 Tested using `./manage.py populate_db --extra-users 400 --extra-streams 30`


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Stream Names: 
![stream_populate_db_streamnames](https://user-images.githubusercontent.com/42570356/113184297-a198ba00-9272-11eb-8dab-fe3bd2881487.JPG)

User Names : 
![stream_populate_db_usernames](https://user-images.githubusercontent.com/42570356/113184314-a5c4d780-9272-11eb-90ae-24c78dc96dd5.JPG)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
