### PR TITLE
Frontend settings support for configuring "playground" feature

### DIFF
--- a/frontend_tests/puppeteer_tests/realm-playground.ts
+++ b/frontend_tests/puppeteer_tests/realm-playground.ts
@@ -1,0 +1,84 @@
+import {strict as assert} from "assert";
+
+import type {Page} from "puppeteer";
+
+import common from "../puppeteer_lib/common";
+
+type Playground = {
+    name: string;
+    pygments_language: string;
+    url_prefix: string;
+};
+
+async function _add_playground_and_return_status(page: Page, payload: Playground): Promise<string> {
+    await page.waitForSelector(".admin-playground-form", {visible: true});
+    // Let's first ensure that the success/failure status from an earlier step has disappeared.
+    const admin_playground_status_selector = "div#admin-playground-status";
+    await page.waitForSelector(admin_playground_status_selector, {hidden: true, timeout: 4000});
+
+    // Now we can fill and click the submit button.
+    await common.fill_form(page, "form.admin-playground-form", payload);
+    // Not sure why, but page.click() doesn't seem to always click the submit button.
+    // So we resort to using eval with the button ID instead.
+    await page.$eval("#submit_playground_button", (el) => (el as HTMLInputElement).click());
+
+    // We return the success/failure status message back to the caller.
+    await page.waitForSelector(admin_playground_status_selector, {visible: true});
+    const admin_playground_status = await common.get_text_from_selector(
+        page,
+        admin_playground_status_selector,
+    );
+    return admin_playground_status;
+}
+
+async function test_successful_playground_creation(page: Page): Promise<void> {
+    const payload = {
+        pygments_language: "Python",
+        name: "Python3 playground",
+        url_prefix: "https://python.example.com",
+    };
+    const status = await _add_playground_and_return_status(page, payload);
+    assert.strictEqual(status, "Custom playground added!");
+    await page.waitForSelector(".playground_row", {visible: true});
+    assert.strictEqual(
+        await common.get_text_from_selector(
+            page,
+            ".playground_row span.playground_pygments_language",
+        ),
+        "Python",
+    );
+    assert.strictEqual(
+        await common.get_text_from_selector(page, ".playground_row span.playground_name"),
+        "Python3 playground",
+    );
+    assert.strictEqual(
+        await common.get_text_from_selector(page, ".playground_row span.playground_url_prefix"),
+        "https://python.example.com",
+    );
+}
+
+async function test_invalid_playground_parameters(page: Page): Promise<void> {
+    const payload = {
+        pygments_language: "Python",
+        name: "Python3 playground",
+        url_prefix: "not_a_url",
+    };
+    let status = await _add_playground_and_return_status(page, payload);
+    assert.strictEqual(status, "Failed: url_prefix is not a URL");
+
+    payload.url_prefix = "https://python.example.com";
+    payload.pygments_language = "py!@%&";
+    status = await _add_playground_and_return_status(page, payload);
+    assert.strictEqual(status, "Failed: Invalid characters in pygments language");
+}
+
+async function playground_test(page: Page): Promise<void> {
+    await common.log_in(page);
+    await common.manage_organization(page);
+    await page.click("li[data-section='playground-settings']");
+
+    await test_successful_playground_creation(page);
+    await test_invalid_playground_parameters(page);
+}
+
+common.run_test(playground_test);

