### PR TITLE
puppet: Turn on "authentication" which defaults to user with all rights.

### DIFF
--- a/puppet/zulip_ops/templates/nagios3/cgi.cfg.template.erb
+++ b/puppet/zulip_ops/templates/nagios3/cgi.cfg.template.erb
@@ -88,7 +88,7 @@ nagios_check_command=/usr/lib/nagios/plugins/check_nagios /var/cache/nagios3/sta
 # authentication (bad idea), while any other value will make them
 # use the authentication functions (the default).
 
-use_authentication=0
+use_authentication=1
 
 
 
@@ -117,7 +117,7 @@ use_ssl_authentication=0
 # define this variable, anyone who has not authenticated to the web
 # server will inherit all rights you assign to this user!
 
-#default_user_name=guest
+default_user_name=nagiosadmin
 
 
 


### PR DESCRIPTION
Nagios refuses to allow any modifications with use_authentication off;
re-enabled "authentication" but set a default user, which (by way of
the `*` permissions in 359f37389a17) is allowed to take all actions.

----

A more robust approach would use e.g. https://github.com/AnthonyDeroche/mod_authnz_jwt to auth with the JWT that teleport presents, but that's not all that necessary here.