### PR TITLE
frontend_tests: Make better use of assert methods

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -488,7 +488,7 @@ test("redraw_muted_user", () => {
     };
 
     activity.redraw_user(mark.user_id);
-    assert(appended_html === undefined);
+    assert.equal(appended_html, undefined);
 });
 
 test("update_presence_info", (override) => {

--- a/frontend_tests/node_tests/compose_video.js
+++ b/frontend_tests/node_tests/compose_video.js
@@ -213,7 +213,7 @@ test("videos", (override) => {
             realm_available_video_chat_providers.big_blue_button.id;
 
         channel.get = (options) => {
-            assert(options.url === "/json/calls/bigbluebutton/create");
+            assert.equal(options.url, "/json/calls/bigbluebutton/create");
             options.success({
                 url: "/calls/bigbluebutton/join?meeting_id=%22zulip-1%22&password=%22AAAAAAAAAA%22&checksum=%2232702220bff2a22a44aee72e96cfdb4c4091752e%22",
             });

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -109,7 +109,7 @@ emoji.initialize({realm_emoji, emoji_codes});
 function assert_same(actual, expected) {
     // This helper prevents us from getting false positives
     // where actual and expected are both undefined.
-    assert(expected !== undefined);
+    assert.notEqual(expected, undefined);
     assert.deepEqual(actual, expected);
 }
 

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -106,7 +106,7 @@ function config_fake_channel(conf) {
             throw new Error("only use this for one call");
         }
         if (!conf.can_call_again) {
-            assert(self.success === undefined);
+            assert.equal(self.success, undefined);
         }
         assert.deepEqual(opts.data, conf.expected_opts_data);
         self.success = opts.success;

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -230,7 +230,7 @@ test("errors", () => {
     with_field(
         pm_conversations,
         "set_partner",
-        () => assert(false),
+        () => assert.fail(),
         () => {
             pm_conversations.process_message(message);
         },

--- a/frontend_tests/node_tests/narrow_local.js
+++ b/frontend_tests/node_tests/narrow_local.js
@@ -44,15 +44,15 @@ function test_with(fixture) {
         },
         empty: () => fixture.empty,
         all_messages: () => {
-            assert(fixture.all_messages !== undefined);
+            assert.notEqual(fixture.all_messages, undefined);
             return fixture.all_messages;
         },
         first: () => {
-            assert(fixture.all_messages !== undefined);
+            assert.notEqual(fixture.all_messages, undefined);
             return fixture.all_messages[0];
         },
         last: () => {
-            assert(fixture.all_messages !== undefined);
+            assert.notEqual(fixture.all_messages, undefined);
             return fixture.all_messages[fixture.all_messages.length - 1];
         },
     };

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -279,20 +279,10 @@ run_test("move_array_elements_to_front", () => {
         "something@zulip.com",
     ];
     const emails_actual = util.move_array_elements_to_front(emails, emails_selection);
-    let i;
-    assert(strings_no_selection.length === strings.length);
-    for (i = 0; i < strings_no_selection.length; i += 1) {
-        assert(strings_no_selection[i] === strings[i]);
-    }
-    assert(strings_no_array.length === 0);
-    assert(strings_actual.length === strings_expected.length);
-    for (i = 0; i < strings_actual.length; i += 1) {
-        assert(strings_actual[i] === strings_expected[i]);
-    }
-    assert(emails_actual.length === emails_expected.length);
-    for (i = 0; i < emails_actual.length; i += 1) {
-        assert(emails_actual[i] === emails_expected[i]);
-    }
+    assert.deepEqual(strings_no_selection, strings);
+    assert.deepEqual(strings_no_array, []);
+    assert.deepEqual(strings_actual, strings_expected);
+    assert.deepEqual(emails_actual, emails_expected);
 });
 
 run_test("clean_user_content_links", () => {

--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -466,7 +466,7 @@ class CommonUtils {
         await page.waitForSelector("#settings_overlay_container.show", {visible: true});
 
         const url = await this.page_url_with_fragment(page);
-        assert(/^http:\/\/[^/]+\/#organization/.test(url), "Unexpected manage organization URL");
+        assert.match(url, /^http:\/\/[^/]+\/#organization/, "Unexpected manage organization URL");
 
         const organization_settings_data_section = "li[data-section='organization-settings']";
         await page.click(organization_settings_data_section);

--- a/frontend_tests/puppeteer_tests/realm-creation.ts
+++ b/frontend_tests/puppeteer_tests/realm-creation.ts
@@ -46,7 +46,7 @@ async function realm_creation_tests(page: Page): Promise<void> {
     const text_in_pitch = await page.evaluate(
         () => document.querySelector(".pitch p")!.textContent,
     );
-    assert(text_in_pitch === "You’re almost there! We just need you to do one last thing.");
+    assert.equal(text_in_pitch, "You’re almost there! We just need you to do one last thing.");
 
     // fill the form.
     const params = {

--- a/frontend_tests/puppeteer_tests/settings.ts
+++ b/frontend_tests/puppeteer_tests/settings.ts
@@ -90,12 +90,12 @@ async function test_get_api_key(page: Page): Promise<void> {
 
     await page.waitForSelector("#show_api_key", {visible: true});
     const api_key = await common.get_text_from_selector(page, "#api_key_value");
-    assert(/[\dA-Za-z]{32}/.test(api_key), "Incorrect API key format.");
+    assert.match(api_key, /[\dA-Za-z]{32}/, "Incorrect API key format.");
 
     const download_zuliprc_selector = "#download_zuliprc";
     await page.click(download_zuliprc_selector);
     const zuliprc_decoded_url = await get_decoded_url_in_selector(page, download_zuliprc_selector);
-    assert(zuliprc_regex.test(zuliprc_decoded_url), "Incorrect zuliprc file");
+    assert.match(zuliprc_decoded_url, zuliprc_regex, "Incorrect zuliprc file");
     await page.click("#api_key_modal .close");
     await common.wait_for_modal_to_close(page);
 }
@@ -121,8 +121,9 @@ async function test_webhook_bot_creation(page: Page): Promise<void> {
     await page.click(download_zuliprc_selector);
 
     const zuliprc_decoded_url = await get_decoded_url_in_selector(page, download_zuliprc_selector);
-    assert(
-        outgoing_webhook_zuliprc_regex.test(zuliprc_decoded_url),
+    assert.match(
+        zuliprc_decoded_url,
+        outgoing_webhook_zuliprc_regex,
         "Incorrect outgoing webhook bot zulirc format",
     );
 }
@@ -147,7 +148,7 @@ async function test_normal_bot_creation(page: Page): Promise<void> {
     await page.waitForSelector(download_zuliprc_selector, {visible: true});
     await page.click(download_zuliprc_selector);
     const zuliprc_decoded_url = await get_decoded_url_in_selector(page, download_zuliprc_selector);
-    assert(zuliprc_regex.test(zuliprc_decoded_url), "Incorrect zuliprc format for bot.");
+    assert.match(zuliprc_decoded_url, zuliprc_regex, "Incorrect zuliprc format for bot.");
 }
 
 async function test_botserverrc(page: Page): Promise<void> {
@@ -159,7 +160,7 @@ async function test_botserverrc(page: Page): Promise<void> {
     );
     const botserverrc_regex =
         /^data:application\/octet-stream;charset=utf-8,\[]\nemail=.+\nkey=.+\nsite=.+\ntoken=.+\n$/;
-    assert(botserverrc_regex.test(botserverrc_decoded_url), "Incorrect botserverrc format.");
+    assert.match(botserverrc_decoded_url, botserverrc_regex, "Incorrect botserverrc format.");
 }
 
 async function test_edit_bot_form(page: Page): Promise<void> {

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -516,7 +516,7 @@ function make_zjquery() {
         // in turn return stubs).  The convention is that
         // they provide a to_$ attribute.
         if (arg.to_$) {
-            assert(typeof arg.to_$ === "function");
+            assert.equal(typeof arg.to_$, "function");
             return arg.to_$();
         }
 


### PR DESCRIPTION
`assert.foo()` methods give more specific error messages than `assert()`.