### PR TITLE
outgoing_webhook: Set a default timeout of 10s.

### DIFF
--- a/templates/zerver/api/outgoing-webhooks.md
+++ b/templates/zerver/api/outgoing-webhooks.md
@@ -34,6 +34,16 @@ There are currently two ways to trigger an outgoing webhook:
 2.  **Send a private message** with the bot as one of the recipients.
     If the bot replies, its reply will be sent to that thread.
 
+## Timeouts
+
+The remote server must respond to a `POST` request in a timely manner.
+The default timeout for outgoing webhooks is 10 seconds, though this
+can be configured by the administrator of the Zulip server by setting
+`OUTGOING_WEBHOOKS_TIMEOUT_SECONDS` in the [server's
+settings][settings].
+
+[settings]: https://zulip.readthedocs.io/en/latest/subsystems/settings.html#server-settings
+
 ## Outgoing webhook format
 
 This is an example of the JSON payload that the Zulip server will `POST`

--- a/zerver/lib/outgoing_http.py
+++ b/zerver/lib/outgoing_http.py
@@ -1,0 +1,25 @@
+from typing import Any, Dict, Optional
+
+import requests
+from urllib3 import HTTPResponse
+
+
+class OutgoingSession(requests.Session):
+    def __init__(self, timeout: int, headers: Optional[Dict[str, str]] = None) -> None:
+        super().__init__()
+        outgoing_adapter = OutgoingHTTPAdapter(timeout=timeout)
+        self.mount("http://", outgoing_adapter)
+        self.mount("https://", outgoing_adapter)
+
+
+class OutgoingHTTPAdapter(requests.adapters.HTTPAdapter):
+    timeout: int
+
+    def __init__(self, timeout: int, *args: Any, **kwargs: Any) -> None:
+        self.timeout = timeout
+        super().__init__(*args, *kwargs)
+
+    def send(self, *args: Any, **kwargs: Any) -> HTTPResponse:
+        if kwargs.get("timeout") is None:
+            kwargs["timeout"] = self.timeout
+        return super().send(*args, **kwargs)

--- a/zerver/lib/outgoing_http.py
+++ b/zerver/lib/outgoing_http.py
@@ -5,17 +5,19 @@ from urllib3 import HTTPResponse
 
 
 class OutgoingSession(requests.Session):
-    def __init__(self, timeout: int, headers: Optional[Dict[str, str]] = None) -> None:
+    def __init__(self, role: str, timeout: int) -> None:
         super().__init__()
-        outgoing_adapter = OutgoingHTTPAdapter(timeout=timeout)
+        outgoing_adapter = OutgoingHTTPAdapter(role=role, timeout=timeout)
         self.mount("http://", outgoing_adapter)
         self.mount("https://", outgoing_adapter)
 
 
 class OutgoingHTTPAdapter(requests.adapters.HTTPAdapter):
+    role: str
     timeout: int
 
-    def __init__(self, timeout: int, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, role: str, timeout: int, *args: Any, **kwargs: Any) -> None:
+        self.role = role
         self.timeout = timeout
         super().__init__(*args, *kwargs)
 
@@ -23,3 +25,6 @@ class OutgoingHTTPAdapter(requests.adapters.HTTPAdapter):
         if kwargs.get("timeout") is None:
             kwargs["timeout"] = self.timeout
         return super().send(*args, **kwargs)
+
+    def proxy_headers(self, proxy: str) -> Dict[str, str]:
+        return {"X-Smokescreen-Role": self.role}

--- a/zerver/lib/outgoing_http.py
+++ b/zerver/lib/outgoing_http.py
@@ -5,11 +5,13 @@ from urllib3 import HTTPResponse
 
 
 class OutgoingSession(requests.Session):
-    def __init__(self, role: str, timeout: int) -> None:
+    def __init__(self, role: str, timeout: int, headers: Optional[Dict[str, str]] = None) -> None:
         super().__init__()
         outgoing_adapter = OutgoingHTTPAdapter(role=role, timeout=timeout)
         self.mount("http://", outgoing_adapter)
         self.mount("https://", outgoing_adapter)
