### PR TITLE
bug fix: Fix today's regression with topic counts.

### DIFF
--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -50,11 +50,12 @@ let num_unread_for_stream;
 
 function create_devel_sidebar_row() {
     const devel_count = $.create("devel-count");
+    const subscription_block = $.create("devel-block");
 
     const sidebar_row = $("<devel sidebar row>");
 
-    sidebar_row.set_find_results(".unread_count", devel_count);
-    devel_count.set_parent(sidebar_row);
+    sidebar_row.set_find_results(".subscription_block", subscription_block);
+    subscription_block.set_find_results(".unread_count", devel_count);
 
     stub_templates((template_name, data) => {
         assert.equal(template_name, "stream_sidebar_row");
@@ -69,10 +70,12 @@ function create_devel_sidebar_row() {
 
 function create_social_sidebar_row() {
     const social_count = $.create("social-count");
+    const subscription_block = $.create("social-block");
+
     const sidebar_row = $("<social sidebar row>");
 
-    sidebar_row.set_find_results(".unread_count", social_count);
-    social_count.set_parent(sidebar_row);
+    sidebar_row.set_find_results(".subscription_block", subscription_block);
+    subscription_block.set_find_results(".unread_count", social_count);
 
     stub_templates((template_name, data) => {
         assert.equal(template_name, "stream_sidebar_row");
@@ -580,50 +583,6 @@ test_ui("separators_only_pinned", () => {
     ];
 
     assert.deepEqual(appended_elems, expected_elems);
-});
-
-test_ui("update_count_in_dom", () => {
-    function make_elem(elem, count_selector) {
-        const count = $(count_selector);
-        elem.set_find_results(".unread_count", count);
-        count.set_parent(elem);
-
-        return elem;
-    }
-
-    const stream_li = make_elem($("<stream li>"), "<stream-count>");
-
-    $("<stream li>").length = 0;
-    stream_li.addClass("subscription_block");
-    stream_li.addClass("stream-with-count");
-    assert(stream_li.hasClass("stream-with-count"));
-
-    const stream_count = new Map();
-    const stream_id = 11;
-
-    const stream_row = {
-        get_li() {
-            return stream_li;
-        },
-    };
-
-    stream_list.stream_sidebar.set_row(stream_id, stream_row);
-
-    stream_count.set(stream_id, 0);
-    const counts = {
-        stream_count,
-        topic_count: new Map(),
-    };
-
-    stream_list.update_dom_with_unread_counts(counts);
-    assert.equal($("<stream li>").text(), "never-been-set");
-    assert(!stream_li.hasClass("stream-with-count"));
-
-    stream_count.set(stream_id, 99);
-
-    stream_list.update_dom_with_unread_counts(counts);
-    assert.equal($("<stream-count>").text(), "99");
-    assert(stream_li.hasClass("stream-with-count"));
 });
 
 narrow_state.active = () => false;

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -27,19 +27,18 @@ export let stream_cursor;
 
 let has_scrolled = false;
 
-export function update_count_in_dom(unread_count_elem, count) {
-    ui_util.update_unread_count_in_dom(unread_count_elem, count);
+export function update_count_in_dom(stream_li, count) {
+    // The subsription_block properly excludes the topic list,
+    // and it also has sensitive margins related to whether the
+    // count is there or not.
+    const subscription_block = stream_li.find(".subscription_block");
 
-    const count_span = unread_count_elem.find(".unread_count");
+    ui_util.update_unread_count_in_dom(subscription_block, count);
+
     if (count === 0) {
-        if (count_span.parent().hasClass("subscription_block")) {
-            count_span.parent(".subscription_block").removeClass("stream-with-count");
-        }
-        return;
-    }
-
-    if (count_span.parent().hasClass("subscription_block")) {
-        count_span.parent(".subscription_block").addClass("stream-with-count");
+        subscription_block.removeClass("stream-with-count");
+    } else {
+        subscription_block.addClass("stream-with-count");
     }
 }
 
@@ -319,14 +318,14 @@ export function redraw_stream_privacy(sub) {
 }
 
 function set_stream_unread_count(stream_id, count) {
-    const unread_count_elem = get_stream_li(stream_id);
-    if (!unread_count_elem) {
+    const stream_li = get_stream_li(stream_id);
+    if (!stream_li) {
         // This can happen for legitimate reasons, but we warn
         // just in case.
         blueslip.warn("stream id no longer in sidebar: " + stream_id);
         return;
     }
-    update_count_in_dom(unread_count_elem, count);
+    update_count_in_dom(stream_li, count);
 }
 
 export function update_streams_sidebar(force_rerender) {


### PR DESCRIPTION
The series of commits to consolidate CSS classes
for the various unread-count spans across our app
created a bug where the stream_list.js code's selector
starting capturing the unread spans in topic list items.

Suppose you had a stream with these topics:

    Foo 10
        a 3
        b 3
        c 4

If another unread came in, you would briefly see:

    Foo 11
        a 11
        b 11
        c 11

Now we just use subscription_block to find the
element that we want to tweak.

I remove a convoluted node test here. Part of the
reason the node test was convoluted was that the
original implementation was overly complex. I will
try to re-introduce a simpler test soon, but this
is a bit of an emergency fix.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
