### PR TITLE
Introduce new dataclass for message send event user data.

### DIFF
--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
-from typing import List
+from typing import Collection
 
 
 @dataclass
 class UserMessageNotificationsData:
     id: int
-    flags: List[str]
+    flags: Collection[str]
     mentioned: bool
     online_push_enabled: bool
     stream_push_notify: bool

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -18,3 +18,46 @@ class UserMessageNotificationsData:
             assert "mentioned" in self.flags
         if self.wildcard_mention_notify:
             assert "wildcard_mentioned" in self.flags
+
+    # TODO: The following functions should also look at the `enable_offline_push_notifications` and
+    # `enable_offline_email_notifications` settings (for PMs and mentions), but currently they
+    # don't.
+
+    def is_notifiable(self, private_message: bool, sender_id: int, idle: bool) -> bool:
+        return self.is_email_notifiable(
+            private_message, sender_id, idle
+        ) or self.is_push_notifiable(private_message, sender_id, idle)
+
+    def is_push_notifiable(self, private_message: bool, sender_id: int, idle: bool) -> bool:
+        if not idle and not self.online_push_enabled:
+            return False
+
+        if self.id == sender_id:
+            return False
+
+        if self.sender_is_muted:
+            return False
+
+        return (
+            private_message
+            or self.mentioned
+            or self.wildcard_mention_notify
+            or self.stream_push_notify
+        )
+
+    def is_email_notifiable(self, private_message: bool, sender_id: int, idle: bool) -> bool:
+        if not idle:
+            return False
+
+        if self.id == sender_id:
+            return False
+
+        if self.sender_is_muted:
+            return False
+
+        return (
+            private_message
+            or self.mentioned
+            or self.wildcard_mention_notify
+            or self.stream_email_notify
+        )

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Collection
+from typing import Collection, Set
 
 
 @dataclass
@@ -18,6 +18,31 @@ class UserMessageNotificationsData:
             assert "mentioned" in self.flags
         if self.wildcard_mention_notify:
             assert "wildcard_mentioned" in self.flags
+
+    @classmethod
+    def from_user_id_sets(
+        cls,
+        user_id: int,
+        flags: Collection[str],
+        online_push_user_ids: Set[int],
+        stream_push_user_ids: Set[int],
+        stream_email_user_ids: Set[int],
+        wildcard_mention_user_ids: Set[int],
+        muted_sender_user_ids: Set[int],
+    ) -> "UserMessageNotificationsData":
+        wildcard_mention_notify = (
+            user_id in wildcard_mention_user_ids and "wildcard_mentioned" in flags
+        )
+        return cls(
+            id=user_id,
+            flags=flags,
+            mentioned=("mentioned" in flags),
+            online_push_enabled=(user_id in online_push_user_ids),
+            stream_push_notify=(user_id in stream_push_user_ids),
+            stream_email_notify=(user_id in stream_email_user_ids),
+            wildcard_mention_notify=wildcard_mention_notify,
+            sender_is_muted=(user_id in muted_sender_user_ids),
+        )
 
     # TODO: The following functions should also look at the `enable_offline_push_notifications` and
     # `enable_offline_email_notifications` settings (for PMs and mentions), but currently they

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -55,6 +55,7 @@ from zerver.lib.actions import (
 )
 from zerver.lib.cache import bounce_key_prefix_for_testing
 from zerver.lib.initial_password import initial_password
+from zerver.lib.notification_data import UserMessageNotificationsData
 from zerver.lib.rate_limiter import bounce_redis_key_prefix_for_testing
 from zerver.lib.sessions import get_session_dict_user
 from zerver.lib.stream_subscription import get_stream_subscriptions_for_user
@@ -1321,6 +1322,18 @@ Output:
         django_tornado_api.process_notification = real_event_queue_process_notification
 
         self.assert_length(lst, expected_num_events)
