### PR TITLE
recent topics: Display other sender names in tooltip.

### DIFF
--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -293,6 +293,7 @@ function generate_topic_data(topic_info_array) {
     for (const [stream_id, topic, unread_count, muted, participated] of topic_info_array) {
         data.push({
             other_senders_count: 0,
+            other_sender_names: "",
             invite_only: false,
             is_web_public: true,
             last_msg_time: "Just now",

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -7,6 +7,7 @@ import render_recent_topics_body from "../templates/recent_topics_table.hbs";
 import * as compose_closed_ui from "./compose_closed_ui";
 import * as compose_state from "./compose_state";
 import * as hash_util from "./hash_util";
+import {$t} from "./i18n";
 import * as ListWidget from "./list_widget";
 import {localstorage} from "./localstorage";
 import * as message_store from "./message_store";
@@ -33,6 +34,7 @@ let topics_widget;
 // Sets the number of avatars to display.
 // Rest of the avatars, if present, are displayed as {+x}
 const MAX_AVATAR = 4;
+const MAX_EXTRA_SENDERS = 10;
 
 // Use this to set the focused element.
 //
@@ -317,6 +319,21 @@ function format_topic(topic_data) {
     const senders = all_senders.slice(-MAX_AVATAR);
     const senders_info = people.sender_info_for_recent_topics_row(senders);
 
+    // Collect extra senders fullname for tooltip.
+    const extra_sender_ids = all_senders.slice(0, -MAX_AVATAR);
+    const displayed_other_senders = extra_sender_ids.slice(-MAX_EXTRA_SENDERS);
+    const displayed_other_names = people.get_display_full_names(displayed_other_senders.reverse());
+
+    if (extra_sender_ids.length > MAX_EXTRA_SENDERS) {
+        // We display only 10 extra senders in tooltips,
+        // and just display remaining number of senders.
+        const remaining_senders = extra_sender_ids.length - MAX_EXTRA_SENDERS;
+        displayed_other_names.push(
+            $t({defaultMessage: `and {remaining_senders} other(s).`}, {remaining_senders}),
+        );
+    }
+    const other_sender_names = displayed_other_names.join("<br/>");
+
     return {
         // stream info
         stream_id,
@@ -333,6 +350,7 @@ function format_topic(topic_data) {
         topic_url: hash_util.by_stream_topic_uri(stream_id, topic),
         senders: senders_info,
         other_senders_count: Math.max(0, all_senders.length - MAX_AVATAR),
+        other_sender_names,
         muted,
         topic_muted,
         participated: topic_data.participated,

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -32,7 +32,7 @@
     <td class='recent_topic_users'>
         <ul class="recent_topics_participants">
             {{#if other_senders_count}}
-            <li class="recent_topics_participant_item">
+            <li class="recent_topics_participant_item tippy-zulip-tooltip" data-tippy-content="{{other_sender_names}}" data-tippy-placement="top" data-tippy-allowHtml="true">
                 <span class="recent_topics_participant_overflow">+{{other_senders_count}}</span>
             </li>
             {{/if}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
It is a follow up for #18451 and #18480.
**Testing plan:** Manually on dev server.

As can be seen in the gif, when tooltip is shown with max allowed width(300) and is on the first row, it is not shown in the top. While it's position is as expected(top), when it is not in the first row. On searching more about this on [tiipyjs repo issues](https://github.com/atomiks/tippyjs/issues/190) I found it is a popper.js problem. I'm not sure how to debug that, so I am trying to find a fix about that.

Other than that this work is ready for review.

**GIFs or screenshots:** 
![other_sender_tooltip](https://user-images.githubusercontent.com/63504956/118296594-c97a6f00-b4fa-11eb-91f9-c5c935b5df1b.gif)

