### PR TITLE
performance: Use values_list in message edit code.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5982,7 +5982,7 @@ def do_update_message(
 
             # All users that are subscribed to the stream must be
             # notified when a message is edited
-            subscriber_ids = [user.user_profile_id for user in subscriptions]
+            subscriber_ids = set(subscriptions.values_list("user_profile_id", flat=True))
 
             if new_stream is not None:
                 # TODO: Guest users don't see the new moved topic
@@ -6004,9 +6004,9 @@ def do_update_message(
                 subscriptions = subscriptions.exclude(
                     user_profile_id__in=[sub.user_profile_id for sub in old_stream_unsubbed_guests]
                 )
-                subscriber_ids = [user.user_profile_id for user in subscriptions]
+                subscriber_ids = set(subscriptions.values_list("user_profile_id", flat=True))
 
-            users_to_be_notified += list(map(subscriber_info, subscriber_ids))
+            users_to_be_notified += list(map(subscriber_info, sorted(list(subscriber_ids))))
 
     send_event(user_profile.realm, event, users_to_be_notified)
 


### PR DESCRIPTION
For these subscription queries in the message-edit
code path, we don't need fat objects.

We also just do set substraction in Python
instead of passing a bunch of ids to the
database to exclude. I believe this is less work
in Python (set manipulation vs. ORM), less
work in the DB itself (obviously), and basically
a wash for data over the wire (more return values
but smaller query).

Unfortunately, the numbers on this are too noisy
to draw any obvious conclusions that it's faster.
But I think it's a good simplification if it's
only even a mild performance improvement.

In passing I inlined a few helper functions.

