### PR TITLE
emails: Remove referrer name from 'From' header in invitation emails.

### DIFF
--- a/templates/zerver/emails/invitation.subject.txt
+++ b/templates/zerver/emails/invitation.subject.txt
@@ -1,1 +1,1 @@
-{% trans %}{{referrer_full_name}} invited you to join {{ referrer_realm_name }}{% endtrans %}
+{% trans %}{{referrer_full_name}} has invited you to join {{ referrer_realm_name }}{% endtrans %}

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -6480,11 +6480,9 @@ def do_send_confirmation_email(invitee: PreregistrationUser, referrer: UserProfi
         "activate_url": activation_url,
         "referrer_realm_name": referrer.realm.name,
     }
-    from_name = f"{referrer.full_name} (via Zulip)"
     send_email(
         "zerver/emails/invitation",
         to_emails=[invitee.email],
-        from_name=from_name,
         from_address=FromAddress.tokenized_no_reply_address(),
         language=referrer.realm.default_language,
         context=context,

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -928,9 +928,7 @@ https://www.google.com/images/srpr/logo4w.png</a></p>"""
 
 
 class InviteUserBase(ZulipTestCase):
-    def check_sent_emails(
-        self, correct_recipients: List[str], custom_from_name: Optional[str] = None
-    ) -> None:
+    def check_sent_emails(self, correct_recipients: List[str]) -> None:
         from django.core.mail import outbox
 
         self.assert_length(outbox, len(correct_recipients))
@@ -939,8 +937,7 @@ class InviteUserBase(ZulipTestCase):
         if len(outbox) == 0:
             return
 
-        if custom_from_name is not None:
-            self.assertIn(custom_from_name, self.email_display_from(outbox[0]))
+        self.assertIn("Zulip", self.email_display_from(outbox[0]))
 
         self.assertEqual(self.email_envelope_from(outbox[0]), settings.NOREPLY_EMAIL_ADDRESS)
         self.assertRegex(
@@ -987,7 +984,7 @@ class InviteUserTest(InviteUserBase):
         invitee = "alice-test@zulip.com"
         self.assert_json_success(self.invite(invitee, ["Denmark"]))
         self.assertTrue(find_key_by_email(invitee))
-        self.check_sent_emails([invitee], custom_from_name="Hamlet")
+        self.check_sent_emails([invitee])
 
     def test_newbie_restrictions(self) -> None:
         user_profile = self.example_user("hamlet")
@@ -1274,7 +1271,7 @@ class InviteUserTest(InviteUserBase):
         invitee = f"Alice Test <{email}>"
         self.assert_json_success(self.invite(invitee, ["Denmark"]))
         self.assertTrue(find_key_by_email(email))
-        self.check_sent_emails([email], custom_from_name="Hamlet")
+        self.check_sent_emails([email])
 
     def test_successful_invite_user_with_name_and_normal_one(self) -> None:
         """
@@ -1288,7 +1285,7 @@ class InviteUserTest(InviteUserBase):
         self.assert_json_success(self.invite(invitee, ["Denmark"]))
         self.assertTrue(find_key_by_email(email))
         self.assertTrue(find_key_by_email(email2))
-        self.check_sent_emails([email, email2], custom_from_name="Hamlet")
+        self.check_sent_emails([email, email2])
 
     def test_can_invite_others_to_realm(self) -> None:
         def validation_func(user_profile: UserProfile) -> bool:
@@ -2230,7 +2227,7 @@ class InvitationsTestCase(InviteUserBase):
         prereg_user = PreregistrationUser.objects.get(email=invitee)
 
         # Verify and then clear from the outbox the original invite email
-        self.check_sent_emails([invitee], custom_from_name="Zulip")
+        self.check_sent_emails([invitee])
         from django.core.mail import outbox
 
         outbox.pop()
@@ -2261,7 +2258,7 @@ class InvitationsTestCase(InviteUserBase):
         error_result = self.client_post("/json/invites/" + str(9999) + "/resend")
         self.assert_json_error(error_result, "No such invitation")
 
-        self.check_sent_emails([invitee], custom_from_name="Zulip")
+        self.check_sent_emails([invitee])
 
     def test_successful_member_resend_invitation(self) -> None:
         """A POST call from member a account to /json/invites/<ID>/resend
@@ -2278,7 +2275,7 @@ class InvitationsTestCase(InviteUserBase):
         prereg_user = PreregistrationUser.objects.get(email=invitee)
 
         # Verify and then clear from the outbox the original invite email
-        self.check_sent_emails([invitee], custom_from_name="Zulip")
+        self.check_sent_emails([invitee])
         from django.core.mail import outbox
 
         outbox.pop()
@@ -2309,7 +2306,7 @@ class InvitationsTestCase(InviteUserBase):
         error_result = self.client_post("/json/invites/" + str(9999) + "/resend")
         self.assert_json_error(error_result, "No such invitation")
 
-        self.check_sent_emails([invitee], custom_from_name="Zulip")
+        self.check_sent_emails([invitee])
 
         self.logout()
         self.login("othello")
@@ -2329,7 +2326,7 @@ class InvitationsTestCase(InviteUserBase):
                 invitee, ["Denmark"], invite_as=PreregistrationUser.INVITE_AS["REALM_OWNER"]
             )
         )
-        self.check_sent_emails([invitee], custom_from_name="Zulip")
+        self.check_sent_emails([invitee])
         scheduledemail_filter = ScheduledEmail.objects.filter(
             address__iexact=invitee, type=ScheduledEmail.INVITATION_REMINDER
         )


### PR DESCRIPTION
We should only show the referrer name in subject of invitation
emails, and show only 'Zulip' in the 'From' header. This helps in
preventing the email from being marked as suspicious by detection
systems when they see a employee's name as the sender of an
email sent from unrelated domain.

The behavior is already the same for reminder emails where we do
not show name and only 'Zulip' in the 'From' header.

Fixes #18256.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? --> Updated the tests accordingly.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2021-05-25 12-27-30](https://user-images.githubusercontent.com/35494118/119453087-af3f5d00-bd54-11eb-8af7-b09cf069dbf2.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
