### PR TITLE
compose: Fix bug in draft when stream or topic is not set.

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -187,7 +187,7 @@ export function restore_draft(draft_id) {
     const compose_args = restore_message(draft);
 
     if (compose_args.type === "stream") {
-        if (draft.stream !== "") {
+        if (draft.stream !== "" && draft.topic !== "") {
             narrow.activate(
                 [
                     {operator: "stream", operand: compose_args.stream},

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -208,10 +208,6 @@ export function restore_draft(draft_id) {
     overlays.close_overlay("drafts");
     compose_fade.clear_compose();
     compose.clear_preview_area();
-
-    if (draft.type === "stream" && draft.stream === "") {
-        compose_args.topic = "";
-    }
     compose_actions.start(compose_args.type, compose_args);
     compose_ui.autosize_textarea($("#compose-textarea"));
     $("#compose-textarea").data("draft-id", draft_id);


### PR DESCRIPTION
Fixes #18052
In issue #18052, it got suggested that we don't narrow when the topic is not set, but I think when the stream is set and the topic is not, we should at least narrow to the stream. So this PR implementation narrows to the stream if only stream is set.


**Testing plan:** <!-- How have you tested? -->
Tested Manually by creating drafts, also ran automated tests locally.

GIF:
1. When the stream is set but the topic is not. We don't navigate at all.

![Screen Recording 2021-04-13 at 22 43 23](https://user-images.githubusercontent.com/70478296/114597593-9439f180-9cae-11eb-8b12-6b853a7fd475.gif)

2. Now when the topic is set but stream not. Topic doesn't disappear.

![Screen Recording 2021-04-12 at 21 09 38](https://user-images.githubusercontent.com/70478296/114423654-03dbae00-9bd5-11eb-986b-f93dcfa19b33.gif)
3. When both topic and stream not set. We don't narrow.

![Screen Recording 2021-04-12 at 21 07 39](https://user-images.githubusercontent.com/70478296/114424680-fd016b00-9bd5-11eb-85b3-6ee8a08f3ed5.gif)

