### PR TITLE
Complete "Unstar all messages in topic" feature.

### DIFF
--- a/frontend_tests/node_tests/starred_messages.js
+++ b/frontend_tests/node_tests/starred_messages.js
@@ -43,11 +43,8 @@ run_test("get starred ids in topic", () => {
         starred_messages.starred_ids.add(id);
     }
 
-    assert.deepEqual(
-        starred_messages.get_starred_message_ids_in_topic(undefined, "topic name"),
-        [],
-    );
-    assert.deepEqual(starred_messages.get_starred_message_ids_in_topic(3, undefined), []);
+    assert.deepEqual(starred_messages.get_count_in_topic(undefined, "topic name"), 0);
+    assert.deepEqual(starred_messages.get_count_in_topic(3, undefined), 0);
 
     // id: 1 isn't inserted, to test handling the case
     // when message_store.get() returns undefined
@@ -77,7 +74,7 @@ run_test("get starred ids in topic", () => {
         topic: "topic",
     });
 
-    assert.deepEqual(starred_messages.get_starred_message_ids_in_topic(20, "topic"), [5]);
+    assert.deepEqual(starred_messages.get_count_in_topic(20, "topic"), 1);
 });
 
 run_test("initialize", (override) => {

--- a/static/js/starred_messages.js
+++ b/static/js/starred_messages.js
@@ -39,12 +39,12 @@ export function get_starred_msg_ids() {
     return Array.from(starred_ids);
 }
 
-export function get_starred_message_ids_in_topic(stream_id, topic) {
+export function get_count_in_topic(stream_id, topic) {
     if (stream_id === undefined || topic === undefined) {
-        return [];
+        return 0;
     }
 
-    return Array.from(starred_ids).filter((id) => {
+    const messages = Array.from(starred_ids).filter((id) => {
         const message = message_store.get(id);
 
         if (message === undefined) {
@@ -52,8 +52,12 @@ export function get_starred_message_ids_in_topic(stream_id, topic) {
             // but the message itself hasn't been fetched from the server yet.
             // We ignore this message, since we can't check if it belongs to
             // the topic, but it could, meaning this implementation isn't
-            // completely correct. The right way to do this would be to ask the
-            // backend for starred IDs from the topic.
+            // completely correct.
+            // Since this function is used only when opening the topic popover,
+            // and not for actually unstarring messages, this discrepancy is
+            // probably acceptable. The worst it could manifest as is the topic
+            // popover not having the "Unstar all messages in topic" option, when
+            // it should have had.
             return false;
         }
 
@@ -63,6 +67,8 @@ export function get_starred_message_ids_in_topic(stream_id, topic) {
             message.topic.toLowerCase() === topic.toLowerCase()
         );
     });
+
+    return messages.length;
 }
 
 export function rerender_ui() {

--- a/static/js/starred_messages_ui.js
+++ b/static/js/starred_messages_ui.js
@@ -6,6 +6,7 @@ import render_confirm_unstar_all_messages_in_topic from "../templates/confirm_un
 import * as confirm_dialog from "./confirm_dialog";
 import {$t_html} from "./i18n";
 import * as message_flags from "./message_flags";
+import * as stream_data from "./stream_data";
 
 export function confirm_unstar_all_messages() {
     const modal_parent = $(".left-sidebar-modal-holder");
@@ -25,8 +26,14 @@ export function confirm_unstar_all_messages_in_topic(stream_id, topic) {
         message_flags.unstar_all_messages_in_topic(stream_id, topic);
     }
 
+    const stream_name = stream_data.maybe_get_stream_name(stream_id);
+    if (stream_name === undefined) {
+        return;
+    }
+
     const modal_parent = $(".left-sidebar-modal-holder");
     const html_body = render_confirm_unstar_all_messages_in_topic({
+        stream_name,
         topic,
     });
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -237,8 +237,7 @@ function build_topic_popover(opts) {
     const is_muted = muting.is_topic_muted(sub.stream_id, topic_name);
     const can_mute_topic = !is_muted;
     const can_unmute_topic = is_muted;
-    const has_starred_messages =
-        starred_messages.get_starred_message_ids_in_topic(sub.stream_id, topic_name).length > 0;
+    const has_starred_messages = starred_messages.get_count_in_topic(sub.stream_id, topic_name) > 0;
 
     const content = render_topic_sidebar_actions({
         stream_name: sub.name,

--- a/static/templates/confirm_unstar_all_messages_in_topic.hbs
+++ b/static/templates/confirm_unstar_all_messages_in_topic.hbs
@@ -1,5 +1,6 @@
 <p>
     {{#tr}}
-    Are you sure you want to unstar all messages in topic <b>{topic}</b>?  This action cannot be undone.
+        Are you sure you want to unstar all messages in <stream-topic></stream-topic>?  This action cannot be undone.
+        {{#*inline "stream-topic"}}{{> stream_topic_widget}}{{/inline}}
     {{/tr}}
 </p>

--- a/static/templates/stream_topic_widget.hbs
+++ b/static/templates/stream_topic_widget.hbs
@@ -1,0 +1,3 @@
+<strong>
+    <span class="stream">{{stream_name}}</span> > <span class="topic">{{topic}}</span>
+</strong>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #17790 
This completes the "Unstar all messages in topic" feature implemented in #17440, and also cleans up the confirmation dialog.

**Testing plan:** Added node tests so that `messgage_flags.js` is still at 100% coverage. 
Manually tested using `python manage.py populate_db -n 10000 --max-topics 1`

**GIFs or screenshots:** (for the first commit)<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
**Before**
![image](https://user-images.githubusercontent.com/55339528/114260922-552d4700-99f5-11eb-93b7-ffff45afb086.png)

**After**
![image](https://user-images.githubusercontent.com/55339528/114260907-3b8bff80-99f5-11eb-87aa-64fa21f0e84f.png)


