### PR TITLE
openapi: Add feature level information for playground APIs/events.

### DIFF
--- a/docs/documentation/api.md
+++ b/docs/documentation/api.md
@@ -279,6 +279,12 @@ above.
    make sure that copy-pasting the code in your examples works, and
    post an example of the output in the pull request.
 
+1. Document the new API in `templates/zerver/api/changelog.md` and
+   bump the `API_FEATURE_LEVEL` in `version.py`. Also, make sure to
+   add a `**Changes**` entry in the description of the new API/event
+   in `zerver/openapi/zulip.yaml`, which mentions the API feature level
+   at which they were added.
+
 [javascript-examples]: https://github.com/zulip/zulip-js/tree/master/examples
 
 ## Why a custom system?

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2418,6 +2418,8 @@ paths:
                               description: |
                                 Event sent to all users in a Zulip organization when the
                                 set of configured playgrounds for the organization has changed.
+
+                                **Changes**: New in Zulip 4.0 (feature level 49).
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -6610,6 +6612,8 @@ paths:
         in a code block using playgrounds which supports that language.
 
         `POST {{ api_url }}/v1/realm/playgrounds`
+
+        **Changes**: New in Zulip 4.0 (feature level 49).
       parameters:
         - name: name
           in: query
@@ -6664,6 +6668,8 @@ paths:
         custom playgrounds
 
         `DELETE {{ api_url }}/v1/realm/playgrounds/{playground_id}`
+
+        **Changes**: New in Zulip 4.0 (feature level 49).
       parameters:
         - name: playground_id
           in: path
@@ -6978,6 +6984,8 @@ paths:
 
                           An array of dictionaries where each dictionary describes a playground entry
                           in this Zulip organization.
+
+                          **Changes**: New in Zulip 4.0 (feature level 49).
                       realm_user_groups:
                         type: array
                         items:
@@ -10168,6 +10176,8 @@ components:
             open a code block in, to differentiate between multiple
             configured playground options for a given pygments
             language.
+
+            **Changes**: New in Zulip 4.0 (feature level 49).
         pygments_language:
           type: string
           description: |


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

We missed this when adding the new API endpoints/events for
 configuring realm "playground" options in the series starting
 with 251b415987264a4a18032d0e06b79663e0785a7b.

Also added this step to our REST API endpoint documentation at https://zulip.readthedocs.io/en/latest/documentation/api.html

@timabbott FYI