### PR TITLE
hotkey: Disable left arrow hotkey when view has unreads.

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1272,7 +1272,7 @@ export function edit_last_sent_message(): void {
         return;
     }
 
-    message_lists.current.select_id(msg.id, {then_scroll: true, from_scroll: true});
+    message_lists.current.select_id(msg.id, {then_scroll: true});
 
     const $msg_row = message_lists.current.get_row(msg.id);
     if (!$msg_row) {

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1257,28 +1257,28 @@ export function edit_last_sent_message(): void {
         return;
     }
 
-    const msg = message_lists.current.get_last_message_sent_by_me();
+    const last_sent_msg = message_lists.current.get_last_message_sent_by_me();
 
-    if (!msg) {
+    if (!last_sent_msg) {
         return;
     }
 
-    if (!msg.id) {
+    if (!last_sent_msg.id) {
         blueslip.error("Message has invalid id in edit_last_sent_message.");
         return;
     }
 
-    if (!is_content_editable(msg, 5)) {
+    if (!is_content_editable(last_sent_msg, 5)) {
         return;
     }
 
-    message_lists.current.select_id(msg.id, {then_scroll: true});
+    message_lists.current.select_id(last_sent_msg.id, {then_scroll: true});
 
-    const $msg_row = message_lists.current.get_row(msg.id);
+    const $msg_row = message_lists.current.get_row(last_sent_msg.id);
     if (!$msg_row) {
         // This should never happen, since we got the message above
         // from message_lists.current.
-        blueslip.error("Could not find row for id", {msg_id: msg.id});
+        blueslip.error("Could not find row for id", {msg_id: last_sent_msg.id});
         return;
     }
 

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1272,6 +1272,18 @@ export function edit_last_sent_message(): void {
         return;
     }
 
+    const current_selected_msg = message_store.get(message_lists.current.selected_id());
+    if (current_selected_msg && current_selected_msg.id < last_sent_msg.id) {
+        // If there are any unread messages between the selected message and the
+        // message we want to edit, we don't edit the last sent message to avoid
+        // marking messages as read unintentionally.
+        for (const msg of message_lists.current.all_messages()) {
+            if (current_selected_msg.id < msg.id && msg.id < last_sent_msg.id && msg.unread) {
+                return;
+            }
+        }
+    }
+
     message_lists.current.select_id(last_sent_msg.id, {then_scroll: true});
 
     const $msg_row = message_lists.current.get_row(last_sent_msg.id);

--- a/web/templates/confirm_dialog/confirm_edit_messages.hbs
+++ b/web/templates/confirm_dialog/confirm_edit_messages.hbs
@@ -1,0 +1,5 @@
+<p>
+    {{#tr}}
+    Scrolling to the last message you sent will mark <b>{num_unread}</b> unread messages as read. Would you like to scroll to that message and edit it?
+    {{/tr}}
+</p>


### PR DESCRIPTION
On pressing left arrow key while in narrow stream to edit
the last message, if the user has unread messages sent in
topics other than the one where the user has sent its last
message (considering the topics for same stream) and the unread
messages were sent before the user message, the hotkey unexpectedly
marks the messages as read. Hence we disable the hotkey for
such a case.
Fixes #17737.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
