### PR TITLE
@usergroup syntax for bulk adding user groups to streams.

### DIFF
--- a/frontend_tests/node_tests/pill_typeahead.js
+++ b/frontend_tests/node_tests/pill_typeahead.js
@@ -140,6 +140,9 @@ run_test("set_up", () => {
             query: "me",
         };
         const fake_group_this = {
+            query: "@test",
+        };
+        const wrong_group_query = {
             query: "test",
         };
 
@@ -187,8 +190,14 @@ run_test("set_up", () => {
                 // group query, with correct item.
                 result = config.matcher.call(fake_group_this, testers);
                 assert.ok(result);
+                // group query, with correct item but incorrect syntax.
+                result = config.matcher.call(wrong_group_query, testers);
+                assert.ok(!result);
                 // group query, with wrong item.
                 result = config.matcher.call(fake_group_this, admins);
+                assert.ok(!result);
+                // group query, with person as item.
+                result = config.matcher.call(fake_group_this, me);
                 assert.ok(!result);
                 // person query with correct item.
                 result = config.matcher.call(fake_person_this, me);
@@ -200,6 +209,8 @@ run_test("set_up", () => {
             if (opts.user_group && !opts.user) {
                 result = config.matcher.call(fake_group_this, testers);
                 assert.ok(result);
+                result = config.matcher.call(wrong_group_query, testers);
+                assert.ok(!result);
                 result = config.matcher.call(fake_group_this, admins);
                 assert.ok(!result);
             }
@@ -238,39 +249,40 @@ run_test("set_up", () => {
                 assert.deepEqual(stream_ids, expected_stream_ids);
             }
 
-            let expected_result = [];
-            let actual_result = [];
-            function is_group(item) {
-                return item.members;
-            }
-            result = config.source.call(fake_person_this);
-            actual_result = result
-                .map((item) => {
-                    if (is_group(item)) {
-                        return item.id;
+            function user_source_test(query) {
+                let expected_result = [];
+                let actual_result = [];
+                result = config.source.call(query);
+                actual_result = result.map((item) => item.user_id).filter(Boolean);
+
+                if (opts.user) {
+                    if (opts.user_source) {
+                        expected_result = opts.user_source();
+                    } else {
+                        expected_result = persons;
                     }
-                    return item.user_id;
-                })
-                .filter(Boolean);
-            if (opts.user_group) {
-                expected_result = expected_result.concat(groups);
+                }
+                expected_result = expected_result.map((item) => item.user_id).filter(Boolean);
+                assert.deepEqual(actual_result, expected_result);
             }
-            if (opts.user) {
-                if (opts.user_source) {
-                    expected_result = expected_result.concat(opts.user_source());
-                } else {
-                    expected_result = expected_result.concat(persons);
+
+            if (opts.user_group) {
+                // check we give only user groups for correct user group query.
+                result = config.source.call(fake_group_this);
+                const group_ids = result.map((group) => group.id);
+                const expected_group_ids = [admins.id, testers.id];
+                assert.deepEqual(group_ids, expected_group_ids);
+
+                if (opts.user) {
+                    // for incorrect syntax, we give only user source
+                    // as inclusion of user groups depends on both
+                    // query and opts.
+                    user_source_test(wrong_group_query);
                 }
             }
-            expected_result = expected_result
-                .map((item) => {
-                    if (is_group(item)) {
-                        return item.id;
-                    }
-                    return item.user_id;
-                })
-                .filter(Boolean);
-            assert.deepEqual(actual_result, expected_result);
+            if (opts.user) {
+                user_source_test(fake_person_this);
+            }
         })();
 
         (function test_updater() {

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -172,7 +172,7 @@ test_ui("subscriber_pills", ({override}) => {
             query: "me",
         };
         const fake_group_this = {
-            query: "test",
+            query: "@test",
         };
 
         (function test_highlighter() {

--- a/static/js/pill_typeahead.js
+++ b/static/js/pill_typeahead.js
@@ -52,9 +52,9 @@ export function set_up(input, pills, opts) {
                     // If user_source is specified in opts, it
                     // is given priority. Otherwise we use
                     // default user_pill.typeahead_source.
-                    source = source.concat(opts.user_source());
+                    source = opts.user_source();
                 } else {
-                    source = source.concat(user_pill.typeahead_source(pills));
+                    source = user_pill.typeahead_source(pills);
                 }
             }
             return source;
@@ -83,16 +83,12 @@ export function set_up(input, pills, opts) {
                 return item.name.toLowerCase().includes(query);
             }
 
-            let matches = false;
             if (include_user_groups(this.query)) {
                 query = query.trim().slice(1);
                 return group_matcher(query, item);
             }
 
-            if (include_users) {
-                matches = matches || person_matcher(query, item);
-            }
-            return matches;
+            return person_matcher(query, item);
         },
         sorter(matches) {
             const query = this.query;

--- a/static/js/pill_typeahead.js
+++ b/static/js/pill_typeahead.js
@@ -27,7 +27,7 @@ export function set_up(input, pills, opts) {
         return;
     }
     const include_streams = (query) => opts.stream && query.trim().startsWith("#");
-    const include_user_groups = opts.user_group;
+    const include_user_groups = (query) => opts.user_group && query.trim().startsWith("@");
     const include_users = opts.user;
 
     input.typeahead({
@@ -43,8 +43,8 @@ export function set_up(input, pills, opts) {
                 return stream_pill.typeahead_source(pills);
             }
 
-            if (include_user_groups) {
-                source = source.concat(user_group_pill.typeahead_source(pills));
+            if (include_user_groups(this.query)) {
+                return user_group_pill.typeahead_source(pills);
             }
 
             if (include_users) {
@@ -64,7 +64,7 @@ export function set_up(input, pills, opts) {
                 return typeahead_helper.render_stream(item);
             }
 
-            if (include_user_groups && user_groups.is_user_group(item)) {
+            if (include_user_groups(this.query) && user_groups.is_user_group(item)) {
                 return typeahead_helper.render_user_group(item);
             }
 
@@ -84,8 +84,9 @@ export function set_up(input, pills, opts) {
             }
 
             let matches = false;
-            if (include_user_groups) {
-                matches = matches || group_matcher(query, item);
+            if (include_user_groups(this.query)) {
+                query = query.trim().slice(1);
+                return group_matcher(query, item);
             }
 
             if (include_users) {
@@ -104,8 +105,8 @@ export function set_up(input, pills, opts) {
                 users = matches.filter((ele) => people.is_known_user(ele));
             }
 
-            let groups;
-            if (include_user_groups) {
+            let groups = [];
+            if (include_user_groups(query)) {
                 groups = matches.filter((ele) => user_groups.is_user_group(ele));
             }
             return typeahead_helper.sort_recipients({
@@ -120,7 +121,7 @@ export function set_up(input, pills, opts) {
         updater(item) {
             if (include_streams(this.query)) {
                 stream_pill.append_stream(item, pills);
-            } else if (include_user_groups && user_groups.is_user_group(item)) {
+            } else if (include_user_groups(this.query) && user_groups.is_user_group(item)) {
                 user_group_pill.append_user_group(item, pills);
             } else if (include_users && people.is_known_user(item)) {
                 user_pill.append_user(item, pills);


### PR DESCRIPTION
Require `@usergroup` syntax for bulk adding user group members to streams.
Fixes: #18888.

**Testing plan:** manually and updating node tests.


**GIFs or screenshots:** 
![@group](https://user-images.githubusercontent.com/63504956/122364219-33ad8600-cf77-11eb-9032-7df0e4c9f0d5.gif)

