### PR TITLE
docs: Update svgo path in integrations docs.

### DIFF
--- a/docs/documentation/integrations.md
+++ b/docs/documentation/integrations.md
@@ -28,7 +28,7 @@ Usually, this involves a few steps:
   `static/images/integrations/logos/<name>.svg`, where `<name>` is the
   name of the integration, all in lower case; you can usually find them in the
   product branding or press page. Make sure to optimize the SVG graphic by
-  running `svgo -f path-to-file`.
+  running `yarn run svgo -f path-to-file`.
 
   If you cannot find a SVG graphic of the logo, please find and include a PNG
   image of the logo instead.


### PR DESCRIPTION
I have updated the path for the svgo module in the integrations
documentation as the other path would error out as `svgo` wasn't in
PATH, so have updated to use the full path to the `svgo` command.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

Ran linters

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
