### PR TITLE
Clean up event handling code for topic mutes.

### DIFF
--- a/frontend_tests/node_tests/settings_muted_topics.js
+++ b/frontend_tests/node_tests/settings_muted_topics.js
@@ -21,10 +21,10 @@ const frontend = {
 };
 stream_data.add_sub(frontend);
 
-run_test("settings", () => {
+run_test("settings", (override) => {
     muting.add_muted_topic(frontend.stream_id, "js", 1577836800);
-    let set_up_topic_ui_called = false;
-    muting_ui.set_up_muted_topics_ui = () => {
+    let populate_list_called = false;
+    override(settings_muted_topics, "populate_list", () => {
         const opts = muting.get_muted_topics();
         assert.deepEqual(opts, [
             {
@@ -35,14 +35,15 @@ run_test("settings", () => {
                 topic: "js",
             },
         ]);
-        set_up_topic_ui_called = true;
-    };
+        populate_list_called = true;
+    });
 
     settings_muted_topics.reset();
     assert.equal(settings_muted_topics.loaded, false);
 
     settings_muted_topics.set_up();
     assert.equal(settings_muted_topics.loaded, true);
+    assert(populate_list_called);
 
     const topic_click_handler = $("body").get_on_handler("click", ".settings-unmute-topic");
     assert.equal(typeof topic_click_handler, "function");
@@ -81,6 +82,5 @@ run_test("settings", () => {
     };
     topic_click_handler.call(topic_fake_this, event);
     assert(unmute_topic_called);
-    assert(set_up_topic_ui_called);
     assert.equal(topic_data_called, 2);
 });

--- a/frontend_tests/node_tests/settings_muted_topics.js
+++ b/frontend_tests/node_tests/settings_muted_topics.js
@@ -48,7 +48,7 @@ run_test("settings", () => {
     assert.equal(typeof topic_click_handler, "function");
 
     const event = {
-        stopImmediatePropagation: noop,
+        stopPropagation: noop,
     };
 
     const topic_fake_this = $.create("fake.settings-unmute-topic");

--- a/frontend_tests/node_tests/settings_muted_topics.js
+++ b/frontend_tests/node_tests/settings_muted_topics.js
@@ -59,8 +59,6 @@ run_test("settings", (override) => {
         return topic_tr_html;
     };
 
-    topic_tr_html.remove = () => {};
-
     let topic_data_called = 0;
     topic_tr_html.attr = (opts) => {
         if (opts === "data-stream-id") {

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import _ from "lodash";
 
 import render_confirm_mute_user from "../templates/confirm_mute_user.hbs";
 import render_topic_muted from "../templates/topic_muted.hbs";
@@ -21,20 +22,8 @@ import * as stream_list from "./stream_list";
 import * as stream_popover from "./stream_popover";
 import * as unread_ui from "./unread_ui";
 
-function timestamp_ms() {
-    return Date.now();
-}
-
-let last_topic_update = 0;
-
-export function rerender_on_topic_update() {
-    // Note: We tend to optimistically rerender muting preferences before
-    // the backend actually acknowledges the mute.  This gives a more
-    // immediate feel to the user, and if the backend fails temporarily,
-    // re-doing a mute or unmute is a pretty recoverable thing.
-
+export function rerender_for_muted_topic(old_muted_topics) {
     stream_list.update_streams_sidebar();
-    recent_topics.complete_rerender();
     message_lists.current.update_topic_muting_and_rerender();
     if (message_lists.current !== message_lists.home) {
         message_lists.home.update_topic_muting_and_rerender();
@@ -42,88 +31,73 @@ export function rerender_on_topic_update() {
     if (overlays.settings_open() && settings_muted_topics.loaded) {
         settings_muted_topics.populate_list();
     }
-}
 
-export function persist_topic_mute(stream_id, topic_name) {
-    const data = {
-        stream_id,
-        topic: topic_name,
-        op: "add",
-    };
-    last_topic_update = timestamp_ms();
-    channel.patch({
-        url: "/json/users/me/subscriptions/muted_topics",
-        idempotent: true,
-        data,
-    });
-}
+    // We only update those topics which could have been affected, because
+    // we want to avoid doing a complete rerender of the recent topics view,
+    // because that can be expensive.
+    const current_muted_topics = muting.get_muted_topics();
+    const maybe_affected_topics = _.unionWith(old_muted_topics, current_muted_topics, _.isEqual);
 
-export function persist_topic_unmute(stream_id, topic_name) {
-    const data = {
-        stream_id,
-        topic: topic_name,
-        op: "remove",
-    };
-    last_topic_update = timestamp_ms();
-    channel.patch({
-        url: "/json/users/me/subscriptions/muted_topics",
-        idempotent: true,
-        data,
-    });
+    for (const topic_data of maybe_affected_topics) {
+        recent_topics.update_topic_is_muted(topic_data.stream_id, topic_data.topic);
+    }
 }
 
 export function handle_topic_updates(muted_topics) {
-    if (timestamp_ms() < last_topic_update + 1000) {
-        // This topic update is either the one that we just rendered, or,
-        // much less likely, it's coming from another device and would probably
-        // be overwriting this device's preferences with stale data.
-        return;
-    }
-
-    update_muted_topics(muted_topics);
-    rerender_on_topic_update();
-}
-
-export function update_muted_topics(muted_topics) {
+    const old_muted_topics = muting.get_muted_topics();
     muting.set_muted_topics(muted_topics);
+    stream_popover.hide_topic_popover();
     unread_ui.update_unread_counts();
+    rerender_for_muted_topic(old_muted_topics);
 }
 
 export function mute_topic(stream_id, topic) {
     const stream_name = stream_data.maybe_get_stream_name(stream_id);
+    const data = {
+        stream_id,
+        topic,
+        op: "add",
+    };
 
-    stream_popover.hide_topic_popover();
-    muting.add_muted_topic(stream_id, topic);
-    unread_ui.update_unread_counts();
-    rerender_on_topic_update();
-    persist_topic_mute(stream_id, topic);
-    feedback_widget.show({
-        populate(container) {
-            const rendered_html = render_topic_muted();
-            container.html(rendered_html);
-            container.find(".stream").text(stream_name);
-            container.find(".topic").text(topic);
+    channel.patch({
+        url: "/json/users/me/subscriptions/muted_topics",
+        idempotent: true,
+        data,
+        success() {
+            feedback_widget.show({
+                populate(container) {
+                    const rendered_html = render_topic_muted();
+                    container.html(rendered_html);
+                    container.find(".stream").text(stream_name);
+                    container.find(".topic").text(topic);
+                },
+                on_undo() {
+                    unmute_topic(stream_id, topic);
+                },
+                title_text: $t({defaultMessage: "Topic muted"}),
+                undo_button_text: $t({defaultMessage: "Unmute"}),
+            });
         },
-        on_undo() {
-            unmute_topic(stream_id, topic);
-        },
-        title_text: $t({defaultMessage: "Topic muted"}),
-        undo_button_text: $t({defaultMessage: "Unmute"}),
     });
-    recent_topics.update_topic_is_muted(stream_id, topic);
 }
 
 export function unmute_topic(stream_id, topic) {
-    // we don't run a unmute_notify function because it isn't an issue as much
-    // if someone accidentally unmutes a stream rather than if they mute it
-    // and miss out on info.
-    stream_popover.hide_topic_popover();
-    muting.remove_muted_topic(stream_id, topic);
-    unread_ui.update_unread_counts();
-    rerender_on_topic_update();
-    persist_topic_unmute(stream_id, topic);
-    feedback_widget.dismiss();
-    recent_topics.update_topic_is_muted(stream_id, topic);
+    // Accidentally unmuting a topic isn't as much an issue as accidentally muting
+    // a topic, so we don't show a popup after unmuting.
+    const data = {
+        stream_id,
+        topic,
+        op: "remove",
+    };
+
+    channel.patch({
+        url: "/json/users/me/subscriptions/muted_topics",
+        idempotent: true,
+        data,
+        success() {
+            feedback_widget.dismiss();
+        },
+    });
 }
 
 export function toggle_topic_mute(message) {

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -1,7 +1,6 @@
 import $ from "jquery";
 
 import render_confirm_mute_user from "../templates/confirm_mute_user.hbs";
-import render_muted_topic_ui_row from "../templates/muted_topic_ui_row.hbs";
 import render_topic_muted from "../templates/topic_muted.hbs";
 
 import * as activity from "./activity";
@@ -9,7 +8,6 @@ import * as channel from "./channel";
 import * as confirm_dialog from "./confirm_dialog";
 import * as feedback_widget from "./feedback_widget";
 import {$t} from "./i18n";
-import * as ListWidget from "./list_widget";
 import * as message_lists from "./message_lists";
 import * as muting from "./muting";
 import * as overlays from "./overlays";
@@ -21,7 +19,6 @@ import * as settings_muted_users from "./settings_muted_users";
 import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
 import * as stream_popover from "./stream_popover";
-import * as ui from "./ui";
 import * as unread_ui from "./unread_ui";
 
 function timestamp_ms() {
@@ -43,7 +40,7 @@ export function rerender_on_topic_update() {
         message_lists.home.update_topic_muting_and_rerender();
     }
     if (overlays.settings_open() && settings_muted_topics.loaded) {
-        set_up_muted_topics_ui();
+        settings_muted_topics.populate_list();
     }
 }
 
@@ -90,30 +87,6 @@ export function handle_topic_updates(muted_topics) {
 export function update_muted_topics(muted_topics) {
     muting.set_muted_topics(muted_topics);
     unread_ui.update_unread_counts();
-}
-
-export function set_up_muted_topics_ui() {
-    const muted_topics = muting.get_muted_topics();
-    const muted_topics_table = $("#muted_topics_table");
-    const $search_input = $("#muted_topics_search");
-
-    ListWidget.create(muted_topics_table, muted_topics, {
-        name: "muted-topics-list",
-        modifier(muted_topics) {
-            return render_muted_topic_ui_row({muted_topics});
-        },
-        filter: {
-            element: $search_input,
-            predicate(item, value) {
-                return item.topic.toLocaleLowerCase().includes(value);
-            },
-            onupdate() {
-                ui.reset_scrollbar(muted_topics_table.closest(".progressive-table-wrapper"));
-            },
-        },
-        parent_container: $("#muted-topic-settings"),
-        simplebar_container: $("#muted-topic-settings .progressive-table-wrapper"),
-    });
 }
 
 export function mute_topic(stream_id, topic) {

--- a/static/js/settings_muted_topics.js
+++ b/static/js/settings_muted_topics.js
@@ -11,7 +11,7 @@ export function set_up() {
         const stream_id = Number.parseInt($row.attr("data-stream-id"), 10);
         const topic = $row.attr("data-topic");
 
-        e.stopImmediatePropagation();
+        e.stopPropagation();
 
         muting_ui.unmute_topic(stream_id, topic);
         $row.remove();

--- a/static/js/settings_muted_topics.js
+++ b/static/js/settings_muted_topics.js
@@ -43,7 +43,6 @@ export function set_up() {
         e.stopPropagation();
 
         muting_ui.unmute_topic(stream_id, topic);
-        $row.remove();
     });
 
     populate_list();

--- a/static/js/settings_muted_topics.js
+++ b/static/js/settings_muted_topics.js
@@ -1,8 +1,37 @@
 import $ from "jquery";
 
+import render_muted_topic_ui_row from "../templates/muted_topic_ui_row.hbs";
+
+import * as ListWidget from "./list_widget";
+import * as muting from "./muting";
 import * as muting_ui from "./muting_ui";
+import * as ui from "./ui";
 
 export let loaded = false;
+
+export function populate_list() {
+    const muted_topics = muting.get_muted_topics();
+    const muted_topics_table = $("#muted_topics_table");
+    const $search_input = $("#muted_topics_search");
+
+    ListWidget.create(muted_topics_table, muted_topics, {
+        name: "muted-topics-list",
+        modifier(muted_topics) {
+            return render_muted_topic_ui_row({muted_topics});
+        },
+        filter: {
+            element: $search_input,
+            predicate(item, value) {
+                return item.topic.toLocaleLowerCase().includes(value);
+            },
+            onupdate() {
+                ui.reset_scrollbar(muted_topics_table.closest(".progressive-table-wrapper"));
+            },
+        },
+        parent_container: $("#muted-topic-settings"),
+        simplebar_container: $("#muted-topic-settings .progressive-table-wrapper"),
+    });
+}
 
 export function set_up() {
     loaded = true;
@@ -17,7 +46,7 @@ export function set_up() {
         $row.remove();
     });
 
-    muting_ui.set_up_muted_topics_ui();
+    populate_list();
 }
 
 export function reset() {

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -125,6 +125,7 @@ EXEMPT_FILES = {
     "static/js/settings.js",
     "static/js/settings_linkifiers.js",
     "static/js/settings_playgrounds.js",
+    "static/js/settings_muted_topics.js",
     "static/js/settings_muted_users.js",
     "static/js/settings_notifications.js",
     "static/js/settings_org.js",


### PR DESCRIPTION
Previously, we used to do a kind of "local echo" whenever the user muted/unmuted a topic. Meaning, we used to do most of the UI update work before making the API call to mute the topic, instead of after receiving the `muted_topics` event.
This PR makes it so that all UI work is done only after receiving the `muted_topics` event, along with some other cleanup.

See also - https://github.com/zulip/zulip/pull/16915#discussion_r608290755.

**Testing**: I tested all things which should get updated on muting a topic (unread counts, recent topics, stream-topic list, settings page) using two browser tabs, and asserted that they work correctly.