### PR TITLE
message-edit: Show the edited content on editing message failure.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -819,8 +819,8 @@ export function save_message_row_edit(row) {
 
                     row = message_lists.current.get_row(message_id);
                     if (!is_editing(message_id)) {
-                        // Return to the message editing open UI state.
-                        start_edit_maintaining_scroll(row, echo_data.orig_raw_content);
+                        // Return to the message editing open UI state with the edited content.
+                        start_edit_maintaining_scroll(row, echo_data.raw_content);
                     }
                 }
 


### PR DESCRIPTION
Fixes #18142

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested manually. Adding a gif here for how I tested.
![offline_Message_EDIt](https://user-images.githubusercontent.com/56730716/114668241-20373200-9d1e-11eb-8462-aff67ed480f1.gif)
Before the new edited content was not shown, now it is shown.

[CZO link here](https://chat.zulip.org/#narrow/stream/48-mobile/topic/Message.20edit.20lag/near/1161752)