### PR TITLE
left-sidebar: Subscribe to new streams row visibility.

### DIFF
--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -42,8 +42,12 @@ function get_new_heights() {
     const res = {};
     const viewport_height = message_viewport.height();
     const top_navbar_height = $("#top_navbar").safeOuterHeight(true);
+    const navbar_alerts_height = $("#panels").safeOuterHeight(true) || 0;
     const invite_user_link_height = $("#invite-user-link").safeOuterHeight(true) || 0;
-    const add_streams_link_height = $("#add-stream-link").safeOuterHeight(true) || 0;
+
+    // Change add_stream_link height by adding navbar_alerts height
+    const add_streams_link_height =
+        ($("#add-stream-link").safeOuterHeight(true) || 0) + navbar_alerts_height;
 
     res.bottom_whitespace_height = viewport_height * 0.4;
 


### PR DESCRIPTION
subscribe to new stream row not visible
due to navbar alerts. Add height of alert navbar
to stream link height.

Fixes: #18095

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

- Manual testing



**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
After fix:

![Screenshot (22)](https://user-images.githubusercontent.com/57071700/114343951-9308a780-9b7c-11eb-9e46-9b327fc915ef.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
