### PR TITLE
stream-settings: Add support for subscribing all members of a user groups to stream.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -242,6 +242,8 @@ test_people("basics", () => {
     const email = "isaac@example.com";
 
     assert(!people.is_known_user_id(32));
+    assert(!people.is_known_user(isaac));
+    assert(!people.is_known_user(undefined));
     assert(!people.is_valid_full_name_and_user_id(full_name, 32));
     assert.equal(people.get_user_id_from_name(full_name), undefined);
 
@@ -251,6 +253,7 @@ test_people("basics", () => {
 
     assert(people.is_valid_full_name_and_user_id(full_name, 32));
     assert(people.is_known_user_id(32));
+    assert(people.is_known_user(isaac));
     assert.equal(people.get_active_human_count(), 2);
 
     assert.equal(people.get_user_id_from_name(full_name), 32);

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -232,12 +232,12 @@ test_ui("populate_user_groups", (override) => {
         })();
 
         (function test_sorter() {
-            let sort_recipientbox_typeahead_called = false;
-            typeahead_helper.sort_recipientbox_typeahead = () => {
-                sort_recipientbox_typeahead_called = true;
+            let sort_recipients_typeahead_called = false;
+            typeahead_helper.sort_recipients = function () {
+                sort_recipients_typeahead_called = true;
             };
             config.sorter.call(fake_context);
-            assert(sort_recipientbox_typeahead_called);
+            assert(sort_recipients_typeahead_called);
         })();
 
         (function test_updater() {

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -150,6 +150,9 @@ test_ui("populate_user_groups", (override) => {
         if (user_id === iago.user_id) {
             return iago;
         }
+        if (user_id === alice.user_id) {
+            return alice;
+        }
         if (user_id === undefined) {
             return noop;
         }
@@ -157,6 +160,9 @@ test_ui("populate_user_groups", (override) => {
         blueslip.expect("warn", "Undefined user in function append_user");
         get_by_user_id_called = true;
         return undefined;
+    };
+    people.is_known_user = function () {
+        return people.get_by_user_id !== undefined && people.get_by_user_id !== noop;
     };
 
     override(settings_user_groups, "can_edit", () => true);
@@ -236,7 +242,7 @@ test_ui("populate_user_groups", (override) => {
             typeahead_helper.sort_recipients = function () {
                 sort_recipients_typeahead_called = true;
             };
-            config.sorter.call(fake_context);
+            config.sorter.call(fake_context, []);
             assert(sort_recipients_typeahead_called);
         })();
 

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -34,6 +34,8 @@ const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 const stream_edit = zrequire("stream_edit");
 const stream_pill = zrequire("stream_pill");
+const user_groups = zrequire("user_groups");
+const user_group_pill = zrequire("user_group_pill");
 const user_pill = zrequire("user_pill");
 
 const jill = {
@@ -60,6 +62,24 @@ const me = {
 const persons = [jill, mark, fred, me];
 for (const person of persons) {
     people.add_active_user(person);
+}
+
+const admins = {
+    name: "Admins",
+    description: "foo",
+    id: 1,
+    members: [jill.user_id, mark.user_id],
+};
+const testers = {
+    name: "Testers",
+    description: "bar",
+    id: 2,
+    members: [mark.user_id, fred.user_id, me.user_id],
+};
+
+const groups = [admins, testers];
+for (const group of groups) {
+    user_groups.add(group);
 }
 
 const denmark = {
@@ -144,21 +164,44 @@ test_ui("subscriber_pills", (override) => {
         assert.equal(typeof config.sorter, "function");
         assert.equal(typeof config.updater, "function");
 
-        const fake_this = {
+        const fake_stream_this = {
             query: "#Denmark",
+        };
+        const fake_person_this = {
+            query: "me",
+        };
+        const fake_group_this = {
+            query: "test",
         };
 
         (function test_highlighter() {
-            const fake_stream = $.create("fake-stream");
-            typeahead_helper.render_stream = () => fake_stream;
-            assert.equal(config.highlighter.call(fake_this, denmark), fake_stream);
+            const fake_html = $.create("fake-html");
+            typeahead_helper.render_stream = function () {
+                return fake_html;
+            };
+            assert.equal(config.highlighter.call(fake_stream_this, denmark), fake_html);
+
+            typeahead_helper.render_person_or_user_group = function () {
+                return fake_html;
+            };
+            assert.equal(config.highlighter.call(fake_group_this, testers), fake_html);
+            assert.equal(config.highlighter.call(fake_person_this, me), fake_html);
         })();
 
         (function test_matcher() {
-            let result = config.matcher.call(fake_this, denmark);
+            let result = config.matcher.call(fake_stream_this, denmark);
             assert(result);
+            result = config.matcher.call(fake_stream_this, sweden);
+            assert(!result);
 
-            result = config.matcher.call(fake_this, sweden);
+            result = config.matcher.call(fake_group_this, testers);
+            assert(result);
+            result = config.matcher.call(fake_group_this, admins);
+            assert(!result);
+
+            result = config.matcher.call(fake_person_this, me);
+            assert(result);
+            result = config.matcher.call(fake_person_this, jill);
             assert(!result);
         })();
 
@@ -167,8 +210,19 @@ test_ui("subscriber_pills", (override) => {
             typeahead_helper.sort_streams = () => {
                 sort_streams_called = true;
             };
-            config.sorter.call(fake_this);
+            config.sorter.call(fake_stream_this);
             assert(sort_streams_called);
+
+            let sort_recipients_called = false;
+            typeahead_helper.sort_recipients = function () {
+                sort_recipients_called = true;
+            };
+            config.sorter.call(fake_group_this, [testers]);
+            assert(sort_recipients_called);
+
+            sort_recipients_called = false;
+            config.sorter.call(fake_person_this, [me]);
+            assert(sort_recipients_called);
         })();
 
         (function test_updater() {
@@ -178,21 +232,29 @@ test_ui("subscriber_pills", (override) => {
             }
 
             assert.equal(number_of_pills(), 0);
-            config.updater.call(fake_this, denmark);
+            config.updater.call(fake_stream_this, denmark);
             assert.equal(number_of_pills(), 1);
-            fake_this.query = me.email;
-            config.updater.call(fake_this, me);
+            config.updater.call(fake_person_this, me);
             assert.equal(number_of_pills(), 2);
-            fake_this.query = "#Denmark";
+            config.updater.call(fake_group_this, testers);
+            assert.equal(number_of_pills(), 3);
         })();
 
         (function test_source() {
-            const result = config.source.call(fake_this);
-            const taken_ids = stream_pill.get_stream_ids(stream_edit.pill_widget);
-            const stream_ids = Array.from(result, (stream) => stream.stream_id).sort();
-            let expected_ids = Array.from(subs, (stream) => stream.stream_id).sort();
-            expected_ids = expected_ids.filter((id) => !taken_ids.includes(id));
-            assert.deepEqual(stream_ids, expected_ids);
+            let result = config.source.call(fake_stream_this);
+            const stream_ids = result.map((stream) => stream.stream_id);
+            const expected_stream_ids = [sweden.stream_id];
+            assert.deepEqual(stream_ids, expected_stream_ids);
+
+            result = config.source.call(fake_group_this);
+            const group_ids = result.map((group) => group.id).filter(Boolean);
+            const expected_group_ids = [admins.id];
+            assert.deepEqual(group_ids, expected_group_ids);
+
+            result = config.source.call(fake_person_this);
+            const user_ids = result.map((user) => user.user_id).filter(Boolean);
+            const expected_user_ids = [jill.user_id, fred.user_id];
+            assert.deepEqual(user_ids, expected_user_ids);
         })();
 
         input_typeahead_called = true;
@@ -228,9 +290,10 @@ test_ui("subscriber_pills", (override) => {
         peer_data.get_subscribers(denmark.stream_id),
     ).filter((id) => id !== me.user_id);
 
-    // denmark.stream_id is stubbed. Thus request is
-    // sent to add all subscribers of stream Denmark.
-    expected_user_ids = potential_denmark_stream_subscribers;
+    // `denmark` stream pill, `me` user pill and
+    // `testers` user group pill are stubbed.
+    // Thus request is sent to add all the users.
+    expected_user_ids = [mark.user_id, fred.user_id];
     add_subscribers_handler(event);
 
     add_subscribers_handler = $(subscriptions_table_selector).get_on_handler(
@@ -242,6 +305,7 @@ test_ui("subscriber_pills", (override) => {
     // Only Denmark stream pill is created and a
     // request is sent to add all it's subscribers.
     override(user_pill, "get_user_ids", () => []);
+    override(user_group_pill, "get_user_ids", () => []);
     expected_user_ids = potential_denmark_stream_subscribers;
     add_subscribers_handler(event);
 

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -733,29 +733,3 @@ test("sort_slash_commands", () => {
         {name: "test"},
     ]);
 });
-
-test("sort_recipientbox_typeahead", () => {
-    let recipients = th.sort_recipientbox_typeahead("b, a", matches, ""); // search "a"
-    let recipients_email = recipients.map((person) => person.email);
-    assert.deepEqual(recipients_email, [
-        "a_user@zulip.org", // matches "a"
-        "a_bot@zulip.com", // matches "a"
-        "b_user_1@zulip.net",
-        "b_user_2@zulip.net",
-        "b_user_3@zulip.net",
-        "zman@test.net",
-        "b_bot@example.com",
-    ]);
-
-    recipients = th.sort_recipientbox_typeahead("b, a, b", matches, ""); // search "b"
-    recipients_email = recipients.map((person) => person.email);
-    assert.deepEqual(recipients_email, [
-        "b_user_1@zulip.net",
-        "b_user_2@zulip.net",
-        "b_user_3@zulip.net",
-        "b_bot@example.com",
-        "a_user@zulip.org",
-        "zman@test.net",
-        "a_bot@zulip.com",
-    ]);
-});

--- a/frontend_tests/node_tests/user_group_pill.js
+++ b/frontend_tests/node_tests/user_group_pill.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const {strict: assert} = require("assert");
+
+const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
+
+const user_groups = zrequire("user_groups");
+const user_group_pill = zrequire("user_group_pill");
+
+const admins = {
+    name: "Admins",
+    description: "foo",
+    id: 1,
+    members: [10, 20],
+};
+const testers = {
+    name: "Testers",
+    description: "bar",
+    id: 2,
+    members: [20, 30, 40],
+};
+
+const admins_pill = {
+    id: admins.id,
+    group_name: admins.name,
+    display_value: admins.name + ": " + admins.members.length + " users",
+};
+const testers_pill = {
+    id: testers.id,
+    group_name: testers.name,
+    display_value: testers.name + ": " + testers.members.length + " users",
+};
+
+const groups = [admins, testers];
+for (const group of groups) {
+    user_groups.add(group);
+}
+
+run_test("create_item", () => {
+    function test_create_item(group_name, current_items, expected_item) {
+        const item = user_group_pill.create_item_from_group_name(group_name, current_items);
+        assert.deepEqual(item, expected_item);
+    }
+
+    test_create_item(" admins ", [], admins_pill);
+    test_create_item("admins", [testers_pill], admins_pill);
+    test_create_item("admins", [admins_pill], undefined);
+    test_create_item("unknown", [], undefined);
+});
+
+run_test("get_stream_id", () => {
+    assert.equal(user_group_pill.get_group_name_from_item(admins_pill), admins.name);
+});

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -89,7 +89,7 @@ export function query_matches_person(query, person) {
     return typeahead.query_matches_source_attrs(query, person, ["full_name", email_attr], " ");
 }
 
-function query_matches_name_description(query, user_group_or_stream) {
+export function query_matches_name_description(query, user_group_or_stream) {
     return typeahead.query_matches_source_attrs(
         query,
         user_group_or_stream,

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -163,6 +163,10 @@ export function is_known_user_id(user_id) {
     return people_by_user_id_dict.has(user_id);
 }
 
+export function is_known_user(user) {
+    return user && is_known_user_id(user.user_id);
+}
+
 function sort_numerically(user_ids) {
     user_ids.sort((a, b) => a - b);
 

--- a/static/js/pill_typeahead.js
+++ b/static/js/pill_typeahead.js
@@ -1,8 +1,24 @@
+import * as composebox_typeahead from "./composebox_typeahead";
 import * as people from "./people";
-import * as settings_data from "./settings_data";
 import * as stream_pill from "./stream_pill";
 import * as typeahead_helper from "./typeahead_helper";
+import * as user_group_pill from "./user_group_pill";
+import * as user_groups from "./user_groups";
 import * as user_pill from "./user_pill";
+
+function person_matcher(query, item) {
+    if (people.is_known_user(item)) {
+        return composebox_typeahead.query_matches_person(query, item);
+    }
+    return undefined;
+}
+
+function group_matcher(query, item) {
+    if (user_groups.is_user_group(item)) {
+        return composebox_typeahead.query_matches_name_description(query, item);
+    }
+    return undefined;
+}
 
 export function set_up(input, pills, opts) {
     let source = opts.source;
@@ -10,6 +26,7 @@ export function set_up(input, pills, opts) {
         source = () => user_pill.typeahead_source(pills);
     }
     const include_streams = (query) => opts.stream && query.trim().startsWith("#");
+    const include_user_groups = opts.user_group;
 
     input.typeahead({
         items: 5,
@@ -20,11 +37,19 @@ export function set_up(input, pills, opts) {
                 return stream_pill.typeahead_source(pills);
             }
 
+            if (include_user_groups) {
+                return user_group_pill.typeahead_source(pills).concat(source());
+            }
+
             return source();
         },
         highlighter(item) {
             if (include_streams(this.query)) {
                 return typeahead_helper.render_stream(item);
+            }
+
+            if (include_user_groups) {
+                return typeahead_helper.render_person_or_user_group(item);
             }
 
             return typeahead_helper.render_person(item);
@@ -38,24 +63,36 @@ export function set_up(input, pills, opts) {
                 return item.name.toLowerCase().includes(query);
             }
 
-            if (!settings_data.show_email()) {
-                return item.full_name.toLowerCase().includes(query);
+            if (include_user_groups) {
+                return group_matcher(query, item) || person_matcher(query, item);
             }
-            const email = people.get_visible_email(item);
-            return (
-                email.toLowerCase().includes(query) || item.full_name.toLowerCase().includes(query)
-            );
+
+            return person_matcher(query, item);
         },
         sorter(matches) {
             if (include_streams(this.query)) {
                 return typeahead_helper.sort_streams(matches, this.query.trim().slice(1));
             }
 
-            return typeahead_helper.sort_recipients(matches, this.query, "");
+            const users = matches.filter((ele) => people.is_known_user(ele));
+            let groups;
+            if (include_user_groups) {
+                groups = matches.filter((ele) => user_groups.is_user_group(ele));
+            }
+            return typeahead_helper.sort_recipients(
+                users,
+                this.query,
+                "",
+                undefined,
+                groups,
+                undefined,
+            );
         },
         updater(item) {
             if (include_streams(this.query)) {
                 stream_pill.append_stream(item, pills);
+            } else if (include_user_groups && user_groups.is_user_group(item)) {
+                user_group_pill.append_user_group(item, pills);
             } else {
                 user_pill.append_user(item, pills);
             }

--- a/static/js/pill_typeahead.js
+++ b/static/js/pill_typeahead.js
@@ -51,7 +51,7 @@ export function set_up(input, pills, opts) {
                 return typeahead_helper.sort_streams(matches, this.query.trim().slice(1));
             }
 
-            return typeahead_helper.sort_recipientbox_typeahead(this.query, matches, "");
+            return typeahead_helper.sort_recipients(matches, this.query, "");
         },
         updater(item) {
             if (include_streams(this.query)) {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -33,6 +33,7 @@ import * as sub_store from "./sub_store";
 import * as subs from "./subs";
 import * as ui from "./ui";
 import * as ui_report from "./ui_report";
+import * as user_group_pill from "./user_group_pill";
 import * as user_pill from "./user_pill";
 import * as util from "./util";
 
@@ -243,6 +244,8 @@ function submit_add_subscriber_form(e) {
     const stream_subscription_info_elem = $(".stream_subscription_info").expectOne();
     let user_ids = user_pill.get_user_ids(pill_widget);
     user_ids = user_ids.concat(stream_pill.get_user_ids(pill_widget));
+    user_ids = user_ids.concat(user_group_pill.get_user_ids(pill_widget));
+
     user_ids = new Set(user_ids);
 
     if (user_ids.has(page_params.user_id) && sub.subscribed) {
@@ -400,7 +403,7 @@ function show_subscription_settings(sub) {
         simplebar_container: $(".subscriber_list_container"),
     });
 
-    const opts = {source: get_users_for_subscriber_typeahead, stream: true};
+    const opts = {source: get_users_for_subscriber_typeahead, stream: true, user_group: true};
     pill_typeahead.set_up(sub_settings.find(".input"), pill_widget, opts);
 }
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -322,19 +322,33 @@ export function sort_but_pin_current_user_on_top(users) {
 }
 
 export function create_item_from_text(text, current_items) {
-    const item = stream_pill.create_item_from_stream_name(text, current_items);
-    if (item) {
-        return item;
+    const funcs = [
+        stream_pill.create_item_from_stream_name,
+        user_group_pill.create_item_from_group_name,
+        user_pill.create_item_from_email,
+    ];
+    for (const func of funcs) {
+        const item = func(text, current_items);
+        if (item) {
+            return item;
+        }
     }
-    return user_pill.create_item_from_email(text, current_items);
+    return undefined;
 }
 
 export function get_text_from_item(item) {
-    const text = stream_pill.get_stream_name_from_item(item);
-    if (text) {
-        return text;
+    const funcs = [
+        stream_pill.get_stream_name_from_item,
+        user_group_pill.get_group_name_from_item,
+        user_pill.get_email_from_item,
+    ];
+    for (const func of funcs) {
+        const text = func(item);
+        if (text) {
+            return text;
+        }
     }
-    return user_pill.get_email_from_item(item);
+    return undefined;
 }
 
 function show_subscription_settings(sub) {

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -380,10 +380,3 @@ export function sort_streams(matches, query) {
 
     return name_results.matches.concat(desc_results.matches.concat(desc_results.rest));
 }
-
-export function sort_recipientbox_typeahead(query, matches, current_stream) {
-    // input_text may be one or more pm recipients
-    const cleaned = get_cleaned_pm_recipients(query);
-    query = cleaned[cleaned.length - 1];
-    return sort_recipients(matches, query, current_stream);
-}

--- a/static/js/user_group_pill.js
+++ b/static/js/user_group_pill.js
@@ -1,5 +1,34 @@
 import * as user_groups from "./user_groups";
 
+function display_pill(group) {
+    return group.name + ": " + group.members.size + " users";
+}
+
+export function create_item_from_group_name(group_name, current_items) {
+    group_name = group_name.trim();
+    const group = user_groups.get_user_group_from_name(group_name);
+    if (!group) {
+        return undefined;
+    }
+
+    const in_current_items = current_items.find((item) => item.id === group.id);
+    if (in_current_items !== undefined) {
+        return undefined;
+    }
+
+    const item = {
+        display_value: display_pill(group),
+        id: group.id,
+        group_name: group.name,
+    };
+
+    return item;
+}
+
+export function get_group_name_from_item(item) {
+    return item.group_name;
+}
+
 function get_user_ids_from_user_groups(items) {
     let user_ids = [];
     const group_ids = items.map((item) => item.id).filter(Boolean);
@@ -22,7 +51,7 @@ export function get_user_ids(pill_widget) {
 export function append_user_group(group, pill_widget) {
     if (group !== undefined && group !== null) {
         pill_widget.appendValidatedData({
-            display_value: group.name + ": " + group.members.size + " users",
+            display_value: display_pill(group),
             id: group.id,
         });
         pill_widget.clear_text();

--- a/static/js/user_group_pill.js
+++ b/static/js/user_group_pill.js
@@ -1,0 +1,49 @@
+import * as user_groups from "./user_groups";
+
+function get_user_ids_from_user_groups(items) {
+    let user_ids = [];
+    const group_ids = items.map((item) => item.id).filter(Boolean);
+    for (const group_id of group_ids) {
+        const user_group = user_groups.get_user_group_from_id(group_id);
+        user_ids = user_ids.concat(Array.from(user_group.members));
+    }
+    return user_ids;
+}
+
+export function get_user_ids(pill_widget) {
+    const items = pill_widget.items();
+    let user_ids = get_user_ids_from_user_groups(items);
+    user_ids = Array.from(new Set(user_ids));
+
+    user_ids = user_ids.filter(Boolean);
+    return user_ids;
+}
+
+export function append_user_group(group, pill_widget) {
+    if (group !== undefined && group !== null) {
+        pill_widget.appendValidatedData({
+            display_value: group.name + ": " + group.members.size + " users",
+            id: group.id,
+        });
+        pill_widget.clear_text();
+    }
+}
+
+export function get_group_ids(pill_widget) {
+    const items = pill_widget.items();
+    let group_ids = items.map((item) => item.id);
+    group_ids = group_ids.filter(Boolean);
+
+    return group_ids;
+}
+
+export function filter_taken_groups(items, pill_widget) {
+    const taken_group_ids = get_group_ids(pill_widget);
+    items = items.filter((item) => !taken_group_ids.includes(item.id));
+    return items;
+}
+
+export function typeahead_source(pill_widget) {
+    const groups = user_groups.get_realm_user_groups();
+    return filter_taken_groups(groups, pill_widget);
+}


### PR DESCRIPTION
Fixes: #15186.
It adds support for user group pills to subscribe user groups to stream.
This completes and extends work done by @ryanreh99 in pr #16517

**Testing plan:** 
Manually in dev server.
Adding/modifying node tests to cover new changes.

**GIFs or screenshots:** 
![user_group_pill](https://user-images.githubusercontent.com/63504956/113570908-ecc81980-9632-11eb-9ca2-62053598c85f.gif)

**Checking the working of copy paste**
![copy_paste](https://user-images.githubusercontent.com/63504956/113570971-0c5f4200-9633-11eb-9083-3bcdb4c36c4c.gif)

