### PR TITLE
popovers: Close user popover when clicked on stream name.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1132,7 +1132,14 @@ export function register_click_handlers() {
         e.preventDefault();
     });
 
+    /* These click handlers are implemented as just deep links to the
+     * relevant part of the Zulip UI, so we don't want preventDefault,
+     * but we do want to close the modal when you click them. */
     $("body").on("click", "#user-profile-modal #name #edit-button", () => {
+        hide_user_profile();
+    });
+
+    $("body").on("click", "#user-profile-modal .stream_list_item", () => {
         hide_user_profile();
     });
 

--- a/static/templates/user_stream_list_item.hbs
+++ b/static/templates/user_stream_list_item.hbs
@@ -3,6 +3,6 @@
         <span id="stream_sidebar_privacy_swatch_{{stream_id}}" class="stream-privacy filter-icon" style="color: {{stream_color}}">
             {{> stream_privacy }}
         </span>
-        <a href="{{stream_edit_url}}">{{name}}</a>
+        <a class = "stream_list_item" href="{{stream_edit_url}}">{{name}}</a>
     </td>
 </tr>


### PR DESCRIPTION
<a href = 'https://chat.zulip.org/#narrow/stream/101-design/topic/User.20Profile.20modal'>Link to CZO conversation</a>.

Added a minor commit to close the `user_popover` overlay if a user clicks on any stream name.

<strong>Earlier</strong>:

![issue](https://user-images.githubusercontent.com/53977614/122555847-709d7980-d058-11eb-96ac-381d7a4e263f.gif)

<strong>Now</strong>:


![fix](https://user-images.githubusercontent.com/53977614/122555136-86f70580-d057-11eb-81b8-936b7a9780fe.gif)