### PR TITLE
Use 'virtual path' style URLs for avatar uploads

### DIFF
--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -387,7 +387,7 @@ class S3UploadBackend(ZulipUploadBackend):
         network_location = urllib.parse.urlparse(
             self.avatar_bucket.meta.client.meta.endpoint_url
         ).netloc
-        self.avatar_bucket_url = f"https://{self.avatar_bucket.name}.{network_location}"
+        self.avatar_bucket_url = f"https://{network_location}/{self.avatar_bucket.name}"
 
         self.uploads_bucket = get_bucket(settings.S3_AUTH_UPLOADS_BUCKET, self.session)
 


### PR DESCRIPTION
Per #17762 - use virtual path style so that S3 compatible endpoints work.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
