### PR TITLE
bots settings: Stop modal from getting closed when error is shown.

### DIFF
--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -542,7 +542,6 @@ export function set_up() {
                         loading.destroy_indicator(spinner);
                         edit_button.show();
                         errors.text(JSON.parse(xhr.responseText).msg).show();
-                        overlays.close_modal("#edit_bot_modal");
                     },
                 });
             },

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -825,6 +825,10 @@ input[type="checkbox"] {
     font-weight: 400;
 }
 
+.bot_edit_errors {
+    margin: 20px 20px 0 20px;
+}
+
 #bots_lists_navbar .active a {
     background-color: hsl(0, 0%, 98%);
 }

--- a/static/templates/edit_bot.hbs
+++ b/static/templates/edit_bot.hbs
@@ -18,7 +18,7 @@
                   list_placeholder=(t 'Filter users')
                   reset_button_text=(t '[Remove owner]')}}
             </div>
-            <div class="">
+            <div class="edit-bot-name">
                 <label for="edit_bot_name">{{t "Full name" }}</label>
                 <input id="edit_bot_name" type="text" name="bot_name" class="edit_bot_name required" value="{{bot.full_name}}" maxlength=50 />
                 <div><label for="edit_bot_name" generated="true" class="text-error"></label></div>
@@ -38,7 +38,7 @@
     <div>
         <div class="modal-footer">
             <div class="edit_bot_spinner"></div>
-            <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
+            <button class="button white rounded cancel_bot_button" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
             <input type="submit" class="button rounded sea-green edit_bot_button" value="{{t 'Save' }}" />
         </div>
     </div>


### PR DESCRIPTION
This commit fixes the issue of the error message not getting displayed when the `Full name` field, in bots settings, is given a duplicate name of an already created bot with the same name.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #18091.

**Testing plan:** <!-- How have you tested? -->
Added new test in the 2nd commit.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![bots settings modal](https://user-images.githubusercontent.com/67277428/114450320-7ce9fe00-9bf3-11eb-81b7-b4addd2f431a.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
