### PR TITLE
node_tests: Silence KaTeX warning in markdown test

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -37,8 +37,7 @@ function Image() {
 }
 set_global("Image", Image);
 
-const doc = "";
-set_global("document", doc);
+set_global("document", {compatMode: "CSS1Compat"});
 
 const emoji = zrequire("../shared/js/emoji");
 const emoji_codes = zrequire("../generated/emoji/emoji_codes.json");


### PR DESCRIPTION
Fixes this KaTeX warning:

`Warning: KaTeX doesn't work in quirks mode. Make sure your website has a suitable doctype.`