### PR TITLE
styles: Slightly increase monospace font size

### DIFF
--- a/static/styles/portico/markdown.css
+++ b/static/styles/portico/markdown.css
@@ -299,7 +299,7 @@
 
     code {
         /* Copied from rendered_markdown.css */
-        font-size: 0.786em;
+        font-size: 0.825em;
         unicode-bidi: embed;
         direction: ltr;
         white-space: initial;

--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -497,8 +497,10 @@ rendered_markdown block; we just need to do further analysis to
 confirm doing so won't break anything. */
 
 code {
-    /* 11/14 em, so 11 px when body is the default 14 px */
-    font-size: 0.786em;
+    /* 11.55px when body is the default 14px; this is chosen to be
+       slightly above the 11.5px threshold where the height jumps by a
+       pixel on most platforms. */
+    font-size: 0.825em;
     unicode-bidi: embed;
     direction: ltr;
     color: hsl(0, 0%, 0%);
@@ -520,7 +522,7 @@ code {
 pre {
     direction: ltr;
     /* code block text is a bit smaller than normal text */
-    font-size: 0.786em;
+    font-size: 0.825em;
     line-height: 1.4;
     white-space: pre;
     overflow-x: auto;


### PR DESCRIPTION
Commit d84727ce7f130146c10aa914912331b69a3bff36 (#17970) slightly decreased the apparent size on some platforms depending on which font was in use before, and some users complained that it was a bit hard to read.  Based on experiments with multiple platforms and monitors and resolutions, this appears to be a good compromise that increases the rendered height without increasing the width more than necessary.

**GIFs or screenshots:**

![day](https://user-images.githubusercontent.com/26471/113920421-9d502d80-9799-11eb-87b2-6525feba3ea2.png)

![night](https://user-images.githubusercontent.com/26471/113920424-9de8c400-9799-11eb-99f0-27efc9f67b4f.png)

(From [this message](https://chat.zulip.org/#narrow/stream/65-checkins/topic/Rein/near/1142877) again.)