### PR TITLE
backend: Improve perceived latency for the sender by making sender first to receive message

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1928,6 +1928,15 @@ def do_send_messages(
                about changing the next line.
         """
         user_ids = send_request.active_user_ids | set(user_flags.keys())
+        sender_id = send_request.message.sender_id
+
+        # We make sure the sender is listed first in the `users` list;
+        # this results in the sender receiving the message first if
+        # there are thousands of recipients, decreasing perceived latency.
+        if sender_id in user_ids:
+            user_list = [sender_id] + list(user_ids - {sender_id})
+        else:
+            user_list = list(user_ids)
 
         users = [
             dict(
@@ -1938,7 +1947,7 @@ def do_send_messages(
                 stream_email_notify=(user_id in send_request.stream_email_user_ids),
                 wildcard_mention_notify=(user_id in send_request.wildcard_mention_user_ids),
             )
-            for user_id in user_ids
+            for user_id in user_list
         ]
 
         if send_request.message.is_stream_message():


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #17898 

**Testing plan:** <!-- How have you tested? -->
I tested it in two ways:
1. Automated testing-
I ran `./tools/test-backend` after making the first commit to check if anything has gone wrong. It failed for the file `test_subs.py`, particularly I have mentioned in the file right now (see the first commit file changes). As I am not clear should I change it or not, I have added some comments above the lines at which the tests are failing. Rest all the tests passed.
2. I tested the first commit manually as suggested in the issue comments and also shown that in the second commit. I am not sure if OrderedDict will be used or where it will be used. It is working as expected, the sender is always coming at the first. Here are some screenshots of the outputs:
![image](https://user-images.githubusercontent.com/56730716/113779410-4ae82000-974b-11eb-8d0b-a7e7e4c53277.png)
(The sender is the first one here)
A question: Is this the right data that I am printing to check? (SOLVED)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
