### PR TITLE
Optimize bulk_access_messages and use for the message_edit code path.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5877,6 +5877,7 @@ def do_update_message(
         }
 
         messages_list = update_messages_for_topic_edit(
+            acting_user=user_profile,
             edited_message=target_message,
             propagate_mode=propagate_mode,
             orig_topic_name=orig_topic_name,

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5791,7 +5791,6 @@ def do_update_message(
         event["propagate_mode"] = propagate_mode
         event["stream_id"] = target_message.recipient.type_id
 
-    old_recipient_id = None
     if new_stream is not None:
         assert content is None
         assert target_message.is_stream_message()
@@ -5799,7 +5798,6 @@ def do_update_message(
 
         edit_history_event["prev_stream"] = stream_being_edited.id
         event[ORIG_TOPIC] = orig_topic_name
-        old_recipient_id = target_message.recipient_id
         target_message.recipient_id = new_stream.recipient_id
 
         event["new_stream_id"] = new_stream.id
@@ -5864,6 +5862,8 @@ def do_update_message(
     delete_event_notify_user_ids: List[int] = []
     if propagate_mode in ["change_later", "change_all"]:
         assert topic_name is not None or new_stream is not None
+        assert stream_being_edited is not None
+
         # Other messages should only get topic/stream fields in their edit history.
         topic_only_edit_history_event = {
             k: v
@@ -5883,7 +5883,7 @@ def do_update_message(
             orig_topic_name=orig_topic_name,
             topic_name=topic_name,
             new_stream=new_stream,
-            old_recipient_id=old_recipient_id,
+            old_stream=stream_being_edited,
             edit_history_event=topic_only_edit_history_event,
             last_edit_time=timestamp,
         )

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -729,9 +729,15 @@ def has_message_access(
 def bulk_access_messages(user_profile: UserProfile, messages: Sequence[Message]) -> List[Message]:
     filtered_messages = []
 
+    user_message_set = set(
+        bulk_access_messages_expect_usermessage(
+            user_profile.id, [message.id for message in messages]
+        )
+    )
+
     for message in messages:
-        user_message = get_usermessage_by_message_id(user_profile, message.id)
-        if has_message_access(user_profile, message, has_user_message=user_message is not None):
+        has_user_message = message.id in user_message_set
+        if has_message_access(user_profile, message, has_user_message=has_user_message):
             filtered_messages.append(message)
     return filtered_messages
 

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -671,7 +671,7 @@ def access_message(
 
     user_message = get_usermessage_by_message_id(user_profile, message_id)
 
-    if has_message_access(user_profile, message, user_message):
+    if has_message_access(user_profile, message, has_user_message=user_message is not None):
         return (message, user_message)
     raise JsonableError(_("Invalid message(s)"))
 
@@ -679,8 +679,8 @@ def access_message(
 def has_message_access(
     user_profile: UserProfile,
     message: Message,
-    user_message: Optional[UserMessage],
     *,
+    has_user_message: bool,
     stream: Optional[Stream] = None,
     is_subscribed: Optional[bool] = None,
 ) -> bool:
@@ -693,7 +693,7 @@ def has_message_access(
     """
 
     # If you have a user_message object, you have access.
-    if user_message is not None:
+    if has_user_message:
         return True
 
     if message.recipient.type != Recipient.STREAM:
@@ -731,7 +731,7 @@ def bulk_access_messages(user_profile: UserProfile, messages: Sequence[Message])
 
     for message in messages:
         user_message = get_usermessage_by_message_id(user_profile, message.id)
-        if has_message_access(user_profile, message, user_message):
+        if has_message_access(user_profile, message, has_user_message=user_message is not None):
             filtered_messages.append(message)
     return filtered_messages
 

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -726,7 +726,9 @@ def has_message_access(
     ).exists()
 
 
-def bulk_access_messages(user_profile: UserProfile, messages: Sequence[Message]) -> List[Message]:
+def bulk_access_messages(
+    user_profile: UserProfile, messages: Sequence[Message], *, stream: Optional[Stream] = None
+) -> List[Message]:
     filtered_messages = []
 
     user_message_set = set(
@@ -737,7 +739,9 @@ def bulk_access_messages(user_profile: UserProfile, messages: Sequence[Message])
 
     for message in messages:
         has_user_message = message.id in user_message_set
-        if has_message_access(user_profile, message, has_user_message=has_user_message):
+        if has_message_access(
+            user_profile, message, has_user_message=has_user_message, stream=stream
+        ):
             filtered_messages.append(message)
     return filtered_messages
 

--- a/zerver/lib/stream_subscription.py
+++ b/zerver/lib/stream_subscription.py
@@ -58,6 +58,14 @@ def get_subscribed_stream_ids_for_user(user_profile: UserProfile) -> QuerySet:
     ).values_list("recipient__type_id", flat=True)
 
 
+def get_subscribed_stream_recipient_ids_for_user(user_profile: UserProfile) -> QuerySet:
+    return Subscription.objects.filter(
+        user_profile_id=user_profile,
+        recipient__type=Recipient.STREAM,
+        active=True,
+    ).values_list("recipient_id", flat=True)
+
+
 def get_stream_subscriptions_for_user(user_profile: UserProfile) -> QuerySet:
     # TODO: Change return type to QuerySet[Subscription]
     return Subscription.objects.filter(

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -159,8 +159,18 @@ def update_messages_for_topic_edit(
 
     update_fields = ["edit_history", "last_edit_time"]
 
-    # Evaluate the query before running the update
-    messages_list = list(messages)
+    if new_stream is not None:
+        # If we're moving the messages between streams, only move
+        # messages that the acting user can access, so that one cannot
+        # gain access to messages through moving them.
+        from zerver.lib.message import bulk_access_messages
+
+        messages_list = bulk_access_messages(acting_user, messages, stream=old_stream)
+    else:
+        # For single-message edits or topic moves within a stream, we
+        # allow moving history the user may not have access in order
+        # to keep topics together.
+        messages_list = list(messages)
 
     # The cached ORM objects are not changed by the upcoming
     # messages.update(), and the remote cache update (done by the

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -145,18 +145,11 @@ def update_messages_for_topic_edit(
     orig_topic_name: str,
     topic_name: Optional[str],
     new_stream: Optional[Stream],
-    old_recipient_id: Optional[int],
+    old_stream: Stream,
     edit_history_event: Dict[str, Any],
     last_edit_time: datetime,
 ) -> List[Message]:
-    assert (new_stream and old_recipient_id) or (not new_stream and not old_recipient_id)
-
-    if old_recipient_id is not None:
-        recipient_id = old_recipient_id
-    else:
-        recipient_id = edited_message.recipient_id
-
-    propagate_query = Q(recipient_id=recipient_id, subject__iexact=orig_topic_name)
+    propagate_query = Q(recipient_id=old_stream.recipient_id, subject__iexact=orig_topic_name)
     if propagate_mode == "change_all":
         propagate_query = propagate_query & ~Q(id=edited_message.id)
     if propagate_mode == "change_later":

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -139,6 +139,7 @@ def update_edit_history(
 
 
 def update_messages_for_topic_edit(
+    acting_user: UserProfile,
     edited_message: Message,
     propagate_mode: str,
     orig_topic_name: str,

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -1360,17 +1360,26 @@ class EditMessageTest(ZulipTestCase):
         )
 
         self.assertEqual(
-            has_message_access(guest_user, Message.objects.get(id=msg_id_to_test_acesss), None),
-            True,
-        )
-        self.assertEqual(
             has_message_access(
-                guest_user, Message.objects.get(id=msg_id_to_test_acesss), None, stream=old_stream
+                guest_user, Message.objects.get(id=msg_id_to_test_acesss), has_user_message=False
             ),
             True,
         )
         self.assertEqual(
-            has_message_access(non_guest_user, Message.objects.get(id=msg_id_to_test_acesss), None),
+            has_message_access(
+                guest_user,
+                Message.objects.get(id=msg_id_to_test_acesss),
+                has_user_message=False,
+                stream=old_stream,
+            ),
+            True,
+        )
+        self.assertEqual(
+            has_message_access(
+                non_guest_user,
+                Message.objects.get(id=msg_id_to_test_acesss),
+                has_user_message=False,
+            ),
             True,
         )
 
@@ -1386,11 +1395,19 @@ class EditMessageTest(ZulipTestCase):
         self.assert_json_success(result)
 
         self.assertEqual(
-            has_message_access(guest_user, Message.objects.get(id=msg_id_to_test_acesss), None),
+            has_message_access(
+                guest_user,
+                Message.objects.get(id=msg_id_to_test_acesss),
+                has_user_message=False,
+            ),
             False,
         )
         self.assertEqual(
-            has_message_access(non_guest_user, Message.objects.get(id=msg_id_to_test_acesss), None),
+            has_message_access(
+                non_guest_user,
+                Message.objects.get(id=msg_id_to_test_acesss),
+                has_user_message=False,
+            ),
             True,
         )
         self.assertEqual(
@@ -1400,7 +1417,7 @@ class EditMessageTest(ZulipTestCase):
             has_message_access(
                 guest_user,
                 Message.objects.get(id=msg_id_to_test_acesss),
-                None,
+                has_user_message=False,
                 stream=new_stream,
                 is_subscribed=True,
             ),
@@ -1409,14 +1426,20 @@ class EditMessageTest(ZulipTestCase):
 
         self.assertEqual(
             has_message_access(
-                guest_user, Message.objects.get(id=msg_id_to_test_acesss), None, stream=new_stream
+                guest_user,
+                Message.objects.get(id=msg_id_to_test_acesss),
+                has_user_message=False,
+                stream=new_stream,
             ),
             False,
         )
         with self.assertRaises(AssertionError):
             # Raises assertion if you pass an invalid stream.
             has_message_access(
-                guest_user, Message.objects.get(id=msg_id_to_test_acesss), None, stream=old_stream
+                guest_user,
+                Message.objects.get(id=msg_id_to_test_acesss),
+                has_user_message=False,
+                stream=old_stream,
             )
 
         self.assertEqual(
@@ -1428,7 +1451,9 @@ class EditMessageTest(ZulipTestCase):
         )
         self.assertEqual(
             has_message_access(
-                self.example_user("iago"), Message.objects.get(id=msg_id_to_test_acesss), None
+                self.example_user("iago"),
+                Message.objects.get(id=msg_id_to_test_acesss),
+                has_user_message=False,
             ),
             True,
         )

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -1326,7 +1326,7 @@ class EditMessageTest(ZulipTestCase):
                     "topic": "new topic",
                 },
             )
-        self.assertEqual(len(queries), 50)
+        self.assertEqual(len(queries), 52)
         self.assertEqual(len(cache_tries), 13)
 
         messages = get_topic_messages(user_profile, old_stream, "test")

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -1307,7 +1307,7 @@ class MessageAccessTests(ZulipTestCase):
 
         with queries_captured() as queries:
             filtered_messages = bulk_access_messages(later_subscribed_user, messages)
-        self.assert_length(queries, 4)
+        self.assert_length(queries, 3)
 
         # Message sent before subscribing wouldn't be accessible by later
         # subscribed user as stream has protected history
@@ -1318,7 +1318,7 @@ class MessageAccessTests(ZulipTestCase):
 
         with queries_captured() as queries:
             filtered_messages = bulk_access_messages(later_subscribed_user, messages)
-        self.assert_length(queries, 5)
+        self.assert_length(queries, 4)
 
         # Message sent before subscribing are accessible by 8user as stream
         # don't have protected history
@@ -1329,7 +1329,7 @@ class MessageAccessTests(ZulipTestCase):
 
         with queries_captured() as queries:
             filtered_messages = bulk_access_messages(unsubscribed_user, messages)
-        self.assert_length(queries, 8)
+        self.assert_length(queries, 7)
 
         self.assertEqual(len(filtered_messages), 0)
 

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -1307,7 +1307,7 @@ class MessageAccessTests(ZulipTestCase):
 
         with queries_captured() as queries:
             filtered_messages = bulk_access_messages(later_subscribed_user, messages, stream=stream)
-        self.assert_length(queries, 1)
+        self.assert_length(queries, 2)
 
         # Message sent before subscribing wouldn't be accessible by later
         # subscribed user as stream has protected history
@@ -1329,7 +1329,7 @@ class MessageAccessTests(ZulipTestCase):
 
         with queries_captured() as queries:
             filtered_messages = bulk_access_messages(unsubscribed_user, messages, stream=stream)
-        self.assert_length(queries, 3)
+        self.assert_length(queries, 2)
 
         self.assertEqual(len(filtered_messages), 0)
 
@@ -1364,14 +1364,14 @@ class MessageAccessTests(ZulipTestCase):
         with queries_captured() as queries:
             filtered_messages = bulk_access_messages(later_subscribed_user, messages, stream=stream)
         self.assertEqual(len(filtered_messages), 2)
-        self.assert_length(queries, 1)
+        self.assert_length(queries, 2)
 
         unsubscribed_user = self.example_user("ZOE")
         with queries_captured() as queries:
             filtered_messages = bulk_access_messages(unsubscribed_user, messages, stream=stream)
 
         self.assertEqual(len(filtered_messages), 2)
-        self.assert_length(queries, 1)
+        self.assert_length(queries, 2)
 
 
 class PersonalMessagesFlagTest(ZulipTestCase):


### PR DESCRIPTION
This will mainly be used in #18051, but I figure it's worth doing a separate PR for this new prefix as its own PR, to facilitate dedicated review on this logic, which does touch security-sensitive functions.