### PR TITLE
markdown: Don't convert emoticons present inside blockquote.

### DIFF
--- a/static/shared/js/emoji.js
+++ b/static/shared/js/emoji.js
@@ -11,6 +11,8 @@ export const emojis_by_name = new Map();
 export const all_realm_emojis = new Map();
 export const active_realm_emojis = new Map();
 
+export const emoji_to_emoticon_conversions = new Map();
+
 const default_emoji_aliases = new Map();
 
 // For legacy reasons we track server_realm_emoji_data,
@@ -60,6 +62,8 @@ function build_emoticon_translations() {
             regex,
             replacement_text,
         });
+
+        emoji_to_emoticon_conversions.set(replacement_text, emoticon);
     }
 
     emoticon_translations = translations;

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1794,11 +1794,11 @@ class LinkifierPattern(markdown.inlinepatterns.Pattern):
         self,
         source_pattern: str,
         format_string: str,
-        markdown_instance: Optional[markdown.Markdown] = None,
+        md: Optional[markdown.Markdown] = None,
     ) -> None:
         self.pattern = prepare_linkifier_pattern(source_pattern)
         self.format_string = format_string
-        markdown.inlinepatterns.Pattern.__init__(self, self.pattern, markdown_instance)
+        super().__init__(self.pattern, md)
 
     def handleMatch(self, m: Match[str]) -> Union[Element, str]:
         db_data = self.md.zulip_db_data

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1363,6 +1363,15 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
                             found_url.family.child.text = text
 
 
+class CompiledInlineProcessor(markdown.inlinepatterns.InlineProcessor):
+    def __init__(self, compiled_re: Pattern[str], md: markdown.Markdown) -> None:
+        # This is similar to the superclass's small __init__ function,
+        # but we skip the compilation step and let the caller give us
+        # a compiled regex.
+        self.compiled_re = compiled_re
+        self.md = md
+
+
 class Timestamp(markdown.inlinepatterns.Pattern):
     def handleMatch(self, match: Match[str]) -> Optional[Element]:
         time_input_string = match.group("time")
@@ -1809,14 +1818,7 @@ class LinkifierPattern(markdown.inlinepatterns.Pattern):
         )
 
 
-class UserMentionPattern(markdown.inlinepatterns.InlineProcessor):
-    def __init__(self, compiled_re: Pattern[str], md: markdown.Markdown) -> None:
-        # This is similar to the superclass's small __init__ function,
-        # but we skip the compilation step and let the caller give us
-        # a compiled regex.
-        self.compiled_re = compiled_re
-        self.md = md
-
+class UserMentionPattern(CompiledInlineProcessor):
     def handleMatch(  # type: ignore[override] # supertype incompatible with supersupertype
         self, m: Match[str], data: str
     ) -> Union[Tuple[None, None, None], Tuple[Element, int, int]]:
@@ -1870,14 +1872,7 @@ class UserMentionPattern(markdown.inlinepatterns.InlineProcessor):
         return None, None, None
 
 
-class UserGroupMentionPattern(markdown.inlinepatterns.InlineProcessor):
-    def __init__(self, compiled_re: Pattern[str], md: markdown.Markdown) -> None:
-        # This is similar to the superclass's small __init__ function,
-        # but we skip the compilation step and let the caller give us
-        # a compiled regex.
-        self.compiled_re = compiled_re
-        self.md = md
-
+class UserGroupMentionPattern(CompiledInlineProcessor):
     def handleMatch(  # type: ignore[override] # supertype incompatible with supersupertype
         self, m: Match[str], data: str
     ) -> Union[Tuple[None, None, None], Tuple[Element, int, int]]:
@@ -1910,14 +1905,7 @@ class UserGroupMentionPattern(markdown.inlinepatterns.InlineProcessor):
         return None, None, None
 
 
-class StreamPattern(markdown.inlinepatterns.InlineProcessor):
-    def __init__(self, compiled_re: Pattern[str], md: markdown.Markdown) -> None:
-        # This is similar to the superclass's small __init__ function,
-        # but we skip the compilation step and let the caller give us
-        # a compiled regex.
-        self.compiled_re = compiled_re
-        self.md = md
-
+class StreamPattern(CompiledInlineProcessor):
     def find_stream_by_name(self, name: str) -> Optional[Dict[str, Any]]:
         db_data = self.md.zulip_db_data
         if db_data is None:
@@ -1950,14 +1938,7 @@ class StreamPattern(markdown.inlinepatterns.InlineProcessor):
         return None, None, None
 
 
-class StreamTopicPattern(markdown.inlinepatterns.InlineProcessor):
-    def __init__(self, compiled_re: Pattern[str], md: markdown.Markdown) -> None:
-        # This is similar to the superclass's small __init__ function,
-        # but we skip the compilation step and let the caller give us
-        # a compiled regex.
-        self.compiled_re = compiled_re
-        self.md = md
-
+class StreamTopicPattern(CompiledInlineProcessor):
     def find_stream_by_name(self, name: str) -> Optional[Dict[str, Any]]:
         db_data = self.md.zulip_db_data
         if db_data is None:

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -953,6 +953,27 @@
         "name": "telephone_sms_link",
         "input": "[call me](tel:+14155551234) [or maybe not](sms:+14155551234)",
         "expected_output": "<p><a href=\"tel:+14155551234\">call me</a> <a href=\"sms:+14155551234\">or maybe not</a></p>"
