### PR TITLE
hotkey: Preview shortcut

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -99,6 +99,20 @@ export function clear_private_stream_alert() {
     $("#compose_private_stream_alert").empty();
 }
 
+export function show_preview_area() {
+    const content = $("#compose-textarea").val();
+    $("#compose-textarea").hide();
+    $("#compose .markdown_preview").hide();
+    $("#compose .undo_markdown_preview").show();
+    $("#compose .preview_message_area").show();
+
+    render_and_show_preview(
+        $("#compose .markdown_preview_spinner"),
+        $("#compose .preview_content"),
+        content,
+    );
+}
+
 export function clear_preview_area() {
     $("#compose-textarea").show();
     $("#compose .undo_markdown_preview").hide();
@@ -820,17 +834,7 @@ export function initialize() {
 
     $("#compose").on("click", ".markdown_preview", (e) => {
         e.preventDefault();
-        const content = $("#compose-textarea").val();
-        $("#compose-textarea").hide();
-        $("#compose .markdown_preview").hide();
-        $("#compose .undo_markdown_preview").show();
-        $("#compose .preview_message_area").show();
-
-        render_and_show_preview(
-            $("#compose .markdown_preview_spinner"),
-            $("#compose .preview_content"),
-            content,
-        );
+        show_preview_area();
     });
 
     $("#compose").on("click", ".undo_markdown_preview", (e) => {

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -96,6 +96,10 @@ const keydown_cmd_or_ctrl_mappings = {
     190: {name: "narrow_to_compose_target", message_view_only: true}, // '.'
 };
 
+const keydown_cmd_or_ctrl_with_shift_mappings = {
+    80: {name: "toggle_edit_preview", message_view_only: true}, // 'P'
+};
+
 const keydown_either_mappings = {
     // these can be triggered by key or Shift + key
     // Note that codes for letters are still case sensitive!
@@ -177,6 +181,10 @@ export function get_keydown_hotkey(e) {
         }
         return undefined;
     } else if (e.metaKey || e.ctrlKey) {
+        hotkey = keydown_cmd_or_ctrl_with_shift_mappings[e.which];
+        if (hotkey) {
+            return hotkey;
+        }
         return undefined;
     }
 
@@ -645,6 +653,16 @@ export function process_hotkey(e, hotkey) {
     if (event_name === "narrow_to_compose_target") {
         narrow.to_compose_target();
         return true;
+    }
+
+    if (event_name === "toggle_edit_preview" && compose_state.composing()) {
+        e.preventDefault();
+
+        if ($("#compose .markdown_preview").css("display") !== "none") {
+            compose.show_preview_area();
+        } else {
+            compose.clear_preview_area();
+        }
     }
 
     // Process hotkeys specially when in an input, select, textarea, or send button

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -115,6 +115,9 @@ below, and add more to your repertoire as needed.
 * **Cancel compose**: `Esc` or `Ctrl + [` — Close the compose box and save
   the unsent message as a draft.
 
+* **Toggle Preview**: `Ctrl + Shift + P` — Show preview of the message when
+  composebox is open.
+
 ## Message actions
 
 * **Edit last message**: `←` — Open the last editable message in the current


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #18471

When composing a message if someone uses ctrl + shift + P, it checks the preview or edit and calls the desired function.

**Testing plan:** <!-- How have you tested? -->
Tested manually right now, will adds tests soon.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
