### PR TITLE
Cleanup `send_event` mocks.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1258,7 +1258,9 @@ Output:
         self.assertFalse(validation_func(guest_user))
 
     @contextmanager
-    def tornado_redirected_to_list(self, lst: List[Mapping[str, Any]]) -> Iterator[None]:
+    def tornado_redirected_to_list(
+        self, lst: List[Mapping[str, Any]], expected_num_events: int = 1
+    ) -> Iterator[None]:
         real_event_queue_process_notification = django_tornado_api.process_notification
         django_tornado_api.process_notification = lambda notice: lst.append(notice)
         # process_notification takes a single parameter called 'notice'.
@@ -1268,6 +1270,8 @@ Output:
         # So explicitly change parameter name to 'notice' to work around this problem
         yield
         django_tornado_api.process_notification = real_event_queue_process_notification
+
+        self.assert_length(lst, expected_num_events)
 
 
 class WebhookTestCase(ZulipTestCase):

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -92,30 +92,6 @@ def simulated_queue_client(client: Callable[[], object]) -> Iterator[None]:
         yield
 
 
-class EventInfo:
-    def populate(self, call_args_list: List[Any]) -> None:
-        args = call_args_list[0][0]
-        self.realm_id = args[0]
-        self.payload = args[1]
-        self.user_ids = args[2]
-
-
-@contextmanager
-def capture_event(event_info: EventInfo) -> Iterator[None]:
-    # Use this for simple endpoints that throw a single event
-    # in zerver.lib.actions.
-    with mock.patch("zerver.lib.actions.send_event") as m:
-        yield
-
-    if len(m.call_args_list) == 0:
-        raise AssertionError("No event was sent inside actions.py")
-
-    if len(m.call_args_list) > 1:
-        raise AssertionError("Too many events sent by action")
-
-    event_info.populate(m.call_args_list)
-
-
 @contextmanager
 def cache_tries_captured() -> Iterator[List[Tuple[str, Union[str, List[str]], Optional[str]]]]:
     cache_queries: List[Tuple[str, Union[str, List[str]], Optional[str]]] = []

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -166,7 +166,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.login("hamlet")
         self.assert_num_bots_equal(0)
         events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events, expected_num_events=2):
             result = self.create_bot()
         self.assert_num_bots_equal(1)
 
@@ -332,7 +332,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.login_user(user)
         self.assert_num_bots_equal(0)
         events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events, expected_num_events=2):
             result = self.create_bot()
         self.assert_num_bots_equal(1)
 
@@ -386,7 +386,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             "principals": '["' + iago.email + '"]',
         }
         events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events, expected_num_events=3):
             result = self.common_subscribe_to_streams(hamlet, ["Rome"], request_data)
             self.assert_json_success(result)
 
@@ -403,7 +403,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             "principals": '["hambot-bot@zulip.testserver"]',
         }
         events_bot: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events_bot):
+        with self.tornado_redirected_to_list(events_bot, expected_num_events=2):
             result = self.common_subscribe_to_streams(hamlet, ["Rome"], bot_request_data)
             self.assert_json_success(result)
 
@@ -424,7 +424,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         self.assert_num_bots_equal(0)
         events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events, expected_num_events=2):
             result = self.create_bot(default_sending_stream="Denmark")
         self.assert_num_bots_equal(1)
         self.assertEqual(result["default_sending_stream"], "Denmark")
@@ -496,7 +496,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         self.assert_num_bots_equal(0)
         events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events):
+        with self.tornado_redirected_to_list(events, expected_num_events=2):
             result = self.create_bot(default_events_register_stream="Denmark")
         self.assert_num_bots_equal(1)
         self.assertEqual(result["default_events_register_stream"], "Denmark")

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -234,7 +234,6 @@ class UnreadCountTests(ZulipTestCase):
             )
 
         self.assert_json_success(result)
-        self.assertTrue(len(events) == 1)
 
         event = events[0]["event"]
         expected = dict(
@@ -306,7 +305,6 @@ class UnreadCountTests(ZulipTestCase):
             )
 
         self.assert_json_success(result)
