### PR TITLE
docs: Update path to nginx.conf, as it is now a template.

### DIFF
--- a/docs/production/install-existing-server.md
+++ b/docs/production/install-existing-server.md
@@ -29,9 +29,16 @@ one created by Zulip into it:
 ```shell
 sudo cp /etc/nginx/nginx.conf /etc/nginx.conf.before-zulip-install
 sudo wget -O /etc/nginx/nginx.conf.zulip \
-    https://raw.githubusercontent.com/zulip/zulip/master/puppet/zulip/files/nginx/nginx.conf
+    https://raw.githubusercontent.com/zulip/zulip/master/puppet/zulip/templates/nginx.conf.template.erb
 sudo meld /etc/nginx/nginx.conf /etc/nginx/nginx.conf.zulip  # be sure to merge to the right
 ```
+
+Since the file in Zulip is an [ERB Puppet
+template](https://puppet.com/docs/puppet/7/lang_template_erb.html),
+you will also need to replace any `<%= ... %>` sections with
+appropriate content.  For instance `<%= @ca_crt %>` should be replaced
+with `/etc/ssl/certs/ca-certificates.crt` on Debian and Ubuntu
+installs.
 
 After the Zulip installation completes, then you can overwrite (or
 merge) your new nginx.conf with the installed one:

--- a/docs/production/install-existing-server.md
+++ b/docs/production/install-existing-server.md
@@ -19,7 +19,7 @@ existing services if (when) your server goes down.
 These instructions are only for experts.  If you're not an experienced
 Linux sysadmin, you will have a much better experience if you get a
 dedicated VM to install Zulip on instead (or [use
-zulip.com](https://zulip.com).
+zulip.com](https://zulip.com)).
 
 ### Nginx
 


### PR DESCRIPTION
Also provide the right expansion for the one embedded variable
currently in the template.

------

0ae2c5c96e269483d06c23d4d59b84f25d4424a0 was the original reason for it being a template, but 70dfb423e4616006e24cbe6f3d7aa492243f510a is now the only reason.