### PR TITLE
Pill typeahead cleanup

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -757,12 +757,12 @@ test("initialize", (override) => {
         assert.equal(matcher(query, deactivated_user), true);
 
         function sorter(query, people) {
-            return typeahead_helper.sort_recipients(
-                people,
+            return typeahead_helper.sort_recipients({
+                users: people,
                 query,
-                compose_state.stream_name(),
-                compose_state.topic(),
-            );
+                current_stream: compose_state.stream_name(),
+                current_topic: compose_state.topic(),
+            });
         }
 
         // The sorter's output has the items that match the query from the

--- a/frontend_tests/node_tests/pill_typeahead.js
+++ b/frontend_tests/node_tests/pill_typeahead.js
@@ -1,0 +1,77 @@
+"use strict";
+
+const {strict: assert} = require("assert");
+
+const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
+const blueslip = require("../zjsunit/zblueslip");
+const $ = require("../zjsunit/zjquery");
+
+const input_pill = zrequire("input_pill");
+const pill_typeahead = zrequire("pill_typeahead");
+const noop = function () {};
+
+run_test("set_up", () => {
+    // Test set_up without any type
+    let input_pill_typeahead_called = false;
+    const fake_input = $.create(".input");
+    fake_input.typeahead = (config) => {
+        assert.equal(config.items, 5);
+        assert(config.fixed);
+        assert(config.dropup);
+        assert(config.stopAdvance);
+
+        // Working of functions that are part of config
+        // is tested separately based on the widgets that
+        // try to use it. Here we just check if config
+        // passed to the typeahead is in the right format.
+        assert.equal(typeof config.source, "function");
+        assert.equal(typeof config.highlighter, "function");
+        assert.equal(typeof config.matcher, "function");
+        assert.equal(typeof config.sorter, "function");
+        assert.equal(typeof config.updater, "function");
+
+        // input_pill_typeahead_called is set true if
+        // no exception occurs in pill_typeahead.set_up.
+        input_pill_typeahead_called = true;
+    };
+
+    const container = $.create(".pill-container");
+    container.find = () => fake_input;
+
+    const pill_widget = input_pill.create({
+        container,
+        create_item_from_text: noop,
+        get_text_from_item: noop,
+    });
+
+    // call set_up with only user type in opts.
+    pill_typeahead.set_up(fake_input, pill_widget, {user: true});
+    assert(input_pill_typeahead_called);
+
+    // call set_up with only stream type in opts.
+    input_pill_typeahead_called = false;
+    pill_typeahead.set_up(fake_input, pill_widget, {stream: true});
+    assert(input_pill_typeahead_called);
+
+    // call set_up with only user_group type in opts.
+    input_pill_typeahead_called = false;
+    pill_typeahead.set_up(fake_input, pill_widget, {user_group: true});
+    assert(input_pill_typeahead_called);
+
+    // call set_up with combination two types in opts.
+    input_pill_typeahead_called = false;
+    pill_typeahead.set_up(fake_input, pill_widget, {user_group: true, stream: true});
+    assert(input_pill_typeahead_called);
+
+    // call set_up with all three types in opts.
+    input_pill_typeahead_called = false;
+    pill_typeahead.set_up(fake_input, pill_widget, {user_group: true, stream: true, user: true});
+    assert(input_pill_typeahead_called);
+
+    // call set_up without specifying type in opts.
+    input_pill_typeahead_called = false;
+    blueslip.expect("error", "Unspecified possible item types");
+    pill_typeahead.set_up(fake_input, pill_widget, {});
+    assert(!input_pill_typeahead_called);
+});

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -301,12 +301,12 @@ test("sort_languages", () => {
 });
 
 function get_typeahead_result(query, current_stream, current_topic) {
-    const result = th.sort_recipients(
-        people.get_realm_users(),
+    const result = th.sort_recipients({
+        users: people.get_realm_users(),
         query,
         current_stream,
         current_topic,
-    );
+    });
     return result.map((person) => person.email);
 }
 
@@ -411,7 +411,12 @@ test("sort_recipients all mention", () => {
     // Test person email is "all" or "everyone"
     const test_objs = matches.concat([all_obj]);
 
-    const results = th.sort_recipients(test_objs, "a", "Linux", "Linux topic");
+    const results = th.sort_recipients({
+        users: test_objs,
+        query: "a",
+        current_stream: "Linux",
+        current_topic: "Linux topic",
+    });
 
     assertSameEmails(results, [all_obj, a_bot, a_user, b_user_1, b_user_2, b_user_3, b_bot, zman]);
 });
@@ -467,7 +472,12 @@ test("sort_recipients pm counts", () => {
 test("sort_recipients dup bots", () => {
     const dup_objects = matches.concat([a_bot]);
 
-    const recipients = th.sort_recipients(dup_objects, "b", "", "");
+    const recipients = th.sort_recipients({
+        users: dup_objects,
+        query: "b",
+        current_stream: "",
+        current_topic: "",
+    });
     const recipients_email = recipients.map((person) => person.email);
     const expected = [
         "b_user_1@zulip.net",
@@ -488,7 +498,12 @@ test("sort_recipients dup alls", () => {
     // full_name starts with same character but emails are 'all'
     const test_objs = [all_obj, a_user, all_obj];
 
-    const recipients = th.sort_recipients(test_objs, "a", "Linux", "Linux topic");
+    const recipients = th.sort_recipients({
+        users: test_objs,
+        query: "a",
+        current_stream: "Linux",
+        current_topic: "Linux topic",
+    });
 
     const expected = [all_obj, all_obj, a_user];
     assertSameEmails(recipients, expected);
@@ -497,7 +512,12 @@ test("sort_recipients dup alls", () => {
 test("sort_recipients subscribers", () => {
     // b_user_2 is a subscriber and b_user_1 is not.
     const small_matches = [b_user_2, b_user_1];
-    const recipients = th.sort_recipients(small_matches, "b", "Dev", "Dev topic");
+    const recipients = th.sort_recipients({
+        users: small_matches,
+        query: "b",
+        current_stream: "Dev",
+        current_topic: "Dev topic",
+    });
     const recipients_email = recipients.map((person) => person.email);
     const expected = ["b_user_2@zulip.net", "b_user_1@zulip.net"];
     assert.deepEqual(recipients_email, expected);
@@ -507,7 +527,12 @@ test("sort_recipients pm partners", () => {
     // b_user_3 is a pm partner and b_user_2 is not and
     // both are not subscribered to the stream Linux.
     const small_matches = [b_user_3, b_user_2];
-    const recipients = th.sort_recipients(small_matches, "b", "Linux", "Linux topic");
+    const recipients = th.sort_recipients({
+        users: small_matches,
+        query: "b",
+        current_stream: "Linux",
+        current_topic: "Linux topic",
+    });
     const recipients_email = recipients.map((person) => person.email);
     const expected = ["b_user_3@zulip.net", "b_user_2@zulip.net"];
     assert.deepEqual(recipients_email, expected);

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -496,14 +496,14 @@ export function get_person_suggestions(query, opts) {
         filtered_persons = filter_persons(people.get_realm_users());
     }
 
-    return typeahead_helper.sort_recipients(
-        filtered_persons,
+    return typeahead_helper.sort_recipients({
+        users: filtered_persons,
         query,
-        opts.stream,
-        opts.topic,
-        filtered_groups,
+        current_stream: opts.stream,
+        current_topic: opts.topic,
+        groups: filtered_groups,
         max_num_items,
-    );
+    });
 }
 
 export function get_stream_topic_data(hacky_this) {

--- a/static/js/pill_typeahead.js
+++ b/static/js/pill_typeahead.js
@@ -1,3 +1,4 @@
+import * as blueslip from "./blueslip";
 import * as composebox_typeahead from "./composebox_typeahead";
 import * as people from "./people";
 import * as stream_pill from "./stream_pill";
@@ -21,6 +22,10 @@ function group_matcher(query, item) {
 }
 
 export function set_up(input, pills, opts) {
+    if (!opts.user && !opts.user_group && !opts.stream) {
+        blueslip.error("Unspecified possible item types");
+        return;
+    }
     let source = opts.source;
     if (!opts.source) {
         source = () => user_pill.typeahead_source(pills);

--- a/static/js/pill_typeahead.js
+++ b/static/js/pill_typeahead.js
@@ -91,8 +91,9 @@ export function set_up(input, pills, opts) {
             return person_matcher(query, item);
         },
         sorter(matches) {
-            if (include_streams(this.query)) {
-                return typeahead_helper.sort_streams(matches, this.query.trim().slice(1));
+            const query = this.query;
+            if (include_streams(query)) {
+                return typeahead_helper.sort_streams(matches, query.trim().slice(1));
             }
 
             const users = matches.filter((ele) => people.is_known_user(ele));
@@ -100,14 +101,14 @@ export function set_up(input, pills, opts) {
             if (include_user_groups) {
                 groups = matches.filter((ele) => user_groups.is_user_group(ele));
             }
-            return typeahead_helper.sort_recipients(
+            return typeahead_helper.sort_recipients({
                 users,
-                this.query,
-                "",
-                undefined,
+                query,
+                current_stream: "",
+                current_topic: undefined,
                 groups,
-                undefined,
-            );
+                max_num_items: undefined,
+            });
         },
         updater(item) {
             if (include_streams(this.query)) {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -255,13 +255,13 @@ export function initialize_custom_user_type_fields(
             if (is_editable) {
                 const input = pill_container.children(".input");
                 if (set_handler_on_update) {
-                    const opts = {update_func: update_custom_user_field};
+                    const opts = {update_func: update_custom_user_field, user: true};
                     pill_typeahead.set_up(input, pills, opts);
                     pills.onPillRemove(() => {
                         update_custom_user_field();
                     });
                 } else {
-                    pill_typeahead.set_up(input, pills, {});
+                    pill_typeahead.set_up(input, pills, {user: true});
                 }
             }
             user_pills.set(field.id, pills);

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -275,7 +275,7 @@ export function populate_user_groups() {
 
         const input = pill_container.children(".input");
         if (can_edit(data.id)) {
-            const opts = {update_func: update_cancel_button};
+            const opts = {update_func: update_cancel_button, user: true};
             pill_typeahead.set_up(input, pills, opts);
         }
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -418,7 +418,12 @@ function show_subscription_settings(sub) {
         simplebar_container: $(".subscriber_list_container"),
     });
 
-    const opts = {source: get_users_for_subscriber_typeahead, stream: true, user_group: true};
+    const opts = {
+        source: get_users_for_subscriber_typeahead,
+        stream: true,
+        user_group: true,
+        user: true,
+    };
     pill_typeahead.set_up(sub_settings.find(".input"), pill_widget, opts);
 }
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -419,7 +419,7 @@ function show_subscription_settings(sub) {
     });
 
     const opts = {
-        source: get_users_for_subscriber_typeahead,
+        user_source: get_users_for_subscriber_typeahead,
         stream: true,
         user_group: true,
         user: true,

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -287,14 +287,14 @@ export function sort_languages(matches, query) {
     return retain_unique_language_aliases(results.matches.concat(results.rest));
 }
 
-export function sort_recipients(
+export function sort_recipients({
     users,
     query,
     current_stream,
     current_topic,
     groups = [],
     max_num_items = 20,
-) {
+}) {
     function sort_relevance(items) {
         return sort_people_for_relevance(items, current_stream, current_topic);
     }


### PR DESCRIPTION
This cleans up code in pill_typeahead.js as suggested in [https://github.com/zulip/zulip/pull/17994#issuecomment-822886392](https://github.com/zulip/zulip/pull/17994#issuecomment-822886392).

**Testing plan:** node tests.

