### PR TITLE
emails: Fix outgoing email handling inside the dev environment.

### DIFF
--- a/zproject/email_backends.py
+++ b/zproject/email_backends.py
@@ -1,3 +1,4 @@
+# https://zulip.readthedocs.io/en/latest/subsystems/email.html#testing-in-a-real-email-client
 import configparser
 import logging
 from typing import List


### PR DESCRIPTION
Commit 9afde790c6a1855de1714378b1ee3e467a7b0fb1 introduced a bug
concerning outgoing emails inside the development environment. These
emails are not supposed to use a real connection with a mail
server as the send_messages function is overwritten inside the
EmailLogBackEnd class.

The bug was happening inside the initialize_connection function that
was introduced in the above-mentioned commit. This function is used
to refresh the connection with an SMTP server that would have closed
it. As the socket used to communicate with the server is not
initialized inside the development environment this function was
wrongly trying to send no-op commands.

The fix just checks that the connection argument of the function is
an EmailLogBackEnd object before trying the no-op command.
Additionally as it is sometimes useful to be able to send outgoing
emails inside the development environment the get_forward_address
function is used to check if a real connection exists between Zulip
and the server. If it is the case, as EmailLogBackEnd is a subclass
of smtp.EmailBackend, the connection will be nicely refreshed.

**Testing plan:** <!-- How have you tested? -->

This commit was tested manually by checking that the console prints
correctly that an email is sent to the user when it signs in inside
the development environment. It was also tested when a mail provider
is specified and the mails were correctly received.

![image](https://user-images.githubusercontent.com/37901973/116470355-9cc82580-a873-11eb-9097-75232ff7a85a.png)
![image](https://user-images.githubusercontent.com/37901973/116470414-b2d5e600-a873-11eb-93d8-5021653ca6c5.png)

