### PR TITLE
templates: Fix email input field within reset.html

### DIFF
--- a/templates/zerver/reset.html
+++ b/templates/zerver/reset.html
@@ -16,10 +16,10 @@
                 <div class="new-style">
                     <div class="input-box horizontal moving-label">
                         <div class="inline-block relative">
+                            <label for="id_email" class="">{{ _('Email') }}</label>
                             <input id="id_email" class="required" type="text" name="email"
                               value="{% if form.email.value() %}{{ form.email.value() }}{% endif %}"
-                              maxlength="100" autofocus required />
-                            <label for="id_email" class="">{{ _('Email') }}</label>
+                              maxlength="100" placeholder="{{ _("Enter your email address") }}" autofocus required />
                             {% if form.email.errors %}
                                 {% for error in form.email.errors %}
                                 <div class="alert alert-error">{{ error }}</div>


### PR DESCRIPTION
Added a minor commit to rectify the dislocated <code>label</code> tag within the password reset form and added a placeholder value of `Enter your email address` to it (Similar placeholder value is within the <code><a href = 'https://github.com/zulip/zulip/blob/master/templates/zerver/create_realm.html#L20'>create_realm</a></code> form). 

<strong>Earlier</strong>

(Here, the label tag is used to serve as the placeholder value to input field while also kind of looks shifted)

![Screenshot from 2021-04-18 21-59-53](https://user-images.githubusercontent.com/53977614/115153051-8bbc2f00-a091-11eb-8042-96af23df46d8.png)

<strong>Now</strong>

![Screenshot from 2021-04-18 22-01-02](https://user-images.githubusercontent.com/53977614/115153063-98408780-a091-11eb-8a15-da508b0790b9.png)
