### PR TITLE
Rename: All streams to Back to Streams.

### DIFF
--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -78,7 +78,7 @@
                 </div>
             </div>
             <div id="topics_header">
-                <a href="" class="show-all-streams"> <i class="fa fa-chevron-left" aria-hidden="true"></i>{{ _('All streams') }}</a>
+                <a href="" class="show-all-streams"> <i class="fa fa-chevron-left" aria-hidden="true"></i>{{ _('Back to streams') }}</a>
             </div>
             <div id="stream-filters-container" class="scrolling_list" data-simplebar>
                 <ul id="stream_filters" class="filters"></ul>


### PR DESCRIPTION
"All streams" heading in the left-sidebar cause discrepancy for
user, as it is unable to express if it is heading
for the current column as "Streams" is in the previous column or is
it texts descriptions for the back icon.
Renaming "All streams" to "Back to all streams"
removes discrepancy.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
**Testing plan:** <!-- How have you tested? -->
Tested Manually

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![Peek 2021-04-08 17-42](https://user-images.githubusercontent.com/58157064/114024590-da97e680-9891-11eb-9dbc-26158377be5c.gif)





<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
