### PR TITLE
markdown: Add support for user group silent mention and other followups.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -421,6 +421,20 @@ test("content_typeahead_selected", (override) => {
     expected_value = "@**Othello, the Moor of Venice** ";
     assert.equal(actual_value, expected_value);
 
+    fake_this.query = "@back";
+    fake_this.token = "back";
+    with_field(compose, "warn_if_mentioning_unsubscribed_user", unexpected_warn, () => {
+        actual_value = ct.content_typeahead_selected.call(fake_this, backend);
+    });
+    expected_value = "@*Backend* ";
+    assert.equal(actual_value, expected_value);
+
+    fake_this.query = "@*back";
+    fake_this.token = "back";
+    actual_value = ct.content_typeahead_selected.call(fake_this, backend);
+    expected_value = "@*Backend* ";
+    assert.equal(actual_value, expected_value);
+
     // silent mention
     fake_this.completing = "silent_mention";
     function unexpected_warn() {
@@ -454,18 +468,18 @@ test("content_typeahead_selected", (override) => {
     expected_value = "@_**King Hamlet** ";
     assert.equal(actual_value, expected_value);
 
-    fake_this.query = "@back";
+    fake_this.query = "@_back";
     fake_this.token = "back";
     with_field(compose, "warn_if_mentioning_unsubscribed_user", unexpected_warn, () => {
         actual_value = ct.content_typeahead_selected.call(fake_this, backend);
     });
-    expected_value = "@*Backend* ";
+    expected_value = "@_*Backend* ";
     assert.equal(actual_value, expected_value);
 
-    fake_this.query = "@*back";
+    fake_this.query = "@_*back";
     fake_this.token = "back";
     actual_value = ct.content_typeahead_selected.call(fake_this, backend);
-    expected_value = "@*Backend* ";
+    expected_value = "@_*Backend* ";
     assert.equal(actual_value, expected_value);
 
     fake_this.query = "/m";
@@ -1431,7 +1445,7 @@ test("filter_and_sort_mentions (silent)", () => {
 
     const suggestions = ct.filter_and_sort_mentions(is_silent, "al");
 
-    assert.deepEqual(suggestions, [alice, hal]);
+    assert.deepEqual(suggestions, [alice, hal, call_center]);
 });
 
 test("typeahead_results", () => {
@@ -1561,7 +1575,6 @@ test("muted users excluded from results", () => {
     // mentions typeaheads, so we need only test once.
     let results;
     const opts = {
-        want_groups: false,
         want_broadcast: true,
     };
 
@@ -1574,7 +1587,8 @@ test("muted users excluded from results", () => {
     results = ct.get_person_suggestions("corde", opts);
     assert.deepEqual(results, []);
 
-    // Make sure our muting logic doesn't break wildcard mentions.
+    // Make sure our muting logic doesn't break wildcard mentions
+    // or user group mentions.
     results = ct.get_person_suggestions("all", opts);
-    assert.deepEqual(results, [mention_all]);
+    assert.deepEqual(results, [mention_all, call_center]);
 });

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -404,6 +404,21 @@ test("marked", () => {
             expected:
                 '<blockquote>\n<p>Mention in quote: <span class="user-mention silent" data-user-id="101">Cordelia, Lear&#39;s daughter</span></p>\n</blockquote>\n<p>Mention outside quote: <span class="user-mention" data-user-id="101">@Cordelia, Lear&#39;s daughter</span></p>',
         },
+        {
+            input: "Wildcard mention: @**all**\nWildcard silent mention: @_**all**",
+            expected:
+                '<p>Wildcard mention: <span class="user-mention" data-user-id="*">@all</span><br>\nWildcard silent mention: <span class="user-mention silent" data-user-id="*">all</span></p>',
+        },
+        {
+            input: "> Wildcard mention in quote: @**all**\n\n> Another wildcard mention in quote: @_**all**",
+            expected:
+                '<blockquote>\n<p>Wildcard mention in quote: <span class="user-mention silent" data-user-id="*">all</span></p>\n</blockquote>\n<blockquote>\n<p>Another wildcard mention in quote: <span class="user-mention silent" data-user-id="*">all</span></p>\n</blockquote>',
+        },
+        {
+            input: "```quote\nWildcard mention in quote: @**all**\n```\n\n```quote\nAnother wildcard mention in quote: @_**all**\n```",
+            expected:
+                '<blockquote>\n<p>Wildcard mention in quote: <span class="user-mention silent" data-user-id="*">all</span></p>\n</blockquote>\n<blockquote>\n<p>Another wildcard mention in quote: <span class="user-mention silent" data-user-id="*">all</span></p>\n</blockquote>',
+        },
         // Test only those linkifiers which don't return True for
         // `contains_backend_only_syntax()`. Those which return True
         // are tested separately.
@@ -702,6 +717,16 @@ test("message_flags", () => {
     assert.equal(message.mentioned, false);
 
     input = "test @**invalid_user**";
+    message = {topic: "No links here", raw_content: input};
+    markdown.apply_markdown(message);
+    assert.equal(message.mentioned, false);
+
+    input = "test @_**all**";
+    message = {topic: "No links here", raw_content: input};
+    markdown.apply_markdown(message);
+    assert.equal(message.mentioned, false);
+
+    input = "> test @**all**";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
     assert.equal(message.mentioned, false);

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -424,6 +424,16 @@ test("marked", () => {
             expected:
                 '<p>User group mention: <span class="user-group-mention" data-user-group-id="2">@Backend</span><br>\nUser group silent mention: <span class="user-group-mention silent" data-user-group-id="1">hamletcharacters</span></p>',
         },
+        {
+            input: "> User group mention in quote: @*backend*\n\n> Another user group mention in quote: @*hamletcharacters*",
+            expected:
+                '<blockquote>\n<p>User group mention in quote: <span class="user-group-mention silent" data-user-group-id="2">Backend</span></p>\n</blockquote>\n<blockquote>\n<p>Another user group mention in quote: <span class="user-group-mention silent" data-user-group-id="1">hamletcharacters</span></p>\n</blockquote>',
+        },
+        {
+            input: "```quote\nUser group mention in quote: @*backend*\n```\n\n```quote\nAnother user group mention in quote: @*hamletcharacters*\n```",
+            expected:
+                '<blockquote>\n<p>User group mention in quote: <span class="user-group-mention silent" data-user-group-id="2">Backend</span></p>\n</blockquote>\n<blockquote>\n<p>Another user group mention in quote: <span class="user-group-mention silent" data-user-group-id="1">hamletcharacters</span></p>\n</blockquote>',
+        },
         // Test only those linkifiers which don't return True for
         // `contains_backend_only_syntax()`. Those which return True
         // are tested separately.
@@ -737,6 +747,11 @@ test("message_flags", () => {
     assert.equal(message.mentioned, false);
 
     input = "test @_*hamletcharacters*";
+    message = {topic: "No links here", raw_content: input};
+    markdown.apply_markdown(message);
+    assert.equal(message.mentioned, false);
+
+    input = "> test @*hamletcharacters*";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
     assert.equal(message.mentioned, false);

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -419,6 +419,11 @@ test("marked", () => {
             expected:
                 '<blockquote>\n<p>Wildcard mention in quote: <span class="user-mention silent" data-user-id="*">all</span></p>\n</blockquote>\n<blockquote>\n<p>Another wildcard mention in quote: <span class="user-mention silent" data-user-id="*">all</span></p>\n</blockquote>',
         },
+        {
+            input: "User group mention: @*backend*\nUser group silent mention: @_*hamletcharacters*",
+            expected:
+                '<p>User group mention: <span class="user-group-mention" data-user-group-id="2">@Backend</span><br>\nUser group silent mention: <span class="user-group-mention silent" data-user-group-id="1">hamletcharacters</span></p>',
+        },
         // Test only those linkifiers which don't return True for
         // `contains_backend_only_syntax()`. Those which return True
         // are tested separately.
@@ -727,6 +732,11 @@ test("message_flags", () => {
     assert.equal(message.mentioned, false);
 
     input = "> test @**all**";
+    message = {topic: "No links here", raw_content: input};
+    markdown.apply_markdown(message);
+    assert.equal(message.mentioned, false);
+
+    input = "test @_*hamletcharacters*";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
     assert.equal(message.mentioned, false);

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -233,6 +233,18 @@ const plain_noah = {
     full_name: "Nooaah Emerson",
 };
 
+const all1 = {
+    email: "all1@example.com",
+    user_id: 1202,
+    full_name: "all",
+};
+
+const all2 = {
+    email: "all2@example.com",
+    user_id: 1203,
+    full_name: "all",
+};
+
 // This is for error checking--never actually
 // tell people.js about this user.
 const unknown_user = {
@@ -1014,6 +1026,16 @@ test_people("get_mention_syntax", () => {
     assert.equal(people.get_mention_syntax("Stephen King", 601), "@**Stephen King|601**");
     assert.equal(people.get_mention_syntax("Stephen King", 602), "@**Stephen King|602**");
     assert.equal(people.get_mention_syntax("Maria Athens", 603), "@**Maria Athens**");
+
+    // Following tests handle a special case when `full_name` matches with a wildcard.
+    //
+    // At this point, there is no duplicate full name, `all`, so we should still get
+    // mention syntax with `user_id` appended to it.
+    people.add_active_user(all1);
+    assert.equal(people.get_mention_syntax("all", 1202), "@**all|1202**");
+
+    people.add_active_user(all2);
+    assert.equal(people.get_mention_syntax("all", 1203), "@**all|1203**");
 });
 
 test_people("initialize", () => {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -423,7 +423,6 @@ export const slash_commands = [
 export function filter_and_sort_mentions(is_silent, query, opts) {
     opts = {
         want_broadcast: !is_silent,
-        want_groups: !is_silent,
         filter_pills: false,
         ...opts,
     };
@@ -433,7 +432,6 @@ export function filter_and_sort_mentions(is_silent, query, opts) {
 export function get_pm_people(query) {
     const opts = {
         want_broadcast: false,
-        want_groups: true,
         filter_pills: true,
     };
     return get_person_suggestions(query, opts);
@@ -460,13 +458,7 @@ export function get_person_suggestions(query, opts) {
         return persons.filter((item) => query_matches_person(query, item));
     }
 
-    let groups;
-
-    if (opts.want_groups) {
-        groups = user_groups.get_realm_user_groups();
-    } else {
-        groups = [];
-    }
+    const groups = user_groups.get_realm_user_groups();
 
     const filtered_groups = groups.filter((item) => query_matches_name_description(query, item));
 
@@ -827,7 +819,9 @@ export function content_typeahead_selected(item, event) {
                 beginning = beginning.slice(0, -1);
             }
             if (user_groups.is_user_group(item)) {
-                beginning += "@*" + item.name + "* ";
+                let user_group_mention_text = is_silent ? "@_*" : "@*";
+                user_group_mention_text += item.name + "* ";
+                beginning += user_group_mention_text;
                 // We could theoretically warn folks if they are
                 // mentioning a user group that literally has zero
                 // members where we are posting to, but we don't have
@@ -1005,7 +999,7 @@ function get_header_html() {
             tip_text = $t({defaultMessage: "Press > for list of topics"});
             break;
         case "silent_mention":
-            tip_text = $t({defaultMessage: "User will not be notified"});
+            tip_text = $t({defaultMessage: "Silent mentions do not trigger notifications."});
             break;
         case "syntax":
             if (page_params.realm_default_code_block_language !== null) {

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -165,21 +165,24 @@ export function apply_markdown(message) {
             // flags on the message itself that get used by the message
             // view code and possibly our filtering code.
 
-            if (helpers.my_user_id() === user_id && !silently) {
-                message.mentioned = true;
-                message.mentioned_me_directly = true;
-            }
-            let str = "";
-            if (silently) {
-                str += `<span class="user-mention silent" data-user-id="${_.escape(user_id)}">`;
-            } else {
-                str += `<span class="user-mention" data-user-id="${_.escape(user_id)}">@`;
-            }
-
             // If I mention "@aLiCe sMITH", I still want "Alice Smith" to
             // show in the pill.
-            const actual_full_name = helpers.get_actual_name_from_user_id(user_id);
-            return `${str}${_.escape(actual_full_name)}</span>`;
+            let display_text = helpers.get_actual_name_from_user_id(user_id);
+            let classes;
+            if (silently) {
+                classes = "user-mention silent";
+            } else {
+                if (helpers.my_user_id() === user_id) {
+                    message.mentioned = true;
+                    message.mentioned_me_directly = true;
+                }
+                classes = "user-mention";
+                display_text = "@" + display_text;
+            }
+
+            return `<span class="${classes}" data-user-id="${_.escape(user_id)}">${_.escape(
+                display_text,
+            )}</span>`;
         },
         groupMentionHandler(name) {
             const group = helpers.get_user_group_from_name(name);

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -194,15 +194,25 @@ export function apply_markdown(message) {
                 display_text,
             )}</span>`;
         },
-        groupMentionHandler(name) {
+        groupMentionHandler(name, silently) {
             const group = helpers.get_user_group_from_name(name);
             if (group !== undefined) {
-                if (helpers.is_member_of_user_group(group.id, helpers.my_user_id())) {
-                    message.mentioned = true;
+                let display_text;
+                let classes;
+                if (silently) {
+                    display_text = group.name;
+                    classes = "user-group-mention silent";
+                } else {
+                    display_text = "@" + group.name;
+                    classes = "user-group-mention";
+                    if (helpers.is_member_of_user_group(group.id, helpers.my_user_id())) {
+                        message.mentioned = true;
+                    }
                 }
-                return `<span class="user-group-mention" data-user-group-id="${_.escape(
+
+                return `<span class="${classes}" data-user-group-id="${_.escape(
                     group.id,
-                )}">@${_.escape(group.name)}</span>`;
+                )}">${_.escape(display_text)}</span>`;
             }
             return undefined;
         },

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -218,7 +218,7 @@ export function apply_markdown(message) {
         },
         silencedMentionHandler(quote) {
             // Silence quoted mentions.
-            const user_mention_re = /<span.*user-mention.*data-user-id="(\d+|\*)"[^>]*>@/gm;
+            const user_mention_re = /<span[^>]*user-mention[^>]*data-user-id="(\d+|\*)"[^>]*>@/gm;
             quote = quote.replace(user_mention_re, (match) => {
                 match = match.replace(/"user-mention"/g, '"user-mention silent"');
                 match = match.replace(/>@/g, ">");

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -224,6 +224,16 @@ export function apply_markdown(message) {
                 match = match.replace(/>@/g, ">");
                 return match;
             });
+
+            // Silence quoted user group mentions.
+            const user_group_re =
+                /<span[^>]*user-group-mention[^>]*data-user-group-id="\d+"[^>]*>@/gm;
+            quote = quote.replace(user_group_re, (match) => {
+                match = match.replace(/"user-group-mention"/g, '"user-group-mention silent"');
+                match = match.replace(/>@/g, ">");
+                return match;
+            });
+
             // In most cases, if you are being mentioned in the message you're quoting, you wouldn't
             // mention yourself outside of the blockquote (and, above it). If that you do that, the
             // following mentioned status is false; the backend rendering is authoritative and the

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -101,8 +101,18 @@ export function apply_markdown(message) {
     const options = {
         userMentionHandler(mention, silently) {
             if (mention === "all" || mention === "everyone" || mention === "stream") {
-                message.mentioned = true;
-                return `<span class="user-mention" data-user-id="*">@${_.escape(mention)}</span>`;
+                let classes;
+                let display_text;
+                if (silently) {
+                    classes = "user-mention silent";
+                    display_text = mention;
+                } else {
+                    message.mentioned = true;
+                    display_text = "@" + mention;
+                    classes = "user-mention";
+                }
+
+                return `<span class="${classes}" data-user-id="*">${_.escape(display_text)}</span>`;
             }
 
             let full_name;

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -1108,11 +1108,18 @@ export function get_mention_syntax(full_name, user_id, silent) {
     if (!user_id) {
         blueslip.warn("get_mention_syntax called without user_id.");
     }
-    if (is_duplicate_full_name(full_name) && user_id) {
+    if (
+        (is_duplicate_full_name(full_name) || full_name_matches_wildcard_mention(full_name)) &&
+        user_id
+    ) {
         mention += "|" + user_id;
     }
     mention += "**";
     return mention;
+}
+
+function full_name_matches_wildcard_mention(full_name) {
+    return ["all", "everyone", "stream"].includes(full_name);
 }
 
 export function _add_user(person) {

--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -545,7 +545,7 @@ inline.zulip = merge({}, inline.breaks, {
                        '[\u2000-\u206F]|[\u2300-\u27BF]|[\u2B00-\u2BFF]|' +
                        '[\u3000-\u303F]|[\u3200-\u32FF])'),
   usermention: /^(@(_?)(?:\*\*([^\*]+)\*\*))/, // Match potentially multi-word string between @** **
-  groupmention: /^@\*([^\*]+)\*/, // Match multi-word string between @* *
+  groupmention: /^@(_?)(?:\*([^\*]+)\*)/, // Match multi-word string between @* *
   stream_topic: /^#\*\*([^\*>]+)>([^\*]+)\*\*/,
   stream: /^#\*\*([^\*]+)\*\*/,
   tex: /^(\$\$([^\n_$](\\\$|[^\n$])*)\$\$(?!\$))\B/,
@@ -750,7 +750,7 @@ InlineLexer.prototype.output = function(src) {
     // groupmention (Zulip)
     if (cap = this.rules.groupmention.exec(src)) {
       src = src.substring(cap[0].length);
-      out += this.groupmention(unescape(cap[1]), cap[0]);
+      out += this.groupmention(unescape(cap[2]), cap[0], cap[1]);
       continue;
     }
 
@@ -911,14 +911,14 @@ InlineLexer.prototype.usermention = function (username, orig, silent) {
   return orig;
 };
 
-InlineLexer.prototype.groupmention = function (groupname, orig) {
+InlineLexer.prototype.groupmention = function (groupname, orig, silent) {
   orig = escape(orig);
   if (typeof this.options.groupMentionHandler !== 'function')
   {
     return orig;
   }
 
-  var handled = this.options.groupMentionHandler(groupname);
+  var handled = this.options.groupMentionHandler(groupname, silent === '_');
   if (handled !== undefined) {
     return handled;
   }

--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -544,7 +544,7 @@ inline.zulip = merge({}, inline.breaks, {
                        '\ud83d[\ude80-\udeff]|\ud83e[\udd00-\uddff]|' +
                        '[\u2000-\u206F]|[\u2300-\u27BF]|[\u2B00-\u2BFF]|' +
                        '[\u3000-\u303F]|[\u3200-\u32FF])'),
-  usermention: /^(@(_?)(?:\*\*([^\*]+)\*\*))/, // Match potentially multi-word string between @** **
+  usermention: /^@(_?)(?:\*\*([^\*]+)\*\*)/, // Match potentially multi-word string between @** **
   groupmention: /^@(_?)(?:\*([^\*]+)\*)/, // Match multi-word string between @* *
   stream_topic: /^#\*\*([^\*>]+)>([^\*]+)\*\*/,
   stream: /^#\*\*([^\*]+)\*\*/,
@@ -743,7 +743,7 @@ InlineLexer.prototype.output = function(src) {
     // usermention (Zulip)
     if (cap = this.rules.usermention.exec(src)) {
       src = src.substring(cap[0].length);
-      out += this.usermention(unescape(cap[3] || cap[4]), cap[1], cap[2]);
+      out += this.usermention(unescape(cap[2]), cap[0], cap[1]);
       continue;
     }
 


### PR DESCRIPTION
This will add support for user group silent mention and provides typeahead for them.

I see no apparent reason to support the typeahead for wildcard silent mentions. Therefore I've not added it.

Fixes: #11711.