### PR TITLE
data_import: Support importing from Slack conversions in a directory.

### DIFF
--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1362,6 +1362,8 @@ def check_token_access(token: str) -> None:
         data = requests.get(
             "https://slack.com/api/team.info", headers={"Authorization": "Bearer {}".format(token)}
         )
+        if data.status_code != 200 or not data.json()["ok"]:
+            raise ValueError("Invalid Slack token: {}".format(token))
         has_scopes = set(data.headers.get("x-oauth-scopes", "").split(","))
         required_scopes = set(["emoji:read", "users:read", "users:read.email", "team:read"])
         missing_scopes = required_scopes - has_scopes

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1246,7 +1246,7 @@ def fetch_team_icons(
     return records
 
 
-def do_convert_data(slack_zip_file: str, output_dir: str, token: str, threads: int = 6) -> None:
+def do_convert_data(original_path: str, output_dir: str, token: str, threads: int = 6) -> None:
     # Subdomain is set by the user while running the import command
     realm_subdomain = ""
     realm_id = 0
@@ -1254,15 +1254,20 @@ def do_convert_data(slack_zip_file: str, output_dir: str, token: str, threads: i
 
     check_token_access(token)
 
-    slack_data_dir = slack_zip_file.replace(".zip", "")
-    if not os.path.exists(slack_data_dir):
-        os.makedirs(slack_data_dir)
-
     os.makedirs(output_dir, exist_ok=True)
     if os.listdir(output_dir):
         raise Exception("Output directory should be empty!")
 
-    subprocess.check_call(["unzip", "-q", slack_zip_file, "-d", slack_data_dir])
+    if os.path.isfile(original_path) and original_path.endswith(".zip"):
+        slack_data_dir = original_path.replace(".zip", "")
+        if not os.path.exists(slack_data_dir):
+            os.makedirs(slack_data_dir)
+
+        subprocess.check_call(["unzip", "-q", original_path, "-d", slack_data_dir])
+    elif os.path.isdir(original_path):
+        slack_data_dir = original_path
+    else:
+        raise ValueError(f"Don't know how to import Slack data from {original_path}")
 
     if not os.path.isfile(os.path.join(slack_data_dir, "channels.json")):
         raise ValueError(f"{original_path} does not have the layout we expect from a Slack export!")
@@ -1335,7 +1340,9 @@ def do_convert_data(slack_zip_file: str, output_dir: str, token: str, threads: i
     create_converted_data_files(attachment, output_dir, "/attachment.json")
     create_converted_data_files(realm_icon_records, output_dir, "/realm_icons/records.json")
 
-    rm_tree(slack_data_dir)
+    # Clean up the directory if we unpacked it ourselves.
+    if original_path != slack_data_dir:
+        rm_tree(slack_data_dir)
     subprocess.check_call(["tar", "-czf", output_dir + ".tar.gz", output_dir, "-P"])
 
     logging.info("######### DATA CONVERSION FINISHED #########\n")

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1264,6 +1264,9 @@ def do_convert_data(slack_zip_file: str, output_dir: str, token: str, threads: i
 
     subprocess.check_call(["unzip", "-q", slack_zip_file, "-d", slack_data_dir])
 
+    if not os.path.isfile(os.path.join(slack_data_dir, "channels.json")):
+        raise ValueError(f"{original_path} does not have the layout we expect from a Slack export!")
+
     # We get the user data from the legacy token method of Slack API, which is depreciated
     # but we use it as the user email data is provided only in this method
     user_list = get_slack_api_data("https://slack.com/api/users.list", "members", token=token)

--- a/zerver/management/commands/convert_slack_data.py
+++ b/zerver/management/commands/convert_slack_data.py
@@ -14,7 +14,10 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
-            "slack_data_zip", nargs="+", metavar="<Slack data zip>", help="Zipped Slack data"
+            "slack_data_path",
+            nargs="+",
+            metavar="<Slack data path>",
+            help="Zipped Slack data or directory",
         )
 
         parser.add_argument(
@@ -48,7 +51,7 @@ class Command(BaseCommand):
         if num_threads < 1:
             raise CommandError("You must have at least one thread.")
 
-        for path in options["slack_data_zip"]:
+        for path in options["slack_data_path"]:
             if not os.path.exists(path):
                 raise CommandError(f"Slack data directory not found: '{path}'")
 


### PR DESCRIPTION
Sometimes the Slack import zip file we get isn't quite the canonical
form that Slack produces -- often because the user has unzip'd it,
looked at it, and re-zip'd it, resulting in extra nested directories
and the like.

For such cases, support passing in a path to an unpacked Slack export
tree.

-----

Also two adjacent cleanups.