### PR TITLE
clean-unused-caches: Handle non-existent yarn cache.

### DIFF
--- a/scripts/lib/clean_yarn_cache.py
+++ b/scripts/lib/clean_yarn_cache.py
@@ -20,13 +20,16 @@ def remove_unused_versions_dir(args: argparse.Namespace) -> None:
     can always remove the cache entirely.
     """
     current_version_dir = os.path.join(YARN_CACHE_PATH, CURRENT_VERSION)
-    dirs_to_purge = set(
-        [
-            os.path.join(YARN_CACHE_PATH, directory)
-            for directory in os.listdir(YARN_CACHE_PATH)
-            if directory != CURRENT_VERSION
-        ]
-    )
+    try:
+        dirs_to_purge = set(
+            [
+                os.path.join(YARN_CACHE_PATH, directory)
+                for directory in os.listdir(YARN_CACHE_PATH)
+                if directory != CURRENT_VERSION
+            ]
+        )
+    except FileNotFoundError:
+        return
 
     may_be_perform_purging(
         dirs_to_purge,


### PR DESCRIPTION
Hi :)

https://github.com/zulip/zulip/pull/18259 has introduced a new issue on a fresh install which I wanted to upgrade directly to master using `zulip-upgrade-from-git`:
```
Deployments cleaned successfully...
Cleaning orphaned/unused caches...
Cleaning unused venv caches...
Cleaning unused node modules caches...
Traceback (most recent call last):
  File "/home/zulip/deployments/2021-04-27-09-51-44/scripts/lib/clean-unused-caches", line 21, in <module>
    main()
  File "/home/zulip/deployments/2021-04-27-09-51-44/scripts/lib/clean-unused-caches", line 16, in main
    clean_yarn_cache.main(args)
  File "/home/zulip/deployments/2021-04-27-09-51-44/scripts/lib/clean_yarn_cache.py", line 42, in main
    remove_unused_versions_dir(args)
  File "/home/zulip/deployments/2021-04-27-09-51-44/scripts/lib/clean_yarn_cache.py", line 26, in remove_unused_versions_dir
    for directory in os.listdir(YARN_CACHE_PATH)
FileNotFoundError: [Errno 2] No such file or directory: '/root/.cache/yarn/'
Traceback (most recent call last):
  File "./scripts/purge-old-deployments", line 84, in <module>
    main()
  File "./scripts/purge-old-deployments", line 77, in main
    subprocess.check_call(
  File "/usr/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/home/zulip/deployments/2021-04-27-09-51-44/scripts/lib/clean-unused-caches']' returned non-zero exit status 1.
Traceback (most recent call last):
  File "/home/zulip/deployments/2021-04-27-09-51-44/scripts/lib/upgrade-zulip-stage-2", line 324, in <module>
    subprocess.check_call(["./scripts/purge-old-deployments"])
  File "/usr/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['./scripts/purge-old-deployments']' returned non-zero exit status 1.
Traceback (most recent call last):
  File "/home/zulip/deployments/current/scripts/lib/upgrade-zulip-from-git", line 80, in <module>
    preexec_fn=su_to_zulip,
  File "/usr/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/home/zulip/deployments/2021-04-27-09-51-44/scripts/lib/upgrade-zulip-stage-2', '/home/zulip/deployments/2021-04-27-09-51-44', '--from-git']' returned non-zero exit status 1.
```

I think that this pull request should fix the issue and would be happy to receive feedback on this! (I am not sure how to test because the script always gets overwritten during the upgrade process...)