### PR TITLE
settings: Add new setting 'move_messages_to_stream_policy'  for controlling who can move messages between streams.

### DIFF
--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -157,3 +157,8 @@ test_policy(
     "realm_invite_to_realm_policy",
     settings_data.user_can_invite_others_to_realm,
 );
+test_policy(
+    "user_can_move_messages_between_streams",
+    "realm_move_messages_between_streams_policy",
+    settings_data.user_can_move_messages_between_streams,
+);

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -21,6 +21,7 @@ import * as message_viewport from "./message_viewport";
 import {page_params} from "./page_params";
 import * as resize from "./resize";
 import * as rows from "./rows";
+import * as settings_data from "./settings_data";
 import * as stream_bar from "./stream_bar";
 import * as stream_data from "./stream_data";
 import * as ui_report from "./ui_report";
@@ -346,7 +347,8 @@ function edit_message(row, raw_content) {
         file_upload_enabled = true;
     }
 
-    const show_edit_stream = message.is_stream && page_params.is_admin;
+    const show_edit_stream =
+        message.is_stream && settings_data.user_can_move_messages_between_streams();
     // current message's stream has been already been added and selected in handlebar
     const available_streams = show_edit_stream
         ? stream_data.subscribed_subs().filter((s) => s.stream_id !== message.stream_id)

--- a/static/js/settings_data.js
+++ b/static/js/settings_data.js
@@ -126,3 +126,7 @@ export function user_can_subscribe_other_users() {
 export function user_can_create_streams() {
     return user_has_permission(page_params.realm_create_stream_policy);
 }
+
+export function user_can_move_messages_between_streams() {
+    return user_has_permission(page_params.realm_move_messages_between_streams_policy);
+}

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -247,6 +247,7 @@ const simple_dropdown_properties = [
     "realm_add_emoji_by_admins_only",
     "realm_user_invite_restriction",
     "realm_wildcard_mention_policy",
+    "realm_move_messages_between_streams_policy",
 ];
 
 function set_property_dropdown_value(property_name) {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1577,15 +1577,24 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     top: calc(50% - 120px);
 }
 
-#id_realm_giphy_rating,
+/* These have enough space for "Admins and full members" in German. */
 #desktop_icon_count_display,
 #id_realm_waiting_period_setting,
 #id_realm_create_stream_policy,
 #id_realm_invite_to_stream_policy,
-#id_realm_org_join_restrictions,
+#id_realm_private_message_policy,
+#id_realm_add_emoji_by_admins_only,
+#id_realm_user_group_edit_policy,
+#id_realm_email_address_visibility,
+#id_realm_wildcard_mention_policy,
+#id_realm_move_messages_between_streams_policy {
+    width: 250px;
+}
+
 #id_realm_bot_creation_policy,
-#id_realm_user_invite_restriction,
-#id_realm_wildcard_mention_policy {
+#id_realm_giphy_rating,
+#id_realm_org_join_restrictions,
+#id_realm_user_invite_restriction {
     width: 100%;
 }
 

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -115,6 +115,13 @@
                         {{> dropdown_options_widget option_values=wildcard_mention_policy_values}}
                     </select>
                 </div>