+        if headers:
+            self.headers.update(headers)
 
 
 class OutgoingHTTPAdapter(requests.adapters.HTTPAdapter):

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -34,11 +34,11 @@ class OutgoingWebhookServiceInterface(metaclass=abc.ABCMeta):
         self.user_profile: UserProfile = user_profile
         self.service_name: str = service_name
         self.session: requests.Session = OutgoingSession(
+            role="webhook",
             timeout=10,
         )
         self.session.headers.update(
             {
-                "X-Smokescreen-Role": "webhook",
                 "User-Agent": "ZulipOutgoingWebhook/" + ZULIP_VERSION,
             }
         )

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -346,7 +346,7 @@ def do_rest_call(
             bot_profile.realm.string_id,
             perf_counter() - start_time,
         )
-        if not response:
+        if response is None:
             return None
         if str(response.status_code).startswith("2"):
             try:

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -36,11 +36,7 @@ class OutgoingWebhookServiceInterface(metaclass=abc.ABCMeta):
         self.session: requests.Session = OutgoingSession(
             role="webhook",
             timeout=10,
-        )
-        self.session.headers.update(
-            {
-                "User-Agent": "ZulipOutgoingWebhook/" + ZULIP_VERSION,
-            }
+            headers={"User-Agent": "ZulipOutgoingWebhook/" + ZULIP_VERSION},
         )
 
     @abc.abstractmethod

--- a/zerver/tests/test_outgoing_http.py
+++ b/zerver/tests/test_outgoing_http.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+import requests
+import responses
+
+from zerver.lib.outgoing_http import OutgoingSession
+from zerver.lib.test_classes import ZulipTestCase
+
+
+class RequestMockWithTimeoutAsHeader(responses.RequestsMock):
+    def _on_request(
+        self,
+        adapter: requests.adapters.HTTPAdapter,
+        request: requests.PreparedRequest,
+        **kwargs: Any,
+    ) -> requests.Response:
+        if kwargs.get("timeout") is not None:
+            request.headers["X-Timeout"] = kwargs["timeout"]
+        return super()._on_request(  # type: ignore[misc]  # This is an undocumented internal API
+            adapter,
+            request,
+            **kwargs,
+        )
+
+
+class TestOutgoingHttp(ZulipTestCase):
+    def test_timeouts(self) -> None:
+        with RequestMockWithTimeoutAsHeader() as mock_requests:
+            mock_requests.add(responses.GET, "http://example.com/")
+            OutgoingSession(timeout=17).get("http://example.com/")
+            self.assertEqual(len(mock_requests.calls), 1)
+            self.assertEqual(mock_requests.calls[0].request.headers["X-Timeout"], 17)
+
+        with RequestMockWithTimeoutAsHeader() as mock_requests:
+            mock_requests.add(responses.GET, "http://example.com/")
+            OutgoingSession(timeout=17).get("http://example.com/", timeout=42)
+            self.assertEqual(len(mock_requests.calls), 1)
+            self.assertEqual(mock_requests.calls[0].request.headers["X-Timeout"], 42)

--- a/zerver/tests/test_outgoing_http.py
+++ b/zerver/tests/test_outgoing_http.py
@@ -1,10 +1,34 @@
+import os
 from typing import Any
+from unittest import mock
 
 import requests
 import responses
 
 from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.test_classes import ZulipTestCase
+
+
+class RequestMockWithProxySupport(responses.RequestsMock):
+    def _on_request(
+        self,
+        adapter: requests.adapters.HTTPAdapter,
+        request: requests.PreparedRequest,
+        **kwargs: Any,
+    ) -> requests.Response:
+        if "proxies" in kwargs and request.url:
+            proxy_uri = requests.utils.select_proxy(request.url, kwargs["proxies"])
+            if proxy_uri is not None:
+                request = requests.Request(
+                    method="GET",
+                    url="{}/".format(proxy_uri),
+                    headers=adapter.proxy_headers(proxy_uri),
+                ).prepare()
+        return super()._on_request(  # type: ignore[misc]  # This is an undocumented internal API
+            adapter,
+            request,
+            **kwargs,
+        )
 
 
 class RequestMockWithTimeoutAsHeader(responses.RequestsMock):
