### PR TITLE
Refactor certain modals to `confirm_dialog` module

### DIFF
--- a/frontend_tests/puppeteer_tests/user-deactivation.ts
+++ b/frontend_tests/puppeteer_tests/user-deactivation.ts
@@ -23,19 +23,22 @@ async function test_deactivate_user(page: Page): Promise<void> {
     await page.waitForSelector(cordelia_user_row, {visible: true});
     await page.waitForSelector(cordelia_user_row + " .fa-user-times");
     await page.click(cordelia_user_row + " .deactivate");
-    await page.waitForSelector("#deactivation_user_modal", {visible: true});
+    await page.waitForSelector("#confirm_dialog_modal", {visible: true});
 
     assert.strictEqual(
-        await common.get_text_from_selector(page, "#deactivation_user_modal_label"),
+        await common.get_text_from_selector(page, ".confirm_dialog_heading"),
         "Deactivate " + (await common.get_internal_email_from_name(page, "cordelia")),
         "Deactivate modal has wrong user.",
     );
     assert.strictEqual(
-        await common.get_text_from_selector(page, "#deactivation_user_modal .do_deactivate_button"),
+        await common.get_text_from_selector(
+            page,
+            "#confirm_dialog_modal .confirm_dialog_yes_button",
+        ),
         "Confirm",
         "Deactivate button has incorrect text.",
     );
-    await page.click("#deactivation_user_modal .do_deactivate_button");
+    await page.click("#confirm_dialog_modal .confirm_dialog_yes_button");
     await page.waitForSelector("#user-field-status", {hidden: true});
 }
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -910,28 +910,39 @@ export function initialize() {
             );
             return;
         }
-        const stream_name = stream_data.maybe_get_stream_name(stream_id);
-        const deactivate_stream_modal = render_settings_deactivation_stream_modal({
-            stream_name,
-            stream_id,
-        });
-        $("#deactivation_stream_modal").remove();
-        $("#subscriptions_table").append(deactivate_stream_modal);
-        overlays.open_modal("#deactivation_stream_modal");
-    });
 
