### PR TITLE
bot: Add a bot owner tab in realm_activity page.

### DIFF
--- a/analytics/tests/test_activity_views.py
+++ b/analytics/tests/test_activity_views.py
@@ -51,4 +51,4 @@ class ActivityTest(ZulipTestCase):
             result = self.client_get("/user_activity/iago@zulip.com/")
             self.assertEqual(result.status_code, 200)
 
-        self.assert_length(queries, 4)
+        self.assert_length(queries, 5)

--- a/analytics/views/activity_common.py
+++ b/analytics/views/activity_common.py
@@ -84,7 +84,9 @@ def remote_installation_stats_link(server_id: int, hostname: str) -> mark_safe:
     return mark_safe(stats_link)
 
 
-def get_user_activity_summary(records: List[QuerySet]) -> Dict[str, Dict[str, Any]]:
+def get_user_activity_summary(
+    records: List[QuerySet], is_bot: bool = False
+) -> Dict[str, Dict[str, Any]]:
     #: `Any` used above should be `Union(int, datetime)`.
     #: However current version of `Union` does not work inside other function.
     #: We could use something like:
@@ -106,7 +108,13 @@ def get_user_activity_summary(records: List[QuerySet]) -> Dict[str, Dict[str, An
             )
 
     if records:
-        summary["name"] = records[0].user_profile.full_name
+        user = records[0].user_profile
+        summary["name"] = user.full_name
+        summary["role"] = user.get_role_name()
+
+        if is_bot and user.bot_owner is not None:
+            summary["bot_owner"] = user.bot_owner.full_name
+            summary["bot_owner_email"] = user.bot_owner.delivery_email
 
     for record in records:
         client = record.client.name

--- a/analytics/views/realm_activity.py
+++ b/analytics/views/realm_activity.py
@@ -7,6 +7,7 @@ from django.db.models.query import QuerySet
 from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
 from django.shortcuts import render
 from django.utils.timezone import now as timezone_now
+from jinja2 import Markup as mark_safe
 from psycopg2.sql import SQL
 
 from analytics.views.activity_common import (
@@ -23,6 +24,9 @@ def get_user_activity_records_for_realm(realm: str, is_bot: bool) -> QuerySet:
     fields = [
         "user_profile__full_name",
         "user_profile__delivery_email",
+        "user_profile__role",
+        "user_profile__bot_owner__full_name",
+        "user_profile__bot_owner__delivery_email",
         "query",
         "client__name",
         "count",
@@ -35,12 +39,12 @@ def get_user_activity_records_for_realm(realm: str, is_bot: bool) -> QuerySet:
         user_profile__is_bot=is_bot,
     )
     records = records.order_by("user_profile__delivery_email", "-last_visit")
-    records = records.select_related("user_profile", "client").only(*fields)
+    records = records.select_related("user_profile__bot_owner", "client").only(*fields)
     return records
 
 
 def realm_user_summary_table(
-    all_records: List[QuerySet], admin_emails: Set[str]
+    all_records: List[QuerySet], admin_emails: Set[str], is_bot: bool
 ) -> Tuple[Dict[str, Dict[str, Any]], str]:
     user_records = {}
 
@@ -48,7 +52,7 @@ def realm_user_summary_table(
         return record.user_profile.delivery_email
 
     for email, records in itertools.groupby(all_records, by_email):
-        user_records[email] = get_user_activity_summary(list(records))
+        user_records[email] = get_user_activity_summary(list(records), is_bot)
 
     def get_last_visit(user_summary: Dict[str, Dict[str, datetime]], k: str) -> Optional[datetime]:
         if k in user_summary:
@@ -62,6 +66,12 @@ def realm_user_summary_table(
         else:
             return ""
 
+    def get_bot_owner_email(user_summary: Dict[str, Dict[str, str]]) -> mark_safe:
+        email = user_summary["bot_owner_email"]
+        bot_owner = user_summary["bot_owner"]
+        email_link = f'<a href="mailto:{email}">{bot_owner}</a>'
+        return mark_safe(email_link)
+
     def is_recent(val: Optional[datetime]) -> bool:
         age = timezone_now() - val
         return age.total_seconds() < 5 * 60
@@ -71,6 +81,12 @@ def realm_user_summary_table(
         email_link = user_activity_link(email)
         sent_count = get_count(user_summary, "send")
         cells = [user_summary["name"], email_link, sent_count]
+        role = user_summary["role"]
+        cells = [user_summary["name"], email_link, role, sent_count]
+
+        if "bot_owner" in user_summary:
+            cells[2] = get_bot_owner_email(user_summary)
+
         row_class = ""
         for field in ["use", "send", "pointer", "desktop", "ZulipiOS", "Android"]:
             visit = get_last_visit(user_summary, field)
@@ -92,6 +108,7 @@ def realm_user_summary_table(
     cols = [
         "Name",
         "Email",
+        "Role",
         "Total sent",
         "Heard from",
         "Message sent",
@@ -100,6 +117,9 @@ def realm_user_summary_table(
         "ZulipiOS",
         "Android",
     ]
+
+    if is_bot:
+        cols[2] = "Role" if not is_bot else "Bot owner"
 
     title = "Summary"
 
@@ -116,6 +136,9 @@ def realm_client_table(user_summaries: Dict[str, Dict[str, Dict[str, Any]]]) -> 
         "pointer",
         "website",
         "desktop",
+        "bot_owner",
+        "role",
+        "bot_owner_email",
     ]
 
     rows = []
@@ -237,7 +260,7 @@ def get_realm_activity(request: HttpRequest, realm_str: str) -> HttpResponse:
     for is_bot, page_title in [(False, "Humans"), (True, "Bots")]:
         all_records = list(get_user_activity_records_for_realm(realm_str, is_bot))
 
-        user_records, content = realm_user_summary_table(all_records, admin_emails)
+        user_records, content = realm_user_summary_table(all_records, admin_emails, is_bot)
         all_user_records.update(user_records)
 
         data += [(page_title, content)]

--- a/analytics/views/user_activity.py
+++ b/analytics/views/user_activity.py
@@ -58,7 +58,7 @@ def raw_user_activity_table(records: List[QuerySet]) -> str:
 def user_activity_summary_table(user_summary: Dict[str, Dict[str, Any]]) -> str:
     rows = []
     for k, v in user_summary.items():
-        if k == "name":
+        if k in ["name", "role"]:
             continue
         client = k
         count = v["count"]


### PR DESCRIPTION
This PR aims to solve the issue https://github.com/zulip/zulip/issues/18275

Add a bot owner tab in realm_activity page to know who created the bot on the realm, in case they're misbehaving.

Screenshot: 

![image](https://user-images.githubusercontent.com/53316982/117871002-7fa34600-b2ba-11eb-8186-531528704b30.png)

![image](https://user-images.githubusercontent.com/53316982/117871032-8e89f880-b2ba-11eb-8c29-607312ecad1a.png)



