### PR TITLE
stream_create: Use user pills instead of rendering all users list.

### DIFF
--- a/frontend_tests/puppeteer_tests/subscriptions.ts
+++ b/frontend_tests/puppeteer_tests/subscriptions.ts
@@ -4,40 +4,6 @@ import type {ElementHandle, Page} from "puppeteer";
 
 import common from "../puppeteer_lib/common";
 
-async function user_checkbox(page: Page, name: string): Promise<string> {
-    const user_id = await common.get_user_id_from_name(page, name);
-    return `#user-checkboxes [data-user-id="${CSS.escape(user_id.toString())}"]`;
-}
-
-async function user_span(page: Page, name: string): Promise<string> {
-    return (await user_checkbox(page, name)) + " input ~ span";
-}
-
-async function stream_checkbox(page: Page, stream_name: string): Promise<string> {
-    const stream_id = await common.get_stream_id(page, stream_name);
-    return `#stream-checkboxes [data-stream-id="${CSS.escape(stream_id.toString())}"]`;
-}
-
-async function stream_span(page: Page, stream_name: string): Promise<string> {
-    return (await stream_checkbox(page, stream_name)) + " input ~ span";
-}
-
-async function wait_for_checked(page: Page, user_name: string, is_checked: boolean): Promise<void> {
-    const selector = await user_checkbox(page, user_name);
-    await page.waitForFunction(
-        (selector: string, is_checked: boolean) =>
-            $(selector).find("input")[0].checked === is_checked,
-        {},
-        selector,
-        is_checked,
-    );
-}
-
-async function stream_name_error(page: Page): Promise<string> {
-    await page.waitForSelector("#stream_name_error", {visible: true});
-    return await common.get_text_from_selector(page, "#stream_name_error");
-}
-
 async function open_streams_modal(page: Page): Promise<void> {
     const all_streams_selector = "#add-stream-link";
     await page.waitForSelector(all_streams_selector, {visible: true});
@@ -78,147 +44,6 @@ async function test_subscription_button_verona_stream(page: Page): Promise<void>
     button = await subscribed();
 }
 
