### PR TITLE
recent_topics: Extend the borders to bottom of window.

### DIFF
--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -18,6 +18,12 @@
         border-width: 0 1px;
         border-radius: 0;
         margin-top: 40px;
+        /* To make the table span full height
+         * when rows don't reach bottom of the
+         * window. This makes the border span
+         * fully to bottom in that case.
+         */
+        min-height: 100vw;
 
         td {
             vertical-align: middle;


### PR DESCRIPTION

When height of topics is less than window height, the borders
don't reach bottom. So, we min-height for the table to make it
span to the bottom.
<img width="929" alt="Screenshot 2021-05-13 at 3 50 19 AM" src="https://user-images.githubusercontent.com/25124304/118051284-59ef6d00-b39e-11eb-8708-33c6ef4a844e.png">
