### PR TITLE
docs: Update to advise on preferred indented macros in integration docs.

### DIFF
--- a/docs/documentation/integrations.md
+++ b/docs/documentation/integrations.md
@@ -74,7 +74,7 @@ Here are a few common macros used to document Zulip's integrations:
   integration or incoming webhook. For an example rendering, see **Step 1** of
   [the docs for Zulip's GitHub integration][GitHub].
 
-* `{!create-bot-construct-url.md!}` macro - Instructs users to create a bot
+* `{!create-bot-construct-url-indented.md!}` macro - Instructs users to create a bot
   for a given integration and construct a webhook URL using the bot API key
   and stream name. The URL is generated automatically for every incoming webhook
   by using attributes in the `WebhookIntegration` class in
@@ -92,12 +92,12 @@ Here are a few common macros used to document Zulip's integrations:
 * `{!append-stream-name.md!}` macro - Recommends appending `&stream=stream_name`
   to a URL in cases where supplying a stream name in the URL is optional.
   Supplying a stream name is optional for most Zulip integrations. If you use
-  `{!create-bot-construct-url.md!}`, this macro need not be used.
+  `{!create-bot-construct-url-indented.md!}`, this macro need not be used.
 
 * `{!append-topic.md!}` macro - Recommends appending `&topic=my_topic` to a URL
   to supply a custom topic for webhook notification messages. Supplying a custom
   topic is optional for most Zulip integrations. If you use
-  `{!create-bot-construct-url.md!}`, this macro need not be used.
+  `{!create-bot-construct-url-indented.md!}`, this macro need not be used.
 
 * `{!congrats.md!}` macro - Inserts congratulatory lines signifying the
   successful setup of a given integration. This macro is usually used at
@@ -125,7 +125,7 @@ Here are a few common macros used to document Zulip's integrations:
   see the last paragraph of **Step 2** in
   [the docs for Zulip's GitHub integration][GitHub].
 
-* `{!webhook-url.md!}` - Used internally by `{!create-bot-construct-url.md!}`
+* `{!webhook-url.md!}` - Used internally by `{!create-bot-construct-url-indented.md!}`
   to generate the webhook URL.
 
 * `{!zulip-config.md!}` - Used internally by `{!change-zulip-config-file.md!}`
@@ -201,7 +201,7 @@ A typical doc will then have the following steps.
 
 ##### "Create the bot" step
 
-- Typically, use the `create-bot-construct-url` macro.
+- Typically, use the `create-bot-construct-url-indented` macro.
 - [Existing macros](#markdown-macros) should be used for this if they exist, but if the macro
   defaults don’t work, it may make sense to write something custom for the
   integration in question. This step is mandatory for all integrations.


### PR DESCRIPTION
I have update the integrations documentation to advise on the correct
macros to use now we prefer the indented macros.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
