### PR TITLE
puppet: Add a label to teleport applications, to allow RBAC.

### DIFF
--- a/puppet/zulip_ops/manifests/profile/nagios.pp
+++ b/puppet/zulip_ops/manifests/profile/nagios.pp
@@ -57,7 +57,10 @@ class zulip_ops::profile::nagios {
     ],
     notify  => Service['apache2'],
   }
-  zulip_ops::teleport::application{ 'nagios': port => '3000' }
+  zulip_ops::teleport::application{ 'nagios':
+    description => 'Monitoring: nagios and munin',
+    port        => '3000',
+  }
 
   file { '/etc/nagios3/conf.d/contacts.cfg':
     require => Package[nagios3],

--- a/puppet/zulip_ops/manifests/teleport/application.pp
+++ b/puppet/zulip_ops/manifests/teleport/application.pp
@@ -3,11 +3,12 @@
 # See https://goteleport.com/docs/application-access/
 define zulip_ops::teleport::application (
   $port,
+  $description = '',
   $order = '50',
 ) {
   concat::fragment { "teleport_app_${name}":
     target  => '/etc/teleport_node.yaml',
     order   => $order,
-    content => "    - name: ${name}\n      uri: http://127.0.0.1:${port}\n",
+    content => template('zulip_ops/teleport_app.yaml.template.erb'),
   }
 }

--- a/puppet/zulip_ops/templates/teleport_app.yaml.template.erb
+++ b/puppet/zulip_ops/templates/teleport_app.yaml.template.erb
@@ -1,0 +1,8 @@
+<%# This is appended to puppet/zulip_ops/files/teleport_node.yaml, so should be
+    indented.  Specifically, the "-" should be in the same column as the "T" at
+    the start of this comment. -%>
+    - name: "<%= @name %>"
+      description: "<%= @description %>"
+      uri: "http://127.0.0.1:<%= @port %>"
+      labels:
+        name: "<%= @name %>"


### PR DESCRIPTION
Roles can only grant or deny access based on labels; set one based on
the application name.

**Testing plan:** Test-applied.