-        self.assertTrue(len(events) == 1)
 
         event = events[0]["event"]
         expected = dict(

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Optional, Set
+from typing import Any, List, Mapping, Optional, Set
 from unittest import mock
 
 import orjson
@@ -1660,14 +1660,14 @@ class StreamMessagesTest(ZulipTestCase):
         )
 
     def _send_stream_message(self, user: UserProfile, stream_name: str, content: str) -> Set[int]:
-        with mock.patch("zerver.lib.actions.send_event") as m:
+        events: List[Mapping[str, Any]] = []
+        with self.tornado_redirected_to_list(events):
             self.send_stream_message(
                 user,
                 stream_name,
                 content=content,
             )
-        self.assertEqual(m.call_count, 1)
-        users = m.call_args[0][2]
+        users = events[0]["users"]
         user_ids = {u["id"] for u in users}
         return user_ids
 

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -423,7 +423,6 @@ class ReactionEventTest(ZulipTestCase):
                 reaction_sender, f"/api/v1/messages/{pm_id}/reactions", reaction_info
             )
         self.assert_json_success(result)
-        self.assert_length(events, 1)
 
         event = events[0]["event"]
         event_user_ids = set(events[0]["users"])
@@ -468,7 +467,6 @@ class ReactionEventTest(ZulipTestCase):
                 reaction_sender, f"/api/v1/messages/{pm_id}/reactions", reaction_info
             )
         self.assert_json_success(result)
-        self.assert_length(events, 1)
 
         event = events[0]["event"]
         event_user_ids = set(events[0]["users"])
@@ -507,7 +505,6 @@ class ReactionEventTest(ZulipTestCase):
                 iago, f"/api/v1/messages/{message_before_id}/reactions", reaction_info
             )
         self.assert_json_success(result)
-        self.assert_length(events, 1)
         event = events[0]["event"]
         self.assertEqual(event["type"], "reaction")
         event_user_ids = set(events[0]["users"])
@@ -528,7 +525,6 @@ class ReactionEventTest(ZulipTestCase):
                 iago, f"/api/v1/messages/{message_after_id}/reactions", reaction_info
             )
         self.assert_json_success(result)
-        self.assert_length(events, 1)
         event = events[0]["event"]
         self.assertEqual(event["type"], "reaction")
         event_user_ids = set(events[0]["users"])
@@ -549,7 +545,6 @@ class ReactionEventTest(ZulipTestCase):
                 iago, f"/api/v1/messages/{message_before_id}/reactions", reaction_info
             )
         self.assert_json_success(result)
-        self.assert_length(events, 1)
         event = events[0]["event"]
         self.assertEqual(event["type"], "reaction")
         event_user_ids = set(events[0]["users"])
@@ -569,7 +564,6 @@ class ReactionEventTest(ZulipTestCase):
                 iago, f"/api/v1/messages/{message_before_id}/reactions", reaction_info
             )
         self.assert_json_success(result)
-        self.assert_length(events, 1)
         event = events[0]["event"]
         self.assertEqual(event["type"], "reaction")
         event_user_ids = set(events[0]["users"])
@@ -591,7 +585,6 @@ class ReactionEventTest(ZulipTestCase):
                 hamlet, f"/api/v1/messages/{private_message_id}/reactions", reaction_info
             )
         self.assert_json_success(result)
-        self.assert_length(events, 1)
         event = events[0]["event"]
         self.assertEqual(event["type"], "reaction")
         event_user_ids = set(events[0]["users"])
@@ -609,7 +602,6 @@ class ReactionEventTest(ZulipTestCase):
                 polonius, f"/api/v1/messages/{huddle_message_id}/reactions", reaction_info
             )
         self.assert_json_success(result)
-        self.assert_length(events, 1)
         event = events[0]["event"]
         self.assertEqual(event["type"], "reaction")
         event_user_ids = set(events[0]["users"])
@@ -1038,8 +1030,6 @@ class ReactionAPIEventTest(EmojiReactionBase):
         with self.tornado_redirected_to_list(events):
             self.api_post(reaction_sender, f"/api/v1/messages/{pm_id}/reactions", reaction_info)
 
