### PR TITLE
avatar: show loading animation while deleting profile picture.

### DIFF
--- a/static/js/avatar.js
+++ b/static/js/avatar.js
@@ -50,6 +50,18 @@ export function build_bot_edit_widget(target) {
     );
 }
 
+function display_avatar_delete_complete() {
+    $("#user-avatar-upload-widget .upload-spinner-background").css({visibility: "hidden"});
+    $("#user-avatar-upload-widget .image-upload-text").show();
+    $("#user-avatar-source").show();
+}
+
+function display_avatar_delete_started() {
+    $("#user-avatar-upload-widget .upload-spinner-background").css({visibility: "visible"});
+    $("#user-avatar-upload-widget .image-upload-text").hide();
+    $("#user-avatar-upload-widget .image-delete-button").hide();
+}
+
 export function build_user_avatar_widget(upload_function) {
     const get_file_input = function () {
         return $("#user-avatar-upload-widget .image_file_input").expectOne();
@@ -66,15 +78,20 @@ export function build_user_avatar_widget(upload_function) {
         e.preventDefault();
         e.stopPropagation();
         function delete_user_avatar() {
+            display_avatar_delete_started();
             channel.del({
                 url: "/json/users/me/avatar",
                 success() {
-                    $("#user-avatar-upload-widget .image-delete-button").hide();
-                    $("#user-avatar-source").show();
+                    display_avatar_delete_complete();
+
                     // Need to clear input because of a small edge case
                     // where you try to upload the same image you just deleted.
                     get_file_input().val("");
                     // Rest of the work is done via the user_events -> avatar_url event we will get
+                },
+                error() {
+                    display_avatar_delete_complete();
+                    $("#user-avatar-upload-widget .image-delete-button").show();
                 },
             });
         }


### PR DESCRIPTION
This commit displays the loading animation and hides other
avatar options as delete_user_avatar is called and as we get
response from the server, we show the options back and hide
the loading animation.

[CZO link here](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Bootstrap.20modal.20race.20condition/near/1161378)

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![user_avatar](https://user-images.githubusercontent.com/56730716/114612348-a8d2b580-9cbf-11eb-8677-c53c17bec1ae.gif)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested manually.



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
