### PR TITLE
models: Replace __id syntax with _id where possible.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4998,7 +4998,7 @@ def do_mark_stream_messages_as_read(
         where=[UserMessage.where_unread()],
     )
 
-    message_ids = list(msgs.values_list("message__id", flat=True))
+    message_ids = list(msgs.values_list("message_id", flat=True))
 
     count = msgs.update(
         flags=F("flags").bitor(UserMessage.flags.read),
@@ -5038,7 +5038,7 @@ def do_mark_muted_user_messages_as_read(
         user_profile=user_profile, message__sender=muted_user
     ).extra(where=[UserMessage.where_unread()])
 
-    message_ids = list(messages.values_list("message__id", flat=True))
+    message_ids = list(messages.values_list("message_id", flat=True))
 
     count = messages.update(
         flags=F("flags").bitor(UserMessage.flags.read),
@@ -5136,7 +5136,7 @@ def do_update_message_flags(
         raise JsonableError(_("Invalid message flag operation: '{}'").format(operation))
     flagattr = getattr(UserMessage.flags, flag)
 
-    msgs = UserMessage.objects.filter(user_profile=user_profile, message__id__in=messages)
+    msgs = UserMessage.objects.filter(user_profile=user_profile, message_id__in=messages)
     # This next block allows you to star any message, even those you
     # didn't receive (e.g. because you're looking at a public stream
     # you're not subscribed to, etc.).  The problem is that starring
@@ -7202,7 +7202,7 @@ def get_owned_bot_dicts(
             "default_sending_stream": botdict["default_sending_stream__name"],
             "default_events_register_stream": botdict["default_events_register_stream__name"],
             "default_all_public_streams": botdict["default_all_public_streams"],
-            "owner_id": botdict["bot_owner__id"],
+            "owner_id": botdict["bot_owner_id"],
             "avatar_url": avatar_url_from_dict(botdict),
             "services": services_by_ids[botdict["id"]],
         }

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -554,7 +554,7 @@ bot_dict_fields: List[str] = [
     "api_key",
     "avatar_source",
     "avatar_version",
-    "bot_owner__id",
+    "bot_owner_id",
     "bot_type",
     "default_all_public_streams",
     "default_events_register_stream__name",

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -1088,7 +1088,7 @@ def export_partial_message_files(
         ).values_list("id", flat=True)
 
         consented_recipient_ids = Subscription.objects.filter(
-            user_profile__id__in=consented_user_ids
+            user_profile_id__in=consented_user_ids
         ).values_list("recipient_id", flat=True)
 
         recipient_ids = set(public_stream_recipient_ids) | set(consented_recipient_ids)
@@ -1897,7 +1897,7 @@ def get_analytics_config() -> Config:
 def get_consented_user_ids(consent_message_id: int) -> Set[int]:
     return set(
         Reaction.objects.filter(
-            message__id=consent_message_id,
+            message_id=consent_message_id,
             reaction_type="unicode_emoji",
             # outbox = 1f4e4
             emoji_code="1f4e4",

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -63,7 +63,7 @@ class RawReactionRow(TypedDict):
     reaction_type: str
     user_profile__email: str
     user_profile__full_name: str
-    user_profile__id: int
+    user_profile_id: int
 
 
 class RawUnreadMessagesResult(TypedDict):
@@ -646,10 +646,10 @@ class ReactionDict:
             # as a small performance optimization.
             "user": {
                 "email": row["user_profile__email"],
-                "id": row["user_profile__id"],
+                "id": row["user_profile_id"],
                 "full_name": row["user_profile__full_name"],
             },
-            "user_id": row["user_profile__id"],
+            "user_id": row["user_profile_id"],
         }
 
 

--- a/zerver/lib/presence.py
+++ b/zerver/lib/presence.py
@@ -21,13 +21,13 @@ def get_status_dicts_for_rows(
     # here prevents us from having to assume the caller is playing nice.
     all_rows = sorted(
         all_rows,
-        key=lambda row: (row["user_profile__id"], row["timestamp"]),
+        key=lambda row: (row["user_profile_id"], row["timestamp"]),
     )
 
     if slim_presence:
         # Stringify user_id here, since it's gonna be turned
         # into a string anyway by JSON, and it keeps mypy happy.
-        get_user_key = lambda row: str(row["user_profile__id"])
+        get_user_key = lambda row: str(row["user_profile_id"])
         get_user_info = get_modern_user_info
     else:
         get_user_key = lambda row: row["user_profile__email"]
@@ -88,7 +88,7 @@ def get_legacy_user_info(
         dt = row["timestamp"]
         timestamp = datetime_to_timestamp(dt)
         push_enabled = row["user_profile__enable_offline_push_notifications"]
-        has_push_devices = row["user_profile__id"] in mobile_user_ids
+        has_push_devices = row["user_profile_id"] in mobile_user_ids
         pushable = push_enabled and has_push_devices
 
         info = dict(
@@ -129,7 +129,7 @@ def get_presence_for_user(
         "status",
         "timestamp",
         "user_profile__email",
-        "user_profile__id",
+        "user_profile_id",
         "user_profile__enable_offline_push_notifications",
     )
     presence_rows = list(query)
@@ -156,7 +156,7 @@ def get_status_dict_by_realm(
         "status",
         "timestamp",
         "user_profile__email",
-        "user_profile__id",
+        "user_profile_id",
         "user_profile__enable_offline_push_notifications",
     )
 
@@ -167,7 +167,7 @@ def get_status_dict_by_realm(
         flat=True,
     )
 
-    user_profile_ids = [presence_row["user_profile__id"] for presence_row in presence_rows]
+    user_profile_ids = [presence_row["user_profile_id"] for presence_row in presence_rows]
     if len(user_profile_ids) == 0:
         # This conditional is necessary because query_for_ids
         # throws an exception if passed an empty list.

--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -164,7 +164,7 @@ def add_missing_messages(user_profile: UserProfile) -> None:
     subscription_logs = list(
         RealmAuditLog.objects.select_related("modified_stream")
         .filter(
-            modified_user=user_profile, modified_stream__id__in=stream_ids, event_type__in=events
+            modified_user=user_profile, modified_stream_id__in=stream_ids, event_type__in=events
         )
         .order_by("event_last_message_id", "id")
     )
@@ -189,7 +189,7 @@ def add_missing_messages(user_profile: UserProfile) -> None:
 
     all_stream_msgs = list(
         Message.objects.filter(
-            recipient__id__in=recipient_ids, id__gt=user_profile.last_active_message_id
+            recipient_id__in=recipient_ids, id__gt=user_profile.last_active_message_id
         )
         .order_by("id")
         .values("id", "recipient__type_id")
@@ -198,8 +198,8 @@ def add_missing_messages(user_profile: UserProfile) -> None:
         UserMessage.objects.filter(
             user_profile=user_profile,
             message__recipient__type=Recipient.STREAM,
-            message__id__gt=user_profile.last_active_message_id,
-        ).values_list("message__id", flat=True)
+            message_id__gt=user_profile.last_active_message_id,
+        ).values_list("message_id", flat=True)
     )
 
     # Filter those messages for which UserMessage rows have been already created
@@ -232,7 +232,7 @@ def do_soft_deactivate_user(user_profile: UserProfile) -> None:
     try:
         user_profile.last_active_message_id = (
             UserMessage.objects.filter(user_profile=user_profile)
-            .order_by("-message__id")[0]
+            .order_by("-message_id")[0]
             .message_id
         )
     except IndexError:  # nocoverage

--- a/zerver/lib/stream_subscription.py
+++ b/zerver/lib/stream_subscription.py
@@ -272,5 +272,5 @@ def subscriber_ids_with_stream_history_access(stream: Stream) -> Set[int]:
     return set(
         get_active_subscriptions_for_stream_id(
             stream.id, include_deactivated_users=False
-        ).values_list("user_profile__id", flat=True)
+        ).values_list("user_profile_id", flat=True)
     )

--- a/zerver/lib/user_mutes.py
+++ b/zerver/lib/user_mutes.py
@@ -8,12 +8,12 @@ from zerver.models import MutedUser, UserProfile
 
 def get_user_mutes(user_profile: UserProfile) -> List[Dict[str, int]]:
     rows = MutedUser.objects.filter(user_profile=user_profile).values(
-        "muted_user__id",
+        "muted_user_id",
         "date_muted",
     )
     return [
         {
-            "id": row["muted_user__id"],
+            "id": row["muted_user_id"],
             "timestamp": datetime_to_timestamp(row["date_muted"]),
         }
         for row in rows
@@ -48,5 +48,5 @@ def get_muting_users(muted_user: UserProfile) -> Set[int]:
     """
     rows = MutedUser.objects.filter(
         muted_user=muted_user,
-    ).values("user_profile__id")
-    return {row["user_profile__id"] for row in rows}
+    ).values("user_profile_id")
+    return {row["user_profile_id"] for row in rows}

--- a/zerver/management/commands/set_message_flags.py
+++ b/zerver/management/commands/set_message_flags.py
@@ -48,7 +48,7 @@ class Command(ZulipBaseCommand):
         if all_until:
             filt = models.Q(id__lte=all_until)
         else:
-            filt = models.Q(message__id__in=[mid.strip() for mid in sys.stdin.read().split(",")])
+            filt = models.Q(message_id__in=[mid.strip() for mid in sys.stdin.read().split(",")])
         mids = [
             m.id
             for m in UserMessage.objects.filter(filt, user_profile=user_profile).order_by("-id")

--- a/zerver/migrations/0177_user_message_add_and_index_is_private_flag.py
+++ b/zerver/migrations/0177_user_message_add_and_index_is_private_flag.py
@@ -31,7 +31,7 @@ def reset_is_private_flag(apps: StateApps, schema_editor: DatabaseSchemaEditor) 
             # of hackery to generate the SQL just right (with an
             # `ORDER BY` clause that forces using the new index).
             flag_set_objects = (
-                UserMessage.objects.filter(user_profile__id=user_id)
+                UserMessage.objects.filter(user_profile_id=user_id)
                 .extra(where=["flags & 2048 != 0"])
                 .order_by("message_id")[0:1000]
             )

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -2402,7 +2402,7 @@ class Reaction(AbstractReaction):
             "emoji_code",
             "reaction_type",
             "user_profile__email",
-            "user_profile__id",
+            "user_profile_id",
             "user_profile__full_name",
         ]
         return Reaction.objects.filter(message_id__in=needed_ids).values(*fields)
@@ -2537,7 +2537,7 @@ def get_usermessage_by_message_id(
 ) -> Optional[UserMessage]:
     try:
         return UserMessage.objects.select_related().get(
-            user_profile=user_profile, message__id=message_id
+            user_profile=user_profile, message_id=message_id
         )
     except UserMessage.DoesNotExist:
         return None
@@ -3624,11 +3624,11 @@ class Service(models.Model):
 
 
 def get_bot_services(user_profile_id: int) -> List[Service]:
-    return list(Service.objects.filter(user_profile__id=user_profile_id))
+    return list(Service.objects.filter(user_profile_id=user_profile_id))
 
 
 def get_service_profile(user_profile_id: int, service_name: str) -> Service:
-    return Service.objects.get(user_profile__id=user_profile_id, name=service_name)
+    return Service.objects.get(user_profile_id=user_profile_id, name=service_name)
 
 
 class BotStorageData(models.Model):

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -1105,7 +1105,7 @@ def get_messages_backend(
         message_ids = [row[0] for row in rows]
 
         # TODO: This could be done with an outer join instead of two queries
-        um_rows = UserMessage.objects.filter(user_profile=user_profile, message__id__in=message_ids)
+        um_rows = UserMessage.objects.filter(user_profile=user_profile, message_id__in=message_ids)
         user_message_flags = {um.message_id: um.flags_list() for um in um_rows}
 
         for message_id in message_ids:


### PR DESCRIPTION
Original motivation: https://github.com/zulip/zulip/pull/18204#discussion_r615276929

model__id syntax implies needing a JOIN on the model table to fetch the
id. That's usually redundant, because the first table in the query
simply has a 'model_id' column, so the id can be fetched directly.
Django is actually smart enough to not do those redundant joins, but we
should still avoid this misguided syntax.

The exceptions are ManytoMany fields and queries doing a backward
relationship lookup. If "streams" is a many-to-many relationship, then
streams_id is invalid - streams__id syntax is needed. If "y" is a
foreign fields from X to Y:
class X:
  y = models.ForeignKey(Y)

then object x of class X has the field x.y_id, but y of class Y doesn't
have y.x_id. Thus Y queries need to be done like
Y.objects.filter(x__id__in=some_list)
