### PR TITLE
Add M1/aarch64 dev support

### DIFF
--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -80,6 +80,8 @@ Jump to:
 
 #### macOS
 
+##### Intel
+
 1. Install [Vagrant][vagrant-dl] (latest).
 2. Install [VirtualBox][vbox-dl] (latest).
 
@@ -89,6 +91,12 @@ plugin][vagrant-vmware-fusion-dl] or [Parallels Desktop][parallels-desktop-dl] a
 a provider for Vagrant.)
 
 Now you are ready for [Step 2: Get Zulip code](#step-2-get-zulip-code).
+
+##### Apple Silicon
+
+The setup for Apple Silicon (e.g. M1) Macs is very similar to that [for Intel
+above](#intel), except that VirtualBox is not supported. Instead you can use [Docker for
+Mac](https://docs.docker.com/docker-for-mac/install/).
 
 #### Ubuntu
 
@@ -277,12 +285,12 @@ Change into the zulip directory and tell vagrant to start the Zulip
 development environment with `vagrant up`:
 
 ```
-# On Windows or macOS:
+# On Windows or macOS (Intel):
 cd zulip
 vagrant plugin install vagrant-vbguest
 vagrant up --provider=virtualbox
 
-# On Linux:
+# On Linux or macOS (Apple Silicon):
 cd zulip
 vagrant up --provider=docker
 ```

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -202,6 +202,12 @@ elif "debian" in os_families():
     if distro_info["VERSION_CODENAME"] == "bullseye":
         DEBIAN_DEPENDECIES.remove("libappindicator1")
         DEBIAN_DEPENDECIES.append("libgroonga0")
+
+    # If we are on an aarch64 processor, ninja will be built from source,
+    # so cmake is required
+    if platform.machine() == "aarch64":
+        DEBIAN_DEPENDECIES.append("cmake")
+
     SYSTEM_DEPENDENCIES = [
         *DEBIAN_DEPENDECIES,
         f"postgresql-{POSTGRESQL_VERSION}",

--- a/tools/setup/install-shellcheck
+++ b/tools/setup/install-shellcheck
@@ -2,8 +2,12 @@
 set -eu
 
 version=0.7.1
-tarball="shellcheck-v$version.linux.x86_64.tar.xz"
-sha256=64f17152d96d7ec261ad3086ed42d18232fcb65148b44571b564d688269d36c8
+arch="$(uname -m)"
+tarball="shellcheck-v$version.linux.$arch.tar.xz"
+declare -A sha256=(
+    [aarch64]=b50cc31509b354ab5bbfc160bc0967567ed98cd9308fd43f38551b36cccc4446
+    [x86_64]=64f17152d96d7ec261ad3086ed42d18232fcb65148b44571b564d688269d36c8
+)
 
 check_version() {
     out="$(shellcheck --version 2>/dev/null)" && [[ "$out" = *"
@@ -16,7 +20,7 @@ if ! check_version; then
     trap 'rm -r "$tmpdir"' EXIT
     cd "$tmpdir"
     wget -nv "https://github.com/koalaman/shellcheck/releases/download/v$version/$tarball"
-    sha256sum -c <<<"$sha256 $tarball"
+    sha256sum -c <<<"${sha256[$arch]} $tarball"
     tar -xJf "$tarball" --no-same-owner --strip-components=1 -C /usr/local/bin "shellcheck-v$version/shellcheck"
     check_version
 fi

--- a/tools/setup/install-shfmt
+++ b/tools/setup/install-shfmt
@@ -2,8 +2,19 @@
 set -eu
 
 version=3.2.4
-binary="shfmt_v${version}_linux_amd64"
-sha256=3f5a47f8fec27fae3e06d611559a2063f5d27e4b9501171dde9959b8c60a3538
+arch="$(uname -m)"
+
+case $arch in
+    "x86_64")
+        binary="shfmt_v${version}_linux_amd64"
+        sha256=3f5a47f8fec27fae3e06d611559a2063f5d27e4b9501171dde9959b8c60a3538
+        ;;
+
+    "aarch64")
+        binary="shfmt_v${version}_linux_arm64"
+        sha256=6474d9cc08a1c9fe2ef4be7a004951998e3067d46cf55a011ddd5ff7bfab3de6
+        ;;
+esac
 
 check_version() {
     out="$(shfmt --version 2>/dev/null)" && [ "$out" = "v$version" ]


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#18614 

**Testing plan:** <!-- How have you tested? -->

Ran
```bash
vagrant destroy
vagrant up --provider=docker
```

on my M1 Mac. The developer environment is setup without any errors.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
