### PR TITLE
Destroy tooltips when the element for which it is displayed is hidden.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -574,6 +574,7 @@ export function initialize() {
                 observer = new MutationObserver(callback);
                 observer.observe(target_node, config);
             },
+            appendTo: () => document.body,
         });
     }
 

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -53,5 +53,8 @@ export function initialize() {
             const title = reactions.get_reaction_title_data(message_id, local_id);
             instance.setContent(title);
         },
+        // Insert directly into the `.message_reaction` element so
+        // that when the reaction is hidden, tooltip hides as well.
+        appendTo: (reference) => reference,
     });
 }

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -26,6 +26,10 @@ tippy.setDefaultProps({
     // devices.
     touch: ["hold", 750],
 
+    // This has the side effect of some properties of parent applying to
+    // tooltips.
+    appendTo: "parent",
+
     // html content is not supported by default
     // enable it by passing data-tippy-allowHtml="true"
     // in the tag or a parameter.

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -829,6 +829,12 @@ td.pointer {
         }
     }
 
+    /* Tooltips should not follow the width restrictions of their parent element. */
+    [data-tippy-root] {
+        width: max-content;
+        word-wrap: unset;
+    }
+
     > .reaction_button {
         display: inline-block;
         position: relative;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -75,6 +75,16 @@ pre {
      * for tooltips here.
      */
     font-family: "Source Sans 3", sans-serif !important;
+
+    .tippy-arrow::before {
+        /* `.tippy-arrow:before` element sometimes
+         * inherits the height of the parent, we
+         * don't want any height here since we
+         * want it to remain an triangle.
+         * The bug was only found in Firefox.
+         */
+        height: 0 !important;
+    }
 }
 
 .no-select {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -69,6 +69,14 @@ pre {
     font-family: "Source Code Pro", monospace;
 }
 
+[data-tippy-root] {
+    /* Since tooltip elements are sometimes inside elements
+     * which have different font-family, we force font-family
+     * for tooltips here.
+     */
+    font-family: "Source Sans 3", sans-serif !important;
+}
+
 .no-select {
     user-select: none;
 }


### PR DESCRIPTION
We attach tooltip to the element for which tooltip is displayed and hence, when the element is hidden, tooltip is also hidden.

This didn't work for elements contained within `simplebar`. So, we run a cron job to destroy tooltips for which the `reference` elements were hidden or removed from DOM.