### PR TITLE
move_topic_model: Fix the height of dropdown-toggle button.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1592,10 +1592,13 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     button {
         margin: 0 5px;
         &.dropdown-toggle {
-            /* Matches bootstrap hardcoded 30px height for select elements,
-               which we want to match the size of. */
-            height: 30px;
-            padding: 0;
+            /* Match settings for select elements. */
+            padding: 4px 6px;
+
+            span {
+                line-height: 20px;
+                height: 1.4em;
+            }
         }
 
         &:disabled i {


### PR DESCRIPTION
Fixes #18479.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Here we are using `line-height` because it places the text in center itself.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:
![image](https://user-images.githubusercontent.com/59444243/118305227-49a5d200-b505-11eb-99da-456cdffcc2ee.png)

After:
![image](https://user-images.githubusercontent.com/59444243/118350611-4ea26a00-b575-11eb-9e0f-bc8c78169ad0.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
