### PR TITLE
integrations: Make clubhouse integration handle multiple actions

### DIFF
--- a/zerver/webhooks/clubhouse/fixtures/story_update_add_github_multiple_pull_requests.json
+++ b/zerver/webhooks/clubhouse/fixtures/story_update_add_github_multiple_pull_requests.json
@@ -1,0 +1,97 @@
+{
+    "id": "60718721-b87c-4405-96aa-38db82c693de",
+    "changed_at": "2021-04-10T11:08:17.962Z",
+    "version": "v1",
+    "primary_id": 500000032,
+    "actions": [
+        {
+            "id": 500000032,
+            "entity_type": "pull-request",
+            "action": "create",
+            "number": 2,
+            "title": "Testing pull requests with Story",
+            "url": "https://github.com/PIG208/test-clubhouse/pull/2"
+        },
+        {
+            "id": 500000031,
+            "entity_type": "branch",
+            "action": "create",
+            "name": "two",
+            "url": "https://github.com/PIG208/test-clubhouse/tree/two"
+        },
+        {
+            "id": 17,
+            "entity_type": "story",
+            "action": "update",
+            "name": "Story1",
+            "story_type": "feature",
+            "app_url": "https://app.clubhouse.io/pig208/story/17",
+            "changes": {
+                "pull_request_ids": {
+                    "adds": [
+                        500000032
+                    ]
+                },
+                "started": {
+                    "new": true,
+                    "old": false
+                },
+                "position": {
+                    "new": 32147680256,
+                    "old": 12147614720
+                },
+                "workflow_state_id": {
+                    "new": 500000006,
+                    "old": 500000008
+                },
+                "started_at": {
+                    "new": "2021-04-10T11:08:17Z"
+                }
+            }
+        },
+        {
+            "id": 18,
+            "entity_type": "story",
+            "action": "update",
+            "name": "Story2",
+            "story_type": "feature",
+            "app_url": "https://app.clubhouse.io/pig208/story/18",
+            "changes": {
+                "pull_request_ids": {
+                    "adds": [
+                        500000032
+                    ]
+                },
+                "started": {
+                    "new": true,
+                    "old": false
+                },
+                "position": {
+                    "new": 32147745792,
+                    "old": 12147680256
+                },
+                "workflow_state_id": {
+                    "new": 500000006,
+                    "old": 500000008
+                },
+                    "started_at": {
+                    "new": "2021-04-10T11:08:17Z"
+                }
+            }
+        }
+    ],
+    "references": [
+        {
+            "id": 500000006,
+            "entity_type": "workflow-state",
+            "name": "In Development",
+            "type": "started"
+        },
+        {
+            "id": 500000008,
+            "entity_type": "workflow-state",
+            "name": "Unscheduled",
+            "type": "unstarted"
+        }
+    ]
+}

--- a/zerver/webhooks/clubhouse/fixtures/story_update_add_github_multiple_pull_requests_with_comment.json
+++ b/zerver/webhooks/clubhouse/fixtures/story_update_add_github_multiple_pull_requests_with_comment.json
@@ -1,0 +1,90 @@
+{
+    "id": "60721a44-7d30-476b-ae19-514a47359c42",
+    "changed_at": "2021-04-10T21:36:04.138Z",
+    "version": "v1",
+    "primary_id": 500000029,
+    "actions": [
+      {
+        "id": 500000029,
+        "entity_type": "pull-request",
+        "action": "comment",
+        "number": 1,
+        "title": "readme: Update README.md.",
+        "url": "https://github.com/PIG208/test-clubhouse/pull/1"
+      },
+      {
+        "id": 26,
+        "entity_type": "story",
+        "action": "update",
+        "name": "new1",
+        "story_type": "feature",
+        "app_url": "https://app.clubhouse.io/pig208/story/26",
+        "changes": {
+          "pull_request_ids": {
+            "adds": [
+              500000029
+            ]
+          },
+          "started": {
+            "new": true,
+            "old": false
+          },
+          "position": {
+            "new": 32147549184,
+            "old": 12147549184
+          },
+          "workflow_state_id": {
+            "new": 500000006,
+            "old": 500000008
+          },
+          "started_at": {
+            "new": "2021-04-10T21:36:03Z"
+          }
+        }
+      },
+      {
+        "id": 27,
+        "entity_type": "story",
+        "action": "update",
+        "name": "new2",
+        "story_type": "feature",
+        "app_url": "https://app.clubhouse.io/pig208/story/27",
+        "changes": {
+          "pull_request_ids": {
+            "adds": [
+              500000029
+            ]
+          },
+          "started": {
+            "new": true,
+            "old": false
+          },
+          "position": {
+            "new": 32147614720,
+            "old": 12147614720
+          },
+          "workflow_state_id": {
+            "new": 500000006,
+            "old": 500000008
+          },
+          "started_at": {
+            "new": "2021-04-10T21:36:03Z"
+          }
+        }
+      }
+    ],
+    "references": [
+      {
+        "id": 500000006,
+        "entity_type": "workflow-state",
+        "name": "In Development",
+        "type": "started"
+      },
+      {
+        "id": 500000008,
+        "entity_type": "workflow-state",
+        "name": "Unscheduled",
+        "type": "unstarted"
+      }
+    ]
+  }

