### PR TITLE
support: Fix arguments of timesince for expires_in.

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -1238,8 +1238,9 @@ def get_confirmations(
         else:
             link_status = ""
 
-        if timezone_now() < expiry_date:
-            expires_in = timesince(confirmation.date_sent, expiry_date)
+        now = timezone_now()
+        if now < expiry_date:
+            expires_in = timesince(now, expiry_date)
         else:
             expires_in = "Expired"
 


### PR DESCRIPTION
`expires_in` (remaining time before the invite expires) should
be calculated from the time at present, not from the time when
confirmation link was sent.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
