### PR TITLE
[WIP] recent-topics: Fixes overlapped scrollbar on table's header.

### DIFF
--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -468,6 +468,48 @@ function topic_sort(a, b) {
     return -1;
 }
 
+// As simplebar vertical scrollbar goes too high in the table
+// (vertical scrollbar can reach the header of the table),
+// we separate the table into two tables:
+//  1. One consists of the only recent topics table header
+//  2. One consists of only recent topics table body
+//     (comprised of a list of recent topics)
+//
+// However, there will be column width misalignment between
+// table header and table body. In order to prevent such issue,
+// we set each header column width according to respective table
+// body column's width.
+//
+// For instance, $(".recent_topic_stream_header")'s width is set
+// to be same as $(".recent_topic_stream")'s width during recent
+// topic content rendering
+
+function adjust_recent_topics_table_header_width() {
+    const recent_topic_stream_width = $("#recent_topics_main_table .recent_topic_stream").width();
+    const recent_topic_name_width = $("#recent_topics_main_table .recent_topic_name").width();
+    const recent_topic_users_width = $("#recent_topics_main_table .recent_topic_users").width();
+    const recent_topic_timestamp_width = $(
+        "#recent_topics_main_table .recent_topic_timestamp",
+    ).width();
+
+    $("#recent_topics_main_table .recent_topic_stream_header").css(
+        "width",
+        `${recent_topic_stream_width}px`,
+    );
+    $("#recent_topics_main_table .recent_topic_name_header").css(
+        "width",
+        `${recent_topic_name_width}px`,
+    );
+    $("#recent_topics_main_table .participants_header").css(
+        "width",
+        `${recent_topic_users_width}px`,
+    );
+    $("#recent_topics_main_table .last_msg_time_header").css(
+        "width",
+        `${recent_topic_timestamp_width}px`,
+    );
+}
+
 export function complete_rerender() {
     if (!is_visible()) {
         return;
@@ -506,9 +548,11 @@ export function complete_rerender() {
             topic_sort,
         },
         html_selector: get_topic_row,
-        simplebar_container: $("#recent_topics_table .table_fix_head"),
+        simplebar_container: $("#recent_topics_table .table_body"),
         callback_after_render: revive_current_focus,
     });
+    // Initialize header's width
+    adjust_recent_topics_table_header_width();
 }
 
 export function is_visible() {
@@ -748,3 +792,6 @@ export function change_focused_element($elt, input_key) {
 
     return false;
 }
+
+// Always readjust recent topics table's header whenever window size changes
+$(window).on("resize", adjust_recent_topics_table_header_width);

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -61,17 +61,21 @@
             padding-right: 3px;
         }
 
-        .table_fix_head {
+        table {
+            /* To keep border properties to the thead th. */
+            border-collapse: separate;
+        }
+
+        .table_fix_head .table {
+            margin-bottom: 0 !important;
+        }
+
+        .table_body {
             padding: 0 !important;
             /* 100px = space occupied by `recent_topics_filter_buttons`( ~49px)
                      + give user some extra space at the bottom so that last
                        topic row is clearly visible. */
-            max-height: calc(100vh - 100px);
-        }
-
-        .table_fix_head table {
-            /* To keep border properties to the thead th. */
-            border-collapse: separate;
+            max-height: calc(100vh - 140px);
         }
 
         #recent_topics_filter_buttons {
@@ -264,16 +268,6 @@
 
         .recent_topic_timestamp {
             width: 15%;
-        }
-
-        thead .last_msg_time_header {
-            /* The responsive table of bootstrap
-               somehow ignores the width of ::after
-               element. This ensures it is always visible.
-               20px = space occupied by ::after (icon) +
-               some extra padding.
-            */
-            padding-right: 20px;
         }
 
         @media (width < $md_min) {

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -9,16 +9,22 @@
         </button>
     </div>
 </div>
-<div class="table_fix_head" data-simplebar>
-    <table class="table table-responsive">
-        <thead>
-            <tr>
-                <th data-sort="stream_sort">{{t 'Stream' }}</th>
-                <th data-sort="topic_sort">{{t 'Topic' }}</th>
-                <th class='participants_header'>{{t 'Participants' }}</th>
-                <th data-sort="numeric" data-sort-prop="last_msg_id" class="last_msg_time_header active descend">{{t 'Time' }}</th>
-            </tr>
-        </thead>
-        <tbody class="required-text" data-empty="{{t 'No topics match your current filter.' }}"></tbody>
-    </table>
+<div id="recent_topics_main_table">
+    <div class="table_fix_head">
+        <table class="table table-responsive">
+            <thead>
+                <tr>
+                    <th class="recent_topic_stream_header" data-sort="stream_sort">{{t 'Stream' }}</th>
+                    <th class="recent_topic_name_header" data-sort="topic_sort">{{t 'Topic' }}</th>
+                    <th class='participants_header'>{{t 'Participants' }}</th>
+                    <th data-sort="numeric" data-sort-prop="last_msg_id" class="last_msg_time_header active descend">{{t 'Time' }}</th>
+                </tr>
+            </thead>
+        </table>
+    </div>
+    <div class="table_body" data-simplebar>
+        <table class="table table-responsive">
+            <tbody class="required-text" data-empty="{{t 'No topics match your current filter.' }}"></tbody>
+        </table>
+    </div>
 </div>


### PR DESCRIPTION
Fixes #17933.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#17933 

**Idea**
1. Separate recent topics table into two tables
- One consists of table header only (_Stream_, _Topic_, _Participants_, _Time_ )
- One consists of the table body (_A list of recent topics_)

2. The width of the table body's columns remain the same (previously implemented in CSS)
- _$(.recent_topic_stream)_ : 25%
- _$(.recent_topic_name)_ : 40%
- _$(.recent_topic_users)_ : 20%
- _$(.recent_topic_timestamp)_ : 15%

3. The width of the table header is initialized according to the width of the table body's columns upon clients' requests to the recent topics page. The function `adjust_recent_topics_table_header_width()` is implemented locally in recent_topics.js

4. We also implement dynamic resizing on the header in case of window resizing in recent_topic.js

**Testing plan:** <!-- How have you tested? -->
Manually testing, but required to test on header width's changes (to make sure header column's width is similar to respective body column's width)

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
**Scrolling UI** _Before_
https://user-images.githubusercontent.com/67208821/113614087-9b487a80-9684-11eb-80e4-bc5174eafa4d.mp4

**Scrolling UI** _After_
https://user-images.githubusercontent.com/67208821/113614109-a3081f00-9684-11eb-889e-9bbaec4bf4d6.mp4

**Width Responsiveness** _Before_
https://user-images.githubusercontent.com/67208821/113614212-c8952880-9684-11eb-8399-b51a5a31bb8f.mp4

**Width Responsiveness** _After_
https://user-images.githubusercontent.com/67208821/113614239-d185fa00-9684-11eb-941d-19ca301c9761.mp4

**Scrolling UI when height reduces** _Before_
https://user-images.githubusercontent.com/67208821/113614371-fbd7b780-9684-11eb-9a97-84b77e462baa.mp4

**Scrolling UI when height reduces** _After_
https://user-images.githubusercontent.com/67208821/113614386-0003d500-9685-11eb-9300-1497cdc18edb.mp4


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
