### PR TITLE
recent_topics: Optimize for mobile devices.

### DIFF
--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -298,6 +298,11 @@
             thead .last_msg_time_header {
                 display: none;
             }
+
+            .recent_topic_actions {
+                margin-right: 5px;
+                font-size: 15px;
+            }
         }
     }
 }


### PR DESCRIPTION
On small widths, add margin to right to action buttons so
that they don't they trigger scrollbar when clicked upon.

Make action buttons larger so that they are easier to click / tap on small
widths.
before:
<img width="614" alt="Screenshot 2021-05-30 at 12 35 59 PM" src="https://user-images.githubusercontent.com/25124304/120095438-9adbd580-c143-11eb-8d38-2b78d66857d9.png">
after:
<img width="614" alt="Screenshot 2021-05-30 at 12 35 14 PM" src="https://user-images.githubusercontent.com/25124304/120095410-7ed83400-c143-11eb-9c8f-61b89e97a2d8.png">

