### PR TITLE
Clean up some event format code for 4.0 release

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5790,8 +5790,7 @@ def do_delete_messages(realm: Realm, messages: Iterable[Message]) -> None:
         subscribers = get_active_subscriptions_for_stream_id(stream_id)
         # We exclude long-term idle users, since they by definition have no active clients.
         subscribers = subscribers.exclude(user_profile__long_term_idle=True)
-        subscriber_ids = [user.user_profile_id for user in subscribers]
-        users_to_notify = list(map(subscriber_info, subscriber_ids))
+        users_to_notify = list(subscribers.values_list("user_profile_id", flat=True))
         archiving_chunk_size = retention.STREAM_MESSAGE_BATCH_SIZE
 
     move_messages_to_archive(message_ids, realm=realm, chunk_size=archiving_chunk_size)

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -1206,7 +1206,8 @@ def process_notification(notice: Mapping[str, Any]) -> None:
             # compatibility with events in that format still in the
             # queue at the time of upgrade.
             #
-            # TODO: Remove this block in release >= 4.0.
+            # TODO/compatibility: Remove this block once you can no
+            # longer directly upgrade directly from 3.x to master.
             user_ids: List[int] = [user["id"] for user in cast(List[Mapping[str, int]], users)]
         else:
             user_ids = cast(List[int], users)

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -482,7 +482,9 @@ class UserActivityWorker(LoopQueueProcessingWorker):
                 # This is for compatibility with older events still stuck in the queue,
                 # that used the client name in event["client"] instead of having
                 # event["client_id"] directly.
-                # TODO: This can be deleted for release >= 4.0.
+                #
+                # TODO/compatability: We can delete this once it is no
+                # longer possible to directly upgrade from 2.1 to master.
                 if event["client"] not in self.client_id_map:
                     client = get_client(event["client"])
                     self.client_id_map[event["client"]] = client.id


### PR DESCRIPTION
Follow-up to https://github.com/zulip/zulip/commit/85d4536486cd0f4ec4e13b02897c230f837c7e9b. For the second commit - https://github.com/zulip/zulip/commit/cda7b2f5393b803f521f45f566b520ebcd9b8d20 reintroduced message deletion events using dicts instead of user ids in the bulk codepath in 3.*, so after a chat with @amanagr we figured that `do_delete_messages` should be simplified to use user ids in all cases and the goal for deleting the compat code bumped to 5.0 release.