### PR TITLE
actions: Fix “Fix UserActivityInterval overlap bug” bug.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5053,13 +5053,10 @@ def do_update_user_activity_interval(
     # often, and can be corrected for in post-processing
     try:
         last = UserActivityInterval.objects.filter(user_profile=user_profile).order_by("-end")[0]
-        # There are two ways our intervals could overlap:
-        # (1) The start of the new interval could be inside the old interval
-        # (2) The end of the new interval could be inside the old interval
-        # In either case, we just extend the old interval to include the new interval.
-        if (log_time <= last.end and log_time >= last.start) or (
-            effective_end <= last.end and effective_end >= last.start
-        ):
+        # Two intervals overlap iff each interval ends after the other
+        # begins.  In this case, we just extend the old interval to
+        # include the new interval.
+        if log_time <= last.end and effective_end >= last.start:
             last.end = max(last.end, effective_end)
             last.start = min(last.start, log_time)
             last.save(update_fields=["start", "end"])


### PR DESCRIPTION
Commit 1a7ddd9ea3e5cb2784bba5cf1a51eec30ae756f4 “Fix UserActivityInterval overlap bug” introduced a mathematically incorrect assertion about how intervals work. There’s a third way two intervals could overlap: both the start and end of the old interval could be inside the new interval. This probably can’t happen here because the old interval should be at least as long as the new interval. However, a correct overlap test can be formulated in a simpler way anyway.