### PR TITLE
timestamp: Enhance time widget.

### DIFF
--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -165,11 +165,12 @@ export const update_elements = (content) => {
         if (isValid(timestamp)) {
             const text = $(this).text();
             const rendered_time = timerender.render_markdown_timestamp(timestamp, text);
+            const rendered_text = rendered_time.text;
             const rendered_timestamp = render_markdown_timestamp({
-                text: rendered_time.text,
+                text: rendered_text,
             });
             $(this).html(rendered_timestamp);
-            $(this).attr("title", rendered_time.title);
+            $(this).attr("data-title", rendered_time.title);
         } else {
             // This shouldn't happen. If it does, we're very interested in debugging it.
             blueslip.error(`Could not parse datetime supplied by backend: ${time_str}`);

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -95,7 +95,7 @@ export function build_page() {
             page_params.enable_sounds || page_params.enable_stream_audible_notifications,
         zuliprc: "zuliprc",
         botserverrc: "botserverrc",
-        timezones: timezones.timezones,
+        timezones: Object.keys(timezones.timezones),
         can_create_new_bots: settings_bots.can_create_new_bots(),
         settings_label,
         demote_inactive_streams_values: settings_config.demote_inactive_streams_values,

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -1,3 +1,4 @@
+import {isValid, parseISO} from "date-fns";
 import $ from "jquery";
 import tippy, {delegate} from "tippy.js";
 
@@ -7,6 +8,7 @@ import * as popovers from "./popovers";
 import * as reactions from "./reactions";
 import * as rows from "./rows";
 import * as settings_data from "./settings_data";
+import * as timerender from "./timerender";
 
 // We override the defaults set by tippy library here,
 // so make sure to check this too after checking tippyjs
@@ -157,5 +159,27 @@ export function initialize() {
         interactive: true,
         hideOnClick: true,
         theme: "light-border",
+    });
+
+    // Timezone tooltip to show user how far or back the mentioned time is.
+    delegate("body", {
+        target: "time",
+        onShow(instance) {
+            const elem = $(instance.reference);
+            const time_str = elem.attr("datetime");
+            if (time_str === undefined) {
+                instance.hide();
+            }
+            const timestamp = parseISO(time_str);
+            if (isValid(timestamp)) {
+                const text = elem.attr("data-title");
+                const rendered_time = timerender.render_markdown_timestamp(timestamp, text);
+                instance.setContent(rendered_time.title);
+            }
+        },
+        placement: "top",
+        // Append to message_table so that tooltip has enough area to show
+        // itself and doesn't persist when the message_table is hidden.
+        appendTo: () => document.querySelector(".message_table.focused_table"),
     });
 }

--- a/tools/setup/build_timezone_values
+++ b/tools/setup/build_timezone_values
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import datetime
 import json
 import os
 
@@ -7,5 +8,14 @@ import pytz
 ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
 OUT_PATH = os.path.join(ZULIP_PATH, "static", "generated", "timezones.json")
 
+timezone_values = {
+    timezone: {
+        "abbreviation": pytz.timezone(timezone)
+        .localize(datetime.datetime.now(), is_dst=False)
+        .tzname()
+    }
+    for timezone in pytz.all_timezones
+}
+
 with open(OUT_PATH, "w") as f:
-    json.dump({"timezones": pytz.all_timezones}, f)
+    json.dump({"timezones": timezone_values}, f)

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 74
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "150.5"
+PROVISION_VERSION = "150.6"


### PR DESCRIPTION
 - [x] Mention the timezone in the rendered text to clarify to the user that the mentioned time is indeed in their timezone like Mon, Mar 22, 2021, 10:30 PM IST. We have mentioned that the timezone is in their timezone in the title, but users tend to miss that.
 - [x] Mention how long in the future/past was the mentioned time in the title. Like "5 hours ago" or "in 5 hours".
 - [x] Use a tooltip for displaying the title so that users can see it more easily.

Fixes #17731 

## Screenshot
![Screenshot (43)](https://user-images.githubusercontent.com/63552235/121850563-964e1a00-cd0a-11eb-8d0f-d5b8d3be1a5f.png)

