### PR TITLE
17954 shorten string issue fix

### DIFF
--- a/static/js/buddy_list.js
+++ b/static/js/buddy_list.js
@@ -270,6 +270,11 @@ export class BuddyList extends BuddyListConf {
         // Add a fudge factor.
         height += 10;
 
+        if (this.keys.length === 0) {
+            this.container = $(this.container_sel);
+            this.container.append(`<div > ${_('User not found')} </div>`);
+            return;
+        }
         while (this.render_count < this.keys.length) {
             const padding_height = $(this.padding_sel).height();
             const bottom_offset = elem.scrollHeight - elem.scrollTop - padding_height;

--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -589,6 +589,10 @@ function shorten_links(href) {
     if (remaining_path || url.hash) {
       return href;
     }
+    
+    if(type(value)==str){
+      return href;
+    }
 
     if (url.hostname === 'github.com') {
       return shorten_github_links(href, artifact, repo_short_text,

--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -590,6 +590,7 @@ function shorten_links(href) {
       return href;
     }
     
+    // Return orginal url when value is a string
     if(type(value)==str){
       return href;
     }


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
fix #17954

**Testing plan:** <!-- How have you tested? -->
only calling shorten_github_links function when the value is a number .otherwise returning orginal url 



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
