### PR TITLE
puppet: Only set X-Real-IP once.

### DIFF
--- a/puppet/zulip/files/nginx/uwsgi_params
+++ b/puppet/zulip/files/nginx/uwsgi_params
@@ -14,3 +14,5 @@ uwsgi_param SERVER_ADDR     $server_addr;
 uwsgi_param SERVER_PORT     $server_port;
 uwsgi_param SERVER_NAME     $server_name;
 uwsgi_param HTTP_X_REAL_IP  $remote_addr;
+
+uwsgi_pass django;

--- a/puppet/zulip/files/nginx/uwsgi_params
+++ b/puppet/zulip/files/nginx/uwsgi_params
@@ -13,3 +13,4 @@ uwsgi_param REMOTE_PORT     $remote_port;
 uwsgi_param SERVER_ADDR     $server_addr;
 uwsgi_param SERVER_PORT     $server_port;
 uwsgi_param SERVER_NAME     $server_name;
+uwsgi_param HTTP_X_REAL_IP  $remote_addr;

--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -31,8 +31,6 @@ location /static/webpack-bundles/ {
 location /json/events {
     proxy_pass $tornado_server;
     include /etc/nginx/zulip-include/proxy_longpolling;
-
-    proxy_set_header X-Real-IP       $remote_addr;
 }
 
 # Send longpoll requests to Tornado
@@ -45,8 +43,6 @@ location /api/v1/events {
 
     proxy_pass $tornado_server;
     include /etc/nginx/zulip-include/proxy_longpolling;
-
-    proxy_set_header X-Real-IP       $remote_addr;
 }
 
 # Send everything else to Django via uWSGI

--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -48,7 +48,6 @@ location /api/v1/events {
 # Send everything else to Django via uWSGI
 location / {
     include uwsgi_params;
-    uwsgi_pass django;
 }
 
 # These Django routes not under /api are shared between mobile and
@@ -61,13 +60,11 @@ location /thumbnail {
     include /etc/nginx/zulip-include/api_headers;
 
     include uwsgi_params;
-    uwsgi_pass django;
 }
 location /avatar {
     include /etc/nginx/zulip-include/api_headers;
 
     include uwsgi_params;
-    uwsgi_pass django;
 }
 
 # Send all API routes not covered above to Django via uWSGI
@@ -75,7 +72,6 @@ location /api/ {
     include /etc/nginx/zulip-include/api_headers;
 
     include uwsgi_params;
-    uwsgi_pass django;
 }
 
 include /etc/nginx/zulip-include/uploads.route;

--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -54,14 +54,18 @@ location / {
 # web, and thus need API headers added.  We can't easily collapse
 # these blocks with the /api block, because regular expressions take
 # priority over paths in nginx's order-of-operations, and we don't
-# want to override the tornado configuration for /api/v1/events.  The
-# last is handled via uploads-route.
+# want to override the tornado configuration for /api/v1/events.
 location /thumbnail {
     include /etc/nginx/zulip-include/api_headers;
 
     include uwsgi_params;
 }
 location /avatar {
+    include /etc/nginx/zulip-include/api_headers;
+
+    include uwsgi_params;
+}
+location /user_uploads {
     include /etc/nginx/zulip-include/api_headers;
 
     include uwsgi_params;
@@ -74,5 +78,4 @@ location /api/ {
     include uwsgi_params;
 }
 
-include /etc/nginx/zulip-include/uploads.route;
 include /etc/nginx/zulip-include/app.d/*.conf;

--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -48,7 +48,6 @@ location /api/v1/events {
 # Send everything else to Django via uWSGI
 location / {
     include uwsgi_params;
-    uwsgi_param HTTP_X_REAL_IP $remote_addr;
     uwsgi_pass django;
 }
 
@@ -62,14 +61,12 @@ location /thumbnail {
     include /etc/nginx/zulip-include/api_headers;
 
     include uwsgi_params;
-    uwsgi_param HTTP_X_REAL_IP $remote_addr;
     uwsgi_pass django;
 }
 location /avatar {
     include /etc/nginx/zulip-include/api_headers;
 
     include uwsgi_params;
-    uwsgi_param HTTP_X_REAL_IP $remote_addr;
     uwsgi_pass django;
 }
 
@@ -78,7 +75,6 @@ location /api/ {
     include /etc/nginx/zulip-include/api_headers;
 
     include uwsgi_params;
-    uwsgi_param HTTP_X_REAL_IP $remote_addr;
     uwsgi_pass django;
 }
 

--- a/puppet/zulip/files/nginx/zulip-include-maybe/uploads-internal.conf
+++ b/puppet/zulip/files/nginx/zulip-include-maybe/uploads-internal.conf
@@ -5,3 +5,10 @@ location /serve_uploads {
     include /etc/nginx/zulip-include/uploads.types;
     alias /home/zulip/uploads/files;
 }
+
+location /user_avatars {
+    include /etc/nginx/zulip-include/headers;
+    add_header Content-Security-Policy "default-src 'none' img-src 'self'";
+    include /etc/nginx/zulip-include/uploads.types;
+    alias /home/zulip/uploads/avatars;
+}

--- a/puppet/zulip/files/nginx/zulip-include-maybe/uploads-internal.conf
+++ b/puppet/zulip/files/nginx/zulip-include-maybe/uploads-internal.conf
@@ -5,13 +5,3 @@ location /serve_uploads {
     include /etc/nginx/zulip-include/uploads.types;
     alias /home/zulip/uploads/files;
 }
-
-# This Django route not under /api is shared between mobile and web
-# and thus needs API headers added, in addition to the configuration
-# required to have this URL be served by Django.
-
-location /user_uploads {
-    include /etc/nginx/zulip-include/api_headers;
-
-    include uwsgi_params;
-}

--- a/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.internal
+++ b/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.internal
@@ -14,5 +14,4 @@ location /user_uploads {
     include /etc/nginx/zulip-include/api_headers;
 
     include uwsgi_params;
-    uwsgi_pass django;
 }

--- a/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.noserve
+++ b/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.noserve
@@ -1,9 +1,0 @@
-# This Django route not under /api is shared between mobile and web
-# and thus needs API headers added, in addition to the configuration
-# required to have this URL be served by Django.
-
-location /user_uploads {
-    include /etc/nginx/zulip-include/api_headers;
-
-    include uwsgi_params;
-}

--- a/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.noserve
+++ b/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.noserve
@@ -6,5 +6,4 @@ location /user_uploads {
     include /etc/nginx/zulip-include/api_headers;
 
     include uwsgi_params;
-    uwsgi_pass django;
 }

--- a/puppet/zulip/manifests/nginx.pp
+++ b/puppet/zulip/manifests/nginx.pp
@@ -29,15 +29,16 @@ class zulip::nginx {
     notify  => Service['nginx'],
   }
 
-  # Configuration for how uploaded files are served.  The default is
-  # to serve uploaded files using using the `nginx` `internal`
-  # feature via django-sendfile2, which basically does an internal
-  # redirect and returns the file content from nginx in an
-  # HttpResponse that would otherwise have been a redirect.
+  # Configuration for how uploaded files and profile pictures are
+  # served.  The default is to serve uploads using using the `nginx`
+  # `internal` feature via django-sendfile2, which basically does an
+  # internal redirect and returns the file content from nginx in an
+  # HttpResponse that would otherwise have been a redirect.  Profile
+  # pictures are served directly off disk.
   #
   # For installations using S3 to serve uploaded files, we want Django
-  # to handle the /serve_uploads route, so that it can do authentication
-  # and serve a redirect.
+  # to handle the /serve_uploads and /user_avatars routes, so that it
+  # can serve a redirect (after doing authentication, for uploads).
   $no_serve_uploads = zulipconf('application_server', 'no_serve_uploads', '')
   if $no_serve_uploads == '' {
     file { '/etc/nginx/zulip-include/app.d/uploads-internal.conf':

--- a/puppet/zulip/manifests/nginx.pp
+++ b/puppet/zulip/manifests/nginx.pp
@@ -29,23 +29,38 @@ class zulip::nginx {
     notify  => Service['nginx'],
   }
 
+  # Configuration for how uploaded files are served.  The default is
+  # to serve uploaded files using using the `nginx` `internal`
+  # feature via django-sendfile2, which basically does an internal
+  # redirect and returns the file content from nginx in an
+  # HttpResponse that would otherwise have been a redirect.
+  #
+  # For installations using S3 to serve uploaded files, we want Django
+  # to handle the /serve_uploads route, so that it can do authentication
+  # and serve a redirect.
   $no_serve_uploads = zulipconf('application_server', 'no_serve_uploads', '')
-  if $no_serve_uploads != '' {
-    # If we're not serving uploads locally, set the appropriate API headers for it.
-    $uploads_route = 'puppet:///modules/zulip/nginx/zulip-include-maybe/uploads-route.noserve'
+  if $no_serve_uploads == '' {
+    file { '/etc/nginx/zulip-include/app.d/uploads-internal.conf':
+      ensure  => file,
+      require => Package[$zulip::common::nginx],
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      notify  => Service['nginx'],
+      source  => 'puppet:///modules/zulip/nginx/zulip-include-maybe/uploads-internal.conf',
+    }
   } else {
-    $uploads_route = 'puppet:///modules/zulip/nginx/zulip-include-maybe/uploads-route.internal'
+    file { '/etc/nginx/zulip-include/app.d/uploads-internal.conf':
+      ensure  => absent,
+    }
   }
 
+  # Removed 2021-04 in Zulip 4.0; these lines can be removed in Zulip
+  # version 5.0 and later.
   file { '/etc/nginx/zulip-include/uploads.route':
-    ensure  => file,
-    require => Package[$zulip::common::nginx],
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    notify  => Service['nginx'],
-    source  => $uploads_route,
+    ensure  => absent,
   }
+
 
   file { '/etc/nginx/dhparam.pem':
     ensure  => file,

--- a/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
+++ b/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
@@ -26,15 +26,6 @@ server {
     ssl_certificate_key <%= @ssl_dir %>/private/zulip.key;
 <% end -%>
 
-<% if @no_serve_uploads == '' -%>
-    location /user_avatars {
-        include /etc/nginx/zulip-include/headers;
-        add_header Content-Security-Policy "default-src 'none' img-src 'self'";
-        include /etc/nginx/zulip-include/uploads.types;
-        alias /home/zulip/uploads/avatars;
-    }
-<% end -%>
-
     location /local-static {
         alias /home/zulip/local-static;
     }


### PR DESCRIPTION
07779ea879e6 added an additional `proxy_set_header` of `X-Real-IP` to
`puppet/zulip/files/nginx/zulip-include-common/proxy`; as noted in
that commit, Tornado longpoll proxies already included such a line.

Unfortunately, this equates to setting that header _twice_ for Tornado
ports, like so:

```
X-Real-Ip: 198.199.116.58
X-Real-Ip: 198.199.116.58
```

...which is represented, once parsed by Django, as an IP of
`198.199.116.58, 198.199.116.58`.  For IPv4, this odd "IP address" has
no problems, and appears in the access logs accordingly; for IPv6
addresses, however, its length is such that it overflows a call to
`getaddrinfo` when attempting to determine the validity of the IP.

Remove the now-duplicated inclusion of the header.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
