### PR TITLE
hotkey: Map numpad navigation keys to close compose when empty.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -651,7 +651,12 @@ export function process_hotkey(e, hotkey) {
         }
 
         if (
-            (event_name === "up_arrow" || event_name === "down_arrow") &&
+            (event_name === "up_arrow" ||
+                event_name === "down_arrow" ||
+                event_name === "page_up" ||
+                event_name === "page_down" ||
+                event_name === "home" ||
+                event_name === "end") &&
             compose_state.focus_in_empty_compose()
         ) {
             compose_actions.cancel();


### PR DESCRIPTION
This maps pageup/pagedown/home/end to close compose when used in empty
compose box.

Currently, these keys do nothing when used in an empty compose box.
Typically, a user intends to navigate when pressing these keys, so it
makes sense to map them to navigate.

Fixes #17917

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![ezgif com-gif-maker](https://user-images.githubusercontent.com/58626718/113539046-6f80b280-95fa-11eb-8760-3d8cc05fbd5d.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
