### PR TITLE
Refactors and preparatory works for having tabbed navigation in stream edit modal.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -255,10 +255,6 @@ run_test("allow normal typing when processing text", ({override}) => {
     assert_unmapped("bfmoyz");
     assert_unmapped("BEFHILNOQTUWXYZ");
 
-    // We have to skip some checks due to the way the code is
-    // currently organized for mapped keys.
-    override(hotkey, "in_content_editable_widget", () => false);
-
     // All letters should return false if we are composing text.
     override(hotkey, "processing_text", () => true);
 
@@ -477,11 +473,6 @@ run_test("motion_keys", () => {
     assert_mapping("left_arrow", lightbox, "prev");
     assert_mapping("right_arrow", lightbox, "next");
     overlays.lightbox_open = () => false;
-
-    hotkey.__Rewire__("in_content_editable_widget", () => true);
-    assert_unmapped("down_arrow");
-    assert_unmapped("up_arrow");
-    hotkey.__Rewire__("in_content_editable_widget", () => false);
 
     overlays.settings_open = () => true;
     assert_unmapped("end");

--- a/frontend_tests/puppeteer_tests/subscriptions.ts
+++ b/frontend_tests/puppeteer_tests/subscriptions.ts
@@ -174,11 +174,11 @@ async function create_stream(page: Page): Promise<void> {
     await page.waitForFunction(() => $(".stream-name").is(':contains("Puppeteer")'));
     const stream_name = await common.get_text_from_selector(
         page,
-        ".stream-header .stream-name .stream-name-editable",
+        ".stream-header .stream-name .sub-stream-name",
     );
     const stream_description = await common.get_text_from_selector(
         page,
-        ".stream-description-editable ",
+        ".stream-description .sub-stream-description",
     );
     const subscriber_count_selector = "[data-stream-name='Puppeteer'] .subscriber-count";
     assert.strictEqual(stream_name, "Puppeteer");

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -34,7 +34,6 @@ import * as rows from "./rows";
 import * as server_events from "./server_events";
 import * as settings_panel_menu from "./settings_panel_menu";
 import * as settings_toggle from "./settings_toggle";
-import * as stream_edit from "./stream_edit";
 import * as stream_list from "./stream_list";
 import * as stream_popover from "./stream_popover";
 import * as topic_list from "./topic_list";
@@ -711,84 +710,6 @@ export function initialize() {
 
     // Don't focus links on context menu.
     $("body").on("contextmenu", "a", (e) => e.target.blur());
-
-    {
-        const map = {
-            ".stream-description-editable": {
-                on_start: stream_edit.set_raw_description,
-                on_save: stream_edit.change_stream_description,
-            },
-            ".stream-name-editable": {
-                on_start: null,
-                on_save: stream_edit.change_stream_name,
-            },
-        };
-
-        $(document).on("keydown", ".editable-section", function (e) {
-            e.stopPropagation();
-            // Cancel editing description if Escape key is pressed.
-            if (e.key === "Escape") {
-                $("[data-finish-editing='.stream-description-editable']").hide();
-                $(this).attr("contenteditable", false);
-                $(this).text($(this).attr("data-prev-text"));
-                $("[data-make-editable]").html("");
-            } else if (e.key === "Enter") {
-                $(this).siblings(".checkmark").trigger("click");
-            }
-        });
-
-        $(document).on("drop", ".editable-section", () => false);
-
-        $(document).on("input", ".editable-section", function () {
-            // if there are any child nodes, inclusive of <br> which means you
-            // have lines in your description or title, you're doing something
-            // wrong.
-            for (let x = 0; x < this.childNodes.length; x += 1) {
-                if (this.childNodes[x].nodeType !== 3) {
-                    this.textContent = this.textContent.replace(/\n/, "");
-                    break;
-                }
-            }
-        });
-
-        $("body").on("click", "[data-make-editable]", function () {
-            const selector = $(this).attr("data-make-editable");
-            const edit_area = $(this).parent().find(`${selector}`);
-            $(selector).removeClass("stream-name-edit-box");
-            if (edit_area.attr("contenteditable") === "true") {
-                $(`[data-finish-editing='${CSS.escape(selector)}']`).hide();
-                edit_area.attr("contenteditable", false);
-                edit_area.text(edit_area.attr("data-prev-text"));
-                $(this).html("");
-            } else {
-                $(`[data-finish-editing='${CSS.escape(selector)}']`).show();
-
-                $(selector).addClass("stream-name-edit-box");
-                edit_area
-                    .attr("data-prev-text", edit_area.text().trim())
-                    .attr("contenteditable", true);
-
-                if (map[selector].on_start) {
-                    map[selector].on_start(this, edit_area);
-                }
-
-                ui_util.place_caret_at_end(edit_area[0]);
-
-                $(this).html("&times;");
-            }
-        });
-
-        $("body").on("click", "[data-finish-editing]", function (e) {
-            const selector = $(this).attr("data-finish-editing");
-            $(selector).removeClass("stream-name-edit-box");
-            if (map[selector].on_save) {
-                map[selector].on_save(e);
-                $(this).hide();
-                $(this).parent().find(`${selector}`).attr("contenteditable", false);
-                $(`[data-make-editable='${CSS.escape(selector)}']`).html("");
-            }
-        });
-    }
 
     // HOTSPOTS
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -211,7 +211,6 @@ export function processing_text() {
         $focused_elt.is("input") ||
         $focused_elt.is("select") ||
         $focused_elt.is("textarea") ||
-        $focused_elt.hasClass("editable-section") ||
         $focused_elt.parents(".pill-container").length >= 1 ||
         $focused_elt.attr("id") === "compose-send-button"
     );
@@ -232,10 +231,6 @@ export function process_escape_key(e) {
         // Recent topics uses escape to switch focus from RT search / filters to topics table.
         // If focus is already on the table it returns false.
         return true;
-    }
-
-    if (in_content_editable_widget(e)) {
-        return false;
     }
 
     if (feedback_widget.is_open()) {
@@ -398,11 +393,6 @@ export function process_enter_key(e) {
 
     if (emoji_picker.reactions_popped()) {
         return emoji_picker.navigate("enter", e);
-    }
-
-    if (in_content_editable_widget(e)) {
-        $(e.target).parent().find(".checkmark").trigger("click");
-        return false;
     }
 
     if (handle_popover_events("enter")) {
@@ -628,12 +618,6 @@ export function process_hotkey(e, hotkey) {
 
     if ((event_name === "up_arrow" || event_name === "down_arrow") && overlays.streams_open()) {
         return subs.switch_rows(event_name);
-    }
-
-    if (in_content_editable_widget(e)) {
-        // We handle the Enter key in process_enter_key().
-        // We ignore all other keys.
-        return false;
     }
 
     if (event_name === "up_arrow" && list_util.inside_list(e)) {

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -81,9 +81,9 @@ export function update_regular_sub_settings(sub) {
             $settings.find(".email-address").text(sub.email_address);
             $settings.find(".stream-email-box").show();
         }
-        $settings.find(".regular_subscription_settings").addClass("in");
+        $settings.find(".personal_settings").addClass("in");
     } else {
-        $settings.find(".regular_subscription_settings").removeClass("in");
+        $settings.find(".personal_settings").removeClass("in");
         // Clear email address widget
         $settings.find(".email-address").html("");
     }

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -759,9 +759,7 @@
     }
 }
 
-#subscription_overlay
-    .stream-description
-    .stream-description-editable:empty::after,
+#subscription_overlay .stream-description .sub-stream-description:empty::after,
 .stream-row .sub-info-box .description:empty::after {
     content: attr(data-no-description);
     font-style: italic;
@@ -829,20 +827,16 @@
             font-size: 1.5em;
             font-weight: 600;
             margin-left: -3px;
+            margin-top: -5px;
             white-space: nowrap;
             max-width: 260px;
 
-            .stream-name-editable {
+            .sub-stream-name {
                 display: block;
                 max-width: 20ch;
                 overflow: hidden;
                 text-overflow: ellipsis;
                 float: left;
-            }
-
-            .stream-name-edit-box {
-                text-overflow: clip;
-                border-style: groove;
             }
         }
 
@@ -852,8 +846,9 @@
 
             .subscribe-button,
             #preview-stream-button,
+            #open_stream_info_modal,
             .deactivate {
-                margin-right: 5px;
+                margin-right: 3px;
                 text-decoration: none;
             }
         }
@@ -871,59 +866,25 @@
             display: inline-block;
             vertical-align: top;
             margin-right: 5px;
+            margin-top: -5px;
             font-size: 1.5em;
 
             &.hash::after {
                 top: 1px;
             }
         }
+
+        .stream_change_property_info {
+            vertical-align: top;
+            margin: -5px 0 0 0;
+        }
     }
 
     .stream-description {
         margin-bottom: 5px;
-    }
-
-    .editable-section {
-        position: relative;
-        display: inline;
-        min-width: 10px;
-        max-width: 100%;
-
-        &[contenteditable="true"] {
-            display: inline-block;
-            color: hsl(170, 48%, 54%);
-
-            &:focus {
-                outline: none;
-            }
-        }
-    }
-
-    .editable {
-        position: relative;
-        top: -1px;
-        margin-left: 5px;
-        color: hsl(0, 0%, 67%);
-        cursor: pointer;
-        font-size: 1.4rem;
-        font-weight: 300;
-
-        transition: all 0.3s ease;
-
-        &:empty::before {
-            content: "\f040";
-            font-family: FontAwesome;
-            font-size: 0.8rem;
-            font-weight: normal;
-        }
-
-        &:not(:empty) {
-            position: relative;
-            top: 3px;
-        }
-
-        &:hover {
-            color: hsl(0, 0%, 27%);
+        .no-description {
+            font-style: italic;
+            color: hsl(0, 0%, 67%);
         }
     }
 
@@ -981,11 +942,6 @@
 
     #personal_settings_label_container {
         margin-bottom: 5px;
-    }
-
-    .alert-notification:not(:empty) {
-        vertical-align: unset;
-        margin-top: 10px;
     }
 
     .loading_indicator_text {
@@ -1053,6 +1009,18 @@
                 margin-bottom: 0;
             }
         }
+    }
+}
+#change_stream_info_modal {
+    .modal-header h3 {
+        text-overflow: ellipsis;
+        overflow: hidden;
+    }
+
+    #change_stream_description {
+        width: 80%;
+        max-width: 500px;
+        box-sizing: border-box;
     }
 }
 
@@ -1153,6 +1121,21 @@
         display: block;
         float: unset;
         margin-top: 10px;
+    }
+
+    #subscription_overlay .subscription_settings .stream_change_property_info {
+        /* For small widths where there is not enough space
+        to show alert beside stream name we set its display
+        to block so it is shown in new line. But to avoid
+        it covering whole screen width we set max-width
+        so that it does not losses inline-block appearence. */
+
+        /* TODO: This will probably be not required once
+        we have tabbed navigation as button group width
+        will be smaller. */
+        display: block;
+        max-width: max-content;
+        white-space: nowrap;
     }
 }
 

