### PR TITLE
User Status options now turn blue on hover while in night mode

### DIFF
--- a/static/styles/user_status.css
+++ b/static/styles/user_status.css
@@ -56,7 +56,9 @@
         padding: 0 20px 3px;
 
         button.user-status-value:hover {
-            color: hsl(200, 100%, 40%);
+            /* Important is required for generic night them styling to not
+               have precendence over this. */
+            color: hsl(200, 100%, 40%) !important;
         }
 
         .user-status-value {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/17944




**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


https://user-images.githubusercontent.com/43907486/116319777-caec2d80-a7bf-11eb-8556-4aff95804a77.mov





