### PR TITLE
Fix API encoding of strings in corporate/views

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -2299,6 +2299,17 @@ class StripeTest(StripeTestCase):
         self.assertEqual(old_plan.next_invoice_date, None)
         self.assertEqual(old_plan.status, CustomerPlan.ENDED)
 
+    def test_update_plan_with_invalid_status(self, *mocks: Mock) -> None:
+        with patch("corporate.lib.stripe.timezone_now", return_value=self.now):
+            self.local_upgrade(self.seat_count, True, CustomerPlan.ANNUAL, "token")
+        self.login_user(self.example_user("hamlet"))
+
+        response = self.client_post(
+            "/json/billing/plan/change",
+            {"status": CustomerPlan.NEVER_STARTED},
+        )
+        self.assert_json_error_contains(response, "Invalid status")
+
     def test_deactivate_realm(self) -> None:
         user = self.example_user("hamlet")
         with patch("corporate.lib.stripe.timezone_now", return_value=self.now):

--- a/corporate/views.py
+++ b/corporate/views.py
@@ -46,7 +46,7 @@ from zerver.decorator import (
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_error, json_success
 from zerver.lib.send_email import FromAddress, send_email
-from zerver.lib.validator import check_int, check_int_in, check_string_in
+from zerver.lib.validator import check_int_in, check_string_in, to_positive_or_allowed_int
 from zerver.models import UserProfile, get_realm
 
 billing_logger = logging.getLogger("corporate.stripe")
@@ -131,7 +131,7 @@ def upgrade(
     license_management: Optional[str] = REQ(
         default=None, str_validator=check_string_in(VALID_LICENSE_MANAGEMENT_VALUES)
     ),
-    licenses: Optional[int] = REQ(json_validator=check_int, default=None),
+    licenses: Optional[int] = REQ(converter=to_positive_or_allowed_int(), default=None),
     stripe_token: Optional[str] = REQ(default=None),
 ) -> HttpResponse:
 

--- a/corporate/views.py
+++ b/corporate/views.py
@@ -51,6 +51,8 @@ from zerver.models import UserProfile, get_realm
 
 billing_logger = logging.getLogger("corporate.stripe")
 
+VALID_LICENSE_MANAGEMENT_VALUES = ["automatic", "manual"]
+
 
 def unsign_seat_count(signed_seat_count: str, salt: str) -> int:
     try:
@@ -71,7 +73,7 @@ def check_upgrade_parameters(
         raise BillingError("unknown billing_modality")
     if schedule not in ["annual", "monthly"]:
         raise BillingError("unknown schedule")
-    if license_management not in ["automatic", "manual"]:
+    if license_management not in VALID_LICENSE_MANAGEMENT_VALUES:
         raise BillingError("unknown license_management")
 
     if billing_modality == "charge_automatically":

--- a/corporate/views.py
+++ b/corporate/views.py
@@ -51,6 +51,7 @@ from zerver.models import UserProfile, get_realm
 
 billing_logger = logging.getLogger("corporate.stripe")
 
+VALID_BILLING_MODALITY_VALUES = ["send_invoice", "charge_automatically"]
 VALID_LICENSE_MANAGEMENT_VALUES = ["automatic", "manual"]
 
 
@@ -69,7 +70,7 @@ def check_upgrade_parameters(
     has_stripe_token: bool,
     seat_count: int,
 ) -> None:
-    if billing_modality not in ["send_invoice", "charge_automatically"]:
+    if billing_modality not in VALID_BILLING_MODALITY_VALUES:
         raise BillingError("unknown billing_modality")
     if schedule not in ["annual", "monthly"]:
         raise BillingError("unknown schedule")

--- a/corporate/views.py
+++ b/corporate/views.py
@@ -52,6 +52,7 @@ from zerver.models import UserProfile, get_realm
 billing_logger = logging.getLogger("corporate.stripe")
 
 VALID_BILLING_MODALITY_VALUES = ["send_invoice", "charge_automatically"]
+VALID_BILLING_SCHEDULE_VALUES = ["annual", "monthly"]
 VALID_LICENSE_MANAGEMENT_VALUES = ["automatic", "manual"]
 
 
@@ -72,7 +73,7 @@ def check_upgrade_parameters(
 ) -> None:
     if billing_modality not in VALID_BILLING_MODALITY_VALUES:
         raise BillingError("unknown billing_modality")
-    if schedule not in ["annual", "monthly"]:
+    if schedule not in VALID_BILLING_SCHEDULE_VALUES:
         raise BillingError("unknown schedule")
     if license_management not in VALID_LICENSE_MANAGEMENT_VALUES:
         raise BillingError("unknown license_management")

--- a/corporate/views.py
+++ b/corporate/views.py
@@ -46,7 +46,7 @@ from zerver.decorator import (
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_error, json_success
 from zerver.lib.send_email import FromAddress, send_email
-from zerver.lib.validator import check_int, check_string_in
+from zerver.lib.validator import check_int, check_int_in, check_string_in
 from zerver.models import UserProfile, get_realm
 
 billing_logger = logging.getLogger("corporate.stripe")
@@ -354,14 +354,20 @@ def billing_home(request: HttpRequest) -> HttpResponse:
 @require_billing_access
 @has_request_variables
 def change_plan_status(
-    request: HttpRequest, user: UserProfile, status: int = REQ("status", json_validator=check_int)
+    request: HttpRequest,
+    user: UserProfile,
+    status: int = REQ(
+        "status",
+        json_validator=check_int_in(
+            [
+                CustomerPlan.ACTIVE,
+                CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE,
+                CustomerPlan.SWITCH_TO_ANNUAL_AT_END_OF_CYCLE,
+                CustomerPlan.ENDED,
+            ]
+        ),
+    ),
 ) -> HttpResponse:
-    assert status in [
-        CustomerPlan.ACTIVE,
-        CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE,
-        CustomerPlan.SWITCH_TO_ANNUAL_AT_END_OF_CYCLE,
-        CustomerPlan.ENDED,
-    ]
 
     plan = get_current_plan_by_realm(user.realm)
     assert plan is not None  # for mypy

--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -86,11 +86,10 @@ run_test("initialize", (override) => {
     });
 
     create_ajax_request_called = false;
-    function plan_change_ajax(url, form_name, stripe_token, numeric_inputs) {
+    function plan_change_ajax(url, form_name, stripe_token) {
         assert.equal(url, "/json/billing/plan/change");
         assert.equal(form_name, "planchange");
         assert.equal(stripe_token, undefined);
-        assert.deepEqual(numeric_inputs, ["status"]);
         create_ajax_request_called = true;
     }
 

--- a/frontend_tests/node_tests/billing_helpers.js
+++ b/frontend_tests/node_tests/billing_helpers.js
@@ -127,13 +127,13 @@ run_test("create_ajax_request", (override) => {
         assert.equal(url, "/json/billing/upgrade");
 
         assert.equal(Object.keys(data).length, 8);
-        assert.equal(data.stripe_token, '"stripe_token_id"');
-        assert.equal(data.seat_count, '"{{ seat_count }}"');
-        assert.equal(data.signed_seat_count, '"{{ signed_seat_count }}"');
-        assert.equal(data.salt, '"{{ salt }}"');
-        assert.equal(data.billing_modality, '"charge_automatically"');
-        assert.equal(data.schedule, '"monthly"');
-        assert.equal(data.license_management, '"automatic"');
+        assert.equal(data.stripe_token, "stripe_token_id");
+        assert.equal(data.seat_count, "{{ seat_count }}");
+        assert.equal(data.signed_seat_count, "{{ signed_seat_count }}");
+        assert.equal(data.salt, "{{ salt }}");
+        assert.equal(data.billing_modality, "charge_automatically");
+        assert.equal(data.schedule, "monthly");
+        assert.equal(data.license_management, "automatic");
         assert.equal(data.licenses, "");
 
         history.pushState = (state_object, title, path) => {
@@ -174,9 +174,7 @@ run_test("create_ajax_request", (override) => {
         assert.equal(state.free_trial_alert_message_show, 1);
     });
 
-    helpers.create_ajax_request("/json/billing/upgrade", "autopay", {id: "stripe_token_id"}, [
-        "licenses",
-    ]);
+    helpers.create_ajax_request("/json/billing/upgrade", "autopay", {id: "stripe_token_id"});
 });
 
 run_test("format_money", () => {

--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -36,30 +36,24 @@ run_test("initialize", (override) => {
     });
 
     let create_ajax_request_form_call_count = 0;
-    helpers.__Rewire__(
-        "create_ajax_request",
-        (url, form_name, stripe_token, numeric_inputs, redirect_to) => {
-            create_ajax_request_form_call_count += 1;
-            if (form_name === "autopay") {
-                assert.equal(url, "/json/billing/upgrade");
-                assert.equal(stripe_token, "stripe_add_card_token");
-                assert.deepEqual(numeric_inputs, ["licenses"]);
-                assert.equal(redirect_to, undefined);
-            } else if (form_name === "invoice") {
-                assert.equal(url, "/json/billing/upgrade");
-                assert.equal(stripe_token, undefined);
-                assert.deepEqual(numeric_inputs, ["licenses"]);
-                assert.equal(redirect_to, undefined);
-            } else if (form_name === "sponsorship") {
-                assert.equal(url, "/json/billing/sponsorship");
-                assert.equal(stripe_token, undefined);
-                assert.equal(numeric_inputs, undefined);
-                assert.equal(redirect_to, "/");
-            } else {
-                throw new Error("Unhandled case");
-            }
-        },
-    );
+    helpers.__Rewire__("create_ajax_request", (url, form_name, stripe_token, redirect_to) => {
+        create_ajax_request_form_call_count += 1;
+        if (form_name === "autopay") {
+            assert.equal(url, "/json/billing/upgrade");
+            assert.equal(stripe_token, "stripe_add_card_token");
+            assert.equal(redirect_to, undefined);
+        } else if (form_name === "invoice") {
+            assert.equal(url, "/json/billing/upgrade");
+            assert.equal(stripe_token, undefined);
+            assert.equal(redirect_to, undefined);
+        } else if (form_name === "sponsorship") {
+            assert.equal(url, "/json/billing/sponsorship");
+            assert.equal(stripe_token, undefined);
+            assert.equal(redirect_to, "/");
+        } else {
+            throw new Error("Unhandled case");
+        }
+    });
 
     const open_func = (config_opts) => {
         assert.equal(config_opts.name, "Zulip");

--- a/static/js/billing/billing.js
+++ b/static/js/billing/billing.js
@@ -30,9 +30,7 @@ export function initialize() {
     });
 
     $("#change-plan-status").on("click", (e) => {
-        helpers.create_ajax_request("/json/billing/plan/change", "planchange", undefined, [
-            "status",
-        ]);
+        helpers.create_ajax_request("/json/billing/plan/change", "planchange");
         e.preventDefault();
     });
 }

--- a/static/js/billing/helpers.js
+++ b/static/js/billing/helpers.js
@@ -3,13 +3,7 @@ import $ from "jquery";
 import * as loading from "../loading";
 import {page_params} from "../page_params";
 
-export function create_ajax_request(
-    url,
-    form_name,
-    stripe_token = null,
-    numeric_inputs = [],
-    redirect_to = "/billing",
-) {
+export function create_ajax_request(url, form_name, stripe_token = null, redirect_to = "/billing") {
     const form = $(`#${CSS.escape(form_name)}-form`);
     const form_loading_indicator = `#${CSS.escape(form_name)}_loading_indicator`;
     const form_input_section = `#${CSS.escape(form_name)}-input-section`;
@@ -32,15 +26,11 @@ export function create_ajax_request(
 
     const data = {};
     if (stripe_token) {
-        data.stripe_token = JSON.stringify(stripe_token.id);
+        data.stripe_token = stripe_token.id;
     }
 
     for (const item of form.serializeArray()) {
-        if (numeric_inputs.includes(item.name)) {
-            data[item.name] = item.value;
-        } else {
-            data[item.name] = JSON.stringify(item.value);
-        }
+        data[item.name] = item.value;
     }
 
     $.post({

--- a/static/js/billing/upgrade.js
+++ b/static/js/billing/upgrade.js
@@ -12,9 +12,7 @@ export const initialize = () => {
         image: "/static/images/logo/zulip-icon-128x128.png",
         locale: "auto",
         token(stripe_token) {
-            helpers.create_ajax_request("/json/billing/upgrade", "autopay", stripe_token, [
-                "licenses",
-            ]);
+            helpers.create_ajax_request("/json/billing/upgrade", "autopay", stripe_token);
         },
     });
 
@@ -43,7 +41,7 @@ export const initialize = () => {
             return;
         }
         e.preventDefault();
-        helpers.create_ajax_request("/json/billing/upgrade", "invoice", undefined, ["licenses"]);
+        helpers.create_ajax_request("/json/billing/upgrade", "invoice");
     });
 
     $("#sponsorship-button").on("click", (e) => {
@@ -51,13 +49,7 @@ export const initialize = () => {
             return;
         }
         e.preventDefault();
-        helpers.create_ajax_request(
-            "/json/billing/sponsorship",
-            "sponsorship",
-            undefined,
-            undefined,
-            "/",
-        );
+        helpers.create_ajax_request("/json/billing/sponsorship", "sponsorship", undefined, "/");
     });
 
     const prices = {};

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -453,10 +453,10 @@ def to_non_negative_int(s: str, max_int_size: int = 2 ** 32 - 1) -> int:
     return x
 
 
-def to_positive_or_allowed_int(allowed_integer: int) -> Callable[[str], int]:
+def to_positive_or_allowed_int(allowed_integer: Optional[int] = None) -> Callable[[str], int]:
     def converter(s: str) -> int:
         x = int(s)
-        if x == allowed_integer:
+        if allowed_integer is not None and x == allowed_integer:
             return x
         if x == 0:
             raise ValueError("argument is 0")

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -787,12 +787,20 @@ class ValidatorTestCase(ZulipTestCase):
             self.assertEqual(to_non_negative_int(str(2 ** 32)))
 
     def test_to_positive_or_allowed_int(self) -> None:
+        self.assertEqual(to_positive_or_allowed_int()("5"), 5)
         self.assertEqual(to_positive_or_allowed_int(-1)("5"), 5)
+
         self.assertEqual(to_positive_or_allowed_int(-1)("-1"), -1)
         with self.assertRaisesRegex(ValueError, "argument is negative"):
             to_positive_or_allowed_int(-1)("-5")
+        with self.assertRaisesRegex(ValueError, "argument is negative"):
+            to_positive_or_allowed_int()("-5")
+
         with self.assertRaises(ValueError):
             to_positive_or_allowed_int(-1)("0")
+        with self.assertRaises(ValueError):
+            to_positive_or_allowed_int()("0")
+        self.assertEqual(to_positive_or_allowed_int(0)("0"), 0)
 
     def test_check_float(self) -> None:
         x: Any = 5.5


### PR DESCRIPTION
I have verified that this doesn't break anything by manually doing upgrade, request sponsorship, and replace payment source actions. More details below.

* Test /upgrade
	* Upgrade using card
		* [x] Month + Automatic 
		* [x] Annual + Automatic 
		* [x] Monthly + manual
		* [x] Annual + manual
	* Upgrade by invoice
		*  [x] Manual + Annual
* Test sponsorship endpoint
	*  [x] Request sponsorship for event and non_profit
* Test replace payment source endpoint.
	*  [x] Update card from /billing page
* Test plan status by downgrading at end of billing period and canceling it from /billing.