### PR TITLE
Allow puppeteer test in firefox mode to run on CI. 

### DIFF
--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -24,6 +24,7 @@ jobs:
             os: bionic
             is_bionic: true
             include_frontend_tests: true
+            include_puppeteer_test_with_firefox: false
 
           # This docker image was created by a generated Dockerfile at:
           #   tools/ci/images/focal/Dockerfile
@@ -33,6 +34,7 @@ jobs:
             os: focal
             is_focal: true
             include_frontend_tests: false
+            include_puppeteer_test_with_firefox: false
 
           # This docker image was created by a generated Dockerfile at:
           #   tools/ci/images/focal/Dockerfile
@@ -42,6 +44,7 @@ jobs:
             os: bullseye
             is_bullseye: true
             include_frontend_tests: false
+            include_puppeteer_test_with_firefox: true
 
     runs-on: ubuntu-latest
     name: ${{ matrix.name }}
@@ -200,6 +203,12 @@ jobs:
           source tools/ci/activate-venv
           ./tools/test-js-with-puppeteer
 
+      - name: Run puppeteer tests with firefox
+        if: ${{ matrix.include_puppeteer_test_with_firefox }}
+        run: |
+          source tools/ci/activate-venv
+          ./tools/test-js-with-puppeteer --firefox
+
       - name: Check for untracked files
         run: |
           source tools/ci/activate-venv
@@ -232,7 +241,7 @@ jobs:
 
       - name: Store Puppeteer artifacts
         # Upload these on failure, as well
-        if: ${{ always() && matrix.include_frontend_tests }}
+        if: ${{ always() && (matrix.include_frontend_tests || matrix.include_puppeteer_test_with_firefox) }}
         uses: actions/upload-artifact@v2
         with:
           name: puppeteer

--- a/frontend_tests/puppeteer_tests/message-basics.ts
+++ b/frontend_tests/puppeteer_tests/message-basics.ts
@@ -368,6 +368,7 @@ async function test_stream_search_filters_stream_list(page: Page): Promise<void>
     await page.click("#streams_header .sidebar-title");
     await page.type(".stream-list-filter", "ver");
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {hidden: true});
+    await page.waitForSelector(await get_stream_li(page, "Venice"), {hidden: true});
     await page.click(await get_stream_li(page, "Verona"));
     await expect_verona_stream(page);
     assert.strictEqual(

--- a/frontend_tests/puppeteer_tests/settings.ts
+++ b/frontend_tests/puppeteer_tests/settings.ts
@@ -50,7 +50,14 @@ async function test_change_full_name(page: Page): Promise<void> {
 }
 
 async function test_change_password(page: Page): Promise<void> {
-    await page.click("#change_password");
+    const change_password_selector = "#change_password";
+    // We are calling focus on API key modal to avoid the "Not Secure" warning
+    // (see test_get_api_key function) on Firefox, and when it closes
+    // #settings_page loses its focus, which is causing #change_password
+    // click not work.
+    // We are focusing on #change_password to avoid this rare flake.
+    await page.focus(change_password_selector);
+    await page.click(change_password_selector);
 
     const change_password_button_selector = "#change_password_button";
     await page.waitForSelector(change_password_button_selector, {visible: true});


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #17477.




**Testing plan:** <!-- How have you tested? -->
Tested the changes by running 100x in CI.
Here is the link to the [workflow](https://github.com/Riken-Shah/zulip/runs/2442890106).
(It ran successfully for 6 Hours (time limit), it ran 53 times in Bullseye, 61 times in Bionic, and 51 times in Focal)

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
