### PR TITLE
puppet: Bump grafana version to 8.0.1.

### DIFF
--- a/puppet/zulip_ops/manifests/profile/grafana.pp
+++ b/puppet/zulip_ops/manifests/profile/grafana.pp
@@ -4,10 +4,10 @@ class zulip_ops::profile::grafana {
   include zulip_ops::profile::base
   include zulip::supervisor
 
-  $version = '8.0.0'
+  $version = '8.0.1'
   zulip::sha256_tarball_to { 'grafana':
     url     => "https://dl.grafana.com/oss/release/grafana-${version}.linux-amd64.tar.gz",
-    sha256  => '6f006990fcb89307e7911b0b3a4b54810c7e4a6f16240d9deb979f3010a71a9e',
+    sha256  => '6f4e67500a4b8dd416e6f6d2e7a1d42befc65ca707a365001f26df7ba653af75',
     install => {
       "grafana-${version}/" => "/srv/grafana-${version}/",
     },


### PR DESCRIPTION
Most notably, this fixes an annoying bug with CloudWatch metrics being
repeated in graphs.
