### PR TITLE
pm_list: Use "Muted user" placeholder for muted usernames.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -397,8 +397,18 @@ test_people("pm_lookup_key", () => {
 
 test_people("get_recipients", () => {
     people.add_active_user(isaac);
+    people.add_active_user(linus);
     assert.equal(people.get_recipients("30"), "Me Myself");
     assert.equal(people.get_recipients("30,32"), "Isaac Newton");
+
+    muting.add_muted_user(304);
+    assert.equal(people.get_recipients("304,32"), "Isaac Newton, translated: Muted user");
+});
+
+test_people("get_full_name", () => {
+    people.add_active_user(isaac);
+    const names = people.get_full_name(isaac.user_id);
+    assert.equal(names, "Isaac Newton");
 });
 
 test_people("get_full_names_for_poll_option", () => {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -333,7 +333,7 @@ export function get_recipients(user_ids_string) {
         return my_full_name();
     }
 
-    const names = other_ids.map((user_id) => get_full_name(user_id)).sort();
+    const names = get_display_full_names(other_ids).sort();
     return names.join(", ");
 }
 


### PR DESCRIPTION
This also handles a few other places missed earlier like
narrow headings, beacuse they use the same function.

We already rerender the PM list for events, so there's no
need to do anything special when someone is muted/unmuted.

![image](https://user-images.githubusercontent.com/55339528/118094675-aa8db700-b3ec-11eb-8143-b29a95e19a82.png)

I also grepped for patterns like `map((user_id) => get_full_name(user_id)` and there aren't any remaining after this.