### PR TITLE
Remove ancient legacy API endpoints

### DIFF
--- a/docs/subsystems/settings.md
+++ b/docs/subsystems/settings.md
@@ -134,7 +134,7 @@ want those settings.
 ### Testing non-default settings
 
 You can write tests for settings using e.g. `with
-self.settings(GOOGLE_CLIENT_ID=None)`.  However, this only works for
+self.settings(TERMS_OF_SERVICE=None)`.  However, this only works for
 settings which are checked at runtime, not settings which are only
 accessed in initialization of Django (or Zulip) internals
 (e.g. `DATABASES`).  See the [Django docs on overriding settings in

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -867,11 +867,6 @@ class HomeTest(ZulipTestCase):
             compute_navbar_logo_url(page_params), "/static/images/logo/zulip-org-logo.svg?version=0"
         )
 
-    def test_generate_204(self) -> None:
-        self.login("hamlet")
-        result = self.client_get("/api/v1/generate_204")
-        self.assertEqual(result.status_code, 204)
-
     def test_furthest_read_time(self) -> None:
         msg_id = self.send_test_message("hello!", sender_name="iago")
 

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -288,8 +288,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/realm/deactivate",
         "/realm/subdomain/{subdomain}",
         #### Other low value endpoints
-        # Used for dead desktop app to test connectivity.  To delete.
-        "/generate_204",
         # Used for failed approach with dead Android app.
         "/fetch_google_client_id",
         # API for video calls we're planning to remove/replace.

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -287,10 +287,7 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/realm/logo",
         "/realm/deactivate",
         "/realm/subdomain/{subdomain}",
-        #### Other low value endpoints
-        # Used for failed approach with dead Android app.
-        "/fetch_google_client_id",
-        # API for video calls we're planning to remove/replace.
+        # API for Zoom video calls.  Unclear if this can support other apps.
         "/calls/zoom/create",
         #### The following are fake endpoints that live in our zulip.yaml
         #### for tooling convenience reasons, and should eventually be moved.

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -224,6 +224,14 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/users/me/presence",
         "/users/me/alert_words",
         "/users/me/status",
+        # These are a priority to document but don't match our normal URL schemes
+        # and thus may be complicated to document with our current tooling.
+        # (No /api/v1/ or /json prefix).
+        "/avatar/{email_or_id}",
+        ## This one is in zulip.yaml, but not the actual docs.
+        # "/api/v1/user_uploads/{realm_id_str}/{filename}",
+        ## And this one isn't, and isn't really representable
+        # "/user_uploads/{realm_id_str}/{filename}",
         #### These realm administration settings are valuable to document:
         # Delete a file uploaded by current user.
         "/attachments/{attachment_id}",
@@ -246,12 +254,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         # users/me/subscriptions/properties; probably should just be a
         # section of the same page.
         "/users/me/subscriptions/{stream_id}",
-        # Real-time-events endpoint
-        "/real-time",
-        # Rest error handling endpoint
-        "/rest-error-handling",
-        # Zulip outgoing webhook payload
-        "/zulip-outgoing-webhook",
         #### Mobile-app only endpoints; important for mobile developers.
         # Mobile interface for fetching API keys
         "/fetch_api_key",
@@ -292,6 +294,14 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/fetch_google_client_id",
         # API for video calls we're planning to remove/replace.
         "/calls/zoom/create",
+        #### The following are fake endpoints that live in our zulip.yaml
+        #### for tooling convenience reasons, and should eventually be moved.
+        # Real-time-events endpoint
+        "/real-time",
+        # Rest error handling endpoint
+        "/rest-error-handling",
+        # Zulip outgoing webhook payload
+        "/zulip-outgoing-webhook",
     }
 
     # Endpoints where the documentation is currently failing our

--- a/zerver/tests/test_urls.py
+++ b/zerver/tests/test_urls.py
@@ -3,7 +3,6 @@ import os
 from typing import List, Optional
 
 import django.urls.resolvers
-import orjson
 from django.test import Client
 
 from zerver.lib.test_classes import ZulipTestCase
@@ -96,28 +95,6 @@ class PublicURLTest(ZulipTestCase):
             self.fetch("client_post", url_set, status_code)
         for status_code, url_set in patch_urls.items():
             self.fetch("client_patch", url_set, status_code)
-
-    def test_get_gcid_when_not_configured(self) -> None:
-        with self.settings(GOOGLE_CLIENT_ID=None):
-            resp = self.client_get("/api/v1/fetch_google_client_id")
-            self.assertEqual(
-                400,
-                resp.status_code,
-                msg=f"Expected 400, received {resp.status_code} for GET /api/v1/fetch_google_client_id",
-            )
-            self.assertEqual("error", resp.json()["result"])
-
-    def test_get_gcid_when_configured(self) -> None:
-        with self.settings(GOOGLE_CLIENT_ID="ABCD"):
-            resp = self.client_get("/api/v1/fetch_google_client_id")
-            self.assertEqual(
-                200,
-                resp.status_code,
-                msg=f"Expected 200, received {resp.status_code} for GET /api/v1/fetch_google_client_id",
-            )
-            data = orjson.loads(resp.content)
-            self.assertEqual("success", data["result"])
-            self.assertEqual("ABCD", data["google_client_id"])
 
     def test_config_error_endpoints_dev_env(self) -> None:
         """

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -1057,13 +1057,6 @@ def json_fetch_api_key(
     return json_success({"api_key": api_key, "email": user_profile.delivery_email})
 
 
-@csrf_exempt
-def api_fetch_google_client_id(request: HttpRequest) -> HttpResponse:
-    if not settings.GOOGLE_CLIENT_ID:
-        return json_error(_("GOOGLE_CLIENT_ID is not configured"), status=400)
-    return json_success({"google_client_id": settings.GOOGLE_CLIENT_ID})
-
-
 @require_post
 def logout_then_login(request: HttpRequest, **kwargs: Any) -> HttpResponse:
     return django_logout_then_login(request, kwargs)

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -663,10 +663,6 @@ def accounts_home_from_multiuse_invite(request: HttpRequest, confirmation_key: s
     )
 
 
-def generate_204(request: HttpRequest) -> HttpResponse:
-    return HttpResponse(content=None, status=204)
-
-
 def find_account(request: HttpRequest) -> HttpResponse:
     from zerver.context_processors import common_context
 

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -243,9 +243,6 @@ SYSTEM_BOT_REALM = "zulipinternal"
 # than a separate app.
 EXTRA_INSTALLED_APPS = ["analytics"]
 
-# Default GOOGLE_CLIENT_ID to the value needed for Android auth to work
-GOOGLE_CLIENT_ID = "835904834568-77mtr5mtmpgspj9b051del9i9r5t4g4n.apps.googleusercontent.com"
-
 # Used to construct URLs to point to the Zulip server.  Since we
 # only support HTTPS in production, this is just for development.
 EXTERNAL_URI_SCHEME = "https://"

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -129,7 +129,6 @@ from zerver.views.registration import (
     check_prereg_key_and_redirect,
     create_realm,
     find_account,
-    generate_204,
     realm_redirect,
 )
 from zerver.views.report import (
@@ -248,8 +247,6 @@ if settings.TWO_FACTOR_AUTHENTICATION_ENABLED:
 v1_api_and_json_patterns = [
     # realm-level calls
     rest_path("realm", PATCH=update_realm),
-    # Returns a 204, used by desktop app to verify connectivity status
-    path("generate_204", generate_204),
     path("realm/subdomain/<subdomain>", check_subdomain_available),
     # realm/domains -> zerver.views.realm_domains
     rest_path("realm/domains", GET=list_realm_domains, POST=create_realm_domain),

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -24,7 +24,6 @@ from zerver.views.auth import (
     api_dev_fetch_api_key,
     api_dev_list_users,
     api_fetch_api_key,
-    api_fetch_google_client_id,
     api_get_server_settings,
     dev_direct_login,
     json_fetch_api_key,
@@ -723,8 +722,6 @@ v1_api_mobile_patterns = [
     path("dev_fetch_api_key", api_dev_fetch_api_key),
     # This is for fetching the emails of the admins and the users.
     path("dev_list_users", api_dev_list_users),
-    # Used to present the GOOGLE_CLIENT_ID to mobile apps
-    path("fetch_google_client_id", api_fetch_google_client_id),
 ]
 urls += [
     path("api/v1/", include(v1_api_mobile_patterns)),


### PR DESCRIPTION
Untested aside from CI, but it is code for apps that no longer exist.