--- a/static/templates/change_stream_info_modal.hbs
+++ b/static/templates/change_stream_info_modal.hbs
@@ -1,0 +1,34 @@
+<div id="change_stream_info_modal" class="modal modal-bg hide fade new-style" tabindex="-1"
+  role="dialog" aria-labelledby="change_stream_info_label" aria-hidden="true">
+    <div class="modal-header">
+        <button type="button" class="close close-change-stream-info-modal" data-dismiss="modal" aria-label="{{t 'Close' }}">
+            <span aria-hidden="true">&times;</span>
+        </button>
+        <h3 id="change_stream_info_label">
+            {{#tr}}Edit #{stream_name}{{/tr}}
+            <span class="email"></span>
+        </h3>
+    </div>
+    <div class="modal-body">
+        <div class="input-group">
+            <label for="change_stream_name">
+                {{t 'Change stream name' }}
+            </label>
+            <input type="text" id="change_stream_name" value="{{ stream_name }}" />
+        </div>
+        <div class="input-group">
+            <label for="change_stream_description">
+                {{t 'Change stream description' }}
+            </label>
+            <textarea id="change_stream_description" maxlength="1000">{{ stream_description }}</textarea>
+        </div>
+    </div>
+
+    <div class="modal-footer">
+        <button class=" button rounded close-change-stream-info-modal" data-dismiss="modal">{{t "Cancel" }}</button>
+        <button class="button rounded btn-danger save-button" id="save_stream_info"
+          tabindex="-1" data-stream-id="{{stream_id}}">
+            {{t "Save changes"}}
+        </button>
+    </div>
+</div>

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -1,47 +1,47 @@
 <div class="subscription_settings" data-stream-id="{{sub.stream_id}}">
     <div class="inner-box">
 
-        {{#with sub}}
-        <div class="stream-header">
-            {{> subscription_privacy
-              invite_only=invite_only
-              is_web_public=is_web_public }}
-            <div class="stream-name">
-                <span class="sub-stream-name" title="{{name}}">{{name}}</span>
-            </div>
-            <div class="stream_change_property_info alert-notification"></div>
-            <div class="button-group">
-                <button id="open_stream_info_modal" class="button rounded small btn-warning" title="{{t 'Change stream info' }}">
-                    <i class="fa fa-pencil" aria-hidden="true"></i>
-                </button>
-                <div class="sub_unsub_button_wrapper inline-block">
-                    <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}}title="{{t 'Toggle subscription'}} (S)" {{else}}disabled="disabled"{{/if}}>
-                        {{#if subscribed }}{{t "Unsubscribe"}}{{else}}{{t "Subscribe"}}{{/if}}</button>
+        <div class="general_settings">
+            {{#with sub}}
+            <div class="stream-header">
+                {{> subscription_privacy
+                  invite_only=invite_only
+                  is_web_public=is_web_public }}
+                <div class="stream-name">
+                    <span class="sub-stream-name" title="{{name}}">{{name}}</span>
                 </div>
-                <a href="{{preview_url}}" class="button small rounded" id="preview-stream-button" role="button" title="{{t 'View stream'}} (V)" {{#unless should_display_preview_button }}style="display: none"{{/unless}}>
-                    <i class="fa fa-eye"></i>
-                </a>
-                {{#if is_realm_admin}}
-                <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Archive stream for everyone'}}"> <i class="fa fa-archive" aria-hidden="true"></i></button>
-                {{/if}}
+                <div class="stream_change_property_info alert-notification"></div>
+                <div class="button-group">
+                    <button id="open_stream_info_modal" class="button rounded small btn-warning" title="{{t 'Change stream info' }}">
+                        <i class="fa fa-pencil" aria-hidden="true"></i>
+                    </button>
+                    <div class="sub_unsub_button_wrapper inline-block">
+                        <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}}title="{{t 'Toggle subscription'}} (S)" {{else}}disabled="disabled"{{/if}}>
+                            {{#if subscribed }}{{#tr}}Unsubscribe{{/tr}}{{else}}{{#tr}}Subscribe{{/tr}}{{/if}}</button>
+                    </div>
+                    <a href="{{preview_url}}" class="button small rounded" id="preview-stream-button" role="button" title="{{t 'View stream'}} (V)" {{#unless should_display_preview_button }}style="display: none"{{/unless}}><i class="fa fa-eye"></i></a>
+                    {{#if is_realm_admin}}
+                    <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Archive stream for everyone'}}"> <i class="fa fa-archive" aria-hidden="true"></i></button>
+                    {{/if}}
+                </div>
             </div>
-        </div>
-        <div class="stream-description">
-            <span class="sub-stream-description rendered_markdown" data-no-description="{{t 'No description.' }}">
-                {{rendered_markdown rendered_description}}
-            </span>
-        </div>
-        <div class="subscription-type">
-            <div class="subscription-type-text">
-                {{> subscription_type
-                  stream_post_policy_values=../stream_post_policy_values
-                  message_retention_text=../message_retention_text}}
+            <div class="stream-description">
+                <span class="sub-stream-description rendered_markdown" data-no-description="{{t 'No description.' }}">
+                    {{rendered_markdown rendered_description}}
+                </span>
             </div>
-            <a class="change-stream-privacy" {{#unless can_change_stream_permissions}}style="display: none;"{{/unless}}>[{{t "Change" }}]</a>
+            <div class="subscription-type">
+                <div class="subscription-type-text">
+                    {{> subscription_type
+                      stream_post_policy_values=../stream_post_policy_values
+                      message_retention_text=../message_retention_text}}
+                </div>
+                <a class="change-stream-privacy" {{#unless can_change_stream_permissions}}style="display: none;"{{/unless}}>[{{t "Change" }}]</a>
+            </div>
+            {{/with}}
         </div>
-        {{/with}}
 
-        <div class="regular_subscription_settings collapse {{#sub.subscribed}}in{{/sub.subscribed}}">
+        <div class="personal_settings collapse {{#sub.subscribed}}in{{/sub.subscribed}}">
             <div id="personal_settings_label_container">
                 <label class="sub_settings_title inline-block">
                     {{t "Personal settings" }}
@@ -72,19 +72,22 @@
                 </ul>
             </div>
         </div>
-        <div class="stream-email-box" {{#unless sub.email_address}}style="display: none;"{{/unless}}>
-            <label class="sub_settings_title">
-                {{t "Email address" }}
-                {{> help_link_widget link="/help/message-a-stream-by-email" }}
-            </label>
-            <div class="stream-email">
-                <span class="email-address">{{sub.email_address}}</span>
+
+        <div class="subscriber_settings">
+            <div class="stream-email-box" {{#unless sub.email_address}}style="display: none;"{{/unless}}>
+                <label class="sub_settings_title">
+                    {{t "Email address" }}
+                    {{> help_link_widget link="/help/message-a-stream-by-email" }}
+                </label>
+                <div class="stream-email">
+                    <span class="email-address">{{sub.email_address}}</span>
+                </div>
             </div>
+            {{#with sub}}
+            <div class="subscription-members-setting">
+                {{> subscription_members}}
+            </div>
+            {{/with}}
         </div>
-        {{#with sub}}
-        <div class="subscription-members-setting">
-            {{> subscription_members}}
-        </div>
-        {{/with}}
     </div>
 </div>

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -1,6 +1,5 @@
 <div class="subscription_settings" data-stream-id="{{sub.stream_id}}">
     <div class="inner-box">
-        <div class="alert stream_change_property_info"></div>
 
         {{#with sub}}
         <div class="stream-header">
@@ -8,13 +7,13 @@
               invite_only=invite_only
               is_web_public=is_web_public }}
             <div class="stream-name">
-                <span title="{{name}}" class="stream-name-editable editable-section" >{{name}}</span>
-                {{#if can_change_name_description}}
-                <span class="editable" data-make-editable=".stream-name-editable"></span>
-                <span class="checkmark" data-finish-editing=".stream-name-editable">✓</span>
-                {{/if}}
+                <span class="sub-stream-name" title="{{name}}">{{name}}</span>
             </div>
+            <div class="stream_change_property_info alert-notification"></div>
             <div class="button-group">
+                <button id="open_stream_info_modal" class="button rounded small btn-warning" title="{{t 'Change stream info' }}">
+                    <i class="fa fa-pencil" aria-hidden="true"></i>
+                </button>
                 <div class="sub_unsub_button_wrapper inline-block">
                     <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}}title="{{t 'Toggle subscription'}} (S)" {{else}}disabled="disabled"{{/if}}>
                         {{#if subscribed }}{{t "Unsubscribe"}}{{else}}{{t "Subscribe"}}{{/if}}</button>
@@ -28,11 +27,9 @@
             </div>
         </div>
         <div class="stream-description">
-            <span class="stream-description-editable editable-section description rendered_markdown" data-no-description="{{t 'No description.' }}">{{rendered_markdown rendered_description}}</span>
-            {{#if can_change_name_description}}
-            <span class="editable" data-make-editable=".stream-description-editable"></span>
-            <span class="checkmark" data-finish-editing=".stream-description-editable">✓</span>
-            {{/if}}
+            <span class="sub-stream-description rendered_markdown" data-no-description="{{t 'No description.' }}">
+                {{rendered_markdown rendered_description}}
+            </span>
         </div>
         <div class="subscription-type">
             <div class="subscription-type-text">


### PR DESCRIPTION
This PR does following refactors as  preparatory works for having tabbed design stream edit page. It contains commits from @pragatiagrawal31's #15445 . We do following changes commit-wise:

* Use consistent structure using divs instead of `li`s and `ul` for organizing content in stream edit page.
* Showing stream deactivation button at the end.
* Cleanup subscription.css to remove dead CSS rules from it.
* Extract modal related css rules to a separate modal.css files.
**Commits left for merging:**
* Remove content-editable widget for updating stream name and description and add a modal for handling these updates.
* Wrap contents into different settings group (General | Personal | Subscribers).
* Add tabbed widget for navigation between different settings in stream settings page.

**Testing plan:** Mostly manually, and node tests.

**GIFs or screenshots:** 
![tabbed_design](https://user-images.githubusercontent.com/63504956/123514840-7deae180-d6b2-11eb-8045-69c21dc64869.gif)


