### PR TITLE
puppeteer_test: Add `wait_for_modal_to_close` method to `CommonUtils`.

### DIFF
--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -486,6 +486,13 @@ class CommonUtils {
         await entry!.click();
     }
 
+    async wait_for_modal_to_close(page: Page): Promise<void> {
+        // This function will ensure that the mouse events are enabled for the background for further tests.
+        await page.waitForFunction(
+            () => document.querySelector(".overlay.show")?.getAttribute("style") === null,
+        );
+    }
+
     async run_test(test_function: (page: Page) => Promise<void>): Promise<void> {
         // Pass a page instance to test so we can take
         // a screenshot of it when the test fails.

--- a/frontend_tests/puppeteer_tests/realm-linkifier.ts
+++ b/frontend_tests/puppeteer_tests/realm-linkifier.ts
@@ -64,8 +64,7 @@ async function test_edit_linkifier(page: Page): Promise<void> {
     await page.click(".submit-linkifier-info-change");
 
     await page.waitForSelector("#linkifier-edit-form-modal", {hidden: true});
-    // Ensure that the mouse events are enabled for the background for further tests.
-    await page.waitForFunction(() => $(".overlay.show").attr("style") === undefined);
+    await common.wait_for_modal_to_close(page);
 
     await page.waitForSelector(".linkifier_row", {visible: true});
     await page.waitForFunction(

--- a/frontend_tests/puppeteer_tests/settings.ts
+++ b/frontend_tests/puppeteer_tests/settings.ts
@@ -46,8 +46,7 @@ async function test_change_full_name(page: Page): Promise<void> {
     await page.type(full_name_input_selector, "New name");
     await page.click(change_full_name_button_selector);
     await page.waitForFunction(() => $("#change_full_name").text().trim() === "New name");
-    // Ensure that the mouse events are enabled for the background for further tests.
-    await page.waitForFunction(() => $(".overlay.show").attr("style") === undefined);
+    await common.wait_for_modal_to_close(page);
 }
 
 async function test_change_password(page: Page): Promise<void> {
@@ -68,8 +67,7 @@ async function test_change_password(page: Page): Promise<void> {
 
     // On success the change password modal gets closed.
     await page.waitForFunction(() => $("#change_password_modal").attr("aria-hidden") === "true");
-    // Ensure that the mouse events are enabled for the background for further tests.
-    await page.waitForFunction(() => $(".overlay.show").attr("style") === undefined);
+    await common.wait_for_modal_to_close(page);
 }
 
 async function test_get_api_key(page: Page): Promise<void> {
@@ -99,8 +97,7 @@ async function test_get_api_key(page: Page): Promise<void> {
     const zuliprc_decoded_url = await get_decoded_url_in_selector(page, download_zuliprc_selector);
     assert(zuliprc_regex.test(zuliprc_decoded_url), "Incorrect zuliprc file");
     await page.click("#api_key_modal .close");
-    // Ensure that the mouse events are enabled for the background for further tests.
-    await page.waitForFunction(() => $(".overlay.show").attr("style") === undefined);
+    await common.wait_for_modal_to_close(page);
 }
 
 async function test_webhook_bot_creation(page: Page): Promise<void> {
@@ -186,8 +183,7 @@ async function test_edit_bot_form(page: Page): Promise<void> {
         `//*[@class="btn open_edit_bot_form" and @data-email="${bot1_email}"]/ancestor::*[@class="details"]/*[@class="name" and text()="Bot one"]`,
     );
 
-    // Ensure that the mouse events are enabled for the background for further tests.
-    await page.waitForFunction(() => $(".overlay.show").attr("style") === undefined);
+    await common.wait_for_modal_to_close(page);
 }
 
 async function test_invalid_edit_bot_form(page: Page): Promise<void> {
@@ -218,8 +214,7 @@ async function test_invalid_edit_bot_form(page: Page): Promise<void> {
         `//*[@class="btn open_edit_bot_form" and @data-email="${bot1_email}"]/ancestor::*[@class="details"]/*[@class="name" and text()="Bot one"]`,
     );
 
-    // Ensure that the mouse events are enabled for the background for further tests.
-    await page.waitForFunction(() => $(".overlay.show").attr("style") === undefined);
+    await common.wait_for_modal_to_close(page);
 }
 
 async function test_your_bots_section(page: Page): Promise<void> {


### PR DESCRIPTION
This PR adds the `wait_for_modal_to_close` method
and replaces all the instances where we are using jQuery
to check if the modal is closed.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested by running lints and puppeteer test ✅ .


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
