### PR TITLE
populate_db: Add attachments to 3% of development sample messages.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 import ahocorasick
 import orjson
+from dataclasses_json import DataClassJsonMixin
 from django.db import connection
 from django.db.models import Max, Sum
 from django.utils.timezone import now as timezone_now
@@ -107,6 +108,18 @@ class SendMessageRequest:
     submessages: List[Dict[str, Any]] = field(default_factory=list)
     deliver_at: Optional[datetime.datetime] = None
     delivery_type: Optional[str] = None
+
+
+@dataclass
+class TestMessage(DataClassJsonMixin):
+    """
+    Class for keeping track of a test message in populate_db.py.
+    The attachment_paths field is a list of relative paths to
+    files in the project which are to be uploaded and attached.
+    """
+
+    text: str = ""
+    attachment_paths: List[str] = field(default_factory=list)
 
 
 # We won't try to fetch more unread message IDs from the database than

--- a/zerver/tests/fixtures/config.generate_data.json
+++ b/zerver/tests/fixtures/config.generate_data.json
@@ -54,6 +54,16 @@
             "[unreads](/static/images/story-tutorial/zulip-streams-unreads.png)\n"
       ],
 
+      "attachment-paths": [
+        "static/assets/README",
+        "static/audio/zulip.ogg",
+        "static/html/5xx.html",
+        "static/js/admin.js",
+        "static/js/message_list_view.js",
+        "static/styles/app_components.css",
+        "static/styles/reactions.css"
+      ],
+
       "maths": [
         "$$e^{i \\pi } + 1 = 0$$",
         "$$\\frac{1}{\\Gamma(k)\\theta^k x^{k-1} e^{-\\frac{x}{\\theta}}$$"
@@ -77,7 +87,8 @@
     "math": 1,
     "link" : 8,
     "list": 5,
-    "images" : 5
+    "images" : 5,
+    "attachment" : 3
   },
   "corpus":
   {

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -929,7 +929,7 @@ def generate_and_send_messages(
     ) as infile:
         dialog = orjson.loads(infile.read())
     random.shuffle(dialog)
-    texts = itertools.cycle(dialog)
+    texts_with_attachment_paths = itertools.cycle(dialog)
 
     # We need to filter out streams from the analytics realm as we don't want to generate
     # messages to its streams - and they might also have no subscribers, which would break
@@ -960,7 +960,8 @@ def generate_and_send_messages(
         message = Message()
         message.sending_client = get_client("populate_db")
 
-        message.content = next(texts)
+        text_with_attachment_path = next(texts_with_attachment_paths)
+        message.content = text_with_attachment_path[0]
 
         randkey = random.randint(1, random_max)
         if (


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#14991 

**Testing plan:** <!-- How have you tested? -->
For `generate_test_data.py`, we manually checked that the format of `test_messages.json` matched our expectations. `test_messages.json` contained a list of messages. Each message was represented by a dictionary with two fields: `text` and `attachment_paths`. The `attachment_paths` field was a list of strings.

For `populate_db.py`, we successfully ran the following commands:
`./tools/provision`
`./manage.py populate_db`
We then ran `./tools/run-dev.py` and logged into the development environment. We found some of the test messages with attachments. The URIs of the attachments were similar to a URI of a manually uploaded file. There were multiple attachments based on the same local file; each of these attachments was a distinct, exact copy of the local file.

**GIFs or screenshots:**
![image](https://user-images.githubusercontent.com/74227626/115869483-85063100-a470-11eb-8069-103a88c29388.png)
