### PR TITLE
push_notifications: Give full stack information on an exception.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -893,6 +893,7 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
                 "Could not find UserMessage with message_id %s and user_id %s",
                 missed_message["message_id"],
                 user_profile_id,
+                exc_info=True,
             )
             return
 

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1176,6 +1176,7 @@ class HandlePushNotificationTest(PushNotificationTest):
                 "Could not find UserMessage with message_id %s and user_id %s",
                 message_id,
                 self.user_profile.id,
+                exc_info=True,
             )
             mock_push_notifications.assert_called_once()
 


### PR DESCRIPTION
This error has been seen in production instances, but we need more
context to be able to determine what might be causing it.
