### PR TITLE
left_sidebar: Show the users count in presence dot.

### DIFF
--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -95,7 +95,6 @@ test("build_private_messages_list", (override) => {
             is_active: false,
             url: "#narrow/pm-with/101,102-group",
             user_circle_class: "user_circle_fraction",
-            fraction_present: undefined,
             is_group: true,
         },
     ];
@@ -136,7 +135,6 @@ test("build_private_messages_list_bot", (override) => {
             is_active: false,
             url: "#narrow/pm-with/314-outgoingwebhook",
             user_circle_class: "user_circle_green",
-            fraction_present: undefined,
             is_group: false,
         },
         {
@@ -147,7 +145,6 @@ test("build_private_messages_list_bot", (override) => {
             is_active: false,
             url: "#narrow/pm-with/101,102-group",
             user_circle_class: "user_circle_fraction",
-            fraction_present: undefined,
             is_group: true,
         },
     ];

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -75,11 +75,9 @@ export function _get_convos() {
         const is_active = user_ids_string === active_user_ids_string;
 
         let user_circle_class;
-        let fraction_present;
 
         if (is_group) {
             user_circle_class = "user_circle_fraction";
-            fraction_present = buddy_data.huddle_fraction_present(user_ids_string);
         } else {
             const user_id = Number.parseInt(user_ids_string, 10);
             user_circle_class = buddy_data.get_user_circle_class(user_id);
@@ -98,7 +96,6 @@ export function _get_convos() {
             is_active,
             url: hash_util.pm_with_uri(reply_to),
             user_circle_class,
-            fraction_present,
             is_group,
         };
         display_messages.push(display_message);

--- a/static/js/scroll_bar.js
+++ b/static/js/scroll_bar.js
@@ -40,6 +40,9 @@ let sbWidth;
 export function initialize() {
     // Workaround for browsers with fixed scrollbars
     sbWidth = getScrollbarWidth();
+    // These need to agree with zulip.css
+    const left_sidebar_width = 250;
+    const right_sidebar_width = 250;
 
     if (sbWidth > 0) {
         $(".header").css("left", "-" + sbWidth + "px");
@@ -52,7 +55,7 @@ export function initialize() {
         $(".column-right").css("right", sbWidth + "px");
         $(".app-main .right-sidebar").css({
             "margin-left": sbWidth + "px",
-            width: 250 - sbWidth + "px",
+            width: right_sidebar_width - sbWidth + "px",
         });
 
         $("#compose").css("left", "-" + sbWidth + "px");
@@ -63,12 +66,12 @@ export function initialize() {
             "<style> @media (min-width: " +
                 media_breakpoints.xl_min +
                 ") { .compose-content, .header-main .column-middle { margin-right: " +
-                (250 + sbWidth) +
+                (right_sidebar_width + sbWidth) +
                 "px !important; } } " +
                 "@media (min-width: " +
                 media_breakpoints.md_min +
                 ") { .fixed-app .column-middle { margin-left: " +
-                (250 + sbWidth) +
+                (left_sidebar_width + sbWidth) +
                 "px !important; } } " +
                 "</style>",
         );

--- a/static/js/scroll_bar.js
+++ b/static/js/scroll_bar.js
@@ -41,7 +41,7 @@ export function initialize() {
     // Workaround for browsers with fixed scrollbars
     sbWidth = getScrollbarWidth();
     // These need to agree with zulip.css
-    const left_sidebar_width = 250;
+    const left_sidebar_width = 270;
     const right_sidebar_width = 250;
 
     if (sbWidth > 0) {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -43,14 +43,12 @@
     }
 }
 
+/* Main geometry for this element is in zulip.css */
 .compose-content {
     border-top: 1px solid hsla(0, 0%, 0%, 0.07);
     transition: background-color 200ms linear;
 
     padding: 8px 10px 8px 10px;
-    margin-left: 250px;
-    margin-right: 250px;
-    position: relative;
 
     border-left: 1px solid hsl(0, 0%, 93%);
     border-right: 1px solid hsl(0, 0%, 93%);

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -161,6 +161,11 @@ li.show-more-topics {
 
 #private-container {
     max-height: 200px;
+
+    /* Match the opacity for global-filters icons. */
+    span.fa-group {
+        opacity: 0.7;
+    }
 }
 
 :not(.active-sub-filter) {

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -40,6 +40,7 @@ $topic_indent: calc($far_left_gutter_size + $left_col_size + 4px);
 
 .pm_left_col {
     min-width: $left_col_size;
+    margin-left: 15px;
 }
 
 #stream_filters,

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -19,7 +19,7 @@ go beneath the header.
 $sidebar_top: calc($header_height + $header_padding_bottom);
 
 /* These need to agree with scroll_bar.js */
-$left_sidebar_width: 250px;
+$left_sidebar_width: 270px;
 $right_sidebar_width: 250px;
 
 body,

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -18,6 +18,10 @@ go beneath the header.
 */
 $sidebar_top: calc($header_height + $header_padding_bottom);
 
+/* These need to agree with scroll_bar.js */
+$left_sidebar_width: 250px;
+$right_sidebar_width: 250px;
+
 body,
 html {
     width: 100%;
@@ -345,21 +349,19 @@ p.n-margin {
     left: 0;
 }
 
-.column-left,
 .column-right {
-    width: 250px;
-    max-width: 250px;
-}
-
-.column-left {
+    width: $right_sidebar_width;
+    max-width: $right_sidebar_width;
     position: absolute;
-    left: 0;
+    right: 0;
     top: 0;
 }
 
-.column-right {
+.column-left {
+    width: $left_sidebar_width;
+    max-width: $left_sidebar_width;
     position: absolute;
-    right: 0;
+    left: 0;
     top: 0;
 }
 
@@ -375,7 +377,7 @@ p.n-margin {
     }
 
     .column-left .left-sidebar {
-        width: 242px;
+        width: $left_sidebar_width;
         padding-left: 0;
     }
 
@@ -389,9 +391,10 @@ p.n-margin {
     }
 }
 
-.column-middle {
-    margin-right: 250px;
-    margin-left: 250px;
+.column-middle,
+.compose-content {
+    margin-right: $right_sidebar_width;
+    margin-left: $left_sidebar_width;
     position: relative;
 }
 
@@ -2772,7 +2775,7 @@ select.inline_select_topic_edit {
 
                 height: 100%;
                 padding-left: 10px;
-                width: 250px;
+                width: $left_sidebar_width;
             }
         }
     }

--- a/static/templates/pm_list_item.hbs
+++ b/static/templates/pm_list_item.hbs
@@ -3,13 +3,9 @@
 
         <div class="pm_left_col">
             {{#if is_group}}
-                {{#if fraction_present}}
-                <span class="{{user_circle_class}} user_circle" style="background:hsla(106, 74%, 44%, {{fraction_present}});"></span>
-                {{else}}
-                <span class="{{user_circle_class}} user_circle" style="background:none; border-color:hsl(0, 0%, 50%);"></span>
-                {{/if}}
+            <span class="fa fa-group"></span>
             {{else}}
-                <span class="{{user_circle_class}} user_circle"></span>
+            <span class="{{user_circle_class}} user_circle"></span>
             {{/if}}
         </div>
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->Fixes #18069.
Commit 1: e50c62a92281b0706bfb9aeaaf8429bb9025d8bc 

Show group icon (`fa fa-group`) for group PMs.

**Testing plan:** <!-- How have you tested? --> Tested everything manually.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/59444243/116729504-dd0add80-aa04-11eb-903a-142b704b8026.png)
-------

------------
Commit 2: 092421bcab1b96bbdf049f089893f73f4dc12d07

As we are not using the color_class logic for group PMs, commit 2 cleanups all existence of "fraction_present" from the codebase.

-------



Commit 3: 23b769bc1a0b916dd1b3ba121b0391c9d416e678

An idea of adding an identation was arosed in CZO [here](https://chat.zulip.org/#narrow/stream/101-design/topic/private.20messages.20UI/near/1169172) . Commit 3 adds an identation of 10px. Visually it looks like:

![image](https://user-images.githubusercontent.com/59444243/116729734-2824f080-aa05-11eb-81c1-c2d58c003d4b.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->


----------------

Both the commits (1 and 3) are independent of each other, so merging commit 1 with 3 or ignoring commit 3 (if the indentation idea is not good) doesn't make any problem.