### PR TITLE
settings_panel: Bind vim keys to `SettingsPanelMenu`

### DIFF
--- a/static/js/keydown_util.js
+++ b/static/js/keydown_util.js
@@ -2,16 +2,19 @@
     See hotkey.js for handlers that are more app-wide.
 */
 
+// Note that these keycodes differ from those in hotkey.js, because
+// we're using keydown rather than keypress.  It's unclear whether
+// there's a good reason for this difference.
 const keys = {
-    13: "enter_key",
-    37: "left_arrow",
-    38: "up_arrow",
-    39: "right_arrow",
-    40: "down_arrow",
-    72: "vim_left",
-    74: "vim_down",
-    75: "vim_up",
-    76: "vim_right",
+    13: "enter_key", // Enter
+    37: "left_arrow", // // Left arrow
+    38: "up_arrow", // Up arrow
+    39: "right_arrow", // Right arrow
+    40: "down_arrow", // Down arrow
+    72: "vim_left", // 'H'
+    74: "vim_down", // 'J'
+    75: "vim_up", // 'K'
+    76: "vim_right", // 'L'
 };
 
 export function handle(opts) {

--- a/static/js/keydown_util.js
+++ b/static/js/keydown_util.js
@@ -8,6 +8,10 @@ const keys = {
     38: "up_arrow",
     39: "right_arrow",
     40: "down_arrow",
+    72: "vim_left",
+    74: "vim_down",
+    75: "vim_up",
+    76: "vim_right",
 };
 
 export function handle(opts) {

--- a/static/js/settings_panel_menu.js
+++ b/static/js/settings_panel_menu.js
@@ -70,6 +70,12 @@ export class SettingsPanelMenu {
                 enter_key: () => this.enter_panel(),
                 up_arrow: () => this.prev(),
                 down_arrow: () => this.next(),
+
+                // Binding vim keys as well
+                vim_left: toggler.maybe_go_left,
+                vim_right: toggler.maybe_go_right,
+                vim_up: () => this.prev(),
+                vim_down: () => this.next(),
             },
         });
     }


### PR DESCRIPTION
Added commit to bind vim keys to `SettingsPanelMenu` class which allow users to control the settings and organizational tabs using <kbd>h</kbd>,<kbd>j</kbd>,<kbd>k</kbd> and <kbd>l</kbd> keys.
Basically a follow up of #18408.

<strong>Screenshot</strong>

![vim_keys](https://user-images.githubusercontent.com/53977614/117692948-27494700-b1db-11eb-8850-09813864435f.gif)
