### PR TITLE
emails: Change logging level of empty gateway pattern.

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -155,11 +155,10 @@ def get_usable_missed_message_address(address: str) -> MissedMessageEmailAddress
 
 
 def create_missed_message_address(user_profile: UserProfile, message: Message) -> str:
+    # If the email gateway isn't configured, we specify a reply
+    # address, since there's no useful way for the user to reply into
+    # Zulip.
     if settings.EMAIL_GATEWAY_PATTERN == "":
-        logger.warning(
-            "EMAIL_GATEWAY_PATTERN is an empty string, using "
-            "NOREPLY_EMAIL_ADDRESS in the 'from' field."
-        )
         return FromAddress.NOREPLY
 
     mm_address = MissedMessageEmailAddress.objects.create(


### PR DESCRIPTION
Hi :)

The default settings for the production installation set the EMAIL_GATEWAY_PATTERN to an empty string.
This value is only required to change for the incoming email integration as described in the docs:
https://zulip.readthedocs.io/en/latest/production/email-gateway.html
However, on every missed_message delivery, a warning gets logged to `errors.log`:
`WARN [zerver.lib.email_mirror] EMAIL_GATEWAY_PATTERN is an empty string, using NOREPLY_EMAIL_ADDRESS in the 'from' field.`

This commit changes the logging level from "warning" to "debug" in order to avoid these messages in production environments.

Imho, these log messages are a bit annoying as there are **a lot** of them and they don't really provide any useful information, as far as I understand this setting and the docs.

Thanks :)