### PR TITLE
custom_check: Avoid use of `assert` to avoid confusion with `assert.equal`.

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -340,7 +340,7 @@ test("handlers", (override) => {
         narrowed = false;
         activity.user_cursor.go_to(alice.user_id);
         filter_key_handlers.Enter();
-        assert(narrowed);
+        assert.ok(narrowed);
 
         // get line coverage for cleared case
         activity.user_cursor.clear();
@@ -353,7 +353,7 @@ test("handlers", (override) => {
         // so this just tests the called function.
         narrowed = false;
         activity.narrow_for_user({li: alice_li});
-        assert(narrowed);
+        assert.ok(narrowed);
     })();
 
     (function test_blur_filter() {
@@ -393,8 +393,8 @@ test("insert_one_user_into_empty_list", (override) => {
     });
 
     activity.redraw_user(alice.user_id);
-    assert(appended_html.indexOf('data-user-id="1"') > 0);
-    assert(appended_html.indexOf("user_circle_green") > 0);
+    assert.ok(appended_html.indexOf('data-user-id="1"') > 0);
+    assert.ok(appended_html.indexOf("user_circle_green") > 0);
 });
 
 test("insert_alice_then_fred", (override) => {
@@ -405,12 +405,12 @@ test("insert_alice_then_fred", (override) => {
     override(padded_widget, "update_padding", () => {});
 
     activity.redraw_user(alice.user_id);
-    assert(appended_html.indexOf('data-user-id="1"') > 0);
-    assert(appended_html.indexOf("user_circle_green") > 0);
+    assert.ok(appended_html.indexOf('data-user-id="1"') > 0);
+    assert.ok(appended_html.indexOf("user_circle_green") > 0);
 
     activity.redraw_user(fred.user_id);
-    assert(appended_html.indexOf('data-user-id="2"') > 0);
-    assert(appended_html.indexOf("user_circle_green") > 0);
+    assert.ok(appended_html.indexOf('data-user-id="2"') > 0);
+    assert.ok(appended_html.indexOf("user_circle_green") > 0);
 });
 
 test("insert_fred_then_alice_then_rename", (override) => {
@@ -421,8 +421,8 @@ test("insert_fred_then_alice_then_rename", (override) => {
     override(padded_widget, "update_padding", () => {});
 
     activity.redraw_user(fred.user_id);
-    assert(appended_html.indexOf('data-user-id="2"') > 0);
-    assert(appended_html.indexOf("user_circle_green") > 0);
+    assert.ok(appended_html.indexOf('data-user-id="2"') > 0);
+    assert.ok(appended_html.indexOf("user_circle_green") > 0);
 
     const fred_stub = $.create("fred-first");
     buddy_list_add(fred.user_id, fred_stub);
@@ -438,8 +438,8 @@ test("insert_fred_then_alice_then_rename", (override) => {
     };
 
     activity.redraw_user(alice.user_id);
-    assert(inserted_html.indexOf('data-user-id="1"') > 0);
-    assert(inserted_html.indexOf("user_circle_green") > 0);
+    assert.ok(inserted_html.indexOf('data-user-id="1"') > 0);
+    assert.ok(inserted_html.indexOf("user_circle_green") > 0);
 
     // Next rename fred to Aaron.
     const fred_with_new_name = {
@@ -457,8 +457,8 @@ test("insert_fred_then_alice_then_rename", (override) => {
     };
 
     activity.redraw_user(fred_with_new_name.user_id);
-    assert(fred_removed);
-    assert(appended_html.indexOf('data-user-id="2"') > 0);
+    assert.ok(fred_removed);
+    assert.ok(appended_html.indexOf('data-user-id="2"') > 0);
 
     // restore old Fred data
     people.add_active_user(fred);
@@ -516,12 +516,12 @@ test("update_presence_info", (override) => {
 
     presence.presence_info.delete(me.user_id);
     activity.update_presence_info(me.user_id, info, server_time);
-    assert(inserted);
+    assert.ok(inserted);
     assert.deepEqual(presence.presence_info.get(me.user_id).status, "active");
 
     presence.presence_info.delete(alice.user_id);
     activity.update_presence_info(alice.user_id, info, server_time);
-    assert(inserted);
+    assert.ok(inserted);
 
     const expected = {status: "active", last_active: 500};
     assert.deepEqual(presence.presence_info.get(alice.user_id), expected);
@@ -563,9 +563,9 @@ test("initialize", (override) => {
     $(window).trigger("focus");
     clear();
 
-    assert(scroll_handler_started);
-    assert(!activity.new_user_input);
-    assert(!$("#zephyr-mirror-error").hasClass("show"));
+    assert.ok(scroll_handler_started);
+    assert.ok(!activity.new_user_input);
+    assert.ok(!$("#zephyr-mirror-error").hasClass("show"));
     assert.equal(activity.compute_active_status(), "active");
 
     $(window).idle = (params) => {
@@ -581,8 +581,8 @@ test("initialize", (override) => {
         presences: {},
     });
 
-    assert($("#zephyr-mirror-error").hasClass("show"));
-    assert(!activity.new_user_input);
+    assert.ok($("#zephyr-mirror-error").hasClass("show"));
+    assert.ok(!activity.new_user_input);
     assert.equal(activity.compute_active_status(), "idle");
 
     // Exercise the mousemove handler, which just
@@ -596,11 +596,11 @@ test("away_status", (override) => {
     override(pm_list, "update_private_messages", () => {});
     override(buddy_list, "insert_or_move", () => {});
 
-    assert(!user_status.is_away(alice.user_id));
+    assert.ok(!user_status.is_away(alice.user_id));
     activity.on_set_away(alice.user_id);
-    assert(user_status.is_away(alice.user_id));
+    assert.ok(user_status.is_away(alice.user_id));
     activity.on_revoke_away(alice.user_id);
-    assert(!user_status.is_away(alice.user_id));
+    assert.ok(!user_status.is_away(alice.user_id));
 });
 
 test("electron_bridge", (override) => {

--- a/frontend_tests/node_tests/alert_words.js
+++ b/frontend_tests/node_tests/alert_words.js
@@ -88,15 +88,15 @@ const message_with_emoji = {
 };
 
 run_test("notifications", () => {
-    assert(!alert_words.notifies(regular_message));
-    assert(!alert_words.notifies(own_message));
-    assert(alert_words.notifies(other_message));
-    assert(alert_words.notifies(caps_message));
-    assert(!alert_words.notifies(alertwordboundary_message));
-    assert(alert_words.notifies(multialert_message));
-    assert(alert_words.notifies(unsafe_word_message));
-    assert(alert_words.notifies(alert_domain_message));
-    assert(alert_words.notifies(message_with_emoji));
+    assert.ok(!alert_words.notifies(regular_message));
+    assert.ok(!alert_words.notifies(own_message));
+    assert.ok(alert_words.notifies(other_message));
+    assert.ok(alert_words.notifies(caps_message));
+    assert.ok(!alert_words.notifies(alertwordboundary_message));
+    assert.ok(alert_words.notifies(multialert_message));
+    assert.ok(alert_words.notifies(unsafe_word_message));
+    assert.ok(alert_words.notifies(alert_domain_message));
+    assert.ok(alert_words.notifies(message_with_emoji));
 });
 
 run_test("munging", () => {
@@ -161,10 +161,10 @@ run_test("munging", () => {
 
 run_test("basic get/set operations", () => {
     alert_words.initialize({alert_words: []});
-    assert(!alert_words.has_alert_word("breakfast"));
-    assert(!alert_words.has_alert_word("lunch"));
+    assert.ok(!alert_words.has_alert_word("breakfast"));
+    assert.ok(!alert_words.has_alert_word("lunch"));
     alert_words.set_words(["breakfast", "lunch"]);
-    assert(alert_words.has_alert_word("breakfast"));
-    assert(alert_words.has_alert_word("lunch"));
-    assert(!alert_words.has_alert_word("dinner"));
+    assert.ok(alert_words.has_alert_word("breakfast"));
+    assert.ok(alert_words.has_alert_word("lunch"));
+    assert.ok(!alert_words.has_alert_word("dinner"));
 });

--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -36,12 +36,12 @@ run_test("render_alert_words_ui", () => {
     });
 
     const new_alert_word = $("#create_alert_word_name");
-    assert(!new_alert_word.is_focused());
+    assert.ok(!new_alert_word.is_focused());
 
     alert_words_ui.render_alert_words_ui();
 
     assert.deepEqual(appended, ["stub-bar", "stub-foo"]);
-    assert(new_alert_word.is_focused());
+    assert.ok(new_alert_word.is_focused());
 });
 
 run_test("add_alert_word", (override) => {
@@ -60,17 +60,17 @@ run_test("add_alert_word", (override) => {
     // add '' as alert word
     add_func();
     assert.equal(new_alert_word.val(), "");
-    assert(alert_word_status.hasClass("alert-danger"));
+    assert.ok(alert_word_status.hasClass("alert-danger"));
     assert.equal(alert_word_status_text.text(), "translated: Alert word can't be empty!");
-    assert(alert_word_status.visible());
+    assert.ok(alert_word_status.visible());
 
     // add 'foo' as alert word (existing word)
     new_alert_word.val("foo");
 
     add_func();
-    assert(alert_word_status.hasClass("alert-danger"));
+    assert.ok(alert_word_status.hasClass("alert-danger"));
     assert.equal(alert_word_status_text.text(), "translated: Alert word already exists!");
-    assert(alert_word_status.visible());
+    assert.ok(alert_word_status.visible());
 
     // add 'zot' as alert word (new word)
     new_alert_word.val("zot");
@@ -88,15 +88,15 @@ run_test("add_alert_word", (override) => {
 
     // test failure
     fail_func();
-    assert(alert_word_status.hasClass("alert-danger"));
+    assert.ok(alert_word_status.hasClass("alert-danger"));
     assert.equal(alert_word_status_text.text(), "translated: Error adding alert word!");
-    assert(alert_word_status.visible());
+    assert.ok(alert_word_status.visible());
 
     // test success
     success_func();
-    assert(alert_word_status.hasClass("alert-success"));
+    assert.ok(alert_word_status.hasClass("alert-success"));
     assert.equal(alert_word_status_text.text(), 'translated: Alert word "zot" added successfully!');
-    assert(alert_word_status.visible());
+    assert.ok(alert_word_status.visible());
 });
 
 run_test("add_alert_word_keypress", (override) => {
@@ -122,7 +122,7 @@ run_test("add_alert_word_keypress", (override) => {
     };
 
     keypress_func(event);
-    assert(called);
+    assert.ok(called);
 });
 
 run_test("remove_alert_word", (override) => {
@@ -161,15 +161,15 @@ run_test("remove_alert_word", (override) => {
 
     // test failure
     fail_func();
-    assert(alert_word_status.hasClass("alert-danger"));
+    assert.ok(alert_word_status.hasClass("alert-danger"));
     assert.equal(alert_word_status_text.text(), "translated: Error removing alert word!");
-    assert(alert_word_status.visible());
+    assert.ok(alert_word_status.visible());
 
     // test success
     success_func();
-    assert(alert_word_status.hasClass("alert-success"));
+    assert.ok(alert_word_status.hasClass("alert-success"));
     assert.equal(alert_word_status_text.text(), "translated: Alert word removed successfully!");
-    assert(alert_word_status.visible());
+    assert.ok(alert_word_status.visible());
 });
 
 run_test("close_status_message", (override) => {
@@ -190,7 +190,7 @@ run_test("close_status_message", (override) => {
         currentTarget: ".close-alert-word-status",
     };
 
-    assert(alert.visible());
+    assert.ok(alert.visible());
     close(event);
-    assert(!alert.visible());
+    assert.ok(!alert.visible());
 });

--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -76,16 +76,16 @@ run_test("initialize", (override) => {
 
     $.get_initialize_function()();
 
-    assert(set_tab_called);
-    assert(stripe_checkout_configure_called);
+    assert.ok(set_tab_called);
+    assert.ok(stripe_checkout_configure_called);
     const e = {
         preventDefault: () => {},
     };
     const update_card_click_handler = $("#update-card-button").get_on_handler("click");
     with_field(helpers, "create_ajax_request", card_change_ajax, () => {
         update_card_click_handler(e);
-        assert(create_ajax_request_called);
-        assert(open_func_called);
+        assert.ok(create_ajax_request_called);
+        assert.ok(open_func_called);
     });
 
     create_ajax_request_called = false;
@@ -103,7 +103,7 @@ run_test("initialize", (override) => {
 
     with_field(helpers, "create_ajax_request", plan_change_ajax, () => {
         change_plan_status_click_handler(e);
-        assert(create_ajax_request_called);
+        assert.ok(create_ajax_request_called);
     });
 
     create_ajax_request_called = false;
@@ -125,7 +125,7 @@ run_test("initialize", (override) => {
     }
     with_field(helpers, "create_ajax_request", license_change_ajax, () => {
         billing.create_update_license_request();
-        assert(create_ajax_request_called);
+        assert.ok(create_ajax_request_called);
     });
 
     let create_update_license_request_called = false;
@@ -137,7 +137,7 @@ run_test("initialize", (override) => {
         "click",
     );
     confirm_license_update_click_handler(e);
-    assert(create_update_license_request_called);
+    assert.ok(create_update_license_request_called);
 
     let confirm_license_modal_shown = false;
     override(helpers, "is_valid_input", () => true);
@@ -154,14 +154,14 @@ run_test("initialize", (override) => {
     const update_licenses_button_click_handler =
         $("#update-licenses-button").get_on_handler("click");
     update_licenses_button_click_handler(e);
-    assert(create_update_license_request_called);
-    assert(!confirm_license_modal_shown);
+    assert.ok(create_update_license_request_called);
+    assert.ok(!confirm_license_modal_shown);
 
     $("#new_licenses_input").val = () => 25;
     create_update_license_request_called = false;
     update_licenses_button_click_handler(e);
-    assert(!create_update_license_request_called);
-    assert(confirm_license_modal_shown);
+    assert.ok(!create_update_license_request_called);
+    assert.ok(confirm_license_modal_shown);
 
     override(helpers, "is_valid_input", () => false);
     let prevent_default_called = false;
@@ -171,7 +171,7 @@ run_test("initialize", (override) => {
         },
     };
     update_licenses_button_click_handler(event);
-    assert(!prevent_default_called);
+    assert.ok(!prevent_default_called);
 
     const update_next_renewal_licenses_button_click_handler = $(
         "#update-licenses-at-next-renewal-button",
@@ -195,26 +195,26 @@ run_test("initialize", (override) => {
     }
     with_field(helpers, "create_ajax_request", licenses_at_next_renewal_change_ajax, () => {
         update_next_renewal_licenses_button_click_handler(e);
-        assert(create_ajax_request_called);
+        assert.ok(create_ajax_request_called);
     });
 });
 
 run_test("billing_template", () => {
     // Elements necessary for create_ajax_request
-    assert(document.querySelector("#cardchange-error"));
-    assert(document.querySelector("#cardchange-loading"));
-    assert(document.querySelector("#cardchange_loading_indicator"));
-    assert(document.querySelector("#cardchange-success"));
+    assert.ok(document.querySelector("#cardchange-error"));
+    assert.ok(document.querySelector("#cardchange-loading"));
+    assert.ok(document.querySelector("#cardchange_loading_indicator"));
+    assert.ok(document.querySelector("#cardchange-success"));
 
-    assert(document.querySelector("#licensechange-error"));
-    assert(document.querySelector("#licensechange-loading"));
-    assert(document.querySelector("#licensechange_loading_indicator"));
-    assert(document.querySelector("#licensechange-success"));
+    assert.ok(document.querySelector("#licensechange-error"));
+    assert.ok(document.querySelector("#licensechange-loading"));
+    assert.ok(document.querySelector("#licensechange_loading_indicator"));
+    assert.ok(document.querySelector("#licensechange-success"));
 
-    assert(document.querySelector("#planchange-error"));
-    assert(document.querySelector("#planchange-loading"));
-    assert(document.querySelector("#planchange_loading_indicator"));
-    assert(document.querySelector("#planchange-success"));
+    assert.ok(document.querySelector("#planchange-error"));
+    assert.ok(document.querySelector("#planchange-loading"));
+    assert.ok(document.querySelector("#planchange_loading_indicator"));
+    assert.ok(document.querySelector("#planchange-success"));
 
-    assert(document.querySelector("input[name=csrfmiddlewaretoken]"));
+    assert.ok(document.querySelector("input[name=csrfmiddlewaretoken]"));
 });

--- a/frontend_tests/node_tests/billing_helpers.js
+++ b/frontend_tests/node_tests/billing_helpers.js
@@ -136,7 +136,7 @@ run_test("create_ajax_request", (override) => {
         assert.equal(data.schedule, "monthly");
         assert.equal(data.licenses, "");
 
-        assert(!("license_management" in data));
+        assert.ok(!("license_management" in data));
 
         history.pushState = (state_object, title, path) => {
             state.pushState += 1;

--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -116,7 +116,7 @@ test("test_basics", () => {
 
         bot = bot_data.get(43);
         assert.equal("Bot 1", bot.full_name);
-        assert(bot.is_active);
+        assert.ok(bot.is_active);
         bot_data.deactivate(43);
         bot = bot_data.get(43);
         assert.equal(bot.is_active, false);
@@ -135,7 +135,7 @@ test("test_basics", () => {
 
         bot = bot_data.get(43);
         assert.equal("Bot 1", bot.full_name);
-        assert(bot.is_active);
+        assert.ok(bot.is_active);
         bot_data.del(43);
         bot = bot_data.get(43);
         assert.equal(bot, undefined);

--- a/frontend_tests/node_tests/browser_history.js
+++ b/frontend_tests/node_tests/browser_history.js
@@ -32,7 +32,7 @@ test("basics", () => {
     assert.equal(browser_history.old_hash(), hash1);
 
     const was_internal_change = browser_history.save_old_hash();
-    assert(was_internal_change);
+    assert.ok(was_internal_change);
     assert.equal(browser_history.old_hash(), hash2);
 });
 

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -394,12 +394,12 @@ test("muted users excluded from search", () => {
     assert.equal(user_ids.includes(selma.user_id), false);
     user_ids = buddy_data.get_filtered_and_sorted_user_ids("sel");
     assert.deepEqual(user_ids, []);
-    assert(!buddy_data.matches_filter("sel", selma.user_id));
+    assert.ok(!buddy_data.matches_filter("sel", selma.user_id));
 
     muting.remove_muted_user(selma.user_id);
     user_ids = buddy_data.get_filtered_and_sorted_user_ids("sel");
     assert.deepEqual(user_ids, [selma.user_id]);
-    assert(buddy_data.matches_filter("sel", selma.user_id));
+    assert.ok(buddy_data.matches_filter("sel", selma.user_id));
 });
 
 test("bulk_data_hacks", () => {

--- a/frontend_tests/node_tests/buddy_list.js
+++ b/frontend_tests/node_tests/buddy_list.js
@@ -83,7 +83,7 @@ run_test("basics", (override) => {
     buddy_list.populate({
         keys: [alice.user_id],
     });
-    assert(appended);
+    assert.ok(appended);
 
     const alice_li = {length: 1};
 
@@ -185,7 +185,7 @@ run_test("find_li w/force_render", (override) => {
         key,
     });
     assert.equal(empty_li, stub_li);
-    assert(!shown);
+    assert.ok(!shown);
 
     const li = buddy_list.find_li({
         key,
@@ -193,7 +193,7 @@ run_test("find_li w/force_render", (override) => {
     });
 
     assert.equal(li, stub_li);
-    assert(shown);
+    assert.ok(shown);
 });
 
 run_test("find_li w/bad key", (override) => {
@@ -224,10 +224,10 @@ run_test("scrolling", (override) => {
         tried_to_fill = true;
     });
 
-    assert(!tried_to_fill);
+    assert.ok(!tried_to_fill);
 
     buddy_list.start_scroll_handler();
     $(buddy_list.scroll_container_sel).trigger("scroll");
 
-    assert(tried_to_fill);
+    assert.ok(tried_to_fill);
 });

--- a/frontend_tests/node_tests/channel.js
+++ b/frontend_tests/node_tests/channel.js
@@ -42,7 +42,7 @@ function test_with_mock_ajax(test_params) {
     };
 
     run_code();
-    assert(ajax_called);
+    assert.ok(ajax_called);
     check_ajax_options(ajax_options);
 }
 
@@ -176,10 +176,10 @@ test("normal_post", () => {
             assert.equal(options.url, "/json/endpoint");
 
             options.simulate_success("response data", "success");
-            assert(orig_success_called);
+            assert.ok(orig_success_called);
 
             options.simulate_error();
-            assert(orig_error_called);
+            assert.ok(orig_error_called);
         },
     });
 });
@@ -201,7 +201,7 @@ test("patch_with_form_data", () => {
                 data,
                 processData: false,
             });
-            assert(appended);
+            assert.ok(appended);
         },
 
         check_ajax_options(options) {
@@ -233,7 +233,7 @@ test("reload_on_403_error", () => {
             });
 
             options.simulate_error();
-            assert(handler_called);
+            assert.ok(handler_called);
         },
     });
 });
@@ -339,11 +339,11 @@ test("while_reloading", () => {
         check_ajax_options(options) {
             blueslip.expect("log", "Ignoring DELETE /json/endpoint response while reloading");
             options.simulate_success();
-            assert(!orig_success_called);
+            assert.ok(!orig_success_called);
 
             blueslip.expect("log", "Ignoring DELETE /json/endpoint error response while reloading");
             options.simulate_error();
-            assert(!orig_error_called);
+            assert.ok(!orig_error_called);
         },
     });
 });

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -24,18 +24,18 @@ const common = zrequire("common");
 run_test("basics", () => {
     common.autofocus("#home");
     $.get_initialize_function()();
-    assert($("#home").is_focused());
+    assert.ok($("#home").is_focused());
     $.clear_initialize_function();
 });
 
 run_test("phrase_match", () => {
-    assert(common.phrase_match("tes", "test"));
-    assert(common.phrase_match("Tes", "test"));
-    assert(common.phrase_match("Tes", "Test"));
-    assert(common.phrase_match("tes", "Stream Test"));
+    assert.ok(common.phrase_match("tes", "test"));
+    assert.ok(common.phrase_match("Tes", "test"));
+    assert.ok(common.phrase_match("Tes", "Test"));
+    assert.ok(common.phrase_match("tes", "Stream Test"));
 
-    assert(!common.phrase_match("tests", "test"));
-    assert(!common.phrase_match("tes", "hostess"));
+    assert.ok(!common.phrase_match("tests", "test"));
+    assert.ok(!common.phrase_match("tes", "hostess"));
 });
 
 run_test("copy_data_attribute_value", (override) => {
@@ -76,9 +76,9 @@ run_test("copy_data_attribute_value", (override) => {
         faded_in = true;
     };
     common.copy_data_attribute_value(elem, "admin-emails");
-    assert(removed);
-    assert(faded_in);
-    assert(faded_out);
+    assert.ok(removed);
+    assert.ok(faded_in);
+    assert.ok(faded_out);
 });
 
 run_test("adjust_mac_shortcuts non-mac", (override) => {
@@ -147,8 +147,8 @@ run_test("show password", () => {
 
     function check_assertion(type, present_class, absent_class) {
         assert.equal($("#id_password").attr("type"), type);
-        assert($(password_selector).hasClass(present_class));
-        assert(!$(password_selector).hasClass(absent_class));
+        assert.ok($(password_selector).hasClass(present_class));
+        assert.ok(!$(password_selector).hasClass(absent_class));
     }
 
     const ev = {

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -124,39 +124,39 @@ test_ui("test_wildcard_mention_allowed", () => {
         settings_config.wildcard_mention_policy_values.by_everyone.code;
     page_params.is_guest = true;
     page_params.is_admin = false;
-    assert(compose.wildcard_mention_allowed());
+    assert.ok(compose.wildcard_mention_allowed());
 
     page_params.realm_wildcard_mention_policy =
         settings_config.wildcard_mention_policy_values.nobody.code;
     page_params.is_admin = true;
-    assert(!compose.wildcard_mention_allowed());
+    assert.ok(!compose.wildcard_mention_allowed());
 
     page_params.realm_wildcard_mention_policy =
         settings_config.wildcard_mention_policy_values.by_members.code;
     page_params.is_guest = true;
     page_params.is_admin = false;
-    assert(!compose.wildcard_mention_allowed());
+    assert.ok(!compose.wildcard_mention_allowed());
 
     page_params.is_guest = false;
-    assert(compose.wildcard_mention_allowed());
+    assert.ok(compose.wildcard_mention_allowed());
 
     page_params.realm_wildcard_mention_policy =
         settings_config.wildcard_mention_policy_values.by_moderators_only.code;
     page_params.is_moderator = false;
-    assert(!compose.wildcard_mention_allowed());
+    assert.ok(!compose.wildcard_mention_allowed());
 
     page_params.is_moderator = true;
-    assert(compose.wildcard_mention_allowed());
+    assert.ok(compose.wildcard_mention_allowed());
 
     page_params.realm_wildcard_mention_policy =
         settings_config.wildcard_mention_policy_values.by_stream_admins_only.code;
     page_params.is_admin = false;
-    assert(!compose.wildcard_mention_allowed());
+    assert.ok(!compose.wildcard_mention_allowed());
 
     // TODO: Add a by_admins_only case when we implement stream-level administrators.
 
     page_params.is_admin = true;
-    assert(compose.wildcard_mention_allowed());
+    assert.ok(compose.wildcard_mention_allowed());
 
     page_params.realm_wildcard_mention_policy =
         settings_config.wildcard_mention_policy_values.by_full_members.code;
@@ -164,9 +164,9 @@ test_ui("test_wildcard_mention_allowed", () => {
     person.date_joined = new Date(Date.now());
     page_params.realm_waiting_period_threshold = 10;
 
-    assert(compose.wildcard_mention_allowed());
+    assert.ok(compose.wildcard_mention_allowed());
     page_params.is_admin = false;
-    assert(!compose.wildcard_mention_allowed());
+    assert.ok(!compose.wildcard_mention_allowed());
 });
 
 test_ui("right-to-left", () => {
@@ -370,12 +370,12 @@ test_ui("send_message_success", (override) => {
     compose.send_message_success("1001", 12, false);
 
     assert.equal($("#compose-textarea").val(), "");
-    assert($("#compose-textarea").is_focused());
-    assert(!$("#compose-send-status").visible());
+    assert.ok($("#compose-textarea").is_focused());
+    assert.ok(!$("#compose-send-status").visible());
     assert.equal($("#compose-send-button").prop("disabled"), false);
-    assert(!$("#sending-indicator").visible());
+    assert.ok(!$("#sending-indicator").visible());
 
-    assert(reify_message_id_checked);
+    assert.ok(reify_message_id_checked);
 });
 
 test_ui("send_message", (override) => {
@@ -469,10 +469,10 @@ test_ui("send_message", (override) => {
         };
         assert.deepEqual(stub_state, state);
         assert.equal($("#compose-textarea").val(), "");
-        assert($("#compose-textarea").is_focused());
-        assert(!$("#compose-send-status").visible());
+        assert.ok($("#compose-textarea").is_focused());
+        assert.ok(!$("#compose-send-status").visible());
         assert.equal($("#compose-send-button").prop("disabled"), false);
-        assert(!$("#sending-indicator").visible());
+        assert.ok(!$("#sending-indicator").visible());
     })();
 
     // This is the additional setup which is common to both the tests below.
@@ -501,7 +501,7 @@ test_ui("send_message", (override) => {
             send_msg_called: 1,
         };
         assert.deepEqual(stub_state, state);
-        assert(echo_error_msg_checked);
+        assert.ok(echo_error_msg_checked);
     })();
 
     (function test_error_codepath_local_id_undefined() {
@@ -525,14 +525,14 @@ test_ui("send_message", (override) => {
             send_msg_called: 1,
         };
         assert.deepEqual(stub_state, state);
-        assert(!echo_error_msg_checked);
+        assert.ok(!echo_error_msg_checked);
         assert.equal($("#compose-send-button").prop("disabled"), false);
         assert.equal($("#compose-error-msg").html(), "Error sending message: Server says 408");
         assert.equal($("#compose-textarea").val(), "foobarfoobar");
-        assert($("#compose-textarea").is_focused());
-        assert($("#compose-send-status").visible());
+        assert.ok($("#compose-textarea").is_focused());
+        assert.ok($("#compose-send-status").visible());
         assert.equal($("#compose-send-button").prop("disabled"), false);
-        assert(!$("#sending-indicator").visible());
+        assert.ok(!$("#sending-indicator").visible());
     })();
 });
 
@@ -558,16 +558,16 @@ test_ui("enter_with_preview_open", (override) => {
         send_message_called = true;
     });
     compose.enter_with_preview_open();
-    assert($("#compose-textarea").visible());
-    assert(!$("#compose .undo_markdown_preview").visible());
-    assert(!$("#compose .preview_message_area").visible());
-    assert($("#compose .markdown_preview").visible());
-    assert(send_message_called);
+    assert.ok($("#compose-textarea").visible());
+    assert.ok(!$("#compose .undo_markdown_preview").visible());
+    assert.ok(!$("#compose .preview_message_area").visible());
+    assert.ok($("#compose .markdown_preview").visible());
+    assert.ok(send_message_called);
 
     page_params.enter_sends = false;
     $("#compose-textarea").trigger("blur");
     compose.enter_with_preview_open();
-    assert($("#compose-textarea").is_focused());
+    assert.ok($("#compose-textarea").is_focused());
 
     // Test sending a message without content.
     $("#compose-textarea").val("");
@@ -577,7 +577,7 @@ test_ui("enter_with_preview_open", (override) => {
 
     compose.enter_with_preview_open();
 
-    assert($("#enter_sends").prop("checked"));
+    assert.ok($("#enter_sends").prop("checked"));
     assert.equal(
         $("#compose-error-msg").html(),
         $t_html({defaultMessage: "You have nothing to send!"}),
@@ -598,9 +598,9 @@ test_ui("finish", (override) => {
         $("#compose-textarea").val("");
         const res = compose.finish();
         assert.equal(res, false);
-        assert(!$("#compose_invite_users").visible());
-        assert(!$("#sending-indicator").visible());
-        assert(!$("#compose-send-button").is_focused());
+        assert.ok(!$("#compose_invite_users").visible());
+        assert.ok(!$("#sending-indicator").visible());
+        assert.ok(!$("#compose-send-button").is_focused());
         assert.equal($("#compose-send-button").prop("disabled"), false);
         assert.equal(
             $("#compose-error-msg").html(),
@@ -625,13 +625,13 @@ test_ui("finish", (override) => {
         override(compose, "send_message", () => {
             send_message_called = true;
         });
-        assert(compose.finish());
-        assert($("#compose-textarea").visible());
-        assert(!$("#compose .undo_markdown_preview").visible());
-        assert(!$("#compose .preview_message_area").visible());
-        assert($("#compose .markdown_preview").visible());
-        assert(send_message_called);
-        assert(compose_finished_event_checked);
+        assert.ok(compose.finish());
+        assert.ok($("#compose-textarea").visible());
+        assert.ok(!$("#compose .undo_markdown_preview").visible());
+        assert.ok(!$("#compose .preview_message_area").visible());
+        assert.ok($("#compose .markdown_preview").visible());
+        assert.ok(send_message_called);
+        assert.ok(compose_finished_event_checked);
     })();
 });
 
@@ -677,7 +677,7 @@ test_ui("warn_if_private_stream_is_linked", () => {
                 return "fake-compose_private_stream_alert-template";
             });
             return function () {
-                assert(called);
+                assert.ok(called);
             };
         })(),
 
@@ -688,7 +688,7 @@ test_ui("warn_if_private_stream_is_linked", () => {
                 assert.equal(html, "fake-compose_private_stream_alert-template");
             };
             return function () {
-                assert(called);
+                assert.ok(called);
             };
         })(),
     ];
@@ -763,10 +763,10 @@ test_ui("initialize", (override) => {
 
     compose.initialize();
 
-    assert(resize_watch_manual_resize_checked);
-    assert(xmlhttprequest_checked);
-    assert(!$("#compose .compose_upload_file").hasClass("notdisplayed"));
-    assert(setup_upload_called);
+    assert.ok(resize_watch_manual_resize_checked);
+    assert.ok(xmlhttprequest_checked);
+    assert.ok(!$("#compose .compose_upload_file").hasClass("notdisplayed"));
+    assert.ok(setup_upload_called);
 
     function set_up_compose_start_mock(expected_opts) {
         compose_actions_start_checked = false;
@@ -781,7 +781,7 @@ test_ui("initialize", (override) => {
 
         compose.initialize();
 
-        assert(compose_actions_start_checked);
+        assert.ok(compose_actions_start_checked);
     })();
 
     (function test_page_params_narrow_topic() {
@@ -792,7 +792,7 @@ test_ui("initialize", (override) => {
 
         compose.initialize();
 
-        assert(compose_actions_start_checked);
+        assert.ok(compose_actions_start_checked);
     })();
 
     (function test_abort_xhr() {
@@ -804,7 +804,7 @@ test_ui("initialize", (override) => {
         compose.abort_xhr();
 
         assert.equal($("#compose-send-button").attr(), undefined);
-        assert(uppy_cancel_all_called);
+        assert.ok(uppy_cancel_all_called);
     })();
 });
 
@@ -829,13 +829,13 @@ test_ui("update_fade", (override) => {
 
     compose_state.set_message_type(false);
     keyup_handler_func();
-    assert(!set_focused_recipient_checked);
-    assert(!update_all_called);
+    assert.ok(!set_focused_recipient_checked);
+    assert.ok(!update_all_called);
 
     compose_state.set_message_type("private");
     keyup_handler_func();
-    assert(set_focused_recipient_checked);
-    assert(update_all_called);
+    assert.ok(set_focused_recipient_checked);
+    assert.ok(update_all_called);
 });
 
 test_ui("trigger_submit_compose_form", (override) => {
@@ -856,8 +856,8 @@ test_ui("trigger_submit_compose_form", (override) => {
 
     submit_handler(e);
 
-    assert(prevent_default_checked);
-    assert(compose_finish_checked);
+    assert.ok(prevent_default_checked);
+    assert.ok(compose_finish_checked);
 });
 
 test_ui("needs_subscribe_warning", () => {
@@ -947,7 +947,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", (override) => {
                 return true;
             });
             return function () {
-                assert(called);
+                assert.ok(called);
             };
         })(),
 
@@ -962,7 +962,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", (override) => {
                 return "fake-compose-invite-user-template";
             });
             return function () {
-                assert(called);
+                assert.ok(called);
             };
         })(),
 
@@ -973,7 +973,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", (override) => {
                 assert.equal(html, "fake-compose-invite-user-template");
             };
             return function () {
-                assert(called);
+                assert.ok(called);
             };
         })(),
     ];
@@ -1017,7 +1017,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", (override) => {
     stub_templates(noop);
     compose.warn_if_mentioning_unsubscribed_user(mentioned);
     assert.equal($("#compose_invite_users").visible(), true);
-    assert(looked_for_existing);
+    assert.ok(looked_for_existing);
 });
 
 test_ui("on_events", (override) => {
@@ -1074,10 +1074,10 @@ test_ui("on_events", (override) => {
 
         handler(helper.event);
 
-        assert(helper.container_was_removed());
-        assert(compose_finish_checked);
-        assert(!$("#compose-all-everyone").visible());
-        assert(!$("#compose-send-status").visible());
+        assert.ok(helper.container_was_removed());
+        assert.ok(compose_finish_checked);
+        assert.ok(!$("#compose-all-everyone").visible());
+        assert.ok(!$("#compose-send-status").visible());
     })();
 
     (function test_compose_invite_users_clicked() {
@@ -1131,10 +1131,10 @@ test_ui("on_events", (override) => {
 
         handler(helper.event);
 
-        assert(helper.container_was_removed());
-        assert(!$("#compose_invite_users").visible());
-        assert(invite_user_to_stream_called);
-        assert(all_invite_children_called);
+        assert.ok(helper.container_was_removed());
+        assert.ok(!$("#compose_invite_users").visible());
+        assert.ok(invite_user_to_stream_called);
+        assert.ok(all_invite_children_called);
     })();
 
     (function test_compose_invite_close_clicked() {
@@ -1155,9 +1155,9 @@ test_ui("on_events", (override) => {
 
         handler(helper.event);
 
-        assert(helper.container_was_removed());
-        assert(all_invite_children_called);
-        assert(!$("#compose_invite_users").visible());
+        assert.ok(helper.container_was_removed());
+        assert.ok(all_invite_children_called);
+        assert.ok(!$("#compose_invite_users").visible());
     })();
 
     (function test_compose_not_subscribed_clicked() {
@@ -1180,7 +1180,7 @@ test_ui("on_events", (override) => {
 
         handler(helper.event);
 
-        assert(compose_not_subscribed_called);
+        assert.ok(compose_not_subscribed_called);
 
         stream_data.add_sub(subscription);
         $("#stream_message_recipient_stream").val("test");
@@ -1188,7 +1188,7 @@ test_ui("on_events", (override) => {
 
         handler(helper.event);
 
-        assert(!$("#compose-send-status").visible());
+        assert.ok(!$("#compose-send-status").visible());
     })();
 
     (function test_compose_not_subscribed_close_clicked() {
@@ -1207,13 +1207,13 @@ test_ui("on_events", (override) => {
 
         handler(helper.event);
 
-        assert(!$("#compose-send-status").visible());
+        assert.ok(!$("#compose-send-status").visible());
     })();
 
     (function test_attach_files_compose_clicked() {
         const handler = $("#compose").get_on_handler("click", ".compose_upload_file");
         $("#compose .file_input").clone = (param) => {
-            assert(param);
+            assert.ok(param);
         };
         let compose_file_input_clicked = false;
         $("#compose .file_input").on("click", () => {
@@ -1225,7 +1225,7 @@ test_ui("on_events", (override) => {
         };
 
         handler(event);
-        assert(compose_file_input_clicked);
+        assert.ok(compose_file_input_clicked);
     })();
 
     (function test_markdown_preview_compose_clicked() {
@@ -1238,10 +1238,10 @@ test_ui("on_events", (override) => {
         }
 
         function assert_visibilities() {
-            assert(!$("#compose-textarea").visible());
-            assert(!$("#compose .markdown_preview").visible());
-            assert($("#compose .undo_markdown_preview").visible());
-            assert($("#compose .preview_message_area").visible());
+            assert.ok(!$("#compose-textarea").visible());
+            assert.ok(!$("#compose .markdown_preview").visible());
+            assert.ok($("#compose .undo_markdown_preview").visible());
+            assert.ok($("#compose .preview_message_area").visible());
         }
 
         function setup_mock_markdown_contains_backend_only_syntax(msg_content, return_val) {
@@ -1278,8 +1278,8 @@ test_ui("on_events", (override) => {
 
         override(channel, "post", (payload) => {
             assert.equal(payload.url, "/json/messages/render");
-            assert(payload.idempotent);
-            assert(payload.data);
+            assert.ok(payload.idempotent);
+            assert.ok(payload.data);
             assert.deepEqual(payload.data.content, current_message);
 
             function test(func, param) {
@@ -1292,7 +1292,7 @@ test_ui("on_events", (override) => {
 
                 func(param);
 
-                assert(destroy_indicator_called);
+                assert.ok(destroy_indicator_called);
             }
 
             test(test_post_error, payload.error);
@@ -1329,7 +1329,7 @@ test_ui("on_events", (override) => {
 
         handler(event);
 
-        assert(make_indicator_called);
+        assert.ok(make_indicator_called);
         assert_visibilities();
 
         let apply_markdown_called = false;
@@ -1348,7 +1348,7 @@ test_ui("on_events", (override) => {
 
         handler(event);
 
-        assert(apply_markdown_called);
+        assert.ok(apply_markdown_called);
         assert_visibilities();
         assert.equal($("#compose .preview_content").html(), "Server: foobarfoobar");
     })();
@@ -1367,10 +1367,10 @@ test_ui("on_events", (override) => {
 
         handler(event);
 
-        assert($("#compose-textarea").visible());
-        assert(!$("#compose .undo_markdown_preview").visible());
-        assert(!$("#compose .preview_message_area").visible());
-        assert($("#compose .markdown_preview").visible());
+        assert.ok($("#compose-textarea").visible());
+        assert.ok(!$("#compose .undo_markdown_preview").visible());
+        assert.ok(!$("#compose .preview_message_area").visible());
+        assert.ok($("#compose .markdown_preview").visible());
     })();
 });
 

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -66,11 +66,11 @@ const reply_with_mention = compose_actions.reply_with_mention;
 const quote_and_reply = compose_actions.quote_and_reply;
 
 function assert_visible(sel) {
-    assert($(sel).visible());
+    assert.ok($(sel).visible());
 }
 
 function assert_hidden(sel) {
-    assert(!$(sel).visible());
+    assert.ok(!$(sel).visible());
 }
 
 function override_private_message_recipient(override) {
@@ -137,7 +137,7 @@ test("start", (override) => {
     assert.equal($("#stream_message_recipient_stream").val(), "stream1");
     assert.equal($("#stream_message_recipient_topic").val(), "topic1");
     assert.equal(compose_state.get_message_type(), "stream");
-    assert(compose_state.composing());
+    assert.ok(compose_state.composing());
 
     // Autofill stream field for single subscription
     const denmark = {
@@ -198,7 +198,7 @@ test("start", (override) => {
     assert.equal(compose_state.private_message_recipient(), "foo@example.com");
     assert.equal($("#compose-textarea").val(), "hello");
     assert.equal(compose_state.get_message_type(), "private");
-    assert(compose_state.composing());
+    assert.ok(compose_state.composing());
 
     // Cancel compose.
     let pill_cleared;
@@ -215,11 +215,11 @@ test("start", (override) => {
 
     assert_hidden("#compose_controls");
     cancel();
-    assert(abort_xhr_called);
-    assert(pill_cleared);
+    assert.ok(abort_xhr_called);
+    assert.ok(pill_cleared);
     assert_visible("#compose_controls");
     assert_hidden("#private-message");
-    assert(!compose_state.composing());
+    assert.ok(!compose_state.composing());
 });
 
 test("respond_to_message", (override) => {
@@ -371,7 +371,7 @@ test("quote_and_reply", (override) => {
     success_function({
         raw_content: "Testing.",
     });
-    assert(replaced);
+    assert.ok(replaced);
 
     selected_message = {
         type: "stream",
@@ -390,7 +390,7 @@ test("quote_and_reply", (override) => {
     with_field(channel, "get", whiny_get, () => {
         quote_and_reply(opts);
     });
-    assert(replaced);
+    assert.ok(replaced);
 
     selected_message = {
         type: "stream",
@@ -405,7 +405,7 @@ test("quote_and_reply", (override) => {
     expected_replacement =
         "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n````quote\n```\nmultiline code block\nshoudln't mess with quotes\n```\n````";
     quote_and_reply(opts);
-    assert(replaced);
+    assert.ok(replaced);
 });
 
 test("get_focus_area", () => {
@@ -434,16 +434,16 @@ test("focus_in_empty_compose", (override) => {
     override(compose_state, "composing", () => true);
     $("#compose-textarea").val("");
     $("#compose-textarea").trigger("focus");
-    assert(compose_state.focus_in_empty_compose());
+    assert.ok(compose_state.focus_in_empty_compose());
 
     override(compose_state, "composing", () => false);
-    assert(!compose_state.focus_in_empty_compose());
+    assert.ok(!compose_state.focus_in_empty_compose());
 
     $("#compose-textarea").val("foo");
-    assert(!compose_state.focus_in_empty_compose());
+    assert.ok(!compose_state.focus_in_empty_compose());
 
     $("#compose-textarea").trigger("blur");
-    assert(!compose_state.focus_in_empty_compose());
+    assert.ok(!compose_state.focus_in_empty_compose());
 });
 
 test("on_narrow", (override) => {
@@ -463,7 +463,7 @@ test("on_narrow", (override) => {
     compose_actions.on_narrow({
         force_close: true,
     });
-    assert(cancel_called);
+    assert.ok(cancel_called);
 
     let on_topic_narrow_called = false;
     override(compose_actions, "on_topic_narrow", () => {
@@ -473,7 +473,7 @@ test("on_narrow", (override) => {
     compose_actions.on_narrow({
         force_close: false,
     });
-    assert(on_topic_narrow_called);
+    assert.ok(on_topic_narrow_called);
 
     let update_message_list_called = false;
     narrowed_by_topic_reply = false;
@@ -484,7 +484,7 @@ test("on_narrow", (override) => {
     compose_actions.on_narrow({
         force_close: false,
     });
-    assert(update_message_list_called);
+    assert.ok(update_message_list_called);
 
     has_message_content = false;
     let start_called = false;
@@ -497,7 +497,7 @@ test("on_narrow", (override) => {
         trigger: "not-search",
         private_message_recipient: "not@empty.com",
     });
-    assert(start_called);
+    assert.ok(start_called);
 
     start_called = false;
     compose_actions.on_narrow({
@@ -505,12 +505,12 @@ test("on_narrow", (override) => {
         trigger: "search",
         private_message_recipient: "",
     });
-    assert(!start_called);
+    assert.ok(!start_called);
 
     narrowed_by_pm_reply = false;
     cancel_called = false;
     compose_actions.on_narrow({
         force_close: false,
     });
-    assert(cancel_called);
+    assert.ok(cancel_called);
 });

--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -87,6 +87,6 @@ run_test("set_focused_recipient", () => {
         stream_id: 999,
         topic: "lunch",
     };
-    assert(!compose_fade_helper.should_fade_message(good_msg));
-    assert(compose_fade_helper.should_fade_message(bad_msg));
+    assert.ok(!compose_fade_helper.should_fade_message(good_msg));
+    assert.ok(compose_fade_helper.should_fade_message(bad_msg));
 });

--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -49,7 +49,7 @@ run_test("pills", (override) => {
 
     pills.appendValidatedData = (item) => {
         const id = item.user_id;
-        assert(!all_pills.has(id));
+        assert.ok(!all_pills.has(id));
         all_pills.set(id, item);
     };
     pills.items = () => Array.from(all_pills.values());
@@ -102,14 +102,14 @@ run_test("pills", (override) => {
     function test_create_item(handler) {
         (function test_rejection_path() {
             const item = handler(othello.email, pills.items());
-            assert(get_by_email_called);
+            assert.ok(get_by_email_called);
             assert.equal(item, undefined);
         })();
 
         (function test_success_path() {
             get_by_email_called = false;
             const res = handler(iago.email, pills.items());
-            assert(get_by_email_called);
+            assert.ok(get_by_email_called);
             assert.equal(typeof res, "object");
             assert.equal(res.user_id, iago.user_id);
             assert.equal(res.display_value, iago.full_name);
@@ -119,7 +119,7 @@ run_test("pills", (override) => {
     function input_pill_stub(opts) {
         assert.equal(opts.container, pill_container_stub);
         create_item_handler = opts.create_item_from_text;
-        assert(create_item_handler);
+        assert.ok(create_item_handler);
         return pills;
     }
 
@@ -137,7 +137,7 @@ run_test("pills", (override) => {
     };
 
     compose_pm_pill.initialize();
-    assert(compose_pm_pill.widget);
+    assert.ok(compose_pm_pill.widget);
 
     compose_pm_pill.set_from_typeahead(othello);
     compose_pm_pill.set_from_typeahead(hamlet);
@@ -158,12 +158,12 @@ run_test("pills", (override) => {
     test_create_item(create_item_handler);
 
     compose_pm_pill.set_from_emails("othello@example.com");
-    assert(compose_pm_pill.widget);
+    assert.ok(compose_pm_pill.widget);
 
-    assert(get_by_user_id_called);
-    assert(pills_cleared);
-    assert(appendValue_called);
-    assert(text_cleared);
+    assert.ok(get_by_user_id_called);
+    assert.ok(pills_cleared);
+    assert.ok(appendValue_called);
+    assert.ok(text_cleared);
 });
 
 run_test("has_unconverted_data", () => {

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -93,7 +93,7 @@ run_test("autosize_textarea", (override) => {
     const container = "container-stub";
     compose_ui.autosize_textarea(container);
     assert.equal(textarea_autosized.textarea, container);
-    assert(textarea_autosized.autosized);
+    assert.ok(textarea_autosized.autosized);
 });
 
 run_test("insert_syntax_and_focus", () => {
@@ -108,7 +108,7 @@ run_test("insert_syntax_and_focus", () => {
     compose_ui.insert_syntax_and_focus(":octopus:");
     assert.equal($("#compose-textarea").caret(), 4);
     assert.equal($("#compose-textarea").val(), "xyz :octopus: ");
-    assert($("#compose-textarea").is_focused());
+    assert.ok($("#compose-textarea").is_focused());
 });
 
 run_test("smart_insert", () => {
@@ -119,27 +119,27 @@ run_test("smart_insert", () => {
     assert.equal(textbox.insert_pos, 4);
     assert.equal(textbox.insert_text, " :smile: ");
     assert.equal(textbox.val(), "abc :smile: ");
-    assert(textbox.focused);
+    assert.ok(textbox.focused);
 
     textbox.trigger("blur");
     compose_ui.smart_insert(textbox, ":airplane:");
     assert.equal(textbox.insert_text, ":airplane: ");
     assert.equal(textbox.val(), "abc :smile: :airplane: ");
-    assert(textbox.focused);
+    assert.ok(textbox.focused);
 
     textbox.caret(0);
     textbox.trigger("blur");
     compose_ui.smart_insert(textbox, ":octopus:");
     assert.equal(textbox.insert_text, ":octopus: ");
     assert.equal(textbox.val(), ":octopus: abc :smile: :airplane: ");
-    assert(textbox.focused);
+    assert.ok(textbox.focused);
 
     textbox.caret(textbox.val().length);
     textbox.trigger("blur");
     compose_ui.smart_insert(textbox, ":heart:");
     assert.equal(textbox.insert_text, ":heart: ");
     assert.equal(textbox.val(), ":octopus: abc :smile: :airplane: :heart: ");
-    assert(textbox.focused);
+    assert.ok(textbox.focused);
 
     // Test handling of spaces for ```quote
     textbox = make_textbox("");
@@ -148,7 +148,7 @@ run_test("smart_insert", () => {
     compose_ui.smart_insert(textbox, "```quote\nquoted message\n```\n");
     assert.equal(textbox.insert_text, "```quote\nquoted message\n```\n");
     assert.equal(textbox.val(), "```quote\nquoted message\n```\n");
-    assert(textbox.focused);
+    assert.ok(textbox.focused);
 
     textbox = make_textbox("");
     textbox.caret(0);
@@ -156,7 +156,7 @@ run_test("smart_insert", () => {
     compose_ui.smart_insert(textbox, "[Quoting…]\n");
     assert.equal(textbox.insert_text, "[Quoting…]\n");
     assert.equal(textbox.val(), "[Quoting…]\n");
-    assert(textbox.focused);
+    assert.ok(textbox.focused);
 
     textbox = make_textbox("abc");
     textbox.caret(3);
@@ -164,7 +164,7 @@ run_test("smart_insert", () => {
     compose_ui.smart_insert(textbox, " test with space");
     assert.equal(textbox.insert_text, " test with space ");
     assert.equal(textbox.val(), "abc test with space ");
-    assert(textbox.focused);
+    assert.ok(textbox.focused);
 
     // Note that we don't have any special logic for strings that are
     // already surrounded by spaces, since we are usually inserting things

--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -65,7 +65,7 @@ test_ui("validate_stream_message_address_info", () => {
         subscribed: true,
     };
     stream_data.add_sub(sub);
-    assert(compose.validate_stream_message_address_info("social"));
+    assert.ok(compose.validate_stream_message_address_info("social"));
 
     sub.subscribed = false;
     stream_data.add_sub(sub);
@@ -73,7 +73,7 @@ test_ui("validate_stream_message_address_info", () => {
         assert.equal(template_name, "compose_not_subscribed");
         return "compose_not_subscribed_stub";
     });
-    assert(!compose.validate_stream_message_address_info("social"));
+    assert.ok(!compose.validate_stream_message_address_info("social"));
     assert.equal($("#compose-error-msg").html(), "compose_not_subscribed_stub");
 
     page_params.narrow_stream = false;
@@ -82,7 +82,7 @@ test_ui("validate_stream_message_address_info", () => {
         payload.data.subscribed = true;
         payload.success(payload.data);
     };
-    assert(compose.validate_stream_message_address_info("social"));
+    assert.ok(compose.validate_stream_message_address_info("social"));
 
     sub.name = "Frontend";
     sub.stream_id = 102;
@@ -92,14 +92,14 @@ test_ui("validate_stream_message_address_info", () => {
         payload.data.subscribed = false;
         payload.success(payload.data);
     };
-    assert(!compose.validate_stream_message_address_info("Frontend"));
+    assert.ok(!compose.validate_stream_message_address_info("Frontend"));
     assert.equal($("#compose-error-msg").html(), "compose_not_subscribed_stub");
 
     channel.post = (payload) => {
         assert.equal(payload.data.stream, "Frontend");
         payload.error({status: 404});
     };
-    assert(!compose.validate_stream_message_address_info("Frontend"));
+    assert.ok(!compose.validate_stream_message_address_info("Frontend"));
     assert.equal(
         $("#compose-error-msg").html(),
         "translated HTML: <p>The stream <b>Frontend</b> does not exist.</p><p>Manage your subscriptions <a href='#streams/all'>on your Streams page</a>.</p>",
@@ -109,7 +109,7 @@ test_ui("validate_stream_message_address_info", () => {
         assert.equal(payload.data.stream, "social");
         payload.error({status: 500});
     };
-    assert(!compose.validate_stream_message_address_info("social"));
+    assert.ok(!compose.validate_stream_message_address_info("social"));
     assert.equal(
         $("#compose-error-msg").html(),
         $t_html({defaultMessage: "Error checking subscription"}),
@@ -150,9 +150,9 @@ test_ui("validate", (override) => {
     }
 
     initialize_pm_pill();
-    assert(!compose.validate());
-    assert(!$("#sending-indicator").visible());
-    assert(!$("#compose-send-button").is_focused());
+    assert.ok(!compose.validate());
+    assert.ok(!$("#sending-indicator").visible());
+    assert.ok(!$("#compose-send-button").is_focused());
     assert.equal($("#compose-send-button").prop("disabled"), false);
     assert.equal(
         $("#compose-error-msg").html(),
@@ -173,8 +173,8 @@ test_ui("validate", (override) => {
         }
         return false;
     };
-    assert(!compose.validate());
-    assert(zephyr_checked);
+    assert.ok(!compose.validate());
+    assert.ok(zephyr_checked);
     assert.equal(
         $("#compose-error-msg").html(),
         $t_html({
@@ -189,7 +189,7 @@ test_ui("validate", (override) => {
     compose_state.set_message_type("private");
 
     compose_state.private_message_recipient("");
-    assert(!compose.validate());
+    assert.ok(!compose.validate());
     assert.equal(
         $("#compose-error-msg").html(),
         $t_html({defaultMessage: "Please specify at least one valid recipient"}),
@@ -199,7 +199,7 @@ test_ui("validate", (override) => {
     add_content_to_compose_box();
     compose_state.private_message_recipient("foo@zulip.com");
 
-    assert(!compose.validate());
+    assert.ok(!compose.validate());
 
     assert.equal(
         $("#compose-error-msg").html(),
@@ -207,7 +207,7 @@ test_ui("validate", (override) => {
     );
 
     compose_state.private_message_recipient("foo@zulip.com,alice@zulip.com");
-    assert(!compose.validate());
+    assert.ok(!compose.validate());
 
     assert.equal(
         $("#compose-error-msg").html(),
@@ -216,15 +216,15 @@ test_ui("validate", (override) => {
 
     people.add_active_user(bob);
     compose_state.private_message_recipient("bob@example.com");
-    assert(compose.validate());
+    assert.ok(compose.validate());
 
     page_params.realm_is_zephyr_mirror_realm = true;
-    assert(compose.validate());
+    assert.ok(compose.validate());
     page_params.realm_is_zephyr_mirror_realm = false;
 
     compose_state.set_message_type("stream");
     compose_state.stream_name("");
-    assert(!compose.validate());
+    assert.ok(!compose.validate());
     assert.equal(
         $("#compose-error-msg").html(),
         $t_html({defaultMessage: "Please specify a stream"}),
@@ -233,7 +233,7 @@ test_ui("validate", (override) => {
     compose_state.stream_name("Denmark");
     page_params.realm_mandatory_topics = true;
     compose_state.topic("");
-    assert(!compose.validate());
+    assert.ok(!compose.validate());
     assert.equal(
         $("#compose-error-msg").html(),
         $t_html({defaultMessage: "Please specify a topic"}),
@@ -276,9 +276,9 @@ test_ui("validate_stream_message", (override) => {
     };
     stream_data.add_sub(sub);
     compose_state.stream_name("social");
-    assert(compose.validate());
-    assert(!$("#compose-all-everyone").visible());
-    assert(!$("#compose-send-status").visible());
+    assert.ok(compose.validate());
+    assert.ok(!$("#compose-all-everyone").visible());
+    assert.ok(!$("#compose-send-status").visible());
 
     peer_data.get_subscriber_count = (stream_id) => {
         assert.equal(stream_id, 101);
@@ -296,14 +296,14 @@ test_ui("validate_stream_message", (override) => {
 
     override(compose, "wildcard_mention_allowed", () => true);
     compose_state.message_content("Hey @**all**");
-    assert(!compose.validate());
+    assert.ok(!compose.validate());
     assert.equal($("#compose-send-button").prop("disabled"), false);
-    assert(!$("#compose-send-status").visible());
+    assert.ok(!$("#compose-send-status").visible());
     assert.equal(compose_content, "compose_all_everyone_stub");
-    assert($("#compose-all-everyone").visible());
+    assert.ok($("#compose-all-everyone").visible());
 
     override(compose, "wildcard_mention_allowed", () => false);
-    assert(!compose.validate());
+    assert.ok(!compose.validate());
     assert.equal(
         $("#compose-error-msg").html(),
         $t_html({
@@ -330,7 +330,7 @@ test_ui("test_validate_stream_message_post_policy_admin_only", (override) => {
     compose_state.topic("subject102");
     compose_state.stream_name("stream102");
     stream_data.add_sub(sub);
-    assert(!compose.validate());
+    assert.ok(!compose.validate());
     assert.equal(
         $("#compose-error-msg").html(),
         $t_html({defaultMessage: "Only organization admins are allowed to post to this stream."}),
@@ -344,7 +344,7 @@ test_ui("test_validate_stream_message_post_policy_admin_only", (override) => {
 
     compose_state.topic("subject102");
     compose_state.stream_name("stream102");
-    assert(!compose.validate());
+    assert.ok(!compose.validate());
     assert.equal(
         $("#compose-error-msg").html(),
         $t_html({defaultMessage: "Only organization admins are allowed to post to this stream."}),
@@ -368,7 +368,7 @@ test_ui("test_validate_stream_message_post_policy_moderators_only", (override) =
     compose_state.topic("subject104");
     compose_state.stream_name("stream104");
     stream_data.add_sub(sub);
-    assert(!compose.validate());
+    assert.ok(!compose.validate());
     assert.equal(
         $("#compose-error-msg").html(),
         $t_html({
@@ -405,7 +405,7 @@ test_ui("test_validate_stream_message_post_policy_full_members_only", (override)
     compose_state.topic("subject103");
     compose_state.stream_name("stream103");
     stream_data.add_sub(sub);
-    assert(!compose.validate());
+    assert.ok(!compose.validate());
     assert.equal(
         $("#compose-error-msg").html(),
         $t_html({defaultMessage: "Guests are not allowed to post to this stream."}),

--- a/frontend_tests/node_tests/compose_video.js
+++ b/frontend_tests/node_tests/compose_video.js
@@ -102,7 +102,7 @@ test("videos", (override) => {
         $("#compose-textarea").val("");
 
         handler(ev);
-        assert(!called);
+        assert.ok(!called);
     })();
 
     (function test_jitsi_video_link_compose_clicked() {
@@ -131,14 +131,14 @@ test("videos", (override) => {
 
         page_params.jitsi_server_url = null;
         handler(ev);
-        assert(!called);
+        assert.ok(!called);
 
         page_params.jitsi_server_url = "https://meet.jit.si";
         handler(ev);
         // video link ids consist of 15 random digits
         const video_link_regex =
             /\[translated: Click to join video call]\(https:\/\/meet.jit.si\/\d{15}\)/;
-        assert(called);
+        assert.ok(called);
         assert.match(syntax_to_insert, video_link_regex);
     })();
 
@@ -168,7 +168,7 @@ test("videos", (override) => {
         page_params.has_zoom_token = false;
 
         window.open = (url) => {
-            assert(url.endsWith("/calls/zoom/register"));
+            assert.ok(url.endsWith("/calls/zoom/register"));
 
             // The event here has value=true.  We keep it in events.js to
             // allow our tooling to verify its schema.
@@ -183,7 +183,7 @@ test("videos", (override) => {
 
         handler(ev);
         const video_link_regex = /\[translated: Click to join video call]\(example\.zoom\.com\)/;
-        assert(called);
+        assert.ok(called);
         assert.match(syntax_to_insert, video_link_regex);
     })();
 
@@ -222,7 +222,7 @@ test("videos", (override) => {
         handler(ev);
         const video_link_regex =
             /\[translated: Click to join video call]\(\/calls\/bigbluebutton\/join\?meeting_id=%22zulip-1%22&password=%22AAAAAAAAAA%22&checksum=%2232702220bff2a22a44aee72e96cfdb4c4091752e%22\)/;
-        assert(called);
+        assert.ok(called);
         assert.match(syntax_to_insert, video_link_regex);
     })();
 });

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -401,7 +401,7 @@ test("content_typeahead_selected", (override) => {
     actual_value = ct.content_typeahead_selected.call(fake_this, othello);
     expected_value = "@**Othello, the Moor of Venice** ";
     assert.equal(actual_value, expected_value);
-    assert(warned_for_mention);
+    assert.ok(warned_for_mention);
 
     fake_this.query = "Hello @oth";
     fake_this.token = "oth";
@@ -565,11 +565,11 @@ test("content_typeahead_selected", (override) => {
     expected_value = fake_this.query;
     assert.equal(actual_value, expected_value);
 
-    assert(caret_called1);
-    assert(caret_called2);
-    assert(autosize_called);
-    assert(set_timeout_called);
-    assert(warned_for_stream_link);
+    assert.ok(caret_called1);
+    assert.ok(caret_called2);
+    assert.ok(autosize_called);
+    assert.ok(set_timeout_called);
+    assert.ok(warned_for_stream_link);
 });
 
 function sorted_names_from(subs) {
@@ -831,14 +831,14 @@ test("initialize", (override) => {
         options.query = "hamletchar";
         options.updater(hamletcharacters, event);
         assert.deepEqual(appended_names, ["King Lear"]);
-        assert(cleared);
+        assert.ok(cleared);
 
         inserted_users = [lear.user_id];
         appended_names = [];
         cleared = false;
         options.updater(hamletcharacters, event);
         assert.deepEqual(appended_names, []);
-        assert(cleared);
+        assert.ok(cleared);
 
         pm_recipient_typeahead_called = true;
     };
@@ -862,7 +862,7 @@ test("initialize", (override) => {
         fake_this.options = options;
         let actual_value = options.source.call(fake_this, "test #s");
         assert.deepEqual(sorted_names_from(actual_value), ["Denmark", "Sweden", "The Netherlands"]);
-        assert(caret_called);
+        assert.ok(caret_called);
 
         // options.highlighter()
         //
@@ -1048,7 +1048,7 @@ test("initialize", (override) => {
     });
 
     $("form#send_message_form").trigger(event);
-    assert(compose_finish_called);
+    assert.ok(compose_finish_called);
     event.metaKey = false;
     event.ctrlKey = true;
     $("form#send_message_form").trigger(event);
@@ -1122,11 +1122,11 @@ test("initialize", (override) => {
 
     // Now let's make sure that all the stub functions have been called
     // during the initialization.
-    assert(stream_typeahead_called);
-    assert(subject_typeahead_called);
-    assert(pm_recipient_typeahead_called);
-    assert(channel_post_called);
-    assert(compose_textarea_typeahead_called);
+    assert.ok(stream_typeahead_called);
+    assert.ok(subject_typeahead_called);
+    assert.ok(pm_recipient_typeahead_called);
+    assert.ok(channel_post_called);
+    assert.ok(compose_textarea_typeahead_called);
 });
 
 test("begins_typeahead", (override) => {
@@ -1419,15 +1419,15 @@ test("content_highlighter", (override) => {
     ct.content_highlighter.call(fake_this, "py");
 
     fake_this = {completing: "something-else"};
-    assert(!ct.content_highlighter.call(fake_this));
+    assert.ok(!ct.content_highlighter.call(fake_this));
 
     // Verify that all stub functions have been called.
-    assert(th_render_typeahead_item_called);
-    assert(th_render_person_called);
-    assert(th_render_user_group_called);
-    assert(th_render_stream_called);
-    assert(th_render_typeahead_item_called);
-    assert(th_render_slash_command_called);
+    assert.ok(th_render_typeahead_item_called);
+    assert.ok(th_render_person_called);
+    assert.ok(th_render_user_group_called);
+    assert.ok(th_render_stream_called);
+    assert.ok(th_render_typeahead_item_called);
+    assert.ok(th_render_slash_command_called);
 });
 
 test("filter_and_sort_mentions (normal)", () => {

--- a/frontend_tests/node_tests/copy_and_paste.js
+++ b/frontend_tests/node_tests/copy_and_paste.js
@@ -100,7 +100,7 @@ run_test("paste_handler", () => {
         insert_syntax_and_focus_called = true;
     };
     copy_and_paste.paste_handler(event);
-    assert(insert_syntax_and_focus_called);
+    assert.ok(insert_syntax_and_focus_called);
 
     data =
         '<meta http-equiv="content-type" content="text/html; charset=utf-8"><img src="http://localhost:9991/thumbnail?url=user_uploads%2F1%2Fe2%2FHPMCcGWOG9rS2M4ybHN8sEzh%2Fpasted_image.png&amp;size=full"/>';
@@ -108,5 +108,5 @@ run_test("paste_handler", () => {
     event.originalEvent.clipboardData.setData("text/html", data);
     insert_syntax_and_focus_called = false;
     copy_and_paste.paste_handler(event);
-    assert(!insert_syntax_and_focus_called);
+    assert.ok(!insert_syntax_and_focus_called);
 });

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -115,16 +115,16 @@ function assert_same(actual, expected) {
 
 run_test("alert_words", (override) => {
     alert_words.initialize({alert_words: []});
-    assert(!alert_words.has_alert_word("fire"));
-    assert(!alert_words.has_alert_word("lunch"));
+    assert.ok(!alert_words.has_alert_word("fire"));
+    assert.ok(!alert_words.has_alert_word("lunch"));
 
     override(alert_words_ui, "render_alert_words_ui", noop);
     const event = event_fixtures.alert_words;
     dispatch(event);
 
     assert.deepEqual(alert_words.get_word_list(), ["fire", "lunch"]);
-    assert(alert_words.has_alert_word("fire"));
-    assert(alert_words.has_alert_word("lunch"));
+    assert.ok(alert_words.has_alert_word("fire"));
+    assert.ok(alert_words.has_alert_word("lunch"));
 });
 
 run_test("attachments", (override) => {
@@ -305,7 +305,7 @@ run_test("realm settings", (override) => {
             called = true;
         });
 
-        assert(called);
+        assert.ok(called);
     }
 
     // realm
@@ -567,7 +567,7 @@ run_test("realm_user", (override) => {
     // manipulation
     assert.deepEqual(added_person, event.person);
 
-    assert(people.is_active_user_for_popover(event.person.user_id));
+    assert.ok(people.is_active_user_for_popover(event.person.user_id));
 
     event = event_fixtures.realm_user__remove;
     override(stream_events, "remove_deactivated_user_from_all_streams", noop);
@@ -576,7 +576,7 @@ run_test("realm_user", (override) => {
     // We don't actually remove the person, we just deactivate them.
     const removed_person = people.get_by_user_id(event.person.user_id);
     assert.equal(removed_person.full_name, "Test User");
-    assert(!people.is_active_user_for_popover(event.person.user_id));
+    assert.ok(!people.is_active_user_for_popover(event.person.user_id));
 
     event = event_fixtures.realm_user__update;
     const stub = make_stub();

--- a/frontend_tests/node_tests/dispatch_subs.js
+++ b/frontend_tests/node_tests/dispatch_subs.js
@@ -88,14 +88,14 @@ test("peer add/remove", (override) => {
     assert.equal(compose_fade_stub.num_calls, 1);
     assert.equal(subs_stub.num_calls, 1);
 
-    assert(peer_data.is_user_subscribed(event.stream_ids[0], event.user_ids[0]));
+    assert.ok(peer_data.is_user_subscribed(event.stream_ids[0], event.user_ids[0]));
 
     event = event_fixtures.subscription__peer_remove;
     dispatch(event);
     assert.equal(compose_fade_stub.num_calls, 2);
     assert.equal(subs_stub.num_calls, 2);
 
-    assert(!peer_data.is_user_subscribed(event.stream_ids[0], event.user_ids[0]));
+    assert.ok(!peer_data.is_user_subscribed(event.stream_ids[0], event.user_ids[0]));
 });
 
 test("remove", (override) => {

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -171,7 +171,7 @@ test("initialize", (override) => {
             called = true;
         });
         f();
-        assert(called);
+        assert.ok(called);
     };
 
     drafts.initialize();

--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -43,25 +43,25 @@ run_test("basic_functions", () => {
 
     assert.equal(widget.value(), "one");
     assert.equal(updated_value, undefined); // We haven't 'updated' the widget yet.
-    assert(reset_button.visible());
+    assert.ok(reset_button.visible());
 
     widget.update("two");
     assert.equal($widget.text(), "rendered: two");
     assert.equal(widget.value(), "two");
     assert.equal(updated_value, "two");
-    assert(reset_button.visible());
+    assert.ok(reset_button.visible());
 
     widget.update(null);
     assert.equal($widget.text(), "translated: not set");
     assert.equal(widget.value(), "");
     assert.equal(updated_value, null);
-    assert(!reset_button.visible());
+    assert.ok(!reset_button.visible());
 
     widget.update("four");
     assert.equal($widget.text(), "translated: not set");
     assert.equal(widget.value(), "four");
     assert.equal(updated_value, "four");
-    assert(!reset_button.visible());
+    assert.ok(!reset_button.visible());
 });
 
 run_test("no_default_value", () => {

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -226,9 +226,9 @@ run_test("insert_local_message streams", (override) => {
     };
     echo.insert_local_message(message_request, local_id_float);
 
-    assert(apply_markdown_called);
-    assert(add_topic_links_called);
-    assert(insert_message_called);
+    assert.ok(apply_markdown_called);
+    assert.ok(add_topic_links_called);
+    assert.ok(insert_message_called);
 });
 
 run_test("insert_local_message PM", (override) => {
@@ -273,9 +273,9 @@ run_test("insert_local_message PM", (override) => {
         sender_id: 123,
     };
     echo.insert_local_message(message_request, local_id_float);
-    assert(add_topic_links_called);
-    assert(apply_markdown_called);
-    assert(insert_message_called);
+    assert.ok(add_topic_links_called);
+    assert.ok(apply_markdown_called);
+    assert.ok(insert_message_called);
 });
 
 MockDate.reset();

--- a/frontend_tests/node_tests/example1.js
+++ b/frontend_tests/node_tests/example1.js
@@ -25,8 +25,8 @@ const util = zrequire("util");
 // The most basic unit tests load up code, call functions,
 // and assert truths:
 
-assert(!util.find_wildcard_mentions("boring text"));
-assert(util.find_wildcard_mentions("mention @**everyone**"));
+assert.ok(!util.find_wildcard_mentions("boring text"));
+assert.ok(util.find_wildcard_mentions("mention @**everyone**"));
 
 // Let's test with people.js next.  We'll show this technique:
 //  * get a false value
@@ -44,9 +44,9 @@ const isaac = {
 // the tests in people.js in the same directory as this file.
 
 // Let's exercise the code and use assert to verify it works!
-assert(!people.is_known_user_id(isaac.user_id));
+assert.ok(!people.is_known_user_id(isaac.user_id));
 people.add_active_user(isaac);
-assert(people.is_known_user_id(isaac.user_id));
+assert.ok(people.is_known_user_id(isaac.user_id));
 
 // Let's look at stream_data next, and we will start by putting
 // some data at module scope. (You could also declare this inside

--- a/frontend_tests/node_tests/example4.js
+++ b/frontend_tests/node_tests/example4.js
@@ -79,13 +79,13 @@ run_test("add users with event", () => {
         person: bob,
     };
 
-    assert(!people.is_known_user_id(bob.user_id));
+    assert.ok(!people.is_known_user_id(bob.user_id));
 
     // Let's simulate dispatching our event!
     server_events_dispatch.dispatch_normal_event(event);
 
     // And it works!
-    assert(people.is_known_user_id(bob.user_id));
+    assert.ok(people.is_known_user_id(bob.user_id));
 });
 
 /*

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -78,20 +78,20 @@ test("basics", () => {
     assert_same_operators(filter.operators(), operators);
     assert.deepEqual(filter.operands("stream"), ["foo"]);
 
-    assert(filter.has_operator("stream"));
-    assert(!filter.has_operator("search"));
+    assert.ok(filter.has_operator("stream"));
+    assert.ok(!filter.has_operator("search"));
 
-    assert(filter.has_operand("stream", "foo"));
-    assert(!filter.has_operand("stream", "exclude_stream"));
-    assert(!filter.has_operand("stream", "nada"));
+    assert.ok(filter.has_operand("stream", "foo"));
+    assert.ok(!filter.has_operand("stream", "exclude_stream"));
+    assert.ok(!filter.has_operand("stream", "nada"));
 
-    assert(!filter.is_search());
-    assert(!filter.can_mark_messages_read());
-    assert(!filter.contains_only_private_messages());
-    assert(!filter.allow_use_first_unread_when_narrowing());
-    assert(filter.includes_full_stream_history());
-    assert(filter.can_apply_locally());
-    assert(!filter.is_personal_filter());
+    assert.ok(!filter.is_search());
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.allow_use_first_unread_when_narrowing());
+    assert.ok(filter.includes_full_stream_history());
+    assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
 
     operators = [
         {operator: "stream", operand: "foo"},
@@ -100,184 +100,184 @@ test("basics", () => {
     ];
     filter = new Filter(operators);
 
-    assert(filter.is_search());
-    assert(!filter.can_mark_messages_read());
-    assert(!filter.contains_only_private_messages());
-    assert(!filter.allow_use_first_unread_when_narrowing());
-    assert(!filter.can_apply_locally());
-    assert(!filter.is_personal_filter());
-    assert(filter.can_bucket_by("stream"));
-    assert(filter.can_bucket_by("stream", "topic"));
+    assert.ok(filter.is_search());
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.allow_use_first_unread_when_narrowing());
+    assert.ok(!filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(filter.can_bucket_by("stream"));
+    assert.ok(filter.can_bucket_by("stream", "topic"));
 
     // If our only stream operator is negated, then for all intents and purposes,
     // we don't consider ourselves to have a stream operator, because we don't
     // want to have the stream in the tab bar or unsubscribe messaging, etc.
     operators = [{operator: "stream", operand: "exclude", negated: true}];
     filter = new Filter(operators);
-    assert(!filter.contains_only_private_messages());
-    assert(!filter.has_operator("stream"));
-    assert(!filter.can_mark_messages_read());
-    assert(!filter.is_personal_filter());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.has_operator("stream"));
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(!filter.is_personal_filter());
 
     // Negated searches are just like positive searches for our purposes, since
     // the search logic happens on the backend and we need to have can_apply_locally()
     // be false, and we want "Search results" in the tab bar.
     operators = [{operator: "search", operand: "stop_word", negated: true}];
     filter = new Filter(operators);
-    assert(!filter.contains_only_private_messages());
-    assert(filter.has_operator("search"));
-    assert(!filter.can_apply_locally());
-    assert(!filter.can_mark_messages_read());
-    assert(!filter.is_personal_filter());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(filter.has_operator("search"));
+    assert.ok(!filter.can_apply_locally());
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(!filter.is_personal_filter());
 
     // Similar logic applies to negated "has" searches.
     operators = [{operator: "has", operand: "images", negated: true}];
     filter = new Filter(operators);
-    assert(filter.has_operator("has"));
-    assert(filter.can_apply_locally());
-    assert(!filter.can_apply_locally(true));
-    assert(!filter.includes_full_stream_history());
-    assert(!filter.can_mark_messages_read());
-    assert(!filter.is_personal_filter());
+    assert.ok(filter.has_operator("has"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.can_apply_locally(true));
+    assert.ok(!filter.includes_full_stream_history());
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(!filter.is_personal_filter());
 
     operators = [{operator: "streams", operand: "public", negated: true}];
     filter = new Filter(operators);
-    assert(!filter.contains_only_private_messages());
-    assert(!filter.has_operator("streams"));
-    assert(!filter.can_mark_messages_read());
-    assert(filter.has_negated_operand("streams", "public"));
-    assert(!filter.can_apply_locally());
-    assert(!filter.is_personal_filter());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.has_operator("streams"));
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.has_negated_operand("streams", "public"));
+    assert.ok(!filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
 
     operators = [{operator: "streams", operand: "public"}];
     filter = new Filter(operators);
-    assert(!filter.contains_only_private_messages());
-    assert(filter.has_operator("streams"));
-    assert(!filter.can_mark_messages_read());
-    assert(!filter.has_negated_operand("streams", "public"));
-    assert(!filter.can_apply_locally());
-    assert(filter.includes_full_stream_history());
-    assert(!filter.is_personal_filter());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(filter.has_operator("streams"));
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(!filter.has_negated_operand("streams", "public"));
+    assert.ok(!filter.can_apply_locally());
+    assert.ok(filter.includes_full_stream_history());
+    assert.ok(!filter.is_personal_filter());
 
     operators = [{operator: "is", operand: "private"}];
     filter = new Filter(operators);
-    assert(filter.contains_only_private_messages());
-    assert(filter.can_mark_messages_read());
-    assert(!filter.has_operator("search"));
-    assert(filter.can_apply_locally());
-    assert(!filter.is_personal_filter());
+    assert.ok(filter.contains_only_private_messages());
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
 
     operators = [{operator: "is", operand: "mentioned"}];
     filter = new Filter(operators);
-    assert(!filter.contains_only_private_messages());
-    assert(filter.can_mark_messages_read());
-    assert(!filter.has_operator("search"));
-    assert(filter.can_apply_locally());
-    assert(filter.is_personal_filter());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(filter.is_personal_filter());
 
     operators = [{operator: "is", operand: "starred"}];
     filter = new Filter(operators);
-    assert(!filter.contains_only_private_messages());
-    assert(!filter.can_mark_messages_read());
-    assert(!filter.has_operator("search"));
-    assert(filter.can_apply_locally());
-    assert(filter.is_personal_filter());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(filter.is_personal_filter());
 
     operators = [{operator: "pm-with", operand: "joe@example.com"}];
     filter = new Filter(operators);
-    assert(filter.is_non_huddle_pm());
-    assert(filter.contains_only_private_messages());
-    assert(!filter.has_operator("search"));
-    assert(filter.can_apply_locally());
-    assert(!filter.is_personal_filter());
+    assert.ok(filter.is_non_huddle_pm());
+    assert.ok(filter.contains_only_private_messages());
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
 
     operators = [{operator: "pm-with", operand: "joe@example.com,jack@example.com"}];
     filter = new Filter(operators);
-    assert(!filter.is_non_huddle_pm());
-    assert(filter.contains_only_private_messages());
+    assert.ok(!filter.is_non_huddle_pm());
+    assert.ok(filter.contains_only_private_messages());
 
     operators = [{operator: "group-pm-with", operand: "joe@example.com"}];
     filter = new Filter(operators);
-    assert(!filter.is_non_huddle_pm());
-    assert(filter.contains_only_private_messages());
-    assert(!filter.has_operator("search"));
-    assert(filter.can_apply_locally());
+    assert.ok(!filter.is_non_huddle_pm());
+    assert.ok(filter.contains_only_private_messages());
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(filter.can_apply_locally());
 });
 
 function assert_not_mark_read_with_has_operands(additional_operators_to_test) {
     additional_operators_to_test = additional_operators_to_test || [];
     let has_operator = [{operator: "has", operand: "link"}];
     let filter = new Filter(additional_operators_to_test.concat(has_operator));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     has_operator = [{operator: "has", operand: "link", negated: true}];
     filter = new Filter(additional_operators_to_test.concat(has_operator));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     has_operator = [{operator: "has", operand: "image"}];
     filter = new Filter(additional_operators_to_test.concat(has_operator));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     has_operator = [{operator: "has", operand: "image", negated: true}];
     filter = new Filter(additional_operators_to_test.concat(has_operator));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     has_operator = [{operator: "has", operand: "attachment", negated: true}];
     filter = new Filter(additional_operators_to_test.concat(has_operator));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     has_operator = [{operator: "has", operand: "attachment"}];
     filter = new Filter(additional_operators_to_test.concat(has_operator));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 }
 function assert_not_mark_read_with_is_operands(additional_operators_to_test) {
     additional_operators_to_test = additional_operators_to_test || [];
     let is_operator = [{operator: "is", operand: "starred"}];
     let filter = new Filter(additional_operators_to_test.concat(is_operator));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     is_operator = [{operator: "is", operand: "starred", negated: true}];
     filter = new Filter(additional_operators_to_test.concat(is_operator));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     is_operator = [{operator: "is", operand: "mentioned"}];
     filter = new Filter(additional_operators_to_test.concat(is_operator));
     if (additional_operators_to_test.length === 0) {
-        assert(filter.can_mark_messages_read());
+        assert.ok(filter.can_mark_messages_read());
     } else {
-        assert(!filter.can_mark_messages_read());
+        assert.ok(!filter.can_mark_messages_read());
     }
 
     is_operator = [{operator: "is", operand: "mentioned", negated: true}];
     filter = new Filter(additional_operators_to_test.concat(is_operator));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     is_operator = [{operator: "is", operand: "alerted"}];
     filter = new Filter(additional_operators_to_test.concat(is_operator));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     is_operator = [{operator: "is", operand: "alerted", negated: true}];
     filter = new Filter(additional_operators_to_test.concat(is_operator));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     is_operator = [{operator: "is", operand: "unread"}];
     filter = new Filter(additional_operators_to_test.concat(is_operator));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     is_operator = [{operator: "is", operand: "unread", negated: true}];
     filter = new Filter(additional_operators_to_test.concat(is_operator));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 }
 
 function assert_not_mark_read_when_searching(additional_operators_to_test) {
     additional_operators_to_test = additional_operators_to_test || [];
     let search_op = [{operator: "search", operand: "keyword"}];
     let filter = new Filter(additional_operators_to_test.concat(search_op));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     search_op = [{operator: "search", operand: "keyword", negated: true}];
     filter = new Filter(additional_operators_to_test.concat(search_op));
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 }
 
 test("can_mark_messages_read", () => {
@@ -287,21 +287,21 @@ test("can_mark_messages_read", () => {
 
     const stream_operator = [{operator: "stream", operand: "foo"}];
     let filter = new Filter(stream_operator);
-    assert(filter.can_mark_messages_read());
+    assert.ok(filter.can_mark_messages_read());
     assert_not_mark_read_with_has_operands(stream_operator);
     assert_not_mark_read_with_is_operands(stream_operator);
     assert_not_mark_read_when_searching(stream_operator);
 
     const stream_negated_operator = [{operator: "stream", operand: "foo", negated: true}];
     filter = new Filter(stream_negated_operator);
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     const stream_topic_operators = [
         {operator: "stream", operand: "foo"},
         {operator: "topic", operand: "bar"},
     ];
     filter = new Filter(stream_topic_operators);
-    assert(filter.can_mark_messages_read());
+    assert.ok(filter.can_mark_messages_read());
     assert_not_mark_read_with_has_operands(stream_topic_operators);
     assert_not_mark_read_with_is_operands(stream_topic_operators);
     assert_not_mark_read_when_searching(stream_topic_operators);
@@ -311,7 +311,7 @@ test("can_mark_messages_read", () => {
         {operator: "topic", operand: "bar", negated: true},
     ];
     filter = new Filter(stream_negated_topic_operators);
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     const pm_with = [{operator: "pm-with", operand: "joe@example.com,"}];
 
@@ -319,11 +319,11 @@ test("can_mark_messages_read", () => {
 
     const group_pm = [{operator: "pm-with", operand: "joe@example.com,STEVE@foo.com"}];
     filter = new Filter(pm_with);
-    assert(filter.can_mark_messages_read());
+    assert.ok(filter.can_mark_messages_read());
     filter = new Filter(pm_with_negated);
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
     filter = new Filter(group_pm);
-    assert(filter.can_mark_messages_read());
+    assert.ok(filter.can_mark_messages_read());
     assert_not_mark_read_with_is_operands(group_pm);
     assert_not_mark_read_with_is_operands(pm_with);
     assert_not_mark_read_with_has_operands(group_pm);
@@ -333,14 +333,14 @@ test("can_mark_messages_read", () => {
 
     const is_private = [{operator: "is", operand: "private"}];
     filter = new Filter(is_private);
-    assert(filter.can_mark_messages_read());
+    assert.ok(filter.can_mark_messages_read());
     assert_not_mark_read_with_is_operands(is_private);
     assert_not_mark_read_with_has_operands(is_private);
     assert_not_mark_read_when_searching(is_private);
 
     const in_all = [{operator: "in", operand: "all"}];
     filter = new Filter(in_all);
-    assert(filter.can_mark_messages_read());
+    assert.ok(filter.can_mark_messages_read());
     assert_not_mark_read_with_is_operands(in_all);
     assert_not_mark_read_with_has_operands(in_all);
     assert_not_mark_read_when_searching(in_all);
@@ -348,20 +348,20 @@ test("can_mark_messages_read", () => {
     const in_home = [{operator: "in", operand: "home"}];
     const in_home_negated = [{operator: "in", operand: "home", negated: true}];
     filter = new Filter(in_home);
-    assert(filter.can_mark_messages_read());
+    assert.ok(filter.can_mark_messages_read());
     assert_not_mark_read_with_is_operands(in_home);
     assert_not_mark_read_with_has_operands(in_home);
     assert_not_mark_read_when_searching(in_home);
     filter = new Filter(in_home_negated);
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     // Do not mark messages as read when in an unsupported 'in:*' filter.
     const in_random = [{operator: "in", operand: "xxxxxxxxx"}];
     const in_random_negated = [{operator: "in", operand: "xxxxxxxxx", negated: true}];
     filter = new Filter(in_random);
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
     filter = new Filter(in_random_negated);
-    assert(!filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
 
     // test caching of term types
     // init and stub
@@ -374,33 +374,33 @@ test("can_mark_messages_read", () => {
 
     // uncached trial
     filter.calc_can_mark_messages_read_called = false;
-    assert(filter.can_mark_messages_read());
-    assert(filter.calc_can_mark_messages_read_called);
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(filter.calc_can_mark_messages_read_called);
 
     // cached trial
     filter.calc_can_mark_messages_read_called = false;
-    assert(filter.can_mark_messages_read());
-    assert(!filter.calc_can_mark_messages_read_called);
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(!filter.calc_can_mark_messages_read_called);
 });
 
 test("show_first_unread", () => {
     let operators = [{operator: "is", operand: "any"}];
     let filter = new Filter(operators);
-    assert(filter.allow_use_first_unread_when_narrowing());
+    assert.ok(filter.allow_use_first_unread_when_narrowing());
 
     operators = [{operator: "search", operand: "query to search"}];
     filter = new Filter(operators);
-    assert(!filter.allow_use_first_unread_when_narrowing());
+    assert.ok(!filter.allow_use_first_unread_when_narrowing());
 
     filter = new Filter();
-    assert(filter.can_mark_messages_read());
-    assert(filter.allow_use_first_unread_when_narrowing());
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(filter.allow_use_first_unread_when_narrowing());
 
     // Side case
     operators = [{operator: "is", operand: "any"}];
     filter = new Filter(operators);
-    assert(!filter.can_mark_messages_read());
-    assert(filter.allow_use_first_unread_when_narrowing());
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.allow_use_first_unread_when_narrowing());
 });
 
 test("filter_with_new_params_topic", () => {
@@ -410,9 +410,9 @@ test("filter_with_new_params_topic", () => {
     ];
     const filter = new Filter(operators);
 
-    assert(filter.has_topic("foo", "old topic"));
-    assert(!filter.has_topic("wrong", "old topic"));
-    assert(!filter.has_topic("foo", "wrong"));
+    assert.ok(filter.has_topic("foo", "old topic"));
+    assert.ok(!filter.has_topic("wrong", "old topic"));
+    assert.ok(!filter.has_topic("foo", "wrong"));
 
     const new_filter = filter.filter_with_new_params({
         operator: "topic",
@@ -430,9 +430,9 @@ test("filter_with_new_params_stream", () => {
     ];
     const filter = new Filter(operators);
 
-    assert(filter.has_topic("foo", "old topic"));
-    assert(!filter.has_topic("wrong", "old topic"));
-    assert(!filter.has_topic("foo", "wrong"));
+    assert.ok(filter.has_topic("foo", "old topic"));
+    assert.ok(!filter.has_topic("wrong", "old topic"));
+    assert.ok(!filter.has_topic("foo", "wrong"));
 
     const new_filter = filter.filter_with_new_params({
         operator: "stream",
@@ -452,7 +452,7 @@ test("new_style_operators", () => {
     const filter = new Filter(operators);
 
     assert.deepEqual(filter.operands("stream"), ["foo"]);
-    assert(filter.can_bucket_by("stream"));
+    assert.ok(filter.can_bucket_by("stream"));
 });
 
 test("public_operators", () => {
@@ -467,7 +467,7 @@ test("public_operators", () => {
     with_field(page_params, "narrow_stream", undefined, () => {
         assert_same_operators(filter.public_operators(), operators);
     });
-    assert(filter.can_bucket_by("stream"));
+    assert.ok(filter.can_bucket_by("stream"));
 
     operators = [{operator: "stream", operand: "default"}];
     filter = new Filter(operators);
@@ -485,14 +485,14 @@ test("redundancies", () => {
         {operator: "is", operand: "private"},
     ];
     filter = new Filter(terms);
-    assert(filter.can_bucket_by("pm-with"));
+    assert.ok(filter.can_bucket_by("pm-with"));
 
     terms = [
         {operator: "pm-with", operand: "joe@example.com,", negated: true},
         {operator: "is", operand: "private"},
     ];
     filter = new Filter(terms);
-    assert(filter.can_bucket_by("is-private", "not-pm-with"));
+    assert.ok(filter.can_bucket_by("is-private", "not-pm-with"));
 });
 
 test("canonicalization", () => {
@@ -559,10 +559,10 @@ test("predicate_basics", () => {
         ["topic", "Bar"],
     ]);
 
-    assert(predicate({type: "stream", stream_id, topic: "bar"}));
-    assert(!predicate({type: "stream", stream_id, topic: "whatever"}));
-    assert(!predicate({type: "stream", stream_id: 9999999}));
-    assert(!predicate({type: "private"}));
+    assert.ok(predicate({type: "stream", stream_id, topic: "bar"}));
+    assert.ok(!predicate({type: "stream", stream_id, topic: "whatever"}));
+    assert.ok(!predicate({type: "stream", stream_id: 9999999}));
+    assert.ok(!predicate({type: "private"}));
 
     // For old streams that we are no longer subscribed to, we may not have
     // a sub, but these should still match by stream name.
@@ -570,92 +570,92 @@ test("predicate_basics", () => {
         ["stream", "old-Stream"],
         ["topic", "Bar"],
     ]);
-    assert(predicate({type: "stream", stream: "Old-stream", topic: "bar"}));
-    assert(!predicate({type: "stream", stream: "no-match", topic: "whatever"}));
+    assert.ok(predicate({type: "stream", stream: "Old-stream", topic: "bar"}));
+    assert.ok(!predicate({type: "stream", stream: "no-match", topic: "whatever"}));
 
     predicate = get_predicate([["search", "emoji"]]);
-    assert(predicate({}));
+    assert.ok(predicate({}));
 
     predicate = get_predicate([["topic", "Bar"]]);
-    assert(!predicate({type: "private"}));
+    assert.ok(!predicate({type: "private"}));
 
     predicate = get_predicate([["is", "private"]]);
-    assert(predicate({type: "private"}));
-    assert(!predicate({type: "stream"}));
+    assert.ok(predicate({type: "private"}));
+    assert.ok(!predicate({type: "stream"}));
 
     predicate = get_predicate([["streams", "public"]]);
-    assert(predicate({}));
+    assert.ok(predicate({}));
 
     predicate = get_predicate([["is", "starred"]]);
-    assert(predicate({starred: true}));
-    assert(!predicate({starred: false}));
+    assert.ok(predicate({starred: true}));
+    assert.ok(!predicate({starred: false}));
 
     predicate = get_predicate([["is", "unread"]]);
-    assert(predicate({unread: true}));
-    assert(!predicate({unread: false}));
+    assert.ok(predicate({unread: true}));
+    assert.ok(!predicate({unread: false}));
 
     predicate = get_predicate([["is", "alerted"]]);
-    assert(predicate({alerted: true}));
-    assert(!predicate({alerted: false}));
-    assert(!predicate({}));
+    assert.ok(predicate({alerted: true}));
+    assert.ok(!predicate({alerted: false}));
+    assert.ok(!predicate({}));
 
     predicate = get_predicate([["is", "mentioned"]]);
-    assert(predicate({mentioned: true}));
-    assert(!predicate({mentioned: false}));
+    assert.ok(predicate({mentioned: true}));
+    assert.ok(!predicate({mentioned: false}));
 
     predicate = get_predicate([["in", "all"]]);
-    assert(predicate({}));
+    assert.ok(predicate({}));
 
     const unknown_stream_id = 999;
     predicate = get_predicate([["in", "home"]]);
-    assert(!predicate({stream_id: unknown_stream_id, stream: "unknown"}));
-    assert(predicate({type: "private"}));
+    assert.ok(!predicate({stream_id: unknown_stream_id, stream: "unknown"}));
+    assert.ok(predicate({type: "private"}));
 
     with_field(page_params, "narrow_stream", "kiosk", () => {
-        assert(predicate({stream: "kiosk"}));
+        assert.ok(predicate({stream: "kiosk"}));
     });
 
     predicate = get_predicate([["near", 5]]);
-    assert(predicate({}));
+    assert.ok(predicate({}));
 
     predicate = get_predicate([["id", 5]]);
-    assert(predicate({id: 5}));
-    assert(!predicate({id: 6}));
+    assert.ok(predicate({id: 5}));
+    assert.ok(!predicate({id: 6}));
 
     predicate = get_predicate([
         ["id", 5],
         ["topic", "lunch"],
     ]);
-    assert(predicate({type: "stream", id: 5, topic: "lunch"}));
-    assert(!predicate({type: "stream", id: 5, topic: "dinner"}));
+    assert.ok(predicate({type: "stream", id: 5, topic: "lunch"}));
+    assert.ok(!predicate({type: "stream", id: 5, topic: "dinner"}));
 
     predicate = get_predicate([["sender", "Joe@example.com"]]);
-    assert(predicate({sender_id: joe.user_id}));
-    assert(!predicate({sender_email: steve.user_id}));
+    assert.ok(predicate({sender_id: joe.user_id}));
+    assert.ok(!predicate({sender_email: steve.user_id}));
 
     predicate = get_predicate([["pm-with", "Joe@example.com"]]);
-    assert(
+    assert.ok(
         predicate({
             type: "private",
             display_recipient: [{id: joe.user_id}],
         }),
     );
-    assert(
+    assert.ok(
         !predicate({
             type: "private",
             display_recipient: [{id: steve.user_id}],
         }),
     );
-    assert(
+    assert.ok(
         !predicate({
             type: "private",
             display_recipient: [{id: 999999}],
         }),
     );
-    assert(!predicate({type: "stream"}));
+    assert.ok(!predicate({type: "stream"}));
 
     predicate = get_predicate([["pm-with", "Joe@example.com,steve@foo.com"]]);
-    assert(
+    assert.ok(
         predicate({
             type: "private",
             display_recipient: [{id: joe.user_id}, {id: steve.user_id}],
@@ -664,7 +664,7 @@ test("predicate_basics", () => {
 
     // Make sure your own email is ignored
     predicate = get_predicate([["pm-with", "Joe@example.com,steve@foo.com,me@example.com"]]);
-    assert(
+    assert.ok(
         predicate({
             type: "private",
             display_recipient: [{id: joe.user_id}, {id: steve.user_id}],
@@ -672,7 +672,7 @@ test("predicate_basics", () => {
     );
 
     predicate = get_predicate([["pm-with", "nobody@example.com"]]);
-    assert(
+    assert.ok(
         !predicate({
             type: "private",
             display_recipient: [{id: joe.user_id}],
@@ -680,7 +680,7 @@ test("predicate_basics", () => {
     );
 
     predicate = get_predicate([["group-pm-with", "nobody@example.com"]]);
-    assert(
+    assert.ok(
         !predicate({
             type: "private",
             display_recipient: [{id: joe.user_id}],
@@ -688,26 +688,26 @@ test("predicate_basics", () => {
     );
 
     predicate = get_predicate([["group-pm-with", "Joe@example.com"]]);
-    assert(
+    assert.ok(
         predicate({
             type: "private",
             display_recipient: [{id: joe.user_id}, {id: steve.user_id}, {id: me.user_id}],
         }),
     );
-    assert(
+    assert.ok(
         !predicate({
             // you must be a part of the group pm
             type: "private",
             display_recipient: [{id: joe.user_id}, {id: steve.user_id}],
         }),
     );
-    assert(
+    assert.ok(
         !predicate({
             type: "private",
             display_recipient: [{id: steve.user_id}, {id: me.user_id}],
         }),
     );
-    assert(!predicate({type: "stream"}));
+    assert.ok(!predicate({type: "stream"}));
 
     const img_msg = {
         content:
@@ -727,10 +727,10 @@ test("predicate_basics", () => {
     };
 
     predicate = get_predicate([["has", "non_valid_operand"]]);
-    assert(!predicate(img_msg));
-    assert(!predicate(non_img_attachment_msg));
-    assert(!predicate(link_msg));
-    assert(!predicate(no_has_filter_matching_msg));
+    assert.ok(!predicate(img_msg));
+    assert.ok(!predicate(non_img_attachment_msg));
+    assert.ok(!predicate(link_msg));
+    assert.ok(!predicate(no_has_filter_matching_msg));
 
     // HTML content of message is used to determine if image have link, image or attachment.
     // We are using jquery to parse the html and find existence of relevant tags/elements.
@@ -741,33 +741,33 @@ test("predicate_basics", () => {
 
     const has_link = get_predicate([["has", "link"]]);
     set_find_results_for_msg_content(img_msg, "a", ["stub"]);
-    assert(has_link(img_msg));
+    assert.ok(has_link(img_msg));
     set_find_results_for_msg_content(non_img_attachment_msg, "a", ["stub"]);
-    assert(has_link(non_img_attachment_msg));
+    assert.ok(has_link(non_img_attachment_msg));
     set_find_results_for_msg_content(link_msg, "a", ["stub"]);
-    assert(has_link(link_msg));
+    assert.ok(has_link(link_msg));
     set_find_results_for_msg_content(no_has_filter_matching_msg, "a", false);
-    assert(!has_link(no_has_filter_matching_msg));
+    assert.ok(!has_link(no_has_filter_matching_msg));
 
     const has_attachment = get_predicate([["has", "attachment"]]);
     set_find_results_for_msg_content(img_msg, "a[href^='/user_uploads']", ["stub"]);
-    assert(has_attachment(img_msg));
+    assert.ok(has_attachment(img_msg));
     set_find_results_for_msg_content(non_img_attachment_msg, "a[href^='/user_uploads']", ["stub"]);
-    assert(has_attachment(non_img_attachment_msg));
+    assert.ok(has_attachment(non_img_attachment_msg));
     set_find_results_for_msg_content(link_msg, "a[href^='/user_uploads']", false);
-    assert(!has_attachment(link_msg));
+    assert.ok(!has_attachment(link_msg));
     set_find_results_for_msg_content(no_has_filter_matching_msg, "a[href^='/user_uploads']", false);
-    assert(!has_attachment(no_has_filter_matching_msg));
+    assert.ok(!has_attachment(no_has_filter_matching_msg));
 
     const has_image = get_predicate([["has", "image"]]);
     set_find_results_for_msg_content(img_msg, ".message_inline_image", ["stub"]);
-    assert(has_image(img_msg));
+    assert.ok(has_image(img_msg));
     set_find_results_for_msg_content(non_img_attachment_msg, ".message_inline_image", false);
-    assert(!has_image(non_img_attachment_msg));
+    assert.ok(!has_image(non_img_attachment_msg));
     set_find_results_for_msg_content(link_msg, ".message_inline_image", false);
-    assert(!has_image(link_msg));
+    assert.ok(!has_image(link_msg));
     set_find_results_for_msg_content(no_has_filter_matching_msg, ".message_inline_image", false);
-    assert(!has_image(no_has_filter_matching_msg));
+    assert.ok(!has_image(no_has_filter_matching_msg));
 });
 
 test("negated_predicates", () => {
@@ -779,12 +779,12 @@ test("negated_predicates", () => {
 
     narrow = [{operator: "stream", operand: "social", negated: true}];
     predicate = new Filter(narrow).predicate();
-    assert(predicate({type: "stream", stream_id: 999999}));
-    assert(!predicate({type: "stream", stream_id: social_stream_id}));
+    assert.ok(predicate({type: "stream", stream_id: 999999}));
+    assert.ok(!predicate({type: "stream", stream_id: social_stream_id}));
 
     narrow = [{operator: "streams", operand: "public", negated: true}];
     predicate = new Filter(narrow).predicate();
-    assert(predicate({}));
+    assert.ok(predicate({}));
 });
 
 function test_mit_exceptions() {
@@ -792,18 +792,18 @@ function test_mit_exceptions() {
         ["stream", "Foo"],
         ["topic", "personal"],
     ]);
-    assert(predicate({type: "stream", stream: "foo", topic: "personal"}));
-    assert(predicate({type: "stream", stream: "foo.d", topic: "personal"}));
-    assert(predicate({type: "stream", stream: "foo.d", topic: ""}));
-    assert(!predicate({type: "stream", stream: "wrong"}));
-    assert(!predicate({type: "stream", stream: "foo", topic: "whatever"}));
-    assert(!predicate({type: "private"}));
+    assert.ok(predicate({type: "stream", stream: "foo", topic: "personal"}));
+    assert.ok(predicate({type: "stream", stream: "foo.d", topic: "personal"}));
+    assert.ok(predicate({type: "stream", stream: "foo.d", topic: ""}));
+    assert.ok(!predicate({type: "stream", stream: "wrong"}));
+    assert.ok(!predicate({type: "stream", stream: "foo", topic: "whatever"}));
+    assert.ok(!predicate({type: "private"}));
 
     predicate = get_predicate([
         ["stream", "Foo"],
         ["topic", "bar"],
     ]);
-    assert(predicate({type: "stream", stream: "foo", topic: "bar.d"}));
+    assert.ok(predicate({type: "stream", stream: "foo", topic: "bar.d"}));
 
     // Try to get the MIT regex to explode for an empty stream.
     let terms = [
@@ -811,7 +811,7 @@ function test_mit_exceptions() {
         {operator: "topic", operand: "bar"},
     ];
     predicate = new Filter(terms).predicate();
-    assert(!predicate({type: "stream", stream: "foo", topic: "bar"}));
+    assert.ok(!predicate({type: "stream", stream: "foo", topic: "bar"}));
 
     // Try to get the MIT regex to explode for an empty topic.
     terms = [
@@ -819,7 +819,7 @@ function test_mit_exceptions() {
         {operator: "topic", operand: ""},
     ];
     predicate = new Filter(terms).predicate();
-    assert(!predicate({type: "stream", stream: "foo", topic: "bar"}));
+    assert.ok(!predicate({type: "stream", stream: "foo", topic: "bar"}));
 }
 
 test("mit_exceptions", () => {
@@ -833,19 +833,19 @@ test("predicate_edge_cases", () => {
     // The code supports undefined as an operator to Filter, which results
     // in a predicate that accepts any message.
     predicate = new Filter().predicate();
-    assert(predicate({}));
+    assert.ok(predicate({}));
 
     // Upstream code should prevent Filter.predicate from being called with
     // invalid operator/operand combinations, but right now we just silently
     // return a function that accepts all messages.
     predicate = get_predicate([["in", "bogus"]]);
-    assert(!predicate({}));
+    assert.ok(!predicate({}));
 
     predicate = get_predicate([["bogus", 33]]);
-    assert(predicate({}));
+    assert.ok(predicate({}));
 
     predicate = get_predicate([["is", "bogus"]]);
-    assert(!predicate({}));
+    assert.ok(!predicate({}));
 
     // Exercise caching feature.
     const stream_id = 101;
@@ -857,7 +857,7 @@ test("predicate_edge_cases", () => {
     const filter = new Filter(terms);
     filter.predicate();
     predicate = filter.predicate(); // get cached version
-    assert(predicate({type: "stream", stream_id, topic: "Mars"}));
+    assert.ok(predicate({type: "stream", stream_id, topic: "Mars"}));
 });
 
 test("parse", () => {
@@ -1254,13 +1254,13 @@ test("term_type", () => {
     filter._build_sorted_term_types_called = false;
     const built_terms = filter.sorted_term_types();
     assert.deepEqual(built_terms, ["stream", "topic", "sender"]);
-    assert(filter._build_sorted_term_types_called);
+    assert.ok(filter._build_sorted_term_types_called);
 
     // cached trial
     filter._build_sorted_term_types_called = false;
     const cached_terms = filter.sorted_term_types();
     assert.deepEqual(cached_terms, ["stream", "topic", "sender"]);
-    assert(!filter._build_sorted_term_types_called);
+    assert.ok(!filter._build_sorted_term_types_called);
 });
 
 test("first_valid_id_from", (override) => {
@@ -1570,5 +1570,5 @@ test("error_cases", (override) => {
     override(people, "pm_with_user_ids", () => {});
 
     const predicate = get_predicate([["pm-with", "Joe@example.com"]]);
-    assert(!predicate({type: "private"}));
+    assert.ok(!predicate({type: "private"}));
 });

--- a/frontend_tests/node_tests/fold_dict.js
+++ b/frontend_tests/node_tests/fold_dict.js
@@ -53,12 +53,12 @@ run_test("case insensitivity", () => {
 
     assert.deepEqual(Array.from(d.keys()), []);
 
-    assert(!d.has("foo"));
+    assert.ok(!d.has("foo"));
     d.set("fOO", "Hello world");
     assert.equal(d.get("foo"), "Hello world");
-    assert(d.has("foo"));
-    assert(d.has("FOO"));
-    assert(!d.has("not_a_key"));
+    assert.ok(d.has("foo"));
+    assert.ok(d.has("FOO"));
+    assert.ok(!d.has("not_a_key"));
 
     assert.deepEqual(Array.from(d.keys()), ["fOO"]);
 

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -233,7 +233,7 @@ function process(s) {
 
 function assert_mapping(c, module, func_name, shiftKey) {
     stubbing(module, func_name, (stub) => {
-        assert(process(c, shiftKey));
+        assert.ok(process(c, shiftKey));
         assert.equal(stub.num_calls, 1);
     });
 }
@@ -432,7 +432,7 @@ run_test("motion_keys", () => {
 
     function assert_mapping(key_name, module, func_name) {
         stubbing(module, func_name, (stub) => {
-            assert(process(key_name));
+            assert.ok(process(key_name));
             assert.equal(stub.num_calls, 1);
         });
     }

--- a/frontend_tests/node_tests/i18n.js
+++ b/frontend_tests/node_tests/i18n.js
@@ -79,7 +79,7 @@ run_test("t_tag", () => {
     };
 
     const html = require("../../static/templates/actions_popover_content.hbs")(args);
-    assert(html.indexOf("Citer et répondre ou transférer") > 0);
+    assert.ok(html.indexOf("Citer et répondre ou transférer") > 0);
 });
 
 run_test("tr_tag", () => {
@@ -103,5 +103,5 @@ run_test("tr_tag", () => {
     };
 
     const html = require("../../static/templates/settings_tab.hbs")(args);
-    assert(html.indexOf("Déclencheurs de notification") > 0);
+    assert.ok(html.indexOf("Déclencheurs de notification") > 0);
 });

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -93,7 +93,7 @@ run_test("basics", (override) => {
     };
 
     widget.appendValidatedData(item);
-    assert(inserted_before);
+    assert.ok(inserted_before);
 
     assert.deepEqual(widget.items(), [item]);
 });
@@ -222,7 +222,7 @@ run_test("paste to input", () => {
     });
 
     paste_handler(e);
-    assert(entered);
+    assert.ok(entered);
 });
 
 run_test("arrows on pills", () => {
@@ -267,10 +267,10 @@ run_test("arrows on pills", () => {
     // actually cause any real state changes here.  We stub out
     // the only interaction, which is to move the focus.
     test_key("ArrowLeft");
-    assert(prev_focused);
+    assert.ok(prev_focused);
 
     test_key("ArrowRight");
-    assert(next_focused);
+    assert.ok(next_focused);
 });
 
 run_test("left arrow on input", () => {
@@ -299,7 +299,7 @@ run_test("left arrow on input", () => {
         key: "ArrowLeft",
     });
 
-    assert(last_pill_focused);
+    assert.ok(last_pill_focused);
 });
 
 run_test("comma", () => {
@@ -389,8 +389,8 @@ run_test("insert_remove", (override) => {
 
     widget.appendValue("blue,chartreuse,red,yellow,mauve");
 
-    assert(created);
-    assert(!removed);
+    assert.ok(created);
+    assert.ok(!removed);
 
     assert.deepEqual(inserted_html, [
         pill_html("BLUE", "some_id1", example_img_link),
@@ -429,7 +429,7 @@ run_test("insert_remove", (override) => {
         preventDefault: noop,
     });
 
-    assert(removed);
+    assert.ok(removed);
     assert.equal(color_removed, "YELLOW");
 
     assert.deepEqual(widget.items(), [items.blue, items.red]);
@@ -461,7 +461,7 @@ run_test("insert_remove", (override) => {
     });
 
     assert.equal(color_removed, "BLUE");
-    assert(next_pill_focused);
+    assert.ok(next_pill_focused);
 });
 
 run_test("exit button on pill", (override) => {
@@ -515,7 +515,7 @@ run_test("exit button on pill", (override) => {
 
     exit_click_handler.call(exit_button_stub, e);
 
-    assert(next_pill_focused);
+    assert.ok(next_pill_focused);
 
     assert.deepEqual(widget.items(), [items.red]);
 });
@@ -544,7 +544,7 @@ run_test("misc things", () => {
     };
 
     animation_end_handler.call(input_stub);
-    assert(shake_class_removed);
+    assert.ok(shake_class_removed);
 
     // bad data
     blueslip.expect("error", "no display_value returned");

--- a/frontend_tests/node_tests/lazy_set.js
+++ b/frontend_tests/node_tests/lazy_set.js
@@ -27,5 +27,5 @@ run_test("conversions", () => {
     blueslip.expect("error", "not a number", 2);
     const ls = new LazySet([1, 2]);
     ls.add("3");
-    assert(ls.has("3"));
+    assert.ok(ls.has("3"));
 });

--- a/frontend_tests/node_tests/list_cursor.js
+++ b/frontend_tests/node_tests/list_cursor.js
@@ -112,30 +112,30 @@ run_test("multiple item list", (override) => {
 
     cursor.go_to(2);
     assert.equal(cursor.get_key(), 2);
-    assert(!list_items[1].hasClass("highlight"));
-    assert(list_items[2].hasClass("highlight"));
-    assert(!list_items[3].hasClass("highlight"));
+    assert.ok(!list_items[1].hasClass("highlight"));
+    assert.ok(list_items[2].hasClass("highlight"));
+    assert.ok(!list_items[3].hasClass("highlight"));
 
     cursor.next();
     cursor.next();
     cursor.next();
 
     assert.equal(cursor.get_key(), 3);
-    assert(!list_items[1].hasClass("highlight"));
-    assert(!list_items[2].hasClass("highlight"));
-    assert(list_items[3].hasClass("highlight"));
+    assert.ok(!list_items[1].hasClass("highlight"));
+    assert.ok(!list_items[2].hasClass("highlight"));
+    assert.ok(list_items[3].hasClass("highlight"));
 
     cursor.prev();
     cursor.prev();
     cursor.prev();
 
     assert.equal(cursor.get_key(), 1);
-    assert(list_items[1].hasClass("highlight"));
-    assert(!list_items[2].hasClass("highlight"));
-    assert(!list_items[3].hasClass("highlight"));
+    assert.ok(list_items[1].hasClass("highlight"));
+    assert.ok(!list_items[2].hasClass("highlight"));
+    assert.ok(!list_items[3].hasClass("highlight"));
 
     cursor.clear();
     assert.equal(cursor.get_key(), undefined);
     cursor.redraw();
-    assert(!list_items[1].hasClass("highlight"));
+    assert.ok(!list_items[1].hasClass("highlight"));
 });

--- a/frontend_tests/node_tests/list_widget.js
+++ b/frontend_tests/node_tests/list_widget.js
@@ -435,8 +435,8 @@ run_test("sorting", () => {
 
     sort_container.f.apply(button);
 
-    assert(cleared);
-    assert(button.siblings_deactivated);
+    assert.ok(cleared);
+    assert.ok(button.siblings_deactivated);
 
     expected_html = html_for([alice, bob, cal, dave, ellen]);
     assert.deepEqual(container.appended_data.html(), expected_html);
@@ -444,18 +444,18 @@ run_test("sorting", () => {
     // Hit same button again to reverse the data.
     cleared = false;
     sort_container.f.apply(button);
-    assert(cleared);
+    assert.ok(cleared);
     expected_html = html_for([ellen, dave, cal, bob, alice]);
     assert.deepEqual(container.appended_data.html(), expected_html);
-    assert(button.hasClass("descend"));
+    assert.ok(button.hasClass("descend"));
 
     // And then hit a third time to go back to the forward sort.
     cleared = false;
     sort_container.f.apply(button);
-    assert(cleared);
+    assert.ok(cleared);
     expected_html = html_for([alice, bob, cal, dave, ellen]);
     assert.deepEqual(container.appended_data.html(), expected_html);
-    assert(!button.hasClass("descend"));
+    assert.ok(!button.hasClass("descend"));
 
     // Now try a numeric sort.
     button_opts = {
@@ -472,8 +472,8 @@ run_test("sorting", () => {
 
     sort_container.f.apply(button);
 
-    assert(cleared);
-    assert(button.siblings_deactivated);
+    assert.ok(cleared);
+    assert.ok(button.siblings_deactivated);
 
     expected_html = html_for([dave, cal, bob, alice, ellen]);
     assert.deepEqual(container.appended_data.html(), expected_html);
@@ -481,10 +481,10 @@ run_test("sorting", () => {
     // Hit same button again to reverse the numeric sort.
     cleared = false;
     sort_container.f.apply(button);
-    assert(cleared);
+    assert.ok(cleared);
     expected_html = html_for([ellen, alice, bob, cal, dave]);
     assert.deepEqual(container.appended_data.html(), expected_html);
-    assert(button.hasClass("descend"));
+    assert.ok(button.hasClass("descend"));
 });
 
 run_test("custom sort", () => {
@@ -735,7 +735,7 @@ run_test("render item", () => {
         const item = INITIAL_RENDER_COUNT - 1;
         const new_html = `<tr data-item=${item}>updated: ${item}</tr>\n`;
         const regex = new RegExp(`\\<tr data-item=${item}\\>.*?<\\/tr\\>`);
-        assert(expected_queries.includes(query));
+        assert.ok(expected_queries.includes(query));
         if (query.includes(`data-item='${INITIAL_RENDER_COUNT}'`)) {
             return undefined; // This item is not rendered, so we find nothing
         }
@@ -765,17 +765,19 @@ run_test("render item", () => {
     });
     const item = INITIAL_RENDER_COUNT - 1;
 
-    assert(container.appended_data.html().includes("<tr data-item=2>initial: 2</tr>"));
-    assert(container.appended_data.html().includes("<tr data-item=3>initial: 3</tr>"));
+    assert.ok(container.appended_data.html().includes("<tr data-item=2>initial: 2</tr>"));
+    assert.ok(container.appended_data.html().includes("<tr data-item=3>initial: 3</tr>"));
     text = "updated";
     called = false;
     widget.render_item(INITIAL_RENDER_COUNT - 1);
-    assert(called);
-    assert(container.appended_data.html().includes("<tr data-item=2>initial: 2</tr>"));
-    assert(container.appended_data.html().includes(`<tr data-item=${item}>updated: ${item}</tr>`));
+    assert.ok(called);
+    assert.ok(container.appended_data.html().includes("<tr data-item=2>initial: 2</tr>"));
+    assert.ok(
+        container.appended_data.html().includes(`<tr data-item=${item}>updated: ${item}</tr>`),
+    );
 
     // Item 80 should not be in the rendered list. (0 indexed)
-    assert(
+    assert.ok(
         !container.appended_data
             .html()
             .includes(
@@ -784,9 +786,9 @@ run_test("render item", () => {
     );
     called = false;
     widget.render_item(INITIAL_RENDER_COUNT);
-    assert(!called);
+    assert.ok(!called);
     widget.render_item(INITIAL_RENDER_COUNT - 1);
-    assert(called);
+    assert.ok(called);
 
     // Tests below this are for the corner cases, where we abort the rerender.
 
@@ -813,7 +815,7 @@ run_test("render item", () => {
     get_item_called = false;
     widget_2.render_item(item);
     // Test that we didn't try to render the item.
-    assert(!get_item_called);
+    assert.ok(!get_item_called);
 
     let rendering_item = false;
     const widget_3 = ListWidget.create(container, list, {

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -272,18 +272,18 @@ test("marked_shared", () => {
 test("message_flags", () => {
     let message = {raw_content: "@**Leo**"};
     markdown.apply_markdown(message);
-    assert(!message.mentioned);
-    assert(!message.mentioned_me_directly);
+    assert.ok(!message.mentioned);
+    assert.ok(!message.mentioned_me_directly);
 
     message = {raw_content: "@**Cordelia, Lear's daughter**"};
     markdown.apply_markdown(message);
-    assert(message.mentioned);
-    assert(message.mentioned_me_directly);
+    assert.ok(message.mentioned);
+    assert.ok(message.mentioned_me_directly);
 
     message = {raw_content: "@**all**"};
     markdown.apply_markdown(message);
-    assert(message.mentioned);
-    assert(!message.mentioned_me_directly);
+    assert.ok(message.mentioned);
+    assert.ok(!message.mentioned_me_directly);
 });
 
 test("marked", () => {
@@ -671,7 +671,7 @@ test("message_flags", () => {
     markdown.apply_markdown(message);
 
     assert.equal(message.is_me_message, true);
-    assert(!message.unread);
+    assert.ok(!message.unread);
 
     input = "/me is testing\nthis";
     message = {topic: "No links here", raw_content: input};

--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -79,7 +79,7 @@ run_test("update_messages", () => {
     assert.deepEqual(stream_topic_history.get_recent_topic_names(denmark.stream_id), ["lunch"]);
 
     unread.update_message_for_mention(original_message);
-    assert(unread.unread_mentions_counter.has(original_message.id));
+    assert.ok(unread.unread_mentions_counter.has(original_message.id));
 
     const events = [
         {
@@ -121,7 +121,7 @@ run_test("update_messages", () => {
     // TEST THIS:
     message_events.update_messages(events);
 
-    assert(!unread.unread_mentions_counter.has(original_message.id));
+    assert.ok(!unread.unread_mentions_counter.has(original_message.id));
 
     helper.verify();
 

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -293,9 +293,9 @@ run_test("initialize", () => {
     step2.prep();
     step1.finish();
 
-    assert(!home_loaded);
+    assert.ok(!home_loaded);
     const idle_config = step2.finish();
-    assert(home_loaded);
+    assert.ok(home_loaded);
 
     test_backfill_idle(idle_config);
 });

--- a/frontend_tests/node_tests/message_flags.js
+++ b/frontend_tests/node_tests/message_flags.js
@@ -35,7 +35,7 @@ run_test("starred", (override) => {
 
     message_flags.toggle_starred_and_update_server(message);
 
-    assert(ui_updated);
+    assert.ok(ui_updated);
 
     assert.deepEqual(posted_data, {
         messages: "[50]",
@@ -52,7 +52,7 @@ run_test("starred", (override) => {
 
     message_flags.toggle_starred_and_update_server(message);
 
-    assert(ui_updated);
+    assert.ok(ui_updated);
 
     assert.deepEqual(posted_data, {
         messages: "[50]",
@@ -236,7 +236,7 @@ run_test("read", (override) => {
         messages: [3, 4, 5, 6, 7],
     };
     channel_post_opts.success(success_response_data);
-    assert(events.timer_set);
+    assert.ok(events.timer_set);
 
     // Mark them non local
     local_msg_1.locally_echoed = false;

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -46,7 +46,7 @@ run_test("basics", () => {
     });
 
     assert.equal(mld.is_search(), false);
-    assert(mld.can_mark_messages_read());
+    assert.ok(mld.can_mark_messages_read());
     mld.add_anywhere(make_msgs([35, 25, 15, 45]));
 
     assert_contents(mld, [15, 25, 35, 45]);

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -282,7 +282,7 @@ test("merge_message_groups", () => {
     function assert_message_list_equal(list1, list2) {
         const ids1 = extract_message_ids(list1);
         const ids2 = extract_message_ids(list2);
-        assert(ids1.length);
+        assert.ok(ids1.length);
         assert.deepEqual(ids1, ids2);
     }
 
@@ -293,7 +293,7 @@ test("merge_message_groups", () => {
     function assert_message_groups_list_equal(list1, list2) {
         const ids1 = list1.map((group) => extract_group(group));
         const ids2 = list2.map((group) => extract_group(group));
-        assert(ids1.length);
+        assert.ok(ids1.length);
         assert.deepEqual(ids1, ids2);
     }
 
@@ -341,7 +341,7 @@ test("merge_message_groups", () => {
         const list = build_list([message_group1]);
         const result = list.merge_message_groups([message_group2], "bottom");
 
-        assert(!message_group2.group_date_divider_html);
+        assert.ok(!message_group2.group_date_divider_html);
         assert_message_groups_list_equal(list._message_groups, [message_group1, message_group2]);
         assert_message_groups_list_equal(result.append_groups, [message_group2]);
         assert.deepEqual(result.prepend_groups, []);
@@ -385,7 +385,7 @@ test("merge_message_groups", () => {
         assert.deepEqual(result.rerender_groups, []);
         assert.deepEqual(result.append_messages, [message2]);
         assert.deepEqual(result.rerender_messages_next_same_sender, [message1]);
-        assert(list._message_groups[0].message_containers[1].want_date_divider);
+        assert.ok(list._message_groups[0].message_containers[1].want_date_divider);
     })();
 
     (function test_append_message_historical() {
@@ -398,7 +398,7 @@ test("merge_message_groups", () => {
         const list = build_list([message_group1]);
         const result = list.merge_message_groups([message_group2], "bottom");
 
-        assert(message_group2.bookend_top);
+        assert.ok(message_group2.bookend_top);
         assert_message_groups_list_equal(list._message_groups, [message_group1, message_group2]);
         assert_message_groups_list_equal(result.append_groups, [message_group2]);
         assert.deepEqual(result.prepend_groups, []);
@@ -417,7 +417,7 @@ test("merge_message_groups", () => {
         const list = build_list([message_group1]);
         const result = list.merge_message_groups([message_group2], "bottom");
 
-        assert(message2.include_sender);
+        assert.ok(message2.include_sender);
         assert_message_groups_list_equal(list._message_groups, [
             build_message_group([message1, message2]),
         ]);
@@ -518,7 +518,7 @@ test("merge_message_groups", () => {
         const list = build_list([message_group1]);
         const result = list.merge_message_groups([message_group2], "top");
 
-        assert(message_group1.bookend_top);
+        assert.ok(message_group1.bookend_top);
         assert_message_groups_list_equal(list._message_groups, [message_group2, message_group1]);
         assert.deepEqual(result.append_groups, []);
         assert_message_groups_list_equal(result.prepend_groups, [message_group2]);

--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -50,46 +50,46 @@ function test(label, f) {
 
 test("edge_cases", () => {
     // private messages
-    assert(!muting.is_topic_muted(undefined, undefined));
+    assert.ok(!muting.is_topic_muted(undefined, undefined));
 
     // invalid user
-    assert(!muting.is_user_muted(undefined));
+    assert.ok(!muting.is_user_muted(undefined));
 });
 
 test("add_and_remove_mutes", () => {
-    assert(!muting.is_topic_muted(devel.stream_id, "java"));
+    assert.ok(!muting.is_topic_muted(devel.stream_id, "java"));
     muting.add_muted_topic(devel.stream_id, "java");
-    assert(muting.is_topic_muted(devel.stream_id, "java"));
+    assert.ok(muting.is_topic_muted(devel.stream_id, "java"));
 
     // test idempotentcy
     muting.add_muted_topic(devel.stream_id, "java");
-    assert(muting.is_topic_muted(devel.stream_id, "java"));
+    assert.ok(muting.is_topic_muted(devel.stream_id, "java"));
 
     muting.remove_muted_topic(devel.stream_id, "java");
-    assert(!muting.is_topic_muted(devel.stream_id, "java"));
+    assert.ok(!muting.is_topic_muted(devel.stream_id, "java"));
 
     // test idempotentcy
     muting.remove_muted_topic(devel.stream_id, "java");
-    assert(!muting.is_topic_muted(devel.stream_id, "java"));
+    assert.ok(!muting.is_topic_muted(devel.stream_id, "java"));
 
     // test unknown stream is harmless too
     muting.remove_muted_topic(unknown.stream_id, "java");
-    assert(!muting.is_topic_muted(unknown.stream_id, "java"));
+    assert.ok(!muting.is_topic_muted(unknown.stream_id, "java"));
 
-    assert(!muting.is_user_muted(1));
+    assert.ok(!muting.is_user_muted(1));
     muting.add_muted_user(1);
-    assert(muting.is_user_muted(1));
+    assert.ok(muting.is_user_muted(1));
 
     // test idempotentcy
     muting.add_muted_user(1);
-    assert(muting.is_user_muted(1));
+    assert.ok(muting.is_user_muted(1));
 
     muting.remove_muted_user(1);
-    assert(!muting.is_user_muted(1));
+    assert.ok(!muting.is_user_muted(1));
 
     // test idempotentcy
     muting.remove_muted_user(1);
-    assert(!muting.is_user_muted(1));
+    assert.ok(!muting.is_user_muted(1));
 });
 
 test("get_unmuted_users", () => {
@@ -204,8 +204,8 @@ test("unknown streams", () => {
 
 test("case_insensitivity", () => {
     muting.set_muted_topics([]);
-    assert(!muting.is_topic_muted(social.stream_id, "breakfast"));
+    assert.ok(!muting.is_topic_muted(social.stream_id, "breakfast"));
     muting.set_muted_topics([["SOCial", "breakfast"]]);
-    assert(muting.is_topic_muted(social.stream_id, "breakfast"));
-    assert(muting.is_topic_muted(social.stream_id, "breakFAST"));
+    assert.ok(muting.is_topic_muted(social.stream_id, "breakfast"));
+    assert.ok(muting.is_topic_muted(social.stream_id, "breakFAST"));
 });

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -101,83 +101,83 @@ run_test("show_empty_narrow_message", () => {
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
     assert.equal($(".empty_feed_notice").visible(), false);
-    assert($("#empty_narrow_message").visible());
+    assert.ok($("#empty_narrow_message").visible());
 
     // for non-existent or private stream
     set_filter([["stream", "Foo"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#nonsubbed_private_nonexistent_stream_narrow_message").visible());
+    assert.ok($("#nonsubbed_private_nonexistent_stream_narrow_message").visible());
 
     // for non sub public stream
     stream_data.add_sub({name: "ROME", stream_id: 99});
     set_filter([["stream", "Rome"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#nonsubbed_stream_narrow_message").visible());
+    assert.ok($("#nonsubbed_stream_narrow_message").visible());
 
     set_filter([["is", "starred"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_star_narrow_message").visible());
+    assert.ok($("#empty_star_narrow_message").visible());
 
     set_filter([["is", "mentioned"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_narrow_all_mentioned").visible());
+    assert.ok($("#empty_narrow_all_mentioned").visible());
 
     set_filter([["is", "private"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_narrow_all_private_message").visible());
+    assert.ok($("#empty_narrow_all_private_message").visible());
 
     set_filter([["is", "unread"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#no_unread_narrow_message").visible());
+    assert.ok($("#no_unread_narrow_message").visible());
 
     set_filter([["pm-with", ["Yo"]]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#non_existing_user").visible());
+    assert.ok($("#non_existing_user").visible());
 
     people.add_active_user(alice);
     set_filter([["pm-with", ["alice@example.com", "Yo"]]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#non_existing_users").visible());
+    assert.ok($("#non_existing_users").visible());
 
     set_filter([["pm-with", "alice@example.com"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_narrow_private_message").visible());
+    assert.ok($("#empty_narrow_private_message").visible());
 
     people.add_active_user(me);
     people.initialize_current_user(me.user_id);
     set_filter([["pm-with", me.email]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_narrow_self_private_message").visible());
+    assert.ok($("#empty_narrow_self_private_message").visible());
 
     set_filter([["pm-with", me.email + "," + alice.email]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_narrow_multi_private_message").visible());
+    assert.ok($("#empty_narrow_multi_private_message").visible());
 
     set_filter([["group-pm-with", "alice@example.com"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_narrow_group_private_message").visible());
+    assert.ok($("#empty_narrow_group_private_message").visible());
 
     set_filter([["sender", "ray@example.com"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#silent_user").visible());
+    assert.ok($("#silent_user").visible());
 
     set_filter([["sender", "sinwar@example.com"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#non_existing_user").visible());
+    assert.ok($("#non_existing_user").visible());
 
     const display = $("#empty_search_stop_words_string");
 
@@ -189,7 +189,7 @@ run_test("show_empty_narrow_message", () => {
     set_filter([["search", "grail"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_search_narrow_message").visible());
+    assert.ok($("#empty_search_narrow_message").visible());
 
     assert.equal(items.length, 2);
     assert.equal(items[0], " ");
@@ -201,12 +201,12 @@ run_test("show_empty_narrow_message", () => {
     ]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_narrow_message").visible());
+    assert.ok($("#empty_narrow_message").visible());
 
     set_filter([["is", "invalid"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_narrow_message").visible());
+    assert.ok($("#empty_narrow_message").visible());
 
     const my_stream = {
         name: "my stream",
@@ -218,18 +218,18 @@ run_test("show_empty_narrow_message", () => {
     set_filter([["stream", "my stream"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_narrow_message").visible());
+    assert.ok($("#empty_narrow_message").visible());
 
     set_filter([["stream", ""]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#nonsubbed_private_nonexistent_stream_narrow_message").visible());
+    assert.ok($("#nonsubbed_private_nonexistent_stream_narrow_message").visible());
 });
 
 run_test("hide_empty_narrow_message", () => {
     $(".empty_feed_notice").show();
     narrow_banner.hide_empty_narrow_message();
-    assert(!$(".empty_feed_notice").visible());
+    assert.ok(!$(".empty_feed_notice").visible());
 });
 
 run_test("show_search_stopwords", () => {
@@ -249,7 +249,7 @@ run_test("show_search_stopwords", () => {
     set_filter([["search", "what about grail"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_search_narrow_message").visible());
+    assert.ok($("#empty_search_narrow_message").visible());
 
     assert.equal(items.length, 3);
     assert.equal(items[0], "<del>what");
@@ -263,7 +263,7 @@ run_test("show_search_stopwords", () => {
     ]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_search_narrow_message").visible());
+    assert.ok($("#empty_search_narrow_message").visible());
 
     assert.equal(items.length, 4);
     assert.equal(items[0], "<span>stream: streamA");
@@ -279,7 +279,7 @@ run_test("show_search_stopwords", () => {
     ]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_search_narrow_message").visible());
+    assert.ok($("#empty_search_narrow_message").visible());
 
     assert.equal(items.length, 4);
     assert.equal(items[0], "<span>stream: streamA topic: topicA");
@@ -301,7 +301,7 @@ run_test("show_invalid_narrow_message", () => {
     ]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_search_narrow_message").visible());
+    assert.ok($("#empty_search_narrow_message").visible());
     assert.equal(
         display.text(),
         "translated: You are searching for messages that belong to more than one stream, which is not possible.",
@@ -313,7 +313,7 @@ run_test("show_invalid_narrow_message", () => {
     ]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_search_narrow_message").visible());
+    assert.ok($("#empty_search_narrow_message").visible());
     assert.equal(
         display.text(),
         "translated: You are searching for messages that belong to more than one topic, which is not possible.",
@@ -328,7 +328,7 @@ run_test("show_invalid_narrow_message", () => {
     ]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
-    assert($("#empty_search_narrow_message").visible());
+    assert.ok($("#empty_search_narrow_message").visible());
     assert.equal(
         display.text(),
         "translated: You are searching for messages that are sent by more than one person, which is not possible.",

--- a/frontend_tests/node_tests/narrow_local.js
+++ b/frontend_tests/node_tests/narrow_local.js
@@ -22,7 +22,7 @@ function test_with(fixture) {
     if (fixture.unread_info.flavor === "found") {
         for (const msg of fixture.all_messages) {
             if (msg.id === fixture.unread_info.msg_id) {
-                assert(filter.predicate()(msg));
+                assert.ok(filter.predicate()(msg));
             }
         }
     }

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -28,24 +28,24 @@ function test(label, f) {
 
 test("stream", () => {
     assert.equal(narrow_state.public_operators(), undefined);
-    assert(!narrow_state.active());
+    assert.ok(!narrow_state.active());
 
     const test_stream = {name: "Test", stream_id: 15};
     stream_data.add_sub(test_stream);
 
-    assert(!narrow_state.is_for_stream_id(test_stream.stream_id));
+    assert.ok(!narrow_state.is_for_stream_id(test_stream.stream_id));
 
     set_filter([
         ["stream", "Test"],
         ["topic", "Bar"],
         ["search", "yo"],
     ]);
-    assert(narrow_state.active());
+    assert.ok(narrow_state.active());
 
     assert.equal(narrow_state.stream(), "Test");
     assert.equal(narrow_state.stream_sub().stream_id, test_stream.stream_id);
     assert.equal(narrow_state.topic(), "Bar");
-    assert(narrow_state.is_for_stream_id(test_stream.stream_id));
+    assert.ok(narrow_state.is_for_stream_id(test_stream.stream_id));
 
     const expected_operators = [
         {negated: false, operator: "stream", operand: "Test"},
@@ -59,68 +59,68 @@ test("stream", () => {
 });
 
 test("narrowed", () => {
-    assert(!narrow_state.narrowed_to_pms());
-    assert(!narrow_state.narrowed_by_reply());
-    assert(!narrow_state.narrowed_by_pm_reply());
-    assert(!narrow_state.narrowed_by_topic_reply());
-    assert(!narrow_state.narrowed_to_search());
-    assert(!narrow_state.narrowed_to_topic());
-    assert(!narrow_state.narrowed_by_stream_reply());
+    assert.ok(!narrow_state.narrowed_to_pms());
+    assert.ok(!narrow_state.narrowed_by_reply());
+    assert.ok(!narrow_state.narrowed_by_pm_reply());
+    assert.ok(!narrow_state.narrowed_by_topic_reply());
+    assert.ok(!narrow_state.narrowed_to_search());
+    assert.ok(!narrow_state.narrowed_to_topic());
+    assert.ok(!narrow_state.narrowed_by_stream_reply());
     assert.equal(narrow_state.stream_sub(), undefined);
-    assert(!narrow_state.narrowed_to_starred());
+    assert.ok(!narrow_state.narrowed_to_starred());
 
     set_filter([["stream", "Foo"]]);
-    assert(!narrow_state.narrowed_to_pms());
-    assert(!narrow_state.narrowed_by_reply());
-    assert(!narrow_state.narrowed_by_pm_reply());
-    assert(!narrow_state.narrowed_by_topic_reply());
-    assert(!narrow_state.narrowed_to_search());
-    assert(!narrow_state.narrowed_to_topic());
-    assert(narrow_state.narrowed_by_stream_reply());
-    assert(!narrow_state.narrowed_to_starred());
+    assert.ok(!narrow_state.narrowed_to_pms());
+    assert.ok(!narrow_state.narrowed_by_reply());
+    assert.ok(!narrow_state.narrowed_by_pm_reply());
+    assert.ok(!narrow_state.narrowed_by_topic_reply());
+    assert.ok(!narrow_state.narrowed_to_search());
+    assert.ok(!narrow_state.narrowed_to_topic());
+    assert.ok(narrow_state.narrowed_by_stream_reply());
+    assert.ok(!narrow_state.narrowed_to_starred());
 
     set_filter([["pm-with", "steve@zulip.com"]]);
-    assert(narrow_state.narrowed_to_pms());
-    assert(narrow_state.narrowed_by_reply());
-    assert(narrow_state.narrowed_by_pm_reply());
-    assert(!narrow_state.narrowed_by_topic_reply());
-    assert(!narrow_state.narrowed_to_search());
-    assert(!narrow_state.narrowed_to_topic());
-    assert(!narrow_state.narrowed_by_stream_reply());
-    assert(!narrow_state.narrowed_to_starred());
+    assert.ok(narrow_state.narrowed_to_pms());
+    assert.ok(narrow_state.narrowed_by_reply());
+    assert.ok(narrow_state.narrowed_by_pm_reply());
+    assert.ok(!narrow_state.narrowed_by_topic_reply());
+    assert.ok(!narrow_state.narrowed_to_search());
+    assert.ok(!narrow_state.narrowed_to_topic());
+    assert.ok(!narrow_state.narrowed_by_stream_reply());
+    assert.ok(!narrow_state.narrowed_to_starred());
 
     set_filter([
         ["stream", "Foo"],
         ["topic", "bar"],
     ]);
-    assert(!narrow_state.narrowed_to_pms());
-    assert(narrow_state.narrowed_by_reply());
-    assert(!narrow_state.narrowed_by_pm_reply());
-    assert(narrow_state.narrowed_by_topic_reply());
-    assert(!narrow_state.narrowed_to_search());
-    assert(narrow_state.narrowed_to_topic());
-    assert(!narrow_state.narrowed_by_stream_reply());
-    assert(!narrow_state.narrowed_to_starred());
+    assert.ok(!narrow_state.narrowed_to_pms());
+    assert.ok(narrow_state.narrowed_by_reply());
+    assert.ok(!narrow_state.narrowed_by_pm_reply());
+    assert.ok(narrow_state.narrowed_by_topic_reply());
+    assert.ok(!narrow_state.narrowed_to_search());
+    assert.ok(narrow_state.narrowed_to_topic());
+    assert.ok(!narrow_state.narrowed_by_stream_reply());
+    assert.ok(!narrow_state.narrowed_to_starred());
 
     set_filter([["search", "grail"]]);
-    assert(!narrow_state.narrowed_to_pms());
-    assert(!narrow_state.narrowed_by_reply());
-    assert(!narrow_state.narrowed_by_pm_reply());
-    assert(!narrow_state.narrowed_by_topic_reply());
-    assert(narrow_state.narrowed_to_search());
-    assert(!narrow_state.narrowed_to_topic());
-    assert(!narrow_state.narrowed_by_stream_reply());
-    assert(!narrow_state.narrowed_to_starred());
+    assert.ok(!narrow_state.narrowed_to_pms());
+    assert.ok(!narrow_state.narrowed_by_reply());
+    assert.ok(!narrow_state.narrowed_by_pm_reply());
+    assert.ok(!narrow_state.narrowed_by_topic_reply());
+    assert.ok(narrow_state.narrowed_to_search());
+    assert.ok(!narrow_state.narrowed_to_topic());
+    assert.ok(!narrow_state.narrowed_by_stream_reply());
+    assert.ok(!narrow_state.narrowed_to_starred());
 
     set_filter([["is", "starred"]]);
-    assert(!narrow_state.narrowed_to_pms());
-    assert(!narrow_state.narrowed_by_reply());
-    assert(!narrow_state.narrowed_by_pm_reply());
-    assert(!narrow_state.narrowed_by_topic_reply());
-    assert(!narrow_state.narrowed_to_search());
-    assert(!narrow_state.narrowed_to_topic());
-    assert(!narrow_state.narrowed_by_stream_reply());
-    assert(narrow_state.narrowed_to_starred());
+    assert.ok(!narrow_state.narrowed_to_pms());
+    assert.ok(!narrow_state.narrowed_by_reply());
+    assert.ok(!narrow_state.narrowed_by_pm_reply());
+    assert.ok(!narrow_state.narrowed_by_topic_reply());
+    assert.ok(!narrow_state.narrowed_to_search());
+    assert.ok(!narrow_state.narrowed_to_topic());
+    assert.ok(!narrow_state.narrowed_by_stream_reply());
+    assert.ok(narrow_state.narrowed_to_starred());
 });
 
 test("operators", () => {
@@ -147,25 +147,25 @@ test("operators", () => {
 
 test("excludes_muted_topics", () => {
     set_filter([["stream", "devel"]]);
-    assert(narrow_state.excludes_muted_topics());
+    assert.ok(narrow_state.excludes_muted_topics());
 
     narrow_state.reset_current_filter(); // not narrowed, basically
-    assert(narrow_state.excludes_muted_topics());
+    assert.ok(narrow_state.excludes_muted_topics());
 
     set_filter([
         ["stream", "devel"],
         ["topic", "mac"],
     ]);
-    assert(!narrow_state.excludes_muted_topics());
+    assert.ok(!narrow_state.excludes_muted_topics());
 
     set_filter([["search", "whatever"]]);
-    assert(!narrow_state.excludes_muted_topics());
+    assert.ok(!narrow_state.excludes_muted_topics());
 
     set_filter([["is", "private"]]);
-    assert(!narrow_state.excludes_muted_topics());
+    assert.ok(!narrow_state.excludes_muted_topics());
 
     set_filter([["is", "starred"]]);
-    assert(!narrow_state.excludes_muted_topics());
+    assert.ok(!narrow_state.excludes_muted_topics());
 });
 
 test("set_compose_defaults", () => {

--- a/frontend_tests/node_tests/password.js
+++ b/frontend_tests/node_tests/password.js
@@ -50,7 +50,7 @@ run_test("basics w/progress bar", () => {
 
     password = "z!X4@S_&";
     accepted = password_quality(password, bar, password_field(10, 80000));
-    assert(!accepted);
+    assert.ok(!accepted);
     assert.equal(bar.w, "39.7%");
     assert.equal(bar.added_class, "bar-danger");
     warning = password_warning(password, password_field(10));
@@ -58,7 +58,7 @@ run_test("basics w/progress bar", () => {
 
     password = "foo";
     accepted = password_quality(password, bar, password_field(2, 200));
-    assert(accepted);
+    assert.ok(accepted);
     assert.equal(bar.w, "10.390277164940581%");
     assert.equal(bar.added_class, "bar-success");
     warning = password_warning(password, password_field(2));
@@ -66,7 +66,7 @@ run_test("basics w/progress bar", () => {
 
     password = "aaaaaaaa";
     accepted = password_quality(password, bar, password_field(6, 1e100));
-    assert(!accepted);
+    assert.ok(!accepted);
     assert.equal(bar.added_class, "bar-danger");
     warning = password_warning(password, password_field(6));
     assert.equal(warning, 'Repeats like "aaa" are easy to guess');

--- a/frontend_tests/node_tests/peer_data.js
+++ b/frontend_tests/node_tests/peer_data.js
@@ -66,25 +66,25 @@ test("unsubscribe", () => {
     stream_data.add_sub(devel);
 
     // verify clean slate
-    assert(!stream_data.is_subscribed("devel"));
+    assert.ok(!stream_data.is_subscribed("devel"));
 
     // set up our subscription
     devel.subscribed = true;
     peer_data.set_subscribers(devel.stream_id, [me.user_id]);
 
     // ensure our setup is accurate
-    assert(stream_data.is_subscribed("devel"));
+    assert.ok(stream_data.is_subscribed("devel"));
 
     // DO THE UNSUBSCRIBE HERE
     stream_data.unsubscribe_myself(devel);
-    assert(!devel.subscribed);
-    assert(!stream_data.is_subscribed("devel"));
-    assert(!contains_sub(stream_data.subscribed_subs(), devel));
-    assert(contains_sub(stream_data.unsubscribed_subs(), devel));
+    assert.ok(!devel.subscribed);
+    assert.ok(!stream_data.is_subscribed("devel"));
+    assert.ok(!contains_sub(stream_data.subscribed_subs(), devel));
+    assert.ok(contains_sub(stream_data.unsubscribed_subs(), devel));
 
     // make sure subsequent calls work
     const sub = stream_data.get_sub("devel");
-    assert(!sub.subscribed);
+    assert.ok(!sub.subscribed);
 });
 
 test("subscribers", () => {
@@ -96,7 +96,7 @@ test("subscribers", () => {
     people.add_active_user(george);
 
     // verify setup
-    assert(stream_data.is_subscribed(sub.name));
+    assert.ok(stream_data.is_subscribed(sub.name));
 
     const stream_id = sub.stream_id;
 
@@ -113,10 +113,10 @@ test("subscribers", () => {
     ]);
 
     peer_data.set_subscribers(stream_id, [me.user_id, fred.user_id, george.user_id]);
-    assert(stream_data.is_user_subscribed(stream_id, me.user_id));
-    assert(stream_data.is_user_subscribed(stream_id, fred.user_id));
-    assert(stream_data.is_user_subscribed(stream_id, george.user_id));
-    assert(!stream_data.is_user_subscribed(stream_id, gail.user_id));
+    assert.ok(stream_data.is_user_subscribed(stream_id, me.user_id));
+    assert.ok(stream_data.is_user_subscribed(stream_id, fred.user_id));
+    assert.ok(stream_data.is_user_subscribed(stream_id, george.user_id));
+    assert.ok(!stream_data.is_user_subscribed(stream_id, gail.user_id));
 
     assert.deepEqual(potential_subscriber_ids(), [gail.user_id]);
 
@@ -128,11 +128,11 @@ test("subscribers", () => {
         user_id: 104,
     };
     people.add_active_user(brutus);
-    assert(!stream_data.is_user_subscribed(stream_id, brutus.user_id));
+    assert.ok(!stream_data.is_user_subscribed(stream_id, brutus.user_id));
 
     // add
     peer_data.add_subscriber(stream_id, brutus.user_id);
-    assert(stream_data.is_user_subscribed(stream_id, brutus.user_id));
+    assert.ok(stream_data.is_user_subscribed(stream_id, brutus.user_id));
     assert.equal(peer_data.get_subscriber_count(stream_id), 1);
     const sub_email = "Rome:214125235@zulipdev.com:9991";
     stream_data.update_stream_email_address(sub, sub_email);
@@ -140,13 +140,13 @@ test("subscribers", () => {
 
     // verify that adding an already-added subscriber is a noop
     peer_data.add_subscriber(stream_id, brutus.user_id);
-    assert(stream_data.is_user_subscribed(stream_id, brutus.user_id));
+    assert.ok(stream_data.is_user_subscribed(stream_id, brutus.user_id));
     assert.equal(peer_data.get_subscriber_count(stream_id), 1);
 
     // remove
     let ok = peer_data.remove_subscriber(stream_id, brutus.user_id);
-    assert(ok);
-    assert(!stream_data.is_user_subscribed(stream_id, brutus.user_id));
+    assert.ok(ok);
+    assert.ok(!stream_data.is_user_subscribed(stream_id, brutus.user_id));
     assert.equal(peer_data.get_subscriber_count(stream_id), 0);
 
     // verify that checking subscription with undefined user id
@@ -160,14 +160,14 @@ test("subscribers", () => {
     blueslip.expect("warn", "We called get_user_set for an untracked stream: " + bad_stream_id);
     blueslip.expect("warn", "We tried to remove invalid subscriber: 104");
     ok = peer_data.remove_subscriber(bad_stream_id, brutus.user_id);
-    assert(!ok);
+    assert.ok(!ok);
     blueslip.reset();
 
     // verify that removing an already-removed subscriber is a noop
     blueslip.expect("warn", "We tried to remove invalid subscriber: 104");
     ok = peer_data.remove_subscriber(stream_id, brutus.user_id);
-    assert(!ok);
-    assert(!stream_data.is_user_subscribed(stream_id, brutus.user_id));
+    assert.ok(!ok);
+    assert.ok(!stream_data.is_user_subscribed(stream_id, brutus.user_id));
     assert.equal(peer_data.get_subscriber_count(stream_id), 0);
     blueslip.reset();
 
@@ -176,7 +176,7 @@ test("subscribers", () => {
     stream_data.add_sub(sub);
     peer_data.add_subscriber(stream_id, brutus.user_id);
     sub.subscribed = true;
-    assert(stream_data.is_user_subscribed(stream_id, brutus.user_id));
+    assert.ok(stream_data.is_user_subscribed(stream_id, brutus.user_id));
 
     // Verify that we noop and don't crash when unsubscribed.
     sub.subscribed = false;

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -279,19 +279,19 @@ test_people("basics", () => {
     const full_name = "Isaac Newton";
     const email = "isaac@example.com";
 
-    assert(!people.is_known_user_id(32));
-    assert(!people.is_known_user(isaac));
-    assert(!people.is_known_user(undefined));
-    assert(!people.is_valid_full_name_and_user_id(full_name, 32));
+    assert.ok(!people.is_known_user_id(32));
+    assert.ok(!people.is_known_user(isaac));
+    assert.ok(!people.is_known_user(undefined));
+    assert.ok(!people.is_valid_full_name_and_user_id(full_name, 32));
     assert.equal(people.get_user_id_from_name(full_name), undefined);
 
     people.add_active_user(isaac);
 
     assert.equal(people.get_actual_name_from_user_id(32), full_name);
 
-    assert(people.is_valid_full_name_and_user_id(full_name, 32));
-    assert(people.is_known_user_id(32));
-    assert(people.is_known_user(isaac));
+    assert.ok(people.is_valid_full_name_and_user_id(full_name, 32));
+    assert.ok(people.is_known_user_id(32));
+    assert.ok(people.is_known_user(isaac));
     assert.equal(people.get_active_human_count(), 2);
 
     assert.equal(people.get_user_id_from_name(full_name), 32);
@@ -305,7 +305,7 @@ test_people("basics", () => {
     const active_user_ids = people.get_active_user_ids().sort();
     assert.deepEqual(active_user_ids, [me.user_id, isaac.user_id]);
     assert.equal(people.is_active_user_for_popover(isaac.user_id), true);
-    assert(people.is_valid_email_for_compose(isaac.email));
+    assert.ok(people.is_valid_email_for_compose(isaac.email));
 
     // Now deactivate isaac
     people.deactivate(isaac);
@@ -606,40 +606,40 @@ test_people("filtered_users", () => {
     const users = people.get_people_for_stream_create();
     let filtered_people = people.filter_people_by_search_terms(users, [search_term]);
     assert.equal(filtered_people.size, 2);
-    assert(filtered_people.has(ashton.user_id));
-    assert(filtered_people.has(maria.user_id));
-    assert(!filtered_people.has(charles.user_id));
+    assert.ok(filtered_people.has(ashton.user_id));
+    assert.ok(filtered_people.has(maria.user_id));
+    assert.ok(!filtered_people.has(charles.user_id));
 
     filtered_people = people.filter_people_by_search_terms(users, []);
     assert.equal(filtered_people.size, 0);
 
     filtered_people = people.filter_people_by_search_terms(users, ["ltorv"]);
     assert.equal(filtered_people.size, 1);
-    assert(filtered_people.has(linus.user_id));
+    assert.ok(filtered_people.has(linus.user_id));
 
     filtered_people = people.filter_people_by_search_terms(users, ["ch di", "maria"]);
     assert.equal(filtered_people.size, 2);
-    assert(filtered_people.has(charles.user_id));
-    assert(filtered_people.has(maria.user_id));
+    assert.ok(filtered_people.has(charles.user_id));
+    assert.ok(filtered_people.has(maria.user_id));
 
     // Test filtering of names with diacritics
     // This should match Nöôáàh by ignoring diacritics, and also match Nooaah
     filtered_people = people.filter_people_by_search_terms(users, ["noOa"]);
     assert.equal(filtered_people.size, 2);
-    assert(filtered_people.has(noah.user_id));
-    assert(filtered_people.has(plain_noah.user_id));
+    assert.ok(filtered_people.has(noah.user_id));
+    assert.ok(filtered_people.has(plain_noah.user_id));
 
     // This should match ëmerson, but not emerson
     filtered_people = people.filter_people_by_search_terms(users, ["ëm"]);
     assert.equal(filtered_people.size, 1);
-    assert(filtered_people.has(noah.user_id));
+    assert.ok(filtered_people.has(noah.user_id));
 
     // Test filtering with undefined user
     users.push(unknown_user);
 
     filtered_people = people.filter_people_by_search_terms(users, ["ltorv"]);
     assert.equal(filtered_people.size, 1);
-    assert(filtered_people.has(linus.user_id));
+    assert.ok(filtered_people.has(linus.user_id));
 });
 
 people.init();
@@ -821,7 +821,7 @@ test_people("extract_people_from_message", (override) => {
         sender_id: maria.user_id,
         sender_email: maria.email,
     };
-    assert(!people.is_known_user_id(maria.user_id));
+    assert.ok(!people.is_known_user_id(maria.user_id));
 
     let reported;
     override(people, "report_late_add", (user_id, email) => {
@@ -831,8 +831,8 @@ test_people("extract_people_from_message", (override) => {
     });
 
     people.extract_people_from_message(message);
-    assert(people.is_known_user_id(maria.user_id));
-    assert(reported);
+    assert.ok(people.is_known_user_id(maria.user_id));
+    assert.ok(reported);
 
     // Get line coverage
     people.__Rewire__("report_late_add", () => {
@@ -947,7 +947,7 @@ test_people("updates", () => {
 
     // Do sanity checks on our data.
     assert.equal(people.get_by_email(old_email).user_id, user_id);
-    assert(!people.is_cross_realm_email(old_email));
+    assert.ok(!people.is_cross_realm_email(old_email));
 
     assert.equal(people.get_by_email(new_email), undefined);
 
@@ -956,7 +956,7 @@ test_people("updates", () => {
 
     // Now look up using the new email.
     assert.equal(people.get_by_email(new_email).user_id, user_id);
-    assert(!people.is_cross_realm_email(new_email));
+    assert.ok(!people.is_cross_realm_email(new_email));
 
     const all_people = get_all_persons();
     assert.equal(all_people.length, 2);
@@ -993,7 +993,7 @@ test_people("track_duplicate_full_names", () => {
     people.add_active_user(maria);
     people.add_active_user(stephen1);
 
-    assert(!people.is_duplicate_full_name("Stephen King"));
+    assert.ok(!people.is_duplicate_full_name("Stephen King"));
     assert.equal(people.get_user_id_from_name("Stephen King"), stephen1.user_id);
 
     // Now duplicate the Stephen King name.
@@ -1004,16 +1004,16 @@ test_people("track_duplicate_full_names", () => {
     // other codepaths for disambiguation.
     assert.equal(people.get_user_id_from_name("Stephen King"), undefined);
 
-    assert(people.is_duplicate_full_name("Stephen King"));
-    assert(!people.is_duplicate_full_name("Maria Athens"));
-    assert(!people.is_duplicate_full_name("Some Random Name"));
+    assert.ok(people.is_duplicate_full_name("Stephen King"));
+    assert.ok(!people.is_duplicate_full_name("Maria Athens"));
+    assert.ok(!people.is_duplicate_full_name("Some Random Name"));
 
     // It is somewhat janky that we have to clone
     // stephen2 here.  It would be nice if people.set_full_name
     // just took a user_id as the first parameter.
     people.set_full_name({...stephen2}, "Stephen King JP");
-    assert(!people.is_duplicate_full_name("Stephen King"));
-    assert(!people.is_duplicate_full_name("Stephen King JP"));
+    assert.ok(!people.is_duplicate_full_name("Stephen King"));
+    assert.ok(!people.is_duplicate_full_name("Stephen King JP"));
 });
 
 test_people("get_mention_syntax", () => {
@@ -1021,7 +1021,7 @@ test_people("get_mention_syntax", () => {
     people.add_active_user(stephen2);
     people.add_active_user(maria);
 
-    assert(people.is_duplicate_full_name("Stephen King"));
+    assert.ok(people.is_duplicate_full_name("Stephen King"));
 
     blueslip.expect("warn", "get_mention_syntax called without user_id.");
     assert.equal(people.get_mention_syntax("Stephen King"), "@**Stephen King**");
@@ -1074,14 +1074,14 @@ test_people("initialize", () => {
     people.initialize(my_user_id, params);
 
     assert.equal(people.is_active_user_for_popover(17), true);
-    assert(people.is_cross_realm_email("bot@example.com"));
-    assert(people.is_valid_email_for_compose("bot@example.com"));
-    assert(people.is_valid_email_for_compose("alice@example.com"));
-    assert(!people.is_valid_email_for_compose("retiree@example.com"));
-    assert(!people.is_valid_email_for_compose("totally-bogus-username@example.com"));
-    assert(people.is_valid_bulk_emails_for_compose(["bot@example.com", "alice@example.com"]));
-    assert(!people.is_valid_bulk_emails_for_compose(["not@valid.com", "alice@example.com"]));
-    assert(people.is_my_user_id(42));
+    assert.ok(people.is_cross_realm_email("bot@example.com"));
+    assert.ok(people.is_valid_email_for_compose("bot@example.com"));
+    assert.ok(people.is_valid_email_for_compose("alice@example.com"));
+    assert.ok(!people.is_valid_email_for_compose("retiree@example.com"));
+    assert.ok(!people.is_valid_email_for_compose("totally-bogus-username@example.com"));
+    assert.ok(people.is_valid_bulk_emails_for_compose(["bot@example.com", "alice@example.com"]));
+    assert.ok(!people.is_valid_bulk_emails_for_compose(["not@valid.com", "alice@example.com"]));
+    assert.ok(people.is_my_user_id(42));
 
     const fetched_retiree = people.get_by_user_id(15);
     assert.equal(fetched_retiree.full_name, "Retiree");
@@ -1149,9 +1149,9 @@ test_people("matches_user_settings_search", () => {
 });
 
 test_people("is_valid_full_name_and_user_id", () => {
-    assert(!people.is_valid_full_name_and_user_id("bogus", 99));
-    assert(!people.is_valid_full_name_and_user_id(me.full_name, 99));
-    assert(people.is_valid_full_name_and_user_id(me.full_name, me.user_id));
+    assert.ok(!people.is_valid_full_name_and_user_id("bogus", 99));
+    assert.ok(!people.is_valid_full_name_and_user_id(me.full_name, 99));
+    assert.ok(people.is_valid_full_name_and_user_id(me.full_name, me.user_id));
 });
 
 test_people("emails_strings_to_user_ids_array", () => {

--- a/frontend_tests/node_tests/people_errors.js
+++ b/frontend_tests/node_tests/people_errors.js
@@ -102,7 +102,7 @@ run_test("blueslip", (override) => {
     };
     blueslip.expect("error", "Unknown user id in message: 42");
     const reply_to = people.pm_reply_to(message);
-    assert(reply_to.includes("?"));
+    assert.ok(reply_to.includes("?"));
 
     override(people, "pm_with_user_ids", () => [42]);
     override(people, "get_by_user_id", () => {});

--- a/frontend_tests/node_tests/pill_typeahead.js
+++ b/frontend_tests/node_tests/pill_typeahead.js
@@ -17,9 +17,9 @@ run_test("set_up", () => {
     const fake_input = $.create(".input");
     fake_input.typeahead = (config) => {
         assert.equal(config.items, 5);
-        assert(config.fixed);
-        assert(config.dropup);
-        assert(config.stopAdvance);
+        assert.ok(config.fixed);
+        assert.ok(config.dropup);
+        assert.ok(config.stopAdvance);
 
         // Working of functions that are part of config
         // is tested separately based on the widgets that
@@ -47,31 +47,31 @@ run_test("set_up", () => {
 
     // call set_up with only user type in opts.
     pill_typeahead.set_up(fake_input, pill_widget, {user: true});
-    assert(input_pill_typeahead_called);
+    assert.ok(input_pill_typeahead_called);
 
     // call set_up with only stream type in opts.
     input_pill_typeahead_called = false;
     pill_typeahead.set_up(fake_input, pill_widget, {stream: true});
-    assert(input_pill_typeahead_called);
+    assert.ok(input_pill_typeahead_called);
 
     // call set_up with only user_group type in opts.
     input_pill_typeahead_called = false;
     pill_typeahead.set_up(fake_input, pill_widget, {user_group: true});
-    assert(input_pill_typeahead_called);
+    assert.ok(input_pill_typeahead_called);
 
     // call set_up with combination two types in opts.
     input_pill_typeahead_called = false;
     pill_typeahead.set_up(fake_input, pill_widget, {user_group: true, stream: true});
-    assert(input_pill_typeahead_called);
+    assert.ok(input_pill_typeahead_called);
 
     // call set_up with all three types in opts.
     input_pill_typeahead_called = false;
     pill_typeahead.set_up(fake_input, pill_widget, {user_group: true, stream: true, user: true});
-    assert(input_pill_typeahead_called);
+    assert.ok(input_pill_typeahead_called);
 
     // call set_up without specifying type in opts.
     input_pill_typeahead_called = false;
     blueslip.expect("error", "Unspecified possible item types");
     pill_typeahead.set_up(fake_input, pill_widget, {});
-    assert(!input_pill_typeahead_called);
+    assert.ok(!input_pill_typeahead_called);
 });

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -67,7 +67,7 @@ test("close", () => {
         collapsed = true;
     };
     pm_list.close();
-    assert(collapsed);
+    assert.ok(collapsed);
 });
 
 test("build_private_messages_list", (override) => {
@@ -167,7 +167,7 @@ test("update_dom_with_unread_counts", (override) => {
 
     pm_list.update_dom_with_unread_counts(counts);
     assert.equal(total_count.text(), "10");
-    assert(total_count.visible());
+    assert.ok(total_count.visible());
 
     counts = {
         private_message_count: 0,
@@ -175,7 +175,7 @@ test("update_dom_with_unread_counts", (override) => {
 
     pm_list.update_dom_with_unread_counts(counts);
     assert.equal(total_count.text(), "");
-    assert(!total_count.visible());
+    assert.ok(!total_count.visible());
 });
 
 test("get_active_user_ids_string", (override) => {
@@ -230,11 +230,11 @@ test("expand", (override) => {
         html_updated = true;
     });
 
-    assert(!$(".top_left_private_messages").hasClass("active-filter"));
+    assert.ok(!$(".top_left_private_messages").hasClass("active-filter"));
 
     pm_list.expand();
-    assert(html_updated);
-    assert($(".top_left_private_messages").hasClass("active-filter"));
+    assert.ok(html_updated);
+    assert.ok($(".top_left_private_messages").hasClass("active-filter"));
 });
 
 test("update_private_messages", (override) => {
@@ -260,8 +260,8 @@ test("update_private_messages", (override) => {
 
     pm_list.expand();
     pm_list.update_private_messages();
-    assert(html_updated);
-    assert(container_found);
+    assert.ok(html_updated);
+    assert.ok(container_found);
 });
 
 test("ensure coverage", (override) => {

--- a/frontend_tests/node_tests/poll_widget.js
+++ b/frontend_tests/node_tests/poll_widget.js
@@ -233,14 +233,14 @@ run_test("activate another person poll", () => {
 
     poll_widget.activate(opts);
 
-    assert(poll_option_container.visible());
-    assert(poll_question_header.visible());
+    assert.ok(poll_option_container.visible());
+    assert.ok(poll_question_header.visible());
 
-    assert(!poll_question_container.visible());
-    assert(!poll_question_submit.visible());
-    assert(!poll_edit_question.visible());
-    assert(!poll_please_wait.visible());
-    assert(!poll_author_help.visible());
+    assert.ok(!poll_question_container.visible());
+    assert.ok(!poll_question_submit.visible());
+    assert.ok(!poll_edit_question.visible());
+    assert.ok(!poll_please_wait.visible());
+    assert.ok(!poll_author_help.visible());
 
     assert.equal(widget_elem.html(), "widgets/poll_widget");
     assert.equal(widget_option_container.html(), "widgets/poll_widget_results");
@@ -352,18 +352,18 @@ run_test("activate own poll", () => {
     set_widget_find_result("button.poll-question-remove");
 
     function assert_visibility() {
-        assert(poll_option_container.visible());
-        assert(poll_question_header.visible());
-        assert(!poll_question_container.visible());
-        assert(poll_edit_question.visible());
-        assert(!poll_please_wait.visible());
-        assert(!poll_author_help.visible());
+        assert.ok(poll_option_container.visible());
+        assert.ok(poll_question_header.visible());
+        assert.ok(!poll_question_container.visible());
+        assert.ok(poll_edit_question.visible());
+        assert.ok(!poll_please_wait.visible());
+        assert.ok(!poll_author_help.visible());
     }
 
     poll_widget.activate(opts);
 
     assert_visibility();
-    assert(!poll_question_submit.visible());
+    assert.ok(!poll_question_submit.visible());
 
     assert.equal(widget_elem.html(), "widgets/poll_widget");
     assert.equal(widget_option_container.html(), "widgets/poll_widget_results");
@@ -377,7 +377,7 @@ run_test("activate own poll", () => {
         assert.deepEqual(out_data, {type: "question", question: "Is it new?"});
 
         assert_visibility();
-        assert(poll_question_submit.visible());
+        assert.ok(poll_question_submit.visible());
 
         poll_option_input.val("");
         out_data = undefined;

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -210,7 +210,7 @@ test("set_presence_info", () => {
     assert.equal(presence.get_status(zoe.user_id), "offline");
     assert.equal(presence.last_active_date(zoe.user_id), undefined);
 
-    assert(!presence.presence_info.has(bot.user_id));
+    assert.ok(!presence.presence_info.has(bot.user_id));
     assert.equal(presence.get_status(bot.user_id), "offline");
 
     assert.deepEqual(presence.presence_info.get(john.user_id), {
@@ -279,8 +279,8 @@ test("big realms", () => {
     const get_active_human_count = people.get_active_human_count;
     people.get_active_human_count = () => 1000;
     presence.set_info(presences, now);
-    assert(presence.presence_info.has(sally.user_id));
-    assert(!presence.presence_info.has(zoe.user_id));
+    assert.ok(presence.presence_info.has(sally.user_id));
+    assert.ok(!presence.presence_info.has(zoe.user_id));
     people.get_active_human_count = get_active_human_count;
 });
 

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -134,8 +134,8 @@ test("open_reactions_popover (sent by me)", () => {
         assert.equal(target, "action-stub");
     };
 
-    assert(reactions.open_reactions_popover());
-    assert(called);
+    assert.ok(reactions.open_reactions_popover());
+    assert.ok(called);
 });
 
 test("open_reactions_popover (not sent by me)", () => {
@@ -149,16 +149,16 @@ test("open_reactions_popover (not sent by me)", () => {
         assert.equal(target, "reaction-stub");
     };
 
-    assert(reactions.open_reactions_popover());
-    assert(called);
+    assert.ok(reactions.open_reactions_popover());
+    assert.ok(called);
 });
 
 test("basics", () => {
     const message = {...sample_message};
 
     const result = reactions.get_message_reactions(message);
-    assert(reactions.current_user_has_reacted_to_emoji(message, "unicode_emoji,1f642"));
-    assert(!reactions.current_user_has_reacted_to_emoji(message, "bogus"));
+    assert.ok(reactions.current_user_has_reacted_to_emoji(message, "unicode_emoji,1f642"));
+    assert.ok(!reactions.current_user_has_reacted_to_emoji(message, "bogus"));
 
     result.sort((a, b) => a.count - b.count);
 
@@ -616,8 +616,8 @@ test("view.insert_new_reaction (me w/unicode emoji)", (override) => {
     };
 
     reactions.view.insert_new_reaction(opts);
-    assert(template_called);
-    assert(insert_called);
+    assert.ok(template_called);
+    assert.ok(insert_called);
 });
 
 test("view.insert_new_reaction (them w/zulip emoji)", (override) => {
@@ -669,8 +669,8 @@ test("view.insert_new_reaction (them w/zulip emoji)", (override) => {
     };
 
     reactions.view.insert_new_reaction(opts);
-    assert(template_called);
-    assert(insert_called);
+    assert.ok(template_called);
+    assert.ok(insert_called);
 });
 
 test("view.update_existing_reaction (me)", (override) => {
@@ -698,7 +698,7 @@ test("view.update_existing_reaction (me)", (override) => {
 
     reactions.view.update_existing_reaction(opts);
 
-    assert(our_reaction.hasClass("reacted"));
+    assert.ok(our_reaction.hasClass("reacted"));
     assert.equal(
         our_reaction.attr("aria-label"),
         "translated: You (click to remove) and Bob van Roberts reacted with :8ball:",
@@ -730,7 +730,7 @@ test("view.update_existing_reaction (them)", (override) => {
 
     reactions.view.update_existing_reaction(opts);
 
-    assert(!our_reaction.hasClass("reacted"));
+    assert.ok(!our_reaction.hasClass("reacted"));
     assert.equal(
         our_reaction.attr("aria-label"),
         "translated: You (click to remove), Bob van Roberts, Cali and Alexus reacted with :8ball:",
@@ -763,7 +763,7 @@ test("view.remove_reaction (me)", (override) => {
 
     reactions.view.remove_reaction(opts);
 
-    assert(!our_reaction.hasClass("reacted"));
+    assert.ok(!our_reaction.hasClass("reacted"));
     assert.equal(
         our_reaction.attr("aria-label"),
         "translated: Bob van Roberts and Cali reacted with :8ball:",
@@ -797,7 +797,7 @@ test("view.remove_reaction (them)", (override) => {
     our_reaction.addClass("reacted");
     reactions.view.remove_reaction(opts);
 
-    assert(our_reaction.hasClass("reacted"));
+    assert.ok(our_reaction.hasClass("reacted"));
     assert.equal(
         our_reaction.attr("aria-label"),
         "translated: You (click to remove) reacted with :8ball:",
@@ -827,7 +827,7 @@ test("view.remove_reaction (last person)", (override) => {
         removed = true;
     };
     reactions.view.remove_reaction(opts);
-    assert(removed);
+    assert.ok(removed);
 });
 
 test("error_handling", (override) => {

--- a/frontend_tests/node_tests/reload_state.js
+++ b/frontend_tests/node_tests/reload_state.js
@@ -15,13 +15,13 @@ function test(label, f) {
 }
 
 test("set_state_to_pending", () => {
-    assert(!reload_state.is_pending());
+    assert.ok(!reload_state.is_pending());
     reload_state.set_state_to_pending();
-    assert(reload_state.is_pending());
+    assert.ok(reload_state.is_pending());
 });
 
 test("set_state_to_in_progress", () => {
-    assert(!reload_state.is_in_progress());
+    assert.ok(!reload_state.is_in_progress());
     reload_state.set_state_to_in_progress();
-    assert(reload_state.is_in_progress());
+    assert.ok(reload_state.is_in_progress());
 });

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -126,14 +126,14 @@ run_test("user-mention", () => {
     $content.set_find_results(".user-mention", $array([$iago, $cordelia]));
 
     // Initial asserts
-    assert(!$iago.hasClass("user-mention-me"));
+    assert.ok(!$iago.hasClass("user-mention-me"));
     assert.equal($iago.text(), "never-been-set");
     assert.equal($cordelia.text(), "never-been-set");
 
     rm.update_elements($content);
 
     // Final asserts
-    assert($iago.hasClass("user-mention-me"));
+    assert.ok($iago.hasClass("user-mention-me"));
     assert.equal($iago.text(), `@${iago.full_name}`);
     assert.equal($cordelia.text(), `@${cordelia.full_name}`);
 });
@@ -145,9 +145,9 @@ run_test("user-mention (wildcard)", () => {
     $mention.attr("data-user-id", "*");
     $content.set_find_results(".user-mention", $array([$mention]));
 
-    assert(!$mention.hasClass("user-mention-me"));
+    assert.ok(!$mention.hasClass("user-mention-me"));
     rm.update_elements($content);
-    assert($mention.hasClass("user-mention-me"));
+    assert.ok($mention.hasClass("user-mention-me"));
 });
 
 run_test("user-mention (email)", () => {
@@ -159,7 +159,7 @@ run_test("user-mention (email)", () => {
     $content.set_find_results(".user-mention", $array([$mention]));
 
     rm.update_elements($content);
-    assert(!$mention.hasClass("user-mention-me"));
+    assert.ok(!$mention.hasClass("user-mention-me"));
     assert.equal($mention.text(), "@Cordelia Lear");
 });
 
@@ -169,7 +169,7 @@ run_test("user-mention (missing)", () => {
     $content.set_find_results(".user-mention", $array([$mention]));
 
     rm.update_elements($content);
-    assert(!$mention.hasClass("user-mention-me"));
+    assert.ok(!$mention.hasClass("user-mention-me"));
 });
 
 run_test("user-group-mention", () => {
@@ -184,14 +184,14 @@ run_test("user-group-mention", () => {
     $content.set_find_results(".user-group-mention", $array([$group_me, $group_other]));
 
     // Initial asserts
-    assert(!$group_me.hasClass("user-mention-me"));
+    assert.ok(!$group_me.hasClass("user-mention-me"));
     assert.equal($group_me.text(), "never-been-set");
     assert.equal($group_other.text(), "never-been-set");
 
     rm.update_elements($content);
 
     // Final asserts
-    assert($group_me.hasClass("user-mention-me"));
+    assert.ok($group_me.hasClass("user-mention-me"));
     assert.equal($group_me.text(), `@${group_me.name}`);
     assert.equal($group_other.text(), `@${group_other.name}`);
 });
@@ -204,7 +204,7 @@ run_test("user-group-mention (error)", () => {
 
     rm.update_elements($content);
 
-    assert(!$group.hasClass("user-mention-me"));
+    assert.ok(!$group.hasClass("user-mention-me"));
 });
 
 run_test("user-group-mention (missing)", () => {
@@ -214,7 +214,7 @@ run_test("user-group-mention (missing)", () => {
 
     rm.update_elements($content);
 
-    assert(!$group.hasClass("user-mention-me"));
+    assert.ok(!$group.hasClass("user-mention-me"));
 });
 
 run_test("stream-links", () => {
@@ -328,7 +328,7 @@ run_test("emoji", () => {
 
     rm.update_elements($content);
 
-    assert(called);
+    assert.ok(called);
 
     // Set page parameters back so that test run order is independent
     page_params.emojiset = "apple";
@@ -476,7 +476,7 @@ run_test("rtl", () => {
 
     $content.text("مرحبا");
 
-    assert(!$content.hasClass("rtl"));
+    assert.ok(!$content.hasClass("rtl"));
     rm.update_elements($content);
-    assert($content.hasClass("rtl"));
+    assert.ok($content.hasClass("rtl"));
 });

--- a/frontend_tests/node_tests/rtl.js
+++ b/frontend_tests/node_tests/rtl.js
@@ -130,19 +130,19 @@ run_test("get_direction", () => {
 
 run_test("set_rtl_class_for_textarea rtl", () => {
     const textarea = $.create("some-textarea");
-    assert(!textarea.hasClass("rtl"));
+    assert.ok(!textarea.hasClass("rtl"));
     const text = "```quote\nمرحبا";
     textarea.val(text);
     rtl.set_rtl_class_for_textarea(textarea);
-    assert(textarea.hasClass("rtl"));
+    assert.ok(textarea.hasClass("rtl"));
 });
 
 run_test("set_rtl_class_for_textarea ltr", () => {
     const textarea = $.create("some-textarea");
     textarea.addClass("rtl");
-    assert(textarea.hasClass("rtl"));
+    assert.ok(textarea.hasClass("rtl"));
     const text = "```quote\nEnglish text";
     textarea.val(text);
     rtl.set_rtl_class_for_textarea(textarea);
-    assert(!textarea.hasClass("rtl"));
+    assert.ok(!textarea.hasClass("rtl"));
 });

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -60,28 +60,28 @@ test("update_button_visibility", () => {
     narrow_state.active = () => false;
     search_button.prop("disabled", true);
     search.update_button_visibility();
-    assert(search_button.prop("disabled"));
+    assert.ok(search_button.prop("disabled"));
 
     search_query.is = () => true;
     search_query.val("");
     narrow_state.active = () => false;
     search_button.prop("disabled", true);
     search.update_button_visibility();
-    assert(!search_button.prop("disabled"));
+    assert.ok(!search_button.prop("disabled"));
 
     search_query.is = () => false;
     search_query.val("Test search term");
     narrow_state.active = () => false;
     search_button.prop("disabled", true);
     search.update_button_visibility();
-    assert(!search_button.prop("disabled"));
+    assert.ok(!search_button.prop("disabled"));
 
     search_query.is = () => false;
     search_query.val("");
     narrow_state.active = () => true;
     search_button.prop("disabled", true);
     search.update_button_visibility();
-    assert(!search_button.prop("disabled"));
+    assert.ok(!search_button.prop("disabled"));
 });
 
 test("initialize", () => {
@@ -177,8 +177,8 @@ test("initialize", () => {
             _setup("ver");
 
             assert.equal(opts.updater("ver"), "ver");
-            assert(!is_blurred);
-            assert(is_append_search_string_called);
+            assert.ok(!is_blurred);
+            assert.ok(is_append_search_string_called);
 
             operators = [
                 {
@@ -190,15 +190,15 @@ test("initialize", () => {
             _setup("stream:Verona");
 
             assert.equal(opts.updater("stream:Verona"), "stream:Verona");
-            assert(!is_blurred);
-            assert(is_append_search_string_called);
+            assert.ok(!is_blurred);
+            assert.ok(is_append_search_string_called);
 
             search.__Rewire__("is_using_input_method", true);
             _setup("stream:Verona");
 
             assert.equal(opts.updater("stream:Verona"), "stream:Verona");
-            assert(!is_blurred);
-            assert(is_append_search_string_called);
+            assert.ok(!is_blurred);
+            assert.ok(is_append_search_string_called);
 
             search_query_box.off("blur");
         }
@@ -225,7 +225,7 @@ test("initialize", () => {
 
     search.__Rewire__("is_using_input_method", false);
     searchbox_form.trigger("compositionend");
-    assert(search.is_using_input_method);
+    assert.ok(search.is_using_input_method);
 
     const keydown = searchbox_form.get_on_handler("keydown");
     let default_prevented = false;
@@ -238,16 +238,16 @@ test("initialize", () => {
     };
     search_query_box.is = () => false;
     assert.equal(keydown(ev), undefined);
-    assert(!default_prevented);
+    assert.ok(!default_prevented);
 
     ev.key = "Enter";
     assert.equal(keydown(ev), undefined);
-    assert(!default_prevented);
+    assert.ok(!default_prevented);
 
     ev.key = "Enter";
     search_query_box.is = () => true;
     assert.equal(keydown(ev), undefined);
-    assert(default_prevented);
+    assert.ok(default_prevented);
 
     let operators;
     let is_blurred;
@@ -288,38 +288,38 @@ test("initialize", () => {
     search_query_box.is = () => false;
     searchbox_form.trigger(ev);
 
-    assert(!is_blurred);
-    assert(!search_button.prop("disabled"));
+    assert.ok(!is_blurred);
+    assert.ok(!search_button.prop("disabled"));
 
     ev.key = "Enter";
     search_query_box.is = () => false;
     searchbox_form.trigger(ev);
 
-    assert(!is_blurred);
-    assert(!search_button.prop("disabled"));
+    assert.ok(!is_blurred);
+    assert.ok(!search_button.prop("disabled"));
 
     ev.key = "Enter";
     search_query_box.is = () => true;
     searchbox_form.trigger(ev);
-    assert(is_blurred);
+    assert.ok(is_blurred);
 
     _setup("ver");
     search.__Rewire__("is_using_input_method", true);
     searchbox_form.trigger(ev);
     // No change on Enter keyup event when using input tool
-    assert(!is_blurred);
-    assert(!search_button.prop("disabled"));
+    assert.ok(!is_blurred);
+    assert.ok(!search_button.prop("disabled"));
 
     _setup("ver");
     ev.key = "Enter";
     search_query_box.is = () => true;
     searchbox_form.trigger(ev);
-    assert(is_blurred);
-    assert(!search_button.prop("disabled"));
+    assert.ok(is_blurred);
+    assert.ok(!search_button.prop("disabled"));
 
     search_button.prop("disabled", true);
     search_query_box.trigger("focus");
-    assert(!search_button.prop("disabled"));
+    assert.ok(!search_button.prop("disabled"));
 });
 
 test("initiate_search", () => {
@@ -353,8 +353,8 @@ test("initiate_search", () => {
     };
 
     search.initiate_search();
-    assert(typeahead_forced_open);
-    assert(is_searchbox_text_selected);
-    assert(is_searchbox_focused);
+    assert.ok(typeahead_forced_open);
+    assert.ok(is_searchbox_text_selected);
+    assert.ok(is_searchbox_focused);
     assert.deepEqual(css_args, {"box-shadow": "inset 0px 0px 0px 2px hsl(204, 20%, 74%)"});
 });

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -38,28 +38,28 @@ run_test("update_button_visibility", () => {
     narrow_state.active = () => false;
     search_button.prop("disabled", true);
     search.update_button_visibility();
-    assert(search_button.prop("disabled"));
+    assert.ok(search_button.prop("disabled"));
 
     search_query.is = () => true;
     search_query.val("");
     narrow_state.active = () => false;
     search_button.prop("disabled", true);
     search.update_button_visibility();
-    assert(!search_button.prop("disabled"));
+    assert.ok(!search_button.prop("disabled"));
 
     search_query.is = () => false;
     search_query.val("Test search term");
     narrow_state.active = () => false;
     search_button.prop("disabled", true);
     search.update_button_visibility();
-    assert(!search_button.prop("disabled"));
+    assert.ok(!search_button.prop("disabled"));
 
     search_query.is = () => false;
     search_query.val("");
     narrow_state.active = () => true;
     search_button.prop("disabled", true);
     search.update_button_visibility();
-    assert(!search_button.prop("disabled"));
+    assert.ok(!search_button.prop("disabled"));
 });
 
 run_test("initialize", () => {
@@ -142,7 +142,7 @@ run_test("initialize", () => {
             ];
             _setup("ver");
             assert.equal(opts.updater("ver"), "ver");
-            assert(is_blurred);
+            assert.ok(is_blurred);
 
             operators = [
                 {
@@ -153,12 +153,12 @@ run_test("initialize", () => {
             ];
             _setup("stream:Verona");
             assert.equal(opts.updater("stream:Verona"), "stream:Verona");
-            assert(is_blurred);
+            assert.ok(is_blurred);
 
             search.__Rewire__("is_using_input_method", true);
             _setup("stream:Verona");
             assert.equal(opts.updater("stream:Verona"), "stream:Verona");
-            assert(!is_blurred);
+            assert.ok(!is_blurred);
 
             search_query_box.off("blur");
         }
@@ -168,7 +168,7 @@ run_test("initialize", () => {
 
     search_button.prop("disabled", true);
     search_query_box.trigger("focus");
-    assert(!search_button.prop("disabled"));
+    assert.ok(!search_button.prop("disabled"));
 
     search_query_box.val("test string");
     narrow_state.search_string = () => "ver";
@@ -177,7 +177,7 @@ run_test("initialize", () => {
 
     search.__Rewire__("is_using_input_method", false);
     searchbox_form.trigger("compositionend");
-    assert(search.is_using_input_method);
+    assert.ok(search.is_using_input_method);
 
     const keydown = searchbox_form.get_on_handler("keydown");
     let default_prevented = false;
@@ -190,16 +190,16 @@ run_test("initialize", () => {
     };
     search_query_box.is = () => false;
     assert.equal(keydown(ev), undefined);
-    assert(!default_prevented);
+    assert.ok(!default_prevented);
 
     ev.key = "Enter";
     assert.equal(keydown(ev), undefined);
-    assert(!default_prevented);
+    assert.ok(!default_prevented);
 
     ev.key = "Enter";
     search_query_box.is = () => true;
     assert.equal(keydown(ev), undefined);
-    assert(default_prevented);
+    assert.ok(default_prevented);
 
     ev = {
         type: "keyup",
@@ -239,34 +239,34 @@ run_test("initialize", () => {
     search_query_box.is = () => false;
     searchbox_form.trigger(ev);
 
-    assert(!is_blurred);
-    assert(!search_button.prop("disabled"));
+    assert.ok(!is_blurred);
+    assert.ok(!search_button.prop("disabled"));
 
     ev.key = "Enter";
     search_query_box.is = () => false;
     searchbox_form.trigger(ev);
 
-    assert(!is_blurred);
-    assert(!search_button.prop("disabled"));
+    assert.ok(!is_blurred);
+    assert.ok(!search_button.prop("disabled"));
 
     ev.key = "Enter";
     search_query_box.is = () => true;
     searchbox_form.trigger(ev);
-    assert(is_blurred);
+    assert.ok(is_blurred);
 
     _setup("ver");
     search.__Rewire__("is_using_input_method", true);
     searchbox_form.trigger(ev);
     // No change on Enter keyup event when using input tool
-    assert(!is_blurred);
-    assert(!search_button.prop("disabled"));
+    assert.ok(!is_blurred);
+    assert.ok(!search_button.prop("disabled"));
 
     _setup("ver");
     ev.key = "Enter";
     search_query_box.is = () => true;
     searchbox_form.trigger(ev);
-    assert(is_blurred);
-    assert(!search_button.prop("disabled"));
+    assert.ok(is_blurred);
+    assert.ok(!search_button.prop("disabled"));
 });
 
 run_test("initiate_search", () => {
@@ -294,8 +294,8 @@ run_test("initiate_search", () => {
     };
 
     search.initiate_search();
-    assert(typeahead_forced_open);
-    assert(is_searchbox_text_selected);
+    assert.ok(typeahead_forced_open);
+    assert.ok(is_searchbox_text_selected);
     assert.equal($("#search_query").val(), "ver");
 
     assert.deepEqual(searchbox_css_args, {

--- a/frontend_tests/node_tests/search_pill.js
+++ b/frontend_tests/node_tests/search_pill.js
@@ -51,8 +51,8 @@ run_test("append", () => {
 
     search_pill.append_search_string(is_starred_item.display_value, pill_widget);
 
-    assert(appended);
-    assert(cleared);
+    assert.ok(appended);
+    assert.ok(cleared);
 });
 
 run_test("get_items", () => {
@@ -79,6 +79,6 @@ run_test("create_pills", (override) => {
     });
 
     const pills = search_pill.create_pills({});
-    assert(input_pill_create_called);
+    assert.ok(input_pill_create_called);
     assert.deepEqual(pills, {dummy: "dummy"});
 });

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -558,7 +558,7 @@ test("sent_by_me_suggestions", (override) => {
 
     let query = "";
     let suggestions = get_suggestions("", query);
-    assert(suggestions.strings.includes("sender:myself@zulip.com"));
+    assert.ok(suggestions.strings.includes("sender:myself@zulip.com"));
     assert.equal(suggestions.lookup_table.get("sender:myself@zulip.com").description, "Sent by me");
 
     query = "sender";

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -530,7 +530,7 @@ test("sent_by_me_suggestions", (override) => {
 
     let query = "";
     let suggestions = get_suggestions("", query);
-    assert(suggestions.strings.includes("sender:myself@zulip.com"));
+    assert.ok(suggestions.strings.includes("sender:myself@zulip.com"));
     assert.equal(suggestions.lookup_table.get("sender:myself@zulip.com").description, "Sent by me");
 
     query = "sender";

--- a/frontend_tests/node_tests/server_events.js
+++ b/frontend_tests/node_tests/server_events.js
@@ -82,7 +82,7 @@ run_test("message_event", (override) => {
     });
 
     server_events._get_events_success([event]);
-    assert(inserted);
+    assert.ok(inserted);
 });
 
 // Start blueslip tests here

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -101,23 +101,23 @@ function test_create_bot_type_input_box_toggle(f) {
 
     $("#create_bot_type :selected").val(EMBEDDED_BOT_TYPE);
     f();
-    assert(!create_payload_url.hasClass("required"));
-    assert(!payload_url_inputbox.visible());
-    assert($("#select_service_name").hasClass("required"));
-    assert($("#service_name_list").visible());
-    assert(config_inputbox.visible());
+    assert.ok(!create_payload_url.hasClass("required"));
+    assert.ok(!payload_url_inputbox.visible());
+    assert.ok($("#select_service_name").hasClass("required"));
+    assert.ok($("#service_name_list").visible());
+    assert.ok(config_inputbox.visible());
 
     $("#create_bot_type :selected").val(OUTGOING_WEBHOOK_BOT_TYPE);
     f();
-    assert(create_payload_url.hasClass("required"));
-    assert(payload_url_inputbox.visible());
-    assert(!config_inputbox.visible());
+    assert.ok(create_payload_url.hasClass("required"));
+    assert.ok(payload_url_inputbox.visible());
+    assert.ok(!config_inputbox.visible());
 
     $("#create_bot_type :selected").val(GENERIC_BOT_TYPE);
     f();
-    assert(!create_payload_url.hasClass("required"));
-    assert(!payload_url_inputbox.visible());
-    assert(!config_inputbox.visible());
+    assert.ok(!create_payload_url.hasClass("required"));
+    assert.ok(!payload_url_inputbox.visible());
+    assert.ok(!config_inputbox.visible());
 }
 
 test("test tab clicks", (override) => {
@@ -162,41 +162,41 @@ test("test tab clicks", (override) => {
     };
 
     click_on_tab(tabs.add);
-    assert(tabs.add.hasClass("active"));
-    assert(!tabs.active.hasClass("active"));
-    assert(!tabs.inactive.hasClass("active"));
+    assert.ok(tabs.add.hasClass("active"));
+    assert.ok(!tabs.active.hasClass("active"));
+    assert.ok(!tabs.inactive.hasClass("active"));
 
-    assert(forms.add.visible());
-    assert(!forms.active.visible());
-    assert(!forms.inactive.visible());
+    assert.ok(forms.add.visible());
+    assert.ok(!forms.active.visible());
+    assert.ok(!forms.inactive.visible());
 
     click_on_tab(tabs.active);
-    assert(!tabs.add.hasClass("active"));
-    assert(tabs.active.hasClass("active"));
-    assert(!tabs.inactive.hasClass("active"));
+    assert.ok(!tabs.add.hasClass("active"));
+    assert.ok(tabs.active.hasClass("active"));
+    assert.ok(!tabs.inactive.hasClass("active"));
 
-    assert(!forms.add.visible());
-    assert(forms.active.visible());
-    assert(!forms.inactive.visible());
+    assert.ok(!forms.add.visible());
+    assert.ok(forms.active.visible());
+    assert.ok(!forms.inactive.visible());
 
     click_on_tab(tabs.inactive);
-    assert(!tabs.add.hasClass("active"));
-    assert(!tabs.active.hasClass("active"));
-    assert(tabs.inactive.hasClass("active"));
+    assert.ok(!tabs.add.hasClass("active"));
+    assert.ok(!tabs.active.hasClass("active"));
+    assert.ok(tabs.inactive.hasClass("active"));
 
-    assert(!forms.add.visible());
-    assert(!forms.active.visible());
-    assert(forms.inactive.visible());
+    assert.ok(!forms.add.visible());
+    assert.ok(!forms.active.visible());
+    assert.ok(forms.inactive.visible());
 });
 
 test("can_create_new_bots", () => {
     page_params.is_admin = true;
-    assert(settings_bots.can_create_new_bots());
+    assert.ok(settings_bots.can_create_new_bots());
 
     page_params.is_admin = false;
     page_params.realm_bot_creation_policy = 1;
-    assert(settings_bots.can_create_new_bots());
+    assert.ok(settings_bots.can_create_new_bots());
 
     page_params.realm_bot_creation_policy = 3;
-    assert(!settings_bots.can_create_new_bots());
+    assert.ok(!settings_bots.can_create_new_bots());
 });

--- a/frontend_tests/node_tests/settings_emoji.js
+++ b/frontend_tests/node_tests/settings_emoji.js
@@ -27,5 +27,5 @@ run_test("build_emoji_upload_widget", () => {
         build_widget_stub = true;
     };
     settings_emoji.build_emoji_upload_widget();
-    assert(build_widget_stub);
+    assert.ok(build_widget_stub);
 });

--- a/frontend_tests/node_tests/settings_muted_topics.js
+++ b/frontend_tests/node_tests/settings_muted_topics.js
@@ -43,7 +43,7 @@ run_test("settings", (override) => {
 
     settings_muted_topics.set_up();
     assert.equal(settings_muted_topics.loaded, true);
-    assert(populate_list_called);
+    assert.ok(populate_list_called);
 
     const topic_click_handler = $("body").get_on_handler("click", ".settings-unmute-topic");
     assert.equal(typeof topic_click_handler, "function");
@@ -79,6 +79,6 @@ run_test("settings", (override) => {
         unmute_topic_called = true;
     };
     topic_click_handler.call(topic_fake_this, event);
-    assert(unmute_topic_called);
+    assert.ok(unmute_topic_called);
     assert.equal(topic_data_called, 2);
 });

--- a/frontend_tests/node_tests/settings_muted_users.js
+++ b/frontend_tests/node_tests/settings_muted_users.js
@@ -34,7 +34,7 @@ run_test("settings", (override) => {
 
     settings_muted_users.set_up();
     assert.equal(settings_muted_users.loaded, true);
-    assert(populate_list_called);
+    assert.ok(populate_list_called);
 
     const unmute_click_handler = $("body").get_on_handler("click", ".settings-unmute-user");
     assert.equal(typeof unmute_click_handler, "function");
@@ -66,6 +66,6 @@ run_test("settings", (override) => {
     };
 
     unmute_click_handler.call(unmute_button, event);
-    assert(unmute_user_called);
-    assert(row_attribute_fetched);
+    assert.ok(unmute_user_called);
+    assert.ok(row_attribute_fetched);
 });

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -23,7 +23,7 @@ const realm_icon = mock_esm("../../static/js/realm_icon");
 
 stub_templates((name, data) => {
     if (name === "settings/admin_realm_domains_list") {
-        assert(data.realm_domain.domain);
+        assert.ok(data.realm_domain.domain);
         return "stub-domains-list";
     }
     throw new Error(`Unknown template ${name}`);
@@ -95,7 +95,7 @@ function simulate_realm_domains_table() {
     };
 
     return function verify() {
-        assert(appended);
+        assert.ok(appended);
     };
 }
 
@@ -124,7 +124,7 @@ function test_realms_domain_modal(override, add_realm_domain) {
 
     add_realm_domain();
 
-    assert(posted);
+    assert.ok(posted);
 
     success_callback();
     assert.equal(info.val(), "translated HTML: Added successfully!");
@@ -250,7 +250,7 @@ function test_submit_settings_form(override, submit_form) {
 
     patched = false;
     submit_form(ev);
-    assert(patched);
+    assert.ok(patched);
 
     let expected_value = {
         bot_creation_policy: 1,
@@ -284,7 +284,7 @@ function test_submit_settings_form(override, submit_form) {
     ]);
 
     submit_form(ev);
-    assert(patched);
+    assert.ok(patched);
 
     expected_value = {
         default_language: "en",
@@ -361,7 +361,7 @@ function test_upload_realm_icon(override, upload_realm_logo_or_icon) {
     });
 
     upload_realm_logo_or_icon(file_input, null, true);
-    assert(posted);
+    assert.ok(posted);
 }
 
 function test_change_allow_subdomains(change_allow_subdomains) {
@@ -842,64 +842,64 @@ test("misc", (override) => {
     page_params.realm_name_changes_disabled = false;
     page_params.server_name_changes_disabled = false;
     settings_account.update_name_change_display();
-    assert(!$("#full_name").prop("disabled"));
+    assert.ok(!$("#full_name").prop("disabled"));
     assert.equal($(".change_name_tooltip").is(":visible"), false);
 
     page_params.realm_name_changes_disabled = true;
     page_params.server_name_changes_disabled = false;
     settings_account.update_name_change_display();
-    assert($("#full_name").prop("disabled"));
-    assert($(".change_name_tooltip").is(":visible"));
+    assert.ok($("#full_name").prop("disabled"));
+    assert.ok($(".change_name_tooltip").is(":visible"));
 
     page_params.realm_name_changes_disabled = true;
     page_params.server_name_changes_disabled = true;
     settings_account.update_name_change_display();
-    assert($("#full_name").prop("disabled"));
-    assert($(".change_name_tooltip").is(":visible"));
+    assert.ok($("#full_name").prop("disabled"));
+    assert.ok($(".change_name_tooltip").is(":visible"));
 
     page_params.realm_name_changes_disabled = false;
     page_params.server_name_changes_disabled = true;
     settings_account.update_name_change_display();
-    assert($("#full_name").prop("disabled"));
-    assert($(".change_name_tooltip").is(":visible"));
+    assert.ok($("#full_name").prop("disabled"));
+    assert.ok($(".change_name_tooltip").is(":visible"));
 
     page_params.realm_email_changes_disabled = false;
     settings_account.update_email_change_display();
-    assert(!$("#change_email .button").prop("disabled"));
+    assert.ok(!$("#change_email .button").prop("disabled"));
 
     page_params.realm_email_changes_disabled = true;
     settings_account.update_email_change_display();
-    assert($("#change_email .button").prop("disabled"));
+    assert.ok($("#change_email .button").prop("disabled"));
 
     page_params.realm_avatar_changes_disabled = false;
     page_params.server_avatar_changes_disabled = false;
     settings_account.update_avatar_change_display();
-    assert(!$("#user-avatar-upload-widget .image_upload_button").prop("disabled"));
-    assert(!$("#user-avatar-upload-widget .image-delete-button .button").prop("disabled"));
+    assert.ok(!$("#user-avatar-upload-widget .image_upload_button").prop("disabled"));
+    assert.ok(!$("#user-avatar-upload-widget .image-delete-button .button").prop("disabled"));
     page_params.realm_avatar_changes_disabled = true;
     page_params.server_avatar_changes_disabled = false;
     settings_account.update_avatar_change_display();
-    assert($("#user-avatar-upload-widget .image_upload_button").prop("disabled"));
-    assert($("#user-avatar-upload-widget .image-delete-button .button").prop("disabled"));
+    assert.ok($("#user-avatar-upload-widget .image_upload_button").prop("disabled"));
+    assert.ok($("#user-avatar-upload-widget .image-delete-button .button").prop("disabled"));
     page_params.realm_avatar_changes_disabled = false;
     page_params.server_avatar_changes_disabled = true;
     settings_account.update_avatar_change_display();
-    assert($("#user-avatar-upload-widget .image_upload_button").prop("disabled"));
-    assert($("#user-avatar-upload-widget .image-delete-button .button").prop("disabled"));
+    assert.ok($("#user-avatar-upload-widget .image_upload_button").prop("disabled"));
+    assert.ok($("#user-avatar-upload-widget .image-delete-button .button").prop("disabled"));
     page_params.realm_avatar_changes_disabled = true;
     page_params.server_avatar_changes_disabled = true;
     settings_account.update_avatar_change_display();
-    assert($("#user-avatar-upload-widget .image_upload_button").prop("disabled"));
-    assert($("#user-avatar-upload-widget .image-delete-button .button").prop("disabled"));
+    assert.ok($("#user-avatar-upload-widget .image_upload_button").prop("disabled"));
+    assert.ok($("#user-avatar-upload-widget .image-delete-button .button").prop("disabled"));
 
     // If organization admin, these UI elements are never disabled.
     page_params.is_admin = true;
     settings_account.update_name_change_display();
-    assert(!$("#full_name").prop("disabled"));
+    assert.ok(!$("#full_name").prop("disabled"));
     assert.equal($(".change_name_tooltip").is(":visible"), false);
 
     settings_account.update_email_change_display();
-    assert(!$("#change_email .button").prop("disabled"));
+    assert.ok(!$("#change_email .button").prop("disabled"));
 
     override(stream_settings_data, "get_streams_for_settings_page", () => [
         {name: "some_stream", stream_id: 75},
@@ -939,11 +939,11 @@ test("misc", (override) => {
     });
     settings_org.notifications_stream_widget.render(42);
     assert.equal(elem.text(), "#some_stream");
-    assert(!elem.hasClass("text-warning"));
+    assert.ok(!elem.hasClass("text-warning"));
 
     settings_org.notifications_stream_widget.render(undefined);
     assert.equal(elem.text(), "translated: Disabled");
-    assert(elem.hasClass("text-warning"));
+    assert.ok(elem.hasClass("text-warning"));
 
     setting_name = "realm_signup_notifications_stream_id";
     elem = $(`#${CSS.escape(setting_name)}_widget #${CSS.escape(setting_name)}_name`);
@@ -954,9 +954,9 @@ test("misc", (override) => {
     });
     settings_org.signup_notifications_stream_widget.render(75);
     assert.equal(elem.text(), "#some_stream");
-    assert(!elem.hasClass("text-warning"));
+    assert.ok(!elem.hasClass("text-warning"));
 
     settings_org.signup_notifications_stream_widget.render(undefined);
     assert.equal(elem.text(), "translated: Disabled");
-    assert(elem.hasClass("text-warning"));
+    assert.ok(elem.hasClass("text-warning"));
 });

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -41,7 +41,7 @@ function reset_test_setup(pill_container_stub) {
     function input_pill_stub(opts) {
         assert.equal(opts.container, pill_container_stub);
         create_item_handler = opts.create_item_from_text;
-        assert(create_item_handler);
+        assert.ok(create_item_handler);
         return pills;
     }
     input_pill.create = input_pill_stub;
@@ -55,11 +55,11 @@ function test_ui(label, f) {
 test_ui("can_edit", () => {
     page_params.is_guest = false;
     page_params.is_admin = true;
-    assert(settings_user_groups.can_edit(1));
+    assert.ok(settings_user_groups.can_edit(1));
 
     page_params.is_admin = false;
     page_params.is_guest = true;
-    assert(!settings_user_groups.can_edit(1));
+    assert.ok(!settings_user_groups.can_edit(1));
 
     page_params.is_guest = false;
     page_params.is_admin = false;
@@ -68,11 +68,11 @@ test_ui("can_edit", () => {
         assert.equal(user_id, undefined);
         return false;
     };
-    assert(!settings_user_groups.can_edit(1));
+    assert.ok(!settings_user_groups.can_edit(1));
 
     page_params.realm_user_group_edit_policy = 2;
     page_params.is_admin = true;
-    assert(settings_user_groups.can_edit(1));
+    assert.ok(settings_user_groups.can_edit(1));
 
     page_params.is_admin = false;
     user_groups.is_member_of = (group_id, user_id) => {
@@ -80,7 +80,7 @@ test_ui("can_edit", () => {
         assert.equal(user_id, undefined);
         return true;
     };
-    assert(!settings_user_groups.can_edit(1));
+    assert.ok(!settings_user_groups.can_edit(1));
 
     page_params.realm_user_group_edit_policy = 1;
     page_params.is_admin = false;
@@ -89,7 +89,7 @@ test_ui("can_edit", () => {
         assert.equal(user_id, undefined);
         return true;
     };
-    assert(settings_user_groups.can_edit(1));
+    assert.ok(settings_user_groups.can_edit(1));
 });
 
 const user_group_selector = `#user-groups #${CSS.escape(1)}`;
@@ -172,7 +172,7 @@ test_ui("populate_user_groups", (override) => {
     const pill_container_stub = $(`.pill-container[data-group-pills="${CSS.escape(1)}"]`);
     pills.appendValidatedData = (item) => {
         const id = item.user_id;
-        assert(!all_pills.has(id));
+        assert.ok(!all_pills.has(id));
         all_pills.set(id, item);
     };
     pills.items = () => Array.from(all_pills.values());
@@ -188,9 +188,9 @@ test_ui("populate_user_groups", (override) => {
     let input_typeahead_called = false;
     input_field_stub.typeahead = (config) => {
         assert.equal(config.items, 5);
-        assert(config.fixed);
-        assert(config.dropup);
-        assert(config.stopAdvance);
+        assert.ok(config.fixed);
+        assert.ok(config.dropup);
+        assert.ok(config.stopAdvance);
         assert.equal(typeof config.source, "function");
         assert.equal(typeof config.highlighter, "function");
         assert.equal(typeof config.matcher, "function");
@@ -221,20 +221,20 @@ test_ui("populate_user_groups", (override) => {
             /* Here the query doesn't begin with an '@' because typeahead is triggered
             by the '@' sign and thus removed in the query. */
             let result = config.matcher.call(fake_context, iago);
-            assert(!result);
+            assert.ok(!result);
 
             result = config.matcher.call(fake_context, alice);
-            assert(result);
+            assert.ok(result);
 
             page_params.realm_email_address_visibility =
                 settings_config.email_address_visibility_values.admins_only.code;
             page_params.is_admin = false;
             result = config.matcher.call(fake_context_for_email, bob);
-            assert(!result);
+            assert.ok(!result);
 
             page_params.is_admin = true;
             result = config.matcher.call(fake_context_for_email, bob);
-            assert(result);
+            assert.ok(result);
         })();
 
         (function test_sorter() {
@@ -243,7 +243,7 @@ test_ui("populate_user_groups", (override) => {
                 sort_recipients_typeahead_called = true;
             };
             config.sorter.call(fake_context, []);
-            assert(sort_recipients_typeahead_called);
+            assert.ok(sort_recipients_typeahead_called);
         })();
 
         (function test_updater() {
@@ -284,9 +284,9 @@ test_ui("populate_user_groups", (override) => {
             text_cleared = false;
             config.updater(alice);
             // update_cancel_button is called.
-            assert(saved_fade_out_called);
-            assert(cancel_fade_to_called);
-            assert(instructions_fade_to_called);
+            assert.ok(saved_fade_out_called);
+            assert.ok(cancel_fade_to_called);
+            assert.ok(instructions_fade_to_called);
             assert.equal(text_cleared, true);
         })();
         input_typeahead_called = true;
@@ -311,14 +311,14 @@ test_ui("populate_user_groups", (override) => {
     function test_create_item(handler) {
         (function test_rejection_path() {
             const item = handler(iago.email, pills.items());
-            assert(get_by_email_called);
+            assert.ok(get_by_email_called);
             assert.equal(item, undefined);
         })();
 
         (function test_success_path() {
             get_by_email_called = false;
             const res = handler(bob.email, pills.items());
-            assert(get_by_email_called);
+            assert.ok(get_by_email_called);
             assert.equal(typeof res, "object");
             assert.equal(res.user_id, bob.user_id);
             assert.equal(res.display_value, bob.full_name);
@@ -335,10 +335,10 @@ test_ui("populate_user_groups", (override) => {
 
     reset_test_setup(pill_container_stub);
     settings_user_groups.set_up();
-    assert(templates_render_called);
-    assert(user_groups_list_append_called);
-    assert(get_by_user_id_called);
-    assert(input_typeahead_called);
+    assert.ok(templates_render_called);
+    assert.ok(user_groups_list_append_called);
+    assert.ok(get_by_user_id_called);
+    assert.ok(input_typeahead_called);
     test_create_item(create_item_handler);
 
     // Tests for settings_user_groups.set_up workflow.
@@ -478,7 +478,7 @@ test_ui("with_external_user", (override) => {
     assert.equal(set_parents_result_called, 1);
     assert.equal(set_attributes_called, 1);
     assert.equal(can_edit_called, 9);
-    assert(exit_button_called);
+    assert.ok(exit_button_called);
     assert.equal(user_group_find_called, 2);
     assert.equal(pill_container_find_called, 4);
     assert.equal(turned_off["keydown/.pill"], true);
@@ -493,7 +493,7 @@ test_ui("reload", (override) => {
         populate_user_groups_called = true;
     });
     settings_user_groups.reload();
-    assert(populate_user_groups_called);
+    assert.ok(populate_user_groups_called);
     assert.equal($("#user-groups").html(), "");
 });
 
@@ -542,7 +542,7 @@ test_ui("on_events", (override) => {
 
                 opts.success();
 
-                assert(!$("#admin-user-group-status").visible());
+                assert.ok(!$("#admin-user-group-status").visible());
                 assert.equal($("form.admin-user-group-form input[type='text']").val(), "");
             })();
 
@@ -561,7 +561,7 @@ test_ui("on_events", (override) => {
                 };
                 opts.error(xhr);
 
-                assert(!$("#admin-user-group-status").visible());
+                assert.ok(!$("#admin-user-group-status").visible());
             })();
         };
 
@@ -603,7 +603,7 @@ test_ui("on_events", (override) => {
             },
         };
         handler(event);
-        assert(default_action_for_enter_stopped);
+        assert.ok(default_action_for_enter_stopped);
     })();
 
     (function test_do_not_blur() {
@@ -635,7 +635,7 @@ test_ui("on_events", (override) => {
                     return [];
                 };
                 handler.call(fake_this, event);
-                assert(!api_endpoint_called);
+                assert.ok(!api_endpoint_called);
             }
 
             api_endpoint_called = false;
@@ -646,7 +646,7 @@ test_ui("on_events", (override) => {
                 return [];
             };
             handler.call(fake_this, event);
-            assert(!api_endpoint_called);
+            assert.ok(!api_endpoint_called);
 
             // Cancel button triggers blur event.
             let settings_user_groups_reload_called = false;
@@ -664,8 +664,8 @@ test_ui("on_events", (override) => {
                 return [];
             };
             handler.call(fake_this, event);
-            assert(!api_endpoint_called);
-            assert(settings_user_groups_reload_called);
+            assert.ok(!api_endpoint_called);
+            assert.ok(settings_user_groups_reload_called);
         }
     })();
 
@@ -697,23 +697,23 @@ test_ui("on_events", (override) => {
         // Cancel button removed if user group if user group has no changes.
         const fake_this = $.create("fake-#update_cancel_button");
         handler_name.call(fake_this);
-        assert(cancel_fade_out_called);
-        assert(instructions_fade_out_called);
+        assert.ok(cancel_fade_out_called);
+        assert.ok(instructions_fade_out_called);
 
         // Check if cancel button removed if user group error is showing.
         $(user_group_selector + " .user-group-status").show();
         cancel_fade_out_called = false;
         instructions_fade_out_called = false;
         handler_name.call(fake_this);
-        assert(cancel_fade_out_called);
-        assert(instructions_fade_out_called);
+        assert.ok(cancel_fade_out_called);
+        assert.ok(instructions_fade_out_called);
 
         // Check for handler_desc to achieve 100% coverage.
         cancel_fade_out_called = false;
         instructions_fade_out_called = false;
         handler_desc.call(fake_this);
-        assert(cancel_fade_out_called);
-        assert(instructions_fade_out_called);
+        assert.ok(cancel_fade_out_called);
+        assert.ok(instructions_fade_out_called);
     })();
 
     (function test_user_groups_save_group_changes_triggered() {
@@ -760,9 +760,9 @@ test_ui("on_events", (override) => {
                     func();
                 });
                 opts.success();
-                assert(cancel_fade_out_called);
-                assert(instructions_fade_out_called);
-                assert(saved_fade_to_called);
+                assert.ok(cancel_fade_out_called);
+                assert.ok(instructions_fade_out_called);
+                assert.ok(saved_fade_to_called);
             })();
             (function test_post_error() {
                 const user_group_error = $(user_group_selector + " .user-group-status");
@@ -780,7 +780,7 @@ test_ui("on_events", (override) => {
                 };
                 opts.error(xhr);
 
-                assert(user_group_error.visible());
+                assert.ok(user_group_error.visible());
             })();
         };
 
@@ -793,19 +793,19 @@ test_ui("on_events", (override) => {
 
         api_endpoint_called = false;
         handler_name.call(fake_this, event);
-        assert(api_endpoint_called);
+        assert.ok(api_endpoint_called);
 
         // Check API endpoint isn't called if name and desc haven't changed.
         group_data.name = "translated: mobile";
         group_data.description = "translated: All mobile members";
         api_endpoint_called = false;
         handler_name.call(fake_this, event);
-        assert(!api_endpoint_called);
+        assert.ok(!api_endpoint_called);
 
         // Check for handler_desc to achieve 100% coverage.
         api_endpoint_called = false;
         handler_desc.call(fake_this, event);
-        assert(!api_endpoint_called);
+        assert.ok(!api_endpoint_called);
     })();
 
     (function test_user_groups_save_member_changes_triggered() {
@@ -846,9 +846,9 @@ test_ui("on_events", (override) => {
 
             (function test_post_success() {
                 opts.success();
-                assert(cancel_fade_out_called);
-                assert(instructions_fade_out_called);
-                assert(saved_fade_to_called);
+                assert.ok(cancel_fade_out_called);
+                assert.ok(instructions_fade_out_called);
+                assert.ok(saved_fade_to_called);
             })();
         };
 
@@ -861,6 +861,6 @@ test_ui("on_events", (override) => {
 
         api_endpoint_called = false;
         handler.call(fake_this, event);
-        assert(api_endpoint_called);
+        assert.ok(api_endpoint_called);
     })();
 });

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -71,9 +71,9 @@ test("basics", () => {
     };
     stream_data.add_sub(denmark);
     stream_data.add_sub(social);
-    assert(stream_data.all_subscribed_streams_are_in_home_view());
+    assert.ok(stream_data.all_subscribed_streams_are_in_home_view());
     stream_data.add_sub(test);
-    assert(!stream_data.all_subscribed_streams_are_in_home_view());
+    assert.ok(!stream_data.all_subscribed_streams_are_in_home_view());
 
     assert.equal(stream_data.get_sub("denmark"), denmark);
     assert.equal(stream_data.get_sub("Social"), social);
@@ -83,10 +83,10 @@ test("basics", () => {
     assert.deepEqual(stream_data.get_colors(), ["red", "yellow"]);
     assert.deepEqual(stream_data.subscribed_stream_ids(), [social.stream_id, test.stream_id]);
 
-    assert(stream_data.is_subscribed("social"));
-    assert(stream_data.is_subscribed("Social"));
-    assert(!stream_data.is_subscribed("Denmark"));
-    assert(!stream_data.is_subscribed("Rome"));
+    assert.ok(stream_data.is_subscribed("social"));
+    assert.ok(stream_data.is_subscribed("Social"));
+    assert.ok(!stream_data.is_subscribed("Denmark"));
+    assert.ok(!stream_data.is_subscribed("Rome"));
 
     assert.equal(stream_data.get_stream_privacy_policy(test.stream_id), "public");
     assert.equal(stream_data.get_stream_privacy_policy(social.stream_id), "invite-only");
@@ -95,8 +95,8 @@ test("basics", () => {
         "invite-only-public-history",
     );
 
-    assert(stream_data.get_invite_only("social"));
-    assert(!stream_data.get_invite_only("unknown"));
+    assert.ok(stream_data.get_invite_only("social"));
+    assert.ok(!stream_data.get_invite_only("unknown"));
 
     assert.equal(stream_data.get_color("social"), "red");
     assert.equal(stream_data.get_color("unknown"), "#c2c2c2");
@@ -104,17 +104,17 @@ test("basics", () => {
     assert.equal(stream_data.get_name("denMARK"), "Denmark");
     assert.equal(stream_data.get_name("unknown Stream"), "unknown Stream");
 
-    assert(!stream_data.is_muted(social.stream_id));
-    assert(stream_data.is_muted(denmark.stream_id));
+    assert.ok(!stream_data.is_muted(social.stream_id));
+    assert.ok(stream_data.is_muted(denmark.stream_id));
 
     assert.equal(stream_data.maybe_get_stream_name(), undefined);
     assert.equal(stream_data.maybe_get_stream_name(social.stream_id), "social");
     assert.equal(stream_data.maybe_get_stream_name(42), undefined);
 
     stream_data.set_realm_default_streams([denmark]);
-    assert(stream_data.is_default_stream_id(denmark.stream_id));
-    assert(!stream_data.is_default_stream_id(social.stream_id));
-    assert(!stream_data.is_default_stream_id(999999));
+    assert.ok(stream_data.is_default_stream_id(denmark.stream_id));
+    assert.ok(!stream_data.is_default_stream_id(social.stream_id));
+    assert.ok(!stream_data.is_default_stream_id(999999));
 
     assert.equal(stream_data.slug_to_name("2-social"), "social");
     assert.equal(stream_data.slug_to_name("2-whatever"), "social");
@@ -167,19 +167,19 @@ test("is_active", () => {
     sub = {name: "pets", subscribed: false, stream_id: 111};
     stream_data.add_sub(sub);
 
-    assert(stream_data.is_active(sub));
+    assert.ok(stream_data.is_active(sub));
 
     stream_data.subscribe_myself(sub);
-    assert(stream_data.is_active(sub));
+    assert.ok(stream_data.is_active(sub));
 
-    assert(contains_sub(stream_data.subscribed_subs(), sub));
-    assert(!contains_sub(stream_data.unsubscribed_subs(), sub));
+    assert.ok(contains_sub(stream_data.subscribed_subs(), sub));
+    assert.ok(!contains_sub(stream_data.unsubscribed_subs(), sub));
 
     stream_data.unsubscribe_myself(sub);
-    assert(stream_data.is_active(sub));
+    assert.ok(stream_data.is_active(sub));
 
     sub.pin_to_top = true;
-    assert(stream_data.is_active(sub));
+    assert.ok(stream_data.is_active(sub));
     sub.pin_to_top = false;
 
     const opts = {
@@ -189,7 +189,7 @@ test("is_active", () => {
     };
     stream_topic_history.add_message(opts);
 
-    assert(stream_data.is_active(sub));
+    assert.ok(stream_data.is_active(sub));
 
     page_params.demote_inactive_streams =
         settings_config.demote_inactive_streams_values.always.code;
@@ -198,26 +198,26 @@ test("is_active", () => {
     sub = {name: "pets", subscribed: false, stream_id: 111};
     stream_data.add_sub(sub);
 
-    assert(!stream_data.is_active(sub));
+    assert.ok(!stream_data.is_active(sub));
 
     sub.pin_to_top = true;
-    assert(stream_data.is_active(sub));
+    assert.ok(stream_data.is_active(sub));
     sub.pin_to_top = false;
 
     stream_data.subscribe_myself(sub);
-    assert(stream_data.is_active(sub));
+    assert.ok(stream_data.is_active(sub));
 
     stream_data.unsubscribe_myself(sub);
-    assert(!stream_data.is_active(sub));
+    assert.ok(!stream_data.is_active(sub));
 
     sub = {name: "lunch", subscribed: false, stream_id: 222};
     stream_data.add_sub(sub);
 
-    assert(stream_data.is_active(sub));
+    assert.ok(stream_data.is_active(sub));
 
     stream_topic_history.add_message(opts);
 
-    assert(stream_data.is_active(sub));
+    assert.ok(stream_data.is_active(sub));
 
     page_params.demote_inactive_streams = settings_config.demote_inactive_streams_values.never.code;
     stream_data.set_filter_out_inactives();
@@ -225,20 +225,20 @@ test("is_active", () => {
     sub = {name: "pets", subscribed: false, stream_id: 111};
     stream_data.add_sub(sub);
 
-    assert(stream_data.is_active(sub));
+    assert.ok(stream_data.is_active(sub));
 
     stream_data.subscribe_myself(sub);
-    assert(stream_data.is_active(sub));
+    assert.ok(stream_data.is_active(sub));
 
     stream_data.unsubscribe_myself(sub);
-    assert(stream_data.is_active(sub));
+    assert.ok(stream_data.is_active(sub));
 
     sub.pin_to_top = true;
-    assert(stream_data.is_active(sub));
+    assert.ok(stream_data.is_active(sub));
 
     stream_topic_history.add_message(opts);
 
-    assert(stream_data.is_active(sub));
+    assert.ok(stream_data.is_active(sub));
 });
 
 test("admin_options", () => {
@@ -266,8 +266,8 @@ test("admin_options", () => {
     // non-admins can't do anything
     page_params.is_admin = false;
     let sub = make_sub();
-    assert(!is_realm_admin(sub));
-    assert(!can_change_stream_permissions(sub));
+    assert.ok(!is_realm_admin(sub));
+    assert.ok(!can_change_stream_permissions(sub));
 
     // just a sanity check that we leave "normal" fields alone
     assert.equal(sub.color, "blue");
@@ -277,22 +277,22 @@ test("admin_options", () => {
 
     // admins can make public streams become private
     sub = make_sub();
-    assert(is_realm_admin(sub));
-    assert(can_change_stream_permissions(sub));
+    assert.ok(is_realm_admin(sub));
+    assert.ok(can_change_stream_permissions(sub));
 
     // admins can only make private streams become public
     // if they are subscribed
     sub = make_sub();
     sub.invite_only = true;
     sub.subscribed = false;
-    assert(is_realm_admin(sub));
-    assert(!can_change_stream_permissions(sub));
+    assert.ok(is_realm_admin(sub));
+    assert.ok(!can_change_stream_permissions(sub));
 
     sub = make_sub();
     sub.invite_only = true;
     sub.subscribed = true;
-    assert(is_realm_admin(sub));
-    assert(can_change_stream_permissions(sub));
+    assert.ok(is_realm_admin(sub));
+    assert.ok(can_change_stream_permissions(sub));
 });
 
 test("stream_settings", () => {
@@ -417,14 +417,14 @@ test("delete_sub", () => {
 
     stream_data.add_sub(canada);
 
-    assert(stream_data.is_subscribed("Canada"));
+    assert.ok(stream_data.is_subscribed("Canada"));
     assert.equal(stream_data.get_sub("Canada").stream_id, canada.stream_id);
     assert.equal(sub_store.get(canada.stream_id).name, "Canada");
 
     stream_data.delete_sub(canada.stream_id);
-    assert(!stream_data.is_subscribed("Canada"));
-    assert(!stream_data.get_sub("Canada"));
-    assert(!sub_store.get(canada.stream_id));
+    assert.ok(!stream_data.is_subscribed("Canada"));
+    assert.ok(!stream_data.get_sub("Canada"));
+    assert.ok(!sub_store.get(canada.stream_id));
 
     blueslip.expect("warn", "Failed to archive stream 99999");
     stream_data.delete_sub(99999);
@@ -445,60 +445,60 @@ test("notifications", () => {
     };
     stream_data.add_sub(india);
 
-    assert(!stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
-    assert(!stream_data.receives_notifications(india.stream_id, "audible_notifications"));
+    assert.ok(!stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
+    assert.ok(!stream_data.receives_notifications(india.stream_id, "audible_notifications"));
 
     page_params.enable_stream_desktop_notifications = true;
     page_params.enable_stream_audible_notifications = true;
-    assert(stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
-    assert(stream_data.receives_notifications(india.stream_id, "audible_notifications"));
+    assert.ok(stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
+    assert.ok(stream_data.receives_notifications(india.stream_id, "audible_notifications"));
 
     page_params.enable_stream_desktop_notifications = false;
     page_params.enable_stream_audible_notifications = false;
-    assert(!stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
-    assert(!stream_data.receives_notifications(india.stream_id, "audible_notifications"));
+    assert.ok(!stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
+    assert.ok(!stream_data.receives_notifications(india.stream_id, "audible_notifications"));
 
     india.desktop_notifications = true;
     india.audible_notifications = true;
-    assert(stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
-    assert(stream_data.receives_notifications(india.stream_id, "audible_notifications"));
+    assert.ok(stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
+    assert.ok(stream_data.receives_notifications(india.stream_id, "audible_notifications"));
 
     india.desktop_notifications = false;
     india.audible_notifications = false;
     page_params.enable_stream_desktop_notifications = true;
     page_params.enable_stream_audible_notifications = true;
-    assert(!stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
-    assert(!stream_data.receives_notifications(india.stream_id, "audible_notifications"));
+    assert.ok(!stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
+    assert.ok(!stream_data.receives_notifications(india.stream_id, "audible_notifications"));
 
     page_params.wildcard_mentions_notify = true;
-    assert(stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
+    assert.ok(stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
     page_params.wildcard_mentions_notify = false;
-    assert(!stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
+    assert.ok(!stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
     india.wildcard_mentions_notify = true;
-    assert(stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
+    assert.ok(stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
     page_params.wildcard_mentions_notify = true;
     india.wildcard_mentions_notify = false;
-    assert(!stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
+    assert.ok(!stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
 
     page_params.enable_stream_push_notifications = true;
-    assert(stream_data.receives_notifications(india.stream_id, "push_notifications"));
+    assert.ok(stream_data.receives_notifications(india.stream_id, "push_notifications"));
     page_params.enable_stream_push_notifications = false;
-    assert(!stream_data.receives_notifications(india.stream_id, "push_notifications"));
+    assert.ok(!stream_data.receives_notifications(india.stream_id, "push_notifications"));
     india.push_notifications = true;
-    assert(stream_data.receives_notifications(india.stream_id, "push_notifications"));
+    assert.ok(stream_data.receives_notifications(india.stream_id, "push_notifications"));
     page_params.enable_stream_push_notifications = true;
     india.push_notifications = false;
-    assert(!stream_data.receives_notifications(india.stream_id, "push_notifications"));
+    assert.ok(!stream_data.receives_notifications(india.stream_id, "push_notifications"));
 
     page_params.enable_stream_email_notifications = true;
-    assert(stream_data.receives_notifications(india.stream_id, "email_notifications"));
+    assert.ok(stream_data.receives_notifications(india.stream_id, "email_notifications"));
     page_params.enable_stream_email_notifications = false;
-    assert(!stream_data.receives_notifications(india.stream_id, "email_notifications"));
+    assert.ok(!stream_data.receives_notifications(india.stream_id, "email_notifications"));
     india.email_notifications = true;
-    assert(stream_data.receives_notifications(india.stream_id, "email_notifications"));
+    assert.ok(stream_data.receives_notifications(india.stream_id, "email_notifications"));
     page_params.enable_stream_email_notifications = true;
     india.email_notifications = false;
-    assert(!stream_data.receives_notifications(india.stream_id, "email_notifications"));
+    assert.ok(!stream_data.receives_notifications(india.stream_id, "email_notifications"));
 
     const canada = {
         stream_id: 103,
@@ -580,7 +580,7 @@ test("notifications", () => {
     assert.deepEqual(unmatched_streams, expected_streams);
 
     // Get line coverage on defensive code with bogus stream_id.
-    assert(!stream_data.receives_notifications(999999));
+    assert.ok(!stream_data.receives_notifications(999999));
 });
 
 const tony = {
@@ -600,9 +600,9 @@ const jazy = {
 test("is_muted", () => {
     stream_data.add_sub(tony);
     stream_data.add_sub(jazy);
-    assert(!stream_data.is_stream_muted_by_name("tony"));
-    assert(stream_data.is_stream_muted_by_name("jazy"));
-    assert(stream_data.is_stream_muted_by_name("EEXISTS"));
+    assert.ok(!stream_data.is_stream_muted_by_name("tony"));
+    assert.ok(stream_data.is_stream_muted_by_name("jazy"));
+    assert.ok(stream_data.is_stream_muted_by_name("EEXISTS"));
 });
 
 test("is_notifications_stream_muted", () => {
@@ -610,17 +610,17 @@ test("is_notifications_stream_muted", () => {
     stream_data.add_sub(jazy);
 
     page_params.realm_notifications_stream_id = tony.stream_id;
-    assert(!stream_data.is_notifications_stream_muted());
+    assert.ok(!stream_data.is_notifications_stream_muted());
 
     page_params.realm_notifications_stream_id = jazy.stream_id;
-    assert(stream_data.is_notifications_stream_muted());
+    assert.ok(stream_data.is_notifications_stream_muted());
 });
 
 test("realm_has_notifications_stream", () => {
     page_params.realm_notifications_stream_id = 10;
-    assert(stream_data.realm_has_notifications_stream());
+    assert.ok(stream_data.realm_has_notifications_stream());
     page_params.realm_notifications_stream_id = -1;
-    assert(!stream_data.realm_has_notifications_stream());
+    assert.ok(!stream_data.realm_has_notifications_stream());
 });
 
 test("remove_default_stream", () => {
@@ -634,7 +634,7 @@ test("remove_default_stream", () => {
     stream_data.add_sub(remove_me);
     stream_data.set_realm_default_streams([remove_me]);
     stream_data.remove_default_stream(remove_me.stream_id);
-    assert(!stream_data.is_default_stream_id(remove_me.stream_id));
+    assert.ok(!stream_data.is_default_stream_id(remove_me.stream_id));
 });
 
 test("canonicalized_name", () => {
@@ -663,7 +663,7 @@ test("create_sub", (override) => {
     override(color_data, "pick_color", () => "#bd86e5");
 
     const india_sub = stream_data.create_sub_from_server_data(india);
-    assert(india_sub);
+    assert.ok(india_sub);
     assert.equal(india_sub.color, "#bd86e5");
     const new_sub = stream_data.create_sub_from_server_data(india);
     // make sure sub doesn't get created twice
@@ -677,7 +677,7 @@ test("create_sub", (override) => {
     );
 
     const antarctica_sub = stream_data.create_sub_from_server_data(antarctica);
-    assert(antarctica_sub);
+    assert.ok(antarctica_sub);
     assert.equal(antarctica_sub.color, "#76ce90");
 });
 
@@ -719,12 +719,12 @@ test("initialize", () => {
     page_params.realm_notifications_stream_id = -1;
 
     initialize();
-    assert(!stream_data.is_filtering_inactives());
+    assert.ok(!stream_data.is_filtering_inactives());
 
     const stream_names = new Set(stream_data.get_streams_for_admin().map((elem) => elem.name));
-    assert(stream_names.has("subscriptions"));
-    assert(stream_names.has("unsubscribed"));
-    assert(stream_names.has("never_subscribed"));
+    assert.ok(stream_names.has("subscriptions"));
+    assert.ok(stream_names.has("unsubscribed"));
+    assert.ok(stream_names.has("never_subscribed"));
     assert.equal(stream_data.get_notifications_stream(), "");
 
     // Simulate a private stream the user isn't subscribed to
@@ -755,7 +755,7 @@ test("filter inactives", () => {
     params.realm_default_streams = [];
 
     stream_data.initialize(params);
-    assert(!stream_data.is_filtering_inactives());
+    assert.ok(!stream_data.is_filtering_inactives());
 
     _.times(30, (i) => {
         const name = "random" + i.toString();
@@ -770,7 +770,7 @@ test("filter inactives", () => {
         stream_data.add_sub(sub);
     });
     stream_data.initialize(params);
-    assert(stream_data.is_filtering_inactives());
+    assert.ok(stream_data.is_filtering_inactives());
 });
 
 test("edge_cases", () => {

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -155,9 +155,9 @@ test_ui("subscriber_pills", (override) => {
 
     input_field_stub.typeahead = (config) => {
         assert.equal(config.items, 5);
-        assert(config.fixed);
-        assert(config.dropup);
-        assert(config.stopAdvance);
+        assert.ok(config.fixed);
+        assert.ok(config.dropup);
+        assert.ok(config.stopAdvance);
 
         assert.equal(typeof config.source, "function");
         assert.equal(typeof config.highlighter, "function");
@@ -191,19 +191,19 @@ test_ui("subscriber_pills", (override) => {
 
         (function test_matcher() {
             let result = config.matcher.call(fake_stream_this, denmark);
-            assert(result);
+            assert.ok(result);
             result = config.matcher.call(fake_stream_this, sweden);
-            assert(!result);
+            assert.ok(!result);
 
             result = config.matcher.call(fake_group_this, testers);
-            assert(result);
+            assert.ok(result);
             result = config.matcher.call(fake_group_this, admins);
-            assert(!result);
+            assert.ok(!result);
 
             result = config.matcher.call(fake_person_this, me);
-            assert(result);
+            assert.ok(result);
             result = config.matcher.call(fake_person_this, jill);
-            assert(!result);
+            assert.ok(!result);
         })();
 
         (function test_sorter() {
@@ -212,18 +212,18 @@ test_ui("subscriber_pills", (override) => {
                 sort_streams_called = true;
             };
             config.sorter.call(fake_stream_this);
-            assert(sort_streams_called);
+            assert.ok(sort_streams_called);
 
             let sort_recipients_called = false;
             typeahead_helper.sort_recipients = function () {
                 sort_recipients_called = true;
             };
             config.sorter.call(fake_group_this, [testers]);
-            assert(sort_recipients_called);
+            assert.ok(sort_recipients_called);
 
             sort_recipients_called = false;
             config.sorter.call(fake_person_this, [me]);
-            assert(sort_recipients_called);
+            assert.ok(sort_recipients_called);
         })();
 
         (function test_updater() {
@@ -270,8 +270,8 @@ test_ui("subscriber_pills", (override) => {
     let fake_this = $subscription_settings;
     let event = {target: fake_this};
     stream_row_handler.call(fake_this, event);
-    assert(template_rendered);
-    assert(input_typeahead_called);
+    assert.ok(template_rendered);
+    assert.ok(input_typeahead_called);
 
     let add_subscribers_handler = $(subscriptions_table_selector).get_on_handler(
         "submit",
@@ -314,13 +314,13 @@ test_ui("subscriber_pills", (override) => {
     stream_pill.get_user_ids = () => [];
     add_subscribers_request = false;
     add_subscribers_handler(event);
-    assert(!add_subscribers_request);
+    assert.ok(!add_subscribers_request);
 
     // No request is sent if we try to subscribe ourselves
     // only and are already subscribed to the stream.
     override(user_pill, "get_user_ids", () => [me.user_id]);
     add_subscribers_handler(event);
-    assert(!add_subscribers_request);
+    assert.ok(!add_subscribers_request);
 
     // Denmark stream pill and fred and mark user pills are created.
     // But only one request for mark is sent even though a mark user

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -341,12 +341,12 @@ test("marked_subscribed (emails)", (override) => {
     const subs_stub = make_stub();
     override(subs, "update_settings_for_subscribed", subs_stub.f);
 
-    assert(!stream_data.is_subscribed(sub.name));
+    assert.ok(!stream_data.is_subscribed(sub.name));
 
     const user_ids = [15, 20, 25, me.user_id];
     stream_events.mark_subscribed(sub, user_ids, "");
     assert.deepEqual(new Set(peer_data.get_subscribers(sub.stream_id)), new Set(user_ids));
-    assert(stream_data.is_subscribed(sub.name));
+    assert.ok(stream_data.is_subscribed(sub.name));
 
     const args = subs_stub.get_args("sub");
     assert.deepEqual(sub, args.sub);
@@ -355,7 +355,7 @@ test("marked_subscribed (emails)", (override) => {
 test("mark_unsubscribed (update_settings_for_unsubscribed)", (override) => {
     // Test unsubscribe
     const sub = {...dev_help};
-    assert(sub.subscribed);
+    assert.ok(sub.subscribed);
 
     const stub = make_stub();
 
@@ -394,11 +394,11 @@ test("remove_deactivated_user_from_all_streams", () => {
     subs.update_subscribers_ui = subs_stub.f;
 
     // assert starting state
-    assert(!stream_data.is_user_subscribed(dev_help.stream_id, george.user_id));
+    assert.ok(!stream_data.is_user_subscribed(dev_help.stream_id, george.user_id));
 
     // verify that deactivating user should unsubscribe user from all streams
     peer_data.add_subscriber(dev_help.stream_id, george.user_id);
-    assert(stream_data.is_user_subscribed(dev_help.stream_id, george.user_id));
+    assert.ok(stream_data.is_user_subscribed(dev_help.stream_id, george.user_id));
 
     stream_events.remove_deactivated_user_from_all_streams(george.user_id);
 

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -124,7 +124,7 @@ test_ui("create_sidebar_row", (override) => {
 
     stream_list.build_stream_list();
 
-    assert(topic_list_cleared);
+    assert.ok(topic_list_cleared);
 
     const expected_elems = [
         devel_sidebar, // pinned
@@ -154,19 +154,19 @@ test_ui("create_sidebar_row", (override) => {
     assert.equal(privacy_elem.html(), "<div>privacy-html");
 
     stream_list.set_in_home_view(stream_id, false);
-    assert(social_li.hasClass("out_of_home_view"));
+    assert.ok(social_li.hasClass("out_of_home_view"));
 
     stream_list.set_in_home_view(stream_id, true);
-    assert(!social_li.hasClass("out_of_home_view"));
+    assert.ok(!social_li.hasClass("out_of_home_view"));
 
     const row = stream_list.stream_sidebar.get_row(stream_id);
     override(stream_data, "is_active", () => true);
     row.update_whether_active();
-    assert(!social_li.hasClass("inactive_stream"));
+    assert.ok(!social_li.hasClass("inactive_stream"));
 
     override(stream_data, "is_active", () => false);
     row.update_whether_active();
-    assert(social_li.hasClass("inactive_stream"));
+    assert.ok(social_li.hasClass("inactive_stream"));
 
     let removed;
     social_li.remove = () => {
@@ -174,7 +174,7 @@ test_ui("create_sidebar_row", (override) => {
     };
 
     row.remove();
-    assert(removed);
+    assert.ok(removed);
 });
 
 test_ui("pinned_streams_never_inactive", (override) => {
@@ -193,15 +193,15 @@ test_ui("pinned_streams_never_inactive", (override) => {
     override(stream_data, "is_active", () => false);
 
     stream_list.build_stream_list();
-    assert(social_sidebar.hasClass("inactive_stream"));
+    assert.ok(social_sidebar.hasClass("inactive_stream"));
 
     override(stream_data, "is_active", () => true);
     row.update_whether_active();
-    assert(!social_sidebar.hasClass("inactive_stream"));
+    assert.ok(!social_sidebar.hasClass("inactive_stream"));
 
     override(stream_data, "is_active", () => false);
     row.update_whether_active();
-    assert(social_sidebar.hasClass("inactive_stream"));
+    assert.ok(social_sidebar.hasClass("inactive_stream"));
 
     // pinned streams can never be made inactive
     const devel_sidebar = $("<devel sidebar row>");
@@ -210,10 +210,10 @@ test_ui("pinned_streams_never_inactive", (override) => {
     override(stream_data, "is_active", () => false);
 
     stream_list.build_stream_list();
-    assert(!devel_sidebar.hasClass("inactive_stream"));
+    assert.ok(!devel_sidebar.hasClass("inactive_stream"));
 
     row.update_whether_active();
-    assert(!devel_sidebar.hasClass("inactive_stream"));
+    assert.ok(!devel_sidebar.hasClass("inactive_stream"));
 });
 
 function add_row(sub) {
@@ -303,8 +303,8 @@ test_ui("zoom_in_and_zoom_out", () => {
     label1.show();
     label2.show();
 
-    assert(label1.visible());
-    assert(label2.visible());
+    assert.ok(label1.visible());
+    assert.ok(label2.visible());
 
     $.create(".stream-filters-label", {
         children: [elem(label1), elem(label2)],
@@ -313,7 +313,7 @@ test_ui("zoom_in_and_zoom_out", () => {
     const splitter = $.create("hr stub");
 
     splitter.show();
-    assert(splitter.visible());
+    assert.ok(splitter.visible());
 
     $.create(".stream-split", {
         children: [elem(splitter)],
@@ -344,12 +344,12 @@ test_ui("zoom_in_and_zoom_out", () => {
 
     stream_list.zoom_in_topics({stream_id: 42});
 
-    assert(!label1.visible());
-    assert(!label2.visible());
-    assert(!splitter.visible());
-    assert(stream_li1.visible());
-    assert(!stream_li2.visible());
-    assert($("#streams_list").hasClass("zoom-in"));
+    assert.ok(!label1.visible());
+    assert.ok(!label2.visible());
+    assert.ok(!splitter.visible());
+    assert.ok(stream_li1.visible());
+    assert.ok(!stream_li2.visible());
+    assert.ok($("#streams_list").hasClass("zoom-in"));
 
     $("#stream_filters li.narrow-filter").show = () => {
         stream_li1.show();
@@ -359,12 +359,12 @@ test_ui("zoom_in_and_zoom_out", () => {
     stream_li1.length = 1;
     stream_list.zoom_out_topics({stream_li: stream_li1});
 
-    assert(label1.visible());
-    assert(label2.visible());
-    assert(splitter.visible());
-    assert(stream_li1.visible());
-    assert(stream_li2.visible());
-    assert($("#streams_list").hasClass("zoom-out"));
+    assert.ok(label1.visible());
+    assert.ok(label2.visible());
+    assert.ok(splitter.visible());
+    assert.ok(stream_li1.visible());
+    assert.ok(stream_li2.visible());
+    assert.ok($("#streams_list").hasClass("zoom-out"));
 });
 
 test_ui("narrowing", (override) => {
@@ -376,7 +376,7 @@ test_ui("narrowing", (override) => {
     topic_list.get_stream_li = noop;
     override(scroll_util, "scroll_element_into_container", noop);
 
-    assert(!$("<devel sidebar row html>").hasClass("active-filter"));
+    assert.ok(!$("<devel sidebar row html>").hasClass("active-filter"));
 
     stream_list.set_event_handlers();
 
@@ -384,20 +384,20 @@ test_ui("narrowing", (override) => {
 
     filter = new Filter([{operator: "stream", operand: "devel"}]);
     stream_list.handle_narrow_activated(filter);
-    assert($("<devel sidebar row html>").hasClass("active-filter"));
+    assert.ok($("<devel sidebar row html>").hasClass("active-filter"));
 
     filter = new Filter([
         {operator: "stream", operand: "cars"},
         {operator: "topic", operand: "sedans"},
     ]);
     stream_list.handle_narrow_activated(filter);
-    assert(!$("ul.filters li").hasClass("active-filter"));
-    assert(!$("<cars sidebar row html>").hasClass("active-filter")); // false because of topic
+    assert.ok(!$("ul.filters li").hasClass("active-filter"));
+    assert.ok(!$("<cars sidebar row html>").hasClass("active-filter")); // false because of topic
 
     filter = new Filter([{operator: "stream", operand: "cars"}]);
     stream_list.handle_narrow_activated(filter);
-    assert(!$("ul.filters li").hasClass("active-filter"));
-    assert($("<cars sidebar row html>").hasClass("active-filter"));
+    assert.ok(!$("ul.filters li").hasClass("active-filter"));
+    assert.ok($("<cars sidebar row html>").hasClass("active-filter"));
 
     let removed_classes;
     $("ul#stream_filters li").removeClass = (classes) => {
@@ -411,7 +411,7 @@ test_ui("narrowing", (override) => {
 
     stream_list.handle_narrow_deactivated();
     assert.equal(removed_classes, "active-filter");
-    assert(topics_closed);
+    assert.ok(topics_closed);
 });
 
 test_ui("focusout_user_filter", () => {
@@ -482,9 +482,9 @@ test_ui("sort_streams", (override) => {
 
     const denmark_sub = stream_data.get_sub("Denmark");
     const stream_id = denmark_sub.stream_id;
-    assert(stream_list.stream_sidebar.has_row_for(stream_id));
+    assert.ok(stream_list.stream_sidebar.has_row_for(stream_id));
     stream_list.remove_sidebar_row(stream_id);
-    assert(!stream_list.stream_sidebar.has_row_for(stream_id));
+    assert.ok(!stream_list.stream_sidebar.has_row_for(stream_id));
 });
 
 test_ui("separators_only_pinned_and_dormant", (override) => {
@@ -621,7 +621,7 @@ test_ui("rename_stream", (override) => {
     });
 
     stream_list.rename_stream(sub);
-    assert(count_updated);
+    assert.ok(count_updated);
 });
 
 test_ui("refresh_pin", (override) => {
@@ -658,7 +658,7 @@ test_ui("refresh_pin", (override) => {
     });
 
     stream_list.refresh_pinned_or_unpinned_stream(pinned_sub);
-    assert(scrolled);
+    assert.ok(scrolled);
 });
 
 test_ui("create_initial_sidebar_rows", (override) => {

--- a/frontend_tests/node_tests/stream_search.js
+++ b/frontend_tests/node_tests/stream_search.js
@@ -74,24 +74,24 @@ run_test("basics", (override) => {
     cursor_helper = make_cursor_helper();
 
     function verify_expanded() {
-        assert(!section.hasClass("notdisplayed"));
+        assert.ok(!section.hasClass("notdisplayed"));
         simulate_search_expanded();
     }
 
     function verify_focused() {
-        assert(stream_list.searching());
-        assert(input.is_focused());
+        assert.ok(stream_list.searching());
+        assert.ok(input.is_focused());
     }
 
     function verify_blurred() {
-        assert(stream_list.searching());
-        assert(input.is_focused());
+        assert.ok(stream_list.searching());
+        assert.ok(input.is_focused());
     }
 
     function verify_collapsed() {
-        assert(section.hasClass("notdisplayed"));
-        assert(!input.is_focused());
-        assert(!stream_list.searching());
+        assert.ok(section.hasClass("notdisplayed"));
+        assert.ok(!input.is_focused());
+        assert.ok(!stream_list.searching());
         simulate_search_collapsed();
     }
 
@@ -102,7 +102,7 @@ run_test("basics", (override) => {
         });
 
         f();
-        assert(updated);
+        assert.ok(updated);
     }
 
     // Initiate search (so expand widget).

--- a/frontend_tests/node_tests/stream_topic_history.js
+++ b/frontend_tests/node_tests/stream_topic_history.js
@@ -320,7 +320,7 @@ test("server_history_end_to_end", () => {
 
     get_success_callback({topics});
 
-    assert(on_success_called);
+    assert.ok(on_success_called);
 
     const history = stream_topic_history.get_recent_topic_names(stream_id);
     assert.deepEqual(history, ["topic3", "topic2", "topic1"]);
@@ -335,7 +335,7 @@ test("server_history_end_to_end", () => {
     stream_topic_history_util.get_server_history(stream_id, () => {
         on_success_called = true;
     });
-    assert(on_success_called);
+    assert.ok(on_success_called);
 });
 
 test("all_topics_in_cache", (override) => {

--- a/frontend_tests/node_tests/submessage.js
+++ b/frontend_tests/node_tests/submessage.js
@@ -63,7 +63,7 @@ run_test("make_server_callback", () => {
         data: {foo: 32},
     });
 
-    assert(was_posted);
+    assert.ok(was_posted);
 });
 
 run_test("handle_event", () => {

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -115,7 +115,7 @@ run_test("redraw_left_panel", () => {
     // on our current stream, even if it doesn't match the filter.
     const denmark_row = $(`.stream-row[data-stream-id='${CSS.escape(denmark_stream_id)}']`);
     // sanity check it's not set to active
-    assert(!denmark_row.hasClass("active"));
+    assert.ok(!denmark_row.hasClass("active"));
 
     function test_filter(params, expected_streams) {
         const stream_ids = subs.redraw_left_panel(params);
@@ -127,10 +127,10 @@ run_test("redraw_left_panel", () => {
 
     // Search with single keyword
     test_filter({input: "Po", subscribed_only: false}, [poland, pomona]);
-    assert(ui_called);
+    assert.ok(ui_called);
 
     // The denmark row is active, even though it's not displayed.
-    assert(denmark_row.hasClass("active"));
+    assert.ok(denmark_row.hasClass("active"));
 
     // Search with multiple keywords
     test_filter({input: "Denmark, Pol", subscribed_only: false}, [denmark, poland]);
@@ -198,7 +198,7 @@ run_test("redraw_left_panel", () => {
     };
 
     test_filter({input: "d", subscribed_only: true}, [poland]);
-    assert(!$(".stream-row-denmark").hasClass("active"));
-    assert(!$(".right .settings").visible());
-    assert($(".nothing-selected").visible());
+    assert.ok(!$(".stream-row-denmark").hasClass("active"));
+    assert.ok(!$(".right .settings").visible());
+    assert.ok($(".nothing-selected").visible());
 });

--- a/frontend_tests/node_tests/support.js
+++ b/frontend_tests/node_tests/support.js
@@ -38,7 +38,7 @@ run_test("scrub_realm", () => {
 
     window.prompt = () => "zulip";
     click_handler.call(fake_this, event);
-    assert(submit_form_called);
+    assert.ok(submit_form_called);
 
     submit_form_called = false;
     window.prompt = () => "invalid-string-id";
@@ -47,8 +47,8 @@ run_test("scrub_realm", () => {
         alert_called = true;
     };
     click_handler.call(fake_this, event);
-    assert(!submit_form_called);
-    assert(alert_called);
+    assert.ok(!submit_form_called);
+    assert.ok(alert_called);
 
     assert.equal(typeof click_handler, "function");
 

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -29,10 +29,10 @@ run_test("narrowing", (override) => {
         pm_expanded = true;
     });
 
-    assert(!pm_expanded);
+    assert.ok(!pm_expanded);
     let filter = new Filter([{operator: "is", operand: "private"}]);
     top_left_corner.handle_narrow_activated(filter);
-    assert(pm_expanded);
+    assert.ok(pm_expanded);
 
     const alice = {
         email: "alice@example.com",
@@ -51,51 +51,51 @@ run_test("narrowing", (override) => {
     pm_expanded = false;
     filter = new Filter([{operator: "pm-with", operand: "alice@example.com"}]);
     top_left_corner.handle_narrow_activated(filter);
-    assert(pm_expanded);
+    assert.ok(pm_expanded);
 
     pm_expanded = false;
     filter = new Filter([{operator: "pm-with", operand: "bob@example.com,alice@example.com"}]);
     top_left_corner.handle_narrow_activated(filter);
-    assert(pm_expanded);
+    assert.ok(pm_expanded);
 
     pm_expanded = false;
     filter = new Filter([{operator: "pm-with", operand: "not@valid.com"}]);
     top_left_corner.handle_narrow_activated(filter);
-    assert(!pm_expanded);
+    assert.ok(!pm_expanded);
 
     filter = new Filter([{operator: "is", operand: "mentioned"}]);
     top_left_corner.handle_narrow_activated(filter);
-    assert($(".top_left_mentions").hasClass("active-filter"));
+    assert.ok($(".top_left_mentions").hasClass("active-filter"));
 
     filter = new Filter([{operator: "is", operand: "starred"}]);
     top_left_corner.handle_narrow_activated(filter);
-    assert($(".top_left_starred_messages").hasClass("active-filter"));
+    assert.ok($(".top_left_starred_messages").hasClass("active-filter"));
 
     filter = new Filter([{operator: "in", operand: "home"}]);
     top_left_corner.handle_narrow_activated(filter);
-    assert($(".top_left_all_messages").hasClass("active-filter"));
+    assert.ok($(".top_left_all_messages").hasClass("active-filter"));
 
     // deactivating narrow
 
     pm_closed = false;
     top_left_corner.handle_narrow_deactivated();
 
-    assert($(".top_left_all_messages").hasClass("active-filter"));
-    assert(!$(".top_left_mentions").hasClass("active-filter"));
-    assert(!$(".top_left_private_messages").hasClass("active-filter"));
-    assert(!$(".top_left_starred_messages").hasClass("active-filter"));
-    assert(!$(".top_left_recent_topics").hasClass("active-filter"));
-    assert(pm_closed);
+    assert.ok($(".top_left_all_messages").hasClass("active-filter"));
+    assert.ok(!$(".top_left_mentions").hasClass("active-filter"));
+    assert.ok(!$(".top_left_private_messages").hasClass("active-filter"));
+    assert.ok(!$(".top_left_starred_messages").hasClass("active-filter"));
+    assert.ok(!$(".top_left_recent_topics").hasClass("active-filter"));
+    assert.ok(pm_closed);
 
     set_global("setTimeout", (f) => {
         f();
     });
     top_left_corner.narrow_to_recent_topics();
-    assert(!$(".top_left_all_messages").hasClass("active-filter"));
-    assert(!$(".top_left_mentions").hasClass("active-filter"));
-    assert(!$(".top_left_private_messages").hasClass("active-filter"));
-    assert(!$(".top_left_starred_messages").hasClass("active-filter"));
-    assert($(".top_left_recent_topics").hasClass("active-filter"));
+    assert.ok(!$(".top_left_all_messages").hasClass("active-filter"));
+    assert.ok(!$(".top_left_mentions").hasClass("active-filter"));
+    assert.ok(!$(".top_left_private_messages").hasClass("active-filter"));
+    assert.ok(!$(".top_left_starred_messages").hasClass("active-filter"));
+    assert.ok($(".top_left_recent_topics").hasClass("active-filter"));
 });
 
 run_test("update_count_in_dom", () => {
@@ -129,7 +129,7 @@ run_test("update_count_in_dom", () => {
     top_left_corner.update_dom_with_unread_counts(counts);
     top_left_corner.update_starred_count(0);
 
-    assert(!$("<mentioned-count>").visible());
+    assert.ok(!$("<mentioned-count>").visible());
     assert.equal($("<mentioned-count>").text(), "");
     assert.equal($("<starred-count>").text(), "");
 });

--- a/frontend_tests/node_tests/transmit.js
+++ b/frontend_tests/node_tests/transmit.js
@@ -36,7 +36,7 @@ run_test("transmit_message_ajax", () => {
 
     transmit.send_message(request, success);
 
-    assert(success_func_called);
+    assert.ok(success_func_called);
 
     channel.xhr_error_message = (msg) => {
         assert.equal(msg, "Error sending message");
@@ -56,7 +56,7 @@ run_test("transmit_message_ajax", () => {
         error_func_called = true;
     };
     transmit.send_message(request, success, error);
-    assert(error_func_called);
+    assert.ok(error_func_called);
 });
 
 run_test("transmit_message_ajax_reload_pending", () => {
@@ -94,8 +94,8 @@ run_test("transmit_message_ajax_reload_pending", () => {
         opts.error(xhr, "bad request");
     };
     transmit.send_message(request, success, error);
-    assert(!error_func_called);
-    assert(reload_initiated);
+    assert.ok(!error_func_called);
+    assert.ok(reload_initiated);
 });
 
 run_test("reply_message_stream", (override) => {

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -612,7 +612,7 @@ test("render_person when emails hidden", () => {
         return "typeahead-item-stub";
     });
     assert.equal(th.render_person(b_user_1), "typeahead-item-stub");
-    assert(rendered);
+    assert.ok(rendered);
 });
 
 test("render_person", () => {
@@ -627,7 +627,7 @@ test("render_person", () => {
         return "typeahead-item-stub";
     });
     assert.equal(th.render_person(a_user), "typeahead-item-stub");
-    assert(rendered);
+    assert.ok(rendered);
 });
 
 test("render_person special_item_text", () => {
@@ -651,7 +651,7 @@ test("render_person special_item_text", () => {
         return "typeahead-item-stub";
     });
     assert.equal(th.render_person(special_person), "typeahead-item-stub");
-    assert(rendered);
+    assert.ok(rendered);
 });
 
 test("render_stream", () => {
@@ -671,7 +671,7 @@ test("render_stream", () => {
         return "typeahead-item-stub";
     });
     assert.equal(th.render_stream(stream), "typeahead-item-stub");
-    assert(rendered);
+    assert.ok(rendered);
 });
 
 test("render_stream w/long description", () => {
@@ -692,7 +692,7 @@ test("render_stream w/long description", () => {
         return "typeahead-item-stub";
     });
     assert.equal(th.render_stream(stream), "typeahead-item-stub");
-    assert(rendered);
+    assert.ok(rendered);
 });
 
 test("render_emoji", () => {
@@ -721,7 +721,7 @@ test("render_emoji", () => {
         return "typeahead-item-stub";
     });
     assert.equal(th.render_emoji(test_emoji), "typeahead-item-stub");
-    assert(rendered);
+    assert.ok(rendered);
 
     // Test render_emoji with normal emoji.
     rendered = false;
@@ -743,7 +743,7 @@ test("render_emoji", () => {
         return "typeahead-item-stub";
     });
     assert.equal(th.render_emoji(test_emoji), "typeahead-item-stub");
-    assert(rendered);
+    assert.ok(rendered);
 });
 
 test("sort_slash_commands", () => {

--- a/frontend_tests/node_tests/typing_data.js
+++ b/frontend_tests/node_tests/typing_data.js
@@ -39,21 +39,21 @@ test("basics", () => {
     assert.deepEqual(typing_data.get_all_typists(), [7, 10, 15]);
 
     // test basic removal
-    assert(typing_data.remove_typist([15, 7], "7"));
+    assert.ok(typing_data.remove_typist([15, 7], "7"));
     assert.deepEqual(typing_data.get_group_typists([7, 15]), [15]);
 
     // test removing an id that is not there
-    assert(!typing_data.remove_typist([15, 7], 7));
+    assert.ok(!typing_data.remove_typist([15, 7], 7));
     assert.deepEqual(typing_data.get_group_typists([7, 15]), [15]);
     assert.deepEqual(typing_data.get_all_typists(), [10, 15]);
 
     // remove user from one group, but "15" will still be among
     // "all typists"
-    assert(typing_data.remove_typist(["15", 7], "15"));
+    assert.ok(typing_data.remove_typist(["15", 7], "15"));
     assert.deepEqual(typing_data.get_all_typists(), [10, 15]);
 
     // now remove from the other group
-    assert(typing_data.remove_typist([5, 15, 10], 15));
+    assert.ok(typing_data.remove_typist([5, 15, 10], 15));
     assert.deepEqual(typing_data.get_all_typists(), [10]);
 
     // test duplicate ids in a groups

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -84,7 +84,7 @@ run_test("basics", (override) => {
         stopped: false,
         timer_cleared: false,
     });
-    assert(events.idle_callback);
+    assert.ok(events.idle_callback);
 
     // type again 3 seconds later
     worker.get_current_time = returns_time(8);
@@ -100,7 +100,7 @@ run_test("basics", (override) => {
         stopped: false,
         timer_cleared: true,
     });
-    assert(events.idle_callback);
+    assert.ok(events.idle_callback);
 
     // type after 15 secs, so that we can notify the server
     // again
@@ -162,7 +162,7 @@ run_test("basics", (override) => {
         stopped: false,
         timer_cleared: false,
     });
-    assert(events.idle_callback);
+    assert.ok(events.idle_callback);
 
     // Explicitly stop alice.
     call_handler(null);
@@ -192,7 +192,7 @@ run_test("basics", (override) => {
         stopped: false,
         timer_cleared: false,
     });
-    assert(events.idle_callback);
+    assert.ok(events.idle_callback);
 
     // Switch to an invalid conversation.
     call_handler(null);
@@ -236,7 +236,7 @@ run_test("basics", (override) => {
         stopped: false,
         timer_cleared: false,
     });
-    assert(events.idle_callback);
+    assert.ok(events.idle_callback);
 
     // Switch to bob now.
     worker.get_current_time = returns_time(171);
@@ -258,7 +258,7 @@ run_test("basics", (override) => {
         stopped: true,
         timer_cleared: true,
     });
-    assert(events.idle_callback);
+    assert.ok(events.idle_callback);
 
     // test that we correctly detect if worker.get_recipient
     // and typing_status.state.current_recipient are the same

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -119,9 +119,9 @@ test("changing_topics", () => {
 
     count = unread.num_unread_for_topic(stream_id, "Lunch");
     assert.equal(count, 2);
-    assert(unread.topic_has_any_unread(stream_id, "lunch"));
-    assert(!unread.topic_has_any_unread(wrong_stream_id, "lunch"));
-    assert(!unread.topic_has_any_unread(stream_id, "NOT lunch"));
+    assert.ok(unread.topic_has_any_unread(stream_id, "lunch"));
+    assert.ok(!unread.topic_has_any_unread(wrong_stream_id, "lunch"));
+    assert.ok(!unread.topic_has_any_unread(stream_id, "NOT lunch"));
 
     count = unread.num_unread_for_topic(stream_id, "NOT lunch");
     assert.equal(count, 0);
@@ -149,13 +149,13 @@ test("changing_topics", () => {
 
     count = unread.num_unread_for_topic(stream_id, "lunch");
     assert.equal(count, 0);
-    assert(!unread.topic_has_any_unread(stream_id, "lunch"));
-    assert(!unread.topic_has_any_unread(wrong_stream_id, "lunch"));
+    assert.ok(!unread.topic_has_any_unread(stream_id, "lunch"));
+    assert.ok(!unread.topic_has_any_unread(wrong_stream_id, "lunch"));
 
     count = unread.num_unread_for_topic(stream_id, "snack");
     assert.equal(count, 1);
-    assert(unread.topic_has_any_unread(stream_id, "snack"));
-    assert(!unread.topic_has_any_unread(wrong_stream_id, "snack"));
+    assert.ok(unread.topic_has_any_unread(stream_id, "snack"));
+    assert.ok(!unread.topic_has_any_unread(wrong_stream_id, "snack"));
 
     // Test defensive code.  Trying to update a message we don't know
     // about should be a no-op.
@@ -180,12 +180,12 @@ test("changing_topics", () => {
     unread.process_loaded_messages([sticky_message]);
     count = unread.num_unread_for_topic(stream_id, "sticky");
     assert.equal(count, 1);
-    assert(sticky_message.unread);
+    assert.ok(sticky_message.unread);
 
     unread.mark_as_read(sticky_message.id);
     count = unread.num_unread_for_topic(stream_id, "sticky");
     assert.equal(count, 0);
-    assert(!sticky_message.unread);
+    assert.ok(!sticky_message.unread);
 
     event = {
         topic: "sticky",
@@ -594,9 +594,9 @@ test("declare_bankruptcy", () => {
 
 test("message_unread", () => {
     // Test some code that might be overly defensive, for line coverage sake.
-    assert(!unread.message_unread(undefined));
-    assert(unread.message_unread({unread: true}));
-    assert(!unread.message_unread({unread: false}));
+    assert.ok(!unread.message_unread(undefined));
+    assert.ok(unread.message_unread({unread: true}));
+    assert.ok(!unread.message_unread({unread: false}));
 });
 
 test("server_counts", () => {

--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -227,15 +227,15 @@ run_test("autopay_form_fields", () => {
     assert.equal(schedule_options[0].value, "monthly");
     assert.equal(schedule_options[1].value, "annual");
 
-    assert(document.querySelector("#autopay-error"));
-    assert(document.querySelector("#autopay-loading"));
-    assert(document.querySelector("#autopay"));
-    assert(document.querySelector("#autopay-success"));
-    assert(document.querySelector("#autopay_loading_indicator"));
+    assert.ok(document.querySelector("#autopay-error"));
+    assert.ok(document.querySelector("#autopay-loading"));
+    assert.ok(document.querySelector("#autopay"));
+    assert.ok(document.querySelector("#autopay-success"));
+    assert.ok(document.querySelector("#autopay_loading_indicator"));
 
-    assert(document.querySelector("input[name=csrfmiddlewaretoken]"));
+    assert.ok(document.querySelector("input[name=csrfmiddlewaretoken]"));
 
-    assert(document.querySelector("#free-trial-alert-message"));
+    assert.ok(document.querySelector("#free-trial-alert-message"));
 });
 
 run_test("invoice_form_fields", () => {
@@ -259,13 +259,13 @@ run_test("invoice_form_fields", () => {
     assert.equal(schedule_options.length, 1);
     assert.equal(schedule_options[0].value, "annual");
 
-    assert(document.querySelector("#invoice-error"));
-    assert(document.querySelector("#invoice-loading"));
-    assert(document.querySelector("#invoice"));
-    assert(document.querySelector("#invoice-success"));
-    assert(document.querySelector("#invoice_loading_indicator"));
+    assert.ok(document.querySelector("#invoice-error"));
+    assert.ok(document.querySelector("#invoice-loading"));
+    assert.ok(document.querySelector("#invoice"));
+    assert.ok(document.querySelector("#invoice-success"));
+    assert.ok(document.querySelector("#invoice_loading_indicator"));
 
-    assert(document.querySelector("input[name=csrfmiddlewaretoken]"));
+    assert.ok(document.querySelector("input[name=csrfmiddlewaretoken]"));
 
-    assert(document.querySelector("#free-trial-alert-message"));
+    assert.ok(document.querySelector("#free-trial-alert-message"));
 });

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -49,11 +49,11 @@ test("feature_check", (override) => {
     const upload_button = $.create("upload-button-stub");
     upload_button.addClass("notdisplayed");
     upload.feature_check(upload_button);
-    assert(upload_button.hasClass("notdisplayed"));
+    assert.ok(upload_button.hasClass("notdisplayed"));
 
     override(window, "XMLHttpRequest", () => ({upload: true}));
     upload.feature_check(upload_button);
-    assert(!upload_button.hasClass("notdisplayed"));
+    assert.ok(!upload_button.hasClass("notdisplayed"));
 });
 
 test("make_upload_absolute", () => {
@@ -197,9 +197,9 @@ test("show_error_message", () => {
 
     upload.show_error_message({mode: "compose"}, "Error message");
     assert.equal($("#compose-send-button").prop("disabled"), false);
-    assert($("#compose-send-status").hasClass("alert-error"));
+    assert.ok($("#compose-send-status").hasClass("alert-error"));
     assert.equal($("#compose-send-status").hasClass("alert-info"), false);
-    assert($("#compose-send-status").visible());
+    assert.ok($("#compose-send-status").visible());
     assert.equal($("#compose-error-msg").text(), "Error message");
 
     upload.show_error_message({mode: "compose"});
@@ -236,7 +236,7 @@ test("upload_files", (override) => {
     const config = {mode: "compose"};
     $("#compose-send-button").prop("disabled", false);
     upload.upload_files(uppy, config, []);
-    assert(!$("#compose-send-button").prop("disabled"));
+    assert.ok(!$("#compose-send-button").prop("disabled"));
 
     page_params.max_file_upload_size_mib = 0;
     let show_error_message_called = false;
@@ -249,7 +249,7 @@ test("upload_files", (override) => {
         );
     });
     upload.upload_files(uppy, config, files);
-    assert(show_error_message_called);
+    assert.ok(show_error_message_called);
 
     page_params.max_file_upload_size_mib = 25;
     let on_click_close_button_callback;
@@ -275,14 +275,14 @@ test("upload_files", (override) => {
     $("#compose-send-status").removeClass("alert-info").hide();
     $("#compose .undo_markdown_preview").show();
     upload.upload_files(uppy, config, files);
-    assert($("#compose-send-button").prop("disabled"));
-    assert($("#compose-send-status").hasClass("alert-info"));
-    assert($("#compose-send-status").visible());
+    assert.ok($("#compose-send-button").prop("disabled"));
+    assert.ok($("#compose-send-status").hasClass("alert-info"));
+    assert.ok($("#compose-send-status").visible());
     assert.equal($("<p>").text(), "translated: Uploading…");
-    assert(compose_ui_insert_syntax_and_focus_called);
-    assert(compose_ui_autosize_textarea_called);
-    assert(markdown_preview_hide_button_clicked);
-    assert(uppy_add_file_called);
+    assert.ok(compose_ui_insert_syntax_and_focus_called);
+    assert.ok(compose_ui_autosize_textarea_called);
+    assert.ok(markdown_preview_hide_button_clicked);
+    assert.ok(uppy_add_file_called);
 
     files = [
         {
@@ -322,17 +322,17 @@ test("upload_files", (override) => {
         assert.equal(textarea, $("#compose-textarea"));
     });
     on_click_close_button_callback();
-    assert(uppy_cancel_all_called);
-    assert(hide_upload_status_called);
-    assert(compose_ui_autosize_textarea_called);
-    assert(compose_ui_replace_syntax_called);
+    assert.ok(uppy_cancel_all_called);
+    assert.ok(hide_upload_status_called);
+    assert.ok(compose_ui_autosize_textarea_called);
+    assert.ok(compose_ui_replace_syntax_called);
     hide_upload_status_called = false;
     compose_ui_replace_syntax_called = false;
     $("#compose-textarea").val("user modified text");
     on_click_close_button_callback();
-    assert(hide_upload_status_called);
-    assert(compose_ui_autosize_textarea_called);
-    assert(compose_ui_replace_syntax_called);
+    assert.ok(hide_upload_status_called);
+    assert.ok(compose_ui_autosize_textarea_called);
+    assert.ok(compose_ui_replace_syntax_called);
     assert.equal($("#compose-textarea").val(), "user modified text");
 });
 
@@ -348,7 +348,7 @@ test("uppy_config", () => {
         assert.equal(config.autoProceed, true);
         assert.equal(config.restrictions.maxFileSize, 25 * 1024 * 1024);
         assert.equal(Object.keys(config.locale.strings).length, 2);
-        assert("exceedsSize" in config.locale.strings);
+        assert.ok("exceedsSize" in config.locale.strings);
 
         return {
             setMeta: (params) => {
@@ -364,7 +364,7 @@ test("uppy_config", () => {
                     assert.equal(params.fieldName, "file");
                     assert.equal(params.limit, 5);
                     assert.equal(Object.keys(params.locale.strings).length, 1);
-                    assert("timedOut" in params.locale.strings);
+                    assert.ok("timedOut" in params.locale.strings);
                 } else if (func_name === "ProgressBar") {
                     uppy_used_progressbar = true;
                     assert.equal(params.target, "#compose-send-status");
@@ -403,7 +403,7 @@ test("file_input", (override) => {
         upload_files_called = true;
     });
     change_handler(event);
-    assert(upload_files_called);
+    assert.ok(upload_files_called);
 });
 
 test("file_drop", (override) => {
@@ -472,8 +472,8 @@ test("copy_paste", (override) => {
     });
 
     paste_handler(event);
-    assert(get_as_file_called);
-    assert(upload_files_called);
+    assert.ok(get_as_file_called);
+    assert.ok(upload_files_called);
 
     upload_files_called = false;
     event = {
@@ -543,9 +543,9 @@ test("uppy_events", (override) => {
         compose_ui_autosize_textarea_called = true;
     });
     on_upload_success_callback(file, response);
-    assert(compose_actions_start_called);
-    assert(compose_ui_replace_syntax_called);
-    assert(compose_ui_autosize_textarea_called);
+    assert.ok(compose_actions_start_called);
+    assert.ok(compose_ui_replace_syntax_called);
+    assert.ok(compose_ui_autosize_textarea_called);
 
     response = {
         body: {
@@ -584,13 +584,13 @@ test("uppy_events", (override) => {
         },
     ];
     on_complete_callback();
-    assert(hide_upload_status_called);
+    assert.ok(hide_upload_status_called);
     assert.equal(files.length, 0);
 
     hide_upload_status_called = false;
     $("#compose-send-status").addClass("alert-error");
     on_complete_callback();
-    assert(!hide_upload_status_called);
+    assert.ok(!hide_upload_status_called);
 
     $("#compose-send-status").removeClass("alert-error");
     hide_upload_status_called = false;
@@ -609,7 +609,7 @@ test("uppy_events", (override) => {
         },
     ];
     on_complete_callback();
-    assert(!hide_upload_status_called);
+    assert.ok(!hide_upload_status_called);
     assert.equal(files.length, 1);
 
     state = {
@@ -628,8 +628,8 @@ test("uppy_events", (override) => {
         assert.equal(message, "Some error message");
     });
     on_info_visible_callback();
-    assert(uppy_cancel_all_called);
-    assert(show_error_message_called);
+    assert.ok(uppy_cancel_all_called);
+    assert.ok(show_error_message_called);
     override(compose_ui, "replace_syntax", (old_syntax, new_syntax, textarea) => {
         compose_ui_replace_syntax_called = true;
         assert.equal(old_syntax, "[translated: Uploading copenhagen.png…]()");
@@ -637,11 +637,11 @@ test("uppy_events", (override) => {
         assert.equal(textarea, $("#compose-textarea"));
     });
     on_restriction_failed_callback(file, null, null);
-    assert(compose_ui_replace_syntax_called);
+    assert.ok(compose_ui_replace_syntax_called);
     compose_ui_replace_syntax_called = false;
     $("#compose-textarea").val("user modified text");
     on_restriction_failed_callback(file, null, null);
-    assert(compose_ui_replace_syntax_called);
+    assert.ok(compose_ui_replace_syntax_called);
     assert.equal($("#compose-textarea").val(), "user modified text");
 
     state = {
@@ -673,9 +673,9 @@ test("uppy_events", (override) => {
     };
     uppy_cancel_all_called = false;
     on_upload_error_callback(file, null, response);
-    assert(uppy_cancel_all_called);
-    assert(show_error_message_called);
-    assert(compose_ui_replace_syntax_called);
+    assert.ok(uppy_cancel_all_called);
+    assert.ok(show_error_message_called);
+    assert.ok(compose_ui_replace_syntax_called);
 
     compose_ui_replace_syntax_called = false;
     override(upload, "show_error_message", (config, message) => {
@@ -685,15 +685,15 @@ test("uppy_events", (override) => {
     });
     uppy_cancel_all_called = false;
     on_upload_error_callback(file, null, null);
-    assert(uppy_cancel_all_called);
-    assert(show_error_message_called);
-    assert(compose_ui_replace_syntax_called);
+    assert.ok(uppy_cancel_all_called);
+    assert.ok(show_error_message_called);
+    assert.ok(compose_ui_replace_syntax_called);
     show_error_message_called = false;
     $("#compose-textarea").val("user modified text");
     uppy_cancel_all_called = false;
     on_upload_error_callback(file, null);
-    assert(uppy_cancel_all_called);
-    assert(show_error_message_called);
-    assert(compose_ui_replace_syntax_called);
+    assert.ok(uppy_cancel_all_called);
+    assert.ok(show_error_message_called);
+    assert.ok(compose_ui_replace_syntax_called);
     assert.equal($("#compose-textarea").val(), "user modified text");
 });

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -83,14 +83,14 @@ run_test("updates", () => {
         role: settings_config.user_role_values.guest.code,
     });
     person = people.get_by_email(isaac.email);
-    assert(person.is_guest);
+    assert.ok(person.is_guest);
     assert.equal(person.role, settings_config.user_role_values.guest.code);
     user_events.update_person({
         user_id: isaac.user_id,
         role: settings_config.user_role_values.member.code,
     });
     person = people.get_by_email(isaac.email);
-    assert(!person.is_guest);
+    assert.ok(!person.is_guest);
     assert.equal(person.role, settings_config.user_role_values.member.code);
 
     user_events.update_person({
@@ -121,23 +121,23 @@ run_test("updates", () => {
 
     user_events.update_person({user_id: me.user_id, is_billing_admin: true});
     person = people.get_by_email(me.email);
-    assert(person.is_billing_admin);
+    assert.ok(person.is_billing_admin);
     assert.equal(person.role, settings_config.user_role_values.member.code);
-    assert(page_params.is_billing_admin);
+    assert.ok(page_params.is_billing_admin);
 
     user_events.update_person({user_id: me.user_id, is_billing_admin: false});
     person = people.get_by_email(me.email);
     assert.equal(person.user_id, me.user_id);
-    assert(!person.is_billing_admin);
+    assert.ok(!person.is_billing_admin);
     assert.equal(person.role, settings_config.user_role_values.member.code);
-    assert(!page_params.is_billing_admin);
+    assert.ok(!page_params.is_billing_admin);
 
     user_events.update_person({user_id: isaac.user_id, is_billing_admin: false});
     person = people.get_by_email(isaac.email);
     assert.equal(person.user_id, isaac.user_id);
-    assert(!person.is_billing_admin);
+    assert.ok(!person.is_billing_admin);
     assert.equal(person.role, settings_config.user_role_values.owner.code);
-    assert(!page_params.is_billing_admin);
+    assert.ok(!page_params.is_billing_admin);
 
     let user_id;
     let full_name;
@@ -157,7 +157,7 @@ run_test("updates", () => {
         user_id: me.user_id,
         role: settings_config.user_role_values.member.code,
     });
-    assert(!page_params.is_admin);
+    assert.ok(!page_params.is_admin);
 
     user_events.update_person({user_id: me.user_id, full_name: "Me V2"});
     assert.equal(people.my_full_name(), "Me V2");
@@ -201,11 +201,11 @@ run_test("updates", () => {
 
     user_events.update_person({user_id: me.user_id, timezone: "UTC"});
     person = people.get_by_email(me.email);
-    assert(person.timezone);
+    assert.ok(person.timezone);
 
     blueslip.expect("error", "Got update_person event for unexpected user 29");
     blueslip.expect("error", "Unknown user_id in get_by_user_id: 29");
-    assert(!user_events.update_person({user_id: 29, full_name: "Sir Isaac Newton"}));
+    assert.ok(!user_events.update_person({user_id: 29, full_name: "Sir Isaac Newton"}));
 
     me.profile_data = {};
     user_events.update_person({
@@ -223,7 +223,7 @@ run_test("updates", () => {
     };
 
     user_events.update_person({user_id: me.user_id, delivery_email: "you@example.org"});
-    assert(updated);
+    assert.ok(updated);
 
     const test_bot = {
         email: "test-bot@example.com",

--- a/frontend_tests/node_tests/user_groups.js
+++ b/frontend_tests/node_tests/user_groups.js
@@ -80,8 +80,8 @@ run_test("user_groups", () => {
     const groups_of_users_nomatch = user_groups.get_user_groups_of_user(user_id_not_in_any_group);
     assert.equal(groups_of_users_nomatch.length, 0);
 
-    assert(!user_groups.is_member_of(admins.id, 4));
-    assert(user_groups.is_member_of(admins.id, 3));
+    assert.ok(!user_groups.is_member_of(admins.id, 4));
+    assert.ok(user_groups.is_member_of(admins.id, 3));
 
     user_groups.add_members(all.id, [5, 4]);
     assert.deepEqual(user_groups.get_user_group_from_id(all.id).members, new Set([1, 2, 3, 5, 4]));
@@ -89,12 +89,12 @@ run_test("user_groups", () => {
     user_groups.remove_members(all.id, [1, 4]);
     assert.deepEqual(user_groups.get_user_group_from_id(all.id).members, new Set([2, 3, 5]));
 
-    assert(user_groups.is_user_group(admins));
+    assert.ok(user_groups.is_user_group(admins));
     const object = {
         name: "core",
         id: 3,
     };
-    assert(!user_groups.is_user_group(object));
+    assert.ok(!user_groups.is_user_group(object));
 
     user_groups.init();
     assert.equal(user_groups.get_realm_user_groups().length, 0);

--- a/frontend_tests/node_tests/user_pill.js
+++ b/frontend_tests/node_tests/user_pill.js
@@ -96,8 +96,8 @@ test("append", () => {
         pill_widget,
     });
 
-    assert(appended);
-    assert(cleared);
+    assert.ok(appended);
+    assert.ok(cleared);
 });
 
 test("get_items", () => {

--- a/frontend_tests/node_tests/user_search.js
+++ b/frontend_tests/node_tests/user_search.js
@@ -87,11 +87,11 @@ test("clear_search", (override) => {
     override(resize, "resize_sidebars", () => {});
 
     $(".user-list-filter").val("somevalue");
-    assert(!$("#user_search_section").hasClass("notdisplayed"));
+    assert.ok(!$("#user_search_section").hasClass("notdisplayed"));
     $("#clear_search_people_button").trigger("click");
     assert.equal($(".user-list-filter").val(), "");
     $("#clear_search_people_button").trigger("click");
-    assert($("#user_search_section").hasClass("notdisplayed"));
+    assert.ok($("#user_search_section").hasClass("notdisplayed"));
 });
 
 test("escape_search", (override) => {
@@ -104,7 +104,7 @@ test("escape_search", (override) => {
     activity.escape_search();
     assert.equal($(".user-list-filter").val(), "");
     activity.escape_search();
-    assert($("#user_search_section").hasClass("notdisplayed"));
+    assert.ok($("#user_search_section").hasClass("notdisplayed"));
 });
 
 test("blur search right", (override) => {
@@ -205,12 +205,12 @@ test("click on user header to toggle display", (override) => {
 
     page_params.realm_presence_disabled = true;
 
-    assert(!$("#user_search_section").hasClass("notdisplayed"));
+    assert.ok(!$("#user_search_section").hasClass("notdisplayed"));
 
     user_filter.val("bla");
 
     $("#userlist-header").trigger("click");
-    assert($("#user_search_section").hasClass("notdisplayed"));
+    assert.ok($("#user_search_section").hasClass("notdisplayed"));
     assert.equal(user_filter.val(), "");
 
     $(".user-list-filter").closest = (selector) => {

--- a/frontend_tests/node_tests/user_status.js
+++ b/frontend_tests/node_tests/user_status.js
@@ -22,14 +22,14 @@ function initialize() {
 
 run_test("basics", () => {
     initialize();
-    assert(user_status.is_away(2));
-    assert(!user_status.is_away(99));
+    assert.ok(user_status.is_away(2));
+    assert.ok(!user_status.is_away(99));
 
-    assert(!user_status.is_away(4));
+    assert.ok(!user_status.is_away(4));
     user_status.set_away(4);
-    assert(user_status.is_away(4));
+    assert.ok(user_status.is_away(4));
     user_status.revoke_away(4);
-    assert(!user_status.is_away(4));
+    assert.ok(!user_status.is_away(4));
 
     assert.equal(user_status.get_status_text(1), "in a meeting");
 
@@ -76,7 +76,7 @@ run_test("server", () => {
     });
 
     success();
-    assert(called);
+    assert.ok(called);
 });
 
 run_test("defensive checks", () => {

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -41,9 +41,9 @@ run_test("extract_pm_recipients", () => {
 
 run_test("is_pm_recipient", () => {
     const message = {to_user_ids: "31,32,33"};
-    assert(util.is_pm_recipient(31, message));
-    assert(util.is_pm_recipient(32, message));
-    assert(!util.is_pm_recipient(34, message));
+    assert.ok(util.is_pm_recipient(31, message));
+    assert.ok(util.is_pm_recipient(32, message));
+    assert.ok(!util.is_pm_recipient(34, message));
 });
 
 run_test("lower_bound", () => {
@@ -67,43 +67,45 @@ run_test("lower_bound", () => {
 });
 
 run_test("same_recipient", () => {
-    assert(
+    assert.ok(
         util.same_recipient(
             {type: "stream", stream_id: 101, topic: "Bar"},
             {type: "stream", stream_id: 101, topic: "bar"},
         ),
     );
 
-    assert(
+    assert.ok(
         !util.same_recipient(
             {type: "stream", stream_id: 101, topic: "Bar"},
             {type: "stream", stream_id: 102, topic: "whatever"},
         ),
     );
 
-    assert(
+    assert.ok(
         util.same_recipient(
             {type: "private", to_user_ids: "101,102"},
             {type: "private", to_user_ids: "101,102"},
         ),
     );
 
-    assert(
+    assert.ok(
         !util.same_recipient(
             {type: "private", to_user_ids: "101,102"},
             {type: "private", to_user_ids: "103"},
         ),
     );
 
-    assert(!util.same_recipient({type: "stream", stream_id: 101, topic: "Bar"}, {type: "private"}));
+    assert.ok(
+        !util.same_recipient({type: "stream", stream_id: 101, topic: "Bar"}, {type: "private"}),
+    );
 
-    assert(!util.same_recipient({type: "private", to_user_ids: undefined}, {type: "private"}));
+    assert.ok(!util.same_recipient({type: "private", to_user_ids: undefined}, {type: "private"}));
 
-    assert(!util.same_recipient({type: "unknown type"}, {type: "unknown type"}));
+    assert.ok(!util.same_recipient({type: "unknown type"}, {type: "unknown type"}));
 
-    assert(!util.same_recipient(undefined, {type: "private"}));
+    assert.ok(!util.same_recipient(undefined, {type: "private"}));
 
-    assert(!util.same_recipient(undefined, undefined));
+    assert.ok(!util.same_recipient(undefined, undefined));
 });
 
 run_test("robust_uri_decode", () => {
@@ -148,18 +150,18 @@ run_test("get_edit_event_prev_topic", () => {
 
 run_test("is_mobile", () => {
     window.navigator = {userAgent: "Android"};
-    assert(util.is_mobile());
+    assert.ok(util.is_mobile());
 
     window.navigator = {userAgent: "Not mobile"};
-    assert(!util.is_mobile());
+    assert.ok(!util.is_mobile());
 });
 
 run_test("array_compare", () => {
-    assert(util.array_compare([], []));
-    assert(util.array_compare([1, 2, 3], [1, 2, 3]));
-    assert(!util.array_compare([1, 2], [1, 2, 3]));
-    assert(!util.array_compare([1, 2, 3], [1, 2]));
-    assert(!util.array_compare([1, 2, 3, 4], [1, 2, 3, 5]));
+    assert.ok(util.array_compare([], []));
+    assert.ok(util.array_compare([1, 2, 3], [1, 2, 3]));
+    assert.ok(!util.array_compare([1, 2], [1, 2, 3]));
+    assert.ok(!util.array_compare([1, 2, 3], [1, 2]));
+    assert.ok(!util.array_compare([1, 2, 3, 4], [1, 2, 3, 5]));
 });
 
 run_test("normalize_recipients", () => {
@@ -175,8 +177,8 @@ run_test("random_int", () => {
 
     _.times(500, () => {
         const val = util.random_int(min, max);
-        assert(min <= val);
-        assert(val <= max);
+        assert.ok(min <= val);
+        assert.ok(val <= max);
         assert.equal(val, Math.floor(val));
     });
 });
@@ -232,27 +234,27 @@ run_test("all_and_everyone_mentions_regexp", () => {
 
     let i;
     for (i = 0; i < messages_with_all_mentions.length; i += 1) {
-        assert(util.find_wildcard_mentions(messages_with_all_mentions[i]));
+        assert.ok(util.find_wildcard_mentions(messages_with_all_mentions[i]));
     }
 
     for (i = 0; i < messages_with_everyone_mentions.length; i += 1) {
-        assert(util.find_wildcard_mentions(messages_with_everyone_mentions[i]));
+        assert.ok(util.find_wildcard_mentions(messages_with_everyone_mentions[i]));
     }
 
     for (i = 0; i < messages_with_stream_mentions.length; i += 1) {
-        assert(util.find_wildcard_mentions(messages_with_stream_mentions[i]));
+        assert.ok(util.find_wildcard_mentions(messages_with_stream_mentions[i]));
     }
 
     for (i = 0; i < messages_without_all_mentions.length; i += 1) {
-        assert(!util.find_wildcard_mentions(messages_without_everyone_mentions[i]));
+        assert.ok(!util.find_wildcard_mentions(messages_without_everyone_mentions[i]));
     }
 
     for (i = 0; i < messages_without_everyone_mentions.length; i += 1) {
-        assert(!util.find_wildcard_mentions(messages_without_everyone_mentions[i]));
+        assert.ok(!util.find_wildcard_mentions(messages_without_everyone_mentions[i]));
     }
 
     for (i = 0; i < messages_without_stream_mentions.length; i += 1) {
-        assert(!util.find_wildcard_mentions(messages_without_stream_mentions[i]));
+        assert.ok(!util.find_wildcard_mentions(messages_without_stream_mentions[i]));
     }
 });
 

--- a/frontend_tests/node_tests/vdom.js
+++ b/frontend_tests/node_tests/vdom.js
@@ -97,8 +97,8 @@ run_test("attribute updates", () => {
 
     vdom.update(replace_content, find, new_ul, ul);
 
-    assert(updated);
-    assert(removed);
+    assert.ok(updated);
+    assert.ok(removed);
 });
 
 function make_child(i, name) {

--- a/frontend_tests/node_tests/watchdog.js
+++ b/frontend_tests/node_tests/watchdog.js
@@ -62,10 +62,10 @@ run_test("basics", () => {
 
 run_test("suspect_offline", () => {
     watchdog.set_suspect_offline(true);
-    assert(watchdog.suspects_user_is_offline());
+    assert.ok(watchdog.suspects_user_is_offline());
 
     watchdog.set_suspect_offline(false);
-    assert(!watchdog.suspects_user_is_offline());
+    assert.ok(!watchdog.suspects_user_is_offline());
 });
 
 MockDate.reset();

--- a/frontend_tests/node_tests/widgetize.js
+++ b/frontend_tests/node_tests/widgetize.js
@@ -45,7 +45,7 @@ const fake_poll_widget = {
     activate(data) {
         is_widget_activated = true;
         widget_elem = data.elem;
-        assert(widget_elem.hasClass("widget-content"));
+        assert.ok(widget_elem.hasClass("widget-content"));
         widget_elem.handle_events = (e) => {
             is_event_handled = true;
             assert.notDeepStrictEqual(e, events);
@@ -105,19 +105,19 @@ test("activate", (override) => {
     message_content.append = (elem) => {
         is_widget_elem_inserted = true;
         assert.equal(elem, widget_elem);
-        assert(elem.hasClass("widget-content"));
+        assert.ok(elem.hasClass("widget-content"));
     };
 
     is_widget_elem_inserted = false;
     is_widget_activated = false;
     is_event_handled = false;
-    assert(!widgetize.widget_contents.has(opts.message.id));
+    assert.ok(!widgetize.widget_contents.has(opts.message.id));
 
     widgetize.activate(opts);
 
-    assert(is_widget_elem_inserted);
-    assert(is_widget_activated);
-    assert(is_event_handled);
+    assert.ok(is_widget_elem_inserted);
+    assert.ok(is_widget_activated);
+    assert.ok(is_event_handled);
     assert.equal(widgetize.widget_contents.get(opts.message.id), widget_elem);
 
     is_widget_elem_inserted = false;
@@ -126,9 +126,9 @@ test("activate", (override) => {
 
     widgetize.activate(opts);
 
-    assert(is_widget_elem_inserted);
-    assert(!is_widget_activated);
-    assert(!is_event_handled);
+    assert.ok(is_widget_elem_inserted);
+    assert.ok(!is_widget_activated);
+    assert.ok(!is_event_handled);
 
     narrow_active = true;
     is_widget_elem_inserted = false;
@@ -137,9 +137,9 @@ test("activate", (override) => {
 
     widgetize.activate(opts);
 
-    assert(!is_widget_elem_inserted);
-    assert(!is_widget_activated);
-    assert(!is_event_handled);
+    assert.ok(!is_widget_elem_inserted);
+    assert.ok(!is_widget_activated);
+    assert.ok(!is_event_handled);
 
     blueslip.expect("warn", "unknown widget_type");
     narrow_active = false;
@@ -149,17 +149,17 @@ test("activate", (override) => {
     opts.widget_type = "invalid_widget";
 
     widgetize.activate(opts);
-    assert(!is_widget_elem_inserted);
-    assert(!is_widget_activated);
-    assert(!is_event_handled);
+    assert.ok(!is_widget_elem_inserted);
+    assert.ok(!is_widget_activated);
+    assert.ok(!is_event_handled);
     assert.equal(blueslip.get_test_logs("warn")[0].more_info, "invalid_widget");
 
     opts.widget_type = "tictactoe";
 
     widgetize.activate(opts);
-    assert(!is_widget_elem_inserted);
-    assert(!is_widget_activated);
-    assert(!is_event_handled);
+    assert.ok(!is_widget_elem_inserted);
+    assert.ok(!is_widget_activated);
+    assert.ok(!is_event_handled);
 
     /* Testing widgetize.handle_events */
     const post_activate_event = {
@@ -176,12 +176,12 @@ test("activate", (override) => {
     };
     is_event_handled = false;
     widgetize.handle_event(post_activate_event);
-    assert(is_event_handled);
+    assert.ok(is_event_handled);
 
     is_event_handled = false;
     post_activate_event.message_id = 1000;
     widgetize.handle_event(post_activate_event);
-    assert(!is_event_handled);
+    assert.ok(!is_event_handled);
 
     /* Test narrow change message update */
     override(message_lists.current, "get", (idx) => {

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -37,11 +37,11 @@ run_test("basics", () => {
     }
 
     // Before we call show_my_form, we can assert that my-form is hidden:
-    assert(!$("#my-form").visible());
+    assert.ok(!$("#my-form").visible());
 
     // Then calling show_my_form() should make it visible.
     show_my_form();
-    assert($("#my-form").visible());
+    assert.ok($("#my-form").visible());
 
     // Next, look at how several functions correctly simulate setting
     // and getting for you.
@@ -108,7 +108,7 @@ run_test("finding_related_objects", () => {
 
     elem.set_parents_result(".folder", my_parents);
     elem.parents(".folder").addClass("active");
-    assert(my_parents.hasClass("active"));
+    assert.ok(my_parents.hasClass("active"));
 });
 
 run_test("clicks", () => {
@@ -128,8 +128,8 @@ run_test("clicks", () => {
 
     // Setting up the click handlers doesn't change state right away.
     set_up_click_handlers();
-    assert(!state.clicked);
-    assert(!state.keydown);
+    assert.ok(!state.clicked);
+    assert.ok(!state.keydown);
 
     // But we can simulate clicks.
     $("#widget1").trigger("click");
@@ -192,8 +192,8 @@ run_test("create", () => {
     const obj2 = $.create("the collection of rows in the table");
 
     obj1.show();
-    assert(obj1.visible());
+    assert.ok(obj1.visible());
 
     obj2.addClass(".striped");
-    assert(obj2.hasClass(".striped"));
+    assert.ok(obj2.hasClass(".striped"));
 });

--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -261,7 +261,7 @@ class CommonUtils {
         // Wait for a email input in login page so we know login
         // page is loaded. Then check that we are at the login url.
         await page.waitForSelector('input[name="username"]');
-        assert(page.url().includes("/login/"));
+        assert.ok(page.url().includes("/login/"));
     }
 
     async ensure_enter_does_not_send(page: Page): Promise<void> {

--- a/frontend_tests/puppeteer_tests/mention.ts
+++ b/frontend_tests/puppeteer_tests/mention.ts
@@ -26,7 +26,7 @@ async function test_mention(page: Page): Promise<void> {
         zulip_test.set_wildcard_mention_large_stream_threshold(5);
         return zulip_test.wildcard_mention_large_stream_threshold;
     });
-    assert(stream_size > threshold);
+    assert.ok(stream_size > threshold);
     await page.click("#compose-send-button");
 
     await page.waitForXPath(

--- a/frontend_tests/puppeteer_tests/navigation.ts
+++ b/frontend_tests/puppeteer_tests/navigation.ts
@@ -71,7 +71,7 @@ async function test_reload_hash(page: Page): Promise<void> {
     await page.waitForSelector("#zfilt", {visible: true});
 
     const page_load_time = await page.evaluate(() => zulip_test.page_params.page_load_time);
-    assert(page_load_time > initial_page_load_time, "Page not reloaded.");
+    assert.ok(page_load_time > initial_page_load_time, "Page not reloaded.");
 
     const hash = await page.evaluate(() => window.location.hash);
     assert.strictEqual(hash, initial_hash, "Hash not preserved.");

--- a/frontend_tests/puppeteer_tests/realm-creation.ts
+++ b/frontend_tests/puppeteer_tests/realm-creation.ts
@@ -21,7 +21,7 @@ async function realm_creation_tests(page: Page): Promise<void> {
     ]);
 
     // Make sure onfirmation email is sent.
-    assert(page.url().includes("/accounts/new/send_confirm/" + email));
+    assert.ok(page.url().includes("/accounts/new/send_confirm/" + email));
 
     // Special endpoint enabled only during tests for extracting confirmation key
     await page.goto("http://" + host + "/confirmation_key/");

--- a/frontend_tests/puppeteer_tests/settings.ts
+++ b/frontend_tests/puppeteer_tests/settings.ts
@@ -29,7 +29,10 @@ async function open_settings(page: Page): Promise<void> {
 
     await page.waitForSelector("#settings_content .account-settings-form", {visible: true});
     const page_url = await common.page_url_with_fragment(page);
-    assert(page_url.includes("/#settings/"), `Page url: ${page_url} does not contain /#settings/`);
+    assert.ok(
+        page_url.includes("/#settings/"),
+        `Page url: ${page_url} does not contain /#settings/`,
+    );
 }
 
 async function test_change_full_name(page: Page): Promise<void> {

--- a/frontend_tests/puppeteer_tests/subscriptions.ts
+++ b/frontend_tests/puppeteer_tests/subscriptions.ts
@@ -45,7 +45,7 @@ async function open_streams_modal(page: Page): Promise<void> {
 
     await page.waitForSelector("#subscription_overlay.new-style", {visible: true});
     const url = await common.page_url_with_fragment(page);
-    assert(url.includes("#streams/all"));
+    assert.ok(url.includes("#streams/all"));
 }
 
 async function test_subscription_button_verona_stream(page: Page): Promise<void> {
@@ -239,7 +239,7 @@ async function test_streams_search_feature(page: Page): Promise<void> {
         ),
         "Verona",
     );
-    assert(
+    assert.ok(
         !(await common.get_text_from_selector(page, hidden_streams_selector)).includes("Verona"),
         "#Verona is hidden",
     );
@@ -249,11 +249,11 @@ async function test_streams_search_feature(page: Page): Promise<void> {
         await common.get_text_from_selector(page, ".stream-row:not(.notdisplayed) .stream-name"),
         "Puppeteer",
     );
-    assert(
+    assert.ok(
         (await common.get_text_from_selector(page, hidden_streams_selector)).includes("Verona"),
         "#Verona is not hidden",
     );
-    assert(
+    assert.ok(
         !(await common.get_text_from_selector(page, hidden_streams_selector)).includes("Puppeteer"),
         "Puppeteer is hidden after searching.",
     );

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -305,7 +305,7 @@ function make_new_elem(selector, opts) {
         },
         parents(parents_selector) {
             const result = parents_result.get(parents_selector);
-            assert(
+            assert.ok(
                 result,
                 "You need to call set_parents_result for " + parents_selector + " in " + selector,
             );
@@ -385,7 +385,7 @@ function make_new_elem(selector, opts) {
             return text;
         },
         toggle(show) {
-            assert([true, false].includes(show));
+            assert.ok([true, false].includes(show));
             shown = show;
             return self;
         },
@@ -549,7 +549,7 @@ function make_zjquery() {
     };
 
     zjquery.create = function (name, opts) {
-        assert(!elems.has(name), "You already created an object with this name!!");
+        assert.ok(!elems.has(name), "You already created an object with this name!!");
         const elem = new_elem(name, opts);
         elems.set(name, elem);
 

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -212,6 +212,12 @@ js_rules = RuleList(
             "good_lines": ["#my-style {color: blue;}"],
             "bad_lines": ['<p style="color: blue;">Foo</p>', 'style = "color: blue;"'],
         },
+        {
+            "pattern": r"assert\(",
+            "description": "Use 'assert.ok' instead of 'assert'. We avoid the use of 'assert' as it can easily be confused with 'assert.equal'.",
+            "good_lines": ["assert.ok(...)"],
+            "bad_lines": ["assert(...)"],
+        },
         *whitespace_rules,
     ],
 )


### PR DESCRIPTION
This PR bans the use of `assert` and replaces it
with `assert.ok` to avoid confusion with `assert.equal`.

Fixes #18687.

This replaces every `assert` with `assert.ok` except,
```bash
frontend_tests/puppeteer_tests/settings.ts
177:    assert(common.get_text_from_selector(page, name_field_selector), "Bot 1");
--------------------------------------------------------------------------------
201:    assert(common.get_text_from_selector(page, name_field_selector), "Bot one");
```
As this would be removed in https://github.com/zulip/zulip/pull/18744.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested by running node tests and puppeteer tests.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Example of the error message,
![Screenshot 2021-06-10 at 12 36 30 PM](https://user-images.githubusercontent.com/63820270/121480549-d2227000-c9e8-11eb-90d5-f64f7b60aec8.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
