### PR TITLE
puppeteer_test: Add wait call for linkifier table to get updated.

### DIFF
--- a/frontend_tests/puppeteer_tests/realm-linkifier.ts
+++ b/frontend_tests/puppeteer_tests/realm-linkifier.ts
@@ -56,7 +56,7 @@ async function test_add_invalid_linkifier_pattern(page: Page): Promise<void> {
 
 async function test_edit_linkifier(page: Page): Promise<void> {
     await page.click(".linkifier_row .edit");
-    await page.waitForFunction(() => document.activeElement === $("#linkifier-edit-form-modal")[0]);
+    await page.waitForFunction(() => document.activeElement?.id === "linkifier-edit-form-modal");
     await common.fill_form(page, "form.linkifier-edit-form", {
         pattern: "(?P<num>[0-9a-f]{40})",
         url_format_string: "https://trac.example.com/commit/%(num)s",
@@ -81,7 +81,7 @@ async function test_edit_linkifier(page: Page): Promise<void> {
 
 async function test_edit_invalid_linkifier(page: Page): Promise<void> {
     await page.click(".linkifier_row .edit");
-    await page.waitForFunction(() => document.activeElement === $("#linkifier-edit-form-modal")[0]);
+    await page.waitForFunction(() => document.activeElement?.id === "linkifier-edit-form-modal");
     await common.fill_form(page, "form.linkifier-edit-form", {
         pattern: "####",
         url_format_string: "####",

--- a/frontend_tests/puppeteer_tests/realm-linkifier.ts
+++ b/frontend_tests/puppeteer_tests/realm-linkifier.ts
@@ -64,11 +64,9 @@ async function test_edit_linkifier(page: Page): Promise<void> {
     await page.click(".submit-linkifier-info-change");
 
     await page.waitForSelector("#linkifier-edit-form-modal", {hidden: true});
-    await page.waitForFunction(() => $(".edit-linkifier-status").text().trim() === "Saved");
     await page.waitForSelector(".linkifier_row", {visible: true});
-    assert.strictEqual(
-        await common.get_text_from_selector(page, ".linkifier_row span.linkifier_pattern"),
-        "(?P<num>[0-9a-f]{40})",
+    await page.waitForFunction(
+        () => document.querySelector(".linkifier_pattern")?.textContent === "(?P<num>[0-9a-f]{40})",
     );
     assert.strictEqual(
         await common.get_text_from_selector(


### PR DESCRIPTION
This PR solves a rare flake, where the `realm_linkifier.ts` 
test was failing because there was no
appropriate wait call for the table
(`#admin_linkifiers_table`) to get updated after editing
the pattern.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested by running on [CI](https://github.com/Riken-Shah/zulip/runs/2556591464) (Ran for almost 100 times then the workflow was canceled due to 6hr time limit)


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
