### PR TITLE
postgresql-init-db: Fix installation from world-unreadable directory

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -522,8 +522,11 @@ if has_class "zulip::app_frontend_base"; then
 fi
 
 # Set up a basic .gitconfig for the 'zulip' user
-su zulip -c "git config --global user.email $ZULIP_ADMINISTRATOR"
-su zulip -c "git config --global user.name 'Zulip Server ($EXTERNAL_HOST)'"
+(
+    cd / # Make sure the current working directory is readable by zulip
+    su zulip -c "git config --global user.email $ZULIP_ADMINISTRATOR"
+    su zulip -c "git config --global user.name 'Zulip Server ($EXTERNAL_HOST)'"
+)
 
 if [ -n "$NO_INIT_DB" ]; then
     set +x

--- a/scripts/setup/postgresql-init-db
+++ b/scripts/setup/postgresql-init-db
@@ -28,7 +28,7 @@ fi
 
 # Shut down all services to ensure a quiescent state.
 if [ -e "/var/run/supervisor.sock" ]; then
-    su zulip -c "$(dirname "$(dirname "$0")")/stop-server"
+    supervisorctl stop all
 fi
 
 # Drop any open connections to any old database.


### PR DESCRIPTION
This reverts part of commit 476524c0c19af0edd0b579c42e3c9d7811de547d (#18215), to fix this error when running the installer from a directory that isn’t world-readable:

```
+ '[' -e /var/run/supervisor.sock ']'
+++ dirname /root/zulip-server-4.1/scripts/setup/postgresql-init-db
++ dirname /root/zulip-server-4.1/scripts/setup
+ su zulip -c /root/zulip-server-4.1/scripts/stop-server
bash: /root/zulip-server-4.1/scripts/stop-server: Permission denied

Zulip installation failed (exit code 126)!
```

Cc @alexmv.