### PR TITLE
Improve outgoing webhook error handling of invalid responses

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -288,8 +288,7 @@ def process_success_response(
     try:
         response_json = json.loads(response.text)
     except json.JSONDecodeError:
-        fail_with_message(event, "Invalid JSON in response")
-        return
+        raise JsonableError(_("Invalid JSON in response"))
 
     if not isinstance(response_json, dict):
         raise JsonableError(_("Invalid response format"))

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -291,6 +291,9 @@ def process_success_response(
         fail_with_message(event, "Invalid JSON in response")
         return
 
+    if not isinstance(response_json, dict):
+        raise JsonableError(_("Invalid response format"))
+
     success_data = service_handler.process_success(response_json)
 
     if success_data is None:

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -5,6 +5,7 @@ from unittest import mock
 import requests
 
 from zerver.lib.avatar import get_gravatar_url
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import MessageDict
 from zerver.lib.outgoing_webhook import get_service_interface_class, process_success_response
 from zerver.lib.test_classes import ZulipTestCase
@@ -47,13 +48,12 @@ class TestGenericOutgoingWebhookService(ZulipTestCase):
         response.status_code = 200
         response.text = "unparsable text"
 
-        with mock.patch("zerver.lib.outgoing_webhook.fail_with_message") as m:
+        with self.assertRaisesRegex(JsonableError, "Invalid JSON in response"):
             process_success_response(
                 event=event,
                 service_handler=service_handler,
                 response=response,
             )
-        self.assertTrue(m.called)
 
     def test_make_request(self) -> None:
         othello = self.example_user("othello")

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -261,6 +261,33 @@ The outgoing webhook server attempted to send a message in Zulip, but that reque
         assert bot_user.bot_owner is not None
         self.assertEqual(bot_owner_notification.recipient_id, bot_user.bot_owner.recipient_id)
 
+    def test_invalid_response_format(self) -> None:
+        bot_user = self.example_user("outgoing_webhook_bot")
+        mock_event = self.mock_event(bot_user)
+        service_handler = GenericOutgoingWebhookService("token", bot_user, "service")
+
+        expect_logging_info = self.assertLogs(level="INFO")
+        expect_fail = mock.patch("zerver.lib.outgoing_webhook.fail_with_message")
+
+        with responses.RequestsMock(assert_all_requests_are_fired=True) as requests_mock:
+            # We mock the endpoint to return response with valid json which doesn't
+            # translate to a dict like is expected,
+            requests_mock.add(
+                requests_mock.POST, "https://example.zulip.com", status=200, json=True
+            )
+            with expect_logging_info, expect_fail as mock_fail:
+                do_rest_call("https://example.zulip.com", mock_event, service_handler)
+            self.assertTrue(mock_fail.called)
+            bot_owner_notification = self.get_last_message()
+            self.assertEqual(
+                bot_owner_notification.content,
+                """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
+The outgoing webhook server attempted to send a message in Zulip, but that request resulted in the following error:
+> Invalid response format""",
+            )
+        assert bot_user.bot_owner is not None
+        self.assertEqual(bot_owner_notification.recipient_id, bot_user.bot_owner.recipient_id)
+
 
 class TestOutgoingWebhookMessaging(ZulipTestCase):
     def create_outgoing_bot(self, bot_owner: UserProfile) -> UserProfile:

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -86,7 +86,7 @@ class DoRestCallTests(ZulipTestCase):
         for service_class in [GenericOutgoingWebhookService, SlackOutgoingWebhookService]:
             handler = service_class("token", bot_user, "service")
             with mock.patch.object(handler, "session") as session:
-                session.post.return_value = ResponseMock(200)
+                session.post.return_value = ResponseMock(200, b"{}")
                 do_rest_call("", mock_event, handler)
                 session.post.assert_called_once()
 
@@ -158,7 +158,7 @@ The webhook got a response with status code *400*.""",
 
         session = service_handler.session
         with mock.patch.object(session, "send") as mock_send:
-            mock_send.return_value = ResponseMock(200)
+            mock_send.return_value = ResponseMock(200, b"{}")
             final_response = do_rest_call("https://example.com/", mock_event, service_handler)
             assert final_response is not None
 
@@ -332,7 +332,7 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
 
         session = mock.Mock(spec=requests.Session)
         session.headers = {}
-        session.post.return_value = ResponseMock(200)
+        session.post.return_value = ResponseMock(200, b"{}")
         with mock.patch("zerver.lib.outgoing_webhook.Session") as sessionmaker:
             sessionmaker.return_value = session
             self.send_personal_message(


### PR DESCRIPTION
Fixes #18223 and a couple other small improvements, detailed in commit messages.