### PR TITLE
Make reply button look more like a textbox

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -48,6 +48,26 @@
     visibility: hidden;
 }
 
+/*
+Consistent placeholder styling, introduced to allow us to style the
+Reply box like a placeholder.  Chrome uses color to set placeholder,
+while Firefox uses opacity, so we need to set both properties to avoid
+mixed styling.
+
+While we usually prefer opacity for text color in Zulip, there's some
+evidence Edge may have bugs in its handling of placeholder opacity
+CSS: https://github.com/necolas/normalize.css/issues/741
+*/
+.placeholder {
+    color: hsl(0, 0%, 45%);
+    opacity: 1;
+}
+
+textarea::placeholder,
+input::placeholder {
+    @extend .placeholder;
+}
+
 .new-style {
     /* -- base button styling -- */
     .button {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -45,9 +45,11 @@
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
+            cursor: text;
+            padding: 3px 6px;
 
-            .compose_reply_button_recipient_label {
-                color: hsl(215, 47%, 30%);
+            &:active {
+                background-color: inherit;
             }
         }
     }

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -47,6 +47,7 @@
             text-overflow: ellipsis;
             cursor: text;
             padding: 3px 6px;
+            border: 1px solid hsl(0, 0%, 80%);
 
             &:active {
                 background-color: inherit;

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -42,13 +42,6 @@ body.night-mode {
         background-color: hsl(212, 28%, 18%);
     }
 
-    #compose_buttons
-        .reply_button_container
-        .compose_reply_button
-        .compose_reply_button_recipient_label {
-        color: hsl(215, 47%, 80%);
-    }
-
     .compose-send-status-close {
         color: hsl(0, 0%, 100%);
         opacity: 1;

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -42,6 +42,11 @@ body.night-mode {
         background-color: hsl(212, 28%, 18%);
     }
 
+    #compose_buttons .reply_button_container .compose_reply_button {
+        background-color: hsla(0, 0%, 0%, 0.2);
+        border-color: hsla(0, 0%, 0%, 0.6);
+    }
+
     .compose-send-status-close {
         color: hsl(0, 0%, 100%);
         opacity: 1;

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -2,6 +2,16 @@ body.night-mode {
     background-color: hsl(212, 28%, 18%);
     color: hsl(236, 33%, 90%);
 
+    .placeholder {
+        color: hsl(0, 0%, 55%);
+        opacity: 1;
+    }
+
+    textarea::placeholder,
+    input::placeholder {
+        @extend .placeholder;
+    }
+
     a:hover {
         color: hsl(200, 79%, 66%);
     }

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -9,7 +9,7 @@
                 <button type="button" class="button rounded compose_reply_button"
                   id="left_bar_compose_reply_button_big"
                   title="{{t 'Reply' }} (r)">
-                    <span class="compose_reply_button_label">
+                    <span class="compose_reply_button_label placeholder">
                         {{#tr}}
                             Message <z-recipient></z-recipient>
                             {{#*inline "z-recipient"}}<span class="compose_reply_button_recipient_label"></span>{{/inline}}

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -6,7 +6,7 @@
         </div>
         <div id="compose_buttons">
             <span class="new_message_button reply_button_container">
-                <button type="button" class="button rounded compose_reply_button"
+                <button type="button" class="button no-style rounded compose_reply_button"
                   id="left_bar_compose_reply_button_big"
                   title="{{t 'Reply' }} (r)">
                     <span class="compose_reply_button_label placeholder">

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -6,7 +6,7 @@
         </div>
         <div id="compose_buttons">
             <span class="new_message_button reply_button_container">
-                <button type="button" class="button small rounded compose_reply_button"
+                <button type="button" class="button rounded compose_reply_button"
                   id="left_bar_compose_reply_button_big"
                   title="{{t 'Reply' }} (r)">
                     <span class="compose_reply_button_label">


### PR DESCRIPTION
From [#design > bottom row design](https://chat.zulip.org/#narrow/stream/101-design/topic/bottom.20row.20design)

**Testing plan:** manually tested

**GIFs or screenshots:**

![2021-05-08_18 28 46_897x55](https://user-images.githubusercontent.com/5001092/117535996-502ada00-b02b-11eb-8e7f-f3e045472485.png)
![2021-05-08_18 29 04_925x63](https://user-images.githubusercontent.com/5001092/117535997-50c37080-b02b-11eb-856e-e26e4020d497.png)
