### PR TITLE
Rename some notifications related variables for clarity.

### DIFF
--- a/docs/subsystems/events-system.md
+++ b/docs/subsystems/events-system.md
@@ -434,7 +434,10 @@ to make sure we handle backwards-compatibility properly.
   commit. We attempt to contain that sort of logic in the `from_dict`
   function (which is used for changing event queue formats) and
   `client_capabilities` conditionals (E.g. in
-  `process_deletion_event`).
+  `process_deletion_event`). Compatibility code not related to a
+  `client_capabilities` entry should be marked with a
+  `# TODO/compatibility: ...` comment noting when it can be safely deleted;
+  we grep for these comments entries during major releases.
 * Schema changes are a sensitive operation, and like with database
   schema changes, it's critical to do thoughtful manual testing.
   E.g. run the mobile app against your test server and verify it

--- a/docs/subsystems/notifications.md
+++ b/docs/subsystems/notifications.md
@@ -32,7 +32,7 @@ as follows:
   table's `flags` structure, which is in turn passed into
   `send_event` for each user receiving the message.
   * Data about user configuration relevant to the message, such as
-  `push_notify_user_ids` and `stream_notify_user_ids`, are included
+  `online_push_user_ids` and `stream_notify_user_ids`, are included
   alongside `flags` in the per-user data structure.
   * The `presence_idle_user_ids` set, containing the subset of
   recipient users who are mentioned, are PM recipients, have alert

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1420,7 +1420,7 @@ def render_incoming_message(
 
 class RecipientInfoResult(TypedDict):
     active_user_ids: Set[int]
-    push_notify_user_ids: Set[int]
+    online_push_user_ids: Set[int]
     stream_email_user_ids: Set[int]
     stream_push_user_ids: Set[int]
     wildcard_mention_user_ids: Set[int]
@@ -1587,7 +1587,7 @@ def get_recipient_info(
         return row["is_bot"] and (row["bot_type"] in UserProfile.SERVICE_BOT_TYPES)
 
     active_user_ids = get_ids_for(lambda r: True)
-    push_notify_user_ids = get_ids_for(
+    online_push_user_ids = get_ids_for(
         lambda r: r["enable_online_push_notifications"],
     )
 
@@ -1618,7 +1618,7 @@ def get_recipient_info(
 
     info: RecipientInfoResult = dict(
         active_user_ids=active_user_ids,
-        push_notify_user_ids=push_notify_user_ids,
+        online_push_user_ids=online_push_user_ids,
         stream_push_user_ids=stream_push_user_ids,
         stream_email_user_ids=stream_email_user_ids,
         wildcard_mention_user_ids=wildcard_mention_user_ids,
@@ -1811,7 +1811,7 @@ def build_message_send_dict(
         mention_data=mention_data,
         message=message,
         active_user_ids=info["active_user_ids"],
-        push_notify_user_ids=info["push_notify_user_ids"],
+        online_push_user_ids=info["online_push_user_ids"],
         stream_push_user_ids=info["stream_push_user_ids"],
         stream_email_user_ids=info["stream_email_user_ids"],
         um_eligible_user_ids=info["um_eligible_user_ids"],
@@ -1961,7 +1961,7 @@ def do_send_messages(
             dict(
                 id=user_id,
                 flags=user_flags.get(user_id, []),
-                always_push_notify=(user_id in send_request.push_notify_user_ids),
+                always_push_notify=(user_id in send_request.online_push_user_ids),
                 stream_push_notify=(user_id in send_request.stream_push_user_ids),
                 stream_email_notify=(user_id in send_request.stream_email_user_ids),
                 wildcard_mention_notify=(user_id in send_request.wildcard_mention_user_ids),
@@ -5789,7 +5789,7 @@ def do_update_message(
             possible_wildcard_mention=mention_data.message_has_wildcards(),
         )
 
-        event["push_notify_user_ids"] = list(info["push_notify_user_ids"])
+        event["online_push_user_ids"] = list(info["online_push_user_ids"])
         event["stream_push_user_ids"] = list(info["stream_push_user_ids"])
         event["stream_email_user_ids"] = list(info["stream_email_user_ids"])
         event["prior_mention_user_ids"] = list(prior_mention_user_ids)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1961,7 +1961,7 @@ def do_send_messages(
             dict(
                 id=user_id,
                 flags=user_flags.get(user_id, []),
-                always_push_notify=(user_id in send_request.online_push_user_ids),
+                online_push_enabled=(user_id in send_request.online_push_user_ids),
                 stream_push_notify=(user_id in send_request.stream_push_user_ids),
                 stream_email_notify=(user_id in send_request.stream_email_user_ids),
                 wildcard_mention_notify=(user_id in send_request.wildcard_mention_user_ids),

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -95,7 +95,7 @@ class SendMessageRequest:
     realm: Realm
     mention_data: MentionData
     active_user_ids: Set[int]
-    push_notify_user_ids: Set[int]
+    online_push_user_ids: Set[int]
     stream_push_user_ids: Set[int]
     stream_email_user_ids: Set[int]
     um_eligible_user_ids: Set[int]

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -63,7 +63,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=False,
             stream_name=None,
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=True,
             already_notified={},
         )
@@ -80,7 +80,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=True,
             stream_name=None,
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=True,
             already_notified={},
         )
@@ -98,7 +98,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=False,
             stream_name=None,
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=True,
             already_notified={
                 "push_notified": True,
@@ -117,7 +117,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=False,
             stream_name=None,
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=True,
             already_notified={
                 "push_notified": False,
@@ -137,7 +137,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=False,
             stream_name=None,
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=True,
             already_notified={},
         )
@@ -156,7 +156,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=False,
             stream_name=None,
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=True,
             already_notified={},
         )
@@ -173,7 +173,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             stream_push_notify=True,
             stream_email_notify=False,
             stream_name="Denmark",
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=True,
             already_notified={},
         )
@@ -190,7 +190,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=True,
             stream_name="Denmark",
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=True,
             already_notified={},
         )
@@ -207,7 +207,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=True,
             stream_name=None,
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=False,
             already_notified={},
         )
@@ -224,7 +224,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=False,
             stream_name=None,
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=False,
             already_notified={},
         )
@@ -241,14 +241,14 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=False,
             stream_name=None,
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=False,
             already_notified={},
         )
         self.assertTrue(email_notice is None)
         self.assertTrue(mobile_notice is None)
 
-        # Private message sends push but not email if not idle but always_push_notify
+        # Private message sends push but not email if not idle but online_push_enabled
         email_notice, mobile_notice = self.check_will_notify(
             user_profile.id,
             message_id,
@@ -258,14 +258,14 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=True,
             stream_name=None,
-            always_push_notify=True,
+            online_push_enabled=True,
             idle=False,
             already_notified={},
         )
         self.assertTrue(email_notice is None)
         self.assertTrue(mobile_notice is not None)
 
-        # Stream message sends push but not email if not idle but always_push_notify
+        # Stream message sends push but not email if not idle but online_push_enabled
         email_notice, mobile_notice = self.check_will_notify(
             user_profile.id,
             message_id,
@@ -275,7 +275,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             stream_push_notify=True,
             stream_email_notify=True,
             stream_name="Denmark",
-            always_push_notify=True,
+            online_push_enabled=True,
             idle=False,
             already_notified={},
         )

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -193,7 +193,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=False,
             stream_name="Scotland",
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=True,
             already_notified={},
         )
@@ -299,7 +299,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             present_on_web=True,
         )
 
-    def test_always_push_notify_for_fully_present_mentioned_user(self) -> None:
+    def test_online_push_enabled_for_fully_present_mentioned_user(self) -> None:
         cordelia = self.example_user("cordelia")
 
         # Simulate Cordelia is FULLY present, not just in term of
@@ -326,7 +326,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=False,
             stream_name="Scotland",
-            always_push_notify=True,
+            online_push_enabled=True,
             idle=False,
             already_notified={},
         )
