### PR TITLE
typeahead: Fetch stream topic history from server.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -18,6 +18,7 @@ const message_user_ids = mock_esm("../../static/js/message_user_ids", {
     user_ids: () => [],
 });
 const stream_topic_history = mock_esm("../../static/js/stream_topic_history");
+const stream_topic_history_util = mock_esm("../../static/js/stream_topic_history_util");
 
 let autosize_called;
 
@@ -316,6 +317,10 @@ test("topics_seen_for", (override) => {
         return ["With Twisted Metal", "acceptance", "civil fears"];
     });
 
+    override(stream_topic_history_util, "get_server_history", (stream_id) => {
+        assert.equal(stream_id, denmark_stream.stream_id);
+    });
+
     assert.deepEqual(ct.topics_seen_for("Denmark"), [
         "With Twisted Metal",
         "acceptance",
@@ -557,6 +562,8 @@ function sorted_names_from(subs) {
 
 test("initialize", (override) => {
     let expected_value;
+
+    override(stream_topic_history_util, "get_server_history", () => {});
 
     let stream_typeahead_called = false;
     $("#stream_message_recipient_stream").typeahead = (options) => {
@@ -1109,6 +1116,8 @@ test("initialize", (override) => {
 });
 
 test("begins_typeahead", (override) => {
+    override(stream_topic_history_util, "get_server_history", () => {});
+
     const begin_typehead_this = {
         options: {
             completions: {

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -2,9 +2,11 @@
 
 const {strict: assert} = require("assert");
 
-const {with_field, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, with_field, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {page_params} = require("../zjsunit/zpage_params");
+
+const stream_topic_history_util = mock_esm("../../static/js/stream_topic_history_util");
 
 const settings_config = zrequire("settings_config");
 
@@ -629,8 +631,8 @@ test("topic_suggestions", (override) => {
     let suggestions;
     let expected;
 
+    override(stream_topic_history_util, "get_server_history", () => {});
     override(stream_data, "subscribed_streams", () => ["office"]);
-
     override(narrow_state, "stream", () => "office");
 
     const devel_id = 44;

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -2,9 +2,11 @@
 
 const {strict: assert} = require("assert");
 
-const {zrequire} = require("../zjsunit/namespace");
+const {mock_esm, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {page_params} = require("../zjsunit/zpage_params");
+
+const stream_topic_history_util = mock_esm("../../static/js/stream_topic_history_util");
 
 const settings_config = zrequire("settings_config");
 
@@ -596,8 +598,8 @@ test("topic_suggestions", (override) => {
     let suggestions;
     let expected;
 
+    override(stream_topic_history_util, "get_server_history", () => {});
     override(stream_data, "subscribed_streams", () => ["office"]);
-
     override(narrow_state, "stream", () => "office");
 
     const devel_id = 44;

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -21,6 +21,7 @@ import * as rows from "./rows";
 import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
 import * as stream_topic_history from "./stream_topic_history";
+import * as stream_topic_history_util from "./stream_topic_history_util";
 import * as timerender from "./timerender";
 import * as typeahead_helper from "./typeahead_helper";
 import * as user_groups from "./user_groups";
@@ -68,6 +69,9 @@ export function topics_seen_for(stream_name) {
     if (!stream_id) {
         return [];
     }
+
+    // Fetch topic history from the server, in case we will need it soon.
+    stream_topic_history_util.get_server_history(stream_id, () => {});
     const topic_names = stream_topic_history.get_recent_topic_names(stream_id);
     return topic_names;
 }

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -9,6 +9,7 @@ import * as people from "./people";
 import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
 import * as stream_topic_history from "./stream_topic_history";
+import * as stream_topic_history_util from "./stream_topic_history_util";
 import * as typeahead_helper from "./typeahead_helper";
 
 export const max_num_of_search_results = 12;
@@ -341,6 +342,8 @@ function get_topic_suggestions(last, operators) {
         return [];
     }
 
+    // Fetch topic history from the server, in case we will need it.
+    stream_topic_history_util.get_server_history(stream_id, () => {});
     let topics = stream_topic_history.get_recent_topic_names(stream_id);
 
     if (!topics || !topics.length) {


### PR DESCRIPTION
Long ago, we changed Zulip to inspect server-provided topic history in
our compose and search typeahead modules, but did not trigger a query
to the server to fetch data.

This could result in confusing experiences where someone thought that
a topic doesn't exist that just isn't present in recent history.

Once we merge this, we may want to adjust the messaging in typeahead
to advertise that the first option will create a new topic, since this
change may make it feel more like creating topics is a heavyweight
operation.

Fixes #9857.
