### PR TITLE
drafts: Fix restore draft button

### DIFF
--- a/static/templates/draft.hbs
+++ b/static/templates/draft.hbs
@@ -32,7 +32,7 @@
                 <div class="messagebox-content">
                     <div class="message_top_line">
                         <div class="draft_controls">
-                            <i class="fa fa-pencil fa-lg edit-draft tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Restore draft' }}"></i>
+                            <i class="fa fa-pencil fa-lg restore-draft tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Restore draft' }}"></i>
                             <i class="fa fa-trash-o fa-lg delete-draft tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Delete draft' }} (Backspace)"></i>
                         </div>
                     </div>


### PR DESCRIPTION
It was broken by commit 9c2ec9d7d7558b2acc16bbae696e6765744203f4 (#17434).

I noticed #18103 after opening this, but this seems simpler as it doesn’t look like the change to the completely blank `edit-draft` class was intentional.

**Testing plan:** Make a draft, click the restore draft button.