### PR TITLE
giphy: Add just space as a content to fool popover library.

### DIFF
--- a/static/js/giphy.js
+++ b/static/js/giphy.js
@@ -234,6 +234,10 @@ export function initialize() {
             html: true,
             trigger: "manual",
             template: get_popover_content(),
+            /* Popovers without a content property are not displayed,
+             * so we need something here; but we haven't contacted the
+             * Giphy API yet to get the actual content to display. */
+            content: " ",
         });
 
         active_popover_element.popover("show");


### PR DESCRIPTION
Since we don't have content for GIPHY popover at the time
popover is rendered, we need to render with some fake
content otherwise popover library doesn't allows for us
to show the popover.

This came into notice after 5adc6d7297c055de00661db8bd965138a2846091
broke show popover behaviour for GIPHY but didn't break it for
emoji popover as emoji popover already renders with some content.
Prior to this commit, popover library used `title` as content for
GIPHY popover.

Discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/giphy.20integration 