### PR TITLE
compose_area: Fix compose_area cut pasted message bigger than max_length.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -195,6 +195,7 @@ export function create_message_object() {
 
 export function clear_compose_box() {
     $("#compose-textarea").val("").trigger("focus");
+    compose_validate.check_and_set_overflow_text();
     drafts.delete_active_draft();
     compose_ui.autosize_textarea($("#compose-textarea"));
     $("#compose-send-status").hide(0);
@@ -626,6 +627,10 @@ export function initialize() {
     });
     $("#compose-textarea").on("keyup", (event) => {
         handle_keyup(event, $("#compose-textarea").expectOne());
+    });
+
+    $("#compose-textarea").on("input propertychange", () => {
+        compose_validate.check_and_set_overflow_text();
     });
 
     $("#compose form").on("submit", (e) => {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -113,6 +113,7 @@ function clear_box() {
     compose_validate.set_user_acknowledged_announce_flag(undefined);
 
     clear_textarea();
+    compose_validate.check_and_set_overflow_text();
     $("#compose-textarea").removeData("draft-id");
     compose_ui.autosize_textarea($("#compose-textarea"));
     $("#compose-send-status").hide(0);

--- a/static/js/compose_validate.js
+++ b/static/js/compose_validate.js
@@ -464,6 +464,29 @@ function validate_private_message() {
     return true;
 }
 
+export function check_and_set_overflow_text() {
+    const text = compose_state.message_content();
+    const max_length = page_params.max_message_length;
+    const indicator = $("#compose_limit_indicator");
+
+    if (text.length > max_length) {
+        indicator.addClass("over_limit");
+        $("#compose-textarea").addClass("over_limit");
+        indicator.text(text.length + "/" + max_length);
+    } else if (text.length > 0.9 * max_length) {
+        indicator.removeClass("over_limit");
+        $("#compose-textarea").removeClass("over_limit");
+        indicator.text(text.length + "/" + max_length);
+    } else {
+        indicator.text("");
+        $("#compose-textarea").removeClass("over_limit");
+
+        if ($("#compose-send-status").hasClass("alert-error")) {
+            $("#compose-send-status").stop(true).fadeOut();
+        }
+    }
+}
+
 export function validate() {
     $("#compose-send-button").prop("disabled", true).trigger("blur");
     const message_content = compose_state.message_content();
@@ -488,6 +511,12 @@ export function validate() {
                     "You need to be running Zephyr mirroring in order to send messages!",
             }),
         );
+        return false;
+    }
+
+    if (message_content.length > page_params.max_message_length) {
+        // We don't display an error message, since the red box already
+        // communicates clearly what you did wrong.
         return false;
     }
 

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -167,6 +167,20 @@
     margin-top: 6px;
 }
 
+#compose_limit_indicator {
+    position: relative;
+    margin-right: 8px;
+    top: 3px;
+    float: right;
+    font-size: 12px;
+    color: hsl(39, 100%, 50%);
+
+    &.over_limit {
+        color: hsl(0, 100%, 50%);
+        font-weight: bold;
+    }
+}
+
 #compose {
     position: fixed;
     bottom: 0;
@@ -303,6 +317,10 @@ textarea.new_message_textarea {
     margin-bottom: 0;
     resize: vertical !important;
     margin-top: 5px;
+
+    &.over_limit {
+        box-shadow: 0 0 0pt 1pt hsl(0, 100%, 50%) !important;
+    }
 }
 
 textarea.new_message_textarea,

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -84,7 +84,7 @@
                     </div>
                     <div>
                         <div class="messagebox">
-                            <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" maxlength="10000" aria-label="{{t 'Compose your message here...' }}"></textarea>
+                            <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
                             <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area" style="display:none;">
                                 <div class="markdown_preview_spinner"></div>
                                 <div class="preview_content rendered_markdown"></div>
@@ -100,6 +100,7 @@
                                         <span></span>{{t 'Press Enter to send' }}
                                     </label>
                                 </div>
+                                <span id="compose_limit_indicator"></span>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Follow up for https://github.com/zulip/zulip/pull/16061

I have changed the way we were going to solve a bit. The highlighter feature was using a wrapper and I don't think it is good way to fake the highlight. Instead what this does it, it allows writing longer than MAX_LIMIT but also show the error above until, the length is more than the limit and removes it as it gets back in limit.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #15909

**Testing plan:** <!-- How have you tested? -->
In progress. I will add tests soon. Tested with node tests. Once finalized the behavior, will add node tests.




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
[CZO link here](https://chat.zulip.org/#narrow/stream/6-frontend/topic/compose.20long.20message.20.2318871)
