### PR TITLE
web_public_view: Replace `web_public_visitor` with `spectator`.

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -641,7 +641,7 @@ test("electron_bridge", (override) => {
     });
 });
 
-test("test_send_or_receive_no_presence_for_web_public_visitor", () => {
-    page_params.is_web_public_visitor = true;
+test("test_send_or_receive_no_presence_for_spectator", () => {
+    page_params.is_spectator = true;
     activity.send_presence_to_server();
 });

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -183,7 +183,7 @@ export function send_presence_to_server(want_redraw) {
     // which will clear suspect_offline and potentially trigger a
     // reload if the device was offline for more than
     // DEFAULT_EVENT_QUEUE_TIMEOUT_SECS).
-    if (page_params.is_web_public_visitor) {
+    if (page_params.is_spectator) {
         return;
     }
 

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -176,9 +176,9 @@ function get_events({dont_block = false} = {}) {
     }
 
     // TODO: In the future, we may implement Tornado support for live
-    // update for web_public_visitor, but until then, there's nothing
+    // update for spectator, but until then, there's nothing
     // to do here.
-    if (page_params.is_web_public_visitor) {
+    if (page_params.is_spectator) {
         return;
     }
 

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -913,7 +913,7 @@ def zulip_otp_required(
         """
         :if_configured: If ``True``, an authenticated user with no confirmed
         OTP devices will be allowed. Also, non-authenticated users will be
-        allowed as web_public_visitor users. Default is ``False``. If ``False``,
+        allowed as spectator users. Default is ``False``. If ``False``,
         2FA will not do any authentication.
         """
         if_configured = settings.TWO_FACTOR_AUTHENTICATION_ENABLED

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -152,9 +152,9 @@ def build_page_params_for_home_page_load(
             include_streams=False,
         )
     else:
-        # Since events for web_public_visitor is not implemented, we only fetch the data
+        # Since events for spectator is not implemented, we only fetch the data
         # at the time of request and don't register for any events.
-        # TODO: Implement events for web_public_visitor.
+        # TODO: Implement events for spectator.
         from zerver.lib.events import fetch_initial_state_data, post_process_state
 
         register_ret = fetch_initial_state_data(
@@ -215,9 +215,9 @@ def build_page_params_for_home_page_load(
         # Adding two_fa_enabled as condition saves us 3 queries when
         # 2FA is not enabled.
         two_fa_enabled_user=two_fa_enabled and bool(default_device(user_profile)),
-        is_web_public_visitor=user_profile is None,
-        # There is no event queue for web_public_visitors since
-        # events support for web_public_visitors is not implemented yet.
+        is_spectator=user_profile is None,
+        # There is no event queue for spectators since
+        # events support for spectators is not implemented yet.
         no_event_queue=user_profile is None,
         # Required for about_zulip.hbs
         zulip_merge_base=ZULIP_MERGE_BASE,

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -507,22 +507,22 @@ Output:
 
     def check_rendered_logged_in_app(self, result: HttpResponse) -> None:
         """Verifies that a visit of / was a 200 that rendered page_params
-        and not for a logged-out web-public visitor."""
+        and not for a (logged-out) spectator."""
         self.assertEqual(result.status_code, 200)
         page_params = self._get_page_params(result)
-        # It is important to check `is_web_public_visitor` to verify
+        # It is important to check `is_spectator` to verify
         # that we treated this request as a normal logged-in session,
-        # not as a web-public visitor.
-        self.assertEqual(page_params["is_web_public_visitor"], False)
+        # not as a spectator.
+        self.assertEqual(page_params["is_spectator"], False)
 
-    def check_rendered_web_public_visitor(self, result: HttpResponse) -> None:
+    def check_rendered_spectator(self, result: HttpResponse) -> None:
         """Verifies that a visit of / was a 200 that rendered page_params
-        for a logged-out web-public visitor."""
+        for a (logged-out) spectator."""
         self.assertEqual(result.status_code, 200)
         page_params = self._get_page_params(result)
-        # It is important to check `is_web_public_visitor` to verify
-        # that we treated this request to render for a `web_public_visitor`
-        self.assertEqual(page_params["is_web_public_visitor"], True)
+        # It is important to check `is_spectator` to verify
+        # that we treated this request to render for a `spectator`
+        self.assertEqual(page_params["is_spectator"], True)
 
     def login_with_return(
         self, email: str, password: Optional[str] = None, **kwargs: Any

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1121,7 +1121,7 @@ paths:
                                   description: |
                                     Note: Only present if the changed property was `invite_only`.
 
-                                    Whether the stream's history is now readable by web-public visitors.
+                                    Whether the stream's history is now readable by web-public spectators.
 
                                     **Changes**: New in Zulip 5.0 (feature level 71).
                               additionalProperties: false

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -104,7 +104,7 @@ class HomeTest(ZulipTestCase):
         "is_guest",
         "is_moderator",
         "is_owner",
-        "is_web_public_visitor",
+        "is_spectator",
         "jitsi_server_url",
         "language_list",
         "language_list_dbl_col",

--- a/zerver/tests/test_sessions.py
+++ b/zerver/tests/test_sessions.py
@@ -28,7 +28,7 @@ class TestSessions(ZulipTestCase):
         action()
         if expected_result:
             result = self.client_get("/", subdomain=realm.subdomain)
-            self.check_rendered_web_public_visitor(result)
+            self.check_rendered_spectator(result)
         else:
             self.assertIn("_auth_user_id", self.client.session)
 
@@ -39,7 +39,7 @@ class TestSessions(ZulipTestCase):
         for session in user_sessions(user_profile):
             delete_session(session)
         result = self.client_get("/")
-        self.check_rendered_web_public_visitor(result)
+        self.check_rendered_spectator(result)
 
     def test_delete_user_sessions(self) -> None:
         user_profile = self.example_user("hamlet")
@@ -87,7 +87,7 @@ class TestSessions(ZulipTestCase):
         self.client_post("/accounts/logout/")
         delete_all_deactivated_user_sessions()
         result = self.client_get("/")
-        self.check_rendered_web_public_visitor(result)
+        self.check_rendered_spectator(result)
 
         # Test nothing happens to an active user's session
         self.login("othello")
@@ -106,7 +106,7 @@ class TestSessions(ZulipTestCase):
             info_logs.output, ["INFO:root:Deactivating session for deactivated user 8"]
         )
         result = self.client_get("/")
-        self.check_rendered_web_public_visitor(result)
+        self.check_rendered_spectator(result)
 
 
 class TestExpirableSessionVars(ZulipTestCase):

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -1095,7 +1095,7 @@ def get_messages_backend(
     message_ids: List[int] = []
     user_message_flags: Dict[int, List[str]] = {}
     if is_web_public_query:
-        # For web-public users, we treat all historical messages as read.
+        # For spectators, we treat all historical messages as read.
         for row in rows:
             message_id = row[0]
             message_ids.append(message_id)


### PR DESCRIPTION
We use `spectator` term instead of `web_public_visitor` as it is
more concise and better represents this type of users.
