### PR TITLE
"+" menu for browsing and creating streams 

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -694,11 +694,6 @@ export function initialize() {
 
     // LEFT SIDEBAR
 
-    $("#streams_inline_cog").on("click", (e) => {
-        e.stopPropagation();
-        browser_history.go_to_location("streams/subscribed");
-    });
-
     $(".streams_filter_icon").on("click", (e) => {
         e.stopPropagation();
         stream_list.toggle_filter_displayed(e);

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -521,6 +521,10 @@ export function set_event_handlers() {
     $("#streams_header")
         .expectOne()
         .on("click", (e) => {
+            e.preventDefault();
+            if (e.target.id === "streams_inline_cog") {
+                return;
+            }
             toggle_filter_displayed(e);
         });
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -747,7 +747,11 @@ export function launch(section) {
         change_state(section);
     });
     if (!get_active_data().id) {
-        $("#search_stream_name").trigger("focus");
+        if (section === "new") {
+            $("#create_stream_name").trigger("focus");
+        } else {
+            $("#search_stream_name").trigger("focus");
+        }
     }
 }
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -698,6 +698,7 @@ export function change_state(section) {
     if (section === "new") {
         if (!page_params.is_guest) {
             do_open_create_stream();
+            show_right_section();
         } else {
             toggler.goto("subscribed");
         }
@@ -723,6 +724,7 @@ export function change_state(section) {
         if (page_params.is_guest && !stream_data.id_is_subscribed(stream_id)) {
             toggler.goto("subscribed");
         } else {
+            show_right_section();
             switch_to_stream_row(stream_id);
         }
         return;

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -688,6 +688,11 @@ export function switch_to_stream_row(stream_id) {
     }, 100);
 }
 
+function show_right_section() {
+    $(".right").addClass("show");
+    $(".subscriptions-header").addClass("slide-left");
+}
+
 export function change_state(section) {
     // if in #streams/new form.
     if (section === "new") {
@@ -996,10 +1001,7 @@ export function initialize() {
         selectText(this);
     });
 
-    $("#subscriptions_table").on("click", ".stream-row, .create_stream_button", () => {
-        $(".right").addClass("show");
-        $(".subscriptions-header").addClass("slide-left");
-    });
+    $("#subscriptions_table").on("click", ".stream-row, .create_stream_button", show_right_section);
 
     $("#subscriptions_table").on("click", ".fa-chevron-left", () => {
         $(".right").removeClass("show");

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -1,8 +1,11 @@
 import $ from "jquery";
 import tippy, {delegate} from "tippy.js";
 
+import render_left_sidebar_stream_setting_popover from "../templates/left_sidebar_stream_setting_popover.hbs";
+
 import * as reactions from "./reactions";
 import * as rows from "./rows";
+import * as settings_data from "./settings_data";
 
 // We override the defaults set by tippy library here,
 // so make sure to check this too after checking tippyjs
@@ -103,5 +106,24 @@ export function initialize() {
             instance.setContent(content);
             return true;
         },
+    });
+
+    delegate("body", {
+        delay: 0,
+        target: "#streams_inline_cog",
+        onShow(instance) {
+            instance.setContent(
+                render_left_sidebar_stream_setting_popover({
+                    can_create_streams: settings_data.user_can_create_streams(),
+                }),
+            );
+            $(instance.popper).on("click", instance.hide);
+        },
+        appendTo: () => document.body,
+        trigger: "click",
+        allowHTML: true,
+        interactive: true,
+        hideOnClick: true,
+        theme: "light-border",
     });
 }

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -68,6 +68,10 @@ li.show-more-topics {
     }
 }
 
+.streams_inline_cog_wrapper {
+    float: right;
+}
+
 #streams_inline_cog {
     margin-right: 10px;
 }
@@ -501,7 +505,7 @@ li.expanded_private_message {
 }
 
 #streams_header {
-    margin-right: 0;
+    margin-right: 12px;
     padding-left: $far_left_gutter_size;
     cursor: pointer;
     margin-top: 3px;

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -190,10 +190,6 @@
     transition: all 0.2s ease;
     padding-bottom: 0;
     padding-top: 0;
-
-    &:hover {
-        color: hsl(0, 0%, 27%);
-    }
 }
 
 #create_stream_description {

