### PR TITLE
Add moderators only option in wildcard mention policy.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -368,6 +368,14 @@ test_ui("test_wildcard_mention_allowed", () => {
     assert(compose.wildcard_mention_allowed());
 
     page_params.realm_wildcard_mention_policy =
+        settings_config.wildcard_mention_policy_values.by_moderators_only.code;
+    page_params.is_moderator = false;
+    assert(!compose.wildcard_mention_allowed());
+
+    page_params.is_moderator = true;
+    assert(compose.wildcard_mention_allowed());
+
+    page_params.realm_wildcard_mention_policy =
         settings_config.wildcard_mention_policy_values.by_stream_admins_only.code;
     page_params.is_admin = false;
     assert(!compose.wildcard_mention_allowed());

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -522,6 +522,13 @@ export function wildcard_mention_allowed() {
         // TODO: Check the user's stream-level role once stream-level admins exist.
         return page_params.is_admin;
     }
+
+    if (
+        page_params.realm_wildcard_mention_policy ===
+        settings_config.wildcard_mention_policy_values.by_moderators_only.code
+    ) {
+        return page_params.is_admin || page_params.is_moderator;
+    }
     // TODO: Uncomment when we add support for stream-level administrators.
     // if (
     //     page_params.realm_wildcard_mention_policy ===

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -168,11 +168,16 @@ export const wildcard_mention_policy_values = {
         code: 3,
         description: $t({defaultMessage: "Admins and full members"}),
     },
+    by_moderators_only: {
+        order: 4,
+        code: 7,
+        description: $t({defaultMessage: "Admins and moderators"}),
+    },
     // Until we add stream administrators, we mislabel this choice
     // (which we intend to be the long-term default) as "Admins only"
     // and don't offer the long-term "Admins only" option.
     by_stream_admins_only: {
-        order: 4,
+        order: 5,
         code: 4,
         //  description: $t({defaultMessage: "Organization and stream admins"}),
         description: $t({defaultMessage: "Admins only"}),

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,10 @@ below features are supported.
 
 ## Changes in Zulip 4.0
 
+**Feature level 62**
+
+* Added `moderators only` option for `wildcard_mention_policy`.
+
 **Feature level 61**
 
 * Added support for inviting users as moderators to the invitation

--- a/version.py
+++ b/version.py
@@ -30,7 +30,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 61
+API_FEATURE_LEVEL = 62
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -1398,6 +1398,9 @@ def wildcard_mention_allowed(sender: UserProfile, stream: Stream) -> bool:
     if realm.wildcard_mention_policy == Realm.WILDCARD_MENTION_POLICY_ADMINS:
         return sender.is_realm_admin
 
+    if realm.wildcard_mention_policy == Realm.WILDCARD_MENTION_POLICY_MODERATORS:
+        return sender.is_realm_admin or sender.is_moderator
+
     if realm.wildcard_mention_policy == Realm.WILDCARD_MENTION_POLICY_STREAM_ADMINS:
         # TODO: Change this when we implement stream administrators
         return sender.is_realm_admin

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -305,6 +305,7 @@ class Realm(models.Model):
     WILDCARD_MENTION_POLICY_STREAM_ADMINS = 4
     WILDCARD_MENTION_POLICY_ADMINS = 5
     WILDCARD_MENTION_POLICY_NOBODY = 6
+    WILDCARD_MENTION_POLICY_MODERATORS = 7
     wildcard_mention_policy: int = models.PositiveSmallIntegerField(
         default=WILDCARD_MENTION_POLICY_STREAM_ADMINS,
     )
@@ -315,6 +316,7 @@ class Realm(models.Model):
         WILDCARD_MENTION_POLICY_STREAM_ADMINS,
         WILDCARD_MENTION_POLICY_ADMINS,
         WILDCARD_MENTION_POLICY_NOBODY,
+        WILDCARD_MENTION_POLICY_MODERATORS,
     ]
 
     # Who in the organization has access to users' actual email

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3257,11 +3257,13 @@ paths:
                                         * 4 => Only stream and organization administrators can use wildcard mentions in large streams.
                                         * 5 => Only organization administrators can use wildcard mentions in large streams.
                                         * 6 => Nobody can use wildcard mentions in large streams.
+                                        * 7 => Only organization adminstartors and moderators can use wildcard mentions in large streams.
 
                                         All users will receive a warning/reminder when using
                                         mentions in large streams, even when permitted to do so.
 
-                                        **Changes**: New in Zulip 4.0 (feature level 33).
+                                        **Changes**: New in Zulip 4.0 (feature level 33). Moderators option added in
+                                        Zulip 4.0 (feature level 62).
                                     default_language:
                                       type: string
                                       description: |
@@ -8208,11 +8210,13 @@ paths:
                           * 4 => Only stream and organization administrators can use wildcard mentions in large streams.
                           * 5 => Only organization administrators can use wildcard mentions in large streams.
                           * 6 => Nobody can use wildcard mentions in large streams.
+                          * 7 => Only organization adminstartors and moderators can use wildcard mentions in large streams.
 
                           All users will receive a warning/reminder when using
                           mentions in large streams, even when permitted to do so.
 
-                          **Changes**: New in Zulip 4.0 (feature level 33).
+                          **Changes**: New in Zulip 4.0 (feature level 33). Moderators option added in
+                          Zulip 4.0 (feature level 62).
                       realm_default_language:
                         type: string
                         description: |

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1979,7 +1979,7 @@ class RealmPropertyActionTest(BaseAction):
             invite_to_stream_policy=[4, 3, 2, 1],
             private_message_policy=[2, 1],
             user_group_edit_policy=[1, 2],
-            wildcard_mention_policy=[6, 5, 4, 3, 2, 1],
+            wildcard_mention_policy=[7, 6, 5, 4, 3, 2, 1],
             email_address_visibility=[Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS],
             bot_creation_policy=[Realm.BOT_CREATION_EVERYONE],
             video_chat_provider=[

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1832,9 +1832,9 @@ class StreamMessagesTest(ZulipTestCase):
         do_set_realm_property(
             realm, "wildcard_mention_policy", Realm.WILDCARD_MENTION_POLICY_ADMINS, acting_user=None
         )
-        self.send_and_verify_wildcard_mention_message("cordelia", test_fails=True)
+        self.send_and_verify_wildcard_mention_message("shiva", test_fails=True)
         # There is no restriction on small streams.
-        self.send_and_verify_wildcard_mention_message("cordelia", sub_count=10)
+        self.send_and_verify_wildcard_mention_message("shiva", sub_count=10)
         self.send_and_verify_wildcard_mention_message("iago")
 
         do_set_realm_property(

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1827,6 +1827,16 @@ class StreamMessagesTest(ZulipTestCase):
         self.send_and_verify_wildcard_mention_message("cordelia", sub_count=10)
         self.send_and_verify_wildcard_mention_message("iago")
 
+        do_set_realm_property(
+            realm,
+            "wildcard_mention_policy",
+            Realm.WILDCARD_MENTION_POLICY_MODERATORS,
+            acting_user=None,
+        )
+        self.send_and_verify_wildcard_mention_message("cordelia", test_fails=True)
+        self.send_and_verify_wildcard_mention_message("cordelia", sub_count=10)
+        self.send_and_verify_wildcard_mention_message("shiva")
+
         cordelia.date_joined = timezone_now()
         cordelia.save()
         do_set_realm_property(

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -892,6 +892,7 @@ class RealmAPITest(ZulipTestCase):
                 Realm.WILDCARD_MENTION_POLICY_STREAM_ADMINS,
                 Realm.WILDCARD_MENTION_POLICY_ADMINS,
                 Realm.WILDCARD_MENTION_POLICY_NOBODY,
+                Realm.WILDCARD_MENTION_POLICY_MODERATORS,
             ],
             bot_creation_policy=[1, 2],
             email_address_visibility=[


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds `moderators only` option in`wildcard_mention_policy`.
Also added a commit to refactor test.

I have added `WILDCARD_MENTION_POLICY_MODERATORS` as 7 for now after
`WILDCARD_MENTION_POLICY_NOBODY` which is `6`, I know this is not the order
we would want but we would require a migration if we try to keep the order, so I just
did this for now, this can be changed if we want to,
 <!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
