### PR TITLE
actions: Rename kandra-ops to kandra ops in oneclick config file

### DIFF
--- a/.github/workflows/update-oneclick-apps.yml
+++ b/.github/workflows/update-oneclick-apps.yml
@@ -13,7 +13,7 @@ jobs:
           ZULIP_API_KEY: ${{ secrets.ONE_CLICK_ACTION_ZULIP_BOT_API_KEY }}
           ZULIP_EMAIL: ${{ secrets.ONE_CLICK_ACTION_ZULIP_BOT_EMAIL }}
           ZULIP_SITE: https://chat.zulip.org
-          ONE_CLICK_ACTION_STREAM: kandra-ops
+          ONE_CLICK_ACTION_STREAM: kandra ops
           PYTHON_DIGITALOCEAN_REQUEST_TIMEOUT_SEC: 30
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
         run: |


### PR DESCRIPTION
This bug was introduced in f00c13d303a22268115c7ab0b2adb9a6ebd98645 when we started to hardcode stream name in config file instead of storing it as one of the GitHub secrets.

See https://github.com/hackerkid/zulip/runs/2353888093?check_suite_focus=true for the workflow run.
