### PR TITLE
puppet: Ensure a snakeoil certificate, for Postfix and PostgreSQL.

### DIFF
--- a/puppet/zulip/manifests/postfix_localmail.pp
+++ b/puppet/zulip/manifests/postfix_localmail.pp
@@ -1,4 +1,5 @@
 class zulip::postfix_localmail {
+  include zulip::snakeoil
   $postfix_packages = [ 'postfix', ]
 
   if $::fqdn == '' {
@@ -11,6 +12,7 @@ class zulip::postfix_localmail {
   }
 
   service { 'postfix':
+    require => Exec['generate-default-snakeoil'],
   }
 
   file {'/etc/mailname':

--- a/puppet/zulip/manifests/postgresql_common.pp
+++ b/puppet/zulip/manifests/postgresql_common.pp
@@ -1,4 +1,5 @@
 class zulip::postgresql_common {
+  include zulip::snakeoil
   $version = zulipconf('postgresql', 'version', undef)
   case $::osfamily {
     'debian': {
@@ -8,8 +9,6 @@ class zulip::postgresql_common {
         $postgresql,
         # tools for database monitoring; formerly ptop
         'pgtop',
-        # Needed just to support adding postgres user to 'zulip' group
-        'ssl-cert',
         # our dictionary
         'hunspell-en-us',
         # PostgreSQL Nagios check plugin
@@ -59,7 +58,10 @@ class zulip::postgresql_common {
     }
   }
 
-  zulip::safepackage { $postgresql_packages: ensure => 'installed' }
+  zulip::safepackage { $postgresql_packages:
+    ensure  => 'installed',
+    require => Exec['generate-default-snakeoil'],
+  }
 
   if $::osfamily == 'debian' {
     # The logrotate file only created in debian-based systems

--- a/puppet/zulip/manifests/snakeoil.pp
+++ b/puppet/zulip/manifests/snakeoil.pp
@@ -1,0 +1,12 @@
+class zulip::snakeoil {
+  zulip::safepackage { 'ssl-cert': ensure => 'installed' }
+
+  # We use the snakeoil certificate for PostgreSQL and Postfix; some VMs
+  # install the `ssl-cert` package but (reasonably) don't build the
+  # snakeoil certs into the image; build them as needed.
+  exec { 'generate-default-snakeoil':
+    require => Package['ssl-cert'],
+    creates => '/etc/ssl/certs/ssl-cert-snakeoil.pem',
+    command => '/usr/sbin/make-ssl-cert generate-default-snakeoil',
+  }
+}


### PR DESCRIPTION
We use the snakeoil TLS certificate for PostgreSQL and Postfix; some
VMs install the `ssl-cert` package but (reasonably) don't build the
snakeoil certs into the image.

Build them as needed.

Fixes #14955.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** Test install with an without `/etc/ssl/certs/ssl-cert-snakeoil.pem`
