### PR TITLE
Improve styling for starred messages count

### DIFF
--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -235,7 +235,7 @@ li.active-sub-filter {
 
     .count {
         margin-right: 20px;
-        margin-top: 2px;
+        margin-top: 0;
         display: none;
     }
 
@@ -316,8 +316,9 @@ li.top_left_recent_topics {
 .top_left_starred_messages .count {
     background-color: transparent;
     color: inherit;
-    padding: 2px 1px 0 3px;
-    border-color: hsl(105, 2%, 50%);
+    padding: 0 3px 0 3px;
+    border: 1.5px solid hsl(0, 0%, 66%);
+    font-weight: 600;
 }
 
 /* These are true "unread" counts. */


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#17938

**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![(15) Starred messages - Zulip Dev - Zulip - Google Chrome 04-04-2021 12_03_07](https://user-images.githubusercontent.com/77020164/113502410-dbefa900-9549-11eb-9558-1dc680f75195.png)
![(15) Starred messages - Zulip Dev - Zulip - Google Chrome 04-04-2021 12_07_36](https://user-images.githubusercontent.com/77020164/113502416-df833000-9549-11eb-93d0-1be97ee9ea4e.png)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
