### PR TITLE
Night mode alert exit button visibility improvement

### DIFF
--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -771,6 +771,11 @@ on a dark background, and don't change the dark labels dark either. */
 
         .close {
             color: inherit;
+            opacity: 0.8;
+        }
+
+        .close:hover {
+            opacity: 1;
         }
     }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/17824

**Testing plan:** <!-- How have you tested? -->
Manual testing through the Zulip development environment.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:
<img width="1399" alt="Zulip notification before" src="https://user-images.githubusercontent.com/46756019/113893142-bb675f00-9794-11eb-9934-9f197e34eee7.png">

After: Adjusting opacity values:
<img width="1405" alt="Zulip notification after" src="https://user-images.githubusercontent.com/46756019/113893299-de920e80-9794-11eb-90ae-8b9b56b7638b.png">

After: Once the user hovers over the "x" it will become brighter to notify the user.
<img width="1409" alt="Zulip hover" src="https://user-images.githubusercontent.com/46756019/113896264-c5d72800-9797-11eb-8303-25a5851fb4dd.png">



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
