### PR TITLE
left-sidebar: Hide clear filter text button if topic filter is empty.

### DIFF
--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -188,6 +188,13 @@ export class TopicListWidget {
             input.val(this.topic_search_text);
             input.trigger("focus");
 
+            // setup display of clear(x) button.
+            if (this.topic_search_text.length) {
+                $("#clear_search_topic_button").show();
+            } else {
+                $("#clear_search_topic_button").hide();
+            }
+
             // setup event handlers.
             const rebuild_list = () => this.build();
             input.on("input", rebuild_list);


### PR DESCRIPTION
Hide clear filter text button if topic filter is empty. It is a folllow for #18724.
Related thread: [#design > topic filter](https://chat.zulip.org/#narrow/stream/101-design/topic/topic.20filter/near/1204406)

I'll add further commit for `Q`keyboard shortcut.


**Testing plan:** manually.


**GIFs or screenshots:** 
![clear button](https://user-images.githubusercontent.com/63504956/121585704-81466200-ca50-11eb-8f13-36e4dd448bfb.gif)

