### PR TITLE
playgrounds: Improvements to `Language` field typeahead in Code playgrounds

### DIFF
--- a/static/js/realm_playground.js
+++ b/static/js/realm_playground.js
@@ -1,3 +1,6 @@
+import * as typeahead from "../shared/js/typeahead";
+
+import {$t} from "./i18n";
 import * as typeahead_helper from "./typeahead_helper";
 
 const map_language_to_playground_info = new Map();
@@ -39,9 +42,18 @@ export function sort_pygments_pretty_names_by_priority(generated_pygments_data) 
     }
 }
 
-export function get_pygments_typeahead_list() {
+export function get_pygments_typeahead_list(query) {
     const lookup_table = new Map();
     const pygments_pretty_name_list = [];
+
+    // Adds a typeahead that allows selecting a custom language, by adding a
+    // "Custom language" label in the first position of the typeahead list.
+    const clean_query = typeahead.clean_query_lowercase(query);
+    pygments_pretty_name_list.push(clean_query);
+    lookup_table[clean_query] = $t(
+        {defaultMessage: "Custom language: {query}"},
+        {query: clean_query},
+    );
 
     for (const [key, values] of map_pygments_pretty_name_to_aliases) {
         lookup_table[key] = key + " (" + Array.from(values).join(", ") + ")";

--- a/static/js/realm_playground.js
+++ b/static/js/realm_playground.js
@@ -49,11 +49,13 @@ export function get_pygments_typeahead_list(query) {
     // Adds a typeahead that allows selecting a custom language, by adding a
     // "Custom language" label in the first position of the typeahead list.
     const clean_query = typeahead.clean_query_lowercase(query);
-    pygments_pretty_name_list.push(clean_query);
-    lookup_table[clean_query] = $t(
-        {defaultMessage: "Custom language: {query}"},
-        {query: clean_query},
-    );
+    if (clean_query !== "") {
+        pygments_pretty_name_list.push(clean_query);
+        lookup_table[clean_query] = $t(
+            {defaultMessage: "Custom language: {query}"},
+            {query: clean_query},
+        );
+    }
 
     for (const [key, values] of map_pygments_pretty_name_to_aliases) {
         lookup_table[key] = key + " (" + Array.from(values).join(", ") + ")";

--- a/static/js/settings_playgrounds.js
+++ b/static/js/settings_playgrounds.js
@@ -7,7 +7,6 @@ import {$t_html} from "./i18n";
 import * as ListWidget from "./list_widget";
 import {page_params} from "./page_params";
 import * as realm_playground from "./realm_playground";
-import * as typeahead_helper from "./typeahead_helper";
 import * as ui from "./ui";
 import * as ui_report from "./ui_report";
 
@@ -152,14 +151,18 @@ function build_page() {
             });
         });
 
+    let lookup_table = new Map();
+
     $("#playground_pygments_language").typeahead({
         source() {
-            return realm_playground.get_pygments_pretty_names_list();
+            const suggestions = realm_playground.get_pygments_typeahead_list();
+            lookup_table = suggestions.lookup_table;
+            return suggestions.pygments_pretty_name_list;
         },
         items: 5,
         fixed: true,
         highlighter(item) {
-            return typeahead_helper.render_typeahead_item({primary: item});
+            return lookup_table[item];
         },
         matcher(item) {
             const q = this.query.trim().toLowerCase();

--- a/static/js/settings_playgrounds.js
+++ b/static/js/settings_playgrounds.js
@@ -151,9 +151,10 @@ function build_page() {
             });
         });
 
+    const search_pygments_box = $("#playground_pygments_language");
     let lookup_table = new Map();
 
-    $("#playground_pygments_language").typeahead({
+    search_pygments_box.typeahead({
         source(query) {
             const suggestions = realm_playground.get_pygments_typeahead_list(query);
             lookup_table = suggestions.lookup_table;
@@ -161,6 +162,7 @@ function build_page() {
         },
         items: 5,
         fixed: true,
+        helpOnEmptyStrings: true,
         highlighter(item) {
             return lookup_table[item];
         },
@@ -168,5 +170,11 @@ function build_page() {
             const q = this.query.trim().toLowerCase();
             return item.toLowerCase().startsWith(q);
         },
+    });
+
+    search_pygments_box.on("click", (e) => {
+        search_pygments_box.typeahead("lookup").trigger("select");
+        e.preventDefault();
+        e.stopPropagation();
     });
 }

--- a/static/js/settings_playgrounds.js
+++ b/static/js/settings_playgrounds.js
@@ -154,8 +154,8 @@ function build_page() {
     let lookup_table = new Map();
 
     $("#playground_pygments_language").typeahead({
-        source() {
-            const suggestions = realm_playground.get_pygments_typeahead_list();
+        source(query) {
+            const suggestions = realm_playground.get_pygments_typeahead_list(query);
             lookup_table = suggestions.lookup_table;
             return suggestions.pygments_pretty_name_list;
         },

--- a/static/templates/settings/playground_settings_admin.hbs
+++ b/static/templates/settings/playground_settings_admin.hbs
@@ -36,7 +36,7 @@
                     </div>
                     <div class="control-group">
                         <label for="playground_name" class="control-label"> {{t "Name" }}</label>
-                        <input type="text" id="playground_name" name="name" placeholder="Python3 playground" />
+                        <input type="text" id="playground_name" name="name" autocomplete="off" placeholder="Python3 playground" />
                     </div>
                     <div class="control-group">
                         <label for="playground_url_prefix" class="control-label"> {{t "URL prefix" }}</label>

--- a/templates/zerver/help/code-blocks.md
+++ b/templates/zerver/help/code-blocks.md
@@ -108,8 +108,8 @@ the user will get to choose which playground to open the code in.
 * The `Language` field is the human-readable Pygments language name for that
 programming language. The language tag for a code block is internally mapped
 to these human-readable Pygments names. E.g: `py3` and `py` are mapped to
-`Python`. We are working on implementing a typeahead for looking up the
-Pygments name. Until then, one can use [this Pygments method][get_lexer_by_name].
+`Python`. One can use the typeahead (which appears when you type something
+or just click on the language field) to lookup the Pygments name.
 
 * The links for opening code playgrounds are always constructed by concatenating
 the provided URL prefix with the URL-encoded contents of the code block.


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR implements the follow-ups mentioned in https://github.com/zulip/zulip/pull/18212#issuecomment-832135652, related to the typeahead we display for the `Language` field in the newly added `Code playgrounds` form.

- The first commit adds the Pygment aliases into a parenthetical E.g. "Python 2.x (py2, python2)" in the typeahead.
- The second adds a label to select a "custom language" in the typeahead.
- The third displays the typeahead as soon as one clicks on that field, before typing anything.
- The last removes a typeahead workaround mentioned in our code-block help center documentation.

**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/30312566/117539482-7c912700-b028-11eb-8393-2dab660cda7e.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->