### PR TITLE
template_parser: Add new (block)translate tags to is_django_block_tag.

### DIFF
--- a/tools/lib/template_parser.py
+++ b/tools/lib/template_parser.py
@@ -361,7 +361,9 @@ def is_django_block_tag(tag: str) -> bool:
         "macro",
         "verbatim",
         "blocktrans",
+        "blocktranslate",
         "trans",
+        "translate",
         "raw",
         "with",
     ]


### PR DESCRIPTION
Django 3.1 adds these tags (equivalent to blocktrans and trans,
respectively), so this function should have them in its list for
correctness.

https://docs.djangoproject.com/en/3.1/releases/3.1/
The renamed translate and blocktranslate template tags are introduced
for internationalization in template code. The older trans and
blocktrans template tags aliases continue to work, and will be retained
for the foreseeable future.

https://github.com/zulip/zulip/issues/16031 mentions:
> "The renamed translate and blocktranslate template tags are introduced for internationalization in template code. The older trans and blocktrans template tags aliases continue to work, and will be retained for the foreseeable future.". We'll probably want to bulk-migrate for readability benefits. (3.1)

However, as far as I understand, we're using almost only Jinja2 templates, and this change applies to Django Template Language? We have no instances of `blocktrans` in our templates, and if this understand of mine is correct, all the `trans` instances are Jinja2 language and thus should not be migrated? But `is_django_block_tag` should have this change nonetheless, just to be correct I think.