### PR TITLE
activity: Add `@never_cache` to `/activity` endpoints to avoid caching headers on response.

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -24,6 +24,7 @@ from django.utils import translation
 from django.utils.timesince import timesince
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
+from django.views.decorators.cache import never_cache
 from jinja2 import Markup as mark_safe
 from psycopg2.sql import SQL, Composable, Literal
 
@@ -1195,6 +1196,7 @@ def ad_hoc_queries() -> List[Dict[str, str]]:
 
 @require_server_admin
 @has_request_variables
+@never_cache
 def get_activity(request: HttpRequest) -> HttpResponse:
     duration_content, realm_minutes = user_activity_intervals()
     counts_content: str = realm_summary_table(realm_minutes)
@@ -1258,6 +1260,7 @@ def get_confirmations(
 
 
 @require_server_admin
+@never_cache
 def support(request: HttpRequest) -> HttpResponse:
     context: Dict[str, Any] = {}
 


### PR DESCRIPTION
This PR aims to solve the issue https://github.com/zulip/zulip/issues/17766

Like all the API endpoints use @never-cache to put explicit never-cache
headers on the response. `/activity/` endpoint currently does not set
any cache headers, but would benefit from the same set of never-cache
headers. This commit adds `@never_cache` to the views used in `/activity`
endpoint.

