### PR TITLE
styles, portico_signin: Make login-social-button responsive to larger fonts.

### DIFF
--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -663,7 +663,9 @@ html {
 
 button.login-social-button {
     width: 328px;
+    height: auto;
     padding-left: 35px;
+    line-height: 1;
 
     background-size: auto 60%;
     background-repeat: no-repeat;


### PR DESCRIPTION
Hi :)

I noticed that at a larger font size, the text in the SAML login buttons overflows:
![Screenshot from 2021-05-11 02-06-09](https://user-images.githubusercontent.com/50044286/117739124-e878b880-b1fd-11eb-8d37-3d6ee981e6dc.png)

This can be prevented by adding `height: auto` to the corresponding CSS definition (see the commit):
![Screenshot from 2021-05-11 02-06-39](https://user-images.githubusercontent.com/50044286/117739169-06deb400-b1fe-11eb-8aed-93431310d8b5.png)

This has a small side effect: the height usual "one-liner" buttons, such as the ones for chat.zulip.org, is reduced a bit.
Before:
![Screenshot from 2021-05-11 01-56-06](https://user-images.githubusercontent.com/50044286/117739297-53c28a80-b1fe-11eb-9bea-52be4d2d4da6.png)
After:
![Screenshot from 2021-05-11 01-56-36](https://user-images.githubusercontent.com/50044286/117739318-5c1ac580-b1fe-11eb-96be-ee8b10062544.png)

Maybe there is a more elegant way to prevent the overflow of long wrapped lines?

Thanks :)
