### PR TITLE
drafts: Add hotkey hint to restore draft.

### DIFF
--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -116,6 +116,11 @@
                 right: 0;
             }
 
+            [data-tippy-root] {
+                width: max-content;
+                word-wrap: unset;
+            }
+
             .restore-draft {
                 cursor: pointer;
                 margin-right: 5px;

--- a/static/templates/draft.hbs
+++ b/static/templates/draft.hbs
@@ -33,7 +33,7 @@
                 <div class="messagebox-content">
                     <div class="message_top_line">
                         <div class="draft_controls">
-                            <i class="fa fa-pencil fa-lg restore-draft tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Restore draft' }}"></i>
+                            <i class="fa fa-pencil fa-lg restore-draft tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Restore draft' }} (Enter)"></i>
                             <i class="fa fa-trash-o fa-lg delete-draft tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Delete draft' }} (Backspace)"></i>
                         </div>
                     </div>


### PR DESCRIPTION
- 1st commit adds hotkey hint to restore the draft.
- 2nd commit fixes tooltip CSS in draft controls (too narrow issue https://github.com/zulip/zulip/pull/18811#discussion_r650321297).
- In the 3rd commit, I have added the commit setting the tooltip placement to the top in the draft controls.

Not sure if we want to set the tooltip placement to the top, so I've kept it in a separate commit.

![Screenshot from 2021-06-12 16-12-31](https://user-images.githubusercontent.com/67277428/121781626-503a6e80-cbc3-11eb-9452-97ec1da4e23d.png) ![Screenshot from 2021-06-12 16-12-38](https://user-images.githubusercontent.com/67277428/121781629-57617c80-cbc3-11eb-8e98-4b834039be11.png)