--- a/static/js/realm_playground.js
+++ b/static/js/realm_playground.js
@@ -1,6 +1,3 @@
-import {page_params} from "./page_params";
-import * as settings_config from "./settings_config";
-
 const map_language_to_playground_info = new Map();
 
 export function update_playgrounds(playgrounds_data) {
@@ -21,14 +18,7 @@ export function update_playgrounds(playgrounds_data) {
 }
 
 export function get_playground_info_for_languages(lang) {
-    if (page_params.realm_playgrounds) {
-        return map_language_to_playground_info.get(lang);
-    }
-
-    // FIXME: To avoid breaking the configured hardcoded playgrounds, this approach
-    // is used. This will be removed in the commit which adds the UI for playground
-    // creation.
-    return settings_config.get_playground_info_for_languages(lang);
+    return map_language_to_playground_info.get(lang);
 }
 
 export function initialize(playground_data) {

--- a/static/js/realm_playground.js
+++ b/static/js/realm_playground.js
@@ -1,4 +1,7 @@
+import * as typeahead_helper from "./typeahead_helper";
+
 const map_language_to_playground_info = new Map();
+const pygments_pretty_name_list = new Set();
 
 export function update_playgrounds(playgrounds_data) {
     map_language_to_playground_info.clear();
@@ -21,6 +24,25 @@ export function get_playground_info_for_languages(lang) {
     return map_language_to_playground_info.get(lang);
 }
 
-export function initialize(playground_data) {
+export function sort_pygments_pretty_names_by_priority(generated_pygments_data) {
+    const priority_sorted_pygments_data = Object.keys(generated_pygments_data.langs).sort(
+        typeahead_helper.compare_by_popularity,
+    );
+    for (const data of priority_sorted_pygments_data) {
+        const pretty_name = generated_pygments_data.langs[data].pretty_name;
+        // JS maintains the order of insertion in a set so we don't need to worry about
+        // the priority changing.
+        if (!pygments_pretty_name_list.has(pretty_name)) {
+            pygments_pretty_name_list.add(pretty_name);
+        }
+    }
+}
+
+export function get_pygments_pretty_names_list() {
+    return Array.from(pygments_pretty_name_list);
+}
+
+export function initialize(playground_data, generated_pygments_data) {
     update_playgrounds(playground_data);
+    sort_pygments_pretty_names_by_priority(generated_pygments_data);
 }

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -417,55 +417,6 @@ export const all_notifications = () => ({
     },
 });
 
-const map_language_to_playground_info = {
-    // TODO: This is being hardcoded just for the prototype, post which we should
-    // add support for realm admins to configure their own choices. The keys here
-    // are the pygment lexer subclass names for the different language alias it
-    // supports.
-    Rust: [
-        {
-            name: "Rust playground",
-            url_prefix: "https://play.rust-lang.org/?edition=2018&code=",
-        },
-    ],
-    Julia: [
-        {
-            name: "Julia playground",
-            url_prefix: "https://repl.it/languages/julia/?code=",
-        },
-    ],
-    Python: [
-        {
-            name: "Python 3 playground",
-            url_prefix: "https://repl.it/languages/python3/?code=",
-        },
-    ],
-    "Python 2.7": [
-        {
-            name: "Python 2.7 playground",
-            url_prefix: "https://repl.it/languages/python/?code=",
-        },
-    ],
-    JavaScript: [
-        {
-            name: "JavaScript playground",
-            url_prefix: "https://repl.it/languages/javascript/?code=",
-        },
-    ],
-    Lean: [
-        {
-            name: "Lean playground",
-            url_prefix: "https://leanprover.github.io/live/latest/#code=",
-        },
-        {
-            name: "Lean community playground",
-            url_prefix: "https://leanprover-community.github.io/lean-web-editor/#code=",
-        },
-    ],
-};
-
-export const get_playground_info_for_languages = (lang) => map_language_to_playground_info[lang];
-
 export const desktop_icon_count_display_values = {
     messages: {
         code: 1,

--- a/static/js/settings_playgrounds.js
+++ b/static/js/settings_playgrounds.js
@@ -54,7 +54,9 @@ export function populate_playgrounds(playgrounds_data) {
                     playground_name: playground.name,
                     pygments_language: playground.pygments_language,
                     url_prefix: playground.url_prefix,
+                    id: playground.id,
                 },
+                can_modify: page_params.is_admin,
             });
         },
         filter: {
@@ -87,6 +89,21 @@ export function set_up() {
 function build_page() {
     meta.loaded = true;
     populate_playgrounds(page_params.realm_playgrounds);
+
+    $(".admin_playgrounds_table").on("click", ".delete", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        const btn = $(this);
+
+        channel.del({
+            url: "/json/realm/playgrounds/" + encodeURIComponent(btn.attr("data-playground-id")),
+            error(xhr) {
+                ui_report.generic_row_button_error(xhr, btn);
+            },
+            // There is no need for an on-success action here since the row is removed by the
+            // `realm_playgrounds` events handler which builds the playground list again.
+        });
+    });
 
     $(".organization form.admin-playground-form")
         .off("submit")

--- a/static/js/settings_playgrounds.js
+++ b/static/js/settings_playgrounds.js
@@ -6,6 +6,8 @@ import * as channel from "./channel";
 import {$t_html} from "./i18n";
 import * as ListWidget from "./list_widget";
 import {page_params} from "./page_params";
+import * as realm_playground from "./realm_playground";
+import * as typeahead_helper from "./typeahead_helper";
 import * as ui from "./ui";
 import * as ui_report from "./ui_report";
 
@@ -149,4 +151,19 @@ function build_page() {
                 },
             });
         });