+    },
+    {
+      "name": "emoticon_and_emoji_inside_blockquotes_1",
+      "input": "```quote\nHi there! :) :|\nOh! ;) :D :surprise:\n:smile:\n```\n:/ <3 :astonished:",
+      "expected_output": "<blockquote>\n<p>Hi there! :) :|<br>\nOh! ;) :D <span aria-label=\"surprise\" class=\"emoji emoji-1f62e\" role=\"img\" title=\"surprise\">:surprise:</span><br>\n<span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>\n</blockquote>\n<p><span aria-label=\"confused\" class=\"emoji emoji-1f615\" role=\"img\" title=\"confused\">:confused:</span> <span aria-label=\"heart\" class=\"emoji emoji-2764\" role=\"img\" title=\"heart\">:heart:</span> <span aria-label=\"astonished\" class=\"emoji emoji-1f632\" role=\"img\" title=\"astonished\">:astonished:</span></p>",
+      "marked_expected_output": "<blockquote>\n<p>Hi there! (: :|<br>\nOh! ;) :D <span aria-label=\"surprise\" class=\"emoji emoji-1f62e\" role=\"img\" title=\"surprise\">:surprise:</span><br>\n(:</p>\n</blockquote>\n<p><span aria-label=\"confused\" class=\"emoji emoji-1f615\" role=\"img\" title=\"confused\">:confused:</span> <span aria-label=\"heart\" class=\"emoji emoji-2764\" role=\"img\" title=\"heart\">:heart:</span> <span aria-label=\"astonished\" class=\"emoji emoji-1f632\" role=\"img\" title=\"astonished\">:astonished:</span></p>",
+      "translate_emoticons": true
+    },
+    {
+      "name": "emoticon_and_emoji_inside_blockquotes_2",
+      "input": "> Hi there! :) :|\nOh! <3 :D :surprise:\n:smile:\n\n:/ <3 :astonished:",
+      "expected_output": "<blockquote>\n<p>Hi there! :) :|<br>\nOh! <3 :D <span aria-label=\"surprise\" class=\"emoji emoji-1f62e\" role=\"img\" title=\"surprise\">:surprise:</span><br>\n<span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>\n</blockquote>\n<p><span aria-label=\"confused\" class=\"emoji emoji-1f615\" role=\"img\" title=\"confused\">:confused:</span> <span aria-label=\"heart\" class=\"emoji emoji-2764\" role=\"img\" title=\"heart\">:heart:</span> <span aria-label=\"astonished\" class=\"emoji emoji-1f632\" role=\"img\" title=\"astonished\">:astonished:</span></p>",
+      "marked_expected_output": "<blockquote>\n<p>Hi there! (: :|<br>\nOh! &lt;3 :D <span aria-label=\"surprise\" class=\"emoji emoji-1f62e\" role=\"img\" title=\"surprise\">:surprise:</span><br>\n(:</p>\n</blockquote>\n<p><span aria-label=\"confused\" class=\"emoji emoji-1f615\" role=\"img\" title=\"confused\">:confused:</span> <span aria-label=\"heart\" class=\"emoji emoji-2764\" role=\"img\" title=\"heart\">:heart:</span> <span aria-label=\"astonished\" class=\"emoji emoji-1f632\" role=\"img\" title=\"astonished\">:astonished:</span></p>",
+      "translate_emoticons": true
+    },
+    {
+      "name": "emoticon_and_emoji_inside_blockquotes_3",
+      "input": "```quote\nHi there! :) :|\nOh! ;) :D :surprise:\n:smile:\n```\n:/ <3 :astonished:",
+      "expected_output": "<blockquote>\n<p>Hi there! :) :|<br>\nOh! ;) :D <span aria-label=\"surprise\" class=\"emoji emoji-1f62e\" role=\"img\" title=\"surprise\">:surprise:</span><br>\n<span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>\n</blockquote>\n<p>:/ &lt;3 <span aria-label=\"astonished\" class=\"emoji emoji-1f632\" role=\"img\" title=\"astonished\">:astonished:</span></p>",
+      "marked_expected_output": "<blockquote>\n<p>Hi there! :) :|<br>\nOh! ;) :D <span aria-label=\"surprise\" class=\"emoji emoji-1f62e\" role=\"img\" title=\"surprise\">:surprise:</span><br>\n(:</p>\n</blockquote>\n<p>:/ &lt;3 <span aria-label=\"astonished\" class=\"emoji emoji-1f632\" role=\"img\" title=\"astonished\">:astonished:</span></p>",
+      "translate_emoticons": false
     }
   ],
   "linkify_tests": [


### PR DESCRIPTION
I've explained the Backend and Frontend approach in the commit message. https://github.com/zulip/zulip/commit/62e87db30cedc881b7abda0445a5ce07d7a5bd2b

Fixes: #17789.