### PR TITLE
activity: Show the effective rate of the realms in /activity page

### DIFF
--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -18,15 +18,17 @@ from zerver.lib.actions import (
     do_set_realm_property,
 )
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import reset_emails_in_zulip_realm
+from zerver.lib.test_helpers import queries_captured, reset_emails_in_zulip_realm
 from zerver.lib.timestamp import ceiling_to_day, ceiling_to_hour, datetime_to_timestamp
 from zerver.models import (
     Client,
     MultiuseInvite,
     PreregistrationUser,
     Realm,
+    UserActivity,
     UserMessage,
     UserProfile,
+    flush_per_request_caches,
     get_realm,
 )
 
@@ -1144,6 +1146,53 @@ class TestGetChartDataHelpers(ZulipTestCase):
             "user": {"a": [6], "b": [5], "d": [4], "e": [3], "f": [2], "g": [1]},
         }
         self.assertEqual(sort_client_labels(data), ["a", "b", "c", "d", "e", "f", "g", "h"])
+
+
+class ActivityTest(ZulipTestCase):
+    @mock.patch("stripe.Customer.list", return_value=[])
+    def test_activity(self, unused_mock: mock.Mock) -> None:
+        self.login("hamlet")
+        client, _ = Client.objects.get_or_create(name="website")
+        query = "/json/messages/flags"
+        last_visit = timezone_now()
+        count = 150
+        for activity_user_profile in UserProfile.objects.all():
+            UserActivity.objects.get_or_create(
+                user_profile=activity_user_profile,
+                client=client,
+                query=query,
+                count=count,
+                last_visit=last_visit,
+            )
+
+        # Fails when not staff
+        result = self.client_get("/activity")
+        self.assertEqual(result.status_code, 302)
+
+        user_profile = self.example_user("hamlet")
+        user_profile.is_staff = True
+        user_profile.save(update_fields=["is_staff"])
+
+        flush_per_request_caches()
+        with queries_captured() as queries:
+            result = self.client_get("/activity")
+            self.assertEqual(result.status_code, 200)
+
+        self.assert_length(queries, 19)
+
+        flush_per_request_caches()
+        with queries_captured() as queries:
+            result = self.client_get("/realm_activity/zulip/")
+            self.assertEqual(result.status_code, 200)
+
+        self.assert_length(queries, 8)
+
+        flush_per_request_caches()
+        with queries_captured() as queries:
+            result = self.client_get("/user_activity/iago@zulip.com/")
+            self.assertEqual(result.status_code, 200)
+
+        self.assert_length(queries, 4)
 
 
 class TestTimeRange(ZulipTestCase):

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -760,7 +760,7 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
             row["history"] = ""
 
     # estimate annual subscription revenue
-    total_amount = 0
+    total_arr = 0
     if settings.BILLING_ENABLED:
         estimated_arrs = estimate_annual_recurring_revenue_by_realm()
         realms_to_default_discount = get_realms_to_default_discount_dict()
@@ -771,7 +771,7 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
             string_id = row["string_id"]
 
             if string_id in estimated_arrs:
-                row["amount"] = estimated_arrs[string_id]
+                row["arr"] = estimated_arrs[string_id]
 
             if row["plan_type"] == Realm.STANDARD:
                 row["effective_rate"] = 100 - int(realms_to_default_discount.get(string_id, 0))
@@ -782,7 +782,7 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
             else:
                 row["effective_rate"] = ""
 
-        total_amount += sum(estimated_arrs.values())
+        total_arr += sum(estimated_arrs.values())
 
     # augment data with realm_minutes
     total_hours = 0.0
