### PR TITLE
right-sidebar: Replace invite-link height with shortcut height.

### DIFF
--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -42,7 +42,7 @@ function get_new_heights() {
     const res = {};
     const viewport_height = message_viewport.height();
     const top_navbar_height = $("#top_navbar").safeOuterHeight(true);
-    const invite_user_link_height = $("#invite-user-link").safeOuterHeight(true) || 0;
+    const right_sidebar_shorcuts_height = $(".right-sidebar-shortcuts").safeOuterHeight(true) || 0;
     const add_streams_link_height = $("#add-stream-link").safeOuterHeight(true) || 0;
 
     res.bottom_whitespace_height = viewport_height * 0.4;
@@ -68,7 +68,7 @@ function get_new_heights() {
         Number.parseInt($("#right-sidebar").css("marginTop"), 10) -
         $("#userlist-header").safeOuterHeight(true) -
         $("#user_search_section").safeOuterHeight(true) -
-        invite_user_link_height;
+        right_sidebar_shorcuts_height;
 
     res.buddy_list_wrapper_max_height = Math.max(80, usable_height);
 


### PR DESCRIPTION

To calculate the max-height of buddy_list_wrapper, we use
invite-link-height. This works alright if inviting is enabled
for all. However for users who aren't permitted to invite,
the element does not render, hence the logic uses `0` as
default value for subtraction in `get_new_heights` function
under resize.js. This leads to the keyboard-shortcut icon
rendered below the browser window. Hence use the parent div
`right-sidebar-shortcuts` height for the logic.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot_2021-05-10 (8) Recent topics - Zulip Dev - Zulip](https://user-images.githubusercontent.com/55033316/117691797-edc40c00-b1d9-11eb-8066-499d2954b960.png)

![Screenshot_2021-05-10 Zulip Dev - Zulip](https://user-images.githubusercontent.com/55033316/117691846-f87ea100-b1d9-11eb-88b2-8414b06e82e7.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
