### PR TITLE
issue #17998 - Add alert when mentioning user in one on one private messaging.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -834,6 +834,7 @@ export function content_typeahead_selected(item, event) {
                 beginning += mention_text + " ";
                 if (!is_silent) {
                     compose.warn_if_mentioning_unsubscribed_user(item);
+                    compose.warn_if_mention_one_on_one(item);
                 }
             }
             break;

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -192,12 +192,14 @@
 }
 
 #compose_invite_users,
+#compose_mention_one_on_one_alerts,
 #compose_private_stream_alert {
     /* Don't overlap into the compose_close × */
     margin-right: 10px;
 }
 
 .compose_invite_user,
+.compose_mention_one_on_one_alert,
 .compose_private_stream_alert,
 .compose-all-everyone,
 .compose-announce,
@@ -214,6 +216,7 @@
 }
 
 .compose_invite_close,
+.compose_mention_one_on_one_alert_close,
 .compose_private_stream_alert_close {
     display: inline-block;
     margin-top: 4px;
@@ -224,6 +227,7 @@
 .compose-all-everyone-controls,
 .compose-announce-controls,
 .compose_invite_user_controls,
+.compose_mention_one_on_one_alert_controls,
 .compose_private_stream_alert_controls {
     float: right;
     position: relative;

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -47,6 +47,7 @@
         <div id="compose-all-everyone" class="alert home-error-bar"></div>
         <div id="compose-announce" class="alert home-error-bar"></div>
         <div id="compose_not_subscribed" class="alert home-error-bar"></div>
+        <div id="compose_mention_one_on_one_alerts" class="alert home-error-bar"></div>
         <div id="compose_private_stream_alert" class="alert home-error-bar"></div>
         <div id="out-of-view-notification" class="notification-alert"></div>
         <div class="composition-area">

--- a/static/templates/compose_mention_one_on_one_alert.hbs
+++ b/static/templates/compose_mention_one_on_one_alert.hbs
@@ -1,0 +1,6 @@
+<div class="compose_mention_one_on_one_alert" data-user-id="{{user_id}}">
+    <span>{{#tr}}Mentioning @<strong>{name}</strong> will highlight this message. Did you mean to use a silent mention @_<strong>{name}</strong> instead?{{/tr}}</span>
+    <div class="compose_mention_one_on_one_alert_controls">
+        <button type="button" class="compose_mention_one_on_one_alert_close close">&times;</button>
+    </div>
+</div>


### PR DESCRIPTION
Fixes #17998.

Updates test in composebox_lookahead, and adds node test to compose.
Node test includes noop and op testing, template checks, and duplicate alerts check.

![image](https://user-images.githubusercontent.com/28717368/121760744-531d5c80-cafa-11eb-95eb-c76fd204de91.png)