### PR TITLE
Exclude muted users from more UI parts.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -39,6 +39,7 @@ const typeahead = zrequire("../shared/js/typeahead");
 const compose_state = zrequire("compose_state");
 zrequire("templates");
 const typeahead_helper = zrequire("typeahead_helper");
+const muting = zrequire("muting");
 const people = zrequire("people");
 const user_groups = zrequire("user_groups");
 const stream_data = zrequire("stream_data");
@@ -1542,4 +1543,27 @@ test("message people", (override) => {
     results = get_results("Ha");
     // harry is excluded since it has been deactivated.
     assert.deepEqual(results, [hamletcharacters, hal]);
+});
+
+test("muted users excluded from results", () => {
+    // This logic is common to PM recipients as well as
+    // mentions typeaheads, so we need only test once.
+    let results;
+    const opts = {
+        want_groups: false,
+        want_broadcast: true,
+    };
+
+    // Nobody is muted
+    results = ct.get_person_suggestions("corde", opts);
+    assert.deepEqual(results, [cordelia]);
+
+    // Mute Cordelia, and test that she's excluded from results.
+    muting.add_muted_user(cordelia.user_id);
+    results = ct.get_person_suggestions("corde", opts);
+    assert.deepEqual(results, []);
+
+    // Make sure our muting logic doesn't break wildcard mentions.
+    results = ct.get_person_suggestions("all", opts);
+    assert.deepEqual(results, [mention_all]);
 });

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -14,6 +14,7 @@ import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
 import {$t} from "./i18n";
 import * as message_store from "./message_store";
+import * as muting from "./muting";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as rows from "./rows";
@@ -445,10 +446,13 @@ export function get_person_suggestions(query, opts) {
         } else {
             persons = all_persons;
         }
+        // Exclude muted users from typeaheads.
+        persons = muting.filter_muted_users(persons);
 
         if (opts.want_broadcast) {
             persons = persons.concat(broadcast_mentions());
         }
+
         return persons.filter((item) => query_matches_person(query, item));
     }
 


### PR DESCRIPTION
This deals with-
- Typing notifications
- PM recipients typeahead
- @ mentions typeahead

Tested manually, and also added node tests.