### PR TITLE
frontend tests: Replace incorrect asserts with assert.equal

### DIFF
--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -142,11 +142,11 @@ run_test("initialize", (override) => {
     let confirm_license_modal_shown = false;
     override(helpers, "is_valid_input", () => true);
     $("#confirm-licenses-modal").modal = (action) => {
-        assert(action, "show");
+        assert.equal(action, "show");
         confirm_license_modal_shown = true;
     };
     $("#licensechange-input-section").data = (key) => {
-        assert(key, "licenses");
+        assert.equal(key, "licenses");
         return 20;
     };
     $("#new_licenses_input").val = () => 15;

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -514,7 +514,7 @@ run_test("realm_emoji", (override) => {
 
     // Make sure our UI modules all got dispatched the same simple way.
     for (const stub of ui_stubs) {
-        assert(stub.num_calls, 1);
+        assert.equal(stub.num_calls, 1);
         assert.equal(stub.last_call_args.length, 0);
     }
 });
@@ -716,7 +716,7 @@ run_test("update_display_settings", (override) => {
         override(night_mode, "enable", stub.f); // automatically checks if called
         dispatch(event);
         assert.equal(stub.num_calls, 1);
-        assert(page_params.color_scheme, 2);
+        assert.equal(page_params.color_scheme, 2);
     }
 
     {
@@ -726,14 +726,14 @@ run_test("update_display_settings", (override) => {
         override(night_mode, "disable", stub.f); // automatically checks if called
         dispatch(event);
         assert.equal(stub.num_calls, 1);
-        assert(page_params.color_scheme, 3);
+        assert.equal(page_params.color_scheme, 3);
     }
 
     {
         event = event_fixtures.update_display_settings__default_view_recent_topics;
         page_params.default_view = "all_messages";
         dispatch(event);
-        assert(page_params.default_view, "recent_topics");
+        assert.equal(page_params.default_view, "recent_topics");
     }
 
     {
@@ -750,7 +750,7 @@ run_test("update_display_settings", (override) => {
         override(night_mode, "default_preference_checker", stub.f); // automatically checks if called
         dispatch(event);
         assert.equal(stub.num_calls, 1);
-        assert(page_params.color_scheme, 1);
+        assert.equal(page_params.color_scheme, 1);
     }
 
     {

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -88,9 +88,12 @@ test("basics", () => {
     assert(!stream_data.is_subscribed("Denmark"));
     assert(!stream_data.is_subscribed("Rome"));
 
-    assert(stream_data.get_stream_privacy_policy(test.stream_id), "public");
-    assert(stream_data.get_stream_privacy_policy(social.stream_id), "invite-only");
-    assert(stream_data.get_stream_privacy_policy(denmark.stream_id), "invite-only-public-history");
+    assert.equal(stream_data.get_stream_privacy_policy(test.stream_id), "public");
+    assert.equal(stream_data.get_stream_privacy_policy(social.stream_id), "invite-only");
+    assert.equal(
+        stream_data.get_stream_privacy_policy(denmark.stream_id),
+        "invite-only-public-history",
+    );
 
     assert(stream_data.get_invite_only("social"));
     assert(!stream_data.get_invite_only("unknown"));
@@ -415,8 +418,8 @@ test("delete_sub", () => {
     stream_data.add_sub(canada);
 
     assert(stream_data.is_subscribed("Canada"));
-    assert(stream_data.get_sub("Canada").stream_id, canada.stream_id);
-    assert(sub_store.get(canada.stream_id).name, "Canada");
+    assert.equal(stream_data.get_sub("Canada").stream_id, canada.stream_id);
+    assert.equal(sub_store.get(canada.stream_id).name, "Canada");
 
     stream_data.delete_sub(canada.stream_id);
     assert(!stream_data.is_subscribed("Canada"));

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -231,7 +231,7 @@ test("upload_files", (override) => {
     let hide_upload_status_called = false;
     override(upload, "hide_upload_status", (config) => {
         hide_upload_status_called = true;
-        assert(config.mode, "compose");
+        assert.equal(config.mode, "compose");
     });
     const config = {mode: "compose"};
     $("#compose-send-button").prop("disabled", false);
@@ -333,7 +333,7 @@ test("upload_files", (override) => {
     assert(hide_upload_status_called);
     assert(compose_ui_autosize_textarea_called);
     assert(compose_ui_replace_syntax_called);
-    assert($("#compose-textarea").val(), "user modified text");
+    assert.equal($("#compose-textarea").val(), "user modified text");
 });
 
 test("uppy_config", () => {

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -83,14 +83,14 @@ run_test("updates", () => {
     });
     person = people.get_by_email(isaac.email);
     assert(person.is_guest);
-    assert(person.role, settings_config.user_role_values.guest.code);
+    assert.equal(person.role, settings_config.user_role_values.guest.code);
     user_events.update_person({
         user_id: isaac.user_id,
         role: settings_config.user_role_values.member.code,
     });
     person = people.get_by_email(isaac.email);
     assert(!person.is_guest);
-    assert(person.role, settings_config.user_role_values.member.code);
+    assert.equal(person.role, settings_config.user_role_values.member.code);
 
     user_events.update_person({
         user_id: isaac.user_id,
@@ -98,7 +98,7 @@ run_test("updates", () => {
     });
     person = people.get_by_email(isaac.email);
     assert.equal(person.is_moderator, true);
-    assert(person.role, settings_config.user_role_values.moderator.code);
+    assert.equal(person.role, settings_config.user_role_values.moderator.code);
 
     user_events.update_person({
         user_id: isaac.user_id,
@@ -108,7 +108,7 @@ run_test("updates", () => {
     assert.equal(person.full_name, "Isaac Newton");
     assert.equal(person.is_moderator, false);
     assert.equal(person.is_admin, true);
-    assert(person.role, settings_config.user_role_values.admin.code);
+    assert.equal(person.role, settings_config.user_role_values.admin.code);
 
     user_events.update_person({
         user_id: isaac.user_id,
@@ -116,7 +116,7 @@ run_test("updates", () => {
     });
     assert.equal(person.is_admin, true);
     assert.equal(person.is_owner, true);
-    assert(person.role, settings_config.user_role_values.owner.code);
+    assert.equal(person.role, settings_config.user_role_values.owner.code);
 
     let user_id;
     let full_name;


### PR DESCRIPTION
We should also add a lint rule to make sure that this does not happen again.

Opened issue #18687 for that.