### PR TITLE
mypy: Fix strict_equality violations

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,15 +7,23 @@ show_traceback = True
 mypy_path = $MYPY_CONFIG_FILE_DIR/stubs
 cache_dir = $MYPY_CONFIG_FILE_DIR/var/mypy-cache
 
-# Options to make the checking stricter.
-check_untyped_defs = True
-disallow_untyped_defs = True
+# These are all the options that would be enabled by mypy --strict, in
+# the order listed by the mypy --help documentation of --strict.  We
+# do not yet enable all of them.
+warn_unused_configs = True
 disallow_any_generics = True
-warn_no_return = True
-strict_optional = True
+disallow_subclassing_any = False
+disallow_untyped_calls = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = False
 no_implicit_optional = True
 warn_redundant_casts = True
 warn_unused_ignores = True
+warn_return_any = False
+no_implicit_reexport = False
+strict_equality = False
 
 # Display the codes needed for # type: ignore[code] annotations.
 show_error_codes = True

--- a/puppet/zulip/files/nagios_plugins/zulip_postgresql/check_postgresql_replication_lag
+++ b/puppet/zulip/files/nagios_plugins/zulip_postgresql/check_postgresql_replication_lag
@@ -95,7 +95,7 @@ else:
     replication_info = run_sql_query(
         "client_addr, state, sent_lsn, write_lsn, flush_lsn, replay_lsn from pg_stat_replication"
     )
-    if replication_info == 0:
+    if not replication_info:
         report("CRITICAL", "No replicas!")
     elif len(replication_info) == 1:
         report("WARNING", "Only one replica!")

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -849,7 +849,7 @@ Output:
         self.assertNotEqual(json["msg"], "Error parsing JSON in response!")
         return json
 
-    def get_json_error(self, result: HttpResponse, status_code: int = 400) -> Dict[str, Any]:
+    def get_json_error(self, result: HttpResponse, status_code: int = 400) -> str:
         try:
             json = orjson.loads(result.content)
         except orjson.JSONDecodeError:  # nocoverage

--- a/zerver/management/commands/edit_linkifiers.py
+++ b/zerver/management/commands/edit_linkifiers.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from zerver.lib.actions import do_add_linkifier, do_remove_linkifier
 from zerver.lib.management import CommandError, ZulipBaseCommand
-from zerver.models import all_linkifiers_for_installation
+from zerver.models import linkifiers_for_realm
 
 
 class Command(ZulipBaseCommand):
@@ -41,7 +41,7 @@ Example: ./manage.py realm_filters --realm=zulip --op=show
         realm = self.get_realm(options)
         assert realm is not None  # Should be ensured by parser
         if options["op"] == "show":
-            print(f"{realm.string_id}: {all_linkifiers_for_installation().get(realm.id, [])}")
+            print(f"{realm.string_id}: {linkifiers_for_realm(realm.id)}")
             sys.exit(0)
 
         pattern = options["pattern"]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3,13 +3,11 @@ import datetime
 import re
 import secrets
 import time
-from collections import defaultdict
 from datetime import timedelta
 from typing import (
     AbstractSet,
     Any,
     Callable,
-    DefaultDict,
     Dict,
     Iterable,
     List,
@@ -928,20 +926,6 @@ def linkifiers_for_realm_remote_cache(realm_id: int) -> List[LinkifierDict]:
     filters = []
     for linkifier in RealmFilter.objects.filter(realm_id=realm_id):
         filters.append(
-            LinkifierDict(
-                pattern=linkifier.pattern,
-                url_format=linkifier.url_format_string,
-                id=linkifier.id,
-            )
-        )
-
-    return filters
-
-
-def all_linkifiers_for_installation() -> Dict[int, List[LinkifierDict]]:
-    filters: DefaultDict[int, List[LinkifierDict]] = defaultdict(list)
-    for linkifier in RealmFilter.objects.all():
-        filters[linkifier.realm_id].append(
             LinkifierDict(
                 pattern=linkifier.pattern,
                 url_format=linkifier.url_format_string,

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -45,7 +45,6 @@ from zerver.lib.message import render_markdown
 from zerver.lib.request import JsonableError
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.tex import render_tex
-from zerver.lib.types import LinkifierDict
 from zerver.lib.user_groups import create_user_group
 from zerver.models import (
     MAX_MESSAGE_LENGTH,
@@ -1418,30 +1417,6 @@ class MarkdownTest(ZulipTestCase):
                 {"url": "https://trac.example.com/ticket/ABC-123", "text": "ABC-123"},
                 {"url": "https://other-trac.example.com/ticket/ABC-123", "text": "ABC-123"},
             ],
-        )
-
-    def test_maybe_update_markdown_engines(self) -> None:
-        realm = get_realm("zulip")
-        url_format_string = r"https://trac.example.com/ticket/%(id)s"
-        linkifier = RealmFilter(
-            realm=realm, pattern=r"#(?P<id>[0-9]{2,8})", url_format_string=url_format_string
-        )
-        linkifier.save()
-
-        import zerver.lib.markdown
-
-        zerver.lib.markdown.linkifier_data = {}
-        maybe_update_markdown_engines(None, False)
-        all_linkifiers = zerver.lib.markdown.linkifier_data
-        zulip_linkifiers = all_linkifiers[realm.id]
-        self.assertEqual(len(zulip_linkifiers), 1)
-        self.assertDictEqual(
-            zulip_linkifiers[0],
-            LinkifierDict(
-                pattern="#(?P<id>[0-9]{2,8})",
-                url_format="https://trac.example.com/ticket/%(id)s",
-                id=linkifier.id,
-            ),
         )
 
     def test_flush_linkifier(self) -> None:


### PR DESCRIPTION
```
puppet/zulip/files/nagios_plugins/zulip_postgresql/check_postgresql_replication_lag:98: error: Non-overlapping equality check (left operand type: "List[List[str]]", right operand type: "Literal[0]")  [comparison-overlap]
zerver/lib/markdown/__init__.py:2585: error: Non-overlapping container check (element type: "int", container item type: "Tuple[int, bool]")  [comparison-overlap]
zerver/tests/test_realm.py:650: error: Non-overlapping container check (element type: "Dict[str, Any]", container item type: "str")  [comparison-overlap]
```