### PR TITLE
tools: Have `optimize-svg` do the optimization automatiically.

### DIFF
--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -161,7 +161,7 @@ jobs:
           # ./tools/test-queue-worker-reload
 
           ./tools/test-migrations
-          ./tools/setup/optimize-svg
+          ./tools/setup/optimize-svg --check
           ./tools/setup/generate_integration_bots_avatars.py --check-missing
 
       - name: Run documentation and api tests

--- a/docs/documentation/integrations.md
+++ b/docs/documentation/integrations.md
@@ -28,15 +28,14 @@ Usually, this involves a few steps:
   `static/images/integrations/logos/<name>.svg`, where `<name>` is the
   name of the integration, all in lower case; you can usually find them in the
   product branding or press page. Make sure to optimize the SVG graphic by
-  running `yarn run svgo -f path-to-file`.
+  running `tools/setup/optimize-svg`. This will also run
+  `tools/setup/generate_integration_bots_avatars.py` automatically to generate
+  a smaller version of the image you just added and optimized. This smaller image will be
+  used as the bot avatar in the documentation screenshot that will be generated
+  in the next step.
 
   If you cannot find an SVG graphic of the logo, please find and include a PNG
   image of the logo instead.
-
-* Run `tools/setup/generate_integration_bots_avatars.py` to generate a smaller
-  version of the image added in the previous step. This smaller image will be
-  used as the bot avatar in the documentation screenshot that will be generated
-  in the next step.
 
 * Finally, generate a message sent by the integration and take a screenshot of
   the message to provide an example message in the documentation.

--- a/tools/setup/optimize-svg
+++ b/tools/setup/optimize-svg
@@ -1,9 +1,57 @@
 #!/usr/bin/env bash
+set -e
 
-if [ "$(node_modules/.bin/svgo -f static/images/integrations/logos | grep -o '\.[0-9]% = ' | wc -l)" -ge 1 ]; then
-    echo "ERROR: svgo detected unoptimized SVG files in the \`static/images/integrations/logos\` folder." 1>&2
-    echo "Please run \`svgo -f static/images/integrations/logos\` and commit the file changes to optimize them."
+usage() {
+    cat <<'EOF'
+Usage:
+  optimize-svg --check
+  optimize-svg --help
+
+Options:
+  --check
+      This will check for unoptimized SVG files rather than automatically optimizing them.
+      This allows us to run the script in CI.
+
+EOF
+}
+
+# Shell option parsing.  Over time, we'll want to move some of the
+# environment variables below into this self-documenting system.
+args="$(getopt -o '' --long help,check -n "$0" -- "$@")"
+eval "set -- $args"
+while true; do
+    case "$1" in
+        --help)
+            usage
+            exit 0
+            ;;
+        --check)
+            CHECK_UNOPTIMIZED=1
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+    esac
+done
+
+if [ "$#" -gt 0 ]; then
+    usage >&2
     exit 1
+fi
+
+ZULIP_PATH="$(readlink -f "$(dirname "$0")"/../..)"
+
+if [ -n "$CHECK_UNOPTIMIZED" ]; then
+    if [ "$(node_modules/.bin/svgo -f static/images/integrations/logos | grep -o '\.[0-9]% = ' | wc -l)" -ge 1 ]; then
+        echo "ERROR: svgo detected unoptimized SVG files in the \`static/images/integrations/logos\` folder." 1>&2
+        echo "Please run tools/setup/optimize-svg and commit the file changes to optimize them."
+        exit 1
+    else
+        echo "SUCCESS: SVG files in static/images/integrations/logos are all optimized!"
+    fi
 else
-    echo "SUCCESS: SVG files in static/images/integrations/logos are all optimized!"
+    yarn run svgo -q -f static/images/integrations/logos
+    "$ZULIP_PATH"/tools/setup/generate_integration_bots_avatars.py
 fi


### PR DESCRIPTION
I have made `tools/setup/optimize-svg` do the SVG optimization
automatically rather than just telling you the command to run if they
need optimizing. This included adding a `--check-unoptimized` paramater
to use in CI to only check as we previously did rather than actually
running the optimization.

I have also made `tools/setup/optimize-svg` execute
`tools/setup/generate_integration_bots_avatars.py` once it has run the
optimization to ensure it is always ran. This makes it one less command
to run when creating an integration, but also means that we catch
instances where a PNG has just been copied into the
`static/images/integrations/bot_avatars` folder as the only instance
where this won't be run is if `optimize-svg` has not been run which
would be caught in CI.

Fixes #18183. Fixes #18184.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

Ran the tool. Ran CI.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
