### PR TITLE
command: Add change_realm_subdomain management command and document it. 

### DIFF
--- a/docs/production/management-commands.md
+++ b/docs/production/management-commands.md
@@ -116,6 +116,7 @@ There are dozens of useful management commands under
   users.
 * `./manage.py send_password_reset_email`: Sends password reset email(s)
   to one or more users.
+* `./manage.py change_realm_subdomain`: Change subdomain of a realm.
 * `./manage.py change_user_email`: Change a user's email address.
 * `./manage.py change_user_role`: Can change are user's role
   (easier done [via the

--- a/templates/zerver/help/change-organization-url.md
+++ b/templates/zerver/help/change-organization-url.md
@@ -24,23 +24,9 @@ for paid plans.
 If you're self-hosting, you can change the root domain of your Zulip
 server by changing the `EXTERNAL_HOST` [setting][zulip-settings].  If
 you're [hosting multiple organizations][zulip-multiple-organizations]
-and want to change the subdomain for one of them, you can follow these
-steps:
-
-{start_tabs}
-
-1. Get the `string_id` for your organization as [described here][find-string-id]
-
-2. Run the following commands in a [management shell][management-shell]:
-
-    ```
-    realm = get_realm("string_id")
-    do_change_realm_subdomain(realm, "new_subdomain")
-    ```
-
-{end_tabs}
+and want to change the subdomain for one of them, you can do this
+using the `change_realm_subdomain` [management command][management-commands].
 
 [zulip-settings]: https://zulip.readthedocs.io/en/stable/production/settings.html
 [zulip-multiple-organizations]: https://zulip.readthedocs.io/en/stable/production/multiple-organizations.html
-[management-shell]: https://zulip.readthedocs.io/en/stable/production/management-commands.html#manage-py-shell
-[find-string-id]: https://zulip.readthedocs.io/en/stable/production/management-commands.html#accessing-an-organization-s-string-id
+[management-commands]: https://zulip.readthedocs.io/en/latest/production/management-commands.html#other-useful-manage-py-commands

--- a/zerver/lib/management.py
+++ b/zerver/lib/management.py
@@ -45,7 +45,7 @@ class ZulipBaseCommand(BaseCommand):
         return parser
 
     def add_realm_args(
-        self, parser: ArgumentParser, required: bool = False, help: Optional[str] = None
+        self, parser: ArgumentParser, *, required: bool = False, help: Optional[str] = None
     ) -> None:
         if help is None:
             help = """The numeric or string ID (subdomain) of the Zulip organization to modify.

--- a/zerver/management/commands/add_users_to_streams.py
+++ b/zerver/management/commands/add_users_to_streams.py
@@ -10,7 +10,7 @@ class Command(ZulipBaseCommand):
     help = """Add some or all users in a realm to a set of streams."""
 
     def add_arguments(self, parser: CommandParser) -> None:
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
         self.add_user_list_args(parser, all_users_help="Add all users in realm to these streams.")
 
         parser.add_argument(

--- a/zerver/management/commands/bulk_change_user_name.py
+++ b/zerver/management/commands/bulk_change_user_name.py
@@ -16,7 +16,7 @@ class Command(ZulipBaseCommand):
             metavar="<data file>",
             help="file containing rows of the form <email>,<desired name>",
         )
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
     def handle(self, *args: Any, **options: str) -> None:
         data_file = options["data_file"]

--- a/zerver/management/commands/change_realm_subdomain.py
+++ b/zerver/management/commands/change_realm_subdomain.py
@@ -1,0 +1,21 @@
+from argparse import ArgumentParser
+from typing import Any
+
+from zerver.lib.actions import do_change_realm_subdomain
+from zerver.lib.management import ZulipBaseCommand
+
+
+class Command(ZulipBaseCommand):
+    help = """Change realm's subdomain."""
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        self.add_realm_args(parser, required=True)
+        parser.add_argument("new_subdomain", metavar="<new subdomain>", help="realm new subdomain")
+
+    def handle(self, *args: Any, **options: str) -> None:
+        realm = self.get_realm(options)
+        assert realm is not None  # Should be ensured by parser
+
+        new_subdomain = options["new_subdomain"]
+        do_change_realm_subdomain(realm, new_subdomain, acting_user=None)
+        print("Done!")

--- a/zerver/management/commands/change_user_role.py
+++ b/zerver/management/commands/change_user_role.py
@@ -40,7 +40,7 @@ ONLY perform this on customer request from an authorized person.
             action="store_false",
             help="Remove can_forge_sender or can_create_users permission.",
         )
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
     def handle(self, *args: Any, **options: Any) -> None:
         email = options["email"]

--- a/zerver/management/commands/create_default_stream_groups.py
+++ b/zerver/management/commands/create_default_stream_groups.py
@@ -14,7 +14,7 @@ Create default stream groups which the users can choose during sign up.
 """
 
     def add_arguments(self, parser: ArgumentParser) -> None:
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
         parser.add_argument(
             "-n",

--- a/zerver/management/commands/create_stream.py
+++ b/zerver/management/commands/create_stream.py
@@ -12,7 +12,7 @@ This should be used for TESTING only, unless you understand the limitations of
 the command."""
 
     def add_arguments(self, parser: ArgumentParser) -> None:
-        self.add_realm_args(parser, True, "realm in which to create the stream")
+        self.add_realm_args(parser, required=True, help="realm in which to create the stream")
         parser.add_argument("stream_name", metavar="<stream name>", help="name of stream to create")
 
     def handle(self, *args: Any, **options: str) -> None:

--- a/zerver/management/commands/create_user.py
+++ b/zerver/management/commands/create_user.py
@@ -53,7 +53,7 @@ Omit both <email> and <full name> for interactive user creation.
             help="full name of new user",
         )
         self.add_realm_args(
-            parser, True, "The name of the existing realm to which to add the user."
+            parser, required=True, help="The name of the existing realm to which to add the user."
         )
 
     def handle(self, *args: Any, **options: Any) -> None:

