### PR TITLE
Add `Q` hotkey for zoomed topic view.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -69,6 +69,7 @@ const search = mock_esm("../../static/js/search");
 const settings_data = mock_esm("../../static/js/settings_data");
 const stream_list = mock_esm("../../static/js/stream_list");
 const stream_settings_ui = mock_esm("../../static/js/stream_settings_ui");
+const topic_zoom = mock_esm("../../static/js/topic_zoom");
 
 mock_esm("../../static/js/hotspots", {
     is_open: () => false,
@@ -262,7 +263,7 @@ run_test("allow normal typing when processing text", ({override, override_rewire
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
     assert_unmapped("bfmoyz");
-    assert_unmapped("BEFHILNOQTUWXYZ");
+    assert_unmapped("BEFHILNOTUWXYZ");
 
     // All letters should return false if we are composing text.
     override_rewire(hotkey, "processing_text", () => true);
@@ -303,6 +304,7 @@ run_test("basic mappings", () => {
     assert_mapping("/", search, "initiate_search");
     assert_mapping_rewire("w", activity, "initiate_search");
     assert_mapping("q", stream_list, "initiate_search");
+    assert_mapping("Q", topic_zoom, "handle_topic_zoom_hotkey");
 
     assert_mapping("A", narrow, "stream_cycle_backward");
     assert_mapping("D", narrow, "stream_cycle_forward");

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -132,6 +132,7 @@ const keypress_mappings = {
     75: {name: "vim_page_up", message_view_only: true}, // 'K'
     77: {name: "toggle_topic_mute", message_view_only: true}, // 'M'
     80: {name: "narrow_private", message_view_only: true}, // 'P'
+    81: {name: "zoomed_topic_view", message_view_only: true}, // 'Q'
     82: {name: "respond_to_author", message_view_only: true}, // 'R'
     83: {name: "narrow_by_topic", message_view_only: true}, // 'S'
     86: {name: "view_selected_stream", message_view_only: false}, // 'V'
@@ -795,6 +796,9 @@ export function process_hotkey(e, hotkey) {
             return true;
         case "all_messages":
             browser_history.go_to_location("#all_messages");
+            return true;
+        case "zoomed_topic_view":
+            topic_zoom.handle_topic_zoom_hotkey();
             return true;
     }
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -612,16 +612,19 @@ export function hide_search_section() {
     resize.resize_stream_filters_container();
 }
 
+export function is_left_column_popover_hidden() {
+    // returns true if left column is a popover and is hidden.
+    return (
+        $("#streamlist-toggle").is(":visible") && !$(".app-main .column-left").hasClass("expanded")
+    );
+}
+
 export function initiate_search() {
     show_search_section();
 
     const $filter = $(".stream-list-filter").expectOne();
 
-    if (
-        // Check if left column is a popover and is not visible.
-        $("#streamlist-toggle").is(":visible") &&
-        !$(".app-main .column-left").hasClass("expanded")
-    ) {
+    if (is_left_column_popover_hidden()) {
         popovers.hide_all();
         stream_popover.show_streamlist_sidebar();
     }

--- a/static/js/topic_zoom.js
+++ b/static/js/topic_zoom.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 
 import * as popovers from "./popovers";
 import * as stream_list from "./stream_list";
+import * as stream_popover from "./stream_popover";
 import * as topic_list from "./topic_list";
 
 let zoomed_in = false;
@@ -34,6 +35,30 @@ export function zoom_out() {
     }
 
     zoomed_in = false;
+}
+
+export function handle_topic_zoom_hotkey() {
+    if (is_zoomed_in()) {
+        if (stream_list.is_left_column_popover_hidden()) {
+            popovers.hide_all();
+            stream_popover.show_streamlist_sidebar();
+            document.querySelector("#filter-topic-input").focus();
+        } else {
+            zoom_out();
+        }
+    } else {
+        const active_stream = topic_list.get_stream_li();
+        if (active_stream !== undefined && active_stream.find(".show-more-topics").length > 0) {
+            // Proceed only if there is active stream
+            // in left-sidebar and it is zoomable.
+            zoom_in();
+            if (stream_list.is_left_column_popover_hidden()) {
+                popovers.hide_all();
+                stream_popover.show_streamlist_sidebar();
+            }
+            document.querySelector("#filter-topic-input").focus();
+        }
+    }
 }
 
 export function clear_topics() {

--- a/static/templates/keyboard_shortcuts.hbs
+++ b/static/templates/keyboard_shortcuts.hbs
@@ -71,7 +71,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Filter streams' }}</td>
-                    <td><span class="hotkey"><kbd>Q</kbd></span></td>
+                    <td><span class="hotkey"><kbd>q</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Search people' }}</td>

--- a/static/templates/keyboard_shortcuts.hbs
+++ b/static/templates/keyboard_shortcuts.hbs
@@ -74,6 +74,10 @@
                     <td><span class="hotkey"><kbd>q</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'All possible topics of selected stream' }}</td>
+                    <td><span class="hotkey"><kbd>Q</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{{t 'Search people' }}</td>
                     <td><span class="hotkey"><kbd>W</kbd></span></td>
                 </tr>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -52,6 +52,8 @@ below, and add more to your repertoire as needed.
 
 * **Filter streams**: `q`
 
+* **All possible topics of selected stream**: `Q`
+
 * **Search people**: `w`
 
 * **Last message**: `End` or `G` — Also marks all messages in


### PR DESCRIPTION
Add `Q` hotkey for zoomed topic view.
Its behaviour should be similar to `q` for stream filter toggler.
A follow-up for #18724.
