### PR TITLE
compose_control_buttons: Embed GIF icon in <a> tag.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2562,8 +2562,9 @@ div.topic_edit_spinner .loading_indicator_spinner {
             top: -1px;
         }
 
-        .compose_gif_icon {
+        a.compose_gif_icon {
             top: 6px;
+            font-size: 23px;
         }
     }
 

--- a/static/templates/compose_control_buttons.hbs
+++ b/static/templates/compose_control_buttons.hbs
@@ -6,8 +6,7 @@
 <a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"></a>
 <a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"></a>
 <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 data-tippy-content="{{t 'Add emoji' }}"></a>
-<a role="button" class="compose_control_button compose_giphy_link {{#unless giphy_enabled }} hide {{/unless}}" aria-label="{{t 'Add GIF' }}" data-tippy-content="{{t 'Add GIF' }}">
-    <i class="compose_gif_icon zulip-icon zulip-icon-gif" tabindex=0></i>
+<a role="button" class="compose_control_button compose_giphy_link compose_gif_icon zulip-icon zulip-icon-gif{{#unless giphy_enabled }} hide {{/unless}}" aria-label="{{t 'Add GIF' }}" data-tippy-content="{{t 'Add GIF' }}" tabindex=0>
 </a>
 {{#unless hide_drafts_link}}
 <a class="message-control-link drafts-link" href="#drafts" title="{{t 'Drafts' }} (d)">{{t 'Drafts' }}</a>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? --> GIF icon has some vertical alignment issue due to increase in font size. On a way to fix it. 


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/59444243/118083780-2849c680-b3dd-11eb-8ac4-ef4963c7accc.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
