### PR TITLE
refactor: Make acting_user a mandatory kwarg.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4155,7 +4155,7 @@ def do_change_default_sending_stream(
 
 
 def do_change_default_events_register_stream(
-    user_profile: UserProfile, stream: Optional[Stream], acting_user: Optional[UserProfile] = None
+    user_profile: UserProfile, stream: Optional[Stream], *, acting_user: Optional[UserProfile]
 ) -> None:
     old_value = user_profile.default_events_register_stream_id
     user_profile.default_events_register_stream = stream

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4010,7 +4010,7 @@ def do_delete_avatar_image(user: UserProfile, *, acting_user: Optional[UserProfi
 
 
 def do_change_icon_source(
-    realm: Realm, icon_source: str, acting_user: Optional[UserProfile] = None
+    realm: Realm, icon_source: str, *, acting_user: Optional[UserProfile]
 ) -> None:
     realm.icon_source = icon_source
     realm.icon_version += 1

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3984,7 +3984,8 @@ def do_change_avatar_fields(
     user_profile: UserProfile,
     avatar_source: str,
     skip_notify: bool = False,
-    acting_user: Optional[UserProfile] = None,
+    *,
+    acting_user: Optional[UserProfile],
 ) -> None:
     user_profile.avatar_source = avatar_source
     user_profile.avatar_version += 1

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3704,7 +3704,8 @@ def do_change_subscription_property(
     stream: Stream,
     property_name: str,
     value: Any,
-    acting_user: Optional[UserProfile] = None,
+    *,
+    acting_user: Optional[UserProfile],
 ) -> None:
     database_property_name = property_name
     event_property_name = property_name

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4038,7 +4038,7 @@ def do_change_icon_source(
 
 
 def do_change_logo_source(
-    realm: Realm, logo_source: str, night: bool, acting_user: Optional[UserProfile] = None
+    realm: Realm, logo_source: str, night: bool, *, acting_user: Optional[UserProfile]
 ) -> None:
     if not night:
         realm.logo_source = logo_source

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4512,7 +4512,8 @@ def do_change_notification_settings(
     user_profile: UserProfile,
     name: str,
     value: Union[bool, int, str],
-    acting_user: Optional[UserProfile] = None,
+    *,
+    acting_user: Optional[UserProfile],
 ) -> None:
     """Takes in a UserProfile object, the name of a global notification
     preference to update, and the value to update to

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4004,7 +4004,7 @@ def do_change_avatar_fields(
         notify_avatar_url_change(user_profile)
 
 
-def do_delete_avatar_image(user: UserProfile, acting_user: Optional[UserProfile] = None) -> None:
+def do_delete_avatar_image(user: UserProfile, *, acting_user: Optional[UserProfile]) -> None:
     do_change_avatar_fields(user, UserProfile.AVATAR_FROM_GRAVATAR, acting_user=acting_user)
     delete_avatar_image(user)
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4114,7 +4114,7 @@ def do_change_plan_type(
 
 
 def do_change_default_sending_stream(
-    user_profile: UserProfile, stream: Optional[Stream], acting_user: Optional[UserProfile] = None
+    user_profile: UserProfile, stream: Optional[Stream], *, acting_user: Optional[UserProfile]
 ) -> None:
     old_value = user_profile.default_sending_stream_id
     user_profile.default_sending_stream = stream

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4196,7 +4196,7 @@ def do_change_default_events_register_stream(
 
 
 def do_change_default_all_public_streams(
-    user_profile: UserProfile, value: bool, acting_user: Optional[UserProfile] = None
+    user_profile: UserProfile, value: bool, *, acting_user: Optional[UserProfile]
 ) -> None:
     old_value = user_profile.default_all_public_streams
     user_profile.default_all_public_streams = value

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -6590,7 +6590,7 @@ def do_change_realm_domain(realm_domain: RealmDomain, allow_subdomains: bool) ->
 
 
 def do_remove_realm_domain(
-    realm_domain: RealmDomain, acting_user: Optional[UserProfile] = None
+    realm_domain: RealmDomain, *, acting_user: Optional[UserProfile]
 ) -> None:
     realm = realm_domain.realm
     domain = realm_domain.domain

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -672,7 +672,10 @@ class TestMissedMessages(ZulipTestCase):
     def test_message_content_disabled_in_missed_message_notifications(self) -> None:
         # Test when user disabled message content in email notifications.
         do_change_notification_settings(
-            self.example_user("hamlet"), "message_content_in_email_notifications", False
+            self.example_user("hamlet"),
+            "message_content_in_email_notifications",
+            False,
+            acting_user=None,
         )
         self._extra_context_in_missed_stream_messages_mention(False, show_message_content=False)
         mail.outbox = []
@@ -781,12 +784,16 @@ class TestMissedMessages(ZulipTestCase):
         realm.save(update_fields=["message_content_allowed_in_email_notifications"])
 
         # Emails have missed message content when message content is enabled by the user
-        do_change_notification_settings(user, "message_content_in_email_notifications", True)
+        do_change_notification_settings(
+            user, "message_content_in_email_notifications", True, acting_user=None
+        )
         mail.outbox = []
         self._extra_context_in_personal_missed_stream_messages(False, show_message_content=True)
 
         # Emails don't have missed message content when message content is disabled by the user
-        do_change_notification_settings(user, "message_content_in_email_notifications", False)
+        do_change_notification_settings(
+            user, "message_content_in_email_notifications", False, acting_user=None
+        )
         mail.outbox = []
         self._extra_context_in_personal_missed_stream_messages(
             False, show_message_content=False, message_content_disabled_by_user=True
@@ -798,13 +805,17 @@ class TestMissedMessages(ZulipTestCase):
         realm.message_content_allowed_in_email_notifications = False
         realm.save(update_fields=["message_content_allowed_in_email_notifications"])
 
-        do_change_notification_settings(user, "message_content_in_email_notifications", True)
+        do_change_notification_settings(
+            user, "message_content_in_email_notifications", True, acting_user=None
+        )
         mail.outbox = []
         self._extra_context_in_personal_missed_stream_messages(
             False, show_message_content=False, message_content_disabled_by_realm=True
         )
 
-        do_change_notification_settings(user, "message_content_in_email_notifications", False)
+        do_change_notification_settings(
+            user, "message_content_in_email_notifications", False, acting_user=None
+        )
         mail.outbox = []
         self._extra_context_in_personal_missed_stream_messages(
             False,

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -355,7 +355,9 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             properties: Dict[str, bool],
         ) -> None:
             for property_name, value in properties.items():
-                do_change_subscription_property(user_profile, sub, stream, property_name, value)
+                do_change_subscription_property(
+                    user_profile, sub, stream, property_name, value, acting_user=None
+                )
 
         def allocate_event_queue() -> ClientDescriptor:
             result = self.tornado_call(

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1362,7 +1362,7 @@ class NormalActionsTest(BaseAction):
         self.assertEqual(events[0]["realm_domain"]["domain"], "zulip.org")
         self.assertEqual(events[0]["realm_domain"]["allow_subdomains"], True)
 
-        events = self.verify_action(lambda: do_remove_realm_domain(test_domain))
+        events = self.verify_action(lambda: do_remove_realm_domain(test_domain, acting_user=None))
 
         check_realm_domains_remove("events[0]", events[0])
         self.assertEqual(events[0]["domain"], "zulip.org")

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1474,11 +1474,11 @@ class NormalActionsTest(BaseAction):
         bot = self.create_bot("test")
         stream = get_stream("Rome", bot.realm)
 
-        action = lambda: do_change_default_events_register_stream(bot, stream)
+        action = lambda: do_change_default_events_register_stream(bot, stream, acting_user=None)
         events = self.verify_action(action)
         check_realm_bot_update("events[0]", events[0], "default_events_register_stream")
 
-        action = lambda: do_change_default_events_register_stream(bot, None)
+        action = lambda: do_change_default_events_register_stream(bot, None, acting_user=None)
         events = self.verify_action(action)
         check_realm_bot_update("events[0]", events[0], "default_events_register_stream")
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1432,7 +1432,9 @@ class NormalActionsTest(BaseAction):
         self.assertEqual(events[1]["type"], "realm_user")
 
     def test_change_realm_icon_source(self) -> None:
-        action = lambda: do_change_icon_source(self.user_profile.realm, Realm.ICON_UPLOADED)
+        action = lambda: do_change_icon_source(
+            self.user_profile.realm, Realm.ICON_UPLOADED, acting_user=None
+        )
         events = self.verify_action(action, state_change_expected=True)
         check_realm_update_dict("events[0]", events[0])
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1454,7 +1454,7 @@ class NormalActionsTest(BaseAction):
 
     def test_change_bot_default_all_public_streams(self) -> None:
         bot = self.create_bot("test")
-        action = lambda: do_change_default_all_public_streams(bot, True)
+        action = lambda: do_change_default_all_public_streams(bot, True, acting_user=None)
         events = self.verify_action(action)
         check_realm_bot_update("events[0]", events[0], "default_all_public_streams")
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1281,7 +1281,9 @@ class NormalActionsTest(BaseAction):
         notification_setting = "notification_sound"
 
         events = self.verify_action(
-            lambda: do_change_notification_settings(self.user_profile, notification_setting, "ding")
+            lambda: do_change_notification_settings(
+                self.user_profile, notification_setting, "ding", acting_user=self.user_profile
+            )
         )
         check_update_global_notifications("events[0]", events[0], "ding")
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1462,11 +1462,11 @@ class NormalActionsTest(BaseAction):
         bot = self.create_bot("test")
         stream = get_stream("Rome", bot.realm)
 
-        action = lambda: do_change_default_sending_stream(bot, stream)
+        action = lambda: do_change_default_sending_stream(bot, stream, acting_user=None)
         events = self.verify_action(action)
         check_realm_bot_update("events[0]", events[0], "default_sending_stream")
 
-        action = lambda: do_change_default_sending_stream(bot, None)
+        action = lambda: do_change_default_sending_stream(bot, None, acting_user=None)
         events = self.verify_action(action)
         check_realm_bot_update("events[0]", events[0], "default_sending_stream")
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1093,11 +1093,13 @@ class NormalActionsTest(BaseAction):
     def test_change_pin_stream(self) -> None:
         stream = get_stream("Denmark", self.user_profile.realm)
         sub = get_subscription(stream.name, self.user_profile)
-        do_change_subscription_property(self.user_profile, sub, stream, "pin_to_top", False)
+        do_change_subscription_property(
+            self.user_profile, sub, stream, "pin_to_top", False, acting_user=None
+        )
         for pinned in (True, False):
             events = self.verify_action(
                 lambda: do_change_subscription_property(
-                    self.user_profile, sub, stream, "pin_to_top", pinned
+                    self.user_profile, sub, stream, "pin_to_top", pinned, acting_user=None
                 )
             )
             check_subscription_update(
@@ -1116,7 +1118,7 @@ class NormalActionsTest(BaseAction):
             for value in (True, False):
                 events = self.verify_action(
                     lambda: do_change_subscription_property(
-                        self.user_profile, sub, stream, setting_name, value
+                        self.user_profile, sub, stream, setting_name, value, acting_user=None
                     ),
                     notification_settings_null=True,
                 )
@@ -1130,7 +1132,7 @@ class NormalActionsTest(BaseAction):
             for value in (True, False):
                 events = self.verify_action(
                     lambda: do_change_subscription_property(
-                        self.user_profile, sub, stream, setting_name, value
+                        self.user_profile, sub, stream, setting_name, value, acting_user=None
                     )
                 )
                 check_subscription_update(

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -284,7 +284,7 @@ class ImportExportTest(ZulipTestCase):
 
         with get_test_image_file("img.png") as img_file:
             upload.upload_backend.upload_realm_icon_image(img_file, user_profile)
-            do_change_icon_source(realm, Realm.ICON_UPLOADED)
+            do_change_icon_source(realm, Realm.ICON_UPLOADED, acting_user=None)
 
         with get_test_image_file("img.png") as img_file:
             upload.upload_backend.upload_realm_logo_image(img_file, user_profile, night=False)

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -105,13 +105,13 @@ class SendLoginEmailTest(ZulipTestCase):
         user.date_joined = mock_time - datetime.timedelta(seconds=JUST_CREATED_THRESHOLD + 1)
         user.save()
 
-        do_change_notification_settings(user, "enable_login_emails", False)
+        do_change_notification_settings(user, "enable_login_emails", False, acting_user=None)
         self.assertFalse(user.enable_login_emails)
         with mock.patch("zerver.signals.timezone_now", return_value=mock_time):
             self.login_user(user)
         self.assertEqual(len(mail.outbox), 0)
 
-        do_change_notification_settings(user, "enable_login_emails", True)
+        do_change_notification_settings(user, "enable_login_emails", True, acting_user=None)
         self.assertTrue(user.enable_login_emails)
         with mock.patch("zerver.signals.timezone_now", return_value=mock_time):
             self.login_user(user)

--- a/zerver/tests/test_realm_domains.py
+++ b/zerver/tests/test_realm_domains.py
@@ -122,7 +122,7 @@ class RealmDomainTest(ZulipTestCase):
 
         self.assertTrue(realm.emails_restricted_to_domains)
         for realm_domain in query.all():
-            do_remove_realm_domain(realm_domain)
+            do_remove_realm_domain(realm_domain, acting_user=None)
         self.assertEqual(query.count(), 0)
         # Deleting last realm_domain should set `emails_restricted_to_domains` to False.
         # This should be tested on a fresh instance, since the cached objects

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -401,7 +401,12 @@ class StreamAdminTest(ZulipTestCase):
 
         sub = get_subscription("private_stream_2", user_profile)
         do_change_subscription_property(
-            user_profile, sub, stream, "role", Subscription.ROLE_STREAM_ADMINISTRATOR
+            user_profile,
+            sub,
+            stream,
+            "role",
+            Subscription.ROLE_STREAM_ADMINISTRATOR,
+            acting_user=None,
         )
         result = self.client_patch(f"/json/streams/{stream.id}", params)
         self.assert_json_success(result)
@@ -451,7 +456,12 @@ class StreamAdminTest(ZulipTestCase):
 
         sub = get_subscription("public_stream_2", user_profile)
         do_change_subscription_property(
-            user_profile, sub, stream, "role", Subscription.ROLE_STREAM_ADMINISTRATOR
+            user_profile,
+            sub,
+            stream,
+            "role",
+            Subscription.ROLE_STREAM_ADMINISTRATOR,
+            acting_user=None,
         )
         result = self.client_patch(f"/json/streams/{stream.id}", params)
         self.assert_json_success(result)
@@ -572,7 +582,12 @@ class StreamAdminTest(ZulipTestCase):
         self.subscribe(user_profile, stream.name)
         sub = get_subscription(stream.name, user_profile)
         do_change_subscription_property(
-            user_profile, sub, stream, "role", Subscription.ROLE_STREAM_ADMINISTRATOR
+            user_profile,
+            sub,
+            stream,
+            "role",
+            Subscription.ROLE_STREAM_ADMINISTRATOR,
+            acting_user=None,
         )
 
         result = self.client_delete(f"/json/streams/{stream.id}")
@@ -859,7 +874,12 @@ class StreamAdminTest(ZulipTestCase):
         self.subscribe(user_profile, "new_stream")
         sub = get_subscription("new_stream", user_profile)
         do_change_subscription_property(
-            user_profile, sub, new_stream, "role", Subscription.ROLE_STREAM_ADMINISTRATOR
+            user_profile,
+            sub,
+            new_stream,
+            "role",
+            Subscription.ROLE_STREAM_ADMINISTRATOR,
+            acting_user=None,
         )
         del events[:]
         with tornado_redirected_to_list(events):
@@ -1055,7 +1075,12 @@ class StreamAdminTest(ZulipTestCase):
         do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         sub = get_subscription("stream_name1", user_profile)
         do_change_subscription_property(
-            user_profile, sub, stream, "role", Subscription.ROLE_STREAM_ADMINISTRATOR
+            user_profile,
+            sub,
+            stream,
+            "role",
+            Subscription.ROLE_STREAM_ADMINISTRATOR,
+            acting_user=None,
         )
 
         with tornado_redirected_to_list(events):
@@ -1076,7 +1101,9 @@ class StreamAdminTest(ZulipTestCase):
         sub = get_subscription("stream_name1", user_profile)
 
         do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
-        do_change_subscription_property(user_profile, sub, stream, "role", Subscription.ROLE_MEMBER)
+        do_change_subscription_property(
+            user_profile, sub, stream, "role", Subscription.ROLE_MEMBER, acting_user=None
+        )
 
         stream_id = get_stream("stream_name1", user_profile.realm).id
         result = self.client_patch(
@@ -1107,7 +1134,9 @@ class StreamAdminTest(ZulipTestCase):
         sub = get_subscription("stream_name1", user_profile)
 
         do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
-        do_change_subscription_property(user_profile, sub, stream, "role", Subscription.ROLE_MEMBER)
+        do_change_subscription_property(
+            user_profile, sub, stream, "role", Subscription.ROLE_MEMBER, acting_user=None
+        )
 
         do_set_realm_property(user_profile.realm, "waiting_period_threshold", 10, acting_user=None)
 
@@ -1132,7 +1161,12 @@ class StreamAdminTest(ZulipTestCase):
             test_non_admin(how_old=5, is_new=True, policy=policy)
 
         do_change_subscription_property(
-            user_profile, sub, stream, "role", Subscription.ROLE_STREAM_ADMINISTRATOR
+            user_profile,
+            sub,
+            stream,
+            "role",
+            Subscription.ROLE_STREAM_ADMINISTRATOR,
+            acting_user=None,
         )
 
         for policy in policies:
@@ -1498,7 +1532,12 @@ class StreamAdminTest(ZulipTestCase):
             if is_stream_admin:
                 sub = get_subscription(stream_name, user_profile)
                 do_change_subscription_property(
-                    user_profile, sub, stream, "role", Subscription.ROLE_STREAM_ADMINISTRATOR
+                    user_profile,
+                    sub,
+                    stream,
+                    "role",
+                    Subscription.ROLE_STREAM_ADMINISTRATOR,
+                    acting_user=None,
                 )
         if target_users_subbed:
             for user in target_users:

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1331,7 +1331,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
     def test_get_gravatar_icon(self) -> None:
         self.login("hamlet")
         realm = get_realm("zulip")
-        do_change_icon_source(realm, Realm.ICON_FROM_GRAVATAR)
+        do_change_icon_source(realm, Realm.ICON_FROM_GRAVATAR, acting_user=None)
         with self.settings(ENABLE_GRAVATAR=True):
             response = self.client_get("/json/realm/icon", {"foo": "bar"})
             redirect_url = response["Location"]
@@ -1346,7 +1346,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
         self.login("hamlet")
 
         realm = get_realm("zulip")
-        do_change_icon_source(realm, Realm.ICON_UPLOADED)
+        do_change_icon_source(realm, Realm.ICON_UPLOADED, acting_user=None)
         response = self.client_get("/json/realm/icon", {"foo": "bar"})
         redirect_url = response["Location"]
         self.assertTrue(redirect_url.endswith(realm_icon_url(realm) + "&foo=bar"))
@@ -1392,7 +1392,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
         """
         self.login("iago")
         realm = get_realm("zulip")
-        do_change_icon_source(realm, Realm.ICON_UPLOADED)
+        do_change_icon_source(realm, Realm.ICON_UPLOADED, acting_user=None)
 
         result = self.client_delete("/json/realm/icon")
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This make acting_user a mandatory keyword argument for functions in zerver/lib/actions.py.
https://github.com/zulip/zulip/issues/14808#issuecomment-663700003.

