### PR TITLE
minor: Remove irrelevant comments in stream_edit.js.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -655,7 +655,6 @@ export function change_stream_name(e) {
     }
 
     channel.patch({
-        // Stream names might contain unsafe characters so we must encode it first.
         url: "/json/streams/" + stream_id,
         data: {new_name},
         success() {
@@ -707,7 +706,6 @@ export function change_stream_description(e) {
     }
 
     channel.patch({
-        // Description might contain unsafe characters so we must encode it first.
         url: "/json/streams/" + stream_id,
         data: {
             description,


### PR DESCRIPTION
Remove comments in the module stream_edit.js that became
irrelevant after changes in commit 96e035a.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
