### PR TITLE
Remove `recipient_id` and `sender_id` from `delete_message` event.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -11,6 +11,12 @@ below features are supported.
 
 ## Changes in Zulip 5.0
 
+**Feature level 77**
+
+* [`GET /events`](/api/get-events): Removed `recipient_id` and
+  `sender_id` field in responses of `delete_message` event when
+  `message_type` is `private`.
+
 **Feature level 76**
 
 * [`POST /fetch_api_key`](/api/fetch_api_key), [`POST

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 76
+API_FEATURE_LEVEL = 77
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5897,7 +5897,6 @@ class DeleteMessagesEvent(TypedDict, total=False):
     message_ids: List[int]
     message_type: str
     sender_id: int
-    recipient_id: int
     topic: str
     stream_id: int
 
@@ -6325,7 +6324,6 @@ def do_delete_messages(realm: Realm, messages: Iterable[Message]) -> None:
         ums = UserMessage.objects.filter(message_id__in=message_ids)
         users_to_notify = [um.user_profile_id for um in ums]
         # TODO: We should plan to remove `sender_id` here.
-        event["recipient_id"] = sample_message.recipient_id
         event["sender_id"] = sample_message.sender_id
         archiving_chunk_size = retention.MESSAGE_BATCH_SIZE
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5896,7 +5896,6 @@ class DeleteMessagesEvent(TypedDict, total=False):
     type: str
     message_ids: List[int]
     message_type: str
-    sender_id: int
     topic: str
     stream_id: int
 
@@ -6323,8 +6322,6 @@ def do_delete_messages(realm: Realm, messages: Iterable[Message]) -> None:
         message_type = "private"
         ums = UserMessage.objects.filter(message_id__in=message_ids)
         users_to_notify = [um.user_profile_id for um in ums]
-        # TODO: We should plan to remove `sender_id` here.
-        event["sender_id"] = sample_message.sender_id
         archiving_chunk_size = retention.MESSAGE_BATCH_SIZE
 
     if message_type == "stream":

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -230,7 +230,6 @@ delete_message_event = event_dict_type(
         ("message_ids", ListType(int)),
         ("stream_id", int),
         ("topic", str),
-        ("recipient_id", int),
         ("sender_id", int),
     ],
 )
@@ -253,7 +252,7 @@ def check_delete_message(
     if message_type == "stream":
         keys |= {"stream_id", "topic"}
     elif message_type == "private":
-        keys |= {"recipient_id", "sender_id"}
+        keys |= {"sender_id"}
     else:
         raise AssertionError("unexpected message_type")
 

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -230,7 +230,6 @@ delete_message_event = event_dict_type(
         ("message_ids", ListType(int)),
         ("stream_id", int),
         ("topic", str),
-        ("sender_id", int),
     ],
 )
 _check_delete_message = make_checker(delete_message_event)
@@ -252,7 +251,7 @@ def check_delete_message(
     if message_type == "stream":
         keys |= {"stream_id", "topic"}
     elif message_type == "private":
-        keys |= {"sender_id"}
+        pass
     else:
         raise AssertionError("unexpected message_type")
 

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -987,23 +987,6 @@ def apply_event(
         if "raw_recent_private_conversations" not in state or event["message_type"] != "private":
             return
 
-        recipient_id = get_recent_conversations_recipient_id(
-            user_profile, event["recipient_id"], event["sender_id"]
-        )
-
-        # Ideally, we'd have test coverage for these two blocks.  To
-        # do that, we'll need a test where we delete not-the-latest
-        # messages or delete a private message not in
-        # recent_private_conversations.
-        if recipient_id not in state["raw_recent_private_conversations"]:  # nocoverage
-            return
-
-        old_max_message_id = state["raw_recent_private_conversations"][recipient_id][
-            "max_message_id"
-        ]
-        if old_max_message_id not in message_ids:  # nocoverage
-            return
-
         # OK, we just deleted what had been the max_message_id for
         # this recent conversation; we need to recompute that value
         # from scratch.  Definitely don't need to re-query everything,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1660,6 +1660,10 @@ paths:
                               description: |
                                 Event sent when a message has been deleted.
                                 Sent to all users who received the message.
+
+                                **Changes**: Before Zulip 5.0 (feature level 77), events
+                                for private messages contained additional `sender_id` and
+                                `recipient_id` fields.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -1693,12 +1697,6 @@ paths:
                                   enum:
                                     - private
                                     - stream
-                                sender_id:
-                                  type: integer
-                                  description: |
-                                    Only present for private messages.
-
-                                    The ID of the user who sent the private message.
                                 stream_id:
                                   type: integer
                                   description: |
@@ -1714,7 +1712,6 @@ paths:
                               example:
                                 {
                                   "type": "delete_message",
-                                  "sender_id": 8,
                                   "message_type": "private",
                                   "message_id": 37,
                                   "id": 0,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1693,12 +1693,6 @@ paths:
                                   enum:
                                     - private
                                     - stream
-                                recipient_id:
-                                  type: integer
-                                  description: |
-                                    Only present for private messages.
-
-                                    The ID of the user (or group of users) who received the private message.
                                 sender_id:
                                   type: integer
                                   description: |
@@ -1720,7 +1714,6 @@ paths:
                               example:
                                 {
                                   "type": "delete_message",
-                                  "recipient_id": 10,
                                   "sender_id": 8,
                                   "message_type": "private",
                                   "message_id": 37,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Remove `recipient_id` and `sender_id` from `delete_message` event.

**Testing plan:** <!-- How have you tested? -->
Backend testing.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