-        self.assert_length(events, 1)
-
         event = events[0]["event"]
         event_user_ids = set(events[0]["users"])
 
@@ -1085,7 +1075,6 @@ class ReactionAPIEventTest(EmojiReactionBase):
             )
 
         self.assert_json_success(result)
-        self.assert_length(events, 1)
 
         event = events[0]["event"]
         event_user_ids = set(events[0]["users"])

--- a/zerver/tests/test_submessage.py
+++ b/zerver/tests/test_submessage.py
@@ -1,5 +1,4 @@
-from typing import Any, Dict, List
-from unittest import mock
+from typing import Any, Dict, List, Mapping
 
 from zerver.lib.message import MessageDict
 from zerver.lib.test_classes import ZulipTestCase
@@ -114,7 +113,8 @@ class TestBasics(ZulipTestCase):
             msg_type="whatever",
             content='{"name": "alice", "salary": 20}',
         )
-        with mock.patch("zerver.lib.actions.send_event") as m:
+        events: List[Mapping[str, Any]] = []
+        with self.tornado_redirected_to_list(events):
             result = self.client_post("/json/submessage", payload)
         self.assert_json_success(result)
 
@@ -129,10 +129,9 @@ class TestBasics(ZulipTestCase):
             type="submessage",
         )
 
-        self.assertEqual(m.call_count, 1)
-        data = m.call_args[0][1]
+        data = events[0]["event"]
         self.assertEqual(data, expected_data)
-        users = m.call_args[0][2]
+        users = events[0]["users"]
         self.assertIn(cordelia.id, users)
         self.assertIn(hamlet.id, users)
 

--- a/zerver/tests/test_user_status.py
+++ b/zerver/tests/test_user_status.py
@@ -139,6 +139,15 @@ class UserStatusTest(ZulipTestCase):
         away_user_ids = get_away_user_ids(realm_id=realm_id)
         self.assertEqual(away_user_ids, {cordelia.id})
 
+    def update_status_and_assert_event(
+        self, payload: Dict[str, Any], expected_event: Dict[str, Any]
+    ) -> None:
+        event_info = EventInfo()
+        with capture_event(event_info):
+            result = self.client_post("/json/users/me/status", payload)
+        self.assert_json_success(result)
+        self.assertEqual(event_info.payload, expected_event)
+
     def test_endpoints(self) -> None:
         hamlet = self.example_user("hamlet")
         realm_id = hamlet.realm_id
@@ -156,54 +165,33 @@ class UserStatusTest(ZulipTestCase):
         result = self.client_post("/json/users/me/status", payload)
         self.assert_json_error(result, "status_text is too long (limit: 60 characters)")
 
