### PR TITLE
left-sidebar: Expand private message container without interleaved view.

### DIFF
--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -7,6 +7,9 @@ const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 
 mock_cjs("jquery", $);
+mock_esm("../../static/js/resize", {
+    resize_stream_filters_container: () => {},
+});
 const narrow_state = mock_esm("../../static/js/narrow_state");
 const pm_list_dom = mock_esm("../../static/js/pm_list_dom");
 const unread = mock_esm("../../static/js/unread");
@@ -226,7 +229,6 @@ test("is_all_privates", (override) => {
 
 test("expand", (override) => {
     override(narrow_state, "filter", private_filter);
-    override(narrow_state, "active", () => true);
     override(pm_list, "_build_private_messages_list", () => "PM_LIST_CONTENTS");
     let html_updated;
     override(vdom, "update", () => {
@@ -238,6 +240,20 @@ test("expand", (override) => {
     pm_list.expand();
     assert(html_updated);
     assert($(".top_left_private_messages").hasClass("active-filter"));
+});
+
+test("handle_private_message_sidebar_click", (override) => {
+    override(narrow_state, "filter", () => false);
+    override(pm_list, "_build_private_messages_list", () => "PM_LIST_CONTENTS");
+    let html_updated;
+    override(vdom, "update", () => {
+        html_updated = true;
+    });
+
+    pm_list.handle_private_message_sidebar_click();
+
+    assert(html_updated);
+    assert(!$(".top_left_private_messages").hasClass("active-filter"));
 });
 
 test("update_private_messages", (override) => {

--- a/frontend_tests/puppeteer_tests/message-basics.ts
+++ b/frontend_tests/puppeteer_tests/message-basics.ts
@@ -256,21 +256,6 @@ async function search_tests(page: Page): Promise<void> {
     );
 }
 
-async function expect_all_pm(page: Page): Promise<void> {
-    await page.waitForSelector("#zfilt", {visible: true});
-    await common.check_messages_sent(page, "zfilt", [
-        ["You and Cordelia, Lear's daughter, King Hamlet", ["group pm a", "group pm b"]],
-        ["You and Cordelia, Lear's daughter", ["pm c"]],
-        ["You and Cordelia, Lear's daughter, King Hamlet", ["group pm d"]],
-        ["You and Cordelia, Lear's daughter", ["pm e"]],
-    ]);
-    assert.strictEqual(
-        await common.get_text_from_selector(page, "#left_bar_compose_stream_button_big"),
-        "New stream message",
-    );
-    assert.strictEqual(await page.title(), "Private messages - Zulip Dev - Zulip");
-}
-
 async function test_narrow_by_clicking_the_left_sidebar(page: Page): Promise<void> {
     console.log("Narrowing with left sidebar");
 
@@ -279,9 +264,6 @@ async function test_narrow_by_clicking_the_left_sidebar(page: Page): Promise<voi
 
     await page.click(".top_left_all_messages a");
     await expect_home(page);
-
-    await page.click(".top_left_private_messages a");
-    await expect_all_pm(page);
 
     await un_narrow(page);
 }

--- a/frontend_tests/puppeteer_tests/navigation.ts
+++ b/frontend_tests/puppeteer_tests/navigation.ts
@@ -94,7 +94,6 @@ async function navigation_tests(page: Page): Promise<void> {
     await navigate_to_subscriptions(page);
     await navigate_using_left_sidebar(page, "all_messages", "message_feed_container");
     await navigate_to_settings(page);
-    await navigate_using_left_sidebar(page, "narrow/is/private", "message_feed_container");
     await navigate_to_subscriptions(page);
     await navigate_using_left_sidebar(page, verona_narrow, "message_feed_container");
 

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -30,6 +30,7 @@ import * as narrow from "./narrow";
 import * as notifications from "./notifications";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
+import * as pm_list from "./pm_list";
 import * as popovers from "./popovers";
 import * as reactions from "./reactions";
 import * as recent_topics from "./recent_topics";
@@ -526,6 +527,12 @@ export function initialize() {
             popovers.hide_all();
             $(".tooltip").remove();
         });
+
+    $("li.top_left_private_messages").on("click", ".private_messages_header", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        pm_list.handle_private_message_sidebar_click();
+    });
 
     function do_render_buddy_list_tooltip(elem, title_data) {
         let placement = "left";

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -6,6 +6,7 @@ import * as narrow_state from "./narrow_state";
 import * as people from "./people";
 import * as pm_conversations from "./pm_conversations";
 import * as pm_list_dom from "./pm_list_dom";
+import * as resize from "./resize";
 import * as stream_popover from "./stream_popover";
 import * as ui from "./ui";
 import * as ui_util from "./ui_util";
@@ -113,8 +114,13 @@ export function _build_private_messages_list() {
     return dom_ast;
 }
 
-export function update_private_messages() {
-    if (!narrow_state.active()) {
+export function update_private_messages(skip_narrow_state_check) {
+    // As all_messages and recent topics view have no narrow associated
+    // with them so if Private messages is clicked on the left sidebar then
+    // in order to expand the private message container we need to skip
+    // narrow state check. This flag is added to, handle left-sidebars clicks
+    // on Private messages without affecting other codebase that uses it.
+    if (!skip_narrow_state_check && !narrow_state.active()) {
         return;
     }
 
@@ -148,7 +154,8 @@ export function is_all_privates() {
 export function expand() {
     private_messages_open = true;
     stream_popover.hide_topic_popover();
-    update_private_messages();
+    const skip_narrow_state_check = true;
+    update_private_messages(skip_narrow_state_check);
     if (is_all_privates()) {
         $(".top_left_private_messages").addClass("active-filter");
     }
@@ -157,4 +164,11 @@ export function expand() {
 export function update_dom_with_unread_counts(counts) {
     update_private_messages();
     set_count(counts.private_message_count);
+}
+
+export function handle_private_message_sidebar_click() {
+    if (!private_messages_open) {
+        expand();
+        resize.resize_stream_filters_container();
+    }
 }

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -519,8 +519,12 @@ li.expanded_private_message {
 }
 
 li.top_left_all_messages a,
-li.top_left_private_messages a,
 li.top_left_mentions a,
 li.top_left_starred_messages a {
     display: block;
+}
+
+li.top_left_private_messages .private_messages_header {
+    display: block;
+    cursor: pointer;
 }

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -15,14 +15,14 @@
             </li>
             <li class="top_left_private_messages">
                 <div class="private_messages_header top_left_row" title="{{ _('Private messages') }} (P)">
-                    <a href="#narrow/is/private">
-                        <span class="filter-icon">
-                            <i class="fa fa-envelope" aria-hidden="true"></i>
-                        </span>
-                        {#- squash whitespace -#}
-                        <span>{{ _('Private messages') }}</span>
-                        <span class="unread_count"></span>
-                    </a>
+                    <span class="filter-icon">
+                        <i class="fa fa-envelope" aria-hidden="true"></i>
+                    </span>
+                    {#- squash whitespace -#}
+                    <span>{{ _('Private messages') }}</span>
+                    <span class="count">
+                        <span class="value"></span>
+                    </span>
                 </div>
                 <div id="private-container" class="scrolling_list" data-simplebar>
                 </div>


### PR DESCRIPTION
Avoid jumping into interleaved view when `Private messages` is clicked on left-sidebar.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
 Issue: #17306 

**Testing plan:** <!-- How have you tested? -->
Tested manually and by adding new node test for changes.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
* Behavior with other top left corner elements:
![top_left_corner](https://user-images.githubusercontent.com/63504956/114775914-7bedd380-9d8f-11eb-9fa0-9f94926a3403.gif)


* Behavior with other stream elements on left sidebars:
![stream_reactions](https://user-images.githubusercontent.com/63504956/114775935-827c4b00-9d8f-11eb-8856-8b9aa3e6b9e4.gif)
