### PR TITLE
Add feature that displays nudge for old servers.

### DIFF
--- a/static/js/panels.js
+++ b/static/js/panels.js
@@ -80,6 +80,8 @@ export function initialize() {
     const ls = localstorage();
     if (page_params.insecure_desktop_app) {
         open($("[data-process='insecure-desktop-app']"));
+    } else if (page_params.server_needs_upgrade) {
+        open($("[data-process='server-needs-upgrade']"));
     } else if (page_params.warn_no_email === true && page_params.is_admin) {
         // if email has not been set up and the user is the admin,
         // display a warning to tell them to set up an email server.

--- a/templates/zerver/app/navbar_alerts.html
+++ b/templates/zerver/app/navbar_alerts.html
@@ -45,6 +45,15 @@
         </div>
         <span class="close" data-dismiss="alert" aria-label="{{ _('Close') }}" role="button" tabindex=0>&times;</span>
     </div>
+    <div data-process="server-needs-upgrade" class="alert alert-info red">
+        <div data-step="1">
+            {{ _("This Zulip server is running an old version and should be upgraded.") }}
+            <a class="alert-link" href="https://zulip.readthedocs.io/en/latest/production/upgrade-or-modify.html" target="_blank" rel="noopener noreferrer">
+                {{ _("Learn more.") }}
+            </a>
+        </div>
+        <span class="close" data-dismiss="alert" aria-label="{{ _('Close') }}" role="button" tabindex=0>&times;</span>
+    </div>
     <div data-process="bankruptcy" class="alert alert-info brankruptcy">
         <div data-step="1">
             {% trans count=page_params.unread_msgs.count %}

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -1,11 +1,15 @@
 import calendar
+import datetime
+import os
 import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
+import pytz
 from django.conf import settings
 from django.http import HttpRequest
 from django.utils import translation
+from django.utils.timezone import now as timezone_now
 from two_factor.utils import default_device
 
 from zerver.lib.events import do_events_register
@@ -33,6 +37,33 @@ class UserPermissionInfo:
     is_realm_admin: bool
     is_realm_owner: bool
     show_webathena: bool
+
+
+# LAST_SERVER_UPGRADE_TIME is the last time the server had a version deployed.
+if settings.PRODUCTION:  # nocoverage
+    timestamp = os.path.basename(os.path.abspath(settings.DEPLOY_ROOT))
+    LAST_SERVER_UPGRADE_TIME = datetime.datetime.strptime(timestamp, "%Y-%m-%d-%H-%M-%S").replace(
+        tzinfo=pytz.utc
+    )
+else:
+    LAST_SERVER_UPGRADE_TIME = timezone_now()
+
+
+def is_outdated_server(user_profile: Optional[UserProfile]) -> bool:
+    # TODO: We should ideally be using the minimum of this calculation
+    # and the date the release tarball was generated.
+    tzaware_last_upgrade_time = LAST_SERVER_UPGRADE_TIME
+    deadline = tzaware_last_upgrade_time + datetime.timedelta(
+        days=settings.SERVER_UPGRADE_NAG_DEADLINE
+    )
+
+    if user_profile is None or not user_profile.is_realm_admin:
+        # Administrators get warned at the deadline; all users 30 days later.
+        deadline = deadline + datetime.timedelta(days=30)
+
+    if timezone_now() > deadline:
+        return True
+    return False
 
 
 def get_furthest_read_time(user_profile: Optional[UserProfile]) -> Optional[float]:
@@ -174,6 +205,7 @@ def build_page_params_for_home_page_load(
         test_suite=settings.TEST_SUITE,
         poll_timeout=settings.POLL_TIMEOUT,
         insecure_desktop_app=insecure_desktop_app,
+        server_needs_upgrade=is_outdated_server(user_profile),
         login_page=settings.HOME_NOT_LOGGED_IN,
         root_domain_uri=settings.ROOT_DOMAIN_URI,
         save_stacktraces=settings.SAVE_FRONTEND_STACKTRACES,

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -441,3 +441,6 @@ NAGIOS_BOT_HOST = EXTERNAL_HOST
 
 # Use half of the available CPUs for data import purposes.
 DEFAULT_DATA_EXPORT_IMPORT_PARALLELISM = (len(os.sched_getaffinity(0)) // 2) or 1
+
+# How long after the last upgrade to nag users that the server is insecure
+SERVER_UPGRADE_NAG_DEADLINE = 365


### PR DESCRIPTION
This pull request seeks to solve  #17826 

![Screenshot from 2021-04-09 19-20-39](https://user-images.githubusercontent.com/32811823/114757617-fac51b00-9d53-11eb-81f8-dc484821f68a.png)

I ran automated tests locally and they all passed. I also tested the feature locally with the dev server. See screenshot above.
@timabbott I'd appreciate a review