@@ -822,8 +822,8 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
     total_row = dict(
         string_id="Total",
         plan_type_string="",
-        amount=total_amount,
         effective_rate="",
+        arr=total_arr,
         stats_link="",
         date_created_day="",
         realm_owner_emails="",

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -747,7 +747,6 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
 
     for row in rows:
         row["date_created_day"] = row["date_created"].strftime("%Y-%m-%d")
-        row["plan_type_string"] = get_plan_name(row["plan_type"])
         row["age_days"] = int((now - row["date_created"]).total_seconds() / 86400)
         row["is_new"] = row["age_days"] < 12 * 7
         row["realm_owner_emails"] = ", ".join(realm_owners[row["string_id"]])
@@ -767,6 +766,8 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
         realms_to_default_discount = get_realms_to_default_discount_dict()
 
         for row in rows:
+            row["plan_type_string"] = get_plan_name(row["plan_type"])
+
             string_id = row["string_id"]
 
             if string_id in estimated_arrs:
@@ -837,7 +838,12 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
 
     content = loader.render_to_string(
         "analytics/realm_summary_table.html",
-        dict(rows=rows, num_active_sites=num_active_sites, utctime=now.strftime("%Y-%m-%d %H:%MZ")),
+        dict(
+            rows=rows,
+            num_active_sites=num_active_sites,
+            utctime=now.strftime("%Y-%m-%d %H:%MZ"),
+            billing_enabled=settings.BILLING_ENABLED,
+        ),
     )
     return content
 

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -891,6 +891,14 @@ def estimate_annual_recurring_revenue_by_realm() -> Dict[str, int]:  # nocoverag
     return annual_revenue
 
 
+def get_realms_to_default_discount_dict() -> Dict[str, Decimal]:
+    realms_to_default_discount = {}
+    customers = Customer.objects.exclude(default_discount=None).exclude(default_discount=0)
+    for customer in customers:
+        realms_to_default_discount[customer.realm.string_id] = customer.default_discount
+    return realms_to_default_discount
+
+
 # During realm deactivation we instantly downgrade the plan to Limited.
 # Extra users added in the final month are not charged. Also used
 # for the cancellation of Free Trial.

--- a/templates/analytics/realm_summary_table.html
+++ b/templates/analytics/realm_summary_table.html
@@ -59,8 +59,8 @@
             </td>
 
             <td class="number">
-                {% if row.amount %}
-                {{ row.amount }}
+                {% if row.arr %}
+                {{ row.arr }}
                 {% endif %}
             </td>
 

--- a/templates/analytics/realm_summary_table.html
+++ b/templates/analytics/realm_summary_table.html
@@ -24,6 +24,7 @@
             <th>Created (green if ≤12wk)</th>
             <th>Plan type</th>
             <th>ARR</th>
+            <th>Effective rate (%)</th>
             <th></th>
             <th>DAU</th>
             <th>WAU</th>
@@ -57,6 +58,12 @@
             <td class="number">
                 {% if row.amount %}
                 {{ row.amount }}
+                {% endif %}
+            </td>
+
+            <td class="number">
+                {% if row.effective_rate != "" %}
+                {{ row.effective_rate }}
                 {% endif %}
             </td>
 

--- a/templates/analytics/realm_summary_table.html
+++ b/templates/analytics/realm_summary_table.html
@@ -22,9 +22,11 @@
         <tr>
             <th>Realm</th>
             <th>Created (green if ≤12wk)</th>
+            {% if billing_enabled %}
             <th>Plan type</th>
             <th>ARR</th>
             <th>Effective rate (%)</th>
+            {% endif %}
             <th></th>
             <th>DAU</th>
             <th>WAU</th>
@@ -51,6 +53,7 @@
                 {{ row.date_created_day }}
             </td>
 
+            {% if billing_enabled %}
             <td>
                 {{ row.plan_type_string }}
             </td>
@@ -66,6 +69,7 @@
                 {{ row.effective_rate }}
                 {% endif %}
             </td>
+            {% endif %}
 
             <td>
                 {% if not loop.first %}

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -45,7 +45,7 @@ class ActivityTest(ZulipTestCase):
 
         user_profile = self.example_user("hamlet")
         user_profile.is_staff = True
-        user_profile.save()
+        user_profile.save(update_fields=["is_staff"])
 
         flush_per_request_caches()
         with queries_captured() as queries:

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -9,64 +9,15 @@ from zerver.lib.actions import do_deactivate_user
 from zerver.lib.presence import get_status_dict_by_realm
 from zerver.lib.statistics import seconds_usage_between
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import make_client, queries_captured, reset_emails_in_zulip_realm
+from zerver.lib.test_helpers import make_client, reset_emails_in_zulip_realm
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.models import (
-    Client,
     PushDeviceToken,
     UserActivity,
     UserActivityInterval,
     UserPresence,
     UserProfile,
-    flush_per_request_caches,
 )
-
-
-class ActivityTest(ZulipTestCase):
-    @mock.patch("stripe.Customer.list", return_value=[])
-    def test_activity(self, unused_mock: mock.Mock) -> None:
-        self.login("hamlet")
-        client, _ = Client.objects.get_or_create(name="website")
-        query = "/json/messages/flags"
-        last_visit = timezone_now()
-        count = 150
-        for activity_user_profile in UserProfile.objects.all():
-            UserActivity.objects.get_or_create(
-                user_profile=activity_user_profile,
-                client=client,
-                query=query,
-                count=count,
-                last_visit=last_visit,
-            )
-
-        # Fails when not staff
-        result = self.client_get("/activity")
-        self.assertEqual(result.status_code, 302)
-
-        user_profile = self.example_user("hamlet")
-        user_profile.is_staff = True
-        user_profile.save(update_fields=["is_staff"])
-
-        flush_per_request_caches()
-        with queries_captured() as queries:
-            result = self.client_get("/activity")
-            self.assertEqual(result.status_code, 200)
-
-        self.assert_length(queries, 19)
-
-        flush_per_request_caches()
-        with queries_captured() as queries:
-            result = self.client_get("/realm_activity/zulip/")
-            self.assertEqual(result.status_code, 200)
-
-        self.assert_length(queries, 8)
-
-        flush_per_request_caches()
-        with queries_captured() as queries:
-            result = self.client_get("/user_activity/iago@zulip.com/")
-            self.assertEqual(result.status_code, 200)
-
-        self.assert_length(queries, 4)
 
 
 class TestClientModel(ZulipTestCase):

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -52,7 +52,7 @@ class ActivityTest(ZulipTestCase):
             result = self.client_get("/activity")
             self.assertEqual(result.status_code, 200)
 
-        self.assert_length(queries, 18)
+        self.assert_length(queries, 19)
 
         flush_per_request_caches()
         with queries_captured() as queries:


### PR DESCRIPTION
Screenshot showing the discount in /activity. analytics and realm-24 have a non zero discount attached to it.

![Screenshot from 2021-06-09 21-37-10](https://user-images.githubusercontent.com/7190633/121390395-f50e3f00-c96a-11eb-8ae4-09fb670d03c9.png)


When settings.BILLING_ENABLED is set to False discount, ARR and plan_type is hidden.

![Screenshot from 2021-06-09 21-37-37](https://user-images.githubusercontent.com/7190633/121390415-f93a5c80-c96a-11eb-96af-aaf5e2e454b1.png)

