### PR TITLE
css: Remove grey styling for day theme compose buttons.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -11,7 +11,6 @@
             font-size: 1em;
             padding: 3px 10px;
             vertical-align: middle;
-            background-color: hsla(0, 0%, 0%, 0.1);
         }
 
         .compose_mobile_button {

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -32,10 +32,6 @@ body.night-mode {
         background-color: hsl(212, 28%, 18%);
     }
 
-    #compose_buttons .new_message_button .button.small {
-        background-color: hsla(0, 0%, 0%, 0.2);
-    }
-
     #compose_buttons
         .reply_button_container
         .compose_reply_button


### PR DESCRIPTION
This day theme styling was added in
74dbcdf2a89d5a63894848ea10bf6eb798de644d, and some users interpreted
this buttons styling as suggesting that these buttons were disabled.
