### PR TITLE
Add moderator option in email_address_visibility setting.

### DIFF
--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -45,6 +45,17 @@ run_test("email_for_user_settings", () => {
     page_params.realm_email_address_visibility =
         settings_config.email_address_visibility_values.everyone.code;
     assert.equal(email(isaac), isaac.email);
+
+    page_params.realm_email_address_visibility =
+        settings_config.email_address_visibility_values.moderators.code;
+    assert.equal(email(isaac), undefined);
+
+    page_params.is_moderator = true;
+    assert.equal(email(isaac), isaac.delivery_email);
+
+    page_params.is_moderator = false;
+    page_params.is_admin = true;
+    assert.equal(email(isaac), isaac.delivery_email);
 });
 
 run_test("user_can_change_name", () => {

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -93,6 +93,10 @@ export const email_address_visibility_values = {
     //     code: 2,
     //     description: $t({defaultMessage: "Members and admins"}),
     // },
+    moderators: {
+        code: 5,
+        description: $t({defaultMessage: "Admins and moderators"}),
+    },
     admins_only: {
         code: 3,
         description: $t({defaultMessage: "Admins only"}),

--- a/static/js/settings_data.js
+++ b/static/js/settings_data.js
@@ -26,13 +26,15 @@ function user_can_access_delivery_email() {
     ) {
         return page_params.is_admin;
     }
+
     if (
         page_params.realm_email_address_visibility ===
         settings_config.email_address_visibility_values.moderators.code
     ) {
         return page_params.is_admin || page_params.is_moderator;
     }
-    return undefined;
+
+    return false;
 }
 
 export function show_email() {

--- a/static/js/settings_data.js
+++ b/static/js/settings_data.js
@@ -12,6 +12,29 @@ import * as settings_config from "./settings_config";
     about page_params and settings_config details.
 */
 
+function user_can_access_delivery_email() {
+    // This function checks whether the current user should expect to
+    // see .delivery_email fields on user objects that it can access.
+    //
+    // If false, either everyone has access to emails (and there is no
+    // delivery_email field for anyone) or this user does not have
+    // access to emails (and this client will never receive a user
+    // object with a delivery_email field).
+    if (
+        page_params.realm_email_address_visibility ===
+        settings_config.email_address_visibility_values.admins_only.code
+    ) {
+        return page_params.is_admin;
+    }
+    if (
+        page_params.realm_email_address_visibility ===
+        settings_config.email_address_visibility_values.moderators.code
+    ) {
+        return page_params.is_admin || page_params.is_moderator;
+    }
+    return undefined;
+}
+
 export function show_email() {
     if (
         page_params.realm_email_address_visibility ===
@@ -19,13 +42,7 @@ export function show_email() {
     ) {
         return true;
     }
-    if (
-        page_params.realm_email_address_visibility ===
-        settings_config.email_address_visibility_values.admins_only.code
-    ) {
-        return page_params.is_admin;
-    }
-    return undefined;
+    return user_can_access_delivery_email();
 }
 
 export function email_for_user_settings(person) {
@@ -33,12 +50,7 @@ export function email_for_user_settings(person) {
         return undefined;
     }
 
-    if (
-        page_params.is_admin &&
-        person.delivery_email &&
-        page_params.realm_email_address_visibility ===
-            settings_config.email_address_visibility_values.admins_only.code
-    ) {
+    if (person.delivery_email && user_can_access_delivery_email()) {
         return person.delivery_email;
     }
 

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -359,6 +359,17 @@ def compute_show_invites_and_add_streams(user_profile: Optional[UserProfile]) ->
     return user_profile.can_invite_others_to_realm(), True
 
 
+def can_access_delivery_email(user_profile: UserProfile) -> bool:
+    realm = user_profile.realm
+    if realm.email_address_visibility == Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS:
+        return user_profile.is_realm_admin
+
+    if realm.email_address_visibility == Realm.EMAIL_ADDRESS_VISIBILITY_MODERATORS:
+        return user_profile.is_realm_admin or user_profile.is_moderator
+
+    return False
+
+
 def format_user_row(
     realm: Realm,
     acting_user: Optional[UserProfile],
@@ -422,10 +433,7 @@ def format_user_row(
             client_gravatar=client_gravatar,
         )
 
-    if acting_user is not None and (
-        realm.email_address_visibility == Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS
-        and acting_user.is_realm_admin
-    ):
+    if acting_user is not None and can_access_delivery_email(acting_user):
         result["delivery_email"] = row["delivery_email"]
 
     if is_bot:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -326,6 +326,7 @@ class Realm(models.Model):
     EMAIL_ADDRESS_VISIBILITY_MEMBERS = 2
     EMAIL_ADDRESS_VISIBILITY_ADMINS = 3
     EMAIL_ADDRESS_VISIBILITY_NOBODY = 4
+    EMAIL_ADDRESS_VISIBILITY_MODERATORS = 5
     email_address_visibility: int = models.PositiveSmallIntegerField(
         default=EMAIL_ADDRESS_VISIBILITY_EVERYONE,
     )
@@ -335,6 +336,7 @@ class Realm(models.Model):
         ## EMAIL_ADDRESS_VISIBILITY_MEMBERS,
         EMAIL_ADDRESS_VISIBILITY_ADMINS,
         EMAIL_ADDRESS_VISIBILITY_NOBODY,
+        EMAIL_ADDRESS_VISIBILITY_MODERATORS,
     ]
 
     # Threshold in days for new users to create streams, and potentially take

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3312,6 +3312,7 @@ paths:
                                         * 2 = members only
                                         * 3 = administrators only
                                         * 4 = nobody (though note that administrators can change this setting).
+                                        * 5 = moderators only
                                     email_changes_disabled:
                                       type: boolean
                                       description: |
@@ -8281,6 +8282,7 @@ paths:
                           * 2 = members only
                           * 3 = administrators only
                           * 4 = nobody (though note that administrators can change this setting).
+                          * 5 = moderators only
                       realm_email_changes_disabled:
                         type: boolean
                         description: |

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -857,6 +857,7 @@ class RealmAPITest(ZulipTestCase):
                 Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
                 Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS,
                 Realm.EMAIL_ADDRESS_VISIBILITY_NOBODY,
+                Realm.EMAIL_ADDRESS_VISIBILITY_MODERATORS,
             ],
             video_chat_provider=[
                 dict(

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1902,6 +1902,26 @@ class GetProfileTest(ZulipTestCase):
         do_set_realm_property(
             realm,
             "email_address_visibility",
+            Realm.EMAIL_ADDRESS_VISIBILITY_MODERATORS,
+            acting_user=None,
+        )
+
+        # Check that moderator can access email when setting is set to
+        # EMAIL_ADDRESS_VISIBILITY_MODERATORS.
+        result = orjson.loads(self.client_get(f"/json/users/{hamlet.id}").content)
+        self.assertEqual(result["user"].get("delivery_email"), hamlet.delivery_email)
+        self.assertEqual(result["user"].get("email"), f"user{hamlet.id}@zulip.testserver")
+
+        # Check that normal user cannot access email when setting is set to
+        # EMAIL_ADDRESS_VISIBILITY_MODERATORS.
+        self.login("cordelia")
+        result = orjson.loads(self.client_get(f"/json/users/{hamlet.id}").content)
+        self.assertEqual(result["user"].get("delivery_email"), None)
+        self.assertEqual(result["user"].get("email"), f"user{hamlet.id}@zulip.testserver")
+
+        do_set_realm_property(
+            realm,
+            "email_address_visibility",
             Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
             acting_user=None,
         )


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
There are 3 commits in this PR -
- FIrst commit just refactors the tests to move the tests for checking when `delivery_email` field is present in user dicts to `test_users.py`.
- Second commit adds backend code for moderator option in `email_address_visibility`
- Third commit adds frontend code for moderator option in `email_address_visibility`

 <!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
