### PR TITLE
Create a common "edit_fields_modal" widget for modals containing forms.

### DIFF
--- a/frontend_tests/puppeteer_tests/realm-linkifier.ts
+++ b/frontend_tests/puppeteer_tests/realm-linkifier.ts
@@ -56,14 +56,14 @@ async function test_add_invalid_linkifier_pattern(page: Page): Promise<void> {
 
 async function test_edit_linkifier(page: Page): Promise<void> {
     await page.click(".linkifier_row .edit");
-    await page.waitForFunction(() => document.activeElement?.id === "linkifier-edit-form-modal");
+    await page.waitForFunction(() => document.activeElement?.id === "edit-fields-modal");
     await common.fill_form(page, "form.linkifier-edit-form", {
         pattern: "(?P<num>[0-9a-f]{40})",
         url_format_string: "https://trac.example.com/commit/%(num)s",
     });
-    await page.click(".submit-linkifier-info-change");
+    await page.click(".submit-modal-button");
 
-    await page.waitForSelector("#linkifier-edit-form-modal", {hidden: true});
+    await page.waitForSelector("#edit-fields-modal", {hidden: true});
     await common.wait_for_modal_to_close(page);
 
     await page.waitForSelector(".linkifier_row", {visible: true});
@@ -81,12 +81,12 @@ async function test_edit_linkifier(page: Page): Promise<void> {
 
 async function test_edit_invalid_linkifier(page: Page): Promise<void> {
     await page.click(".linkifier_row .edit");
-    await page.waitForFunction(() => document.activeElement?.id === "linkifier-edit-form-modal");
+    await page.waitForFunction(() => document.activeElement?.id === "edit-fields-modal");
     await common.fill_form(page, "form.linkifier-edit-form", {
         pattern: "####",
         url_format_string: "####",
     });
-    await page.click(".submit-linkifier-info-change");
+    await page.click(".submit-modal-button");
 
     const edit_linkifier_pattern_status_selector = "div#edit-linkifier-status";
     await page.waitForSelector(edit_linkifier_pattern_status_selector, {visible: true});
@@ -110,8 +110,8 @@ async function test_edit_invalid_linkifier(page: Page): Promise<void> {
         "Failed: Enter a valid URL.,Invalid URL format string.",
     );
 
-    await page.click(".cancel-linkifier-info-change");
-    await page.waitForSelector("#linkifier-edit-form-modal", {hidden: true});
+    await page.click(".close-modal-button");
+    await page.waitForSelector("#edit-fields-modal", {hidden: true});
 
     await page.waitForSelector(".linkifier_row", {visible: true});
     assert.strictEqual(

--- a/static/js/edit_fields_modal.js
+++ b/static/js/edit_fields_modal.js
@@ -1,0 +1,67 @@
+import $ from "jquery";
+
+import render_edit_fields_modal from "../templates/settings/edit_fields_modal.hbs";
+
+import * as blueslip from "./blueslip";
+import * as overlays from "./overlays";
+
+/*
+    Look for edit_fields_modal in settings_users.js to see an
+    example of how to use this widget.
+
+    Some things to note:
+
+        1) We create the DOM elements on the fly, and we remove the
+           DOM elements once it's closed.
+
+        2) We attach the DOM elements for the modal to modal_fields.parent.
+
+        3) The cancel button is driven by bootstrap.js.
+
+        4) We do not handle closing the modal on clicking "Save
+           changes" here, because some modals show errors, if the
+           request fails, in the modal itself without closing.
+
+        5) If a caller needs to run code after the modal body is added
+           to DOM, it can do so by passing a post_render hook.
+*/
+
+export function launch(modal_fields) {
+    const required_modal_fields = ["modal_label", "parent", "modal_body_html", "on_click"];
+
+    for (const field of required_modal_fields) {
+        if (!modal_fields[field]) {
+            blueslip.error("programmer omitted " + field);
+        }
+    }
+
+    const html = render_edit_fields_modal({
+        modal_label: modal_fields.modal_label,
+    });
+    const edit_fields_modal = $(html);
+    modal_fields.parent.append(edit_fields_modal);
+
+    if (overlays.is_modal_open()) {
+        overlays.close_modal("#edit-fields-modal");
+    }
+
+    edit_fields_modal.find(".edit-fields-modal-body").html(modal_fields.modal_body_html);
+
+    if (modal_fields.post_render !== undefined) {
+        modal_fields.post_render();
+    }
+
+    // Set up handlers.
+    $(".submit-modal-button").on("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        modal_fields.on_click();
+    });
+
+    edit_fields_modal.on("hidden.bs.modal", () => {
+        edit_fields_modal.remove();
+    });
+
+    // Open the modal
+    overlays.open_modal("#edit-fields-modal");
+}

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1528,7 +1528,7 @@ input[type="checkbox"] {
 }
 
 #account-settings,
-#admin-human-form {
+#user-name-form {
     .user-role button {
         cursor: default;
     }

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1930,15 +1930,15 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     }
 }
 
-#linkifier-edit-form-modal {
+#edit-fields-modal-status {
+    margin-top: 6px;
+    margin-bottom: 8px;
+}
+
+#edit-linkifier-form {
     #edit-linkifier-pattern,
     #edit-linkifier-url-format-string {
         width: 400px;
-    }
-
-    #edit-linkifier-status {
-        margin-top: 6px;
-        margin-bottom: 8px;
     }
 
     label {

--- a/static/templates/settings/admin_bot_form.hbs
+++ b/static/templates/settings/admin_bot_form.hbs
@@ -1,32 +1,20 @@
-<div id="admin-bot-form" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="admin-bot-form-label" aria-hidden="true">
-    <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-        <h3 id="admin-bot-form-label">{{t "Change bot info and owner" }}</h3>
-    </div>
-    <div class="modal-body">
-        <div id="user-name-form" data-user-id="{{user_id}}">
-            <form class="form-horizontal name-setting">
-                <input type="hidden" name="is_full_name" value="true" />
-                <div class="input-group edit_bot_owner_container">
-                    <label for="bot_owner_select">{{t "Owner" }}</label>
-                    {{> dropdown_list_widget
-                      widget_name="edit_bot_owner"
-                      list_placeholder=(t 'Filter users')
-                      reset_button_text=(t '[Remove owner]')}}
-                </div>
-                <div class="input-group name_change_container">
-                    <label for="full_name">{{t "Full name" }}</label>
-                    <input type="text" autocomplete="off" name="full_name" value="{{ full_name }}" />
-                </div>
-                <div class="input-group email_change_container">
-                    <label for="email">{{t "Email" }}</label>
-                    <input type="text" autocomplete="off" name="email" value="{{ email }}" readonly/>
-                </div>
-            </form>
+<div id="bot-edit-form" data-user-id="{{user_id}}">
+    <form class="form-horizontal name-setting">
+        <input type="hidden" name="is_full_name" value="true" />
+        <div class="input-group edit_bot_owner_container">
+            <label for="bot_owner_select">{{t "Owner" }}</label>
+            {{> dropdown_list_widget
+              widget_name="edit_bot_owner"
+              list_placeholder=(t 'Filter users')
+              reset_button_text=(t '[Remove owner]')}}
         </div>
-    </div>
-    <div class="modal-footer">
-        <button type="submit" class="button rounded sea-green submit_bot_change">{{t 'Save changes' }}</button>
-        <button type="button" class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
-    </div>
+        <div class="input-group name_change_container">
+            <label for="full_name">{{t "Full name" }}</label>
+            <input type="text" autocomplete="off" name="full_name" value="{{ full_name }}" />
+        </div>
+        <div class="input-group email_change_container">
+            <label for="email">{{t "Email" }}</label>
+            <input type="text" autocomplete="off" name="email" value="{{ email }}" readonly/>
+        </div>
+    </form>
 </div>

--- a/static/templates/settings/admin_human_form.hbs
+++ b/static/templates/settings/admin_human_form.hbs
@@ -1,34 +1,22 @@
-<div id="admin-human-form" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="admin-human-form-label" aria-hidden="true">
-    <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-        <h3 id="admin-human-form-label">{{t "Change user info and roles" }}</h3>
-    </div>
-    <div class="modal-body">
-        <div id="user-name-form" data-user-id="{{user_id}}">
-            <form class="form-horizontal name-setting">
-                <input type="hidden" name="is_full_name" value="true" />
-                <div class="input-group name_change_container">
-                    <label for="full_name">{{t "Full name" }}</label>
-                    <input type="text" autocomplete="off" name="full_name" value="{{ full_name }}" />
-                </div>
-                <div class="input-group email_change_container">
-                    <label for="email">{{t "Email" }}</label>
-                    <input type="text" autocomplete="off" name="email" value="{{ email }}" readonly/>
-                </div>
-                <div class="input-group">
-                    <label class="input-label" for="user-role-select">{{t 'User role' }}
-                        {{> ../help_link_widget link="/help/roles-and-permissions" }}
-                    </label>
-                    <select name="user-role-select" id="user-role-select" data-setting-widget-type="number" {{#if disable_role_dropdown}}disabled{{/if}}>
-                        {{> dropdown_options_widget option_values=user_role_values}}
-                    </select>
-                </div>
-                <div class="custom-profile-field-form"></div>
-            </form>
+<div id="user-name-form" data-user-id="{{user_id}}">
+    <form class="form-horizontal name-setting">
+        <input type="hidden" name="is_full_name" value="true" />
+        <div class="input-group name_change_container">
+            <label for="full_name">{{t "Full name" }}</label>
+            <input type="text" autocomplete="off" name="full_name" value="{{ full_name }}" />
         </div>
-    </div>
-    <div class="modal-footer">
-        <button type="submit" class="button rounded sea-green submit_human_change">{{t 'Save changes' }}</button>
-        <button type="button" class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
-    </div>
+        <div class="input-group email_change_container">
+            <label for="email">{{t "Email" }}</label>
+            <input type="text" autocomplete="off" name="email" value="{{ email }}" readonly/>
+        </div>
+        <div class="input-group">
+            <label class="input-label" for="user-role-select">{{t 'User role' }}
+                {{> ../help_link_widget link="/help/roles-and-permissions" }}
+            </label>
+            <select name="user-role-select" id="user-role-select" data-setting-widget-type="number" {{#if disable_role_dropdown}}disabled{{/if}}>
+                {{> dropdown_options_widget option_values=user_role_values}}
+            </select>
+        </div>
+        <div class="custom-profile-field-form"></div>
+    </form>
 </div>

--- a/static/templates/settings/admin_linkifier_edit_form.hbs
+++ b/static/templates/settings/admin_linkifier_edit_form.hbs
@@ -1,27 +1,14 @@
-<div id="linkifier-edit-form-modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="linkifier-edit-form-modal-label" aria-hidden="true">
-    <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-        <h3 id="linkifier-edit-form-modal-label">{{t "Edit linkifiers" }}</h3>
-        <div class="alert" id="edit-linkifier-status"></div>
-    </div>
-    <div class="modal-body">
-        <div id="edit-linkifier-form">
-            <form class="form-horizontal linkifier-edit-form">
-                <div class="input-group name_change_container">
-                    <label for="edit-linkifier-pattern" >{{t "Pattern" }}</label>
-                    <input type="text" autocomplete="off" id="edit-linkifier-pattern" name="pattern" placeholder="#(?P<id>[0-9]+)" value="{{ pattern }}" />
-                    <div class="alert" id="edit-linkifier-pattern-status"></div>
-                </div>
-                <div class="input-group name_change_container">
-                    <label for="edit-linkifier-url-format-string" >{{t "URL format string" }}</label>
-                    <input type="text" autocomplete="off" id="edit-linkifier-url-format-string" name="url_format_string" placeholder="https://github.com/zulip/zulip/issues/%(id)s" value="{{ url_format_string }}" />
-                    <div class="alert" id="edit-linkifier-format-status"></div>
-                </div>
-            </form>
+<div id="edit-linkifier-form">
+    <form class="form-horizontal linkifier-edit-form">
+        <div class="input-group name_change_container">
+            <label for="edit-linkifier-pattern" >{{t "Pattern" }}</label>
+            <input type="text" autocomplete="off" id="edit-linkifier-pattern" name="pattern" placeholder="#(?P<id>[0-9]+)" value="{{ pattern }}" />
+            <div class="alert" id="edit-linkifier-pattern-status"></div>
         </div>
-    </div>
-    <div class="modal-footer">
-        <button type="submit" class="button rounded sea-green submit-linkifier-info-change">{{t "Save changes" }}</button>
-        <button type="button" class="button rounded cancel-linkifier-info-change" data-dismiss="modal">{{t "Cancel" }}</button>
-    </div>
+        <div class="input-group name_change_container">
+            <label for="edit-linkifier-url-format-string" >{{t "URL format string" }}</label>
+            <input type="text" autocomplete="off" id="edit-linkifier-url-format-string" name="url_format_string" placeholder="https://github.com/zulip/zulip/issues/%(id)s" value="{{ url_format_string }}" />
+            <div class="alert" id="edit-linkifier-format-status"></div>
+        </div>
+    </form>
 </div>

--- a/static/templates/settings/edit_fields_modal.hbs
+++ b/static/templates/settings/edit_fields_modal.hbs
@@ -1,0 +1,12 @@
+<div id="edit-fields-modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="edit-fields-modal-label" aria-hidden="true">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        <h3 id="edit-fields-modal-label">{{modal_label}}</h3>
+        <div class="alert" id="edit-fields-modal-status"></div>
+    </div>
+    <div class="modal-body edit-fields-modal-body"></div>
+    <div class="modal-footer">
+        <button type="submit" class="button rounded sea-green submit-modal-button">{{t 'Save changes' }}</button>
+        <button type="button" class="button rounded close-modal-button" data-dismiss="modal">{{t "Cancel" }}</button>
+    </div>
+</div>

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -134,6 +134,7 @@ js_rules = RuleList(
                 "static/js/lightbox.js",
                 "static/js/ui_report.ts",
                 "static/js/confirm_dialog.js",
+                "static/js/edit_fields_modal.js",
                 "frontend_tests/",
             },
             "description": "Setting HTML content with jQuery .html() can lead to XSS security bugs.  Consider .text() or using rendered_foo as a variable name if content comes from handlebars and thus is already sanitized.",

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -60,6 +60,7 @@ EXEMPT_FILES = {
     "static/js/desktop_integration.js",
     "static/js/drafts.js",
     "static/js/echo.js",
+    "static/js/edit_fields_modal.js",
     "static/js/emoji_picker.js",
     "static/js/emojisets.js",
     "static/js/favicon.js",


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR creates a new `edit_fields_modal` widget, similar to `confirm_modal` widget
for modals like linkifier edit modal, user info edit modal, and bot-info edit modal.

<!-- How have you tested? -->


**Screenshots**<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
**Linkfiier edit modal**
_Before_
![Screenshot from 2021-06-09 22-00-58](https://user-images.githubusercontent.com/35494118/121581114-20685b00-ca4b-11eb-94b4-935f1f740a37.png)
_After_
![Screenshot from 2021-06-11 00-15-25](https://user-images.githubusercontent.com/35494118/121581147-252d0f00-ca4b-11eb-9e79-5de4693d5b58.png)

**Bot profile edit modal**
_Before_
![Screenshot from 2021-06-09 22-00-38](https://user-images.githubusercontent.com/35494118/121581359-5e657f00-ca4b-11eb-91bd-d01e95699075.png)
_After_
![Screenshot from 2021-06-11 00-15-03](https://user-images.githubusercontent.com/35494118/121581388-658c8d00-ca4b-11eb-8d9a-abfb5a991bc5.png)

**User profile edit modal**
_Before_
![Screenshot from 2021-06-09 22-00-14](https://user-images.githubusercontent.com/35494118/121581616-a4bade00-ca4b-11eb-9aca-39970b005c75.png)
_After_
![Screenshot from 2021-06-11 00-14-46](https://user-images.githubusercontent.com/35494118/121581651-b0a6a000-ca4b-11eb-8e12-6f25bca89760.png)






<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
