### PR TITLE
emails: Make it obvious registering creates new org.

### DIFF
--- a/templates/zerver/emails/confirm_registration.source.html
+++ b/templates/zerver/emails/confirm_registration.source.html
@@ -6,10 +6,18 @@
 
 {% block content %}
 <p>
+    {% if create_realm %}
+    {{ _('You have requested a new Zulip organization. Awesome!') }}
+    {% else %}
     {{ _('You recently signed up for Zulip. Awesome!') }}
+    {% endif %}
 </p>
 <p>
+    {% if create_realm %}
+    {{ _('Click the button below to create the organization and register your account.') }}
+    {% else %}
     {{ _('Click the button below to complete registration.') }}
+    {% endif %}
     <a class="button" href="{{ activate_url }}">{{ _('Complete registration') }}</a>
 </p>
 <p>{% trans support_email=macros.email_tag(support_email) %}Contact us any time at {{ support_email }} if you run into trouble, have any feedback, or just want to chat!{% endtrans %}</p>

--- a/templates/zerver/emails/confirm_registration.subject.txt
+++ b/templates/zerver/emails/confirm_registration.subject.txt
@@ -1,1 +1,5 @@
+{% if create_realm %}
+{{ _("Create your Zulip organization") }}
+{% else %}
 {{ _("Activate your Zulip account") }}
+{% endif %}

--- a/templates/zerver/emails/confirm_registration.txt
+++ b/templates/zerver/emails/confirm_registration.txt
@@ -1,6 +1,14 @@
+{% if create_realm %}
+{{ _('You have requested a new Zulip organization. Awesome!') }}
+{% else %}
 {{ _('You recently signed up for Zulip. Awesome!') }}
+{% endif %}
 
-{{ _('Click the link below to complete registration.') }}
+{% if create_realm %}
+{{ _('Click the button below to create the organization and register your account.') }}
+{% else %}
+{{ _('Click the button below to complete registration.') }}
+{% endif %}
     <{{ activate_url }}>
 
 {% trans %}Contact us any time at {{ support_email }} if you run into trouble,have any feedback, or just want to chat!{% endtrans %}

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -649,6 +649,8 @@ Output:
         email_address: str,
         *,
         url_pattern: Optional[str] = None,
+        email_subject_contains: Optional[str] = None,
+        email_body_contains: Optional[str] = None,
     ) -> str:
         from django.core.mail import outbox
 
@@ -661,6 +663,13 @@ Output:
             ):
                 match = re.search(url_pattern, message.body)
                 assert match is not None
+
+                if email_subject_contains:
+                    self.assertIn(email_subject_contains, message.subject)
+
+                if email_body_contains:
+                    self.assertIn(email_body_contains, message.body)
+
                 [confirmation_url] = match.groups()
                 return confirmation_url
         else:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2769,8 +2769,13 @@ class RealmCreationTest(ZulipTestCase):
         result = self.client_get(result["Location"])
         self.assert_in_response("Check your email so we can get started.", result)
 
-        # Visit the confirmation link.
-        confirmation_url = self.get_confirmation_url_from_outbox(email)
+        # Check confirmation email has the correct subject and body, extract
+        # confirmation link and visit it
+        confirmation_url = self.get_confirmation_url_from_outbox(
+            email,
+            email_subject_contains="Create your Zulip organization",
+            email_body_contains="You have requested a new Zulip organization",
+        )
         result = self.client_get(confirmation_url)
         self.assertEqual(result.status_code, 200)
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -534,7 +534,10 @@ def send_confirm_registration_email(
         to_emails=[email],
         from_address=FromAddress.tokenized_no_reply_address(),
         language=language,
-        context={"activate_url": activation_url},
+        context={
+            "create_realm": (realm is None),
+            "activate_url": activation_url,
+        },
         realm=realm,
     )
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#17786.

**Testing plan:** <!-- How have you tested? -->
Checked the email looked OK in `/emails` for both creating realm and registering within an existing one. Both plaintext and html.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
