### PR TITLE
Show alert state in Grafana webhook message body

### DIFF
--- a/docs/subsystems/logging.md
+++ b/docs/subsystems/logging.md
@@ -10,10 +10,10 @@ and zero known JavaScript exceptions on the frontend.  While there
 will always be new bugs being introduced, that goal is impossible
 without an efficient and effective error reporting framework.
 
-We expect to in the future integrate a service like [Sentry][sentry]
-to make it easier for very large installations like zulip.com to
-manage their exceptions and ensure they are all tracked down, but our
-default email-based system is great for small installations.
+We provide integration with [Sentry][sentry] to make it easier for
+very large installations like zulip.com to manage their exceptions and
+ensure they are all tracked down, but our default email-based system
+is great for small installations.
 
 ## Backend error reporting
 
@@ -39,6 +39,11 @@ infrastructure needed by our error reporting system:
 Since 500 errors in any Zulip server are usually a problem the server
 administrator should investigate and/or report upstream, we have this
 email reporting system configured to report errors by default.
+
+Zulip's optional [Sentry][sentry] integration will aggregate errors to
+show which users and realms are affected, any logging which happened
+prior to the exception, local variables in each frame of the
+exception, and the full request headers which triggered it.
 
 ### Backend logging
 


### PR DESCRIPTION
Show alert state in Grafana webhook message body

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Having the Alert State in the message body is useful when Alert Topics are not defined by alert description but encoded in url.

E.g. in large environments having a topic for each alert [alerting] and [ok] would make harder to properly track if an alert has been resolved.

When each Alert is in a single topic, so far, the alert state has been missing. This PR rectifies this. (This is similar to the Prometheus Alertmanager integration)

**Testing plan:** <!-- How have you tested? -->
Tested with Zulip 3.4

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![zulipAlerting](https://user-images.githubusercontent.com/15871966/117270277-55d0c600-ae59-11eb-91e0-13e4f285bfb3.png)




