### PR TITLE
api: Add max_message_length field along with others in ZFL 53.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -13,7 +13,7 @@ below features are supported.
 **Feature level 53**
 
 * [`POST /register`](/api/register-queue): Added `max_topic_length`
-  and renamed `max_stream_name_length` and
+  and `max_message_length`, and renamed `max_stream_name_length` and
   `max_stream_description_length` to allow clients to transparently
   support these values changing in a future server version.
 

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -49,6 +49,7 @@ from zerver.lib.user_mutes import get_user_mutes
 from zerver.lib.user_status import get_user_info_dict
 from zerver.lib.users import get_cross_realm_dicts, get_raw_user_data, is_administrator_role
 from zerver.models import (
+    MAX_MESSAGE_LENGTH,
     MAX_TOPIC_NAME_LENGTH,
     Client,
     CustomProfileField,
@@ -254,6 +255,7 @@ def fetch_initial_state_data(
         state["max_stream_name_length"] = Stream.MAX_NAME_LENGTH
         state["max_stream_description_length"] = Stream.MAX_DESCRIPTION_LENGTH
         state["max_topic_length"] = MAX_TOPIC_NAME_LENGTH
+        state["max_message_length"] = MAX_MESSAGE_LENGTH
 
     if want("realm_domains"):
         state["realm_domains"] = get_realm_domains(realm)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6920,6 +6920,17 @@ paths:
 
                           **Changes**: New in Zulip 4.0 (feature level 53).  Previously,
                           this always had value 60.
+                      max_message_length:
+                        type: integer
+                        description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
+                          The maximum allowed length for a message.  Clients should use
+                          these properties rather than hardcoding field sizes, as they may
+                          change in a future Zulip release.
+
+                          **Changes**: New in Zulip 4.0 (feature level 53).  Previously,
+                          this always had value 10000.
                       muted_topics:
                         type: array
                         description: |

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -106,6 +106,7 @@ class HomeTest(ZulipTestCase):
         "max_icon_file_size",
         "max_logo_file_size",
         "max_message_id",
+        "max_message_length",
         "max_stream_description_length",
         "max_stream_name_length",
         "max_topic_length",


### PR DESCRIPTION
Commit 4a3ad0d introduced some extra stream-level parameters
to the `realm` object. This commit extends that to add a
max_message_length paramter too in the same server_level.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** Tested locally




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
