### PR TITLE
streams: Allow admins to fetch private streams via the get streams API.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -6584,7 +6584,7 @@ def do_get_streams(
 ) -> List[Dict[str, Any]]:
     # This function is only used by API clients now.
 
-    if include_all_active and not user_profile.can_forge_sender:
+    if include_all_active and not user_profile.is_realm_admin:
         raise JsonableError(_("User not authorized for this query"))
 
     include_public = include_public and user_profile.can_access_public_streams()

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4577,27 +4577,11 @@ class GetStreamsTest(ZulipTestCase):
         result = self.api_get(normal_user, url, data)
         self.assertEqual(result.status_code, 400)
 
-        # Even realm admin users can't see all
-        # active streams (without additional privileges).
+        # Realm admin users can see all active streams.
         admin_user = self.example_user("iago")
         self.assertTrue(admin_user.is_realm_admin)
+
         result = self.api_get(admin_user, url, data)
-        self.assertEqual(result.status_code, 400)
-
-        """
-        HAPPY PATH:
-
-            We can get all active streams ONLY if we are
-            an API "super user".  We typically create
-            api-super-user accounts for things like
-            Zephyr/Jabber mirror API users, but here
-            we just "knight" Hamlet for testing expediency.
-        """
-        super_user = self.example_user("hamlet")
-        super_user.can_forge_sender = True
-        super_user.save()
-
-        result = self.api_get(super_user, url, data)
         self.assert_json_success(result)
         json = result.json()
 


### PR DESCRIPTION
We send a list of all private streams to realm admins in
fetch_initial_state since 73c30774cb362604d1da91197e5471e64a9ac242
anyway and this API code just didn't catch up.

https://chat.zulip.org/#narrow/stream/19-documentation/topic/include_all_active.20option.20of.20get_streams