### PR TITLE
[Incorrect fix]compose: Change the tag of compose_drafts_button.

### DIFF
--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -32,9 +32,9 @@
             </span>
             {{/unless}}
             <span class="new_message_button">
-                <a class="drafts-link no-underline button small rounded compose_drafts_button" href="#drafts" title="{{t 'Drafts' }} (d)">
+                <button class="drafts-link no-underline button small rounded compose_drafts_button" href="#drafts" title="{{t 'Drafts' }} (d)">
                     {{t 'Drafts' }}
-                </a>
+                </button>
             </span>
         </div>
     </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? --> This is not the correct fix.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/59444243/118088737-22f07a00-b3e5-11eb-8afa-2be30dbe15a7.png)

After zoomed-in
![image](https://user-images.githubusercontent.com/59444243/118089533-14ef2900-b3e6-11eb-8d24-da92e88121ea.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
