### PR TITLE
templates: Remove form-inline class from stream setting forms.

### DIFF
--- a/static/templates/stream_creation_form.hbs
+++ b/static/templates/stream_creation_form.hbs
@@ -1,6 +1,6 @@
 <div class="hide" id="stream-creation" tabindex="-1" role="dialog"
   aria-label="{{t 'Stream creation' }}">
-    <form id="stream_creation_form" class="form-inline">
+    <form id="stream_creation_form">
         <div class="alert stream_create_info"></div>
         <div id="stream_creating_indicator"></div>
         <div class="stream-creation-body">

--- a/static/templates/stream_member_list_entry.hbs
+++ b/static/templates/stream_member_list_entry.hbs
@@ -6,7 +6,7 @@
     {{#if displaying_for_admin}}
     <td class="unsubscribe">
         <div class="subscriber_list_remove">
-            <form class="form-inline remove-subscriber-form">
+            <form class="remove-subscriber-form">
                 <button type="submit" name="unsubscribe" class="remove-subscriber-button button small rounded btn-danger">
                     {{t 'Unsubscribe' }}
                 </button>

--- a/static/templates/subscription_members.hbs
+++ b/static/templates/subscription_members.hbs
@@ -8,7 +8,7 @@
             <input type="text" class="search" placeholder="{{t 'Search subscribers' }}" />
         </div>
         <div class="subscriber_list_add float-left">
-            <form class="form-inline">
+            <form>
                 <div class="add_subscribers_container">
                     <div class="pill-container person_picker">
                         <div class="input" contenteditable="true"


### PR DESCRIPTION
`.form-inline` is a class provided by bootstrap and one of its most
important job is to set the display of inputs and labels in
the form in such a way that if there is sufficient
horizontal space then they are shown side by side.

As we override most of the bootstrap classes to organize
content, CSS rules set by it were not applied. So we remove
these safely without having any visual changes.

**Also, we had only three instances of this class in the complete
template directory.**

It is another pr in series of refactors being done to stream setting pages.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** Browser dev-tools to confirm none of rules set by `form-inline` were applied and then manually checking that design is not affected after removing.


**GIFs or screenshots:** No visual changes.
