### PR TITLE
installation: Create a .gitconfig file for zulip user.

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -521,6 +521,10 @@ if has_class "zulip::app_frontend_base"; then
     fi
 fi
 
+# setting up the gitconfig
+su zulip -c "git config --global user.email $ZULIP_ADMINISTRATOR"
+su zulip -c "git config --global user.name $EXTERNAL_HOST"
+
 if [ -n "$NO_INIT_DB" ]; then
     set +x
     cat <<EOF


### PR DESCRIPTION
## Whats this PR for?
The PR aims to be a solution for https://github.com/zulip/zulip/issues/18039

This PR adds commands to scripts/lib/install to create a .gitconfig
file at installation time. `name` and `email` fields are set in the
config. `name` is set equal to hostname (stored in `EXTERNAL_HOST`
variable in the script) and `email` is set equal to --email passed to
the script (stored in `ZULIP_ADMINISTRATOR` variable in the script).
