### PR TITLE
zjsunit: Fix no matching users.

### DIFF
--- a/static/js/buddy_list.js
+++ b/static/js/buddy_list.js
@@ -270,6 +270,12 @@ export class BuddyList extends BuddyListConf {
         // Add a fudge factor.
         height += 10;
 
+        if (this.keys.length === 0) {
+            this.container = $(this.container_sel);
+            this.container.append('<div class="no-matching-users"> No matching users </div>');
+            return;
+        }
+
         while (this.render_count < this.keys.length) {
             const padding_height = $(this.padding_sel).height();
             const bottom_offset = elem.scrollHeight - elem.scrollTop - padding_height;


### PR DESCRIPTION
https://github.com/zulip/zulip/issues/17842

'No matching users' message is shown when their is no user with the name used in the search bar.

Used test lints and js puppeteer for testing.


![No matching users](https://user-images.githubusercontent.com/79971715/121588572-bd70c700-ca3e-11eb-9ae5-e68b5506f3f6.PNG)



