### PR TITLE
Debian bullseye support

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -127,6 +127,11 @@ jobs:
             is_buster: true
             os: buster
 
+          - docker_image: zulip/ci:bullseye
+            name: Bullseye production install
+            is_bullseye: true
+            os: bullseye
+
     name: ${{ matrix.name  }}
     container: ${{ matrix.docker_image }}
     runs-on: ubuntu-latest

--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -34,6 +34,15 @@ jobs:
             is_focal: true
             include_frontend_tests: false
 
+          # This docker image was created by a generated Dockerfile at:
+          #   tools/ci/images/focal/Dockerfile
+          # Bullseye ships with Python 3.9.2.
+          - docker_image: zulip/ci:bullseye
+            name: Debian 11 Bullseye (Python 3.9, backend)
+            os: bullseye
+            is_bullseye: true
+            include_frontend_tests: false
+
     runs-on: ubuntu-latest
     name: ${{ matrix.name }}
     container: ${{ matrix.docker_image }}
@@ -231,7 +240,7 @@ jobs:
           retention-days: 60
 
       - name: Check development database build
-        if: ${{ matrix.is_focal }}
+        if: ${{ matrix.is_focal || matrix.is_bullseye }}
         run: ./tools/ci/setup-backend
 
       - name: Report status

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -14,7 +14,7 @@ If you'd like to install a Zulip development environment on a computer
 that's running one of:
 
 * Ubuntu 20.04 Focal, 18.04 Bionic
-* Debian 10 Buster
+* Debian 10 Buster, 11 Bullseye (beta)
 * CentOS 7 (beta)
 * Fedora 33 (beta)
 * RHEL 7 (beta)

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -49,7 +49,7 @@ a proxy to access the internet.)
 - **All**: 2GB available RAM, Active broadband internet connection, [GitHub account][set-up-git].
 - **macOS**: macOS (10.11 El Capitan or newer recommended)
 - **Ubuntu LTS**: 20.04 or 18.04
-  - or **Debian**: 10 "buster"
+  - or **Debian**: 10 "buster" or 11 "bullseye"
 - **Windows**: Windows 64-bit (Win 10 recommended), hardware
   virtualization enabled (VT-x or AMD-V), administrator access.
 

--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -23,6 +23,7 @@ class zulip::profile::base {
         /^8\.[0-9]*$/  => 'jessie',
         /^9\.[0-9]*$/  => 'stretch',
         /^10\.[0-9]*$/ => 'buster',
+        /^11\.[0-9]*$/ => 'bullseye',
         # Ubuntu releases
         '12.04' => 'precise',
         '14.04' => 'trusty',

--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -24,6 +24,8 @@ class zulip::profile::base {
         /^9\.[0-9]*$/  => 'stretch',
         /^10\.[0-9]*$/ => 'buster',
         /^11\.[0-9]*$/ => 'bullseye',
+        # This next line is temporary until bullseye releases.
+        /bullseye\/sid/ => 'bullseye',
         # Ubuntu releases
         '12.04' => 'precise',
         '14.04' => 'trusty',

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -196,7 +196,7 @@ if [ -f /etc/os-release ]; then
 fi
 
 case "$os_id$os_version_id" in
-    debian10 | ubuntu18.04 | ubuntu20.04) ;;
+    debian10 | debian11 | ubuntu18.04 | ubuntu20.04) ;;
     *)
         set +x
         cat <<EOF
@@ -204,6 +204,7 @@ case "$os_id$os_version_id" in
 Unsupported OS release: $os_id $os_version_id
 
 Zulip in production is supported only on:
+ - Debian 11 "bullseye" (beta)
  - Debian 10 "buster"
  - Ubuntu 18.04 LTS "bionic"
  - Ubuntu 20.04 LTS "focal"

--- a/scripts/lib/setup-apt-repo
+++ b/scripts/lib/setup-apt-repo
@@ -67,7 +67,7 @@ deb-src http://apt.postgresql.org/pub/repos/apt/ $release-pgdg main
 deb http://ppa.launchpad.net/groonga/ppa/ubuntu $release main
 deb-src http://ppa.launchpad.net/groonga/ppa/ubuntu $release main
 EOF
-elif [[ "$release" =~ ^(buster)$ ]]; then
+elif [[ "$release" =~ ^(buster|bullseye)$ ]]; then
     distribution=debian
     apt-key add "$SCRIPTS_PATH"/setup/pgdg.asc
     cat >$SOURCES_FILE <<EOF

--- a/scripts/lib/setup-apt-repo-ksplice
+++ b/scripts/lib/setup-apt-repo-ksplice
@@ -56,7 +56,7 @@ apt-get -y install "${pre_setup_deps[@]}"
 SCRIPTS_PATH="$(cd "$(dirname "$(dirname "$0")")" && pwd)"
 
 release=$(lsb_release -sc)
-if [[ "$release" =~ ^(buster|bionic|cosmic|disco|eoan|focal|groovy)$ ]]; then
+if [[ "$release" =~ ^(buster|bullseye|bionic|cosmic|disco|eoan|focal|groovy)$ ]]; then
     apt-key add "$SCRIPTS_PATH"/setup/ksplice.asc
     cat >$SOURCES_FILE <<EOF
 deb http://www.ksplice.com/apt $release ksplice

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -425,6 +425,11 @@ def parse_os_release() -> Dict[str, str]:
                 continue
             k, v = line.split("=", 1)
             [distro_info[k]] = shlex.split(v)
