### PR TITLE
Infrastructure for unsubscribe links in marketing emails

### DIFF
--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -164,6 +164,16 @@ def build_email(
     if len(sanitize_address(extra_headers["From"], "utf-8")) > 320:
         extra_headers["From"] = str(Address(addr_spec=from_address))
 
+    # If we have an unsubscribe link for this email, configure it for
+    # "Unsubscribe" buttons in email clients via the List-Unsubscribe header.
+    #
+    # Note that Microsoft ignores URLs in List-Unsubscribe headers, as
+    # they only support the alternative `mailto:` format, which we
+    # have not implemented.
+    if "unsubscribe_link" in context:
+        extra_headers["List-Unsubscribe"] = f"<{context['unsubscribe_link']}>"
+        extra_headers["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
+
     reply_to = None
     if reply_to_email is not None:
         reply_to = [reply_to_email]

--- a/zerver/views/unsubscribe.py
+++ b/zerver/views/unsubscribe.py
@@ -2,6 +2,7 @@ from typing import Callable
 
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
+from django.views.decorators.csrf import csrf_exempt
 
 from confirmation.models import Confirmation, ConfirmationKeyException, get_object_from_key
 from zerver.context_processors import common_context
@@ -72,6 +73,7 @@ email_unsubscribers = {
 }
 
 # Login NOT required. These are for one-click unsubscribes.
+@csrf_exempt
 def email_unsubscribe(request: HttpRequest, email_type: str, confirmation_key: str) -> HttpResponse:
     if email_type in email_unsubscribers:
         display_name, unsubscribe_function = email_unsubscribers[email_type]


### PR DESCRIPTION
Tested in a development environment.  This changes `manage.py send_custom_email` emails to have an unsubscribe link, adds a notification setting (only visible in Zulip Cloud configurations) to control whether a user wants "occasional marketing emails", and fixes adjacent issues.

The last commit needs testing on a production server to verify we are generating the mailing list headers such that they work correctly in Gmail.