### PR TITLE
puppet: Adjust thresholds on autovac_freeze.

### DIFF
--- a/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
+++ b/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
@@ -157,7 +157,7 @@ define service {
 define service {
         use                             generic-service
         service_description             Check PostgreSQL autovac_freeze
-        check_command                   check_postgres!zulip!nagios!autovac_freeze
+        check_command                   check_postgres_alert_args!zulip!nagios!autovac_freeze!101%!105%
         hostgroup                       postgresql_primary
         contact_groups                  admins
 }


### PR DESCRIPTION
These thresholds are in relationship to the
`autovacuum_freeze_max_age`, *not* the XID wraparound, which happens
at 2^31-1.  As such, it is *perfectly normal* that they hit 100%, and
then autovacuum kicks in and brings it back down.  The unusual
condition is that PostgreSQL pushes past the point where an autovacuum
would be triggered -- therein lies the XID wraparound danger.

With the `autovacuum_freeze_max_age` set to 2000000000 in
`postgresql.conf`, XID wraparound happens at 107.3%.  Set the warning
and error thresholds to below this, but above 100% so this does not
trigger constantly.

**Testing plan:** Ran:
```
root@postgres-host:~# sudo -i -u postgres /usr/bin/check_postgres --action autovac_freeze --warning=101% --critical=105%
POSTGRES_AUTOVAC_FREEZE OK: DB "postgres"  zulip=83%;101;105  postgres=60%;101;105  template1=60%;101;105 | time=0.04s zulip=83%;101;105  postgres=60%;101;105  template1=60%;101;105
```
