### PR TITLE
outgoing_webhook: Send response payload to bot owner if it was invalid.

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -251,10 +251,11 @@ def notify_bot_owner(
         )
     elif status_code:
         notification_message += f"\nThe webhook got a response with status code *{status_code}*."
-        if response_content:
-            notification_message += (
-                f"\nThe response contains the following payload:\n```\n{response_content!r}\n```"
-            )
+
+    if response_content:
+        notification_message += (
+            f"\nThe response contains the following payload:\n```\n{response_content!r}\n```"
+        )
 
     message_info = dict(
         type="private",
@@ -340,7 +341,9 @@ def do_rest_call(
                 logging.info("Outhook trigger failed:", stack_info=True)
                 fail_with_message(event, response_message)
                 response_message = f"The outgoing webhook server attempted to send a message in Zulip, but that request resulted in the following error:\n> {e}"
-                notify_bot_owner(event, failure_message=response_message)
+                notify_bot_owner(
+                    event, response_content=response.text, failure_message=response_message
+                )
                 return None
         else:
             logging.warning(

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -272,7 +272,7 @@ I'm a generic exception :(
                 bot_owner_notification.content,
                 """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
 The outgoing webhook server attempted to send a message in Zulip, but that request resulted in the following error:
-> Widgets: API programmer sent invalid JSON content""",
+> Widgets: API programmer sent invalid JSON content\nThe response contains the following payload:\n```\n'{"content": "whatever", "widget_content": "test"}'\n```""",
             )
         assert bot_user.bot_owner is not None
         self.assertEqual(bot_owner_notification.recipient_id, bot_user.bot_owner.recipient_id)
@@ -299,7 +299,7 @@ The outgoing webhook server attempted to send a message in Zulip, but that reque
                 bot_owner_notification.content,
                 """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
 The outgoing webhook server attempted to send a message in Zulip, but that request resulted in the following error:
-> Invalid response format""",
+> Invalid response format\nThe response contains the following payload:\n```\n'true'\n```""",
             )
         assert bot_user.bot_owner is not None
         self.assertEqual(bot_owner_notification.recipient_id, bot_user.bot_owner.recipient_id)
@@ -328,7 +328,7 @@ The outgoing webhook server attempted to send a message in Zulip, but that reque
                 bot_owner_notification.content,
                 """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
 The outgoing webhook server attempted to send a message in Zulip, but that request resulted in the following error:
-> Invalid JSON in response""",
+> Invalid JSON in response\nThe response contains the following payload:\n```\n"this isn't valid json"\n```""",
             )
         assert bot_user.bot_owner is not None
         self.assertEqual(bot_owner_notification.recipient_id, bot_user.bot_owner.recipient_id)


### PR DESCRIPTION
When the format of the response received from the outgoing webhook
server is invalid (unparsable json, or just wrong format that doesn't
translate into a dictionary etc.), a message with the error is sent to
the bot owner. We should include the actual payload to make reasonable
debugging possible.

In notify_bot_owner we have to move the `if response_content` block to
append the payload to the message whenever it was specified as an
argument to the function. It shouldn't be nested inside
`elif status_code` as before.
