### PR TITLE
user_sidebar: Set personal presence dot based on the user's settings.

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -145,6 +145,12 @@ test("get_status", () => {
     assert.equal(presence.get_status(mark.user_id), "idle");
     assert.equal(presence.get_status(fred.user_id), "active");
 
+    page_params.presence_enabled = false;
+    assert.equal(presence.get_status(page_params.user_id), "offline");
+    page_params.presence_enabled = true;
+    assert.equal(presence.get_status(page_params.user_id), "active");
+    delete page_params.presence_enabled;
+
     presence_info.delete(zoe.user_id);
     assert.equal(presence.get_status(zoe.user_id), "offline");
 

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -3,6 +3,7 @@ import _ from "lodash";
 
 import render_compose_notification from "../templates/compose_notification.hbs";
 
+import {redraw_user} from "./activity";
 import * as alert_words from "./alert_words";
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
@@ -687,6 +688,9 @@ export function handle_global_notification_updates(notification_name, setting) {
     // particular stream should receive notifications.
     if (settings_config.all_notification_settings.includes(notification_name)) {
         page_params[notification_name] = setting;
+        if (notification_name === "presence_enabled") {
+            redraw_user(page_params.user_id);
+        }
     }
 
     if (settings_config.stream_notification_settings.includes(notification_name)) {

--- a/static/js/presence.js
+++ b/static/js/presence.js
@@ -1,4 +1,5 @@
 import * as blueslip from "./blueslip";
+import {page_params} from "./page_params";
 import * as people from "./people";
 import * as reload_state from "./reload_state";
 import * as watchdog from "./watchdog";
@@ -40,7 +41,10 @@ export function is_active(user_id) {
 
 export function get_status(user_id) {
     if (people.is_my_user_id(user_id)) {
-        return "active";
+        if (!("presence_enabled" in page_params) || page_params.presence_enabled === true) {
+            return "active";
+        }
+        return "offline";
     }
     if (presence_info.has(user_id)) {
         return presence_info.get(user_id).status;


### PR DESCRIPTION
If a user chooses to not broadcast their presence status to others, we
still show the user as available in their own user sidebar. Instead, one's
own availability should appear the same as it does for other users.

Fixes #18846

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Manually tested. Recorded a gif to show the changes. 

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![personal_presence](https://user-images.githubusercontent.com/19680585/122265950-e38edf00-cef6-11eb-968c-2dfadb679e67.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
