### PR TITLE
fixed internal server error when gathering subscriptions for stream without recipient id

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3486,6 +3486,8 @@ def bulk_get_subscriber_user_ids(
         stream_id = stream_dict["id"]
         is_subscribed = stream_id in subscribed_stream_ids
 
+        if stream_dict.get("recipient_id") is None:
+            continue
         try:
             validate_user_access_to_subscribers_helper(
                 user_profile,


### PR DESCRIPTION
Since `Stream.recipient_id` field can be null, gathering subscribers will always cause internal server error if you have such stream. It is better to return not full data and investigate why my stream was created without recipient as a separate task.

It fails few rows below at
`recipient_ids = sorted([stream["recipient_id"] for stream in target_stream_dicts])`
with error 
`TypeError: '<' not supported between instances of 'NoneType' and 'int'`