### PR TITLE
Pill typeahead cleanup

### DIFF
--- a/frontend_tests/node_tests/pill_typeahead.js
+++ b/frontend_tests/node_tests/pill_typeahead.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {zrequire} = require("../zjsunit/namespace");
+const {zrequire, mock_esm, mock_cjs} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
 const $ = require("../zjsunit/zjquery");
@@ -11,30 +11,105 @@ const input_pill = zrequire("input_pill");
 const pill_typeahead = zrequire("pill_typeahead");
 const noop = function () {};
 
+mock_cjs("jquery", $);
+const peer_data = zrequire("peer_data");
+const people = zrequire("people");
+const stream_data = zrequire("stream_data");
+const user_groups = zrequire("user_groups");
+
+// set global test variables.
+let sort_recipients_called = false;
+let sort_streams_called = false;
+const fake_rendered_person = $.create("fake-rendered-person");
+const fake_rendered_stream = $.create("fake-rendered-stream");
+const fake_rendered_group = $.create("fake-redered-group");
+
+mock_esm("../../static/js/typeahead_helper", {
+    render_person() {
+        return fake_rendered_person;
+    },
+    render_user_group() {
+        return fake_rendered_group;
+    },
+    render_stream() {
+        return fake_rendered_stream;
+    },
+    sort_streams() {
+        sort_streams_called = true;
+    },
+    sort_recipients() {
+        sort_recipients_called = true;
+    },
+});
+
+const jill = {
+    email: "jill@zulip.com",
+    user_id: 10,
+    full_name: "Jill Hill",
+};
+const mark = {
+    email: "mark@zulip.com",
+    user_id: 20,
+    full_name: "Marky Mark",
+};
+const fred = {
+    email: "fred@zulip.com",
+    user_id: 30,
+    full_name: "Fred Flintstone",
+};
+const me = {
+    email: "me@example.com",
+    user_id: 40,
+    full_name: "me",
+};
+
+const persons = [jill, mark, fred, me];
+for (const person of persons) {
+    people.add_active_user(person);
+}
+
+const admins = {
+    name: "Admins",
+    description: "foo",
+    id: 1,
+    members: [jill.user_id, mark.user_id],
+};
+const testers = {
+    name: "Testers",
+    description: "bar",
+    id: 2,
+    members: [mark.user_id, fred.user_id, me.user_id],
+};
+
+const groups = [admins, testers];
+for (const group of groups) {
+    user_groups.add(group);
+}
+
+const denmark = {
+    stream_id: 1,
+    name: "Denmark",
+    subscribed: true,
+    render_subscribers: true,
+};
+peer_data.set_subscribers(denmark.stream_id, [me.user_id, mark.user_id]);
+
+const sweden = {
+    stream_id: 2,
+    name: "Sweden",
+    subscribed: false,
+};
+peer_data.set_subscribers(sweden.stream_id, [mark.user_id, jill.user_id]);
+
+const subs = [denmark, sweden];
+for (const sub of subs) {
+    stream_data.add_sub(sub);
+}
+
 run_test("set_up", () => {
-    // Test set_up without any type
     let input_pill_typeahead_called = false;
     const fake_input = $.create(".input");
-    fake_input.typeahead = (config) => {
-        assert.equal(config.items, 5);
-        assert.ok(config.fixed);
-        assert.ok(config.dropup);
-        assert.ok(config.stopAdvance);
-
-        // Working of functions that are part of config
-        // is tested separately based on the widgets that
-        // try to use it. Here we just check if config
-        // passed to the typeahead is in the right format.
-        assert.equal(typeof config.source, "function");
-        assert.equal(typeof config.highlighter, "function");
-        assert.equal(typeof config.matcher, "function");
-        assert.equal(typeof config.sorter, "function");
-        assert.equal(typeof config.updater, "function");
-
-        // input_pill_typeahead_called is set true if
-        // no exception occurs in pill_typeahead.set_up.
-        input_pill_typeahead_called = true;
-    };
+    fake_input.before = noop;
 
     const container = $.create(".pill-container");
     container.find = () => fake_input;
@@ -45,31 +120,218 @@ run_test("set_up", () => {
         get_text_from_item: noop,
     });
 
-    // call set_up with only user type in opts.
-    pill_typeahead.set_up(fake_input, pill_widget, {user: true});
-    assert.ok(input_pill_typeahead_called);
+    let opts = {};
+    fake_input.typeahead = (config) => {
+        assert.equal(config.items, 5);
+        assert.ok(config.fixed);
+        assert.ok(config.dropup);
+        assert.ok(config.stopAdvance);
 
-    // call set_up with only stream type in opts.
-    input_pill_typeahead_called = false;
-    pill_typeahead.set_up(fake_input, pill_widget, {stream: true});
-    assert.ok(input_pill_typeahead_called);
+        assert.equal(typeof config.source, "function");
+        assert.equal(typeof config.highlighter, "function");
+        assert.equal(typeof config.matcher, "function");
+        assert.equal(typeof config.sorter, "function");
+        assert.equal(typeof config.updater, "function");
 
-    // call set_up with only user_group type in opts.
-    input_pill_typeahead_called = false;
-    pill_typeahead.set_up(fake_input, pill_widget, {user_group: true});
-    assert.ok(input_pill_typeahead_called);
+        // test queries
+        const fake_stream_this = {
+            query: "#Denmark",
+        };
+        const fake_person_this = {
+            query: "me",
+        };
+        const fake_group_this = {
+            query: "test",
+        };
 
-    // call set_up with combination two types in opts.
-    input_pill_typeahead_called = false;
-    pill_typeahead.set_up(fake_input, pill_widget, {user_group: true, stream: true});
-    assert.ok(input_pill_typeahead_called);
+        (function test_highlighter() {
+            if (opts.stream) {
+                // Test stream highlighter for widgets that allow stream pills.
+                assert.equal(
+                    config.highlighter.call(fake_stream_this, denmark),
+                    fake_rendered_stream,
+                );
+            }
+            if (opts.user_group && opts.user) {
+                // If user is also allowed along with user_group
+                // then we should check that each of them rendered correctly.
+                assert.equal(
+                    config.highlighter.call(fake_group_this, testers),
+                    fake_rendered_group,
+                );
+                assert.equal(config.highlighter.call(fake_person_this, me), fake_rendered_person);
+            }
+            if (opts.user && !opts.user_group) {
+                assert.equal(config.highlighter.call(fake_person_this, me), fake_rendered_person);
+            }
+            if (!opts.user && opts.user_group) {
+                assert.equal(
+                    config.highlighter.call(fake_group_this, testers),
+                    fake_rendered_group,
+                );
+            }
+        })();
 
-    // call set_up with all three types in opts.
-    input_pill_typeahead_called = false;
-    pill_typeahead.set_up(fake_input, pill_widget, {user_group: true, stream: true, user: true});
-    assert.ok(input_pill_typeahead_called);
+        (function test_matcher() {
+            let result;
+            if (opts.stream) {
+                result = config.matcher.call(fake_stream_this, denmark);
+                assert.ok(result);
+                result = config.matcher.call(fake_stream_this, sweden);
+                assert.ok(!result);
+            }
+            if (opts.user_group && opts.user) {
+                /* If user pills are also allowed along with user groups.
+                We should check that queries matching either a person
+                or group is returned. */
 
-    // call set_up without specifying type in opts.
+                // group query, with correct item.
+                result = config.matcher.call(fake_group_this, testers);
+                assert.ok(result);
+                // group query, with wrong item.
+                result = config.matcher.call(fake_group_this, admins);
+                assert.ok(!result);
+                // person query with correct item.
+                result = config.matcher.call(fake_person_this, me);
+                assert.ok(result);
+                // person query with wrong item.
+                result = config.matcher.call(fake_person_this, jill);
+                assert.ok(!result);
+            }
+            if (opts.user_group && !opts.user) {
+                result = config.matcher.call(fake_group_this, testers);
+                assert.ok(result);
+                result = config.matcher.call(fake_group_this, admins);
+                assert.ok(!result);
+            }
+            if (opts.user && !opts.user_group) {
+                result = config.matcher.call(fake_person_this, me);
+                assert.ok(result);
+                result = config.matcher.call(fake_person_this, jill);
+                assert.ok(!result);
+            }
+        })();
+
+        (function test_sorter() {
+            if (opts.stream) {
+                sort_streams_called = false;
+                config.sorter.call(fake_stream_this);
+                assert.ok(sort_streams_called);
+            }
+            if (opts.user_group) {
+                sort_recipients_called = false;
+                config.sorter.call(fake_group_this, [testers]);
+                assert.ok(sort_recipients_called);
+            }
+            if (opts.user) {
+                sort_recipients_called = false;
+                config.sorter.call(fake_person_this, [me]);
+                assert.ok(sort_recipients_called);
+            }
+        })();
+
+        (function test_source() {
+            let result;
+            if (opts.stream) {
+                result = config.source.call(fake_stream_this);
+                const stream_ids = result.map((stream) => stream.stream_id);
+                const expected_stream_ids = [denmark.stream_id, sweden.stream_id];
+                assert.deepEqual(stream_ids, expected_stream_ids);
+            }
+
+            let expected_result = [];
+            let actual_result = [];
+            function is_group(item) {
+                return item.members;
+            }
+            result = config.source.call(fake_person_this);
+            actual_result = result
+                .map((item) => {
+                    if (is_group(item)) {
+                        return item.id;
+                    }
+                    return item.user_id;
+                })
+                .filter(Boolean);
+            if (opts.user_group) {
+                expected_result = expected_result.concat(groups);
+            }
+            if (opts.user) {
+                if (opts.user_source) {
+                    expected_result = expected_result.concat(opts.user_source());
+                } else {
+                    expected_result = expected_result.concat(persons);
+                }
+            }
+            expected_result = expected_result
+                .map((item) => {
+                    if (is_group(item)) {
+                        return item.id;
+                    }
+                    return item.user_id;
+                })
+                .filter(Boolean);
+            assert.deepEqual(actual_result, expected_result);
+        })();
+
+        (function test_updater() {
+            if (opts.user && opts.user_group && opts.stream) {
+                // Test it only for the case when all types of pills
+                // are allowed, as it would be difficult to keep track
+                // of number of items as we call with different types multiple
+                // times in this test. So this case checks all possible cases handled by
+                // updater in pill_typeahead.
+
+                function number_of_pills() {
+                    const pills = pill_widget.items();
+                    return pills.length;
+                }
+                assert.equal(number_of_pills(), 0);
+                config.updater.call(fake_stream_this, denmark);
+                assert.equal(number_of_pills(), 1);
+                config.updater.call(fake_person_this, me);
+                assert.equal(number_of_pills(), 2);
+                config.updater.call(fake_group_this, testers);
+                assert.equal(number_of_pills(), 3);
+            }
+        })();
+
+        // input_pill_typeahead_called is set true if
+        // no exception occurs in pill_typeahead.set_up.
+        input_pill_typeahead_called = true;
+    };
+
+    function test_pill_typeahead(opts) {
+        pill_typeahead.set_up(fake_input, pill_widget, opts);
+        assert.ok(input_pill_typeahead_called);
+    }
+
+    const all_possible_opts = [
+        // These are various possible cases of opts that
+        // currently occur in web-app codebase. This list
+        // can be extended if some other configuration
+        // is added later and its logic is to be tested.
+
+        {user: true},
+        // user and custom user source.
+        {user: true, user_source: () => [fred, mark]},
+        {stream: true},
+        {user_group: true},
+        {user_group: true, stream: true},
+        {user_group: true, user: true},
+        {user: true, stream: true},
+        {user_group: true, stream: true, user: true},
+    ];
+
+    for (const config of all_possible_opts) {
+        opts = config;
+        test_pill_typeahead(config);
+    }
+
+    // Special case to test coverage and to test
+    // that we enforce type is always specified
+    // by caller.
+    opts = {};
     input_pill_typeahead_called = false;
     blueslip.expect("error", "Unspecified possible item types");
     pill_typeahead.set_up(fake_input, pill_widget, {});

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -182,9 +182,14 @@ test_ui("subscriber_pills", (override) => {
             };
             assert.equal(config.highlighter.call(fake_stream_this, denmark), fake_html);
 
-            typeahead_helper.render_person_or_user_group = function () {
+            typeahead_helper.render_user_group = function () {
                 return fake_html;
             };
+
+            typeahead_helper.render_person = function () {
+                return fake_html;
+            };
+
             assert.equal(config.highlighter.call(fake_group_this, testers), fake_html);
             assert.equal(config.highlighter.call(fake_person_this, me), fake_html);
         })();

--- a/static/js/pill_typeahead.js
+++ b/static/js/pill_typeahead.js
@@ -64,10 +64,14 @@ export function set_up(input, pills, opts) {
                 return typeahead_helper.render_stream(item);
             }
 
-            if (include_user_groups) {
-                return typeahead_helper.render_person_or_user_group(item);
+            if (include_user_groups && user_groups.is_user_group(item)) {
+                return typeahead_helper.render_user_group(item);
             }
 
+            // After reaching this point, it is sure
+            // that given item is a person. So this
+            // handles `include_users` cases along with
+            // default cases.
             return typeahead_helper.render_person(item);
         },
         matcher(item) {
@@ -79,11 +83,15 @@ export function set_up(input, pills, opts) {
                 return item.name.toLowerCase().includes(query);
             }
 
+            let matches = false;
             if (include_user_groups) {
-                return group_matcher(query, item) || person_matcher(query, item);
+                matches = matches || group_matcher(query, item);
             }
 
-            return person_matcher(query, item);
+            if (include_users) {
+                matches = matches || person_matcher(query, item);
+            }
+            return matches;
         },
         sorter(matches) {
             const query = this.query;
@@ -91,7 +99,11 @@ export function set_up(input, pills, opts) {
                 return typeahead_helper.sort_streams(matches, query.trim().slice(1));
             }
 
-            const users = matches.filter((ele) => people.is_known_user(ele));
+            let users = [];
+            if (include_users) {
+                users = matches.filter((ele) => people.is_known_user(ele));
+            }
+
             let groups;
             if (include_user_groups) {
                 groups = matches.filter((ele) => user_groups.is_user_group(ele));
@@ -110,7 +122,7 @@ export function set_up(input, pills, opts) {
                 stream_pill.append_stream(item, pills);
             } else if (include_user_groups && user_groups.is_user_group(item)) {
                 user_group_pill.append_user_group(item, pills);
-            } else {
+            } else if (include_users && people.is_known_user(item)) {
                 user_pill.append_user(item, pills);
             }
 

--- a/static/js/pill_typeahead.js
+++ b/static/js/pill_typeahead.js
@@ -11,14 +11,14 @@ function person_matcher(query, item) {
     if (people.is_known_user(item)) {
         return composebox_typeahead.query_matches_person(query, item);
     }
-    return undefined;
+    return false;
 }
 
 function group_matcher(query, item) {
     if (user_groups.is_user_group(item)) {
         return composebox_typeahead.query_matches_name_description(query, item);
     }
-    return undefined;
+    return false;
 }
 
 export function set_up(input, pills, opts) {
@@ -29,11 +29,6 @@ export function set_up(input, pills, opts) {
     const include_streams = (query) => opts.stream && query.trim().startsWith("#");
     const include_user_groups = opts.user_group;
     const include_users = opts.user;
-
-    let user_source;
-    if (opts.user_source) {
-        user_source = opts.user_source;
-    }
 
     input.typeahead({
         items: 5,
@@ -53,11 +48,11 @@ export function set_up(input, pills, opts) {
             }
 
             if (include_users) {
-                if (user_source !== undefined) {
+                if (opts.user_source !== undefined) {
                     // If user_source is specified in opts, it
                     // is given priority. Otherwise we use
                     // default user_pill.typeahead_source.
-                    source = source.concat(user_source());
+                    source = source.concat(opts.user_source());
                 } else {
                     source = source.concat(user_pill.typeahead_source(pills));
                 }


### PR DESCRIPTION
Reference: [https://github.com/zulip/zulip/pull/18592#issuecomment-847948095](https://github.com/zulip/zulip/pull/18592#issuecomment-847948095)
* Add node tests, to test complete working of typeahead functions in `pill_typeahead.js` at one place. Earlier it was only dependent on tests of other widgets that used it and those tests are more focused in testing working of those widgets rather than logic of these functions.
* Remove redundant variables in `pill_typeahead.js`, and use common variables like `include_users` if possible.
**Testing plan:** `node tests`


**GIFs or screenshots:** There shouldn't be any visual changes due to this.
