### PR TITLE
puppeteer_tests: Show filename when failed for quicker debugging.

### DIFF
--- a/tools/test-js-with-puppeteer
+++ b/tools/test-js-with-puppeteer
@@ -113,11 +113,13 @@ def run_tests(files: Iterable[str], external_host: str) -> None:
                     response = input('Tests failed. Press Enter to re-run tests, "q" to quit: ')
         else:
             ret = 1
-            ret = run_tests()[0]
+            ret, current_test_num = run_tests()
     if ret != 0:
+        failed_test_file_name = os.path.basename(test_files[current_test_num])
         print(
             f"""
-{FAIL}The Puppeteer frontend tests failed!{ENDC}
+{FAIL}The Puppeteer frontend tests failed! The failing test was:
+    ./tools/test-js-with-puppeteer {"--firefox " if options.firefox else ""}{failed_test_file_name}{ENDC}
 For help debugging, read:
   https://zulip.readthedocs.io/en/latest/testing/testing-with-puppeteer.html
 or report and ask for help in chat.zulip.org""",


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
[Link to CZO thread](https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/master.20failing/near/1176888)

Here is how output would look after it fails,
![Screenshot 2021-05-11 at 1 26 18 AM](https://user-images.githubusercontent.com/63820270/117717029-e90e5080-b1f7-11eb-8606-060cd6675779.png)


I have also added a firefox option, 
![Screenshot 2021-05-11 at 1 24 07 AM](https://user-images.githubusercontent.com/63820270/117716906-c1b78380-b1f7-11eb-944b-158b5bd1f44f.png)





**Testing plan:** <!-- How have you tested? -->



**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
