### PR TITLE
populate_db : Add links to topic names.

### DIFF
--- a/zerver/lib/generate_test_data.py
+++ b/zerver/lib/generate_test_data.py
@@ -24,18 +24,31 @@ def generate_topics(num_topics: int) -> List[str]:
     # it is important we test on it.
     num_single_word_topics = num_topics // 3
     for _ in itertools.repeat(None, num_single_word_topics):
-        topics.append(random.choice(config["nouns"]))
+        url = ""
+        # Add urls to 5 percent of the single word topics.
+        if random.random() <= 0.05:
+            url = " [ {} ]".format(random.choice(config["embedded_links"]))
+        topics.append(random.choice(config["nouns"]) + url)
+
+    # 2 Percent chance that a topic name will be a url.
+    num_url_topics = num_topics // 60
+    for _ in itertools.repeat(None, num_url_topics):
+        topics.append(random.choice(config["embedded_links"]))
 
     sentence = ["adjectives", "nouns", "connectors", "verbs", "adverbs"]
     for pos in sentence:
         # Add an empty string so that we can generate variable length topics.
         config[pos].append("")
 
-    for _ in itertools.repeat(None, num_topics - num_single_word_topics):
+    for _ in itertools.repeat(None, num_topics - num_single_word_topics - num_url_topics):
         generated_topic = [random.choice(config[pos]) for pos in sentence]
         topic = " ".join(filter(None, generated_topic))
-        topics.append(topic)
-
+        url = ""
+        # Calculating length of topic name so that the final length
+        # doesn't exceed 60 when a url is added.
+        if random.random() <= 0.10 and len(topic) <= 35:
+            url = " [ {} ]".format(random.choice(config["embedded_links"]))
+        topics.append(topic + url)
     return topics
 
 

--- a/zerver/tests/fixtures/config.generate_data.json
+++ b/zerver/tests/fixtures/config.generate_data.json
@@ -17,6 +17,15 @@
 
       "emoji": [":thumbs_up:", ":thumbs_down:", ":shirt:", ":zulip:", ":tada:", ":earth_asia:",
         ":cop:", ":8ball:", ":boat:", ":egg:", ":heartpulse:", ":moon_ceremony:", ":cupid:", ":mag:"],
+
+      "embedded_links": [
+          "www.google.com",
+          "www.youtube.com",
+          "www.github.com",
+          "www.twitter.com",
+          "www.zulip.com"
+      ],
+
       "links":
        ["https://zulip.readthedocs.io/en/latest/subsystems/emoji.html",
          "https://zulip.readthedocs.io/en/latest/subsystems/full-text-search.html",


### PR DESCRIPTION
Previously, we had only plain texts as our topic names on `populate_db`, with this PR
the generated topic names will have a 5 percent chance (approximately) to contain a URL.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Related issue: #14991

**Testing plan:** <!-- How have you tested? -->
 Tested using `./manage.py populate_db` and `./manage.py populate_db --max-topics 500`

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Preview 1 : 
![Topic Urls](https://user-images.githubusercontent.com/42570356/113503283-810c8080-954e-11eb-9b50-0933117384e0.JPG)
Preview 2 :
![topic urls 2](https://user-images.githubusercontent.com/42570356/113503392-33444800-954f-11eb-97f4-152b8f5175e5.JPG)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
