### PR TITLE
`actions` and `event_queue` miscellaneous refactors.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, field
 from operator import itemgetter
 from typing import (
     AbstractSet,
@@ -5308,6 +5308,16 @@ def do_update_user_status(
     send_event(realm, event, active_user_ids(realm.id))
 
 
+@dataclass
+class ReadMessagesEvent:
+    messages: List[int]
+    all: bool
+    type: str = field(default="update_message_flags", init=False)
+    op: str = field(default="add", init=False)
+    operation: str = field(default="add", init=False)
+    flag: str = field(default="read", init=False)
+
+
 def do_mark_all_as_read(user_profile: UserProfile, client: Client) -> int:
     log_statsd_event("bankruptcy")
 
@@ -5332,13 +5342,11 @@ def do_mark_all_as_read(user_profile: UserProfile, client: Client) -> int:
         flags=F("flags").bitor(UserMessage.flags.read),
     )
 
-    event = dict(
-        type="update_message_flags",
-        op="add",
-        operation="add",
-        flag="read",
-        messages=[],  # we don't send messages, since the client reloads anyway
-        all=True,
+    event = asdict(
+        ReadMessagesEvent(
+            messages=[],  # we don't send messages, since the client reloads anyway
+            all=True,
+        )
     )
     event_time = timezone_now()
 
@@ -5385,13 +5393,11 @@ def do_mark_stream_messages_as_read(
         flags=F("flags").bitor(UserMessage.flags.read),
     )
 
-    event = dict(
-        type="update_message_flags",
-        op="add",
-        operation="add",
-        flag="read",
-        messages=message_ids,
-        all=False,
+    event = asdict(
+        ReadMessagesEvent(
+            messages=message_ids,
+            all=False,
+        )
     )
     event_time = timezone_now()
 
@@ -5425,13 +5431,11 @@ def do_mark_muted_user_messages_as_read(
         flags=F("flags").bitor(UserMessage.flags.read),
     )
 
-    event = dict(
-        type="update_message_flags",
-        op="add",
-        operation="add",
-        flag="read",
-        messages=message_ids,
-        all=False,
+    event = asdict(
+        ReadMessagesEvent(
+            messages=message_ids,
+            all=False,
+        )
     )
     event_time = timezone_now()
 

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -42,7 +42,6 @@ from zerver.lib.queue import queue_json_publish, retry_event
 from zerver.lib.request import JsonableError
 from zerver.lib.utils import statsd
 from zerver.middleware import async_request_timer_restart
-from zerver.models import UserProfile
 from zerver.tornado.autoreload import add_reload_hook
 from zerver.tornado.descriptors import clear_descriptor_by_handler_id, set_descriptor_by_handler_id
 from zerver.tornado.exceptions import BadEventQueueIdError
@@ -1158,7 +1157,7 @@ def process_message_update_event(
 
 
 def maybe_enqueue_notifications_for_message_update(
-    user_profile_id: UserProfile,
+    user_profile_id: int,
     message_id: int,
     private_message: bool,
     mentioned: bool,

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -1139,14 +1139,15 @@ def process_message_update_event(
         maybe_enqueue_notifications_for_message_update(
             user_profile_id=user_profile_id,
             message_id=message_id,
-            stream_name=stream_name,
-            prior_mention_user_ids=prior_mention_user_ids,
+            private_message=(stream_name is None),
             mention_user_ids=mention_user_ids,
             wildcard_mention_notify=wildcard_mention_notify,
-            presence_idle_user_ids=presence_idle_user_ids,
             stream_push_user_ids=stream_push_user_ids,
             stream_email_user_ids=stream_email_user_ids,
+            stream_name=stream_name,
             online_push_user_ids=online_push_user_ids,
+            presence_idle_user_ids=presence_idle_user_ids,
+            prior_mention_user_ids=prior_mention_user_ids,
         )
 
         for client in get_client_descriptors_for_user(user_profile_id):
@@ -1159,17 +1160,16 @@ def process_message_update_event(
 def maybe_enqueue_notifications_for_message_update(
     user_profile_id: UserProfile,
     message_id: int,
-    stream_name: Optional[str],
-    prior_mention_user_ids: Set[int],
+    private_message: bool,
     mention_user_ids: Set[int],
     wildcard_mention_notify: bool,
-    presence_idle_user_ids: Set[int],
     stream_push_user_ids: Set[int],
     stream_email_user_ids: Set[int],
+    stream_name: Optional[str],
     online_push_user_ids: Set[int],
+    presence_idle_user_ids: Set[int],
+    prior_mention_user_ids: Set[int],
 ) -> None:
-    private_message = stream_name is None
-
     if private_message:
         # We don't do offline notifications for PMs, because
         # we already notified the user of the original message


### PR DESCRIPTION
The first two commits are follow-up to https://github.com/zulip/zulip/pull/16915#discussion_r608294833

The next two are prep changes for if we decide to create a `dataclass` for the `maybe_enqueue_*` functions, but I think are nice changes to do even if we don't 😄 

@ryanreh99 could you take a look?