### PR TITLE
lightbox_overlay: Fix `&` not being rendered as desired.

### DIFF
--- a/static/templates/lightbox_overlay.hbs
+++ b/static/templates/lightbox_overlay.hbs
@@ -7,7 +7,7 @@
         <div class="exit" aria-label="{{t 'Close' }}"><span aria-hidden="true">x</span></div>
         <div class="image-actions">
             <div class="lightbox-canvas-trigger">
-                <div class="title">{{t "Pan &amp; Zoom" }}</div>
+                <div class="title">{{t "Pan and Zoom" }}</div>
                 <div class="status" data-disabled="{{t 'Disabled' }}" data-enabled="{{t 'Enabled' }}"></div>
             </div>
             <a class="button small open" rel="noopener noreferrer" target="_blank">{{t "Open" }}</a>


### PR DESCRIPTION
The attempt to render `&` doesn't work. So, just replacing it
with `and` to make it always work.

before:
![image](https://user-images.githubusercontent.com/25124304/122680103-535cdc80-d20b-11eb-870f-34f5d41199b3.png)


after:
![image](https://user-images.githubusercontent.com/25124304/122680098-4e982880-d20b-11eb-94ba-6e60200259c2.png)


discussion:https://chat.zulip.org/#narrow/stream/6-frontend/topic/UI.20issues.20on.20MacOS.20desktop.20app