### PR TITLE
Avoid useless work when switching a modern Zulip server to Pgroonga

### DIFF
--- a/pgroonga/migrations/0001_enable.py
+++ b/pgroonga/migrations/0001_enable.py
@@ -11,43 +11,11 @@ class Migration(migrations.Migration):
     database_setting = settings.DATABASES["default"]
 
     operations = [
+        # This previously had additional operations, but they are all
+        # undone in migration 0003 because we switched to using the
+        # PGroonga v2 API.
         migrations.RunSQL(
-            [
-                (
-                    """
-DO $$BEGIN
-EXECUTE format('ALTER ROLE %%I SET search_path TO %%L,public,pgroonga,pg_catalog', %(USER)s, %(SCHEMA)s);
-
-SET search_path = %(SCHEMA)s,public,pgroonga,pg_catalog;
-
-ALTER TABLE zerver_message ADD COLUMN search_pgroonga text;
-
--- TODO: We want to use CREATE INDEX CONCURRENTLY but it can't be used in
--- transaction. Django uses transaction implicitly.
--- Django 1.10 may solve the problem.
-CREATE INDEX zerver_message_search_pgroonga ON zerver_message
-  USING pgroonga(search_pgroonga pgroonga.text_full_text_search_ops);
-END$$
-""",
-                    database_setting,
-                )
-            ],
-            [
-                (
-                    """
-DO $$BEGIN
-SET search_path = %(SCHEMA)s,public,pgroonga,pg_catalog;
-
-DROP INDEX zerver_message_search_pgroonga;
-ALTER TABLE zerver_message DROP COLUMN search_pgroonga;
-
-SET search_path = %(SCHEMA)s,public;
-
-EXECUTE format('ALTER ROLE %%I SET search_path TO %%L,public', %(USER)s, %(SCHEMA)s);
-END$$
-""",
-                    database_setting,
-                )
-            ],
+            sql="ALTER TABLE zerver_message ADD COLUMN search_pgroonga text;",
+            reverse_sql="ALTER TABLE zerver_message DROP COLUMN search_pgroonga;",
         ),
     ]

--- a/pgroonga/migrations/0001_enable.py
+++ b/pgroonga/migrations/0001_enable.py
@@ -9,12 +9,12 @@ class Migration(migrations.Migration):
     ]
 
     database_setting = settings.DATABASES["default"]
-    if "postgres" in database_setting["ENGINE"]:
-        operations = [
-            migrations.RunSQL(
-                [
-                    (
-                        """
+
+    operations = [
+        migrations.RunSQL(
+            [
+                (
+                    """
 DO $$BEGIN
 EXECUTE format('ALTER ROLE %%I SET search_path TO %%L,public,pgroonga,pg_catalog', %(USER)s, %(SCHEMA)s);
 
@@ -29,12 +29,12 @@ CREATE INDEX zerver_message_search_pgroonga ON zerver_message
   USING pgroonga(search_pgroonga pgroonga.text_full_text_search_ops);
 END$$
 """,
-                        database_setting,
-                    )
-                ],
-                [
-                    (
-                        """
+                    database_setting,
+                )
+            ],
+            [
+                (
+                    """
 DO $$BEGIN
 SET search_path = %(SCHEMA)s,public,pgroonga,pg_catalog;
 
@@ -46,10 +46,8 @@ SET search_path = %(SCHEMA)s,public;
 EXECUTE format('ALTER ROLE %%I SET search_path TO %%L,public', %(USER)s, %(SCHEMA)s);
 END$$
 """,
-                        database_setting,
-                    )
-                ],
-            ),
-        ]
-    else:
-        operations = []
+                    database_setting,
+                )
+            ],
+        ),
+    ]


### PR DESCRIPTION
This avoids creating an index that we're going to drop in an immediately following migration.

@kou FYI.

As of yet untested beyond CI.