### PR TITLE
alert_words: Revert back `before_punctuation` regex to stable one.

### DIFF
--- a/static/js/alert_words.js
+++ b/static/js/alert_words.js
@@ -32,7 +32,7 @@ export function process_message(message) {
 
     for (const word of my_alert_words) {
         const clean = _.escapeRegExp(word);
-        const before_punctuation = "(?<=\\s)|^|>|[\\(\\\".,';\\[]";
+        const before_punctuation = "\\s|^|>|[\\(\\\".,';\\[]";
         const after_punctuation = "(?=\\s)|$|<|[\\)\\\"\\?!:.,';\\]!]";
 
         const regex = new RegExp(`(${before_punctuation})(${clean})(${after_punctuation})`, "ig");


### PR DESCRIPTION
In this 009b7bca24112bf4d429fe8f01e62edf8fc130ba commit `before_punctuation`
regex was updated to use lookbehind feature of regex.

This caused a regex error in some browsers (reported in
Safari) because lookbehind feature is not yet supported
on all the browsers (https://caniuse.com/js-regexp-lookbehind).

This PR fixes that error by reverting to stable regex which
works on all the browsers.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested by running node tests and logging in on safari.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
