### PR TITLE
settings_org: Fix incorrect selector for the save changes button.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1013,7 +1013,7 @@ export function build_page() {
             e.preventDefault();
             $(e.target)
                 .closest(".org-subsection-parent")
-                .find(".subsection-changes-save button")
+                .find(".subsection-changes-save .button")
                 .trigger("click");
         }
     });


### PR DESCRIPTION
This change fixes a bug where pressing Enter does not save the
changes as expected, due to an incorrect selector, when the
save/discard changes button shows up in settings. Tested by changing
the Organization name and pressing Enter at Manage Organization >
Organization profile > Organization name.