### PR TITLE
openapi: Fix display of boolean types in examples.

### DIFF
--- a/zerver/lib/markdown/api_arguments_table_generator.py
+++ b/zerver/lib/markdown/api_arguments_table_generator.py
@@ -124,7 +124,14 @@ class APIArgumentsTablePreprocessor(Preprocessor):
             # (path, querystring, form data...).  We should document this detail.
             example = ""
             if "example" in argument:
-                example = argument["example"]
+                # We use this style without explicit JSON encoding for
+                # integers, strings, and booleans.
+                # * For booleans, JSON encoding correctly corrects for Python's
+                #   str(True)="True" not matching the encoding of "true".
+                # * For strings, doing so nicely results in strings being quoted
+                #   in the documentation, improving readability.
+                # * For integers, it is a noop, since json.dumps(3) == str(3) == "3".
+                example = json.dumps(argument["example"])
             else:
                 example = json.dumps(argument["content"]["application/json"]["example"])
 

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -208,6 +208,7 @@ def get_openapi_param_example_value_as_string(
         # union type.  But for this logic's purpose, it's good enough
         # to just check the first parameter.
         param_type = param["schema"]["oneOf"][0]["type"]
+
     if param_type in ["object", "array"]:
         example_value = param.get("example", None)
         if not example_value:
@@ -225,7 +226,9 @@ cURL example."""
     else:
         example_value = param.get("example", DEFAULT_EXAMPLE[param_type])
         if isinstance(example_value, bool):
-            example_value = str(example_value).lower()
+            # Booleans are effectively JSON-encoded, in that we pass
+            # true/false, not the Python str(True) = "True"
+            jsonify = True
         if jsonify:
             example_value = json.dumps(example_value)
         if curl_argument:


### PR DESCRIPTION
Fixed boolean statements being displayed in camel case in API
documentations to match JSON format.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #18010

**Testing plan:** <!-- How have you tested? -->
Manually tested in browser

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![boolean](https://user-images.githubusercontent.com/42570356/113869287-2a14de80-97ce-11eb-86e3-5cec5852532d.JPG)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
