### PR TITLE
test_home: Fix user_activity queue event format in a test.

### DIFF
--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -887,7 +887,7 @@ class HomeTest(ZulipTestCase):
         activity_time = calendar.timegm(now.timetuple())
         user_activity_event = {
             "user_profile_id": hamlet.id,
-            "client": "test-client",
+            "client_id": 1,
             "query": "update_message_flags",
             "time": activity_time,
         }
@@ -896,7 +896,7 @@ class HomeTest(ZulipTestCase):
         activity_time_2 = calendar.timegm(yesterday.timetuple())
         user_activity_event_2 = {
             "user_profile_id": hamlet.id,
-            "client": "test-client-2",
+            "client_id": 2,
             "query": "update_message_flags",
             "time": activity_time_2,
         }


### PR DESCRIPTION
This is a leftover hunk from https://github.com/zulip/zulip/pull/18164 - we ended up not merging the commit deleting the compat code from the queue worker, but the test_home test should be updated to have new format events. It should have been adjusted in https://github.com/zulip/zulip/commit/200ce821a2172d82170c5357c5b32eba9d369f16 but I missed it back then.

Current production code uses client_id in the event dict and this test
should be updated to reflect that. Old format event can still be
consumed by the worker, but that is already tested by
WorkerTest.test_UserActivityWorker.