--- a/static/templates/left_sidebar_stream_setting_popover.hbs
+++ b/static/templates/left_sidebar_stream_setting_popover.hbs
@@ -1,0 +1,14 @@
+<ul class="nav nav-list">
+    <li>
+        <a href="#streams/all">
+            {{t "Browse streams" }}
+        </a>
+    </li>
+    {{#if can_create_streams }}
+    <li>
+        <a href="#streams/new">
+            {{t "Create a stream" }}
+        </a>
+    </li>
+    {{/if}}
+</ul>

--- a/static/templates/subscription_table_body.hbs
+++ b/static/templates/subscription_table_body.hbs
@@ -12,7 +12,7 @@
                 <div class="search-container">
                     <div id="add_new_subscription">
                         {{#if can_create_streams}}
-                        <button class="create_stream_button" title="{{t 'Create new stream' }} (n)">+</button>
+                        <button class="create_stream_button tippy-zulip-tooltip" data-tippy-content="{{t 'Create new stream' }} (n)" data-tippy-placement="bottom">+</button>
                         {{/if}}
                         <div class="float-clear"></div>
                     </div>

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -63,7 +63,7 @@
                 <span class="tippy-zulip-tooltip streams_inline_cog_wrapper" data-tippy-content="{{ _('Add streams') }}" data-tippy-placement="top">
                     <i id="streams_inline_cog" class='fa fa-plus' aria-hidden="true" ></i>
                 </span>
-                <i class='streams_filter_icon fa fa-filter tippy-zulip-tooltip' aria-hidden="true" data-tippy-content="{{ _('Filter streams') }} (q)"></i>
+                <i class='streams_filter_icon fa fa-filter tippy-zulip-tooltip' aria-hidden="true" data-tippy-content="{{ _('Filter streams') }} (q)" data-tippy-placement="top"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{ _('Filter streams') }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -60,7 +60,9 @@
         </ul>
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title tippy-zulip-tooltip" data-tippy-content="{{ _('Filter streams') }} (q)">{{ _('STREAMS') }}</h4>
-                <i id="streams_inline_cog" class='fa fa-cog tippy-zulip-tooltip' aria-hidden="true" data-tippy-content="{{ _('Subscribe, add, or configure streams') }}"></i>
+                <span class="tippy-zulip-tooltip streams_inline_cog_wrapper" data-tippy-content="{{ _('Add streams') }}" data-tippy-placement="top">
+                    <i id="streams_inline_cog" class='fa fa-plus' aria-hidden="true" ></i>
+                </span>
                 <i class='streams_filter_icon fa fa-search tippy-zulip-tooltip' aria-hidden="true" data-tippy-content="{{ _('Filter streams') }} (q)"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{ _('Filter streams') }}" />

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -63,7 +63,7 @@
                 <span class="tippy-zulip-tooltip streams_inline_cog_wrapper" data-tippy-content="{{ _('Add streams') }}" data-tippy-placement="top">
                     <i id="streams_inline_cog" class='fa fa-plus' aria-hidden="true" ></i>
                 </span>
-                <i class='streams_filter_icon fa fa-search tippy-zulip-tooltip' aria-hidden="true" data-tippy-content="{{ _('Filter streams') }} (q)"></i>
+                <i class='streams_filter_icon fa fa-filter tippy-zulip-tooltip' aria-hidden="true" data-tippy-content="{{ _('Filter streams') }} (q)"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{ _('Filter streams') }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">


### PR DESCRIPTION
Fixes #18694

- [x] Replace the gear in the **STREAMS** header (left sidebar) with a `+` icon.
- [x] Make the icon bigger and align it further to the left. Alignment with unread message counts seems right; an alternative option is aligning with the "..." menu.
- [x] Clicking on the `+` should pop up a two-option menu:
    * Browse streams
    * Create a stream
- [x] Clicking "Browse streams" should open the **All streams** tab of the **Streams** settings menu.
- [x] Clicking "Create a stream" should open the  **All streams** tab of the **Streams** settings menu with the **Create stream** form open, as if the user had already clicked the **Create stream** button.

<img width="511" alt="Screenshot 2021-06-05 at 11 31 10 PM" src="https://user-images.githubusercontent.com/25124304/120901068-2aa6e580-c656-11eb-9347-ddbe3a68a5bc.png">
