### PR TITLE
Fixed Issue #17248

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,8 @@ Zulip is distributed under the
 [Apache 2.0](https://github.com/zulip/zulip/blob/master/LICENSE) license.
 
 [beginner-friendly]: https://github.com/zulip/zulip/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
+
+
+**What I changed in this project
+I fixed a bug in where the highlighting of keywords would change the color to the wrong color.  So I found the bug within the code and then fixed it.
+ 

--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -138,7 +138,7 @@
     }
 
     .alert-word {
-        background-color: hsla(102, 85%, 57%, 0.5);
+        background-color: hsla(102, 45%, 47%);
     }
 
     /* Timestamps */


### PR DESCRIPTION
Signed-off-by: Colin <fitzpatrick4937@uwlax.edu>

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/17248

**Testing plan:** <!-- How have you tested? -->
Ran the background tests in the environment seems that everything is running smooth.  Also, have tested several different times
in the environment itself, adding my own alert words and making sure the changes do what is intended

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  --> 
![SettingTheAlertWords](https://user-images.githubusercontent.com/73244922/117855902-9319c700-b250-11eb-86fb-ac39fbf49a01.PNG)
![ProofItWorks](https://user-images.githubusercontent.com/73244922/117855930-9b720200-b250-11eb-8549-21a6650df555.PNG)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  --> A bug within the css file named rendered_markdown has it so when a alert word was a substring of another alert word it would highlight the two in different colors.  This is now changed with a simple fix to the .alert-word, changing a couple values in that statement. The bug is now fixed.

Fixes #17248 
