### PR TITLE
refactor: Clean up subs for settings code.

### DIFF
--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -16,6 +16,7 @@ const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const presence = zrequire("presence");
 const stream_data = zrequire("stream_data");
+const stream_settings_data = zrequire("stream_settings_data");
 const user_status = zrequire("user_status");
 const buddy_data = zrequire("buddy_data");
 
@@ -179,7 +180,7 @@ test("compose fade interactions (streams)", () => {
     };
     stream_data.add_sub(sub);
     stream_data.subscribe_myself(sub);
-    stream_data.update_calculated_fields(sub);
+    stream_settings_data.update_calculated_fields(sub);
 
     people.add_active_user(fred);
 
@@ -225,7 +226,7 @@ test("compose fade interactions (missing topic)", () => {
     };
     stream_data.add_sub(sub);
     stream_data.subscribe_myself(sub);
-    stream_data.update_calculated_fields(sub);
+    stream_settings_data.update_calculated_fields(sub);
 
     people.add_active_user(fred);
 

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -16,7 +16,6 @@ const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const presence = zrequire("presence");
 const stream_data = zrequire("stream_data");
-const stream_settings_data = zrequire("stream_settings_data");
 const user_status = zrequire("user_status");
 const buddy_data = zrequire("buddy_data");
 
@@ -180,7 +179,6 @@ test("compose fade interactions (streams)", () => {
     };
     stream_data.add_sub(sub);
     stream_data.subscribe_myself(sub);
-    stream_settings_data.update_calculated_fields(sub);
 
     people.add_active_user(fred);
 
@@ -226,7 +224,6 @@ test("compose fade interactions (missing topic)", () => {
     };
     stream_data.add_sub(sub);
     stream_data.subscribe_myself(sub);
-    stream_settings_data.update_calculated_fields(sub);
 
     people.add_active_user(fred);
 

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1149,7 +1149,6 @@ test_ui("needs_subscribe_warning", () => {
     const sub = {
         stream_id: 110,
         name: "stream",
-        can_access_subscribers: true,
     };
 
     stream_data.add_sub(sub);

--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -59,7 +59,6 @@ run_test("set_focused_recipient", () => {
         stream_id: 101,
         name: "social",
         subscribed: true,
-        can_access_subscribers: true,
     };
 
     compose_fade.set_focused_recipient("stream");

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -172,7 +172,6 @@ const sweden_stream = {
     description: "Cold, mountains and home decor.",
     stream_id: 1,
     subscribed: true,
-    can_access_subscribers: true,
 };
 const denmark_stream = {
     name: "Denmark",

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -49,7 +49,6 @@ const settings_config = zrequire("settings_config");
 const pygments_data = zrequire("../generated/pygments_data.json");
 
 // To be eliminated in next commit:
-stream_data.__Rewire__("update_calculated_fields", () => {});
 stream_data.__Rewire__("set_filter_out_inactives", () => false);
 
 const ct = composebox_typeahead;

--- a/frontend_tests/node_tests/dispatch_subs.js
+++ b/frontend_tests/node_tests/dispatch_subs.js
@@ -187,7 +187,6 @@ test("stream create", (override) => {
     const stub = make_stub();
     override(stream_data, "create_streams", stub.f);
     override(stream_data, "get_sub_by_id", noop);
-    override(stream_data, "update_calculated_fields", noop);
     override(subs, "add_sub_to_table", noop);
     override(overlays, "streams_open", () => true);
     dispatch(event);

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -16,6 +16,7 @@ const narrow_banner = zrequire("narrow_banner");
 const narrow_state = zrequire("narrow_state");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
+const stream_settings_data = zrequire("stream_settings_data");
 const {Filter} = zrequire("../js/filter");
 const narrow = zrequire("narrow");
 
@@ -117,7 +118,7 @@ run_test("show_empty_narrow_message", () => {
 
     // for non sub public stream
     stream_data.add_sub({name: "ROME", stream_id: 99});
-    stream_data.update_calculated_fields(stream_data.get_sub("ROME"));
+    stream_settings_data.update_calculated_fields(stream_data.get_sub("ROME"));
     set_filter([["stream", "Rome"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -16,7 +16,6 @@ const narrow_banner = zrequire("narrow_banner");
 const narrow_state = zrequire("narrow_state");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
-const stream_settings_data = zrequire("stream_settings_data");
 const {Filter} = zrequire("../js/filter");
 const narrow = zrequire("narrow");
 
@@ -118,7 +117,6 @@ run_test("show_empty_narrow_message", () => {
 
     // for non sub public stream
     stream_data.add_sub({name: "ROME", stream_id: 99});
-    stream_settings_data.update_calculated_fields(stream_data.get_sub("ROME"));
     set_filter([["stream", "Rome"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();

--- a/frontend_tests/node_tests/peer_data.js
+++ b/frontend_tests/node_tests/peer_data.js
@@ -16,6 +16,7 @@ const {page_params} = require("../zjsunit/zpage_params");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
+const stream_settings_data = zrequire("stream_settings_data");
 
 page_params.is_admin = false;
 page_params.realm_users = [];
@@ -113,7 +114,7 @@ test("subscribers", () => {
     ]);
 
     peer_data.set_subscribers(stream_id, [me.user_id, fred.user_id, george.user_id]);
-    stream_data.update_calculated_fields(sub);
+    stream_settings_data.update_calculated_fields(sub);
     assert(stream_data.is_user_subscribed(stream_id, me.user_id));
     assert(stream_data.is_user_subscribed(stream_id, fred.user_id));
     assert(stream_data.is_user_subscribed(stream_id, george.user_id));
@@ -181,7 +182,7 @@ test("subscribers", () => {
 
     // Verify that we noop and don't crash when unsubscribed.
     sub.subscribed = false;
-    stream_data.update_calculated_fields(sub);
+    stream_settings_data.update_calculated_fields(sub);
     peer_data.add_subscriber(stream_id, brutus.user_id);
     assert.equal(stream_data.is_user_subscribed(stream_id, brutus.user_id), true);
     peer_data.remove_subscriber(stream_id, brutus.user_id);
@@ -195,7 +196,7 @@ test("subscribers", () => {
         2,
     );
     sub.invite_only = true;
-    stream_data.update_calculated_fields(sub);
+    stream_settings_data.update_calculated_fields(sub);
     assert.equal(stream_data.is_user_subscribed(stream_id, brutus.user_id), undefined);
     peer_data.remove_subscriber(stream_id, brutus.user_id);
     assert.equal(stream_data.is_user_subscribed(stream_id, brutus.user_id), undefined);

--- a/frontend_tests/node_tests/peer_data.js
+++ b/frontend_tests/node_tests/peer_data.js
@@ -16,7 +16,6 @@ const {page_params} = require("../zjsunit/zpage_params");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
-const stream_settings_data = zrequire("stream_settings_data");
 
 page_params.is_admin = false;
 page_params.realm_users = [];
@@ -114,7 +113,6 @@ test("subscribers", () => {
     ]);
 
     peer_data.set_subscribers(stream_id, [me.user_id, fred.user_id, george.user_id]);
-    stream_settings_data.update_calculated_fields(sub);
     assert(stream_data.is_user_subscribed(stream_id, me.user_id));
     assert(stream_data.is_user_subscribed(stream_id, fred.user_id));
     assert(stream_data.is_user_subscribed(stream_id, george.user_id));
@@ -182,7 +180,6 @@ test("subscribers", () => {
 
     // Verify that we noop and don't crash when unsubscribed.
     sub.subscribed = false;
-    stream_settings_data.update_calculated_fields(sub);
     peer_data.add_subscriber(stream_id, brutus.user_id);
     assert.equal(stream_data.is_user_subscribed(stream_id, brutus.user_id), true);
     peer_data.remove_subscriber(stream_id, brutus.user_id);
@@ -196,7 +193,6 @@ test("subscribers", () => {
         2,
     );
     sub.invite_only = true;
-    stream_settings_data.update_calculated_fields(sub);
     assert.equal(stream_data.is_user_subscribed(stream_id, brutus.user_id), undefined);
     peer_data.remove_subscriber(stream_id, brutus.user_id);
     assert.equal(stream_data.is_user_subscribed(stream_id, brutus.user_id), undefined);

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -55,6 +55,7 @@ set_global("FormData", _FormData);
 const settings_config = zrequire("settings_config");
 const settings_bots = zrequire("settings_bots");
 const stream_data = zrequire("stream_data");
+const stream_settings_data = zrequire("stream_settings_data");
 const settings_account = zrequire("settings_account");
 const settings_org = zrequire("settings_org");
 const dropdown_list_widget = zrequire("dropdown_list_widget");
@@ -901,7 +902,7 @@ test("test get_sorted_options_list", () => {
     assert.deepEqual(settings_org.get_sorted_options_list(option_values_2), expected_option_values);
 });
 
-test("misc", () => {
+test("misc", (override) => {
     page_params.is_admin = false;
 
     const stub_notification_disable_parent = $.create("<stub notification_disable parent");
@@ -972,7 +973,7 @@ test("misc", () => {
     settings_account.update_email_change_display();
     assert(!$("#change_email .button").prop("disabled"));
 
-    stream_data.__Rewire__("get_streams_for_settings_page", () => [
+    override(stream_settings_data, "get_streams_for_settings_page", () => [
         {name: "some_stream", stream_id: 75},
         {name: "some_stream", stream_id: 42},
     ]);

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -13,6 +13,7 @@ const color_data = zrequire("color_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
+const stream_settings_data = zrequire("stream_settings_data");
 const settings_config = zrequire("settings_config");
 
 const me = {
@@ -253,7 +254,7 @@ test("admin_options", () => {
     // non-admins can't do anything
     page_params.is_admin = false;
     let sub = make_sub();
-    stream_data.update_calculated_fields(sub);
+    stream_settings_data.update_calculated_fields(sub);
     assert(!sub.is_realm_admin);
     assert(!sub.can_change_stream_permissions);
 
@@ -265,7 +266,7 @@ test("admin_options", () => {
 
     // admins can make public streams become private
     sub = make_sub();
-    stream_data.update_calculated_fields(sub);
+    stream_settings_data.update_calculated_fields(sub);
     assert(sub.is_realm_admin);
     assert(sub.can_change_stream_permissions);
 
@@ -274,14 +275,14 @@ test("admin_options", () => {
     sub = make_sub();
     sub.invite_only = true;
     sub.subscribed = false;
-    stream_data.update_calculated_fields(sub);
+    stream_settings_data.update_calculated_fields(sub);
     assert(sub.is_realm_admin);
     assert(!sub.can_change_stream_permissions);
 
     sub = make_sub();
     sub.invite_only = true;
     sub.subscribed = true;
-    stream_data.update_calculated_fields(sub);
+    stream_settings_data.update_calculated_fields(sub);
     assert(sub.is_realm_admin);
     assert(sub.can_change_stream_permissions);
 });
@@ -317,7 +318,7 @@ test("stream_settings", () => {
     stream_data.add_sub(amber);
     stream_data.add_sub(blue);
 
-    let sub_rows = stream_data.get_streams_for_settings_page();
+    let sub_rows = stream_settings_data.get_streams_for_settings_page();
     assert.equal(sub_rows[0].color, "blue");
     assert.equal(sub_rows[1].color, "amber");
     assert.equal(sub_rows[2].color, "cinnamon");
@@ -344,17 +345,17 @@ test("stream_settings", () => {
     });
     stream_data.update_stream_post_policy(sub, 1);
     stream_data.update_message_retention_setting(sub, -1);
-    stream_data.update_calculated_fields(sub);
+    stream_settings_data.update_calculated_fields(sub);
     assert.equal(sub.invite_only, false);
     assert.equal(sub.history_public_to_subscribers, false);
     assert.equal(sub.stream_post_policy, stream_data.stream_post_policy_values.everyone.code);
     assert.equal(sub.message_retention_days, -1);
 
     // For guest user only retrieve subscribed streams
-    sub_rows = stream_data.get_updated_unsorted_subs();
+    sub_rows = stream_settings_data.get_updated_unsorted_subs();
     assert.equal(sub_rows.length, 3);
     page_params.is_guest = true;
-    sub_rows = stream_data.get_updated_unsorted_subs();
+    sub_rows = stream_settings_data.get_updated_unsorted_subs();
     assert.equal(sub_rows[0].name, "c");
     assert.equal(sub_rows[1].name, "a");
     assert.equal(sub_rows.length, 2);
@@ -542,7 +543,7 @@ test("notifications", () => {
     antarctica.push_notifications = null;
     antarctica.wildcard_mentions_notify = null;
 
-    const unmatched_streams = stream_data.get_unmatched_streams_for_notification_settings();
+    const unmatched_streams = stream_settings_data.get_unmatched_streams_for_notification_settings();
     const expected_streams = [
         {
             desktop_notifications: true,
@@ -765,7 +766,7 @@ test("edge_cases", () => {
     const bad_stream_ids = [555555, 99999];
 
     // just make sure we don't explode
-    stream_data.sort_for_stream_settings(bad_stream_ids);
+    stream_settings_data.sort_for_stream_settings(bad_stream_ids);
 });
 
 test("get_invite_stream_data", () => {

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -570,6 +570,9 @@ test("notifications", () => {
     ];
 
     assert.deepEqual(unmatched_streams, expected_streams);
+
+    // Get line coverage on defensive code with bogus stream_id.
+    assert(!stream_data.receives_notifications(999999));
 });
 
 const tony = {

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -251,12 +251,19 @@ test("admin_options", () => {
         return sub;
     }
 
+    function is_realm_admin(sub) {
+        return stream_settings_data.get_sub_for_settings(sub).is_realm_admin;
+    }
+
+    function can_change_stream_permissions(sub) {
+        return stream_settings_data.get_sub_for_settings(sub).can_change_stream_permissions;
+    }
+
     // non-admins can't do anything
     page_params.is_admin = false;
     let sub = make_sub();
-    stream_settings_data.update_calculated_fields(sub);
-    assert(!sub.is_realm_admin);
-    assert(!sub.can_change_stream_permissions);
+    assert(!is_realm_admin(sub));
+    assert(!can_change_stream_permissions(sub));
 
     // just a sanity check that we leave "normal" fields alone
     assert.equal(sub.color, "blue");
@@ -266,25 +273,22 @@ test("admin_options", () => {
 
     // admins can make public streams become private
     sub = make_sub();
-    stream_settings_data.update_calculated_fields(sub);
-    assert(sub.is_realm_admin);
-    assert(sub.can_change_stream_permissions);
+    assert(is_realm_admin(sub));
+    assert(can_change_stream_permissions(sub));
 
     // admins can only make private streams become public
     // if they are subscribed
     sub = make_sub();
     sub.invite_only = true;
     sub.subscribed = false;
-    stream_settings_data.update_calculated_fields(sub);
-    assert(sub.is_realm_admin);
-    assert(!sub.can_change_stream_permissions);
+    assert(is_realm_admin(sub));
+    assert(!can_change_stream_permissions(sub));
 
     sub = make_sub();
     sub.invite_only = true;
     sub.subscribed = true;
-    stream_settings_data.update_calculated_fields(sub);
-    assert(sub.is_realm_admin);
-    assert(sub.can_change_stream_permissions);
+    assert(is_realm_admin(sub));
+    assert(can_change_stream_permissions(sub));
 });
 
 test("stream_settings", () => {
@@ -345,7 +349,6 @@ test("stream_settings", () => {
     });
     stream_data.update_stream_post_policy(sub, 1);
     stream_data.update_message_retention_setting(sub, -1);
-    stream_settings_data.update_calculated_fields(sub);
     assert.equal(sub.invite_only, false);
     assert.equal(sub.history_public_to_subscribers, false);
     assert.equal(sub.stream_post_policy, stream_data.stream_post_policy_values.everyone.code);

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -67,7 +67,6 @@ const denmark = {
     name: "Denmark",
     subscribed: true,
     render_subscribers: true,
-    should_display_subscription_button: true,
 };
 peer_data.set_subscribers(denmark.stream_id, [me.user_id, mark.user_id]);
 

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -402,8 +402,6 @@ test("remove_deactivated_user_from_all_streams", () => {
     const subs_stub = make_stub();
     subs.update_subscribers_ui = subs_stub.f;
 
-    dev_help.can_access_subscribers = true;
-
     // assert starting state
     assert(!stream_data.is_user_subscribed(dev_help.stream_id, george.user_id));
 

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -46,7 +46,6 @@ const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 const stream_events = zrequire("stream_events");
-const stream_settings_data = zrequire("stream_settings_data");
 
 const george = {
     email: "george@zulip.com",
@@ -267,8 +266,6 @@ test("marked_subscribed (normal)", (override) => {
     const sub = {...frontend};
     stream_data.add_sub(sub);
     override(stream_data, "subscribe_myself", noop);
-    override(stream_settings_data, "update_calculated_fields", noop);
-
     override(stream_color, "update_stream_color", noop);
 
     narrow_to_frontend();
@@ -304,7 +301,6 @@ test("marked_subscribed (normal)", (override) => {
 
 test("marked_subscribed (color)", (override) => {
     override(stream_data, "subscribe_myself", noop);
-    override(stream_settings_data, "update_calculated_fields", noop);
     override(message_util, "do_unread_count_updates", noop);
     override(stream_list, "add_sidebar_row", noop);
 
@@ -335,7 +331,6 @@ test("marked_subscribed (color)", (override) => {
 test("marked_subscribed (emails)", (override) => {
     const sub = {...frontend};
     stream_data.add_sub(sub);
-    override(stream_settings_data, "update_calculated_fields", noop);
     override(stream_color, "update_stream_color", noop);
 
     // Test assigning subscriber emails
@@ -358,8 +353,6 @@ test("marked_subscribed (emails)", (override) => {
 });
 
 test("mark_unsubscribed (update_settings_for_unsubscribed)", (override) => {
-    override(stream_settings_data, "update_calculated_fields", noop);
-
     // Test unsubscribe
     const sub = {...dev_help};
     assert(sub.subscribed);
@@ -378,8 +371,6 @@ test("mark_unsubscribed (update_settings_for_unsubscribed)", (override) => {
 test("mark_unsubscribed (render_title_area)", (override) => {
     const sub = {...frontend, subscribed: true};
     stream_data.add_sub(sub);
-
-    override(stream_settings_data, "update_calculated_fields", noop);
 
     // Test update bookend and remove done event
     narrow_to_frontend();

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -46,6 +46,7 @@ const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 const stream_events = zrequire("stream_events");
+const stream_settings_data = zrequire("stream_settings_data");
 
 const george = {
     email: "george@zulip.com",
@@ -266,7 +267,7 @@ test("marked_subscribed (normal)", (override) => {
     const sub = {...frontend};
     stream_data.add_sub(sub);
     override(stream_data, "subscribe_myself", noop);
-    override(stream_data, "update_calculated_fields", noop);
+    override(stream_settings_data, "update_calculated_fields", noop);
 
     override(stream_color, "update_stream_color", noop);
 
@@ -303,7 +304,7 @@ test("marked_subscribed (normal)", (override) => {
 
 test("marked_subscribed (color)", (override) => {
     override(stream_data, "subscribe_myself", noop);
-    override(stream_data, "update_calculated_fields", noop);
+    override(stream_settings_data, "update_calculated_fields", noop);
     override(message_util, "do_unread_count_updates", noop);
     override(stream_list, "add_sidebar_row", noop);
 
@@ -334,7 +335,7 @@ test("marked_subscribed (color)", (override) => {
 test("marked_subscribed (emails)", (override) => {
     const sub = {...frontend};
     stream_data.add_sub(sub);
-    override(stream_data, "update_calculated_fields", noop);
+    override(stream_settings_data, "update_calculated_fields", noop);
     override(stream_color, "update_stream_color", noop);
 
     // Test assigning subscriber emails
@@ -357,7 +358,7 @@ test("marked_subscribed (emails)", (override) => {
 });
 
 test("mark_unsubscribed (update_settings_for_unsubscribed)", (override) => {
-    override(stream_data, "update_calculated_fields", noop);
+    override(stream_settings_data, "update_calculated_fields", noop);
 
     // Test unsubscribe
     const sub = {...dev_help};
@@ -378,7 +379,7 @@ test("mark_unsubscribed (render_title_area)", (override) => {
     const sub = {...frontend, subscribed: true};
     stream_data.add_sub(sub);
 
-    override(stream_data, "update_calculated_fields", noop);
+    override(stream_settings_data, "update_calculated_fields", noop);
 
     // Test update bookend and remove done event
     narrow_to_frontend();

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -305,9 +305,6 @@ function get_typeahead_result(query, current_stream, current_topic) {
 }
 
 test("sort_recipients", () => {
-    const dev_sub = stream_data.get_sub("Dev");
-    const linux_sub = stream_data.get_sub("Linux");
-
     // Typeahead for recipientbox [query, "", undefined]
     assert.deepEqual(get_typeahead_result("b", ""), [
         "b_user_1@zulip.net",
@@ -336,9 +333,6 @@ test("sort_recipients", () => {
     peer_data.add_subscriber(1, people.get_user_id(subscriber_email_1));
     peer_data.add_subscriber(1, people.get_user_id(subscriber_email_2));
     peer_data.add_subscriber(1, people.get_user_id(subscriber_email_3));
-
-    stream_data.update_calculated_fields(dev_sub);
-    stream_data.update_calculated_fields(linux_sub);
 
     // For splitting based on whether a PM was sent
     pm_conversations.set_partner(5);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -661,7 +661,7 @@ export function validation_error(error_type, stream_name) {
         case "not-subscribed": {
             const sub = stream_data.get_sub(stream_name);
             const new_row = render_compose_not_subscribed({
-                should_display_sub_button: sub.should_display_subscription_button,
+                should_display_sub_button: stream_data.can_toggle_subscription(sub),
             });
             compose_not_subscribed_error(new_row, $("#stream_message_recipient_stream"));
             return false;

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -131,7 +131,7 @@ function pick_empty_narrow_banner() {
                 // You are narrowed to a stream which does not exist or is a private stream
                 // in which you were never subscribed.
 
-                function should_display_subscription_button() {
+                function can_toggle_narrowed_stream() {
                     const stream_name = narrow_state.stream();
 
                     if (!stream_name) {
@@ -139,10 +139,10 @@ function pick_empty_narrow_banner() {
                     }
 
                     const stream_sub = stream_data.get_sub(first_operand);
-                    return stream_sub && stream_sub.should_display_subscription_button;
+                    return stream_sub && stream_data.can_toggle_subscription(stream_sub);
                 }
 
-                if (should_display_subscription_button()) {
+                if (can_toggle_narrowed_stream()) {
                     return $("#nonsubbed_stream_narrow_message");
                 }
 

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -406,7 +406,6 @@ export function dispatch_normal_event(event) {
 
                     for (const stream of event.streams) {
                         const sub = stream_data.get_sub_by_id(stream.stream_id);
-                        stream_data.update_calculated_fields(sub);
                         if (overlays.streams_open()) {
                             subs.add_sub_to_table(sub);
                         }

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -9,8 +9,8 @@ import {page_params} from "./page_params";
 import * as settings_config from "./settings_config";
 import * as settings_org from "./settings_org";
 import * as settings_ui from "./settings_ui";
-import * as stream_data from "./stream_data";
 import * as stream_edit from "./stream_edit";
+import * as stream_settings_data from "./stream_settings_data";
 import * as unread_ui from "./unread_ui";
 
 function rerender_ui() {
@@ -20,7 +20,7 @@ function rerender_ui() {
         return;
     }
 
-    const unmatched_streams = stream_data.get_unmatched_streams_for_notification_settings();
+    const unmatched_streams = stream_settings_data.get_unmatched_streams_for_notification_settings();
 
     unmatched_streams_table.find(".stream-row").remove();
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -17,7 +17,7 @@ import * as realm_logo from "./realm_logo";
 import * as settings_config from "./settings_config";
 import * as settings_notifications from "./settings_notifications";
 import * as settings_ui from "./settings_ui";
-import * as stream_data from "./stream_data";
+import * as stream_settings_data from "./stream_settings_data";
 import * as ui_report from "./ui_report";
 
 export let parse_time_limit;
@@ -613,7 +613,7 @@ export function save_discard_widget_status_handler(subsection) {
 }
 
 export function init_dropdown_widgets() {
-    const streams = stream_data.get_streams_for_settings_page();
+    const streams = stream_settings_data.get_streams_for_settings_page();
     const notification_stream_options = {
         data: streams.map((x) => ({
             name: x.name,

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -12,6 +12,7 @@ import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as people from "./people";
 import * as stream_data from "./stream_data";
+import * as stream_settings_data from "./stream_settings_data";
 import * as subs from "./subs";
 import * as ui_report from "./ui_report";
 
@@ -271,7 +272,7 @@ export function show_new_stream_modal() {
         all_users.unshift(people.get_by_user_id(page_params.user_id));
         return render_new_stream_users({
             users: all_users,
-            streams: stream_data.get_streams_for_settings_page(),
+            streams: stream_settings_data.get_streams_for_settings_page(),
             is_admin: page_params.is_admin,
         });
     });

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -500,6 +500,13 @@ export function is_notifications_stream_muted() {
     return is_muted(page_params.realm_notifications_stream_id);
 }
 
+export function can_toggle_subscription(sub) {
+    // If stream is public then any user can subscribe. If stream is private then only
+    // subscribed users can unsubscribe.
+    // Guest users can't subscribe themselves to any stream.
+    return sub.subscribed || (!page_params.is_guest && !sub.invite_only);
+}
+
 export function is_subscribed(stream_name) {
     const sub = get_sub(stream_name);
     return sub !== undefined && sub.subscribed;

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -520,6 +520,11 @@ export function can_view_subscribers(sub) {
     return page_params.is_admin || sub.subscribed || (!page_params.is_guest && !sub.invite_only);
 }
 
+export function can_subscribe_others(sub) {
+    // User can add other users to stream if stream is public or user is subscribed to stream.
+    return !page_params.is_guest && (!sub.invite_only || sub.subscribed);
+}
+
 export function is_subscribed(stream_name) {
     const sub = get_sub(stream_name);
     return sub !== undefined && sub.subscribed;

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -1,12 +1,12 @@
 import * as blueslip from "./blueslip";
 import * as color_data from "./color_data";
 import {FoldDict} from "./fold_dict";
-import * as hash_util from "./hash_util";
 import {i18n} from "./i18n";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as people from "./people";
 import * as settings_config from "./settings_config";
+import * as stream_settings_data from "./stream_settings_data";
 import * as stream_topic_history from "./stream_topic_history";
 import * as util from "./util";
 
@@ -374,44 +374,6 @@ export function get_unsorted_subs() {
     return Array.from(stream_info.values());
 }
 
-export function get_sub_for_settings(sub) {
-    // Since we make a copy of the sub here, it may eventually
-    // make sense to get the other calculated fields here as
-    // well, instead of using update_calculated_fields everywhere.
-    const sub_count = peer_data.get_subscriber_count(sub.stream_id);
-    return {
-        ...sub,
-        subscriber_count: sub_count,
-    };
-}
-
-function get_subs_for_settings(subs) {
-    // We may eventually add subscribers to the subs here, rather than
-    // delegating, so that we can more efficiently compute subscriber counts
-    // (in bulk).  If that plan appears to have been aborted, feel free to
-    // inline this.
-    return subs.map((sub) => get_sub_for_settings(sub));
-}
-
-export function get_updated_unsorted_subs() {
-    // This function is expensive in terms of calculating
-    // some values (particularly stream counts) but avoids
-    // prematurely sorting subs.
-    let all_subs = Array.from(stream_info.values());
-
-    // Add in admin options and stream counts.
-    for (const sub of all_subs) {
-        update_calculated_fields(sub);
-    }
-
-    // We don't display unsubscribed streams to guest users.
-    if (page_params.is_guest) {
-        all_subs = all_subs.filter((sub) => sub.subscribed);
-    }
-
-    return get_subs_for_settings(all_subs);
-}
-
 export function num_subscribed_subs() {
     return stream_info.num_true_items();
 }
@@ -493,39 +455,6 @@ export function receives_notifications(stream_id, notification_name) {
         return page_params[notification_name];
     }
     return page_params["enable_stream_" + notification_name];
-}
-
-export function update_calculated_fields(sub) {
-    // Note that we don't calculate subscriber counts here.
-
-    sub.is_realm_admin = page_params.is_admin;
-    // Admin can change any stream's name & description either stream is public or
-    // private, subscribed or unsubscribed.
-    sub.can_change_name_description = page_params.is_admin;
-    // If stream is public then any user can subscribe. If stream is private then only
-    // subscribed users can unsubscribe.
-    // Guest users can't subscribe themselves to any stream.
-    sub.should_display_subscription_button =
-        sub.subscribed || (!page_params.is_guest && !sub.invite_only);
-    sub.should_display_preview_button =
-        sub.subscribed || !sub.invite_only || sub.previously_subscribed;
-    sub.can_change_stream_permissions =
-        page_params.is_admin && (!sub.invite_only || sub.subscribed);
-    // User can add other users to stream if stream is public or user is subscribed to stream.
-    // Guest users can't access subscribers of any(public or private) non-subscribed streams.
-    sub.can_access_subscribers =
-        page_params.is_admin || sub.subscribed || (!page_params.is_guest && !sub.invite_only);
-    sub.preview_url = hash_util.by_stream_uri(sub.stream_id);
-    sub.can_add_subscribers = !page_params.is_guest && (!sub.invite_only || sub.subscribed);
-    sub.is_old_stream = sub.stream_weekly_traffic !== null;
-    if (sub.rendered_description !== undefined) {
-        sub.rendered_description = sub.rendered_description.replace("<p>", "").replace("</p>", "");
-    }
-
-    // Apply the defaults for our notification settings for rendering.
-    for (const setting of settings_config.stream_specific_notification_settings) {
-        sub[setting + "_display"] = receives_notifications(sub.stream_id, setting);
-    }
 }
 
 export function all_subscribed_streams_are_in_home_view() {
@@ -724,127 +653,13 @@ export function create_sub_from_server_data(attrs) {
         sub.color = color_data.pick_color();
     }
 
-    update_calculated_fields(sub);
+    // TODO: Let stream settings code add these fields.
+    stream_settings_data.update_calculated_fields(sub);
 
     stream_info.set(sub.name, sub);
     subs_by_stream_id.set(sub.stream_id, sub);
 
     return sub;
-}
-
-export function get_unmatched_streams_for_notification_settings() {
-    const subscribed_rows = subscribed_subs();
-    subscribed_rows.sort((a, b) => util.strcmp(a.name, b.name));
-
-    const notification_settings = [];
-    for (const row of subscribed_rows) {
-        const settings_values = {};
-        let make_table_row = false;
-        for (const notification_name of settings_config.stream_specific_notification_settings) {
-            const prepend =
-                notification_name === "wildcard_mentions_notify" ? "" : "enable_stream_";
-            const default_setting = page_params[prepend + notification_name];
-            const stream_setting = receives_notifications(row.stream_id, notification_name);
-
-            settings_values[notification_name] = stream_setting;
-            if (stream_setting !== default_setting) {
-                make_table_row = true;
-            }
-        }
-        // We do not need to display the streams whose settings
-        // match with the global settings defined by the user.
-        if (make_table_row) {
-            settings_values.stream_name = row.name;
-            settings_values.stream_id = row.stream_id;
-            settings_values.invite_only = row.invite_only;
-            settings_values.is_web_public = row.is_web_public;
-
-            notification_settings.push(settings_values);
-        }
-    }
-    return notification_settings;
-}
-
-export function get_streams_for_settings_page() {
-    // TODO: This function is only used for copy-from-stream, so
-    //       the current name is slightly misleading now, plus
-    //       it's not entirely clear we need unsubscribed streams
-    //       for that.  Also we may be revisiting that UI.
-
-    // Build up our list of subscribed streams from the data we already have.
-    const subscribed_rows = subscribed_subs();
-    const unsubscribed_rows = unsubscribed_subs();
-
-    // Sort and combine all our streams.
-    function by_name(a, b) {
-        return util.strcmp(a.name, b.name);
-    }
-    subscribed_rows.sort(by_name);
-    unsubscribed_rows.sort(by_name);
-    const all_subs = unsubscribed_rows.concat(subscribed_rows);
-
-    // Add in admin options and stream counts.
-    for (const sub of all_subs) {
-        update_calculated_fields(sub);
-    }
-
-    return get_subs_for_settings(all_subs);
-}
-
-export function sort_for_stream_settings(stream_ids, order) {
-    // TODO: We may want to simply use util.strcmp here,
-    //       which uses Intl.Collator() when possible.
-
-    function name(stream_id) {
-        const sub = get_sub_by_id(stream_id);
-        if (!sub) {
-            return "";
-        }
-        return sub.name.toLocaleLowerCase();
-    }
-
-    function weekly_traffic(stream_id) {
-        const sub = get_sub_by_id(stream_id);
-        if (sub && sub.is_old_stream) {
-            return sub.stream_weekly_traffic;
-        }
-        // don't intersperse new streams with zero-traffic existing streams
-        return -1;
-    }
-
-    function by_stream_name(id_a, id_b) {
-        const stream_a_name = name(id_a);
-        const stream_b_name = name(id_b);
-        return String.prototype.localeCompare.call(stream_a_name, stream_b_name);
-    }
-
-    function by_subscriber_count(id_a, id_b) {
-        const out = peer_data.get_subscriber_count(id_b) - peer_data.get_subscriber_count(id_a);
-        if (out === 0) {
-            return by_stream_name(id_a, id_b);
-        }
-        return out;
-    }
-
-    function by_weekly_traffic(id_a, id_b) {
-        const out = weekly_traffic(id_b) - weekly_traffic(id_a);
-        if (out === 0) {
-            return by_stream_name(id_a, id_b);
-        }
-        return out;
-    }
-
-    const orders = new Map([
-        ["by-stream-name", by_stream_name],
-        ["by-subscriber-count", by_subscriber_count],
-        ["by-weekly-traffic", by_weekly_traffic],
-    ]);
-
-    if (order === undefined || !orders.has(order)) {
-        order = "by-stream-name";
-    }
-
-    stream_ids.sort(orders.get(order));
 }
 
 export function get_streams_for_admin() {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -515,6 +515,11 @@ export function can_change_permissions(sub) {
     return page_params.is_admin && (!sub.invite_only || sub.subscribed);
 }
 
+export function can_view_subscribers(sub) {
+    // Guest users can't access subscribers of any(public or private) non-subscribed streams.
+    return page_params.is_admin || sub.subscribed || (!page_params.is_guest && !sub.invite_only);
+}
+
 export function is_subscribed(stream_name) {
     const sub = get_sub(stream_name);
     return sub !== undefined && sub.subscribed;
@@ -592,7 +597,7 @@ export function maybe_get_stream_name(stream_id) {
 
 export function is_user_subscribed(stream_id, user_id) {
     const sub = get_sub_by_id(stream_id);
-    if (sub === undefined || !sub.can_access_subscribers) {
+    if (sub === undefined || !can_view_subscribers(sub)) {
         // If we don't know about the stream, or we ourselves cannot access subscriber list,
         // so we return undefined (treated as falsy if not explicitly handled).
         blueslip.warn(

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -631,6 +631,12 @@ export function create_streams(streams) {
     }
 }
 
+export function clean_up_description(sub) {
+    if (sub.rendered_description !== undefined) {
+        sub.rendered_description = sub.rendered_description.replace("<p>", "").replace("</p>", "");
+    }
+}
+
 export function create_sub_from_server_data(attrs) {
     if (!attrs.stream_id) {
         // fail fast
@@ -680,6 +686,7 @@ export function create_sub_from_server_data(attrs) {
 
     // TODO: Let stream settings code add these fields.
     stream_settings_data.update_calculated_fields(sub);
+    clean_up_description(sub);
 
     stream_info.set(sub.name, sub);
     subs_by_stream_id.set(sub.stream_id, sub);

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -507,6 +507,10 @@ export function can_toggle_subscription(sub) {
     return sub.subscribed || (!page_params.is_guest && !sub.invite_only);
 }
 
+export function can_preview(sub) {
+    return sub.subscribed || !sub.invite_only || sub.previously_subscribed;
+}
+
 export function is_subscribed(stream_name) {
     const sub = get_sub(stream_name);
     return sub !== undefined && sub.subscribed;

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -6,7 +6,6 @@ import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as people from "./people";
 import * as settings_config from "./settings_config";
-import * as stream_settings_data from "./stream_settings_data";
 import * as stream_topic_history from "./stream_topic_history";
 import * as util from "./util";
 
@@ -684,8 +683,6 @@ export function create_sub_from_server_data(attrs) {
         sub.color = color_data.pick_color();
     }
 
-    // TODO: Let stream settings code add these fields.
-    stream_settings_data.update_calculated_fields(sub);
     clean_up_description(sub);
 
     stream_info.set(sub.name, sub);

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -511,6 +511,10 @@ export function can_preview(sub) {
     return sub.subscribed || !sub.invite_only || sub.previously_subscribed;
 }
 
+export function can_change_permissions(sub) {
+    return page_params.is_admin && (!sub.invite_only || sub.subscribed);
+}
+
 export function is_subscribed(stream_name) {
     const sub = get_sub(stream_name);
     return sub !== undefined && sub.subscribed;

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -439,10 +439,10 @@ export function stream_settings(sub) {
 
 export function show_settings_for(node) {
     const stream_id = get_stream_id(node);
-    const sub = stream_data.get_sub_by_id(stream_id);
+    const slim_sub = stream_data.get_sub_by_id(stream_id);
+    stream_data.clean_up_description(slim_sub);
+    const sub = stream_settings_data.get_sub_for_settings(slim_sub);
 
-    stream_settings_data.update_calculated_fields(sub);
-    stream_data.clean_up_description(sub);
     const html = render_subscription_settings({
         sub,
         settings: stream_settings(sub),

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -353,7 +353,7 @@ function show_subscription_settings(sub) {
     if (!sub.render_subscribers) {
         return;
     }
-    if (!sub.should_display_subscription_button) {
+    if (!stream_data.can_toggle_subscription(sub)) {
         stream_ui_updates.initialize_cant_subscribe_popover(sub);
     }
     // fetch subscriber list from memory.

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -436,6 +436,7 @@ export function show_settings_for(node) {
     const sub = stream_data.get_sub_by_id(stream_id);
 
     stream_settings_data.update_calculated_fields(sub);
+    stream_data.clean_up_description(sub);
     const html = render_subscription_settings({
         sub,
         settings: stream_settings(sub),

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -421,7 +421,13 @@ export function stream_settings(sub) {
             is_notification_setting: is_notification_setting(setting),
         };
         if (is_notification_setting(setting)) {
-            ret.is_checked = sub[setting + "_display"] && !check_realm_setting[setting];
+            // This block ensures we correctly display to users the
+            // current state of stream-level notification settings
+            // with a value of `null`, which inherit the user's global
+            // notification settings for streams.
+            ret.is_checked =
+                stream_data.receives_notifications(sub.stream_id, setting) &&
+                !check_realm_setting[setting];
             ret.is_disabled = ret.is_disabled || sub.is_muted;
             return ret;
         }

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -27,6 +27,7 @@ import * as settings_ui from "./settings_ui";
 import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
 import * as stream_pill from "./stream_pill";
+import * as stream_settings_data from "./stream_settings_data";
 import * as stream_ui_updates from "./stream_ui_updates";
 import * as subs from "./subs";
 import * as ui from "./ui";
@@ -434,7 +435,7 @@ export function show_settings_for(node) {
     const stream_id = get_stream_id(node);
     const sub = stream_data.get_sub_by_id(stream_id);
 
-    stream_data.update_calculated_fields(sub);
+    stream_settings_data.update_calculated_fields(sub);
     const html = render_subscription_settings({
         sub,
         settings: stream_settings(sub),

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -15,7 +15,6 @@ import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
 import * as stream_muting from "./stream_muting";
-import * as stream_settings_data from "./stream_settings_data";
 import * as subs from "./subs";
 
 // In theory, this function should apply the account-level defaults,
@@ -118,7 +117,6 @@ export function mark_subscribed(sub, subscribers, color) {
     if (subscribers) {
         peer_data.set_subscribers(sub.stream_id, subscribers);
     }
-    stream_settings_data.update_calculated_fields(sub);
 
     if (overlays.streams_open()) {
         subs.update_settings_for_subscribed(sub);
@@ -144,7 +142,6 @@ export function mark_unsubscribed(sub) {
         return;
     } else if (sub.subscribed) {
         stream_data.unsubscribe_myself(sub);
-        stream_settings_data.update_calculated_fields(sub);
         if (overlays.streams_open()) {
             subs.update_settings_for_unsubscribed(sub);
         }

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -15,6 +15,7 @@ import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
 import * as stream_muting from "./stream_muting";
+import * as stream_settings_data from "./stream_settings_data";
 import * as subs from "./subs";
 
 // In theory, this function should apply the account-level defaults,
@@ -117,7 +118,7 @@ export function mark_subscribed(sub, subscribers, color) {
     if (subscribers) {
         peer_data.set_subscribers(sub.stream_id, subscribers);
     }
-    stream_data.update_calculated_fields(sub);
+    stream_settings_data.update_calculated_fields(sub);
 
     if (overlays.streams_open()) {
         subs.update_settings_for_subscribed(sub);
@@ -143,7 +144,7 @@ export function mark_unsubscribed(sub) {
         return;
     } else if (sub.subscribed) {
         stream_data.unsubscribe_myself(sub);
-        stream_data.update_calculated_fields(sub);
+        stream_settings_data.update_calculated_fields(sub);
         if (overlays.streams_open()) {
             subs.update_settings_for_unsubscribed(sub);
         }

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -245,7 +245,7 @@ function build_topic_popover(opts) {
         topic_name,
         can_mute_topic,
         can_unmute_topic,
-        is_realm_admin: sub.is_realm_admin,
+        is_realm_admin: page_params.is_realm_admin,
         color: sub.color,
         has_starred_messages,
     });

--- a/static/js/stream_settings_data.js
+++ b/static/js/stream_settings_data.js
@@ -53,8 +53,7 @@ export function update_calculated_fields(sub) {
 
     sub.should_display_subscription_button = stream_data.can_toggle_subscription(sub);
     sub.should_display_preview_button = stream_data.can_preview(sub);
-    sub.can_change_stream_permissions =
-        page_params.is_admin && (!sub.invite_only || sub.subscribed);
+    sub.can_change_stream_permissions = stream_data.can_change_permissions(sub);
     // User can add other users to stream if stream is public or user is subscribed to stream.
     // Guest users can't access subscribers of any(public or private) non-subscribed streams.
     sub.can_access_subscribers =

--- a/static/js/stream_settings_data.js
+++ b/static/js/stream_settings_data.js
@@ -146,7 +146,7 @@ export function sort_for_stream_settings(stream_ids, order) {
 
     function weekly_traffic(stream_id) {
         const sub = stream_data.get_sub_by_id(stream_id);
-        if (sub && sub.is_old_stream) {
+        if (sub && sub.stream_weekly_traffic !== null) {
             return sub.stream_weekly_traffic;
         }
         // don't intersperse new streams with zero-traffic existing streams

--- a/static/js/stream_settings_data.js
+++ b/static/js/stream_settings_data.js
@@ -1,0 +1,195 @@
+import * as hash_util from "./hash_util";
+import {page_params} from "./page_params";
+import * as peer_data from "./peer_data";
+import * as settings_config from "./settings_config";
+import * as stream_data from "./stream_data";
+import * as util from "./util";
+
+export function get_sub_for_settings(sub) {
+    // Since we make a copy of the sub here, it may eventually
+    // make sense to get the other calculated fields here as
+    // well, instead of using update_calculated_fields everywhere.
+    const sub_count = peer_data.get_subscriber_count(sub.stream_id);
+    return {
+        ...sub,
+        subscriber_count: sub_count,
+    };
+}
+
+function get_subs_for_settings(subs) {
+    // We may eventually add subscribers to the subs here, rather than
+    // delegating, so that we can more efficiently compute subscriber counts
+    // (in bulk).  If that plan appears to have been aborted, feel free to
+    // inline this.
+    return subs.map((sub) => get_sub_for_settings(sub));
+}
+
+export function get_updated_unsorted_subs() {
+    // This function is expensive in terms of calculating
+    // some values (particularly stream counts) but avoids
+    // prematurely sorting subs.
+    let all_subs = stream_data.get_unsorted_subs();
+
+    // Add in admin options and stream counts.
+    for (const sub of all_subs) {
+        update_calculated_fields(sub);
+    }
+
+    // We don't display unsubscribed streams to guest users.
+    if (page_params.is_guest) {
+        all_subs = all_subs.filter((sub) => sub.subscribed);
+    }
+
+    return get_subs_for_settings(all_subs);
+}
+
+export function update_calculated_fields(sub) {
+    // Note that we don't calculate subscriber counts here.
+
+    sub.is_realm_admin = page_params.is_admin;
+    // Admin can change any stream's name & description either stream is public or
+    // private, subscribed or unsubscribed.
+    sub.can_change_name_description = page_params.is_admin;
+    // If stream is public then any user can subscribe. If stream is private then only
+    // subscribed users can unsubscribe.
+    // Guest users can't subscribe themselves to any stream.
+    sub.should_display_subscription_button =
+        sub.subscribed || (!page_params.is_guest && !sub.invite_only);
+    sub.should_display_preview_button =
+        sub.subscribed || !sub.invite_only || sub.previously_subscribed;
+    sub.can_change_stream_permissions =
+        page_params.is_admin && (!sub.invite_only || sub.subscribed);
+    // User can add other users to stream if stream is public or user is subscribed to stream.
+    // Guest users can't access subscribers of any(public or private) non-subscribed streams.
+    sub.can_access_subscribers =
+        page_params.is_admin || sub.subscribed || (!page_params.is_guest && !sub.invite_only);
+    sub.preview_url = hash_util.by_stream_uri(sub.stream_id);
+    sub.can_add_subscribers = !page_params.is_guest && (!sub.invite_only || sub.subscribed);
+    sub.is_old_stream = sub.stream_weekly_traffic !== null;
+    if (sub.rendered_description !== undefined) {
+        sub.rendered_description = sub.rendered_description.replace("<p>", "").replace("</p>", "");
+    }
+
+    // Apply the defaults for our notification settings for rendering.
+    for (const setting of settings_config.stream_specific_notification_settings) {
+        sub[setting + "_display"] = stream_data.receives_notifications(sub.stream_id, setting);
+    }
+}
+
+export function get_unmatched_streams_for_notification_settings() {
+    const subscribed_rows = stream_data.subscribed_subs();
+    subscribed_rows.sort((a, b) => util.strcmp(a.name, b.name));
+
+    const notification_settings = [];
+    for (const row of subscribed_rows) {
+        const settings_values = {};
+        let make_table_row = false;
+        for (const notification_name of settings_config.stream_specific_notification_settings) {
+            const prepend =
+                notification_name === "wildcard_mentions_notify" ? "" : "enable_stream_";
+            const default_setting = page_params[prepend + notification_name];
+            const stream_setting = stream_data.receives_notifications(
+                row.stream_id,
+                notification_name,
+            );
+
+            settings_values[notification_name] = stream_setting;
+            if (stream_setting !== default_setting) {
+                make_table_row = true;
+            }
+        }
+        // We do not need to display the streams whose settings
+        // match with the global settings defined by the user.
+        if (make_table_row) {
+            settings_values.stream_name = row.name;
+            settings_values.stream_id = row.stream_id;
+            settings_values.invite_only = row.invite_only;
+            settings_values.is_web_public = row.is_web_public;
+
+            notification_settings.push(settings_values);
+        }
+    }
+    return notification_settings;
+}
+
+export function get_streams_for_settings_page() {
+    // TODO: This function is only used for copy-from-stream, so
+    //       the current name is slightly misleading now, plus
+    //       it's not entirely clear we need unsubscribed streams
+    //       for that.  Also we may be revisiting that UI.
+
+    // Build up our list of subscribed streams from the data we already have.
+    const subscribed_rows = stream_data.subscribed_subs();
+    const unsubscribed_rows = stream_data.unsubscribed_subs();
+
+    // Sort and combine all our streams.
+    function by_name(a, b) {
+        return util.strcmp(a.name, b.name);
+    }
+    subscribed_rows.sort(by_name);
+    unsubscribed_rows.sort(by_name);
+    const all_subs = unsubscribed_rows.concat(subscribed_rows);
+
+    // Add in admin options and stream counts.
+    for (const sub of all_subs) {
+        update_calculated_fields(sub);
+    }
+
+    return get_subs_for_settings(all_subs);
+}
+
+export function sort_for_stream_settings(stream_ids, order) {
+    // TODO: We may want to simply use util.strcmp here,
+    //       which uses Intl.Collator() when possible.
+
+    function name(stream_id) {
+        const sub = stream_data.get_sub_by_id(stream_id);
+        if (!sub) {
+            return "";
+        }
+        return sub.name.toLocaleLowerCase();
+    }
+
+    function weekly_traffic(stream_id) {
+        const sub = stream_data.get_sub_by_id(stream_id);
+        if (sub && sub.is_old_stream) {
+            return sub.stream_weekly_traffic;
+        }
+        // don't intersperse new streams with zero-traffic existing streams
+        return -1;
+    }
+
+    function by_stream_name(id_a, id_b) {
+        const stream_a_name = name(id_a);
+        const stream_b_name = name(id_b);
+        return String.prototype.localeCompare.call(stream_a_name, stream_b_name);
+    }
+
+    function by_subscriber_count(id_a, id_b) {
+        const out = peer_data.get_subscriber_count(id_b) - peer_data.get_subscriber_count(id_a);
+        if (out === 0) {
+            return by_stream_name(id_a, id_b);
+        }
+        return out;
+    }
+
+    function by_weekly_traffic(id_a, id_b) {
+        const out = weekly_traffic(id_b) - weekly_traffic(id_a);
+        if (out === 0) {
+            return by_stream_name(id_a, id_b);
+        }
+        return out;
+    }
+
+    const orders = new Map([
+        ["by-stream-name", by_stream_name],
+        ["by-subscriber-count", by_subscriber_count],
+        ["by-weekly-traffic", by_weekly_traffic],
+    ]);
+
+    if (order === undefined || !orders.has(order)) {
+        order = "by-stream-name";
+    }
+
+    stream_ids.sort(orders.get(order));
+}

--- a/static/js/stream_settings_data.js
+++ b/static/js/stream_settings_data.js
@@ -6,14 +6,10 @@ import * as stream_data from "./stream_data";
 import * as util from "./util";
 
 export function get_sub_for_settings(sub) {
-    // Since we make a copy of the sub here, it may eventually
-    // make sense to get the other calculated fields here as
-    // well, instead of using update_calculated_fields everywhere.
-    const sub_count = peer_data.get_subscriber_count(sub.stream_id);
-    return {
-        ...sub,
-        subscriber_count: sub_count,
-    };
+    const settings_sub = {...sub};
+    add_settings_fields(settings_sub);
+    settings_sub.subscriber_count = peer_data.get_subscriber_count(sub.stream_id);
+    return settings_sub;
 }
 
 function get_subs_for_settings(subs) {
@@ -25,15 +21,7 @@ function get_subs_for_settings(subs) {
 }
 
 export function get_updated_unsorted_subs() {
-    // This function is expensive in terms of calculating
-    // some values (particularly stream counts) but avoids
-    // prematurely sorting subs.
     let all_subs = stream_data.get_unsorted_subs();
-
-    // Add in admin options and stream counts.
-    for (const sub of all_subs) {
-        update_calculated_fields(sub);
-    }
 
     // We don't display unsubscribed streams to guest users.
     if (page_params.is_guest) {
@@ -43,7 +31,7 @@ export function get_updated_unsorted_subs() {
     return get_subs_for_settings(all_subs);
 }
 
-export function update_calculated_fields(sub) {
+export function add_settings_fields(sub) {
     // Note that we don't calculate subscriber counts here.
 
     sub.is_realm_admin = page_params.is_admin;
@@ -114,11 +102,6 @@ export function get_streams_for_settings_page() {
     subscribed_rows.sort(by_name);
     unsubscribed_rows.sort(by_name);
     const all_subs = unsubscribed_rows.concat(subscribed_rows);
-
-    // Add in admin options and stream counts.
-    for (const sub of all_subs) {
-        update_calculated_fields(sub);
-    }
 
     return get_subs_for_settings(all_subs);
 }

--- a/static/js/stream_settings_data.js
+++ b/static/js/stream_settings_data.js
@@ -52,8 +52,7 @@ export function update_calculated_fields(sub) {
     sub.can_change_name_description = page_params.is_admin;
 
     sub.should_display_subscription_button = stream_data.can_toggle_subscription(sub);
-    sub.should_display_preview_button =
-        sub.subscribed || !sub.invite_only || sub.previously_subscribed;
+    sub.should_display_preview_button = stream_data.can_preview(sub);
     sub.can_change_stream_permissions =
         page_params.is_admin && (!sub.invite_only || sub.subscribed);
     // User can add other users to stream if stream is public or user is subscribed to stream.

--- a/static/js/stream_settings_data.js
+++ b/static/js/stream_settings_data.js
@@ -55,11 +55,11 @@ export function update_calculated_fields(sub) {
     sub.should_display_preview_button = stream_data.can_preview(sub);
     sub.can_change_stream_permissions = stream_data.can_change_permissions(sub);
     sub.can_access_subscribers = stream_data.can_view_subscribers(sub);
+    sub.can_add_subscribers = stream_data.can_subscribe_others(sub);
 
     sub.preview_url = hash_util.by_stream_uri(sub.stream_id);
-    // User can add other users to stream if stream is public or user is subscribed to stream.
-    sub.can_add_subscribers = !page_params.is_guest && (!sub.invite_only || sub.subscribed);
     sub.is_old_stream = sub.stream_weekly_traffic !== null;
+
     if (sub.rendered_description !== undefined) {
         sub.rendered_description = sub.rendered_description.replace("<p>", "").replace("</p>", "");
     }

--- a/static/js/stream_settings_data.js
+++ b/static/js/stream_settings_data.js
@@ -50,11 +50,8 @@ export function update_calculated_fields(sub) {
     // Admin can change any stream's name & description either stream is public or
     // private, subscribed or unsubscribed.
     sub.can_change_name_description = page_params.is_admin;
-    // If stream is public then any user can subscribe. If stream is private then only
-    // subscribed users can unsubscribe.
-    // Guest users can't subscribe themselves to any stream.
-    sub.should_display_subscription_button =
-        sub.subscribed || (!page_params.is_guest && !sub.invite_only);
+
+    sub.should_display_subscription_button = stream_data.can_toggle_subscription(sub);
     sub.should_display_preview_button =
         sub.subscribed || !sub.invite_only || sub.previously_subscribed;
     sub.can_change_stream_permissions =

--- a/static/js/stream_settings_data.js
+++ b/static/js/stream_settings_data.js
@@ -54,11 +54,10 @@ export function update_calculated_fields(sub) {
     sub.should_display_subscription_button = stream_data.can_toggle_subscription(sub);
     sub.should_display_preview_button = stream_data.can_preview(sub);
     sub.can_change_stream_permissions = stream_data.can_change_permissions(sub);
-    // User can add other users to stream if stream is public or user is subscribed to stream.
-    // Guest users can't access subscribers of any(public or private) non-subscribed streams.
-    sub.can_access_subscribers =
-        page_params.is_admin || sub.subscribed || (!page_params.is_guest && !sub.invite_only);
+    sub.can_access_subscribers = stream_data.can_view_subscribers(sub);
+
     sub.preview_url = hash_util.by_stream_uri(sub.stream_id);
+    // User can add other users to stream if stream is public or user is subscribed to stream.
     sub.can_add_subscribers = !page_params.is_guest && (!sub.invite_only || sub.subscribed);
     sub.is_old_stream = sub.stream_weekly_traffic !== null;
     if (sub.rendered_description !== undefined) {

--- a/static/js/stream_settings_data.js
+++ b/static/js/stream_settings_data.js
@@ -60,10 +60,6 @@ export function update_calculated_fields(sub) {
     sub.preview_url = hash_util.by_stream_uri(sub.stream_id);
     sub.is_old_stream = sub.stream_weekly_traffic !== null;
 
-    if (sub.rendered_description !== undefined) {
-        sub.rendered_description = sub.rendered_description.replace("<p>", "").replace("</p>", "");
-    }
-
     // Apply the defaults for our notification settings for rendering.
     for (const setting of settings_config.stream_specific_notification_settings) {
         sub[setting + "_display"] = stream_data.receives_notifications(sub.stream_id, setting);

--- a/static/js/stream_settings_data.js
+++ b/static/js/stream_settings_data.js
@@ -59,11 +59,6 @@ export function update_calculated_fields(sub) {
 
     sub.preview_url = hash_util.by_stream_uri(sub.stream_id);
     sub.is_old_stream = sub.stream_weekly_traffic !== null;
-
-    // Apply the defaults for our notification settings for rendering.
-    for (const setting of settings_config.stream_specific_notification_settings) {
-        sub[setting + "_display"] = stream_data.receives_notifications(sub.stream_id, setting);
-    }
 }
 
 export function get_unmatched_streams_for_notification_settings() {

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -151,7 +151,7 @@ export function update_subscribers_list(sub) {
         return;
     }
 
-    if (!sub.can_access_subscribers) {
+    if (!stream_data.can_view_subscribers(sub)) {
         $(".subscriber_list_settings_container").hide();
     } else {
         const subscribers = peer_data.get_subscribers(sub.stream_id);

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -58,7 +58,7 @@ export function update_settings_button_for_sub(sub) {
     } else {
         settings_button.text(i18n.t("Subscribe")).addClass("unsubscribed");
     }
-    if (sub.should_display_subscription_button) {
+    if (stream_data.can_toggle_subscription(sub)) {
         settings_button.prop("disabled", false);
         settings_button.popover("destroy");
         settings_button.css("pointer-events", "");

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -360,7 +360,7 @@ export function update_settings_for_unsubscribed(sub) {
     stream_data.update_stream_email_address(sub, "");
     // If user unsubscribed from private stream then user cannot subscribe to
     // stream without invitation and cannot add subscribers to stream.
-    if (!sub.should_display_subscription_button) {
+    if (!stream_data.can_toggle_subscription(sub)) {
         stream_ui_updates.update_add_subscriptions_elements(sub);
     }
     if (page_params.is_guest) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -28,6 +28,7 @@ import * as stream_data from "./stream_data";
 import * as stream_edit from "./stream_edit";
 import * as stream_list from "./stream_list";
 import * as stream_muting from "./stream_muting";
+import * as stream_settings_data from "./stream_settings_data";
 import * as stream_ui_updates from "./stream_ui_updates";
 import * as ui from "./ui";
 import * as ui_report from "./ui_report";
@@ -64,7 +65,7 @@ export function update_left_panel_row(sub) {
     }
 
     blueslip.debug(`Updating row in left panel of stream settings for: ${sub.name}`);
-    const setting_sub = stream_data.get_sub_for_settings(sub);
+    const setting_sub = stream_settings_data.get_sub_for_settings(sub);
     const html = render_subscription(setting_sub);
     const new_row = $(html);
 
@@ -223,7 +224,7 @@ export function update_stream_description(sub, description, rendered_description
 
 export function update_stream_privacy(sub, values) {
     stream_data.update_stream_privacy(sub, values);
-    stream_data.update_calculated_fields(sub);
+    stream_settings_data.update_calculated_fields(sub);
 
     // Update UI elements
     update_left_panel_row(sub);
@@ -239,7 +240,7 @@ export function update_stream_privacy(sub, values) {
 
 export function update_stream_post_policy(sub, new_value) {
     stream_data.update_stream_post_policy(sub, new_value);
-    stream_data.update_calculated_fields(sub);
+    stream_settings_data.update_calculated_fields(sub);
 
     stream_ui_updates.update_stream_subscription_type_text(sub);
 }
@@ -272,7 +273,7 @@ export function add_sub_to_table(sub) {
         return;
     }
 
-    const setting_sub = stream_data.get_sub_for_settings(sub);
+    const setting_sub = stream_settings_data.get_sub_for_settings(sub);
     const html = render_subscription(setting_sub);
     const new_row = $(html);
     add_tooltip_to_left_panel_row(new_row);
@@ -421,8 +422,8 @@ function get_stream_id_buckets(stream_ids, left_panel_params) {
         }
     }
 
-    stream_data.sort_for_stream_settings(buckets.name, left_panel_params.sort_order);
-    stream_data.sort_for_stream_settings(buckets.desc, left_panel_params.sort_order);
+    stream_settings_data.sort_for_stream_settings(buckets.name, left_panel_params.sort_order);
+    stream_settings_data.sort_for_stream_settings(buckets.desc, left_panel_params.sort_order);
 
     return buckets;
 }
@@ -432,7 +433,7 @@ export function render_left_panel_superset() {
     // allowed to know about and put them in the DOM, then we do
     // a second pass where we filter/sort them.
     const html = blueslip.measure_time("render left panel", () => {
-        const sub_rows = stream_data.get_updated_unsorted_subs();
+        const sub_rows = stream_settings_data.get_updated_unsorted_subs();
 
         const template_data = {
             subscriptions: sub_rows,

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -209,7 +209,8 @@ export function update_stream_name(sub, new_name) {
 
 export function update_stream_description(sub, description, rendered_description) {
     sub.description = description;
-    sub.rendered_description = rendered_description.replace("<p>", "").replace("</p>", "");
+    sub.rendered_description = rendered_description;
+    stream_data.clean_up_description(sub);
 
     // Update stream row
     const sub_row = row_for_stream_id(sub.stream_id);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -225,7 +225,6 @@ export function update_stream_description(sub, description, rendered_description
 
 export function update_stream_privacy(sub, values) {
     stream_data.update_stream_privacy(sub, values);
-    stream_settings_data.update_calculated_fields(sub);
 
     // Update UI elements
     update_left_panel_row(sub);
@@ -241,8 +240,6 @@ export function update_stream_privacy(sub, values) {
 
 export function update_stream_post_policy(sub, new_value) {
     stream_data.update_stream_post_policy(sub, new_value);
-    stream_settings_data.update_calculated_fields(sub);
-
     stream_ui_updates.update_stream_subscription_type_text(sub);
 }
 


### PR DESCRIPTION
This change breaks a dependency that gets us one edge closer to a tree, based on the @andersk tooling.

It also avoids a lot of action-at-a-distance.  Instead of constantly updating the sub with calculated fields that only matter for the stream settings code, we just have the stream settings code ask for the bigger sub objects when we need them.

I also consolidate all the logic for whether you can subscribe, preview, change permissions, view subscribers, or subscribe others for a stream.

The performance impact of this change should be completely negligible.  We avoid some unnecessary computation and memory usage during normal operation.  All the computations here are really cheap.