### PR TITLE
plans_page: Compute sponsorship link for subdomain pages correctly.

### DIFF
--- a/templates/zerver/faq.html
+++ b/templates/zerver/faq.html
@@ -23,11 +23,11 @@
                     {% if free_trial_days %}
                     You can request sponsorship during
                     <a href="/new">organization creation</a>, in an organization's
-                    <a href="/accounts/go/?next=/upgrade%23sponsorship">billing page</a>, or contact us at
+                    <a href="{{ sponsorship_url }}">billing page</a>, or contact us at
                     <a href="mailto:sales@zulip.com">sales@zulip.com</a>.
                     {% else %}
                     You can request sponsorship from an organization's
-                    <a href="/accounts/go/?next=/upgrade%23sponsorship">billing page</a>, or contact us at
+                    <a href="{{ sponsorship_url }}">billing page</a>, or contact us at
                     <a href="mailto:sales@zulip.com">sales@zulip.com</a>.
                     {% endif %}
                 </p>

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -385,6 +385,8 @@ class PlansPageTest(ZulipTestCase):
         root_domain = ""
         result = self.client_get("/plans/", subdomain=root_domain)
         self.assert_in_success_response(["Sign up now"], result)
+        self.assert_not_in_success_response(["/upgrade#sponsorship"], result)
+        self.assert_in_success_response(["/accounts/go/?next=/upgrade%23sponsorship"], result)
 
         non_existent_domain = "moo"
         result = self.client_get("/plans/", subdomain=non_existent_domain)
@@ -407,6 +409,9 @@ class PlansPageTest(ZulipTestCase):
         self.login(organization_member)
         result = self.client_get("/plans/", subdomain="zulip")
         self.assert_in_success_response(["Current plan"], result)
+        self.assert_in_success_response(["/upgrade#sponsorship"], result)
+        self.assert_not_in_success_response(["/accounts/go/?next=/upgrade%23sponsorship"], result)
+
         # Test root domain, with login on different domain
         result = self.client_get("/plans/", subdomain="")
         # TODO: works in manual testing, but I suspect something is funny in

--- a/zerver/views/portico.py
+++ b/zerver/views/portico.py
@@ -1,3 +1,4 @@
+import urllib.parse
 from typing import Optional
 
 import orjson
@@ -9,6 +10,7 @@ from django.template.response import TemplateResponse
 from zerver.context_processors import get_realm_from_request, latest_info_context
 from zerver.decorator import add_google_analytics
 from zerver.lib.github import InvalidPlatform, get_latest_github_release_download_link_for_platform
+from zerver.lib.subdomains import is_subdomain_root_or_alias
 from zerver.models import Realm
 
 
@@ -36,6 +38,10 @@ def plans_view(request: HttpRequest) -> HttpResponse:
     realm_plan_type = 0
     free_trial_days = settings.FREE_TRIAL_DAYS
     sponsorship_pending = False
+    sponsorship_url = "/upgrade#sponsorship"
+    if is_subdomain_root_or_alias(request):
+        # If we're on the root domain, we make this link first ask you which organization.
+        sponsorship_url = f"/accounts/go/?next={urllib.parse.quote(sponsorship_url)}"
 
     if realm is not None:
         realm_plan_type = realm.plan_type
@@ -59,6 +65,7 @@ def plans_view(request: HttpRequest) -> HttpResponse:
             "realm_plan_type": realm_plan_type,
             "free_trial_days": free_trial_days,
             "sponsorship_pending": sponsorship_pending,
+            "sponsorship_url": sponsorship_url,
         },
     )
 


### PR DESCRIPTION
Currently, in the FAQ on our /plans page, when the user clicks on
the sponsorship link in the answer for the first question, they
are always taken to /accounts/go, causing them to have to input
their organization URL even if they are on a subdomain page.

This commit makes it so that when the user is on a subdomain page,
they are taken to /upgrade#sponsorship directly. On the other
hand, when they are on a root domain (/) page, they have to go
through /accounts/go and specify their organization's name.

@timabbott FYI :)
