### PR TITLE
Clean up some code around ldap custom field sync

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -7336,7 +7336,7 @@ def do_update_user_custom_profile_data_if_changed(
 
             if not created and field_value.value == str(field["value"]):
                 # If the field value isn't actually being changed to a different one,
-                # and always_notify is disabled, we have nothing to do here for this field.
+                # we have nothing to do here for this field.
                 # Note: field_value.value is a TextField() so we need to cast field['value']
                 # to a string for the comparison in this if.
                 continue

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -5696,35 +5696,6 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
         ).value
         self.assertEqual(actual_value, expected_value)
 
-    def test_update_custom_profile_field_no_update(self) -> None:
-        hamlet = self.example_user("hamlet")
-        phone_number_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Phone number")
-        birthday_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Birthday")
-        phone_number_field_value = CustomProfileFieldValue.objects.get(
-            user_profile=hamlet, field=phone_number_field
-        )
-        phone_number_field_value.value = "123456789"
-        phone_number_field_value.save(update_fields=["value"])
-        expected_call_args = [
-            hamlet,
-            [
-                {
-                    "id": birthday_field.id,
-                    "value": "1900-09-08",
-                },
-            ],
-        ]
-        with self.settings(
-            AUTH_LDAP_USER_ATTR_MAP={
-                "full_name": "cn",
-                "custom_profile_field__birthday": "birthDate",
-                "custom_profile_field__phone_number": "homePhone",
-            }
-        ):
-            with mock.patch("zproject.backends.do_update_user_custom_profile_data_if_changed") as f:
-                self.perform_ldap_sync(self.example_user("hamlet"))
-                f.assert_called_once_with(*expected_call_args)
-
     def test_update_custom_profile_field_not_present_in_ldap(self) -> None:
         hamlet = self.example_user("hamlet")
         no_op_field = CustomProfileField.objects.get(realm=hamlet.realm, name="Birthday")

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -713,7 +713,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
         with mock.patch("zerver.lib.actions.notify_user_update_custom_profile_data") as mock_notify:
             # Attempting to "update" the field value, when it wouldn't actually change,
-            # if always_notify is disabled, shouldn't trigger notify.
+            # shouldn't trigger notify.
             do_update_user_custom_profile_data_if_changed(iago, data)
             mock_notify.assert_not_called()
 

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -742,19 +742,13 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
             var_name = "_".join(field.name.lower().split(" "))
             fields_by_var_name[var_name] = field
 
-        existing_values = {}
-        for data in user_profile.profile_data:
-            var_name = "_".join(data["name"].lower().split(" "))
-            existing_values[var_name] = data["value"]
-
         profile_data: List[Dict[str, Union[int, str, List[int]]]] = []
         for var_name, value in values_by_var_name.items():
             try:
                 field = fields_by_var_name[var_name]
             except KeyError:
                 raise ZulipLDAPException(f"Custom profile field with name {var_name} not found.")
-            if existing_values.get(var_name) == value:
-                continue
+
             try:
                 validate_user_custom_profile_field(user_profile.realm.id, field, value)
             except ValidationError as error:


### PR DESCRIPTION
This clean up could have been done with d66cbd2832b6e8dc74ec7be34117ae20aea37319 but it was missed back then.