### PR TITLE
Added `Help link` widget across certain UI modals

### DIFF
--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -161,7 +161,10 @@
         <div id="deactivate_self_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="deactivation_self_modal_label" aria-hidden="true">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-                <h3 id="deactivation_self_modal_label">{{t "Deactivate your account" }} </h3>
+                <h3 id="deactivation_self_modal_label">
+                    {{t "Deactivate your account" }}
+                    {{> ../help_link_widget link="/help/deactivate-your-account" }}
+                </h3>
             </div>
             <div class="modal-body">
                 <p>{{#tr}}By deactivating your account, you will be logged out immediately.{{/tr}}</p>

--- a/static/templates/settings/deactivate_realm_modal.hbs
+++ b/static/templates/settings/deactivate_realm_modal.hbs
@@ -1,7 +1,10 @@
 <div id="deactivate-realm-modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="deactivate_realm_modal_label" aria-hidden="true">
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-        <h3 id="deactivate_realm_modal_label">{{t "Deactivate organization" }} <span class="realm_name"></span></h3>
+        <h3 id="deactivate_realm_modal_label">
+            {{t "Deactivate organization" }} <span class="realm_name"></span>
+            {{> ../help_link_widget link="/help/deactivate-your-organization" }}
+        </h3>
     </div>
     <div class="modal-body">
         <p>{{t "This action is permanent and cannot be undone. All users will permanently lose access to their Zulip accounts." }}</p>

--- a/static/templates/settings/deactivation_stream_modal.hbs
+++ b/static/templates/settings/deactivation_stream_modal.hbs
@@ -1,7 +1,10 @@
 <div id="deactivation_stream_modal" class="modal modal-bg hide fade new-style" tabindex="-1" role="dialog" aria-labelledby="deactivation_stream_modal_label" aria-hidden="true">
     <div class="modal-header">
         <button type="button" class="close close-modal-btn" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-        <h3 id="deactivation_stream_modal_label">{{t "Archive stream" }} <span class="stream_name">{{stream_name}}</span></h3>
+        <h3 id="deactivation_stream_modal_label">
+            {{t "Archive stream" }} <span class="stream_name">{{stream_name}}</span>
+            {{> ../help_link_widget link="/help/archive-a-stream" }}
+        </h3>
     </div>
     <div class="modal-body">
         Archiving stream <strong>{{stream_name}}</strong> <span>will immediately unsubscribe everyone. This action cannot be undone </span>

--- a/static/templates/settings/deactivation_stream_modal.hbs
+++ b/static/templates/settings/deactivation_stream_modal.hbs
@@ -7,7 +7,7 @@
         </h3>
     </div>
     <div class="modal-body">
-        Archiving stream <strong>{{stream_name}}</strong> <span>will immediately unsubscribe everyone. This action cannot be undone </span>
+        Archiving stream <strong>{{stream_name}}</strong> <span>will immediately unsubscribe everyone. This action cannot be undone.</span>
         <p><strong>{{t "Are you sure you want to archive this stream?" }}</strong></p>
     </div>
     <div class="modal-footer">


### PR DESCRIPTION
Added `Help link` widget across various UI modals which needed some more useful information other than the text within the modal before proceeding further.

Modified the following modals: 
- [x] deactivate_account -- a4476ae9040b2adfde559dc8d8c71323b9def98d
- [x] deactivate_realm -- 876f86c74dc746d38a7ef94317e68e81818a1b63
- [x] deactivate_stream -- 93efd0e2cc346f349abaea464050887aca6380f6

<strong>Screenshots</strong>

<strong>Account deactivation</strong>: 

![Screenshot from 2021-04-28 23-12-20](https://user-images.githubusercontent.com/53977614/116450762-4cec5d00-a879-11eb-8a1e-c6548f0311f4.png)


<strong>Realm deactivation</strong>: 

![Screenshot from 2021-04-28 23-12-43](https://user-images.githubusercontent.com/53977614/116450870-6f7e7600-a879-11eb-850a-27d8974792df.png)


<strong>Stream deletion</strong>: 

![Screenshot from 2021-04-28 23-13-04](https://user-images.githubusercontent.com/53977614/116450906-7dcc9200-a879-11eb-9668-81a33cc4f330.png)

Would be great if @timabbott can have a look at it :) 