### PR TITLE
popovers: Migrate user status indicator tooltip to tippy.

### DIFF
--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -7,7 +7,7 @@
                 {{#if is_bot}}
                 <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
                 {{else}}
-                <span class="{{user_circle_class}} user_circle popover_user_presence" title="{{user_last_seen_time_status}}"></span>
+                <span class="{{user_circle_class}} user_circle popover_user_presence tippy-zulip-tooltip" data-tippy-content="{{user_last_seen_time_status}}" data-tippy-placement="top"></span>
                 {{/if}}
             {{/if}}
         </li>


### PR DESCRIPTION
Added a minor commit to replace the user status indicator tooltip with tippy.
As of now, kept the tooltip position (`data-tippy-placement`) as `top`.

<strong>Screeshots:</strong>
![active](https://user-images.githubusercontent.com/53977614/120831501-37a3d600-c57d-11eb-8745-a98eeb10c0cb.png)
<hr/>

![idle](https://user-images.githubusercontent.com/53977614/120831558-48544c00-c57d-11eb-95fb-dae6c67250ac.png)
<hr/>

![last-active](https://user-images.githubusercontent.com/53977614/120831631-5d30df80-c57d-11eb-996c-fe4ff4386f3d.png)
