### PR TITLE
Fix filter UI widgets incorrectly labeled as a search element

### DIFF
--- a/frontend_tests/puppeteer_tests/message-basics.ts
+++ b/frontend_tests/puppeteer_tests/message-basics.ts
@@ -319,7 +319,7 @@ async function test_search_venice(page: Page): Promise<void> {
 }
 
 async function test_stream_search_filters_stream_list(page: Page): Promise<void> {
-    console.log("Search streams using left side bar");
+    console.log("Filter streams using left side bar");
 
     await page.waitForSelector(".input-append.notdisplayed"); // Stream filter box invisible initially
     await page.click("#streams_header .sidebar-title");

--- a/static/templates/settings/attachments_settings.hbs
+++ b/static/templates/settings/attachments_settings.hbs
@@ -1,6 +1,6 @@
 <div id="attachments-settings" class="settings-section" data-name="uploaded-files">
     <div id="attachment-stats-holder"></div>
-    <input id="upload_file_search" class="search" type="text" placeholder="{{t 'Search uploads...' }}" aria-label="{{t 'Search uploads...' }}"/>
+    <input id="upload_file_search" class="search" type="text" placeholder="{{t 'Filter uploads' }}" aria-label="{{t 'Filter uploads' }}"/>
     <div class="clear-float"></div>
     <div class="alert" id="delete-upload-status"></div>
     <div class="progressive-table-wrapper" data-simplebar>

--- a/static/templates/settings/muted_topics_settings.hbs
+++ b/static/templates/settings/muted_topics_settings.hbs
@@ -1,5 +1,5 @@
 <div id="muted-topic-settings" class="settings-section" data-name="muted-topics">
-    <input id="muted_topics_search" class="search" type="text" placeholder="{{t 'Search muted topics...' }}" aria-label="{{t 'Search muted topics...' }}"/>
+    <input id="muted_topics_search" class="search" type="text" placeholder="{{t 'Filter muted topics' }}" aria-label="{{t 'Filter muted topics' }}"/>
     <div class="progressive-table-wrapper" data-simplebar data-list-widget="muted-topics-list">
         <table class="table table-condensed table-striped wrapped-table">
             <thead>

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -70,7 +70,7 @@
                     <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>K</kbd> or <kbd>/</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{% trans %}Search streams{% endtrans %}</td>
+                    <td class="definition">{% trans %}Filter streams{% endtrans %}</td>
                     <td><span class="hotkey"><kbd>Q</kbd></span></td>
                 </tr>
                 <tr>

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -63,7 +63,7 @@
                 <i id="streams_inline_cog" class='fa fa-cog tippy-zulip-tooltip' aria-hidden="true" data-tippy-content="{{ _('Subscribe, add, or configure streams') }}"></i>
                 <i id="streams_filter_icon" class='fa fa-search tippy-zulip-tooltip' aria-hidden="true" data-tippy-content="{{ _('Filter streams') }} (q)"></i>
                 <div class="input-append notdisplayed stream_search_section">
-                    <input class="stream-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{ _('Search streams') }}" />
+                    <input class="stream-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{ _('Filter streams') }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -48,7 +48,7 @@ below, and add more to your repertoire as needed.
 
 * **Search messages**: `/` or `Ctrl+k`
 
-* **Search streams**: `q`
+* **Filter streams**: `q`
 
 * **Search people**: `w`
 

--- a/templates/zerver/help/organize-the-streams-sidebar.md
+++ b/templates/zerver/help/organize-the-streams-sidebar.md
@@ -46,7 +46,7 @@ To learn more about pinning a stream, see [here](/help/pin-a-stream).
     !!! tip ""
         You can also use the hotkey "w" to open the search box directly
 
-2. A search box entitled **Search streams** will appear. You can type the
+2. A text box entitled **Filter streams** will appear. You can type the
  name of a stream into this box and the **Streams** section will be filtered
  accordingly.
 

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -547,7 +547,7 @@ html_rules: List["Rule"] = [
         },
         "exclude": {"templates/analytics/support.html"},
         "good_lines": [
-            '<input class="stream-list-filter" type="text" placeholder="{{ _(\'Search streams\') }}" />'
+            '<input class="stream-list-filter" type="text" placeholder="{{ _(\'Filter streams\') }}" />'
         ],
         "bad_lines": ['<input placeholder="foo">'],
     },
@@ -567,7 +567,7 @@ html_rules: List["Rule"] = [
         "pattern": "placeholder='[^{]",
         "description": "`placeholder` value should be translatable.",
         "good_lines": [
-            '<input class="stream-list-filter" type="text" placeholder="{{ _(\'Search streams\') }}" />'
+            '<input class="stream-list-filter" type="text" placeholder="{{ _(\'Filter streams\') }}" />'
         ],
         "bad_lines": ["<input placeholder='foo'>"],
     },

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -244,7 +244,7 @@ class HomeTest(ZulipTestCase):
             "Manage streams",
             "Narrow to topic",
             "Next message",
-            "Search streams",
+            "Filter streams",
             # Verify that the app styles get included
             "app-stubentry.js",
             "data-params",


### PR DESCRIPTION
This fixes:
* "Search streams" in the left sidebar
* A couple settings UI widgets

This PR does not change the right sidebar from "Search people", since I'm not sure what the right path forward is for that.

See https://chat.zulip.org/#narrow/stream/101-design/topic/Search.20streams/near/1163469 for background.