### PR TITLE
subdomains: Extend "static" to include resources hosted on S3.

### DIFF
--- a/zerver/tests/test_subdomains.py
+++ b/zerver/tests/test_subdomains.py
@@ -3,8 +3,10 @@ from unittest import mock
 
 from django.conf import settings
 
+import zerver.lib.upload
 from zerver.lib.subdomains import get_subdomain, is_static_or_current_realm_url
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.test_helpers import create_s3_buckets, use_s3_backend
 from zerver.models import Realm
 
 
@@ -82,3 +84,18 @@ class SubdomainsTest(ZulipTestCase):
             self.assertTrue(test(f"{settings.STATIC_URL}/x"))
             self.assertFalse(test(evil_url))
             self.assertFalse(test(f"{evil_url}/x"))
+
+    @use_s3_backend
+    def test_is_static_or_current_realm_url_with_s3(self) -> None:
+        create_s3_buckets(settings.S3_AVATAR_BUCKET)[0]
+
+        realm = self.example_user("hamlet").realm
+
+        def test(url: str) -> bool:
+            return is_static_or_current_realm_url(url, realm)
+
+        upload_backend = zerver.lib.upload.upload_backend
+        self.assertTrue(test(upload_backend.get_realm_icon_url(realm.id, version=1)))
+        self.assertTrue(test(upload_backend.get_realm_logo_url(realm.id, version=1, night=False)))
+        self.assertTrue(test(upload_backend.get_avatar_url("deadbeefcafe")))
+        self.assertTrue(test(upload_backend.get_emoji_url("emoji.gif", realm.id)))

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -912,6 +912,7 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
     def test_avatar_url(self) -> None:
         """Verifies URL schemes for avatars and realm icons."""
         backend: ZulipUploadBackend = LocalUploadBackend()
+        self.assertEqual(backend.get_public_upload_root_url(), "/user_avatars/")
         self.assertEqual(backend.get_avatar_url("hash", False), "/user_avatars/hash.png?x=x")
         self.assertEqual(backend.get_avatar_url("hash", True), "/user_avatars/hash-medium.png?x=x")
         self.assertEqual(


### PR DESCRIPTION
This causes avatars and emoji which are hosted by Zulip in S3 (or
compatible) servers to no longer go through camo.  Routing these
requests through camo does not add any privacy benefit (as the request
logs there go to the Zulip admins regardless), and may break emoji
imported from Slack before 1bf385e35f04aad8121d685c42e46a3829130508,
which have `application/octet-stream` as their stored Content-Type.