--- a/zerver/management/commands/deactivate_realm.py
+++ b/zerver/management/commands/deactivate_realm.py
@@ -12,7 +12,7 @@ class Command(ZulipBaseCommand):
         parser.add_argument(
             "--redirect_url", metavar="<redirect_url>", help="URL to which the realm has moved"
         )
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
     def handle(self, *args: Any, **options: str) -> None:
         realm = self.get_realm(options)

--- a/zerver/management/commands/delete_realm.py
+++ b/zerver/management/commands/delete_realm.py
@@ -12,7 +12,7 @@ class Command(ZulipBaseCommand):
 realms used for testing; consider using deactivate_realm instead."""
 
     def add_arguments(self, parser: ArgumentParser) -> None:
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
     def handle(self, *args: Any, **options: str) -> None:
         realm = self.get_realm(options)

--- a/zerver/management/commands/dump_messages.py
+++ b/zerver/management/commands/dump_messages.py
@@ -13,7 +13,7 @@ class Command(ZulipBaseCommand):
 
     def add_arguments(self, parser: CommandParser) -> None:
         default_cutoff = time.time() - 60 * 60 * 24 * 30  # 30 days.
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
         parser.add_argument(
             "--since",
             type=int,

--- a/zerver/management/commands/edit_linkifiers.py
+++ b/zerver/management/commands/edit_linkifiers.py
@@ -35,7 +35,7 @@ Example: ./manage.py realm_filters --realm=zulip --op=show
             nargs="?",
             help="format string to substitute",
         )
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
     def handle(self, *args: Any, **options: str) -> None:
         realm = self.get_realm(options)

--- a/zerver/management/commands/export.py
+++ b/zerver/management/commands/export.py
@@ -110,7 +110,7 @@ class Command(ZulipBaseCommand):
             action="store_true",
             help="Automatically delete the local tarball after a successful export",
         )
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
     def handle(self, *args: Any, **options: Any) -> None:
         realm = self.get_realm(options)

--- a/zerver/management/commands/generate_invite_links.py
+++ b/zerver/management/commands/generate_invite_links.py
@@ -24,7 +24,7 @@ class Command(ZulipBaseCommand):
             nargs="*",
             help="email of users to generate an activation link for",
         )
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
     def handle(self, *args: Any, **options: Any) -> None:
         duplicates = False

--- a/zerver/management/commands/generate_multiuse_invite_link.py
+++ b/zerver/management/commands/generate_multiuse_invite_link.py
@@ -10,7 +10,7 @@ class Command(ZulipBaseCommand):
     help = "Generates invite link that can be used for inviting multiple users"
 
     def add_arguments(self, parser: ArgumentParser) -> None:
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
         parser.add_argument("-s", "--streams", help="A comma-separated list of stream names.")
 

--- a/zerver/management/commands/merge_streams.py
+++ b/zerver/management/commands/merge_streams.py
@@ -29,7 +29,7 @@ class Command(ZulipBaseCommand):
         parser.add_argument(
             "stream_to_destroy", help="name of stream to merge into the stream being kept"
         )
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
     def handle(self, *args: Any, **options: str) -> None:
         realm = self.get_realm(options)

--- a/zerver/management/commands/reactivate_realm.py
+++ b/zerver/management/commands/reactivate_realm.py
@@ -9,7 +9,7 @@ class Command(ZulipBaseCommand):
     help = """Script to reactivate a deactivated realm."""
 
     def add_arguments(self, parser: ArgumentParser) -> None:
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
     def handle(self, *args: Any, **options: str) -> None:
         realm = self.get_realm(options)

--- a/zerver/management/commands/realm_domain.py
+++ b/zerver/management/commands/realm_domain.py
@@ -21,7 +21,7 @@ class Command(ZulipBaseCommand):
             "--allow-subdomains", action="store_true", help="Whether subdomains are allowed or not."
         )
         parser.add_argument("domain", metavar="<domain>", nargs="?", help="domain to add or remove")
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
     def handle(self, *args: Any, **options: str) -> None:
         realm = self.get_realm(options)

--- a/zerver/management/commands/remove_users_from_stream.py
+++ b/zerver/management/commands/remove_users_from_stream.py
@@ -13,7 +13,7 @@ class Command(ZulipBaseCommand):
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("-s", "--stream", required=True, help="A stream name.")
 
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
         self.add_user_list_args(
             parser, all_users_help="Remove all users in realm from this stream."
         )

--- a/zerver/management/commands/rename_stream.py
+++ b/zerver/management/commands/rename_stream.py
@@ -14,7 +14,7 @@ class Command(ZulipBaseCommand):
         parser.add_argument(
             "new_name", metavar="<new name>", help="new name to rename the stream to"
         )
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
     def handle(self, *args: Any, **options: str) -> None:
         realm = self.get_realm(options)

--- a/zerver/management/commands/scrub_realm.py
+++ b/zerver/management/commands/scrub_realm.py
@@ -9,7 +9,7 @@ class Command(ZulipBaseCommand):
     help = """Script to scrub a deactivated realm."""
 
     def add_arguments(self, parser: ArgumentParser) -> None:
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
     def handle(self, *args: Any, **options: str) -> None:
         realm = self.get_realm(options)

--- a/zerver/management/commands/send_realm_reactivation_email.py
+++ b/zerver/management/commands/send_realm_reactivation_email.py
@@ -9,7 +9,7 @@ class Command(ZulipBaseCommand):
     help = """Sends realm reactivation email to admins"""
 
     def add_arguments(self, parser: ArgumentParser) -> None:
-        self.add_realm_args(parser, True)
+        self.add_realm_args(parser, required=True)
 
     def handle(self, *args: Any, **options: str) -> None:
         realm = self.get_realm(options)


### PR DESCRIPTION
The PR aims to be a solution for the issue #17857 

The PR adds the following features:
- Add a management command called, `change_realm_subdomain`, which takes `realm_id` and `new subdomain` and changes the subdomain of the realm to the new subdomain.
- Update the documentation in `help` and `mangement commands` page in ReadTheDocs. 
