### PR TITLE
node_tests: Add remaining tests for `panels.js`.

### DIFF
--- a/frontend_tests/node_tests/panels.js
+++ b/frontend_tests/node_tests/panels.js
@@ -7,6 +7,7 @@ const {addDays} = require("date-fns");
 const {mock_cjs, set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
+const {page_params} = require("../zjsunit/zpage_params");
 
 mock_cjs("jquery", $);
 
@@ -26,9 +27,17 @@ const localStorage = set_global("localStorage", {
         ls_container.clear();
     },
 });
+// Dependencies
+set_global("document", {
+    hasFocus() {
+        return true;
+    },
+});
 
 const {localstorage} = zrequire("localstorage");
 const panels = zrequire("panels");
+const notifications = zrequire("notifications");
+const util = zrequire("util");
 
 function test(label, f) {
     run_test(label, (override) => {
@@ -36,6 +45,55 @@ function test(label, f) {
         f(override);
     });
 }
+
+test("allow_notification_alert", () => {
+    const ls = localstorage();
+
+    // Show alert.
+    assert.equal(ls.get("dontAskForNotifications"), undefined);
+    util.is_mobile = () => false;
+    notifications.granted_desktop_notifications_permission = () => false;
+    notifications.permission_state = () => "granted";
+    assert.equal(panels.should_show_notifications(ls), true);
+
+    // Avoid showing if the user said to never show alert on this computer again.
+    ls.set("dontAskForNotifications", true);
+    assert.equal(panels.should_show_notifications(ls), false);
+
+    // Avoid showing if device is mobile.
+    ls.set("dontAskForNotifications", undefined);
+    assert.equal(panels.should_show_notifications(ls), true);
+    util.is_mobile = () => true;
+    assert.equal(panels.should_show_notifications(ls), false);
+
+    // Avoid showing if notificaiton permission is denied.
+    util.is_mobile = () => false;
+    assert.equal(panels.should_show_notifications(ls), true);
+    notifications.permission_state = () => "denied";
+    assert.equal(panels.should_show_notifications(ls), false);
+
+    // Avoid showing if notification is already granted.
+    notifications.permission_state = () => "granted";
+    notifications.granted_desktop_notifications_permission = () => "granted";
+    assert.equal(panels.should_show_notifications(ls), false);
+});
+
+test("profile_incomplete_alert", () => {
+    // Show alert.
+    page_params.is_admin = true;
+    page_params.realm_description = "Organization imported from Slack!";
+    assert.equal(panels.check_profile_incomplete(), true);
+
+    // Avoid showing if the user is not admin.
+    page_params.is_admin = false;
+    assert.equal(panels.check_profile_incomplete(), false);
+
+    // Avoid showing if the realm description is already updated.
+    page_params.is_admin = true;
+    assert.equal(panels.check_profile_incomplete(), true);
+    page_params.realm_description = "Organization description already set!";
+    assert.equal(panels.check_profile_incomplete(), false);
+});
 
 test("server_upgrade_alert hide_duration_expired", (override) => {
     const ls = localstorage();

--- a/static/js/panels.js
+++ b/static/js/panels.js
@@ -35,7 +35,7 @@ const get_step = function ($process) {
     return $process.find("[data-step]:visible").data("step");
 };
 
-function should_show_notifications(ls) {
+export function should_show_notifications(ls) {
     // if the user said to never show banner on this computer again, it will
     // be stored as `true` so we want to negate that.
     if (localstorage.supported() && ls.get("dontAskForNotifications") === true) {


### PR DESCRIPTION
In this PR, we add the node tests for `panels.js`,
which started in 2f36c5aefc812799f3a48bad432a2ffaf2dcac66 commit (it added
tests for server upgrade alert).

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested by running node test.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
