### PR TITLE
frontend : fix overflowing of alert-word-status-text when the window narrowed

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -492,6 +492,10 @@ input[type="checkbox"] {
     margin-top: 1px;
 }
 
+.alert_word_status_text {
+    word-break: break-word;
+}
+
 .alert-notification {
     display: inline-block;
     vertical-align: top;


### PR DESCRIPTION
when a window is narrowed the alert-word-status-text overflow out of the alert-success.


**Testing plan:** Tested locally


**GIFs or screenshots:**
Before
------------------------------
![(8) Private mess (1)](https://user-images.githubusercontent.com/56171689/115992670-76dd1f80-a5ec-11eb-9538-c8e2b545906b.png)

After
-------------------------------
![FIRST keurig was](https://user-images.githubusercontent.com/56171689/115992676-7d6b9700-a5ec-11eb-9637-d152c6763f7f.png)

