### PR TITLE
django: Upgrade Zulip to Django 3.2 LTS.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -3,7 +3,7 @@
 # and requirements/prod.txt.
 # See requirements/README.md for more detail.
 # Django itself
-Django[argon2]==3.1.*
+Django[argon2]==3.2.*
 
 # needed for Literal, TypedDict
 typing-extensions

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -380,9 +380,9 @@ django-two-factor-auth[call,phonenumberslite,sms]==1.13.1 \
     --hash=sha256:a20e03d256fd9fd668988545f052cedcc47e5a981888562e5e27d0bb83deae89 \
     --hash=sha256:d270d4288731233621a9462a89a8dfed2dcb86fa354125c816a89772d55f9e29
     # via -r requirements/common.in
-django[argon2]==3.1.8 \
-    --hash=sha256:c348b3ddc452bf4b62361f0752f71a339140c777ebea3cdaaaa8fdb7f417a862 \
-    --hash=sha256:f8393103e15ec2d2d313ccbb95a3f1da092f9f58d74ac1c61ca2ac0436ae1eac
+django[argon2]==3.2 \
+    --hash=sha256:0604e84c4fb698a5e53e5857b5aea945b2f19a18f25f10b8748dbdf935788927 \
+    --hash=sha256:21f0f9643722675976004eb683c55d33c05486f94506672df3d6a141546f389d
     # via
     #   -r requirements/common.in
     #   django-auth-ldap

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -244,9 +244,9 @@ django-two-factor-auth[call,phonenumberslite,sms]==1.13.1 \
     --hash=sha256:a20e03d256fd9fd668988545f052cedcc47e5a981888562e5e27d0bb83deae89 \
     --hash=sha256:d270d4288731233621a9462a89a8dfed2dcb86fa354125c816a89772d55f9e29
     # via -r requirements/common.in
