### PR TITLE
settings_users: Fix the sorting of owner and admin in users list.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -57,16 +57,19 @@ function sort_bot_email(a, b) {
 
 function sort_role(a, b) {
     function role(user) {
-        if (user.is_admin) {
+        if (user.is_owner) {
             return 0;
         }
-        if (user.is_moderator) {
+        if (user.is_admin) {
             return 1;
         }
-        if (user.is_guest) {
-            return 3;
+        if (user.is_moderator) {
+            return 2;
         }
-        return 2; // member
+        if (user.is_guest) {
+            return 4;
+        }
+        return 3; // member
     }
     return compare_a_b(role(a), role(b));
 }


### PR DESCRIPTION
We were not considering the owner role in `sort_role` function
which was leading to improper sorting when sorting the users
list according to role. This PR fixes this bug by considering
role in `sort_role` function.

Reported here - https://chat.zulip.org/#narrow/stream/9-issues/topic/user.20list.20sorting/near/1174252

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


 <!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