@@ -24,15 +48,24 @@ class RequestMockWithTimeoutAsHeader(responses.RequestsMock):
 
 
 class TestOutgoingHttp(ZulipTestCase):
+    @mock.patch.dict(os.environ, {"http_proxy": "http://localhost:4242"})
+    def test_proxy_headers(self) -> None:
+        with RequestMockWithProxySupport() as mock_requests:
+            mock_requests.add(responses.GET, "http://localhost:4242/")
+            OutgoingSession(role="testing", timeout=1).get("http://example.com/")
+            self.assertEqual(len(mock_requests.calls), 1)
+            headers = mock_requests.calls[0].request.headers
+            self.assertEqual(headers["X-Smokescreen-Role"], "testing")
+
     def test_timeouts(self) -> None:
         with RequestMockWithTimeoutAsHeader() as mock_requests:
             mock_requests.add(responses.GET, "http://example.com/")
-            OutgoingSession(timeout=17).get("http://example.com/")
+            OutgoingSession(role="testing", timeout=17).get("http://example.com/")
             self.assertEqual(len(mock_requests.calls), 1)
             self.assertEqual(mock_requests.calls[0].request.headers["X-Timeout"], 17)
 
         with RequestMockWithTimeoutAsHeader() as mock_requests:
             mock_requests.add(responses.GET, "http://example.com/")
-            OutgoingSession(timeout=17).get("http://example.com/", timeout=42)
+            OutgoingSession(role="testing", timeout=17).get("http://example.com/", timeout=42)
             self.assertEqual(len(mock_requests.calls), 1)
             self.assertEqual(mock_requests.calls[0].request.headers["X-Timeout"], 42)

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -207,7 +207,7 @@ The webhook got a response with status code *400*.""",
             self.assertEqual(bot_owner_notification.recipient_id, bot_user.bot_owner.recipient_id)
 
         with self.assertLogs(level="INFO") as i:
-            helper(side_effect=timeout_error, error_text="A timeout occurred.")
+            helper(side_effect=timeout_error, error_text="Request timed out after")
             helper(side_effect=connection_error, error_text="A connection error occurred.")
 
             log_output = [

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -185,7 +185,6 @@ The webhook got a response with status code *400*.""",
             headers = {
                 "Content-Type": "application/json",
                 "User-Agent": user_agent,
-                "X-Smokescreen-Role": "webhook",
             }
             self.assertLessEqual(headers.items(), prepared_request.headers.items())
 

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -450,3 +450,6 @@ DEFAULT_DATA_EXPORT_IMPORT_PARALLELISM = (len(os.sched_getaffinity(0)) // 2) or 
 # Default is 18 months, constructed as 12 months before someone should
 # upgrade, plus 6 months for the system administrator to get around to it.
 SERVER_UPGRADE_NAG_DEADLINE_DAYS = 30 * 18
+
+# How long servers have to respond to outgoing webhook requests
+OUTGOING_WEBHOOK_TIMEOUT_SECONDS = 10

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -588,6 +588,9 @@ SOCIAL_AUTH_SAML_SUPPORT_CONTACT = {
 ################
 ## Miscellaneous settings.
 
+## How long outgoing webhook requests time out after
+# OUTGOING_WEBHOOK_TIMEOUT_SECONDS = 10
+
 ## Support for mobile push notifications.  Setting controls whether
 ## push notifications will be forwarded through a Zulip push
 ## notification bouncer server to the mobile apps.  See


### PR DESCRIPTION
Support for the timeouts, and tests for them, was added in
53a8b2ac87bf -- though no code could have set them after 31597cf33e23.

Add a 10-second default timeout.  Observationally, p99 is just about
5s, with everything else being previously being destined to meet the
30s worker timeout; 10s provides a sizable buffer between them.

Fixes #17742.
