### PR TITLE
actions: Fix incorrect audit logging in bulk_remove_subscriptions

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3921,7 +3921,7 @@ def bulk_remove_subscriptions(
         event_last_message_id = get_last_message_id()
         all_subscription_logs = [
             RealmAuditLog(
-                realm=sub.user.realm,
+                realm=sub_info.user.realm,
                 acting_user=acting_user,
                 modified_user=sub_info.user,
                 modified_stream=sub_info.stream,
@@ -3929,7 +3929,7 @@ def bulk_remove_subscriptions(
                 event_type=RealmAuditLog.SUBSCRIPTION_DEACTIVATED,
                 event_time=event_time,
             )
-            for sub in subs_to_deactivate
+            for sub_info in subs_to_deactivate
         ]
 
         # Now since we have all log objects generated we can do a bulk insert


### PR DESCRIPTION
`modified_user=sub_info.user` and `modified_stream=sub_info.stream`, added by commit 6d1f9de7d386145d35646b76a413c3f4db2f3fec (#16553), were always coming from the last entry in the loop above, not from the enclosing list comprehension.

Found by the Pylint rule `undefined-loop-variable`.

**Testing plan:** Not tested.

Cc @showell.