--- a/zerver/webhooks/clubhouse/fixtures/story_update_add_github_pull_request.json
+++ b/zerver/webhooks/clubhouse/fixtures/story_update_add_github_pull_request.json
@@ -36,6 +36,11 @@
                     "new":true,
                     "old":false
                 },
+                "pull_request_ids": {
+                    "adds": [
+                        500000032
+                    ]
+                },
                 "workflow_state_id":{
                     "new":500000010,
                     "old":500000008

--- a/zerver/webhooks/clubhouse/fixtures/story_update_add_github_pull_request_with_comment.json
+++ b/zerver/webhooks/clubhouse/fixtures/story_update_add_github_pull_request_with_comment.json
@@ -1,0 +1,32 @@
+{
+    "id": "6071f11a-1681-41f8-afa8-fd24ae747a5d",
+    "changed_at": "2021-04-10T18:40:26.876Z",
+    "version": "v1",
+    "primary_id": 500000032,
+    "actions": [
+        {
+        "id": 500000032,
+        "entity_type": "pull-request",
+        "action": "comment",
+        "number": 2,
+        "title": "Two",
+        "url": "https://github.com/PIG208/test-clubhouse/pull/2"
+        },
+        {
+        "id": 15,
+        "entity_type": "story",
+        "action": "update",
+        "name": "asd2",
+        "story_type": "bug",
+        "app_url": "https://app.clubhouse.io/pig208/story/15",
+        "changes":
+            {
+            "pull_request_ids": {
+            "adds": [
+                500000032
+            ]
+            }
+            }
+        }
+    ]
+  }

--- a/zerver/webhooks/clubhouse/fixtures/story_update_add_github_pull_request_without_workflow_state.json
+++ b/zerver/webhooks/clubhouse/fixtures/story_update_add_github_pull_request_without_workflow_state.json
@@ -1,0 +1,55 @@
+{
+    "changed_at":"2019-01-24T02:18:20.031Z",
+    "primary_id":500000035,
+    "references":[
+        {
+            "id":500000010,
+            "entity_type":"workflow-state",
+            "name":"Ready for Review",
+            "type":"started"
+        },
+        {
+            "id":500000008,
+            "entity_type":"workflow-state",
+            "name":"Unscheduled",
+            "type":"unstarted"
+        }
+    ],
+    "actions":[
+        {
+            "id":500000035,
+            "entity_type":"pull-request",
+            "action":"create",
+            "number":10,
+            "title":"Testing pull requests with Story",
+            "url":"https://github.com/eeshangarg/Scheduler/pull/10"
+        },
+        {
+            "id":28,
+            "entity_type":"story",
+            "action":"update",
+            "name":"Testing pull requests with Story",
+            "story_type":"feature",
+            "app_url":"https://app.clubhouse.io/zulip/story/28",
+            "changes":{
+                "started":{
+                    "new":true,
+                    "old":false
+                },
+                "pull_request_ids": {
+                    "adds": [
+                        500000035
+                    ]
+                },
+                "started_at":{
+                    "new":"2019-01-24T02:18:20Z"
+                }
+            }
+        }
+    ],
+    "member_id":"5b1fda16-626f-487f-9ecf-f3a4abf42b8b",
+    "external_id":"50e81c40-1f7e-11e9-8645-17f96d5e1138",
+    "id":"5c49206c-506f-4312-a1b1-b1b8bfccbc9b",
+    "version":"v1",
+    "webhook_id":"5c491814-1d65-44c4-92af-aece6fc41092"
+}

--- a/zerver/webhooks/clubhouse/fixtures/story_update_add_multiple_labels.json
+++ b/zerver/webhooks/clubhouse/fixtures/story_update_add_multiple_labels.json
@@ -1,0 +1,37 @@
+{
+    "id":"5c37d3a3-6e3d-4b17-963c-adfa0a023d84",
+    "changed_at":"2019-01-10T23:22:11.694Z",
+    "primary_id":23,
+    "version":"v1",
+    "member_id":"5b1fda16-626f-487f-9ecf-f3a4abf42b8b",
+    "actions":[
+        {
+            "id":23,
+            "entity_type":"story",
+            "action":"update",
+            "name":"An epic story!",
+            "story_type":"feature",
+            "app_url":"https://app.clubhouse.io/zulip/story/23",
+            "changes":{
+                "label_ids":{
+                    "adds":[
+                        18,
+                        19
+                    ]
+                }
+            }
+        }
+    ],
+    "references":[
+        {
+            "id":18,
+            "entity_type":"label",
+            "name":"mockup"
+        },
+        {
+            "id":19,
+            "entity_type":"label",
+            "name":"label"
+        }
+    ]
+}

--- a/zerver/webhooks/clubhouse/fixtures/story_update_everything_at_once.json
+++ b/zerver/webhooks/clubhouse/fixtures/story_update_everything_at_once.json
@@ -1,0 +1,233 @@
+{
+  "id": "60723fdc-2c6d-4b31-b160-ef4d438dc5bc",
+  "changed_at": "2021-04-11T00:16:28.845Z",
+  "version": "v1",
+  "member_id": "6071752f-e16e-4f79-b41e-7c78b76aa4bd",
+  "actions": [
+    {
+      "id": 17,
+      "entity_type": "story",
+      "action": "update",
+      "name": "asd4",
+      "story_type": "bug",
+      "app_url": "https://app.clubhouse.io/pig208/story/17",
+      "changes": {
+        "story_type": {
+          "new": "bug",
+          "old": "feature"
+        },
+        "epic_id": {
+          "new": 23,
+          "old": 29
+        },
+        "requested_by_id": {
+          "new": "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae",
+          "old": "6071752f-e16e-4f79-b41e-7c78b76aa4bd"
+        },
+        "label_ids": {
+          "adds": [
+            8
+          ]
+        },
+        "group_id": {
+          "new": "6071adb0-641f-46c4-b5e1-4945dae399ea",
+          "old": "6071752f-ece0-4772-854c-05a9666c480f"
+        },
+        "workflow_state_id": {
+          "new": 500000010,
+          "old": 500000006
+        },
+        "follower_ids": {
+          "adds": [
+            "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae"
+          ]
+        },
+        "owner_ids": {
+          "adds": [
+            "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae"
+          ]
+        },
+        "position": {
+          "new": 42147811328,
+          "old": 32147483648
+        },
+        "project_id": {
+          "new": 28,
+          "old": 2
+        },
+        "deadline": {
+          "new": "2021-04-12T16:00:00Z",
+          "old": "2021-04-11T16:00:00Z"
+        }
+      }
+    },
+    {
+      "id": 26,
+      "entity_type": "story",
+      "action": "update",
+      "name": "new1",
+      "story_type": "bug",
+      "app_url": "https://app.clubhouse.io/pig208/story/26",
+      "changes": {
+        "story_type": {
+          "new": "bug",
+          "old": "feature"
+        },
+        "epic_id": {
+          "new": 23,
+          "old": 29
+        },
+        "requested_by_id": {
+          "new": "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae",
+          "old": "6071752f-e16e-4f79-b41e-7c78b76aa4bd"
+        },
+        "label_ids": {
+          "adds": [
+            8
+          ]
+        },
+        "group_id": {
+          "new": "6071adb0-641f-46c4-b5e1-4945dae399ea",
+          "old": "6071752f-ece0-4772-854c-05a9666c480f"
+        },
+        "workflow_state_id": {
+          "new": 500000010,
+          "old": 500000006
+        },
+        "follower_ids": {
+          "adds": [
+            "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae"
+          ]
+        },
+        "owner_ids": {
+          "adds": [
+            "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae"
+          ]
+        },
+        "position": {
+          "new": 42147942400,
+          "old": 32147680256
+        },
+        "project_id": {
+          "new": 28,
+          "old": 2
+        },
+        "deadline": {
+          "new": "2021-04-12T16:00:00Z",
+          "old": "2021-04-11T16:00:00Z"
+        }
+      }
+    },
+    {
+      "id": 27,
+      "entity_type": "story",
+      "action": "update",
+      "name": "new2",
+      "story_type": "bug",
+      "app_url": "https://app.clubhouse.io/pig208/story/27",
+      "changes": {
+        "story_type": {
+          "new": "bug",
+          "old": "feature"
+        },
+        "epic_id": {
+          "new": 23,
+          "old": 29
+        },
+        "requested_by_id": {
+          "new": "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae",
+          "old": "6071752f-e16e-4f79-b41e-7c78b76aa4bd"
+        },
+        "label_ids": {
+          "adds": [
+            8
+          ]
+        },
+        "group_id": {
+          "new": "6071adb0-641f-46c4-b5e1-4945dae399ea",
+          "old": "6071752f-ece0-4772-854c-05a9666c480f"
+        },
+        "workflow_state_id": {
+          "new": 500000010,
+          "old": 500000006
+        },
+        "follower_ids": {
+          "adds": [
+            "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae"
+          ]
+        },
+        "owner_ids": {
+          "adds": [
+            "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae"
+          ]
+        },
+        "position": {
+          "new": 42147876864,
+          "old": 32147614720
+        },
+        "project_id": {
+          "new": 28,
+          "old": 2
+        },
+        "deadline": {
+          "new": "2021-04-12T16:00:00Z",
+          "old": "2021-04-11T16:00:00Z"
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "id": "6071752f-ece0-4772-854c-05a9666c480f",
+      "entity_type": "group",
+      "name": "Team 1"
+    },
+    {
+      "id": 500000010,
+      "entity_type": "workflow-state",
+      "name": "Ready for Review",
+      "type": "started"
+    },
+    {
+      "id": 500000006,
+      "entity_type": "workflow-state",
+      "name": "In Development",
+      "type": "started"
+    },
+    {
+      "id": 8,
+      "entity_type": "label",
+      "name": "low priority",
+      "app_url": "https://app.clubhouse.io/pig208/label/8"
+    },
+    {
+      "id": 23,
+      "entity_type": "epic",
+      "name": "testeipc",
+      "app_url": "https://app.clubhouse.io/pig208/epic/23"
+    },
+    {
+      "id": 2,
+      "entity_type": "project",
+      "name": "Product Development",
+      "app_url": "https://app.clubhouse.io/pig208/project/2"
+    },
+    {
+      "id": "6071adb0-641f-46c4-b5e1-4945dae399ea",
+      "entity_type": "group",
+      "name": "team2"
+    },
+    {
+      "id": 29,
+      "entity_type": "epic",
+      "name": "epic",
+      "app_url": "https://app.clubhouse.io/pig208/epic/29"
+    },
+    {
+      "id": 28,
+      "entity_type": "project",
+      "name": "test2",
+      "app_url": "https://app.clubhouse.io/pig208/project/28"
+    }
+  ]
+}

--- a/zerver/webhooks/clubhouse/fixtures/story_update_multiple_at_once.json
+++ b/zerver/webhooks/clubhouse/fixtures/story_update_multiple_at_once.json
@@ -1,0 +1,133 @@
+{
+  "id": "60723fdc-2c6d-4b31-b160-ef4d438dc5bc",
+  "changed_at": "2021-04-11T00:16:28.845Z",
+  "version": "v1",
+  "member_id": "6071752f-e16e-4f79-b41e-7c78b76aa4bd",
+  "actions": [
+    {
+      "id": 17,
+      "entity_type": "story",
+      "action": "update",
+      "name": "asd4",
+      "story_type": "bug",
+      "app_url": "https://app.clubhouse.io/pig208/story/17",
+      "changes": {
+        "story_type": {
+          "new": "bug",
+          "old": "feature"
+        }
+      }
+    },
+    {
+      "id": 26,
+      "entity_type": "story",
+      "action": "update",
+      "name": "new1",
+      "story_type": "bug",
+      "app_url": "https://app.clubhouse.io/pig208/story/26",
+      "changes": {
+        "epic_id": {
+          "new": 23,
+          "old": 29
+        }
+      }
+    },
+    {
+      "id": 27,
+      "entity_type": "story",
+      "action": "update",
+      "name": "new2",
+      "story_type": "bug",
+      "app_url": "https://app.clubhouse.io/pig208/story/27",
+      "changes": {
+        "label_ids": {
+          "adds": [
+            8
+          ]
+        }
+      }
+    },
+    {
+      "id": 28,
+      "entity_type": "story",
+      "action": "update",
+      "name": "new3",
+      "story_type": "bug",
+      "app_url": "https://app.clubhouse.io/pig208/story/28",
+      "changes": {
+        "workflow_state_id": {
+          "new": 500000010,
+          "old": 500000006
+        }
+      }
+    },
+    {
+      "id": 29,
+      "entity_type": "story",
+      "action": "update",
+      "name": "new4",
+      "story_type": "bug",
+      "app_url": "https://app.clubhouse.io/pig208/story/29",
+      "changes": {
+        "project_id": {
+          "new": 28,
+          "old": 2
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "id": "6071752f-ece0-4772-854c-05a9666c480f",
+      "entity_type": "group",
+      "name": "Team 1"
+    },
+    {
+      "id": 500000010,
+      "entity_type": "workflow-state",
+      "name": "Ready for Review",
+      "type": "started"
+    },
+    {
+      "id": 500000006,
+      "entity_type": "workflow-state",
+      "name": "In Development",
+      "type": "started"
+    },
+    {
+      "id": 8,
+      "entity_type": "label",
+      "name": "low priority",
+      "app_url": "https://app.clubhouse.io/pig208/label/8"
+    },
+    {
+      "id": 23,
+      "entity_type": "epic",
+      "name": "testeipc",
+      "app_url": "https://app.clubhouse.io/pig208/epic/23"
+    },
+    {
+      "id": 2,
+      "entity_type": "project",
+      "name": "Product Development",
+      "app_url": "https://app.clubhouse.io/pig208/project/2"
+    },
+    {
+      "id": "6071adb0-641f-46c4-b5e1-4945dae399ea",
+      "entity_type": "group",
+      "name": "team2"
+    },
+    {
+      "id": 29,
+      "entity_type": "epic",
+      "name": "epic",
+      "app_url": "https://app.clubhouse.io/pig208/epic/29"
+    },
+    {
+      "id": 28,
+      "entity_type": "project",
+      "name": "test2",
+      "app_url": "https://app.clubhouse.io/pig208/project/28"
+    }
+  ]
+}

--- a/zerver/webhooks/clubhouse/fixtures/story_update_multiple_not_supported.json
+++ b/zerver/webhooks/clubhouse/fixtures/story_update_multiple_not_supported.json
@@ -1,0 +1,52 @@
+{
+  "id": "60723fdc-2c6d-4b31-b160-ef4d438dc5bc",
+  "changed_at": "2021-04-11T00:16:28.845Z",
+  "version": "v1",
+  "member_id": "6071752f-e16e-4f79-b41e-7c78b76aa4bd",
+  "actions": [
+    {
+      "id": 17,
+      "entity_type": "story",
+      "action": "update",
+      "name": "asd4",
+      "story_type": "bug",
+      "app_url": "https://app.clubhouse.io/pig208/story/17",
+      "changes": {
+        "deadline": {
+          "new": "2021-04-12T16:00:00Z",
+          "old": "2021-04-11T16:00:00Z"
+        }
+      }
+    },
+    {
+      "id": 26,
+      "entity_type": "story",
+      "action": "update",
+      "name": "new1",
+      "story_type": "bug",
+      "app_url": "https://app.clubhouse.io/pig208/story/26",
+      "changes": {
+        "owner_ids": {
+          "adds": [
+            "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae"
+          ]
+        }
+      }
+    },
+    {
+      "id": 27,
+      "entity_type": "story",
+      "action": "update",
+      "name": "new2",
+      "story_type": "bug",
+      "app_url": "https://app.clubhouse.io/pig208/story/27",
+      "changes": {
+        "follower_ids": {
+          "adds": [
+            "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/zerver/webhooks/clubhouse/tests.py
+++ b/zerver/webhooks/clubhouse/tests.py
@@ -172,6 +172,10 @@ class ClubhouseWebhookTest(WebhookTestCase):
         expected_message = "The label **mockup** was added to the story [An epic story!](https://app.clubhouse.io/zulip/story/23)."
         self.check_webhook("story_update_add_label", "An epic story!", expected_message)
 
+    def test_story_label_multiple_added(self) -> None:
+        expected_message = "The labels **mockup**, **label** were added to the story [An epic story!](https://app.clubhouse.io/zulip/story/23)."
+        self.check_webhook("story_update_add_multiple_labels", "An epic story!", expected_message)
+
     def test_story_label_added_label_name_in_actions(self) -> None:
         expected_message = "The label **sad** was added to the story [An emotional story!](https://app.clubhouse.io/zulip/story/28)."
         self.check_webhook(

--- a/zerver/webhooks/clubhouse/tests.py
+++ b/zerver/webhooks/clubhouse/tests.py
@@ -121,7 +121,7 @@ class ClubhouseWebhookTest(WebhookTestCase):
         expected_message = "Task **A new task for this story** ([Add cool feature!](https://app.clubhouse.io/zulip/story/11)) was completed. :tada:"
         self.check_webhook("story_task_complete", "Add cool feature!", expected_message)
 
-    @patch("zerver.lib.webhooks.common.check_send_webhook_message")
+    @patch("zerver.webhooks.clubhouse.view.check_send_webhook_message")
     def test_story_task_incomplete_ignore(self, check_send_webhook_message_mock: MagicMock) -> None:
         payload = self.get_body("story_task_not_complete")
         result = self.client_post(self.url, payload, content_type="application/json")
@@ -159,7 +159,7 @@ class ClubhouseWebhookTest(WebhookTestCase):
         expected_message = "A file attachment `zuliprc` was added to the story [Add cool feature!](https://app.clubhouse.io/zulip/story/11)."
         self.check_webhook("story_update_add_attachment", "Add cool feature!", expected_message)
 
-    @patch("zerver.lib.webhooks.common.check_send_webhook_message")
+    @patch("zerver.webhooks.clubhouse.view.check_send_webhook_message")
     def test_story_file_attachment_removed_ignore(
         self, check_send_webhook_message_mock: MagicMock
     ) -> None:
@@ -178,7 +178,7 @@ class ClubhouseWebhookTest(WebhookTestCase):
             "story_update_add_label_name_in_action", "An emotional story!", expected_message
         )
 
-    @patch("zerver.lib.webhooks.common.check_send_webhook_message")
+    @patch("zerver.webhooks.clubhouse.view.check_send_webhook_message")
     def test_story_label_removed_ignore(self, check_send_webhook_message_mock: MagicMock) -> None:
         payload = self.get_body("story_update_remove_label")
         result = self.client_post(self.url, payload, content_type="application/json")
@@ -207,7 +207,7 @@ class ClubhouseWebhookTest(WebhookTestCase):
             "story_update_add_github_branch", "Testing pull requests with Story", expected_message
         )
 
-    @patch("zerver.lib.webhooks.common.check_send_webhook_message")
+    @patch("zerver.webhooks.clubhouse.view.check_send_webhook_message")
     def test_empty_post_request_body_ignore(
         self, check_send_webhook_message_mock: MagicMock
     ) -> None:
@@ -216,7 +216,7 @@ class ClubhouseWebhookTest(WebhookTestCase):
         self.assertFalse(check_send_webhook_message_mock.called)
         self.assert_json_success(result)
 
-    @patch("zerver.lib.webhooks.common.check_send_webhook_message")
+    @patch("zerver.webhooks.clubhouse.view.check_send_webhook_message")
     def test_story_comment_updated_ignore(self, check_send_webhook_message_mock: MagicMock) -> None:
         payload = self.get_body("story_comment_updated")
         result = self.client_post(self.url, payload, content_type="application/json")


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fix #18022

**Testing plan:** <!-- How have you tested? -->
It has been tested with existing tests in addition to more tests on handling requests with multiple stories.

#### Instead of ignoring one of the stories, the integration will now send messages to all of them
![image](https://user-images.githubusercontent.com/39874143/114289252-050fbc80-9aa9-11eb-9b0a-f811e67dc834.png)
![image](https://user-images.githubusercontent.com/39874143/114289258-0e992480-9aa9-11eb-91f9-76992a4880d6.png)
---
#### When the webhook is directed to a single topic with three PRs this time
![image](https://user-images.githubusercontent.com/39874143/114289300-6cc60780-9aa9-11eb-8934-8198bdbc1709.png)
---
#### When updating multiple stories at the same time
![image](https://user-images.githubusercontent.com/39874143/114328449-3fdc2800-9b6f-11eb-965e-54a7e09fce37.png)
---
#### When updating multiple stories at the same time, but only one change is made for each story
![image](https://user-images.githubusercontent.com/39874143/114330977-89c80c80-9b75-11eb-8e4d-5e18eb700ff2.png)