### PR TITLE
Fixed #17958  Show "user not found" if there is no user matches with that string

### DIFF
--- a/static/js/buddy_list.js
+++ b/static/js/buddy_list.js
@@ -269,7 +269,13 @@ export class BuddyList extends BuddyListConf {
 
         // Add a fudge factor.
         height += 10;
-
+        
+        if (this.keys.length === 0) {
+            this.container = $(this.container_sel);
+            this.container.append(`<div > ${_('User not found')} </div>`);
+            return;
+        }
+        
         while (this.render_count < this.keys.length) {
             const padding_height = $(this.padding_sel).height();
             const bottom_offset = elem.scrollHeight - elem.scrollTop - padding_height;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixed #17842

**Testing plan:** <!-- How have you tested? -->
added i18n support .

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2021-04-03 01-37-00](https://user-images.githubusercontent.com/52108435/113451523-c2ead900-941f-11eb-907e-f536c6f805dc.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
