### PR TITLE
Fix HTTP 500 when `topic` specified for private message edit.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2719,6 +2719,8 @@ def validate_message_edit_payload(
     if not message.is_stream_message():
         if stream_id is not None:
             raise JsonableError(_("Private messages cannot be moved to streams."))
+        if topic_name is not None:
+            raise JsonableError(_("Private messages cannot have topics."))
 
     if propagate_mode != "change_one" and topic_name is None and stream_id is None:
         raise JsonableError(_("Invalid propagate_mode without topic edit"))

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4859,7 +4859,7 @@ paths:
         - name: stream_id
           in: query
           description: |
-            The ID of the stream to access.
+            The stream ID to move the message(s) to, if moving to another stream.
           schema:
             type: integer
           example: 42

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -127,6 +127,22 @@ class EditMessagePayloadTest(EditMessageTestCase):
 
         self.assert_json_error(result, "Private messages cannot be moved to streams.")
 
+    def test_private_message_edit_topic(self) -> None:
+        hamlet = self.example_user("hamlet")
+        self.login("hamlet")
+        cordelia = self.example_user("cordelia")
+        msg_id = self.send_personal_message(hamlet, cordelia)
+
+        result = self.client_patch(
+            "/json/messages/" + str(msg_id),
+            {
+                "message_id": msg_id,
+                "topic": "Should not exist",
+            },
+        )
+
+        self.assert_json_error(result, "Private messages cannot have topics.")
+
     def test_propagate_invalid(self) -> None:
         self.login("hamlet")
         id1 = self.send_stream_message(self.example_user("hamlet"), "Scotland", topic_name="topic1")


### PR DESCRIPTION
The `assert` statements still remain for readability, but I've moved the data validation logic toghether.
**Testing**: Added automated tests.

Fixes: #18604 