### PR TITLE
Use `UserMessageNotificationsData` in `process_message_update_event`

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2894,7 +2894,6 @@ def check_update_message(
     rendered_content = None
     links_for_embed: Set[str] = set()
     prior_mention_user_ids: Set[int] = set()
-    mention_user_ids: Set[int] = set()
     mention_data: Optional[MentionData] = None
     if content is not None:
         if content.rstrip() == "":
@@ -2920,8 +2919,6 @@ def check_update_message(
             mention_data=mention_data,
         )
         links_for_embed |= message.links_for_preview
-
-        mention_user_ids = message.mentions_user_ids
 
     new_stream = None
     number_changed = 0
@@ -2953,7 +2950,6 @@ def check_update_message(
         content,
         rendered_content,
         prior_mention_user_ids,
-        mention_user_ids,
         mention_data,
     )
 
@@ -5862,7 +5858,6 @@ def do_update_message(
     content: Optional[str],
     rendered_content: Optional[str],
     prior_mention_user_ids: Set[int],
-    mention_user_ids: Set[int],
     mention_data: Optional[MentionData] = None,
 ) -> int:
     """
@@ -5969,7 +5964,6 @@ def do_update_message(
         event["stream_email_user_ids"] = list(info["stream_email_user_ids"])
         event["muted_sender_user_ids"] = list(info["muted_sender_user_ids"])
         event["prior_mention_user_ids"] = list(prior_mention_user_ids)
-        event["mention_user_ids"] = list(mention_user_ids)
         event["presence_idle_user_ids"] = filter_presence_idle_user_ids(info["active_user_ids"])
         if target_message.mentions_wildcard:
             event["wildcard_mention_user_ids"] = list(info["wildcard_mention_user_ids"])

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -453,7 +453,6 @@ class NormalActionsTest(BaseAction):
         content = "new content"
         rendered_content = render_markdown(message, content)
         prior_mention_user_ids: Set[int] = set()
-        mentioned_user_ids: Set[int] = set()
         mention_data = MentionData(
             realm_id=self.user_profile.realm_id,
             content=content,
@@ -471,7 +470,6 @@ class NormalActionsTest(BaseAction):
                 content,
                 rendered_content,
                 prior_mention_user_ids,
-                mentioned_user_ids,
                 mention_data,
             ),
             state_change_expected=True,
@@ -514,7 +512,6 @@ class NormalActionsTest(BaseAction):
                 True,
                 None,
                 None,
-                set(),
                 set(),
                 None,
             ),

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -953,7 +953,6 @@ class EditMessageTest(EditMessageTestCase):
                 content=None,
                 rendered_content=None,
                 prior_mention_user_ids=set(),
-                mention_user_ids=set(),
                 mention_data=None,
             )
 

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -3724,7 +3724,6 @@ class MessageHasKeywordsTest(ZulipTestCase):
             content,
             rendered_content,
             set(),
-            set(),
             mention_data=mention_data,
         )
 

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -1105,7 +1105,6 @@ def process_message_update_event(
     # belong in the actual events.
     event_template = dict(orig_event)
     prior_mention_user_ids = set(event_template.pop("prior_mention_user_ids", []))
-    mention_user_ids = set(event_template.pop("mention_user_ids", []))
     presence_idle_user_ids = set(event_template.pop("presence_idle_user_ids", []))
     stream_push_user_ids = set(event_template.pop("stream_push_user_ids", []))
     stream_email_user_ids = set(event_template.pop("stream_email_user_ids", []))
@@ -1130,16 +1129,18 @@ def process_message_update_event(
         for key in user_data.keys():
             if key != "id":
                 user_event[key] = user_data[key]
-        wildcard_mentioned = "wildcard_mentioned" in user_event["flags"]
+        flags = user_event["flags"]
+        wildcard_mentioned = "wildcard_mentioned" in flags
         wildcard_mention_notify = wildcard_mentioned and (
             user_profile_id in wildcard_mention_user_ids
         )
+        mentioned = "mentioned" in user_event["flags"]
 
         maybe_enqueue_notifications_for_message_update(
             user_profile_id=user_profile_id,
             message_id=message_id,
             private_message=(stream_name is None),
-            mentioned=(user_profile_id in mention_user_ids),
+            mentioned=mentioned,
             wildcard_mention_notify=wildcard_mention_notify,
             stream_push_notify=(user_profile_id in stream_push_user_ids),
             stream_email_notify=(user_profile_id in stream_email_user_ids),


### PR DESCRIPTION
This is a followup to #18853, and a prep for using this dataclass also in `maybe_enqueue_notifications` (which I expect will have a huge diff because of tests, so separating this out)