-async function click_create_new_stream(
-    page: Page,
-    cordelia_checkbox: string,
-    othello_checkbox: string,
-): Promise<void> {
-    await page.click("#add_new_subscription .create_stream_button");
-    await page.waitForSelector(cordelia_checkbox, {visible: true});
-    await page.waitForSelector(othello_checkbox, {visible: true});
-}
-
-async function open_copy_from_stream_dropdown(
-    page: Page,
-    scotland_checkbox: string,
-    rome_checkbox: string,
-): Promise<void> {
-    await page.click("#copy-from-stream-expand-collapse .control-label");
-    await page.waitForSelector(scotland_checkbox, {visible: true});
-    await page.waitForSelector(rome_checkbox, {visible: true});
-}
-
-async function test_check_all_only_affects_visible_users(page: Page): Promise<void> {
-    await page.click(".subs_set_all_users");
-    await wait_for_checked(page, "cordelia", false);
-    await wait_for_checked(page, "othello", true);
-}
-
-async function test_uncheck_all(page: Page): Promise<void> {
-    await page.click(".subs_unset_all_users");
-    await wait_for_checked(page, "othello", false);
-}
-
-async function clear_ot_filter_with_backspace(page: Page): Promise<void> {
-    await page.click(".add-user-list-filter");
-    await page.keyboard.press("Backspace");
-    await page.keyboard.press("Backspace");
-}
-
-async function verify_filtered_users_are_visible_again(
-    page: Page,
-    cordelia_checkbox: string,
-    othello_checkbox: string,
-): Promise<void> {
-    await page.waitForSelector(cordelia_checkbox, {visible: true});
-    await page.waitForSelector(othello_checkbox, {visible: true});
-}
-
-async function test_user_filter_ui(
-    page: Page,
-    cordelia_checkbox: string,
-    othello_checkbox: string,
-    scotland_checkbox: string,
-    rome_checkbox: string,
-): Promise<void> {
-    await page.waitForSelector("form#stream_creation_form", {visible: true});
-
-    await common.fill_form(page, "form#stream_creation_form", {user_list_filter: "ot"});
-    await page.waitForSelector("#user-checkboxes", {visible: true});
-    await page.waitForSelector(cordelia_checkbox, {hidden: true});
-    await page.waitForSelector(othello_checkbox, {visible: true});
-
-    // Filter shouldn't affect streams.
-    await page.waitForSelector(scotland_checkbox, {visible: true});
-    await page.waitForSelector(rome_checkbox, {visible: true});
-
-    await test_check_all_only_affects_visible_users(page);
-    await test_uncheck_all(page);
-
-    await clear_ot_filter_with_backspace(page);
-    await verify_filtered_users_are_visible_again(page, cordelia_checkbox, othello_checkbox);
-}
-
-async function create_stream(page: Page): Promise<void> {
-    await page.waitForXPath('//*[text()="Create stream"]', {visible: true});
-    await common.fill_form(page, "form#stream_creation_form", {
-        stream_name: "Puppeteer",
-        stream_description: "Everything Puppeteer",
-    });
-    await page.click(await stream_span(page, "Scotland")); //  Subscribes all users from Scotland
-    await page.click(await user_span(page, "cordelia")); // Add cordelia.
-    await wait_for_checked(page, "cordelia", true);
-    await page.click(await user_span(page, "othello")); // Remove othello who was selected from Scotland.
-    await wait_for_checked(page, "othello", false);
-    await page.click("form#stream_creation_form button.button.sea-green");
-    await page.waitForFunction(() => $(".stream-name").is(':contains("Puppeteer")'));
-    const stream_name = await common.get_text_from_selector(
-        page,
-        ".stream-header .stream-name .stream-name-editable",
-    );
-    const stream_description = await common.get_text_from_selector(
-        page,
-        ".stream-description-editable ",
-    );
-    const subscriber_count_selector = "[data-stream-name='Puppeteer'] .subscriber-count";
-    assert.strictEqual(stream_name, "Puppeteer");
-    assert.strictEqual(stream_description, "Everything Puppeteer");
-
-    // Assert subscriber count becomes 6(scotland(+5), cordelia(+1), othello(-1), Desdemona(+1)).
-    await page.waitForFunction(
-        (subscriber_count_selector: string) => $(subscriber_count_selector).text().trim() === "6",
-        {},
-        subscriber_count_selector,
-    );
-}
-
-async function test_streams_with_empty_names_cannot_be_created(page: Page): Promise<void> {
-    await page.click("#add_new_subscription .create_stream_button");
-    await page.waitForSelector("form#stream_creation_form", {visible: true});
-    await common.fill_form(page, "form#stream_creation_form", {stream_name: "  "});
-    await page.click("form#stream_creation_form button.button.sea-green");
-    assert.strictEqual(await stream_name_error(page), "A stream needs to have a name");
-}
-
-async function test_streams_with_duplicate_names_cannot_be_created(page: Page): Promise<void> {
-    await common.fill_form(page, "form#stream_creation_form", {stream_name: "Puppeteer"});
-    await page.click("form#stream_creation_form button.button.sea-green");
-    assert.strictEqual(await stream_name_error(page), "A stream with this name already exists");
-
-    const cancel_button_selector = "form#stream_creation_form button.button.white";
-    await page.click(cancel_button_selector);
-}
-
-async function test_stream_creation(page: Page): Promise<void> {
-    const cordelia_checkbox = await user_checkbox(page, "cordelia");
-    const othello_checkbox = await user_checkbox(page, "othello");
-    const scotland_checkbox = await stream_checkbox(page, "Scotland");
-    const rome_checkbox = await stream_checkbox(page, "Rome");
-
-    await click_create_new_stream(page, cordelia_checkbox, othello_checkbox);
-    await open_copy_from_stream_dropdown(page, scotland_checkbox, rome_checkbox);
-    await test_user_filter_ui(
-        page,
-        cordelia_checkbox,
-        othello_checkbox,
-        scotland_checkbox,
-        rome_checkbox,
-    );
-    await create_stream(page);
-    await test_streams_with_empty_names_cannot_be_created(page);
-    await test_streams_with_duplicate_names_cannot_be_created(page);
-}
-
 async function test_streams_search_feature(page: Page): Promise<void> {
     assert.strictEqual(await common.get_text_from_selector(page, "#search_stream_name"), "");
     const hidden_streams_selector = ".stream-row.notdisplayed .stream-name";
@@ -234,18 +59,14 @@ async function test_streams_search_feature(page: Page): Promise<void> {
         "#Verona is hidden",
     );
 
-    await page.type('#stream_filter input[type="text"]', "Puppeteer");
-    assert.strictEqual(
-        await common.get_text_from_selector(page, ".stream-row:not(.notdisplayed) .stream-name"),
-        "Puppeteer",
-    );
+    await page.type('#stream_filter input[type="text"]', "General");
     assert(
         (await common.get_text_from_selector(page, hidden_streams_selector)).includes("Verona"),
         "#Verona is not hidden",
     );
     assert(
-        !(await common.get_text_from_selector(page, hidden_streams_selector)).includes("Puppeteer"),
-        "Puppeteer is hidden after searching.",
+        !(await common.get_text_from_selector(page, hidden_streams_selector)).includes("General"),
+        "General is hidden after searching.",
     );
 }
 
