### PR TITLE
webpack: Set ignoreHelpers for handlebars-loader

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -135,6 +135,7 @@ export default (_env: unknown, argv: {mode?: string}): webpack.Configuration[] =
                         {
                             loader: "handlebars-loader",
                             options: {
+                                ignoreHelpers: true,
                                 // Tell webpack not to explicitly require these.
                                 knownHelpers: [
                                     "if",


### PR DESCRIPTION
We don’t use the helper reference feature of handlebars-loader, so we might as well not pay for it.

**Testing plan:** Checked some frontend template uses in the dev server, and verified with `strace` that `webpack` does fewer spurious file accesses.