### PR TITLE
confirm_dialog: Change the text of the dialog modals.

### DIFF
--- a/static/templates/confirm_unstar_all_messages.hbs
+++ b/static/templates/confirm_unstar_all_messages.hbs
@@ -1,5 +1,5 @@
 <p>
     {{#tr}}
-    Would you like to unstar all starred messages?  This action cannot be undone.
+    Are you sure you want to unstar all starred messages?  This action cannot be undone.
     {{/tr}}
 </p>

--- a/static/templates/delete_topic_modal.hbs
+++ b/static/templates/delete_topic_modal.hbs
@@ -7,8 +7,8 @@
         </h3>
     </div>
     <div class="modal-body">
-        <p>{{#tr}}Are you sure you want to permanently delete <b>{topic_name}</b>?{{/tr}}</p>
         <p>{{t "Deleting a topic will immediately remove it and its messages for everyone. Other users may find this confusing, especially if they had received an email or push notification related to the deleted messages." }}</p>
+        <p>{{#tr}}Are you sure you want to permanently delete <b>{topic_name}</b>?{{/tr}}</p>
     </div>
     <div class="modal-footer">
         <button class="button" data-dismiss="modal">{{t "Cancel" }}</button>

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -166,6 +166,7 @@
             <div class="modal-body">
                 <p>{{#tr}}By deactivating your account, you will be logged out immediately.{{/tr}}</p>
                 <p>{{t "Note that any bots that you maintain will be disabled." }}</p>
+                <p>{{t "Are you sure you want to deactivate your account?"}}</p>
             </div>
             <div class="modal-footer">
                 <button class="button" data-dismiss="modal">{{t "Cancel" }}</button>

--- a/static/templates/settings/deactivate_realm_modal.hbs
+++ b/static/templates/settings/deactivate_realm_modal.hbs
@@ -5,6 +5,7 @@
     </div>
     <div class="modal-body">
         <p>{{t "This action is permanent and cannot be undone. All users will permanently lose access to their Zulip accounts." }}</p>
+        <p>{{t "Are you sure you want to deactivate this organization?"}}</p>
     </div>
     <div class="modal-footer">
         <button type="button" class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>

--- a/static/templates/settings/deactivation_stream_modal.hbs
+++ b/static/templates/settings/deactivation_stream_modal.hbs
@@ -4,7 +4,8 @@
         <h3 id="deactivation_stream_modal_label">{{t "Archive stream" }} <span class="stream_name">{{stream_name}}</span></h3>
     </div>
     <div class="modal-body">
-        <p>{{t "Archiving this stream will immediately unsubscribe everyone, and this action cannot be undone." }} <strong>{{t "Are you sure you want to do this?" }}</strong></p>
+        Archiving stream <strong>{{stream_name}}</strong> <span>will immediately unsubscribe everyone. This action cannot be undone </span>
+        <p><strong>{{t "Are you sure you want to archieve this stream?" }}</strong></p>
     </div>
     <div class="modal-footer">
         <button class="button rounded close-modal-btn" data-dismiss="modal">{{t "Cancel" }}</button>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) --> This PR is based on the feedback of PR #17947.



**Testing plan:** <!-- How have you tested? --> Puppeteer tests are failing for `deactivation_user_modal_label` because we have added `user_name` in the header [here](https://github.com/zulip/zulip/pull/18073#discussion_r611135730)


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<details>
  <summary>Screenshots</summary>
  
![image](https://user-images.githubusercontent.com/59444243/114293697-cdf3d800-9ab5-11eb-8668-1f518dfe79b9.png)
![image](https://user-images.githubusercontent.com/59444243/114293699-d3e9b900-9ab5-11eb-9bb4-dd5aca3d01ca.png)
![image](https://user-images.githubusercontent.com/59444243/114293703-d8ae6d00-9ab5-11eb-81eb-fda6e32d950a.png)
![image](https://user-images.githubusercontent.com/59444243/114293709-dfd57b00-9ab5-11eb-80d4-d81109a9057f.png)
![image](https://user-images.githubusercontent.com/59444243/114293710-e3690200-9ab5-11eb-94d9-b9e8bec58f80.png)
![image](https://user-images.githubusercontent.com/59444243/114293711-e6fc8900-9ab5-11eb-944e-493b4ce2c578.png)
![image](https://user-images.githubusercontent.com/59444243/114293715-e9f77980-9ab5-11eb-905f-93d88a730851.png)

</details>


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
