### PR TITLE
filter: Return false for invalid filters.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -832,13 +832,13 @@ test("predicate_edge_cases", () => {
     // invalid operator/operand combinations, but right now we just silently
     // return a function that accepts all messages.
     predicate = get_predicate([["in", "bogus"]]);
-    assert(predicate({}));
+    assert(!predicate({}));
 
     predicate = get_predicate([["bogus", 33]]);
     assert(predicate({}));
 
     predicate = get_predicate([["is", "bogus"]]);
-    assert(predicate({}));
+    assert(!predicate({}));
 
     // Exercise caching feature.
     const stream_id = 101;

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -89,7 +89,7 @@ function message_matches_search_term(message, operator, operand) {
             } else if (operand === "unread") {
                 return unread.message_unread(message);
             }
-            return true; // is:whatever returns true
+            return false; // is:whatever returns false
 
         case "in":
             if (operand === "home") {
@@ -97,7 +97,7 @@ function message_matches_search_term(message, operator, operand) {
             } else if (operand === "all") {
                 return true;
             }
-            return true; // in:whatever returns true
+            return false; // in:whatever returns false
 
         case "near":
             // this is all handled server side


### PR DESCRIPTION
For filter values which don't exist or are invalid in some
way, we return false to show user that there are no messages
in the filter user is trying to render. Our previous behaviour
was to show all the messages and ignore the filter which
isn't good.


https://chat.zulip.org/#narrow/stream/9-issues/topic/is.3Ainvalid.20search