### PR TITLE
compose: Clarify title for wide reply button.

### DIFF
--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -4,7 +4,7 @@
             <span class="new_message_button reply_button_container">
                 <button type="button" class="button small rounded compose_reply_button"
                   id="left_bar_compose_reply_button_big"
-                  title="{{t 'Reply' }} (r)">
+                  title="{{t 'Reply to selected message' }} (r)">
                     <span class="compose_reply_button_label">{{t 'Compose message' }}</span>
                 </button>
             </span>


### PR DESCRIPTION
This changes the button text from "Reply" to "Reply to selected
message". Here's the thinking:

* The title "Reply" was a little confusing/inconsistent with the
  button's label.

* If you're hovering over the button, it's because you want more
  information about what it does -- not just a repeat of the button's
  label.

* The "Message foo > bar" content of the button already cleanly
  expresses what the button will do if you click it right now.

* The hover text "Reply to selected message (r)" explains to you what
  that button's role is in all situation, not just with the current
  selection, and thus documents the concept.  And it also gives you
  clarify if you're thinking "but how do I reply to something in
  Zulip?" and try hovering over the buttons at the bottom to find out.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
