### PR TITLE
dropdown_list_widget: Add 'type' attribute to reset button.

### DIFF
--- a/static/templates/settings/dropdown_list_widget.hbs
+++ b/static/templates/settings/dropdown_list_widget.hbs
@@ -19,7 +19,7 @@
         </ul>
     </span>
     {{#if reset_button_text}}
-    <button class="button small dropdown_list_reset_button">
+    <button class="button small dropdown_list_reset_button" type="button">
         <a>{{reset_button_text}}</a>
     </button>
     {{/if}}


### PR DESCRIPTION
Noticed this issue with the `Edit Bot` modal where pressing the <kbd>Enter</kbd> key triggers the `dropdown_list_widget` reset button instead of submitting the form.

<strong>Before</strong>

![error](https://user-images.githubusercontent.com/53977614/118317166-57635380-b515-11eb-9d8e-b10aa086ca36.gif)
<strong>After</strong>

![fix](https://user-images.githubusercontent.com/53977614/118317176-592d1700-b515-11eb-92da-d55e3adf17bc.gif)

Basically a followup of #18486.

I wonder where all do we modals that have an explicitly binded keydown/keypress event where a simple fix was by defining the button `type` attribute to actually be a `button` :) 




