### PR TITLE
puppeteer: Fix the selector for opening the message action menu.

### DIFF
--- a/frontend_tests/puppeteer_tests/edit.ts
+++ b/frontend_tests/puppeteer_tests/edit.ts
@@ -5,7 +5,7 @@ import common from "../puppeteer_lib/common";
 async function trigger_edit_last_message(page: Page): Promise<void> {
     await page.evaluate(() => {
         const msg = $("#zhome .message_row").last();
-        msg.find(".info").trigger("click");
+        msg.find(".message_control_button.actions_hover").trigger("click");
         $(".popover_edit_message").trigger("click");
     });
     await page.waitForSelector(".message_edit_content", {visible: true});


### PR DESCRIPTION
In this https://github.com/zulip/zulip/commit/90041ff453734f80441391f6c0b65be29a842daa, we remove the `info` class from the message action
menu, that's why it was failing.

This PR replaces it with the correct selector.


<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested by running puppeteer test.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
