### PR TITLE
 drafts: Allow vim up and down key to scroll between drafts

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -471,13 +471,13 @@ export function drafts_handle_events(e, event_key) {
 
     // This detects up arrow key presses when the draft overlay
     // is open and scrolls through the drafts.
-    if (event_key === "up_arrow") {
+    if (event_key === "up_arrow" || event_key === "vim_up") {
         drafts_scroll(row_before_focus());
     }
 
     // This detects down arrow key presses when the draft overlay
     // is open and scrolls through the drafts.
-    if (event_key === "down_arrow") {
+    if (event_key === "down_arrow" || event_key === "vim_down") {
         drafts_scroll(row_after_focus());
     }
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -569,6 +569,8 @@ export function process_hotkey(e, hotkey) {
     switch (event_name) {
         case "up_arrow":
         case "down_arrow":
+        case "vim_up":
+        case "vim_down":
         case "backspace":
         case "delete":
             if (overlays.drafts_open()) {

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -427,7 +427,7 @@ export function process_enter_key(e) {
         return false;
     }
 
-    // This handles when pressing Rnter while looking at drafts.
+    // This handles when pressing Enter while looking at drafts.
     // It restores draft that is focused.
     if (overlays.drafts_open()) {
         drafts.drafts_handle_events(e, "enter");


### PR DESCRIPTION
Added commit to bind the `vim_up`(k) and `vim_down`(j) with the drafts overlay allowing users to scroll between their drafts.

`vim_up`(k) -> Move up.
`vim_down`(j) -> Move down.

<strong>Screenshot:</strong>
![draft_focus](https://user-images.githubusercontent.com/53977614/117542774-8f5f2800-b037-11eb-970c-d6e84b009a27.gif)

Fixes #18397