### PR TITLE
zjquery: Eliminate css() helper.

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -94,6 +94,10 @@ function override_private_message_recipient(override) {
 
 function test(label, f) {
     run_test(label, (override) => {
+        // We don't test the css calls; we just skip over them.
+        $("#compose").css = () => {};
+        $(".new_message_textarea").css = () => {};
+
         people.init();
         compose_state.set_message_type(false);
         f(override);

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -76,6 +76,7 @@ const short_msg = {
 
 function test(label, f) {
     run_test(label, (override) => {
+        $("#draft_overlay").css = () => {};
         localStorage.clear();
         f(override);
     });

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -339,6 +339,8 @@ function stub_out_filter_buttons() {
 
 function test(label, f) {
     run_test(label, (override) => {
+        $(".header").css = () => {};
+
         messages = sample_messages.map((message) => ({...message}));
         f(override);
     });

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -216,9 +216,12 @@ test("initialize", () => {
     search_query_box.trigger(new $.Event("blur", stub_event));
     assert.equal(search_query_box.val(), "test string");
 
-    searchbox.css({"box-shadow": "inset 0px 0px 0px 2px hsl(204, 20%, 74%)"});
+    let css_args;
+    searchbox.css = (args) => {
+        css_args = args;
+    };
     searchbox.trigger("focusout");
-    assert.deepEqual(searchbox.css(), {"box-shadow": "unset"});
+    assert.deepEqual(css_args, {"box-shadow": "unset"});
 
     search.__Rewire__("is_using_input_method", false);
     searchbox_form.trigger("compositionend");
@@ -343,8 +346,15 @@ test("initiate_search", () => {
 
     $("#search_query")[0] = "stub";
 
+    const searchbox = $("#searchbox");
+    let css_args;
+    searchbox.css = (args) => {
+        css_args = args;
+    };
+
     search.initiate_search();
     assert(typeahead_forced_open);
     assert(is_searchbox_text_selected);
     assert(is_searchbox_focused);
+    assert.deepEqual(css_args, {"box-shadow": "inset 0px 0px 0px 2px hsl(204, 20%, 74%)"});
 });

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -287,10 +287,20 @@ run_test("initiate_search", () => {
         is_searchbox_text_selected = true;
     });
 
+    let searchbox_css_args;
+
+    $("#searchbox").css = (args) => {
+        searchbox_css_args = args;
+    };
+
     search.initiate_search();
     assert(typeahead_forced_open);
     assert(is_searchbox_text_selected);
     assert.equal($("#search_query").val(), "ver");
+
+    assert.deepEqual(searchbox_css_args, {
+        "box-shadow": "inset 0px 0px 0px 2px hsl(204, 20%, 74%)",
+    });
 
     // test that we append space for user convenience
     narrow_state.filter = () => ({is_search: () => false});

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -62,6 +62,7 @@ const dropdown_list_widget = zrequire("dropdown_list_widget");
 
 function test(label, f) {
     run_test(label, (override) => {
+        $("#realm-icon-upload-widget .upload-spinner-background").css = () => {};
         page_params.is_admin = false;
         page_params.realm_domains = [
             {domain: "example.com", allow_subdomains: true},

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -174,7 +174,6 @@ function make_new_elem(selector, opts) {
     let html = "never-been-set";
     let text = "never-been-set";
     let value;
-    let css;
     let shown = false;
     let height;
 
@@ -200,13 +199,6 @@ function make_new_elem(selector, opts) {
                 return attrs.get(name);
             }
             attrs.set(name, val);
-            return self;
-        },
-        css(...args) {
-            if (args.length === 0) {
-                return css || {};
-            }
-            [css] = args;
             return self;
         },
         data(name, val) {


### PR DESCRIPTION
We use css() pretty rarely in our codebase, and
it can sometimes be used mistakenly, when a better
alternative is to toggle a class for external css.

It's hard to support the full API in zjquery, so
we just punt and tell folks to create their own
stubs.

Most of the existing tests that were "fixed" here
weren't actually verifying the behavior of the css()
calls, and for those I just create no-op stubs.

In a few places I verify that css() was called as
expected.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
