### PR TITLE
deliver_scheduled_emails: Make codepath go through EmailSendingWorker.

### DIFF
--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -27,6 +27,7 @@ from django.utils.translation import override as override_language
 from confirmation.models import generate_key, one_click_unsubscribe_link
 from scripts.setup.inline_email_css import inline_template
 from zerver.lib.logging_util import log_to_file
+from zerver.lib.queue import queue_json_publish
 from zerver.models import EMAIL_TYPES, Realm, ScheduledEmail, UserProfile, get_user_profile_by_id
 from zproject.email_backends import EmailLogBackEnd, get_forward_address
 
@@ -441,8 +442,7 @@ def deliver_scheduled_emails(email: ScheduledEmail) -> None:
         data["to_user_ids"] = user_ids
     if email.address is not None:
         data["to_emails"] = [email.address]
-    handle_send_email_format_changes(data)
-    send_email(**data)
+    queue_json_publish("email_senders", data)
     email.delete()
 
 

--- a/zerver/management/commands/deliver_scheduled_emails.py
+++ b/zerver/management/commands/deliver_scheduled_emails.py
@@ -19,7 +19,7 @@ from django.utils.timezone import now as timezone_now
 
 from zerver.lib.logging_util import log_to_file
 from zerver.lib.management import sleep_forever
-from zerver.lib.send_email import EmailNotDeliveredException, deliver_scheduled_emails
+from zerver.lib.send_email import deliver_scheduled_emails
 from zerver.models import ScheduledEmail
 
 ## Setup ##
@@ -47,10 +47,7 @@ Usage: ./manage.py deliver_scheduled_emails
             )
             if email_jobs_to_deliver:
                 for job in email_jobs_to_deliver:
-                    try:
-                        deliver_scheduled_emails(job)
-                    except EmailNotDeliveredException:
-                        logger.warning("%r not delivered", job)
+                    deliver_scheduled_emails(job)
                 time.sleep(10)
             else:
                 # Less load on the db during times of activity,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

https://github.com/zulip/zulip/issues/17896.

**Testing plan:** <!-- How have you tested? -->

Automated tests. There exists already plenty of tests that verify that `deliver_scheduled_emails` and all the functions called insied it work fine. 

**Description**

Previously `deliver_scheduled_emails` was sending outgoing emails by
itself rather than through `EmailSendingWorker` that is designed for
this purpose. With these changes the `deliver_scheduled_emails`
command will benefit from the retry mechanisms and performance
optimizations that are implemented inside the forementioned worker.

As the exceptions are already handled inside the worker the
`command/deliver_scheduled_emails` file doesn't need to manage them
anymore.

Fixes: #17896.

**Grey area**

In the current implementation I think that if the email was not correctly sent it is not deleted from the `ScheduledEmail.objects` pool because the exception is raised before the `email.delete()` statement and this allows to resend it later. 

I'm not sure if we want to keep that as `EmailSendingWorker` is supposed to handle the exceptions and to give up only when we consider that it is not worth to continue trying anymore. If we do I must find a way to detect that the particular `SheduledEmail` object that we want to send was not sent properly and should remain in the pool but I'm not sure about how to do that as `queue_json_publish` doesn't raise any exception when this happens.

Is there a way to check a log file or anything else to detect that a specific scheduled email was not sent ?