### PR TITLE
recent_topics: Don't change background color on thead hover.

### DIFF
--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -454,9 +454,6 @@ on a dark background, and don't change the dark labels dark either. */
     .btn-recent-selected,
     #recent_topics_table thead th {
         background-color: hsl(0, 0%, 0%) !important;
-        &:hover {
-            background-color: hsl(211, 29%, 14%) !important;
-        }
     }
 
     #recent_topics_table td a {

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -240,8 +240,6 @@
 
             &[data-sort]:hover {
                 cursor: pointer;
-                background-color: hsla(0, 0%, 95%);
-                transition: background-color 100ms ease-in-out;
 
                 &:not(.active)::after {
                     opacity: 0.3;


### PR DESCRIPTION
We expect to give recent topics a cleaner look by doing so.

Fixes #17934