+
+    $("#playground_pygments_language").typeahead({
+        source() {
+            return realm_playground.get_pygments_pretty_names_list();
+        },
+        items: 5,
+        fixed: true,
+        highlighter(item) {
+            return typeahead_helper.render_typeahead_item({primary: item});
+        },
+        matcher(item) {
+            const q = this.query.trim().toLowerCase();
+            return item.toLowerCase().startsWith(q);
+        },
+    });
 }

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -504,7 +504,7 @@ export function initialize_everything() {
         emoji_codes: generated_emoji_codes,
     });
     markdown.initialize(page_params.realm_linkifiers, markdown_config.get_helpers());
-    realm_playground.initialize(page_params.realm_playgrounds);
+    realm_playground.initialize(page_params.realm_playgrounds, generated_pygments_data);
     composebox_typeahead.initialize(); // Must happen after compose.initialize()
     search.initialize();
     tutorial.initialize();

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -194,6 +194,14 @@ h3 .fa-question-circle-o {
     }
 }
 
+#playground-settings {
+    #playground_pygments_language,
+    #playground_name,
+    #playground_url_prefix {
+        width: calc(100% - 10em - 6em);
+    }
+}
+
 td .button {
     margin: 2px 0;
     box-shadow: none;
@@ -669,7 +677,8 @@ input[type="checkbox"] {
 }
 
 .add-new-profile-field-box,
-.add-new-linkifier-box {
+.add-new-linkifier-box,
+.add-new-playground-box {
     button {
         margin-left: calc(10em + 20px) !important;
     }
@@ -892,6 +901,7 @@ input[type="checkbox"] {
 #create_alert_word_form,
 .admin-emoji-form,
 .admin-linkifier-form,
+.admin-playground-form,
 .admin-profile-field-form,
 .edit_bot_form {
     .control-label {
@@ -1867,11 +1877,13 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     }
 
     #linkifier-settings .new-linkifier-form,
+    #playground-settings .new-playground-form,
     #profile-field-settings .new-profile-field-form {
         width: 100%;
     }
 
     #linkifier-settings .new-linkifier-form .control-label,
+    #playground-settings .new-playground-form .control-label,
     #profile-field-settings .new-profile-field-form .control-label {
         display: block;
         width: 120px;
@@ -1883,6 +1895,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     }
 
     #linkifier-settings .new-linkifier-form .controls,
+    #playground-settings .new-playground-form .controls,
     #profile-field-settings .new-profile-field-form .controls {
         margin: auto;
         text-align: center;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -89,6 +89,11 @@ pre {
          */
         height: 0 !important;
     }
+    /* If the text in the tooltips stretches to multiple lines,
+     * we want the lines to be left-indented and not right-indented
+     * by default.
+     */
+    text-align: left;
 }
 
 .no-select {

--- a/static/templates/settings/admin_playground_list.hbs
+++ b/static/templates/settings/admin_playground_list.hbs
@@ -9,5 +9,12 @@
     <td>
         <span>{{url_prefix}}</span>
     </td>
+    {{#if ../can_modify}}
+    <td class="no-select actions">
+        <button class="button small delete btn-danger tippy-zulip-tooltip" data-playground-id="{{id}}" data-tippy-content="{{t 'Delete' }} {{ playground_name }}" aria-label="{{t 'Delete' }} {{ playground_name }}">
+            <i class="fa fa-trash-o"></i>
+        </button>
+    </td>
+    {{/if}}
 </tr>
 {{/with}}

--- a/static/templates/settings/admin_playground_list.hbs
+++ b/static/templates/settings/admin_playground_list.hbs
@@ -1,13 +1,13 @@
 {{#with playground}}
-<tr>
+<tr class="playground_row">
     <td>
-        <span>{{pygments_language}}</span>
+        <span class="playground_pygments_language">{{pygments_language}}</span>
     </td>
     <td>
-        <span>{{playground_name}}</span>
+        <span class="playground_name">{{playground_name}}</span>
     </td>
     <td>
-        <span>{{url_prefix}}</span>
+        <span class="playground_url_prefix">{{url_prefix}}</span>
     </td>
     {{#if ../can_modify}}
     <td class="no-select actions">

--- a/static/templates/settings/playground_settings_admin.hbs
+++ b/static/templates/settings/playground_settings_admin.hbs
@@ -25,7 +25,10 @@
         <form class="form-horizontal admin-playground-form">
             <div class="add-new-playground-box grey-box">
                 <div class="new-playground-form wrapper">
-                    <div class="settings-section-title">{{t "Add a new code playground" }}</div>
+                    <div class="settings-section-title">
+                        {{t "Add a new code playground" }}
+                        {{> ../help_link_widget link="/help/add-a-custom-playground" }}
+                    </div>
                     <div class="alert" id="admin-playground-status"></div>
                     <div class="control-group">
                         <label for="playground_pygments_language" class="control-label"> {{t "Language" }}</label>

--- a/static/templates/settings/playground_settings_admin.hbs
+++ b/static/templates/settings/playground_settings_admin.hbs
@@ -42,7 +42,7 @@
                         <label for="playground_url_prefix" class="control-label"> {{t "URL prefix" }}</label>
                         <input type="text" id="playground_url_prefix" name="url_prefix" placeholder="https://replit.com/languages/python3/?code=" />
                     </div>
-                    <button type="submit" class="button rounded sea-green">
+                    <button type="submit" id="submit_playground_button" class="button rounded sea-green">
                         {{t 'Add code playground' }}
                     </button>
                 </div>

--- a/static/templates/settings/playground_settings_admin.hbs
+++ b/static/templates/settings/playground_settings_admin.hbs
@@ -2,10 +2,53 @@
     <div class="admin-table-wrapper">
         <p>
             {{#tr}}
-            Configure external sites that can run code present in a Zulip code block.
+                Configure external code playgrounds for your Zulip organization. Code playgrounds are interactive in-browser development
+                environments, such as <z-link-repl>replit</z-link-repl>, that are designed to make it convenient to edit and debug
+                code. Zulip code blocks that are <z-link-markdown-help>tagged with a programming language</z-link-markdown-help> will have
+                a button visible on hover that allows you to open the code block in the code playground site.
+                {{#*inline "z-link-repl"}}<a href="https://replit.com/" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+                {{#*inline "z-link-markdown-help"}}<a href="/help/format-your-message-using-markdown#code" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         </p>
-        <input type="text" class="search" placeholder="{{t 'Filter playgrounds' }}" aria-label="{{t 'Filter playgrounds' }}"/>
+        <p>
+            {{#tr}}
+            For example, to configure code playgrounds for languages like Python or JavaScript, you could specify the <i>Language</i>
+            and <i>URL Prefix</i> fields as:
+            {{/tr}}
+        </p>
+        <ul>
+            <li><code>Python</code> {{t "and" }} <code>https://replit.com/languages/python3/?code=</code></li>
+            <li><code>JavaScript</code>  {{t "and" }} <code>https://replit.com/languages/javascript/?code=</code></li>
+        </ul>
+
+        {{#if is_admin}}
+        <form class="form-horizontal admin-playground-form">
+            <div class="add-new-playground-box grey-box">
+                <div class="new-playground-form wrapper">
+                    <div class="settings-section-title">{{t "Add a new code playground" }}</div>
+                    <div class="alert" id="admin-playground-status"></div>
+                    <div class="control-group">
+                        {{!-- TODO: This should have a typeahead suggestion popover --}}
+                        <label for="playground_pygments_language" class="control-label"> {{t "Language" }}</label>
+                        <input type="text" id="playground_pygments_language" name="pygments_language" autocomplete="off" placeholder="Python" />
+                    </div>
+                    <div class="control-group">
+                        <label for="playground_name" class="control-label"> {{t "Name" }}</label>
+                        <input type="text" id="playground_name" name="name" placeholder="Python3 playground" />
+                    </div>
+                    <div class="control-group">
+                        <label for="playground_url_prefix" class="control-label"> {{t "URL prefix" }}</label>
+                        <input type="text" id="playground_url_prefix" name="url_prefix" placeholder="https://replit.com/languages/python3/?code=" />
+                    </div>
+                    <button type="submit" class="button rounded sea-green">
+                        {{t 'Add code playground' }}
+                    </button>
+                </div>
+            </div>
+        </form>
+        {{/if}}
+
+        <input type="text" class="search" placeholder="{{t 'Filter code playgrounds' }}" aria-label="{{t 'Filter code playgrounds' }}"/>
         <div class="progressive-table-wrapper" data-simplebar>
             <table class="table table-condensed table-striped wrapped-table admin_playgrounds_table">
                 <thead>

--- a/static/templates/settings/playground_settings_admin.hbs
+++ b/static/templates/settings/playground_settings_admin.hbs
@@ -55,6 +55,9 @@
                     <th class="active" data-sort="pygments_language">{{t "Language" }}</th>
                     <th data-sort="playground_name">{{t "Name" }}</th>
                     <th data-sort="url">{{t "URL prefix" }}</th>
+                    {{#if is_admin}}
+                    <th class="actions">{{t "Actions" }}</th>
+                    {{/if}}
                 </thead>
                 <tbody id="admin_playgrounds_table" class="required-text" data-empty="{{t 'No playgrounds configured.' }}"></tbody>
             </table>

--- a/static/templates/settings/playground_settings_admin.hbs
+++ b/static/templates/settings/playground_settings_admin.hbs
@@ -28,7 +28,6 @@
                     <div class="settings-section-title">{{t "Add a new code playground" }}</div>
                     <div class="alert" id="admin-playground-status"></div>
                     <div class="control-group">
-                        {{!-- TODO: This should have a typeahead suggestion popover --}}
                         <label for="playground_pygments_language" class="control-label"> {{t "Language" }}</label>
                         <input type="text" id="playground_pygments_language" name="pygments_language" autocomplete="off" placeholder="Python" />
                     </div>

--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -140,7 +140,6 @@
                     <i class="locked fa fa-lock" title="{{ _('Only organization administrators can edit these settings.') }}"></i>
                     {% endif %}
                 </li>
-                {% if development_environment %}
                 <li tabindex="0" data-section="playground-settings">
                     <i class="icon fa fa-external-link" aria-hidden="true"></i>
                     <div class="text">{{ _('Code playgrounds') }}</div>
@@ -148,7 +147,6 @@
                     <i class="locked fa fa-lock" title="{{ _('Only organization administrators can edit these settings.') }}"></i>
                     {% endif %}
                 </li>
-                {% endif %}
                 {% if is_admin %}
                 <li tabindex="0" data-section="profile-field-settings">
                     <i class="icon fa fa-user" aria-hidden="true"></i>

--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -64,6 +64,16 @@
                     “#1235” or a commit ID.
                 </p>
             </div>
+            <div class="feature-block">
+                <h3>CODE BLOCKS</h3>
+                <p>
+                    With a single click, one can easily copy code block
+                    contents to the clipboard or transfer the contents
+                    to
+                    an <a href="/help/add-a-custom-playground">external
+                    code playground</a> that can run the code.
+                </p>
+            </div>
         </div>
         <img class="image" src="/static/images/features/message-formatting.png" alt="" />
     </section>

--- a/templates/zerver/for/open-source.md
+++ b/templates/zerver/for/open-source.md
@@ -126,11 +126,16 @@ Import your existing organization from [Slack](/help/import-from-slack),
 [Mattermost](/help/import-from-mattermost), or
 [Gitter](/help/import-from-gitter).
 
-### Syntax highlighting.
+### Collaborate on code and formulas
 
-[Full Markdown support](/help/format-your-message-using-markdown), including
-syntax highlighting, makes it easy to discuss code, paste an error message,
-or explain a complicated point. Full LaTeX support as well.
+[Markdown code blocks](/help/format-your-message-using-markdown#code)
+with syntax highlighting make it easy to discuss code, paste an error
+message, or explain a complicated point. Native LaTeX support provides
+the same benefits when talking about math.
+
+You can also instantly copy a code block to your clipboard or transfer
+it to an [external code playground](/help/add-a-custom-playground) to
+interactively run and debug the code.
 
 If your community primarily uses a single programming language,
 consider setting a default language for syntax highlighting.

--- a/templates/zerver/help/add-a-custom-playground.md
+++ b/templates/zerver/help/add-a-custom-playground.md
@@ -1,0 +1,72 @@
+# Add a custom playground
+
+{!admin-only.md!}
+
+Code playgrounds allow users to open the contents of a [code
+block][code-block] in an external playground of your choice by
+clicking a widget that appears when hovering over the code block.
+
+Code playgrounds can be configured for any programming language (the
+language of a code block is determined by the logic for syntax
+highlighting).  You can also use a custom language name to implement
+simple integrations.  For example, a playground for the language
+`send_tweet` could be used with a "playground" that sends the content
+of the code block as a Tweet.
+
+[code-block]: /help/format-your-message-using-markdown#code
+
+### Add a custom playground
+
+{start_tabs}
+
+{settings_tab|playground-settings}
+
+1. Under **Add a new playground**, enter a **Name**, **Language** and
+**URL prefix**.
+
+1. Click **Add playground**.
+
+{end_tabs}
+
+## Walkthrough with an example
+
+Consider the following example.
+
+* Name: `Rust playground`
+* Language: `Rust`
+* URL prefix: `https://play.rust-lang.org/?edition=2018&code=`
+
+When composing a message `rust` can be mentioned as the syntax highlighting
+language in the code blocks.
+
+~~~
+``` rust
+fn main() {
+    // A hello world Rust program for demo purposes
+    println!("Hello World!");
+}
+```
+~~~
+
+The user would then get a on-hover option to open the above code in the playground
+they had previously configured.
+
+## Technical details
+
+* You can configure multiple playgrounds for a given language; if you do that,
+  the user will get to choose which playground to open the code in.
+* The `Language` field is the human-readable Pygments language name for that
+  programming language. The syntax highlighting language in a code block
+  is internally mapped to these human-readable Pygments names.
+  E.g: `py3` and `py` are mapped to `Python`. We are working on implementing a
+  typeahead for looking up the Pygments name. Until then, one can use
+  [this Pygments method](https://pygments-doc.readthedocs.io/en/latest/lexers/lexers.html#pygments.lexers.get_lexer_by_name).
+* The links for opening code playgrounds are always constructed by
+  concatenating the provided URL prefix with the URL-encoded contents
+  of the code block.
+* Code playground sites do not always clearly document their URL
+  format; often you can just get the prefix from your browser's URL bar.
+
+If you have any trouble setting in setting up a code playground, please [contact
+us](/help/contact-support) with details on what you're trying to do, and we'll be
+happy to help you out.

--- a/templates/zerver/help/format-your-message-using-markdown.md
+++ b/templates/zerver/help/format-your-message-using-markdown.md
@@ -118,6 +118,10 @@ Organization administrators can also configure a default syntax
 highlighting language.  In this configuration, one can use ````text`
 to display content without any syntax highlighting.
 
+Hovering over a Zulip code block reveals buttons to copy the code or
+open it in one of the organization's configured [custom code
+playgrounds](/help/add-a-custom-playground).
+
 ## LaTeX
 ~~~
 Inline: $$O(n^2)$$

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -140,6 +140,7 @@
 * [Add custom emoji](/help/add-custom-emoji)
 * [Configure authentication methods](/help/configure-authentication-methods)
 * [Add a custom linkifier](/help/add-a-custom-linkifier)
+* [Add a custom playground](/help/add-a-custom-playground)
 * [Message retention policy](/help/message-retention-policy)
 * [SAML authentication](/help/saml-authentication)
 

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -546,7 +546,12 @@ html_rules: List["Rule"] = [
             ("templates/zerver/register.html", 'placeholder="acme"'),
             ("templates/zerver/register.html", 'placeholder="Acme or Ακμή"'),
         },
-        "exclude": {"templates/analytics/support.html"},
+        "exclude": {
+            "templates/analytics/support.html",
+            # We have URL prefix and Pygments language name as placeholders
+            # in the below template which we don't want to be translatable.
+            "static/templates/settings/playground_settings_admin.hbs",
+        },
         "good_lines": [
             '<input class="stream-list-filter" type="text" placeholder="{{ _(\'Filter streams\') }}" />'
         ],

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -62,6 +62,11 @@ link_mapping = {
         "Linkifiers",
         "/#organization/linkifier-settings",
     ],
+    "playground-settings": [
+        "Manage organization",
+        "Playgrounds",
+        "/#organization/playground-settings",
+    ],
     "profile-field-settings": [
         "Manage organization",
         "Custom profile fields",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2629,7 +2629,8 @@ paths:
                               additionalProperties: false
                               description: |
                                 Event sent to all users in a Zulip organization when the
-                                set of configured playgrounds for the organization has changed.
+                                set of configured [code playgrounds](/help/add-a-custom-playground)
+                                for the organization has changed.
 
                                 **Changes**: New in Zulip 4.0 (feature level 49).
                               properties:
@@ -6985,8 +6986,7 @@ paths:
       operationId: add_realm_playground
       tags: ["server_and_organizations"]
       description: |
-        Configure realm playgrounds options to run code snippets occurring
-        in a code block using playgrounds which supports that language.
+        Configure [code playgrounds](/help/add-a-custom-playground) for the organization.
 
         `POST {{ api_url }}/v1/realm/playgrounds`
 
@@ -7042,8 +7042,8 @@ paths:
       operationId: remove_realm_playground
       tags: ["server_and_organizations"]
       description: |
-        Remove realm playground options to run code snippets in
-        custom playgrounds
+        Remove a [code playground](/help/add-a-custom-playground) previously
+        configured for an organization.
 
         `DELETE {{ api_url }}/v1/realm/playgrounds/{playground_id}`
 
@@ -7449,8 +7449,8 @@ paths:
                         description: |
                           Present if `realm_playgrounds` is present in `fetch_event_types`.
 
-                          An array of dictionaries where each dictionary describes a playground entry
-                          in this Zulip organization.
+                          An array of dictionaries where each dictionary describes a
+                          [code playground](/help/add-a-custom-playground) configured for this Zulip organization.
 
                           **Changes**: New in Zulip 4.0 (feature level 49).
                       realm_user_groups:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This picks up where #16496 finished and adds frontend support for configuring playgrounds. The third, fourth, and fifth commits add the majority of the UI for reading, creating and deleting playgrounds. The issue filed for the feature is #16432.

**Testing plan:** <!-- How have you tested? -->
Tested manually and added puppeteer frontend tests for the playground UI.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/30312566/115808861-b64b1680-a408-11eb-9b2e-bd097d338e24.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
Here is a list of pending TODO items (ordered on priority):
- [x] We need to implement a typeahead popup for the pygments_language field in the playgrounds form. (I'll probably do this soon)
- [ ] Add a way for organizations that want to disable the feature (due to concerns of sending code to a third party) and document it.
- [ ] Investigate what services like `repl.it` exist and contact a few for permission when thinking about what defaults to support. 
- [ ] Also, now would be a good time to discuss how we want to manage the default playgrounds for an organization.
- [ ] Support editing the playground links (similar to #17045) - we may want to push this off for a bit longer.
