### PR TITLE
install: Tell NVM to not change $PATH earlier.

### DIFF
--- a/scripts/lib/install-node
+++ b/scripts/lib/install-node
@@ -45,6 +45,10 @@ if [ "$current_node_version" != "v$node_version" ] || ! [ -L "$node_wrapper_path
         . "$NVM_DIR/nvm.sh"
     fi
 
+    # Tell NVM that we don't want it messing around with $PATH; we'll
+    # adjust which npm to use by symlinks below.
+    nvm alias default system
+
     nvm install "$node_version"
     NODE_BIN="$(nvm which $node_version)"
 
@@ -57,12 +61,6 @@ if [ "$current_node_version" != "v$node_version" ] || ! [ -L "$node_wrapper_path
     ln -nsf "$NODE_BIN" /usr/local/bin/node
     ln -nsf "$(dirname "$NODE_BIN")/npm" /usr/local/bin/npm
     ln -nsf "$(dirname "$NODE_BIN")/npx" /usr/local/bin/npx
-
-    # Tell NVM that we don't want it messing around with $PATH, which
-    # can get us into trouble, if we've just upgraded but our parent
-    # env still has the old version first in its PATH.  Tell it to use
-    # the newly-symlinked one that it will find in /usr/local/bin
-    nvm alias default system
 fi
 
 # Work around the fact that apparently sudo doesn't clear the HOME


### PR DESCRIPTION
This removes a possible window where an installer error could leave
`nvm` in a state where it had prepended the full path to the
newly-installed `npm` to `$PATH`; we would like to avoid `nvm`
fiddling with path whenever possible (ref ebe930ab2cf9).

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** Ran the test-installer:
```
[...]
=> Downloading nvm from git to '/usr/local/nvm'
=> Cloning into '/usr/local/nvm'...
* (HEAD detached at FETCH_HEAD)
  master
=> Compressing and cleaning up git repository

=> Appending nvm source string to /root/.bashrc
=> Appending bash_completion source string to /root/.bashrc
=> Close and reopen your terminal to start using nvm or run the following to use it now:

export NVM_DIR="/usr/local/nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
! WARNING: Version 'system' does not exist.
default -> system (-> N/A)
Downloading and installing node v14.16.1...
Downloading https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-x64.tar.xz...
#################################################################################### 100.0%
Computing checksum with sha256sum
Checksums matched!
Now using node v14.16.1 (npm v6.14.12)
[...]
```

The `Version 'system' does not exist.` is reasonable and expected, and isn't a problem in this case.