### PR TITLE
compose_mobile_button: Use tippyjs for popover.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -920,7 +920,13 @@ export function initialize() {
                 '.popover-inner, #user-profile-modal, .emoji-info-popover, .app-main [class^="column-"].expanded',
             ).has(e.target).length === 0
         ) {
-            popovers.hide_all();
+            // Since tippy instance can handle outside clicks on their own,
+            // we don't need to trigger them from here.
+            // This fixes the bug of `hideAll` being called
+            // after a tippy popover has been triggered which hides
+            // the popover without being displayed.
+            const not_hide_tippy_instances = true;
+            popovers.hide_all(not_hide_tippy_instances);
         }
 
         if (compose_state.composing()) {

--- a/static/js/compose_closed_ui.js
+++ b/static/js/compose_closed_ui.js
@@ -6,7 +6,6 @@ import * as message_lists from "./message_lists";
 import * as message_store from "./message_store";
 import * as narrow_state from "./narrow_state";
 import * as people from "./people";
-import * as popovers from "./popovers";
 import * as recent_topics_util from "./recent_topics_util";
 
 function update_stream_button(btn_text, title) {
@@ -113,22 +112,10 @@ export function initialize() {
 
     // Click handlers for buttons in the compose compose box.
     $("body").on("click", ".compose_stream_button", () => {
-        popovers.hide_mobile_message_buttons_popover();
         compose_actions.start("stream", {trigger: "new topic button"});
     });
 
     $("body").on("click", ".compose_private_button", () => {
-        popovers.hide_mobile_message_buttons_popover();
-        compose_actions.start("private");
-    });
-
-    $("body").on("click", ".compose_mobile_stream_button", () => {
-        popovers.hide_mobile_message_buttons_popover();
-        compose_actions.start("stream", {trigger: "new topic button"});
-    });
-
-    $("body").on("click", ".compose_mobile_private_button", () => {
-        popovers.hide_mobile_message_buttons_popover();
         compose_actions.start("private");
     });
 

--- a/static/js/popover_menus.js
+++ b/static/js/popover_menus.js
@@ -1,0 +1,85 @@
+import $ from "jquery";
+import {delegate} from "tippy.js";
+
+import render_left_sidebar_stream_setting_popover from "../templates/left_sidebar_stream_setting_popover.hbs";
+import render_mobile_message_buttons_popover_content from "../templates/mobile_message_buttons_popover_content.hbs";
+
+import * as compose_actions from "./compose_actions";
+import * as narrow_state from "./narrow_state";
+import * as popovers from "./popovers";
+import * as settings_data from "./settings_data";
+
+let left_sidebar_stream_setting_popover_displayed = false;
+let compose_mobile_button_popover_displayed = false;
+
+export function is_left_sidebar_stream_setting_popover_displayed() {
+    return left_sidebar_stream_setting_popover_displayed;
+}
+
+export function is_compose_mobile_button_popover_displayed() {
+    return compose_mobile_button_popover_displayed;
+}
+
+export function initialize() {
+    delegate("body", {
+        delay: 0,
+        target: "#streams_inline_cog",
+        onShow(instance) {
+            popovers.hide_all_except_sidebars(instance);
+            instance.setContent(
+                render_left_sidebar_stream_setting_popover({
+                    can_create_streams: settings_data.user_can_create_streams(),
+                }),
+            );
+            left_sidebar_stream_setting_popover_displayed = true;
+            $(instance.popper).one("click", instance.hide);
+        },
+        appendTo: () => document.body,
+        trigger: "click",
+        allowHTML: true,
+        interactive: true,
+        hideOnClick: true,
+        theme: "light-border",
+        touch: true,
+        onHidden() {
+            left_sidebar_stream_setting_popover_displayed = false;
+        },
+    });
+
+    // compose box buttons popover shown on mobile widths.
+    delegate("body", {
+        target: ".compose_mobile_button",
+        placement: "top",
+        onShow(instance) {
+            popovers.hide_all_except_sidebars(instance);
+            instance.setContent(
+                render_mobile_message_buttons_popover_content({
+                    is_in_private_narrow: narrow_state.narrowed_to_pms(),
+                }),
+            );
+            compose_mobile_button_popover_displayed = true;
+
+            const $popper = $(instance.popper);
+            $popper.one("click", instance.hide);
+            $popper.one("click", ".compose_mobile_stream_button", () => {
+                compose_actions.start("stream", {trigger: "new topic button"});
+            });
+            $popper.one("click", ".compose_mobile_private_button", () => {
+                compose_actions.start("private");
+            });
+        },
+        appendTo: () => document.body,
+        trigger: "click",
+        allowHTML: true,
+        interactive: true,
+        hideOnClick: true,
+        theme: "light-border",
+        touch: true,
+        onHidden(instance) {
+            // Destroy instance so that event handlers
+            // are destroyed too.
+            instance.destroy();
+            compose_mobile_button_popover_displayed = false;
+        },
+    });
+}

--- a/static/js/popover_menus.js
+++ b/static/js/popover_menus.js
@@ -12,6 +12,17 @@ import * as settings_data from "./settings_data";
 let left_sidebar_stream_setting_popover_displayed = false;
 let compose_mobile_button_popover_displayed = false;
 
+const default_popover_props = {
+    delay: 0,
+    appendTo: () => document.body,
+    trigger: "click",
+    allowHTML: true,
+    interactive: true,
+    hideOnClick: true,
+    theme: "light-border",
+    touch: true,
+};
+
 export function is_left_sidebar_stream_setting_popover_displayed() {
     return left_sidebar_stream_setting_popover_displayed;
 }
@@ -22,7 +33,7 @@ export function is_compose_mobile_button_popover_displayed() {
 
 export function initialize() {
     delegate("body", {
-        delay: 0,
+        ...default_popover_props,
         target: "#streams_inline_cog",
         onShow(instance) {
             popovers.hide_all_except_sidebars(instance);
@@ -34,13 +45,6 @@ export function initialize() {
             left_sidebar_stream_setting_popover_displayed = true;
             $(instance.popper).one("click", instance.hide);
         },
-        appendTo: () => document.body,
-        trigger: "click",
-        allowHTML: true,
-        interactive: true,
-        hideOnClick: true,
-        theme: "light-border",
-        touch: true,
         onHidden() {
             left_sidebar_stream_setting_popover_displayed = false;
         },
@@ -48,6 +52,7 @@ export function initialize() {
 
     // compose box buttons popover shown on mobile widths.
     delegate("body", {
+        ...default_popover_props,
         target: ".compose_mobile_button",
         placement: "top",
         onShow(instance) {
@@ -68,13 +73,6 @@ export function initialize() {
                 compose_actions.start("private");
             });
         },
-        appendTo: () => document.body,
-        trigger: "click",
-        allowHTML: true,
-        interactive: true,
-        hideOnClick: true,
-        theme: "light-border",
-        touch: true,
         onHidden(instance) {
             // Destroy instance so that event handlers
             // are destroyed too.

--- a/static/js/popover_menus.js
+++ b/static/js/popover_menus.js
@@ -1,3 +1,7 @@
+/* Module for popovers that have been ported to the modern
+   TippyJS/Popper popover library from the legacy Bootstrap
+   popovers system in popovers.js. */
+
 import $ from "jquery";
 import {delegate} from "tippy.js";
 
@@ -19,6 +23,9 @@ const default_popover_props = {
     allowHTML: true,
     interactive: true,
     hideOnClick: true,
+    /* The light-border TippyJS theme is a bit of a misnomer; it
+       is a popover styling similar to Bootstrap.  We've also customized
+       its CSS to support Zulip's night theme. */
     theme: "light-border",
     touch: true,
 };

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -2,6 +2,7 @@ import ClipboardJS from "clipboard";
 import {add, formatISO, parseISO, set} from "date-fns";
 import ConfirmDatePlugin from "flatpickr/dist/plugins/confirmDate/confirmDate";
 import $ from "jquery";
+import {hideAll} from "tippy.js";
 
 import render_actions_popover_content from "../templates/actions_popover_content.hbs";
 import render_mobile_message_buttons_popover from "../templates/mobile_message_buttons_popover.hbs";
@@ -50,6 +51,7 @@ import * as settings_data from "./settings_data";
 import * as settings_profile_fields from "./settings_profile_fields";
 import * as stream_data from "./stream_data";
 import * as stream_popover from "./stream_popover";
+import * as tippyjs from "./tippyjs";
 import * as user_groups from "./user_groups";
 import * as user_status from "./user_status";
 import * as user_status_ui from "./user_status_ui";
@@ -1466,6 +1468,7 @@ export function any_active() {
     // True if any popover (that this module manages) is currently shown.
     // Expanded sidebars on mobile view count as popovers as well.
     return (
+        tippyjs.is_left_sidebar_stream_setting_popover_displayed() ||
         actions_popped() ||
         user_sidebar_popped() ||
         stream_popover.stream_popped() ||
@@ -1480,8 +1483,13 @@ export function any_active() {
 // This function will hide all true popovers (the streamlist and
 // userlist sidebars use the popover infrastructure, but doesn't work
 // like a popover structurally).
-export function hide_all_except_sidebars() {
+export function hide_all_except_sidebars(opts) {
     $(".has_popover").removeClass("has_popover has_actions_popover has_emoji_popover");
+    if (!opts || !opts.not_hide_tippy_instances) {
+        hideAll();
+    } else if (opts.exclude_tippy_instance) {
+        hideAll({exclude: opts.exclude_tippy_instance});
+    }
     hide_actions_popover();
     hide_message_info_popover();
     emoji_picker.hide_emoji_popover();
@@ -1506,10 +1514,13 @@ export function hide_all_except_sidebars() {
 
 // This function will hide all the popovers, including the mobile web
 // or narrow window sidebars.
-export function hide_all() {
+export function hide_all(not_hide_tippy_instances) {
     hide_userlist_sidebar();
     stream_popover.hide_streamlist_sidebar();
-    hide_all_except_sidebars();
+    hide_all_except_sidebars({
+        exclude_tippy_instance: undefined,
+        not_hide_tippy_instances,
+    });
 }
 
 export function set_userlist_placement(placement) {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -5,8 +5,6 @@ import $ from "jquery";
 import {hideAll} from "tippy.js";
 
 import render_actions_popover_content from "../templates/actions_popover_content.hbs";
-import render_mobile_message_buttons_popover from "../templates/mobile_message_buttons_popover.hbs";
-import render_mobile_message_buttons_popover_content from "../templates/mobile_message_buttons_popover_content.hbs";
 import render_no_arrow_popover from "../templates/no_arrow_popover.hbs";
 import render_playground_links_popover_content from "../templates/playground_links_popover_content.hbs";
 import render_remind_me_popover_content from "../templates/remind_me_popover_content.hbs";
@@ -60,7 +58,6 @@ import * as util from "./util";
 let current_actions_popover_elem;
 let current_flatpickr_instance;
 let current_message_info_popover_elem;
-let current_mobile_message_buttons_popover_elem;
 let current_user_info_popover_elem;
 let current_playground_links_popover_elem;
 let userlist_placement = "right";
@@ -71,7 +68,6 @@ export function clear_for_testing() {
     current_actions_popover_elem = undefined;
     current_flatpickr_instance = undefined;
     current_message_info_popover_elem = undefined;
-    current_mobile_message_buttons_popover_elem = undefined;
     current_user_info_popover_elem = undefined;
     current_playground_links_popover_elem = undefined;
     list_of_popovers.length = 0;
@@ -341,37 +337,6 @@ function show_user_info_popover_for_message(element, user, message) {
         );
 
         current_message_info_popover_elem = elt;
-    }
-}
-
-function show_mobile_message_buttons_popover(element) {
-    const last_popover_elem = current_mobile_message_buttons_popover_elem;
-    hide_all();
-    if (last_popover_elem !== undefined && last_popover_elem.get()[0] === element) {
-        // We want it to be the case that a user can dismiss a popover
-        // by clicking on the same element that caused the popover.
-        return;
-    }
-
-    const $element = $(element);
-    $element.popover({
-        placement: "left",
-        template: render_mobile_message_buttons_popover(),
-        content: render_mobile_message_buttons_popover_content({
-            is_in_private_narrow: narrow_state.narrowed_to_pms(),
-        }),
-        html: true,
-        trigger: "manual",
-    });
-    $element.popover("show");
-
-    current_mobile_message_buttons_popover_elem = $element;
-}
-
-export function hide_mobile_message_buttons_popover() {
-    if (current_mobile_message_buttons_popover_elem) {
-        current_mobile_message_buttons_popover_elem.popover("destroy");
-        current_mobile_message_buttons_popover_elem = undefined;
     }
 }
 
@@ -1145,12 +1110,6 @@ export function register_click_handlers() {
         hide_user_profile();
     });
 
-    $("body").on("click", ".compose_mobile_button", function (e) {
-        show_mobile_message_buttons_popover(this);
-        e.stopPropagation();
-        e.preventDefault();
-    });
-
     $("body").on("click", ".set_away_status", (e) => {
         hide_all();
         user_status.server_set_away();
@@ -1469,6 +1428,7 @@ export function any_active() {
     // Expanded sidebars on mobile view count as popovers as well.
     return (
         tippyjs.is_left_sidebar_stream_setting_popover_displayed() ||
+        tippyjs.is_compose_mobile_button_popover_displayed() ||
         actions_popped() ||
         user_sidebar_popped() ||
         stream_popover.stream_popped() ||
@@ -1499,7 +1459,6 @@ export function hide_all_except_sidebars(opts) {
     stream_popover.hide_all_messages_popover();
     stream_popover.hide_starred_messages_popover();
     hide_user_sidebar_popover();
-    hide_mobile_message_buttons_popover();
     hide_user_info_popover();
     hide_playground_links_popover();
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -40,6 +40,7 @@ import * as narrow_state from "./narrow_state";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import * as popover_menus from "./popover_menus";
 import * as realm_playground from "./realm_playground";
 import * as reminder from "./reminder";
 import * as resize from "./resize";
@@ -49,7 +50,6 @@ import * as settings_data from "./settings_data";
 import * as settings_profile_fields from "./settings_profile_fields";
 import * as stream_data from "./stream_data";
 import * as stream_popover from "./stream_popover";
-import * as tippyjs from "./tippyjs";
 import * as user_groups from "./user_groups";
 import * as user_status from "./user_status";
 import * as user_status_ui from "./user_status_ui";
@@ -1427,8 +1427,8 @@ export function any_active() {
     // True if any popover (that this module manages) is currently shown.
     // Expanded sidebars on mobile view count as popovers as well.
     return (
-        tippyjs.is_left_sidebar_stream_setting_popover_displayed() ||
-        tippyjs.is_compose_mobile_button_popover_displayed() ||
+        popover_menus.is_left_sidebar_stream_setting_popover_displayed() ||
+        popover_menus.is_compose_mobile_button_popover_displayed() ||
         actions_popped() ||
         user_sidebar_popped() ||
         stream_popover.stream_popped() ||

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -1,15 +1,8 @@
 import $ from "jquery";
 import tippy, {delegate} from "tippy.js";
 
-import render_left_sidebar_stream_setting_popover from "../templates/left_sidebar_stream_setting_popover.hbs";
-import render_mobile_message_buttons_popover_content from "../templates/mobile_message_buttons_popover_content.hbs";
-
-import * as compose_actions from "./compose_actions";
-import * as narrow_state from "./narrow_state";
-import * as popovers from "./popovers";
 import * as reactions from "./reactions";
 import * as rows from "./rows";
-import * as settings_data from "./settings_data";
 
 // We override the defaults set by tippy library here,
 // so make sure to check this too after checking tippyjs
@@ -41,17 +34,6 @@ tippy.setDefaultProps({
     // enable it by passing data-tippy-allowHtml="true"
     // in the tag or a parameter.
 });
-
-let left_sidebar_stream_setting_popover_displayed = false;
-let compose_mobile_button_popover_displayed = false;
-
-export function is_left_sidebar_stream_setting_popover_displayed() {
-    return left_sidebar_stream_setting_popover_displayed;
-}
-
-export function is_compose_mobile_button_popover_displayed() {
-    return compose_mobile_button_popover_displayed;
-}
 
 export function initialize() {
     delegate("body", {
@@ -150,70 +132,6 @@ export function initialize() {
             }
             instance.setContent(content);
             return true;
-        },
-    });
-
-    // ------------------ Popovers ----------------------------------------------
-
-    delegate("body", {
-        delay: 0,
-        target: "#streams_inline_cog",
-        onShow(instance) {
-            popovers.hide_all_except_sidebars(instance);
-            instance.setContent(
-                render_left_sidebar_stream_setting_popover({
-                    can_create_streams: settings_data.user_can_create_streams(),
-                }),
-            );
-            left_sidebar_stream_setting_popover_displayed = true;
-            $(instance.popper).one("click", instance.hide);
-        },
-        appendTo: () => document.body,
-        trigger: "click",
-        allowHTML: true,
-        interactive: true,
-        hideOnClick: true,
-        theme: "light-border",
-        touch: true,
-        onHidden() {
-            left_sidebar_stream_setting_popover_displayed = false;
-        },
-    });
-
-    // compose box buttons popover shown on mobile widths.
-    delegate("body", {
-        target: ".compose_mobile_button",
-        placement: "top",
-        onShow(instance) {
-            popovers.hide_all_except_sidebars(instance);
-            instance.setContent(
-                render_mobile_message_buttons_popover_content({
-                    is_in_private_narrow: narrow_state.narrowed_to_pms(),
-                }),
-            );
-            compose_mobile_button_popover_displayed = true;
-
-            const $popper = $(instance.popper);
-            $popper.one("click", instance.hide);
-            $popper.one("click", ".compose_mobile_stream_button", () => {
-                compose_actions.start("stream", {trigger: "new topic button"});
-            });
-            $popper.one("click", ".compose_mobile_private_button", () => {
-                compose_actions.start("private");
-            });
-        },
-        appendTo: () => document.body,
-        trigger: "click",
-        allowHTML: true,
-        interactive: true,
-        hideOnClick: true,
-        theme: "light-border",
-        touch: true,
-        onHidden(instance) {
-            // Destroy instance so that event handlers
-            // are destroyed too.
-            instance.destroy();
-            compose_mobile_button_popover_displayed = false;
         },
     });
 }

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -157,5 +157,6 @@ export function initialize() {
         interactive: true,
         hideOnClick: true,
         theme: "light-border",
+        touch: true,
     });
 }

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -39,6 +39,12 @@ tippy.setDefaultProps({
     // in the tag or a parameter.
 });
 
+let left_sidebar_stream_setting_popover_displayed = false;
+
+export function is_left_sidebar_stream_setting_popover_displayed() {
+    return left_sidebar_stream_setting_popover_displayed;
+}
+
 export function initialize() {
     delegate("body", {
         // Add elements here which are not displayed on
@@ -143,12 +149,13 @@ export function initialize() {
         delay: 0,
         target: "#streams_inline_cog",
         onShow(instance) {
-            popovers.hide_all_except_sidebars();
+            popovers.hide_all_except_sidebars(instance);
             instance.setContent(
                 render_left_sidebar_stream_setting_popover({
                     can_create_streams: settings_data.user_can_create_streams(),
                 }),
             );
+            left_sidebar_stream_setting_popover_displayed = true;
             $(instance.popper).one("click", instance.hide);
         },
         appendTo: () => document.body,
@@ -158,5 +165,8 @@ export function initialize() {
         hideOnClick: true,
         theme: "light-border",
         touch: true,
+        onHidden() {
+            left_sidebar_stream_setting_popover_displayed = false;
+        },
     });
 }

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -149,7 +149,7 @@ export function initialize() {
                     can_create_streams: settings_data.user_can_create_streams(),
                 }),
             );
-            $(instance.popper).on("click", instance.hide);
+            $(instance.popper).one("click", instance.hide);
         },
         appendTo: () => document.body,
         trigger: "click",

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -48,6 +48,7 @@ import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as pm_conversations from "./pm_conversations";
+import * as popover_menus from "./popover_menus";
 import * as presence from "./presence";
 import * as realm_playground from "./realm_playground";
 import * as recent_topics_util from "./recent_topics_util";
@@ -470,6 +471,7 @@ export function initialize_everything() {
 
     i18n.initialize(i18n_params);
     tippyjs.initialize();
+    popover_menus.initialize();
     // We need to initialize compose early, because other modules'
     // initialization expects `#compose` to be already present in the
     // DOM, dating from when the compose area was part of the backend

--- a/static/templates/mobile_message_buttons_popover.hbs
+++ b/static/templates/mobile_message_buttons_popover.hbs
@@ -1,7 +1,0 @@
-<div class="popover mobile-message-buttons-popover">
-    <div class="popover-inner">
-        <div class="popover-content">
-            <div></div>
-        </div>
-    </div>
-</div>

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -104,6 +104,7 @@ EXEMPT_FILES = {
     "static/js/pm_list_dom.js",
     "static/js/poll_widget.js",
     "static/js/popovers.js",
+    "static/js/popover_menus.js",
     "static/js/ready.js",
     "static/js/realm_icon.js",
     "static/js/realm_logo.js",


### PR DESCRIPTION
There are several benefits of using tippyjs here:
* Removes dependency on bootstrap.
* We don't have to manually handle show/hide of popover.
* There cannot be any memory leak since we don't store
  the instance.

![image](https://user-images.githubusercontent.com/25124304/122204826-30ee5a80-cebd-11eb-9828-f4bde04d1d48.png)
![image](https://user-images.githubusercontent.com/25124304/122204865-39df2c00-cebd-11eb-8881-0c2d66232431.png)