+                <div class="input-group">
+                    <label for="realm_move_messages_between_streams_policy">{{t "Who can move messages between streams" }}
+                    </label>
+                    <select name="realm_move_messages_between_streams_policy" class="setting-widget prop-element" id="id_realm_move_messages_between_streams_policy" data-setting-widget-type="number">
+                        {{> dropdown_options_widget option_values=common_policy_values}}
+                    </select>
+                </div>
             </div>
         </div>
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2802,7 +2802,7 @@ def check_update_message(
     if stream_id is not None:
         if not message.is_stream_message():
             raise JsonableError(_("Message must be a stream message"))
-        if not user_profile.is_realm_admin:
+        if not user_profile.can_move_messages_between_streams():
             raise JsonableError(_("You don't have permission to move this message"))
         try:
             access_stream_by_id(user_profile, message.recipient.type_id)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -143,6 +143,7 @@ from zerver.lib.streams import (
     access_stream_by_id,
     access_stream_for_send_message,
     can_access_stream_user_ids,
+    check_stream_access_based_on_stream_post_policy,
     check_stream_name,
     create_stream_if_needed,
     get_default_value_for_history_public_to_subscribers,
@@ -2816,6 +2817,7 @@ def check_update_message(
             raise JsonableError(_("Cannot change message content while changing stream"))
 
         new_stream = access_stream_by_id(user_profile, stream_id, require_active=True)[0]
+        check_stream_access_based_on_stream_post_policy(user_profile, new_stream)
 
     number_changed = do_update_message(
         user_profile,

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -8,6 +8,7 @@ from django.db import IntegrityError
 from django.http import HttpResponse
 
 from zerver.lib.actions import (
+    do_change_user_role,
     do_set_realm_property,
     do_update_message,
     get_topic_messages,
@@ -17,7 +18,7 @@ from zerver.lib.message import MessageDict, has_message_access, messages_for_ids
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import cache_tries_captured, queries_captured
 from zerver.lib.topic import LEGACY_PREV_TOPIC, TOPIC_NAME
-from zerver.models import Message, Stream, UserMessage, UserProfile, get_realm, get_stream
+from zerver.models import Message, Realm, Stream, UserMessage, UserProfile, get_realm, get_stream
 
 
 class EditMessageTest(ZulipTestCase):
@@ -1268,26 +1269,89 @@ class EditMessageTest(ZulipTestCase):
             f"This topic was moved here from #**test move stream>test** by @_**Iago|{user_profile.id}**",
         )
 
-    def test_move_message_to_stream_no_allowed(self) -> None:
+    def test_move_message_between_streams_policy_setting(self) -> None:
         (user_profile, old_stream, new_stream, msg_id, msg_id_later) = self.prepare_move_topics(
-            "aaron", "test move stream", "new stream", "test"
+            "othello", "old_stream_1", "new_stream_1", "test"
         )
 
-        result = self.client_patch(
-            "/json/messages/" + str(msg_id),
-            {
-                "message_id": msg_id,
-                "stream_id": new_stream.id,
-                "propagate_mode": "change_all",
-            },
+        def check_move_message_according_to_policy(role: int, expect_fail: bool = False) -> None:
+            do_change_user_role(user_profile, role, acting_user=None)
+
+            result = self.client_patch(
+                "/json/messages/" + str(msg_id),
+                {
+                    "message_id": msg_id,
+                    "stream_id": new_stream.id,
+                    "propagate_mode": "change_all",
+                },
+            )
+
+            if expect_fail:
+                self.assert_json_error(result, "You don't have permission to move this message")
+                messages = get_topic_messages(user_profile, old_stream, "test")
+                self.assertEqual(len(messages), 3)
+                messages = get_topic_messages(user_profile, new_stream, "test")
+                self.assertEqual(len(messages), 0)
+            else:
+                self.assert_json_success(result)
+                messages = get_topic_messages(user_profile, old_stream, "test")
+                self.assertEqual(len(messages), 1)
+                messages = get_topic_messages(user_profile, new_stream, "test")
+                self.assertEqual(len(messages), 4)
+
+        # Check sending messages when policy is Realm.POLICY_ADMINS_ONLY.
+        do_set_realm_property(
+            user_profile.realm,
+            "move_messages_between_streams_policy",
+            Realm.POLICY_ADMINS_ONLY,
+            acting_user=None,
         )
-        self.assert_json_error(result, "You don't have permission to move this message")
+        check_move_message_according_to_policy(UserProfile.ROLE_MODERATOR, expect_fail=True)
+        check_move_message_according_to_policy(UserProfile.ROLE_REALM_ADMINISTRATOR)
 
-        messages = get_topic_messages(user_profile, old_stream, "test")
-        self.assertEqual(len(messages), 3)
+        (user_profile, old_stream, new_stream, msg_id, msg_id_later) = self.prepare_move_topics(
+            "othello", "old_stream_2", "new_stream_2", "test"
+        )
+        # Check sending messages when policy is Realm.POLICY_MODERATORS_ONLY.
+        do_set_realm_property(
+            user_profile.realm,
+            "move_messages_between_streams_policy",
+            Realm.POLICY_MODERATORS_ONLY,
+            acting_user=None,
+        )
+        check_move_message_according_to_policy(UserProfile.ROLE_MEMBER, expect_fail=True)
+        check_move_message_according_to_policy(UserProfile.ROLE_MODERATOR)
 
-        messages = get_topic_messages(user_profile, new_stream, "test")
-        self.assertEqual(len(messages), 0)
+        (user_profile, old_stream, new_stream, msg_id, msg_id_later) = self.prepare_move_topics(
+            "othello", "old_stream_3", "new_stream_3", "test"
+        )
+        # Check sending messages when policy is Realm.POLICY_FULL_MEMBERS_ONLY.
+        do_set_realm_property(
+            user_profile.realm,
+            "move_messages_between_streams_policy",
+            Realm.POLICY_FULL_MEMBERS_ONLY,
+            acting_user=None,
+        )
+        do_set_realm_property(
+            user_profile.realm, "waiting_period_threshold", 100000, acting_user=None
+        )
+        check_move_message_according_to_policy(UserProfile.ROLE_MEMBER, expect_fail=True)
+
+        do_set_realm_property(user_profile.realm, "waiting_period_threshold", 0, acting_user=None)
+        check_move_message_according_to_policy(UserProfile.ROLE_MEMBER)
+
+        (user_profile, old_stream, new_stream, msg_id, msg_id_later) = self.prepare_move_topics(
+            "othello", "old_stream_4", "new_stream_4", "test"
+        )
+        # Check sending messages when policy is Realm.POLICY_MEMBERS_ONLY.
+        do_set_realm_property(
+            user_profile.realm,
+            "move_messages_between_streams_policy",
+            Realm.POLICY_MEMBERS_ONLY,
+            acting_user=None,
+        )
+        check_move_message_according_to_policy(UserProfile.ROLE_GUEST, expect_fail=True)
+        check_move_message_according_to_policy(UserProfile.ROLE_MEMBER)
 
     def test_move_message_to_stream_with_content(self) -> None:
         (user_profile, old_stream, new_stream, msg_id, msg_id_later) = self.prepare_move_topics(


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds a new setting `move_messages_to_stream_policy` for controlling
who can move messages between streams.

I have kept the default value to allow only admins for now, but this can be discussed.

**Testing plan:** <!-- How have you tested? --> Added tests.


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
