### PR TITLE
Prepare smokescreen better to be a documented feature

### DIFF
--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -80,9 +80,7 @@ on hardware requirements for larger organizations.
   that Zulip can properly manage image and website previews and mobile
   push notifications.  Outgoing Internet access is not required if you
   [disable those
-  features](https://zulip.com/help/allow-image-link-previews), or
-  configure an [existing outgoing HTTP
-  proxy](../production/deployment.html#using-an-outgoing-http-proxy).
+  features](https://zulip.com/help/allow-image-link-previews).
 * Outgoing SMTP access (usually port 587) to your [SMTP
   server](../production/email.md) so that Zulip can send emails.
 * A domain name (e.g. `zulip.example.com`) that your users will use to
@@ -93,7 +91,13 @@ on hardware requirements for larger organizations.
   address as its external hostname (though we don't recommend that
   configuration).
 * Zulip supports [running behind a reverse proxy][reverse-proxy].
+* Zulip servers running inside a private network should configure the
+  [`smokescreen` integration][smokescreen-proxy] to protect against
+  [SSRF attacks][SSRF], where users could make the Zulip server make
+  requests to private resources.
 
+[SSRF]: https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
+[smokescreen-proxy]: ../production/deployment.html#using-an-outgoing-http-proxy
 [reverse-proxy]: ../production/deployment.html#putting-the-zulip-application-behind-a-reverse-proxy
 [email-mirror-code]: https://github.com/zulip/zulip/blob/master/zerver/management/commands/email_mirror.py
 

--- a/docs/production/security-model.md
+++ b/docs/production/security-model.md
@@ -27,10 +27,10 @@ announcement).
 
 ## Encryption and authentication
 
-* Traffic between clients (web, desktop and mobile) and the Zulip is
-  encrypted using HTTPS.  By default, all Zulip services talk to each
-  other either via a localhost connection or using an encrypted SSL
-  connection.
+* Traffic between clients (web, desktop and mobile) and the Zulip
+  server is encrypted using HTTPS.  By default, all Zulip services
+  talk to each other either via a localhost connection or using an
+  encrypted SSL connection.
 
 * Zulip requires CSRF tokens in all interactions with the web API to
   prevent CSRF attacks.

--- a/docs/production/security-model.md
+++ b/docs/production/security-model.md
@@ -195,7 +195,7 @@ strength allowed is controlled by two settings in
     organization owners. They can only be created on the command
     line (via `manage.py change_user_role can_forge_sender`).
 
-## User-uploaded content
+## User-uploaded content and user-generated requests
 
 * Zulip supports user-uploaded files.  Ideally they should be hosted
   from a separate domain from the main Zulip server to protect against
@@ -242,6 +242,18 @@ strength allowed is controlled by two settings in
 * By default, Zulip will provide image previews inline in the body of
   messages when a message contains a link to an image.  You can
   control this using the `INLINE_IMAGE_PREVIEW` setting.
+
+* A Zulip server can make outgoing HTTP requests through features like
+  outgoing webhooks and embedded video previews. End users have
+  (limited) control the content of these HTTP requests. As a result,
+  Zulip supports routing these outgoing requests [through
+  `smokescreen`][smokescreen-setup] to ensure that Zulip cannot be
+  used to execute [SSRF attacks][SSRF] against other systems on an
+  internal corporate network.  The default `smokescreen` configuration
+  denies access to all non-public IP addresses, including 127.0.0.1.
+
+[SSRF]: https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
+[smokescreen-setup]: ../production/deployment.html#using-an-outgoing-http-proxy
 
 ## Final notes and security response
 

--- a/docs/production/security-model.md
+++ b/docs/production/security-model.md
@@ -235,8 +235,8 @@ strength allowed is controlled by two settings in
   browser is logged into a Zulip account that has received the
   uploaded file in question).
 
-* Zulip supports using the Camo image proxy to proxy content like
-  inline image previews that can be inserted into the Zulip message
+* Zulip supports using the Camo image proxy to proxy content, like
+  inline image previews, that can be inserted into the Zulip message
   feed by other users over HTTPS.
 
 * By default, Zulip will provide image previews inline in the body of

--- a/puppet/zulip/manifests/profile/smokescreen.pp
+++ b/puppet/zulip/manifests/profile/smokescreen.pp
@@ -42,7 +42,7 @@ class zulip::profile::smokescreen {
     notify  => Service[supervisor],
   }
 
-  file { '/etc/supervisor/conf.d/smokescreen.conf':
+  file { '/etc/supervisor/conf.d/zulip/smokescreen.conf':
     ensure  => file,
     require => [
       Package[supervisor],
@@ -53,5 +53,10 @@ class zulip::profile::smokescreen {
     mode    => '0644',
     content => template('zulip/supervisor/smokescreen.conf.erb'),
     notify  => Service[supervisor],
+  }
+  # Removed 2021-03 in version 4.0; these lines can be removed in
+  # Zulip version 5.0 and later.
+  file { '/etc/supervisor/conf.d/smokescreen.conf':
+    ensure  => absent,
   }
 }


### PR DESCRIPTION
This PR has a couple items I wrote down while updating our changelog.

* Document that smokescreen exists in a few more natural places.  I think this is probably the complete set of places we want to link, but perhaps it's worth your spending a few minutes thinking about adding more.
* Move its configuration to the right directory.

@alexmv I don't love the documentation text, in part because many readers won't know what SSRF is (maybe a third-party link can help).  I'd appreciate it if you just did an edit pass and pushed back here, as I'm trying to juggle a dozen tasks like this.