### PR TITLE
docs: Describe the process of upgrading settings.py files.

### DIFF
--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -133,6 +133,14 @@ suggest using that updated template to update
    section in `/etc/zulip/settings-new.py` and copy the setting from
    `settings.py` into there.
 
+   The following tool may help, by finding the most likely version of
+   the template that your `/etc/zulip/settings.py` was installed
+   using, and the differences that your file has from that:
+
+   ```
+   /home/zulip/deployments/current/scripts/setup/compare-settings-to-template
+   ```
+
    If there are settings which you cannot find documented in
    `/etc/zulip/settings-new.py`, check the [changelog][changelog] to see
    if they have been removed.

--- a/scripts/setup/compare-settings-to-template
+++ b/scripts/setup/compare-settings-to-template
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import difflib
+import os
+import re
+import sys
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(BASE_DIR)
+from scripts.lib.setup_path import setup_path
+
+setup_path()
+
+
+current_path = "/etc/zulip/settings.py"
+if len(sys.argv) >= 2:
+    current_path = sys.argv[1]
+
+print(f"Reading current configuration from {current_path}...")
+with open(current_path, "r") as f:
+    current_contents = f.read()
+
+import requests
+
+print("Fetching old versions of setting templates from Github...")
+templ = {}
+resp = requests.get("https://api.github.com/repos/zulip/zulip/tags")
+if resp.status_code != 200:
+    print(resp.content)
+    sys.exit(1)
+
+for tag in [t["name"] for t in resp.json()]:
+    if re.match(r"^\d+\.\d+(\.\d+)?$", tag):
+        print(f"  - {tag}")
+        resp = requests.get(
+            f"https://raw.githubusercontent.com/zulip/zulip/{tag}/zproject/prod_settings_template.py",
+        )
+        if resp.status_code == 200:
+            templ[tag] = resp.content.decode("utf-8")
+        else:
+            print("Failure: ")
+            print(resp)
+
+print("Computing minimal difference...")
+sequence_matchers = {}
+for version, contents in templ.items():
+    sm = difflib.SequenceMatcher(None, current_contents, contents)
+    sequence_matchers[version] = sm
+
+likely = sorted(sequence_matchers.keys(), key=lambda v: sequence_matchers[v].ratio(), reverse=True)
+print(f"Most likely version: {likely[0]}")
+
+
+diff = difflib.unified_diff(
+    templ[likely[0]].splitlines(keepends=True),
+    current_contents.splitlines(keepends=True),
+    fromfile="zulip-server-{version}/zproject/prod_settings_template.py",
+    tofile=current_path,
+)
+
+print()
+print("".join(diff), end="")


### PR DESCRIPTION
Fixes zulip#17782.