-    $("#subscriptions_table").on("click", "#do_deactivate_stream_button", (e) => {
-        const stream_id = $(e.target).data("stream-id");
-        overlays.close_modal("#deactivation_stream_modal");
-        if (!stream_id) {
-            ui_report.client_error(
-                $t_html({defaultMessage: "Invalid stream id"}),
-                $(".stream_change_property_info"),
-            );
-            return;
+        function do_archive_stream() {
+            const stream_id = $(".confirm_dialog_yes_button").data("stream-id");
+            if (!stream_id) {
+                ui_report.client_error(
+                    $t_html({defaultMessage: "Invalid stream id"}),
+                    $(".stream_change_property_info"),
+                );
+                return;
+            }
+            const row = $(".stream-row.active");
+            archive_stream(stream_id, $(".stream_change_property_info"), row);
         }
-        const row = $(".stream-row.active");
-        archive_stream(stream_id, $(".stream_change_property_info"), row);
+
+        const modal_parent = $("#subscription_overlay");
+        const stream_name = stream_data.maybe_get_stream_name(stream_id);
+        const html_body = render_settings_deactivation_stream_modal({
+            stream_name,
+        });
+
+        confirm_dialog.launch({
+            parent: modal_parent,
+            html_heading: $t_html(
+                {defaultMessage: "Archive stream {stream}"},
+                {stream: stream_name},
+            ),
+            help_link: "/help/archive-a-stream",
+            html_body,
+            html_yes_button: $t_html({defaultMessage: "Confirm"}),
+            on_click: do_archive_stream,
+        });
+
+        $(".confirm_dialog_yes_button").attr("data-stream-id", stream_id);
     });
 
     $("#subscriptions_table").on("click", ".stream-row", function (e) {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1574,8 +1574,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     background-color: hsl(0, 0%, 100%);
 }
 
-#confirm_dialog_modal,
-#deactivation_user_modal.fade.in {
+#confirm_dialog_modal {
     top: calc(50% - 120px);
 }
 

--- a/static/templates/settings/admin_settings_modals.hbs
+++ b/static/templates/settings/admin_settings_modals.hbs
@@ -1,5 +1,3 @@
-{{> deactivation_user_modal }}
-
 {{> realm_domains_modal }}
 
 <div id="user-info-form-modal-container"></div>

--- a/static/templates/settings/deactivate_realm_modal.hbs
+++ b/static/templates/settings/deactivate_realm_modal.hbs
@@ -1,17 +1,2 @@
-<div id="deactivate-realm-modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="deactivate_realm_modal_label" aria-hidden="true">
-    <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-        <h3 id="deactivate_realm_modal_label">
-            {{t "Deactivate organization" }} <span class="realm_name"></span>
-            {{> ../help_link_widget link="/help/deactivate-your-organization" }}
-        </h3>
-    </div>
-    <div class="modal-body">
-        <p>{{t "This action is permanent and cannot be undone. All users will permanently lose access to their Zulip accounts." }}</p>
-        <p>{{t "Are you sure you want to deactivate this organization?"}}</p>
-    </div>
-    <div class="modal-footer">
-        <button type="button" class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
-        <button type="button" class="button rounded btn-danger" id="do_deactivate_realm_button">{{t "Confirm" }}</button>
-    </div>
-</div>
+<p>{{t "This action is permanent and cannot be undone. All users will permanently lose access to their Zulip accounts." }}</p>
+<p>{{t "Are you sure you want to deactivate this organization?"}}</p>

--- a/static/templates/settings/deactivation_stream_modal.hbs
+++ b/static/templates/settings/deactivation_stream_modal.hbs
@@ -1,17 +1,2 @@
-<div id="deactivation_stream_modal" class="modal modal-bg hide fade new-style" tabindex="-1" role="dialog" aria-labelledby="deactivation_stream_modal_label" aria-hidden="true">
-    <div class="modal-header">
-        <button type="button" class="close close-modal-btn" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-        <h3 id="deactivation_stream_modal_label">
-            {{t "Archive stream" }} <span class="stream_name">{{stream_name}}</span>
-            {{> ../help_link_widget link="/help/archive-a-stream" }}
-        </h3>
-    </div>
-    <div class="modal-body">
-        Archiving stream <strong>{{stream_name}}</strong> <span>will immediately unsubscribe everyone. This action cannot be undone.</span>
-        <p><strong>{{t "Are you sure you want to archive this stream?" }}</strong></p>
-    </div>
-    <div class="modal-footer">
-        <button class="button rounded close-modal-btn" data-dismiss="modal">{{t "Cancel" }}</button>
-        <button class="button rounded btn-danger" id="do_deactivate_stream_button" data-stream-id="{{stream_id}}">{{t "Confirm" }}</button>
-    </div>
-</div>
+Archiving stream <strong>{{stream_name}}</strong> <span>will immediately unsubscribe everyone. This action cannot be undone.</span>
+<p><strong>{{t "Are you sure you want to archive this stream?" }}</strong></p>

--- a/static/templates/settings/deactivation_user_modal.hbs
+++ b/static/templates/settings/deactivation_user_modal.hbs
@@ -1,19 +1,7 @@
-<div id="deactivation_user_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="deactivation_user_modal_label" aria-hidden="true">
-    <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-        <h3 id="deactivation_user_modal_label">{{t "Deactivate" }} <span class="email"></span></h3>
-    </div>
-    <div class="modal-body">
-        <p>
-            {{#tr}}
-                By deactivating <z-user></z-user>, they will be logged out immediately.
-                {{#*inline "z-user"}}<strong><span class="user_name"></span></strong> &lt;<span class="email"></span>&gt;{{/inline}}
-            {{/tr}}
-        </p>
-        <p>{{t "Their password will be cleared from our systems, and any bots they maintain will be disabled." }}</p>
-    </div>
-    <div class="modal-footer">
-        <button class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
-        <button class="button rounded btn-danger do_deactivate_button">{{t "Confirm" }}</button>
-    </div>
-</div>
+<p>
+    {{#tr}}
+        By deactivating <z-user></z-user>, they will be logged out immediately.
+        {{#*inline "z-user"}}<strong>{{username}}</strong> &lt;{{email}}&gt;{{/inline}}
+    {{/tr}}
+</p>
+<p>{{t "Their password will be cleared from our systems, and any bots they maintain will be disabled." }}</p>

--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -75,7 +75,6 @@
                     {{t 'Deactivate organization' }}
                 </button>
             </div>
-            {{> deactivate_realm_modal}}
         </div>
     </form>
 </div>


### PR DESCRIPTION
Refactored multiple UI modals to use the `confirm_dialog` module. Essentially, converted the ones that presented the user with a simple 'Cancel'/'Confirm' type question. 

These includes: 

- [x] delete_topic -- 3c22739 
- [x] subscription_invites_warning -- 8ef944e 
- [x] revoke_invite -- 800cfe7 
- [x] resend_invite -- 0416203 
- [x] user_deactivation -- d7f0147 
- [x] stream_deactivation -- 52d8589 
- [x] realm_deactivation -- 82b300a 


Maybe @sumanthvrao can have a look at it :)