### PR TITLE
apidocs: Fix description of topic parameter in update_message.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4828,7 +4828,9 @@ paths:
         - name: topic
           in: query
           description: |
-            The topic of the message.
+            The topic to move the message(s) to, to request changing the topic.
+            Should only be sent when changing the topic, and will throw an error
+            if the target message is not a stream message.
 
             Maximum length of 60 characters.
 
@@ -4882,7 +4884,11 @@ paths:
         - name: stream_id
           in: query
           description: |
-            The stream ID to move the message(s) to, if moving to another stream.
+            The stream ID to move the message(s) to, to request moving
+            messages to another stream.
+
+            Should only be sent when changing the stream, and will throw an error
+            if the target message is not a stream message.
           schema:
             type: integer
           example: 42

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4302,7 +4302,19 @@ paths:
               example: [9, 10]
           required: true
         - $ref: "#/components/parameters/RequiredContent"
-        - $ref: "#/components/parameters/Topic"
+        - name: topic
+          in: query
+          description: |
+            The topic of the message. Only required for stream messages
+            (`type="stream"`), ignored otherwise.
+
+            Maximum length of 60 characters.
+
+            **Changes**: New in Zulip 2.0.  Previous Zulip releases encoded
+            this as `subject`, which is currently a deprecated alias.
+          schema:
+            type: string
+          example: Castle
         - name: queue_id
           in: query
           schema:
@@ -4813,7 +4825,18 @@ paths:
         message you wish you update.
       parameters:
         - $ref: "#/components/parameters/MessageId"
-        - $ref: "#/components/parameters/Topic"
+        - name: topic
+          in: query
+          description: |
+            The topic of the message.
+
+            Maximum length of 60 characters.
+
+            **Changes**: New in Zulip 2.0.  Previous Zulip releases encoded
+            this as `subject`, which is currently a deprecated alias.
+          schema:
+            type: string
+          example: Castle
         - name: propagate_mode
           in: query
           description: |
@@ -12259,20 +12282,6 @@ components:
         type: integer
       example: 1
       required: true
-    Topic:
-      name: topic
-      in: query
-      description: |
-        The topic of the message. Only required for stream messages
-        (`type="stream"`), ignored otherwise.
-
-        Maximum length of 60 characters.
-
-        **Changes**: New in Zulip 2.0.  Previous Zulip releases encoded
-        this as `subject`, which is currently a deprecated alias.
-      schema:
-        type: string
-      example: Castle
     QueueId:
       name: queue_id
       in: query


### PR DESCRIPTION
The information of topic being required for stream messages
in update_message OperationID wasn't true. Fixed the
incorrect description.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
