### PR TITLE
Remove default_language_name and language_list_dbl_col from page_params.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -646,6 +646,7 @@ run_test("typing", ({override}) => {
 });
 
 run_test("update_display_settings", ({override}) => {
+    settings_display.set_default_language_name = () => {};
     let event = event_fixtures.update_display_settings__default_language;
     page_params.default_language = "en";
     override(settings_display, "update_page", noop);

--- a/frontend_tests/node_tests/i18n.js
+++ b/frontend_tests/node_tests/i18n.js
@@ -25,7 +25,7 @@ page_params.translation_data = {
 // `i18n.js` initializes FormatJS and is imported by
 // `templates.js`.
 unmock_module("../../static/js/i18n");
-const {$t, $t_html, get_language_list_columns} = zrequire("i18n");
+const {$t, $t_html, get_language_name, get_language_list_columns, initialize} = zrequire("i18n");
 
 run_test("$t", () => {
     // Normally the id would be provided by babel-plugin-formatjs, but
@@ -108,7 +108,7 @@ run_test("tr_tag", () => {
 });
 
 run_test("language_list", () => {
-    page_params.language_list = [
+    const language_list = [
         {
             code: "en",
             locale: "en",
@@ -127,6 +127,8 @@ run_test("language_list", () => {
             percent_translated: 32,
         },
     ];
+    initialize({language_list});
+    assert.equal(get_language_name("en"), "English");
 
     const successful_formatted_list = [
         {

--- a/static/js/i18n.js
+++ b/static/js/i18n.js
@@ -44,13 +44,24 @@ export function $t_html(descriptor, values) {
     });
 }
 
-// This formats language data for the language selection modal in a
-// 2-column format.
-export function get_language_list_columns(default_language) {
-    const language_list = [];
+let language_list;
 
-    // Only render languages with percentage translation >= 5%
-    for (const language of page_params.language_list) {
+export function get_language_name(language_code) {
+    const language_list_map = {};
+
+    // One-to-one mapping from code to name for all languages
+    for (const language of language_list) {
+        language_list_map[language.code] = language.name;
+    }
+    return language_list_map[language_code];
+}
+
+export function initialize(language_params) {
+    const language_list_raw = language_params.language_list;
+
+    // Limit offered languages to options with percentage translation >= 5%
+    language_list = [];
+    for (const language of language_list_raw) {
         if (language.percent_translated === undefined || language.percent_translated >= 5) {
             language_list.push({
                 code: language.code,
@@ -60,13 +71,16 @@ export function get_language_list_columns(default_language) {
             });
         }
     }
+}
 
+// This formats language data for the language selection modal in a
+// 2-column format.
+export function get_language_list_columns(default_language) {
     const formatted_list = [];
     const language_len = language_list.length;
     const firsts_end = Math.floor(language_len / 2) + (language_len % 2);
     const firsts = _.range(0, firsts_end);
     const seconds = _.range(firsts_end, language_len);
-
     const longest_zip = [];
 
     // Create a zip (itertool.zip_longest in python)

--- a/static/js/i18n.js
+++ b/static/js/i18n.js
@@ -43,3 +43,68 @@ export function $t_html(descriptor, values) {
         ),
     });
 }
+
+// This formats language data for the language selection modal in a
+// 2-column format.
+export function get_language_list_columns(default_language) {
+    const language_list = [];
+
+    // Only render languages with percentage translation >= 5%
+    for (const language of page_params.language_list) {
+        if (language.percent_translated === undefined || language.percent_translated >= 5) {
+            language_list.push({
+                code: language.code,
+                locale: language.locale,
+                name: language.name,
+                percent_translated: language.percent_translated,
+            });
+        }
+    }
+
+    const formatted_list = [];
+    const language_len = language_list.length;
+    const firsts_end = Math.floor(language_len / 2) + (language_len % 2);
+    const firsts = _.range(0, firsts_end);
+    const seconds = _.range(firsts_end, language_len);
+
+    const longest_zip = [];
+
+    // Create a zip (itertool.zip_longest in python)
+    for (const value of firsts) {
+        longest_zip.push([value, seconds[value]]);
+    }
+
+    for (const row of longest_zip) {
+        const item = {};
+        const zip_row = [
+            ["first", row[0]],
+            ["second", row[1]],
+        ];
+        for (const zip_value of zip_row) {
+            if (zip_value[1] !== undefined) {
+                const lang = language_list[zip_value[1]];
+                const name = lang.name;
+                let name_with_percent = name;
+                if (lang.percent_translated !== undefined) {
+                    name_with_percent = name + " (" + lang.percent_translated + "%)";
+                }
+
+                let selected = false;
+
+                if (default_language === lang.code || default_language === lang.locale) {
+                    selected = true;
+                }
+
+                item[zip_value[0]] = {
+                    name,
+                    code: lang.code,
+                    name_with_percent,
+                    selected,
+                };
+            }
+        }
+
+        formatted_list.push(item);
+    }
+    return formatted_list;
+}

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -564,7 +564,7 @@ export function dispatch_normal_event(event) {
                 // a reload is fundamentally required because we
                 // cannot rerender with the new language the strings
                 // present in the backend/Jinja2 templates.
-                page_params.default_language_name = event.language_name;
+                settings_display.set_default_language_name(event.language_name);
             }
             if (event.setting_name === "twenty_four_hour_time") {
                 // Rerender the whole message list UI

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -7,7 +7,7 @@ import render_settings_tab from "../templates/settings_tab.hbs";
 import * as admin from "./admin";
 import * as blueslip from "./blueslip";
 import * as common from "./common";
-import {$t, $t_html} from "./i18n";
+import {$t, $t_html, get_language_list_columns} from "./i18n";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import * as people from "./people";
@@ -113,6 +113,7 @@ export function build_page() {
         user_can_change_avatar: settings_data.user_can_change_avatar(),
         user_role_text: people.get_user_type(page_params.user_id),
         default_language_name: settings_display.default_language_name,
+        language_list_dbl_col: get_language_list_columns(page_params.default_language),
     });
 
     $(".settings-box").html(rendered_settings_tab);

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -14,6 +14,7 @@ import * as people from "./people";
 import * as settings_bots from "./settings_bots";
 import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
+import * as settings_display from "./settings_display";
 import * as settings_panel_menu from "./settings_panel_menu";
 import * as settings_sections from "./settings_sections";
 import * as settings_toggle from "./settings_toggle";
@@ -111,6 +112,7 @@ export function build_page() {
         user_can_change_name: settings_data.user_can_change_name(),
         user_can_change_avatar: settings_data.user_can_change_avatar(),
         user_role_text: people.get_user_type(page_params.user_id),
+        default_language_name: settings_display.default_language_name,
     });
 
     $(".settings-box").html(rendered_settings_tab);

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -14,6 +14,22 @@ const meta = {
     loaded: false,
 };
 
+function get_default_language_name(language_code) {
+    const language_list_map = {};
+
+    // One-to-one mapping from code to name for all languages
+    for (const language of page_params.language_list) {
+        language_list_map[language.code] = language.name;
+    }
+    return language_list_map[language_code];
+}
+
+export let default_language_name;
+
+export function set_default_language_name(name) {
+    default_language_name = name;
+}
+
 function change_display_setting(data, status_element, success_msg_html, sticky) {
     const $status_el = $(status_element);
     const status_is_sticky = $status_el.data("is_sticky");
@@ -196,7 +212,7 @@ export async function report_emojiset_change() {
 
 export function update_page() {
     $("#left_side_userlist").prop("checked", page_params.left_side_userlist);
-    $("#default_language_name").text(page_params.default_language_name);
+    $("#default_language_name").text(default_language_name);
     $("#translate_emoticons").prop("checked", page_params.translate_emoticons);
     $("#twenty_four_hour_time").val(JSON.stringify(page_params.twenty_four_hour_time));
     $("#color_scheme").val(JSON.stringify(page_params.color_scheme));
@@ -204,4 +220,9 @@ export function update_page() {
 
     // TODO: Set emojiset selector here.
     // Longer term, we'll want to automate this function
+}
+
+export function initialize() {
+    const language_name = get_default_language_name(page_params.default_language);
+    set_default_language_name(language_name);
 }

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -2,7 +2,7 @@ import $ from "jquery";
 
 import * as channel from "./channel";
 import * as emojisets from "./emojisets";
-import {$t_html} from "./i18n";
+import {$t_html, get_language_name} from "./i18n";
 import * as loading from "./loading";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
@@ -13,16 +13,6 @@ import * as ui_report from "./ui_report";
 const meta = {
     loaded: false,
 };
-
-function get_default_language_name(language_code) {
-    const language_list_map = {};
-
-    // One-to-one mapping from code to name for all languages
-    for (const language of page_params.language_list) {
-        language_list_map[language.code] = language.name;
-    }
-    return language_list_map[language_code];
-}
 
 export let default_language_name;
 
@@ -223,6 +213,6 @@ export function update_page() {
 }
 
 export function initialize() {
-    const language_name = get_default_language_name(page_params.default_language);
+    const language_name = get_language_name(page_params.default_language);
     set_default_language_name(language_name);
 }

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -58,6 +58,7 @@ import * as search from "./search";
 import * as search_pill_widget from "./search_pill_widget";
 import * as sent_messages from "./sent_messages";
 import * as server_events from "./server_events";
+import * as settings_display from "./settings_display";
 import * as settings_panel_menu from "./settings_panel_menu";
 import * as settings_sections from "./settings_sections";
 import * as settings_toggle from "./settings_toggle";
@@ -520,6 +521,7 @@ export function initialize_everything() {
     gear_menu.initialize();
     giphy.initialize();
     presence.initialize(presence_params);
+    settings_display.initialize();
     settings_panel_menu.initialize();
     settings_sections.initialize();
     settings_toggle.initialize();

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -27,6 +27,7 @@ import * as gear_menu from "./gear_menu";
 import * as giphy from "./giphy";
 import * as hashchange from "./hashchange";
 import * as hotspots from "./hotspots";
+import * as i18n from "./i18n";
 import * as invite from "./invite";
 import * as lightbox from "./lightbox";
 import * as linkifiers from "./linkifiers";
@@ -465,7 +466,9 @@ export function initialize_everything() {
     const user_groups_params = pop_fields("realm_user_groups");
 
     const user_status_params = pop_fields("user_status");
+    const i18n_params = pop_fields("language_list");
 
+    i18n.initialize(i18n_params);
     tippyjs.initialize();
     // We need to initialize compose early, because other modules'
     // initialization expects `#compose` to be already present in the

--- a/static/templates/default_language_modal.hbs
+++ b/static/templates/default_language_modal.hbs
@@ -21,23 +21,23 @@
         </p>
         <div>
             <table>
-                {{#each page_params.language_list_dbl_col}}
+                {{#each language_list}}
                 <tr>
                     <td>
                         <a class="language" data-code="{{this.first.code}}" data-name="{{this.first.name}}">
                             {{#if this.first.selected}}
-                            <b>{{this.first.percent}}</b>
+                            <b>{{this.first.name_with_percent}}</b>
                             {{else}}
-                            {{this.first.percent}}
+                            {{this.first.name_with_percent}}
                             {{/if}}
                         </a>
                     </td>
                     <td>
                         <a class="language" data-code="{{this.second.code}}" data-name="{{this.second.name}}">
                             {{#if this.second.selected}}
-                            <b>{{this.second.percent}}</b>
+                            <b>{{this.second.name_with_percent}}</b>
                             {{else}}
-                            {{this.second.percent}}
+                            {{this.second.name_with_percent}}
                             {{/if}}
                         </a>
                     </td>

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -14,7 +14,7 @@
                 </button>
             </div>
 
-            {{> ../default_language_modal guidelines_link="https://zulip.readthedocs.io/en/latest/translating/translating.html"}}
+            {{> ../default_language_modal language_list=language_list_dbl_col guidelines_link="https://zulip.readthedocs.io/en/latest/translating/translating.html"}}
         </div>
 
         <div id="user-display-settings">

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -9,7 +9,7 @@
             <div class="input-group user-name-section">
                 <label class="inline-block title">{{t "Default language" }}</label>
                 <button id="default_language" type="button" class="button btn-link rounded small inline-block">
-                    <span id="default_language_name">{{page_params.default_language_name}}</span>
+                    <span id="default_language_name">{{default_language_name}}</span>
                     <i class="fa fa-pencil"></i>
                 </button>
             </div>

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -15,7 +15,6 @@ from zerver.lib.i18n import (
     get_and_set_request_language,
     get_language_list,
     get_language_list_for_templates,
-    get_language_name,
     get_language_translation_data,
 )
 from zerver.lib.users import compute_show_invites_and_add_streams
@@ -197,7 +196,6 @@ def build_page_params_for_home_page_load(
         # Only show marketing email settings if on Zulip Cloud
         corporate_enabled=settings.CORPORATE_ENABLED,
         ## Misc. extra data.
-        default_language_name=get_language_name(register_ret["default_language"]),
         language_list_dbl_col=get_language_list_for_templates(register_ret["default_language"]),
         language_list=get_language_list(),
         needs_tutorial=needs_tutorial,

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -14,7 +14,6 @@ from zerver.lib.events import do_events_register
 from zerver.lib.i18n import (
     get_and_set_request_language,
     get_language_list,
-    get_language_list_for_templates,
     get_language_translation_data,
 )
 from zerver.lib.users import compute_show_invites_and_add_streams
@@ -196,7 +195,6 @@ def build_page_params_for_home_page_load(
         # Only show marketing email settings if on Zulip Cloud
         corporate_enabled=settings.CORPORATE_ENABLED,
         ## Misc. extra data.
-        language_list_dbl_col=get_language_list_for_templates(register_ret["default_language"]),
         language_list=get_language_list(),
         needs_tutorial=needs_tutorial,
         first_in_realm=first_in_realm,

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -1,10 +1,8 @@
 # See https://zulip.readthedocs.io/en/latest/translating/internationalization.html
 
 import logging
-import operator
 import os
 from functools import lru_cache
-from itertools import zip_longest
 from typing import Any, Dict, List, Optional
 
 import orjson
@@ -19,46 +17,6 @@ def get_language_list() -> List[Dict[str, Any]]:
     with open(path, "rb") as reader:
         languages = orjson.loads(reader.read())
         return languages["name_map"]
-
-
-def get_language_list_for_templates(default_language: str) -> List[Dict[str, Dict[str, str]]]:
-    language_list = [
-        lang
-        for lang in get_language_list()
-        if "percent_translated" not in lang or lang["percent_translated"] >= 5.0
-    ]
-
-    formatted_list = []
-    lang_len = len(language_list)
-    firsts_end = (lang_len // 2) + operator.mod(lang_len, 2)
-    firsts = list(range(0, firsts_end))
-    seconds = list(range(firsts_end, lang_len))
-    assert len(firsts) + len(seconds) == lang_len
-    for row in zip_longest(firsts, seconds):
-        item = {}
-        for position, ind in zip(["first", "second"], row):
-            if ind is None:
-                continue
-
-            lang = language_list[ind]
-            percent = name = lang["name"]
-            if "percent_translated" in lang:
-                percent = "{} ({}%)".format(name, lang["percent_translated"])
-
-            selected = False
-            if default_language in (lang["code"], lang["locale"]):
-                selected = True
-
-            item[position] = {
-                "name": name,
-                "code": lang["code"],
-                "percent": percent,
-                "selected": selected,
-            }
-
-        formatted_list.append(item)
-
-    return formatted_list
 
 
 def get_language_name(code: str) -> str:

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -106,7 +106,6 @@ class HomeTest(ZulipTestCase):
         "is_spectator",
         "jitsi_server_url",
         "language_list",
-        "language_list_dbl_col",
         "last_event_id",
         "left_side_userlist",
         "login_page",

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -65,7 +65,6 @@ class HomeTest(ZulipTestCase):
         "custom_profile_field_types",
         "custom_profile_fields",
         "default_language",
-        "default_language_name",
         "default_view",
         "delivery_email",
         "demote_inactive_streams",


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Remove default_language_name and language_list_dbl_col from page_params and shift the code
used for their evaluation to frontend instead.

Fixes part of #18673 

**Testing plan:** <!-- How have you tested? -->
Manual testing.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
