### PR TITLE
muted_user_settings: Add table-sticky-headers class to table header.

### DIFF
--- a/static/templates/settings/muted_users_settings.hbs
+++ b/static/templates/settings/muted_users_settings.hbs
@@ -2,7 +2,7 @@
     <input id="muted_users_search" class="search" type="text" placeholder="{{t 'Filter muted users' }}" aria-label="{{t 'Filter muted users' }}"/>
     <div class="progressive-table-wrapper" data-simplebar data-list-widget="muted-users-list">
         <table class="table table-condensed table-striped wrapped-table">
-            <thead>
+            <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="user_name">{{t "User" }}</th>
                 <th data-sort="numeric" data-sort-prop="date_muted">{{t "Date muted" }}</th>
                 <th class="actions">{{t "Actions" }}</th>


### PR DESCRIPTION
table-sticky-headers class is used to make the header of the table fix at the top.
 

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
