### PR TITLE
Use Source Code Pro as our monospace font

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "simplebar": "^5.2.1",
     "sortablejs": "^1.9.0",
     "sorttable": "^1.0.2",
+    "source-code-pro": "^2.30.2",
     "source-sans": "^3.28.0",
     "spectrum-colorpicker": "^1.8.1",
     "stacktrace-gps": "^3.0.4",

--- a/static/js/bundles/common.js
+++ b/static/js/bundles/common.js
@@ -12,6 +12,7 @@ import "simplebar/dist/simplebar.css";
 import "font-awesome/css/font-awesome.css";
 import "../../assets/icons/zulip-icons.font";
 import "source-sans/source-sans-3.css";
+import "source-code-pro/source-code-pro.css";
 import "../../styles/pygments.css";
 import "@uppy/core/dist/style.css";
 import "@uppy/progress-bar/dist/style.css";

--- a/static/styles/alerts.css
+++ b/static/styles/alerts.css
@@ -93,7 +93,7 @@ $alert-error-red: hsl(0, 80%, 40%);
         }
 
         .stacktrace-content {
-            font-family: monospace;
+            font-family: "Source Code Pro", monospace;
             font-size: 0.85rem;
 
             margin-top: 1rem;

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -469,7 +469,7 @@
         display: inline;
         margin-right: 8px;
 
-        font-family: FontAwesome, Yantramanav, "Source Sans 3";
+        font-family: FontAwesome;
         font-weight: 600;
     }
 }

--- a/static/styles/portico/archive.css
+++ b/static/styles/portico/archive.css
@@ -1,5 +1,5 @@
 body {
-    font-family: "Source Sans 3", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: "Source Sans 3", sans-serif;
     font-size: 14px;
 }
 

--- a/static/styles/portico/billing.css
+++ b/static/styles/portico/billing.css
@@ -1,5 +1,5 @@
 .billing-upgrade-page {
-    font-family: "Source Sans 3", Helvetica, Arial, sans-serif;
+    font-family: "Source Sans 3", sans-serif;
     background-color: hsl(0, 0%, 98%);
     height: 100vh;
 
@@ -131,7 +131,7 @@
         span {
             background: 0;
             box-shadow: none;
-            font-family: "Source Sans 3", Helvetica, Arial;
+            font-family: "Source Sans 3", sans-serif;
             font-size: 1.4em;
             line-height: 20px;
         }

--- a/static/styles/portico/integrations.css
+++ b/static/styles/portico/integrations.css
@@ -84,7 +84,7 @@ $category-text: hsl(219, 23%, 33%);
         max-width: 100%;
         overflow: auto;
 
-        font-family: Monaco, Menlo, Consolas, "Courier New", Courier, monospace;
+        font-family: "Source Code Pro", monospace;
         font-size: 0.85em;
     }
 

--- a/static/styles/portico/markdown.css
+++ b/static/styles/portico/markdown.css
@@ -242,14 +242,14 @@
     .tip::before {
         display: inline;
         content: "\f0eb   Tip:  ";
-        font-family: FontAwesome, Yantramanav, "Source Sans 3";
+        font-family: FontAwesome, "Source Sans 3", sans-serif;
         font-weight: 600;
     }
 
     .keyboard_tip::before {
         display: inline;
         content: "\f11c   Keyboard Shortcut:  ";
-        font-family: FontAwesome, Yantramanav, "Source Sans 3";
+        font-family: FontAwesome, "Source Sans 3", sans-serif;
         font-weight: 600;
     }
 

