### PR TITLE
clean-unused-caches: Add script to remove redundant yarn cache.

### DIFF
--- a/scripts/lib/clean-unused-caches
+++ b/scripts/lib/clean-unused-caches
@@ -4,7 +4,7 @@ import sys
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(ZULIP_PATH)
-from scripts.lib import clean_emoji_cache, clean_node_cache, clean_venv_cache
+from scripts.lib import clean_emoji_cache, clean_node_cache, clean_venv_cache, clean_yarn_cache
 from scripts.lib.zulip_tools import parse_cache_script_args
 
 
@@ -13,6 +13,7 @@ def main() -> None:
     os.chdir(ZULIP_PATH)
     clean_venv_cache.main(args)
     clean_node_cache.main(args)
+    clean_yarn_cache.main(args)
     clean_emoji_cache.main(args)
 
 

--- a/scripts/lib/clean_yarn_cache.py
+++ b/scripts/lib/clean_yarn_cache.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import sys
+
+ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(ZULIP_PATH)
+
+from scripts.lib.zulip_tools import may_be_perform_purging, parse_cache_script_args
+
+YARN_CACHE_PATH = os.path.expanduser("~/.cache/yarn/")
+CURRENT_VERSION = "v6"
+
+
+def remove_unused_versions_dir(args: argparse.Namespace) -> None:
+    """Deletes cache data from obsolete Yarn versions.
+
+    Yarn does not provide an interface for removing obsolete data from
+    ~/.cache/yarn for packages that you haven't installed in years; but one
+    can always remove the cache entirely.
+    """
+    current_version_dir = os.path.join(YARN_CACHE_PATH, CURRENT_VERSION)
+    dirs_to_purge = set(
+        [
+            os.path.join(YARN_CACHE_PATH, directory)
+            for directory in os.listdir(YARN_CACHE_PATH)
+            if directory != CURRENT_VERSION
+        ]
+    )
+
+    may_be_perform_purging(
+        dirs_to_purge,
+        {current_version_dir},
+        "yarn cache",
+        args.dry_run,
+        args.verbose,
+        args.no_headings,
+    )
+
+
+def main(args: argparse.Namespace) -> None:
+    remove_unused_versions_dir(args)
+
+
+if __name__ == "__main__":
+    args = parse_cache_script_args("This script cleans redundant Zulip yarn caches.")
+    main(args)


### PR DESCRIPTION
Fixes #15964.

This PR removes redundant yarn cache by:
- Removing the old version directories, i.e. All the directory under
`~/.cache/yarn` except `~/.cache/yarn/v6`.


<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested in the local environment by creating directories under `~/.cache/yarn`.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
