### PR TITLE
sidebars: Fix truncated lists when notifications panel is visible.

### DIFF
--- a/static/js/panels.js
+++ b/static/js/panels.js
@@ -7,6 +7,8 @@ import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
 import * as util from "./util";
 
+/* This is called by resize.js, and thus indirectly when we trigger
+ * resize events in the logic below. */
 export function resize_app() {
     const panels_height = $("#panels").height();
     $("body > .app").height("calc(100% - " + panels_height + "px)");
@@ -97,13 +99,13 @@ export function initialize() {
         e.preventDefault();
         $(this).closest(".alert").hide();
         notifications.request_desktop_notifications_permission();
-        resize_app();
+        $(window).trigger("resize");
     });
 
     $(".reject-notifications").on("click", function () {
         $(this).closest(".alert").hide();
         ls.set("dontAskForNotifications", true);
-        resize_app();
+        $(window).trigger("resize");
     });
 
     $(".accept-bankruptcy").on("click", function (e) {
@@ -111,7 +113,7 @@ export function initialize() {
         $(this).closest(".alert").hide();
         $(".bankruptcy-loader").show();
         setTimeout(unread_ops.mark_all_as_read, 1000);
-        resize_app();
+        $(window).trigger("resize");
     });
 
     $("#panels").on("click", ".alert .close, .alert .exit", function (e) {
@@ -122,7 +124,7 @@ export function initialize() {
         } else {
             $(this).closest(".alert").hide();
         }
-        resize_app();
+        $(window).trigger("resize");
     });
 
     // Treat Enter with links in the panels UI focused like a click.,
@@ -137,5 +139,5 @@ export function initialize() {
 export function open($process) {
     $("[data-process]").hide();
     $process.show();
-    resize_app();
+    $(window).trigger("resize");
 }

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -214,9 +214,9 @@ export function resize_sidebars() {
 }
 
 export function resize_page_components() {
+    panels.resize_app();
     const h = resize_sidebars();
     resize_bottom_whitespace(h);
-    panels.resize_app();
 }
 
 let _old_width = $(window).width();

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -469,6 +469,7 @@ export function initialize_everything() {
     people.initialize(page_params.user_id, people_params);
     scroll_bar.initialize();
     message_viewport.initialize();
+    panels.initialize();
     initialize_kitchen_sink_stuff();
     echo.initialize();
     stream_edit.initialize();
@@ -522,7 +523,6 @@ export function initialize_everything() {
     sent_messages.initialize();
     hotspots.initialize();
     ui.initialize();
-    panels.initialize();
     typing.initialize();
     starred_messages.initialize();
     user_status_ui.initialize();


### PR DESCRIPTION
When notifications panel is open at the top, the buddy list and
streams-filter container gets truncated due to max-height exceeding
the necessary value. The commit fixes the issue by subtracting the
panels height when it is visible.

Fixes: #18221
Fixes: #17823
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
