### PR TITLE
Raise same error for all values of policies using COMMON_POLICY_TYPES.

### DIFF
--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -617,13 +617,9 @@ def list_to_streams(
     else:
         # autocreate=True path starts here
         if not user_profile.can_create_streams():
-            if user_profile.realm.create_stream_policy == Realm.POLICY_ADMINS_ONLY:
-                raise JsonableError(_("Only administrators can create streams."))
-            if user_profile.realm.create_stream_policy == Realm.POLICY_MODERATORS_ONLY:
-                raise JsonableError(_("Only administrators and moderators can create streams."))
-            if user_profile.realm.create_stream_policy == Realm.POLICY_FULL_MEMBERS_ONLY:
-                raise JsonableError(_("Your account is too new to create streams."))
-            raise JsonableError(_("Not allowed for guest users"))
+            # Guest users case will not be handled here as it will be
+            # handled by the decorator in add_subscriptions_backend.
+            raise JsonableError(_("Insufficient permission"))
         elif not autocreate:
             raise JsonableError(
                 _("Stream(s) ({}) do not exist").format(

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1255,7 +1255,7 @@ class InviteUserTest(InviteUserBase):
         invitee = f"Alice Test <{email}>, {email2}"
         self.assert_json_error(
             self.invite(invitee, ["Denmark"]),
-            "Only administrators can invite others to this organization.",
+            "Insufficient permission",
         )
 
         # Now verify an administrator can do it
@@ -1279,7 +1279,7 @@ class InviteUserTest(InviteUserBase):
         invitee = f"Carol Test <{email}>, {email2}"
         self.assert_json_error(
             self.invite(invitee, ["Denmark"]),
-            "Only administrators and moderators can invite others to this organization.",
+            "Insufficient permission",
         )
 
         self.login("shiva")
@@ -1323,7 +1323,7 @@ class InviteUserTest(InviteUserBase):
         invitee = f"Issac Test <{email}>, {email2}"
         self.assert_json_error(
             self.invite(invitee, ["Denmark"]),
-            "Your account is too new to invite others to this organization.",
+            "Insufficient permission",
         )
 
         do_set_realm_property(realm, "waiting_period_threshold", 0, acting_user=None)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1761,7 +1761,7 @@ class StreamAdminTest(ZulipTestCase):
         # Cannot create stream because not an admin.
         stream_name = ["admins_only"]
         result = self.common_subscribe_to_streams(user_profile, stream_name, allow_fail=True)
-        self.assert_json_error(result, "Only administrators can create streams.")
+        self.assert_json_error(result, "Insufficient permission")
 
         # Make current user an admin.
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
@@ -1789,7 +1789,7 @@ class StreamAdminTest(ZulipTestCase):
         # period.
         stream_name = ["waiting_period"]
         result = self.common_subscribe_to_streams(user_profile, stream_name, allow_fail=True)
-        self.assert_json_error(result, "Your account is too new to create streams.")
+        self.assert_json_error(result, "Insufficient permission")
 
         # Make user account 11 days old..
         user_profile.date_joined = timezone_now() - timedelta(days=11)
@@ -3239,7 +3239,7 @@ class SubscriptionAPITest(ZulipTestCase):
         )
         with mock.patch("zerver.models.UserProfile.can_create_streams", return_value=False):
             result = self.common_subscribe_to_streams(self.test_user, ["stream1"], allow_fail=True)
-            self.assert_json_error(result, "Only administrators can create streams.")
+            self.assert_json_error(result, "Insufficient permission")
 
         with mock.patch("zerver.models.UserProfile.can_create_streams", return_value=True):
             self.common_subscribe_to_streams(self.test_user, ["stream2"])
@@ -3261,7 +3261,7 @@ class SubscriptionAPITest(ZulipTestCase):
             ["new_stream1"],
             allow_fail=True,
         )
-        self.assert_json_error(result, "Only administrators can create streams.")
+        self.assert_json_error(result, "Insufficient permission")
 
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         self.common_subscribe_to_streams(user_profile, ["new_stream1"])
@@ -3278,7 +3278,7 @@ class SubscriptionAPITest(ZulipTestCase):
             ["new_stream2"],
             allow_fail=True,
         )
-        self.assert_json_error(result, "Only administrators and moderators can create streams.")
+        self.assert_json_error(result, "Insufficient permission")
 
         do_change_user_role(user_profile, UserProfile.ROLE_MODERATOR, acting_user=None)
         self.common_subscribe_to_streams(user_profile, ["new_stream2"])
@@ -3309,7 +3309,7 @@ class SubscriptionAPITest(ZulipTestCase):
             ["new_stream4"],
             allow_fail=True,
         )
-        self.assert_json_error(result, "Your account is too new to create streams.")
+        self.assert_json_error(result, "Insufficient permission")
 
         do_set_realm_property(realm, "waiting_period_threshold", 0, acting_user=None)
         self.common_subscribe_to_streams(user_profile, ["new_stream3"])
@@ -3711,7 +3711,7 @@ class SubscriptionAPITest(ZulipTestCase):
             }
         ]
 
