### PR TITLE
Allow outgoing webhook to add reaction when sending a response without additional calls to the REST API.

### DIFF
--- a/templates/zerver/api/outgoing-webhooks.md
+++ b/templates/zerver/api/outgoing-webhooks.md
@@ -89,9 +89,37 @@ you would like to send a response message:
 
 The `content` field should contain Zulip-format Markdown.
 
+Here's an example of the JSON your server should respond with if
+you would like to add emoji reactions to the message that triggered the
+outgoing webhook:
+```
+{
+    "reactions": [
+        {"emoji_name": "wave"},
+        {"emoji_name": "smile"},
+    ]
+}
+```
+
+You can also specify `emoji_code` and `reaction_type` for each emoji,
+but they are not required. The API documentation for [adding an emoji
+reaction](/api/add-reaction#parameters) has more details about
+supported parameters.
+
+Here's an example of the JSON your server should respond with if
+you would like to send a response message and add reactions:
+```
+{
+    "content": "Hey, we just received **something** from Zulip!"
+    "reactions": [
+        {"emoji_name": "wave"}
+    ]
+}
+```
+
 Note that an outgoing webhook bot can use the [Zulip REST
 API](/api/rest) with its API key in case your bot needs to do
-something else, like add an emoji reaction or upload a file.
+something else, like editing a message or uploading a file.
 
 ## Slack-format webhook format
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes: #12811

**Testing plan:** <!-- How have you tested? -->
It has been tested both manually and with automated tests.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
This introduces a new format for response messages for outgoing webhooks:
```json
{
  "reactions": [
    {"emoji_name": "wave"}
  ]
}
```
It also works with `content`:
```json
{
  "content": "test",
  "reactions": [
    {"emoji_name": "wave"}
  ]
}
```
Responding with two emoji reactions along with a message:
![image](https://user-images.githubusercontent.com/39874143/114476115-3e246a00-9c2c-11eb-83db-0da7ffd8b0b5.png)
When the `emoji_name` field is missing in a specified emoji reaction:
![image](https://user-images.githubusercontent.com/39874143/114476076-2b119a00-9c2c-11eb-8a4e-8ae978686225.png)
Updated documentation for the API:
![image](https://user-images.githubusercontent.com/39874143/114475940-e38b0e00-9c2b-11eb-9df2-0bec154e4aa2.png)
Error messages;
![image](https://user-images.githubusercontent.com/39874143/114477444-be4bcf00-9c2e-11eb-92d4-d700662e3c02.png)
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
