### PR TITLE
emails: Update registration email when creating new org. [WIP] 

### DIFF
--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Alex Schneider Zis <alexszis@gmail.com>, 2018
 # Andrei Bernardo Simoni <andrei_simoni@hotmail.com>, 2021
@@ -1657,6 +1657,12 @@ msgstr "Se você não solicitou essa alteração, entre em contato conosco imedi
 #: templates/zerver/emails/compiled/confirm_registration.html:10
 #: templates/zerver/emails/confirm_registration.source.html:9
 #: templates/zerver/emails/confirm_registration.txt:1
+msgid "You have requested a new Zulip organization. Awesome!"
+msgstr "Você solicitou uma nova organização Zulip. Incrível!"
+
+#: templates/zerver/emails/compiled/confirm_registration.html:10
+#: templates/zerver/emails/confirm_registration.source.html:12
+#: templates/zerver/emails/confirm_registration.txt:6
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Você recentemente se inscreveu no Zulip. Incrível!"
 

--- a/templates/zerver/emails/confirm_registration.source.html
+++ b/templates/zerver/emails/confirm_registration.source.html
@@ -7,16 +7,16 @@
 {% block content %}
 <p>
     {% if realm_creation %}
-    {{ _('You recently signed up for Zulip. Awesome!') }}
-    {% else %}
     {{ _('You have requested a new Zulip organization. Awesome!') }}
+    {% else %}
+    {{ _('You recently signed up for Zulip. Awesome!') }}
     {% endif %}
 </p>
 <p>
     {% if realm_creation %}
-    {{ _('Click the button below to complete registration.') }}
-    {% else %}
     {{ _('Click the button below to create the organization and register your account.') }}
+    {% else %}
+    {{ _('Click the button below to complete registration.') }}
     {% endif %}
     <a class="button" href="{{ activate_url }}">{{ _('Complete registration') }}</a>
 </p>

--- a/templates/zerver/emails/confirm_registration.source.html
+++ b/templates/zerver/emails/confirm_registration.source.html
@@ -6,10 +6,18 @@
 
 {% block content %}
 <p>
+    {% if realm_creation %}
     {{ _('You recently signed up for Zulip. Awesome!') }}
+    {% else %}
+    {{ _('You have requested a new Zulip organization. Awesome!') }}
+    {% endif %}
 </p>
 <p>
+    {% if realm_creation %}
     {{ _('Click the button below to complete registration.') }}
+    {% else %}
+    {{ _('Click the button below to create the organization and register your account.') }}
+    {% endif %}
     <a class="button" href="{{ activate_url }}">{{ _('Complete registration') }}</a>
 </p>
 <p>{% trans support_email=macros.email_tag(support_email) %}Contact us any time at {{ support_email }} if you run into trouble, have any feedback, or just want to chat!{% endtrans %}</p>

--- a/templates/zerver/emails/confirm_registration.subject.txt
+++ b/templates/zerver/emails/confirm_registration.subject.txt
@@ -1,1 +1,5 @@
+{% if realm_creation %}
+{{ _("Create your Zulip organization") }}
+{% else %}
 {{ _("Activate your Zulip account") }}
+{% endif %}

--- a/templates/zerver/emails/confirm_registration.txt
+++ b/templates/zerver/emails/confirm_registration.txt
@@ -1,6 +1,13 @@
+{% if realm_creation %}
+{{ _('You have requested a new Zulip organization. Awesome!') }}
+
+{{ _('Click the button below to create the organization and register your account.') }}
+{% else %}
 {{ _('You recently signed up for Zulip. Awesome!') }}
 
 {{ _('Click the link below to complete registration.') }}
+{% endif %}
+
     <{{ activate_url }}>
 
 {% trans %}Contact us any time at {{ support_email }} if you run into trouble,have any feedback, or just want to chat!{% endtrans %}

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -527,7 +527,7 @@ def send_confirm_registration_email(
         to_emails=[email],
         from_address=FromAddress.tokenized_no_reply_address(),
         language=language,
-        context={"activate_url": activation_url},
+        context={"activate_url": activation_url, "realm_creation": bool(realm)},
         realm=realm,
     )
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/17786

**Testing plan:** <!-- How have you tested? -->
1. Register for a new account then check `/emails` page for the registration email when and ensure the text is correct if `realm_creation` is `true`.
2.  Register for a new account then check `/emails` page for the registration email when and ensure the text is correct if `realm_creation` is `false`.
3. Add a unit test to test registration email contents when `realm_creation` is `true`

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
![zulip-email](https://user-images.githubusercontent.com/9859770/115128132-9bf8df00-9fa9-11eb-800a-b1eef0f9ba77.png)
