### PR TITLE
node_tests: Update alert words tests to handle a corner case.

### DIFF
--- a/frontend_tests/node_tests/alert_words.js
+++ b/frontend_tests/node_tests/alert_words.js
@@ -48,7 +48,7 @@ const alertwordboundary_message = {
 };
 const multialert_message = {
     sender_email: "another@zulip.com",
-    content: "<p>another alertthreemessage alertone and then alerttwo</p>",
+    content: "<p>another emoji alertone and then alerttwo</p>",
     alerted: true,
 };
 const unsafe_word_message = {
@@ -128,7 +128,7 @@ run_test("munging", () => {
 
     assert_transform(
         multialert_message,
-        "<p>another alertthreemessage <span class='alert-word'>alertone</span> and then <span class='alert-word'>alerttwo</span></p>",
+        "<p>another <span class='alert-word'>emoji</span> <span class='alert-word'>alertone</span> and then <span class='alert-word'>alerttwo</span></p>",
     );
 
     assert_transform(


### PR DESCRIPTION
This corner case was reported in #17320, basically, the
issue was when two or more alert words were used
consecutively with a single space between them, it didn't
detect the even number word as `alert word`.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested by running node tests.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
