### PR TITLE
curl_examples: Migrate exclude and include config.

### DIFF
--- a/templates/zerver/api/add-reaction.md
+++ b/templates/zerver/api/add-reaction.md
@@ -13,7 +13,7 @@
 
 {tab|curl}
 
-{generate_code_example(curl, exclude=["emoji_code","reaction_type"])|/messages/{message_id}/reactions:post|example}
+{generate_code_example(curl)|/messages/{message_id}/reactions:post|example}
 
 {end_tabs}
 

--- a/templates/zerver/api/get-events.md
+++ b/templates/zerver/api/get-events.md
@@ -32,7 +32,7 @@ a queue for you.
 
 {tab|curl}
 
-{generate_code_example(curl, include=["queue_id", "last_event_id"])|/events:get|example}
+{generate_code_example(curl)|/events:get|example}
 
 {end_tabs}
 

--- a/templates/zerver/api/get-messages.md
+++ b/templates/zerver/api/get-messages.md
@@ -13,7 +13,7 @@
 
 {tab|curl}
 
-{generate_code_example(curl, exclude=["client_gravatar", "apply_markdown", "use_first_unread_anchor"])|/messages:get|example}
+{generate_code_example(curl)|/messages:get|example}
 
 {end_tabs}
 

--- a/templates/zerver/api/get-streams.md
+++ b/templates/zerver/api/get-streams.md
@@ -13,7 +13,7 @@
 
 {tab|curl}
 
-{generate_code_example(curl, include=[""])|/streams:get|example}
+{generate_code_example(curl)|/streams:get|example}
 
 You may pass in one or more of the parameters mentioned above
 as URL query parameters, like so:

--- a/templates/zerver/api/mute-topic.md
+++ b/templates/zerver/api/mute-topic.md
@@ -13,7 +13,7 @@
 
 {tab|curl}
 
-{generate_code_example(curl, exclude=["stream_id"])|/users/me/subscriptions/muted_topics:patch|example}
+{generate_code_example(curl)|/users/me/subscriptions/muted_topics:patch|example}
 
 {end_tabs}
 

--- a/templates/zerver/api/register-queue.md
+++ b/templates/zerver/api/register-queue.md
@@ -56,7 +56,7 @@ potentially messy races, etc.
 
 {tab|curl}
 
-{generate_code_example(curl, include=["event_types"])|/register:post|example}
+{generate_code_example(curl)|/register:post|example}
 
 {end_tabs}
 

--- a/templates/zerver/api/remove-reaction.md
+++ b/templates/zerver/api/remove-reaction.md
@@ -13,7 +13,7 @@
 
 {tab|curl}
 
-{generate_code_example(curl, exclude=["emoji_code", "reaction_type"])|/messages/{message_id}/reactions:delete|example}
+{generate_code_example(curl)|/messages/{message_id}/reactions:delete|example}
 
 
 {end_tabs}

--- a/templates/zerver/api/set-typing-status.md
+++ b/templates/zerver/api/set-typing-status.md
@@ -13,7 +13,7 @@
 
 {tab|curl}
 
-{generate_code_example(curl, exclude=["topic"])|/typing:post|example}
+{generate_code_example(curl)|/typing:post|example}
 
 {end_tabs}
 

--- a/templates/zerver/api/subscribe.md
+++ b/templates/zerver/api/subscribe.md
@@ -13,12 +13,12 @@
 
 {tab|curl}
 
-{generate_code_example(curl, include=["subscriptions"])|/users/me/subscriptions:post|example}
+{generate_code_example(curl)|/users/me/subscriptions:post|example}
 
 To subscribe another user to a stream, you may pass in
 the `principals` parameter, like so:
 
-{generate_code_example(curl, include=["subscriptions", "principals"])|/users/me/subscriptions:post|example}
+{generate_code_example(curl, include=["principals"])|/users/me/subscriptions:post|example}
 
 {end_tabs}
 

--- a/templates/zerver/api/unsubscribe.md
+++ b/templates/zerver/api/unsubscribe.md
@@ -13,11 +13,11 @@
 
 {tab|curl}
 
-{generate_code_example(curl, include=["subscriptions"])|/users/me/subscriptions:delete|example}
+{generate_code_example(curl)|/users/me/subscriptions:delete|example}
 
 You may specify the `principals` parameter like so:
 
-{generate_code_example(curl)|/users/me/subscriptions:delete|example}
+{generate_code_example(curl, include=["principals"])|/users/me/subscriptions:delete|example}
 
 **Note**: Unsubscribing another user from a stream requires
 administrative privileges.

--- a/templates/zerver/api/update-display-settings.md
+++ b/templates/zerver/api/update-display-settings.md
@@ -13,7 +13,7 @@
 
 {tab|curl}
 
-{generate_code_example(curl, include=["left_side_userlist", "emojiset"])|/settings/display:patch|example}
+{generate_code_example(curl)|/settings/display:patch|example}
 
 {end_tabs}
 

--- a/templates/zerver/api/update-message.md
+++ b/templates/zerver/api/update-message.md
@@ -13,7 +13,7 @@
 
 {tab|curl}
 
-{generate_code_example(curl, exclude=["stream_id"])|/messages/{message_id}:patch|example}
+{generate_code_example(curl)|/messages/{message_id}:patch|example}
 
 {end_tabs}
 

--- a/templates/zerver/api/update-notification-settings.md
+++ b/templates/zerver/api/update-notification-settings.md
@@ -13,7 +13,7 @@
 
 {tab|curl}
 
-{generate_code_example(curl, include=["enable_offline_push_notifications", "enable_online_push_notifications"])|/settings/notifications:patch|example}
+{generate_code_example(curl)|/settings/notifications:patch|example}
 
 {end_tabs}
 

--- a/templates/zerver/api/update-stream.md
+++ b/templates/zerver/api/update-stream.md
@@ -13,7 +13,7 @@
 
 {tab|curl}
 
-{generate_code_example(curl, include=["new_name", "description", "is_private"])|/streams/{stream_id}:patch|example}
+{generate_code_example(curl)|/streams/{stream_id}:patch|example}
 
 {end_tabs}
 

--- a/templates/zerver/api/update-user-group-members.md
+++ b/templates/zerver/api/update-user-group-members.md
@@ -13,7 +13,7 @@
 
 {tab|curl}
 
-{generate_code_example(curl, exclude=["delete"])|/user_groups/{user_group_id}/members:post|example}
+{generate_code_example(curl)|/user_groups/{user_group_id}/members:post|example}
 
 {end_tabs}
 


### PR DESCRIPTION
Currently, the include and exclude configurations
were hardoded in the templates, but as a part
of moving towards a common template, we need
to move all configurations out of the templates.

Added a dictionary to store parameters for include
and exclude, and modified the logic to add include
and exclude from dictionaries to the ones hardcoded
in template, which are useful if there are different
variants of include and exclude present, with the base
one in the dictionary, and the variants being added
in the dictionary.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
