### PR TITLE
tooltip: Tranfer stream-name tooltip to tippy.

### DIFF
--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import _ from "lodash";
+import tippy from "tippy.js";
 
 import render_stream_privacy from "../templates/stream_privacy.hbs";
 import render_stream_sidebar_row from "../templates/stream_sidebar_row.hbs";
@@ -502,6 +503,15 @@ export function initialize() {
     // when new messages come in, but it's fairly quick.
     build_stream_list();
     set_event_handlers();
+    // build tippy tooltips for stream name
+    build_stream_tippy_tooltip();
+}
+
+function build_stream_tippy_tooltip() {
+    tippy(".stream-name", {
+        placement: "bottom",
+        delay: 500,
+    });
 }
 
 export function set_event_handlers() {

--- a/static/templates/stream_sidebar_row.hbs
+++ b/static/templates/stream_sidebar_row.hbs
@@ -8,7 +8,7 @@
                 {{> stream_privacy }}
             </span>
 
-            <a href="{{uri}}" title="{{name}}" class="stream-name">{{name}}</a>
+            <a href="{{uri}}" data-tippy-content="{{name}}" class="stream-name tippy-zulip-tooltip">{{name}}</a>
 
             <div class="count"><div class="value"></div></div>
         </div>


### PR DESCRIPTION
As zulip is tranferring tooltips to use tippyjs
stream-name tooltips are should also use it.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Peek 2021-04-10 15-08](https://user-images.githubusercontent.com/58157064/114265476-a4cc3c80-9a0e-11eb-94f2-9809aa34210a.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
