### PR TITLE
Change display name for Json integration to use a capital F.

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -405,7 +405,7 @@ WEBHOOK_INTEGRATIONS: List[WebhookIntegration] = [
     WebhookIntegration("intercom", ["customer-support"], display_name="Intercom"),
     WebhookIntegration("jira", ["project-management"], display_name="JIRA"),
     WebhookIntegration("jotform", ["misc"], display_name="Jotform"),
-    WebhookIntegration("json", ["misc"], display_name="JSON formatter"),
+    WebhookIntegration("json", ["misc"], display_name="JSON Formatter"),
     WebhookIntegration("librato", ["monitoring"]),
     WebhookIntegration("mention", ["marketing"], display_name="Mention"),
     WebhookIntegration("netlify", ["continuous-integration", "deployment"], display_name="Netlify"),


### PR DESCRIPTION
Change display name for Json integration to use a cpital F instead of
lowercase which is the standard across the rest of our integrations.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
