### PR TITLE
tests: Refactor check_has_permission_polices to check for all user roles for each policy value.

### DIFF
--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1233,12 +1233,11 @@ class InviteUserTest(InviteUserBase):
         self.check_sent_emails([email, email2], custom_from_name="Hamlet")
 
     def test_can_invite_others_to_realm(self) -> None:
-        othello = self.example_user("othello")
+        def validation_func(user_profile: UserProfile) -> bool:
+            user_profile.refresh_from_db()
+            return user_profile.can_invite_others_to_realm()
 
-        def validation_func() -> bool:
-            return othello.can_invite_others_to_realm()
-
-        self.check_has_permission_policies(othello, "invite_to_realm_policy", validation_func)
+        self.check_has_permission_policies("invite_to_realm_policy", validation_func)
 
     def test_invite_others_to_realm_setting(self) -> None:
         """

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3352,12 +3352,11 @@ class SubscriptionAPITest(ZulipTestCase):
         self.common_subscribe_to_streams(user_profile, ["new_stream3"])
 
     def test_can_create_streams(self) -> None:
-        othello = self.example_user("othello")
+        def validation_func(user_profile: UserProfile) -> bool:
+            user_profile.refresh_from_db()
+            return user_profile.can_create_streams()
 
-        def validation_func() -> bool:
-            return othello.can_create_streams()
-
-        self.check_has_permission_policies(othello, "create_stream_policy", validation_func)
+        self.check_has_permission_policies("create_stream_policy", validation_func)
 
     def test_user_settings_for_subscribing_other_users(self) -> None:
         """
@@ -3454,12 +3453,12 @@ class SubscriptionAPITest(ZulipTestCase):
         You can't subscribe other people to streams if you are a guest or your account is not old
         enough.
         """
-        othello = self.example_user("othello")
 
-        def validation_func() -> bool:
-            return othello.can_subscribe_other_users()
+        def validation_func(user_profile: UserProfile) -> bool:
+            user_profile.refresh_from_db()
+            return user_profile.can_subscribe_other_users()
 
-        self.check_has_permission_policies(othello, "invite_to_stream_policy", validation_func)
+        self.check_has_permission_policies("invite_to_stream_policy", validation_func)
 
     def test_subscriptions_add_invalid_stream(self) -> None:
         """


### PR DESCRIPTION
We refactor the check_has_permission_policies to check for all user
roles for each value of policy. This will help in handle a case where
a guest is allowed to do something but moderator isn't.

Also, we are passing user email to the validation_func because the
the realm object of user_profile is used in the actual has_permission
function and thus we need a latest user_profile object after changing
the policy each time.

This is a follow-up commit to 9a4c58cb (#18015).

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


<!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
