### PR TITLE
Default settings rename

### DIFF
--- a/templates/zerver/api/upload-custom-emoji.md
+++ b/templates/zerver/api/upload-custom-emoji.md
@@ -32,8 +32,8 @@ handles emoji).
 ## Maximum file size
 
 The maximum file size for uploads can be configured by the
-administrator of the Zulip server by setting `MAX_EMOJI_FILE_SIZE`
-in the [server's settings][1]. `MAX_EMOJI_FILE_SIZE` defaults
+administrator of the Zulip server by setting `MAX_EMOJI_FILE_SIZE_MIB`
+in the [server's settings][1]. `MAX_EMOJI_FILE_SIZE_MIB` defaults
 to 5MB.
 
 [1]: https://zulip.readthedocs.io/en/latest/subsystems/settings.html#server-settings

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -81,7 +81,7 @@ def add_realm_logo_fields(state: Dict[str, Any], realm: Realm) -> None:
     state["realm_logo_source"] = get_realm_logo_source(realm, night=False)
     state["realm_night_logo_url"] = get_realm_logo_url(realm, night=True)
     state["realm_night_logo_source"] = get_realm_logo_source(realm, night=True)
-    state["max_logo_file_size_mib"] = settings.MAX_LOGO_FILE_SIZE
+    state["max_logo_file_size_mib"] = settings.MAX_LOGO_FILE_SIZE_MIB
 
 
 def always_want(msg_type: str) -> bool:

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -241,7 +241,7 @@ def fetch_initial_state_data(
         state["realm_presence_disabled"] = True if user_profile is None else realm.presence_disabled
 
         # Important: Encode units in the client-facing API name.
-        state["max_avatar_file_size_mib"] = settings.MAX_AVATAR_FILE_SIZE
+        state["max_avatar_file_size_mib"] = settings.MAX_AVATAR_FILE_SIZE_MIB
         state["max_file_upload_size_mib"] = settings.MAX_FILE_UPLOAD_SIZE
         state["max_icon_file_size_mib"] = settings.MAX_ICON_FILE_SIZE
         state["realm_upload_quota_mib"] = realm.upload_quota_bytes()

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -243,7 +243,7 @@ def fetch_initial_state_data(
         # Important: Encode units in the client-facing API name.
         state["max_avatar_file_size_mib"] = settings.MAX_AVATAR_FILE_SIZE_MIB
         state["max_file_upload_size_mib"] = settings.MAX_FILE_UPLOAD_SIZE
-        state["max_icon_file_size_mib"] = settings.MAX_ICON_FILE_SIZE
+        state["max_icon_file_size_mib"] = settings.MAX_ICON_FILE_SIZE_MIB
         state["realm_upload_quota_mib"] = realm.upload_quota_bytes()
 
         state["realm_icon_url"] = realm_icon_url(realm)

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -207,7 +207,7 @@ class RealmEmojiTest(ZulipTestCase):
     def test_emoji_upload_file_size_error(self) -> None:
         self.login("iago")
         with get_test_image_file("img.png") as fp:
-            with self.settings(MAX_EMOJI_FILE_SIZE=0):
+            with self.settings(MAX_EMOJI_FILE_SIZE_MIB=0):
                 result = self.client_post("/json/realm/emoji/my_emoji", {"file": fp})
         self.assert_json_error(result, "Uploaded file is larger than the allowed limit of 0 MiB")
 

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1238,7 +1238,7 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
     def test_avatar_upload_file_size_error(self) -> None:
         self.login("hamlet")
         with get_test_image_file(self.correct_files[0][0]) as fp:
-            with self.settings(MAX_AVATAR_FILE_SIZE=0):
+            with self.settings(MAX_AVATAR_FILE_SIZE_MIB=0):
                 result = self.client_post("/json/users/me/avatar", {"file": fp})
         self.assert_json_error(result, "Uploaded file is larger than the allowed limit of 0 MiB")
 

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1601,7 +1601,7 @@ class RealmLogoTest(UploadSerializeMixin, ZulipTestCase):
     def test_logo_upload_file_size_error(self) -> None:
         self.login("iago")
         with get_test_image_file(self.correct_files[0][0]) as fp:
-            with self.settings(MAX_LOGO_FILE_SIZE=0):
+            with self.settings(MAX_LOGO_FILE_SIZE_MIB=0):
                 result = self.client_post(
                     "/json/realm/logo", {"file": fp, "night": orjson.dumps(self.night).decode()}
                 )

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1416,7 +1416,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
     def test_realm_icon_upload_file_size_error(self) -> None:
         self.login("iago")
         with get_test_image_file(self.correct_files[0][0]) as fp:
-            with self.settings(MAX_ICON_FILE_SIZE=0):
+            with self.settings(MAX_ICON_FILE_SIZE_MIB=0):
                 result = self.client_post("/json/realm/icon", {"file": fp})
         self.assert_json_error(result, "Uploaded file is larger than the allowed limit of 0 MiB")
 

--- a/zerver/views/realm_emoji.py
+++ b/zerver/views/realm_emoji.py
@@ -32,10 +32,10 @@ def upload_emoji(
     if len(request.FILES) != 1:
         return json_error(_("You must upload exactly one file."))
     emoji_file = list(request.FILES.values())[0]
-    if (settings.MAX_EMOJI_FILE_SIZE * 1024 * 1024) < emoji_file.size:
+    if (settings.MAX_EMOJI_FILE_SIZE_MIB * 1024 * 1024) < emoji_file.size:
         return json_error(
             _("Uploaded file is larger than the allowed limit of {} MiB").format(
-                settings.MAX_EMOJI_FILE_SIZE,
+                settings.MAX_EMOJI_FILE_SIZE_MIB,
             )
         )
 

--- a/zerver/views/realm_icon.py
+++ b/zerver/views/realm_icon.py
@@ -19,10 +19,10 @@ def upload_icon(request: HttpRequest, user_profile: UserProfile) -> HttpResponse
         return json_error(_("You must upload exactly one icon."))
 
     icon_file = list(request.FILES.values())[0]
-    if (settings.MAX_ICON_FILE_SIZE * 1024 * 1024) < icon_file.size:
+    if (settings.MAX_ICON_FILE_SIZE_MIB * 1024 * 1024) < icon_file.size:
         return json_error(
             _("Uploaded file is larger than the allowed limit of {} MiB").format(
-                settings.MAX_ICON_FILE_SIZE,
+                settings.MAX_ICON_FILE_SIZE_MIB,
             )
         )
     upload_icon_image(icon_file, user_profile)

--- a/zerver/views/realm_logo.py
+++ b/zerver/views/realm_logo.py
@@ -24,10 +24,10 @@ def upload_logo(
     if len(request.FILES) != 1:
         return json_error(_("You must upload exactly one logo."))
     logo_file = list(request.FILES.values())[0]
-    if (settings.MAX_LOGO_FILE_SIZE * 1024 * 1024) < logo_file.size:
+    if (settings.MAX_LOGO_FILE_SIZE_MIB * 1024 * 1024) < logo_file.size:
         return json_error(
             _("Uploaded file is larger than the allowed limit of {} MiB").format(
-                settings.MAX_LOGO_FILE_SIZE,
+                settings.MAX_LOGO_FILE_SIZE_MIB,
             )
         )
     upload_logo_image(logo_file, user_profile, night)

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -297,10 +297,10 @@ def set_avatar_backend(request: HttpRequest, user_profile: UserProfile) -> HttpR
         return json_error(str(AVATAR_CHANGES_DISABLED_ERROR))
 
     user_file = list(request.FILES.values())[0]
-    if (settings.MAX_AVATAR_FILE_SIZE * 1024 * 1024) < user_file.size:
+    if (settings.MAX_AVATAR_FILE_SIZE_MIB * 1024 * 1024) < user_file.size:
         return json_error(
             _("Uploaded file is larger than the allowed limit of {} MiB").format(
-                settings.MAX_AVATAR_FILE_SIZE,
+                settings.MAX_AVATAR_FILE_SIZE_MIB,
             )
         )
     upload_avatar_image(user_file, user_profile, user_profile)

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -126,6 +126,7 @@ LOGGING_SHOW_PID = False
 SENTRY_DSN: Optional[str] = None
 
 # File uploads and avatars
+# TODO: Rename MAX_FILE_UPLOAD_SIZE to have unit in name.
 DEFAULT_AVATAR_URI = "/static/images/default-avatar.png"
 DEFAULT_LOGO_URI = "/static/images/logo/zulip-org-logo.svg"
 S3_AVATAR_BUCKET = ""
@@ -310,7 +311,7 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 25 * 1024 * 1024
 MAX_AVATAR_FILE_SIZE_MIB = 5
 MAX_ICON_FILE_SIZE_MIB = 5
 MAX_LOGO_FILE_SIZE_MIB = 5
-MAX_EMOJI_FILE_SIZE = 5
+MAX_EMOJI_FILE_SIZE_MIB = 5
 
 # Limits to help prevent spam, in particular by sending invitations.
 #

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -308,7 +308,7 @@ ZULIP_IOS_APP_ID = "org.zulip.Zulip"
 # Limits related to the size of file uploads; last few in MB.
 DATA_UPLOAD_MAX_MEMORY_SIZE = 25 * 1024 * 1024
 MAX_AVATAR_FILE_SIZE_MIB = 5
-MAX_ICON_FILE_SIZE = 5
+MAX_ICON_FILE_SIZE_MIB = 5
 MAX_LOGO_FILE_SIZE = 5
 MAX_EMOJI_FILE_SIZE = 5
 

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -307,7 +307,7 @@ ZULIP_IOS_APP_ID = "org.zulip.Zulip"
 
 # Limits related to the size of file uploads; last few in MB.
 DATA_UPLOAD_MAX_MEMORY_SIZE = 25 * 1024 * 1024
-MAX_AVATAR_FILE_SIZE = 5
+MAX_AVATAR_FILE_SIZE_MIB = 5
 MAX_ICON_FILE_SIZE = 5
 MAX_LOGO_FILE_SIZE = 5
 MAX_EMOJI_FILE_SIZE = 5

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -309,7 +309,7 @@ ZULIP_IOS_APP_ID = "org.zulip.Zulip"
 DATA_UPLOAD_MAX_MEMORY_SIZE = 25 * 1024 * 1024
 MAX_AVATAR_FILE_SIZE_MIB = 5
 MAX_ICON_FILE_SIZE_MIB = 5
-MAX_LOGO_FILE_SIZE = 5
+MAX_LOGO_FILE_SIZE_MIB = 5
 MAX_EMOJI_FILE_SIZE = 5
 
 # Limits to help prevent spam, in particular by sending invitations.


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Rename MAX_LOGO_FILE_SIZE, MAX_EMOJI_FILE_SIZE, MAX_AVATAR_FILE_SIZE and MAX_ICON_FILE_SIZE to have
suffix `_MIB` reflecting size in mebibytes. Follow up for #18576.

**Testing plan:** <!-- How have you tested? -->
Automated tests, manual testings.
