### PR TITLE
Pass individual parameters to `build_message_send_dict` instead of a single dictionary.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1813,7 +1813,7 @@ def build_message_send_dict(
         service_bot_tuples=info["service_bot_tuples"],
         wildcard_mention_user_ids=wildcard_mention_user_ids,
         links_for_embed=links_for_embed,
-        widget_content=message_dict.get("widget_content", None),
+        widget_content=message_dict.get("widget_content_dict", None),
     )
 
     return message_send_dict
@@ -3116,14 +3116,15 @@ def check_message(
         if id is not None:
             raise ZephyrMessageAlreadySentException(id)
 
+    widget_content_dict = None
     if widget_content is not None:
         try:
-            widget_content = orjson.loads(widget_content)
+            widget_content_dict = orjson.loads(widget_content)
         except orjson.JSONDecodeError:
             raise JsonableError(_("Widgets: API programmer sent invalid JSON content"))
 
         try:
-            check_widget_content(widget_content)
+            check_widget_content(widget_content_dict)
         except ValidationError as error:
             raise JsonableError(
                 _("Widgets: {error_msg}").format(
@@ -3137,7 +3138,7 @@ def check_message(
         "local_id": local_id,
         "sender_queue_id": sender_queue_id,
         "realm": realm,
-        "widget_content": widget_content,
+        "widget_content_dict": widget_content_dict,
     }
     message_send_dict = build_message_send_dict(message_dict, email_gateway)
 

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -90,8 +90,8 @@ class UnreadMessagesResult(TypedDict):
 class SendMessageRequest:
     message: Message
     stream: Optional[Stream]
-    local_id: Optional[int]
-    sender_queue_id: Optional[int]
+    local_id: Optional[str]
+    sender_queue_id: Optional[str]
     realm: Realm
     mention_data: MentionData
     active_user_ids: Set[int]

--- a/zerver/management/commands/deliver_scheduled_messages.py
+++ b/zerver/management/commands/deliver_scheduled_messages.py
@@ -44,12 +44,9 @@ Usage: ./manage.py deliver_scheduled_messages
                 settings.NOTIFICATION_BOT, original_sender.realm
             )
 
-        message_dict = {
-            "message": message,
-            "stream": scheduled_message.stream,
-            "realm": scheduled_message.realm,
-        }
-        return build_message_send_dict(message_dict)
+        return build_message_send_dict(
+            message=message, stream=scheduled_message.stream, realm=scheduled_message.realm
+        )
 
     def handle(self, *args: Any, **options: Any) -> None:
         try:

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1552,7 +1552,7 @@ class StreamMessagesTest(ZulipTestCase):
                 sending_client=sending_client,
             )
             message.set_topic_name(topic_name)
-            message_dict = build_message_send_dict({"message": message})
+            message_dict = build_message_send_dict(message=message)
             do_send_messages([message_dict])
 
         before_um_count = UserMessage.objects.count()

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -1038,7 +1038,7 @@ def send_messages(messages: List[Message]) -> None:
     settings.USING_RABBITMQ = False
     message_dict_list = []
     for message in messages:
-        message_dict = build_message_send_dict({"message": message})
+        message_dict = build_message_send_dict(message=message)
         message_dict_list.append(message_dict)
     do_send_messages(message_dict_list)
     bulk_create_reactions(messages)


### PR DESCRIPTION
This will allow stronger type checking and better readability.