### PR TITLE
recent_topics: Don't rerender which topic_data is unchanged.

### DIFF
--- a/frontend_tests/node_tests/example5.js
+++ b/frontend_tests/node_tests/example5.js
@@ -37,7 +37,6 @@ const message_events = zrequire("message_events");
 const message_store = zrequire("message_store");
 const narrow_state = zrequire("narrow_state");
 const people = zrequire("people");
-const recent_topics = zrequire("recent_topics");
 
 const isaac = {
     email: "isaac@example.com",
@@ -77,7 +76,6 @@ run_test("insert_message", (override) => {
     message_store.clear_for_testing();
 
     override(pm_list, "update_private_messages", () => {});
-    override(recent_topics, "is_visible", () => false);
 
     const helper = test_helper(override);
 

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -161,20 +161,30 @@ function get_topic_key(stream_id, topic) {
 }
 
 export function process_messages(messages) {
-    // FIX: Currently, we do a complete_rerender every time
-    // we process a new message.
     // While this is inexpensive and handles all the cases itself,
     // the UX can be bad if user wants to scroll down the list as
     // the UI will be returned to the beginning of the list on every
     // update.
+    //
+    // Only rerender if topic_data actually
+    // changed.
+    let topic_data_changed = false;
     for (const msg of messages) {
-        process_message(msg);
+        if (process_message(msg)) {
+            topic_data_changed = true;
+        }
     }
-    complete_rerender();
+
+    if (topic_data_changed) {
+        complete_rerender();
+    }
 }
 
 export function process_message(msg) {
+    // This function returns if topic_data
+    // has changed or not.
     if (msg.type !== "stream") {
+        // We don't process private messages yet.
         return false;
     }
     // Initialize topic data


### PR DESCRIPTION
Since we don't process private messages yet, we don't
need to re-render when we receive a new private message
as it doesn't change any data related to recent_topics.
