### PR TITLE
github-actions: Ensure cancel previous run job never fails.

### DIFF
--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -36,7 +36,7 @@ jobs:
           ids=$(node -e "$script")
           echo "::set-output name=ids::$ids"
 
-      - uses: styfle/cancel-workflow-action@0.4.1
+      - uses: styfle/cancel-workflow-action@0.9.0
         continue-on-error: true # Don't fail this job on failure
         with:
           workflow_id: ${{ steps.workflow_ids.outputs.ids }}

--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -22,6 +22,7 @@ jobs:
       # so this is required.
       - name: Get workflow IDs.
         id: workflow_ids
+        continue-on-error: true # Don't fail this job on failure
         env:
           # This is in <owner>/<repo> format e.g. zulip/zulip
           REPOSITORY: ${{ github.repository }}
@@ -36,6 +37,7 @@ jobs:
           echo "::set-output name=ids::$ids"
 
       - uses: styfle/cancel-workflow-action@0.4.1
+        continue-on-error: true # Don't fail this job on failure
         with:
           workflow_id: ${{ steps.workflow_ids.outputs.ids }}
           access_token: ${{ github.token }}


### PR DESCRIPTION
**Testing plan:** 
- Updated the workflow API url to be incorrect and made sure this job didn't fail.
- Tested by force-pushing and making sure that the previous runs cancel successfully.
