### PR TITLE
modals: Remove `in` class once modal is hidden.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -912,6 +912,10 @@ export function initialize() {
     $("body").on("hidden.bs.modal", () => {
         // Enable mouse events for the background as the modal closes.
         overlays.enable_background_mouse_events();
+
+        // TODO: Remove this once Bootstrap is upgraded.
+        // See: https://github.com/zulip/zulip/pull/18720
+        $(".modal.in").removeClass("in");
     });
 
     // MAIN CLICK HANDLER


### PR DESCRIPTION
Rapdly clicking a button that shows a modal cause a race condition
in Bootstrap. Specifically, Bootstrap adds an "in" class to a modal
on the "shown" event and removes it on the "hide" event. Frequent clicks
cause the "hide" event to trigger before the "shown" event. Therefore, the
"in" class isn't removed. We use the "in" class to check if a modal is
active in overlays.js

For now, we manually remove it once the modal is hidden.

So, I just noticed that we use Bootstrap 2 which is like super old.
Newer versions of Bootstrap probably handle this better internally.
Look into removing this once it's upgraded.

For instance, Bootstrap 4 handles rapid clicks better (Demo: https://jsfiddle.net/q256fysj/1/) while Bootstrap 2 doesn't do it so well (Demo: https://jsfiddle.net/3et8ab0x/1/).

So, I think upgrading Bootstrap will fix this naturally.

### Before

https://user-images.githubusercontent.com/58626718/120934948-2a721d00-c71e-11eb-88c9-f6b488ce8ae1.mp4

### After (I am clicking rapidly here)
https://user-images.githubusercontent.com/58626718/120934970-41b10a80-c71e-11eb-9ab8-dbbde6c77fc5.mp4

### Similarly

https://user-images.githubusercontent.com/58626718/120935010-6c02c800-c71e-11eb-95a6-a8a80bba0c96.mp4

