### PR TITLE
faq: Add instruction for requesting sponsorship when free trial is disabled.

### DIFF
--- a/templates/zerver/faq.html
+++ b/templates/zerver/faq.html
@@ -22,10 +22,16 @@
                     salaries pay full price.
                 </p>
                 <p class="answer">
+                    {% if free_trial_days %}
                     You can request sponsorship during
                     <a href="/new">organization creation</a>, in an organization's
                     <a href="/accounts/go/?next=/upgrade%23sponsorship">billing page</a>, or contact us at
-                    <a href="mailto:sales@zulip.com">sales@zulip.com</a>
+                    <a href="mailto:sales@zulip.com">sales@zulip.com</a>.
+                    {% else %}
+                    You can request sponsorship from an organization's
+                    <a href="/accounts/go/?next=/upgrade%23sponsorship">billing page</a>, or contact us at
+                    <a href="mailto:sales@zulip.com">sales@zulip.com</a>.
+                    {% endif %}
                 </p>
                 <p class="answer">
                     You may also be interested in


### PR DESCRIPTION
The request sponsorship form(/upgrade page) is shown after the organization creation only when the free trial is enabled. So we need to have separate set of instructions on how to request sponsorship when the free trial is enabled and disabled.

### When the free trial is enabled

![Screenshot from 2021-04-05 21-11-03](https://user-images.githubusercontent.com/7190633/113594294-214ccd00-9655-11eb-93c8-cc064873cf1e.png)

### When the free trial is disabled

![Screenshot from 2021-04-05 21-38-41](https://user-images.githubusercontent.com/7190633/113595970-4f331100-9657-11eb-9c04-2c20724b233b.png)
