### PR TITLE
hotkeys: Quote selected text when > hotkey is pressed.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -355,7 +355,7 @@ run_test("misc", () => {
     assert_mapping("u", popovers, "show_sender_info");
     assert_mapping("i", popovers, "open_message_menu");
     assert_mapping(":", reactions, "open_reactions_popover", true);
-    assert_mapping(">", compose_actions, "quote_and_reply");
+    assert_mapping(">", compose_actions, "quote_selected_text_and_reply");
     assert_mapping("e", message_edit, "start");
 });
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -900,7 +900,7 @@ export function process_hotkey(e, hotkey) {
             condense.toggle_collapse(msg);
             return true;
         case "compose_quote_reply": // > : respond to selected message with quote
-            compose_actions.quote_and_reply({trigger: "hotkey"});
+            compose_actions.quote_selected_text_and_reply({trigger: "hotkey"});
             return true;
         case "edit_message": {
             const row = message_lists.current.get_row(msg.id);


### PR DESCRIPTION
Follow up for https://github.com/zulip/zulip/pull/15235 (See this for details on the issue)
Rebased and tested.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
[CZO link here](https://chat.zulip.org/#narrow/stream/6-frontend/topic/select.20and.20reply)

**Testing plan:** <!-- How have you tested? -->
Tested manually selecting and works as shown in the original PR.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->


![select-reply](https://user-images.githubusercontent.com/56730716/122050611-40a86900-ce01-11eb-9098-a563d3cf1e97.gif)
Ignore the `search | copy` that  comes in the gif, it is a browser feature of opera.
