### PR TITLE
[WIP] Labels for Arrows on Landing Page

### DIFF
--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -141,8 +141,16 @@
                         </div>
                     </div>
 
-                    <a class="carousel-control left visibility-control hide" href="#tour-carousel" data-slide="prev"><i class="fa fa-chevron-left" aria-hidden="true"></i></a>
-                    <a class="carousel-control right visibility-control" href="#tour-carousel" data-slide="next"><i class="fa fa-chevron-right" aria-hidden="true"></i></a>
+                    <a class="carousel-control left visibility-control hide"
+                      href="#tour-carousel" data-slide="prev"
+                      aria-label="{{ _('Previous') }}" title="{{ _('Previous') }}">
+                        <i class="fa fa-chevron-left"></i>
+                    </a>
+                    <a class="carousel-control right visibility-control"
+                      href="#tour-carousel" data-slide="next"
+                      aria-label="{{ _('Next') }}" title="{{ _('Next') }}">
+                        <i class="fa fa-chevron-right"></i>
+                    </a>
                     <ol class="carousel-indicators">
                         <li data-target="#tour-carousel" data-slide-to="0" class="active"></li>
                         <li data-target="#tour-carousel" data-slide-to="1"></li>


### PR DESCRIPTION
**What's this PR for?**
Add a label for Next and Previous arrow button on the Landing page of Zulip. [#17467](https://github.com/zulip/zulip/issues/17467)

**Testing plan:** Locally tested using Voiceover


**GIFs or screenshots:** 
![Screen Shot 2021-04-26 at 8 55 33 PM](https://user-images.githubusercontent.com/33763942/116170029-f7c31680-a6d3-11eb-9514-013406e5eb72.png)
![Screen Shot 2021-04-26 at 8 55 47 PM](https://user-images.githubusercontent.com/33763942/116170032-fb569d80-a6d3-11eb-8e07-bbeb2352ef56.png)

