### PR TITLE
subs: Disable the retention dropdown in stream creation form also.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -645,6 +645,8 @@ export function setup_page(callback) {
                 stream_edit.get_display_text_for_realm_message_retention_setting,
             upgrade_text_for_wide_organization_logo:
                 page_params.upgrade_text_for_wide_organization_logo,
+            disable_message_retention_setting:
+                !page_params.zulip_plan_is_not_limited || !page_params.is_owner,
         };
 
         const rendered = render_subscription_table_body(template_data);


### PR DESCRIPTION
We should disable the stream message retention dropdown for owners
of realm with limited plans. The behavior is correct in other
places, will also just explain the behavior in other places -

For limited plans-
1. Owners can see the dropdown in stream creation form but others
cannot, and in stream privacy modal, the modal is visible to all.
But the modal is disabled in all cases since the realm is on
limited plan.

For standard plans -
1. Owners can see and edit the dropdown in both stream creation
form and stream privacy modal. Non-owners cannot see the modal
in stream creation form but they can see the dropdown in stream
privacy modal and it will be disabled.

Thus, the only change in this PR is to disable the dropdown
in the stream creation form for owners and in limited plan realms.
The other behavior mentioned above was already there.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
