### PR TITLE
compose_control_buttons: Use data-tippy-content instead of title.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -64,7 +64,6 @@ export function initialize() {
 
     delegate("body", {
         target: ".compose_control_button",
-        content: (reference) => reference.getAttribute("title"),
         placement: "top",
         // Add some additional delay when they open
         // so that regular users don't have to see

--- a/static/templates/compose_control_buttons.hbs
+++ b/static/templates/compose_control_buttons.hbs
@@ -1,12 +1,12 @@
 <input type="file" class="file_input notvisible pull-left" multiple />
 {{#if file_upload_enabled }}
-<a role="button" class="compose_control_button compose_upload_file fa fa-paperclip notdisplayed" aria-label="{{t 'Upload files' }}" tabindex=0 title="{{t 'Upload files' }}"></a>
+<a role="button" class="compose_control_button compose_upload_file fa fa-paperclip notdisplayed" aria-label="{{t 'Upload files' }}" tabindex=0 data-tippy-content="{{t 'Upload files' }}"></a>
 {{/if}}
-<a role="button" class="markdown_preview compose_control_button fa fa-eye" aria-label="{{t 'Preview' }}" tabindex=0 title="{{t 'Preview' }}"></a>
-<a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" title="{{t 'Write' }}"></a>
-<a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 title="{{t 'Add video call' }}"></a>
-<a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 title="{{t 'Add emoji' }}"></a>
-<a role="button" class="compose_control_button compose_giphy_link {{#unless giphy_enabled }} hide {{/unless}}" aria-label="{{t 'Add GIF' }}" title="{{t 'Add GIF' }}">
+<a role="button" class="markdown_preview compose_control_button fa fa-eye" aria-label="{{t 'Preview' }}" tabindex=0 data-tippy-content="{{t 'Preview' }}"></a>
+<a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"></a>
+<a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"></a>
+<a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 data-tippy-content="{{t 'Add emoji' }}"></a>
+<a role="button" class="compose_control_button compose_giphy_link {{#unless giphy_enabled }} hide {{/unless}}" aria-label="{{t 'Add GIF' }}" data-tippy-content="{{t 'Add GIF' }}">
     <i class="compose_gif_icon zulip-icon zulip-icon-gif" tabindex=0></i>
 </a>
 {{#unless hide_drafts_link}}


### PR DESCRIPTION
We don't want browser default titles and tooltips to overlap,
so we remove titles here.

see discussion in https://chat.zulip.org/#narrow/stream/101-design/topic/giphy.20integration