### PR TITLE
Add helper functions for checking policies in settings_data.js and remove complex update logic from server_events_dispatch.js.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -70,6 +70,9 @@ mock_esm("../../static/js/notifications", {
 mock_esm("../../static/js/rendered_markdown", {
     update_elements: () => {},
 });
+mock_esm("../../static/js/settings_data", {
+    user_can_subscribe_other_users: () => true,
+});
 set_global("navigator", _navigator);
 
 // Setting these up so that we can test that links to uploads within messages are

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -13,7 +13,6 @@ const {
 const {make_stub} = require("../zjsunit/stub");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
-const {page_params} = require("../zjsunit/zpage_params");
 
 // Important note on these tests:
 
@@ -74,6 +73,7 @@ const popovers = mock_esm("../../static/js/popovers", {
 });
 const reactions = mock_esm("../../static/js/reactions");
 const search = mock_esm("../../static/js/search");
+const settings_data = mock_esm("../../static/js/settings_data");
 const stream_list = mock_esm("../../static/js/stream_list");
 const subs = mock_esm("../../static/js/subs");
 
@@ -281,13 +281,13 @@ run_test("allow normal typing when processing text", (override) => {
 });
 
 run_test("streams", (override) => {
-    page_params.can_create_streams = true;
+    settings_data.user_can_create_streams = () => true;
     override(overlays, "streams_open", () => true);
     override(overlays, "is_active", () => true);
     assert_mapping("S", subs, "keyboard_sub");
     assert_mapping("V", subs, "view_stream");
     assert_mapping("n", subs, "open_create_stream");
-    page_params.can_create_streams = false;
+    settings_data.user_can_create_streams = () => false;
     assert_unmapped("n");
 });
 

--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -167,3 +167,33 @@ run_test("user_can_subscribe_other_users", () => {
     isaac.date_joined = new Date(Date.now() - 20 * 86400000);
     assert.equal(can_subscribe_other_users(), true);
 });
+
+run_test("user_can_create_streams", () => {
+    const can_create_streams = settings_data.user_can_create_streams;
+
+    page_params.is_admin = true;
+    page_params.realm_create_stream_policy =
+        settings_config.common_policy_values.by_admins_only.code;
+    assert.equal(can_create_streams(), true);
+
+    page_params.is_admin = false;
+    assert.equal(can_create_streams(), false);
+
+    page_params.is_guest = true;
+    page_params.realm_create_stream_policy = settings_config.common_policy_values.by_members.code;
+    assert.equal(can_create_streams(), false);
+
+    page_params.is_guest = false;
+    assert.equal(can_create_streams(), true);
+
+    page_params.realm_create_stream_policy =
+        settings_config.common_policy_values.by_full_members.code;
+    page_params.user_id = 30;
+    people.add_active_user(isaac);
+    isaac.date_joined = new Date(Date.now());
+    page_params.realm_waiting_period_threshold = 10;
+    assert.equal(can_create_streams(), false);
+
+    isaac.date_joined = new Date(Date.now() - 20 * 86400000);
+    assert.equal(can_create_streams(), true);
+});

--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -136,3 +136,34 @@ run_test("user_can_invite_others_to_realm", () => {
     isaac.date_joined = new Date(Date.now() - 20 * 86400000);
     assert.equal(can_invite_others_to_realm(), true);
 });
+
+run_test("user_can_subscribe_other_users", () => {
+    const can_subscribe_other_users = settings_data.user_can_subscribe_other_users;
+
+    page_params.is_admin = true;
+    page_params.realm_invite_to_stream_policy =
+        settings_config.common_policy_values.by_admins_only.code;
+    assert.equal(can_subscribe_other_users(), true);
+
+    page_params.is_admin = false;
+    assert.equal(can_subscribe_other_users(), false);
+
+    page_params.is_guest = true;
+    page_params.realm_invite_to_stream_policy =
+        settings_config.common_policy_values.by_members.code;
+    assert.equal(can_subscribe_other_users(), false);
+
+    page_params.is_guest = false;
+    assert.equal(can_subscribe_other_users(), true);
+
+    page_params.realm_invite_to_stream_policy =
+        settings_config.common_policy_values.by_full_members.code;
+    page_params.user_id = 30;
+    people.add_active_user(isaac);
+    isaac.date_joined = new Date(Date.now());
+    page_params.realm_waiting_period_threshold = 10;
+    assert.equal(can_subscribe_other_users(), false);
+
+    isaac.date_joined = new Date(Date.now() - 20 * 86400000);
+    assert.equal(can_subscribe_other_users(), true);
+});

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -179,9 +179,8 @@ function test_submit_settings_form(override, submit_form) {
         realm_waiting_period_threshold: 1,
         realm_default_language: '"es"',
         realm_default_twenty_four_hour_time: false,
-        realm_invite_to_stream_policy:
-            settings_config.invite_to_stream_policy_values.by_admins_only.code,
-        realm_create_stream_policy: settings_config.create_stream_policy_values.by_members.code,
+        realm_invite_to_stream_policy: settings_config.common_policy_values.by_admins_only.code,
+        realm_create_stream_policy: settings_config.common_policy_values.by_members.code,
     });
 
     override(global, "setTimeout", (func) => func());
@@ -466,7 +465,7 @@ function test_sync_realm_settings() {
         settings_org.sync_realm_settings("create_stream_policy");
         assert.equal(
             $("#id_realm_create_stream_policy").val(),
-            settings_config.create_stream_policy_values.by_full_members.code,
+            settings_config.common_policy_values.by_full_members.code,
         );
     }
 
@@ -484,7 +483,7 @@ function test_sync_realm_settings() {
         settings_org.sync_realm_settings("create_stream_policy");
         assert.equal(
             $("#id_realm_create_stream_policy").val(),
-            settings_config.create_stream_policy_values.by_members.code,
+            settings_config.common_policy_values.by_members.code,
         );
     }
 
@@ -502,7 +501,7 @@ function test_sync_realm_settings() {
         settings_org.sync_realm_settings("create_stream_policy");
         assert.equal(
             $("#id_realm_create_stream_policy").val(),
-            settings_config.create_stream_policy_values.by_admins_only.code,
+            settings_config.common_policy_values.by_admins_only.code,
         );
     }
 
@@ -520,7 +519,7 @@ function test_sync_realm_settings() {
         settings_org.sync_realm_settings("invite_to_stream_policy");
         assert.equal(
             $("#id_realm_invite_to_stream_policy").val(),
-            settings_config.create_stream_policy_values.by_full_members.code,
+            settings_config.common_policy_values.by_full_members.code,
         );
     }
 
@@ -538,7 +537,7 @@ function test_sync_realm_settings() {
         settings_org.sync_realm_settings("invite_to_stream_policy");
         assert.equal(
             $("#id_realm_invite_to_stream_policy").val(),
-            settings_config.create_stream_policy_values.by_members.code,
+            settings_config.common_policy_values.by_members.code,
         );
     }
 
@@ -556,7 +555,7 @@ function test_sync_realm_settings() {
         settings_org.sync_realm_settings("invite_to_stream_policy");
         assert.equal(
             $("#id_realm_invite_to_stream_policy").val(),
-            settings_config.create_stream_policy_values.by_admins_only.code,
+            settings_config.common_policy_values.by_admins_only.code,
         );
     }
 
@@ -807,8 +806,8 @@ test("set_up", (override) => {
 
 test("test get_organization_settings_options", () => {
     const sorted_option_values = settings_org.get_organization_settings_options();
-    const sorted_create_stream_policy_values = sorted_option_values.create_stream_policy_values;
-    const expected_create_stream_policy_values = [
+    const sorted_common_policy_values = sorted_option_values.common_policy_values;
+    const expected_common_policy_values = [
         {
             key: "by_admins_only",
             order: 1,
@@ -828,7 +827,7 @@ test("test get_organization_settings_options", () => {
             description: $t({defaultMessage: "Admins and members"}),
         },
     ];
-    assert.deepEqual(sorted_create_stream_policy_values, expected_create_stream_policy_values);
+    assert.deepEqual(sorted_common_policy_values, expected_common_policy_values);
 });
 
 test("test get_sorted_options_list", () => {

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -124,7 +124,7 @@ export function build_page() {
         msg_delete_limit_dropdown_values: settings_config.msg_delete_limit_dropdown_values,
         bot_creation_policy_values: settings_bots.bot_creation_policy_values,
         email_address_visibility_values: settings_config.email_address_visibility_values,
-        can_invite_others_to_realm: page_params.can_invite_others_to_realm,
+        can_invite_others_to_realm: settings_data.user_can_invite_others_to_realm(),
         ...settings_org.get_organization_settings_options(),
     };
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -33,6 +33,7 @@ import * as rtl from "./rtl";
 import * as sent_messages from "./sent_messages";
 import * as server_events from "./server_events";
 import * as settings_config from "./settings_config";
+import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
 import * as stream_edit from "./stream_edit";
 import * as sub_store from "./sub_store";
@@ -1088,7 +1089,7 @@ export function warn_if_mentioning_unsubscribed_user(mentioned) {
                 user_id,
                 stream_id: sub.stream_id,
                 name: mentioned.full_name,
-                can_subscribe_other_users: page_params.can_subscribe_other_users,
+                can_subscribe_other_users: settings_data.user_can_subscribe_other_users(),
             };
 
             const new_row = render_compose_invite_users(context);

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -32,6 +32,7 @@ import * as popovers from "./popovers";
 import * as reactions from "./reactions";
 import * as recent_topics from "./recent_topics";
 import * as search from "./search";
+import * as settings_data from "./settings_data";
 import * as stream_list from "./stream_list";
 import * as stream_popover from "./stream_popover";
 import * as subs from "./subs";
@@ -724,7 +725,11 @@ export function process_hotkey(e, hotkey) {
             subs.view_stream();
             return true;
         }
-        if (event_name === "n_key" && overlays.streams_open() && page_params.can_create_streams) {
+        if (
+            event_name === "n_key" &&
+            overlays.streams_open() &&
+            settings_data.user_can_create_streams()
+        ) {
             subs.open_create_stream();
             return true;
         }

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -226,11 +226,6 @@ export function dispatch_normal_event(event) {
                             page_params.can_create_streams =
                                 page_params.is_admin ||
                                 page_params.realm_create_stream_policy === 1;
-                        } else if (event.property === "invite_to_stream_policy") {
-                            // TODO: Add waiting_period_threshold logic here.
-                            page_params.can_invite_to_stream =
-                                page_params.is_admin ||
-                                page_params.realm_invite_to_stream_policy === 1;
                         }
 
                         if (event.property === "name" && window.electron_bridge !== undefined) {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -221,12 +221,6 @@ export function dispatch_normal_event(event) {
                         page_params["realm_" + event.property] = event.value;
                         realm_settings[event.property]();
                         settings_org.sync_realm_settings(event.property);
-                        if (event.property === "create_stream_policy") {
-                            // TODO: Add waiting_period_threshold logic here.
-                            page_params.can_create_streams =
-                                page_params.is_admin ||
-                                page_params.realm_create_stream_policy === 1;
-                        }
 
                         if (event.property === "name" && window.electron_bridge !== undefined) {
                             window.electron_bridge.send_event("realm_name", event.value);

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -231,11 +231,6 @@ export function dispatch_normal_event(event) {
                             page_params.can_invite_to_stream =
                                 page_params.is_admin ||
                                 page_params.realm_invite_to_stream_policy === 1;
-                        } else if (event.property === "invite_to_realm_policy") {
-                            // TODO: Add waiting period threshold logic here.
-                            page_params.can_invite_others_to_realm =
-                                page_params.is_admin ||
-                                page_params.realm_invite_to_realm_policy === 1;
                         }
 
                         if (event.property === "name" && window.electron_bridge !== undefined) {

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -103,7 +103,7 @@ export const email_address_visibility_values = {
     },
 };
 
-export const create_stream_policy_values = {
+export const common_policy_values = {
     by_admins_only: {
         order: 1,
         code: 2,
@@ -119,14 +119,6 @@ export const create_stream_policy_values = {
         code: 1,
         description: $t({defaultMessage: "Admins and members"}),
     },
-};
-
-export const invite_to_stream_policy_values = create_stream_policy_values;
-
-export const invite_to_realm_policy_values = {
-    by_members: 1,
-    by_admins_only: 2,
-    by_full_members: 3,
 };
 
 export const user_group_edit_policy_values = {

--- a/static/js/settings_data.js
+++ b/static/js/settings_data.js
@@ -110,3 +110,7 @@ function user_has_permission(policy_value) {
 export function user_can_invite_others_to_realm() {
     return user_has_permission(page_params.realm_invite_to_realm_policy);
 }
+
+export function user_can_subscribe_other_users() {
+    return user_has_permission(page_params.realm_invite_to_stream_policy);
+}

--- a/static/js/settings_data.js
+++ b/static/js/settings_data.js
@@ -114,3 +114,7 @@ export function user_can_invite_others_to_realm() {
 export function user_can_subscribe_other_users() {
     return user_has_permission(page_params.realm_invite_to_stream_policy);
 }
+
+export function user_can_create_streams() {
+    return user_has_permission(page_params.realm_create_stream_policy);
+}

--- a/static/js/settings_data.js
+++ b/static/js/settings_data.js
@@ -1,4 +1,5 @@
 import {page_params} from "./page_params";
+import * as people from "./people";
 import * as settings_config from "./settings_config";
 
 /*
@@ -79,4 +80,33 @@ export function user_can_change_avatar() {
 
 export function user_can_change_logo() {
     return page_params.is_admin && page_params.zulip_plan_is_not_limited;
+}
+
+function user_has_permission(policy_value) {
+    if (page_params.is_admin) {
+        return true;
+    }
+
+    if (page_params.is_guest) {
+        return false;
+    }
+
+    if (policy_value === settings_config.common_policy_values.by_admins_only.code) {
+        return false;
+    }
+
+    if (policy_value === settings_config.common_policy_values.by_members.code) {
+        return true;
+    }
+
+    const person = people.get_by_user_id(page_params.user_id);
+    const current_datetime = new Date(Date.now());
+    const person_date_joined = new Date(person.date_joined);
+    const days = (current_datetime - person_date_joined) / 1000 / 86400;
+
+    return days >= page_params.realm_waiting_period_threshold;
+}
+
+export function user_can_invite_others_to_realm() {
+    return user_has_permission(page_params.realm_invite_to_realm_policy);
 }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -92,12 +92,7 @@ export function get_sorted_options_list(option_values_object) {
 
 export function get_organization_settings_options() {
     const options = {};
-    options.create_stream_policy_values = get_sorted_options_list(
-        settings_config.create_stream_policy_values,
-    );
-    options.invite_to_stream_policy_values = get_sorted_options_list(
-        settings_config.invite_to_stream_policy_values,
-    );
+    options.common_policy_values = get_sorted_options_list(settings_config.common_policy_values);
     options.user_group_edit_policy_values = get_sorted_options_list(
         settings_config.user_group_edit_policy_values,
     );
@@ -189,13 +184,13 @@ function get_property_value(property_name) {
         if (!page_params.realm_invite_required) {
             if (
                 page_params.realm_invite_to_realm_policy ===
-                settings_config.invite_to_realm_policy_values.by_admins_only
+                settings_config.common_policy_values.by_admins_only.code
             ) {
                 return "no_invite_required_by_admins_only";
             }
             if (
                 page_params.realm_invite_to_realm_policy ===
-                settings_config.invite_to_realm_policy_values.by_full_members
+                settings_config.common_policy_values.by_full_members.code
             ) {
                 return "no_invite_required_by_full_members";
             }
@@ -203,13 +198,13 @@ function get_property_value(property_name) {
         }
         if (
             page_params.realm_invite_to_realm_policy ===
-            settings_config.invite_to_realm_policy_values.by_admins_only
+            settings_config.common_policy_values.by_admins_only.code
         ) {
             return "by_admins_only";
         }
         if (
             page_params.realm_invite_to_realm_policy ===
-            settings_config.invite_to_realm_policy_values.by_full_members
+            settings_config.common_policy_values.by_full_members.code
         ) {
             return "by_full_members";
         }
@@ -838,28 +833,26 @@ export function build_page() {
             const user_invite_restriction = $("#id_realm_user_invite_restriction").val();
             if (user_invite_restriction === "no_invite_required") {
                 data.invite_required = false;
-                data.invite_to_realm_policy =
-                    settings_config.invite_to_realm_policy_values.by_members;
+                data.invite_to_realm_policy = settings_config.common_policy_values.by_members.code;
             } else if (user_invite_restriction === "no_invite_required_by_admins_only") {
                 data.invite_required = false;
                 data.invite_to_realm_policy =
-                    settings_config.invite_to_realm_policy_values.by_admins_only;
+                    settings_config.common_policy_values.by_admins_only.code;
             } else if (user_invite_restriction === "no_invite_required_by_full_members") {
                 data.invite_required = false;
                 data.invite_to_realm_policy =
-                    settings_config.invite_to_realm_policy_values.by_full_members;
+                    settings_config.common_policy_values.by_full_members.code;
             } else if (user_invite_restriction === "by_admins_only") {
                 data.invite_required = true;
                 data.invite_to_realm_policy =
-                    settings_config.invite_to_realm_policy_values.by_admins_only;
+                    settings_config.common_policy_values.by_admins_only.code;
             } else if (user_invite_restriction === "by_full_members") {
                 data.invite_required = true;
                 data.invite_to_realm_policy =
-                    settings_config.invite_to_realm_policy_values.by_full_members;
+                    settings_config.common_policy_values.by_full_members.code;
             } else {
                 data.invite_required = true;
-                data.invite_to_realm_policy =
-                    settings_config.invite_to_realm_policy_values.by_members;
+                data.invite_to_realm_policy = settings_config.common_policy_values.by_members.code;
             }
 
             const waiting_period_threshold = $("#id_realm_waiting_period_setting").val();

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -24,6 +24,7 @@ import {page_params} from "./page_params";
 import * as people from "./people";
 import * as scroll_util from "./scroll_util";
 import * as search_util from "./search_util";
+import * as settings_data from "./settings_data";
 import * as stream_create from "./stream_create";
 import * as stream_data from "./stream_data";
 import * as stream_edit from "./stream_edit";
@@ -626,7 +627,7 @@ export function setup_page(callback) {
         $("#subscriptions_table").empty();
 
         const template_data = {
-            can_create_streams: page_params.can_create_streams,
+            can_create_streams: settings_data.user_can_create_streams(),
             hide_all_streams: !should_list_all_streams(),
             max_name_length: page_params.max_stream_name_length,
             max_description_length: page_params.max_stream_description_length,

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -98,13 +98,13 @@
                 <div class="input-group">
                     <label for="realm_create_stream_policy" class="dropdown-title">{{t "Who can create streams" }}</label>
                     <select name="realm_create_stream_policy" id="id_realm_create_stream_policy" class="prop-element" data-setting-widget-type="number">
-                        {{> dropdown_options_widget option_values=create_stream_policy_values}}
+                        {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
                 </div>
                 <div class="input-group">
                     <label for="realm_invite_to_stream_policy" class="dropdown-title">{{t "Who can add users to streams" }}</label>
                     <select name="realm_invite_to_stream_policy" id="id_realm_invite_to_stream_policy" class="prop-element" data-setting-widget-type="number">
-                        {{> dropdown_options_widget option_values=invite_to_stream_policy_values}}
+                        {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
                 </div>
                 <div class="input-group">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds separate functions `user_can_create_streams`, `user_can_subscribe_other_users` and
`user_can_invite_others_to_realm` to replace the usage of page_params object for checking whether ths
user is allowed to do the specified task or not and helps in removing the complex logic from
`server_events_dispatch,js`.
Discussed here - https://github.com/zulip/zulip/pull/18246#discussion_r620740435


**Testing plan:** <!-- How have you tested? --> Added new tests and updated exisitng tests.


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
