### PR TITLE
changelog: Fix repetition of feature levels in changelog.md.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -11,7 +11,7 @@ below features are supported.
 
 ## Changes in Zulip 5.0
 
-**Feature level 70**
+**Feature level 71**
 
 * [`GET /events`](/api/get-events): Added `is_web_public` field to
   `stream` events changing `invite_only`.


### PR DESCRIPTION
This typo was introduced in 70c0abc2e59d9b221a.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


<!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
