### PR TITLE
user_deactivation: Move modal_parent one level up in confirm_dialog.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -490,7 +490,7 @@ function open_bot_form(person) {
 
 function confirm_deactivation(row, user_id, status_field) {
     const user = people.get_by_user_id(user_id);
-    const modal_parent = $("#admin-user-list");
+    const modal_parent = $("#settings_content .organization-box");
     const opts = {
         username: user.full_name,
         email: user.email,


### PR DESCRIPTION
The user deactivate button is also present in the "Deactivated users"
tab, a sibling element of the current modal_parent, #admin-user-list.
Adding the confirm_dialog modal to #admin-user-list won't have any
effect in the "Deactivated users" tab.
Move it one level up, i.e. to the parent element of #admin-user-list
and #admin-deactivated-users-list.

Fixes #18928

<!-- What's this PR for?  (Just a link to an issue is fine.) -->



**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Reactivate_Deactivate](https://user-images.githubusercontent.com/58626718/122765838-86ac7380-d2be-11eb-90a2-6a2cc79deffc.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
