### PR TITLE
plans_page: Fix broken redirection to /accounts/login/.

### DIFF
--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -399,7 +399,7 @@ class PlansPageTest(ZulipTestCase):
         realm.save(update_fields=["plan_type"])
         result = self.client_get("/plans/", subdomain="zulip")
         self.assertEqual(result.status_code, 302)
-        self.assertEqual(result["Location"], "/accounts/login/?next=plans")
+        self.assertEqual(result["Location"], "/accounts/login/?next=/plans")
 
         guest_user = "polonius"
         self.login(guest_user)

--- a/zerver/views/portico.py
+++ b/zerver/views/portico.py
@@ -47,7 +47,7 @@ def plans_view(request: HttpRequest) -> HttpResponse:
         if realm.plan_type == Realm.SELF_HOSTED and settings.PRODUCTION:
             return HttpResponseRedirect("https://zulip.com/plans")
         if not request.user.is_authenticated:
-            return redirect_to_login(next="plans")
+            return redirect_to_login(next="/plans")
         if request.user.is_guest:
             return TemplateResponse(request, "404.html", status=404)
         if settings.CORPORATE_ENABLED:


### PR DESCRIPTION
When an unauthenticated user tries to access the /plans page, we redirect to `/accounts/login/?next=plans` (note the missing slash before "plans"). After the user is authenticated, they are then redirected to `/accounts/login/plans`, which is an invalid URL. The correct URL should be just `/plans`.

This commit solves this by prefixing the "plans" in the query parameter with a forward slash, which results in the correct redirect URL, i.e., `/plans`.

@timabbott @alya: FYI :)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->