### PR TITLE
default data: Add non ASCII and non BMP characters to default stream names.

### DIFF
--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -755,9 +755,15 @@ class Command(BaseCommand):
                 # suite fast, don't add these users and subscriptions
                 # when running populate_db for the test suite
 
+                # to imitate emoji insertions in stream names
+                raw_emojis = ["😎", "😂", "🐱‍👤"]
+
                 zulip_stream_dict: Dict[str, Dict[str, Any]] = {
                     "devel": {"description": "For developing"},
-                    "all": {"description": "For **everything**"},
+                    # ビデオゲーム - VideoGames (japanese)
+                    "ビデオゲーム": {
+                        "description": "Share your favorite video games!  {}".format(raw_emojis[2])
+                    },
                     "announce": {
                         "description": "For announcements",
                         "stream_post_policy": Stream.STREAM_POST_POLICY_ADMINS,
@@ -767,7 +773,9 @@ class Command(BaseCommand):
                     "social": {"description": "For socializing"},
                     "test": {"description": "For testing `code`"},
                     "errors": {"description": "For errors"},
-                    "sales": {"description": "For sales discussion"},
+                    # 조리법 - Recipes (Korean) , Пельмени - Dumplings (Russian)
+                    "조리법 "
+                    + raw_emojis[0]: {"description": "Everything cooking, from pasta to Пельмени"},
                 }
 
                 extra_stream_names = [


### PR DESCRIPTION
Added emojis and Non-ASCII characters to default stream names and descriptions.

Related issue: #14991
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
 Tested using `./manage.py populate_db`  , `./tools/run-dev.py`



**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

stream with non ASCII name and non BMP description 
![New stream name 2](https://user-images.githubusercontent.com/42570356/113375508-24159c80-938d-11eb-9796-869f577a448c.JPG)

stream with non ASCII  , non BMP name and non ASCII description
![New stream name 1](https://user-images.githubusercontent.com/42570356/113375523-3263b880-938d-11eb-88da-fade8aa69c8f.JPG)


Updated Streams :
![Updated default stream names](https://user-images.githubusercontent.com/42570356/113327493-a9bb2d00-9338-11eb-9e9e-494d5085a88a.JPG)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
