### PR TITLE
Fix bug of disabling "Add" button used for adding subscribers on live update after subscribing.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -284,7 +284,8 @@ export function remove_stream(stream_id) {
     }
 }
 
-export function update_settings_for_subscribed(sub) {
+export function update_settings_for_subscribed(slim_sub) {
+    const sub = stream_settings_data.get_sub_for_settings(slim_sub);
     stream_ui_updates.update_add_subscriptions_elements(sub);
     $(
         `.subscription_settings[data-stream-id='${CSS.escape(


### PR DESCRIPTION
We live update the "Add subscribers" UI on subscribing/unsubscribing
the stream and the field sub.can_add_subscribers is used to check
whether user is allowed to add subscribers or not.

The sub object used here is not the complete sub object and thus
sub.can_add_subscribers is undefined. We need to use the updated
sub obejcts with all the setting fields that we can get from
'stream_settings_data.get_sub_for_settings' before rendering UI.

This calculation of additional fields was done previously by
'stream_data.update_calculated_fields', but in d50462568ba9aa
call to 'updated_calculated_fields' was removed with the aim to
call 'get_sub_for_settings' before updating UI which was missed
in this part of UI update.

Fixes #18616.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


 <!-- How have you tested? -->

![add-btn](https://user-images.githubusercontent.com/35494118/119886041-2bea5b00-bf50-11eb-85b8-56dc3d8ce3ad.gif)

<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
