### PR TITLE
subs: Remove obsolete form

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -360,6 +360,10 @@ function show_subscription_settings(sub) {
     stream_color.set_colorpicker_color(colorpicker, color);
     stream_ui_updates.update_add_subscriptions_elements(sub);
 
+    if (!sub.render_subscribers) {
+        return;
+    }
+
     const container = $(
         `#subscription_overlay .subscription_settings[data-stream-id='${CSS.escape(
             stream_id,
@@ -372,9 +376,6 @@ function show_subscription_settings(sub) {
         get_text_from_item,
     });
 
-    if (!sub.render_subscribers) {
-        return;
-    }
     if (!stream_data.can_toggle_subscription(sub)) {
         stream_ui_updates.initialize_cant_subscribe_popover(sub);
     }

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -182,7 +182,7 @@ export function update_add_subscriptions_elements(sub) {
         return;
     }
 
-    if (page_params.is_guest) {
+    if (page_params.is_guest || page_params.realm_is_zephyr_mirror_realm) {
         // For guest users, we just hide the add_subscribers feature.
         $(".add_subscribers_container").hide();
         return;

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -657,6 +657,27 @@ export function setup_page(callback) {
             throttled_redraw_left_panel();
         });
 
+        // When hitting Enter in the stream creation box, we open the
+        // "create stream" UI with the stream name prepopulated.  This
+        // is only useful if the user has permission to create
+        // streams, either explicitly via user_can_create_streams, or
+        // implicitly because page_params.realm_is_zephyr_mirror_realm.
+        $("#stream_filter input[type='text']").on("keypress", (e) => {
+            if (e.which !== 13) {
+                return;
+            }
+
+            if (
+                settings_data.user_can_create_streams() ||
+                page_params.realm_is_zephyr_mirror_realm
+            ) {
+                open_create_stream();
+                e.preventDefault();
+                e.stopPropagation();
+                return;
+            }
+        });
+
         $("#clear_search_stream_name").on("click", () => {
             $("#stream_filter input[type='text']").val("");
             redraw_left_panel();

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -65,10 +65,6 @@
     font-weight: 300;
 }
 
-#add_new_subscription {
-    text-align: left;
-}
-
 .subscription_header {
     min-height: 47px;
 }
@@ -176,10 +172,6 @@
     text-decoration: none;
     background-color: hsl(0, 0%, 92%);
     border: 1px solid hsl(0, 0%, 68%);
-}
-
-form#add_new_subscription {
-    margin: 0;
 }
 
 .create_stream_button {

--- a/static/templates/subscription_table_body.hbs
+++ b/static/templates/subscription_table_body.hbs
@@ -10,17 +10,16 @@
             </div>
             <div class="left">
                 <div class="search-container">
-                    <form id="add_new_subscription" class="form-inline" action="">
+                    <div id="add_new_subscription">
                         {{#if can_create_streams}}
-                        <input type="submit" class="create_stream_button"
-                          value="+" title="{{t 'Create new stream' }} (n)"/>
+                        <button class="create_stream_button" title="{{t 'Create new stream' }} (n)">+</button>
                         {{/if}}
                         <div class="float-clear"></div>
-                    </form>
+                    </div>
                 </div>
                 <div class="input-append stream_name_search_section" id="stream_filter">
                     <input type="text" name="stream_name" id="search_stream_name" autocomplete="off"
-                      placeholder="{{t 'Filter streams' }}" value="" form="add_new_subscription" />
+                      placeholder="{{t 'Filter streams' }}" value=""/>
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_name">
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>


### PR DESCRIPTION
<a href = 'https://chat.zulip.org/#narrow/stream/9-issues/topic/reload.20from.20Manage.20streams'>Link to czo conversation</a>

Basically, Previously if a user (not having permission to create streams) tries to open the `stream-creation` modal by pressing the `Enter` hotkey, the browser would incorrectly reload the page and then put the user back to `Manage-stream` modal. 

The following pr resolves the mentioned issue by preventing the default behaviour of `stream-creation` modal if the user isn't permitted to create streams within the realm.

<details>
<summary><strong>Screenshots</strong></summary>
<br/>
<strong>Before</strong>

![earlier](https://user-images.githubusercontent.com/53977614/116814457-b53b8700-ab76-11eb-8ac4-dba15ce6c943.gif)

<strong>After</strong>

(No action takes place here if I press the `Enter` key!)
![fix](https://user-images.githubusercontent.com/53977614/116814615-7a861e80-ab77-11eb-9ff0-b0cf8c182751.gif)

</details> 

Edit: Was difficult for me to concise the exact bug and write it down within the commit summary!