### PR TITLE
mypy: Don’t use Iterable for values iterated multiple times

### DIFF
--- a/docs/testing/mypy.md
+++ b/docs/testing/mypy.md
@@ -390,14 +390,21 @@ if s is None:  # good
 
 ### Read-only types
 
-The basic Python collections `List`, `Dict`, and `Set` are mutable,
-but it's confusing for a function to mutate a collection that was
-passed to it as an argument, especially by accident.  To avoid this,
-prefer annotating function parameters with read-only types:
+The basic Python collections
+[`List`](https://docs.python.org/3/library/typing.html#typing.List),
+[`Dict`](https://docs.python.org/3/library/typing.html#typing.Dict),
+and [`Set`](https://docs.python.org/3/library/typing.html#typing.Set)
+are mutable, but it's confusing for a function to mutate a collection
+that was passed to it as an argument, especially by accident.  To
+avoid this, prefer annotating function parameters with read-only
+types:
 
-* `Sequence` or `Iterable` instead of `List`,
-* `Mapping` instead of `Dict`,
-* `AbstractSet` instead of `Set`.
+* [`Sequence`](https://docs.python.org/3/library/typing.html#typing.Sequence)
+  instead of `List`,
+* [`Mapping`](https://docs.python.org/3/library/typing.html#typing.Mapping)
+  instead of `Dict`,
+* [`AbstractSet`](https://docs.python.org/3/library/typing.html#typing.AbstractSet)
+  instead of `Set`.
 
 This is especially important for parameters with default arguments,
 since a mutable default argument is confusingly shared between all
@@ -408,6 +415,14 @@ def f(items: Sequence[int] = []) -> int:
     items.append(1)  # mypy catches this mistake
     return sum(items)
 ```
+
+In some cases the more general
+[`Collection`](https://docs.python.org/3/library/typing.html#typing.Collection)
+or
+[`Iterable`](https://docs.python.org/3/library/typing.html#typing.Iterable)
+types might be appropriate.  (But don’t use `Iterable` for a value
+that might be iterated multiple times, since a one-use iterator is
+`Iterable` too.)
 
 A function's return type can be mutable if the return value is always
 a freshly created collection, since the caller ends up with the only

--- a/templates/zerver/api/incoming-webhooks-walkthrough.md
+++ b/templates/zerver/api/incoming-webhooks-walkthrough.md
@@ -82,30 +82,32 @@ python file, `zerver/webhooks/mywebhook/view.py`.
 The Hello World integration is in `zerver/webhooks/helloworld/view.py`:
 
 ```
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Sequence
 
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import gettext as _
 
 from zerver.decorator import webhook_view
-from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
-from zerver.lib.validator import check_dict, check_string
+from zerver.lib.response import json_success
+from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
-@webhook_view('HelloWorld')
+
+@webhook_view("HelloWorld")
 @has_request_variables
 def api_helloworld_webhook(
-        request: HttpRequest, user_profile: UserProfile,
-        payload: Dict[str, Iterable[Dict[str, Any]]]=REQ(argument_type='body')
+    request: HttpRequest,
+    user_profile: UserProfile,
+    payload: Dict[str, Sequence[Dict[str, Any]]] = REQ(argument_type="body"),
 ) -> HttpResponse:
 
     # construct the body of the message
-    body = 'Hello! I am happy to be here! :smile:'
+    body = "Hello! I am happy to be here! :smile:"
 
     # try to add the Wikipedia article of the day
-    body_template = '\nThe Wikipedia featured article for today is **[{featured_title}]({featured_url})**'
+    body_template = (
+        "\nThe Wikipedia featured article for today is **[{featured_title}]({featured_url})**"
+    )
     body += body_template.format(**payload)
 
     topic = "Hello World"

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2550,7 +2550,7 @@ def extract_private_recipients(s: str) -> Union[List[str], List[int]]:
     return get_validated_user_ids(data)
 
 
-def get_validated_user_ids(user_ids: Iterable[int]) -> List[int]:
+def get_validated_user_ids(user_ids: Collection[int]) -> List[int]:
     for user_id in user_ids:
         if not isinstance(user_id, int):
             raise JsonableError(_("Recipient lists may contain emails or user IDs, but not both."))
@@ -2558,7 +2558,7 @@ def get_validated_user_ids(user_ids: Iterable[int]) -> List[int]:
     return list(set(user_ids))
 
 
-def get_validated_emails(emails: Iterable[str]) -> List[str]:
+def get_validated_emails(emails: Collection[str]) -> List[str]:
     for email in emails:
         if not isinstance(email, str):
             raise JsonableError(_("Recipient lists may contain emails or user IDs, but not both."))
@@ -3216,7 +3216,7 @@ def validate_user_access_to_subscribers_helper(
 
 
 def bulk_get_subscriber_user_ids(
-    stream_dicts: Iterable[Mapping[str, Any]],
+    stream_dicts: Collection[Mapping[str, Any]],
     user_profile: UserProfile,
     subscribed_stream_ids: Set[int],
 ) -> Dict[int, List[int]]:
@@ -3348,7 +3348,7 @@ SubT = Tuple[List[SubInfo], List[SubInfo]]
 
 def bulk_add_subscriptions(
     realm: Realm,
-    streams: Iterable[Stream],
+    streams: Collection[Stream],
     users: Iterable[UserProfile],
     color_map: Mapping[str, str] = {},
     from_user_creation: bool = False,
@@ -6197,7 +6197,7 @@ def get_active_presence_idle_user_ids(
 
     user_ids = set()
     for user_id in active_user_ids:
-        flags: Iterable[str] = user_flags.get(user_id, [])
+        flags = user_flags.get(user_id, [])
         mentioned = "mentioned" in flags or "wildcard_mentioned" in flags
         private_message = is_pm and user_id != sender_id
         alerted = "has_alert_word" in flags
@@ -6289,7 +6289,7 @@ class InvitationError(JsonableError):
         self.sent_invitations: bool = sent_invitations
 
 
-def estimate_recent_invites(realms: Iterable[Realm], *, days: int) -> int:
+def estimate_recent_invites(realms: Collection[Realm], *, days: int) -> int:
     """An upper bound on the number of invites sent in the last `days` days"""
     recent_invites = RealmCount.objects.filter(
         realm__in=realms,
@@ -6342,7 +6342,7 @@ def check_invite_limit(realm: Realm, num_invitees: int) -> None:
 def do_invite_users(
     user_profile: UserProfile,
     invitee_emails: Collection[str],
-    streams: Iterable[Stream],
+    streams: Collection[Stream],
     invite_as: int = PreregistrationUser.INVITE_AS["MEMBER"],
 ) -> None:
 
@@ -6597,7 +6597,7 @@ def do_remove_realm_emoji(realm: Realm, name: str) -> None:
     notify_realm_emoji(realm)
 
 
-def notify_alert_words(user_profile: UserProfile, words: Iterable[str]) -> None:
+def notify_alert_words(user_profile: UserProfile, words: Sequence[str]) -> None:
     event = dict(type="alert_words", alert_words=words)
     send_event(user_profile.realm, event, [user_profile.id])
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -11,6 +11,7 @@ from typing import (
     AbstractSet,
     Any,
     Callable,
+    Collection,
     Dict,
     Iterable,
     List,
@@ -260,9 +261,6 @@ class SubscriptionInfo:
     never_subscribed: List[Dict[str, Any]]
 
 
-# This will be used to type annotate parameters in a function if the function
-# works on both str and unicode in python 2 but in python 3 it only works on str.
-SizedTextIterable = Union[Sequence[str], AbstractSet[str]]
 ONBOARDING_TOTAL_MESSAGES = 1000
 ONBOARDING_UNREAD_MESSAGES = 20
 
@@ -6343,7 +6341,7 @@ def check_invite_limit(realm: Realm, num_invitees: int) -> None:
 
 def do_invite_users(
     user_profile: UserProfile,
-    invitee_emails: SizedTextIterable,
+    invitee_emails: Collection[str],
     streams: Iterable[Stream],
     invite_as: int = PreregistrationUser.INVITE_AS["MEMBER"],
 ) -> None:

--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Any, Collection, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from django.db.models import Model
 
@@ -98,7 +98,7 @@ def bulk_create_users(
 
 def bulk_set_users_or_streams_recipient_fields(
     model: Model,
-    objects: Union[Iterable[UserProfile], Iterable[Stream]],
+    objects: Union[Collection[UserProfile], Collection[Stream]],
     recipients: Optional[Iterable[Recipient]] = None,
 ) -> None:
     assert model in [UserProfile, Stream]

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1,7 +1,7 @@
 # See https://zulip.readthedocs.io/en/latest/subsystems/events-system.html for
 # high-level documentation on how this system works.
 import copy
-from typing import Any, Callable, Dict, Iterable, Optional, Sequence, Set
+from typing import Any, Callable, Collection, Dict, Iterable, Optional, Sequence, Set
 
 from django.conf import settings
 from django.utils.translation import gettext as _
@@ -492,7 +492,7 @@ def apply_events(
     *,
     state: Dict[str, Any],
     events: Iterable[Dict[str, Any]],
-    fetch_event_types: Optional[Iterable[str]],
+    fetch_event_types: Optional[Collection[str]],
     client_gravatar: bool,
     slim_presence: bool,
     include_subscribers: bool,
@@ -1081,14 +1081,14 @@ def do_events_register(
     apply_markdown: bool = True,
     client_gravatar: bool = False,
     slim_presence: bool = False,
-    event_types: Optional[Iterable[str]] = None,
+    event_types: Optional[Sequence[str]] = None,
     queue_lifespan_secs: int = 0,
     all_public_streams: bool = False,
     include_subscribers: bool = True,
     include_streams: bool = True,
     client_capabilities: Dict[str, bool] = {},
-    narrow: Iterable[Sequence[str]] = [],
-    fetch_event_types: Optional[Iterable[str]] = None,
+    narrow: Collection[Sequence[str]] = [],
+    fetch_event_types: Optional[Collection[str]] = None,
 ) -> Dict[str, Any]:
     # Technically we don't need to check this here because
     # build_narrow_filter will check it, but it's nicer from an error

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence
+from typing import Any, Callable, Collection, Dict, Iterable, List, Mapping, Optional, Sequence
 
 from django.conf import settings
 from django.utils.translation import gettext as _
@@ -56,7 +56,7 @@ def is_web_public_narrow(narrow: Optional[Iterable[Dict[str, Any]]]) -> bool:
     return False
 
 
-def build_narrow_filter(narrow: Iterable[Sequence[str]]) -> Callable[[Mapping[str, Any]], bool]:
+def build_narrow_filter(narrow: Collection[Sequence[str]]) -> Callable[[Mapping[str, Any]], bool]:
     """Changes to this function should come with corresponding changes to
     BuildNarrowFilterTest."""
     check_supported_events_narrow_filter(narrow)

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Optional, Set, Tuple, Union
+from typing import Collection, List, Optional, Set, Tuple, Union
 
 from django.db.models.query import QuerySet
 from django.utils.timezone import now as timezone_now
@@ -565,7 +565,7 @@ def can_access_stream_history_by_id(user_profile: UserProfile, stream_id: int) -
 
 
 def filter_stream_authorization(
-    user_profile: UserProfile, streams: Iterable[Stream]
+    user_profile: UserProfile, streams: Collection[Stream]
 ) -> Tuple[List[Stream], List[Stream]]:
     recipient_ids = [stream.recipient_id for stream in streams]
     subscribed_recipient_ids = set(
@@ -599,7 +599,7 @@ def filter_stream_authorization(
 
 
 def list_to_streams(
-    streams_raw: Iterable[StreamDict],
+    streams_raw: Collection[StreamDict],
     user_profile: UserProfile,
     autocreate: bool = False,
     admin_access_required: bool = False,

--- a/zerver/lib/test_console_output.py
+++ b/zerver/lib/test_console_output.py
@@ -2,7 +2,7 @@ import logging
 import re
 import sys
 from types import TracebackType
-from typing import Iterable, Optional, Type, cast
+from typing import Optional, Sequence, Type, cast
 
 
 class ExtraConsoleOutputInTestException(Exception):
@@ -81,7 +81,7 @@ class TeeStderrAndFindExtraConsoleOutput:
         self.stderr_stream.write(data)
         self.extra_output_finder.find_extra_output(data)
 
-    def writelines(self, data: Iterable[str]) -> None:
+    def writelines(self, data: Sequence[str]) -> None:
         self.stderr_stream.writelines(data)
         lines = "".join(data)
         self.extra_output_finder.find_extra_output(lines)
@@ -110,7 +110,7 @@ class TeeStdoutAndFindExtraConsoleOutput:
         self.stdout_stream.write(data)
         self.extra_output_finder.find_extra_output(data)
 
-    def writelines(self, data: Iterable[str]) -> None:
+    def writelines(self, data: Sequence[str]) -> None:
         self.stdout_stream.writelines(data)
         lines = "".join(data)
         self.extra_output_finder.find_extra_output(lines)

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -29,7 +29,19 @@ for any particular type of object.
 """
 import re
 from datetime import datetime
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union, cast, overload
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+    overload,
+)
 
 import orjson
 from django.core.exceptions import ValidationError
@@ -213,8 +225,8 @@ def check_tuple(sub_validators: List[Validator[ResultT]]) -> Validator[Tuple[Any
 # https://zulip.readthedocs.io/en/latest/testing/mypy.html#using-overload-to-accurately-describe-variations
 @overload
 def check_dict(
-    required_keys: Iterable[Tuple[str, Validator[object]]] = [],
-    optional_keys: Iterable[Tuple[str, Validator[object]]] = [],
+    required_keys: Collection[Tuple[str, Validator[object]]] = [],
+    optional_keys: Collection[Tuple[str, Validator[object]]] = [],
     *,
     _allow_only_listed_keys: bool = False,
 ) -> Validator[Dict[str, object]]:
@@ -223,8 +235,8 @@ def check_dict(
 
 @overload
 def check_dict(
-    required_keys: Iterable[Tuple[str, Validator[ResultT]]] = [],
-    optional_keys: Iterable[Tuple[str, Validator[ResultT]]] = [],
+    required_keys: Collection[Tuple[str, Validator[ResultT]]] = [],
+    optional_keys: Collection[Tuple[str, Validator[ResultT]]] = [],
     *,
     value_validator: Validator[ResultT],
     _allow_only_listed_keys: bool = False,
@@ -233,8 +245,8 @@ def check_dict(
 
 
 def check_dict(
-    required_keys: Iterable[Tuple[str, Validator[ResultT]]] = [],
-    optional_keys: Iterable[Tuple[str, Validator[ResultT]]] = [],
+    required_keys: Collection[Tuple[str, Validator[ResultT]]] = [],
+    optional_keys: Collection[Tuple[str, Validator[ResultT]]] = [],
     *,
     value_validator: Optional[Validator[ResultT]] = None,
     _allow_only_listed_keys: bool = False,
@@ -283,8 +295,8 @@ def check_dict(
 
 
 def check_dict_only(
-    required_keys: Iterable[Tuple[str, Validator[ResultT]]],
-    optional_keys: Iterable[Tuple[str, Validator[ResultT]]] = [],
+    required_keys: Collection[Tuple[str, Validator[ResultT]]],
+    optional_keys: Collection[Tuple[str, Validator[ResultT]]] = [],
 ) -> Validator[Dict[str, ResultT]]:
     return cast(
         Validator[Dict[str, ResultT]],
@@ -292,7 +304,7 @@ def check_dict_only(
     )
 
 
-def check_union(allowed_type_funcs: Iterable[Validator[ResultT]]) -> Validator[ResultT]:
+def check_union(allowed_type_funcs: Collection[Validator[ResultT]]) -> Validator[ResultT]:
     """
     Use this validator if an argument is of a variable type (e.g. processing
     properties that might be strings or booleans).

--- a/zerver/management/commands/makemessages.py
+++ b/zerver/management/commands/makemessages.py
@@ -38,7 +38,7 @@ import os
 import re
 import subprocess
 from argparse import ArgumentParser
-from typing import Any, Dict, Iterable, Iterator, List, Mapping
+from typing import Any, Collection, Dict, Iterator, List, Mapping
 
 from django.core.management.commands import makemessages
 from django.template.base import BLOCK_TAG_END, BLOCK_TAG_START
@@ -220,7 +220,7 @@ class Command(makemessages.Command):
     def get_namespace(self) -> str:
         return self.frontend_namespace
 
-    def get_locales(self) -> Iterable[str]:
+    def get_locales(self) -> Collection[str]:
         locale = self.frontend_locale
         exclude = self.frontend_exclude
         process_all = self.frontend_all

--- a/zerver/management/commands/set_message_flags.py
+++ b/zerver/management/commands/set_message_flags.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from typing import Any, Iterable
+from typing import Any, Collection
 
 from django.core.management.base import CommandParser
 from django.db import models
@@ -59,7 +59,7 @@ class Command(ZulipBaseCommand):
             sys.stdout.close()
             sys.stderr.close()
 
-        def do_update(batch: Iterable[int]) -> None:
+        def do_update(batch: Collection[int]) -> None:
             msgs = UserMessage.objects.filter(id__in=batch)
             if op == "add":
                 msgs.update(flags=models.F("flags").bitor(flag))

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -9,7 +9,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Iterable,
     List,
     Optional,
     Sequence,
@@ -589,11 +588,11 @@ class Realm(models.Model):
         return f"<Realm: {self.string_id} {self.id}>"
 
     @cache_with_key(get_realm_emoji_cache_key, timeout=3600 * 24 * 7)
-    def get_emoji(self) -> Dict[str, Dict[str, Iterable[str]]]:
+    def get_emoji(self) -> Dict[str, Dict[str, Any]]:
         return get_realm_emoji_uncached(self)
 
     @cache_with_key(get_active_realm_emoji_cache_key, timeout=3600 * 24 * 7)
-    def get_active_emoji(self) -> Dict[str, Dict[str, Iterable[str]]]:
+    def get_active_emoji(self) -> Dict[str, Dict[str, Any]]:
         return get_active_realm_emoji_uncached(self)
 
     def get_admin_users_and_bots(

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -2,7 +2,7 @@ import base64
 import os
 import re
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, List, Sequence, Tuple
 from unittest import mock, skipUnless
 
 import orjson
@@ -167,7 +167,7 @@ class DecoratorTestCase(ZulipTestCase):
 
         @has_request_variables
         def get_total(
-            request: HttpRequest, numbers: Iterable[int] = REQ(converter=my_converter)
+            request: HttpRequest, numbers: Sequence[int] = REQ(converter=my_converter)
         ) -> int:
             return sum(numbers)
 
@@ -202,7 +202,7 @@ class DecoratorTestCase(ZulipTestCase):
     def test_REQ_validator(self) -> None:
         @has_request_variables
         def get_total(
-            request: HttpRequest, numbers: Iterable[int] = REQ(json_validator=check_list(check_int))
+            request: HttpRequest, numbers: Sequence[int] = REQ(json_validator=check_list(check_int))
         ) -> int:
             return sum(numbers)
 

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -3,19 +3,7 @@ import os
 import re
 import sys
 from collections import abc
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Set, Tuple, Union
 from unittest.mock import MagicMock, patch
 
 import yaml
@@ -383,8 +371,6 @@ so maybe we shouldn't mark it as intentionally undocumented in the URLs.
                 origin = list
             elif origin == Dict:
                 origin = dict
-            elif origin == Iterable:
-                origin = abc.Iterable
             elif origin == Mapping:
                 origin = abc.Mapping
             elif origin == Sequence:
@@ -397,7 +383,7 @@ so maybe we shouldn't mark it as intentionally undocumented in the URLs.
         elif origin == Union:
             subtypes = [self.get_standardized_argument_type(st) for st in t.__args__]
             return self.get_type_by_priority(subtypes)
-        elif origin in [list, abc.Iterable, abc.Sequence]:
+        elif origin in [list, abc.Sequence]:
             [st] = t.__args__
             return (list, self.get_standardized_argument_type(st))
         elif origin in [dict, abc.Mapping]:

--- a/zerver/tornado/django_api.py
+++ b/zerver/tornado/django_api.py
@@ -70,7 +70,7 @@ def request_event_queue(
     client_gravatar: bool,
     slim_presence: bool,
     queue_lifespan_secs: int,
-    event_types: Optional[Iterable[str]] = None,
+    event_types: Optional[Sequence[str]] = None,
     all_public_streams: bool = False,
     narrow: Iterable[Sequence[str]] = [],
     bulk_message_deletion: bool = False,

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -1,5 +1,5 @@
 import time
-from typing import Iterable, Optional, Sequence
+from typing import Optional, Sequence
 
 import orjson
 from django.http import HttpRequest, HttpResponse
@@ -86,7 +86,7 @@ def get_events_backend(
         default=None, json_validator=check_list(check_string), intentionally_undocumented=True
     ),
     dont_block: bool = REQ(default=False, json_validator=check_bool),
-    narrow: Iterable[Sequence[str]] = REQ(
+    narrow: Sequence[Sequence[str]] = REQ(
         default=[],
         json_validator=check_list(check_list(check_string)),
         intentionally_undocumented=True,

--- a/zerver/views/events_register.py
+++ b/zerver/views/events_register.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable, Optional, Sequence
+from typing import Dict, Optional, Sequence
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
@@ -20,15 +20,15 @@ def _default_all_public_streams(
 
 
 def _default_narrow(
-    user_profile: UserProfile, narrow: Iterable[Sequence[str]]
-) -> Iterable[Sequence[str]]:
+    user_profile: UserProfile, narrow: Sequence[Sequence[str]]
+) -> Sequence[Sequence[str]]:
     default_stream: Optional[Stream] = user_profile.default_events_register_stream
     if not narrow and default_stream is not None:
         narrow = [["stream", default_stream.name]]
     return narrow
 
 
-NarrowT = Iterable[Sequence[str]]
+NarrowT = Sequence[Sequence[str]]
 
 
 @has_request_variables
@@ -58,10 +58,10 @@ def events_register_backend(
         ),
         default=None,
     ),
-    event_types: Optional[Iterable[str]] = REQ(
+    event_types: Optional[Sequence[str]] = REQ(
         json_validator=check_list(check_string), default=None
     ),
-    fetch_event_types: Optional[Iterable[str]] = REQ(
+    fetch_event_types: Optional[Sequence[str]] = REQ(
         json_validator=check_list(check_string), default=None
     ),
     narrow: NarrowT = REQ(

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Set, Union
 
 import orjson
 from django.conf import settings
@@ -336,8 +336,8 @@ remove_subscriptions_schema = check_list(check_string)
 def update_subscriptions_backend(
     request: HttpRequest,
     user_profile: UserProfile,
-    delete: Iterable[str] = REQ(json_validator=remove_subscriptions_schema, default=[]),
-    add: Iterable[Mapping[str, str]] = REQ(json_validator=add_subscriptions_schema, default=[]),
+    delete: Sequence[str] = REQ(json_validator=remove_subscriptions_schema, default=[]),
+    add: Sequence[Mapping[str, str]] = REQ(json_validator=add_subscriptions_schema, default=[]),
 ) -> HttpResponse:
     if not add and not delete:
         return json_error(_('Nothing to do. Specify at least one of "add" or "delete".'))
@@ -380,7 +380,7 @@ check_principals: Validator[Union[List[str], List[int]]] = check_union(
 def remove_subscriptions_backend(
     request: HttpRequest,
     user_profile: UserProfile,
-    streams_raw: Iterable[str] = REQ("subscriptions", json_validator=remove_subscriptions_schema),
+    streams_raw: Sequence[str] = REQ("subscriptions", json_validator=remove_subscriptions_schema),
     principals: Optional[Union[List[str], List[int]]] = REQ(
         json_validator=check_principals, default=None
     ),
@@ -446,7 +446,7 @@ EMPTY_PRINCIPALS: Union[Sequence[str], Sequence[int]] = []
 def add_subscriptions_backend(
     request: HttpRequest,
     user_profile: UserProfile,
-    streams_raw: Iterable[Mapping[str, str]] = REQ(
+    streams_raw: Sequence[Mapping[str, str]] = REQ(
         "subscriptions", json_validator=add_subscriptions_schema
     ),
     invite_only: bool = REQ(json_validator=check_bool, default=False),

--- a/zerver/webhooks/helloworld/view.py
+++ b/zerver/webhooks/helloworld/view.py
@@ -1,5 +1,5 @@
 # Webhooks for external integrations.
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Sequence
 
 from django.http import HttpRequest, HttpResponse
 
@@ -15,7 +15,7 @@ from zerver.models import UserProfile
 def api_helloworld_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Iterable[Dict[str, Any]]] = REQ(argument_type="body"),
+    payload: Dict[str, Sequence[Dict[str, Any]]] = REQ(argument_type="body"),
 ) -> HttpResponse:
 
     # construct the body of the message

--- a/zerver/webhooks/mention/view.py
+++ b/zerver/webhooks/mention/view.py
@@ -1,5 +1,5 @@
 # Webhooks for external integrations.
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Sequence
 
 from django.http import HttpRequest, HttpResponse
 
@@ -15,7 +15,7 @@ from zerver.models import UserProfile
 def api_mention_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Iterable[Dict[str, Any]]] = REQ(argument_type="body"),
+    payload: Dict[str, Sequence[Dict[str, Any]]] = REQ(argument_type="body"),
 ) -> HttpResponse:
     title = payload["title"]
     source_url = payload["url"]

--- a/zerver/webhooks/netlify/view.py
+++ b/zerver/webhooks/netlify/view.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Sequence
 
 from django.http import HttpRequest, HttpResponse
 
@@ -23,7 +23,7 @@ fixture_to_headers = get_http_headers_from_filename("HTTP_X_NETLIFY_EVENT")
 def api_netlify_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Iterable[Dict[str, Any]]] = REQ(argument_type="body"),
+    payload: Dict[str, Sequence[Dict[str, Any]]] = REQ(argument_type="body"),
 ) -> HttpResponse:
 
     message_template = get_template(request, payload)

--- a/zerver/webhooks/pagerduty/view.py
+++ b/zerver/webhooks/pagerduty/view.py
@@ -1,5 +1,5 @@
 # Webhooks for external integrations.
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Sequence
 
 from django.http import HttpRequest, HttpResponse
 
@@ -166,7 +166,7 @@ def send_formated_pagerduty(
 def api_pagerduty_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Iterable[Dict[str, Any]]] = REQ(argument_type="body"),
+    payload: Dict[str, Sequence[Dict[str, Any]]] = REQ(argument_type="body"),
 ) -> HttpResponse:
     for message in payload["messages"]:
         message_type = message.get("type")

--- a/zerver/webhooks/reviewboard/view.py
+++ b/zerver/webhooks/reviewboard/view.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Sequence
 
 from django.http import HttpRequest, HttpResponse
 
@@ -178,7 +178,7 @@ RB_MESSAGE_FUNCTIONS = {
 def api_reviewboard_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Iterable[Dict[str, Any]]] = REQ(argument_type="body"),
+    payload: Dict[str, Sequence[Dict[str, Any]]] = REQ(argument_type="body"),
 ) -> HttpResponse:
     event_type = validate_extract_webhook_http_header(request, "X_REVIEWBOARD_EVENT", "ReviewBoard")
     assert event_type is not None


### PR DESCRIPTION
`Iterable` should not be used for a value that might be iterated multiple times, since a one-use iterator is `Iterable` too.