### PR TITLE
draft: Fix edit button not working in the draft overlay.

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -364,7 +364,7 @@ export function launch() {
     }
 
     function setup_event_handlers() {
-        $(".restore-draft").on("click", function (e) {
+        $(".restore-draft, .edit-draft").on("click", function (e) {
             if (document.getSelection().type === "Range") {
                 return;
             }

--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -115,7 +115,8 @@
                 right: 0;
             }
 
-            .restore-draft {
+            .restore-draft,
+            .edit-draft {
                 cursor: pointer;
                 margin-right: 5px;
                 color: hsl(170, 48%, 54%);


### PR DESCRIPTION

[Link to CZO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/draft.20edit.20button.20not.20working.20in.20CZO).

This bug was introduced in 9c2ec9d7d7 because the
edit-button selector (in draft overlay) was changed from
`restore-draft` to `edit-draft`, but it's corresponding
code was not updated.



This PR fixes that and also fixes its styles.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested it locally on the dev server.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
