### PR TITLE
portico: Hide the custom show password for MS browsers.

### DIFF
--- a/static/js/common.js
+++ b/static/js/common.js
@@ -110,6 +110,24 @@ function toggle_password_visibility(password_field_id, password_selector, tippy_
     set_password_toggle_label(password_selector, label, tippy_tooltips);
 }
 
+// Function to hide the visibility toggle for MS Browsers
+function check_if_show_password_to_hide() {
+    const user_agent = window.navigator.userAgent.toLowerCase();
+
+    // Internet Explorer
+    const is_IE = false || user_agent.includes("trident");
+
+    // MS Edge
+    const is_edge = false || user_agent.includes("edge");
+
+    // Edge (based on chromium)
+    const is_edge_chromium = false || user_agent.includes("edg");
+
+    if (is_IE || is_edge || is_edge_chromium) {
+        $(".password_visibility_toggle").css("display", "none");
+    }
+}
+
 export function reset_password_toggle_icons(password_field, password_selector) {
     $(password_field).attr("type", "password");
     $(password_selector).removeClass("fa-eye").addClass("fa-eye-slash");
@@ -126,4 +144,6 @@ export function setup_password_visibility_toggle(password_field_id, password_sel
         e.stopPropagation();
         toggle_password_visibility(password_field_id, password_selector, opts.tippy_tooltips);
     });
+
+    check_if_show_password_to_hide();
 }


### PR DESCRIPTION
This commit creates the function "check_if_show_password_to_hide" that checks
the browser type if it is MS browser (IE, Edge, Chromium Edge) and hides the
password visibiltiy toggle.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
CZO Link describing the problem in detail.
https://chat.zulip.org/#narrow/stream/101-design/topic/Show.20password/near/1173890

**Testing plan:** <!-- How have you tested? -->
From [this website](https://social.msdn.microsoft.com/Forums/en-US/edde0150-9478-4ca6-ba0f-9e084b5a4719/how-to-detect-microsoft-edge-chromium-chrome-ie-browser-using-javascript?forum=iewebdevelopment#:~:text=General%20discussion&text=User%20could%20use%20the%20window,%2C%20FireFox%2C%20Safari%20or%20Chrome.), I found the way to detect the browser type.

Have tested this PR on
- [x] Chrome
- [x] MS Edge Dev on Ubuntu (Testing this PR on this browser)
- [x] Opera browser
- [x] Brave browser
- [x] Chromium browser
- [x] Firefox browser
- [ ] IE
- [ ] Older Edge

I have tested on the type of browsers I have. If someone can check for other browser that are left in this list, it would be helpful.

**GIFs or screenshots:** <!-- If a UI chang.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
The screenshot from MS Edge browser.
![Screenshot from 2021-05-16 16-19-23](https://user-images.githubusercontent.com/56730716/118394456-85a27980-b662-11eb-9cd2-5e3c0461cff7.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
