### PR TITLE
markdown: Increase max rendered message length to 1MB.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2612,9 +2612,9 @@ def do_convert(
         # rest of the codebase from any bugs where we end up rendering
         # something huge.
         MAX_MESSAGE_LENGTH = settings.MAX_MESSAGE_LENGTH
-        if len(rendered_content) > MAX_MESSAGE_LENGTH * 10:
+        if len(rendered_content) > MAX_MESSAGE_LENGTH * 100:
             raise MarkdownRenderingException(
-                f"Rendered content exceeds {MAX_MESSAGE_LENGTH * 10} characters (message {logging_message_id})"
+                f"Rendered content exceeds {MAX_MESSAGE_LENGTH * 100} characters (message {logging_message_id})"
             )
         return rendered_content
     except Exception:

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -2749,9 +2749,9 @@ class MarkdownErrorTests(ZulipTestCase):
 
     @override_settings(MAX_MESSAGE_LENGTH=10)
     def test_ultra_long_rendering(self) -> None:
-        """A rendered message with an ultra-long length (> 10 * MAX_MESSAGE_LENGTH)
+        """A rendered message with an ultra-long length (> 100 * MAX_MESSAGE_LENGTH)
         throws an exception"""
-        msg = "mock rendered message\n" * settings.MAX_MESSAGE_LENGTH
+        msg = "mock rendered message\n" * 10 * settings.MAX_MESSAGE_LENGTH
 
         with mock.patch("zerver.lib.markdown.timeout", return_value=msg), mock.patch(
             "zerver.lib.markdown.markdown_logger"


### PR DESCRIPTION
This should help with #17425, where messages with lots of LaTeX are
lost, due to the large expansion factor.

This isn't a total fix for this - large messages with lots of LaTeX can
still end up larger than 1MB, but this fix should help significantly.

1MB is still small enough that I don't expect we'll run into any DOS
problems - my testing didn't show any problems rendering messages that
contain ~1MB of LaTeX.

**Testing plan:** Tested manually with large LaTeX messages