### PR TITLE
docs: Deemphasize Hubot as an integration bridge

### DIFF
--- a/templates/zerver/api/integrations-overview.md
+++ b/templates/zerver/api/integrations-overview.md
@@ -2,7 +2,7 @@
 
 Integrations allow you to send data from other products into or out of
 Zulip. Zulip natively integrates with dozens of products, and with hundreds
-more through Zapier, IFTTT, and Hubot.
+more through Zapier and IFTTT.
 
 Zulip also makes it very easy to write your own integration, and (if you'd
 like) to get it merged into the main Zulip repository.
@@ -32,10 +32,6 @@ Zulip.
   [Slack's webhook API](https://api.slack.com/messaging/webhooks)
   pointed at Zulip's
   [Slack-compatible webhook API](/integrations/slack/slack_incoming).
-
-* Check if [Hubot](https://github.com/hubot-scripts) has an integration with
-  the product. If it does, follow
-  [these instructions](/integrations/doc/hubot) to set it up.
 
 * If the product can send email notifications, you can
   [send those emails to a stream](/help/message-a-stream-by-email).

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -386,8 +386,7 @@
             <p>
                 Zulip has more than 90 native integrations. Several hundred more
                 are available through
-                <a href="/integrations/doc/hubot">Hubot</a>,
-                <a href="/integrations/doc/zapier">Zapier</a>,
+                <a href="/integrations/doc/zapier">Zapier</a>
                 and
                 <a href="/integrations/doc/ifttt">IFTTT</a>.
             </p>

--- a/templates/zerver/help/request-an-integration.md
+++ b/templates/zerver/help/request-an-integration.md
@@ -1,7 +1,7 @@
 # Request an integration
 
 Zulip comes with over 100 native integrations. Hundreds more are
-available through [Hubot](https://hubot.github.com/),
+available through
 [Zapier](https://zapier.com/home), [IFTTT](https://ifttt.com/), and
 the [Slack compatible webhook](/integrations/doc/slack_incoming).
 

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -26,8 +26,7 @@
                     <h2 class="portico-page-subheading">
                         {% trans %}
                         And hundreds more through
-                        <a href="/integrations/doc/hubot">Hubot</a>,
-                        <a href="/integrations/doc/zapier">Zapier</a>,
+                        <a href="/integrations/doc/zapier">Zapier</a>
                         and
                         <a href="/integrations/doc/ifttt">IFTTT</a>.
                         {% endtrans %}

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -197,7 +197,6 @@ class DocPageTest(ZulipTestCase):
             "native integrations.",
             extra_strings=[
                 "And hundreds more through",
-                "Hubot",
                 "Zapier",
                 "IFTTT",
             ],

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -154,8 +154,8 @@ def add_integrations_open_graph_context(context: Dict[str, Any], request: HttpRe
     path_name = request.path.rstrip("/").split("/")[-1]
     description = (
         "Zulip comes with over a hundred native integrations out of the box, "
-        "and integrates with Zapier, IFTTT, and Hubot to provide hundreds more. "
-        "Connect the apps you use everyday to Zulip."
+        "and integrates with Zapier and IFTTT to provide hundreds more. "
+        "Connect the apps you use every day to Zulip."
     )
 
     if path_name in INTEGRATIONS:


### PR DESCRIPTION
The Hubot project looks to be abandoned; it hasn’t been updated in years and its own installation instructions don’t work anymore. Remove our special placement of Hubot alongside Zapier and IFTTT.