### PR TITLE
Add a send test notification button for push notifications.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -282,6 +282,25 @@ export function create_message_object() {
     return message;
 }
 
+export function send_test_notification_message() {
+    const notification_bot = "notification-bot@zulip.com";
+    const notification_bot_id = page_params.zulip_user_bots[notification_bot];
+    const message_object = {
+        type: "private",
+        content: i18n.t("__emoji__ Hey, notification bot send me a message!", {
+            emoji: ":smile:",
+        }),
+        private_message_recipient: notification_bot,
+        sender_id: page_params.user_id,
+        queue_id: page_params.queue_id,
+        reply_to: notification_bot,
+        to: [notification_bot_id],
+        to_user_ids: notification_bot_id,
+    };
+
+    send_message(message_object);
+}
+
 export function compose_error(error_text, bad_input) {
     $("#compose-send-status")
         .removeClass(common.status_classes)

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -229,7 +229,7 @@ export function process_notification(notification) {
         content = message.sender_full_name + content.slice(3);
     }
 
-    if (message.type === "private" || message.type === "test-notification") {
+    if (message.type === "private") {
         if (
             page_params.pm_content_in_desktop_notifications !== undefined &&
             !page_params.pm_content_in_desktop_notifications
@@ -311,9 +311,7 @@ export function process_notification(notification) {
             // unavailable for them.
             notification_object.addEventListener("click", () => {
                 notification_object.close();
-                if (message.type !== "test-notification") {
-                    narrow.by_topic(message.id, {trigger: "notification"});
-                }
+                narrow.by_topic(message.id, {trigger: "notification"});
                 window.focus();
             });
             notification_object.addEventListener("close", () => {
@@ -369,11 +367,6 @@ export function message_is_notifiable(message) {
 }
 
 export function should_send_desktop_notification(message) {
-    // Always notify for testing notifications.
-    if (message.type === "test-notification") {
-        return true;
-    }
-
     // For streams, send if desktop notifications are enabled for all
     // message on this stream.
     if (
@@ -431,7 +424,7 @@ export function should_send_audible_notification(message) {
 
     // And then we need to check if the message is a PM, mention,
     // wildcard mention with wildcard_mentions_notify, or alert.
-    if (message.type === "private" || message.type === "test-notification") {
+    if (message.type === "private") {
         return true;
     }
 
@@ -486,20 +479,6 @@ export function received_messages(messages) {
             $("#notification-sound-audio")[0].play();
         }
     }
-}
-
-export function send_test_notification(content) {
-    received_messages([
-        {
-            id: Math.random(),
-            type: "test-notification",
-            sender_email: "notification-bot@zulip.com",
-            sender_full_name: "Notification Bot",
-            display_reply_to: "Notification Bot",
-            content,
-            unread: true,
-        },
-    ]);
 }
 
 // Note that this returns values that are not HTML-escaped, for use in

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -3,8 +3,6 @@ import $ from "jquery";
 import render_stream_specific_notification_row from "../templates/settings/stream_specific_notification_row.hbs";
 
 import * as channel from "./channel";
-import {i18n} from "./i18n";
-import * as notifications from "./notifications";
 import {page_params} from "./page_params";
 import * as settings_config from "./settings_config";
 import * as settings_org from "./settings_org";
@@ -84,12 +82,6 @@ export function set_up() {
     });
 
     update_desktop_icon_count_display();
-
-    $("#send_test_notification").on("click", () => {
-        notifications.send_test_notification(
-            i18n.t("This is what a Zulip notification looks like."),
-        );
-    });
 
     $("#play_notification_sound").on("click", () => {
         $("#notification-sound-audio")[0].play();

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -53,6 +53,8 @@
 
             <h5>{{t "Desktop" }}</h5>
 
+            <p><a class="send_test_notification desktop">{{t "Send test notification" }}</a></p>
+
             {{#each notification_settings.desktop_notification_settings}}
             {{> settings_checkbox
               setting_name=this
@@ -87,6 +89,8 @@
             </div>
 
             <h5>{{t "Mobile" }}</h5>
+
+            <p><a class="send_test_notification mobile">{{t "Send test notification" }}</a></p>
 
             {{#each notification_settings.mobile_notification_settings}}
             {{> settings_checkbox

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -53,8 +53,6 @@
 
             <h5>{{t "Desktop" }}</h5>
 
-            <p><a id="send_test_notification">{{t "Send test notification" }}</a></p>
-
             {{#each notification_settings.desktop_notification_settings}}
             {{> settings_checkbox
               setting_name=this

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -16,7 +16,7 @@ from zerver.lib.i18n import (
     get_language_name,
     get_language_translation_data,
 )
-from zerver.models import Message, Realm, Stream, UserProfile
+from zerver.models import Message, Realm, Stream, UserProfile, get_system_bot
 from zerver.views.message_flags import get_latest_update_message_flag_activity
 
 
@@ -99,6 +99,10 @@ def get_user_permission_info(user_profile: Optional[UserProfile]) -> UserPermiss
             is_realm_owner=False,
             show_webathena=False,
         )
+
+
+def get_zulip_user_bots() -> Dict[str, int]:
+    return {email: get_system_bot(email).id for email in settings.CROSS_REALM_BOT_EMAILS}
 
 
 def build_page_params_for_home_page_load(
@@ -190,6 +194,7 @@ def build_page_params_for_home_page_load(
         furthest_read_time=furthest_read_time,
         has_mobile_devices=has_mobile_devices,
         bot_types=get_bot_types(user_profile),
+        zulip_user_bots=get_zulip_user_bots(),
         two_fa_enabled=two_fa_enabled,
         # Adding two_fa_enabled as condition saves us 3 queries when
         # 2FA is not enabled.

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -222,6 +222,7 @@ class HomeTest(ZulipTestCase):
         "wildcard_mentions_notify",
         "zulip_feature_level",
         "zulip_plan_is_not_limited",
+        "zulip_user_bots",
         "zulip_version",
     ]
 
@@ -260,8 +261,8 @@ class HomeTest(ZulipTestCase):
             set(result["Cache-Control"].split(", ")), {"must-revalidate", "no-store", "no-cache"}
         )
 
-        self.assert_length(queries, 39)
-        self.assert_length(cache_mock.call_args_list, 5)
+        self.assert_length(queries, 42)
+        self.assert_length(cache_mock.call_args_list, 8)
 
         html = result.content.decode("utf-8")
 
@@ -339,8 +340,8 @@ class HomeTest(ZulipTestCase):
             with patch("zerver.lib.cache.cache_set") as cache_mock:
                 result = self._get_home_page()
                 self.check_rendered_logged_in_app(result)
-                self.assert_length(cache_mock.call_args_list, 6)
-            self.assert_length(queries, 36)
+                self.assert_length(cache_mock.call_args_list, 9)
+            self.assert_length(queries, 39)
 
     def test_num_queries_with_streams(self) -> None:
         main_user = self.example_user("hamlet")
@@ -371,7 +372,7 @@ class HomeTest(ZulipTestCase):
         with queries_captured() as queries2:
             result = self._get_home_page()
 
-        self.assert_length(queries2, 34)
+        self.assert_length(queries2, 37)
 
         # Do a sanity check that our new streams were in the payload.
         html = result.content.decode("utf-8")

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -752,7 +752,7 @@ class LoginTest(ZulipTestCase):
         # seem to be any O(N) behavior.  Some of the cache hits are related
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
-        self.assertEqual(len(cache_tries), 15)
+        self.assertEqual(len(cache_tries), 16)
 
         user_profile = self.nonreg_user("test")
         self.assert_logged_in_user_id(user_profile.id)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -820,7 +820,7 @@ class QueryCountTest(ZulipTestCase):
                     )
 
         self.assert_length(queries, 68)
-        self.assert_length(cache_tries, 20)
+        self.assert_length(cache_tries, 22)
         self.assert_length(events, 7)
 
         peer_add_events = [event for event in events if event["event"].get("op") == "peer_add"]

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -32,6 +32,7 @@ from .configured_settings import (
     DEBUG,
     DEBUG_ERROR_REPORTING,
     EMAIL_BACKEND,
+    EMAIL_GATEWAY_BOT,
     EMAIL_HOST,
     ERROR_REPORTING,
     EXTERNAL_HOST,
@@ -43,6 +44,7 @@ from .configured_settings import (
     LOCAL_UPLOADS_DIR,
     MEMCACHED_LOCATION,
     MEMCACHED_USERNAME,
+    NOTIFICATION_BOT,
     REALM_HOSTS,
     REGISTER_LINK_DISABLED,
     REMOTE_POSTGRES_HOST,
@@ -61,6 +63,7 @@ from .configured_settings import (
     STATSD_HOST,
     TORNADO_PORTS,
     USING_PGROONGA,
+    WELCOME_BOT,
     ZULIP_ADMINISTRATOR,
 )
 
@@ -1160,9 +1163,9 @@ if PRODUCTION:
 PROFILE_ALL_REQUESTS = False
 
 CROSS_REALM_BOT_EMAILS = {
-    "notification-bot@zulip.com",
-    "welcome-bot@zulip.com",
-    "emailgateway@zulip.com",
+    NOTIFICATION_BOT,
+    WELCOME_BOT,
+    EMAIL_GATEWAY_BOT,
 }
 
 THUMBOR_KEY = get_secret("thumbor_key")


### PR DESCRIPTION
Fixes #17059 and related to #14433.

This is still WIP.
Opened to check whether this approach is acceptable or not.
When the test notification link is clicked, we send a message through the users client
and in the `do_send_messages` codepath we check for this case and the bot replies.


For every message the user sends to the notification bot it replies.
So, added a check where the bot only replies if the message starts with the `:smile:` emoji.
( Not sure how to compare the message content for different languages. )

____

The number of queries increases by 3 due to fetching the ids of the 3 cross realm bots
for the initial home page load. Only the notification bot id is required, so I guess I
will update it to only pass the notification bot's id (num queries increases by 1 instead of 3).


https://user-images.githubusercontent.com/40122794/113513765-d6658380-9588-11eb-9c43-ea2ba3a10343.mp4

