### PR TITLE
Hover effect for status list messages on night_mode.css

### DIFF
--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -49,6 +49,10 @@ body.night-mode {
     .stream_label {
         color: hsl(212, 28%, 18%);
     }
+    
+    button.user-status-value:hover {
+        color: hsl(200, 100%, 40%) !important;
+    }
 
     .new-style label.checkbox input[type="checkbox"] ~ span {
         border-color: hsla(0, 0%, 100%, 0.4);

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -49,7 +49,7 @@ body.night-mode {
     .stream_label {
         color: hsl(212, 28%, 18%);
     }
-    
+
     button.user-status-value:hover {
         color: hsl(200, 100%, 40%) !important;
     }


### PR DESCRIPTION
What's this PR for?!
No hover effect on status list messages in night mode. [#17944](https://github.com/zulip/zulip/issues/17944)


Testing plan: Tested locally


GIFs or screenshots:
![Screen Shot 2021-04-26 at 6 51 53 PM](https://user-images.githubusercontent.com/33763942/116160803-b1b08780-a6c0-11eb-8a55-364eb0cd2d29.png)
![Screen Shot 2021-04-26 at 6 52 03 PM](https://user-images.githubusercontent.com/33763942/116160817-b4ab7800-a6c0-11eb-836b-05931341c612.png)
![Screen Shot 2021-04-26 at 6 52 10 PM](https://user-images.githubusercontent.com/33763942/116160821-b70dd200-a6c0-11eb-9730-c0c654c94a11.png)
![Screen Shot 2021-04-26 at 6 52 16 PM](https://user-images.githubusercontent.com/33763942/116160827-b8d79580-a6c0-11eb-91b7-32c30c34c7f5.png)
![Screen Shot 2021-04-26 at 6 52 23 PM](https://user-images.githubusercontent.com/33763942/116160832-bbd28600-a6c0-11eb-9e5f-0db9fda7d851.png)

