### PR TITLE
Finish up `mute users` feature.

### DIFF
--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -98,7 +98,6 @@ function test_ui(label, f) {
         page_params.is_admin = false;
         page_params.realm_email_address_visibility = 3;
         page_params.custom_profile_fields = [];
-        page_params.development_environment = false;
         override(popovers, "clipboard_enable", noop);
         popovers.clear_for_testing();
         popovers.register_click_handlers();
@@ -160,7 +159,7 @@ test_ui("sender_hover", (override) => {
                 assert.deepEqual(opts, {
                     can_set_away: false,
                     can_revoke_away: false,
-                    can_mute: false,
+                    can_mute: true,
                     can_unmute: false,
                     user_full_name: "Alice Smith",
                     user_email: "alice@example.com",

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -143,6 +143,7 @@ export function confirm_mute_user(user_id) {
     confirm_dialog.launch({
         parent: modal_parent,
         html_heading: $t({defaultMessage: "Mute user"}),
+        help_link: "/help/mute-a-user",
         html_body,
         html_yes_button: $t({defaultMessage: "Confirm"}),
         on_click,

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -235,8 +235,7 @@ function render_user_info_popover(
         }
     }
 
-    const is_dev = page_params.development_environment;
-    const muting_allowed = is_dev && !is_me && !user.is_bot;
+    const muting_allowed = !is_me && !user.is_bot;
     const is_muted = muting.is_user_muted(user.user_id);
 
     const args = {

--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -43,12 +43,10 @@
                     <i class="icon fa fa-bell-slash" aria-hidden="true"></i>
                     <div class="text">{{ _('Muted topics') }}</div>
                 </li>
-                {% if development_environment %}
                 <li tabindex="0" data-section="muted-users">
                     <i class="icon fa fa-eye-slash" aria-hidden="true"></i>
                     <div class="text">{{ _('Muted users') }}</div>
                 </li>
-                {% endif %}
             </ul>
 
             <ul class="org-settings-list">

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -78,6 +78,7 @@
 * [PMs, mentions, and alerts](/help/pm-mention-alert-notifications)
 * [Mute a stream](/help/mute-a-stream)
 * [Mute a topic](/help/mute-a-topic)
+* [Mute a user](/help/mute-a-user)
 * [Alert words](/help/add-an-alert-word)
 * [Disable new login emails](/help/disable-new-login-emails)
 * [Configure message notification emails](/help/configure-message-notification-emails)

--- a/templates/zerver/help/moderating-open-organizations.md
+++ b/templates/zerver/help/moderating-open-organizations.md
@@ -6,7 +6,8 @@ Moderation is a big part of making an open community work.
 
 ## Prevention
 
-Zulip has many features designed to simplify moderation:
+Zulip has many features designed to simplify moderation by preventing
+problematic behavior:
 
 * [Disallow disposable email addresses](/help/allow-anyone-to-join-without-an-invitation)
   or [require users to log in via GitHub or GitLab](/help/configure-authentication-methods).
@@ -22,32 +23,39 @@ Zulip has many features designed to simplify moderation:
   post](/help/stream-sending-policy).
 * Add a [waiting period](/help/restrict-permissions-of-new-members) before
   new users can take disruptive actions.
-* [Restrict email visibility](/help/restrict-visibility-of-email-addresses)
-  to reduce the likelihood of off-platform spam.
+* [Restrict visibility of email addresses](/help/restrict-visibility-of-email-addresses)
+  to prevent off-platform spam.
 * [Restrict wildcard mentions](/help/restrict-wildcard-mentions)
   so only [moderators](/help/roles-and-permissions) can mention everyone in your organization.
 
 ## Response
 
+The following features are an important part of an organization's
+playbook when responding to abuse or spam that is not prevented by the
+organization's policy choices.
+
+* Individual users can [mute abusive users](/help/mute-a-user) to stop
+  harassment that moderators have not yet addressed, or [collapse
+  individual messages](/help/collapse-a-message) that they don't want
+  to see.
 * [Ban (deactivate) users](/help/deactivate-or-reactivate-a-user) acting in
   bad faith. You can reactivate them later if they repent.
-* Use the `streams:public sender:user@example.com`
-  [search operators](/help/search-for-messages) to find all messages sent by a user.
+* Investigate behavior using the `streams:public
+  sender:user@example.com` [search
+  operators](/help/search-for-messages) to find all messages sent by a
+  user.
 * Delete messages, [archive streams](/help/archive-a-stream), and
   [unsubscribe users from streams](/help/add-or-remove-users-from-a-stream).
 * [Rename topics](/help/rename-a-topic).
-* [Change users' names](/help/change-a-users-name) (e.g. to "Spammer")
+* [Change users' names](/help/change-a-users-name) (e.g. to "Name (Spammer)")
+  for users who sent spam private messages to many community members.
 * [Deactivate bots](/help/deactivate-or-reactivate-a-bot) or
   [delete custom emoji](/help/add-custom-emoji#delete-custom-emoji).
-* Instruct users to [collapse](/help/collapse-a-message) messages that they don't
-  want to see.
 
 ## In the works
 
 * **Delete spammer**. This will wipe the user from your Zulip, by deleting
   all their messages and reactions, banning them, etc.
-* **Mute user**. This will allow an individual user to hide the messages of
-  another individual user.
 * **New users join as guests**. This will allow users joining via open
   registration to have extremely limited permissions by default, but still
   enough permissions to ask the core team a question or to get a feel for your

--- a/templates/zerver/help/mute-a-stream.md
+++ b/templates/zerver/help/mute-a-stream.md
@@ -35,3 +35,5 @@ Muted streams still appear in the left sidebar, though they are grayed out.
 ## Related articles
 
 * [Mute a topic](/help/mute-a-topic)
+
+* [Mute a user](/help/mute-a-user)

--- a/templates/zerver/help/mute-a-topic.md
+++ b/templates/zerver/help/mute-a-topic.md
@@ -51,3 +51,5 @@ From there, you can also unmute any muted topics.
 ## Related articles
 
 * [Mute a stream](/help/mute-a-stream)
+
+* [Mute a user](/help/mute-a-user)

--- a/templates/zerver/help/mute-a-user.md
+++ b/templates/zerver/help/mute-a-user.md
@@ -1,0 +1,90 @@
+# Mute a user
+
+!!! tip ""
+    This feature mutes a user from your personal perspective, and does not
+    automatically notify anyone. Consider also reporting abusive behavior to
+    organization [owners and administrators](/help/roles-and-permissions),
+    who can take organization-level actions like
+    [deactivating a user](/help/deactivate-or-reactivate-a-user).
+
+You can mute any user you do not wish to interact with. Muting someone will
+have the following effects:
+
+* All messages sent by a muted user will automatically be [marked as
+  read](/help/marking-messages-as-read) for you, and will never
+  generate any desktop, email, or mobile push notifications.
+
+* Muted users are hidden from [**Private
+  messages**](/help/private-messages) in the left sidebar and the list
+  of users in the right sidebar. Private messages between you and a
+  muted user will only be visible if you [explicitly
+  search](/help/search-for-messages) for your private messages with
+  the user.
+
+* All stream messages and group private messages sent by muted users
+  are hidden behind a **Click to reveal** banner. This allows you to
+  understand whether other users' messages are responses to messages
+  sent by a muted user, while only seeing the muted user's name,
+  profile picture, or message content for messages you have not opted
+  into reading.
+
+* Muted users have their name displayed as "Muted user" for [emoji
+  reactions][view-emoji-reactions], [polls](/help/create-a-poll), and
+  when displaying the recipients of group private messages sent by
+  unmuted users.
+
+* Muted users are excluded from the autocomplete for composing a
+  private message or [mentioning a user](/help/mention-a-user-or-group).
+
+* To avoid interfering with administration, settings UI, such as the
+  list of subscribers to a stream or members of the organization,
+  display muted users name and other details as normal.
+
+!!! tip ""
+    Zulip offers no way to distinguish a user
+    that has muted you from a user that is ignoring you.
+
+
+[view-emoji-reactions]: /help/emoji-reactions#see-who-reacted-to-a-message
+
+### From the message view
+
+{start_tabs}
+
+1. Click on a user's profile picture or [mention](/help/mention-a-user-or-group).
+
+1. Click **Mute this user**.
+
+1. On the confirmation popup, click **Confirm**.
+
+{end_tabs}
+
+### Via the right sidebar
+
+{start_tabs}
+
+1. Hover over a user's name in the right sidebar.
+
+1. Click on the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>) to
+  the right of their name.
+
+1. Click **Mute this user**.
+
+1. On the confirmation popup, click **Confirm**.
+
+{end_tabs}
+
+### See your list of muted users
+
+{start_tabs}
+
+{settings_tab|muted-users}
+
+{end_tabs}
+
+From there, you can also search for and **unmute** users.
+
+## Related articles
+
+* [Mute a stream](/help/mute-a-stream)
+* [Mute a topic](/help/mute-a-topic)

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -23,6 +23,7 @@ link_mapping = {
     "alert-words": ["Settings", "Alert words", "/#settings/alert-words"],
     "uploaded-files": ["Settings", "Uploaded files", "/#settings/uploaded-files"],
     "muted-topics": ["Settings", "Muted topics", "/#settings/muted-topics"],
+    "muted-users": ["Settings", "Muted users", "/#settings/muted-users"],
     "organization-profile": [
         "Manage organization",
         "Organization profile",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6004,8 +6004,8 @@ paths:
       operationId: mute_user
       tags: ["users"]
       description: |
-        This endpoint mutes a user.  Messages sent by users you've muted will
-        be automatically marked as read and hidden.
+        This endpoint [mutes a user](/help/mute-a-user).  Messages sent by users
+        you've muted will be automatically marked as read and hidden.
 
         `POST {{ api_url }}/v1/users/me/muted_users/{muted_user_id}`
 


### PR DESCRIPTION
Continuation of #16915. This removes the `page_params.development_environment` checks, adds a user docs page, and finished up some remaining UI work.


Here's what the /help page looks like
![image](https://user-images.githubusercontent.com/55339528/117548370-4cf71480-b052-11eb-9d2c-19daf099d651.png)

Other UI parts
![image](https://user-images.githubusercontent.com/55339528/117548590-66e52700-b053-11eb-9d23-fae315233277.png)
![image](https://user-images.githubusercontent.com/55339528/117548620-972cc580-b053-11eb-9c14-1ee1b85c744e.png)
