### PR TITLE
Update help pages for moderator role and fixes some other parts as well in help pages.

### DIFF
--- a/templates/zerver/help/add-or-remove-users-from-a-stream.md
+++ b/templates/zerver/help/add-or-remove-users-from-a-stream.md
@@ -2,9 +2,14 @@
 
 ## Add users to a stream
 
-Anyone (other than guests) subscribed to a stream can add users to that
-stream. Additionally, anyone (other than guests) can add users to a public
-stream, whether or not they are subscribed to the stream.
+By default, anyone (other than guests) subscribed to a stream can add
+users to that stream. Additionally, anyone (other than guests) can add
+users to a public stream, whether or not they are subscribed to the
+stream.
+
+Organization administrators can configure which
+[roles](/help/roles-and-permissions) have access to [add other users
+to a stream][configure-invites].
 
 {start_tabs}
 
@@ -39,3 +44,5 @@ including streams the admin is not subscribed to.
 1. Click **Unsubscribe** to the right of their email address.
 
 {end_tabs}
+
+[configure-invites]: /help/configure-who-can-invite-to-streams

--- a/templates/zerver/help/change-a-users-role.md
+++ b/templates/zerver/help/change-a-users-role.md
@@ -2,7 +2,7 @@
 
 {!admin-only.md!}
 
