### PR TITLE
Hide muted users from buddy list.

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -57,6 +57,7 @@ set_global("document", _document);
 
 const huddle_data = zrequire("huddle_data");
 const compose_fade = zrequire("compose_fade");
+const muting = zrequire("muting");
 const narrow = zrequire("narrow");
 const presence = zrequire("presence");
 const people = zrequire("people");
@@ -213,6 +214,7 @@ function clear_buddy_list() {
 function test_ui(label, f) {
     run_test(label, (override) => {
         clear_buddy_list();
+        muting.set_muted_users([]);
         f(override);
     });
 }
@@ -420,6 +422,21 @@ test_ui("filter_user_ids", () => {
         mark.user_id,
     ]);
 
+    muting.add_muted_user(jill.user_id);
+    muting.add_muted_user(mark.user_id);
+
+    // Test no match for muted user when there is no filter.
+    user_ids = get_user_ids();
+    assert.deepEqual(user_ids, [alice.user_id, fred.user_id, norbert.user_id, zoe.user_id]);
+
+    // Test no match for muted users even with filter text.
+    user_filter.val("ji,ma");
+    user_ids = get_user_ids();
+    assert.deepEqual(user_ids, []);
+
+    muting.remove_muted_user(jill.user_id);
+    muting.remove_muted_user(mark.user_id);
+
     user_filter.val("abc"); // no match
     user_ids = get_user_ids();
     assert.deepEqual(user_ids, []);
@@ -542,6 +559,17 @@ test_ui("realm_presence_disabled", () => {
 
     activity.redraw_user();
     activity.build_user_sidebar();
+});
+
+test_ui("redraw_muted_user", () => {
+    muting.add_muted_user(mark.user_id);
+    let appended_html;
+    $("#user_presences").append = function (html) {
+        appended_html = html;
+    };
+
+    activity.redraw_user(mark.user_id);
+    assert(appended_html === undefined);
 });
 
 test_ui("clear_search", () => {

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -12,6 +12,7 @@ const {page_params} = require("../zjsunit/zpage_params");
 const timerender = mock_esm("../../static/js/timerender");
 
 const compose_fade_helper = zrequire("compose_fade_helper");
+const muting = zrequire("muting");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const presence = zrequire("presence");
@@ -104,6 +105,7 @@ function test(label, f) {
         people.init();
         people.add_active_user(me);
         people.initialize_current_user(me.user_id);
+        muting.set_muted_users([]);
         f(override);
     });
 }
@@ -369,6 +371,17 @@ test("simple search", () => {
     const user_ids = buddy_data.get_filtered_and_sorted_user_ids("sel");
 
     assert.deepEqual(user_ids, [selma.user_id]);
+});
+
+test("muted users excluded from search", () => {
+    muting.add_muted_user(selma.user_id);
+
+    let user_ids = buddy_data.get_filtered_and_sorted_user_ids();
+    assert.equal(user_ids.includes(selma.user_id), false);
+    user_ids = buddy_data.get_filtered_and_sorted_user_ids("sel");
+    assert.deepEqual(user_ids, []);
+
+    muting.remove_muted_user(selma.user_id);
 });
 
 test("bulk_data_hacks", () => {

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -340,7 +340,7 @@ function filter_user_ids(user_filter_text, user_ids) {
     return Array.from(user_id_dict.keys());
 }
 
-function get_user_id_list(user_filter_text) {
+function get_filtered_user_id_list(user_filter_text) {
     let base_user_id_list;
 
     if (user_filter_text) {
@@ -360,7 +360,7 @@ function get_user_id_list(user_filter_text) {
 
 export function get_filtered_and_sorted_user_ids(user_filter_text) {
     let user_ids;
-    user_ids = get_user_id_list(user_filter_text);
+    user_ids = get_filtered_user_id_list(user_filter_text);
     user_ids = maybe_shrink_list(user_ids, user_filter_text);
     return sort_users(user_ids);
 }

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -309,7 +309,7 @@ function maybe_shrink_list(user_ids, user_filter_text) {
 }
 
 function filter_user_ids(user_filter_text, user_ids) {
-    if (user_filter_text === "") {
+    if (!user_filter_text) {
         return user_ids;
     }
 
@@ -325,18 +325,20 @@ function filter_user_ids(user_filter_text, user_ids) {
 }
 
 function get_user_id_list(user_filter_text) {
-    let user_ids;
+    let base_user_id_list;
 
     if (user_filter_text) {
         // If there's a filter, select from all users, not just those
         // recently active.
-        user_ids = filter_user_ids(user_filter_text, people.get_active_user_ids());
+        base_user_id_list = people.get_active_user_ids();
     } else {
         // From large realms, the user_ids in presence may exclude
         // users who have been idle more than three weeks.  When the
         // filter text is blank, we show only those recently active users.
-        user_ids = presence.get_user_ids();
+        base_user_id_list = presence.get_user_ids();
     }
+
+    let user_ids = filter_user_ids(user_filter_text, base_user_id_list);
 
     user_ids = user_ids.filter((user_id) => {
         const person = people.get_by_user_id(user_id);

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -2,6 +2,7 @@ import * as blueslip from "./blueslip";
 import * as compose_fade_users from "./compose_fade_users";
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
+import * as muting from "./muting";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as presence from "./presence";
@@ -319,8 +320,19 @@ function filter_user_ids(user_filter_text, user_ids) {
             return false;
         }
 
-        // if the user is bot, do not show in presence data.
-        return !person.is_bot;
+        if (person.is_bot) {
+            // Bots should never appear in the right sidebar.  This
+            // case should never happen, since bots cannot have
+            // presence data.
+            return false;
+        }
+
+        if (muting.is_user_muted(user_id)) {
+            // Muted users are hidden from the right sidebar entirely.
+            return false;
+        }
+
+        return true;
     });
 
     if (!user_filter_text) {

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -4,6 +4,7 @@ import render_confirm_mute_user from "../templates/confirm_mute_user.hbs";
 import render_muted_topic_ui_row from "../templates/muted_topic_ui_row.hbs";
 import render_topic_muted from "../templates/topic_muted.hbs";
 
+import * as activity from "./activity";
 import * as channel from "./channel";
 import * as confirm_dialog from "./confirm_dialog";
 import * as feedback_widget from "./feedback_widget";
@@ -200,6 +201,8 @@ export function rerender_for_muted_user() {
     if (overlays.settings_open() && settings_muted_users.loaded) {
         settings_muted_users.populate_list();
     }
+
+    activity.redraw();
 }
 
 export function handle_user_updates(muted_user_ids) {


### PR DESCRIPTION
This is a subpart of #16915 to hide muted users from the buddy list. I've addressed the review comment from there-

https://github.com/zulip/zulip/pull/16915#discussion_r608295934
> Would it be cleaner to put this check in buddy_list.insert_or_move? That seems better given that the main enforcement of this behavior is in the buddy_list redraw logic.

I simplified the code so that we now need just one `if` block to filter muted users, instead of two.

> It's a little awkward because for some reason buddy_data doesn't call its key user_id, but I'm not sure why we do that.

`buddy_data.js` calls it `user_id` alright, but `buddy_list.js` calls it `key`, which is definitely weird 😅 

---

**Testing and GIFs**
<s>I tested this with a super-hacky patch which adds UI to mute/unmute a user. It is available at https://github.com/abhijeetbodas2001/zulip/commits/patch_mute_ui and is basically a stripped down version of the main commit which adds this UI in #16915. </s>
Edit: Tested this manually from master.

<details><summary>Here's a GIF</summary>
<img src="https://user-images.githubusercontent.com/55339528/115375366-5a577680-a1eb-11eb-8da3-c9b710f44986.gif" />

</details>