### PR TITLE
Added puppeteer tests for `recent topic view`. 

### DIFF
--- a/frontend_tests/puppeteer_tests/drafts.ts
+++ b/frontend_tests/puppeteer_tests/drafts.ts
@@ -4,7 +4,7 @@ import type {Page} from "puppeteer";
 
 import common from "../puppeteer_lib/common";
 
-async function wait_for_drafts_to_dissapear(page: Page): Promise<void> {
+async function wait_for_drafts_to_disappear(page: Page): Promise<void> {
     await page.waitForFunction(
         () => $("#draft_overlay").length === 0 || $("#draft_overlay").css("opacity") === "0",
     );
@@ -33,7 +33,7 @@ async function test_empty_drafts(page: Page): Promise<void> {
     assert.strictEqual(await common.get_text_from_selector(page, ".drafts-list"), "No drafts.");
 
     await page.click(`${drafts_overlay} .exit`);
-    await wait_for_drafts_to_dissapear(page);
+    await wait_for_drafts_to_disappear(page);
 }
 
 async function create_stream_message_draft(page: Page): Promise<void> {
@@ -118,7 +118,7 @@ async function test_previously_created_drafts_rendered(page: Page): Promise<void
 async function test_restore_message_draft(page: Page): Promise<void> {
     console.log("Restoring Stream Message Draft");
     await page.click("#drafts_table .message_row:not(.private-message) .restore-draft");
-    await wait_for_drafts_to_dissapear(page);
+    await wait_for_drafts_to_disappear(page);
     await page.waitForSelector("#stream-message", {visible: true});
     await page.waitForSelector("#preview_message_area", {hidden: true});
     await common.check_form_contents(page, "form#send_message_form", {
@@ -173,7 +173,7 @@ async function test_edited_draft_message(page: Page): Promise<void> {
 async function test_restore_private_message_draft(page: Page): Promise<void> {
     console.log("Restoring private message draft.");
     await page.click("#drafts_table .message_row.private-message .restore-draft");
-    await wait_for_drafts_to_dissapear(page);
+    await wait_for_drafts_to_disappear(page);
     await page.waitForSelector("#private-message", {visible: true});
     await common.check_form_contents(page, "form#send_message_form", {
         content: "Test private message.",
@@ -199,7 +199,7 @@ async function test_delete_draft(page: Page): Promise<void> {
     assert.strictEqual(drafts_count, 1, "Draft not deleted.");
     await page.waitForSelector("#drafts_table .message_row.private-message", {hidden: true});
     await page.click(`${drafts_overlay} .exit`);
-    await wait_for_drafts_to_dissapear(page);
+    await wait_for_drafts_to_disappear(page);
     await page.click("body");
 }
 
@@ -243,7 +243,7 @@ async function test_save_draft_by_reloading(page: Page): Promise<void> {
 
 async function test_delete_draft_on_sending(page: Page): Promise<void> {
     await page.click("#drafts_table .message_row.private-message .restore-draft");
-    await wait_for_drafts_to_dissapear(page);
+    await wait_for_drafts_to_disappear(page);
     await page.waitForSelector("#private-message", {visible: true});
     await common.ensure_enter_does_not_send(page);
     await page.waitForSelector("#compose-send-button", {visible: true});

--- a/frontend_tests/puppeteer_tests/recent-topic.ts
+++ b/frontend_tests/puppeteer_tests/recent-topic.ts
@@ -233,6 +233,37 @@ async function test_all_filters(page: Page): Promise<void> {
     await trigger_filter_button(page, participated_filter_button);
 }
 
+// Tests the `t` hotkey which navigates back to recent topic page.
+async function test_recent_topic_hotkey(page: Page): Promise<void> {
+    await page.waitForSelector("#zfilt", {visible: true});
+    await page.keyboard.press("t");
+    await page.waitForSelector(recent_topic_page, {visible: true});
+}
+
+async function test_stream_navigation(page: Page, stream_name: string): Promise<void> {
+    await page.waitForSelector(recent_topic_page, {visible: true});
+
+    const stream = await page.evaluate((stream_name: string) => {
+        const stream_selector = $(`.recent_topic_stream a:contains('${stream_name}')`).first();
+        return stream_selector.attr("href");
+    }, stream_name);
+
+    await page.click(`${recent_topic_page} a[href = '${stream}']`);
+    await page.waitForSelector("#zfilt", {visible: true});
+}
+
+async function test_topic_navigation(page: Page, topic_name: string): Promise<void> {
+    await page.waitForSelector(recent_topic_page, {visible: true});
+
+    const topic = await page.evaluate((topic_name: string) => {
+        const topic_selector = $(`.recent_topic_name a:contains('${topic_name}')`).first();
+        return topic_selector.attr("href");
+    }, topic_name);
+
+    await page.click(`${recent_topic_page} a[href = '${topic}']`);
+    await page.waitForSelector("#zfilt", {visible: true});
+}
+
 async function test_recent_topic(page: Page): Promise<void> {
     await common.log_in(page);
     await page.click(".top_left_recent_topics");
@@ -249,6 +280,11 @@ async function test_recent_topic(page: Page): Promise<void> {
     await test_unread_and_participated_filter_button(page);
     await test_include_muted_and_participated_filter_button(page);
     await test_all_filters(page);
+
+    await test_stream_navigation(page, "Verona");
+    await test_recent_topic_hotkey(page); // Tests for 't' hotkey.
+    await test_topic_navigation(page, "plotter");
+    await test_recent_topic_hotkey(page); // Navigate back to recent topic page.
 }
 
 common.run_test(test_recent_topic);

--- a/frontend_tests/puppeteer_tests/recent-topic.ts
+++ b/frontend_tests/puppeteer_tests/recent-topic.ts
@@ -5,6 +5,10 @@ import type {Page} from "puppeteer";
 import common from "../puppeteer_lib/common";
 
 const recent_topic_page = "#recent_topics_view";
+const all_filter_button = ".btn-recent-filters[data-filter='all']";
+const include_muted_filter_button = ".btn-recent-filters[data-filter='include_muted']";
+const unread_filter_button = ".btn-recent-filters[data-filter='unread']";
+const participated_filter_button = ".btn-recent-filters[data-filter='participated']";
 
 // Returns an array based on all text found within the selector passed.
 async function get_selector_text(page: Page, selector: string): Promise<string[]> {
@@ -14,6 +18,11 @@ async function get_selector_text(page: Page, selector: string): Promise<string[]
     ).then((value) => value);
 
     return text;
+}
+
+async function trigger_filter_button(page: Page, selector: string): Promise<void> {
+    await page.waitForSelector(selector);
+    await page.click(selector);
 }
 
 async function get_stream_names(page: Page): Promise<string[]> {
@@ -61,12 +70,185 @@ async function test_initial_topics(page: Page): Promise<void> {
     ]);
 }
 
+// Should yield same result as `test_initial_topics`.
+async function test_all_filter_button(page: Page): Promise<void> {
+    await page.waitForSelector(recent_topic_page);
+
+    // Triggering the `All` filter button.
+    await trigger_filter_button(page, all_filter_button);
+
+    const stream_names = await get_stream_names(page);
+    assert.deepStrictEqual(stream_names, [
+        "Verona",
+        "Denmark",
+        "Venice",
+        "Denmark",
+        "Venice",
+        "Verona",
+        "Verona",
+    ]);
+
+    const topic_names = await get_topic_names(page);
+    assert.deepStrictEqual(topic_names, [
+        "last nas is loading",
+        "last database linking",
+        "URLS",
+        "last server wasn't loading slowly",
+        "database isn't skipping erratically",
+        "plotter",
+        "green printer is running quickly",
+    ]);
+}
+
+async function test_include_muted_filter_button(page: Page): Promise<void> {
+    await page.waitForSelector(recent_topic_page);
+
+    // Triggering the `Include muted` filter button.
+    await trigger_filter_button(page, include_muted_filter_button);
+
+    const stream_names = await get_stream_names(page);
+    assert.deepStrictEqual(stream_names, [
+        "Verona",
+        "Denmark",
+        "Venice",
+        "Denmark",
+        "Venice",
+        "Verona",
+        "Verona",
+    ]);
+
+    const topic_names = await get_topic_names(page);
+    assert.deepStrictEqual(topic_names, [
+        "last nas is loading",
+        "last database linking",
+        "URLS",
+        "last server wasn't loading slowly",
+        "database isn't skipping erratically",
+        "plotter",
+        "green printer is running quickly",
+    ]);
+
+    // Unchecking the checkbox by clicking the button again.
+    await trigger_filter_button(page, include_muted_filter_button);
+}
+
+async function test_unread_filter_button(page: Page): Promise<void> {
+    await page.waitForSelector(recent_topic_page);
+
+    // Triggering the `Unread` filter button.
+    await trigger_filter_button(page, unread_filter_button);
+
+    const stream_names = await get_stream_names(page);
+    assert.deepStrictEqual(stream_names, []);
+
+    const topic_names = await get_topic_names(page);
+    assert.deepStrictEqual(topic_names, []);
+
+    await trigger_filter_button(page, unread_filter_button);
+}
+
+async function test_participated_filter_button(page: Page): Promise<void> {
+    await page.waitForSelector(recent_topic_page);
+
+    // Triggering the `Participated` filter button.
+    await trigger_filter_button(page, participated_filter_button);
+
+    const stream_names = await get_stream_names(page);
+    assert.deepStrictEqual(stream_names, ["Venice", "Denmark", "Verona"]);
+
+    const topic_names = await get_topic_names(page);
+    assert.deepStrictEqual(topic_names, ["URLS", "last server wasn't loading slowly", "plotter"]);
+
+    await trigger_filter_button(page, participated_filter_button);
+}
+
+async function test_include_muted_and_unread_filter_button(page: Page): Promise<void> {
+    await page.waitForSelector(recent_topic_page);
+
+    // Triggering the `Include Muted` and `Unread` filter button.
+    await trigger_filter_button(page, include_muted_filter_button);
+    await trigger_filter_button(page, unread_filter_button);
+
+    const stream_names = await get_stream_names(page);
+    assert.deepStrictEqual(stream_names, []);
+
+    const topic_names = await get_topic_names(page);
+    assert.deepStrictEqual(topic_names, []);
+
+    // Unchecking the checkboxes again by triggering them.
+    await trigger_filter_button(page, include_muted_filter_button);
+    await trigger_filter_button(page, unread_filter_button);
+}
+
+async function test_unread_and_participated_filter_button(page: Page): Promise<void> {
+    await page.waitForSelector(recent_topic_page);
+
+    // Triggering the `Unread` and `Participated` filter button.
+    await trigger_filter_button(page, unread_filter_button);
+    await trigger_filter_button(page, participated_filter_button);
+
+    const stream_names = await get_stream_names(page);
+    assert.deepStrictEqual(stream_names, []);
+
+    const topic_names = await get_topic_names(page);
+    assert.deepStrictEqual(topic_names, []);
+
+    await trigger_filter_button(page, unread_filter_button);
+    await trigger_filter_button(page, participated_filter_button);
+}
+
+async function test_include_muted_and_participated_filter_button(page: Page): Promise<void> {
+    await page.waitForSelector(recent_topic_page);
+
+    // Triggering the `Include muted` and `Participated` filter button.
+    await trigger_filter_button(page, include_muted_filter_button);
+    await trigger_filter_button(page, participated_filter_button);
+
+    const stream_names = await get_stream_names(page);
+    assert.deepStrictEqual(stream_names, ["Venice", "Denmark", "Verona"]);
+
+    const topic_names = await get_topic_names(page);
+    assert.deepStrictEqual(topic_names, ["URLS", "last server wasn't loading slowly", "plotter"]);
+
+    await trigger_filter_button(page, include_muted_filter_button);
+    await trigger_filter_button(page, participated_filter_button);
+}
+
+async function test_all_filters(page: Page): Promise<void> {
+    await page.waitForSelector(recent_topic_page);
+
+    // Triggering all filter buttons.
+    await trigger_filter_button(page, include_muted_filter_button);
+    await trigger_filter_button(page, unread_filter_button);
+    await trigger_filter_button(page, participated_filter_button);
+
+    const stream_names = await get_stream_names(page);
+    assert.deepStrictEqual(stream_names, []);
+
+    const topic_names = await get_topic_names(page);
+    assert.deepStrictEqual(topic_names, []);
+
+    await trigger_filter_button(page, include_muted_filter_button);
+    await trigger_filter_button(page, unread_filter_button);
+    await trigger_filter_button(page, participated_filter_button);
+}
+
 async function test_recent_topic(page: Page): Promise<void> {
     await common.log_in(page);
     await page.click(".top_left_recent_topics");
     await page.waitForSelector("#recent_topics_view", {visible: true});
 
     await test_initial_topics(page);
+
+    await test_all_filter_button(page);
+    await test_include_muted_filter_button(page);
+    await test_unread_filter_button(page);
+    await test_participated_filter_button(page);
+
+    await test_include_muted_and_unread_filter_button(page);
+    await test_unread_and_participated_filter_button(page);
+    await test_include_muted_and_participated_filter_button(page);
+    await test_all_filters(page);
 }
 
 common.run_test(test_recent_topic);

--- a/frontend_tests/puppeteer_tests/recent-topic.ts
+++ b/frontend_tests/puppeteer_tests/recent-topic.ts
@@ -1,0 +1,72 @@
+import {strict as assert} from "assert";
+
+import type {Page} from "puppeteer";
+
+import common from "../puppeteer_lib/common";
+
+const recent_topic_page = "#recent_topics_view";
+
+// Returns an array based on all text found within the selector passed.
+async function get_selector_text(page: Page, selector: string): Promise<string[]> {
+    const elements = await page.$$(selector);
+    const text = await Promise.all<string>(
+        elements.map(async (element) => common.get_element_text(element)),
+    ).then((value) => value);
+
+    return text;
+}
+
+async function get_stream_names(page: Page): Promise<string[]> {
+    await page.waitForSelector(recent_topic_page);
+
+    const stream_name_cells = ".recent_topic_stream a";
+    const stream_names = await get_selector_text(page, stream_name_cells);
+
+    return stream_names;
+}
+
+async function get_topic_names(page: Page): Promise<string[]> {
+    await page.waitForSelector(recent_topic_page);
+
+    const topic_name_cells = ".recent_topic_name a";
+    const topic_names = await get_selector_text(page, topic_name_cells);
+
+    return topic_names;
+}
+
+// Tests for streams and topic at initial page load.
+async function test_initial_topics(page: Page): Promise<void> {
+    await page.waitForSelector(recent_topic_page);
+
+    const stream_names = await get_stream_names(page);
+    assert.deepStrictEqual(stream_names, [
+        "Verona",
+        "Denmark",
+        "Venice",
+        "Denmark",
+        "Venice",
+        "Verona",
+        "Verona",
+    ]);
+
+    const topic_names = await get_topic_names(page);
+    assert.deepStrictEqual(topic_names, [
+        "last nas is loading",
+        "last database linking",
+        "URLS",
+        "last server wasn't loading slowly",
+        "database isn't skipping erratically",
+        "plotter",
+        "green printer is running quickly",
+    ]);
+}
+
+async function test_recent_topic(page: Page): Promise<void> {
+    await common.log_in(page);
+    await page.click(".top_left_recent_topics");
+    await page.waitForSelector("#recent_topics_view", {visible: true});
+
+    await test_initial_topics(page);
+}
+
+common.run_test(test_recent_topic);

--- a/frontend_tests/puppeteer_tests/recent-topic.ts
+++ b/frontend_tests/puppeteer_tests/recent-topic.ts
@@ -106,6 +106,22 @@ async function test_initial_topics(page: Page): Promise<void> {
     ]);
 }
 
+// Marks a specific topic as read.
+async function mark_as_read(page: Page, topic: string): Promise<void> {
+    await page.evaluate((topic: string) => {
+        const mark_as_read_icon = $(`.on_hover_topic_read[data-topic-name='${topic}']`);
+        mark_as_read_icon.trigger("click");
+    }, topic);
+}
+
+// Mutes the topic for the corresponding topic name passed.
+async function mute_topic(page: Page, topic: string): Promise<void> {
+    await page.evaluate((topic: string) => {
+        const mute_icon = $(`.on_hover_topic_mute[data-topic-name='${topic}']`);
+        mute_icon.trigger("click");
+    }, topic);
+}
+
 // Should yield same result as `test_initial_topics`.
 async function test_all_filter_button(page: Page): Promise<void> {
     await page.waitForSelector(recent_topic_page);
@@ -343,6 +359,62 @@ async function test_filter_topic_input(page: Page): Promise<void> {
     await clear_input_field(page, input_field, stream_filter);
 }
 
+async function test_mark_as_read_button(page: Page, topic: string): Promise<void> {
+    await page.waitForSelector(recent_topic_page);
+
+    // Marking the topic passed as read.
+    await mark_as_read(page, topic);
+
+    const stream_names = await get_stream_names(page);
+    assert.deepStrictEqual(stream_names, [
+        "Verona",
+        "Denmark",
+        "Venice",
+        "Denmark",
+        "Venice",
+        "Verona",
+        "Verona",
+    ]);
+
+    const topic_names = await get_topic_names(page);
+    assert.deepStrictEqual(topic_names, [
+        "last nas is loading",
+        "last database linking",
+        "URLS",
+        "last server wasn't loading slowly",
+        "database isn't skipping erratically",
+        "plotter",
+        "green printer is running quickly",
+    ]);
+}
+
+async function test_muted_topic_button(page: Page, topic: string): Promise<void> {
+    await page.waitForSelector(recent_topic_page);
+
+    // Muting the topic passed.
+    await mute_topic(page, topic);
+
+    const stream_names = await get_stream_names(page);
+    assert.deepStrictEqual(stream_names, [
+        "Verona",
+        "Denmark",
+        "Denmark",
+        "Venice",
+        "Verona",
+        "Verona",
+    ]);
+
+    const topic_names = await get_topic_names(page);
+    assert.deepStrictEqual(topic_names, [
+        "last nas is loading",
+        "last database linking",
+        "last server wasn't loading slowly",
+        "database isn't skipping erratically",
+        "plotter",
+        "green printer is running quickly",
+    ]);
+}
+
 async function test_recent_topic(page: Page): Promise<void> {
     await common.log_in(page);
     await page.click(".top_left_recent_topics");
@@ -366,6 +438,9 @@ async function test_recent_topic(page: Page): Promise<void> {
     await test_recent_topic_hotkey(page); // Navigate back to recent topic page.
 
     await test_filter_topic_input(page); // Inputs `nas` in filter input text field.
+
+    await test_mark_as_read_button(page, "plotter"); // Marks the plotter topic as read.
+    await test_muted_topic_button(page, "URLS"); // Mutes the URLS topic.
 }
 
 common.run_test(test_recent_topic);


### PR DESCRIPTION
Added puppeteer tests for Recent topic View as listed within #18031 and <a href = '5ffc2a7d489ed5b796056cb2dc9ee884628551d3'>fixed</a> a minor typo within <a href = 'https://github.com/zulip/zulip/blob/8362865c8dffaa6e34fc7a112cbf5db6037ad46d/frontend_tests/puppeteer_tests/drafts.ts#L7'><code>drafts.ts</code></a>.

<strong>Updated checklist:</strong>
- [x] Filters selection -- ce7b593813992ed719e0684ed7f655582d7790ee
- [x] Search for topics -- 88c65f4a25bf2d3d438c092f62347735ef766cd4
- [x] Clicking on row elements like stream and topic takes them to appropriate narrow -- 3c0f9a7e4c5828595bc31a9cfa13d44759cbbc62
- [x] Read and mute action buttons work properly -- f3886f515327fba47b8c679c2cdee0f56b6e874f
- [ ] Compose actions work as intended.

<strong>Issues:</strong>

Added few comments below addressing the issues. 
#
<br/>
Would appreciate a review @amanagr.

Also, Thanks to @Riken-Shah for guiding me with the hurdles faced with nondeterminstic failures.(Still need to fix them though!)