### PR TITLE
Fix content edit history propagated to all the edited messages when topic and content is edited simultaneously.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5562,9 +5562,22 @@ def do_update_message(
         edit_history_event[LEGACY_PREV_TOPIC] = orig_topic_name
 
     update_edit_history(message, timestamp, edit_history_event)
+
     delete_event_notify_user_ids: List[int] = []
     if propagate_mode in ["change_later", "change_all"]:
         assert topic_name is not None or new_stream is not None
+        # Other messages should only get topic/stream fields in their edit history.
+        topic_only_edit_history_event = {
+            k: v
+            for (k, v) in edit_history_event.items()
+            if k
+            not in [
+                "prev_content",
+                "prev_rendered_content",
+                "prev_rendered_content_version",
+            ]
+        }
+
         messages_list = update_messages_for_topic_edit(
             edited_message=message,
             propagate_mode=propagate_mode,
@@ -5572,7 +5585,7 @@ def do_update_message(
             topic_name=topic_name,
             new_stream=new_stream,
             old_recipient_id=old_recipient_id,
-            edit_history_event=edit_history_event,
+            edit_history_event=topic_only_edit_history_event,
             last_edit_time=timestamp,
         )
         changed_messages += messages_list


### PR DESCRIPTION
discussion - https://chat.zulip.org/#narrow/stream/137-feedback/topic/edit.20history.3F

Issue: quoting @cyphase


> For the record, the issue is [this block](https://github.com/zulip/zulip/commit/e566e985e4d2e824ecbafef74f171883e3a77b2a#diff-d0ab74f5d9d9240e4315c65a162dd4ecace2237050bca26a77f237d6b6c37a9bR143). It's adding the edit history event to every message in the renamed topic, which is a problem if the edit history event also contains a content edit. The webapp won't include a content edit if there wasn't actually one, but ZT does (a no-op edit); at least last I checked, and presumably still since that explains this. And as I mentioned, you can reproduce the problem in the webapp by editing the content in the same edit where you edit the topic.