### PR TITLE
change-your-name: names to reserved words can be mentioned

### DIFF
--- a/templates/zerver/help/change-your-name.md
+++ b/templates/zerver/help/change-your-name.md
@@ -24,8 +24,3 @@ is useful when users' names are managed via LDAP or another data source.
     that your organization allows name changes. Follow the steps at
     [prevent users from changing their names](/help/restrict-name-and-email-changes)
     to view your organization's settings.
-
-## Reserved words
-
-The words "all", "everyone", and "stream" have special meanings, and if you choose them as your
-display name, people may unintentionally [mention](/help/mention-a-user-or-group) you instead of the group.

--- a/templates/zerver/help/change-your-name.md
+++ b/templates/zerver/help/change-your-name.md
@@ -28,4 +28,4 @@ is useful when users' names are managed via LDAP or another data source.
 ## Reserved words
 
 The words "all", "everyone", and "stream" have special meanings, and if you choose them as your
-display name, nobody will be able to [mention](/help/mention-a-user-or-group) you.
+display name, people may unintentionally [mention](/help/mention-a-user-or-group) you instead of the group.


### PR DESCRIPTION
In https://zulip.com/help/change-your-name#change-your-name_1
"The words "all", "everyone", and "stream" have special meanings, and if you choose them as your display name, nobody will be able to mention you."

However, it seems that if you change your name to something like "everyone," you can still @ yourself. The difference between @'ing everyone and @'ing yourself is something like @everyone and @everyone|24 respectively. 