Also included is a second commit which attempts to find the changes you made from the template you most recently used.  Here's what that looks like:
```
root@alexmv-prod:~# ~zulip/deployments/current/scripts/minimal-template-diff
Reading current configuration from /etc/zulip/settings.py...
Fetching old versions of setting templates from Github...
  - 3.4
  - 3.3
  - 3.2
  - 3.1
  - 3.0
  - 2.1.7
  - 2.1.6
  - 2.1.5
  - 2.1.4
  - 2.1.3
  - 2.1.2
  - 2.1.1
  - 2.1.0
  - 2.0.8
Computing minimal difference...
Most likely version: 3.2

--- zulip-server-{version}/zproject/prod_settings_template.py
+++ /etc/zulip/settings.py
@@ -1,4 +1,6 @@
 from typing import Any, Dict, Tuple
+
+from zproject.config import get_secret

 ################################################################
 # Zulip Server settings.
@@ -27,7 +29,7 @@
 # support@example.com is totally reasonable, as is admin@example.com.
 # Do not put a display name; e.g. 'support@example.com', not
 # 'Zulip Support <support@example.com>'.
-ZULIP_ADMINISTRATOR = 'zulip-admin@example.com'
+ZULIP_ADMINISTRATOR = 'alexmv@zulip.com'

 # The user-accessible Zulip hostname for this installation, e.g.
 # zulip.example.com.  This should match what users will put in their
@@ -36,7 +38,7 @@
 #
 # If you need to access the server on a specific port, you should set
 # EXTERNAL_HOST to e.g. zulip.example.com:1234 here.
-EXTERNAL_HOST = 'zulip.example.com'
+EXTERNAL_HOST = 'alexmv-prod.zulipdev.org'

 # Alternative hostnames.  A comma-separated list of strings
 # representing the host/domain names that your users can enter in
@@ -69,18 +71,15 @@
 # advice for troubleshooting, see the Zulip documentation:
 #   https://zulip.readthedocs.io/en/latest/production/email.html

-# EMAIL_HOST and EMAIL_HOST_USER are generally required.
-#EMAIL_HOST = 'smtp.example.com'
-#EMAIL_HOST_USER = ''
-
-# Passwords and secrets are not stored in this file.  The password
-# for user EMAIL_HOST_USER goes in `/etc/zulip/zulip-secrets.conf`.
-# In that file, set `email_password`.  For example:
-#   email_password = abcd1234
-
-# EMAIL_USE_TLS and EMAIL_PORT are required for most SMTP providers.
-#EMAIL_USE_TLS = True
-#EMAIL_PORT = 587
+#EMAIL_BACKEND = 'django_ses.SESBackend'
+#AWS_SES_ACCESS_KEY_ID = get_secret("email_username")
+#AWS_SES_SECRET_ACCESS_KEY = get_secret("email_password")
+
+# Send using SES; see https://docs.aws.amazon.com/general/latest/gr/ses.html for hosts.
+EMAIL_HOST = "email-smtp.us-east-1.amazonaws.com"
+EMAIL_HOST_USER = get_secret("email_username")
+EMAIL_USE_TLS = True
+EMAIL_PORT = 587

 # The noreply address to be used as the sender for certain generated
 # emails.  Messages sent to this address could contain sensitive user
@@ -362,9 +361,9 @@

 # Controls whether or not error reports (tracebacks) are emailed to the
 # server administrators.
-#ERROR_REPORTING = True
+ERROR_REPORTING = True
 # For frontend (JavaScript) tracebacks
-#BROWSER_ERROR_REPORTING = False
+BROWSER_ERROR_REPORTING = True

 # If True, each log message in the server logs will identify the
 # Python module where it came from.  Useful for tracking down a
@@ -437,9 +436,9 @@
 # Valid values for REMOTE_POSTGRES_SSLMODE are documented in the
 # "SSL Mode Descriptions" table in
 #   https://www.postgresql.org/docs/9.5/static/libpq-ssl.html
-#REMOTE_POSTGRES_HOST = 'dbserver.example.com'
+#REMOTE_POSTGRES_HOST = 'localhost'
 #REMOTE_POSTGRES_PORT = '5432'
-#REMOTE_POSTGRES_SSLMODE = 'require'
+#REMOTE_POSTGRES_SSLMODE = 'disable'

 # If you want to set a Terms of Service for your server, set the path
 # to your markdown file, and uncomment the following line.
@@ -643,12 +642,12 @@
 # thumbor on a different server, you can configure that by setting
 # THUMBOR_URL here.  Setting THUMBOR_URL='' will let Zulip server know that
 # thumbor is not running or configured.
-#THUMBOR_URL = 'http://127.0.0.1:9995'
+THUMBOR_URL = 'http://127.0.0.1:9995'
 #
 # This setting controls whether images shown in Zulip's inline image
 # previews should be thumbnailed by thumbor, which saves bandwidth but
 # can modify the image's appearance.
-#THUMBNAIL_IMAGES = True
+THUMBNAIL_IMAGES = False

 # Controls the Jitsi Meet video call integration.  By default, the
 # integration uses the SaaS meet.jit.si server.  You can specify
```

One problem is that the unauth'd Github API is [rate-limited to 60 requests per hour](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting) so you can only run the tool 4 times per hour, and that number will go down as we make more releases.

If this seems plausibly useful, I'll amend the second commit with instructions pointing at it.