### PR TITLE
install: Install procps, for pgrep.

### DIFF
--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -45,6 +45,7 @@ class zulip::profile::base {
         'curl',
         'wget',
         'jq',
+        'procps',
         # Used to read /etc/zulip/zulip.conf for `zulipconf` Puppet function
         'crudini',
         # Accurate time is essential

--- a/puppet/zulip/manifests/profile/rabbitmq.pp
+++ b/puppet/zulip/manifests/profile/rabbitmq.pp
@@ -59,7 +59,7 @@ class zulip::profile::rabbitmq {
   # running and exits if so.
   exec { 'epmd':
     command => 'epmd -daemon',
-    unless  => 'pgrep -f [e]pmd >/dev/null',
+    unless  => 'which pgrep && pgrep -f [e]pmd >/dev/null',
     require => Package[$erlang],
     path    => '/usr/bin/:/bin/',
   }

--- a/puppet/zulip/manifests/profile/rabbitmq.pp
+++ b/puppet/zulip/manifests/profile/rabbitmq.pp
@@ -59,7 +59,7 @@ class zulip::profile::rabbitmq {
   # running and exits if so.
   exec { 'epmd':
     command => 'epmd -daemon',
-    unless  => 'pgrep -f epmd >/dev/null',
+    unless  => 'pgrep -f [e]pmd >/dev/null',
     require => Package[$erlang],
     path    => '/usr/bin/:/bin/',
   }


### PR DESCRIPTION
In puppet, we use pgrep in the collection stage, to see if rabbitmq is
running.  Sufficiently bare-bones systems will not have procps
installed yet, which makes the install abort when running `puppet` for
the first time.

**Testing plan:** `docker run -it debian:buster` and tried to run the installer.