### PR TITLE
worker: Allow long MissedMessageWorker consumes.

### DIFF
--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -561,6 +561,12 @@ class MissedMessageWorker(QueueProcessingWorker):
     # of the consumer.
     lock = Lock()
 
+    # Because the background `maybe_send_batched_email` thread can
+    # hold the lock for an indeterminate amount of time, the `consume`
+    # can block on that for longer than 30s, the default worker
+    # timeout.  Allow arbitrarily-long worker `consume` calls.
+    MAX_CONSUME_SECONDS = None
+
     def consume(self, event: Dict[str, Any]) -> None:
         with self.lock:
             logging.debug("Received missedmessage_emails event: %s", event)


### PR DESCRIPTION
This will stop dropping events in the case that the background
`maybe_send_batched_email` thread takes longer than 30s.  However, see
also #15280 and the TODO comment about how we lose events upon
restart; this worker is still lossy.
