### PR TITLE
Fix: Highlight filter term when returning to Recent topics view.

### DIFF
--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -536,6 +536,10 @@ export function show() {
     message_view_header.render_title_area();
 
     complete_rerender();
+    //once recent topic search input box and results are rendered , if input is not empty highlight contents of searchbox.
+    if ($("#recent_topics_search").val() !=""){
+        $("#recent_topics_search").select();
+    }
 }
 
 function filter_buttons() {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/17941

**Testing plan:** <!-- How have you tested? -->
manual testing

**GIFs or screenshots:** <!-- If a UI change.  See:
before fix:
![beforechanges](https://user-images.githubusercontent.com/10942163/113492039-c4390600-94f2-11eb-9eea-5cd54987c534.gif)

after fix:
![after changes](https://user-images.githubusercontent.com/10942163/113491961-31986700-94f2-11eb-861f-61b9135237a1.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
