### PR TITLE
Don't change hash if the new hash has already been set.

### DIFF
--- a/static/js/browser_history.js
+++ b/static/js/browser_history.js
@@ -55,7 +55,7 @@ export function update(new_hash) {
 }
 
 export function exit_overlay() {
-    if (hash_util.is_overlay_hash(window.location.hash)) {
+    if (hash_util.is_overlay_hash(window.location.hash) && !state.changing_hash) {
         ui_util.blur_active_element();
         const new_hash = state.hash_before_overlay || "#";
         update(new_hash);

--- a/static/js/browser_history.js
+++ b/static/js/browser_history.js
@@ -2,10 +2,11 @@ import * as blueslip from "./blueslip";
 import * as hash_util from "./hash_util";
 import * as ui_util from "./ui_util";
 
-const state = {
+export const state = {
     is_internal_change: false,
     hash_before_overlay: null,
     old_hash: window.location.hash,
+    changing_hash: false,
 };
 
 export function clear_for_testing() {

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -289,7 +289,9 @@ function hashchanged(from_reload, e) {
     }
 
     if (hash_util.is_overlay_hash(window.location.hash)) {
+        browser_history.state.changing_hash = true;
         do_hashchange_overlay(old_hash);
+        browser_history.state.changing_hash = false;
         return undefined;
     }
 

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -25,7 +25,6 @@ import * as ui_util from "./ui_util";
 
 // Read https://zulip.readthedocs.io/en/latest/subsystems/hashchange-system.html
 // or locally: docs/subsystems/hashchange-system.md
-let changing_hash = false;
 
 function get_full_url(hash) {
     const location = window.location;
@@ -70,7 +69,7 @@ export function in_recent_topics_hash() {
 }
 
 export function changehash(newhash) {
-    if (changing_hash) {
+    if (browser_history.state.changing_hash) {
         return;
     }
     maybe_hide_recent_topics();
@@ -79,7 +78,7 @@ export function changehash(newhash) {
 }
 
 export function save_narrow(operators) {
-    if (changing_hash) {
+    if (browser_history.state.changing_hash) {
         return;
     }
     const new_hash = hash_util.operators_to_hash(operators);
@@ -296,9 +295,9 @@ function hashchanged(from_reload, e) {
 
     // We are changing to a "main screen" view.
     overlays.close_for_hash_change();
-    changing_hash = true;
+    browser_history.state.changing_hash = true;
     const ret = do_hashchange_normal(from_reload);
-    changing_hash = false;
+    browser_history.state.changing_hash = false;
     return ret;
 }
 


### PR DESCRIPTION
See the last 2 commits for description on what happened.

Reproducer of the issue:
In this [thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/Settings.2Finvites.20flashing), @abhijeetbodas2001 talks about a weird bug in the UI, which can be reproduced by doing the following.
>1. Go to organization settings/invitations
>1. Click on "Invite more users"
>1. The invite-users modal will open (with URL that of the message feed). Click on the "cancel" button in the bottom. The invite modal will close now.
>1. Click on the browser back button. The invite modal will open again (this time, with URL equal to /#invite!).
>1. Click on the browser back button again. This will cause the settings pane to flash, while the URL keeps flipping between the 
>1. message feed one and the settings one. This loop seems to continue indefinitely if not intervened.



@abhijeetbodas2001 FYI
Fixes #18011