### PR TITLE
ui: Use unicode U+2026 instead of literal "..." characters.

### DIFF
--- a/static/templates/admin_user_group_list.hbs
+++ b/static/templates/admin_user_group_list.hbs
@@ -18,7 +18,7 @@
     </h4>
     <p class="subscribers">{{t 'Subscribers' }}</p>
     <div class="pill-container" data-group-pills="{{id}}">
-        <div class="input" contenteditable="true" data-placeholder="{{t 'Add member...' }}"></div>
+        <div class="input" contenteditable="true" data-placeholder="{{t 'Add member…' }}"></div>
     </div>
     <p class="save-instructions">
         {{t "Click outside the input box to save. We'll automatically notify anyone that was added or removed."}}

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -45,6 +45,6 @@
 <div class="message_edit">
     <div class="message_edit_form"></div>
 </div>
-<div class="message_expander message_length_controller" title="{{t 'Expand message (-)' }}">{{t "[More...]" }}</div>
+<div class="message_expander message_length_controller" title="{{t 'Expand message (-)' }}">{{t "[More…]" }}</div>
 <div class="message_condenser message_length_controller" title="{{t 'Condense message (-)' }}">{{t "[Condense message]" }}</div>
 <div class="message_reactions">{{> message_reactions }}</div>


### PR DESCRIPTION
The unicode horizontal ellipsis is visually nicer.
b40e50f2959998d0193b65a3e5b4065ff5abfea5 removed many of these,
by changing the text itself.
This commit handles the remaining few.
See also https://github.com/zulip/zulip/pull/16915#discussion_r608291592.

## Before
![image](https://user-images.githubusercontent.com/55339528/115111141-731e1d00-9f9c-11eb-9320-aa8efd65e088.png)
![image](https://user-images.githubusercontent.com/55339528/115111298-4e767500-9f9d-11eb-98ac-7166096ebebc.png)

## After
![image](https://user-images.githubusercontent.com/55339528/115111104-479b3280-9f9c-11eb-8dfe-6d103158c42d.png)
![image](https://user-images.githubusercontent.com/55339528/115111314-6b12ad00-9f9d-11eb-82a9-1f1b62fe6262.png)

