### PR TITLE
click_handlers: Prevent opening of replybox when clicked on codeblock copy button.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -132,6 +132,13 @@ export function initialize() {
             return true;
         }
 
+        // Ideally, this should be done via ClipboardJS, but it does't support
+        // feature of stopPropagation once clicked.
+        // See https://github.com/zenorocha/clipboard.js/pull/475
+        if (target.is(".copy_codeblock") || target.parents(".copy_codeblock").length > 0) {
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
<code><a href = 'https://github.com/zenorocha/clipboard.js'>Clipboard.js</a></code> lacks the ability to `stopPropogate` an event when clicked. A relevant pr <a href = 'https://github.com/zenorocha/clipboard.js/pull/475'>#475</a> was closed because of it being stale.
Hence added a fix by explicitly stopPropogating the event within `click_handlers`.

<strong>Before</strong>

![error](https://user-images.githubusercontent.com/53977614/113868642-875c6000-97cd-11eb-9dc4-eec33de584cc.gif)

<strong>After</strong>

![fix](https://user-images.githubusercontent.com/53977614/113868665-904d3180-97cd-11eb-85c0-2314b07abb8d.gif)


<strong>Tested in</strong>
- [x] Chrome
- [x] Mozilla Firefox
- [x] Safari (Thanks @sumanthvrao!)
- [ ] Brave

Would love a review @timabbott.


Closes #17861.
