### PR TITLE
docs: Remove a file which no longer exists from THIRDPARTY.

### DIFF
--- a/docs/THIRDPARTY
+++ b/docs/THIRDPARTY
@@ -33,15 +33,6 @@ Copyright: 2011, Krzysztof Wilczynski
  2011, Puppet Labs Inc
 License: Apache-2.0
 
-File: puppet/zulip_ops/files/mediawiki/Auth_remoteuser.php
-Copyright: 2006 Otheus Shelling
- 2007 Rusty Burchfield
- 2009 James Kinsman
- 2010 Daniel Thomas
- 2010 Ian Ward Comfort
-License: GPL-2.0
-Comment: Not linked.
-
 Files: puppet/zulip/files/nagios_plugins/zulip_base/check_debian_packages
 Copyright: 2005 Francesc Guasch
 License: GPL-2.0


### PR DESCRIPTION
It was removed in 771e03cfa7f7d7dcaac7c4bb05d75828306000ef.

**Testing plan:** This is the only such file:
```
$ rg --replace 'ls $1;' '^Files?: (.*)' docs/THIRDPARTY | cat | bash 2>&1 | grep No
ls: cannot access 'puppet/zulip_ops/files/mediawiki/Auth_remoteuser.php': No such file or directory
```
