### PR TITLE
integrations: Enhance Grafana integration with alert state

### DIFF
--- a/zerver/webhooks/grafana/fixtures/alert_ok.json
+++ b/zerver/webhooks/grafana/fixtures/alert_ok.json
@@ -1,0 +1,20 @@
+{
+    "dashboardId": 1,
+    "evalMatches": [
+      {
+        "value": 0,
+        "metric": "High value",
+        "tags": null
+      }
+    ],
+    "imageUrl": "https://grafana.com/assets/img/blog/mixed_styles.png",
+    "message": "Someone is testing the alert notification within grafana.",
+    "orgId": 0,
+    "panelId": 1,
+    "ruleId": 0,
+    "ruleName": "Test rule",
+    "ruleUrl": "http://localhost:3000/",
+    "state": "ok",
+    "tags": {},
+    "title": "[Ok] Test notification"
+  }

--- a/zerver/webhooks/grafana/fixtures/alert_paused.json
+++ b/zerver/webhooks/grafana/fixtures/alert_paused.json
@@ -1,0 +1,13 @@
+{
+    "dashboardId": 1,
+    "imageUrl": "https://grafana.com/assets/img/blog/mixed_styles.png",
+    "message": "Someone is testing the alert notification within grafana.",
+    "orgId": 0,
+    "panelId": 1,
+    "ruleId": 0,
+    "ruleName": "Test rule",
+    "ruleUrl": "http://localhost:3000/",
+    "state": "paused",
+    "tags": {},
+    "title": "[Paused] Test notification"
+  }

--- a/zerver/webhooks/grafana/fixtures/alert_pending.json
+++ b/zerver/webhooks/grafana/fixtures/alert_pending.json
@@ -1,0 +1,25 @@
+{
+    "dashboardId": 1,
+    "evalMatches": [
+      {
+        "value": 100,
+        "metric": "High value",
+        "tags": null
+      },
+      {
+        "value": 200,
+        "metric": "Higher Value",
+        "tags": null
+      }
+    ],
+    "imageUrl": "https://grafana.com/assets/img/blog/mixed_styles.png",
+    "message": "Someone is testing the alert notification within grafana.",
+    "orgId": 0,
+    "panelId": 1,
+    "ruleId": 0,
+    "ruleName": "Test rule",
+    "ruleUrl": "http://localhost:3000/",
+    "state": "pending",
+    "tags": {},
+    "title": "[Pending] Test notification"
+  }

--- a/zerver/webhooks/grafana/tests.py
+++ b/zerver/webhooks/grafana/tests.py
@@ -10,6 +10,8 @@ class GrafanaHookTests(WebhookTestCase):
     def test_alert(self) -> None:
         expected_topic = "[Alerting] Test notification"
         expected_message = """
+:alert: **ALERTING**
+
 [Test rule](http://localhost:3000/)
 
 Someone is testing the alert notification within grafana.
@@ -31,6 +33,8 @@ Someone is testing the alert notification within grafana.
     def test_no_data_alert(self) -> None:
         expected_topic = "[Alerting] No Data alert"
         expected_message = """
+:alert: **ALERTING**
+
 [No Data alert](http://localhost:3000/d/GG2qhR3Wz/alerttest?fullscreen&edit&tab=alert&panelId=6&orgId=1)
 
 The panel has no data.
@@ -48,6 +52,8 @@ The panel has no data.
     def test_no_message_alert(self) -> None:
         expected_topic = "[Alerting] No Message alert"
         expected_message = """
+:alert: **ALERTING**
+
 [No Message alert](http://localhost:3000/d/GG2qhR3Wz/alerttest?fullscreen&edit&tab=alert&panelId=8&orgId=1)
 
 **A-series:** 21.573108436586445
@@ -56,6 +62,75 @@ The panel has no data.
         # use fixture named helloworld_hello
         self.check_webhook(
             "no_message_alert",
+            expected_topic,
+            expected_message,
+            content_type="application/x-www-form-urlencoded",
+        )
+
+    # Note: Include a test function per each distinct message condition your integration supports
+    def test_alert_ok(self) -> None:
+        expected_topic = "[Ok] Test notification"
+        expected_message = """
+:squared_ok: **OK**
+
+[Test rule](http://localhost:3000/)
+
+Someone is testing the alert notification within grafana.
+
+**High value:** 0
+
+[Click to view visualization](https://grafana.com/assets/img/blog/mixed_styles.png)
+""".strip()
+
+        # use fixture named helloworld_hello
+        self.check_webhook(
+            "alert_ok",
+            expected_topic,
+            expected_message,
+            content_type="application/x-www-form-urlencoded",
+        )
+
+    # Note: Include a test function per each distinct message condition your integration supports
+    def test_alert_paused(self) -> None:
+        expected_topic = "[Paused] Test notification"
+        expected_message = """
+:info: **PAUSED**
+
+[Test rule](http://localhost:3000/)
+
+Someone is testing the alert notification within grafana.
+
+
+[Click to view visualization](https://grafana.com/assets/img/blog/mixed_styles.png)
+""".strip()
+
+        # use fixture named helloworld_hello
+        self.check_webhook(
+            "alert_paused",
+            expected_topic,
+            expected_message,
+            content_type="application/x-www-form-urlencoded",
+        )
+
+    # Note: Include a test function per each distinct message condition your integration supports
+    def test_alert_pending(self) -> None:
+        expected_topic = "[Pending] Test notification"
+        expected_message = """
+:info: **PENDING**
+
+[Test rule](http://localhost:3000/)
+
+Someone is testing the alert notification within grafana.
+
+**High value:** 100
+**Higher Value:** 200
+
+[Click to view visualization](https://grafana.com/assets/img/blog/mixed_styles.png)
+""".strip()
+
+        # use fixture named helloworld_hello
+        self.check_webhook(
+            "alert_pending",
             expected_topic,
             expected_message,
             content_type="application/x-www-form-urlencoded",


### PR DESCRIPTION
Having the alert state in the message body is useful when alert topics are not defined by alert description but encoded in url.

E.g. in large environments having a topic for each alert [alerting] and [ok] would make it harder to properly track if an alert has been resolved.

When each alert is in a single topic, so far, the alert state has been missing.

This change will add the current alert state and a fitting icon in front of the alert name. (Similar to the prometheus alertmanager integration)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Feature enhancement, no issue existing.

**Testing plan:** <!-- How have you tested? -->

Tested with development instance on current master,
also tested on a prod env running 3.4 
Linted with ```./tools/lint```

Gitlab Actions are also all green.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![zulipAlerting](https://user-images.githubusercontent.com/15871966/117270277-55d0c600-ae59-11eb-91e0-13e4f285bfb3.png)

This is an improvement/duplicate of #18372 now with added tests.