### PR TITLE
i18n: Tag strings in status message settings for translation

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -271,7 +271,7 @@ export function initialize() {
 
     $(".user-status-value").on("click", (e) => {
         e.stopPropagation();
-        const user_status_value = $(e.currentTarget).attr("data-user-status-value");
+        const user_status_value = $(e.currentTarget).text();
         $("input.user_status").val(user_status_value);
         user_status_ui.toggle_clear_message_button();
         user_status_ui.update_button();

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -144,29 +144,29 @@
     <div class="user_status_overlay overlay new-style" data-overlay="user_status_overlay" aria-hidden="true">
         <div class="overlay-content modal-bg">
             <div class="user-status-header">
-                <h1>Set a status</h1>
+                <h1>{{ _("Set a status") }}</h1>
                 <div class="exit">
                     <span class="exit-sign">&times;</span>
                 </div>
             </div>
             <div class="modal-body">
-                <label for="user_status">Status message</label>
+                <label for="user_status">{{ _("Status message") }}</label>
                 <input type="text" class="user_status" maxlength="60" />
                 <button type="button" class="btn clear_search_button" id="clear_status_message_button" disabled="disabled">
                     <i class="fa fa-remove" aria-hidden="true"></i>
                 </button>
             </div>
             <div class="user-status-options">
-                <button type="button" class="button no-style user-status-value">In a meeting</button>
-                <button type="button" class="button no-style user-status-value">Commuting</button>
-                <button type="button" class="button no-style user-status-value">Out sick</button>
-                <button type="button" class="button no-style user-status-value">Vacationing</button>
-                <button type="button" class="button no-style user-status-value">Working remotely</button>
+                <button type="button" class="button no-style user-status-value">{{ _("In a meeting") }}</button>
+                <button type="button" class="button no-style user-status-value">{{ _("Commuting") }}</button>
+                <button type="button" class="button no-style user-status-value">{{ _("Out sick") }}</button>
+                <button type="button" class="button no-style user-status-value">{{ _("Vacationing") }}</button>
+                <button type="button" class="button no-style user-status-value">{{ _("Working remotely") }}</button>
             </div>
             <div class="modal-footer">
-                <button class="button exit small rounded">Cancel</button>
+                <button class="button exit small rounded">{{ _("Cancel") }}</button>
                 <button class="sea-green small rounded button set_user_status">
-                    Save
+                    {{ _("Save") }}
                 </button>
             </div>
         </div>

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -157,11 +157,11 @@
                 </button>
             </div>
             <div class="user-status-options">
-                <button type="button" class="button no-style user-status-value" data-user-status-value="In a meeting">In a meeting</button>
-                <button type="button" class="button no-style user-status-value" data-user-status-value="Commuting">Commuting</button>
-                <button type="button" class="button no-style user-status-value" data-user-status-value="Out sick">Out sick</button>
-                <button type="button" class="button no-style user-status-value" data-user-status-value="Vacationing">Vacationing</button>
-                <button type="button" class="button no-style user-status-value" data-user-status-value="Working remotely">Working remotely</button>
+                <button type="button" class="button no-style user-status-value">In a meeting</button>
+                <button type="button" class="button no-style user-status-value">Commuting</button>
+                <button type="button" class="button no-style user-status-value">Out sick</button>
+                <button type="button" class="button no-style user-status-value">Vacationing</button>
+                <button type="button" class="button no-style user-status-value">Working remotely</button>
             </div>
             <div class="modal-footer">
                 <button class="button exit small rounded">Cancel</button>


### PR DESCRIPTION
PR created for tagging the missing strings in status message UI for translation. See

* https://chat.zulip.org/#narrow/stream/58-translation/topic/missing.20strings for related conversation.
* https://github.com/zulip/zulip/issues/18609

**Testing plan:** <!-- How have you tested? -->
* I have tested this manually by changing statuses in Zulip dev environment.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

https://user-images.githubusercontent.com/7190633/119690006-f3bb1d80-be66-11eb-8335-a1225c8d6f91.mp4

