### PR TITLE
event_queue: Don't check for "read" flag when processing events.

### DIFF
--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -351,30 +351,6 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             )
         destroy_event_queue(client_descriptor.event_queue.id)
 
-        # Test the hook with a wildcard mention sent by the user
-        # themself using a human client; should not notify.
-        client_descriptor = allocate_event_queue()
-        self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(
-            self.example_user("hamlet"),
-            "Denmark",
-            content="@**all** what's up?",
-            sending_client_name="website",
-        )
-        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(user_profile.id, client_descriptor, True)
-            mock_enqueue.assert_called_once()
-            args_list = mock_enqueue.call_args_list[0][0]
-
-            assert_maybe_enqueue_notifications_call_args(
-                args_list=args_list,
-                user_profile_id=user_profile.id,
-                message_id=msg_id,
-                stream_name="Denmark",
-                already_notified={"email_notified": False, "push_notified": False},
-            )
-        destroy_event_queue(client_descriptor.event_queue.id)
-
         # Wildcard mentions in muted streams don't notify.
         change_subscription_properties(user_profile, stream, sub, {"is_muted": True})
         client_descriptor = allocate_event_queue()

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -200,6 +200,8 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         user_profile.enable_online_push_notifications = False
         user_profile.save()
 
+        iago = self.example_user("iago")
+
         # Fetch the Denmark stream for testing
         stream = get_stream("Denmark", user_profile.realm)
         sub = Subscription.objects.get(
@@ -268,7 +270,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         client_descriptor = allocate_event_queue()
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             # To test the missed_message hook, we first need to send a message
-            msg_id = self.send_stream_message(self.example_user("iago"), "Denmark")
+            msg_id = self.send_stream_message(iago, "Denmark")
 
             # Verify that nothing happens if you call it as not the
             # "last client descriptor", in which case the function
@@ -294,7 +296,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         # Test the hook with a private message; this should trigger notifications
         client_descriptor = allocate_event_queue()
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_personal_message(self.example_user("iago"), user_profile)
+        msg_id = self.send_personal_message(iago, user_profile)
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
@@ -333,9 +335,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         # Test the hook with a wildcard mention; this should trigger notifications
         client_descriptor = allocate_event_queue()
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(
-            self.example_user("iago"), "Denmark", content="@**all** what's up?"
-        )
+        msg_id = self.send_stream_message(iago, "Denmark", content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
@@ -379,9 +379,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         change_subscription_properties(user_profile, stream, sub, {"is_muted": True})
         client_descriptor = allocate_event_queue()
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(
-            self.example_user("iago"), "Denmark", content="@**all** what's up?"
-        )
+        msg_id = self.send_stream_message(iago, "Denmark", content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
@@ -402,9 +400,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         user_profile.save()
         client_descriptor = allocate_event_queue()
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(
-            self.example_user("iago"), "Denmark", content="@**all** what's up?"
-        )
+        msg_id = self.send_stream_message(iago, "Denmark", content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
@@ -429,9 +425,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         sub.save()
         client_descriptor = allocate_event_queue()
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(
-            self.example_user("iago"), "Denmark", content="@**all** what's up?"
-        )
+        msg_id = self.send_stream_message(iago, "Denmark", content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
@@ -455,9 +449,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         change_subscription_properties(user_profile, stream, sub, {"push_notifications": True})
         client_descriptor = allocate_event_queue()
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(
-            self.example_user("iago"), "Denmark", content="what's up everyone?"
-        )
+        msg_id = self.send_stream_message(iago, "Denmark", content="what's up everyone?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
@@ -480,9 +472,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             user_profile, stream, sub, {"push_notifications": False, "email_notifications": True}
         )
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(
-            self.example_user("iago"), "Denmark", content="what's up everyone?"
-        )
+        msg_id = self.send_stream_message(iago, "Denmark", content="what's up everyone?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
@@ -509,7 +499,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         self.assertTrue(client_descriptor.event_queue.empty())
         do_mute_topic(user_profile, stream, "mutingtest")
         msg_id = self.send_stream_message(
-            self.example_user("iago"),
+            iago,
             "Denmark",
             content="what's up everyone?",
             topic_name="mutingtest",
@@ -537,9 +527,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
 
         self.assertTrue(client_descriptor.event_queue.empty())
         change_subscription_properties(user_profile, stream, sub, {"is_muted": True})
-        msg_id = self.send_stream_message(
-            self.example_user("iago"), "Denmark", content="what's up everyone?"
-        )
+        msg_id = self.send_stream_message(iago, "Denmark", content="what's up everyone?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -740,15 +740,13 @@ def missedmessage_hook(
 
         flags = event["flags"]
 
-        mentioned = "mentioned" in flags and "read" not in flags
+        mentioned = "mentioned" in flags
         private_message = event["message"]["type"] == "private"
         # stream_push_notify is set in process_message_event.
         stream_push_notify = internal_data.get("stream_push_notify", False)
         stream_email_notify = internal_data.get("stream_email_notify", False)
         wildcard_mention_notify = (
-            internal_data.get("wildcard_mention_notify", False)
-            and "read" not in flags
-            and "wildcard_mentioned" in flags
+            internal_data.get("wildcard_mention_notify", False) and "wildcard_mentioned" in flags
         )
 
         stream_name = None
@@ -949,13 +947,11 @@ def process_message_event(
         # If the recipient was offline and the message was a single or group PM to them
         # or they were @-notified potentially notify more immediately
         private_message = message_type == "private" and user_profile_id != sender_id
-        mentioned = "mentioned" in flags and "read" not in flags
+        mentioned = "mentioned" in flags
         stream_push_notify = user_data.get("stream_push_notify", False)
         stream_email_notify = user_data.get("stream_email_notify", False)
         wildcard_mention_notify = (
-            user_data.get("wildcard_mention_notify", False)
-            and "wildcard_mentioned" in flags
-            and "read" not in flags
+            user_data.get("wildcard_mention_notify", False) and "wildcard_mentioned" in flags
         )
         sender_is_muted = user_data.get("sender_is_muted", False)
 

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -733,6 +733,9 @@ def missedmessage_hook(
     for event in client.event_queue.contents(include_internal_data=True):
         if event["type"] != "message":
             continue
+
+        internal_data = event.get("internal_data", {})
+
         assert "flags" in event
 
         flags = event["flags"]
@@ -740,10 +743,10 @@ def missedmessage_hook(
         mentioned = "mentioned" in flags and "read" not in flags
         private_message = event["message"]["type"] == "private"
         # stream_push_notify is set in process_message_event.
-        stream_push_notify = event.get("internal_data", {}).get("stream_push_notify", False)
-        stream_email_notify = event.get("internal_data", {}).get("stream_email_notify", False)
+        stream_push_notify = internal_data.get("stream_push_notify", False)
+        stream_email_notify = internal_data.get("stream_email_notify", False)
         wildcard_mention_notify = (
-            event.get("internal_data", {}).get("wildcard_mention_notify", False)
+            internal_data.get("wildcard_mention_notify", False)
             and "read" not in flags
             and "wildcard_mentioned" in flags
         )
@@ -760,8 +763,8 @@ def missedmessage_hook(
         message_id = event["message"]["id"]
         # Pass on the information on whether a push or email notification was already sent.
         already_notified = dict(
-            push_notified=event.get("internal_data", {}).get("push_notified", False),
-            email_notified=event.get("internal_data", {}).get("email_notified", False),
+            push_notified=internal_data.get("push_notified", False),
+            email_notified=internal_data.get("email_notified", False),
         )
         maybe_enqueue_notifications(
             user_profile_id,


### PR DESCRIPTION
* In `event_queue.py`, only the sender and recipient users who have muted
the sender will have the "read" flag set.

* We already skip enqueueing notifications for users who've muted the sender
after 58da384.

* The queue consume functions for email and push notifications already
check filter messages which have been read before sending notifications.

* So, the "read" logic in `event_queue.py` is unnecessary, and the
processing power saved from not enqueueing notifications for a single
user should be insignificant, so we remove these checks all toghether.