### PR TITLE
Add queue_workers_multiprocess setting

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -492,6 +492,20 @@ non-empty value is currently equivalent to true).
 
 [s3-uploads]: ../production/upload-backends.html#s3-backend-configuration
 
+#### `queue_workers_multiprocess`
+
+By default, Zulip automatically detects whether the system has enough
+memory to run Zulip queue processors in the higher-throughput but more
+multiprocess mode (or to save 1.5GiB of RAM with the multithreaded
+mode). The calculation is based on whether the system has enough
+memory (currently 3.5GiB) to run a single-server Zulip installation in
+the multiprocess mode.
+
+Set to `true` or `false` to override the automatic calculation.  This
+override is useful both Docker systems (where the above algorithm
+might see the host's memory, not the container's) and/or when using
+remote servers for postgres, memcached, redis, and RabbitMQ.
+
 #### `uwsgi_buffer_size`
 
 Override the default uwsgi buffer size of 8192.

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -72,7 +72,8 @@ class zulip::app_frontend_base {
   # This determines whether we run queue processors multithreaded or
   # multiprocess.  Multiprocess scales much better, but requires more
   # RAM; we just auto-detect based on available system RAM.
-  $queues_multiprocess = $zulip::common::total_memory_mb > 3500
+  $queues_multiprocess_default = $zulip::common::total_memory_mb > 3500
+  $queues_multiprocess = Boolean(zulipconf('application_server', 'queue_workers_multiprocess', $queues_multiprocess_default))
   $queues = [
     'deferred_work',
     'digest_emails',


### PR DESCRIPTION
Add queue_workers_multiprocess setting to allow administrators to override setting based on system memory detection.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Zulip auto-detects how much system memory is available when deciding whether to run queue workers in a multiprocess or multithreaded fashion ([Conversation on Zulip](https://chat.zulip.org/#narrow/stream/2-general/topic/Zulip.201-Click.20self-hosting/near/1150342)). For docker containers, the available memory of the host is detected. This is not representative of the container's available memory.

**Testing plan:** <!-- How have you tested? -->
I tested this using [docker-zulip](https://github.com/zulip/docker-zulip) on Render by adding `queue_workers_multiprocess = false` to `/etc/zulip/zulip.conf`.

Memory usage dropped as expected after the deploy:
<img width="437" alt="Screen Shot 2021-04-20 at 12 39 56 PM" src="https://user-images.githubusercontent.com/2397765/115456435-02fbdb00-a1d8-11eb-93de-646c0ccfcf67.png">

On the server with the deployment:
```
> cat /etc/zulip/zulip.conf 
[machine]
puppet_classes = zulip::dockervoyager
deploy_type = production


[rabbitmq]
nodename = zulip@localhost


[application_server]
http_only = true
queue_workers_multiprocess = false
```

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->