### PR TITLE
Issue 15686

### DIFF
--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -6,9 +6,11 @@ import {$t} from "./i18n";
 import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
+import * as people from "./people";
 import * as recent_topics from "./recent_topics";
 import * as rendered_markdown from "./rendered_markdown";
 import * as search from "./search";
+import * as user_status from "./user_status";
 
 function get_formatted_sub_count(sub_count) {
     if (sub_count >= 1000) {
@@ -40,6 +42,15 @@ function make_message_view_header(filter) {
         message_view_header.rendered_narrow_description = $t({
             defaultMessage: "This stream does not exist or is private.",
         });
+        return message_view_header;
+    }
+    if (filter.has_operator("pm-with")) {
+        const user_email = filter.operands("pm-with")[0];
+        // We dont fetch user status if the following is a group pm.
+        if (user_email.split(",").length < 2) {
+            const user_id = people.get_user_id(user_email);
+            message_view_header.user_status = user_status.get_status_text(user_id);
+        }
         return message_view_header;
     }
     if (filter._sub) {

--- a/static/templates/message_view_header.hbs
+++ b/static/templates/message_view_header.hbs
@@ -12,6 +12,13 @@
     {{t "(no description)"}}
     {{/if}}
 </span>
+{{else if user_status}}
+<span>
+    {{> navbar_icon_and_title }}
+</span>
+<span class="narrow_description rendered_markdown">
+    {{user_status}}
+</span>
 {{else}}
 <span>
     {{> navbar_icon_and_title }}


### PR DESCRIPTION

This PR resolves issue #15686. User status is now shown next to user's name in 1:1 (PM) conversations. 

I run the lint tests for the 2 files that were changed and resolved the errors.
Also i tested the functionality on localhost to ensure that it works as intended. 

![Screenshot 2021-05-08 at 12 33 55 AM](https://user-images.githubusercontent.com/43907486/117510897-8ae23300-af95-11eb-81bf-c99edfadeab0.jpg)

I have highlighted with green the change that was made.
  
