### PR TITLE
Allow `clean_unused_cache` to run on `purge-old-deployments`.

### DIFF
--- a/scripts/lib/clean_yarn_cache.py
+++ b/scripts/lib/clean_yarn_cache.py
@@ -31,13 +31,14 @@ def remove_unused_versions_dir(args: argparse.Namespace) -> None:
     except FileNotFoundError:
         return
 
+    no_headings = getattr(args, "no_headings", False)
     may_be_perform_purging(
         dirs_to_purge,
         {current_version_dir},
         "yarn cache",
         args.dry_run,
         args.verbose,
-        args.no_headings,
+        no_headings,
     )
 
 

--- a/scripts/purge-old-deployments
+++ b/scripts/purge-old-deployments
@@ -43,6 +43,13 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="If specified then script will print a detailed report of what is going on.",
     )
+    parser.add_argument(
+        "--no-print-headings",
+        dest="no_headings",
+        action="store_true",
+        help="If specified then script will not print headings for "
+        "what will be deleted/kept back.",
+    )
 
     args = parser.parse_args()
     args.verbose |= args.dry_run  # Always print a detailed report in case of dry run.
@@ -83,8 +90,9 @@ def main() -> None:
                 ["git", "worktree", "prune"], cwd=LOCAL_GIT_CACHE_DIR, preexec_fn=su_to_zulip
             )
 
-        print("Deployments cleaned successfully...")
-        print("Cleaning orphaned/unused caches...")
+        if not args.no_headings:
+            print("Deployments cleaned successfully...")
+            print("Cleaning orphaned/unused caches...")
 
     # Call 'clean_unused_caches.py' script to clean any orphaned/unused caches.
     clean_unused_caches.main(args)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested it by running the scripts individually and `purge-old-deployments`.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
