### PR TITLE
topic_sidebar_actions: Remove "Narrow to topics" option.

### DIFF
--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -14,7 +14,6 @@ import * as hash_util from "./hash_util";
 import * as message_edit from "./message_edit";
 import * as muting from "./muting";
 import * as muting_ui from "./muting_ui";
-import * as narrow from "./narrow";
 import {page_params} from "./page_params";
 import * as popovers from "./popovers";
 import * as resize from "./resize";
@@ -507,42 +506,7 @@ export function register_stream_handlers() {
     });
 }
 
-function topic_popover_sub(e) {
-    const stream_id = topic_popover_stream_id(e);
-    if (!stream_id) {
-        blueslip.error("cannot find stream id");
-        return undefined;
-    }
-
-    const sub = stream_data.get_sub_by_id(stream_id);
-    if (!sub) {
-        blueslip.error("Unknown stream: " + stream_id);
-        return undefined;
-    }
-    return sub;
-}
-
 export function register_topic_handlers() {
-    // Narrow to topic
-    $("body").on("click", ".narrow_to_topic", (e) => {
-        hide_topic_popover();
-
-        const sub = topic_popover_sub(e);
-        if (!sub) {
-            return;
-        }
-
-        const topic = $(e.currentTarget).attr("data-topic-name");
-
-        const operators = [
-            {operator: "stream", operand: sub.name},
-            {operator: "topic", operand: topic},
-        ];
-        narrow.activate(operators, {trigger: "sidebar"});
-
-        e.stopPropagation();
-    });
-
     // Mute the topic
     $("body").on("click", ".sidebar-popover-mute-topic", (e) => {
         const stream_id = topic_popover_stream_id(e);

--- a/static/templates/topic_sidebar_actions.hbs
+++ b/static/templates/topic_sidebar_actions.hbs
@@ -8,15 +8,6 @@
 
     <hr>
 
-    {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
-    <li>
-        <a tabindex="0" class="narrow_to_topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
-            <i class="fa fa-bullhorn" aria-hidden="true"></i>
-            {{t "Narrow to topic"}}
-        </a>
-    </li>
-
-
     {{#if can_mute_topic}}
     <li>
         <a tabindex="0" class="sidebar-popover-mute-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) --> Fixes #18027 


**Testing plan:** <!-- How have you tested? --> Tested everything manually and running all tests.

Removed ".narrow_to_topic" existence completely from its .hbs file and on click event code.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before: 
<img width="332" alt="before_remove_narrow_to_topic" src="https://user-images.githubusercontent.com/59444243/113905756-1dee4880-97f1-11eb-94ba-f87f3b138976.PNG">
After: 
<img width="330" alt="after_remove_narrow_to_topic_option" src="https://user-images.githubusercontent.com/59444243/113905781-25155680-97f1-11eb-9395-844631ee68f2.PNG">



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
