### PR TITLE
hotkey: Fix Ctrl+C not working when recent topics view is visible.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -759,7 +759,7 @@ export function process_hotkey(e, hotkey) {
         return false;
     }
 
-    // Compose box hotkeys
+    // Shortcuts that are useful with an empty message feed, like opening compose.
     switch (event_name) {
         case "compose": // 'c': compose
             compose_actions.start("stream", {trigger: "compose_hotkey"});
@@ -781,16 +781,14 @@ export function process_hotkey(e, hotkey) {
         case "star_deprecated":
             ui.maybe_show_deprecation_notice("*");
             return true;
-        case "copy_with_c":
-            copy_and_paste.copy_handler();
-            return true;
     }
 
     if (message_lists.current.empty()) {
         return false;
     }
 
-    // Navigation shortcuts
+    // Shortcuts for navigation and other applications that require a
+    // nonempty message feed but do not depend on the selected message.
     switch (event_name) {
         case "down_arrow":
         case "vim_down":
@@ -816,6 +814,9 @@ export function process_hotkey(e, hotkey) {
         case "vim_page_down":
         case "spacebar":
             navigate.page_down();
+            return true;
+        case "copy_with_c":
+            copy_and_paste.copy_handler();
             return true;
     }
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -756,7 +756,7 @@ export function process_hotkey(e, hotkey) {
     // open. These involve compose box hotkeys and hotkeys that can only
     // be done performed on a message.
     if (recent_topics.is_visible()) {
-        return true;
+        return false;
     }
 
     // Compose box hotkeys


### PR DESCRIPTION
Currently, hitting Ctrl+C doesn't copy when the recent topics view is
visible. So, say, a user can't copy topic names from recent topics list
or a developer can't copy error messages from blueslip alert boxes.
This is because the `copy_with_c` hotkey event is shadowed by the
`recent_topics.is_visible()` check just above it.

This commit places the `copy_with_c` event above the check
so that Ctrl+C works everywhere.

**Testing plan:** <!-- How have you tested? -->
Tested manually.

CC: @amanagr 