### PR TITLE
hotkey: Render default_view via changing hash.

### DIFF
--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -94,7 +94,14 @@ function show_all_message_view() {
     setTimeout(navigate.maybe_scroll_to_selected, 0);
 }
 
-export function show_default_view() {
+export function set_hash_to_default_view() {
+    window.location.hash = "";
+}
+
+function show_default_view() {
+    // This function should only be called from the hashchange
+    // handlers, as it does not set the hash to "".
+    //
     // We only allow all_messages and recent_topics
     // to be rendered without a hash.
     if (page_params.default_view === "recent_topics") {

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -332,7 +332,7 @@ export function process_escape_key(e) {
         return true;
     }
 
-    hashchange.show_default_view();
+    hashchange.set_hash_to_default_view();
     return true;
 }
 


### PR DESCRIPTION
Directly rendering the default view on pressing `escape` key
will lead to default_view being rendered on the current window
hash. So, we set empty hash to load default view and let
hashchange handle it.


Bug:
1. Narrow to any stream
2. press escape
3. hash doesn't change but default_view is rendered.