### PR TITLE
Fix typos using codespell.

### DIFF
--- a/frontend_tests/node_tests/panels.js
+++ b/frontend_tests/node_tests/panels.js
@@ -66,7 +66,7 @@ test("allow_notification_alert", () => {
     util.is_mobile = () => true;
     assert.equal(panels.should_show_notifications(ls), false);
 
-    // Avoid showing if notificaiton permission is denied.
+    // Avoid showing if notification permission is denied.
     util.is_mobile = () => false;
     assert.equal(panels.should_show_notifications(ls), true);
     notifications.permission_state = () => "denied";

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -283,7 +283,7 @@ test("sort_languages", () => {
     Object.assign(pygments_data, actual_pygments_data);
     test_langs = ["j", "java", "javascript", "js"];
 
-    // Sort acccording to priority only.
+    // Sort according to priority only.
     test_langs = th.sort_languages(test_langs, "jav");
     assert.deepEqual(test_langs, ["javascript", "java", "js", "j"]);
 

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -112,7 +112,7 @@ function show_default_view() {
         // NOTE: Setting a hash which is not rendered on
         // empty hash (like a stream narrow) will
         // introduce a bug that user will not be able to
-        // go back in broswer history. See
+        // go back in browser history. See
         // https://chat.zulip.org/#narrow/stream/9-issues/topic/Browser.20back.20button.20on.20RT
         // for detailed description of the issue.
         window.location.hash = page_params.default_view;

--- a/static/js/vdom.js
+++ b/static/js/vdom.js
@@ -141,7 +141,7 @@ export function update(replace_content, find, new_dom, old_dom) {
 
     if (new_opts.keyed_nodes === undefined) {
         // We generally want to use vdom on lists, and
-        // adding keys for childrens lets us avoid unnecessary
+        // adding keys for children lets us avoid unnecessary
         // redraws (or lets us know we should just rebuild
         // the dom).
         blueslip.error("We need keyed_nodes for updates.");

--- a/static/styles/user_status.css
+++ b/static/styles/user_status.css
@@ -57,7 +57,7 @@
 
         button.user-status-value:hover {
             /* Important is required for generic night them styling to not
-               have precendence over this. */
+               have precedence over this. */
             color: hsl(200, 100%, 40%) !important;
         }
 

--- a/templates/zerver/help/code-blocks.md
+++ b/templates/zerver/help/code-blocks.md
@@ -98,7 +98,7 @@ JavaScript, you could specify the language and URL prefix fields as:
 
 When a code block is labeled as Python or JavaScript (either explicitly or by
 organization default), users would get a on-hover option to open the code block
-in the speficied code playground.
+in the specified code playground.
 
 ### Technical details
 

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -1056,7 +1056,7 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
             event_type=RealmAuditLog.REALM_CREATED,
             event_time=realm.date_created,
             # Mark these as backfilled, since they weren't created
-            # when the realm was actaully created, and thus do not
+            # when the realm was actually created, and thus do not
             # have the creating user associated with them.
             backfilled=True,
         )

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -688,7 +688,7 @@ def has_message_access(
     """
     Returns whether a user has access to a given message.
 
-    * The user_message parameter must be provded if the user has a UserMessage
+    * The user_message parameter must be provided if the user has a UserMessage
       row for the target message.
     * The optional stream parameter is validated; is_subscribed is not.
     """


### PR DESCRIPTION
The command:
```
codespell --skip='./locale,*.svg,./docs/translating,postgresql.conf.template.erb,.*fixtures,./yarn.lock,./docs/THIRDPARTY,./tools/setup/emoji/emoji_names.py,./tools/setup/emoji/emoji_map.json,./zerver/management/data/unified_reactions.json' --ignore-words=codespell_ignore_words.txt .
```

The content of codespell_ignore_words:
```
te
ans
pullrequest
ist
cros
wit
nwe
circularly
ned
ba
ressemble
ser
sur
hel
fpr
alls
nd
ot
```

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
