### PR TITLE
Implement react and update_message for EmbeddedBotHandler

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -316,6 +316,7 @@ EMBEDDED_BOTS: List[EmbeddedBotIntegration] = [
     EmbeddedBotIntegration("virtual_fs", []),
     EmbeddedBotIntegration("giphy", []),
     EmbeddedBotIntegration("followup", []),
+    EmbeddedBotIntegration("incrementor", []),
 ]
 
 WEBHOOK_INTEGRATIONS: List[WebhookIntegration] = [


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#17860

**Testing plan:** <!-- How have you tested? -->
Unit tests were added for testing `react` and `update_message`.

**Side notes**
The implementation for `update_message` is largely the same as that for the equivalent view `update_message_backend` as I extract part of it to reuse the code.

This PR doesn't yet introduce custom exceptions to embedded bot handlers, but it's worth considering to add it in the future as Anders [suggests](https://chat.zulip.org/#narrow/stream/49-development-help/topic/Error.20Handling.20for.20EmbeddedBotHandler/near/1150009).
Currently, the implementation just returns a dictionary object containing the error message to be consistent with `ExternalBotHandler`.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
