### PR TITLE
refactor: Make acting_user a mandatory kwarg.

### DIFF
--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -985,7 +985,7 @@ class TestSupportEndpoint(ZulipTestCase):
             result = self.client_post(
                 "/activity/support", {"realm_id": f"{lear_realm.id}", "status": "deactivated"}
             )
-            m.assert_called_once_with(lear_realm, self.example_user("iago"))
+            m.assert_called_once_with(lear_realm, acting_user=self.example_user("iago"))
             self.assert_in_success_response(["lear deactivated"], result)
 
         with mock.patch("analytics.views.do_send_realm_reactivation_email") as m:

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -1312,7 +1312,7 @@ def support(request: HttpRequest) -> HttpResponse:
                     "success_message"
                 ] = f"Realm reactivation email sent to admins of {realm.string_id}."
             elif status == "deactivated":
-                do_deactivate_realm(realm, request.user)
+                do_deactivate_realm(realm, acting_user=request.user)
                 context["success_message"] = f"{realm.string_id} deactivated."
         elif request.POST.get("billing_method", None) is not None:
             billing_method = request.POST.get("billing_method")

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -2271,7 +2271,7 @@ class StripeTest(StripeTestCase):
         self.assertEqual(last_ledger_entry.licenses, 20)
         self.assertEqual(last_ledger_entry.licenses_at_next_renewal, 20)
 
-        do_deactivate_realm(get_realm("zulip"))
+        do_deactivate_realm(get_realm("zulip"), acting_user=None)
 
         plan.refresh_from_db()
         self.assertTrue(get_realm("zulip").deactivated)
@@ -2302,7 +2302,7 @@ class StripeTest(StripeTestCase):
         with patch("corporate.lib.stripe.timezone_now", return_value=self.now):
             self.local_upgrade(self.seat_count, True, CustomerPlan.ANNUAL, "token")
 
-        do_deactivate_realm(get_realm("zulip"))
+        do_deactivate_realm(get_realm("zulip"), acting_user=None)
         self.assertTrue(get_realm("zulip").deactivated)
         do_reactivate_realm(get_realm("zulip"))
 

--- a/tools/generate-integration-docs-screenshot
+++ b/tools/generate-integration-docs-screenshot
@@ -90,7 +90,7 @@ def create_integration_stream(integration: WebhookIntegration, bot: UserProfile)
     assert isinstance(bot.bot_owner, UserProfile)
     realm = bot.bot_owner.realm
     stream, created = create_stream_if_needed(realm, integration.stream_name)
