### PR TITLE
upgrade: Show fewer stacktraces.

### DIFF
--- a/scripts/lib/upgrade-zulip
+++ b/scripts/lib/upgrade-zulip
@@ -65,8 +65,13 @@ try:
     # version is much better for fixing bugs in the upgrade process).
     deploy_path = deploy_path.strip()
     os.chdir(deploy_path)
-    subprocess.check_call(
-        [os.path.abspath("./scripts/lib/upgrade-zulip-stage-2"), deploy_path, *deploy_options]
-    )
+    try:
+        subprocess.check_call(
+            [os.path.abspath("./scripts/lib/upgrade-zulip-stage-2"), deploy_path, *deploy_options]
+        )
+    except subprocess.CalledProcessError:
+        # There's no use in showing a stacktrace here; it just hides
+        # the error from stage 2.
+        sys.exit(1)
 finally:
     release_deployment_lock()

--- a/scripts/lib/upgrade-zulip-from-git
+++ b/scripts/lib/upgrade-zulip-from-git
@@ -85,13 +85,18 @@ try:
 
     overwrite_symlink(deploy_path, os.path.join(DEPLOYMENTS_DIR, "next"))
 
-    subprocess.check_call(
-        [
-            os.path.join(deploy_path, "scripts", "lib", "upgrade-zulip-stage-2"),
-            deploy_path,
-            "--from-git",
-            *deploy_options,
-        ]
-    )
+    try:
+        subprocess.check_call(
+            [
+                os.path.join(deploy_path, "scripts", "lib", "upgrade-zulip-stage-2"),
+                deploy_path,
+                "--from-git",
+                *deploy_options,
+            ]
+        )
+    except subprocess.CalledProcessError:
+        # There's no use in showing a stacktrace here; it just hides
+        # the error from stage 2.
+        sys.exit(1)
 finally:
     release_deployment_lock()

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -238,7 +238,7 @@ def run(args: Sequence[str], **kwargs: Any) -> None:
         )
         print(WHITEONRED + "Actual error output for the subcommand is just above this." + ENDC)
         print()
-        raise
+        sys.exit(1)
 
 
 def log_management_command(cmd: Sequence[str], log_path: str) -> None:


### PR DESCRIPTION
The stacktraces here are seldom useful -- for the calls to
upgrade-stage-2, we know precisely what was run.  For the `run`
wrapper, the output contains the command that failed, which is
sufficient to identify where in the upgrade process it was.  Showing
more stacktrace below the actual error merely confuses users and
scrolls the real error off of the screen.
