### PR TITLE
Add support for moderators only stream post policy in frontend.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -475,6 +475,43 @@ test_ui("test_validate_stream_message_post_policy_admin_only", () => {
     );
 });
 
+test_ui("test_validate_stream_message_post_policy_moderators_only", () => {
+    page_params.is_admin = false;
+    page_params.is_moderator = false;
+    page_params.is_guest = false;
+
+    const sub = {
+        stream_id: 104,
+        name: "stream104",
+        subscribed: true,
+        stream_post_policy: stream_data.stream_post_policy_values.moderators.code,
+    };
+
+    compose_state.topic("subject104");
+    compose_state.stream_name("stream104");
+    stream_data.add_sub(sub);
+    assert(!compose.validate());
+    assert.equal(
+        $("#compose-error-msg").html(),
+        $t_html({
+            defaultMessage:
+                "Only organization admins and moderators are allowed to post to this stream.",
+        }),
+    );
+
+    // Reset error message.
+    compose_state.stream_name("social");
+
+    page_params.is_guest = true;
+    assert.equal(
+        $("#compose-error-msg").html(),
+        $t_html({
+            defaultMessage:
+                "Only organization admins and moderators are allowed to post to this stream.",
+        }),
+    );
+});
+
 test_ui("test_validate_stream_message_post_policy_full_members_only", () => {
     page_params.is_admin = false;
     page_params.is_guest = true;

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -625,6 +625,20 @@ function validate_stream_message_post_policy(sub) {
         return false;
     }
 
+    if (page_params.is_moderator) {
+        return true;
+    }
+
+    if (stream_post_policy === stream_post_permission_type.moderators.code) {
+        compose_error(
+            $t_html({
+                defaultMessage:
+                    "Only organization admins and moderators are allowed to post to this stream.",
+            }),
+        );
+        return false;
+    }
+
     if (page_params.is_guest && stream_post_policy !== stream_post_permission_type.everyone.code) {
         compose_error($t_html({defaultMessage: "Guests are not allowed to post to this stream."}));
         return false;

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -137,6 +137,12 @@ export const stream_post_policy_values = {
         code: 2,
         description: $t({defaultMessage: "Only organization administrators can post"}),
     },
+    moderators: {
+        code: 4,
+        description: $t({
+            defaultMessage: "Only organization administrators and moderators can post",
+        }),
+    },
     non_new_members: {
         code: 3,
         description: $t({defaultMessage: "Only organization full members can post"}),

--- a/static/templates/subscription_type.hbs
+++ b/static/templates/subscription_type.hbs
@@ -19,6 +19,8 @@
 {{/if}}
 {{#if (eq stream_post_policy stream_post_policy_values.admins.code)}}
 {{t 'Only organization administrators can post.'}}
+{{else if (eq stream_post_policy stream_post_policy_values.moderators.code)}}
+{{t 'Only organization administrators and moderators can post.'}}
 {{else if (eq stream_post_policy stream_post_policy_values.non_new_members.code)}}
 {{t 'Only organization full members can post.'}}
 {{else}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds support for moderators only stream post policy in frontend.

 <!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
