### PR TITLE
api_docs: Clarify further how message flags can change.

### DIFF
--- a/templates/zerver/api/update-message-flags.md
+++ b/templates/zerver/api/update-message-flags.md
@@ -30,8 +30,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
     <table>
         <thead>
             <tr>
-                <th style="width:30%">Flag</th>
-                <th style="width:70%">Purpose</th>
+                <th style="width:20%">Flag</th>
+                <th style="width:55%">Purpose</th>
+                <th style="width:25%">Modified by</th>
             </tr>
         </thead>
         <tbody>
@@ -43,14 +44,17 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
                     themself sent using a non-API client) and can
                     later be marked as read.
                 </td>
+                <td>the user directly, <a href="/api/get-events#update_message_flags-add">update_message_flags_event</a></td>
             </tr>
             <tr>
                 <td><code>starred</code></td>
                 <td>Whether the user has <a href="/help/star-a-message">starred this message</a>.</td>
+                <td>the user directly, <a href="/api/get-events#update_message_flags-add">update_message_flags_event</a></td>
             </tr>
             <tr>
                 <td><code>collapsed</code></td>
                 <td>Whether the user has <a href="/help/collapse-a-message">collapsed this message</a>.</td>
+                <td>the user directly, <a href="/api/get-events#update_message_flags-add">update_message_flags_event</a></td>
             </tr>
             <tr>
                 <td><code>mentioned</code></td>
@@ -62,6 +66,10 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
                     can change if the message is edited to add/remove
                     a mention of the current user.
                 </td>
+                <td>
+                    <a href="/api/get-events#message">message_event</a>,
+                    <a href="/api/get-events#update_message">update_message_event</a>
+                </td>
             </tr>
             <tr>
                 <td><code>wildcard_mentioned</code></td>
@@ -71,6 +79,10 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
                     like @**all**. Cannot be changed by the user directly, but
                     can change if the message is edited to add/remove
                     a wildcard mention.
+                </td>
+                <td>
+                    <a href="/api/get-events#message">message_event</a>,
+                    <a href="/api/get-events#update_message">update_message_event</a>
                 </td>
             </tr>
             <tr>
@@ -82,6 +94,10 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
                     can change if the message is edited to add/remove
                     one of the current user's alert words.
                 </td>
+                <td>
+                    <a href="/api/get-events#message">message_event</a>,
+                    <a href="/api/get-events#update_message">update_message_event</a>
+                </td>
             </tr>
             <tr>
                 <td><code>historical</code></td>
@@ -92,6 +108,10 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
                     reacted to a message sent to a public stream
                     before they subscribed to that stream). Cannot be
                     changed by the user directly.
+                </td>
+                <td>
+                    <a href="/api/get-events#message">message_event</a>,
+                    <a href="/api/get-events#update_message">update_message_event</a>
                 </td>
             </tr>
         </tbody>

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4482,7 +4482,13 @@ paths:
       tags: ["messages"]
       description: |
         Add or remove personal message flags like `read` and `starred`
-        on a collection of message IDs.
+        on a collection of message IDs. This endpoint can only modify
+        the directly modifiable flags. i.e. read, starred and collapsed.
+        Other flags are added/removed either from
+        [message_events](/api/get-events#message) or
+        [update_message_events](/api/get-events#update_message).
+        The ways by which each flag could be modified is listed in the
+        table below.
 
         `POST {{ api_url }}/v1/messages/flags`
 


### PR DESCRIPTION
This commit tries to further clarify how message flags could change
succeeding commit 7d1db08. We add another column in the Available
flags table that lists all the ways a specific message flag could be
changed.

It also clarifies that the update_message_flags endpoint can only
directly modify three flags i.e. read, starred and collapsed according
to our current API design.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
