### PR TITLE
puppeteer_test: Add missing `wait_for_checked` call to avoid rare flake.

### DIFF
--- a/frontend_tests/puppeteer_tests/subscriptions.ts
+++ b/frontend_tests/puppeteer_tests/subscriptions.ts
@@ -140,6 +140,7 @@ async function test_user_filter_ui(
 
     // Test check all
     await page.click(".subs_set_all_users");
+    await wait_for_checked(page, "othello", true);
     await clear_ot_filter_with_backspace(page);
     await verify_filtered_users_are_visible_again(page, cordelia_checkbox, othello_checkbox);
     await verify_check_all_only_affects_visible_users(page);


### PR DESCRIPTION
[Link to CZO Thread](https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/chat.2Ezulip.2Eorg.20failing)

This PR fixes a rare flake which was most probably
caused when we clicked on the `Check All` button, and
we instantly cleared the filter when it was still marking
the user `checked`, which nullified the effect of clicking
on `Check All` button.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
