### PR TITLE
Fix bugs when Giphy API key is not added.

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -135,6 +135,12 @@ export function build_page() {
         options.realm_night_logo_url = options.realm_logo_url;
     }
 
+    options.giphy_help_link = "/help/animated-gifs-from-giphy";
+    if (options.giphy_api_key_empty) {
+        options.giphy_help_link =
+            "https://zulip.readthedocs.io/en/latest/production/giphy-gif-integration.html";
+    }
+
     const rendered_admin_tab = render_admin_tab(options);
     $("#settings_content .organization-box").html(rendered_admin_tab);
     $("#settings_content .alert").removeClass("show");

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -197,6 +197,7 @@
                 <div class="input-group">
                     <label for="realm_giphy_rating" class="dropdown-title">
                         {{t 'GIPHY integration' }}
+                        {{> ../help_link_widget link=giphy_help_link }}
                     </label>
                     <select name="realm_giphy_rating" class ="setting-widget prop-element" id="id_realm_giphy_rating" data-setting-widget-type="number" {{#if giphy_api_key_empty}}disabled{{/if}}>
                         {{#each giphy_rating_options}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- Disable the giphy settings dropdown when API key is not added.
- Do not show giphy icon on live update if API key is not added.
- Reduced the width of upgrade tips to max content
- Added tip for adding giphy API key, which on clicking takes to https://zulip.readthedocs.io/en/latest/production/giphy-gif-integration.html

**Testing plan:** <!-- How have you tested? --> Tested manually in dev server.


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Attaching the screenshots of giphy tip and reduced width of other tips as well -
![Screenshot from 2021-05-19 19-16-26](https://user-images.githubusercontent.com/35494118/118824047-239e7a00-b8d7-11eb-80bb-4d00ec4ca94f.png)

![Screenshot from 2021-05-19 19-16-32](https://user-images.githubusercontent.com/35494118/118824055-2600d400-b8d7-11eb-868d-2f68911a36f2.png)

![Screenshot from 2021-05-19 19-16-45](https://user-images.githubusercontent.com/35494118/118824059-26996a80-b8d7-11eb-964e-56cce0a4aee6.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
