### PR TITLE
Fix stream list bug in user info modal

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -433,7 +433,7 @@ export function show_user_profile(user) {
     const profile_data = page_params.custom_profile_fields
         .map((f) => get_custom_profile_field_data(user, f, field_types, dateFormat))
         .filter((f) => f.name !== undefined);
-    const user_streams = stream_data.subscribed_subs();
+    const user_streams = stream_data.get_subscribed_streams_for_user(user.user_id);
     const groups_of_user = user_groups.get_user_groups_of_user(user.user_id);
     const args = {
         full_name: user.full_name,

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -379,6 +379,26 @@ export function subscribed_stream_ids() {
     return subscribed_subs().map((sub) => sub.stream_id);
 }
 
+export function get_subscribed_streams_for_user(user_id) {
+    // Note that we only have access to subscribers of some streams
+    // depending on our role.
+    const all_subs = get_unsorted_subs();
+    const subscribed_subs = [];
+    for (const sub of all_subs) {
+        if (!can_view_subscribers(sub)) {
+            // Private streams that we have been removed from appear
+            // in get_unsorted_subs; we don't attempt to check their
+            // subscribers (which would trigger a warning).
+            continue;
+        }
+        if (is_user_subscribed(sub.stream_id, user_id)) {
+            subscribed_subs.push(sub);
+        }
+    }
+
+    return subscribed_subs;
+}
+
 export function get_invite_stream_data() {
     function get_data(sub) {
         return {


### PR DESCRIPTION
Reference: [https://github.com/zulip/zulip/pull/18671/commits/b080417960497324cea7fe2b69db56373f98f9bc#r651027799](https://github.com/zulip/zulip/pull/18671/commits/b080417960497324cea7fe2b69db56373f98f9bc#r651027799)
We need this to correctly show only allowed streams in user info
popover. 


**Testing plan:** `node tests` and added new test for this.
