### PR TITLE
docs: Document password hashing change from PBKDF2 to Argon2

### DIFF
--- a/docs/production/security-model.md
+++ b/docs/production/security-model.md
@@ -43,7 +43,10 @@ announcement).
 
 ### Passwords
 
-Zulip stores user passwords using the standard PBKDF2 algorithm.
+Zulip stores user passwords using the standard Argon2 and PBKDF2
+algorithms.  Argon2 is used for all new and changed passwords as of
+Zulip Server 1.6.0, but legacy PBKDF2 passwords that were last changed
+before the 1.6.0 upgrade are still supported.
 
 When the user is choosing a password, Zulip checks the password's
 strength using the popular [zxcvbn][zxcvbn] library.  Weak passwords


### PR DESCRIPTION
This changed in commit 483a351d44f34c1fb6667ea06e7a578a22f07738 (#3410).