### PR TITLE
Catch exception in social auth flow if an invalid multiuse invite key is passed

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1439,6 +1439,27 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase):
         )
 
     @override_settings(TERMS_OF_SERVICE=None)
+    def test_social_auth_with_invalid_multiuse_invite(self) -> None:
+        email = "newuser@zulip.com"
+        name = "Full Name"
+        subdomain = "zulip"
+
+        multiuse_object_key = "invalid"
+        account_data_dict = self.get_account_data_dict(email=email, name=name)
+        result = self.social_auth_test(
+            account_data_dict,
+            subdomain=subdomain,
+            is_signup=True,
+            expect_choose_email_screen=True,
+            multiuse_object_key=multiuse_object_key,
+        )
+        self.assertEqual(result.status_code, 302)
+        result = self.client_get(result.url)
+
+        self.assertEqual(result.status_code, 404)
+        self.assert_in_response("The registration link has expired or is not valid.", result)
+
+    @override_settings(TERMS_OF_SERVICE=None)
     def test_social_auth_registration_using_multiuse_invite(self) -> None:
         """If the user doesn't exist yet, social auth can be used to register an account"""
         email = "newuser@zulip.com"

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1968,10 +1968,8 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         response = self.client_post(
             url, {"key": registration_key, "from_confirmation": 1, "full_nme": "alice"}
         )
-        self.assertEqual(response.status_code, 200)
-        self.assert_in_success_response(
-            ["The registration link has expired or is not valid."], response
-        )
+        self.assertEqual(response.status_code, 404)
+        self.assert_in_response("The registration link has expired or is not valid.", response)
 
         registration_key = confirmation_link.split("/")[-1]
         response = self.client_post(
@@ -3567,10 +3565,8 @@ class UserSignUpTest(InviteUserBase):
             },
         )
         # Error page should be displayed
-        self.assert_in_success_response(
-            ["The registration link has expired or is not valid."], result
-        )
-        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.status_code, 404)
+        self.assert_in_response("The registration link has expired or is not valid.", result)
 
     def test_signup_with_multiple_default_stream_groups(self) -> None:
         # Check if user is subscribed to the streams of default

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -123,11 +123,11 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
         key = request.POST.get("key", default="")
         confirmation = Confirmation.objects.get(confirmation_key=key)
     except Confirmation.DoesNotExist:
-        return render(request, "zerver/confirmation_link_expired_error.html")
+        return render(request, "zerver/confirmation_link_expired_error.html", status=404)
 
     prereg_user = confirmation.content_object
     if prereg_user.status == confirmation_settings.STATUS_REVOKED:
-        return render(request, "zerver/confirmation_link_expired_error.html")
+        return render(request, "zerver/confirmation_link_expired_error.html", status=404)
     email = prereg_user.email
     realm_creation = prereg_user.realm_creation
     password_required = prereg_user.password_required


### PR DESCRIPTION
I'm undecided if perhaps these should be status code 400 rather than 404