### PR TITLE
outgoing_webhook: Treat "" json in response as response_not_required.

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -292,6 +292,12 @@ def process_success_response(
     except json.JSONDecodeError:
         raise JsonableError(_("Invalid JSON in response"))
 
+    if response_json == "":
+        # Versions of zulip_botserver before 2021-05 used
+        # json.dumps("") as their "no response required" success
+        # response; handle that for backwards-compatibility.
+        return
+
     if not isinstance(response_json, dict):
         raise JsonableError(_("Invalid response format"))
 


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/127-integrations/topic/deploying.20bots.20on.20heroku.3F.3F.3F/near/1179806

b7b1ec0aebbf75c2f66a4c81a42bf4da0ac7c9e1 made our checks of the response
format stronger, to enforce that the json translates to a valid dict.
However, old client code (zulip_botserver) was using "" as equivalent to
response_not_required - so we need to keep backward-compatibility to not
break things built on it.