### PR TITLE
Add translation policy on API error msg

### DIFF
--- a/docs/translating/translating.md
+++ b/docs/translating/translating.md
@@ -101,6 +101,11 @@ Some useful tips for your translating journey:
 - Take advantage of the hotkeys the Transifex Web Editor provides, such as
   `Tab` for saving and going to the next string.
 
+- While one should definitely prioritize translating
+  `translations.json`, since the most prominent user-facing strings
+  are there, API error messages in `django.po` are presented to users,
+  so a full translation should include them.
+
 ### Testing translations
 
 This section assumes you have a


### PR DESCRIPTION
Record Zulip's translation policy on API error messages

This was discussed at [CZO](https://chat.zulip.org/#narrow/stream/58-translation/topic/error.20messages/near/179912) but not recorded in documentation. 

When I was working on a translation I had the same question

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