+    if distro_info["PRETTY_NAME"] == "Debian GNU/Linux bullseye/sid":
+        # This hack can be removed once bullseye releases and reports
+        # its VERSION_ID in /etc/os-release.
+        distro_info["VERSION_CODENAME"] = "bullseye"
+        distro_info["VERSION_ID"] = "11"
     return distro_info
 
 

--- a/tools/ci/Dockerfile.template
+++ b/tools/ci/Dockerfile.template
@@ -105,6 +105,14 @@ RUN export git_version=$(git --version | cut -d ' ' -f3 | cut -d 'v' -f2) && \
       sudo apt-get install -y git; \
     fi
 
+# Remove systemd package as it is not required and hinders with install
+RUN if [ ! "$(dpkg-query -f='$(Version)' --show systemd)" = "" ]; then \
+      apt-get remove --purge --auto-remove systemd -y && \
+      echo 'Package: systemd\nPin: release *\nPin-Priority: -1' | sudo tee -a /etc/apt/preferences.d/systemd && \
+      echo '\n\nPackage: *systemd*\nPin: release *\nPin-Priority: -1' | sudo tee -a /etc/apt/preferences.d/systemd && \
+      echo '\nPackage: systemd:amd64\nPin: release *\nPin-Priority: -1' | sudo tee -a /etc/apt/preferences.d/systemd; \
+    fi
+
 ARG USERNAME=github
 RUN groupadd --gid 3434 $USERNAME \
   && useradd --uid 3434 --gid $USERNAME --shell /bin/bash --create-home $USERNAME \

--- a/tools/ci/images.yml
+++ b/tools/ci/images.yml
@@ -6,3 +6,6 @@ focal:
 
 buster:
   base_image: buildpack-deps:buster-scm
+
+bullseye:
+  base_image: buildpack-deps:bullseye-scm

--- a/tools/ci/production-install
+++ b/tools/ci/production-install
@@ -11,6 +11,21 @@ APT_OPTIONS=(-o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-co
 apt-get update
 
 if [ -f /etc/os-release ]; then
+    # This is a temporary hack to test Debian Bullseye systems as
+    # though Bullseye was already released, so we don't need to
+    # change all of our scripts to parse bullseye/sid.
+    check_pretty_name="$(
+        . /etc/os-release
+        printf '%s\n' "$PRETTY_NAME"
+    )"
+    { read -r pretty_name; } <<<"$check_pretty_name"
+
+    if [ "$pretty_name" = "Debian GNU/Linux bullseye/sid" ]; then
+        echo "VERSION_CODENAME=bullseye" | tee -a >>/etc/os-release
+        echo "VERSION_ID=\"11\"" | tee -a >>/etc/os-release
+    fi
+    # End hack
+
     os_info="$(
         . /etc/os-release
         printf '%s\n' "$VERSION_CODENAME"

--- a/tools/ci/production-verify
+++ b/tools/ci/production-verify
@@ -71,7 +71,7 @@ nginx_version="$(nginx -v 2>&1 | awk '{print $3, $4}' | xargs)"
 
 # Simplify the diff by getting replacing 4-5 digit length numbers with <Length>.
 sed -i 's|Length: [0-9]\+\( [(][0-9]\+[.][0-9]K[)]\)\?|Length: <Length>|' /tmp/http-headers-processed
-if [ "$os_version_codename" = "buster" ]; then
+if [ "$os_version_codename" = "buster" ] || [ "$os_version_codename" = "bullseye" ]; then
     success_header_file="/tmp/success-http-headers.template.debian.txt"
     check_header
 else

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -97,6 +97,8 @@ vendor = distro_info["ID"]
 os_version = distro_info["VERSION_ID"]
 if vendor == "debian" and os_version == "10":  # buster
     POSTGRESQL_VERSION = "11"
+elif vendor == "debian" and os_version == "11":  # bullseye
+    POSTGRESQL_VERSION = "13"
 elif vendor == "ubuntu" and os_version in ["18.04", "18.10"]:  # bionic, cosmic
     POSTGRESQL_VERSION = "10"
 elif vendor == "ubuntu" and os_version in ["19.04", "19.10"]:  # disco, eoan
@@ -197,8 +199,17 @@ if vendor == "debian" and os_version in [] or vendor == "ubuntu" and os_version 
         *VENV_DEPENDENCIES,
     ]
 elif "debian" in os_families():
+    DEBIAN_DEPENDECIES = UBUNTU_COMMON_APT_DEPENDENCIES
+    # The below condition is required since libappindicator is
+    # not available for bullseye (sid). "libgroonga1" is an
+    # additional depedency for postgresql-13-pgdg-pgroonga.
+    #
+    # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895037
+    if distro_info["VERSION_CODENAME"] == "bullseye":
+        DEBIAN_DEPENDECIES.remove("libappindicator1")
+        DEBIAN_DEPENDECIES.append("libgroonga0")
     SYSTEM_DEPENDENCIES = [
-        *UBUNTU_COMMON_APT_DEPENDENCIES,
+        *DEBIAN_DEPENDECIES,
         f"postgresql-{POSTGRESQL_VERSION}",
         f"postgresql-{POSTGRESQL_VERSION}-pgdg-pgroonga",
         *VENV_DEPENDENCIES,


### PR DESCRIPTION
Add production and Dev support for Debian Bullseye.
Fixes part of #17863.
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
