### PR TITLE
refactor: Almost break stream_data out of the cluster.

### DIFF
--- a/docs/testing/testing-with-node.md
+++ b/docs/testing/testing-with-node.md
@@ -32,7 +32,7 @@ in `frontend_tests/node_tests`.  Here is an example test from
     stream_data.add_sub('Denmark', sub);
     sub = stream_data.get_sub('Denmark');
     assert.equal(sub.color, 'red');
-    sub = stream_data.get_sub_by_id(id);
+    sub = sub_store.get(id);
     assert.equal(sub.color, 'red');
 }());
 ```

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -16,6 +16,7 @@ const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const presence = zrequire("presence");
 const stream_data = zrequire("stream_data");
+const sub_store = zrequire("sub_store");
 const user_status = zrequire("user_status");
 const buddy_data = zrequire("buddy_data");
 
@@ -206,7 +207,7 @@ test("compose fade interactions (streams)", () => {
 
     // Test our punting logic.
     const bogus_stream_id = 99999;
-    assert.equal(stream_data.get_sub_by_id(bogus_stream_id), undefined);
+    assert.equal(sub_store.get(bogus_stream_id), undefined);
 
     compose_fade_helper.set_focused_recipient({
         type: "stream",

--- a/frontend_tests/node_tests/dispatch_subs.js
+++ b/frontend_tests/node_tests/dispatch_subs.js
@@ -186,7 +186,6 @@ test("stream create", (override) => {
 
     const stub = make_stub();
     override(stream_data, "create_streams", stub.f);
-    override(stream_data, "get_sub_by_id", noop);
     override(subs, "add_sub_to_table", noop);
     override(overlays, "streams_open", () => true);
     dispatch(event);

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -103,18 +103,6 @@ mock_esm("../../static/js/recent_senders", {
     get_topic_recent_senders: () => [1, 2],
 });
 mock_esm("../../static/js/stream_data", {
-    get_sub_by_id: (stream) => {
-        if (stream === stream5) {
-            // No data is available for deactivated streams
-            return undefined;
-        }
-
-        return {
-            color: "",
-            invite_only: false,
-            is_web_public: true,
-        };
-    },
     is_muted: () =>
         // We only test via muted topics for now.
         // TODO: Make muted streams and test them.
@@ -131,6 +119,20 @@ mock_esm("../../static/js/timerender", {
         date: "date",
         time: "time",
     }),
+});
+mock_esm("../../static/js/sub_store", {
+    get: (stream) => {
+        if (stream === stream5) {
+            // No data is available for deactivated streams
+            return undefined;
+        }
+
+        return {
+            color: "",
+            invite_only: false,
+            is_web_public: true,
+        };
+    },
 });
 mock_esm("../../static/js/top_left_corner", {
     narrow_to_recent_topics: noop,

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -54,10 +54,10 @@ set_global("FormData", _FormData);
 
 const settings_config = zrequire("settings_config");
 const settings_bots = zrequire("settings_bots");
-const stream_data = zrequire("stream_data");
 const stream_settings_data = zrequire("stream_settings_data");
 const settings_account = zrequire("settings_account");
 const settings_org = zrequire("settings_org");
+const sub_store = zrequire("sub_store");
 const dropdown_list_widget = zrequire("dropdown_list_widget");
 
 function test(label, f) {
@@ -1008,7 +1008,7 @@ test("misc", (override) => {
     let setting_name = "realm_notifications_stream_id";
     let elem = $(`#${CSS.escape(setting_name)}_widget #${CSS.escape(setting_name)}_name`);
     elem.closest = () => stub_notification_disable_parent;