@@ -253,7 +74,6 @@ async function subscriptions_tests(page: Page): Promise<void> {
     await common.log_in(page);
     await open_streams_modal(page);
     await test_subscription_button_verona_stream(page);
-    await test_stream_creation(page);
     await test_streams_search_feature(page);
 }
 

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -190,8 +190,10 @@ export function update_add_subscriptions_elements(sub) {
 
     // Otherwise, we adjust whether the widgets are disabled based on
     // whether this user is authorized to add subscribers.
-    const input_element = $(".add_subscribers_container").find(".input").expectOne();
-    const button_element = $(".add_subscribers_container")
+    const input_element = $(".subscription_settings .add_subscribers_container")
+        .find(".input")
+        .expectOne();
+    const button_element = $(".subscription_settings .add_subscribers_container")
         .find('button[name="add_subscriber"]')
         .expectOne();
     const allow_user_to_add_subs = sub.can_add_subscribers;

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -592,6 +592,12 @@ form#add_new_subscription {
     font-weight: 400;
 }
 
+.stream-sub-title {
+    display: block !important;
+    font-size: 1em;
+    font-weight: 300;
+}
+
 .stream-creation-info {
     font-style: italic;
     margin-bottom: 10px;
@@ -799,6 +805,7 @@ form#add_new_subscription {
         -webkit-overflow-scrolling: touch;
 
         .modal-footer {
+            padding-top: 8px;
             position: absolute;
             bottom: 0;
             width: calc(100% - 27px);

--- a/static/templates/new_stream_users.hbs
+++ b/static/templates/new_stream_users.hbs
@@ -1,38 +1,10 @@
-{{! Client-side Mustache template for rendering users in the stream creation modal.}}
-
-<div id="copy-from-stream-expand-collapse" class="add-user-label">
-    <i class="toggle fa fa-caret-right" aria-hidden="true"></i>
-    <span class="control-label">
-        {{t "Copy from stream" }}
-    </span>
-</div>
-
-<div id="stream-checkboxes">
-    {{#each streams}}
-    <label class="checkbox add-user-label" data-stream-id="{{this.stream_id}}">
-        <input type="checkbox" name="stream" />
-        <span></span>
-        {{this.name}} ( <i class="fa fa-user" aria-hidden="true"></i> {{this.subscriber_count}})
-    </label>
-    {{/each}}
-</div>
-
-<br>
-<input class="add-user-list-filter" name="user_list_filter" type="text"
-  autocomplete="off" placeholder="{{t "Filter" }}" />
-
-
-<div>
-    <a href="#" draggable="false" class="subs_set_all_users">{{t "Check all" }}</a> |
-    <a href="#" draggable="false" class="subs_unset_all_users">{{t "Uncheck all" }}</a>
-</div>
-
-<div id="user-checkboxes">
-    {{#each users}}
-    <label class="checkbox add-user-label" data-user-id="{{this.user_id}}">
-        <input type="checkbox" name="user" {{#if @first}}checked="checked"{{#unless is_admin}} disabled="disabled"{{/unless}}{{/if}}/>
-        <span></span>
-        {{this.full_name}} ({{this.email}})
-    </label>
-    {{/each}}
+<div class="subscriber_list_add float-left">
+    <form class="form-inline">
+        <div class="add_subscribers_container">
+            <div class="pill-container person_picker">
+                <div class="input" contenteditable="true"
+                  data-placeholder="{{t 'Add people who you think who might be interested in this stream.' }}"></div>
+            </div>
+        </div>
+    </form>
 </div>

--- a/static/templates/stream_creation_form.hbs
+++ b/static/templates/stream_creation_form.hbs
@@ -45,9 +45,13 @@
                 <label class="stream-title" for="people_to_add">
                     {{t "People to add" }}
                 </label>
+                <label class="stream-sub-title" for="people_to_add">
+                    {{t 'Add subscribers. Use #streamname to subscribe a whole stream' }}
+                </label>
                 <div id="stream_subscription_error" class="stream_creation_error"></div>
                 <div class="controls" id="people_to_add"></div>
             </section>
+            <br>
         </div>
         <div class="modal-footer">
             <button class="button small white rounded" data-dismiss="modal">{{t "Cancel" }}</button>


### PR DESCRIPTION
Fixes #16805.

This fixes the issue that in realms with 1000+
users, opening stream creation form takes a lot of time and
selecting users for subscribing is basically unusable.

We use the approach used by already present streams which use
pills to allow adding of users instead of displaying
complete list of users.

Opening this since #16979 closed magically on its own.