### PR TITLE
eslint: Enable sort-imports for member sorting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -87,6 +87,7 @@
             }
         ],
         "radix": "error",
+        "sort-imports": ["error", {"ignoreDeclarationSort": true}],
         "spaced-comment": ["error", "always", {"markers": ["/"]}],
         "strict": "error",
         "unicorn/consistent-function-scoping": "off",

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1,5 +1,5 @@
 import ClipboardJS from "clipboard";
-import {parseISO, formatISO, add, set} from "date-fns";
+import {add, formatISO, parseISO, set} from "date-fns";
 import ConfirmDatePlugin from "flatpickr/dist/plugins/confirmDate/confirmDate";
 import $ from "jquery";
 

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -1,5 +1,5 @@
 import ClipboardJS from "clipboard";
-import {parseISO, isValid} from "date-fns";
+import {isValid, parseISO} from "date-fns";
 import $ from "jquery";
 
 import copy_code_button from "../templates/copy_code_button.hbs";

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -1,6 +1,6 @@
 import {
-    differenceInMinutes,
     differenceInCalendarDays,
+    differenceInMinutes,
     format,
     formatISO,
     isEqual,


### PR DESCRIPTION
This sorts the members imported within each individual declaration; we use `import/order` for sorting multiple declarations.