### PR TITLE
ci: Unpack installation tarball under /root/.

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -151,12 +151,8 @@ jobs:
           # cache action to work. It is owned by root currently.
           sudo chmod -R 0777 /__w/_temp/
 
-          # Create the zulip directory that the tools/ci/ scripts needs
-          mkdir -p /home/github/zulip
-
           # Since actions/download-artifact@v2 loses all the permissions
           # of the tarball uploaded by the upload artifact fix those.
-          chmod +x /tmp/production-extract-tarball
           chmod +x /tmp/production-upgrade-pg
           chmod +x /tmp/production-install
           chmod +x /tmp/production-verify
@@ -181,9 +177,6 @@ jobs:
           # Temporary hack till `sudo service redis-server start` gets fixes in Bionic. See
           # https://chat.zulip.org/#narrow/stream/3-backend/topic/Ubuntu.20bionic.20CircleCI
           sudo sed -i '/^bind/s/bind.*/bind 0.0.0.0/' /etc/redis/redis.conf
-
-      - name: Production extract tarball
-        run: /tmp/production-extract-tarball
 
       - name: Install production
         run: |

--- a/tools/ci/production-build
+++ b/tools/ci/production-build
@@ -38,7 +38,6 @@ cp -a \
     tools/ci/production-install \
     tools/ci/production-verify \
     tools/ci/production-upgrade-pg \
-    tools/ci/production-extract-tarball \
     tools/ci/send-failure-message \
     package.json yarn.lock \
     \

--- a/tools/ci/production-extract-tarball
+++ b/tools/ci/production-extract-tarball
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-set -x
-
-ZULIP_PATH=/home/github/zulip
-tar -xf /tmp/zulip-server-test.tar.gz -C "$ZULIP_PATH" --strip-components=1

--- a/tools/ci/production-install
+++ b/tools/ci/production-install
@@ -4,7 +4,9 @@
 set -e
 set -x
 
-ZULIP_PATH=/home/github/zulip
+ZULIP_PATH=/root/zulip-latest
+mkdir -p "$ZULIP_PATH"
+tar -xf /tmp/zulip-server-test.tar.gz -C "$ZULIP_PATH" --strip-components=1
 
 # Do an apt upgrade to start with an up-to-date machine
 APT_OPTIONS=(-o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold')

--- a/tools/ci/production-upgrade-pg
+++ b/tools/ci/production-upgrade-pg
@@ -3,11 +3,9 @@
 set -e
 set -x
 
-cd /home/github/zulip
-
-su zulip -c ./scripts/stop-server
-./scripts/setup/upgrade-postgresql
-su zulip -c ./scripts/start-server
+su zulip -c /home/zulip/deployments/current/scripts/stop-server
+/home/zulip/deployments/current/scripts/setup/upgrade-postgresql
+su zulip -c /home/zulip/deployments/current/scripts/start-server
 
 echo "Upgrade of PostgreSQL complete!"
 exit 0


### PR DESCRIPTION
This ensures that we exercise the fact that the Zulip installer may be
unpacked to a directory that may not be world-readable.

bc4552536993c98eec6bc350fe9dd920d454a691 fixed a recent regression in
this behavior that would have been caught by this commit.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
