### PR TITLE
compose: Restore the last draft when compose box is opened.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -27,7 +27,9 @@ const fake_now = 555;
 
 const channel = mock_esm("../../static/js/channel");
 const compose_actions = mock_esm("../../static/js/compose_actions");
-const drafts = mock_esm("../../static/js/drafts");
+const drafts = mock_esm("../../static/js/drafts", {
+    restore_last_draft_based_on_compose_state: noop,
+});
 const giphy = mock_esm("../../static/js/giphy");
 const loading = mock_esm("../../static/js/loading");
 const markdown = mock_esm("../../static/js/markdown");

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -33,6 +33,7 @@ mock_esm("../../static/js/recent_topics_util", {
 });
 mock_esm("../../static/js/drafts", {
     update_draft: noop,
+    restore_last_draft_based_on_compose_state: noop,
 });
 mock_esm("../../static/js/common", {
     status_classes: "status_classes",

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -84,6 +84,14 @@ test("legacy", () => {
     assert.deepEqual(drafts.restore_message(legacy_draft), compose_args_for_legacy_draft);
 });
 
+test("draft_model get_drafts_id_by", ({override}) => {
+    assert.deepEqual(drafts.draft_model.getDraftsIdByStreamAndTopic("stream", "topic"), []);
+    assert.deepEqual(drafts.draft_model.getDraftsIdByRecipients("stream", "topic"), []);
+    override(drafts.draft_model, "get", () => ({random_id_1: draft_1, random_id_2: draft_2}));
+    assert.equal(drafts.draft_model.getDraftsIdByStreamAndTopic("stream", "topic").length, 1);
+    assert.equal(drafts.draft_model.getDraftsIdByRecipients("aaron@zulip.com").length, 1);
+});
+
 test("draft_model add", ({override}) => {
     const draft_model = drafts.draft_model;
     const ls = localstorage();

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -51,6 +51,7 @@ const compose_args_for_legacy_draft = {
     topic: "lunch",
     type: "stream",
     content: "whatever",
+    trigger: "restore draft",
 };
 
 const draft_1 = {

--- a/frontend_tests/puppeteer_tests/drafts.ts
+++ b/frontend_tests/puppeteer_tests/drafts.ts
@@ -41,7 +41,7 @@ async function create_stream_message_draft(page: Page): Promise<void> {
     await page.keyboard.press("KeyC");
     await page.waitForSelector("#stream-message", {visible: true});
     await common.fill_form(page, "form#send_message_form", {
-        stream_message_recipient_stream: "all",
+        stream_message_recipient_stream: "Verona",
         stream_message_recipient_topic: "tests",
         content: "Test stream message.",
     });
@@ -83,7 +83,7 @@ async function test_previously_created_drafts_rendered(page: Page): Promise<void
             page,
             ".draft-row .message_header_stream .stream_label",
         ),
-        "all",
+        "Verona",
     );
     assert.strictEqual(
         await common.get_text_from_selector(
@@ -115,14 +115,14 @@ async function test_previously_created_drafts_rendered(page: Page): Promise<void
     );
 }
 
-async function test_restore_message_draft(page: Page): Promise<void> {
+async function test_restore_message_draft_via_draft_overlay(page: Page): Promise<void> {
     console.log("Restoring stream message draft");
     await page.click("#drafts_table .message_row:not(.private-message) .restore-draft");
     await wait_for_drafts_to_dissapear(page);
     await page.waitForSelector("#stream-message", {visible: true});
     await page.waitForSelector("#preview_message_area", {hidden: true});
     await common.check_form_contents(page, "form#send_message_form", {
-        stream_message_recipient_stream: "all",
+        stream_message_recipient_stream: "Verona",
         stream_message_recipient_topic: "tests",
         content: "Test stream message.",
     });
@@ -135,7 +135,7 @@ async function test_restore_message_draft(page: Page): Promise<void> {
 
 async function edit_stream_message_draft(page: Page): Promise<void> {
     await common.fill_form(page, "form#send_message_form", {
-        stream_message_recipient_stream: "all",
+        stream_message_recipient_stream: "Verona",
         stream_message_recipient_topic: "tests",
         content: "Updated stream message",
     });
@@ -152,7 +152,7 @@ async function test_edited_draft_message(page: Page): Promise<void> {
             page,
             ".draft-row .message_header_stream .stream_label",
         ),
-        "all",
+        "Verona",
     );
     assert.strictEqual(
         await common.get_text_from_selector(
@@ -170,7 +170,7 @@ async function test_edited_draft_message(page: Page): Promise<void> {
     );
 }
 
-async function test_restore_private_message_draft(page: Page): Promise<void> {
+async function test_restore_private_message_draft_via_draft_overlay(page: Page): Promise<void> {
     console.log("Restoring private message draft.");
     await page.click("#drafts_table .message_row.private-message .restore-draft");
     await wait_for_drafts_to_dissapear(page);
@@ -283,11 +283,11 @@ async function drafts_test(page: Page): Promise<void> {
     await open_drafts_through_compose(page);
     await test_previously_created_drafts_rendered(page);
 
-    await test_restore_message_draft(page);
+    await test_restore_message_draft_via_draft_overlay(page);
     await edit_stream_message_draft(page);
     await test_edited_draft_message(page);
 
-    await test_restore_private_message_draft(page);
+    await test_restore_private_message_draft_via_draft_overlay(page);
     await test_delete_draft(page);
     await test_save_draft_by_reloading(page);
     await test_delete_draft_on_sending(page);

--- a/frontend_tests/puppeteer_tests/drafts.ts
+++ b/frontend_tests/puppeteer_tests/drafts.ts
@@ -241,6 +241,20 @@ async function test_save_draft_by_reloading(page: Page): Promise<void> {
     );
 }
 
+async function test_delete_draft_on_clearing_text(page: Page): Promise<void> {
+    console.log("Deleting draft by clearing compose box textarea.");
+    await page.click("#drafts_table .message_row:not(.private-message) .restore-draft");
+    await wait_for_drafts_to_dissapear(page);
+    await page.waitForSelector("#stream-message", {visible: true});
+    await page.keyboard.press("Backspace");
+    await page.click("#compose_close");
+    await page.waitForSelector("#stream-message", {hidden: true});
+    await page.click(drafts_button);
+    await wait_for_drafts_to_appear(page);
+    const drafts_count = await get_drafts_count(page);
+    assert.strictEqual(drafts_count, 0, "Draft not deleted.");
+}
+
 async function test_delete_draft_on_sending(page: Page): Promise<void> {
     await page.click("#drafts_table .message_row.private-message .restore-draft");
     await wait_for_drafts_to_dissapear(page);
@@ -277,6 +291,7 @@ async function drafts_test(page: Page): Promise<void> {
     await test_delete_draft(page);
     await test_save_draft_by_reloading(page);
     await test_delete_draft_on_sending(page);
+    await test_delete_draft_on_clearing_text(page);
 }
 
 common.run_test(drafts_test);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -844,6 +844,7 @@ export function initialize() {
 
     $("#compose-textarea").on("focus", () => {
         compose_actions.update_placeholder_text();
+        drafts.restore_last_draft_based_on_compose_state();
     });
 
     $("#stream_message_recipient_topic").on("focus", () => {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -268,6 +268,11 @@ export function start(msg_type, opts) {
 
     compose_state.set_message_type(msg_type);
 
+    // Restore the last saved draft if it exists.
+    if (opts.trigger !== "restore draft") {
+        drafts.restore_last_draft_based_on_compose_state();
+    }
+
     // Show either stream/topic fields or "You and" field.
     show_box(msg_type, opts);
 

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -1089,6 +1089,7 @@ export function initialize() {
         },
         items: 3,
         fixed: true,
+        on_select: () => $("#compose-textarea").trigger("focus"),
         highlighter(item) {
             return typeahead_helper.render_typeahead_item({primary: item});
         },
@@ -1107,6 +1108,7 @@ export function initialize() {
         },
         items: 3,
         fixed: true,
+        on_select: () => $("#compose-textarea").trigger("focus"),
         highlighter(item) {
             return typeahead_helper.render_typeahead_item({primary: item});
         },

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -157,7 +157,7 @@ export function restore_message(draft) {
         };
     }
 
-    return compose_args;
+    return {...compose_args, trigger: "restore draft"};
 }
 
 function draft_notify() {

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -153,17 +153,17 @@ function draft_notify() {
 
 export function update_draft() {
     const draft = snapshot_message();
+    const draft_id = $("#compose-textarea").data("draft-id");
 
     if (draft === undefined) {
         // The user cleared the compose box, which means
-        // there is nothing to save here.  Don't obliterate
-        // the existing draft yet--the user may have mistakenly
-        // hit delete after select-all or something.
-        // Just do nothing.
+        // there is nothing to save here but delete the
+        // draft if exists.
+        if (draft_id) {
+            delete_active_draft();
+        }
         return;
     }
-
-    const draft_id = $("#compose-textarea").data("draft-id");
 
     if (draft_id !== undefined) {
         // We don't save multiple drafts of the same message;

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -1,6 +1,7 @@
 import {subDays} from "date-fns";
 import Handlebars from "handlebars/runtime";
 import $ from "jquery";
+import _ from "lodash";
 import tippy from "tippy.js";
 
 import render_draft_table_body from "../templates/draft_table_body.hbs";
@@ -84,6 +85,28 @@ export const draft_model = (function () {
 
         delete drafts[id];
         save(drafts);
+    };
+
+    exports.getDraftsIdByStreamAndTopic = function (stream, topic) {
+        const drafts = this.get();
+        return Object.keys(drafts).filter(
+            (draft_id) =>
+                drafts[draft_id].type === "stream" &&
+                drafts[draft_id].stream === stream &&
+                drafts[draft_id].topic === topic,
+        );
+    };
+
+    exports.getDraftsIdByRecipients = function (private_message_recipient) {
+        const drafts = this.get();
+        return Object.keys(drafts).filter(
+            (draft_id) =>
+                drafts[draft_id].type === "private" &&
+                _.isEqual(
+                    drafts[draft_id].private_message_recipient.split(",").sort(),
+                    private_message_recipient.split(",").sort(),
+                ),
+        );
     };
 
     return exports;

--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -95,6 +95,7 @@
     this.fixed = this.options.fixed || false;
     this.automated = this.options.automated || this.automated;
     this.trigger_selection = this.options.trigger_selection || this.trigger_selection;
+    this.on_select = this.options.on_select;
     this.on_move = this.options.on_move;
     this.on_escape = this.options.on_escape;
     this.header = this.options.header || this.header;
@@ -121,6 +122,10 @@
         this.$element.html('');
       } else {
         this.$element.val(this.updater(val, e)).trigger("change");
+      }
+
+      if (this.on_select) {
+        this.on_select();
       }
 
       return this.hide()


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes part of #18555.

**Testing plan:** <!-- How have you tested? -->
Tested by simulating the behavior and by running tests.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Demo,

https://user-images.githubusercontent.com/63820270/120027861-8a2b4280-c011-11eb-9765-90c0b07f6f83.mov










<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
