### PR TITLE
hashchange: Show default view when the hash is unknown.

### DIFF
--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -179,6 +179,8 @@ function do_hashchange_normal(from_reload) {
         case "#about-zulip":
             blueslip.error("overlay logic skipped for: " + hash);
             break;
+        default:
+            show_default_view();
     }
     return false;
 }


### PR DESCRIPTION
Fixes #18870.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested locally.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
