### PR TITLE
Fix for Making Blueslip Error Popups Available for Portico Pages

### DIFF
--- a/static/js/alert_popup.ts
+++ b/static/js/alert_popup.ts
@@ -1,16 +1,14 @@
 import $ from "jquery";
 
-export function initialize(): void {
-    // this will hide the alerts that you click "x" on.
-    $("body").on("click", ".alert-box > div .exit", function () {
-        const $alert = $(this).closest(".alert-box > div");
-        $alert.addClass("fade-out");
-        setTimeout(() => {
-            $alert.removeClass("fade-out show");
-        }, 300);
-    });
+// this will hide the alerts that you click "x" on.
+$("body").on("click", ".alert-box > div .exit", function () {
+    const $alert = $(this).closest(".alert-box > div");
+    $alert.addClass("fade-out");
+    setTimeout(() => {
+        $alert.removeClass("fade-out show");
+    }, 300);
+});
 
-    $(".alert-box").on("click", ".stackframe", function () {
-        $(this).siblings(".code-context").toggle("fast");
-    });
-}
+$(".alert-box").on("click", ".stackframe", function () {
+    $(this).siblings(".code-context").toggle("fast");
+});

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -32,7 +32,6 @@ import "../../styles/components.css";
 import "../../styles/app_components.css";
 import "../../styles/rendered_markdown.css";
 import "../../styles/zulip.css";
-import "../../styles/alerts.css";
 import "../../styles/settings.css";
 import "../../styles/image_upload_widget.css";
 import "../../styles/subscriptions.css";

--- a/static/js/bundles/common.js
+++ b/static/js/bundles/common.js
@@ -3,6 +3,7 @@ import "core-js/features/symbol";
 import "css.escape";
 import "../webpack_public_path";
 import "../../../tools/debug-require";
+import "../alert_popup";
 import "../csrf";
 import "../blueslip";
 import "../../third/bootstrap/js/bootstrap";

--- a/static/js/bundles/common.js
+++ b/static/js/bundles/common.js
@@ -13,6 +13,7 @@ import "font-awesome/css/font-awesome.css";
 import "../../assets/icons/zulip-icons.font";
 import "source-sans/source-sans-3.css";
 import "source-code-pro/source-code-pro.css";
+import "../../styles/alerts.css";
 import "../../styles/pygments.css";
 import "@uppy/core/dist/style.css";
 import "@uppy/progress-bar/dist/style.css";

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -8,7 +8,6 @@ import * as fenced_code from "../shared/js/fenced_code";
 import render_edit_content_button from "../templates/edit_content_button.hbs";
 
 import * as activity from "./activity";
-import * as alert_popup from "./alert_popup";
 import * as alert_words from "./alert_words";
 import * as blueslip from "./blueslip";
 import * as bot_data from "./bot_data";
@@ -465,7 +464,6 @@ export function initialize_everything() {
     // template.
     compose.initialize();
     message_lists.initialize();
-    alert_popup.initialize();
     alert_words.initialize(alert_words_params);
     emojisets.initialize();
     people.initialize(page_params.user_id, people_params);

--- a/static/styles/alerts.css
+++ b/static/styles/alerts.css
@@ -27,23 +27,6 @@ $alert-error-red: hsl(0, 80%, 40%);
     }
 }
 
-/* general alert styling changes */
-.alert {
-    @extend .alert-display;
-
-    &#organization-status {
-        margin: 20px;
-    }
-
-    &.stream_create_info {
-        margin: 10px 10px 0 10px;
-    }
-
-    .bankruptcy_unread_count {
-        font-weight: 600;
-    }
-}
-
 /* alert box component changes */
 .alert-box {
     position: absolute;

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -494,3 +494,26 @@ div.overlay {
     background-color: hsl(105, 2%, 50%);
     color: hsl(0, 0%, 100%);
 }
+
+/* Implement the webapp's default-hidden convention for alert
+   elements.  Portico pages lack this CSS and thus show them by
+   default. */
+.alert {
+    display: none;
+
+    &.show {
+        display: block;
+    }
+
+    &#organization-status {
+        margin: 20px;
+    }
+
+    &.stream_create_info {
+        margin: 10px 10px 0 10px;
+    }
+
+    .bankruptcy_unread_count {
+        font-weight: 600;
+    }
+}

--- a/templates/zerver/portico.html
+++ b/templates/zerver/portico.html
@@ -20,6 +20,7 @@
             </div>
         </div>
     </div>
+    <div class="alert-box"></div>
     {% if not isolated_page %}
     {% include 'zerver/footer.html' %}
     {% endif %}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Regarding issue #17801, and the problem discussed in https://chat.zulip.org/#narrow/stream/16-desktop/topic/can't.20log.20in/near/1150044, this PR is created for preventing `alert.css` from overriding some styles that existed in portico pages (which might cause the error message for the login page to be hidden), and fixing the problem that the "x" doesn't respond to clicks.

Related: #17936

**Testing plan:** <!-- How have you tested? -->
It has been tested manually on both portico pages and webapp pages.

![image](https://user-images.githubusercontent.com/39874143/116001638-f63c1480-a627-11eb-88da-6ca89ec264fc.png)
Note that the `.alert` style that defaults `display` to `None` will not be shared in portico pages now. Instead, it will only be available in the webapp. And the error message shows correctly.