### PR TITLE
message view: Allow muted user's message to be rehidden.

### DIFF
--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -203,7 +203,7 @@ test("muted_message_vars", () => {
         assert.equal(result[1].contains_mention, false);
 
         // Now, reveal the hidden messages.
-        const is_revealed = true;
+        let is_revealed = true;
         result = calculate_variables(list, messages, is_revealed);
 
         // Check that `is_hidden` is false and `include_sender` is true on all messages.
@@ -217,6 +217,22 @@ test("muted_message_vars", () => {
 
         // Additionally test that, `contains_mention` is true on that message which has a mention.
         assert.equal(result[1].contains_mention, true);
+
+        // Now test rehiding muted user's messsage
+        is_revealed = false;
+        result = calculate_variables(list, messages, is_revealed);
+
+        // Check that `is_hidden` is false and `include_sender` is false on all messages.
+        assert.equal(result[0].is_hidden, true);
+        assert.equal(result[1].is_hidden, true);
+        assert.equal(result[2].is_hidden, true);
+
+        assert.equal(result[0].include_sender, false);
+        assert.equal(result[1].include_sender, false);
+        assert.equal(result[2].include_sender, false);
+
+        // Additionally test that, `contains_mention` is false on that message which has a mention.
+        assert.equal(result[1].contains_mention, false);
     })();
 });
 

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -21,7 +21,11 @@ mock_esm("../../static/js/giphy", {
     hide_giphy_popover: noop,
 });
 const message_lists = mock_esm("../../static/js/message_lists", {
-    current: {},
+    current: {
+        view: {
+            message_containers: {},
+        },
+    },
 });
 mock_esm("../../static/js/message_viewport", {
     height: () => 500,
@@ -228,6 +232,13 @@ test_ui("actions_popover", (override) => {
     message_lists.current.get = (msg_id) => {
         assert.equal(msg_id, message.id);
         return message;
+    };
+
+    message_lists.current.view.message_containers.get = (msg_id) => {
+        assert.equal(msg_id, message.id);
+        return {
+            is_hidden: false,
+        };
     };
 
     override(message_edit, "get_editability", () => 4);

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -244,6 +244,11 @@ export function initialize() {
     });
 
     $("body").on("click", ".reveal_hidden_message", (e) => {
+        // Hide actions popover to keep its options
+        // in sync with revealed/hidden state of
+        // muted user's message.
+        popovers.hide_actions_popover();
+
         const message_id = rows.id($(e.currentTarget).closest(".message_row"));
         message_lists.current.view.reveal_hidden_message(message_id);
         e.stopPropagation();

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -1186,6 +1186,11 @@ export class MessageListView {
         this._rerender_message(message_container, false, true);
     }
 
+    hide_revealed_message(message_id) {
+        const message_container = this.message_containers.get(message_id);
+        this._rerender_message(message_container, false, false);
+    }
+
     rerender_messages(messages, message_content_edited) {
         // Convert messages to list messages
         let message_containers = messages.map((message) => this.message_containers.get(message.id));

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -1163,7 +1163,7 @@ export class MessageListView {
         header.replaceWith(rendered_recipient_row);
     }
 
-    _rerender_message(message_container, message_content_edited, is_revealed) {
+    _rerender_message(message_container, {message_content_edited, is_revealed}) {
         const row = this.get_row(message_container.msg.id);
         const was_selected = this.list.selected_message() === message_container.msg;
 
@@ -1183,12 +1183,18 @@ export class MessageListView {
 
     reveal_hidden_message(message_id) {
         const message_container = this.message_containers.get(message_id);
-        this._rerender_message(message_container, false, true);
+        this._rerender_message(message_container, {
+            message_content_edited: false,
+            is_revealed: true,
+        });
     }
 
     hide_revealed_message(message_id) {
         const message_container = this.message_containers.get(message_id);
-        this._rerender_message(message_container, false, false);
+        this._rerender_message(message_container, {
+            message_content_edited: false,
+            is_revealed: false,
+        });
     }
 
     rerender_messages(messages, message_content_edited) {
@@ -1212,7 +1218,7 @@ export class MessageListView {
                 message_groups.push(current_group);
                 current_group = [];
             }
-            this._rerender_message(message_container, message_content_edited);
+            this._rerender_message(message_container, {message_content_edited, is_revealed: false});
         }
 
         if (current_group.length !== 0) {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -524,6 +524,8 @@ export function toggle_actions_popover(element, id) {
     const elt = $(element);
     if (elt.data("popover") === undefined) {
         const message = message_lists.current.get(id);
+        const message_container = message_lists.current.view.message_containers.get(message.id);
+        const should_display_hide_option = !message_container.is_hidden;
         const editability = message_edit.get_editability(message);
         let use_edit_icon;
         let editability_menu_item;
@@ -582,6 +584,7 @@ export function toggle_actions_popover(element, id) {
             should_display_uncollapse,
             should_display_add_reaction_option: message.sent_by_me,
             should_display_edit_history_option,
+            should_display_hide_option,
             conversation_time_uri,
             narrowed: narrow_state.active(),
             should_display_delete_option,
@@ -1246,6 +1249,21 @@ export function register_click_handlers() {
         const row = message_lists.current.get_row(message_id);
         hide_actions_popover();
         message_edit.start(row);
+        e.stopPropagation();
+        e.preventDefault();
+    });
+    $("body").on("click", ".rehide_muted_user_message", (e) => {
+        const message_id = $(e.currentTarget).data("message-id");
+        const row = message_lists.current.get_row(message_id);
+        const message = message_lists.current.get(rows.id(row));
+        const message_container = message_lists.current.view.message_containers.get(message.id);
+
+        hide_actions_popover();
+
+        if (row && !message_container.is_hidden) {
+            message_lists.current.view.hide_revealed_message(message_id);
+        }
+
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -1,5 +1,14 @@
 {{! Contents of the "message actions" popup }}
 <ul class="nav nav-list actions_popover">
+    {{#if should_display_hide_option}}
+    <li>
+        <a href="#" class="rehide_muted_user_message" data-message-id="{{message_id}}">
+            <i class="fa fa-eye-slash" aria-hidden="true"></i>
+            {{t "Hide muted message again" }}
+        </a>
+    </li>
+    {{/if}}
+
     {{#if should_display_edit_and_view_source}}
     <li>
         <a href="#" class="popover_edit_message" data-message-id="{{message_id}}">

--- a/templates/zerver/help/mute-a-user.md
+++ b/templates/zerver/help/mute-a-user.md
@@ -13,7 +13,7 @@ have the following effects:
 
 * All messages sent by muted users, including the name, profile
   picture, and message content, are hidden behind a **Click here to
-  reveal** banner.
+  reveal** banner. A revealed message can later be [re-hidden](/help/mute-a-user#re-hide-a-message-that-has-been-revealed).
 
 * Muted users are hidden from [**Private
   messages**](/help/private-messages) in the left sidebar and the list
@@ -65,6 +65,16 @@ have the following effects:
 1. Click **Mute this user**.
 
 1. On the confirmation popup, click **Confirm**.
+
+{end_tabs}
+
+### Re-hide a message that has been revealed
+
+{start_tabs}
+
+{!message-actions-menu.md!}
+
+3. Click **Hide muted message again**.
 
 {end_tabs}
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
An new option is added in message action popover of a muted user
message that allows a muted user's message to be rehidden. 
Fixes: #18452.

**Testing plan:** Manually and existing node tests.


**GIFs or screenshots:** 
![rehide](https://user-images.githubusercontent.com/63504956/118269724-b35db600-b4dc-11eb-980a-479eb34a3a07.gif)


