### PR TITLE
recent-topics: Fix tooltip placement and details.

### DIFF
--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -50,7 +50,7 @@
         </ul>
     </td>
     <td class="recent_topic_timestamp">
-        <div class="last_msg_time tippy-zulip-tooltip" data-tippy-content="{{this.full_last_msg_date_time}}">
+        <div class="last_msg_time tippy-zulip-tooltip" data-tippy-content="{{this.full_last_msg_date_time}}" data-tippy-placement="top">
             {{ last_msg_time }}
         </div>
     </td>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Currently it only fixes placement of tooltip for time displayed in recent topic rows, it went unnoticed in #18480 .

If this remains open by then, I plan to add another commit about tooltip with extra senders(for which we show `+n`) fullnames. Work on that is also completed but is blocked due to a minor problem I mentioned on [https://chat.zulip.org/#narrow/stream/6-frontend/topic/Recent.20topics.20tooltips/near/1180254](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Recent.20topics.20tooltips/near/1180254).
