### PR TITLE
draft: Fix incorrectly centered topics in drafts modal

### DIFF
--- a/static/templates/draft.hbs
+++ b/static/templates/draft.hbs
@@ -13,6 +13,7 @@
                         {{topic}}
                     </div>
                 </span>
+                <span class="recipient_bar_controls"></span>
                 <div class="recipient_row_date" title="{{t 'Last modified'}}">{{ time_stamp }}</div>
             </div>
         </div>


### PR DESCRIPTION
**GIFs or screenshots:**

Before:

![before](https://user-images.githubusercontent.com/26471/120044827-7822b300-bfc3-11eb-9df3-b442233f6fca.png)

After:

![after](https://user-images.githubusercontent.com/26471/120044838-7e189400-bfc3-11eb-94fd-a5eac2d9912f.png)
