### PR TITLE
create_stream: Failure in referencing a stream name.

### DIFF
--- a/frontend_tests/puppeteer_tests/subscriptions.ts
+++ b/frontend_tests/puppeteer_tests/subscriptions.ts
@@ -199,6 +199,19 @@ async function test_streams_with_duplicate_names_cannot_be_created(page: Page): 
     await page.click(cancel_button_selector);
 }
 
+async function test_streams_with_name_containing_asterisk_character(page: Page): Promise<void> {
+    await page.click("#add_new_subscription .create_stream_button");
+    await page.waitForSelector("form#stream_creation_form", {visible: true});
+    await common.fill_form(page, "form#stream_creation_form", {stream_name: "ab*cd"});
+    await page.click("form#stream_creation_form button.button.sea-green");
+    assert.strictEqual(
+        await stream_name_error(page),
+        "A stream name should not any contain '*' character",
+    );
+    const cancel_button_selector = "form#stream_creation_form button.button.white";
+    await page.click(cancel_button_selector);
+}
+
 async function test_stream_creation(page: Page): Promise<void> {
     const cordelia_checkbox = await user_checkbox(page, "cordelia");
     const othello_checkbox = await user_checkbox(page, "othello");
@@ -217,6 +230,7 @@ async function test_stream_creation(page: Page): Promise<void> {
     await create_stream(page);
     await test_streams_with_empty_names_cannot_be_created(page);
     await test_streams_with_duplicate_names_cannot_be_created(page);
+    await test_streams_with_name_containing_asterisk_character(page);
 }
 
 async function test_streams_search_feature(page: Page): Promise<void> {

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -67,11 +67,33 @@ class StreamNameError {
         $("#stream_name_error").show();
     }
 
+    report_invalid_stream_name() {
+        $("#stream_name_error").text(i18n.t("A stream name should not any contain '*' character"));
+        $("#stream_name_error").show();
+    }
+
+    is_valid_stream_name(stream_name) {
+        if (stream_name.includes("*")) {
+            return false;
+        }
+
+        return true;
+    }
+
     select() {
         $("#create_stream_name").trigger("focus").trigger("select");
     }
 
     pre_validate(stream_name) {
+        // Failure in referencing a stream name. #17921
+        // we check for valid stream name meaning stream_name should not contain
+        // * character if it is present we report invalid stream name
+        // this is done so that when referencing the stream in a message
+        // it doesnt mangle the stream link because of *
+        if (stream_name && !this.is_valid_stream_name(stream_name)) {
+            this.report_invalid_stream_name();
+            return;
+        }
         // Don't worry about empty strings...we just want to call this
         // to warn users early before they start doing too much work
         // after they make the effort to type in a stream name.  (The
@@ -91,6 +113,11 @@ class StreamNameError {
         if (!stream_name) {
             this.report_empty_stream();
             this.select();
+            return false;
+        }
+
+        if (stream_name && !this.is_valid_stream_name(stream_name)) {
+            this.report_invalid_stream_name();
             return false;
         }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
issue: when stream is created with asterisk character and if it is referenced as message in other streams , it does'nt reference as link to stream

solution: when creating a stream we do prevalidation and validation before submit , as part of prevalidation & validation i added a condition to check if stream has a asterisk  character , if found I am raising an error and preventing user from submitting.


Fixes:#17921

**Testing plan:** <!-- How have you tested? -->
wrote automation test ( puppeteer automation test when stream name has a asterisk character) and manual testing

**GIFs or screenshots:** <!-- If a UI change.  See:
![create_stream_with_astrek](https://user-images.githubusercontent.com/10942163/114213964-57ee5480-9981-11eb-8d1f-3f1aabe183b0.gif)