### PR TITLE
lightbox_overlay: “Pan and Zoom” → “Pan & zoom”

### DIFF
--- a/static/templates/lightbox_overlay.hbs
+++ b/static/templates/lightbox_overlay.hbs
@@ -7,7 +7,7 @@
         <div class="exit" aria-label="{{t 'Close' }}"><span aria-hidden="true">x</span></div>
         <div class="image-actions">
             <div class="lightbox-canvas-trigger">
-                <div class="title">{{t "Pan and Zoom" }}</div>
+                <div class="title">{{t "Pan & zoom" }}</div>
                 <div class="status" data-disabled="{{t 'Disabled' }}" data-enabled="{{t 'Enabled' }}"></div>
             </div>
             <a class="button small open" rel="noopener noreferrer" target="_blank">{{t "Open" }}</a>


### PR DESCRIPTION
The `t` helper operates on text strings, not HTML. The `&` works fine, and is correctly escaped for output by Handlebars, like any text string interpolated with ‘{{}}’.

(Followup to #18923.)