### PR TITLE
login: Remove browser show password in IE, edge.

### DIFF
--- a/static/styles/components.css
+++ b/static/styles/components.css
@@ -121,6 +121,12 @@ i.zulip-icon.zulip-icon-bot {
     font-size: 12px;
 }
 
+/* Hide the somewhat buggy browser show password feature in IE, Edge,
+   since it duplicates our own "show password" widget. */
+input::-ms-reveal {
+    display: none;
+}
+
 .password-div {
     position: relative;
 


### PR DESCRIPTION
The Microsoft browsers such as IE and Edge has their own
show password that is a bit bugy and also conflicts with
the show password in Zulip that was added in #17305.
This fixes the issue by making the display none for the
ms-reveal that comes in the input.

More details can be found at
https://chat.zulip.org/#narrow/stream/101-design/topic/Show.20password/near/1173890

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested this manually on MS Edge Dev based on chromium on Ubuntu 18.04.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Now the browser  show password doesn't come
![image](https://user-images.githubusercontent.com/56730716/121770990-54966580-cb8a-11eb-908b-f63b4596b987.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
