### PR TITLE
message_edit: Refactor message_edit to use dropdown_list_widget.

### DIFF
--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -10,12 +10,11 @@
         <div class="controls edit-controls">
             <div class="message_edit_header">
                 <div class="stream_header_colorblock" {{#unless is_stream_editable}}style="display:none"{{/unless}}></div>
-                <select class="select_edit_stream" id="select_stream_id_{{ message_id }}" {{#unless is_stream_editable}}style="display:none"{{/unless}}>
-                    <option value="{{ stream_id }}" selected='selected'>#{{ stream_name }}</option>
-                    {{#each available_streams}}
-                    <option value="{{ this.stream_id }}">#{{this.name}}</option>
-                    {{/each}}
-                </select>
+                <div class="select_stream_dropdown" {{#unless is_stream_editable}}style="display:none"{{/unless}}>
+                    {{> settings/dropdown_list_widget
+                      widget_name=select_move_stream_widget_name
+                      list_placeholder=(t 'Filter streams')}}
+                </div>
                 <i class="fa fa-angle-right" aria-hidden="true" {{#unless is_stream_editable}}style="display:none"{{/unless}}></i>
                 <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" autocomplete="off" />
                 <div class="message_edit_breadcrumb_messages"  style='display:none;'>


### PR DESCRIPTION
Added a pr to refactor the `message_edit` UI to use the `dropdown_list_widget` instead of the ugly HTML dropdowns. 


<strong>Static image :</strong>

![Screenshot from 2021-05-19 18-17-29](https://user-images.githubusercontent.com/53977614/118815132-8b03fc00-b8ce-11eb-9a86-d22bf26915de.png)

<strong>GIF:</strong>
![owner](https://user-images.githubusercontent.com/53977614/118708234-1a5ed000-b839-11eb-966e-c56251fa3ff8.gif)

<hr/>

Closes #18416.
