### PR TITLE
tornado: Explicitly mark requests as varying by cookie.

### DIFF
--- a/zerver/tests/test_tornado.py
+++ b/zerver/tests/test_tornado.py
@@ -117,6 +117,7 @@ class EventsTestCase(TornadoWebTestCase):
 
         self.io_loop.call_later(0.1, process_events)
         response = self.wait()
+        self.assertEqual(response.headers["Vary"], "Accept-Language, Cookie")
         data = orjson.loads(response.body)
         self.assertEqual(
             data["events"],

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -9,6 +9,7 @@ from django.core.handlers import base
 from django.core.handlers.wsgi import WSGIRequest, get_script_name
 from django.http import HttpRequest, HttpResponse
 from django.urls import set_script_prefix
+from django.utils.cache import patch_vary_headers
 from tornado.wsgi import WSGIContainer
 
 from zerver.lib.response import json_response
@@ -243,6 +244,9 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
 
         try:
             response = self.get_response(request)
+            # Explicitly mark requests as varying by cookie, since the
+            # middleware will not have seen a session access
+            patch_vary_headers(response, ("Cookie",))
         finally:
             # Tell Django we're done processing this request
             #


### PR DESCRIPTION
The Session middleware only adds `Vary: cookie` if it sees an access
to the from inside of it.  Because we are effectively, from the Django
session middleware's point of view, returning the static content of
`request.saved_response` and never accessing the session, it does not
set `Vary: cookie` on longpoll requests.

Explicitly mark Tornado requests as varying by cookie.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** Added a test.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
