### PR TITLE
tippy: Fix reaction tooltip placement when message-fade is active.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -52,14 +52,16 @@ export function initialize() {
     // message reaction tooltip showing who reacted.
     let observer;
     delegate("body", {
-        target: ".message_reaction",
+        target: ".message_reaction, .reaction_button",
         placement: "bottom",
         onShow(instance) {
             const elem = $(instance.reference);
-            const local_id = elem.attr("data-reaction-id");
-            const message_id = rows.get_message_id(instance.reference);
-            const title = reactions.get_reaction_title_data(message_id, local_id);
-            instance.setContent(title);
+            if (!instance.reference.classList.contains("reaction_button")) {
+                const local_id = elem.attr("data-reaction-id");
+                const message_id = rows.get_message_id(instance.reference);
+                const title = reactions.get_reaction_title_data(message_id, local_id);
+                instance.setContent(title);
+            }
 
             // Use MutationObserver to check for removal of nodes on which tooltips
             // are still active.

--- a/static/templates/message_reactions.hbs
+++ b/static/templates/message_reactions.hbs
@@ -1,7 +1,7 @@
 {{#each this/msg/message_reactions}}
 {{> message_reaction}}
 {{/each}}
-<div class="reaction_button tippy-zulip-tooltip" data-tippy-content="{{t 'Add emoji reaction' }}" aria-label="{{t 'Add emoji reaction' }} (:)">
+<div class="reaction_button" data-tippy-content="{{t 'Add emoji reaction' }}" aria-label="{{t 'Add emoji reaction' }} (:)">
     <i class="fa fa-smile-o" role="button" aria-haspopup="true" tabindex="0" aria-label="{{t 'Add emoji reaction' }} (:)"></i>
     <div class="message_reaction_count">+</div>
 </div>


### PR DESCRIPTION
discussion - https://chat.zulip.org/#narrow/stream/6-frontend/topic/tippy.20bug
When message for which tooltip is active has reduced opacity in
an interleaved view due `.message-fade` class being applied to
it, then the tooltip used stack vertically under the recipient_row
which looked awful.

Appending the tooltip to document.body and manually fixing the
bug of tooltip persisting after the reference element is no
longer visible in DOM using MutationObserver does the trick
for us.