### PR TITLE
Add moderators and full members options in user_group_edit_policy.

### DIFF
--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -181,6 +181,11 @@ test_policy(
     "realm_move_messages_between_streams_policy",
     settings_data.user_can_move_messages_between_streams,
 );
+test_policy(
+    "user_can_edit_user_groups",
+    "realm_user_group_edit_policy",
+    settings_data.user_can_edit_user_groups,
+);
 
 function test_message_policy(label, policy, validation_func) {
     run_test(label, () => {

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -32,6 +32,7 @@ const ui_report = mock_esm("../../static/js/ui_report");
 
 const people = zrequire("people");
 const settings_config = zrequire("settings_config");
+const settings_data = zrequire("settings_data");
 const settings_user_groups = zrequire("settings_user_groups");
 const user_pill = zrequire("user_pill");
 
@@ -51,16 +52,10 @@ function test_ui(label, f) {
 }
 
 test_ui("can_edit", () => {
-    page_params.is_guest = false;
-    page_params.is_admin = true;
-    assert.ok(settings_user_groups.can_edit(1));
-
-    page_params.is_admin = false;
-    page_params.is_guest = true;
+    settings_data.user_can_edit_user_groups = () => false;
     assert.ok(!settings_user_groups.can_edit(1));
 
-    page_params.is_guest = false;
-    page_params.is_admin = false;
+    settings_data.user_can_edit_user_groups = () => true;
     user_groups.is_member_of = (group_id, user_id) => {
         assert.equal(group_id, 1);
         assert.equal(user_id, undefined);
@@ -68,20 +63,15 @@ test_ui("can_edit", () => {
     };
     assert.ok(!settings_user_groups.can_edit(1));
 
-    page_params.realm_user_group_edit_policy = 2;
     page_params.is_admin = true;
     assert.ok(settings_user_groups.can_edit(1));
 
     page_params.is_admin = false;
-    user_groups.is_member_of = (group_id, user_id) => {
-        assert.equal(group_id, 1);
-        assert.equal(user_id, undefined);
-        return true;
-    };
-    assert.ok(!settings_user_groups.can_edit(1));
+    page_params.is_moderator = true;
+    assert.ok(settings_user_groups.can_edit(1));
 
-    page_params.realm_user_group_edit_policy = 1;
     page_params.is_admin = false;
+    page_params.is_moderator = false;
     user_groups.is_member_of = (group_id, user_id) => {
         assert.equal(group_id, 1);
         assert.equal(user_id, undefined);

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -73,7 +73,6 @@ export function build_page() {
         realm_default_twenty_four_hour_time_values: settings_config.twenty_four_hour_time_values,
         realm_authentication_methods: page_params.realm_authentication_methods,
         realm_user_group_edit_policy: page_params.realm_user_group_edit_policy,
-        USER_GROUP_EDIT_POLICY_MEMBERS: 1,
         realm_name_changes_disabled: page_params.realm_name_changes_disabled,
         realm_email_changes_disabled: page_params.realm_email_changes_disabled,
         realm_avatar_changes_disabled: page_params.realm_avatar_changes_disabled,
@@ -122,6 +121,8 @@ export function build_page() {
         email_address_visibility_values: settings_config.email_address_visibility_values,
         can_invite_others_to_realm: settings_data.user_can_invite_others_to_realm(),
         realm_invite_required: page_params.realm_invite_required,
+        can_edit_user_groups: settings_data.user_can_edit_user_groups(),
+        policy_values: settings_config.common_policy_values,
         ...settings_org.get_organization_settings_options(),
     };
 

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -130,19 +130,6 @@ export const common_policy_values = {
     },
 };
 
-export const user_group_edit_policy_values = {
-    by_admins_only: {
-        order: 1,
-        code: 2,
-        description: $t({defaultMessage: "Admins"}),
-    },
-    by_members: {
-        order: 2,
-        code: 1,
-        description: $t({defaultMessage: "Admins and members"}),
-    },
-};
-
 export const private_message_policy_values = {
     by_anyone: {
         order: 1,

--- a/static/js/settings_data.js
+++ b/static/js/settings_data.js
@@ -149,6 +149,10 @@ export function user_can_move_messages_between_streams() {
     return user_has_permission(page_params.realm_move_messages_between_streams_policy);
 }
 
+export function user_can_edit_user_groups() {
+    return user_has_permission(page_params.realm_user_group_edit_policy);
+}
+
 export function user_can_edit_topic_of_any_message() {
     if (
         page_params.realm_edit_topic_policy ===

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -95,9 +95,6 @@ export function get_sorted_options_list(option_values_object) {
 export function get_organization_settings_options() {
     const options = {};
     options.common_policy_values = get_sorted_options_list(settings_config.common_policy_values);
-    options.user_group_edit_policy_values = get_sorted_options_list(
-        settings_config.user_group_edit_policy_values,
-    );
     options.private_message_policy_values = get_sorted_options_list(
         settings_config.private_message_policy_values,
     );

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -10,6 +10,7 @@ import {$t, $t_html} from "./i18n";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as pill_typeahead from "./pill_typeahead";
+import * as settings_data from "./settings_data";
 import * as ui_report from "./ui_report";
 import * as user_groups from "./user_groups";
 import * as user_pill from "./user_pill";
@@ -32,19 +33,16 @@ export function reload() {
     populate_user_groups();
 }
 
-const USER_GROUP_EDIT_POLICY_MEMBERS = 1;
-
 export function can_edit(group_id) {
-    if (page_params.is_admin) {
+    if (!settings_data.user_can_edit_user_groups()) {
+        return false;
+    }
+
+    // Admins and moderators are allowed to edit user groups even if they
+    // are not a member of that user group. Members can edit user groups
+    // only if they belong to that group.
+    if (page_params.is_admin || page_params.is_moderator) {
         return true;
-    }
-
-    if (page_params.is_guest) {
-        return false;
-    }
-
-    if (page_params.realm_user_group_edit_policy !== USER_GROUP_EDIT_POLICY_MEMBERS) {
-        return false;
     }
 
     return user_groups.is_member_of(group_id, people.my_current_user_id());

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -205,7 +205,7 @@
                 <div class="input-group">
                     <label for="realm_user_group_edit_policy" class="dropdown-title">{{t "Who can create and manage user groups" }}</label>
                     <select name="realm_user_group_edit_policy" id="id_realm_user_group_edit_policy" class="prop-element" data-setting-widget-type="number">
-                        {{> dropdown_options_widget option_values=user_group_edit_policy_values}}
+                        {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
                 </div>
 

--- a/static/templates/settings/user_groups_admin.hbs
+++ b/static/templates/settings/user_groups_admin.hbs
@@ -1,11 +1,9 @@
 <div id="user-groups-admin" class="settings-section" data-name="user-groups-admin">
-    {{#unless is_admin}}
-        {{#if (eq realm_user_group_edit_policy USER_GROUP_EDIT_POLICY_MEMBERS) }}
-        <div class="tip">{{t 'Only group members and organization administrators can modify a group.' }}</div>
-        {{else}}
-        <div class="tip">{{t 'Only organization administrators can modify user groups in this organization.' }}</div>
-        {{/if}}
-    {{/unless}}
+    {{#if (eq realm_user_group_edit_policy USER_GROUP_EDIT_POLICY_MEMBERS) }}
+    <div class="tip">{{t 'Only group members and organization administrators can modify a group.' }}</div>
+    {{else}}
+    <div class="tip">{{t 'Only organization administrators can modify user groups in this organization.' }}</div>
+    {{/if}}
 
     {{#unless is_guest}}
         <p>

--- a/static/templates/settings/user_groups_admin.hbs
+++ b/static/templates/settings/user_groups_admin.hbs
@@ -1,6 +1,10 @@
 <div id="user-groups-admin" class="settings-section" data-name="user-groups-admin">
-    {{#if (eq realm_user_group_edit_policy USER_GROUP_EDIT_POLICY_MEMBERS) }}
-    <div class="tip">{{t 'Only group members and organization administrators can modify a group.' }}</div>
+    {{#if (eq realm_user_group_edit_policy policy_values.by_members.code) }}
+    <div class="tip">{{t 'Only group members, organization administrators and moderators can modify a group.' }}</div>
+    {{else if (eq realm_user_group_edit_policy policy_values.by_full_members.code) }}
+    <div class="tip">{{t 'Only full members belonging to the group, organization administrators and moderators can modify a group.' }}</div>
+    {{else if (eq realm_user_group_edit_policy policy_values.by_moderators_only.code) }}
+    <div class="tip">{{t 'Only organization administrators and moderators can modify user groups in this organization.' }}</div>
     {{else}}
     <div class="tip">{{t 'Only organization administrators can modify user groups in this organization.' }}</div>
     {{/if}}
@@ -12,7 +16,7 @@
                 {{#*inline "z-link"}}<a href="/help/mention-a-user-or-group" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         </p>
-        {{#if (or is_admin (eq realm_user_group_edit_policy USER_GROUP_EDIT_POLICY_MEMBERS))}}
+        {{#if can_edit_user_groups}}
         <form class="form-horizontal admin-user-group-form">
             <div class="add-new-user-group-box grey-box">
                 <div class="new-user-group-form">

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -575,12 +575,8 @@ def require_user_group_edit_permission(view_func: ViewFuncT) -> ViewFuncT:
     def _wrapped_view_func(
         request: HttpRequest, user_profile: UserProfile, *args: object, **kwargs: object
     ) -> HttpResponse:
-        realm = user_profile.realm
-        if (
-            realm.user_group_edit_policy != Realm.USER_GROUP_EDIT_POLICY_MEMBERS
-            and not user_profile.is_realm_admin
-        ):
-            raise OrganizationAdministratorRequired()
+        if not user_profile.can_edit_user_groups():
+            raise JsonableError(_("Insufficient permission"))
         return view_func(request, user_profile, *args, **kwargs)
 
     return cast(ViewFuncT, _wrapped_view_func)  # https://github.com/python/mypy/issues/1927

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -11,9 +11,8 @@ def access_user_group_by_id(user_group_id: int, user_profile: UserProfile) -> Us
     try:
         user_group = UserGroup.objects.get(id=user_group_id, realm=user_profile.realm)
         group_member_ids = get_user_group_members(user_group)
-        msg = _("Only group members and organization administrators can administer this group.")
         if not user_profile.is_realm_admin and user_profile.id not in group_member_ids:
-            raise JsonableError(msg)
+            raise JsonableError(_("Insufficient permission"))
     except UserGroup.DoesNotExist:
         raise JsonableError(_("Invalid user group"))
     return user_group

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -11,7 +11,11 @@ def access_user_group_by_id(user_group_id: int, user_profile: UserProfile) -> Us
     try:
         user_group = UserGroup.objects.get(id=user_group_id, realm=user_profile.realm)
         group_member_ids = get_user_group_members(user_group)
-        if not user_profile.is_realm_admin and user_profile.id not in group_member_ids:
+        if (
+            not user_profile.is_realm_admin
+            and not user_profile.is_moderator
+            and user_profile.id not in group_member_ids
+        ):
             raise JsonableError(_("Insufficient permission"))
     except UserGroup.DoesNotExist:
         raise JsonableError(_("Invalid user group"))

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -291,15 +291,7 @@ class Realm(models.Model):
         default=POLICY_ADMINS_ONLY
     )
 
-    USER_GROUP_EDIT_POLICY_MEMBERS = 1
-    USER_GROUP_EDIT_POLICY_ADMINS = 2
-    user_group_edit_policy: int = models.PositiveSmallIntegerField(
-        default=USER_GROUP_EDIT_POLICY_MEMBERS
-    )
-    USER_GROUP_EDIT_POLICY_TYPES = [
-        USER_GROUP_EDIT_POLICY_MEMBERS,
-        USER_GROUP_EDIT_POLICY_ADMINS,
-    ]
+    user_group_edit_policy: int = models.PositiveSmallIntegerField(default=POLICY_MEMBERS_ONLY)
 
     PRIVATE_MESSAGE_POLICY_UNLIMITED = 1
     PRIVATE_MESSAGE_POLICY_DISABLED = 2

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3464,6 +3464,8 @@ paths:
 
                                         * 1 = All members can create and edit user groups
                                         * 2 = Only organization administrators can create and edit user groups
+                                        * 3 = Only full members can create and edit user groups
+                                        * 4 = Only organization administrators and moderators can create and edit user groups
                                     default_code_block_language:
                                       type: string
                                       nullable: true
@@ -9009,6 +9011,8 @@ paths:
 
                           * 1 = All members can create and edit user groups
                           * 2 = Only organization administrators can create and edit user groups
+                          * 3 = Only full members can create and edit user groups.
+                          * 4 = Only organization administrators and moderators can create and edit user groups.
                       realm_default_code_block_language:
                         type: string
                         nullable: true

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2029,7 +2029,7 @@ class RealmPropertyActionTest(BaseAction):
             create_stream_policy=[4, 3, 2, 1],
             invite_to_stream_policy=[4, 3, 2, 1],
             private_message_policy=[2, 1],
-            user_group_edit_policy=[1, 2],
+            user_group_edit_policy=[1, 2, 3, 4],
             wildcard_mention_policy=[7, 6, 5, 4, 3, 2, 1],
             email_address_visibility=[Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS],
             bot_creation_policy=[Realm.BOT_CREATION_EVERYONE],

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -757,7 +757,7 @@ class RealmAPITest(ZulipTestCase):
             name=["Zulip", "New Name"],
             waiting_period_threshold=[10, 20],
             create_stream_policy=Realm.COMMON_POLICY_TYPES,
-            user_group_edit_policy=Realm.USER_GROUP_EDIT_POLICY_TYPES,
+            user_group_edit_policy=Realm.COMMON_POLICY_TYPES,
             private_message_policy=Realm.PRIVATE_MESSAGE_POLICY_TYPES,
             invite_to_stream_policy=Realm.COMMON_POLICY_TYPES,
             wildcard_mention_policy=Realm.WILDCARD_MENTION_POLICY_TYPES,

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -178,9 +178,7 @@ class UserGroupAPITestCase(ZulipTestCase):
             "description": "Troubleshooting",
         }
         result = self.client_patch(f"/json/user_groups/{user_group.id}", info=params)
-        self.assert_json_error(
-            result, "Only group members and organization administrators can administer this group."
-        )
+        self.assert_json_error(result, "Insufficient permission")
 
         self.logout()
         # Test when organization admin tries to modify group
@@ -264,9 +262,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         self.login_user(cordelia)
 
         result = self.client_delete(f"/json/user_groups/{user_group.id}")
-        self.assert_json_error(
-            result, "Only group members and organization administrators can administer this group."
-        )
+        self.assert_json_error(result, "Insufficient permission")
         self.assertEqual(UserGroup.objects.count(), 2)
 
         self.logout()
@@ -333,9 +329,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         add = [cordelia.id]
         params = {"add": orjson.dumps(add).decode()}
         result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
-        self.assert_json_error(
-            result, "Only group members and organization administrators can administer this group."
-        )
+        self.assert_json_error(result, "Insufficient permission")
         self.assertEqual(UserGroupMembership.objects.count(), 4)
 
         self.logout()
@@ -380,9 +374,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         self.login_user(cordelia)
         params = {"delete": orjson.dumps([hamlet.id]).decode()}
         result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
-        self.assert_json_error(
-            result, "Only group members and organization administrators can administer this group."
-        )
+        self.assert_json_error(result, "Insufficient permission")
         self.assertEqual(UserGroupMembership.objects.count(), 4)
 
         self.logout()

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -1,6 +1,9 @@
+from datetime import timedelta
+from typing import Optional
 from unittest import mock
 
 import orjson
+from django.utils.timezone import now as timezone_now
 
 from zerver.lib.actions import do_set_realm_property, ensure_stream
 from zerver.lib.test_classes import ZulipTestCase
@@ -77,7 +80,7 @@ class UserGroupTestCase(ZulipTestCase):
             self.assertFalse(check_remove_user_from_user_group(othello, user_group))
 
 
-class UserGroupAPITestCase(ZulipTestCase):
+class UserGroupAPITestCase(UserGroupTestCase):
     def test_user_group_create(self) -> None:
         hamlet = self.example_user("hamlet")
 
@@ -129,19 +132,6 @@ class UserGroupAPITestCase(ZulipTestCase):
 
         self.check_has_permission_policies("user_group_edit_policy", validation_func)
 
-    def test_user_group_create_by_guest_user(self) -> None:
-        guest_user = self.example_user("polonius")
-
-        # Guest users can't create user group
-        self.login_user(guest_user)
-        params = {
-            "name": "support",
-            "members": orjson.dumps([guest_user.id]).decode(),
-            "description": "Support team",
-        }
-        result = self.client_post("/json/user_groups/create", info=params)
-        self.assert_json_error(result, "Not allowed for guest users")
-
     def test_user_group_update(self) -> None:
         hamlet = self.example_user("hamlet")
         self.login("hamlet")
@@ -168,50 +158,6 @@ class UserGroupAPITestCase(ZulipTestCase):
         params = {"name": "help"}
         result = self.client_patch("/json/user_groups/1111", info=params)
         self.assert_json_error(result, "Invalid user group")
-
-        self.logout()
-        # Test when user not a member of user group tries to modify it
-        cordelia = self.example_user("cordelia")
-        self.login_user(cordelia)
-        params = {
-            "name": "help",
-            "description": "Troubleshooting",
-        }
-        result = self.client_patch(f"/json/user_groups/{user_group.id}", info=params)
-        self.assert_json_error(result, "Insufficient permission")
-
-        self.logout()
-        # Test when organization admin tries to modify group
-        iago = self.example_user("iago")
-        self.login_user(iago)
-        params = {
-            "name": "help",
-            "description": "Troubleshooting",
-        }
-        result = self.client_patch(f"/json/user_groups/{user_group.id}", info=params)
-        self.assert_json_success(result)
-
-    def test_user_group_update_by_guest_user(self) -> None:
-        hamlet = self.example_user("hamlet")
-        guest_user = self.example_user("polonius")
-        self.login_user(hamlet)
-        params = {
-            "name": "support",
-            "members": orjson.dumps([hamlet.id, guest_user.id]).decode(),
-            "description": "Support team",
-        }
-        result = self.client_post("/json/user_groups/create", info=params)
-        self.assert_json_success(result)
-        user_group = UserGroup.objects.get(name="support")
-
-        # Guest user can't edit any detail of an user group
-        self.login_user(guest_user)
-        params = {
-            "name": "help",
-            "description": "Troubleshooting team",
-        }
-        result = self.client_patch(f"/json/user_groups/{user_group.id}", info=params)
-        self.assert_json_error(result, "Not allowed for guest users")
 
     def test_user_group_update_to_already_existing_name(self) -> None:
         hamlet = self.example_user("hamlet")
@@ -248,51 +194,6 @@ class UserGroupAPITestCase(ZulipTestCase):
         result = self.client_delete("/json/user_groups/1111")
         self.assert_json_error(result, "Invalid user group")
 
-        # Test when user not a member of user group tries to delete it
-        params = {
-            "name": "Development",
-            "members": orjson.dumps([hamlet.id]).decode(),
-            "description": "Development team",
-        }
-        self.client_post("/json/user_groups/create", info=params)
-        user_group = UserGroup.objects.get(name="Development")
-        self.assertEqual(UserGroup.objects.count(), 2)
-        self.logout()
-        cordelia = self.example_user("cordelia")
-        self.login_user(cordelia)
-
-        result = self.client_delete(f"/json/user_groups/{user_group.id}")
-        self.assert_json_error(result, "Insufficient permission")
-        self.assertEqual(UserGroup.objects.count(), 2)
-
-        self.logout()
-        # Test when organization admin tries to delete group
-        iago = self.example_user("iago")
-        self.login_user(iago)
-
-        result = self.client_delete(f"/json/user_groups/{user_group.id}")
-        self.assert_json_success(result)
-        self.assertEqual(UserGroup.objects.count(), 1)
-        self.assertEqual(UserGroupMembership.objects.count(), 2)
-
-    def test_user_group_delete_by_guest_user(self) -> None:
-        hamlet = self.example_user("hamlet")
-        guest_user = self.example_user("polonius")
-        self.login_user(hamlet)
-        params = {
-            "name": "support",
-            "members": orjson.dumps([hamlet.id, guest_user.id]).decode(),
-            "description": "Support team",
-        }
-        result = self.client_post("/json/user_groups/create", info=params)
-        self.assert_json_success(result)
-        user_group = UserGroup.objects.get(name="support")
-
-        # Guest users can't delete any user group(not even those of which they are a member)
-        self.login_user(guest_user)
-        result = self.client_delete(f"/json/user_groups/{user_group.id}")
-        self.assert_json_error(result, "Not allowed for guest users")
-
     def test_update_members_of_user_group(self) -> None:
         hamlet = self.example_user("hamlet")
         self.login("hamlet")
@@ -322,28 +223,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         members = get_memberships_of_users(user_group, [hamlet, othello])
         self.assert_length(members, 2)
 
-        self.logout()
-        # Test when user not a member of user group tries to add members to it
-        cordelia = self.example_user("cordelia")
-        self.login_user(cordelia)
-        add = [cordelia.id]
-        params = {"add": orjson.dumps(add).decode()}
-        result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
-        self.assert_json_error(result, "Insufficient permission")
-        self.assertEqual(UserGroupMembership.objects.count(), 4)
-
-        self.logout()
-        # Test when organization admin tries to add members to group
-        iago = self.example_user("iago")
-        self.login_user(iago)
         aaron = self.example_user("aaron")
-        add = [aaron.id]
-        params = {"add": orjson.dumps(add).decode()}
-        result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
-        self.assert_json_success(result)
-        self.assertEqual(UserGroupMembership.objects.count(), 5)
-        members = get_memberships_of_users(user_group, [hamlet, othello, aaron])
-        self.assert_length(members, 3)
 
         # For normal testing we again log in with hamlet
         self.logout()
@@ -352,40 +232,22 @@ class UserGroupAPITestCase(ZulipTestCase):
         params = {"delete": orjson.dumps([othello.id]).decode()}
         result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
         self.assert_json_success(result)
-        self.assertEqual(UserGroupMembership.objects.count(), 4)
+        self.assertEqual(UserGroupMembership.objects.count(), 3)
         members = get_memberships_of_users(user_group, [hamlet, othello, aaron])
-        self.assert_length(members, 2)
+        self.assert_length(members, 1)
 
         # Test remove a member that's already removed
         params = {"delete": orjson.dumps([othello.id]).decode()}
         result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
         self.assert_json_error(result, f"There is no member '{othello.id}' in this user group")
-        self.assertEqual(UserGroupMembership.objects.count(), 4)
+        self.assertEqual(UserGroupMembership.objects.count(), 3)
         members = get_memberships_of_users(user_group, [hamlet, othello, aaron])
-        self.assert_length(members, 2)
+        self.assert_length(members, 1)
 
         # Test when nothing is provided
         result = self.client_post(f"/json/user_groups/{user_group.id}/members", info={})
         msg = 'Nothing to do. Specify at least one of "add" or "delete".'
         self.assert_json_error(result, msg)
-
-        # Test when user not a member of user group tries to remove members
-        self.logout()
-        self.login_user(cordelia)
-        params = {"delete": orjson.dumps([hamlet.id]).decode()}
-        result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
-        self.assert_json_error(result, "Insufficient permission")
-        self.assertEqual(UserGroupMembership.objects.count(), 4)
-
-        self.logout()
-        # Test when organization admin tries to remove members from group
-        iago = self.example_user("iago")
-        self.login_user(iago)
-        result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
-        self.assert_json_success(result)
-        self.assertEqual(UserGroupMembership.objects.count(), 3)
-        members = get_memberships_of_users(user_group, [hamlet, othello, aaron])
-        self.assert_length(members, 1)
 
     def test_mentions(self) -> None:
         cordelia = self.example_user("cordelia")
@@ -436,82 +298,311 @@ class UserGroupAPITestCase(ZulipTestCase):
             um = most_recent_usermessage(user)
             self.assertFalse(um.flags.mentioned)
 
-    def test_only_admin_manage_groups(self) -> None:
-        iago = self.example_user("iago")
+    def test_user_group_edit_policy_for_creating_and_deleting_user_group(self) -> None:
         hamlet = self.example_user("hamlet")
-        cordelia = self.example_user("cordelia")
-        self.login_user(iago)
+
+        def check_create_user_group(acting_user: str, error_msg: Optional[str] = None) -> None:
+            self.login(acting_user)
+            params = {
+                "name": "support",
+                "members": orjson.dumps([hamlet.id]).decode(),
+                "description": "Support Team",
+            }
+            result = self.client_post("/json/user_groups/create", info=params)
+            if error_msg is None:
+                self.assert_json_success(result)
+                # One group already exists in the test database.
+                self.assert_length(UserGroup.objects.all(), 2)
+            else:
+                self.assert_json_error(result, error_msg)
+
+        def check_delete_user_group(acting_user: str, error_msg: Optional[str] = None) -> None:
+            self.login(acting_user)
+            user_group = UserGroup.objects.get(name="support")
+            result = self.client_delete(f"/json/user_groups/{user_group.id}")
+            if error_msg is None:
+                self.assert_json_success(result)
+                self.assert_length(UserGroup.objects.all(), 1)
+            else:
+                self.assert_json_error(result, error_msg)
+
+        realm = hamlet.realm
+
+        # Check only admins are allowed to create/delete user group. Admins are allowed even if
+        # they are not a member of the group.
         do_set_realm_property(
-            iago.realm,
+            realm,
             "user_group_edit_policy",
-            Realm.USER_GROUP_EDIT_POLICY_ADMINS,
+            Realm.POLICY_ADMINS_ONLY,
             acting_user=None,
         )
+        check_create_user_group("shiva", "Insufficient permission")
+        check_create_user_group("iago")
 
+        check_delete_user_group("shiva", "Insufficient permission")
+        check_delete_user_group("iago")
+
+        # Check moderators are allowed to create/delete user group but not members. Moderators are
+        # allowed even if they are not a member of the group.
+        do_set_realm_property(
+            realm,
+            "user_group_edit_policy",
+            Realm.POLICY_MODERATORS_ONLY,
+            acting_user=None,
+        )
+        check_create_user_group("cordelia", "Insufficient permission")
+        check_create_user_group("shiva")
+
+        check_delete_user_group("hamlet", "Insufficient permission")
+        check_delete_user_group("shiva")
+
+        # Check only members are allowed to create the user group and they are allowed to delete
+        # a user group only if they are a member of that group.
+        do_set_realm_property(
+            realm,
+            "user_group_edit_policy",
+            Realm.POLICY_MEMBERS_ONLY,
+            acting_user=None,
+        )
+        check_create_user_group("polonius", "Not allowed for guest users")
+        check_create_user_group("cordelia")
+
+        check_delete_user_group("polonius", "Not allowed for guest users")
+        check_delete_user_group("cordelia", "Insufficient permission")
+        check_delete_user_group("hamlet")
+
+        # Check only full members are allowed to create the user group and they are allowed to delete
+        # a user group only if they are a member of that group.
+        do_set_realm_property(
+            realm,
+            "user_group_edit_policy",
+            Realm.POLICY_FULL_MEMBERS_ONLY,
+            acting_user=None,
+        )
+        cordelia = self.example_user("cordelia")
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+
+        cordelia.date_joined = timezone_now() - timedelta(days=9)
+        cordelia.save()
+        check_create_user_group("cordelia", "Insufficient permission")
+
+        cordelia.date_joined = timezone_now() - timedelta(days=11)
+        cordelia.save()
+        check_create_user_group("cordelia")
+
+        hamlet.date_joined = timezone_now() - timedelta(days=9)
+        hamlet.save()
+
+        check_delete_user_group("cordelia", "Insufficient permission")
+        check_delete_user_group("hamlet", "Insufficient permission")
+
+        hamlet.date_joined = timezone_now() - timedelta(days=11)
+        hamlet.save()
+        check_delete_user_group("hamlet")
+
+    def test_user_group_edit_policy_for_updating_user_groups(self) -> None:
+        othello = self.example_user("othello")
+        self.login("othello")
         params = {
             "name": "support",
-            "members": orjson.dumps([iago.id, hamlet.id]).decode(),
+            "members": orjson.dumps([othello.id]).decode(),
             "description": "Support team",
         }
-
-        result = self.client_post("/json/user_groups/create", info=params)
-        self.assert_json_success(result)
+        self.client_post("/json/user_groups/create", info=params)
         user_group = UserGroup.objects.get(name="support")
 
-        # Test add member
-        params = {"add": orjson.dumps([cordelia.id]).decode()}
-        result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
-        self.assert_json_success(result)
+        def check_update_user_group(
+            new_name: str,
+            new_description: str,
+            acting_user: str,
+            error_msg: Optional[str] = None,
+        ) -> None:
+            self.login(acting_user)
+            params = {
+                "name": new_name,
+                "description": new_description,
+            }
+            result = self.client_patch(f"/json/user_groups/{user_group.id}", info=params)
+            if error_msg is None:
+                self.assert_json_success(result)
+            else:
+                self.assert_json_error(result, error_msg)
 
-        # Test remove member
-        params = {"delete": orjson.dumps([cordelia.id]).decode()}
-        result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
-        self.assert_json_success(result)
+        realm = othello.realm
 
-        # Test changing groups name
-        params = {
-            "name": "help",
-            "description": "Troubleshooting",
-        }
-        result = self.client_patch(f"/json/user_groups/{user_group.id}", info=params)
-        self.assert_json_success(result)
-
-        # Test delete a group
-        result = self.client_delete(f"/json/user_groups/{user_group.id}")
-        self.assert_json_success(result)
-
-        user_group = create_user_group(
-            name="support",
-            members=[hamlet, iago],
-            realm=iago.realm,
+        # Check only admins are allowed to update user group. Admins are allowed even if
+        # they are not a member of the group.
+        do_set_realm_property(
+            realm,
+            "user_group_edit_policy",
+            Realm.POLICY_ADMINS_ONLY,
+            acting_user=None,
         )
+        check_update_user_group("help", "Troubleshooting team", "shiva", "Insufficient permission")
+        check_update_user_group("help", "Troubleshooting team", "iago")
 
-        self.logout()
+        # Check moderators are allowed to update user group but not members. Moderators are
+        # allowed even if they are not a member of the group.
+        do_set_realm_property(
+            realm,
+            "user_group_edit_policy",
+            Realm.POLICY_MODERATORS_ONLY,
+            acting_user=None,
+        )
+        check_update_user_group("support", "Support team", "othello", "Insufficient permission")
+        check_update_user_group("support", "Support team", "iago")
 
-        self.login("hamlet")
+        # Check only members are allowed to update the user group and only if belong to the
+        # user group.
+        do_set_realm_property(
+            realm,
+            "user_group_edit_policy",
+            Realm.POLICY_MEMBERS_ONLY,
+            acting_user=None,
+        )
+        check_update_user_group(
+            "help", "Troubleshooting team", "polonius", "Not allowed for guest users"
+        )
+        check_update_user_group(
+            "help",
+            "Troubleshooting team",
+            "cordelia",
+            "Insufficient permission",
+        )
+        check_update_user_group("help", "Troubleshooting team", "othello")
 
-        # Test creating a group
-        params = {
-            "name": "support2",
-            "members": orjson.dumps([hamlet.id]).decode(),
-            "description": "Support team",
-        }
-        result = self.client_post("/json/user_groups/create", info=params)
-        self.assert_json_error(result, "Must be an organization administrator")
+        # Check only full members are allowed to update the user group and only if belong to the
+        # user group.
+        do_set_realm_property(
+            realm, "user_group_edit_policy", Realm.POLICY_FULL_MEMBERS_ONLY, acting_user=None
+        )
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+        othello = self.example_user("othello")
+        othello.date_joined = timezone_now() - timedelta(days=9)
+        othello.save()
 
-        # Test add member
-        params = {"add": orjson.dumps([cordelia.id]).decode()}
-        result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
-        self.assert_json_error(result, "Must be an organization administrator")
+        cordelia = self.example_user("cordelia")
+        cordelia.date_joined = timezone_now() - timedelta(days=11)
+        cordelia.save()
+        check_update_user_group(
+            "support",
+            "Support team",
+            "cordelia",
+            "Insufficient permission",
+        )
+        check_update_user_group("support", "Support team", "othello", "Insufficient permission")
 
-        # Test delete a group
-        result = self.client_delete(f"/json/user_groups/{user_group.id}")
-        self.assert_json_error(result, "Must be an organization administrator")
+        othello.date_joined = timezone_now() - timedelta(days=11)
+        othello.save()
+        check_update_user_group("support", "Support team", "othello")
 
-        # Test changing groups name
-        params = {
-            "name": "help",
-            "description": "Troubleshooting",
-        }
-        result = self.client_patch(f"/json/user_groups/{user_group.id}", info=params)
-        self.assert_json_error(result, "Must be an organization administrator")
+    def test_user_group_edit_policy_for_updating_members(self) -> None:
+        user_group = self.create_user_group_for_test("support")
+        aaron = self.example_user("aaron")
+        othello = self.example_user("othello")
+        cordelia = self.example_user("cordelia")
+
+        def check_adding_members_to_group(
+            acting_user: str, error_msg: Optional[str] = None
+        ) -> None:
+            self.login(acting_user)
+            params = {"add": orjson.dumps([aaron.id]).decode()}
+            result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
+            if error_msg is None:
+                self.assert_json_success(result)
+                self.assertEqual(UserGroupMembership.objects.count(), 4)
+                members = get_memberships_of_users(user_group, [aaron, othello])
+                self.assert_length(members, 2)
+            else:
+                self.assert_json_error(result, error_msg)
+
+        def check_removing_members_from_group(
+            acting_user: str, error_msg: Optional[str] = None
+        ) -> None:
+            self.login(acting_user)
+            params = {"delete": orjson.dumps([aaron.id]).decode()}
+            result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
+            if error_msg is None:
+                self.assert_json_success(result)
+                self.assertEqual(UserGroupMembership.objects.count(), 3)
+                members = get_memberships_of_users(user_group, [aaron, othello])
+                self.assert_length(members, 1)
+            else:
+                self.assert_json_error(result, error_msg)
+
+        realm = get_realm("zulip")
+        # Check only admins are allowed to add/remove users from the group. Admins are allowed even if
+        # they are not a member of the group.
+        do_set_realm_property(
+            realm,
+            "user_group_edit_policy",
+            Realm.POLICY_ADMINS_ONLY,
+            acting_user=None,
+        )
+        check_adding_members_to_group("shiva", "Insufficient permission")
+        check_adding_members_to_group("iago")
+
+        check_removing_members_from_group("shiva", "Insufficient permission")
+        check_removing_members_from_group("iago")
+
+        # Check moderators are allowed to add/remove users from the group but not members. Moderators are
+        # allowed even if they are not a member of the group.
+        do_set_realm_property(
+            realm,
+            "user_group_edit_policy",
+            Realm.POLICY_MODERATORS_ONLY,
+            acting_user=None,
+        )
+        check_adding_members_to_group("cordelia", "Insufficient permission")
+        check_adding_members_to_group("shiva")
+
+        check_removing_members_from_group("hamlet", "Insufficient permission")
+        check_removing_members_from_group("shiva")
+
+        # Check only members are allowed to add/remove users in the group and only if belong to the
+        # user group.
+        do_set_realm_property(
+            realm,
+            "user_group_edit_policy",
+            Realm.POLICY_MEMBERS_ONLY,
+            acting_user=None,
+        )
+        check_adding_members_to_group("polonius", "Not allowed for guest users")
+        check_adding_members_to_group("cordelia", "Insufficient permission")
+        check_adding_members_to_group("othello")
+
+        check_removing_members_from_group("polonius", "Not allowed for guest users")
+        check_removing_members_from_group("cordelia", "Insufficient permission")
+        check_removing_members_from_group("othello")
+
+        # Check only full members are allowed to add/remove users in the group and only if belong to the
+        # user group.
+        do_set_realm_property(
+            realm,
+            "user_group_edit_policy",
+            Realm.POLICY_FULL_MEMBERS_ONLY,
+            acting_user=None,
+        )
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+
+        othello.date_joined = timezone_now() - timedelta(days=9)
+        othello.save()
+        check_adding_members_to_group("cordelia", "Insufficient permission")
+
+        cordelia.date_joined = timezone_now() - timedelta(days=11)
+        cordelia.save()
+        check_adding_members_to_group("cordelia", "Insufficient permission")
+
+        othello.date_joined = timezone_now() - timedelta(days=11)
+        othello.save()
+        check_adding_members_to_group("othello")
+
+        othello.date_joined = timezone_now() - timedelta(days=9)
+        othello.save()
+
+        check_removing_members_from_group("cordelia", "Insufficient permission")
+        check_removing_members_from_group("othello", "Insufficient permission")
+
+        othello.date_joined = timezone_now() - timedelta(days=11)
+        othello.save()
+        check_removing_members_from_group("othello")

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -102,7 +102,7 @@ def update_realm(
         json_validator=check_int_in(Realm.COMMON_POLICY_TYPES), default=None
     ),
     user_group_edit_policy: Optional[int] = REQ(
-        json_validator=check_int_in(Realm.USER_GROUP_EDIT_POLICY_TYPES), default=None
+        json_validator=check_int_in(Realm.COMMON_POLICY_TYPES), default=None
     ),
     private_message_policy: Optional[int] = REQ(
         json_validator=check_int_in(Realm.PRIVATE_MESSAGE_POLICY_TYPES), default=None


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds moderators and full members options in `user_group_edit_policy`.

There are 3 commits -
- Adds a helper `can_edit_user_group`.
- Adds the moderators and full member options in backend. Most of this commit is addition of tests or all the user roles. And I have also removed the role based checks of other tests as they are added in the new test functions.
- Add the moderators and full members options in frontend.

1. Moderators are allowed to delete and edit user groups even if they are not member of the group.
2. Full members are allowed to delete and edit user groups only if they are member of the group.
(Both the above conditions are valid only if that role is allowed to perform the task according to
`user_group_edit_policy`)

**Testing plan:** <!-- How have you tested? --> Updated and added tests.


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
