### PR TITLE
timerender: Use 12 hours to switch to display yesterday.

### DIFF
--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -261,7 +261,9 @@ run_test("last_seen_status_from_date", () => {
 
     assert_same({hours: -2}, $t({defaultMessage: "2 hours ago"}));
 
-    assert_same({hours: -20}, $t({defaultMessage: "20 hours ago"}));
+    assert_same({hours: -12}, $t({defaultMessage: "12 hours ago"}));
+
+    assert_same({hours: -20}, $t({defaultMessage: "Yesterday"}));
 
     assert_same({hours: -24}, $t({defaultMessage: "Yesterday"}));
 

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -81,7 +81,7 @@ export function last_seen_status_from_date(last_active_date, current_date = new 
     const days_old = differenceInCalendarDays(current_date, last_active_date);
     const hours = Math.floor(minutes / 60);
 
-    if (hours < 24) {
+    if (hours <= 12) {
         if (hours === 1) {
             return $t({defaultMessage: "An hour ago"});
         }


### PR DESCRIPTION
This allows us to not directly jump to showing 2days ago from showing
timestamps in hours when now is around midnight.