### PR TITLE
templates: Remove context argument from {{#tr}} block helper

### DIFF
--- a/docs/translating/internationalization.md
+++ b/docs/translating/internationalization.md
@@ -258,12 +258,11 @@ If you are passing a translated string to a Handlebars partial, you can use:
 The syntax for block strings or strings containing variables is:
 
 ```
-{{#tr context}}
+{{#tr}}
     Block of English text.
 {{/tr}}
 
-var context = {'variable': 'variable value'};
-{{#tr context}}
+{{#tr}}
     Block of English text with a {variable}.
 {{/tr}}
 ```

--- a/static/js/templates.js
+++ b/static/js/templates.js
@@ -59,25 +59,22 @@ Handlebars.registerHelper("t", (message) => {
     return intl.formatMessage(descriptor);
 });
 
-Handlebars.registerHelper("tr", function (context, options) {
+Handlebars.registerHelper("tr", function (options) {
     // Marks a block for translation.
     // Example usage 1:
-    //     {{#tr context}}
+    //     {{#tr}}
     //         <p>some English text</p>
     //     {{/tr}}
     //
     // Example usage 2:
-    //     {{#tr context}}
-    //         <p>This {variable} will get value from context</p>
+    //     {{#tr}}
+    //         <p>This {variable} will get value from the current context</p>
     //     {{/tr}}
     //
-    // Notes:
-    //     1. `context` is very important. It can be `this` or an
-    //        object or key of the current context.
-    //     2. Use `{` and `}` instead of `{{` and `}}` to declare
-    //        expressions.
+    // Note: use `{` and `}` instead of `{{` and `}}` to declare
+    // variables.
     const message = options
-        .fn(context)
+        .fn(this)
         .trim()
         .split("\n")
         .map((s) => s.trim())
@@ -92,7 +89,7 @@ Handlebars.registerHelper("tr", function (context, options) {
             ]),
         ),
         ...Object.fromEntries(
-            Object.entries(context ?? {}).map(([key, value]) => [
+            Object.entries(this ?? {}).map(([key, value]) => [
                 key,
                 Handlebars.Utils.escapeExpression(value),
             ]),

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -64,7 +64,7 @@
     <li>
         <a href="#" class="popover_mute_topic" data-msg-stream-id="{{stream_id}}" data-msg-topic="{{topic}}">
             <i class="fa fa-bell-slash" aria-hidden="true"></i>
-            {{#tr this}}Mute the topic <b>{topic}</b>{{/tr}} <span class="hotkey-hint">(M)</span>
+            {{#tr}}Mute the topic <b>{topic}</b>{{/tr}} <span class="hotkey-hint">(M)</span>
         </a>
     </li>
     {{/if}}
@@ -73,7 +73,7 @@
     <li>
         <a href="#" class="popover_unmute_topic" data-msg-stream-id="{{stream_id}}" data-msg-topic="{{topic}}">
             <i class="fa fa-bell" aria-hidden="true"></i>
-            {{#tr this}}Unmute the topic <b>{topic}</b>{{/tr}}
+            {{#tr}}Unmute the topic <b>{topic}</b>{{/tr}}
         </a>
     </li>
     {{/if}}
@@ -82,7 +82,7 @@
     <li>
         <a href="#" class="reaction_button" data-message-id="{{message_id}}">
             <i class="fa fa-smile-o" aria-hidden="true"></i>
-            {{#tr this}}Add emoji reaction{{/tr}}
+            {{#tr}}Add emoji reaction{{/tr}}
         </a>
     </li>
     {{/if}}

--- a/static/templates/all_messages_sidebar_actions.hbs
+++ b/static/templates/all_messages_sidebar_actions.hbs
@@ -4,7 +4,7 @@
         {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
         <a tabindex="0" id="mark_all_messages_as_read">
             <i class="fa fa-book" aria-hidden="true"></i>
-            {{#tr this}}Mark all messages as read{{/tr}}
+            {{#tr}}Mark all messages as read{{/tr}}
         </a>
     </li>
 </ul>

--- a/static/templates/announce_stream_docs.hbs
+++ b/static/templates/announce_stream_docs.hbs
@@ -1,7 +1,7 @@
 {{! Explanation of what "announce stream" does when creating a stream }}
 <div>
 
-    {{#tr this}}
+    {{#tr}}
     <p>Stream will be announced in <b>#{notifications_stream}</b>.</p>
     {{/tr}}
     <p>{{t 'Organization administrators can change this in the organization settings.' }}</p>

--- a/static/templates/archive_recipient_row.hbs
+++ b/static/templates/archive_recipient_row.hbs
@@ -5,7 +5,7 @@
             <a class="message_label_clickable narrows_by_recipient stream_label {{color_class}}"
               style="background: {{background_color}}; border-left-color: {{background_color}};"
               href="{{stream_url}}"
-              title="{{#tr this}}Narrow to stream &quot;{display_recipient}&quot;{{/tr}}">
+              title="{{#tr}}Narrow to stream &quot;{display_recipient}&quot;{{/tr}}">
                 {{display_recipient}}
             </a>
             {{! topic stuff }}
@@ -13,7 +13,7 @@
                 {{! topic link }}
                 <a class="message_label_clickable narrows_by_topic"
                   href="{{topic_url}}"
-                  title="{{#tr this}}Narrow to stream &quot;{display_recipient}&quot;, topic &quot;{topic}&quot;{{/tr}}">
+                  title="{{#tr}}Narrow to stream &quot;{display_recipient}&quot;, topic &quot;{topic}&quot;{{/tr}}">
                     {{topic}}
                 </a>
             </span>

--- a/static/templates/compose_all_everyone.hbs
+++ b/static/templates/compose_all_everyone.hbs
@@ -1,6 +1,6 @@
 <div class="compose-all-everyone">
     <span class="compose-all-everyone-msg">
-        {{#tr this}}
+        {{#tr}}
         Are you sure you want to mention all <strong>{count}</strong> people in this stream?
         <br>
         This will send email and mobile push notifications to most of those <strong>{count}</strong> users.

--- a/static/templates/compose_announce.hbs
+++ b/static/templates/compose_announce.hbs
@@ -1,6 +1,6 @@
 <div class="compose-announce">
     <span class="compose-announce-msg">
-        {{#tr this}}
+        {{#tr}}
         This stream is reserved for <strong>announcements</strong>.
         <br>
         Are you sure you want to message all <strong>{count}</strong> people in this stream?

--- a/static/templates/compose_invite_users.hbs
+++ b/static/templates/compose_invite_users.hbs
@@ -1,10 +1,10 @@
 <div class="compose_invite_user" data-user-id="{{user_id}}" data-stream-id="{{stream_id}}">
     {{#if can_subscribe_other_users}}
-    <p>{{#tr this}}<strong>{name}</strong> is not subscribed to this stream. They will not be notified unless you subscribe them.{{/tr}}</p>
+    <p>{{#tr}}<strong>{name}</strong> is not subscribed to this stream. They will not be notified unless you subscribe them.{{/tr}}</p>
     <div class="compose_invite_user_controls">
         <button class="btn btn-warning compose_invite_link" >{{t "Subscribe" }}</button><button type="button" class="compose_invite_close close">&times;</button>
     </div>
     {{else}}
-    <p>{{#tr this}}<strong>{name}</strong> is not subscribed to this stream. They will not be notified if you mention them.{{/tr}}</p>
+    <p>{{#tr}}<strong>{name}</strong> is not subscribed to this stream. They will not be notified if you mention them.{{/tr}}</p>
     {{/if}}
 </div>

--- a/static/templates/compose_not_subscribed.hbs
+++ b/static/templates/compose_not_subscribed.hbs
@@ -1,6 +1,6 @@
 <div class="compose_not_subscribed">
     <p>
-        {{#tr this}}
+        {{#tr}}
         You're not subscribed to this stream. You will not be notified if other users reply to your message.
         {{/tr}}
     </p>

--- a/static/templates/compose_private_stream_alert.hbs
+++ b/static/templates/compose_private_stream_alert.hbs
@@ -1,5 +1,5 @@
 <div class="compose_private_stream_alert" data-stream_name="{{stream_name}}">
-    <span>{{#tr this}}Warning: <strong>{stream_name}</strong> is a private stream.{{/tr}}</span>
+    <span>{{#tr}}Warning: <strong>{stream_name}</strong> is a private stream.{{/tr}}</span>
     <div class="compose_private_stream_alert_controls">
         <button type="button" class="compose_private_stream_alert_close close">&times;</button>
     </div>

--- a/static/templates/confirm_delete_user.hbs
+++ b/static/templates/confirm_delete_user.hbs
@@ -1,5 +1,5 @@
 <p>
-    {{#tr this}}
+    {{#tr}}
     Are you sure you want to delete <b>{group_name}</b>?
     {{/tr}}
 </p>

--- a/static/templates/confirm_delete_user_avatar.hbs
+++ b/static/templates/confirm_delete_user_avatar.hbs
@@ -1,5 +1,5 @@
 <p>
-    {{#tr this}}
+    {{#tr}}
     Are you sure you want to delete your profile picture?
     {{/tr}}
 </p>

--- a/static/templates/confirm_unstar_all_messages.hbs
+++ b/static/templates/confirm_unstar_all_messages.hbs
@@ -1,5 +1,5 @@
 <p>
-    {{#tr this}}
+    {{#tr}}
     Would you like to unstar all starred messages?  This action cannot be undone.
     {{/tr}}
 </p>

--- a/static/templates/confirm_unstar_all_messages_in_topic.hbs
+++ b/static/templates/confirm_unstar_all_messages_in_topic.hbs
@@ -1,5 +1,5 @@
 <p>
-    {{#tr this}}
+    {{#tr}}
     Are you sure you want to unstar all messages in topic <b>{topic}</b>?  This action cannot be undone.
     {{/tr}}
 </p>

--- a/static/templates/delete_topic_modal.hbs
+++ b/static/templates/delete_topic_modal.hbs
@@ -7,7 +7,7 @@
         </h3>
     </div>
     <div class="modal-body">
-        <p>{{#tr this}}Are you sure you want to permanently delete <b>{topic_name}</b>?{{/tr}}</p>
+        <p>{{#tr}}Are you sure you want to permanently delete <b>{topic_name}</b>?{{/tr}}</p>
         <p>{{t "Deleting a topic will immediately remove it and its messages for everyone. Other users may find this confusing, especially if they had received an email or push notification related to the deleted messages." }}</p>
     </div>
     <div class="modal-footer">

--- a/static/templates/draft.hbs
+++ b/static/templates/draft.hbs
@@ -20,7 +20,7 @@
         <div class="message_header message_header_private_message dark_background">
             <div class="message-header-contents">
                 <div class="message_label_clickable stream_label">
-                    {{#tr this}}You and {recipients}{{/tr}}
+                    {{#tr}}You and {recipients}{{/tr}}
                 </div>
                 <div class="recipient_row_date" title="{{t 'Last modified'}}">{{ time_stamp }}</div>
             </div>

--- a/static/templates/draft_table_body.hbs
+++ b/static/templates/draft_table_body.hbs
@@ -7,7 +7,7 @@
                     <span class="exit-sign">&times;</span>
                 </div>
                 <div class="removed-drafts">
-                    {{#tr this}} Drafts older than <strong>{draft_lifetime}</strong> days are automatically removed. {{/tr}}
+                    {{#tr}} Drafts older than <strong>{draft_lifetime}</strong> days are automatically removed. {{/tr}}
                 </div>
                 <div class="draft-hotkey-reminder">
                     {{t "Pro tip: You can use 'd' to open your drafts."}}

--- a/static/templates/edited_notice.hbs
+++ b/static/templates/edited_notice.hbs
@@ -1,9 +1,9 @@
 {{#if msg/local_edit_timestamp}}
-<div class="message_edit_notice auto-select" title="{{#tr this}}Edited ({last_edit_timestr}){{/tr}}">
+<div class="message_edit_notice auto-select" title="{{#tr}}Edited ({last_edit_timestr}){{/tr}}">
     ({{t "SAVING" }})
 </div>
 {{else}}
-<div class="message_edit_notice auto-select" title="{{#tr this}}Edited ({last_edit_timestr}){{/tr}}">
+<div class="message_edit_notice auto-select" title="{{#tr}}Edited ({last_edit_timestr}){{/tr}}">
     ({{t "EDITED" }})
 </div>
 {{/if}}

--- a/static/templates/invitation_failed_error.hbs
+++ b/static/templates/invitation_failed_error.hbs
@@ -7,7 +7,7 @@
 {{#if is_invitee_deactivated}}
     {{#if is_admin}}
     <p id="invitation_admin_message">
-        {{#tr this}}
+        {{#tr}}
             You can reactivate deactivated users from <z-link>organization settings</z-link>.
             {{#*inline "z-link"}}<a href="#organization/deactivated-users-admin">{{> @partial-block}}</a>{{/inline}}
         {{/tr}}

--- a/static/templates/message_controls.hbs
+++ b/static/templates/message_controls.hbs
@@ -5,13 +5,13 @@
 
     {{#unless msg/sent_by_me}}
     <div class="reaction_button tippy-zulip-tooltip" data-tippy-content="{{t 'Add emoji reaction' }}">
-        <i class="fa fa-smile-o" aria-label="{{#tr this}}Add emoji reaction{{/tr}} (:)" role="button" aria-haspopup="true" tabindex="0"></i>
+        <i class="fa fa-smile-o" aria-label="{{#tr}}Add emoji reaction{{/tr}} (:)" role="button" aria-haspopup="true" tabindex="0"></i>
     </div>
     {{/unless}}
 
     {{#unless msg/locally_echoed}}
     <div class="info actions_hover">
-        <i class="zulip-icon ellipsis-v-solid" title="{{#tr this}}Message actions{{/tr}} (i)" title="{{#tr this}}Message actions{{/tr}}" role="button" aria-haspopup="true" tabindex="0" aria-label="{{#tr this}}Message actions{{/tr}}"></i>
+        <i class="zulip-icon ellipsis-v-solid" title="{{#tr}}Message actions{{/tr}} (i)" title="{{#tr}}Message actions{{/tr}}" role="button" aria-haspopup="true" tabindex="0" aria-label="{{#tr}}Message actions{{/tr}}"></i>
     </div>
     {{/unless}}
 
@@ -22,7 +22,7 @@
 
     {{#unless msg/locally_echoed}}
     <div class="star_container {{#if msg/starred}}{{else}}empty-star{{/if}}">
-        <i role="button" tabindex="0" class="star fa {{#if msg/starred}}fa-star{{else}}fa-star-o{{/if}}" title="{{#tr this.msg}}{starred_status} this message{{/tr}} (Ctrl + s)"></i>
+        <i role="button" tabindex="0" class="star fa {{#if msg/starred}}fa-star{{else}}fa-star-o{{/if}}" title="{{#with msg}}{{#tr}}{starred_status} this message{{/tr}}{{/with}} (Ctrl + s)"></i>
     </div>
     {{/unless}}
 

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -82,7 +82,7 @@
             {{#if has_been_editable}}
             <div class="message-edit-timer-control-group">
                 <span class="message_edit_countdown_timer"></span>
-                <span><i id="message_edit_tooltip" class="tippy-zulip-tooltip message_edit_tooltip fa fa-question-circle" aria-hidden="true" data-tippy-content="{{#tr this}}This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.{{/tr}}"></i>
+                <span><i id="message_edit_tooltip" class="tippy-zulip-tooltip message_edit_tooltip fa fa-question-circle" aria-hidden="true" data-tippy-content="{{#tr}}This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.{{/tr}}"></i>
                 </span>
             </div>
             {{/if}}

--- a/static/templates/move_topic_to_stream.hbs
+++ b/static/templates/move_topic_to_stream.hbs
@@ -4,7 +4,7 @@
         <h3 id="move_topic_modal_label">{{t "Move topic" }} </h3>
     </div>
     <div class="modal-body">
-        <p>{{#tr this}}Move all messages in <strong>{topic_name}</strong>{{/tr}} to:</p>
+        <p>{{#tr}}Move all messages in <strong>{topic_name}</strong>{{/tr}} to:</p>
         <form id="move_topic_form">
             <div id="topic_stream_edit_form_error" class="alert">
                 <span class="send-status-close">&times;</span>

--- a/static/templates/playground_links_popover_content.hbs
+++ b/static/templates/playground_links_popover_content.hbs
@@ -3,7 +3,7 @@
     {{#each playground_info}}
     <li>
         <a href="{{this/playground_url}}" target="_blank" rel="noopener noreferrer" class="popover_playground_link">
-            {{#tr this}}
+            {{#tr}}
             View in {name}
             {{/tr}}
         </a>

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -6,7 +6,7 @@
             <a class="message_label_clickable narrows_by_recipient stream_label {{color_class}}"
                 style="background: {{background_color}}; border-left-color: {{background_color}};"
                 href="{{stream_url}}"
-                title="{{#tr this}}Narrow to stream &quot;{display_recipient}&quot;{{/tr}}">
+                title="{{#tr}}Narrow to stream &quot;{display_recipient}&quot;{{/tr}}">
                 {{! invite only lock }}
                 {{#if invite_only}}
                 <i class="fa fa-lock invite-stream-icon" title="{{t 'This is a private stream' }}" aria-label="{{t 'This is a private stream' }}"></i>
@@ -21,7 +21,7 @@
                 {{! topic link }}
                 <a class="message_label_clickable narrows_by_topic"
                     href="{{topic_url}}"
-                    title="{{#tr this}}Narrow to stream &quot;{display_recipient}&quot;, topic &quot;{topic}&quot;{{/tr}}">
+                    title="{{#tr}}Narrow to stream &quot;{display_recipient}&quot;, topic &quot;{topic}&quot;{{/tr}}">
                     {{#if use_match_properties}}
                     {{{match_topic}}}
                     {{else}}
@@ -62,8 +62,8 @@
         <div class="message-header-contents">
             <a class="message_label_clickable narrows_by_recipient stream_label"
                 href="{{pm_with_url}}"
-                title="{{#tr this}}Narrow to your private messages with {display_reply_to}{{/tr}}">
-                {{#tr this}}You and {display_reply_to}{{/tr}}
+                title="{{#tr}}Narrow to your private messages with {display_reply_to}{{/tr}}">
+                {{#tr}}You and {display_reply_to}{{/tr}}
             </a>
 
             <span class="recipient_row_date {{#if group_date_divider_html}}{{else}}hide-date{{/if}}">{{{date}}}</span>

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -172,7 +172,7 @@
                 <h3 id="deactivation_self_modal_label">{{t "Deactivate your account" }} </h3>
             </div>
             <div class="modal-body">
-                <p>{{#tr this}}By deactivating your account, you will be logged out immediately.{{/tr}}</p>
+                <p>{{#tr}}By deactivating your account, you will be logged out immediately.{{/tr}}</p>
                 <p>{{t "Note that any bots that you maintain will be disabled." }}</p>
             </div>
             <div class="modal-footer">
@@ -191,7 +191,7 @@
 
             <div class="input-group">
                 <p class="api-key-note">
-                    {{#tr this}}
+                    {{#tr}}
                     An API key can be used to programmatically access a Zulip account.
                     Anyone with access to your API key has the ability to read your messages, send
                     messages on your behalf, and otherwise impersonate you on Zulip, so you should

--- a/static/templates/settings/bot_settings.hbs
+++ b/static/templates/settings/bot_settings.hbs
@@ -2,7 +2,7 @@
     <div class="bot-settings-form">
         {{#unless page_params.is_guest}}
         <div class="tip">
-            {{#tr this}}
+            {{#tr}}
                 Looking for our <z-integrations>integrations</z-integrations> or <z-api>API</z-api> documentation?
                 {{#*inline "z-integrations"}}<a href="/integrations" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
                 {{#*inline "z-api"}}<a href="/api" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}

--- a/static/templates/settings/data_exports_admin.hbs
+++ b/static/templates/settings/data_exports_admin.hbs
@@ -8,7 +8,7 @@
         {{t 'Depending on the size of your organization, an export can take anywhere from seconds to an hour.' }}
     </p>
     <p>
-        {{#tr this}}
+        {{#tr}}
             <z-link>Click here</z-link> to learn about exporting private streams and messages.
             {{#*inline "z-link"}}<a href="/help/export-your-organization" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
         {{/tr}}

--- a/static/templates/settings/deactivation_user_modal.hbs
+++ b/static/templates/settings/deactivation_user_modal.hbs
@@ -5,7 +5,7 @@
     </div>
     <div class="modal-body">
         <p>
-            {{#tr this}}
+            {{#tr}}
                 By deactivating <z-user></z-user>, they will be logged out immediately.
                 {{#*inline "z-user"}}<strong><span class="user_name"></span></strong> &lt;<span class="email"></span>&gt;{{/inline}}
             {{/tr}}

--- a/static/templates/settings/default_streams_list_admin.hbs
+++ b/static/templates/settings/default_streams_list_admin.hbs
@@ -1,6 +1,6 @@
 <div id="admin-default-streams-list" class="settings-section" data-name="default-streams-list">
     <div class="side-padded-container">
-        <p>{{#tr this}}Configure the default streams new users are subscribed to when joining your organization.{{/tr}}</p>
+        <p>{{#tr}}Configure the default streams new users are subscribed to when joining your organization.{{/tr}}</p>
     </div>
 
     {{#if is_admin}}

--- a/static/templates/settings/emoji_settings_admin.hbs
+++ b/static/templates/settings/emoji_settings_admin.hbs
@@ -3,7 +3,7 @@
         {{> emoji_settings_tip}}
     </div>
     <p class="add-emoji-text {{#unless can_add_emojis}}hide{{/unless}}">
-        {{#tr this}}Add extra emoji for members of the {realm_name} organization.{{/tr}}
+        {{#tr}}Add extra emoji for members of the {realm_name} organization.{{/tr}}
     </p>
     <form class="form-horizontal admin-emoji-form {{#unless can_add_emojis}}hide{{/unless}}">
         <div class="add-new-emoji-box grey-box">

--- a/static/templates/settings/linkifier_settings_admin.hbs
+++ b/static/templates/settings/linkifier_settings_admin.hbs
@@ -2,7 +2,7 @@
     <div class="admin-table-wrapper">
 
         <p>
-            {{#tr this}}
+            {{#tr}}
             Configure regular expression patterns that will be
             automatically linkified when used in Zulip message bodies or
             topics.  For example to automatically linkify commit IDs and
@@ -23,7 +23,7 @@
             </li>
         </ul>
         <p>
-            {{#tr this}}
+            {{#tr}}
             Or, to automatically linkify GitHub's <code>org/repo#1234</code> syntax:
             {{/tr}}
         </p>
@@ -35,7 +35,7 @@
             </li>
         </ul>
         <p>
-            {{#tr this}}
+            {{#tr}}
                 More details are available <z-link>in the Help Center article</z-link>.
                 {{#*inline "z-link"}}<a href="/help/add-a-custom-linkifier" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}

--- a/static/templates/settings/resend_invite_modal.hbs
+++ b/static/templates/settings/resend_invite_modal.hbs
@@ -2,7 +2,7 @@
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <h3 id="resend_invite_modal_label">
-            {{#tr this}}
+            {{#tr}}
                 Resend invitation to <z-email></z-email>
                 {{#*inline "z-email"}}<span class="email"></span>{{/inline}}
             {{/tr}}
@@ -10,7 +10,7 @@
     </div>
     <div class="modal-body">
         <p>
-            {{#tr this}}
+            {{#tr}}
                 Are you sure you want to resend the invitation to <z-email></z-email>?
                 {{#*inline "z-email"}}<strong><span class="email"></span></strong>{{/inline}}
             {{/tr}}

--- a/static/templates/settings/revoke_invite_modal.hbs
+++ b/static/templates/settings/revoke_invite_modal.hbs
@@ -2,16 +2,16 @@
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         {{#if is_multiuse}}
-        <h3 id="revoke_invite_modal_label">{{#tr this}}Revoke invitation link{{/tr}}</h3>
+        <h3 id="revoke_invite_modal_label">{{#tr}}Revoke invitation link{{/tr}}</h3>
         {{else}}
-        <h3 id="revoke_invite_modal_label">{{#tr this}}Revoke invitation to {email}{{/tr}}</h3>
+        <h3 id="revoke_invite_modal_label">{{#tr}}Revoke invitation to {email}{{/tr}}</h3>
         {{/if}}
     </div>
     <div class="modal-body" id="revoke_invite_message">
         {{#if is_multiuse}}
-        <p>{{#tr this}}Are you sure you want to revoke this invitation link created by <strong>{referred_by}</strong>?{{/tr}}</p>
+        <p>{{#tr}}Are you sure you want to revoke this invitation link created by <strong>{referred_by}</strong>?{{/tr}}</p>
         {{else}}
-        <p>{{#tr this}}Are you sure you want to revoke the invitation to <strong>{email}</strong>?{{/tr}}</p>
+        <p>{{#tr}}Are you sure you want to revoke the invitation to <strong>{email}</strong>?{{/tr}}</p>
         {{/if}}
     </div>
     <div class="modal-footer">

--- a/static/templates/settings/upload_space_stats.hbs
+++ b/static/templates/settings/upload_space_stats.hbs
@@ -1,7 +1,7 @@
 <span>
-    {{#tr this}}Organization using {percent_used}% of {upload_quota}.{{/tr}}
+    {{#tr}}Organization using {percent_used}% of {upload_quota}.{{/tr}}
     {{#if show_upgrade_message}}
-        {{#tr this}}
+        {{#tr}}
             <z-link>Upgrade</z-link> for more space.
             {{#*inline "z-link"}}<a href="/upgrade" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
         {{/tr}}

--- a/static/templates/starred_messages_sidebar_actions.hbs
+++ b/static/templates/starred_messages_sidebar_actions.hbs
@@ -5,7 +5,7 @@
     <li>
         <a tabindex="0" id="unstar_all_messages">
             <i class="fa fa-star-o" aria-hidden="true"></i>
-            {{#tr this}}Unstar all messages{{/tr}}
+            {{#tr}}Unstar all messages{{/tr}}
         </a>
     </li>
     {{/if}}
@@ -13,10 +13,10 @@
         <a tabindex="0" id="toggle_display_starred_msg_count">
             {{#if starred_message_counts}}
                 <i class="fa fa-eye-slash" aria-hidden="true"></i>
-                {{#tr this}}Hide starred message count{{/tr}}
+                {{#tr}}Hide starred message count{{/tr}}
             {{else}}
                 <i class="fa fa-eye" aria-hidden="true"></i>
-                {{#tr this}}Show starred message count{{/tr}}
+                {{#tr}}Show starred message count{{/tr}}
             {{/if}}
         </a>
     </li>

--- a/static/templates/stream_creation_form.hbs
+++ b/static/templates/stream_creation_form.hbs
@@ -24,7 +24,7 @@
                     {{t "Stream permissions" }}
                 </div>
                 <div class="stream-creation-info">
-                    {{#tr this}}
+                    {{#tr}}
                         These settings are explained in detail in the <z-link>help center</z-link>.
                         {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="/help/stream-permissions">{{> @partial-block }}</a>{{/inline}}
                     {{/tr}}

--- a/static/templates/stream_settings_checkbox.hbs
+++ b/static/templates/stream_settings_checkbox.hbs
@@ -14,7 +14,7 @@
     {{!-- Tooltips for settings --}}
     {{#if (eq setting_name "is_muted")}}
     <p class="mute-note {{#unless is_muted}}hide-mute-note{{/unless}}">
-        {{#tr this}}
+        {{#tr}}
         Muted streams don't show up in "All messages" or generate notifications unless you are mentioned.
         {{/tr}}
     </p>

--- a/static/templates/subscription_invites_warning_modal.hbs
+++ b/static/templates/subscription_invites_warning_modal.hbs
@@ -5,11 +5,11 @@
             <h3 id="invites-warning-label">{{t "Large number of subscribers" }}</h3>
         </div>
         <div class="modal-body">
-            <p>{{#tr this}}Are you sure you want to create stream ''''{stream_name}'''' and subscribe {count} users to it?{{/tr}}</p>
+            <p>{{#tr}}Are you sure you want to create stream ''''{stream_name}'''' and subscribe {count} users to it?{{/tr}}</p>
         </div>
         <div class="modal-footer">
             <button class="btn btn-default close-invites-warning-modal">{{t "Go back" }}</button>
-            <button class="btn btn-warning confirm-invites-warning-modal">{{#tr this}}Yes, subscribe {count} users!{{/tr}}</button>
+            <button class="btn btn-warning confirm-invites-warning-modal">{{#tr}}Yes, subscribe {count} users!{{/tr}}</button>
         </div>
     </div>
 </div>

--- a/static/templates/subscription_table_body.hbs
+++ b/static/templates/subscription_table_body.hbs
@@ -37,7 +37,7 @@
                     {{#if can_create_streams}}
                     <button type="button" class="create_stream_button button small rounded sea-green">{{t 'Create stream' }}</button>
                     <span>
-                        {{#tr this}}
+                        {{#tr}}
                             First time? Read our <z-link>guidelines</z-link> for creating and naming streams.
                             {{#*inline "z-link"}}<a href="/help/getting-your-organization-started-with-zulip#create-streams" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
                         {{/tr}}

--- a/static/templates/subscription_type.hbs
+++ b/static/templates/subscription_type.hbs
@@ -1,5 +1,5 @@
 {{#if invite_only}}
-    {{#tr this}}
+    {{#tr}}
         This is a <z-icon></z-icon> <b>private stream</b>. Only people who have been invited can access its content, but any member of the stream can invite others.
         {{#*inline "z-icon"}}<span class="fa fa-lock" aria-hidden="true"></span>{{/inline}}
     {{/tr}}
@@ -7,12 +7,12 @@
     {{else}}{{t 'New members can only see messages sent after they join.' }}
     {{/if}}
     {{else if is_web_public}}
-    {{#tr this}}
+    {{#tr}}
         This is a <z-icon></z-icon> <b>web public stream</b>. Any member of the organization can join without an invitation and anyone on the internet can read the content published.
         {{#*inline "z-icon"}}<i class="fa fa-globe" aria-hidden="true"></i>{{/inline}}
     {{/tr}}
 {{else}}
-    {{#tr this}}
+    {{#tr}}
         This is a <z-icon></z-icon> <b>public stream</b>. Any member of the organization can join without an invitation.
         {{#*inline "z-icon"}}<i class="hash" aria-hidden="true"></i>{{/inline}}
     {{/tr}}

--- a/static/templates/topic_muted.hbs
+++ b/static/templates/topic_muted.hbs
@@ -1,4 +1,4 @@
-{{#tr this}}
+{{#tr}}
     You have muted <z-stream-topic></z-stream-topic>.
     {{#*inline "z-stream-topic"}}<strong><span class="stream"></span> &gt; <span class="topic"></span></strong>{{/inline}}
 {{/tr}}

--- a/static/templates/topic_sidebar_actions.hbs
+++ b/static/templates/topic_sidebar_actions.hbs
@@ -30,7 +30,7 @@
     <li>
         <a href="#" class="sidebar-popover-unstar-all-in-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-star-o" aria-hidden="true"></i>
-            {{#tr this}}Unstar all messages in topic{{/tr}}
+            {{#tr}}Unstar all messages in topic{{/tr}}
         </a>
     </li>
     {{/if}}
@@ -44,7 +44,7 @@
 
     {{#if is_realm_admin}}
 
-    <div class="admin-separator">{{#tr this}}ADMIN ACTIONS{{/tr}}</div>
+    <div class="admin-separator">{{#tr}}ADMIN ACTIONS{{/tr}}</div>
 
     <li>
         <a tabindex="0" class="sidebar-popover-delete-topic-messages" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">

--- a/static/templates/typing_notification.hbs
+++ b/static/templates/typing_notification.hbs
@@ -1,1 +1,1 @@
-<li data-email="{{this.email}}" class="typing_notification">{{#tr this}}{full_name} is typing…{{/tr}}</li>
+<li data-email="{{this.email}}" class="typing_notification">{{#tr}}{full_name} is typing…{{/tr}}</li>

--- a/static/templates/user_groups_admin.hbs
+++ b/static/templates/user_groups_admin.hbs
@@ -9,7 +9,7 @@
 
     {{#unless is_guest}}
         <p>
-            {{#tr this}}
+            {{#tr}}
                 User groups allow you to <z-link>mention</z-link> multiple users at once. When you mention a user group, everyone in the group is notified as if they were individually mentioned.
                 {{#*inline "z-link"}}<a href="/help/mention-a-user-or-group" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -24,26 +24,26 @@
             </li>
             {{/if}}
         {{else}}
-            <li class="user_popover_email half-opacity italic">{{#tr this}}(This user has been deactivated){{/tr}}</li>
+            <li class="user_popover_email half-opacity italic">{{#tr}}(This user has been deactivated){{/tr}}</li>
         {{/if}}
 
 
         {{#if user_time}}
-        <li>{{ user_time }} {{#tr this}}Local time{{/tr}}</li>
+        <li>{{ user_time }} {{#tr}}Local time{{/tr}}</li>
         {{/if}}
 
         {{#if is_bot}}
             {{#if bot_owner}}
-                <li>{{#tr this}}Owner{{/tr}}:
+                <li>{{#tr}}Owner{{/tr}}:
                     <span class="bot-owner-name view_user_profile" data-user-id='{{ bot_owner.user_id }}'>
                         {{bot_owner.full_name}}
                     </span>
                 </li>
             {{else}}
                 {{#if is_cross_realm_bot}}
-                <li>{{#tr this}}System bot{{/tr}}</li>
+                <li>{{#tr}}System bot{{/tr}}</li>
                 {{else}}
-                <li>{{#tr this}}Bot{{/tr}}</li>
+                <li>{{#tr}}Bot{{/tr}}</li>
                 {{/if}}
             {{/if}}
         {{else}}
@@ -56,14 +56,14 @@
         {{#if can_set_away}}
         <li>
             <a tabindex="0" class="set_away_status">
-                <i class="fa fa-minus-circle" aria-hidden="true"></i> {{#tr this}}Set yourself as unavailable{{/tr}}
+                <i class="fa fa-minus-circle" aria-hidden="true"></i> {{#tr}}Set yourself as unavailable{{/tr}}
             </a>
         </li>
         {{/if}}
         {{#if can_revoke_away}}
         <li>
             <a tabindex="0" class="revoke_away_status">
-                <i class="fa fa-minus-circle" aria-hidden="true"></i> {{#tr this}}Set yourself as active{{/tr}}
+                <i class="fa fa-minus-circle" aria-hidden="true"></i> {{#tr}}Set yourself as active{{/tr}}
             </a>
         </li>
         {{/if}}
@@ -71,9 +71,9 @@
             <a tabindex="0" class="update_status_text">
                 <i class="fa fa-comments" aria-hidden="true"></i>
                 {{#if status_text}}
-                    {{#tr this}}Edit status message{{/tr}}
+                    {{#tr}}Edit status message{{/tr}}
                 {{else}}
-                    {{#tr this}}Set a status message{{/tr}}
+                    {{#tr}}Set a status message{{/tr}}
                 {{/if}}
             </a>
         </li>
@@ -84,7 +84,7 @@
         <li class="user_info_status_text">
             <span id="status_message">
                 {{status_text}}
-                {{#if is_me}}(<a tabindex="0" class="clear_status">{{#tr this}}clear{{/tr}}</a>){{/if}}
+                {{#if is_me}}(<a tabindex="0" class="clear_status">{{#tr}}clear{{/tr}}</a>){{/if}}
             </span>
         </li>
     {{/if}}
@@ -94,9 +94,9 @@
     <li>
         <a tabindex="0" class="view_full_user_profile">
             {{#if is_me}}
-                <i class="fa fa-user" aria-hidden="true"></i> {{#tr this}}View your profile{{/tr}}
+                <i class="fa fa-user" aria-hidden="true"></i> {{#tr}}View your profile{{/tr}}
             {{else}}
-                <i class="fa fa-user" aria-hidden="true"></i> {{#tr this}}View full profile{{/tr}}
+                <i class="fa fa-user" aria-hidden="true"></i> {{#tr}}View full profile{{/tr}}
             {{/if}}
         </a>
     </li>
@@ -105,7 +105,7 @@
         {{#unless is_me}}
         <li>
             <a tabindex="0" class="{{ private_message_class }}">
-                <i class="fa fa-envelope" aria-hidden="true"></i> {{#tr this}}Send private message{{/tr}} {{#if is_sender_popover}}<span class="hotkey-hint">(R)</span>{{/if}}
+                <i class="fa fa-envelope" aria-hidden="true"></i> {{#tr}}Send private message{{/tr}} {{#if is_sender_popover}}<span class="hotkey-hint">(R)</span>{{/if}}
             </a>
         </li>
         {{/unless}}
@@ -115,13 +115,13 @@
         {{#if has_message_context}}
         <a tabindex="0" class="mention_user">
             <i class="fa fa-at" aria-hidden="true"></i>
-            {{#tr this}}Reply mentioning user{{/tr}}
+            {{#tr}}Reply mentioning user{{/tr}}
             {{#if is_sender_popover}}<span class="hotkey-hint">(@)</span>{{/if}}
         </a>
         {{else}}
         <a tabindex="0" class="copy_mention_syntax" data-clipboard-text="{{ user_mention_syntax }}">
             <i class="fa fa-at" aria-hidden="true"></i>
-            {{#tr this}}Copy mention syntax{{/tr}}
+            {{#tr}}Copy mention syntax{{/tr}}
             {{#if is_sender_popover}}<span class="hotkey-hint">(@)</span>{{/if}}
         </a>
         {{/if}}
@@ -130,7 +130,7 @@
     {{#if is_me}}
     <li>
         <a href="/#settings/your-account">
-            <i class="fa fa-edit" aria-hidden="true"></i> {{#tr this}}Edit your profile{{/tr}}
+            <i class="fa fa-edit" aria-hidden="true"></i> {{#tr}}Edit your profile{{/tr}}
         </a>
     </li>
     {{/if}}
@@ -139,15 +139,15 @@
         <a href="{{ pm_with_uri }}" class="narrow_to_private_messages">
             <i class="fa fa-lock" aria-hidden="true"></i>
             {{#if is_me}}
-                {{#tr this}}View private messages to myself{{/tr}}
+                {{#tr}}View private messages to myself{{/tr}}
             {{else}}
-                {{#tr this}}View private messages{{/tr}}
+                {{#tr}}View private messages{{/tr}}
             {{/if}}
         </a>
     </li>
     <li>
         <a href="{{ sent_by_uri }}" class="narrow_to_messages_sent">
-            <i class="fa fa-paper-plane" aria-hidden="true"></i> {{#tr this}}View messages sent{{/tr}}
+            <i class="fa fa-paper-plane" aria-hidden="true"></i> {{#tr}}View messages sent{{/tr}}
         </a>
     </li>
 </ul>

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -17,25 +17,25 @@
             <br>
             {{#if show_email}}
             <div id="email" class="default-field">
-                <span class="name">{{#tr this}}Email{{/tr}}</span>
+                <span class="name">{{#tr}}Email{{/tr}}</span>
                 <span class="value">{{email}}</span>
             </div>
             {{/if}}
             <div id="date-joined" class="default-field">
-                <span class="name">{{#tr this}}Joined{{/tr}}</span>
+                <span class="name">{{#tr}}Joined{{/tr}}</span>
                 <span class="value">{{date_joined}}</span>
             </div>
             <div id="user-type" class="default-field">
-                <span class="name">{{#tr this}}Role{{/tr}}</span>
+                <span class="name">{{#tr}}Role{{/tr}}</span>
                 <span class="value">{{user_type}}</span>
             </div>
             <div class="default-field">
-                <span class="name">{{#tr this}}Last active{{/tr}}</span>
+                <span class="name">{{#tr}}Last active{{/tr}}</span>
                 <span class="value">{{last_seen}}</span>
             </div>
             {{#if user_time}}
             <div class="default-field">
-                <span class="name">{{#tr this}}Local time{{/tr}}</span>
+                <span class="name">{{#tr}}Local time{{/tr}}</span>
                 <span class="value">{{user_time}}</span>
             </div>
             {{/if}}

--- a/zerver/management/commands/makemessages.py
+++ b/zerver/management/commands/makemessages.py
@@ -52,7 +52,7 @@ strip_whitespace_left = re.compile(
 )
 
 regexes = [
-    r"{{#tr .*?}}([\s\S]*?)(?:{{/tr}}|{{#\*inline )",  # '.' doesn't match '\n' by default
+    r"{{#tr}}([\s\S]*?)(?:{{/tr}}|{{#\*inline )",  # '.' doesn't match '\n' by default
     r'{{\s*t "(.*?)"\W*}}',
     r"{{\s*t '(.*?)'\W*}}",
     r'\(t "(.*?)"\)',

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -160,8 +160,8 @@ class FrontendRegexTestCase(ZulipTestCase):
 
         data = [
             (
-                "{{#tr context}}english text with __variable__{{/tr}}{{/tr}}",
-                "english text with __variable__",
+                "{{#tr}}english text with {variable}{{/tr}}{{/tr}}",
+                "english text with {variable}",
             ),
             ('{{t "english text" }}, "extra"}}', "english text"),
             ("{{t 'english text' }}, 'extra'}}", "english text"),


### PR DESCRIPTION
It only had one nontrivial use, and it’s easily replaced using the builtin `{{#with}}` block helper.

**Testing plan:** Tested in dev server, with a focus on the message star tooltip.