### PR TITLE
models: Update `group_match_regex` to correctly detect parameters in `url_format_string`.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -973,7 +973,7 @@ class RealmFilter(models.Model):
         # this regex will incorrectly reject patterns that attempt to
         # escape % using %%.
         found_group_set: Set[str] = set()
-        group_match_regex = r"%\((?P<group_name>[^()]+)\)s"
+        group_match_regex = r"(?<!%)%\((?P<group_name>[^()]+)\)s"
         for m in re.finditer(group_match_regex, self.url_format_string):
             group_name = m.group("group_name")
             found_group_set.add(group_name)


### PR DESCRIPTION
This is a follow-up for 98f8d94b25296f854b478975ebf657b4446ed94d.
For cases when `url_format_string` is like `https://example.com/%%(foo)s/%(bar)s`, `group_match_regex` should only detect `bar` as the intended parameter and not `foo`.

I've not added any new test for this. But this will clear the error in [this test](https://github.com/zulip/zulip/blob/8ce1fd1c50194cb7ef256480ca0e76afcd1e95af/zerver/tests/test_realm_linkifiers.py#L124-L130) when issue: #12323 will be resolved.

@andersk I hope this resolves the concern you raised in https://github.com/zulip/zulip/pull/16860#discussion_r539112625?
