### PR TITLE
Update remote dev docs and run-dev.py to output correct subdomain.

### DIFF
--- a/docs/development/remote.md
+++ b/docs/development/remote.md
@@ -58,13 +58,16 @@ the remote virtual machine, we recommend installing
 need to.
 
 The main difference from the standard instructions is that for a
-remote development environment, you'll need to run `export
-EXTERNAL_HOST=<REMOTE_IP>:9991` in a shell before running `run-dev.py`
-(and see also the `--interface=''` option documented below).  If your
-server has a static IP address, we recommend putting this command in
-`~/.bashrc`, so you don't need to remember to run it every time. This
-allows you to access Zulip running in your development environment
-using a browser on another host.
+remote development environment, and you're not using our Digital Ocean
+Droplet infrastructure (which handles `EXTERNAL_HOST` for you), you'll
+need to run `export EXTERNAL_HOST=<REMOTE_IP>:9991` in a shell before
+running `run-dev.py` (and see also the `--interface=''` option
+documented below).
+
+If your server has a static IP address, we recommend putting this
+command in `~/.bashrc`, so you don't need to remember to run it every
+time. This allows you to access Zulip running in your development
+environment using a browser on another host.
 
 ## Running the development server
 

--- a/docs/development/request-remote.md
+++ b/docs/development/request-remote.md
@@ -63,7 +63,10 @@ Once your remote dev instance is ready:
 - Once you log in, you should see `(zulip-py3-venv) ~$`.
 - To start the dev server, `cd zulip` and then run `./tools/run-dev.py`.
 - While the dev server is running, you can see the Zulip server in your browser
-  at http://username.zulipdev.org:9991.
+  at http://zulip.username.zulipdev.org:9991.
+- The development server actually runs on all subdomains of
+  `username.zulipdev.org`; this is important for testing Zulip's
+  support for multiple organizations in your development server.
 
 Once you've confirmed you can connect to your remote server, take a look at:
 

--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -370,7 +370,10 @@ def print_listeners() -> None:
     # EXTERNAL_HOST logic from dev_settings.py.
     IS_DEV_DROPLET = pwd.getpwuid(os.getuid()).pw_name == "zulipdev"
     if IS_DEV_DROPLET:
-        default_hostname = os.uname()[1].lower()
+        # Technically, the `zulip.` is a subdomain of the server, so
+        # this is kinda misleading, but 99% of development is done on
+        # the default/zulip subdomain.
+        default_hostname = "zulip." + os.uname()[1].lower()
     else:
         default_hostname = "localhost"
     external_host = os.getenv("EXTERNAL_HOST", f"{default_hostname}:{proxy_port}")


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Update remote dev docs and run-dev.py to output correct subdomain.

**Testing plan:** <!-- How have you tested? -->

Built docs locally and tested running `tools/run-dev.py`

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
