### PR TITLE
user docs: Update change-your-profile-picture section within docs.

### DIFF
--- a/templates/zerver/help/change-your-profile-picture.md
+++ b/templates/zerver/help/change-your-profile-picture.md
@@ -24,7 +24,9 @@ You can also upload a custom profile picture to Zulip.
 {settings_tab|your-account}
 
 2. Under **Profile picture**, click on the **(X)** icon in the top
-right corner of the profile picture.  This will remove your current
+right corner of the profile picture.
+
+3. Approve by clicking **Confirm**. This will remove your current
 profile picture, reverting to the Gravatar default.
 
 {end_tabs}


### PR DESCRIPTION
Commit dc67870 introduced a user confirmation modal before deleting profile picture  leaving the user documentation
unchanged.
Hence, added a minor commit to update the <a href = 'https://zulip.com/help/change-your-profile-picture#set-profile-picture-back-to-gravatar'>`change-your-profile-picture`</a> section within the user documentation with respect to the newly added feature.

<strong>Screenshot</strong>


![Screenshot from 2021-04-30 21-15-11](https://user-images.githubusercontent.com/53977614/116719877-30772e80-a9f9-11eb-9e7a-97c6ff34846a.png)



