### PR TITLE
message_events: Pass correct new stream id to recent_senders.

### DIFF
--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -387,12 +387,16 @@ export function update_messages(events) {
                 pre_edit_topic = msg.topic;
                 post_edit_topic = pre_edit_topic;
             }
-            const args = [event.stream_id, pre_edit_topic, post_edit_topic, new_stream_id];
+
+            // new_stream_id is undefined if this is only a topic edit.
+            const post_edit_stream_id = new_stream_id || event.stream_id;
+
+            const args = [event.stream_id, pre_edit_topic, post_edit_topic, post_edit_stream_id];
             recent_senders.process_topic_edit({
                 message_ids: event.message_ids,
                 old_stream_id: event.stream_id,
                 old_topic: pre_edit_topic,
-                new_stream_id,
+                new_stream_id: post_edit_stream_id,
                 new_topic: post_edit_topic,
             });
             recent_topics.process_topic_edit(...args);


### PR DESCRIPTION
Bug: Empty participants' column in recent topics as noted in https://chat.zulip.org/#narrow/stream/9-issues/topic/Recent.20topics.20participants.20bug after a topic edit.