-        with self.assertRaisesRegex(JsonableError, "Not allowed for guest users"):
+        with self.assertRaisesRegex(JsonableError, "Insufficient permission"):
             list_to_streams(streams_raw, guest_user)
 
         stream = self.make_stream("private_stream", invite_only=True)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1838,9 +1838,7 @@ class StreamAdminTest(ZulipTestCase):
             {"principals": orjson.dumps([cordelia_user_id]).decode()},
             allow_fail=True,
         )
-        self.assert_json_error(
-            result, "Your account is too new to modify other users' subscriptions."
-        )
+        self.assert_json_error(result, "Insufficient permission")
 
         # Anyone can invite users..
         do_set_realm_property(hamlet_user.realm, "waiting_period_threshold", 0, acting_user=None)
@@ -3344,7 +3342,7 @@ class SubscriptionAPITest(ZulipTestCase):
             {"principals": orjson.dumps([invitee_user_id]).decode()},
             allow_fail=True,
         )
-        self.assert_json_error(result, "Only administrators can modify other users' subscriptions.")
+        self.assert_json_error(result, "Insufficient permission")
 
         do_change_user_role(self.test_user, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         self.common_subscribe_to_streams(
@@ -3364,9 +3362,7 @@ class SubscriptionAPITest(ZulipTestCase):
             {"principals": orjson.dumps([invitee_user_id]).decode()},
             allow_fail=True,
         )
-        self.assert_json_error(
-            result, "Only administrators and moderators can modify other users' subscriptions."
-        )
+        self.assert_json_error(result, "Insufficient permission")
 
         do_change_user_role(self.test_user, UserProfile.ROLE_MODERATOR, acting_user=None)
         self.common_subscribe_to_streams(
@@ -3407,9 +3403,7 @@ class SubscriptionAPITest(ZulipTestCase):
             {"principals": orjson.dumps([invitee_user_id]).decode()},
             allow_fail=True,
         )
-        self.assert_json_error(
-            result, "Your account is too new to modify other users' subscriptions."
-        )
+        self.assert_json_error(result, "Insufficient permission")
 
         do_set_realm_property(realm, "waiting_period_threshold", 0, acting_user=None)
         self.common_subscribe_to_streams(

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -18,7 +18,7 @@ from zerver.lib.request import REQ, JsonableError, has_request_variables
 from zerver.lib.response import json_error, json_success
 from zerver.lib.streams import access_stream_by_id
 from zerver.lib.validator import check_int, check_list
-from zerver.models import MultiuseInvite, PreregistrationUser, Realm, Stream, UserProfile
+from zerver.models import MultiuseInvite, PreregistrationUser, Stream, UserProfile
 
 
 def check_if_owner_required(invited_as: int, user_profile: UserProfile) -> None:
@@ -40,16 +40,9 @@ def invite_users_backend(
 ) -> HttpResponse:
 
     if not user_profile.can_invite_others_to_realm():
-        if user_profile.realm.invite_to_realm_policy == Realm.POLICY_ADMINS_ONLY:
-            return json_error(_("Only administrators can invite others to this organization."))
-        if user_profile.realm.invite_to_realm_policy == Realm.POLICY_MODERATORS_ONLY:
-            return json_error(
-                _("Only administrators and moderators can invite others to this organization.")
-            )
-        if user_profile.realm.invite_to_realm_policy == Realm.POLICY_FULL_MEMBERS_ONLY:
-            return json_error(_("Your account is too new to invite others to this organization."))
-        # Guest case will be handled by require_member_or_admin decorator.
-        raise AssertionError("Unexpected policy validation failure")
+        # Guest users case will not be handled here as it will
+        # be handled by the decorator above.
+        raise JsonableError(_("Insufficient permission"))
     if invite_as not in PreregistrationUser.INVITE_AS.values():
         return json_error(_("Must be invited as an valid type of user"))
     check_if_owner_required(invite_as, user_profile)

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -512,19 +512,9 @@ def add_subscriptions_backend(
                 _("You can only invite other Zephyr mirroring users to private streams.")
             )
         if not user_profile.can_subscribe_other_users():
-            if user_profile.realm.invite_to_stream_policy == Realm.POLICY_ADMINS_ONLY:
-                return json_error(_("Only administrators can modify other users' subscriptions."))
-            if user_profile.realm.invite_to_stream_policy == Realm.POLICY_MODERATORS_ONLY:
-                return json_error(
-                    _("Only administrators and moderators can modify other users' subscriptions.")
-                )
-            # Realm.POLICY_MEMBERS_ONLY only fails if the
-            # user is a guest, which happens in the decorator above.
-            if user_profile.realm.invite_to_stream_policy == Realm.POLICY_FULL_MEMBERS_ONLY:
-                return json_error(
-                    _("Your account is too new to modify other users' subscriptions.")
-                )
-            raise AssertionError("Unexpected policy validation failure")
+            # Guest users case will not be handled here as it will
+            # be handled by the decorator above.
+            raise JsonableError(_("Insufficient permission"))
         subscribers = {
             principal_to_user_profile(user_profile, principal) for principal in principals
         }


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is for raising the same error "Insufficient permission" for all values of
following policies -
1. create_stream_policy
2. invite_to_stream_policy
3. invite_to_realm_policy

We show different error message for guest cases because it is handled by
decorators.
 <!-- How have you tested? -->


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
