### PR TITLE
markdown: Fix shortening of unwanted GitHub link.

### DIFF
--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -604,7 +604,7 @@ function shorten_links(href) {
 
 function shorten_github_links(href, artifact, repo_short_text,
                               value, commit_id_prefix_length) {
-  if (['pull', 'issues'].includes(artifact)) {
+  if (['pull', 'issues'].includes(artifact) && /^[0-9]+$/.test(value)) {
     return repo_short_text + '#' + value;
   }
   if (artifact == 'commit') {

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1672,7 +1672,7 @@ class AutoLink(CompiledPattern):
     def shorten_github_links(
         self, artifact: str, repo_short_text: str, value: str
     ) -> Optional[str]:
-        if artifact in ["pull", "issues"]:
+        if artifact in ["pull", "issues"] and re.match(r"^[0-9]+$", value) is not None:
             return "{}#{}".format(repo_short_text, value)
         if artifact == "commit":
             return "{}@{}".format(repo_short_text, value[0 : self.COMMIT_ID_PREFIX_LENGTH])

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -1047,6 +1047,11 @@
       "name": "auto_shorten_github_link",
       "input": "https://github.com",
       "expected_output": "<p><a href=\"https://github.com\">https://github.com</a></p>"
+    },
+    {
+      "name": "auto_shorten_github_issue_new",
+      "input": "Open issue in https://github.com/zulip/zulip/issues/new and not in https://github.com/zulip/zulip/issues/123new or https://github.com/zulip/zulip/issues/new456 or https://github.com/zulip/zulip/issues/created_by",
+      "expected_output": "<p>Open issue in <a href=\"https://github.com/zulip/zulip/issues/new\">https://github.com/zulip/zulip/issues/new</a> and not in <a href=\"https://github.com/zulip/zulip/issues/123new\">https://github.com/zulip/zulip/issues/123new</a> or <a href=\"https://github.com/zulip/zulip/issues/new456\">https://github.com/zulip/zulip/issues/new456</a> or <a href=\"https://github.com/zulip/zulip/issues/created_by\">https://github.com/zulip/zulip/issues/created_by</a></p>"
     }
   ],
   "linkify_tests": [


### PR DESCRIPTION
This commit fixes the shortening of GitHub links similar to `https://github.com/zulip/zulip/issues/new`.
Shortening of the links similar to this one looks wrong visually.

We now check if `artifact/value` contains only numbers in `value` or not, where `artifact` is `issues` here.

Fixes #17954.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

A new test case is added.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
