### PR TITLE
upgrade: Use restart-server unless --skip-puppet is used.

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -310,7 +310,10 @@ if migrations_needed:
 subprocess.check_call(["./manage.py", "create_realm_internal_bots"], preexec_fn=su_to_zulip)
 
 logging.info("Restarting Zulip...")
-if IS_SERVER_UP:
+if IS_SERVER_UP or not args.skip_puppet:
+    # Even if the server wasn't up previously, puppet might have
+    # started it if there were supervisord configuration changes, so
+    # we need to use restart-server if puppet ran.
     subprocess.check_output(["./scripts/restart-server", "--fill-cache"], preexec_fn=su_to_zulip)
 else:
     subprocess.check_output(["./scripts/start-server", "--fill-cache"], preexec_fn=su_to_zulip)


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/9-issues/topic/Upgrade.20to.20master.20causes.20server.20unable.20to.20connect.20to.20Tornado

In some cases, puppet can end up restarting supervisord services - which
will use code from the old deployment, because when puppet runs,
/home/zulip/deployments/current still points there. Thus restart-server
needs to be used in favor of start-server, unless we know that puppet
has been skipped.
