### PR TITLE
Improve error handling for uploading custom emojis and other minor modifications.

### DIFF
--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -79,6 +79,28 @@ class RealmEmojiTest(ZulipTestCase):
         author = UserProfile.objects.get(id=test_emoji["author_id"])
         self.assertEqual(author.email, email)
 
+    def test_override_built_in_emoji_by_admin(self) -> None:
+        # Test that only administrators can override built-in emoji.
+        self.login("othello")
+        with get_test_image_file("img.png") as fp1:
+            emoji_data = {"f1": fp1}
+            result = self.client_post("/json/realm/emoji/laughing", info=emoji_data)
+        self.assert_json_error(
+            result,
+            "Only administrators can override built-in emoji.",
+        )
+
+        user = self.example_user("iago")
+        email = user.email
+        self.login_user(user)
+        with get_test_image_file("img.png") as fp1:
+            emoji_data = {"f1": fp1}
+            result = self.client_post("/json/realm/emoji/smile", info=emoji_data)
+        self.assert_json_success(result)
+        self.assertEqual(200, result.status_code)
+        realm_emoji = RealmEmoji.objects.get(name="smile")
+        self.assertEqual(realm_emoji.author.email, email)
+
     def test_realm_emoji_repr(self) -> None:
         realm_emoji = RealmEmoji.objects.get(name="green_tick")
         file_name = str(realm_emoji.id) + ".png"


### PR DESCRIPTION
Improved error handling and modified the `emoji_settings_warning_modal` text for a clearer understanding. 
@alya FYI. 

<strong>Screenshots:</strong>

Commit 9229de0 and 9d91121: 
![3](https://user-images.githubusercontent.com/53977614/122279180-65860480-cf05-11eb-89bd-c60b4e2709ad.png)

Commit aa01c62: 

![1](https://user-images.githubusercontent.com/53977614/122279252-7767a780-cf05-11eb-9cd0-896c3588fda5.png)

Commit 5e9c99d:

![2](https://user-images.githubusercontent.com/53977614/122279283-7fbfe280-cf05-11eb-971a-00a99f1d3292.png)
 

Fixes #18860 and #18269. 