### PR TITLE
manage: Restore `changepassword` back to documented_commands.

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -53,6 +53,7 @@ def get_filtered_commands() -> Dict[str, str]:
     ]
     documented_command_subsets = {
         "django.core": {
+            "changepassword",
             "dbshell",
             "makemigrations",
             "migrate",


### PR DESCRIPTION
The current help text in manage.py does not displays `changepassword`
command under the set of django commands subset. Hence, add back
`changepassword` to the help text.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
