### PR TITLE
invites_modal: Replace modal confirmation text to Confirm.

### DIFF
--- a/static/templates/settings/resend_invite_modal.hbs
+++ b/static/templates/settings/resend_invite_modal.hbs
@@ -18,6 +18,6 @@
     </div>
     <div class="modal-footer">
         <button class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
-        <button class="button rounded btn-danger" id="do_resend_invite_button" data-invite-id="{{invite_id}}">{{t "Resend now" }}</button>
+        <button class="button rounded btn-danger" id="do_resend_invite_button" data-invite-id="{{invite_id}}">{{t "Confirm" }}</button>
     </div>
 </div>

--- a/static/templates/settings/revoke_invite_modal.hbs
+++ b/static/templates/settings/revoke_invite_modal.hbs
@@ -16,6 +16,6 @@
     </div>
     <div class="modal-footer">
         <button class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
-        <button class="button rounded btn-danger" id="do_revoke_invite_button">{{t "Revoke now" }}</button>
+        <button class="button rounded btn-danger" id="do_revoke_invite_button">{{t "Confirm" }}</button>
     </div>
 </div>


### PR DESCRIPTION
Followup of #17926 (Basically, should have been a part of #18073).

<strong>Screenshots</strong>

<strong>Revoke confirmation modal</strong>
![Screenshot from 2021-05-04 00-56-18](https://user-images.githubusercontent.com/53977614/116922924-9cfd6200-ac73-11eb-9b0d-63faae10888f.png)

<strong>Resend confirmation modal</strong>
![Screenshot from 2021-05-04 00-56-28](https://user-images.githubusercontent.com/53977614/116922928-9d95f880-ac73-11eb-9d75-07774265dac7.png)

FYI @nikhilmaske-2001.