+
+    def create_user_notifications_data_object(self, **kwargs: Any) -> UserMessageNotificationsData:
+        return UserMessageNotificationsData(
+            id=kwargs.get("id", self.example_user("hamlet").id),
+            flags=kwargs.get("flags", []),
+            mentioned=kwargs.get("mentioned", False),
+            online_push_enabled=kwargs.get("online_push_enabled", False),
+            stream_email_notify=kwargs.get("stream_email_notify", False),
+            stream_push_notify=kwargs.get("stream_push_notify", False),
+            wildcard_mention_notify=kwargs.get("wildcard_mention_notify", False),
+            sender_is_muted=kwargs.get("sender_is_muted", False),
+        )
 
     def get_maybe_enqueue_notifications_parameters(self, **kwargs: Any) -> Dict[str, Any]:
         """

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -439,7 +439,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
                 stream_push_notify=True,
                 stream_email_notify=False,
                 stream_name="Denmark",
-                already_notified={"email_notified": False, "push_notified": False},
+                already_notified={"email_notified": False, "push_notified": True},
             )
         destroy_event_queue(client_descriptor.event_queue.id)
 
@@ -462,7 +462,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
                 stream_push_notify=False,
                 stream_email_notify=True,
                 stream_name="Denmark",
-                already_notified={"email_notified": False, "push_notified": False},
+                already_notified={"email_notified": True, "push_notified": False},
             )
         destroy_event_queue(client_descriptor.event_queue.id)
 

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -16,6 +16,7 @@ from zerver.tornado.event_queue import (
     maybe_enqueue_notifications,
     missedmessage_hook,
     persistent_queue_filename,
+    process_notification,
 )
 from zerver.tornado.views import cleanup_event_queue, get_events
 
@@ -862,3 +863,67 @@ class EventQueueTest(ZulipTestCase):
 
         queue.prune(1)
         self.verify_to_dict_end_to_end(client)
+
+
+class SchemaMigrationsTests(ZulipTestCase):
+    def test_reformat_legacy_send_message_event(self) -> None:
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        othello = self.example_user("othello")
+        old_format_event = dict(
+            type="message",
+            message=1,
+            message_dict={},
+            presence_idle_user_ids=[hamlet.id, othello.id],
+        )
+        old_format_users = [
+            dict(
+                id=hamlet.id,
+                flags=["mentioned"],
+                mentioned=True,
+                online_push_enabled=True,
+                stream_push_notify=False,
+                stream_email_notify=True,
+                wildcard_mention_notify=False,
+                sender_is_muted=False,
+            ),
+            dict(
+                id=cordelia.id,
+                flags=["wildcard_mentioned"],
+                mentioned=False,
+                online_push_enabled=True,
+                stream_push_notify=True,
+                stream_email_notify=False,
+                wildcard_mention_notify=True,
+                sender_is_muted=False,
+            ),
+        ]
+        notice = dict(event=old_format_event, users=old_format_users)
+
+        expected_current_format_users = [
+            dict(
+                id=hamlet.id,
+                flags=["mentioned"],
+            ),
+            dict(
+                id=cordelia.id,
+                flags=["wildcard_mentioned"],
+            ),
+        ]
+
+        expected_current_format_event = dict(
+            type="message",
+            message=1,
+            message_dict={},
+            presence_idle_user_ids=[hamlet.id, othello.id],
+            online_push_user_ids=[hamlet.id, cordelia.id],
+            stream_push_user_ids=[cordelia.id],
+            stream_email_user_ids=[hamlet.id],
+            wildcard_mention_user_ids=[cordelia.id],
+            muted_sender_user_ids=[],
+        )
+        with mock.patch("zerver.tornado.event_queue.process_message_event") as m:
+            process_notification(notice)
+            m.assert_called_once()
+            self.assertDictEqual(m.call_args[0][0], expected_current_format_event)
+            self.assertEqual(m.call_args[0][1], expected_current_format_users)

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict, List
+from typing import List
 
 from django.utils.timezone import now as timezone_now
 
@@ -22,17 +22,18 @@ class MissedMessageTest(ZulipTestCase):
         realm = sender.realm
         hamlet = self.example_user("hamlet")
         othello = self.example_user("othello")
-        recipient_ids = {hamlet.id, othello.id}
-        message_type = "stream"
-        user_flags: Dict[int, List[str]] = {}
+        user_data_objects = [
+            self.create_user_notifications_data_object(id=hamlet.id),
+            self.create_user_notifications_data_object(id=othello.id),
+        ]
+        message_type = "private"
 
         def assert_missing(user_ids: List[int]) -> None:
             presence_idle_user_ids = get_active_presence_idle_user_ids(
                 realm=realm,
                 sender_id=sender.id,
                 message_type=message_type,
-                active_user_ids=recipient_ids,
-                user_flags=user_flags,
+                active_users_data=user_data_objects,
             )
             self.assertEqual(sorted(user_ids), sorted(presence_idle_user_ids))
 
@@ -48,16 +49,34 @@ class MissedMessageTest(ZulipTestCase):
         message_type = "private"
         assert_missing([hamlet.id, othello.id])
 
+        # We have already thoroughly tested the `is_notifiable` function elsewhere,
+        # so we needn't test all cases here. This test exists mainly to avoid a bug
+        # which existed earlier with `get_active_presence_idle_user_ids` only looking
+        # at `private_message` and the `mentioned` flag, not stream level notifications.
+        # Simulate Hamlet has turned on notifications for the stream, and test that he's
+        # in the list.
         message_type = "stream"
-        user_flags[hamlet.id] = ["mentioned"]
+        user_data_objects[0].stream_email_notify = True
         assert_missing([hamlet.id])
 
+        # We don't currently send push or email notifications for alert words -- only
+        # desktop notifications, so `is_notifiable` will return False even if the flags contain
+        # alert words. Test that `get_active_presence_idle_user_ids` correctly includes even
+        # the alert word case in the list.
+        user_data_objects[0].stream_email_notify = False
+        user_data_objects[0].flags = ["has_alert_word"]
+        assert_missing([hamlet.id])
+
+        # Hamlet is idle (and the message has an alert word), so he should be in the list.
         set_presence(hamlet, "iPhone", ago=5000)
         assert_missing([hamlet.id])
 
+        # If Hamlet is active, don't include him in the `presence_idle` list.
         set_presence(hamlet, "website", ago=15)
         assert_missing([])
 
+        # Hamlet is active now, so only Othello should be in the list for a huddle
+        # message.
         message_type = "private"
         assert_missing([othello.id])
 

--- a/zerver/tests/test_notification_data.py
+++ b/zerver/tests/test_notification_data.py
@@ -1,0 +1,153 @@
+from zerver.lib.test_classes import ZulipTestCase
+
+
+class TestNotificationData(ZulipTestCase):
+    def test_is_push_notifiable(self) -> None:
+        sender_id = self.example_user("cordelia").id
+
+        # Boring case
+        user_data = self.create_user_notifications_data_object()
+        self.assertFalse(
+            user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
+        )
+
+        # Notifiable cases for PMs, mentions, stream notifications
+        user_data = self.create_user_notifications_data_object()
+        self.assertTrue(
+            user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=True)
+        )
+
+        user_data = self.create_user_notifications_data_object(flags=["mentioned"], mentioned=True)
+        self.assertTrue(
+            user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
+        )
+
+        user_data = self.create_user_notifications_data_object(
+            flags=["wildcard_mentioned"], wildcard_mention_notify=True
+        )
+        self.assertTrue(
+            user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
+        )
+
+        user_data = self.create_user_notifications_data_object(stream_push_notify=True)
+        self.assertTrue(
+            user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
+        )
+
+        # Now, test the `online_push_enabled` property
+        # Test no notifications when not idle
+        user_data = self.create_user_notifications_data_object()
+        self.assertFalse(
+            user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=False)
+        )
+
+        # Test notifications are sent when not idle but `online_push_enabled = True`
+        user_data = self.create_user_notifications_data_object(online_push_enabled=True)
+        self.assertTrue(
+            user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=False)
+        )
+
+        # The following are hypothetical cases, since a private message can never have `stream_push_notify = True`.
+        # We just want to test the early (False) return patterns in these special cases:
+        # Message sender is muted.
+        user_data = self.create_user_notifications_data_object(
+            sender_is_muted=True,
+            flags=["mentioned", "wildcard_mentioned"],
+            wildcard_mention_notify=True,
+            mentioned=True,
+            stream_email_notify=True,
+            stream_push_notify=True,
+        )
+        self.assertFalse(
+            user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=True)
+        )
+
+        # Message sender is the user the object corresponds to.
+        user_data = self.create_user_notifications_data_object(
+            id=sender_id,
+            sender_is_muted=False,
+            flags=["mentioned", "wildcard_mentioned"],
+            wildcard_mention_notify=True,
+            mentioned=True,
+            stream_email_notify=True,
+            stream_push_notify=True,
+        )
+        self.assertFalse(
+            user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=True)
+        )
+
+    def test_is_email_notifiable(self) -> None:
+        sender_id = self.example_user("cordelia").id
+
+        # Boring case
+        user_data = self.create_user_notifications_data_object()
+        self.assertFalse(
+            user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
+        )
+
+        # Notifiable cases for PMs, mentions, stream notifications
+        user_data = self.create_user_notifications_data_object()
+        self.assertTrue(
+            user_data.is_email_notifiable(private_message=True, sender_id=sender_id, idle=True)
+        )
+
+        user_data = self.create_user_notifications_data_object(flags=["mentioned"], mentioned=True)
+        self.assertTrue(
+            user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
+        )
+
+        user_data = self.create_user_notifications_data_object(
+            flags=["wildcard_mentioned"], wildcard_mention_notify=True
+        )
+        self.assertTrue(
+            user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
+        )
+
+        user_data = self.create_user_notifications_data_object(stream_email_notify=True)
+        self.assertTrue(
+            user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
+        )
+
+        # Test no notifications when not idle
+        user_data = self.create_user_notifications_data_object()
+        self.assertFalse(
+            user_data.is_email_notifiable(private_message=True, sender_id=sender_id, idle=False)
+        )
+
+        # The following are hypothetical cases, since a private message can never have `stream_email_notify = True`.
+        # We just want to test the early (False) return patterns in these special cases:
+        # Message sender is muted.
+        user_data = self.create_user_notifications_data_object(
+            sender_is_muted=True,
+            flags=["mentioned", "wildcard_mentioned"],
+            wildcard_mention_notify=True,
+            mentioned=True,
+            stream_email_notify=True,
+            stream_push_notify=True,
+        )
+        self.assertFalse(
+            user_data.is_email_notifiable(private_message=True, sender_id=sender_id, idle=True)
+        )
+
+        # Message sender is the user the object corresponds to.
+        user_data = self.create_user_notifications_data_object(
+            id=sender_id,
+            sender_is_muted=False,
+            flags=["mentioned", "wildcard_mentioned"],
+            wildcard_mention_notify=True,
+            mentioned=True,
+            stream_email_notify=True,
+            stream_push_notify=True,
+        )
+        self.assertFalse(
+            user_data.is_email_notifiable(private_message=True, sender_id=sender_id, idle=True)
+        )
+
+    def test_is_notifiable(self) -> None:
+        # This is just for coverage purposes. We've already tested all scenarios above,
+        # and `is_notifiable` is a simple OR of the email and push functions.
+        sender_id = self.example_user("cordelia").id
+        user_data = self.create_user_notifications_data_object()
+        self.assertTrue(
+            user_data.is_notifiable(private_message=True, sender_id=sender_id, idle=True)
+        )

--- a/zerver/tornado/django_api.py
+++ b/zerver/tornado/django_api.py
@@ -147,9 +147,8 @@ def send_notification_http(realm: Realm, data: Mapping[str, Any]) -> None:
 def send_event(
     realm: Realm, event: Mapping[str, Any], users: Union[Iterable[int], Iterable[Mapping[str, Any]]]
 ) -> None:
-    """`users` is a list of user IDs, or in the case of `message` type
-    events, a list of dicts describing the users and metadata about
-    the user/message pair."""
+    """`users` is a list of user IDs, or in some special cases like message
+    send/update or embeds, dictionaries containing extra data."""
     port = get_tornado_port(realm)
     queue_json_publish(
         notify_tornado_queue_name(port),

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -948,7 +948,7 @@ def process_message_event(
 
     for user_data in users:
         user_profile_id: int = user_data["id"]
-        flags: Iterable[str] = user_data.get("flags", [])
+        flags: Collection[str] = user_data.get("flags", [])
 
         # If the recipient was offline and the message was a single or group PM to them
         # or they were @-notified potentially notify more immediately


### PR DESCRIPTION
This is a prep to fix the bug described in https://chat.zulip.org/#narrow/stream/3-backend/topic/get_active_presence_idle_user_ids.

The first two commits are follow ups to #18719 