### PR TITLE
docs: Add link to latest when viewing old changelog.

### DIFF
--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -6,8 +6,9 @@ All notable changes to the Zulip server are documented in this file.
 
 ### 4.0 -- Unreleased
 
-This section lists notable unreleased changes; it is generally updated
-in bursts.
+This section is an incomplete draft of the release notes for the next
+major release, and is only updated occasionally.  See the [commit
+log][commit-log] for an up-to-date list of raw changes.
 
 ### 4.0-rc1 -- May 3, 2021
 
@@ -40,7 +41,6 @@ in bursts.
   better error handling for the mobile and terminal apps.
 - The frontend internationalization library was switched from i18next
   to FormatJS.
-
 
 [roles-and-permissions]: https://zulip.com/help/roles-and-permissions
 
@@ -2112,3 +2112,4 @@ easily read them all when upgrading across multiple releases.
 * [Upgrade notes for 1.7.0](#upgrade-notes-for-1-7-0)
 
 [docker-zulip]: https://github.com/zulip/docker-zulip
+[commit-log]: https://github.com/zulip/zulip/commits/master


### PR DESCRIPTION
This will help prevent a common confusion that we've seen -- where a
user visits our /stable/ ReadTheDocs (since that's where we link for
the installer), and then sees that we haven't released in a while and
worries that the project is dead.

We may want to do further changes to clarify the situation on these
/stable/ pages, but this at least will get them to the current
changelog.md file.

Here's a screenshot; note that the version would be e.g. `3.4` in reality:

![image](https://user-images.githubusercontent.com/2746074/114745624-b01bb280-9d03-11eb-86de-9a9913164e81.png)

See https://chat.zulip.org/#narrow/stream/31-production-help/topic/Upgrade.20to.204.2E0/near/1162431 for motivation.