### PR TITLE
fixed starred message style

### DIFF
--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -322,7 +322,7 @@ li.top_left_recent_topics {
     font-weight: normal;
     letter-spacing: 0.6px;
     border-radius: 4px;
-    background-color:  hsl(43, 74%, 49%);
+    background-color: hsl(43, 74%, 49%);
     color: hsl(0, 0%, 100%);
 }
 

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -295,7 +295,6 @@ li.top_left_recent_topics {
 */
 .top_left_all_messages .count,
 .top_left_private_messages .count,
-.top_left_starred_messages .count,
 .top_left_mentions .count,
 #stream_filters .count,
 .topic-unread-count,
@@ -310,14 +309,25 @@ li.top_left_recent_topics {
     border-radius: 4px;
 }
 
+/* Style starred message counts differently
+*/
+.top_left_starred_messages .count {
+    float: right;
+    padding: 0 4px;
+    height: 16px;
+    line-height: 16px;
+    font-size: 12px;
+    font-weight: normal;
+    letter-spacing: 0.6px;
+    border-radius: 4px;
+}
+
 /* Starred messaged counts aren't really unread
    counts, so we style them differently.
 */
 .top_left_starred_messages .count {
-    background-color: transparent;
-    color: inherit;
-    padding: 2px 1px 0 3px;
-    border-color: hsl(105, 2%, 50%);
+    background-color:  goldenrod;
+    color: white;
 }
 
 /* These are true "unread" counts. */

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -307,6 +307,8 @@ li.top_left_recent_topics {
     font-weight: normal;
     letter-spacing: 0.6px;
     border-radius: 4px;
+    background-color: hsl(105, 2%, 50%);
+    color: hsl(0, 0%, 100%);
 }
 
 /* Style starred message counts differently
@@ -320,24 +322,7 @@ li.top_left_recent_topics {
     font-weight: normal;
     letter-spacing: 0.6px;
     border-radius: 4px;
-}
-
-/* Starred messaged counts aren't really unread
-   counts, so we style them differently.
-*/
-.top_left_starred_messages .count {
-    background-color:  goldenrod;
-    color: white;
-}
-
-/* These are true "unread" counts. */
-.top_left_all_messages .count,
-.top_left_private_messages .count,
-.top_left_mentions .count,
-#stream_filters .count,
-.topic-unread-count,
-.private_message_count {
-    background-color: hsl(105, 2%, 50%);
+    background-color:  hsl(43, 74%, 49%);
     color: hsl(0, 0%, 100%);
 }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

https://github.com/zulip/zulip/issues/17938


**Testing plan:** <!-- How have you tested? -->

Ran the test server and viewed the style changes

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![image](https://user-images.githubusercontent.com/33680232/113662046-50733680-9675-11eb-9eaa-660b9946e3f9.png)
![image](https://user-images.githubusercontent.com/33680232/113662110-70a2f580-9675-11eb-81d4-c8f25c9551ec.png)

