### PR TITLE
dependencies: Upgrade Source Code Pro font from Git

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "simplebar": "^5.2.1",
     "sortablejs": "^1.9.0",
     "sorttable": "^1.0.2",
-    "source-code-pro": "^2.30.2",
+    "source-code-pro": "https://codeload.github.com/adobe-fonts/source-code-pro/tar.gz/72d3d0eb3567e68669a2b97904a1274ac3b376fa",
     "source-sans": "^3.28.0",
     "spectrum-colorpicker": "^1.8.1",
     "stacktrace-gps": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "openapi-examples-validator": "^4.0.0",
     "prettier": "^2.0.5",
     "puppeteer": "^8.0.0",
-    "source-map": "https://github.com/benthemonkey/source-map.git#d95423f77edef6cbb9e21d2d6014c7de85ae220a",
+    "source-map": "https://codeload.github.com/benthemonkey/source-map/tar.gz/d95423f77edef6cbb9e21d2d6014c7de85ae220a",
     "stylelint": "^13.0.0",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-standard": "^21.0.0",
@@ -123,7 +123,7 @@
     "zulip-js": "^2.0.8"
   },
   "resolutions": {
-    "/source-map": "https://github.com/benthemonkey/source-map.git#d95423f77edef6cbb9e21d2d6014c7de85ae220a"
+    "/source-map": "https://codeload.github.com/benthemonkey/source-map/tar.gz/d95423f77edef6cbb9e21d2d6014c7de85ae220a"
   },
   "scripts": {
     "postinstall": "rm -rf ./var/webpack-cache",

--- a/version.py
+++ b/version.py
@@ -45,4 +45,4 @@ API_FEATURE_LEVEL = 51
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "139.0"
+PROVISION_VERSION = "139.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11720,10 +11720,9 @@ sorttable@^1.0.2:
   resolved "https://registry.yarnpkg.com/sorttable/-/sorttable-1.0.2.tgz#da67e34d32f6198bc12942b183b7a0f7c650f1a4"
   integrity sha512-dY6xMviQb4+zeZ11MSOqYfgXbv3pA6q4y35/lqVRulAXhR36MYvYjxTSWbctwiVWaRk0ufY10gNwFrcdrXPeWA==
 
-source-code-pro@^2.30.2:
+"source-code-pro@https://codeload.github.com/adobe-fonts/source-code-pro/tar.gz/72d3d0eb3567e68669a2b97904a1274ac3b376fa":
   version "2.30.2"
-  resolved "https://registry.yarnpkg.com/source-code-pro/-/source-code-pro-2.30.2.tgz#1577e4bc93d2399d271d00f8426a8cd1b7f86da2"
-  integrity sha512-KctdxE5xBzf9wjYjTO9JWEQ1F2tdAR+yloz1rUmP5n0p6wEXB33B0myGTz49K6I3/EQpnJ9zot10r9ThQ+GARg==
+  resolved "https://codeload.github.com/adobe-fonts/source-code-pro/tar.gz/72d3d0eb3567e68669a2b97904a1274ac3b376fa#edec8306ee67623bc1e9d57b3df47c50fa944e5a"
 
 source-list-map@^2.0.0:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11764,9 +11764,9 @@ source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.0, source-map@^0.6.1, "source-map@https://github.com/benthemonkey/source-map.git#d95423f77edef6cbb9e21d2d6014c7de85ae220a", source-map@~0.6.0, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, "source-map@https://codeload.github.com/benthemonkey/source-map/tar.gz/d95423f77edef6cbb9e21d2d6014c7de85ae220a", source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
-  resolved "https://github.com/benthemonkey/source-map.git#d95423f77edef6cbb9e21d2d6014c7de85ae220a"
+  resolved "https://codeload.github.com/benthemonkey/source-map/tar.gz/d95423f77edef6cbb9e21d2d6014c7de85ae220a#e545acc18a90e6bc2308fcf8126de26793c8e0af"
 
 source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"


### PR DESCRIPTION
This works around a bug where code text appears dark on dark in night mode with Firefox on macOS:
https://bugzilla.mozilla.org/show_bug.cgi?id=1520157

**Testing plan:** Confirmed the fix in Firefox on macOS using https://andersk.zulipdev.org.