### PR TITLE
apps: Link to macOS Apple silicon native build

### DIFF
--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -111,10 +111,10 @@ const apps_events = function () {
 
         $(".info .platform").text(version_info.alt);
         $(".info .description").text(version_info.description);
-        $(".info .desktop-download-link").attr("href", version_info.download_link);
-        $(".download-from-google-play-store").attr("href", version_info.play_store_link);
-        $(".download-from-apple-app-store").attr("href", version_info.app_store_link);
-        $("#download-android-apk a").attr("href", version_info.download_link);
+        $desktop_download_link.attr("href", version_info.download_link);
+        $download_from_google_play_store.attr("href", version_info.play_store_link);
+        $download_from_apple_app_store.attr("href", version_info.app_store_link);
+        $download_android_apk.attr("href", version_info.download_link);
         $(".image img").attr("src", version_info.image);
         $download_instructions.find("a").attr("href", version_info.install_guide);
 

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -41,6 +41,7 @@ const apps_events = function () {
             description:
                 "Zulip on macOS is even better than Zulip on the web, with a cleaner look, tray integration, native notifications, and support for multiple Zulip accounts.",
             download_link: "/apps/download/mac",
+            mac_arm64_link: "/apps/download/mac-arm64",
             show_instructions: true,
             install_guide: "/help/desktop-app-install-guide",
             app_type: "desktop",
@@ -106,6 +107,7 @@ const apps_events = function () {
         const $download_android_apk = $("#download-android-apk");
         const $download_from_google_play_store = $(".download-from-google-play-store");
         const $download_from_apple_app_store = $(".download-from-apple-app-store");
+        const $download_mac_arm64 = $("#download-mac-arm64");
         const $desktop_download_link = $(".desktop-download-link");
         const version_info = info[version];
 
@@ -115,6 +117,7 @@ const apps_events = function () {
         $download_from_google_play_store.attr("href", version_info.play_store_link);
         $download_from_apple_app_store.attr("href", version_info.app_store_link);
         $download_android_apk.attr("href", version_info.download_link);
+        $download_mac_arm64.attr("href", version_info.mac_arm64_link);
         $(".image img").attr("src", version_info.image);
         $download_instructions.find("a").attr("href", version_info.install_guide);
 
@@ -125,6 +128,7 @@ const apps_events = function () {
         $download_android_apk.toggle(version === "android");
         $download_from_google_play_store.toggle(version === "android");
         $download_from_apple_app_store.toggle(version === "ios");
+        $download_mac_arm64.toggle(version === "mac");
     };
 
     $(window).on("popstate", () => {

--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -3857,7 +3857,8 @@ nav {
     }
 }
 
-#download-android-apk {
+#download-android-apk,
+#download-mac-arm64 {
     display: inline-block;
     color: hsl(0, 0%, 100%);
     font-size: 13px;

--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -3857,7 +3857,7 @@ nav {
     }
 }
 
-#download-android-apk a {
+#download-android-apk {
     display: inline-block;
     color: hsl(0, 0%, 100%);
     font-size: 13px;

--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -25,7 +25,7 @@
                         <a class="desktop-download-link no-action" hidden href=""><span class="button green">Download Zulip for <span class="platform"></span></span></a>
                         <a class="download-from-google-play-store" hidden href=""><img src='/static/images/store-badges/google-play-badge.png' alt=""/></a>
                         <a class="download-from-apple-app-store" hidden href=""><img src='/static/images/store-badges/app-store-badge.svg' alt=""/></a>
-                        <span id="download-android-apk" hidden><a href="https://github.com/zulip/zulip-mobile/releases/latest">or manually download APK</a></span>
+                        <span><a id="download-android-apk" hidden href="https://github.com/zulip/zulip-mobile/releases/latest">or manually download APK</a></span>
                     </div>
                 </div>
             </div>

--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -26,6 +26,7 @@
                         <a class="download-from-google-play-store" hidden href=""><img src='/static/images/store-badges/google-play-badge.png' alt=""/></a>
                         <a class="download-from-apple-app-store" hidden href=""><img src='/static/images/store-badges/app-store-badge.svg' alt=""/></a>
                         <span><a id="download-android-apk" hidden href="https://github.com/zulip/zulip-mobile/releases/latest">or manually download APK</a></span>
+                        <span><a id="download-mac-arm64" hidden href="">or download Apple silicon native build</a></span>
                     </div>
                 </div>
             </div>

--- a/zerver/lib/github.py
+++ b/zerver/lib/github.py
@@ -29,6 +29,7 @@ def verify_release_download_link(link: str) -> bool:
 PLATFORM_TO_SETUP_FILE = {
     "linux": "Zulip-{version}-x86_64.AppImage",
     "mac": "Zulip-{version}.dmg",
+    "mac-arm64": "Zulip-{version}-arm64.dmg",
     "windows": "Zulip-Web-Setup-{version}.exe",
 }
 


### PR DESCRIPTION
Leave the Intel build as the prominent default, since it will run on both platforms.  (I would have liked to detect the appropriate platform, but Apple seems to have put significant effort into making that impossible for anti-fingerprinting reasons, which is probably an overall good.)

**GIFs or screenshots:**

![Screenshot 2021-05-05 at 15-52-34 Chat for distributed teams](https://user-images.githubusercontent.com/26471/117219362-f8396c80-adb9-11eb-83b5-3fe79637c191.png)