-    bulk_add_subscriptions(realm, [stream], [bot, bot.bot_owner])
+    bulk_add_subscriptions(realm, [stream], [bot, bot.bot_owner], acting_user=bot)
 
 
 def get_integration(integration_name: str) -> WebhookIntegration:

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -968,7 +968,7 @@ def do_set_realm_signup_notifications_stream(
     send_event(realm, event, active_user_ids(realm.id))
 
 
-def do_deactivate_realm(realm: Realm, acting_user: Optional[UserProfile] = None) -> None:
+def do_deactivate_realm(realm: Realm, *, acting_user: Optional[UserProfile]) -> None:
     """
     Deactivate this realm. Do NOT deactivate the users -- we need to be able to
     tell the difference between users that were intentionally deactivated,
@@ -1048,7 +1048,7 @@ def do_change_realm_subdomain(realm: Realm, new_subdomain: str) -> None:
     # it's deactivated redirect to new_subdomain so that we can tell the users that
     # the realm has been moved to a new subdomain.
     placeholder_realm = do_create_realm(old_subdomain, "placeholder-realm")
-    do_deactivate_realm(placeholder_realm)
+    do_deactivate_realm(placeholder_realm, acting_user=None)
     do_add_deactivated_redirect(placeholder_realm, realm.uri)
 
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2258,7 +2258,8 @@ def ensure_stream(
     stream_name: str,
     invite_only: bool = False,
     stream_description: str = "",
-    acting_user: Optional[UserProfile] = None,
+    *,
+    acting_user: Optional[UserProfile],
 ) -> Stream:
     return create_stream_if_needed(
         realm,

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3557,7 +3557,8 @@ def bulk_remove_subscriptions(
     users: Iterable[UserProfile],
     streams: Iterable[Stream],
     acting_client: Client,
-    acting_user: Optional[UserProfile] = None,
+    *,
+    acting_user: Optional[UserProfile],
 ) -> SubAndRemovedT:
 
     users = list(users)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1206,7 +1206,7 @@ def do_deactivate_user(
 
 
 def do_deactivate_stream(
-    stream: Stream, log: bool = True, acting_user: Optional[UserProfile] = None
+    stream: Stream, log: bool = True, *, acting_user: Optional[UserProfile]
 ) -> None:
     # We want to mark all messages in the to-be-deactivated stream as
     # read for all users; otherwise they will pollute queries like

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -481,7 +481,11 @@ def process_new_human_user(
                 streams.append(stream)
 
     bulk_add_subscriptions(
-        realm, streams, [user_profile], acting_user=acting_user, from_user_creation=True
+        realm,
+        streams,
+        [user_profile],
+        from_user_creation=True,
+        acting_user=acting_user,
     )
 
     add_new_user_history(user_profile, streams)
@@ -3239,8 +3243,9 @@ def bulk_add_subscriptions(
     streams: Iterable[Stream],
     users: Iterable[UserProfile],
     color_map: Mapping[str, str] = {},
-    acting_user: Optional[UserProfile] = None,
     from_user_creation: bool = False,
+    *,
+    acting_user: Optional[UserProfile],
 ) -> SubT:
     users = list(users)
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -908,10 +908,7 @@ def do_set_realm_message_editing(
 
 
 def do_set_realm_notifications_stream(
-    realm: Realm,
-    stream: Optional[Stream],
-    stream_id: int,
-    acting_user: Optional[UserProfile] = None,
+    realm: Realm, stream: Optional[Stream], stream_id: int, *, acting_user: Optional[UserProfile]
 ) -> None:
     old_value = realm.notifications_stream_id
     realm.notifications_stream = stream

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1057,7 +1057,7 @@ def do_add_deactivated_redirect(realm: Realm, redirect_url: str) -> None:
     realm.save(update_fields=["deactivated_redirect"])
 
 
-def do_scrub_realm(realm: Realm, acting_user: Optional[UserProfile] = None) -> None:
+def do_scrub_realm(realm: Realm, *, acting_user: Optional[UserProfile]) -> None:
     if settings.BILLING_ENABLED:
         downgrade_now_without_creating_additional_invoices(realm)
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -939,10 +939,7 @@ def do_set_realm_notifications_stream(
 
 
 def do_set_realm_signup_notifications_stream(
-    realm: Realm,
-    stream: Optional[Stream],
-    stream_id: int,
-    acting_user: Optional[UserProfile] = None,
+    realm: Realm, stream: Optional[Stream], stream_id: int, *, acting_user: Optional[UserProfile]
 ) -> None:
     old_value = realm.signup_notifications_stream_id
     realm.signup_notifications_stream = stream

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -965,7 +965,7 @@ Output:
     def unsubscribe(self, user_profile: UserProfile, stream_name: str) -> None:
         client = get_client("website")
         stream = get_stream(stream_name, user_profile.realm)
-        bulk_remove_subscriptions([user_profile], [stream], client)
+        bulk_remove_subscriptions([user_profile], [stream], client, acting_user=None)
 
     # Subscribe to a stream by making an API request
     def common_subscribe_to_streams(

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -959,7 +959,7 @@ Output:
             stream = get_stream(stream_name, user_profile.realm)
         except Stream.DoesNotExist:
             stream, from_stream_creation = create_stream_if_needed(realm, stream_name)
-        bulk_add_subscriptions(realm, [stream], [user_profile])
+        bulk_add_subscriptions(realm, [stream], [user_profile], acting_user=None)
         return stream
 
     def unsubscribe(self, user_profile: UserProfile, stream_name: str) -> None:

--- a/zerver/management/commands/add_users_to_streams.py
+++ b/zerver/management/commands/add_users_to_streams.py
@@ -28,7 +28,7 @@ class Command(ZulipBaseCommand):
             for user_profile in user_profiles:
                 stream = ensure_stream(realm, stream_name, acting_user=None)
                 _ignore, already_subscribed = bulk_add_subscriptions(
-                    realm, [stream], [user_profile]
+                    realm, [stream], [user_profile], acting_user=None
                 )
                 was_there_already = user_profile.id in (info.user.id for info in already_subscribed)
                 print(

--- a/zerver/management/commands/deactivate_realm.py
+++ b/zerver/management/commands/deactivate_realm.py
@@ -28,5 +28,5 @@ class Command(ZulipBaseCommand):
             exit(0)
 
         print("Deactivating", options["realm_id"])
-        do_deactivate_realm(realm)
+        do_deactivate_realm(realm, acting_user=None)
         print("Done!")

--- a/zerver/management/commands/export.py
+++ b/zerver/management/commands/export.py
@@ -204,7 +204,7 @@ class Command(ZulipBaseCommand):
 
         if options["deactivate_realm"]:
             print(f"\033[94mDeactivating realm\033[0m: {realm.string_id}")
-            do_deactivate_realm(realm)
+            do_deactivate_realm(realm, acting_user=None)
 
         def percent_callback(bytes_transferred: Any) -> None:
             sys.stdout.write(".")

--- a/zerver/management/commands/merge_streams.py
+++ b/zerver/management/commands/merge_streams.py
@@ -82,4 +82,4 @@ class Command(ZulipBaseCommand):
         do_deactivate_stream(stream_to_destroy, acting_user=None)
         if len(users_to_activate) > 0:
             print(f"Adding {len(users_to_activate)} subscriptions")
-            bulk_add_subscriptions(realm, [stream_to_keep], users_to_activate)
+            bulk_add_subscriptions(realm, [stream_to_keep], users_to_activate, acting_user=None)

--- a/zerver/tests/test_archive.py
+++ b/zerver/tests/test_archive.py
@@ -76,7 +76,7 @@ class GlobalPublicStreamTest(ZulipTestCase):
         self.assert_length(info.never_subscribed, 0)
         self.assertNotEqual(info.subscriptions[0]["color"], info.subscriptions[1]["color"])
 
-        do_deactivate_stream(test_stream)
+        do_deactivate_stream(test_stream, acting_user=None)
         public_streams = get_web_public_streams(realm)
         self.assert_length(public_streams, 1)
         info = get_web_public_subs(realm)

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -305,9 +305,10 @@ class TestRealmAuditLog(ZulipTestCase):
 
     def test_realm_activation(self) -> None:
         realm = get_realm("zulip")
-        do_deactivate_realm(realm)
+        user = self.example_user("desdemona")
+        do_deactivate_realm(realm, acting_user=user)
         log_entry = RealmAuditLog.objects.get(
-            realm=realm, event_type=RealmAuditLog.REALM_DEACTIVATED
+            realm=realm, event_type=RealmAuditLog.REALM_DEACTIVATED, acting_user=user
         )
         extra_data = orjson.loads(log_entry.extra_data)
         self.check_role_count_schema(extra_data[RealmAuditLog.ROLE_COUNT])

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -182,7 +182,7 @@ class AuthBackendTest(ZulipTestCase):
         self.assertEqual(user_profile, result)
 
         # Verify auth fails with a deactivated realm
-        do_deactivate_realm(user_profile.realm)
+        do_deactivate_realm(user_profile.realm, acting_user=None)
         self.assertIsNone(backend.authenticate(**good_kwargs))
 
         # Verify auth works again after reactivating the realm
@@ -3821,7 +3821,7 @@ class FetchAPIKeyTest(ZulipTestCase):
         self.assert_json_error_contains(result, "Your account has been disabled", 403)
 
     def test_deactivated_realm(self) -> None:
-        do_deactivate_realm(self.user_profile.realm)
+        do_deactivate_realm(self.user_profile.realm, acting_user=None)
         result = self.client_post(
             "/api/v1/fetch_api_key",
             dict(username=self.email, password=initial_password(self.email)),
@@ -3859,7 +3859,7 @@ class DevFetchAPIKeyTest(ZulipTestCase):
         self.assert_json_error_contains(result, "Your account has been disabled", 403)
 
     def test_deactivated_realm(self) -> None:
-        do_deactivate_realm(self.user_profile.realm)
+        do_deactivate_realm(self.user_profile.realm, acting_user=None)
         result = self.client_post("/api/v1/dev_fetch_api_key", dict(username=self.email))
         self.assert_json_error_contains(result, "This organization has been deactivated", 403)
 
@@ -5073,7 +5073,7 @@ class TestLDAP(ZulipLDAPTestCase):
         with self.settings(AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map):
             backend = self.backend
             email = "nonexisting@zulip.com"
-            do_deactivate_realm(backend._realm)
+            do_deactivate_realm(backend._realm, acting_user=None)
             with self.assertRaisesRegex(Exception, "Realm has been deactivated"):
                 backend.get_or_build_user(email, _LDAPUser())
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1460,7 +1460,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase):
         stream_names = ["new_stream_1", "new_stream_2"]
         streams = []
         for stream_name in set(stream_names):
-            stream = ensure_stream(realm, stream_name)
+            stream = ensure_stream(realm, stream_name, acting_user=None)
             streams.append(stream)
 
         referrer = self.example_user("hamlet")
@@ -3628,7 +3628,7 @@ class GoogleAuthBackendTest(SocialAuthBase):
         stream_names = ["new_stream_1", "new_stream_2"]
         streams = []
         for stream_name in set(stream_names):
-            stream = ensure_stream(realm, stream_name)
+            stream = ensure_stream(realm, stream_name, acting_user=None)
             streams.append(stream)
 
         # Without the invite link, we can't create an account due to invite_required

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1037,7 +1037,7 @@ class DeactivatedRealmTest(ZulipTestCase):
 
         """
         realm = get_realm("zulip")
-        do_deactivate_realm(get_realm("zulip"))
+        do_deactivate_realm(get_realm("zulip"), acting_user=None)
 
         result = self.client_post(
             "/json/messages",
@@ -1107,7 +1107,7 @@ class DeactivatedRealmTest(ZulipTestCase):
         Using a webhook while in a deactivated realm fails
 
         """
-        do_deactivate_realm(get_realm("zulip"))
+        do_deactivate_realm(get_realm("zulip"), acting_user=None)
         user_profile = self.example_user("hamlet")
         api_key = get_api_key(user_profile)
         url = f"/api/v1/external/jira?api_key={api_key}&stream=jira_custom"

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -75,7 +75,7 @@ class TestEncodeDecode(ZulipTestCase):
     def test_encode_decode(self) -> None:
         realm = get_realm("zulip")
         stream_name = "dev. help"
-        stream = ensure_stream(realm, stream_name)
+        stream = ensure_stream(realm, stream_name, acting_user=None)
         email_address = encode_email_address(stream)
         self.assertEqual(email_address, f"dev-help.{stream.email_token}@testserver")
 
@@ -134,7 +134,7 @@ class TestEncodeDecode(ZulipTestCase):
     def test_encode_decode_nonlatin_alphabet_stream_name(self) -> None:
         realm = get_realm("zulip")
         stream_name = "Тестовы some ascii letters"
-        stream = ensure_stream(realm, stream_name)
+        stream = ensure_stream(realm, stream_name, acting_user=None)
         email_address = encode_email_address(stream)
 
         msg_string = get_email_gateway_message_string_from_address(email_address)
@@ -149,7 +149,7 @@ class TestEncodeDecode(ZulipTestCase):
         self.assertEqual(token, stream.email_token)
 
         asciiable_stream_name = "ąężć"
-        stream = ensure_stream(realm, asciiable_stream_name)
+        stream = ensure_stream(realm, asciiable_stream_name, acting_user=None)
         email_address = encode_email_address(stream)
         self.assertTrue(email_address.startswith("aezc."))
 

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1078,7 +1078,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
 
         mm_address = create_missed_message_address(user_profile, message)
 
-        do_deactivate_realm(user_profile.realm)
+        do_deactivate_realm(user_profile.realm, acting_user=None)
 
         incoming_valid_message = EmailMessage()
         incoming_valid_message.set_content("TestMissedMessageEmailMessages Body")

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2045,7 +2045,9 @@ class SubscribeActionTest(BaseAction):
         stream.save()
 
         user_profile = self.example_user("hamlet")
-        action = lambda: bulk_add_subscriptions(user_profile.realm, [stream], [user_profile])
+        action = lambda: bulk_add_subscriptions(
+            user_profile.realm, [stream], [user_profile], acting_user=None
+        )
         events = self.verify_action(action, include_subscribers=include_subscribers, num_events=2)
         check_stream_create("events[0]", events[0])
         check_subscription_add("events[1]", events[1])

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1499,7 +1499,7 @@ class NormalActionsTest(BaseAction):
 
     def test_do_deactivate_realm(self) -> None:
         realm = self.user_profile.realm
-        action = lambda: do_deactivate_realm(realm)
+        action = lambda: do_deactivate_realm(realm, acting_user=None)
 
         # We delete sessions of all active users when a realm is
         # deactivated, and redirect them to a deactivated page in

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1570,7 +1570,7 @@ class NormalActionsTest(BaseAction):
         stream = get_stream("test_stream", self.user_profile.realm)
 
         action = lambda: bulk_remove_subscriptions(
-            [self.example_user("othello")], [stream], get_client("website")
+            [self.example_user("othello")], [stream], get_client("website"), acting_user=None
         )
         events = self.verify_action(action)
         check_subscription_peer_remove("events[0]", events[0])
@@ -1968,7 +1968,7 @@ class SubscribeActionTest(BaseAction):
         # Now remove the first user, to test the normal unsubscribe flow and
         # 'peer_remove' event for subscribed streams.
         action = lambda: bulk_remove_subscriptions(
-            [self.example_user("othello")], [stream], get_client("website")
+            [self.example_user("othello")], [stream], get_client("website"), acting_user=None
         )
         events = self.verify_action(
             action,
@@ -1979,7 +1979,7 @@ class SubscribeActionTest(BaseAction):
 
         # Now remove the user himself, to test the 'remove' event flow
         action = lambda: bulk_remove_subscriptions(
-            [self.example_user("hamlet")], [stream], get_client("website")
+            [self.example_user("hamlet")], [stream], get_client("website"), acting_user=None
         )
         events = self.verify_action(
             action, include_subscribers=include_subscribers, include_streams=False, num_events=2
@@ -2003,7 +2003,7 @@ class SubscribeActionTest(BaseAction):
 
         # Remove the user to test 'peer_remove' event flow for unsubscribed stream.
         action = lambda: bulk_remove_subscriptions(
-            [self.example_user("iago")], [stream], get_client("website")
+            [self.example_user("iago")], [stream], get_client("website"), acting_user=None
         )
         events = self.verify_action(
             action,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1152,7 +1152,10 @@ class NormalActionsTest(BaseAction):
         for notifications_stream, notifications_stream_id in ((stream, stream.id), (None, -1)):
             events = self.verify_action(
                 lambda: do_set_realm_notifications_stream(
-                    self.user_profile.realm, notifications_stream, notifications_stream_id
+                    self.user_profile.realm,
+                    notifications_stream,
+                    notifications_stream_id,
+                    acting_user=None,
                 )
             )
             check_realm_update("events[0]", events[0], "notifications_stream_id")

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1172,6 +1172,7 @@ class NormalActionsTest(BaseAction):
                     self.user_profile.realm,
                     signup_notifications_stream,
                     signup_notifications_stream_id,
+                    acting_user=None,
                 )
             )
             check_realm_update("events[0]", events[0], "signup_notifications_stream_id")

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1555,7 +1555,7 @@ class NormalActionsTest(BaseAction):
     def test_deactivate_stream_neversubscribed(self) -> None:
         for i, include_streams in enumerate([True, False]):
             stream = self.make_stream(f"stream{i}")
-            action = lambda: do_deactivate_stream(stream)
+            action = lambda: do_deactivate_stream(stream, acting_user=None)
             events = self.verify_action(action, include_streams=include_streams)
             check_stream_delete("events[0]", events[0])
 

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -958,7 +958,7 @@ class ScrubRealmTest(ZulipTestCase):
         self.assertNotEqual(CustomProfileField.objects.filter(realm=zulip).count(), 0)
 
         with self.assertLogs(level="WARNING"):
-            do_scrub_realm(zulip)
+            do_scrub_realm(zulip, acting_user=None)
 
         self.assertEqual(Message.objects.filter(sender__in=[iago, othello]).count(), 0)
         self.assertEqual(Message.objects.filter(sender__in=[cordelia, king]).count(), 10)

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -341,7 +341,7 @@ class RealmTest(ZulipTestCase):
         notifications_stream = realm.get_notifications_stream()
         assert notifications_stream is not None
         self.assertEqual(notifications_stream.id, verona.id)
-        do_deactivate_stream(notifications_stream)
+        do_deactivate_stream(notifications_stream, acting_user=None)
         self.assertIsNone(realm.get_notifications_stream())
 
     def test_change_signup_notifications_stream(self) -> None:
@@ -393,7 +393,7 @@ class RealmTest(ZulipTestCase):
         signup_notifications_stream = realm.get_signup_notifications_stream()
         assert signup_notifications_stream is not None
         self.assertEqual(signup_notifications_stream, verona)
-        do_deactivate_stream(signup_notifications_stream)
+        do_deactivate_stream(signup_notifications_stream, acting_user=None)
         self.assertIsNone(realm.get_signup_notifications_stream())
 
     def test_change_realm_default_language(self) -> None:

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -180,7 +180,7 @@ class RealmTest(ZulipTestCase):
         hamlet_id = self.example_user("hamlet").id
         get_user_profile_by_id(hamlet_id)
         realm = get_realm("zulip")
-        do_deactivate_realm(realm)
+        do_deactivate_realm(realm, acting_user=None)
         user = get_user_profile_by_id(hamlet_id)
         self.assertTrue(user.realm.deactivated)
 
@@ -210,7 +210,7 @@ class RealmTest(ZulipTestCase):
             delay=datetime.timedelta(hours=1),
         )
         self.assertEqual(ScheduledEmail.objects.count(), 1)
-        do_deactivate_realm(user.realm)
+        do_deactivate_realm(user.realm, acting_user=None)
         self.assertEqual(ScheduledEmail.objects.count(), 0)
 
     def test_do_change_realm_description_clears_cached_descriptions(self) -> None:
@@ -234,10 +234,10 @@ class RealmTest(ZulipTestCase):
         realm = get_realm("zulip")
         self.assertFalse(realm.deactivated)
 
-        do_deactivate_realm(realm)
+        do_deactivate_realm(realm, acting_user=None)
         self.assertTrue(realm.deactivated)
 
-        do_deactivate_realm(realm)
+        do_deactivate_realm(realm, acting_user=None)
         self.assertTrue(realm.deactivated)
 
     def test_do_set_deactivated_redirect_on_deactivated_realm(self) -> None:
@@ -245,7 +245,7 @@ class RealmTest(ZulipTestCase):
         realm = get_realm("zulip")
 
         redirect_url = "new_server.zulip.com"
-        do_deactivate_realm(realm)
+        do_deactivate_realm(realm, acting_user=None)
         self.assertTrue(realm.deactivated)
         do_add_deactivated_redirect(realm, redirect_url)
         self.assertEqual(realm.deactivated_redirect, redirect_url)
@@ -257,7 +257,7 @@ class RealmTest(ZulipTestCase):
 
     def test_realm_reactivation_link(self) -> None:
         realm = get_realm("zulip")
-        do_deactivate_realm(realm)
+        do_deactivate_realm(realm, acting_user=None)
         self.assertTrue(realm.deactivated)
         confirmation_url = create_confirmation_link(realm, Confirmation.REALM_REACTIVATION)
         response = self.client_get(confirmation_url)
@@ -269,7 +269,7 @@ class RealmTest(ZulipTestCase):
 
     def test_realm_reactivation_confirmation_object(self) -> None:
         realm = get_realm("zulip")
-        do_deactivate_realm(realm)
+        do_deactivate_realm(realm, acting_user=None)
         self.assertTrue(realm.deactivated)
         create_confirmation_link(realm, Confirmation.REALM_REACTIVATION)
         confirmation = Confirmation.objects.last()

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -467,7 +467,7 @@ class PasswordResetTest(ZulipTestCase):
     def test_password_reset_with_deactivated_realm(self) -> None:
         user_profile = self.example_user("hamlet")
         email = user_profile.delivery_email
-        do_deactivate_realm(user_profile.realm)
+        do_deactivate_realm(user_profile.realm, acting_user=None)
 
         # start the password reset process by supplying an email address
         with self.assertLogs(level="INFO") as m:
@@ -4779,7 +4779,7 @@ class TestFindMyTeam(ZulipTestCase):
         self.assertEqual(len(outbox), 0)
 
     def test_find_team_deactivated_realm(self) -> None:
-        do_deactivate_realm(get_realm("zulip"))
+        do_deactivate_realm(get_realm("zulip"), acting_user=None)
         data = {"emails": self.example_email("hamlet")}
         result = self.client_post("/accounts/find/", data)
         self.assertEqual(result.status_code, 302)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -555,7 +555,7 @@ class StreamAdminTest(ZulipTestCase):
         stream = self.make_stream("new_stream")
         do_add_default_stream(stream)
         self.assertEqual(1, DefaultStream.objects.filter(stream_id=stream.id).count())
-        do_deactivate_stream(stream)
+        do_deactivate_stream(stream, acting_user=None)
         self.assertEqual(0, DefaultStream.objects.filter(stream_id=stream.id).count())
 
     def test_deactivate_stream_removes_stream_from_default_stream_groups(self) -> None:
@@ -580,7 +580,7 @@ class StreamAdminTest(ZulipTestCase):
         default_stream_groups = get_default_stream_groups(realm)
         self.assertEqual(get_streams(default_stream_groups[0]), all_streams)
 
-        do_deactivate_stream(streams_to_remove[0])
+        do_deactivate_stream(streams_to_remove[0], acting_user=None)
         self.assertEqual(get_streams(default_stream_groups[0]), streams_to_keep)
 
     def test_deactivate_stream_marks_messages_as_read(self) -> None:
@@ -603,7 +603,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertFalse(new_stream_usermessage.flags.read)
         self.assertFalse(denmark_usermessage.flags.read)
 
-        do_deactivate_stream(stream)
+        do_deactivate_stream(stream, acting_user=None)
         new_stream_usermessage.refresh_from_db()
         denmark_usermessage.refresh_from_db()
         self.assertTrue(new_stream_usermessage.flags.read)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3865,6 +3865,7 @@ class SubscriptionAPITest(ZulipTestCase):
                         [user1, user2],
                         [stream1, stream2, stream3, private],
                         get_client("website"),
+                        acting_user=None,
                     )
 
         self.assert_length(query_count, 28)
@@ -3934,6 +3935,7 @@ class SubscriptionAPITest(ZulipTestCase):
                 users=[mit_user],
                 streams=streams,
                 acting_client=get_client("website"),
+                acting_user=None,
             )
 
         self.assert_length(events, 0)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3610,7 +3610,7 @@ class SubscriptionAPITest(ZulipTestCase):
         realm3 = user_profile.realm
         stream = get_stream("multi_user_stream", realm)
         with tornado_redirected_to_list(events):
-            bulk_add_subscriptions(realm, [stream], [user_profile])
+            bulk_add_subscriptions(realm, [stream], [user_profile], acting_user=None)
 
         self.assert_length(events, 2)
         add_event, add_peer_event = events
@@ -3639,14 +3639,14 @@ class SubscriptionAPITest(ZulipTestCase):
         stream = ensure_stream(realm, stream_name, invite_only=True, acting_user=None)
 
         existing_user_profile = self.example_user("hamlet")
-        bulk_add_subscriptions(realm, [stream], [existing_user_profile])
+        bulk_add_subscriptions(realm, [stream], [existing_user_profile], acting_user=None)
 
         # Now subscribe Cordelia to the stream, capturing events
         user_profile = self.example_user("cordelia")
 
         events: List[Mapping[str, Any]] = []
         with tornado_redirected_to_list(events):
-            bulk_add_subscriptions(realm, [stream], [user_profile])
+            bulk_add_subscriptions(realm, [stream], [user_profile], acting_user=None)
 
         self.assert_length(events, 3)
         create_event, add_event, add_peer_event = events
@@ -3678,7 +3678,9 @@ class SubscriptionAPITest(ZulipTestCase):
         new_stream = ensure_stream(realm, "private stream", invite_only=True, acting_user=None)
         events = []
         with tornado_redirected_to_list(events):
-            bulk_add_subscriptions(realm, [new_stream], [self.example_user("iago")])
+            bulk_add_subscriptions(
+                realm, [new_stream], [self.example_user("iago")], acting_user=None
+            )
 
         # Note that since iago is an admin, he won't get a stream/create
         # event here.

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -401,7 +401,7 @@ class UserGroupAPITestCase(ZulipTestCase):
 
         content_with_group_mention = "hey @*support* can you help us with this?"
 
-        ensure_stream(realm, stream_name)
+        ensure_stream(realm, stream_name, acting_user=None)
 
         all_users = {cordelia, hamlet, othello, zoe}
         support_team = {hamlet, zoe}

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -236,7 +236,7 @@ def update_realm(
 @has_request_variables
 def deactivate_realm(request: HttpRequest, user: UserProfile) -> HttpResponse:
     realm = user.realm
-    do_deactivate_realm(realm, user)
+    do_deactivate_realm(realm, acting_user=user)
     return json_success()
 
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -413,7 +413,9 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
             )
 
         if realm_creation:
-            bulk_add_subscriptions(realm, [realm.signup_notifications_stream], [user_profile])
+            bulk_add_subscriptions(
+                realm, [realm.signup_notifications_stream], [user_profile], acting_user=None
+            )
             send_initial_realm_messages(realm)
 
             # Because for realm creation, registration happens on the

--- a/zilencer/management/commands/add_mock_conversation.py
+++ b/zilencer/management/commands/add_mock_conversation.py
@@ -64,7 +64,9 @@ From image editing program:
         )
         self.set_avatar(twitter_bot, "static/images/features/twitter.png")
 
-        bulk_add_subscriptions(realm, [stream], list(UserProfile.objects.filter(realm=realm)))
+        bulk_add_subscriptions(
+            realm, [stream], list(UserProfile.objects.filter(realm=realm)), acting_user=None
+        )
 
         staged_messages: List[Dict[str, Any]] = [
             {

--- a/zilencer/management/commands/add_new_realm.py
+++ b/zilencer/management/commands/add_new_realm.py
@@ -23,6 +23,6 @@ class Command(ZulipBaseCommand):
             acting_user=None,
         )
         assert realm.signup_notifications_stream is not None
-        bulk_add_subscriptions(realm, [realm.signup_notifications_stream], [user])
+        bulk_add_subscriptions(realm, [realm.signup_notifications_stream], [user], acting_user=None)
 
         send_initial_realm_messages(realm)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This make acting_user a mandatory keyword argument for functions in zerver/lib/actions.py.
https://github.com/zulip/zulip/issues/14808#issuecomment-663700003

**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