-Users join as [owners, administrators, members, or
+Users join as [owners, administrators, moderators, members, or
 guests](/help/roles-and-permissions), depending on how they were
 invited.
 
@@ -29,7 +29,7 @@ automatically converted during the upgrade to Zulip 3.0 into owners
 1. Find the user you would like to manage. Click the **pencil**
 (<i class="fa fa-pencil"></i>) to the right of their name.
 
-1. Under **User role**, select **Owner**, **Administrator**, **Member** or **Guest**.
+1. Under **User role**, select **Owner**, **Administrator**, **Moderators**, **Member** or **Guest**.
 
 1. Click **Save changes**. The new rights will take effect immediately.
 

--- a/templates/zerver/help/configure-who-can-create-streams.md
+++ b/templates/zerver/help/configure-who-can-create-streams.md
@@ -20,7 +20,7 @@ heavy use has as many streams as users.
 
 {settings_tab|organization-permissions}
 
-2. Under **Other permissions**, configure **Who can create streams**.
+2. Under **Stream permissions**, configure **Who can create streams**.
 
 {!save-changes.md!}
 

--- a/templates/zerver/help/configure-who-can-create-streams.md
+++ b/templates/zerver/help/configure-who-can-create-streams.md
@@ -6,6 +6,7 @@ By default, anyone other than guests can create new streams. However, you can re
 creation to:
 
 * Organization administrators
+* Organization administrators and moderators
 * Organization administrators and all members
 * Organization administrators and [full members](/help/restrict-permissions-of-new-members)
 

--- a/templates/zerver/help/configure-who-can-invite-to-streams.md
+++ b/templates/zerver/help/configure-who-can-invite-to-streams.md
@@ -5,6 +5,7 @@
 By default, anyone other than guests can add other users to streams. However, you can restrict this to:
 
 * Organization administrators
+* Organization administrators and moderators
 * Organization administrators and all members
 * Organization administrators and [full members](/help/restrict-permissions-of-new-members)
 

--- a/templates/zerver/help/configure-who-can-invite-to-streams.md
+++ b/templates/zerver/help/configure-who-can-invite-to-streams.md
@@ -15,7 +15,7 @@ By default, anyone other than guests can add other users to streams. However, yo
 
 {settings_tab|organization-permissions}
 
-2. Under **Other permissions**, configure **Who can add users to streams**.
+2. Under **Stream permissions**, configure **Who can add users to streams**.
 
 {!save-changes.md!}
 

--- a/templates/zerver/help/create-a-stream.md
+++ b/templates/zerver/help/create-a-stream.md
@@ -4,7 +4,7 @@ By default, all users other than guests can create streams.
 
 Organization administrators can
 [restrict stream creation](/help/configure-who-can-create-streams) to
-admins only, or to members meeting a minimum account age.
+admins only, moderators only or to members meeting a minimum account age.
 
 If you are an administrator setting up streams for the first time, we highly
 recommend reading our

--- a/templates/zerver/help/invite-new-users.md
+++ b/templates/zerver/help/invite-new-users.md
@@ -121,16 +121,21 @@ and reusable invitation links expire 10 days after they are sent.
 
 ## Change who can send invitations
 
-By default, organization admins and members can send invitations. You can
-restrict invites to admins only.
+By default, all members can invite new users to join your Zulip
+organization. However, you can restrict the permission to invite new
+users to other sets of roles:
+
+* Organization administrators
+* Organization administrators and moderators
+* Organization administrators and all members
+* Organization administrators and [full members](/help/restrict-permissions-of-new-members)
 
 {start_tabs}
 
 {settings_tab|organization-permissions}
 
-1. Under Joining the organization, set
-   **Are invitations required for joining the organization?** to
-   **Yes. Only admins can send invitations**.
+1. Under **Joining the organization**, configure
+   **Are invitations required for joining the organization?**.
 
 1. Click **Save changes**.
 

--- a/templates/zerver/help/restrict-bot-creation.md
+++ b/templates/zerver/help/restrict-bot-creation.md
@@ -12,7 +12,7 @@ change who is allowed to add bots.
 
 {settings_tab|organization-permissions}
 
-2. Under **Organization permissions**, configure **Who can add bots**.
+2. Under **Other permissions**, configure **Who can add bots**.
 
 {!save-changes.md!}
 

--- a/templates/zerver/help/restrict-permissions-of-new-members.md
+++ b/templates/zerver/help/restrict-permissions-of-new-members.md
@@ -17,6 +17,7 @@ Currently, the following actions support limiting access to full members.
 - [Creating streams](/help/configure-who-can-create-streams)
 - [Adding users to streams](/help/configure-who-can-invite-to-streams)
 - [Restricting posting to a stream](/help/stream-sending-policy)
+- [Restricting inviting users to organization](/help/invite-new-users)
 
 ### Set waiting period for new members
 
@@ -24,7 +25,7 @@ Currently, the following actions support limiting access to full members.
 
 {settings_tab|organization-permissions}
 
-2. Under **Other permissions**, configure **Waiting period before new members turn into full members**.
+2. Under **Joining the organization**, configure **Waiting period before new members turn into full members**.
 
 {!save-changes.md!}
 

--- a/templates/zerver/help/restrict-private-messages.md
+++ b/templates/zerver/help/restrict-private-messages.md
@@ -14,7 +14,7 @@ administrators can change who is allowed to use private messages.
 
 {settings_tab|organization-permissions}
 
-2. Under **Organization permissions**, configure **Who can use private messages**.
+2. Under **Other permissions**, configure **Who can use private messages**.
 
 {!save-changes.md!}
 

--- a/templates/zerver/help/restrict-visibility-of-email-addresses.md
+++ b/templates/zerver/help/restrict-visibility-of-email-addresses.md
@@ -12,7 +12,7 @@ admins (or nobody) can view other users' email addresses.
 
 {settings_tab|organization-permissions}
 
-2. Under **Organization permissions**, configure **Who can access user email addresses**.
+2. Under **User identity**, configure **Who can access user email addresses**.
 
 {!save-changes.md!}
 

--- a/templates/zerver/help/restrict-wildcard-mentions.md
+++ b/templates/zerver/help/restrict-wildcard-mentions.md
@@ -20,7 +20,7 @@ receiving email and mobile push notifications.
 
 {settings_tab|organization-permissions}
 
-2. Under **Organization permissions**, configure
+2. Under **Stream permissions**, configure
    **Who can use wildcard mentions in large streams**.
 
 {!save-changes.md!}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Updated the help pages to include moderator role. Also fixed some other parts where incorrect subsection was being used.

Have not updated stream permissions page yet to mention that adding users to a stream is configurable. Cannot think of correct symbol to use, Tim suggested `[1]` but I think it does not go well with the exisiting symbols. Maybe we can use `+` or any other suggestions would be helpful.

 <!-- How have you tested? -->


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
