### PR TITLE
message view: Show re-hide option in revealed muted user's message only.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -525,7 +525,8 @@ export function toggle_actions_popover(element, id) {
     if (elt.data("popover") === undefined) {
         const message = message_lists.current.get(id);
         const message_container = message_lists.current.view.message_containers.get(message.id);
-        const should_display_hide_option = !message_container.is_hidden;
+        const should_display_hide_option =
+            muting.is_user_muted(message.sender_id) && !message_container.is_hidden;
         const editability = message_edit.get_editability(message);
         let use_edit_icon;
         let editability_menu_item;


### PR DESCRIPTION
Related conversation: [#design > Hiding user-muted messages](https://chat.zulip.org/#narrow/stream/101-design/topic/Hiding.20user-muted.20messages/near/1187374)

Rehide message option in message action popover was shown for messages of unmuted users too(as their messages are revealed by default), it is fixed to show this option only for revealed messages of muted users.
**Testing plan:** Manually.


**GIFs or screenshots:** 
![rehide](https://user-images.githubusercontent.com/63504956/119479712-8cba3d80-bd6e-11eb-912e-af3eaa498d95.gif)

