### PR TITLE
Use Event.key, Event.button instead of deprecated Event.keyCode and Event.which.

### DIFF
--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -111,7 +111,7 @@ run_test("add_alert_word_keypress", (override) => {
 
     const event = {
         preventDefault: () => {},
-        which: 13,
+        key: "Enter",
         target: "#create_alert_word_name",
     };
 

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -173,7 +173,7 @@ test_ui("right-to-left", () => {
     const textarea = $("#compose-textarea");
 
     const event = {
-        keyCode: 65, // A
+        key: "A",
     };
 
     assert.equal(textarea.hasClass("rtl"), false);
@@ -192,7 +192,7 @@ test_ui("right-to-left", () => {
 test_ui("markdown_shortcuts", (override) => {
     let queryCommandEnabled = true;
     const event = {
-        keyCode: 66,
+        key: "b",
         target: {
             id: "compose-textarea",
         },
@@ -232,8 +232,7 @@ test_ui("markdown_shortcuts", (override) => {
     function test_i_typed(isCtrl, isCmd) {
         // Test 'i' is typed correctly.
         $("#compose-textarea").val("i");
-        event.keyCode = undefined;
-        event.which = 73;
+        event.key = "i";
         event.metaKey = isCmd;
         event.ctrlKey = isCtrl;
         compose.handle_keydown(event, $("#compose-textarea"));
@@ -252,7 +251,7 @@ test_ui("markdown_shortcuts", (override) => {
         // Test bold:
         // Mac env = Cmd+b
         // Windows/Linux = Ctrl+b
-        event.keyCode = 66;
+        event.key = "b";
         event.ctrlKey = isCtrl;
         event.metaKey = isCmd;
         compose.handle_keydown(event, $("#compose-textarea"));
@@ -267,10 +266,11 @@ test_ui("markdown_shortcuts", (override) => {
         // Test italic:
         // Mac = Cmd+I
         // Windows/Linux = Ctrl+I
+        // We use event.key = "I" to emulate user using Caps Lock key.
         $("#compose-textarea").val(input_text);
         range_start = compose_value.search(selected_word);
         range_length = selected_word.length;
-        event.keyCode = 73;
+        event.key = "I";
         event.shiftKey = false;
         compose.handle_keydown(event, $("#compose-textarea"));
         assert.equal("Any *text*.", $("#compose-textarea").val());
@@ -287,8 +287,7 @@ test_ui("markdown_shortcuts", (override) => {
         $("#compose-textarea").val(input_text);
         range_start = compose_value.search(selected_word);
         range_length = selected_word.length;
-        event.keyCode = 76;
-        event.which = undefined;
+        event.key = "l";
         event.shiftKey = true;
         compose.handle_keydown(event, $("#compose-textarea"));
         assert.equal("Any [text](url).", $("#compose-textarea").val());
@@ -311,16 +310,16 @@ test_ui("markdown_shortcuts", (override) => {
         event.metaKey = isCmd;
         event.ctrlKey = isCtrl;
 
-        event.keyCode = 66;
+        event.key = "b";
         compose.handle_keydown(event, $("#compose-textarea"));
         assert.equal(input_text, $("#compose-textarea").val());
 
-        event.keyCode = 73;
+        event.key = "i";
         event.shiftKey = false;
         compose.handle_keydown(event, $("#compose-textarea"));
         assert.equal(input_text, $("#compose-textarea").val());
 
-        event.keyCode = 76;
+        event.key = "l";
         event.shiftKey = true;
         compose.handle_keydown(event, $("#compose-textarea"));
         assert.equal(input_text, $("#compose-textarea").val());

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -999,7 +999,7 @@ test("initialize", (override) => {
     // handle_keydown()
     let event = {
         type: "keydown",
-        keyCode: 13,
+        key: "Enter",
         target: {
             id: "stream_message_recipient_stream",
         },
@@ -1016,8 +1016,7 @@ test("initialize", (override) => {
     $("#compose-textarea").data = stub_typeahead_hidden;
     $("form#send_message_form").trigger(event);
 
-    event.keyCode = undefined;
-    event.which = 9;
+    event.key = "Tab";
     event.shiftKey = false;
     event.target.id = "subject";
     $("form#send_message_form").trigger(event);
@@ -1037,7 +1036,7 @@ test("initialize", (override) => {
     });
     $("#compose-textarea").caret = noop;
 
-    event.keyCode = 13;
+    event.key = "Enter";
     event.target.id = "stream_message_recipient_topic";
     $("form#send_message_form").trigger(event);
     event.target.id = "compose-textarea";
@@ -1068,13 +1067,13 @@ test("initialize", (override) => {
     event.target.id = "private_message_recipient";
     $("form#send_message_form").trigger(event);
 
-    event.keyCode = 42;
+    event.key = "a";
     $("form#send_message_form").trigger(event);
 
     // handle_keyup()
     event = {
         type: "keydown",
-        keyCode: 13,
+        key: "Enter",
         target: {
             id: "stream_message_recipient_stream",
         },
@@ -1086,11 +1085,10 @@ test("initialize", (override) => {
     $("#stream_message_recipient_topic").off("mouseup");
     event.type = "keyup";
     $("form#send_message_form").trigger(event);
-    event.keyCode = undefined;
-    event.which = 9;
+    event.key = "Tab";
     event.shiftKey = false;
     $("form#send_message_form").trigger(event);
-    event.keyCode = 42;
+    event.key = "a";
     $("form#send_message_form").trigger(event);
 
     // select_on_focus()

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -237,12 +237,9 @@ run_test("arrows on pills", () => {
 
     function test_key(c) {
         key_handler({
-            charCode: c,
+            key: c,
         });
     }
-
-    const LEFT_ARROW = 37;
-    const RIGHT_ARROW = 39;
 
     let prev_focused = false;
     let next_focused = false;
@@ -269,10 +266,10 @@ run_test("arrows on pills", () => {
     // We use the same stub to test both arrows, since we don't
     // actually cause any real state changes here.  We stub out
     // the only interaction, which is to move the focus.
-    test_key(LEFT_ARROW);
+    test_key("ArrowLeft");
     assert(prev_focused);
 
-    test_key(RIGHT_ARROW);
+    test_key("ArrowRight");
     assert(next_focused);
 });
 
@@ -284,7 +281,6 @@ run_test("left arrow on input", () => {
     const widget = input_pill.create(config);
     widget.appendValue("blue,red");
 
-    const LEFT_ARROW = 37;
     const key_handler = container.get_on_handler("keydown", ".input");
 
     let last_pill_focused = false;
@@ -300,7 +296,7 @@ run_test("left arrow on input", () => {
     });
 
     key_handler({
-        keyCode: LEFT_ARROW,
+        key: "ArrowLeft",
     });
 
     assert(last_pill_focused);
@@ -318,13 +314,12 @@ run_test("comma", () => {
 
     assert.deepEqual(widget.items(), [items.blue, items.red]);
 
-    const COMMA = 188;
     const key_handler = container.get_on_handler("keydown", ".input");
 
     pill_input.text(" yel");
 
     key_handler({
-        keyCode: COMMA,
+        key: ",",
         preventDefault: noop,
     });
 
@@ -333,7 +328,7 @@ run_test("comma", () => {
     pill_input.text(" yellow");
 
     key_handler({
-        keyCode: COMMA,
+        key: ",",
         preventDefault: noop,
     });
 
@@ -351,11 +346,10 @@ run_test("Enter key with text", () => {
 
     assert.deepEqual(widget.items(), [items.blue, items.red]);
 
-    const ENTER = 13;
     const key_handler = container.get_on_handler("keydown", ".input");
 
     key_handler({
-        keyCode: ENTER,
+        key: "Enter",
         preventDefault: noop,
         stopPropagation: noop,
         target: {
@@ -425,11 +419,10 @@ run_test("insert_remove", (override) => {
         pill.$element.remove = set_colored_removed_func(pill.item.display_value);
     }
 
-    const BACKSPACE = 8;
     let key_handler = container.get_on_handler("keydown", ".input");
 
     key_handler({
-        keyCode: BACKSPACE,
+        key: "Backspace",
         target: {
             textContent: "",
         },
@@ -463,7 +456,7 @@ run_test("insert_remove", (override) => {
 
     key_handler = container.get_on_handler("keydown", ".pill");
     key_handler({
-        keyCode: BACKSPACE,
+        key: "Backspace",
         preventDefault: noop,
     });
 

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -228,7 +228,7 @@ test("initialize", () => {
     let default_prevented = false;
     let ev = {
         type: "keydown",
-        which: 15,
+        key: "a",
         preventDefault() {
             default_prevented = true;
         },
@@ -237,11 +237,11 @@ test("initialize", () => {
     assert.equal(keydown(ev), undefined);
     assert(!default_prevented);
 
-    ev.which = 13;
+    ev.key = "Enter";
     assert.equal(keydown(ev), undefined);
     assert(!default_prevented);
 
-    ev.which = 13;
+    ev.key = "Enter";
     search_query_box.is = () => true;
     assert.equal(keydown(ev), undefined);
     assert(default_prevented);
@@ -288,14 +288,14 @@ test("initialize", () => {
     assert(!is_blurred);
     assert(!search_button.prop("disabled"));
 
-    ev.which = 13;
+    ev.key = "Enter";
     search_query_box.is = () => false;
     searchbox_form.trigger(ev);
 
     assert(!is_blurred);
     assert(!search_button.prop("disabled"));
 
-    ev.which = 13;
+    ev.key = "Enter";
     search_query_box.is = () => true;
     searchbox_form.trigger(ev);
     assert(is_blurred);
@@ -308,7 +308,7 @@ test("initialize", () => {
     assert(!search_button.prop("disabled"));
 
     _setup("ver");
-    ev.which = 13;
+    ev.key = "Enter";
     search_query_box.is = () => true;
     searchbox_form.trigger(ev);
     assert(is_blurred);

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -192,11 +192,11 @@ run_test("initialize", () => {
     assert.equal(keydown(ev), undefined);
     assert(!default_prevented);
 
-    ev.which = 13;
+    ev.key = "Enter";
     assert.equal(keydown(ev), undefined);
     assert(!default_prevented);
 
-    ev.which = 13;
+    ev.key = "Enter";
     search_query_box.is = () => true;
     assert.equal(keydown(ev), undefined);
     assert(default_prevented);
@@ -235,21 +235,21 @@ run_test("initialize", () => {
     ];
     _setup("");
 
-    ev.which = 15;
+    ev.key = "a";
     search_query_box.is = () => false;
     searchbox_form.trigger(ev);
 
     assert(!is_blurred);
     assert(!search_button.prop("disabled"));
 
-    ev.which = 13;
+    ev.key = "Enter";
     search_query_box.is = () => false;
     searchbox_form.trigger(ev);
 
     assert(!is_blurred);
     assert(!search_button.prop("disabled"));
 
-    ev.which = 13;
+    ev.key = "Enter";
     search_query_box.is = () => true;
     searchbox_form.trigger(ev);
     assert(is_blurred);
@@ -262,7 +262,7 @@ run_test("initialize", () => {
     assert(!search_button.prop("disabled"));
 
     _setup("ver");
-    ev.which = 13;
+    ev.key = "Enter";
     search_query_box.is = () => true;
     searchbox_form.trigger(ev);
     assert(is_blurred);

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -597,7 +597,7 @@ test_ui("on_events", (override) => {
         const handler = $("#user-groups").get_on_handler("keypress", ".user-group h4 > span");
         let default_action_for_enter_stopped = false;
         const event = {
-            which: 13,
+            key: "Enter",
             preventDefault() {
                 default_action_for_enter_stopped = true;
             },

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -301,7 +301,7 @@ test_ui("subscriber_pills", (override) => {
         "keyup",
         ".subscriber_list_add form",
     );
-    event.which = 13;
+    event.key = "Enter";
 
     // Only Denmark stream pill is created and a
     // request is sent to add all it's subscribers.

--- a/static/js/alert_words_ui.js
+++ b/static/js/alert_words_ui.js
@@ -97,9 +97,8 @@ export function set_up_alert_words() {
     });
 
     $("#create_alert_word_form").on("keypress", "#create_alert_word_name", (event) => {
-        const key = event.which;
-        // Handle Enter (13) as "add".
-        if (key === 13) {
+        // Handle Enter as "add".
+        if (event.key === "Enter") {
             event.preventDefault();
             const word = $(event.target).val();
             add_alert_word(word);

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -782,12 +782,12 @@ export function initialize() {
         $(document).on("keydown", ".editable-section", function (e) {
             e.stopPropagation();
             // Cancel editing description if Escape key is pressed.
-            if (e.which === 27) {
+            if (e.key === "Escape") {
                 $("[data-finish-editing='.stream-description-editable']").hide();
                 $(this).attr("contenteditable", false);
                 $(this).text($(this).attr("data-prev-text"));
                 $("[data-make-editable]").html("");
-            } else if (e.which === 13) {
+            } else if (e.key === "Enter") {
                 $(this).siblings(".checkmark").trigger("click");
             }
         });

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -758,7 +758,7 @@ export function initialize() {
 
     // Don't focus links on middle click.
     $("body").on("mouseup", "a", (e) => {
-        if (e.which === 2) {
+        if (e.button === 1) {
             // middle click
             e.target.blur();
         }

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -821,10 +821,14 @@ export function validate() {
 }
 
 export function handle_keydown(event, textarea) {
-    const code = event.keyCode || event.which;
-    const isBold = code === 66;
-    const isItalic = code === 73 && !event.shiftKey;
-    const isLink = code === 76 && event.shiftKey;
+    // The event.key property will have uppercase letter if
+    // the "Shift + <key>" combo was used or the Caps Lock
+    // key was on. We turn to key to lowercase so the keybindings
+    // work regardless of whether Caps Lock was on or not.
+    const key = event.key.toLowerCase();
+    const isBold = key === "b";
+    const isItalic = key === "i" && !event.shiftKey;
+    const isLink = key === "l" && event.shiftKey;
 
     // detect Cmd and Ctrl key
     const isCmdOrCtrl = common.has_mac_keyboard() ? event.metaKey : event.ctrlKey;

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -190,9 +190,9 @@ export function handle_enter(textarea, e) {
 let nextFocus = false;
 
 function handle_keydown(e) {
-    const code = e.keyCode || e.which;
+    const key = e.key;
 
-    if (code === 13 || (code === 9 && !e.shiftKey)) {
+    if (key === "Enter" || (key === "Tab" && !e.shiftKey)) {
         // Enter key or Tab key
         let target_sel;
 
@@ -206,7 +206,7 @@ function handle_keydown(e) {
         const on_compose = target_sel === "#compose-textarea";
 
         if (on_compose) {
-            if (code === 9) {
+            if (key === "Tab") {
                 // This if branch is only here to make Tab+Enter work on Safari,
                 // which does not make <button>s tab-accessible by default
                 // (even if we were to set tabindex=0).
@@ -244,11 +244,9 @@ function handle_keydown(e) {
 }
 
 function handle_keyup(e) {
-    const code = e.keyCode || e.which;
-
     if (
         // Enter key or Tab key
-        (code === 13 || (code === 9 && !e.shiftKey)) &&
+        (e.key === "Enter" || (e.key === "Tab" && !e.shiftKey)) &&
         nextFocus
     ) {
         nextFocus.trigger("focus");

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -64,7 +64,7 @@ export const DropdownListWidget = function ({
             function (e) {
                 const setting_elem = $(this).closest(`.${CSS.escape(widget_name)}_setting`);
                 if (e.type === "keypress") {
-                    if (e.which === 13) {
+                    if (e.key === "Enter") {
                         setting_elem.find(".dropdown-menu").dropdown("toggle");
                     } else {
                         return;
@@ -129,15 +129,17 @@ export const DropdownListWidget = function ({
         });
 
         search_input.on("keydown", (e) => {
-            if (!/(38|40|27)/.test(e.keyCode)) {
+            const {key, keyCode, which} = e;
+            if (!/(ArrowUp|ArrowDown|Escape)/.test(key)) {
                 return;
             }
             e.preventDefault();
             e.stopPropagation();
-            const custom_event = new $.Event("keydown.dropdown.data-api", {
-                keyCode: e.keyCode,
-                which: e.keyCode,
-            });
+
+            // We pass keyCode instead of key here because the outdated
+            // bootstrap library we have at static/third/ still uses the
+            // deprecated keyCode & which properties.
+            const custom_event = new $.Event("keydown.dropdown.data-api", {keyCode, which});
             dropdown_toggle.trigger(custom_event);
         });
 

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -272,8 +272,7 @@ function is_composition(emoji) {
 }
 
 function process_enter_while_filtering(e) {
-    if (e.keyCode === 13) {
-        // Enter key
+    if (e.key === "Enter") {
         e.preventDefault();
         const first_emoji = get_rendered_emoji(0, 0);
         if (first_emoji) {

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -11,16 +11,6 @@ export function random_id() {
 }
 
 export function create(opts) {
-    // a dictionary of the key codes that are associated with each key
-    // to make if/else more human readable.
-    const KEY = {
-        ENTER: 13,
-        BACKSPACE: 8,
-        LEFT_ARROW: 37,
-        RIGHT_ARROW: 39,
-        COMMA: 188,
-    };
-
     if (!opts.container) {
         blueslip.error("Pill needs container.");
         return undefined;
@@ -247,9 +237,7 @@ export function create(opts) {
 
     {
         store.$parent.on("keydown", ".input", (e) => {
-            const char = e.keyCode || e.charCode;
-
-            if (char === KEY.ENTER) {
+            if (e.key === "Enter") {
                 // regardless of the value of the input, the ENTER keyword
                 // should be ignored in favor of keeping content to one line
                 // always.
@@ -278,7 +266,7 @@ export function create(opts) {
             // if the user backspaces and there is input, just do normal char
             // deletion, otherwise delete the last pill in the sequence.
             if (
-                char === KEY.BACKSPACE &&
+                e.key === "Backspace" &&
                 (funcs.value(e.target).length === 0 || window.getSelection().anchorOffset === 0)
             ) {
                 e.preventDefault();
@@ -291,13 +279,13 @@ export function create(opts) {
             // should switch to focus the last pill in the list.
             // the rest of the events then will be taken care of in the function
             // below that handles events on the ".pill" class.
-            if (char === KEY.LEFT_ARROW && window.getSelection().anchorOffset === 0) {
+            if (e.key === "ArrowLeft" && window.getSelection().anchorOffset === 0) {
                 store.$parent.find(".pill").last().trigger("focus");
             }
 
             // Typing of the comma is prevented if the last field doesn't validate,
             // as well as when the new pill is created.
-            if (char === KEY.COMMA) {
+            if (e.key === ",") {
                 // if the pill is successful, it will create the pill and clear
                 // the input.
                 if (funcs.appendPill(store.$input.text().trim()) !== false) {
@@ -312,18 +300,16 @@ export function create(opts) {
         // handle events while hovering on ".pill" elements.
         // the three primary events are next, previous, and delete.
         store.$parent.on("keydown", ".pill", (e) => {
-            const char = e.keyCode || e.charCode;
-
             const $pill = store.$parent.find(".pill:focus");
 
-            switch (char) {
-                case KEY.LEFT_ARROW:
+            switch (e.key) {
+                case "ArrowLeft":
                     $pill.prev().trigger("focus");
                     break;
-                case KEY.RIGHT_ARROW:
+                case "ArrowRight":
                     $pill.next().trigger("focus");
                     break;
-                case KEY.BACKSPACE: {
+                case "Backspace": {
                     const $next = $pill.next();
                     const id = $pill.data("id");
                     funcs.removePill(id);

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -236,9 +236,8 @@ export function end_if_focused_on_message_row_edit() {
 }
 
 function handle_message_row_edit_keydown(e) {
-    const code = e.keyCode || e.which;
-    switch (code) {
-        case 13:
+    switch (e.key) {
+        case "Enter":
             if ($(e.target).hasClass("message_edit_content")) {
                 // Pressing Enter to save edits is coupled with Enter to send
                 if (composebox_typeahead.should_enter_send(e)) {
@@ -269,7 +268,7 @@ function handle_message_row_edit_keydown(e) {
                 e.preventDefault();
             }
             return;
-        case 27: // Handle escape keys in the message_edit form.
+        case "Escape": // Handle escape keys in the message_edit form.
             end_if_focused_on_message_row_edit();
             e.stopPropagation();
             e.preventDefault();
@@ -281,15 +280,14 @@ function handle_message_row_edit_keydown(e) {
 
 function handle_inline_topic_edit_keydown(e) {
     let row;
-    const code = e.keyCode || e.which;
-    switch (code) {
-        case 13: // Handle Enter key in the recipient bar/inline topic edit form
+    switch (e.key) {
+        case "Enter": // Handle Enter key in the recipient bar/inline topic edit form
             row = $(e.target).closest(".recipient_row");
             save_inline_topic_edit(row);
             e.stopPropagation();
             e.preventDefault();
             return;
-        case 27: // handle Esc
+        case "Escape": // handle Esc
             end_if_focused_on_inline_topic_edit();
             e.stopPropagation();
             e.preventDefault();

--- a/static/js/poll_widget.js
+++ b/static/js/poll_widget.js
@@ -125,12 +125,12 @@ export function activate({
         elem.find("input.poll-question").on("keydown", (e) => {
             e.stopPropagation();
 
-            if (e.keyCode === 13) {
+            if (e.key === "Enter") {
                 submit_question();
                 return;
             }
 
-            if (e.keyCode === 27) {
+            if (e.key === "Escape") {
                 abort_edit();
                 return;
             }
@@ -159,12 +159,12 @@ export function activate({
         elem.find("input.poll-option").on("keydown", (e) => {
             e.stopPropagation();
 
-            if (e.keyCode === 13) {
+            if (e.key === "Enter") {
                 submit_option();
                 return;
             }
 
-            if (e.keyCode === 27) {
+            if (e.key === "Escape") {
                 $("input.poll-option").val("");
                 return;
             }

--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -303,7 +303,7 @@ function toggle_categories_dropdown() {
 
 function integration_events() {
     $('#integration-search input[type="text"]').on("keypress", (e) => {
-        if (e.which === 13 && e.target.value !== "") {
+        if (e.key === "Enter" && e.target.value !== "") {
             for (const integration_element of $(".integration-lozenges").children()) {
                 const integration = $(integration_element).find(".integration-lozenge");
 

--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -155,8 +155,8 @@ $(() => {
         "focusout keydown",
         function (e) {
             // check if it is the "focusout" or if it is a keydown, then check if
-            // the keycode was the one for "enter" (13).
-            if (e.type === "focusout" || e.which === 13) {
+            // the keycode was the one for "Enter".
+            if (e.type === "focusout" || e.key === "Enter") {
                 $(this).val($(this).val().trim());
             }
         },

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -134,8 +134,7 @@ export function initialize() {
     searchbox_form
         .on("keydown", (e) => {
             update_button_visibility();
-            const code = e.which;
-            if (code === 13 && search_query_box.is(":focus")) {
+            if (e.key === "Enter" && search_query_box.is(":focus")) {
                 // Don't submit the form so that the typeahead can instead
                 // handle our Enter keypress. Any searching that needs
                 // to be done will be handled in the keyup.
@@ -147,8 +146,8 @@ export function initialize() {
                 is_using_input_method = false;
                 return;
             }
-            const code = e.which;
-            if (code === 13 && search_query_box.is(":focus")) {
+
+            if (e.key === "Enter" && search_query_box.is(":focus")) {
                 // We just pressed Enter and the box had focus, which
                 // means we didn't use the typeahead at all.  In that
                 // case, we should act as though we're searching by

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1009,7 +1009,7 @@ export function build_page() {
 
     $(".org-subsection-parent").on("keydown", "input", (e) => {
         e.stopPropagation();
-        if (e.keyCode === 13) {
+        if (e.key === "Enter") {
             e.preventDefault();
             $(e.target)
                 .closest(".org-subsection-parent")

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -110,7 +110,7 @@ export function build_page() {
     update_default_streams_table();
 
     $(".create_default_stream").on("keypress", (e) => {
-        if (e.which === 13) {
+        if (e.key === "Enter") {
             e.preventDefault();
             e.stopPropagation();
             const default_stream_input = $(".create_default_stream");

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -372,7 +372,7 @@ export function set_up() {
     });
 
     $("#user-groups").on("keypress", ".user-group h4 > span", (e) => {
-        if (e.which === 13) {
+        if (e.key === "Enter") {
             e.preventDefault();
         }
     });

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -483,7 +483,7 @@ export function set_up_handlers() {
     // Do not allow the user to enter newline characters while typing out the
     // stream's description during it's creation.
     container.on("keydown", "#create_stream_description", (e) => {
-        if ((e.keyCode || e.which) === 13) {
+        if (e.key === "Enter") {
             e.preventDefault();
         }
     });

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -808,7 +808,7 @@ export function initialize() {
     );
 
     $("#subscriptions_table").on("keyup", ".subscriber_list_add form", (e) => {
-        if (e.which === 13) {
+        if (e.key === "Enter") {
             e.preventDefault();
             submit_add_subscriber_form(e);
         }

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -407,7 +407,7 @@ export function register_click_handlers() {
         // and thus don't want to kill the natural bubbling of event.
         e.preventDefault();
 
-        if (e.type === "keypress" && e.which !== 13) {
+        if (e.type === "keypress" && e.key !== "Enter") {
             return;
         }
         const stream_name = stream_data.maybe_get_stream_name(

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -639,7 +639,7 @@ export function setup_page(callback) {
         // streams, either explicitly via user_can_create_streams, or
         // implicitly because page_params.realm_is_zephyr_mirror_realm.
         $("#stream_filter input[type='text']").on("keypress", (e) => {
-            if (e.which !== 13) {
+            if (e.key !== "Enter") {
                 return;
             }
 

--- a/static/js/ui_util.js
+++ b/static/js/ui_util.js
@@ -32,9 +32,7 @@ export function blur_active_element() {
 }
 
 export function convert_enter_to_click(e) {
-    const key = e.which;
-    if (key === 13) {
-        // Enter
+    if (e.key === "Enter") {
         e.preventDefault();
         e.stopPropagation();
         $(e.currentTarget).trigger("click");


### PR DESCRIPTION
The only modules left are `hotkeys` and `emoji_picker`.

**Testing plan:** Manually tested that each handler works as expected (more detailed on how it was tested is in each commit message.)