### PR TITLE
compose: Convert pasted url to named link.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -835,30 +835,32 @@ export function handle_keydown(event, textarea) {
 
     if ((isBold || isItalic || isLink) && isCmdOrCtrl) {
         const range = textarea.range();
-        function wrap_text_with_markdown(prefix, suffix) {
-            if (!document.execCommand("insertText", false, prefix + range.text + suffix)) {
-                textarea.range(range.start, range.end).range(prefix + range.text + suffix);
-            }
-            event.preventDefault();
-        }
 
         if (isBold) {
             // Ctrl + B: Convert selected text to bold text
-            wrap_text_with_markdown("**", "**");
+            compose_ui.wrap_text_with_markdown(textarea, "**", "**");
+            event.preventDefault();
+
             if (!range.length) {
                 textarea.caret(textarea.caret() - 2);
             }
         }
+
         if (isItalic) {
             // Ctrl + I: Convert selected text to italic text
-            wrap_text_with_markdown("*", "*");
+            compose_ui.wrap_text_with_markdown(textarea, "*", "*");
+            event.preventDefault();
+
             if (!range.length) {
                 textarea.caret(textarea.caret() - 1);
             }
         }
+
         if (isLink) {
             // Ctrl + L: Insert a link to selected text
-            wrap_text_with_markdown("[", "](url)");
+            compose_ui.wrap_text_with_markdown(textarea, "[", "](url)");
+            event.preventDefault();
+
             const position = textarea.caret();
             const txt = textarea[0];
 

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -122,3 +122,11 @@ export function compute_placeholder_text(opts) {
     }
     return $t({defaultMessage: "Compose your message here"});
 }
+
+export function wrap_text_with_markdown(textarea, prefix, suffix) {
+    const range = textarea.range();
+
+    if (!document.execCommand("insertText", false, prefix + range.text + suffix)) {
+        textarea.range(range.start, range.end).range(prefix + range.text + suffix);
+    }
+}

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -306,6 +306,19 @@ export function paste_handler_converter(paste_html) {
     return markdown_text;
 }
 
+// https://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url
+function isValidHttpUrl(string) {
+    let url;
+
+    try {
+        url = new URL(string);
+    } catch {
+        return false;
+    }
+
+    return url.protocol === "http:" || url.protocol === "https:";
+}
+
 export function paste_handler(event) {
     const clipboardData = event.originalEvent.clipboardData;
     if (!clipboardData) {
@@ -318,6 +331,20 @@ export function paste_handler(event) {
     }
 
     if (clipboardData.getData) {
+        const paste_text = clipboardData.getData("text");
+        if (paste_text && isValidHttpUrl(paste_text) && document.getSelection().type === "Range") {
+            event.preventDefault();
+            event.stopPropagation();
+
+            const textarea = $(this);
+            const prefix = "[";
+            const suffix = "](" + paste_text + ")";
+            compose_ui.wrap_text_with_markdown(textarea, prefix, suffix);
+            compose_ui.autosize_textarea(textarea);
+
+            return;
+        }
+
         const paste_html = clipboardData.getData("text/html");
         if (paste_html && page_params.development_environment) {
             const text = paste_handler_converter(paste_html);

--- a/static/js/info_overlay.js
+++ b/static/js/info_overlay.js
@@ -34,6 +34,14 @@ const markdown_help_rows = [
         usage_html: "(or <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd>)",
     },
     {
+        markdown: "Zulip website",
+        output_html:
+            '<p><a href="https://zulip.org" target="_blank" rel="noopener noreferrer" title="https://zulip.org/">Zulip website</a></p>',
+        usage_html:
+            "(Pasting a link using <kbd>Ctrl</kbd>+<kbd>V</kbd> having some text selected.)",
+        effect_html: "(Converts pasted url to named link)",
+    },
+    {
         markdown: `\
 * Milk
 * Tea


### PR DESCRIPTION
Fixes #18692

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
[CZO link here](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Linkify.20on.20Paste.20.2318692)

**Testing plan:** <!-- How have you tested? -->
I tested this manually right now for these cases.
1. Pasting a link
2. Pasting simple text
3. Pasting an image

Tested this on Opera, Edge browsers for now.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

Select and paste a link
![magic-link](https://user-images.githubusercontent.com/56730716/122051388-2c18a080-ce02-11eb-9f92-355685f3114c.gif)
