### PR TITLE
api: Fix encoding of strings in realm endpoint.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -247,11 +247,11 @@ function test_submit_settings_form(override, submit_form) {
     assert(patched);
 
     let expected_value = {
-        bot_creation_policy: "1",
-        invite_to_stream_policy: "1",
-        email_address_visibility: "1",
+        bot_creation_policy: 1,
+        invite_to_stream_policy: 1,
+        email_address_visibility: 1,
         add_emoji_by_admins_only: false,
-        create_stream_policy: "2",
+        create_stream_policy: 2,
     };
     assert.deepEqual(data, expected_value);
 
@@ -281,7 +281,7 @@ function test_submit_settings_form(override, submit_form) {
     assert(patched);
 
     expected_value = {
-        default_language: '"en"',
+        default_language: "en",
         default_twenty_four_hour_time: "true",
     };
     assert.deepEqual(data, expected_value);

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -795,7 +795,8 @@ export function build_page() {
             }
         } else if (subsection === "other_settings") {
             const code_block_language_value = default_code_language_widget.value();
-            data.default_code_block_language = JSON.stringify(code_block_language_value);
+            // No need to JSON-encode, since this value is already a string.
+            data.default_code_block_language = code_block_language_value;
         } else if (subsection === "other_permissions") {
             const add_emoji_permission = $("#id_realm_add_emoji_by_admins_only").val();
 
@@ -866,7 +867,7 @@ export function build_page() {
                 const input_value = get_input_element_value(input_elem);
                 if (input_value !== undefined) {
                     const property_name = input_elem.attr("id").replace("id_realm_", "");
-                    data[property_name] = JSON.stringify(input_value);
+                    data[property_name] = input_value;
                 }
             }
         }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -778,11 +778,10 @@ export function build_page() {
                 ).seconds;
             }
         } else if (subsection === "notifications") {
-            data.notifications_stream_id = JSON.stringify(
-                Number.parseInt(notifications_stream_widget.value(), 10),
-            );
-            data.signup_notifications_stream_id = JSON.stringify(
-                Number.parseInt(signup_notifications_stream_widget.value(), 10),
+            data.notifications_stream_id = Number.parseInt(notifications_stream_widget.value(), 10);
+            data.signup_notifications_stream_id = Number.parseInt(
+                signup_notifications_stream_widget.value(),
+                10,
             );
         } else if (subsection === "message_retention") {
             const message_retention_setting_value = $("#id_realm_message_retention_setting").val();

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,12 @@ below features are supported.
 
 ## Changes in Zulip 4.0
 
+**Feature level 52**
+
+* `PATCH /realm`: Removed unnecessary JSON-encoding of string
+  parameters `name`, `description`, `default_language`, and
+  `default_code_block_language`.
+
 **Feature level 51**
 
 * [`POST /register`](/api/register-queue): Added a new boolean field

--- a/version.py
+++ b/version.py
@@ -30,7 +30,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 51
+API_FEATURE_LEVEL = 52
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -184,6 +184,7 @@ def clear_supported_auth_backends_cache() -> None:
 
 class Realm(models.Model):
     MAX_REALM_NAME_LENGTH = 40
+    MAX_REALM_DESCRIPTION_LENGTH = 1000
     MAX_REALM_SUBDOMAIN_LENGTH = 40
     MAX_REALM_REDIRECT_URL_LENGTH = 128
 


### PR DESCRIPTION
* Don't require strings to be unnecessarily JSON-encoded.
* Use check_capped_string rather than custom code for length checks.
* Update frontend to pass the right parameters.

I manually tested the web UI settings widgets for these things.  And
they are neither documented (yet) nor supported by the mobile/terminal
apps, being organization-level settings, so we don't need to worry
about breaking existing clients.

Fixes part of #18035.
