### PR TITLE
timerender: Render past time till 24 hours before showing yesterday.

### DIFF
--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -257,13 +257,15 @@ run_test("last_seen_status_from_date", () => {
 
     assert_same({minutes: -30}, $t({defaultMessage: "30 minutes ago"}));
 
-    assert_same({hours: -1}, $t({defaultMessage: "Yesterday"}));
+    assert_same({hours: -1}, $t({defaultMessage: "An hour ago"}));
 
-    assert_same({hours: -2}, $t({defaultMessage: "Yesterday"}));
+    assert_same({hours: -2}, $t({defaultMessage: "2 hours ago"}));
 
-    assert_same({hours: -20}, $t({defaultMessage: "Yesterday"}));
+    assert_same({hours: -20}, $t({defaultMessage: "20 hours ago"}));
 
-    assert_same({days: -1}, $t({defaultMessage: "Yesterday"}));
+    assert_same({hours: -24}, $t({defaultMessage: "Yesterday"}));
+
+    assert_same({hours: -48}, $t({defaultMessage: "2 days ago"}));
 
     assert_same({days: -2}, $t({defaultMessage: "2 days ago"}));
 

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -81,7 +81,7 @@ export function last_seen_status_from_date(last_active_date, current_date = new 
     const days_old = differenceInCalendarDays(current_date, last_active_date);
     const hours = Math.floor(minutes / 60);
 
-    if (days_old === 0) {
+    if (hours < 24) {
         if (hours === 1) {
             return $t({defaultMessage: "An hour ago"});
         }


### PR DESCRIPTION
This avoids the issue of all the topics in recent topics marked
as yesterday after mid-night.

This change also affects other pieces of UI using this function
like buddy list in a similar way.

discussion: https://chat.zulip.org/#narrow/stream/137-feedback/topic/recent.20topics.20timestamps