### PR TITLE
css: Fix vertical alignment mismatch for view_in_playground button.

### DIFF
--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -445,7 +445,7 @@
         visibility: hidden;
         position: absolute;
         right: 23px;
-        margin-top: -2px;
+        margin-top: -4px;
         font-size: 1.4em;
         /* The default icon and on-hover colors are inherited from <a> tag.
         so we set our own to match the copy-to-clipbord icon */


### PR DESCRIPTION
We'll be changing the icon and probably even doing the alignment in
a better fashion in the future, so this is just a temporary fix
till then.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
Manual testing

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
### Before
![image](https://user-images.githubusercontent.com/30312566/113962828-19a04a80-9846-11eb-85f0-1d577a46940e.png)


### After
![image](https://user-images.githubusercontent.com/30312566/113962766-f2497d80-9845-11eb-9db9-7aa2196a7ad8.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
