### PR TITLE
Modify UI to have separate elements for 'who can invite users' and 'are invitations required to join the organzization'

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -181,6 +181,7 @@ function test_submit_settings_form(override, submit_form) {
         realm_default_twenty_four_hour_time: false,
         realm_invite_to_stream_policy: settings_config.common_policy_values.by_admins_only.code,
         realm_create_stream_policy: settings_config.common_policy_values.by_members.code,
+        realm_invite_to_realm_policy: settings_config.common_policy_values.by_members.code,
     });
 
     override(global, "setTimeout", (func) => func());
@@ -230,6 +231,11 @@ function test_submit_settings_form(override, submit_form) {
     email_address_visibility_elem.val("1");
     email_address_visibility_elem.attr("id", "id_realm_email_address_visibility");
     email_address_visibility_elem.data = () => "number";
+
+    const invite_to_realm_policy_elem = $("#id_realm_invite_to_realm_policy");
+    invite_to_realm_policy_elem.val("2");
+    invite_to_realm_policy_elem.attr("id", "id_realm_invite_to_realm_policy");
+    invite_to_realm_policy_elem.data = () => "number";
 
     let subsection_elem = $(`#org-${CSS.escape(subsection)}`);
     subsection_elem.closest = () => subsection_elem;
@@ -470,6 +476,7 @@ function test_sync_realm_settings() {
 
     test_common_policy("create_stream_policy");
     test_common_policy("invite_to_stream_policy");
+    test_common_policy("invite_to_realm_policy");
 
     {
         /* Test message content edit limit minutes sync */

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -43,6 +43,9 @@ const admin_settings_label = {
         defaultMessage: "Prevent users from changing their email address",
     }),
     realm_avatar_changes_disabled: $t({defaultMessage: "Prevent users from changing their avatar"}),
+    realm_invite_required: $t({
+        defaultMessage: "Invitations are required for joining this organization",
+    }),
 };
 
 function insert_tip_box() {
@@ -122,6 +125,7 @@ export function build_page() {
         bot_creation_policy_values: settings_bots.bot_creation_policy_values,
         email_address_visibility_values: settings_config.email_address_visibility_values,
         can_invite_others_to_realm: settings_data.user_can_invite_others_to_realm(),
+        realm_invite_required: page_params.realm_invite_required,
         ...settings_org.get_organization_settings_options(),
     };
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -180,49 +180,6 @@ function get_property_value(property_name) {
         return "no_restriction";
     }
 
-    if (property_name === "realm_user_invite_restriction") {
-        if (!page_params.realm_invite_required) {
-            if (
-                page_params.realm_invite_to_realm_policy ===
-                settings_config.common_policy_values.by_admins_only.code
-            ) {
-                return "no_invite_required_by_admins_only";
-            }
-            if (
-                page_params.realm_invite_to_realm_policy ===
-                settings_config.common_policy_values.by_moderators_only.code
-            ) {
-                return "no_invite_required_by_moderators_only";
-            }
-            if (
-                page_params.realm_invite_to_realm_policy ===
-                settings_config.common_policy_values.by_full_members.code
-            ) {
-                return "no_invite_required_by_full_members";
-            }
-            return "no_invite_required";
-        }
-        if (
-            page_params.realm_invite_to_realm_policy ===
-            settings_config.common_policy_values.by_admins_only.code
-        ) {
-            return "by_admins_only";
-        }
-        if (
-            page_params.realm_invite_to_realm_policy ===
-            settings_config.common_policy_values.by_moderators_only.code
-        ) {
-            return "by_moderators_only";
-        }
-        if (
-            page_params.realm_invite_to_realm_policy ===
-            settings_config.common_policy_values.by_full_members.code
-        ) {
-            return "by_full_members";
-        }
-        return "by_anyone";
-    }
-
     if (property_name === "realm_default_twenty_four_hour_time") {
         return JSON.stringify(page_params[property_name]);
     }
@@ -245,7 +202,7 @@ const simple_dropdown_properties = [
     "realm_user_group_edit_policy",
     "realm_private_message_policy",
     "realm_add_emoji_by_admins_only",
-    "realm_user_invite_restriction",
+    "realm_invite_to_realm_policy",
     "realm_wildcard_mention_policy",
     "realm_move_messages_between_streams_policy",
 ];
@@ -501,10 +458,6 @@ export function sync_realm_settings(property) {
             break;
         case "allow_message_deleting":
             property = "msg_delete_limit_setting";
-            break;
-        case "invite_required":
-        case "invite_to_realm_policy":
-            property = "user_invite_restriction";
             break;
     }
     const element = $(`#id_realm_${CSS.escape(property)}`);
@@ -894,49 +847,6 @@ export function build_page() {
                         data.disallow_disposable_email_addresses = false;
                         data.emails_restricted_to_domains = false;
                         break;
-                }
-
-                const user_invite_restriction = $("#id_realm_user_invite_restriction").val();
-                switch (user_invite_restriction) {
-                    case "no_invite_required":
-                        data.invite_required = false;
-                        data.invite_to_realm_policy =
-                            settings_config.common_policy_values.by_members.code;
-                        break;
-                    case "no_invite_required_by_admins_only":
-                        data.invite_required = false;
-                        data.invite_to_realm_policy =
-                            settings_config.common_policy_values.by_admins_only.code;
-                        break;
-                    case "no_invite_required_by_moderators_only":
-                        data.invite_required = false;
-                        data.invite_to_realm_policy =
-                            settings_config.common_policy_values.by_moderators_only.code;
-                        break;
-                    case "no_invite_required_by_full_members":
-                        data.invite_required = false;
-                        data.invite_to_realm_policy =
-                            settings_config.common_policy_values.by_full_members.code;
-                        break;
-                    case "by_admins_only":
-                        data.invite_required = true;
-                        data.invite_to_realm_policy =
-                            settings_config.common_policy_values.by_admins_only.code;
-                        break;
-                    case "by_moderators_only":
-                        data.invite_required = true;
-                        data.invite_to_realm_policy =
-                            settings_config.common_policy_values.by_moderators_only.code;
-                        break;
-                    case "by_full_members":
-                        data.invite_required = true;
-                        data.invite_to_realm_policy =
-                            settings_config.common_policy_values.by_full_members.code;
-                        break;
-                    default:
-                        data.invite_required = true;
-                        data.invite_to_realm_policy =
-                            settings_config.common_policy_values.by_members.code;
                 }
 
                 const waiting_period_threshold = $("#id_realm_waiting_period_setting").val();

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1589,14 +1589,14 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 #id_realm_user_group_edit_policy,
 #id_realm_email_address_visibility,
 #id_realm_wildcard_mention_policy,
-#id_realm_move_messages_between_streams_policy {
+#id_realm_move_messages_between_streams_policy,
+#id_realm_invite_to_realm_policy {
     width: 250px;
 }
 
 #id_realm_bot_creation_policy,
 #id_realm_giphy_rating,
-#id_realm_org_join_restrictions,
-#id_realm_user_invite_restriction {
+#id_realm_org_join_restrictions {
     width: 100%;
 }
 

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -8,17 +8,15 @@
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
-                    <label for="realm_user_invite_restriction" class="dropdown-title">{{t "Are invitations required for joining the organization?" }}</label>
-                    <select name="realm_user_invite_restriction" id="id_realm_user_invite_restriction" class="prop-element">
-                        <option value="no_invite_required">{{t "No. Members and admins can send invitations." }}</option>
-                        <option value="no_invite_required_by_full_members">{{t "No. Only full members and admins can send invitations." }}</option>
-                        <option value="no_invite_required_by_moderators_only">{{t "No. Only moderators and admins can send invitations." }}</option>
-                        <option value="no_invite_required_by_admins_only">{{t "No. Only admins can send invitations." }}</option>
-                        <option value="by_anyone">{{t "Yes. Members and admins can send invitations." }}</option>
-                        <option value="by_full_members">{{t "Yes. Only full members and admins can send invitations."}}</option>
-                        <option value="by_moderators_only">{{t "Yes. Only moderators and admins can send invitations." }}</option>
-                        <option value="by_admins_only">{{t "Yes. Only admins can send invitations." }}</option>
+                    <label for="realm_invite_to_realm_policy" class="dropdown-title">{{t "Who can invite users to this organization" }}</label>
+                    <select name="realm_invite_to_realm_policy" id="id_realm_invite_to_realm_policy" class="prop-element" data-setting-widget-type="number">
+                        {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
+                    {{> settings_checkbox
+                      setting_name="realm_invite_required"
+                      prefix="id_"
+                      is_checked=realm_invite_required
+                      label=admin_settings_label.realm_invite_required}}
                 </div>
 
                 <div class="input-group">

--- a/templates/zerver/help/allow-anyone-to-join-without-an-invitation.md
+++ b/templates/zerver/help/allow-anyone-to-join-without-an-invitation.md
@@ -13,7 +13,7 @@ up so that anyone can join without an invitation.
 
 1. Find the section **Joining the organization**.
 
-1. Set **Are invitations required for joining the organization** to **No**.
+1. Toggle **Invitations are required for joining this organization**.
 
 1. Set **Restrict email domains of new users?** to either
    **Don't allow disposable email addresses** (recommended) or **No**.

--- a/templates/zerver/help/invite-new-users.md
+++ b/templates/zerver/help/invite-new-users.md
@@ -32,7 +32,7 @@ invitation, but require them to authenticate via LDAP.
 
 1. Find the section **Joining the organization**.
 
-1. Set **Are invitations required for joining the organization** to **No**.
+1. Toggle **Invitations are required for joining this organization**.
 
 1. Set **Restrict email domains of new users?** to
    **Restrict to a list of domains**.
@@ -50,7 +50,7 @@ invitation, but require them to authenticate via LDAP.
 
 1. Find the section **Joining the organization**.
 
-1. Set **Are invitations required for joining the organization** to **No**.
+1. Toggle **Invitations are required for joining this organization**.
 
 1. Set **Restrict email domains of new users?** to either
    **Don't allow disposable email addresses** (recommended) or **No**.
@@ -135,7 +135,7 @@ users to other sets of roles:
 {settings_tab|organization-permissions}
 
 1. Under **Joining the organization**, configure
-   **Are invitations required for joining the organization?**.
+   **Who can invite users to this organization**.
 
 1. Click **Save changes**.
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) --> Have added some prep commits also along with the main commit.
Following commits have been added -
- Use role directly to sort by role in the user settings table instead of a custom function.
- Do not pass the policy values which are not required to `admin_tab.hbs`.
- Deduplicate `test_sync_realm_settings` in `node_tests/settings_org.js`.
- Add a checkbox for `Are invitations required to join this organization` and keep the `who can invite users` as a separate dropdwon.
- Update the docs accordingly.

<!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2021-05-24 21-33-48](https://user-images.githubusercontent.com/35494118/119374935-d9066e80-bcd7-11eb-80d6-0513c34381f8.png)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