-        payload = dict(
-            away=orjson.dumps(True).decode(),
-            status_text="on vacation",
+        self.update_status_and_assert_event(
+            payload=dict(
+                away=orjson.dumps(True).decode(),
+                status_text="on vacation",
+            ),
+            expected_event=dict(
+                type="user_status", user_id=hamlet.id, away=True, status_text="on vacation"
+            ),
         )
-
-        event_info = EventInfo()
-        with capture_event(event_info):
-            result = self.client_post("/json/users/me/status", payload)
-        self.assert_json_success(result)
-
-        self.assertEqual(
-            event_info.payload,
-            dict(type="user_status", user_id=hamlet.id, away=True, status_text="on vacation"),
-        )
-
         self.assertEqual(
             user_info(hamlet),
             dict(away=True, status_text="on vacation"),
         )
 
         # Now revoke "away" status.
-        payload = dict(away=orjson.dumps(False).decode())
-
-        event_info = EventInfo()
-        with capture_event(event_info):
-            result = self.client_post("/json/users/me/status", payload)
-        self.assert_json_success(result)
-
-        self.assertEqual(
-            event_info.payload,
-            dict(type="user_status", user_id=hamlet.id, away=False),
+        self.update_status_and_assert_event(
+            payload=dict(away=orjson.dumps(False).decode()),
+            expected_event=dict(type="user_status", user_id=hamlet.id, away=False),
         )
-
         away_user_ids = get_away_user_ids(realm_id=realm_id)
         self.assertEqual(away_user_ids, set())
 
         # And now just update your info.
         # The server will trim the whitespace here.
-        payload = dict(status_text="   in office  ")
-
-        event_info = EventInfo()
-        with capture_event(event_info):
-            result = self.client_post("/json/users/me/status", payload)
-        self.assert_json_success(result)
-
-        self.assertEqual(
-            event_info.payload,
-            dict(type="user_status", user_id=hamlet.id, status_text="in office"),
+        self.update_status_and_assert_event(
+            payload=dict(status_text="   in office  "),
+            expected_event=dict(type="user_status", user_id=hamlet.id, status_text="in office"),
         )
 
         self.assertEqual(
@@ -212,52 +200,28 @@ class UserStatusTest(ZulipTestCase):
         )
 
         # And finally clear your info.
-        payload = dict(status_text="")
-
-        event_info = EventInfo()
-        with capture_event(event_info):
-            result = self.client_post("/json/users/me/status", payload)
-        self.assert_json_success(result)
-
-        self.assertEqual(
-            event_info.payload,
-            dict(type="user_status", user_id=hamlet.id, status_text=""),
+        self.update_status_and_assert_event(
+            payload=dict(status_text=""),
+            expected_event=dict(type="user_status", user_id=hamlet.id, status_text=""),
         )
-
         self.assertEqual(
             get_user_info_dict(realm_id=realm_id),
             {},
         )
 
         # Turn on "away" status again.
-        payload = dict(away=orjson.dumps(True).decode())
-
-        event_info = EventInfo()
-        with capture_event(event_info):
-            result = self.client_post("/json/users/me/status", payload)
-        self.assert_json_success(result)
-
-        self.assertEqual(
-            event_info.payload,
-            dict(type="user_status", user_id=hamlet.id, away=True),
+        self.update_status_and_assert_event(
+            payload=dict(away=orjson.dumps(True).decode()),
+            expected_event=dict(type="user_status", user_id=hamlet.id, away=True),
         )
-
         away_user_ids = get_away_user_ids(realm_id=realm_id)
         self.assertEqual(away_user_ids, {hamlet.id})
 
         # And set status text while away.
-        payload = dict(status_text="   at the beach  ")
-
-        event_info = EventInfo()
-        with capture_event(event_info):
-            result = self.client_post("/json/users/me/status", payload)
-        self.assert_json_success(result)
-
-        self.assertEqual(
-            event_info.payload,
-            dict(type="user_status", user_id=hamlet.id, status_text="at the beach"),
+        self.update_status_and_assert_event(
+            payload=dict(status_text="   at the beach  "),
+            expected_event=dict(type="user_status", user_id=hamlet.id, status_text="at the beach"),
         )
-
         self.assertEqual(
             user_info(hamlet),
             dict(status_text="at the beach", away=True),

--- a/zerver/tests/test_user_status.py
+++ b/zerver/tests/test_user_status.py
@@ -1,9 +1,8 @@
-from typing import Any, Dict, Set
+from typing import Any, Dict, List, Mapping, Set
 
 import orjson
 
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import EventInfo, capture_event
 from zerver.lib.user_status import get_user_info_dict, update_user_status
 from zerver.models import UserProfile, UserStatus, get_client
 
@@ -142,11 +141,11 @@ class UserStatusTest(ZulipTestCase):
     def update_status_and_assert_event(
         self, payload: Dict[str, Any], expected_event: Dict[str, Any]
     ) -> None:
-        event_info = EventInfo()
-        with capture_event(event_info):
+        events: List[Mapping[str, Any]] = []
+        with self.tornado_redirected_to_list(events):
             result = self.client_post("/json/users/me/status", payload)
         self.assert_json_success(result)
-        self.assertEqual(event_info.payload, expected_event)
+        self.assertEqual(events[0]["event"], expected_event)
 
     def test_endpoints(self) -> None:
         hamlet = self.example_user("hamlet")


### PR DESCRIPTION
As suggested in https://github.com/zulip/zulip/pull/18559#discussion_r638382499 and discussed in https://chat.zulip.org/#narrow/stream/3-backend/topic/message.20edit.20race.20.2316502/near/1189195.