### PR TITLE
buddy_list: Show `(you)` in the tooltip.

### DIFF
--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -347,13 +347,16 @@ test("title_data", () => {
         first_line: "Human Myself",
         second_line: "out to lunch",
         third_line: "translated: Active now",
+        show_you: true,
     };
+    page_params.user_id = me.user_id;
     assert.deepEqual(buddy_data.get_title_data(me.user_id, is_group), expected_data);
 
     expected_data = {
         first_line: "Old User",
         second_line: "translated: Last active: translated: More than 2 weeks ago",
         third_line: "",
+        show_you: false,
     };
     assert.deepEqual(buddy_data.get_title_data(old_user.user_id, is_group), expected_data);
 });

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -250,6 +250,7 @@ export function get_title_data(user_ids_string, is_group) {
     // a single, human, user.
     const active_status = presence.get_status(user_id);
     const last_seen = user_last_seen_time_status(user_id);
+    const is_my_user = people.is_my_user_id(user_id);
 
     // Users has a status.
     if (user_status.get_status_text(user_id)) {
@@ -257,6 +258,7 @@ export function get_title_data(user_ids_string, is_group) {
             first_line: person.full_name,
             second_line: user_status.get_status_text(user_id),
             third_line: get_last_seen(active_status, last_seen),
+            show_you: is_my_user,
         };
     }
 
@@ -265,6 +267,7 @@ export function get_title_data(user_ids_string, is_group) {
         first_line: person.full_name,
         second_line: get_last_seen(active_status, last_seen),
         third_line: "",
+        show_you: is_my_user,
     };
 }
 

--- a/static/templates/buddy_list_tooltip_content.hbs
+++ b/static/templates/buddy_list_tooltip_content.hbs
@@ -1,5 +1,9 @@
 <div class="buddy_list_tooltip_content">
-    <span class="tooltip_inner_content">{{first_line}}</span>
+    <span class="tooltip_inner_content">{{first_line}}
+        {{#if show_you}}
+        <span class="my_user_status">{{t "(you)" }}</span>
+        {{/if}}
+    </span>
     {{#if second_line}}
     <br><span class="tooltip_inner_content">{{second_line}}</span>
     {{/if}}


### PR DESCRIPTION
When the user's full name is greater than 22 characters,
the full name + `(you)` in the buddy list starts to
truncate, but when hover, the tooltip displays the full name
but not `(you)`.

This PR fixes this by adding `(you)` in the tooltip.

[Link to CZO conversation](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Buddy.20list.20.60.28you.29.60overflow/near/1150958)
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested it by running node tests.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
|Before | After
|---|---
| ![Screenshot 2021-04-02 at 5 42 02 PM](https://user-images.githubusercontent.com/63820270/113414527-d4f65880-93da-11eb-98b8-16a124678566.png) |  ![Screenshot 2021-04-02 at 3 20 34 PM](https://user-images.githubusercontent.com/63820270/113414546-dcb5fd00-93da-11eb-9f91-94962a73ef29.png)
| ![Screenshot 2021-04-02 at 5 42 23 PM](https://user-images.githubusercontent.com/63820270/113414620-066f2400-93db-11eb-8f41-acddccfe6561.png) | ![Screenshot 2021-04-02 at 3 43 20 PM](https://user-images.githubusercontent.com/63820270/113414632-0c650500-93db-11eb-928f-b2c1ff69abbc.png)





<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