@@ -337,7 +337,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
 
         self.assert_length(queue_messages, 1)
 
-    def test_always_push_notify_for_fully_present_boring_user(self) -> None:
+    def test_online_push_enabled_for_fully_present_boring_user(self) -> None:
         cordelia = self.example_user("cordelia")
 
         # Simulate Cordelia is FULLY present, not just in term of
@@ -364,7 +364,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=False,
             stream_name="Scotland",
-            always_push_notify=True,
+            online_push_enabled=True,
             idle=False,
             already_notified={},
         )
@@ -404,7 +404,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=False,
             stream_name="Scotland",
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=True,
             already_notified={},
         )
@@ -440,7 +440,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=False,
             stream_name="Scotland",
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=True,
             already_notified={},
         )
@@ -501,7 +501,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             stream_push_notify=False,
             stream_email_notify=False,
             stream_name="Scotland",
-            always_push_notify=False,
+            online_push_enabled=False,
             idle=False,
             already_notified={},
         )

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1520,7 +1520,7 @@ class RecipientInfoTest(ZulipTestCase):
 
         expected_info = dict(
             active_user_ids=all_user_ids,
-            push_notify_user_ids=set(),
+            online_push_user_ids=set(),
             stream_push_user_ids=set(),
             stream_email_user_ids=set(),
             wildcard_mention_user_ids=set(),

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -753,8 +753,8 @@ def missedmessage_hook(
         if not private_message:
             stream_name = event["message"]["display_recipient"]
 
-        # Since one is by definition idle, we don't need to check always_push_notify
-        always_push_notify = False
+        # Since one is by definition idle, we don't need to check online_push_enabled
+        online_push_enabled = False
         # Since we just GC'd the last event queue, the user is definitely idle.
         idle = True
 
@@ -773,7 +773,7 @@ def missedmessage_hook(
             stream_push_notify,
             stream_email_notify,
             stream_name,
-            always_push_notify,
+            online_push_enabled,
             idle,
             already_notified,
         )
@@ -799,7 +799,7 @@ def maybe_enqueue_notifications(
     stream_push_notify: bool,
     stream_email_notify: bool,
     stream_name: Optional[str],
-    always_push_notify: bool,
+    online_push_enabled: bool,
     idle: bool,
     already_notified: Dict[str, bool],
 ) -> Dict[str, bool]:
@@ -812,7 +812,7 @@ def maybe_enqueue_notifications(
     """
     notified: Dict[str, bool] = {}
 
-    if (idle or always_push_notify) and (
+    if (idle or online_push_enabled) and (
         private_message or mentioned or wildcard_mention_notify or stream_push_notify
     ):
         notice = build_offline_notification(user_profile_id, message_id)
@@ -968,7 +968,17 @@ def process_message_event(
             idle = receiver_is_off_zulip(user_profile_id) or (
                 user_profile_id in presence_idle_user_ids
             )
-            always_push_notify = user_data.get("always_push_notify", False)
+
+            # TODO/compatibility: Translation code for the rename of
+            # `always_push_notify` to `online_push_enabled`.  Remove this
+            # when one can no longer directly upgrade from 4.x to master.
+            if "online_push_enabled" in user_data:
+                online_push_enabled = user_data["online_push_enabled"]
+            elif "always_push_notify" in user_data:
+                online_push_enabled = user_data["always_push_notify"]
+            else:
+                online_push_enabled = False
+
             stream_name = event_template.get("stream_name")
 
             result: Dict[str, Any] = {}
@@ -981,7 +991,7 @@ def process_message_event(
                 stream_push_notify,
                 stream_email_notify,
                 stream_name,
-                always_push_notify,
+                online_push_enabled,
                 idle,
                 {},
             )
@@ -1195,7 +1205,7 @@ def maybe_enqueue_notifications_for_message_update(
     # We can have newly mentioned people in an updated message.
     mentioned = user_profile_id in mention_user_ids
 
-    always_push_notify = user_profile_id in online_push_user_ids
+    online_push_enabled = user_profile_id in online_push_user_ids
 
     idle = (user_profile_id in presence_idle_user_ids) or receiver_is_off_zulip(user_profile_id)
 
@@ -1208,7 +1218,7 @@ def maybe_enqueue_notifications_for_message_update(
         stream_push_notify=stream_push_notify,
         stream_email_notify=stream_email_notify,
         stream_name=stream_name,
-        always_push_notify=always_push_notify,
+        online_push_enabled=online_push_enabled,
         idle=idle,
         already_notified={},
     )


### PR DESCRIPTION
These proposed changes will make it clear that we are dealing with user settings, not computed data, and will also make the naming scheme consistent.