### PR TITLE
realm_playground: Stop using Map incorrectly

### DIFF
--- a/static/js/realm_playground.js
+++ b/static/js/realm_playground.js
@@ -43,29 +43,23 @@ export function sort_pygments_pretty_names_by_priority(generated_pygments_data) 
 }
 
 export function get_pygments_typeahead_list(query) {
-    const lookup_table = new Map();
-    const pygments_pretty_name_list = [];
+    const language_labels = new Map();
 
     // Adds a typeahead that allows selecting a custom language, by adding a
     // "Custom language" label in the first position of the typeahead list.
     const clean_query = typeahead.clean_query_lowercase(query);
     if (clean_query !== "") {
-        pygments_pretty_name_list.push(clean_query);
-        lookup_table[clean_query] = $t(
-            {defaultMessage: "Custom language: {query}"},
-            {query: clean_query},
+        language_labels.set(
+            clean_query,
+            $t({defaultMessage: "Custom language: {query}"}, {query: clean_query}),
         );
     }
 
     for (const [key, values] of map_pygments_pretty_name_to_aliases) {
-        lookup_table[key] = key + " (" + Array.from(values).join(", ") + ")";
-        pygments_pretty_name_list.push(key);
+        language_labels.set(key, key + " (" + Array.from(values).join(", ") + ")");
     }
 
-    return {
-        pygments_pretty_name_list,
-        lookup_table,
-    };
+    return language_labels;
 }
 
 export function initialize(playground_data, generated_pygments_data) {

--- a/static/js/settings_playgrounds.js
+++ b/static/js/settings_playgrounds.js
@@ -152,19 +152,18 @@ function build_page() {
         });
 
     const search_pygments_box = $("#playground_pygments_language");
-    let lookup_table = new Map();
+    let language_labels = new Map();
 
     search_pygments_box.typeahead({
         source(query) {
-            const suggestions = realm_playground.get_pygments_typeahead_list(query);
-            lookup_table = suggestions.lookup_table;
-            return suggestions.pygments_pretty_name_list;
+            language_labels = realm_playground.get_pygments_typeahead_list(query);
+            return Array.from(language_labels.keys());
         },
         items: 5,
         fixed: true,
         helpOnEmptyStrings: true,
         highlighter(item) {
-            return lookup_table[item];
+            return language_labels.get(item);
         },
         matcher(item) {
             const q = this.query.trim().toLowerCase();


### PR DESCRIPTION
Commit ad76df25ac310181c6d9a38e487131f29bc7a558 (#18405) uses `Map` incorrectly. A JavaScript `Map` needs to be indexed with `.get()` and `.set()`, not with `[]`.

Also, clean up the API: ‘`lookup_table`’ is a meaningless variable name, and there was no information in the array that wasn’t also in the `Map`.

Cc @sumanthvrao.