### PR TITLE
stream_popovers: Use page_params.is_admin while building popover.

### DIFF
--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -246,7 +246,7 @@ function build_topic_popover(opts) {
         topic_name,
         can_mute_topic,
         can_unmute_topic,
-        is_realm_admin: page_params.is_realm_admin,
+        is_realm_admin: page_params.is_admin,
         color: sub.color,
         has_starred_messages,
     });


### PR DESCRIPTION
Within 9c9d74f, page_params.is_realm_admin was incorrectly stated while building popover which lead to admin actions not being populated within popover.
This is so beacuse `is_realm_admin` is not a valid object of page_params.
Rectified by renaming `is_realm_admin` to `is_admin`.


<strong>Before:</strong>
![Screenshot from 2021-04-06 20-17-26](https://user-images.githubusercontent.com/53977614/113730152-41dc5c00-9715-11eb-9a09-b8649e5460f0.png)

<strong>After</strong>
![Screenshot from 2021-04-06 20-17-43](https://user-images.githubusercontent.com/53977614/113730173-486ad380-9715-11eb-8ad5-95eb96afbc46.png)

