### PR TITLE
fix formatting on key to tables in stream-permissions

### DIFF
--- a/static/styles/portico/markdown.css
+++ b/static/styles/portico/markdown.css
@@ -86,6 +86,22 @@
         text-align: center;
     }
 
+    .legend_symbol {
+        position: absolute;
+        left: calc(40px);
+        transform: translateX(-50%);
+
+        /* Adjust for 50px closed left sidebar state */
+        @media (width <= 800px) {
+            left: calc(5% + 50px);
+        }
+    }
+
+    .legend_label {
+        position: relative;
+        left: calc(30px);
+    }
+
     ul,
     ol {
         margin-left: 30px;

--- a/templates/zerver/help/stream-permissions.md
+++ b/templates/zerver/help/stream-permissions.md
@@ -67,14 +67,14 @@ administrator can access private stream messages:
 | Remove others         | &#10004;          |            |           |
 | Delete                | &#10004;          |            |           |
 
-&#10004; Always
+<span class="legend_symbol">&#10004;</span><span class="legend_label">Always</span>
 
-&#9726; If subscribed to the stream
+<span class="legend_symbol">&#9726;</span><span class="legend_label">If subscribed to the stream</span>
 
-&#10038; [Configurable](/help/stream-sending-policy).  Owners,
+<span class="legend_symbol">&#10038;</span><span class="legend_label">[Configurable](/help/stream-sending-policy).  Owners,
 Administrators, and Members can, by default, post to any public
 stream, and Guests can only post to public streams if they are
-subscribed.
+subscribed.</span>
 
 ### Private streams
 
@@ -95,12 +95,12 @@ subscribed.
 | Remove others         | &#10004;          |            |           |
 | Delete                | &#10004;          |            |           |
 
-&#10004; Always
+<span class="legend_symbol">&#10004;</span><span class="legend_label">Always</span>
 
-&#9726; If subscribed to the stream
+<span class="legend_symbol">&#9726;</span><span class="legend_label">If subscribed to the stream</span>
 
-&#10038; [Configurable](/help/stream-sending-policy), but at minimum
-must be subscribed to the stream.
+<span class="legend_symbol">&#10038;</span><span class="legend_label">[Configurable](/help/stream-sending-policy), but at minimum
+must be subscribed to the stream.</span>
 
 ## Related articles
 


### PR DESCRIPTION
Feedback is appreciated! I'm new to open source.
Here is what the page now looks like:
![Screen Shot 2021-05-19 at 11 15 08 AM](https://user-images.githubusercontent.com/57022538/118847608-853cf500-b893-11eb-83ad-d3c4098f8d87.png)

Closes #18062 