### PR TITLE
webpack: Fix CSS source map generation on 1-CPU systems

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -189,7 +189,11 @@ export default (_env: unknown, argv: {mode?: string}): webpack.Configuration[] =
                         const out = new CleanCSS({sourceMap: true}).minify({
                             [filename]: {styles, sourceMap},
                         });
-                        return {css: out.styles, map: out.sourceMap, warnings: out.warnings};
+                        return {
+                            css: out.styles,
+                            map: out.sourceMap.toString(),
+                            warnings: out.warnings,
+                        };
                     },
                 }),
                 new TerserPlugin({


### PR DESCRIPTION
We were passing a `SourceMapGenerator` as `map`, but it seems that css-minimizer-webpack-plugin expects a string, and only implicitly stringifies it when running with parallelism.

Fixes #18727.