-    stream_data.__Rewire__("get_sub_by_id", (stream_id) => {
+    sub_store.__Rewire__("get", (stream_id) => {
         assert.equal(stream_id, 42);
         return {name: "some_stream"};
     });
@@ -1023,7 +1023,7 @@ test("misc", (override) => {
     setting_name = "realm_signup_notifications_stream_id";
     elem = $(`#${CSS.escape(setting_name)}_widget #${CSS.escape(setting_name)}_name`);
     elem.closest = () => stub_notification_disable_parent;
-    stream_data.__Rewire__("get_sub_by_id", (stream_id) => {
+    sub_store.__Rewire__("get", (stream_id) => {
         assert.equal(stream_id, 75);
         return {name: "some_stream"};
     });

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -12,6 +12,7 @@ const {page_params} = require("../zjsunit/zpage_params");
 const color_data = zrequire("color_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const people = zrequire("people");
+const sub_store = zrequire("sub_store");
 const stream_data = zrequire("stream_data");
 const stream_settings_data = zrequire("stream_settings_data");
 const settings_config = zrequire("settings_config");
@@ -135,11 +136,11 @@ test("renames", () => {
     stream_data.add_sub(sub);
     sub = stream_data.get_sub("Denmark");
     assert.equal(sub.color, "red");
-    sub = stream_data.get_sub_by_id(id);
+    sub = sub_store.get(id);
     assert.equal(sub.color, "red");
 
     stream_data.rename_sub(sub, "Sweden");
-    sub = stream_data.get_sub_by_id(id);
+    sub = sub_store.get(id);
     assert.equal(sub.color, "red");
     assert.equal(sub.name, "Sweden");
 
@@ -415,12 +416,12 @@ test("delete_sub", () => {
 
     assert(stream_data.is_subscribed("Canada"));
     assert(stream_data.get_sub("Canada").stream_id, canada.stream_id);
-    assert(stream_data.get_sub_by_id(canada.stream_id).name, "Canada");
+    assert(sub_store.get(canada.stream_id).name, "Canada");
 
     stream_data.delete_sub(canada.stream_id);
     assert(!stream_data.is_subscribed("Canada"));
     assert(!stream_data.get_sub("Canada"));
-    assert(!stream_data.get_sub_by_id(canada.stream_id));
+    assert(!sub_store.get(canada.stream_id));
 
     blueslip.expect("warn", "Failed to archive stream 99999");
     stream_data.delete_sub(99999);

--- a/frontend_tests/node_tests/stream_topic_history.js
+++ b/frontend_tests/node_tests/stream_topic_history.js
@@ -12,6 +12,7 @@ const all_messages_data = zrequire("all_messages_data");
 const unread = zrequire("unread");
 const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
+const stream_topic_history_util = zrequire("stream_topic_history_util");
 
 function test(label, f) {
     run_test(label, (override) => {
@@ -313,7 +314,7 @@ test("server_history_end_to_end", () => {
         get_success_callback = opts.success;
     };
 
-    stream_topic_history.get_server_history(stream_id, () => {
+    stream_topic_history_util.get_server_history(stream_id, () => {
         on_success_called = true;
     });
 
@@ -331,7 +332,7 @@ test("server_history_end_to_end", () => {
     };
 
     on_success_called = false;
-    stream_topic_history.get_server_history(stream_id, () => {
+    stream_topic_history_util.get_server_history(stream_id, () => {
         on_success_called = true;
     });
     assert(on_success_called);

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -15,6 +15,7 @@ const message_store = zrequire("message_store");
 const muting = zrequire("muting");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
+const sub_store = zrequire("sub_store");
 const unread = zrequire("unread");
 
 const me = {
@@ -246,7 +247,7 @@ test("num_unread_for_topic", (override) => {
     // messages.
     const stream_id = 301;
 
-    override(stream_data, "get_sub_by_id", (arg) => {
+    override(sub_store, "get", (arg) => {
         if (arg === stream_id) {
             return {name: "Some Stream"};
         }
@@ -320,7 +321,7 @@ test("home_messages", (override) => {
 
     const stream_id = 401;
 
-    override(stream_data, "get_sub_by_id", () => ({
+    override(sub_store, "get", () => ({
         name: "whatever",
     }));
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -33,6 +33,7 @@ import * as server_events from "./server_events";
 import * as settings_config from "./settings_config";
 import * as stream_data from "./stream_data";
 import * as stream_edit from "./stream_edit";
+import * as sub_store from "./sub_store";
 import * as subs from "./subs";
 import * as transmit from "./transmit";
 import * as ui_report from "./ui_report";
@@ -1184,7 +1185,7 @@ export function initialize() {
             failure(error.msg);
         }
 
-        const sub = stream_data.get_sub_by_id(stream_id);
+        const sub = sub_store.get(stream_id);
 
         stream_edit.invite_user_to_stream([user_id], sub, success, xhr_failure);
     });

--- a/static/js/compose_fade_helper.js
+++ b/static/js/compose_fade_helper.js
@@ -1,4 +1,5 @@
 import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 import * as util from "./util";
 
 let focused_recipient;
@@ -17,7 +18,7 @@ export function set_focused_recipient(recipient) {
 
 export function would_receive_message(user_id) {
     if (focused_recipient.type === "stream") {
-        const sub = stream_data.get_sub_by_id(focused_recipient.stream_id);
+        const sub = sub_store.get(focused_recipient.stream_id);
         if (!sub) {
             // If the stream isn't valid, there is no risk of a mix
             // yet, so we sort of "lie" and say they would receive a
@@ -42,7 +43,7 @@ export function want_normal_display() {
     if (focused_recipient.type === "stream") {
         // If a stream doesn't exist, there is no real chance of a mix, so fading
         // is just noise to the user.
-        if (!stream_data.get_sub_by_id(focused_recipient.stream_id)) {
+        if (!sub_store.get(focused_recipient.stream_id)) {
             return true;
         }
 

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -22,9 +22,9 @@ import * as pm_list from "./pm_list";
 import * as recent_senders from "./recent_senders";
 import * as recent_topics from "./recent_topics";
 import * as resize from "./resize";
-import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
 import * as stream_topic_history from "./stream_topic_history";
+import * as sub_store from "./sub_store";
 import * as unread from "./unread";
 import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
@@ -186,7 +186,7 @@ export function update_messages(events) {
                 event.propagate_mode,
             );
 
-            const stream_name = stream_data.get_sub_by_id(event.stream_id).name;
+            const stream_name = sub_store.get(event.stream_id).name;
             const compose_stream_name = compose_state.stream_name();
             const orig_topic = util.get_edit_event_orig_topic(event);
 
@@ -245,7 +245,7 @@ export function update_messages(events) {
                     msg.topic_links = event.topic_links;
                 }
                 if (stream_changed) {
-                    const new_stream_name = stream_data.get_sub_by_id(new_stream_id).name;
+                    const new_stream_name = sub_store.get(new_stream_id).name;
                     msg.stream_id = event.new_stream_id;
                     msg.stream = new_stream_name;
                     msg.display_recipient = new_stream_name;
@@ -287,7 +287,7 @@ export function update_messages(events) {
                     // stream_data lookup here to fail.
                     //
                     // The fix is likely somewhat involved, so punting for now.
-                    const new_stream_name = stream_data.get_sub_by_id(new_stream_id).name;
+                    const new_stream_name = sub_store.get(new_stream_id).name;
                     new_filter = new_filter.filter_with_new_params({
                         operator: "stream",
                         operand: new_stream_name,

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -28,6 +28,7 @@ import * as recent_topics from "./recent_topics";
 import * as rendered_markdown from "./rendered_markdown";
 import * as rows from "./rows";
 import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 import * as submessage from "./submessage";
 import * as timerender from "./timerender";
 import * as util from "./util";
@@ -147,7 +148,7 @@ function populate_group_from_message_container(group, message_container) {
         group.match_topic = util.get_match_topic(message_container.msg);
         group.stream_url = message_container.stream_url;
         group.topic_url = message_container.topic_url;
-        const sub = stream_data.get_sub_by_id(message_container.msg.stream_id);
+        const sub = sub_store.get(message_container.msg.stream_id);
         if (sub === undefined) {
             // Hack to handle unusual cases like the tutorial where
             // the streams used don't actually exist in the subs

--- a/static/js/peer_data.js
+++ b/static/js/peer_data.js
@@ -1,7 +1,7 @@
 import * as blueslip from "./blueslip";
 import {LazySet} from "./lazy_set";
 import * as people from "./people";
-import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 
 // This maps a stream_id to a LazySet of user_ids who are subscribed.
 const stream_subscribers = new Map();
@@ -21,7 +21,7 @@ function get_user_set(stream_id) {
     // We create one on the fly as necessary, but we warn in that case.
     assert_number(stream_id);
 
-    if (!stream_data.get_sub_by_id(stream_id)) {
+    if (!sub_store.get(stream_id)) {
         blueslip.warn("We called get_user_set for an untracked stream: " + stream_id);
     }
 

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -24,6 +24,7 @@ import * as popovers from "./popovers";
 import * as recent_senders from "./recent_senders";
 import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
+import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 import * as top_left_corner from "./top_left_corner";
 import * as unread from "./unread";
@@ -232,7 +233,7 @@ function format_topic(topic_data) {
     const last_msg = message_store.get(topic_data.last_msg_id);
     const stream = last_msg.stream;
     const stream_id = last_msg.stream_id;
-    const stream_info = stream_data.get_sub_by_id(stream_id);
+    const stream_info = sub_store.get(stream_id);
     if (stream_info === undefined) {
         // stream was deleted
         return {};
@@ -319,7 +320,7 @@ export function update_topics_of_deleted_message_ids(message_ids) {
 
 export function filters_should_hide_topic(topic_data) {
     const msg = message_store.get(topic_data.last_msg_id);
-    const sub = stream_data.get_sub_by_id(msg.stream_id);
+    const sub = sub_store.get(msg.stream_id);
 
     if (sub === undefined || !sub.subscribed) {
         // Never try to process deactivated & unsubscribed stream msgs.

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -52,6 +52,7 @@ import * as stream_data from "./stream_data";
 import * as stream_events from "./stream_events";
 import * as stream_list from "./stream_list";
 import * as stream_topic_history from "./stream_topic_history";
+import * as sub_store from "./sub_store";
 import * as submessage from "./submessage";
 import * as subs from "./subs";
 import * as typing_events from "./typing_events";
@@ -414,7 +415,7 @@ export function dispatch_normal_event(event) {
                     stream_data.create_streams(event.streams);
 
                     for (const stream of event.streams) {
-                        const sub = stream_data.get_sub_by_id(stream.stream_id);
+                        const sub = sub_store.get(stream.stream_id);
                         if (overlays.streams_open()) {
                             subs.add_sub_to_table(sub);
                         }
@@ -422,8 +423,7 @@ export function dispatch_normal_event(event) {
                     break;
                 case "delete":
                     for (const stream of event.streams) {
-                        const was_subscribed = stream_data.get_sub_by_id(stream.stream_id)
-                            .subscribed;
+                        const was_subscribed = sub_store.get(stream.stream_id).subscribed;
                         const is_narrowed_to_stream = narrow_state.is_for_stream_id(
                             stream.stream_id,
                         );
@@ -472,7 +472,7 @@ export function dispatch_normal_event(event) {
             switch (event.op) {
                 case "add":
                     for (const rec of event.subscriptions) {
-                        const sub = stream_data.get_sub_by_id(rec.stream_id);
+                        const sub = sub_store.get(rec.stream_id);
                         if (sub) {
                             stream_data.update_stream_email_address(sub, rec.email_address);
                             stream_events.mark_subscribed(sub, rec.subscribers, rec.color);
@@ -484,13 +484,13 @@ export function dispatch_normal_event(event) {
                     }
                     break;
                 case "peer_add": {
-                    const stream_ids = stream_data.validate_stream_ids(event.stream_ids);
+                    const stream_ids = sub_store.validate_stream_ids(event.stream_ids);
                     const user_ids = people.validate_user_ids(event.user_ids);
 
                     peer_data.bulk_add_subscribers({stream_ids, user_ids});
 
                     for (const stream_id of stream_ids) {
-                        const sub = stream_data.get_sub_by_id(stream_id);
+                        const sub = sub_store.get(stream_id);
                         subs.update_subscribers_ui(sub);
                     }
 
@@ -498,13 +498,13 @@ export function dispatch_normal_event(event) {
                     break;
                 }
                 case "peer_remove": {
-                    const stream_ids = stream_data.validate_stream_ids(event.stream_ids);
+                    const stream_ids = sub_store.validate_stream_ids(event.stream_ids);
                     const user_ids = people.validate_user_ids(event.user_ids);
 
                     peer_data.bulk_remove_subscribers({stream_ids, user_ids});
 
                     for (const stream_id of stream_ids) {
-                        const sub = stream_data.get_sub_by_id(stream_id);
+                        const sub = sub_store.get(stream_id);
                         subs.update_subscribers_ui(sub);
                     }
 
@@ -513,7 +513,7 @@ export function dispatch_normal_event(event) {
                 }
                 case "remove":
                     for (const rec of event.subscriptions) {
-                        const sub = stream_data.get_sub_by_id(rec.stream_id);
+                        const sub = sub_store.get(rec.stream_id);
                         stream_events.mark_unsubscribed(sub);
                     }
                     break;

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -8,6 +8,7 @@ import * as ListWidget from "./list_widget";
 import * as loading from "./loading";
 import {page_params} from "./page_params";
 import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 import * as typeahead_helper from "./typeahead_helper";
 import * as ui from "./ui";
 import * as ui_report from "./ui_report";
@@ -34,7 +35,7 @@ export function build_default_stream_table() {
     const table = $("#admin_default_streams_table").expectOne();
 
     const stream_ids = stream_data.get_default_stream_ids();
-    const subs = stream_ids.map((stream_id) => stream_data.get_sub_by_id(stream_id));
+    const subs = stream_ids.map((stream_id) => sub_store.get(stream_id));
 
     ListWidget.create(table, subs, {
         name: "default_streams_list",

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -751,13 +751,3 @@ export function initialize(params) {
 export function remove_default_stream(stream_id) {
     default_stream_ids.delete(stream_id);
 }
-
-export function get_sub_by_id(stream_id) {
-    // TODO: remove this shim in the next commit
-    return sub_store.get(stream_id);
-}
-
-export function validate_stream_ids(stream_ids) {
-    // TODO: remove this shim in the next commit
-    return sub_store.validate_stream_ids(stream_ids);
-}

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -29,6 +29,7 @@ import * as stream_data from "./stream_data";
 import * as stream_pill from "./stream_pill";
 import * as stream_settings_data from "./stream_settings_data";
 import * as stream_ui_updates from "./stream_ui_updates";
+import * as sub_store from "./sub_store";
 import * as subs from "./subs";
 import * as ui from "./ui";
 import * as ui_report from "./ui_report";
@@ -162,7 +163,7 @@ function get_sub_for_target(target) {
         return undefined;
     }
 
-    const sub = stream_data.get_sub_by_id(stream_id);
+    const sub = sub_store.get(stream_id);
     if (!sub) {
         blueslip.error("get_sub_for_target() failed id lookup: " + stream_id);
         return undefined;
@@ -443,7 +444,7 @@ export function stream_settings(sub) {
 
 export function show_settings_for(node) {
     const stream_id = get_stream_id(node);
-    const slim_sub = stream_data.get_sub_by_id(stream_id);
+    const slim_sub = sub_store.get(stream_id);
     stream_data.clean_up_description(slim_sub);
     const sub = stream_settings_data.get_sub_for_settings(slim_sub);
 
@@ -542,7 +543,7 @@ function change_stream_privacy(e) {
     e.stopPropagation();
 
     const stream_id = $(e.target).data("stream-id");
-    const sub = stream_data.get_sub_by_id(stream_id);
+    const sub = sub_store.get(stream_id);
     const data = {};
     const stream_privacy_status = $(".stream-privacy-status");
     stream_privacy_status.hide();
@@ -735,7 +736,7 @@ export function initialize() {
 
     $("#subscriptions_table").on("click", ".change-stream-privacy", (e) => {
         const stream_id = get_stream_id(e.target);
-        const stream = stream_data.get_sub_by_id(stream_id);
+        const stream = sub_store.get(stream_id);
 
         const template_data = {
             stream_id,

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -15,6 +15,7 @@ import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
 import * as stream_muting from "./stream_muting";
+import * as sub_store from "./sub_store";
 import * as subs from "./subs";
 
 // In theory, this function should apply the account-level defaults,
@@ -28,7 +29,7 @@ function update_stream_setting(sub, value, setting) {
 }
 
 export function update_property(stream_id, property, value, other_values) {
-    const sub = stream_data.get_sub_by_id(stream_id);
+    const sub = sub_store.get(stream_id);
     if (sub === undefined) {
         // This isn't a stream we know about, so ignore it.
         blueslip.warn("Update for an unknown subscription", {

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -17,6 +17,7 @@ import * as scroll_util from "./scroll_util";
 import * as stream_data from "./stream_data";
 import * as stream_popover from "./stream_popover";
 import * as stream_sort from "./stream_sort";
+import * as sub_store from "./sub_store";
 import * as topic_list from "./topic_list";
 import * as topic_zoom from "./topic_zoom";
 import * as ui from "./ui";
@@ -471,7 +472,7 @@ function keydown_enter_key() {
         return;
     }
 
-    const sub = stream_data.get_sub_by_id(stream_id);
+    const sub = sub_store.get(stream_id);
 
     if (sub === undefined) {
         blueslip.error("Unknown stream_id for search/enter: " + stream_id);
@@ -505,7 +506,7 @@ export function set_event_handlers() {
             return;
         }
         const stream_id = stream_id_for_elt($(e.target).parents("li"));
-        const sub = stream_data.get_sub_by_id(stream_id);
+        const sub = sub_store.get(stream_id);
         popovers.hide_all();
         narrow.by("stream", sub.name, {trigger: "sidebar"});
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -23,6 +23,7 @@ import * as starred_messages_ui from "./starred_messages_ui";
 import * as stream_bar from "./stream_bar";
 import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 import * as subs from "./subs";
 import * as unread_ops from "./unread_ops";
 
@@ -140,7 +141,7 @@ export function hide_streamlist_sidebar() {
 function stream_popover_sub(e) {
     const elem = $(e.currentTarget).parents("ul");
     const stream_id = elem_to_stream_id(elem);
-    const sub = stream_data.get_sub_by_id(stream_id);
+    const sub = sub_store.get(stream_id);
     if (!sub) {
         blueslip.error("Unknown stream: " + stream_id);
         return undefined;
@@ -192,7 +193,7 @@ function build_stream_popover(opts) {
     show_streamlist_sidebar();
 
     const content = render_stream_sidebar_actions({
-        stream: stream_data.get_sub_by_id(stream_id),
+        stream: sub_store.get(stream_id),
     });
 
     $(elt).popover({
@@ -224,7 +225,7 @@ function build_topic_popover(opts) {
         return;
     }
 
-    const sub = stream_data.get_sub_by_id(stream_id);
+    const sub = sub_store.get(stream_id);
     if (!sub) {
         blueslip.error("cannot build topic popover for stream: " + stream_id);
         return;

--- a/static/js/stream_settings_data.js
+++ b/static/js/stream_settings_data.js
@@ -3,6 +3,7 @@ import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as settings_config from "./settings_config";
 import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 import * as util from "./util";
 
 export function get_sub_for_settings(sub) {
@@ -111,7 +112,7 @@ export function sort_for_stream_settings(stream_ids, order) {
     //       which uses Intl.Collator() when possible.
 
     function name(stream_id) {
-        const sub = stream_data.get_sub_by_id(stream_id);
+        const sub = sub_store.get(stream_id);
         if (!sub) {
             return "";
         }
@@ -119,7 +120,7 @@ export function sort_for_stream_settings(stream_ids, order) {
     }
 
     function weekly_traffic(stream_id) {
-        const sub = stream_data.get_sub_by_id(stream_id);
+        const sub = sub_store.get(stream_id);
         if (sub && sub.stream_weekly_traffic !== null) {
             return sub.stream_weekly_traffic;
         }

--- a/static/js/stream_sort.js
+++ b/static/js/stream_sort.js
@@ -1,4 +1,5 @@
 import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 import * as util from "./util";
 
 let previous_pinned;
@@ -14,8 +15,8 @@ export function get_streams() {
 }
 
 function compare_function(a, b) {
-    const stream_a = stream_data.get_sub_by_id(a);
-    const stream_b = stream_data.get_sub_by_id(b);
+    const stream_a = sub_store.get(a);
+    const stream_b = sub_store.get(b);
 
     const stream_name_a = stream_a ? stream_a.name : "";
     const stream_name_b = stream_b ? stream_b.name : "";
@@ -33,7 +34,7 @@ function filter_streams_by_search(streams, search_term) {
 
     const filtered_streams = streams.filter((stream) =>
         search_terms.some((search_term) => {
-            const lower_stream_name = stream_data.get_sub_by_id(stream).name.toLowerCase();
+            const lower_stream_name = sub_store.get(stream).name.toLowerCase();
             const cands = lower_stream_name.split(" ");
             cands.push(lower_stream_name);
             return cands.some((name) => name.startsWith(search_term));
@@ -55,7 +56,7 @@ export function sort_groups(streams, search_term) {
     const dormant_streams = [];
 
     for (const stream of streams) {
-        const sub = stream_data.get_sub_by_id(stream);
+        const sub = sub_store.get(stream);
         const pinned = sub.pin_to_top;
         if (pinned) {
             pinned_streams.push(stream);

--- a/static/js/stream_topic_history.js
+++ b/static/js/stream_topic_history.js
@@ -1,7 +1,7 @@
 import {all_messages_data} from "./all_messages_data";
 import {FoldDict} from "./fold_dict";
 import * as message_util from "./message_util";
-import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 import * as unread from "./unread";
 
 const stream_dict = new Map(); // stream_id -> PerStreamHistory object
@@ -45,7 +45,7 @@ export function is_complete_for_stream_id(stream_id) {
         return true;
     }
 
-    const sub = stream_data.get_sub_by_id(stream_id);
+    const sub = sub_store.get(stream_id);
     const in_cache = all_topics_in_cache(sub);
 
     if (in_cache) {

--- a/static/js/stream_topic_history.js
+++ b/static/js/stream_topic_history.js
@@ -1,5 +1,4 @@
 import {all_messages_data} from "./all_messages_data";
-import * as channel from "./channel";
 import {FoldDict} from "./fold_dict";
 import * as message_util from "./message_util";
 import * as stream_data from "./stream_data";
@@ -291,23 +290,8 @@ export function add_history(stream_id, server_history) {
     fetched_stream_ids.add(stream_id);
 }
 
-export function get_server_history(stream_id, on_success) {
-    if (fetched_stream_ids.has(stream_id)) {
-        on_success();
-        return;
-    }
-
-    const url = "/json/users/me/" + stream_id + "/topics";
-
-    channel.get({
-        url,
-        data: {},
-        success(data) {
-            const server_history = data.topics;
-            add_history(stream_id, server_history);
-            on_success();
-        },
-    });
+export function has_history_for(stream_id) {
+    return fetched_stream_ids.has(stream_id);
 }
 
 export function get_recent_topic_names(stream_id) {

--- a/static/js/stream_topic_history_util.js
+++ b/static/js/stream_topic_history_util.js
@@ -1,0 +1,21 @@
+import * as channel from "./channel";
+import * as stream_topic_history from "./stream_topic_history";
+
+export function get_server_history(stream_id, on_success) {
+    if (stream_topic_history.has_history_for(stream_id)) {
+        on_success();
+        return;
+    }
+
+    const url = "/json/users/me/" + stream_id + "/topics";
+
+    channel.get({
+        url,
+        data: {},
+        success(data) {
+            const server_history = data.topics;
+            stream_topic_history.add_history(stream_id, server_history);
+            on_success();
+        },
+    });
+}

--- a/static/js/sub_store.js
+++ b/static/js/sub_store.js
@@ -1,0 +1,40 @@
+import * as blueslip from "./blueslip";
+
+const subs_by_stream_id = new Map();
+
+export function get(stream_id) {
+    return subs_by_stream_id.get(stream_id);
+}
+
+export function validate_stream_ids(stream_ids) {
+    const good_ids = [];
+    const bad_ids = [];
+
+    for (const stream_id of stream_ids) {
+        if (subs_by_stream_id.has(stream_id)) {
+            good_ids.push(stream_id);
+        } else {
+            bad_ids.push(stream_id);
+        }
+    }
+
+    if (bad_ids.length > 0) {
+        blueslip.warn(`We have untracked stream_ids: ${bad_ids}`);
+    }
+
+    return good_ids;
+}
+
+export function clear() {
+    subs_by_stream_id.clear();
+}
+
+export function delete_sub(stream_id) {
+    subs_by_stream_id.delete(stream_id);
+}
+
+export function add_hydrated_sub(stream_id, sub) {
+    // The only code that should call this directly is
+    // in stream_data.js. Grep there to find callers.
+    subs_by_stream_id.set(stream_id, sub);
+}

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -31,6 +31,7 @@ import * as stream_list from "./stream_list";
 import * as stream_muting from "./stream_muting";
 import * as stream_settings_data from "./stream_settings_data";
 import * as stream_ui_updates from "./stream_ui_updates";
+import * as sub_store from "./sub_store";
 import * as ui from "./ui";
 import * as ui_report from "./ui_report";
 import * as util from "./util";
@@ -94,7 +95,7 @@ export function settings_button_for_sub(sub) {
 function get_row_data(row) {
     const row_id = Number.parseInt(row.attr("data-stream-id"), 10);
     if (row_id) {
-        const row_object = stream_data.get_sub_by_id(row_id);
+        const row_object = sub_store.get(row_id);
         return {
             id: row_id,
             object: row_object,
@@ -248,7 +249,7 @@ export function update_message_retention_setting(sub, new_value) {
 }
 
 export function set_color(stream_id, color) {
-    const sub = stream_data.get_sub_by_id(stream_id);
+    const sub = sub_store.get(stream_id);
     stream_edit.set_stream_property(sub, "color", color);
 }
 
@@ -301,7 +302,7 @@ export function remove_stream(stream_id) {
     // stream, but we let jQuery silently handle that.
     const row = row_for_stream_id(stream_id);
     row.remove();
-    const sub = stream_data.get_sub_by_id(stream_id);
+    const sub = sub_store.get(stream_id);
     if (stream_edit.is_sub_settings_active(sub)) {
         stream_edit.open_edit_panel_empty();
     }
@@ -399,7 +400,7 @@ function get_stream_id_buckets(stream_ids, left_panel_params) {
     };
 
     for (const stream_id of stream_ids) {
-        const sub = stream_data.get_sub_by_id(stream_id);
+        const sub = sub_store.get(stream_id);
         const match_status = triage_stream(left_panel_params, sub);
 
         if (match_status === "name_match") {

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -10,6 +10,7 @@ import * as narrow from "./narrow";
 import * as stream_data from "./stream_data";
 import * as stream_popover from "./stream_popover";
 import * as stream_topic_history from "./stream_topic_history";
+import * as stream_topic_history_util from "./stream_topic_history_util";
 import * as topic_list_data from "./topic_list_data";
 import * as ui from "./ui";
 import * as vdom from "./vdom";
@@ -251,7 +252,7 @@ export function zoom_in() {
     const spinner = true;
     active_widget.build(spinner);
 
-    stream_topic_history.get_server_history(stream_id, on_success);
+    stream_topic_history_util.get_server_history(stream_id, on_success);
 }
 
 export function initialize() {

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -7,10 +7,10 @@ import render_topic_list_item from "../templates/topic_list_item.hbs";
 
 import * as blueslip from "./blueslip";
 import * as narrow from "./narrow";
-import * as stream_data from "./stream_data";
 import * as stream_popover from "./stream_popover";
 import * as stream_topic_history from "./stream_topic_history";
 import * as stream_topic_history_util from "./stream_topic_history_util";
+import * as sub_store from "./sub_store";
 import * as topic_list_data from "./topic_list_data";
 import * as ui from "./ui";
 import * as vdom from "./vdom";
@@ -269,7 +269,7 @@ export function initialize() {
 
         const stream_row = $(e.target).parents(".narrow-filter");
         const stream_id = Number.parseInt(stream_row.attr("data-stream-id"), 10);
-        const sub = stream_data.get_sub_by_id(stream_id);
+        const sub = sub_store.get(stream_id);
         const topic = $(e.target).parents("li").attr("data-topic-name");
 
         narrow.activate(

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -5,6 +5,7 @@ import {page_params} from "./page_params";
 import * as people from "./people";
 import * as settings_config from "./settings_config";
 import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 import * as util from "./util";
 
 // The unread module tracks the message IDs and locations of the
@@ -242,7 +243,7 @@ class UnreadTopicCounter {
             // unsubscribed.  Since users may re-subscribe, we don't
             // completely throw away the data.  But we do ignore it here,
             // so that callers have a view of the **current** world.
-            const sub = stream_data.get_sub_by_id(stream_id);
+            const sub = sub_store.get(stream_id);
             if (!sub || !stream_data.is_subscribed(sub.name)) {
                 continue;
             }
@@ -297,7 +298,7 @@ class UnreadTopicCounter {
             return 0;
         }
 
-        const sub = stream_data.get_sub_by_id(stream_id);
+        const sub = sub_store.get(stream_id);
         for (const [topic, msgs] of per_stream_bucketer) {
             if (sub && !muting.is_topic_muted(stream_id, topic)) {
                 stream_count += msgs.size;
@@ -329,7 +330,7 @@ class UnreadTopicCounter {
         }
 
         const ids = [];
-        const sub = stream_data.get_sub_by_id(stream_id);
+        const sub = sub_store.get(stream_id);
         for (const [topic, id_set] of per_stream_bucketer) {
             if (sub && !muting.is_topic_muted(stream_id, topic)) {
                 for (const id of id_set) {


### PR DESCRIPTION
This mostly breaks stream_data out of our cluster of dependencies.

There is still some indirect entanglement with UI modules via stream_topic_history and message_util that I need to finally break it out, but these changes move us forward.