### PR TITLE
api: Add dataclass for update_message events.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -31,6 +31,7 @@ FILES_WITH_LEGACY_SUBJECT = {
     # This has lots of query data embedded, so it's hard
     # to fix everything until we migrate the DB to "topic".
     "zerver/tests/test_message_fetch.py",
+    "zerver/lib/actions.py",
 }
 
 shebang_rules: List["Rule"] = [


### PR DESCRIPTION
Different variants of update_message events made it difficult
to keep api changes uniform across them. Created a dataclass for
update_message variant events and refactored to replace Dict with
TypedDict. Fixes #16022.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
