### PR TITLE
Decouple muted-user notification blocking from `read` flag.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1968,6 +1968,7 @@ def do_send_messages(
                 stream_push_notify=(user_id in send_request.stream_push_user_ids),
                 stream_email_notify=(user_id in send_request.stream_email_user_ids),
                 wildcard_mention_notify=(user_id in send_request.wildcard_mention_user_ids),
+                sender_is_muted=(user_id in send_request.muted_sender_user_ids),
             )
             for user_id in user_list
         ]
@@ -5869,6 +5870,7 @@ def do_update_message(
         event["online_push_user_ids"] = list(info["online_push_user_ids"])
         event["stream_push_user_ids"] = list(info["stream_push_user_ids"])
         event["stream_email_user_ids"] = list(info["stream_email_user_ids"])
+        event["muted_sender_user_ids"] = list(info["muted_sender_user_ids"])
         event["prior_mention_user_ids"] = list(prior_mention_user_ids)
         event["mention_user_ids"] = list(mention_user_ids)
         event["presence_idle_user_ids"] = filter_presence_idle_user_ids(info["active_user_ids"])

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1423,6 +1423,7 @@ class RecipientInfoResult(TypedDict):
     stream_email_user_ids: Set[int]
     stream_push_user_ids: Set[int]
     wildcard_mention_user_ids: Set[int]
+    muted_sender_user_ids: Set[int]
     um_eligible_user_ids: Set[int]
     long_term_idle_user_ids: Set[int]
     default_bot_user_ids: Set[int]
@@ -1441,6 +1442,7 @@ def get_recipient_info(
     stream_push_user_ids: Set[int] = set()
     stream_email_user_ids: Set[int] = set()
     wildcard_mention_user_ids: Set[int] = set()
+    muted_sender_user_ids: Set[int] = get_muting_users(sender_id)
 
     if recipient.type == Recipient.PERSONAL:
         # The sender and recipient may be the same id, so
@@ -1621,6 +1623,7 @@ def get_recipient_info(
         stream_push_user_ids=stream_push_user_ids,
         stream_email_user_ids=stream_email_user_ids,
         wildcard_mention_user_ids=wildcard_mention_user_ids,
+        muted_sender_user_ids=muted_sender_user_ids,
         um_eligible_user_ids=um_eligible_user_ids,
         long_term_idle_user_ids=long_term_idle_user_ids,
         default_bot_user_ids=default_bot_user_ids,
@@ -1813,6 +1816,7 @@ def build_message_send_dict(
         online_push_user_ids=info["online_push_user_ids"],
         stream_push_user_ids=info["stream_push_user_ids"],
         stream_email_user_ids=info["stream_email_user_ids"],
+        muted_sender_user_ids=info["muted_sender_user_ids"],
         um_eligible_user_ids=info["um_eligible_user_ids"],
         long_term_idle_user_ids=info["long_term_idle_user_ids"],
         default_bot_user_ids=info["default_bot_user_ids"],
@@ -1862,7 +1866,7 @@ def do_send_messages(
             mentioned_user_ids = send_request.message.mentions_user_ids
 
             # Extend the set with users who have muted the sender.
-            mark_as_read_for_users = get_muting_users(send_request.message.sender_id)
+            mark_as_read_for_users = send_request.muted_sender_user_ids
             mark_as_read_for_users.update(mark_as_read)
 
             user_messages = create_user_messages(

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -98,6 +98,7 @@ class SendMessageRequest:
     online_push_user_ids: Set[int]
     stream_push_user_ids: Set[int]
     stream_email_user_ids: Set[int]
+    muted_sender_user_ids: Set[int]
     um_eligible_user_ids: Set[int]
     long_term_idle_user_ids: Set[int]
     default_bot_user_ids: Set[int]


### PR DESCRIPTION
This is a prep change for if/when we fully implement #18654.