### PR TITLE
left_sidebar: Place all the classes in a single class attribute.

### DIFF
--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -508,6 +508,10 @@ li.expanded_private_message {
     margin-top: 3px;
 }
 
+.stream-list-filter {
+    width: 236px;
+}
+
 .zero_count {
     visibility: hidden;
 }

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -61,7 +61,7 @@
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title tippy-zulip-tooltip" data-tippy-content="{{ _('Filter streams') }} (q)">{{ _('STREAMS') }}</h4>
                 <i id="streams_inline_cog" class='fa fa-cog tippy-zulip-tooltip' aria-hidden="true" data-tippy-content="{{ _('Subscribe, add, or configure streams') }}"></i>
-                <i class="streams_filter_icon" class='fa fa-search tippy-zulip-tooltip' aria-hidden="true" data-tippy-content="{{ _('Filter streams') }} (q)"></i>
+                <i class='streams_filter_icon fa fa-search tippy-zulip-tooltip' aria-hidden="true" data-tippy-content="{{ _('Filter streams') }} (q)"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{ _('Filter streams') }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">


### PR DESCRIPTION
Placing multiple classes in multiple class attributes enforces
them to override each other css properties. To avoid this
streams_filter_icon class is moved to a single class attributes.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:
![Streams](https://user-images.githubusercontent.com/59444243/119448839-7fda2180-bd4f-11eb-8ab7-1f8f536edffe.png)

After:
![image](https://user-images.githubusercontent.com/59444243/119510043-d286fe00-bd8e-11eb-8b60-979dd1f0e32c.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
