### PR TITLE
Render stubbed templates anyway

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -2,7 +2,6 @@
 
 const {strict: assert} = require("assert");
 
-const {JSDOM} = require("jsdom");
 const MockDate = require("mockdate");
 
 const {stub_templates} = require("../zjsunit/handlebars");
@@ -16,8 +15,6 @@ const {page_params} = require("../zjsunit/zpage_params");
 mock_cjs("jquery", $);
 
 const noop = () => {};
-
-set_global("DOMParser", new JSDOM().window.DOMParser);
 
 let compose_actions_start_checked;
 let compose_actions_expected_opts;

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -2,12 +2,9 @@
 
 const {strict: assert} = require("assert");
 
-const {JSDOM} = require("jsdom");
-
-const {set_global, zrequire} = require("../zjsunit/namespace");
+const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-set_global("DOMParser", new JSDOM().window.DOMParser);
 zrequire("templates");
 
 run_test("and", () => {

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -2,13 +2,11 @@
 
 const {strict: assert} = require("assert");
 
-const {JSDOM} = require("jsdom");
 const _ = require("lodash");
 
 const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
-set_global("DOMParser", new JSDOM().window.DOMParser);
 set_global("document", {});
 const util = zrequire("util");
 

--- a/frontend_tests/zjsunit/handlebars.js
+++ b/frontend_tests/zjsunit/handlebars.js
@@ -9,6 +9,7 @@ const {SourceMapConsumer, SourceNode} = require("source-map");
 const templates_path = path.resolve(__dirname, "../../static/templates");
 
 exports.stub_templates = (stub) => {
+    require("../../static/js/templates");
     window.template_stub = stub;
 };
 
@@ -39,7 +40,11 @@ function compile_hbs(module, filename) {
         SourceNode.fromStringWithSourceMap(pc.code, new SourceMapConsumer(pc.map)),
         ");\n",
         "module.exports = (...args) => {\n",
-        "    if (window.template_stub !== undefined) {\n",
+        "    const template_stub = window.template_stub;\n",
+        "    if (template_stub !== undefined) {\n",
+        "        delete window.template_stub;\n",
+        "        template(...args);\n",
+        "        window.template_stub = template_stub;\n",
         "        return window.template_stub(",
         JSON.stringify(name),
         ", ...args);\n",

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -4,6 +4,7 @@ const path = require("path");
 
 require("css.escape");
 const Handlebars = require("handlebars/runtime");
+const {JSDOM} = require("jsdom");
 const _ = require("lodash");
 
 const handlebars = require("./handlebars");
@@ -48,6 +49,8 @@ const window = new Proxy(global, {
 });
 
 // Set up Handlebars
+const {DOMParser} = new JSDOM().window;
+
 handlebars.hook_require();
 
 const noop = function () {};
@@ -83,6 +86,7 @@ try {
         namespace.set_global("location", {
             hash: "#",
         });
+        namespace.set_global("DOMParser", DOMParser);
         namespace.set_global("setTimeout", noop);
         namespace.set_global("setInterval", noop);
         _.throttle = immediate;


### PR DESCRIPTION
Experiment to figure out what our template coverage would be if we removed `stub_templates`.

[Coverage results](https://app.codecov.io/gh/zulip/zulip/compare/18287/tree/static/templates).