### PR TITLE
playgrounds: Rename `name` field to `playground_name`.

### DIFF
--- a/frontend_tests/puppeteer_tests/realm-playground.ts
+++ b/frontend_tests/puppeteer_tests/realm-playground.ts
@@ -5,7 +5,7 @@ import type {Page} from "puppeteer";
 import common from "../puppeteer_lib/common";
 
 type Playground = {
-    name: string;
+    playground_name: string;
     pygments_language: string;
     url_prefix: string;
 };
@@ -34,7 +34,7 @@ async function _add_playground_and_return_status(page: Page, payload: Playground
 async function test_successful_playground_creation(page: Page): Promise<void> {
     const payload = {
         pygments_language: "Python",
-        name: "Python3 playground",
+        playground_name: "Python3 playground",
         url_prefix: "https://python.example.com",
     };
     const status = await _add_playground_and_return_status(page, payload);
@@ -60,7 +60,7 @@ async function test_successful_playground_creation(page: Page): Promise<void> {
 async function test_invalid_playground_parameters(page: Page): Promise<void> {
     const payload = {
         pygments_language: "Python",
-        name: "Python3 playground",
+        playground_name: "Python3 playground",
         url_prefix: "not_a_url",
     };
     let status = await _add_playground_and_return_status(page, payload);

--- a/static/js/settings_playgrounds.js
+++ b/static/js/settings_playgrounds.js
@@ -108,17 +108,21 @@ function build_page() {
 
     $(".organization form.admin-playground-form")
         .off("submit")
-        .on("submit", function (e) {
+        .on("submit", (e) => {
             e.preventDefault();
             e.stopPropagation();
             const playground_status = $("#admin-playground-status");
             const add_playground_button = $(".new-playground-form button");
             add_playground_button.prop("disabled", true);
             playground_status.hide();
-
+            const data = {
+                name: $("#playground_name").val(),
+                pygments_language: $("#playground_pygments_language").val(),
+                url_prefix: $("#playground_url_prefix").val(),
+            };
             channel.post({
                 url: "/json/realm/playgrounds",
-                data: $(this).serialize(),
+                data,
                 success() {
                     $("#playground_pygments_language").val("");
                     $("#playground_name").val("");

--- a/static/templates/settings/playground_settings_admin.hbs
+++ b/static/templates/settings/playground_settings_admin.hbs
@@ -36,7 +36,7 @@
                     </div>
                     <div class="control-group">
                         <label for="playground_name" class="control-label"> {{t "Name" }}</label>
-                        <input type="text" id="playground_name" name="name" autocomplete="off" placeholder="Python3 playground" />
+                        <input type="text" id="playground_name" name="playground_name" autocomplete="off" placeholder="Python3 playground" />
                     </div>
                     <div class="control-group">
                         <label for="playground_url_prefix" class="control-label"> {{t "URL prefix" }}</label>


### PR DESCRIPTION
For some reason, I wasn't able to reproduce the playground name "autofill" behavior observed in https://github.com/zulip/zulip/pull/18405#issuecomment-835934322. However, I put together a fix based on the hunch (renaming the `name` field from name to `playground_name`). So this needs to be verified to fix the issue before merging.

cc @timabbott 
