### PR TITLE
markdown: Fix silent wildcard mentions bug.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1848,7 +1848,8 @@ class UserMentionPattern(markdown.inlinepatterns.InlineProcessor):
                 user = db_data["mention_data"].get_user_by_name(name)
 
             if wildcard:
-                self.md.zulip_message.mentions_wildcard = True
+                if not silent:
+                    self.md.zulip_message.mentions_wildcard = True
                 user_id = "*"
             elif user:
                 if not silent:


### PR DESCRIPTION
A message containing wildcard mention when quoted (which is turned into a silent mention) or message with silent wildcard mention notifies the users by sending desktop, sound, and missed message email notifications. This is clearly a bug which is fixed by this commit.

Fixes: #18354.

Added new tests for the same.