### PR TITLE
documentation: Open external links in new tab

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -22,5 +22,15 @@
         See <a class="reference external" href="https://zulip.readthedocs.io/en/stable/{{ pagename }}.html">documentation for the latest stable release</a>.</p>
     </div>
     {% endif %}
+
+    <script type="text/javascript">
+      // <!-- Adds target=_blank to external links -->
+      $(document).ready(function () {
+        $('a[href^="http://"], a[href^="https://"]')
+        .not('a[class*=internal]')
+        .attr({ 'target': '_blank', 'rel': "noopener noreferrer" });
+      });
+    </script>
+
     {{ super() }}
 {% endblock %}


### PR DESCRIPTION
This should make it easier for people to browse the documentation.

Fixes #18286

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Generate the docs locally by using make html and then running a local webserver to verify that external links open in a new tab.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
A newer pull request of [18814](https://github.com/zulip/zulip/pull/18814)