### PR TITLE
upgrade: Install python3-yaml as needed.

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -160,6 +160,12 @@ if not args.skip_puppet:
     subprocess.check_call(["apt-get", "update"])
     subprocess.check_call(["apt-get", "-y", "upgrade"])
 
+# To bootstrap zulip-puppet-apply, we need to install the system yaml
+# package; new installs get this, but old installs may not have it.
+if not os.path.exists("/usr/share/doc/python3-yaml"):
+    logging.info("Installing system YAML package, for puppet...")
+    subprocess.check_call(["apt-get", "install", "python3-yaml"])
+
 if not os.path.exists(os.path.join(deploy_path, "zproject/prod_settings.py")):
     # This is normally done in unpack-zulip, but for upgrading from
     # zulip<1.4.0, we need to do it.  See discussion in commit 586b23637.


### PR DESCRIPTION
3314fefaec8d started needing a python3-yaml, but incorrectly claimed
that it was alkways an indirect dependency; it is a dependency of
`ubuntu-minimal` on 20.04, but not required on 18.04 or Debian.  We
cannot install it in puppet because then is definitionally too late; it
is needed at load time by zulip-puppet-apply.

Install python3-yaml, but guarded by a simple check soas to not
further slow most installs.

Fixes #18179
