### PR TITLE
Follow-ups from `mute user` backend commit merge.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -167,7 +167,7 @@ from zerver.lib.upload import (
     upload_emoji_image,
 )
 from zerver.lib.user_groups import access_user_group_by_id, create_user_group
-from zerver.lib.user_mutes import add_user_mute, get_user_mutes, remove_user_mute
+from zerver.lib.user_mutes import add_user_mute, get_user_mutes
 from zerver.lib.user_status import update_user_status
 from zerver.lib.users import (
     check_bot_name_available,
@@ -190,6 +190,7 @@ from zerver.models import (
     EmailChangeStatus,
     Message,
     MultiuseInvite,
+    MutedUser,
     PreregistrationUser,
     Reaction,
     Realm,
@@ -6510,8 +6511,9 @@ def do_mute_user(
     send_event(user_profile.realm, event, [user_profile.id])
 
 
-def do_unmute_user(user_profile: UserProfile, muted_user: UserProfile) -> None:
-    remove_user_mute(user_profile, muted_user)
+def do_unmute_user(mute_object: MutedUser) -> None:
+    user_profile = mute_object.user_profile
+    mute_object.delete()
     event = dict(type="muted_users", muted_users=get_user_mutes(user_profile))
     send_event(user_profile.realm, event, [user_profile.id])
 

--- a/zerver/lib/user_mutes.py
+++ b/zerver/lib/user_mutes.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.models import MutedUser, UserProfile
@@ -29,9 +29,8 @@ def add_user_mute(
     )
 
 
-def remove_user_mute(user_profile: UserProfile, muted_user: UserProfile) -> None:
-    MutedUser.objects.get(user_profile=user_profile, muted_user=muted_user).delete()
-
-
-def user_is_muted(user_profile: UserProfile, muted_user: UserProfile) -> bool:
-    return MutedUser.objects.filter(user_profile=user_profile, muted_user=muted_user).exists()
+def get_mute_object(user_profile: UserProfile, muted_user: UserProfile) -> Optional[MutedUser]:
+    try:
+        return MutedUser.objects.get(user_profile=user_profile, muted_user=muted_user)
+    except MutedUser.DoesNotExist:
+        return None

--- a/zerver/lib/user_mutes.py
+++ b/zerver/lib/user_mutes.py
@@ -1,7 +1,5 @@
 import datetime
-from typing import Dict, List, Optional
-
-from django.utils.timezone import now as timezone_now
+from typing import Dict, List
 
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.models import MutedUser, UserProfile
@@ -22,12 +20,8 @@ def get_user_mutes(user_profile: UserProfile) -> List[Dict[str, int]]:
 
 
 def add_user_mute(
-    user_profile: UserProfile,
-    muted_user: UserProfile,
-    date_muted: Optional[datetime.datetime] = None,
+    user_profile: UserProfile, muted_user: UserProfile, date_muted: datetime.datetime
 ) -> None:
-    if date_muted is None:
-        date_muted = timezone_now()
     MutedUser.objects.create(
         user_profile=user_profile,
         muted_user=muted_user,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -170,6 +170,7 @@ from zerver.lib.test_helpers import (
     stdout_suppressed,
 )
 from zerver.lib.topic import TOPIC_NAME
+from zerver.lib.user_mutes import get_mute_object
 from zerver.models import (
     Attachment,
     CustomProfileField,
@@ -1013,7 +1014,14 @@ class NormalActionsTest(BaseAction):
         events = self.verify_action(lambda: do_mute_user(self.user_profile, muted_user))
         check_muted_users("events[0]", events[0])
 
-        events = self.verify_action(lambda: do_unmute_user(self.user_profile, muted_user))
+        mute_object = get_mute_object(self.user_profile, muted_user)
+        assert mute_object is not None
+        # This is a hack to silence mypy errors which result from it not taking
+        # into account type restrictions for nested functions (here, `lambda`).
+        # https://github.com/python/mypy/commit/8780d45507ab1efba33568744967674cce7184d1
+        mute_object2 = mute_object
+
+        events = self.verify_action(lambda: do_unmute_user(mute_object2))
         check_muted_users("events[0]", events[0])
 
     def test_change_avatar_fields(self) -> None:

--- a/zerver/tests/test_muting_users.py
+++ b/zerver/tests/test_muting_users.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.timestamp import datetime_to_timestamp
-from zerver.lib.user_mutes import add_user_mute, get_user_mutes, user_is_muted
+from zerver.lib.user_mutes import get_user_mutes, user_is_muted
 
 
 class MutedUsersTests(ZulipTestCase):
@@ -16,8 +16,10 @@ class MutedUsersTests(ZulipTestCase):
         self.assertEqual(muted_users, [])
         mute_time = datetime(2021, 1, 1, tzinfo=timezone.utc)
 
-        with mock.patch("zerver.lib.user_mutes.timezone_now", return_value=mute_time):
-            add_user_mute(user_profile=hamlet, muted_user=cordelia)
+        with mock.patch("zerver.views.muting.timezone_now", return_value=mute_time):
+            url = "/api/v1/users/me/muted_users/{}".format(cordelia.id)
+            result = self.api_post(hamlet, url)
+            self.assert_json_success(result)
 
         muted_users = get_user_mutes(hamlet)
         self.assertEqual(len(muted_users), 1)
@@ -62,10 +64,9 @@ class MutedUsersTests(ZulipTestCase):
         self.login_user(hamlet)
         cordelia = self.example_user("cordelia")
 
-        add_user_mute(
-            user_profile=hamlet,
-            muted_user=cordelia,
-        )
+        url = "/api/v1/users/me/muted_users/{}".format(cordelia.id)
+        result = self.api_post(hamlet, url)
+        self.assert_json_success(result)
 
         url = "/api/v1/users/me/muted_users/{}".format(cordelia.id)
         result = self.api_post(hamlet, url)
@@ -106,7 +107,9 @@ class MutedUsersTests(ZulipTestCase):
         cordelia = self.example_user("cordelia")
         mute_time = datetime(2021, 1, 1, tzinfo=timezone.utc)
 
-        add_user_mute(user_profile=hamlet, muted_user=cordelia, date_muted=mute_time)
+        url = "/api/v1/users/me/muted_users/{}".format(cordelia.id)
+        result = self.api_post(hamlet, url)
+        self.assert_json_success(result)
 
         url = "/api/v1/users/me/muted_users/{}".format(cordelia.id)
         result = self.api_delete(hamlet, url)

--- a/zerver/tests/test_muting_users.py
+++ b/zerver/tests/test_muting_users.py
@@ -15,10 +15,7 @@ class MutedUsersTests(ZulipTestCase):
         self.assertEqual(muted_users, [])
         mute_time = datetime(2021, 1, 1, tzinfo=timezone.utc)
 
-        with mock.patch(
-            "zerver.lib.user_mutes.timezone_now",
-            return_value=mute_time,
-        ):
+        with mock.patch("zerver.lib.user_mutes.timezone_now", return_value=mute_time):
             add_user_mute(user_profile=othello, muted_user=cordelia)
 
         muted_users = get_user_mutes(othello)
@@ -79,17 +76,20 @@ class MutedUsersTests(ZulipTestCase):
         self.login_user(user)
         muted_user = self.example_user("cordelia")
         muted_id = muted_user.id
+        mute_time = datetime(2021, 1, 1, tzinfo=timezone.utc)
 
-        mock_date_muted = datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp()
-        with mock.patch(
-            "zerver.views.muting.timezone_now",
-            return_value=datetime(2021, 1, 1, tzinfo=timezone.utc),
-        ):
+        with mock.patch("zerver.views.muting.timezone_now", return_value=mute_time):
             url = "/api/v1/users/me/muted_users/{}".format(muted_id)
             result = self.api_post(user, url)
             self.assert_json_success(result)
 
-        self.assertIn({"id": muted_id, "timestamp": mock_date_muted}, get_user_mutes(user))
+        self.assertIn(
+            {
+                "id": muted_id,
+                "timestamp": datetime_to_timestamp(mute_time),
+            },
+            get_user_mutes(user),
+        )
         self.assertTrue(user_is_muted(user, muted_user))
 
     def test_remove_muted_user_unmute_before_muting(self) -> None:
@@ -107,17 +107,19 @@ class MutedUsersTests(ZulipTestCase):
         self.login_user(user)
         muted_user = self.example_user("cordelia")
         muted_id = muted_user.id
+        mute_time = datetime(2021, 1, 1, tzinfo=timezone.utc)
 
-        add_user_mute(
-            user_profile=user,
-            muted_user=muted_user,
-            date_muted=datetime(2021, 1, 1, tzinfo=timezone.utc),
-        )
+        add_user_mute(user_profile=user, muted_user=muted_user, date_muted=mute_time)
 
         url = "/api/v1/users/me/muted_users/{}".format(muted_id)
         result = self.api_delete(user, url)
 
-        mock_date_muted = datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp()
         self.assert_json_success(result)
-        self.assertNotIn({"id": muted_id, "timestamp": mock_date_muted}, get_user_mutes(user))
+        self.assertNotIn(
+            {
+                "id": muted_id,
+                "timestamp": datetime_to_timestamp(mute_time),
+            },
+            get_user_mutes(user),
+        )
         self.assertFalse(user_is_muted(user, muted_user))

--- a/zerver/tests/test_muting_users.py
+++ b/zerver/tests/test_muting_users.py
@@ -7,18 +7,19 @@ from zerver.lib.user_mutes import add_user_mute, get_user_mutes, user_is_muted
 
 
 class MutedUsersTests(ZulipTestCase):
+    # Hamlet does the muting/unmuting, and Cordelia gets muted/unmuted.
     def test_get_user_mutes(self) -> None:
-        othello = self.example_user("othello")
+        hamlet = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")
 
-        muted_users = get_user_mutes(othello)
+        muted_users = get_user_mutes(hamlet)
         self.assertEqual(muted_users, [])
         mute_time = datetime(2021, 1, 1, tzinfo=timezone.utc)
 
         with mock.patch("zerver.lib.user_mutes.timezone_now", return_value=mute_time):
-            add_user_mute(user_profile=othello, muted_user=cordelia)
+            add_user_mute(user_profile=hamlet, muted_user=cordelia)
 
-        muted_users = get_user_mutes(othello)
+        muted_users = get_user_mutes(hamlet)
         self.assertEqual(len(muted_users), 1)
 
         self.assertDictEqual(
@@ -30,16 +31,16 @@ class MutedUsersTests(ZulipTestCase):
         )
 
     def test_add_muted_user_mute_self(self) -> None:
-        user = self.example_user("hamlet")
-        self.login_user(user)
+        hamlet = self.example_user("hamlet")
+        self.login_user(hamlet)
 
-        url = "/api/v1/users/me/muted_users/{}".format(user.id)
-        result = self.api_post(user, url)
+        url = "/api/v1/users/me/muted_users/{}".format(hamlet.id)
+        result = self.api_post(hamlet, url)
         self.assert_json_error(result, "Cannot mute self")
 
     def test_add_muted_user_mute_bot(self) -> None:
-        user = self.example_user("hamlet")
-        self.login_user(user)
+        hamlet = self.example_user("hamlet")
+        self.login_user(hamlet)
 
         bot_info = {
             "full_name": "The Bot of Hamlet",
@@ -51,75 +52,71 @@ class MutedUsersTests(ZulipTestCase):
         muted_id = result.json()["user_id"]
 
         url = "/api/v1/users/me/muted_users/{}".format(muted_id)
-        result = self.api_post(user, url)
+        result = self.api_post(hamlet, url)
         # Currently we do not allow muting bots. This is the error message
         # from `access_user_by_id`.
         self.assert_json_error(result, "No such user")
 
     def test_add_muted_user_mute_twice(self) -> None:
-        user = self.example_user("hamlet")
-        self.login_user(user)
-        muted_user = self.example_user("cordelia")
-        muted_id = muted_user.id
+        hamlet = self.example_user("hamlet")
+        self.login_user(hamlet)
+        cordelia = self.example_user("cordelia")
 
         add_user_mute(
-            user_profile=user,
-            muted_user=muted_user,
+            user_profile=hamlet,
+            muted_user=cordelia,
         )
 
-        url = "/api/v1/users/me/muted_users/{}".format(muted_id)
-        result = self.api_post(user, url)
+        url = "/api/v1/users/me/muted_users/{}".format(cordelia.id)
+        result = self.api_post(hamlet, url)
         self.assert_json_error(result, "User already muted")
 
     def test_add_muted_user_valid_data(self) -> None:
-        user = self.example_user("hamlet")
-        self.login_user(user)
-        muted_user = self.example_user("cordelia")
-        muted_id = muted_user.id
+        hamlet = self.example_user("hamlet")
+        self.login_user(hamlet)
+        cordelia = self.example_user("cordelia")
         mute_time = datetime(2021, 1, 1, tzinfo=timezone.utc)
 
         with mock.patch("zerver.views.muting.timezone_now", return_value=mute_time):
-            url = "/api/v1/users/me/muted_users/{}".format(muted_id)
-            result = self.api_post(user, url)
+            url = "/api/v1/users/me/muted_users/{}".format(cordelia.id)
+            result = self.api_post(hamlet, url)
             self.assert_json_success(result)
 
         self.assertIn(
             {
-                "id": muted_id,
+                "id": cordelia.id,
                 "timestamp": datetime_to_timestamp(mute_time),
             },
-            get_user_mutes(user),
+            get_user_mutes(hamlet),
         )
-        self.assertTrue(user_is_muted(user, muted_user))
+        self.assertTrue(user_is_muted(hamlet, cordelia))
 
     def test_remove_muted_user_unmute_before_muting(self) -> None:
-        user = self.example_user("hamlet")
-        self.login_user(user)
-        muted_user = self.example_user("cordelia")
-        muted_id = muted_user.id
+        hamlet = self.example_user("hamlet")
+        self.login_user(hamlet)
+        cordelia = self.example_user("cordelia")
 
-        url = "/api/v1/users/me/muted_users/{}".format(muted_id)
-        result = self.api_delete(user, url)
+        url = "/api/v1/users/me/muted_users/{}".format(cordelia.id)
+        result = self.api_delete(hamlet, url)
         self.assert_json_error(result, "User is not muted")
 
     def test_remove_muted_user_valid_data(self) -> None:
-        user = self.example_user("hamlet")
-        self.login_user(user)
-        muted_user = self.example_user("cordelia")
-        muted_id = muted_user.id
+        hamlet = self.example_user("hamlet")
+        self.login_user(hamlet)
+        cordelia = self.example_user("cordelia")
         mute_time = datetime(2021, 1, 1, tzinfo=timezone.utc)
 
-        add_user_mute(user_profile=user, muted_user=muted_user, date_muted=mute_time)
+        add_user_mute(user_profile=hamlet, muted_user=cordelia, date_muted=mute_time)
 
-        url = "/api/v1/users/me/muted_users/{}".format(muted_id)
-        result = self.api_delete(user, url)
+        url = "/api/v1/users/me/muted_users/{}".format(cordelia.id)
+        result = self.api_delete(hamlet, url)
 
         self.assert_json_success(result)
         self.assertNotIn(
             {
-                "id": muted_id,
+                "id": cordelia.id,
                 "timestamp": datetime_to_timestamp(mute_time),
             },
-            get_user_mutes(user),
+            get_user_mutes(hamlet),
         )
-        self.assertFalse(user_is_muted(user, muted_user))
+        self.assertFalse(user_is_muted(hamlet, cordelia))

--- a/zerver/tests/test_muting_users.py
+++ b/zerver/tests/test_muting_users.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.timestamp import datetime_to_timestamp
-from zerver.lib.user_mutes import get_user_mutes, user_is_muted
+from zerver.lib.user_mutes import get_mute_object, get_user_mutes
 
 
 class MutedUsersTests(ZulipTestCase):
@@ -90,7 +90,7 @@ class MutedUsersTests(ZulipTestCase):
             },
             get_user_mutes(hamlet),
         )
-        self.assertTrue(user_is_muted(hamlet, cordelia))
+        self.assertIsNotNone(get_mute_object(hamlet, cordelia))
 
     def test_remove_muted_user_unmute_before_muting(self) -> None:
         hamlet = self.example_user("hamlet")
@@ -122,4 +122,4 @@ class MutedUsersTests(ZulipTestCase):
             },
             get_user_mutes(hamlet),
         )
-        self.assertFalse(user_is_muted(hamlet, cordelia))
+        self.assertIsNone(get_mute_object(hamlet, cordelia))


### PR DESCRIPTION
This contains follow-up work from 3bfcaa39689c9996cb7eb0ec65bd37f727074f6e (#16915)

> Link to /help/ for muted users from API docs for the feature, both the main docs and the events.

The `/help` docs will be added in the commit which enables muting/unmuting from the UI. I'll add these links in that commit when I update it.

> We should change the do_ functions to record entries in RealmAuditLog when muting another user. I think modified_user needs to be the current user, as well as acting_user, so probably we need to store the other user in extra_data (no need to record timestamp, since that's there anyway).

This PR doesn't handle this yet. I didn't understand this. Should I create a new event-type in `AbstractRealmAuditLog`? Would `USER_MUTED` be a fine name or maybe `MUTED_USERS_CHANGED`? And what should be the number-key for it?

> For unmute_user, would it be cleaner to pass the MutedUser object from the user_is_muted check to the remove_user_mute function? This would avoid a second fetch.

Done.

> The backend tests should be tweaked to (1) do everything via the API, rather than calling do_ functions directly -- it's better to have tests be more end-to-end, and (2) do all the repeated times in variables. (I changed a few bits in this direction before merging, but decided to leave the rest to you).

Done!