### PR TITLE
Needed LDAP group imports for automation

### DIFF
--- a/tools/linter_lib/pyflakes.py
+++ b/tools/linter_lib/pyflakes.py
@@ -7,6 +7,8 @@ from zulint.linters import run_pyflakes
 def check_pyflakes(files: List[str], options: argparse.Namespace) -> bool:
     suppress_patterns = [
         ("scripts/lib/pythonrc.py", "imported but unused"),
+        # LDAP imports are necessary for docker-zulip.
+        ("zproject/prod_settings_template.py", "imported but unused"),
         # Our ipython startup pythonrc file intentionally imports *
         ("scripts/lib/pythonrc.py", " import *' used; unable to detect undefined names"),
         (

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -155,7 +155,7 @@ AUTHENTICATION_BACKENDS: Tuple[str, ...] = (
 ## optionally using LDAP as an authentication mechanism.
 
 import ldap
-from django_auth_ldap.config import LDAPSearch
+from django_auth_ldap.config import GroupOfNamesType, LDAPGroupQuery, LDAPSearch
 
 ## Connecting to the LDAP server.
 ##


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
To be possible to create group settings automatic with environment variables when using docker.
https://github.com/zulip/docker-zulip/pull/292

**Testing plan:** <!-- How have you tested? -->
Yes, in my kubernetes environment.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
No ui change.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
