### PR TITLE
left-sidebar: Add topic filter input in zoomed topic view.

### DIFF
--- a/frontend_tests/node_tests/topic_list_data.js
+++ b/frontend_tests/node_tests/topic_list_data.js
@@ -16,6 +16,10 @@ const narrow_state = mock_esm("../../static/js/narrow_state", {
     topic() {},
 });
 
+const topic_list = mock_esm("../../static/js/topic_list", {
+    get_topic_search_term() {},
+});
+
 const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const topic_list_data = zrequire("topic_list_data");
@@ -50,13 +54,15 @@ test("get_list_info w/real stream_topic_history", (override) => {
         num_possible_topics: 0,
     });
 
-    for (const i of _.range(7)) {
-        const topic_name = "topic " + i;
+    function add_topic_message(topic_name, message_id) {
         stream_topic_history.add_message({
             stream_id: general.stream_id,
             topic_name,
-            message_id: 1000 + i,
+            message_id,
         });
+    }
+    for (const i of _.range(7)) {
+        add_topic_message("topic " + i, 1000 + i);
     }
 
     override(narrow_state, "topic", () => "topic 6");
@@ -75,12 +81,24 @@ test("get_list_info w/real stream_topic_history", (override) => {
         url: "#narrow/stream/556-general/topic/topic.206",
     });
 
-    // If we zoom in, we'll show all 7 topics.
+    // If we zoom in, our results based on topic filter.
+    // If topic search input is empty, we show all 7 topics.
+
     const zoomed = true;
+    override(topic_list, "get_topic_search_term", () => "");
     list_info = get_list_info(zoomed);
     assert.equal(list_info.items.length, 7);
     assert.equal(list_info.more_topics_unreads, 0);
     assert.equal(list_info.num_possible_topics, 7);
+
+    add_topic_message("After Brooklyn", 1008);
+    add_topic_message("Catering", 1009);
+    // when topic search is open then we list topics based on search term.
+    override(topic_list, "get_topic_search_term", () => "b,c");
+    list_info = get_list_info(zoomed);
+    assert.equal(list_info.items.length, 2);
+    assert.equal(list_info.more_topics_unreads, 0);
+    assert.equal(list_info.num_possible_topics, 2);
 });
 
 test("get_list_info unreads", (override) => {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -40,6 +40,7 @@ import * as settings_toggle from "./settings_toggle";
 import * as stream_edit from "./stream_edit";
 import * as stream_list from "./stream_list";
 import * as stream_popover from "./stream_popover";
+import * as topic_list from "./topic_list";
 import * as ui_util from "./ui_util";
 import * as unread_ops from "./unread_ops";
 import * as user_status_ui from "./user_status_ui";
@@ -693,6 +694,8 @@ export function initialize() {
     });
 
     // LEFT SIDEBAR
+
+    $("body").on("click", "#clear_search_topic_button", topic_list.clear_topic_search);
 
     $(".streams_filter_icon").on("click", (e) => {
         e.stopPropagation();

--- a/static/js/topic_list_data.js
+++ b/static/js/topic_list_data.js
@@ -2,7 +2,9 @@ import * as hash_util from "./hash_util";
 import * as muting from "./muting";
 import * as narrow_state from "./narrow_state";
 import * as stream_topic_history from "./stream_topic_history";
+import * as topic_list from "./topic_list";
 import * as unread from "./unread";
+import * as util from "./util";
 
 const max_topics = 5;
 const max_topics_with_unread = 8;
@@ -17,7 +19,11 @@ export function get_list_info(stream_id, zoomed) {
         active_topic = active_topic.toLowerCase();
     }
 
-    const topic_names = stream_topic_history.get_recent_topic_names(stream_id);
+    let topic_names = stream_topic_history.get_recent_topic_names(stream_id);
+    if (zoomed) {
+        const search_term = topic_list.get_topic_search_term();
+        topic_names = util.filter_by_word_prefix_match(topic_names, search_term, (item) => item);
+    }
 
     const items = [];
 

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -413,6 +413,12 @@ div.overlay {
         width: calc(100% - 34px);
         margin-left: 10px;
     }
+    .input-append .topic-list-filter {
+        /* Input width = 100% - 11px margin x2 - 6px padding x2 - 1px border x2. */
+        width: calc(100% - 36px);
+        margin-left: 11px;
+        margin-bottom: 5px;
+    }
 }
 
 .stream-selection-header-colorblock {

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -100,6 +100,15 @@ li.show-more-topics {
                 padding-right: 0;
                 padding-bottom: 2px;
                 padding-left: $topic_indent;
+
+                &.filter-topics {
+                    padding-bottom: 0;
+                }
+
+                .input-append.topic_search_section {
+                    margin-bottom: 3px;
+                    margin-left: 3px;
+                }
             }
         }
     }
@@ -513,6 +522,14 @@ li.expanded_private_message {
 
 .stream-list-filter {
     width: 236px;
+}
+
+.topic-list-filter {
+    /* Input width = 100% - 30px right-margin - 6px right-padding */
+    /* To keep the right edge of input along with its borders inline with other
+       topic items we consider to subtract the space given for right margin of
+       other items, and right padding of input element.  */
+    width: calc(100% - 36px);
 }
 
 .zero_count {

--- a/static/templates/filter_topics.hbs
+++ b/static/templates/filter_topics.hbs
@@ -1,0 +1,8 @@
+<li class="topic-list-item filter-topics">
+    <div class="input-append topic_search_section">
+        <input class="topic-list-filter home-page-input" id="filter-topic-input" type="text" autocomplete="off" placeholder="{{t 'Filter topics'}}" />
+        <button type="button" class="btn clear_search_button" id="clear_search_topic_button">
+            <i class="fa fa-remove" aria-hidden="true"></i>
+        </button>
+    </div>
+</li>


### PR DESCRIPTION
Fixes: #18505.

**Testing plan:** node tests and manually


**GIFs or screenshots:** Regarding live update when topic filter is on:
* **Sending message to topic which is part of search list:**
[in_list.gif](https://chat.zulip.org/user_uploads/2/a6/Zjv-VDq_4yzAWvqsBigW30V8/in_list.gif) 

* **Sending message to topic which is not part of search list:**
[not_in_list.gif](https://chat.zulip.org/user_uploads/2/ef/O8Hyq7rK3zp9j34H6CqNZ_-i/not_in_list.gif)
