### PR TITLE
lint: Remove custom // spacing rule

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -153,8 +153,6 @@ js_rules = RuleList(
             "pattern": "[\"']json/",
             "description": "Relative URL for JSON route not supported by i18n",
         },
-        # This rule is constructed with + to avoid triggering on itself
-        {"pattern": "^[ ]*//[A-Za-z0-9]", "description": "Missing space after // in comment"},
         {
             "pattern": r"""[.]text\(["'][a-zA-Z]""",
             "description": "Strings passed to $().text should be wrapped in i18n.t() for internationalization",


### PR DESCRIPTION
Commit 7f89cb953535c8358fd6a2c66dc1d8d4f2f736e2 (#17822) enabled the ESLint spaced-comment rule.