### PR TITLE
node tests: Replace assert with assert.equal in dispatch.js.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -740,7 +740,7 @@ run_test("update_display_settings", (override) => {
         event = event_fixtures.update_display_settings__default_view_all_messages;
         page_params.default_view = "recent_topics";
         dispatch(event);
-        assert(page_params.default_view, "all_messages");
+        assert.equal(page_params.default_view, "all_messages");
     }
 
     {

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -659,7 +659,7 @@ exports.fixtures = {
     update_display_settings__default_view_all_messages: {
         type: "update_display_settings",
         setting_name: "default_view",
-        setting: 1,
+        setting: "all_messages",
         user: test_user.email,
     },
 


### PR DESCRIPTION
Above change will result in the failing of the test, this is
becuase `page_params.default_view` was returning a value of 1
but value expected was `all_messages`. Simple fix was to change
value of `setting` to `all_messages`(which was 1 initially) in
`update_display_settings__default_view_all_messages` in event.js.

Fixes #18685.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Ran `tools/test-js-with-node`.  All tests are passing successfully!


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