--- a/static/styles/portico/markdown.css
+++ b/static/styles/portico/markdown.css
@@ -299,7 +299,7 @@
 
     code {
         /* Copied from rendered_markdown.css */
-        font-size: 0.857em;
+        font-size: 0.786em;
         unicode-bidi: embed;
         direction: ltr;
         white-space: initial;

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -1,6 +1,6 @@
 body {
     background-color: hsl(0, 0%, 98%);
-    font-family: "Source Sans 3", Helvetica, Arial, sans-serif;
+    font-family: "Source Sans 3", sans-serif;
     line-height: 150%;
     height: 100%;
     font-weight: 300;
@@ -274,7 +274,7 @@ html {
 }
 
 .title {
-    font-family: Helvetica;
+    font-family: Helvetica, sans-serif;
     font-size: 100px;
     font-weight: bold;
     margin-top: 50px;
@@ -1299,7 +1299,7 @@ input.new-organization-button {
     min-height: calc(100vh - 290px);
     height: 100%;
     background-color: hsl(163, 42%, 85%);
-    font-family: "Source Sans 3", Helvetica, Arial, sans-serif;
+    font-family: "Source Sans 3", sans-serif;
 }
 
 .error_page .container {

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -1679,7 +1679,7 @@ label.label-title {
 
 .api-argument {
     .api-argument-name {
-        font-family: monospace;
+        font-family: "Source Code Pro", monospace;
 
         .api-argument-hover-link i.fa {
             opacity: 0;
@@ -1738,7 +1738,7 @@ label.label-title {
 
     #desktop-data {
         padding: 13px 12px 12px 12px;
-        font-family: monospace;
+        font-family: "Source Code Pro", monospace;
     }
 }
 

--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -323,7 +323,7 @@ html {
         vertical-align: top;
         padding: 13px 22px 13px 22px;
 
-        font-family: "Source Sans 3";
+        font-family: "Source Sans 3", sans-serif;
 
         font-size: 1.2rem;
         font-weight: 400;
@@ -404,7 +404,7 @@ html {
             padding: 10px 32px 10px 12px;
             margin: 25px 0 5px;
 
-            font-family: "Source Sans 3";
+            font-family: "Source Sans 3", sans-serif;
             font-size: 1.2rem;
             line-height: normal;
             height: auto;

--- a/static/styles/portico/stats.css
+++ b/static/styles/portico/stats.css
@@ -1,5 +1,5 @@
 body {
-    font-family: "Source Sans 3", "Helvetica Neue", sans-serif !important;
+    font-family: "Source Sans 3", sans-serif !important;
     background-color: hsl(0, 0%, 98%);
 }
 
@@ -113,7 +113,7 @@ p {
 }
 
 .button {
-    font-family: "Source Sans 3", "Helvetica Neue", sans-serif !important;
+    font-family: "Source Sans 3", sans-serif !important;
     border: none;
     border-radius: 4px;
     outline: none;

--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -497,9 +497,8 @@ rendered_markdown block; we just need to do further analysis to
 confirm doing so won't break anything. */
 
 code {
-    /* 12/14 em, so bootstrap's default 12 px,
-       when body is the default 14 px */
-    font-size: 0.857em;
+    /* 11/14 em, so 11 px when body is the default 14 px */
+    font-size: 0.786em;
     unicode-bidi: embed;
     direction: ltr;
     color: hsl(0, 0%, 0%);
@@ -521,7 +520,7 @@ code {
 pre {
     direction: ltr;
     /* code block text is a bit smaller than normal text */
-    font-size: 0.8em;
+    font-size: 0.786em;
     line-height: 1.4;
     white-space: pre;
     overflow-x: auto;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -799,7 +799,7 @@ input[type="checkbox"] {
     }
 
     .api_key .api-key-value-and-button {
-        font-family: Inconsolata, Menlo, monospace;
+        font-family: "Source Code Pro", monospace;
         font-size: 0.85em;
         display: flex;
     }

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -99,7 +99,7 @@
 }
 
 .stream-email {
-    font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
+    font-family: "Source Code Pro", monospace;
     padding: 5px;
     font-size: 0.9em;
     background-color: hsl(0, 0%, 98%);

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -33,7 +33,7 @@ html {
 }
 
 body {
-    font-family: "Source Sans 3", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: "Source Sans 3", sans-serif;
 }
 
 /* Common background color */
@@ -47,7 +47,7 @@ input,
 button,
 select,
 textarea {
-    font-family: "Source Sans 3", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: "Source Sans 3", sans-serif;
     line-height: normal;
 }
 
@@ -379,7 +379,7 @@ p.n-margin {
 
 textarea,
 input {
-    font-family: "Source Sans 3", Helvetica, Arial, sans-serif;
+    font-family: "Source Sans 3", sans-serif;
 }
 
 /* Override Bootstrap's fixed sizes for various elements */
@@ -1800,7 +1800,7 @@ div.focused_table {
         padding-right: 20px;
         border: none;
         border-radius: 0;
-        font-family: "Source Sans 3";
+        font-family: "Source Sans 3", sans-serif;
         font-weight: 300;
         line-height: $header_height;
     }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -66,7 +66,7 @@ a {
 
 code,
 pre {
-    font-family: Menlo, Consolas, "Courier New", monospace;
+    font-family: "Source Code Pro", monospace;
 }
 
 .no-select {
@@ -2118,12 +2118,12 @@ div.floating_recipient {
 }
 
 .operator_value {
-    font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
+    font-family: "Source Code Pro", monospace;
     color: hsl(353, 70%, 65%);
 }
 
 .operator {
-    font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
+    font-family: "Source Code Pro", monospace;
 }
 
 #loading_older_messages_indicator,

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -5,9 +5,12 @@ module.exports = {
     rules: {
         // Add some exceptions for recommended rules
         "at-rule-no-unknown": [true, {ignoreAtRules: ["extend"]}],
+        "font-family-no-missing-generic-family-keyword": [
+            true,
+            {ignoreFontFamilies: ["FontAwesome"]},
+        ],
 
         // Disable recommended rules we don't comply with yet
-        "font-family-no-missing-generic-family-keyword": null,
         "no-descending-specificity": null,
 
         // Disable standard rules we don't comply with yet

--- a/yarn.lock
+++ b/yarn.lock
@@ -11392,6 +11392,11 @@ sorttable@^1.0.2:
   resolved "https://registry.yarnpkg.com/sorttable/-/sorttable-1.0.2.tgz#da67e34d32f6198bc12942b183b7a0f7c650f1a4"
   integrity sha512-dY6xMviQb4+zeZ11MSOqYfgXbv3pA6q4y35/lqVRulAXhR36MYvYjxTSWbctwiVWaRk0ufY10gNwFrcdrXPeWA==
 
+source-code-pro@^2.30.2:
+  version "2.30.2"
+  resolved "https://registry.yarnpkg.com/source-code-pro/-/source-code-pro-2.30.2.tgz#1577e4bc93d2399d271d00f8426a8cd1b7f86da2"
+  integrity sha512-KctdxE5xBzf9wjYjTO9JWEQ1F2tdAR+yloz1rUmP5n0p6wEXB33B0myGTz49K6I3/EQpnJ9zot10r9ThQ+GARg==
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"


### PR DESCRIPTION
Fixes #15993.

**GIFs or screenshots:**

![day](https://user-images.githubusercontent.com/26471/113465524-869c8600-93e9-11eb-8dc9-30aef6967e14.png)

![night](https://user-images.githubusercontent.com/26471/113465393-76d07200-93e8-11eb-9e04-2bef2fc0eca4.png)

(From [this message](https://chat.zulip.org/#narrow/stream/65-checkins/topic/Rein/near/1142877) if you want to compare with your system’s current rendering, although it’s heavily dependent on which of Monaco, Menlo, Consolas, Courier New, and Courier you have installed and/or your system default monospace font.)