-django[argon2]==3.1.8 \
-    --hash=sha256:c348b3ddc452bf4b62361f0752f71a339140c777ebea3cdaaaa8fdb7f417a862 \
-    --hash=sha256:f8393103e15ec2d2d313ccbb95a3f1da092f9f58d74ac1c61ca2ac0436ae1eac
+django[argon2]==3.2 \
+    --hash=sha256:0604e84c4fb698a5e53e5857b5aea945b2f19a18f25f10b8748dbdf935788927 \
+    --hash=sha256:21f0f9643722675976004eb683c55d33c05486f94506672df3d6a141546f389d
     # via
     #   -r requirements/common.in
     #   django-auth-ldap

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -76,7 +76,6 @@ not_yet_fully_covered = [
     "zerver/lib/markdown/help_relative_links.py",
     "zerver/lib/markdown/nested_code_blocks.py",
     # Other lib files that ideally would coverage, but aren't sorted
-    "zerver/__init__.py",
     "zerver/filters.py",
     "zerver/middleware.py",
     "zerver/lib/bot_lib.py",

--- a/version.py
+++ b/version.py
@@ -45,4 +45,4 @@ API_FEATURE_LEVEL = 61
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "141.3"
+PROVISION_VERSION = "142.0"

--- a/zerver/__init__.py
+++ b/zerver/__init__.py
@@ -1,2 +1,0 @@
-# Load AppConfig app subclass by default on django applications initialization
-default_app_config = "zerver.apps.ZerverConfig"

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -87,11 +87,11 @@ def sanitize_name(value: str) -> str:
 
     This implementation is based on django.utils.text.slugify; it is
     modified by:
-    * adding '.' and '_' to the list of allowed characters.
+    * adding '.' to the list of allowed characters.
     * preserving the case of the value.
     """
     value = unicodedata.normalize("NFKC", value)
-    value = re.sub(r"[^\w\s._-]", "", value, flags=re.U).strip()
+    value = re.sub(r"[^\w\s.-]", "", value, flags=re.U).strip()
     value = re.sub(r"[-\s]+", "-", value, flags=re.U)
     assert value not in {"", ".", ".."}
     return mark_safe(value)

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -89,6 +89,7 @@ def sanitize_name(value: str) -> str:
     modified by:
     * adding '.' to the list of allowed characters.
     * preserving the case of the value.
+    * not stripping trailing dashes and underscores.
     """
     value = unicodedata.normalize("NFKC", value)
     value = re.sub(r"[^\w\s.-]", "", value, flags=re.U).strip()

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -315,6 +315,8 @@ elif REMOTE_POSTGRES_HOST != "":
 
 POSTGRESQL_MISSING_DICTIONARIES = bool(get_config("postgresql", "missing_dictionaries", None))
 
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
 ########################################################################
 # RABBITMQ CONFIGURATION
 ########################################################################


### PR DESCRIPTION
This based on my "Needs checking/doing" points from https://chat.zulip.org/#narrow/stream/3-backend/topic/Django.203.2E2/near/1156248

Commit message:
`####`

This is a straightforward upgrade in terms of changes needed.

Necessary changes were:
- Set `DEFAULT_AUTO_FIELD`
  https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys

- `The default_app_config application configuration variable is deprecated, due
  to the now automatic AppConfig discovery.`
  https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery

To handle this one, we can remove default_app_config from
zerver/__init__.py because it satisfies what release notes describe in
https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery:
"Most pluggable applications define an AppConfig subclass in an apps.py
submodule. Many define a default_app_config variable pointing to this
class in their __init__.py.  When the apps.py submodule exists and
defines a single AppConfig subclass, Django now uses that configuration
automatically, so you can remove default_app_config."

An important note is that rebuild-test-database needs to be run after
this upgrade in dev environment - if tests are run with test db that was
built on the previous version, they will fail due to a mysterious bug
(?), where changing attributes of a user and .save()ing after logging in
in the test via self.login_user, causes getting logged out - the next
requests via self.client_get etc. are unauthed for some reason,
unless self.login_user is called again. This behavior is no longer
exhibited upon rebuilding the test db - and I can't reproduce it in
production or dev db. So this can likely be reasonably dismissed as some
quirk of the test client system that won't be relevant in the future and
doesn't impact production.
`###`

To address the remaining points from my notes:
> - `The minimum supported version of asgiref is increased from 3.2.10 to 3.3.2.` We're on 3.3.1 right now.

This is a noop now, because Zulip is on 3.3.4 now.

> - `SessionMiddleware now raises a SessionInterrupted exception instead of
  SuspiciousOperation when a session is destroyed in a concurrent request.` Do
  we need to update the ignored loggers in `sentry.py` to ignore
  `SessionInterrupted`?

No, because SessionInterrupted doesn't cause logging, it's a subclass of BadRequest, which is just converted to HttpResponseBadRequest by the request handler.

> - `DiscoverRunner now enables faulthandler by default. This can be disabled by
  using the test --no-faulthandler option.` Will this do anything unexpected? 

  https://docs.python.org/3/library/faulthandler.html - looks like it shouldn't break anything. Might
  turn out to be useful, so makes sense to leave it enabled and we can disable if it proves annoying.
  Only affects tests, so not a big concern.

> - `The cache.get_many(), get_or_set(), has_key(), incr(), decr(),
  incr_version(), and decr_version() cache operations now correctly handle None
  stored in the cache, in the same way as any other value, instead of behaving
  as though the key didn’t exist.` Do we rely on the old behavior in some
  important way?

It doesn't look to me like this affects us. But this matter is somewhat complex - https://github.com/django/django/commit/bb64b99b78a579cb2f6178011a4cf9366e634438 is the corresponding commit, for reference. It seems that our default caching backend `BMemcached` is not covered by this fix:
```
In [12]: c = get_cache_backend("default")

In [13]: c.set('somekey6', None)

In [14]: c.has_key('somekey6')
Out[14]: False
```

so `has_key` and the other affected functions still fail to recognize cached `None` values in this cache backend - which is exactly the old behavior - we don't use them though. `cache_get` recognizes cached `None` values though:
```
In [19]: c.set('x', None)

In [20]: c.set('y', 1)

In [21]: c.get_many(['x', 'y'])
Out[21]: {'x': None, 'y': 1}

# But (inconsistent behavior):
In [23]: c.has_key('x')
Out[23]: False

```

Now, other backends do correctly handle None values with `has_key` as well:
```
In [7]: c = get_cache_backend("database")

In [8]: c.set('somekey4', 1)

In [9]: c.has_key('somekey4')
Out[9]: True

In [10]: c.set('somekey5', None)

In [11]: c.has_key('somekey5')
Out[11]: True
```

Overall, it seems to me that we're fine with both behaviors - though the inconsistencies here are pretty bad...
