### PR TITLE
Compose preview changes

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -411,7 +411,7 @@ input.recipient_box {
 
 a.compose_control_button {
     display: block;
-    opacity: 0.4;
+    opacity: 0.7;
     color: inherit;
     text-decoration: none;
     font-size: 15px;

--- a/static/templates/compose_control_buttons.hbs
+++ b/static/templates/compose_control_buttons.hbs
@@ -2,13 +2,13 @@
 {{#if file_upload_enabled }}
 <a role="button" class="compose_control_button compose_upload_file fa fa-paperclip notdisplayed" aria-label="{{t 'Upload files' }}" tabindex=0 data-tippy-content="{{t 'Upload files' }}"></a>
 {{/if}}
-<a role="button" class="markdown_preview compose_control_button fa fa-eye" aria-label="{{t 'Preview' }}" tabindex=0 data-tippy-content="{{t 'Preview' }}"></a>
-<a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"></a>
 <a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"></a>
 <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 data-tippy-content="{{t 'Add emoji' }}"></a>
 <a role="button" class="compose_control_button compose_giphy_link {{#unless giphy_enabled }} hide {{/unless}}" aria-label="{{t 'Add GIF' }}" data-tippy-content="{{t 'Add GIF' }}">
     <i class="compose_gif_icon zulip-icon zulip-icon-gif" tabindex=0></i>
 </a>
+<a role="button" class="message-control-link markdown_preview" tabindex=0>{{t 'Preview' }}</a>
+<a role="button" class="message-control-link undo_markdown_preview" tabindex=0 style="display:none;">{{t 'Write' }}</a>
 {{#unless hide_drafts_link}}
 <a class="message-control-link drafts-link" href="#drafts" title="{{t 'Drafts' }} (d)">{{t 'Drafts' }}</a>
 {{/unless}}


### PR DESCRIPTION
Two things:

* Increase opacity of composebox buttons
* Change "Preview" to be a link/text button, instead of a icon

**Testing plan:** Manually tested

**GIFs or screenshots:**

![2021-06-07_17 25 54_895x145](https://user-images.githubusercontent.com/5001092/121104220-6e186580-c7b6-11eb-9f2e-9b9c7a618d43.png)
![2021-06-07_17 26 00_898x143](https://user-images.githubusercontent.com/5001092/121104221-6eb0fc00-c7b6-11eb-9be6-6c1267065ccf.png)
![2021-06-07_17 26 20_908x143](https://user-images.githubusercontent.com/5001092/121104223-6eb0fc00-c7b6-11eb-8fa0-081be6d5fa03.png)
![2021-06-07_17 26 28_910x142](https://user-images.githubusercontent.com/5001092/121104224-6f499280-c7b6-11eb-89a9-3873c1c8b39e.png)