### PR TITLE
rundjangoserver: Filter stdout instead of forking the code

### DIFF
--- a/tools/linter_lib/exclude.py
+++ b/tools/linter_lib/exclude.py
@@ -6,7 +6,6 @@ EXCLUDED_FILES = [
     "puppet/zulip/files/nagios_plugins/zulip_nagios_server/check_website_response.sh",
     "scripts/lib/third",
     "static/third",
-    "zilencer/management/commands/rundjangoserver.py",
     # Transifex syncs translation.json files without trailing
     # newlines; there's nothing other than trailing newlines we'd be
     # checking for in these anyway.


### PR DESCRIPTION
We failed to update this fork for the Django 3.2 upgrade. Unfork it so that’s not something we need to remember to do.

**Testing plan:** Compared `run-dev.py` output.