### PR TITLE
puppet: Add a database teleport server.

### DIFF
--- a/puppet/zulip_ops/files/postgresql/pg_hba.conf
+++ b/puppet/zulip_ops/files/postgresql/pg_hba.conf
@@ -89,15 +89,17 @@ local   all             postgres                                peer
 # "local" is for Unix domain socket connections only
 local   all             all                                     peer
 # IPv4 local connections:
-host    all             all             127.0.0.1/32            md5
+#host    all             all             127.0.0.1/32            md5
 # IPv6 local connections:
-host    all             all             ::1/128                 md5
+#host    all             all             ::1/128                 md5
 # Allow replication connections from localhost, by a user with the
 # replication privilege.
 #local   replication     postgres                                peer
 #host    replication     postgres        127.0.0.1/32            md5
 #host    replication     postgres        ::1/128                 md5
 
+# Local connections with certs from Teleport
+hostssl zulip           zulip           127.0.0.1/32            cert
 # Zulip app frontends access the zulip user
 hostssl zulip           zulip           172.31.0.0/16           cert
 # Zulip replication accesses the replicator user

--- a/puppet/zulip_ops/files/supervisor/conf.d/teleport_db.conf
+++ b/puppet/zulip_ops/files/supervisor/conf.d/teleport_db.conf
@@ -1,0 +1,8 @@
+[program:teleport_db]
+command=/usr/local/bin/teleport start --config=/etc/teleport_db.yaml
+priority=10
+autostart=true
+autorestart=true
+user=root
+redirect_stderr=true
+stdout_logfile=/var/log/teleport_db.log

--- a/puppet/zulip_ops/manifests/profile/postgresql.pp
+++ b/puppet/zulip_ops/manifests/profile/postgresql.pp
@@ -1,6 +1,7 @@
 class zulip_ops::profile::postgresql {
   include zulip_ops::profile::base
   include zulip::profile::postgresql
+  include zulip_ops::teleport::db
 
   $common_packages = ['xfsprogs']
   package { $common_packages: ensure => 'installed' }

--- a/puppet/zulip_ops/manifests/teleport/db.pp
+++ b/puppet/zulip_ops/manifests/teleport/db.pp
@@ -1,0 +1,29 @@
+# @summary Provide Teleport SSH access to a node.
+#
+# https://goteleport.com/docs/admin-guide/#adding-nodes-to-the-cluster
+# details additional manual steps to allow a node to join the cluster.
+class zulip_ops::teleport::db {
+  include zulip_ops::teleport::base
+
+  file { '/etc/teleport_db.yaml':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('zulip_ops/teleport_db.yaml.template.erb'),
+  }
+
+  file { "${zulip::common::supervisor_conf_dir}/teleport_db.conf":
+    ensure  => file,
+    require => [
+      Package[supervisor],
+      Package[teleport],
+      File['/etc/teleport_db.yaml'],
+    ],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    source  => 'puppet:///modules/zulip_ops/supervisor/conf.d/teleport_db.conf',
+    notify  => Service[$zulip::common::supervisor_service],
+  }
+}

--- a/puppet/zulip_ops/templates/teleport_db.yaml.template.erb
+++ b/puppet/zulip_ops/templates/teleport_db.yaml.template.erb
@@ -1,0 +1,41 @@
+# See https://goteleport.com/docs/config-reference/ and
+# https://goteleport.com/docs/database-access/guides/postgres-self-hosted/
+#
+# This establishes a reverse proxy back to the central auth server,
+# allowing that to connect to the postgres server running on
+# localhost:5432.  Auth is checked using role-based access control,
+# which determines which hosts, databases, and database users the
+# remote user is allowed to connect to.
+teleport:
+  ca_pin: "sha256:df15ba56d56227e288ce183d7eee77a6bef552aaaa5dc25f0f5ea56494ce14c6"
+  auth_servers:
+    # Use the proxy address, to support running the db_service, which requires
+    # a reverse tunnel.
+    - teleport.zulipchat.net:443
+
+ssh_service:
+  enabled: no
+app_service:
+  enabled: no
+proxy_service:
+  enabled: no
+auth_service:
+  enabled: no
+
+db_service:
+  enabled: yes
+  databases:
+    - name: "<%= @hostname %>"
+      protocol: "postgres"
+      uri: "localhost:5432"
+      ca_cert_file: /etc/ssl/certs/teleport-ca.crt
+      static_labels:
+        hostname: "<%= @hostname %>"
+      dynamic_labels:
+        # Every hour, refresh the label that describes if this
+        # instance is a replica; this allows access to be granted only
+        # to replicas.
+        - name: "is_replica"
+          command:
+            ["sudo", "-u", "zulip", "psql", "-tc", "select pg_is_in_recovery()"]
+          period: 1h


### PR DESCRIPTION
Host-based md5 auth for 127.0.0.1 must be removed from `pg_hba.conf`,
otherwise password authentication is preferred over certificate-based
authentication for localhost.

**Testing plan:** Applied to postgres-elegantly.
