### PR TITLE
docs: Remove link to 16.04, which can be confusing.

### DIFF
--- a/docs/production/troubleshooting.md
+++ b/docs/production/troubleshooting.md
@@ -139,13 +139,12 @@ problems and how to resolve them:
 
 ```eval_rst
 .. important::
-    We recommend that you `disable or limit Ubuntu's unattended-upgrades
-    to skip some server packages
-    <https://linoxide.com/ubuntu-how-to/enable-disable-unattended-upgrades-ubuntu-16-04/>`;
-    if you disable them, do not forget to regularly install apt upgrades
-    manually.  With unattended upgrades enabled but not limited, the
-    moment a new PostgreSQL release is published, your Zulip server will
-    have its PostgreSQL server upgraded (and thus restarted).
+    We recommend that you disable or limit Ubuntu's unattended-upgrades
+    to skip some server packages.  With unattended upgrades enabled but
+    not limited, the moment a new PostgreSQL release is published, your
+    Zulip server will have its PostgreSQL server upgraded (and thus
+    restarted).  If you do disable unattended-upgrades, do not forget to
+    regularly install apt upgrades manually!
 ```
 
 Restarting one of the system services that Zulip uses (PostgreSQL,


### PR DESCRIPTION
The instructions do not just apply to 16.04; the block below describes
the settings, which are correct for all relevant Ubuntu versions.
