### PR TITLE
api-docs: Fix table in update_message_flags to use proper html.

### DIFF
--- a/templates/zerver/api/update-message-flags.md
+++ b/templates/zerver/api/update-message-flags.md
@@ -36,7 +36,7 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
         </thead>
         <tbody>
             <tr>
-                <td>`read`</td>
+                <td><code>read</code></td>
                 <td>
                     Whether the user has read the message.  Messages
                     start out unread (except for messages the user
@@ -45,40 +45,40 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
                 </td>
             </tr>
             <tr>
-                <td>`starred`</td>
-                <td>Whether the user has [starred this message](/help/star-a-message).</td>
+                <td><code>starred</code></td>
+                <td>Whether the user has <a href="/help/star-a-message">starred this message</a>.</td>
             </tr>
             <tr>
-                <td>`collapsed`</td>
-                <td>Whether the user has [collapsed this message](/help/collapse-a-message).</td>
+                <td><code>collapsed</code></td>
+                <td>Whether the user has <a href="/help/collapse-a-message">collapsed this message</a>.</td>
             </tr>
             <tr>
-                <td>`mentioned`</td>
+                <td><code>mentioned</code></td>
                 <td>
-                     Whether the current user [was
-                     mentioned](/help/mention-a-user-or-group) by
-                     this message, either directly or via a user
+                     Whether the current user
+                      <a href="/help/mention-a-user-or-group">was mentioned</a>
+                      by this message, either directly or via a user
                      group.  Not editable.
                 </td>
             </tr>
             <tr>
-                <td>`wildcard_mentioned`</td>
+                <td><code>wildcard_mentioned</code></td>
                 <td>
-                     Whether this message contained [wildcard
-                     mention](/help/mention-a-user-or-group#mention-everyone-on-a-stream)
-                     like @**all**.  Not editable.
+                     Whether this message contained
+                      <a href="/help/mention-a-user-or-group#mention-everyone-on-a-stream">wildcard mention</a>
+                      like @**all**.  Not editable.
                 </td>
             </tr>
             <tr>
-                <td>`has_alert_word`</td>
+                <td><code>has_alert_word</code></td>
                 <td>
-                     Whether the message contains any of the current
-                     user's [configured alert
-                     words](/help/add-an-alert-word).  Not editable.
+                     Whether the message contains any of the current user's
+                      <a href="/help/add-an-alert-word">configured alert words</a>.
+                      Not editable.
                 </td>
             </tr>
             <tr>
-                <td>`historical`</td>
+                <td><code>historical</code></td>
                 <td>
                      True for messages that the user did not receive
                      at the time they were sent but later was added to


### PR DESCRIPTION
The Available flags table in update_message_flags.md was using
markdown for certain content inside HTML, which resulted in the
table not being rendered properly.
This commit fixes the table to use proper HTML for content rendering
instead of markdown, since the table was written in markdown's HTML
syntax.

**Testing plan:** <!-- How have you tested? -->
Tested locally

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
*Before*
<img src="https://user-images.githubusercontent.com/54993043/113354174-64a8f200-935c-11eb-8e39-8c8d6b31a17b.png" width="570" height="400" />

*After*
<img src="https://user-images.githubusercontent.com/54993043/113354189-6b376980-935c-11eb-9fac-3bb0cac869db.png" width="570" height="400" />



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
