### PR TITLE
Change label for "Copy link to conversation" and update documentation.

### DIFF
--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -89,7 +89,7 @@
 
     <li>
         <a href="#" class="copy_link" data-message-id="{{message_id}}" data-clipboard-text="{{ conversation_time_uri }}">
-            <i class="fa fa-link" aria-hidden="true"></i> {{t "Copy link to conversation" }}
+            <i class="fa fa-link" aria-hidden="true"></i> {{t "Copy link to message" }}
         </a>
     </li>
 

--- a/templates/zerver/help/link-to-a-message-or-conversation.md
+++ b/templates/zerver/help/link-to-a-message-or-conversation.md
@@ -4,7 +4,7 @@ Share permanent links to messages, threads, and streams. The Zulip project
 uses this feature extensively to link to Zulip conversations from our
 issue tracker.
 
-## Link to a stream or topic (web only)
+## Link to a stream or topic
 
 {start_tabs}
 
@@ -16,7 +16,7 @@ issue tracker.
 
 !!! warn ""
     This works for all views, including searches.
-    All URLs in Zulip are permalinks.
+    All URLs in Zulip are designed to be shareable.
 
 ## Link to a specific message
 
@@ -24,9 +24,11 @@ issue tracker.
 
 {!message-actions-menu.md!}
 
-1. Click **Link to conversation**.
+1. Click **Copy link to message**.
 
 {end_tabs}
 
-The copied link will take you to the topic of the relevant message, scrolled
-down to that message.
+This will copy to your clipboard a permanent link to the message,
+displayed in its thread (i.e. topic view for messages in a stream).
+
+Viewing a thread via a message link will never mark messages as read.

--- a/templates/zerver/help/link-to-a-message-or-conversation.md
+++ b/templates/zerver/help/link-to-a-message-or-conversation.md
@@ -1,8 +1,8 @@
 # Link to a message or conversation
 
-Share permanent links to messages, threads, and streams. The Zulip project
-uses this feature extensively to link to Zulip conversations from our
-issue tracker.
+Share permanent links to messages, threads, and streams.  With Zulip,
+it's easy to to link to specific (parts of) conversations from issue
+trackers, documentation, or other external tools.
 
 ## Link to a stream or topic
 
@@ -32,3 +32,6 @@ This will copy to your clipboard a permanent link to the message,
 displayed in its thread (i.e. topic view for messages in a stream).
 
 Viewing a thread via a message link will never mark messages as read.
+
+Zulip uses the same permanent link syntax when [quoting a
+message](/help/quote-and-reply).

--- a/templates/zerver/help/quote-and-reply.md
+++ b/templates/zerver/help/quote-and-reply.md
@@ -1,12 +1,7 @@
 # Quote and reply
 
-You can quote a previous message in your reply.
-
-Note that quote and reply automatically turns mentions in the quoted
-text into
-[silent mentions](/help/mention-a-user-or-group#silently-mention-a-user).
-
-### Quote and reply
+You can quote a previous message, either replying within a topic or to
+start a new topic.
 
 {start_tabs}
 
@@ -14,7 +9,23 @@ text into
 
 1. Click **Quote and reply**.
 
+1. (optional) Delete paragraphs not relevant to your reply, just like
+   when replying to a multi-paragraph email.
+
+1. Send your message.
+
 {end_tabs}
 
-You can also use the keyboard shortcut `>` to quote the message under the
-blue box.
+You can also use the keyboard shortcut `>` to initiate quote-and-reply.
+
+## Related articles
+
+* The first line of the reply contains a [permanent
+  link](/help/link-to-a-message-or-conversation) to the quoted
+  message.
+* Zulip automatically turns mentions in quoted text into [silent
+  mentions](/help/mention-a-user-or-group#silently-mention-a-user) to
+  avoid unnecessarily mentioning someone twice.
+* You can use [quote
+  blocks](/help/format-your-message-using-markdown#quotes) when
+  quoting emails or other non-Zulip content.

--- a/templates/zerver/help/search-for-messages.md
+++ b/templates/zerver/help/search-for-messages.md
@@ -87,4 +87,3 @@ class="emoji-small"/>.
 Note that Zulip ignores common words like `a`, `the`, and about 100
 others. A quirk in Zulip's current implementation means that if all of your
 keywords are ignored, we'll return 0 search results.
-


### PR DESCRIPTION
Background for change is here: https://chat.zulip.org/#narrow/stream/137-feedback/topic/link.20to.20conversation/near/1150024

I also did some related improvements to the documentation, after noticing that we had a previous iteration of this label in the /help/ article, and generally the adjacent articles weren't very high quality.