### PR TITLE
navbar_alerts: Add button to hide "Server Upgrade" alert for 7 days.

### DIFF
--- a/frontend_tests/node_tests/panels.js
+++ b/frontend_tests/node_tests/panels.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const {strict: assert} = require("assert");
+
+const {addDays} = require("date-fns");
+
+const {mock_cjs, set_global, zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
+const $ = require("../zjsunit/zjquery");
+
+mock_cjs("jquery", $);
+
+const ls_container = new Map();
+
+const localStorage = set_global("localStorage", {
+    getItem(key) {
+        return ls_container.get(key);
+    },
+    setItem(key, val) {
+        ls_container.set(key, val);
+    },
+    removeItem(key) {
+        ls_container.delete(key);
+    },
+    clear() {
+        ls_container.clear();
+    },
+});
+
+const {localstorage} = zrequire("localstorage");
+const panels = zrequire("panels");
+
+function test(label, f) {
+    run_test(label, (override) => {
+        localStorage.clear();
+        f(override);
+    });
+}
+
+test("server_upgrade_alert hide_duration_expired", (override) => {
+    const ls = localstorage();
+    const start_time = new Date(1620327447050); // Thursday 06/5/2021 07:02:27 AM (UTC+0)
+
+    override(Date, "now", () => start_time);
+    assert.equal(ls.get("lastUpgradeNagDismissalTime"), undefined);
+    assert.equal(panels.should_show_server_upgrade_notification(ls), true);
+    panels.dismiss_upgrade_nag(ls);
+    assert.equal(panels.should_show_server_upgrade_notification(ls), false);
+
+    override(Date, "now", () => addDays(start_time, 8)); // Friday 14/5/2021 07:02:27 AM (UTC+0)
+    assert.equal(panels.should_show_server_upgrade_notification(ls), true);
+    panels.dismiss_upgrade_nag(ls);
+    assert.equal(panels.should_show_server_upgrade_notification(ls), false);
+});

--- a/templates/zerver/app/navbar_alerts.html
+++ b/templates/zerver/app/navbar_alerts.html
@@ -48,9 +48,14 @@
     <div data-process="server-needs-upgrade" class="alert alert-info red">
         <div data-step="1">
             {{ _("This Zulip server is running an old version and should be upgraded.") }}
-            <a class="alert-link" href="https://zulip.readthedocs.io/en/latest/overview/release-lifecycle.html#upgrade-nag" target="_blank" rel="noopener noreferrer">
-                {{ _("Learn more.") }}
-            </a>
+            <span class="buttons">
+                <a class="alert-link" href="https://zulip.readthedocs.io/en/latest/overview/release-lifecycle.html#upgrade-nag" target="_blank" rel="noopener noreferrer">
+                    {{ _("Learn more") }}
+                </a>
+                &bull;
+                <a class="alert-link dismiss-upgrade-nag" role="button" tabindex=0>{{ _("Dismiss for a week") }}</a>
+            </span>
+
         </div>
         <span class="close" data-dismiss="alert" aria-label="{{ _('Close') }}" role="button" tabindex=0>&times;</span>
     </div>


### PR DESCRIPTION
Fixes: #18359

This button will help users to avoid a scary red banner
across their screen, while they wait for their sysadmin to
do the upgrade work.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested in the following states locally:
- Avoid for one week.
- After one week.
- If the local storage value doesn't exist.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot 2021-05-05 at 11 08 36 PM](https://user-images.githubusercontent.com/63820270/117188235-7584d180-adfa-11eb-96f3-23b76ab993b2.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
