### PR TITLE
message view: Fix tooltips in message action icons.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -89,7 +89,7 @@ export function initialize() {
                 // content from it.
                 //
                 // TODO: Change the template structure so logic is unnecessary.
-                const edit_button = elem.find("i.edit_content_button").expectOne();
+                const edit_button = elem.find("i.edit_content_button");
                 content = edit_button.attr("data-tippy-content");
             }
             instance.setContent(content);

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -92,7 +92,16 @@ export function initialize() {
                 const edit_button = elem.find("i.edit_content_button");
                 content = edit_button.attr("data-tippy-content");
             }
+            if (content === undefined) {
+                // If content is still undefined it is because content
+                // is specified on inner i tags and is handled by our
+                // general tippy-zulip-tooltip class. So we return
+                // false here to avoid showing an extra empty tooltip
+                // for such cases.
+                return false;
+            }
             instance.setContent(content);
+            return true;
         },
     });
 }

--- a/static/templates/message_controls.hbs
+++ b/static/templates/message_controls.hbs
@@ -16,8 +16,8 @@
     {{/unless}}
 
     <div class="message_failed message_control_button {{#unless msg.failed_request}}notvisible{{/unless}}">
-        <i class="fa fa-refresh refresh-failed-message tippy-zulip-tooltip" data-tippy-content="{{t 'Retry' }}" aria-label="{{t 'Retry' }}" role="button" tabindex="0"></i>
-        <i class="fa fa-times-circle remove-failed-message tippy-zulip-tooltip" data-tippy-content="{{t 'Cancel' }}" aria-label="{{t 'Cancel' }}" role="button" tabindex="0"></i>
+        <i class="fa fa-refresh refresh-failed-message tippy-zulip-tooltip" data-tippy-content="{{t 'Retry' }}" data-tippy-placement="top" aria-label="{{t 'Retry' }}" role="button" tabindex="0"></i>
+        <i class="fa fa-times-circle remove-failed-message tippy-zulip-tooltip" data-tippy-content="{{t 'Cancel' }}" data-tippy-placement="top" aria-label="{{t 'Cancel' }}" role="button" tabindex="0"></i>
     </div>
 
     {{#unless msg/locally_echoed}}


### PR DESCRIPTION
Related thread: [https://chat.zulip.org/#narrow/stream/9-issues/topic/Message.20actions.20tooltip](https://chat.zulip.org/#narrow/stream/9-issues/topic/Message.20actions.20tooltip)

Tooltips in message action buttons for failed message were
not shown properly because they were initialized two times
first because of general tippy-zulip-tooltip class and then
because of message_control_button class. So to avoid showing
an extra empty tooltip for failed message icons we return
false from onShow() method of message_control_button class
initialization of tooltip.

**GIFs or screenshots:** 
![message_action_tooltip](https://user-images.githubusercontent.com/63504956/118357638-d8affa00-b598-11eb-82aa-fb912b800db9.gif)

