### PR TITLE
tools: Add support for generating integration screenshots remotely.

### DIFF
--- a/tools/generate-integration-docs-screenshot
+++ b/tools/generate-integration-docs-screenshot
@@ -187,12 +187,13 @@ def send_bot_payload_message(
 
 def capture_last_message_screenshot(bot: UserProfile, image_path: str) -> None:
     message = Message.objects.filter(sender=bot).last()
+    realm = get_realm("zulip")
     if message is None:
         print(f"No message found for {bot.full_name}")
         return
     message_id = str(message.id)
     screenshot_script = os.path.join(TOOLS_DIR, "message-screenshot.js")
-    subprocess.check_call(["node", screenshot_script, message_id, image_path])
+    subprocess.check_call(["node", screenshot_script, message_id, image_path, realm.uri])
 
 
 def generate_screenshot_from_config(

--- a/tools/message-screenshot.js
+++ b/tools/message-screenshot.js
@@ -9,14 +9,14 @@ require("css.escape");
 const mkdirp = require("mkdirp");
 const puppeteer = require("puppeteer");
 
-const host = "localhost:9991";
 const options = {};
 
 commander
-    .arguments("<message_id> <image_path>")
-    .action((messageId, imagePath) => {
+    .arguments("<message_id> <image_path> <realm_uri")
+    .action((messageId, imagePath, realmUri) => {
         options.messageId = messageId;
         options.imagePath = imagePath;
+        options.realmUri = realmUri;
         console.log(`Capturing screenshot for message ${messageId} to ${imagePath}`);
     })
     .parse(process.argv);
@@ -43,7 +43,7 @@ async function run() {
         const page = await browser.newPage();
         // deviceScaleFactor:2 gives better quality screenshots (higher pixel density)
         await page.setViewport({width: 1280, height: 1024, deviceScaleFactor: 2});
-        await page.goto("http://" + host);
+        await page.goto(options.realmUri);
         // wait for Iago devlogin button and click on it.
         await page.waitForSelector('[value="iago@zulip.com"]');
 
@@ -54,7 +54,7 @@ async function run() {
         ]);
 
         // Navigate to message and capture screenshot
-        await page.goto(`http://${host}/#narrow/id/${options.messageId}`);
+        await page.goto(`${options.realmUri}/#narrow/id/${options.messageId}`);
         const messageSelector = `#zfilt${CSS.escape(options.messageId)}`;
         await page.waitForSelector(messageSelector);
         // remove unread marker and don't select message


### PR DESCRIPTION
I have added support for generating integration screenshots remotely by
adding a `realm_uri` parameter to `tools/message-screenshot.js` which we
then pass `realm.uri` to from within
`tools/generate-integration-docs-screenshot`.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

Ran the tool whilst developing remotely. Also ran it locally to test it still works locally too.

![image](https://user-images.githubusercontent.com/13500254/114961084-406f0a00-9e60-11eb-9843-05b14ef66642.png)


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
