### PR TITLE
queue_processor: Add langauge to the events added to invites queue.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -6957,7 +6957,6 @@ def do_resend_user_invite_email(prereg_user: PreregistrationUser) -> int:
     event = {
         "prereg_id": prereg_user.id,
         "referrer_id": prereg_user.referred_by.id,
-        "email_body": None,
     }
     queue_json_publish("invites", event)
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -6658,7 +6658,9 @@ def filter_presence_idle_user_ids(user_ids: Set[int]) -> List[int]:
     return sorted(idle_user_ids)
 
 
-def do_send_confirmation_email(invitee: PreregistrationUser, referrer: UserProfile) -> str:
+def do_send_confirmation_email(
+    invitee: PreregistrationUser, referrer: UserProfile, email_language: str
+) -> str:
     """
     Send the confirmation/welcome e-mail to an invited user.
     """
@@ -6673,7 +6675,7 @@ def do_send_confirmation_email(invitee: PreregistrationUser, referrer: UserProfi
         "zerver/emails/invitation",
         to_emails=[invitee.email],
         from_address=FromAddress.tokenized_no_reply_address(),
-        language=referrer.realm.default_language,
+        language=email_language,
         context=context,
         realm=referrer.realm,
     )
@@ -6835,7 +6837,11 @@ def do_invite_users(
         stream_ids = [stream.id for stream in streams]
         prereg_user.streams.set(stream_ids)
 
-        event = {"prereg_id": prereg_user.id, "referrer_id": user_profile.id}
+        event = {
+            "prereg_id": prereg_user.id,
+            "referrer_id": user_profile.id,
+            "email_language": user_profile.realm.default_language,
+        }
         queue_json_publish("invites", event)
 
     if skipped:
@@ -6957,6 +6963,7 @@ def do_resend_user_invite_email(prereg_user: PreregistrationUser) -> int:
     event = {
         "prereg_id": prereg_user.id,
         "referrer_id": prereg_user.referred_by.id,
+        "email_language": prereg_user.referred_by.realm.default_language,
     }
     queue_json_publish("invites", event)
 

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -442,6 +442,11 @@ class WorkerTest(ZulipTestCase):
         )
         data: List[Dict[str, Any]] = [
             dict(prereg_id=prereg_alice.id, referrer_id=inviter.id),
+            dict(
+                prereg_id=prereg_alice.id,
+                referrer_id=inviter.id,
+                email_language="en",
+            ),
             # Nonexistent prereg_id, as if the invitation was deleted
             dict(prereg_id=-1, referrer_id=inviter.id),
         ]
@@ -455,7 +460,7 @@ class WorkerTest(ZulipTestCase):
                 "zerver.worker.queue_processors.send_future_email"
             ) as send_mock:
                 worker.start()
-                self.assertEqual(send_mock.call_count, 1)
+                self.assertEqual(send_mock.call_count, 2)
 
     def test_error_handling(self) -> None:
         processed = []

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -441,9 +441,9 @@ class WorkerTest(ZulipTestCase):
             email=self.nonreg_email("bob"), referred_by=inviter, realm=inviter.realm
         )
         data: List[Dict[str, Any]] = [
-            dict(prereg_id=prereg_alice.id, referrer_id=inviter.id, email_body=None),
+            dict(prereg_id=prereg_alice.id, referrer_id=inviter.id),
             # Nonexistent prereg_id, as if the invitation was deleted
-            dict(prereg_id=-1, referrer_id=inviter.id, email_body=None),
+            dict(prereg_id=-1, referrer_id=inviter.id),
         ]
         for element in data:
             fake_client.enqueue("invites", element)

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -424,7 +424,11 @@ class ConfirmationEmailWorker(QueueProcessingWorker):
         logger.info(
             "Sending invitation for realm %s to %s", referrer.realm.string_id, invitee.email
         )
-        activate_url = do_send_confirmation_email(invitee, referrer)
+        if "email_language" in data:
+            email_language = data["email_language"]
+        else:
+            email_language = referrer.realm.default_language
+        activate_url = do_send_confirmation_email(invitee, referrer, email_language)
 
         # queue invitation reminder
         if settings.INVITATION_LINK_VALIDITY_DAYS >= 4:
@@ -440,7 +444,7 @@ class ConfirmationEmailWorker(QueueProcessingWorker):
                 referrer.realm,
                 to_emails=[invitee.email],
                 from_address=FromAddress.tokenized_no_reply_placeholder,
-                language=referrer.realm.default_language,
+                language=email_language,
                 context=context,
                 delay=datetime.timedelta(days=settings.INVITATION_LINK_VALIDITY_DAYS - 2),
             )


### PR DESCRIPTION
This is a prep PR for adding realm-level default for various
user settings. We add the language, in which the invite email will
be sent, to the dict added to queue itself to avoid making queries
in a loop when sending multiple emails from queue.

We also handle the case for old events in the queue.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? --> Updated tests.


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
