### PR TITLE
drafts: Delete the draft if compose box is cleared and closed.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -353,7 +353,7 @@ test_ui("markdown_shortcuts", (override) => {
 });
 
 test_ui("send_message_success", (override) => {
-    override(drafts, "delete_draft_after_send", () => {});
+    override(drafts, "delete_active_draft", () => {});
 
     $("#compose-textarea").val("foobarfoobar");
     $("#compose-textarea").trigger("blur");
@@ -382,7 +382,7 @@ test_ui("send_message_success", (override) => {
 test_ui("send_message", (override) => {
     MockDate.set(new Date(fake_now * 1000));
 
-    override(drafts, "delete_draft_after_send", () => {});
+    override(drafts, "delete_active_draft", () => {});
     override(sent_messages, "start_tracking_message", () => {});
 
     // This is the common setup stuff for all of the four tests.

--- a/frontend_tests/puppeteer_tests/drafts.ts
+++ b/frontend_tests/puppeteer_tests/drafts.ts
@@ -241,6 +241,20 @@ async function test_save_draft_by_reloading(page: Page): Promise<void> {
     );
 }
 
+async function test_delete_draft_on_clearing_text(page: Page): Promise<void> {
+    console.log("Deleting draft by clearing compose box textarea.");
+    await page.click("#drafts_table .message_row:not(.private-message) .restore-draft");
+    await wait_for_drafts_to_dissapear(page);
+    await page.waitForSelector("#stream-message", {visible: true});
+    await page.keyboard.press("Backspace");
+    await page.click("#compose_close");
+    await page.waitForSelector("#stream-message", {hidden: true});
+    await page.click(drafts_button);
+    await wait_for_drafts_to_appear(page);
+    const drafts_count = await get_drafts_count(page);
+    assert.strictEqual(drafts_count, 0, "Draft not deleted.");
+}
+
 async function test_delete_draft_on_sending(page: Page): Promise<void> {
     await page.click("#drafts_table .message_row.private-message .restore-draft");
     await wait_for_drafts_to_dissapear(page);
@@ -277,6 +291,7 @@ async function drafts_test(page: Page): Promise<void> {
     await test_delete_draft(page);
     await test_save_draft_by_reloading(page);
     await test_delete_draft_on_sending(page);
+    await test_delete_draft_on_clearing_text(page);
 }
 
 common.run_test(drafts_test);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -289,7 +289,7 @@ function compose_not_subscribed_error(error_html, bad_input) {
 
 export function clear_compose_box() {
     $("#compose-textarea").val("").trigger("focus");
-    drafts.delete_draft_after_send();
+    drafts.delete_active_draft();
     compose_ui.autosize_textarea($("#compose-textarea"));
     $("#compose-send-status").hide(0);
     $("#compose-send-button").prop("disabled", false);

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -180,7 +180,7 @@ export function update_draft() {
     draft_notify();
 }
 
-export function delete_draft_after_send() {
+export function delete_active_draft() {
     const draft_id = $("#compose-textarea").data("draft-id");
     if (draft_id) {
         draft_model.deleteDraft(draft_id);

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -153,17 +153,17 @@ function draft_notify() {
 
 export function update_draft() {
     const draft = snapshot_message();
+    const draft_id = $("#compose-textarea").data("draft-id");
 
     if (draft === undefined) {
         // The user cleared the compose box, which means
-        // there is nothing to save here.  Don't obliterate
-        // the existing draft yet--the user may have mistakenly
-        // hit delete after select-all or something.
-        // Just do nothing.
+        // there is nothing to save here but delete the
+        // draft if exists.
+        if (draft_id) {
+            delete_active_draft();
+        }
         return;
     }
-
-    const draft_id = $("#compose-textarea").data("draft-id");
 
     if (draft_id !== undefined) {
         // We don't save multiple drafts of the same message;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes part of zulip#18555.


**Testing plan:** <!-- How have you tested? -->
Tested locally ✅ .


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

https://user-images.githubusercontent.com/63820270/120233196-dd500000-c272-11eb-8a6e-e8f1f2bb5846.mov





<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
