### PR TITLE
Add `dry-run` flag to `send_custom_email` management command

### DIFF
--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -207,6 +207,7 @@ def send_email(
     language: Optional[str] = None,
     context: Dict[str, Any] = {},
     realm: Optional[Realm] = None,
+    dry_run: bool = False,
 ) -> None:
     mail = build_email(
         template_prefix,
@@ -221,6 +222,10 @@ def send_email(
     )
     template = template_prefix.split("/")[-1]
     logger.info("Sending %s email to %s", template, mail.to)
+
+    if dry_run:
+        print(mail.message().get_payload()[0])
+        return
 
     if mail.send() == 0:
         logger.error("Error sending %s email to %s", template, mail.to)
@@ -443,4 +448,8 @@ def send_custom_email(users: List[UserProfile], options: Dict[str, Any]) -> None
                 options.get("from_name"), parsed_email_template.get("from"), "from_name"
             ),
             context=context,
+            dry_run=options["dry_run"],
         )
+
+        if options["dry_run"]:
+            break

--- a/zerver/management/commands/send_custom_email.py
+++ b/zerver/management/commands/send_custom_email.py
@@ -37,6 +37,11 @@ class Command(ZulipBaseCommand):
         parser.add_argument(
             "--admins-only", help="Send only to organization administrators", action="store_true"
         )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Prints emails of the recipients and text of the email.",
+        )
 
         self.add_user_list_args(
             parser,
@@ -60,3 +65,8 @@ class Command(ZulipBaseCommand):
                 raise error
 
         send_custom_email(users, options)
+
+        if options["dry_run"]:
+            print("Following are the recipients of the email")
+            for user in users:
+                print(user.email)

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -38,6 +38,7 @@ class TestCustomEmails(ZulipTestCase):
                 "reply_to": reply_to,
                 "subject": email_subject,
                 "from_name": from_name,
+                "dry_run": False,
             },
         )
         self.assertEqual(len(mail.outbox), 1)
@@ -56,6 +57,7 @@ class TestCustomEmails(ZulipTestCase):
             [hamlet],
             {
                 "markdown_template_path": markdown_template_path,
+                "dry_run": False,
             },
         )
         self.assertEqual(len(mail.outbox), 1)
@@ -79,6 +81,7 @@ class TestCustomEmails(ZulipTestCase):
             {
                 "markdown_template_path": markdown_template_path,
                 "from_name": from_name,
+                "dry_run": False,
             },
         )
 
@@ -89,6 +92,7 @@ class TestCustomEmails(ZulipTestCase):
             {
                 "markdown_template_path": markdown_template_path,
                 "subject": email_subject,
+                "dry_run": False,
             },
         )
 
@@ -109,6 +113,7 @@ class TestCustomEmails(ZulipTestCase):
             {
                 "markdown_template_path": markdown_template_path,
                 "subject": email_subject,
+                "dry_run": False,
             },
         )
 
@@ -119,6 +124,7 @@ class TestCustomEmails(ZulipTestCase):
             {
                 "markdown_template_path": markdown_template_path,
                 "from_name": from_name,
+                "dry_run": False,
             },
         )
 
@@ -136,10 +142,30 @@ class TestCustomEmails(ZulipTestCase):
             {
                 "markdown_template_path": markdown_template_path,
                 "admins_only": True,
+                "dry_run": False,
             },
         )
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn(admin_user.delivery_email, mail.outbox[0].to[0])
+
+    def test_send_custom_email_dry_run(self) -> None:
+        hamlet = self.example_user("hamlet")
+        email_subject = "subject_test"
+        reply_to = "reply_to_test"
+        from_name = "from_name_test"
+        markdown_template_path = "templates/zerver/tests/markdown/test_nested_code_blocks.md"
+        with patch("builtins.print") as _:
+            send_custom_email(
+                [hamlet],
+                {
+                    "markdown_template_path": markdown_template_path,
+                    "reply_to": reply_to,
+                    "subject": email_subject,
+                    "from_name": from_name,
+                    "dry_run": True,
+                },
+            )
+            self.assertEqual(len(mail.outbox), 0)
 
 
 class TestFollowupEmails(ZulipTestCase):

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -569,3 +569,29 @@ class TestExport(ZulipTestCase):
                 call("\033[94mExporting realm\033[0m: zulip"),
             ],
         )
+
+
+class TestSendCustomEmail(ZulipTestCase):
+    COMMAND_NAME = "send_custom_email"
+
+    def test_custom_email_with_dry_run(self) -> None:
+        path = "templates/zerver/tests/markdown/test_nested_code_blocks.md"
+        user = self.example_user("hamlet")
+
+        with patch("builtins.print") as mock_print:
+            call_command(
+                self.COMMAND_NAME,
+                "-r=zulip",
+                f"--path={path}",
+                f"-u={user.delivery_email}",
+                "--subject=Test email",
+                "--from-name=zulip@testserver.com",
+                "--dry-run",
+            )
+            self.assertEqual(
+                mock_print.mock_calls[1:],
+                [
+                    call("Following are the recipients of the email"),
+                    call("user10@zulip.testserver"),
+                ],
+            )


### PR DESCRIPTION
## What is this PR for
The PR aims to solve the issue: https://github.com/zulip/zulip/issues/17767

A `dry-run` flag is added to the `send_custom_email` management command.
When the flag is specified, a list of emails of recipients in printed followed by the `text/plain` version of the email.

Here is a screenshot of a sample output:
![image](https://user-images.githubusercontent.com/53316982/113309100-6d7dd180-9324-11eb-9c49-efaf3fc8e157.png)
