### PR TITLE
tests: Clean up tests for realm_domain and update_streams endpoint.

### DIFF
--- a/zerver/tests/test_realm_domains.py
+++ b/zerver/tests/test_realm_domains.py
@@ -26,14 +26,11 @@ class RealmDomainTest(ZulipTestCase):
         RealmDomain.objects.create(realm=realm, domain="acme.com", allow_subdomains=True)
         result = self.client_get("/json/realm/domains")
         self.assert_json_success(result)
-        received = orjson.dumps(result.json()["domains"], option=orjson.OPT_SORT_KEYS)
-        expected = orjson.dumps(
-            [
-                {"domain": "zulip.com", "allow_subdomains": False},
-                {"domain": "acme.com", "allow_subdomains": True},
-            ],
-            option=orjson.OPT_SORT_KEYS,
-        )
+        received = result.json()["domains"]
+        expected = [
+            {"domain": "zulip.com", "allow_subdomains": False},
+            {"domain": "acme.com", "allow_subdomains": True},
+        ]
         self.assertEqual(received, expected)
 
     def test_not_realm_admin(self) -> None:

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -715,7 +715,7 @@ class StreamAdminTest(ZulipTestCase):
             stream_id = get_stream("private_stream", user_profile.realm).id
             result = self.client_patch(
                 f"/json/streams/{stream_id}",
-                {"description": orjson.dumps("Test description").decode()},
+                {"description": "Test description"},
             )
         self.assert_json_success(result)
         # Should be just a description change event
@@ -939,7 +939,7 @@ class StreamAdminTest(ZulipTestCase):
 
         result = self.client_patch(
             f"/json/streams/{stream_id}",
-            {"new_description": orjson.dumps("new description").decode()},
+            {"description": "new description"},
         )
         self.assert_json_success(result)
 
@@ -973,7 +973,7 @@ class StreamAdminTest(ZulipTestCase):
 
         result = self.client_patch(
             f"/json/streams/{stream_id}",
-            {"new_description": "new description"},
+            {"description": "new description"},
         )
         self.assert_json_error(result, "Invalid stream id")
 


### PR DESCRIPTION
Cleaning up test_realm_domains.RealmDomainTest.test_list_realm_domains,
test_subs.StreamAdminTest.test_private_stream_live_updates,
test_subs.StreamAdminTest.test_realm_admin_can_update_unsub_private_stream
and test_subs.StreamAdminTest.test_non_admin_cannot_access_unsub_private_stream.