### PR TITLE
tippyjs: Fix blueslip error on popover add emoji reaction hover.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -53,7 +53,7 @@ export function initialize() {
     // message reaction tooltip showing who reacted.
     let observer;
     delegate("body", {
-        target: ".message_reaction, .reaction_button",
+        target: ".message_reaction, .message_reactions .reaction_button",
         placement: "bottom",
         onShow(instance) {
             const elem = $(instance.reference);


### PR DESCRIPTION
This tippyjs event listener was active on 'add emoji reaction'
option in sender's popover menu of a message but it was only
intended for the add reaction button in message reactions bar
at bottom of a message.

Both of those having common selector `.reaction_button` caused
errors in tippyjs near `observer.observe` having wrong args.

Edited the css selector to be more specific to only target
add reaction button in reactions row of message.

This was introduced in 99e6f25.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
verified the error didn't persist after the chnage

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
error screenshot before fix:
![image](https://user-images.githubusercontent.com/44665669/121819864-15ad0080-ccad-11eb-8a73-552c2dd13788.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
cc: @amanagr 