### PR TITLE
compose: Make the route of message sending through drafts.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -27,7 +27,6 @@ const fake_now = 555;
 
 const channel = mock_esm("../../static/js/channel");
 const compose_actions = mock_esm("../../static/js/compose_actions");
-const drafts = mock_esm("../../static/js/drafts");
 const giphy = mock_esm("../../static/js/giphy");
 const loading = mock_esm("../../static/js/loading");
 const markdown = mock_esm("../../static/js/markdown");
@@ -110,8 +109,6 @@ function initialize_handlers({override}) {
 }
 
 test_ui("send_message_success", ({override}) => {
-    override(drafts, "delete_active_draft", () => {});
-
     $("#compose-textarea").val("foobarfoobar");
     $("#compose-textarea").trigger("blur");
     $("#compose-send-status").show();
@@ -139,7 +136,6 @@ test_ui("send_message_success", ({override}) => {
 test_ui("send_message", ({override}) => {
     MockDate.set(new Date(fake_now * 1000));
 
-    override(drafts, "delete_active_draft", () => {});
     override(sent_messages, "start_tracking_message", () => {});
 
     // This is the common setup stuff for all of the four tests.

--- a/frontend_tests/puppeteer_tests/drafts.ts
+++ b/frontend_tests/puppeteer_tests/drafts.ts
@@ -241,7 +241,7 @@ async function test_save_draft_by_reloading(page: Page): Promise<void> {
     );
 }
 
-async function test_delete_draft_on_sending(page: Page): Promise<void> {
+async function test_not_delete_draft_on_sending(page: Page): Promise<void> {
     await page.click("#drafts_table .message_row.private-message .restore-draft");
     await wait_for_drafts_to_dissapear(page);
     await page.waitForSelector("#private-message", {visible: true});
@@ -253,8 +253,7 @@ async function test_delete_draft_on_sending(page: Page): Promise<void> {
     await page.click(drafts_button_in_compose);
     await wait_for_drafts_to_appear(page);
     const drafts_count = await get_drafts_count(page);
-    assert.strictEqual(drafts_count, 1, "Draft wasn't cleared on sending.");
-    await page.waitForSelector("#drafts_table .message_row.private-message", {hidden: true});
+    assert.strictEqual(drafts_count, 2, "Draft got cleared on sending.");
 }
 
 async function drafts_test(page: Page): Promise<void> {
@@ -276,7 +275,7 @@ async function drafts_test(page: Page): Promise<void> {
     await test_restore_private_message_draft(page);
     await test_delete_draft(page);
     await test_save_draft_by_reloading(page);
-    await test_delete_draft_on_sending(page);
+    await test_not_delete_draft_on_sending(page);
 }
 
 common.run_test(drafts_test);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -11,7 +11,6 @@ import * as compose_fade from "./compose_fade";
 import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
 import * as compose_validate from "./compose_validate";
-import * as drafts from "./drafts";
 import * as echo from "./echo";
 import * as giphy from "./giphy";
 import {$t, $t_html} from "./i18n";
@@ -185,7 +184,7 @@ export function create_message_object() {
 export function clear_compose_box() {
     $("#compose-textarea").val("").trigger("focus");
     compose_validate.check_overflow_text();
-    drafts.delete_active_draft();
+    $("#compose-textarea").removeData("draft-id");
     compose_ui.autosize_textarea($("#compose-textarea"));
     $("#compose-send-status").hide(0);
     $("#compose-send-button").prop("disabled", false);

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -160,7 +160,7 @@ export function update_draft() {
         // the existing draft yet--the user may have mistakenly
         // hit delete after select-all or something.
         // Just do nothing.
-        return;
+        return undefined;
     }
 
     const draft_id = $("#compose-textarea").data("draft-id");
@@ -170,7 +170,7 @@ export function update_draft() {
         // just update the existing draft.
         draft_model.editDraft(draft_id, draft);
         draft_notify();
-        return;
+        return draft_id;
     }
 
     // We have never saved a draft for this message, so add
@@ -178,14 +178,8 @@ export function update_draft() {
     const new_draft_id = draft_model.addDraft(draft);
     $("#compose-textarea").data("draft-id", new_draft_id);
     draft_notify();
-}
 
-export function delete_active_draft() {
-    const draft_id = $("#compose-textarea").data("draft-id");
-    if (draft_id) {
-        draft_model.deleteDraft(draft_id);
-    }
-    $("#compose-textarea").removeData("draft-id");
+    return new_draft_id;
 }
 
 export function restore_draft(draft_id) {

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -4,6 +4,7 @@ import * as alert_words from "./alert_words";
 import {all_messages_data} from "./all_messages_data";
 import * as blueslip from "./blueslip";
 import * as compose from "./compose";
+import * as drafts from "./drafts";
 import * as local_message from "./local_message";
 import * as markdown from "./markdown";
 import * as message_events from "./message_events";
@@ -235,6 +236,11 @@ export function try_deliver_locally(message_request) {
         return undefined;
     }
 
+    // Only saving in draft for locally echoed message
+    // This draft will be cleared after successfull message
+    const draft_id = drafts.update_draft();
+    message_request.draft_id = draft_id;
+
     const message = insert_local_message(message_request, local_id_float);
     return message;
 }
@@ -330,6 +336,11 @@ export function reify_message_id(local_id, server_id) {
 
     message.id = server_id;
     message.locally_echoed = false;
+
+    if (message.draft_id) {
+        // Delete the draft if message was locally echoed
+        drafts.draft_model.deleteDraft(message.draft_id);
+    }
 
     const opts = {old_id: Number.parseFloat(local_id), new_id: server_id};
 


### PR DESCRIPTION
Fixes #17697
See the commit description for more details. I will remove the console logs after few checks.

[CZO Link here](https://chat.zulip.org/#narrow/stream/2-general/topic/Ease.20of.20message.20recovery.20.2317697)
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested this manually right now. Here  I am adding some details on how to test:
1. Testing of locally echoed message -
Try to send a message first simply, it should have sent successfully and the message should not be in the drafts.
Now prepare another message,  and before sending it. In the developer tools -> network tab -> Make the network offline and then try sending the message. The message will get failed, and see the draft of that message will be in the drafts tab.
Now make the network again to no throttling in the network tab of developer tools. And retry sending the message, the message will be sent successfully and the draft will be deleted.

2. Testing of a non locally echoed message (eg. a message including an image)
The draft will not be saved for these messages and they remain in the compose box until the server gives a success signal for it. So, no need to save draft for these. Test by simply following the above procedure.

A gif of the above testing
![draft-message](https://user-images.githubusercontent.com/56730716/121870429-aa9d1180-cd20-11eb-924d-db34c6659fa0.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
Some questions:
1. What if the user deletes the draft and resend the message successfully?
> Well in this case, the draft when doesn't exists. It does not matter, it also do not create any error.

2. If the user again opens the message from draft and tries to send it.
> This is also not creating any problem as it will not allow to locally echo the message in that case. It will allow when the network is good without locally echoing it. Also care is taken that no multiple drafts get created.

3. 