### PR TITLE
Add support for Multiselect Dropdown List Widget

### DIFF
--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {$t} = require("../zjsunit/i18n");
-const {mock_esm, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, zrequire, set_global} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
 const $ = require("../zjsunit/zjquery");
@@ -13,6 +13,14 @@ mock_esm("../../static/js/list_widget", {
     create: () => ({init: noop}),
 });
 
+mock_esm("tippy.js", {
+    default: (arg) => {
+        arg._tippy = {setContent: noop, placement: noop, destroy: noop};
+        return arg._tippy;
+    },
+});
+
+set_global("document", {});
 const {DropdownListWidget, MultiSelectDropdownListWidget} = zrequire("dropdown_list_widget");
 
 // For DropdownListWidget

--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -12,7 +12,7 @@ const noop = () => {};
 mock_esm("../../static/js/list_widget", {
     create: () => ({init: noop}),
 });
-const {DropdownListWidget: dropdown_list_widget} = zrequire("dropdown_list_widget");
+const {DropdownListWidget} = zrequire("dropdown_list_widget");
 
 const setup_zjquery_data = (name) => {
     const input_group = $(".input_group");
@@ -38,7 +38,7 @@ run_test("basic_functions", () => {
 
     const {reset_button, $widget} = setup_zjquery_data(opts.widget_name);
 
-    const widget = dropdown_list_widget(opts);
+    const widget = new DropdownListWidget(opts);
 
     assert.equal(widget.value(), "one");
     assert.equal(updated_value, undefined); // We haven't 'updated' the widget yet.
@@ -77,6 +77,6 @@ run_test("no_default_value", () => {
         "dropdown-list-widget: Called without a default value; using null value",
     );
     setup_zjquery_data(opts.widget_name);
-    const widget = dropdown_list_widget(opts);
+    const widget = new DropdownListWidget(opts);
     assert.equal(widget.value(), "null-value");
 });

--- a/frontend_tests/node_tests/list_widget.js
+++ b/frontend_tests/node_tests/list_widget.js
@@ -832,3 +832,95 @@ run_test("render item", () => {
     widget_3.render_item(item);
     blueslip.reset();
 });
+
+run_test("Multiselect dropdown retain_selected_items", () => {
+    const container = make_container();
+    const scroll_container = make_scroll_container();
+    const filter_element = make_filter_element();
+    let data_rendered = [];
+
+    const list = ["one", "two", "three", "four"].map((x) => ({name: x, value: x}));
+    const data = ["one"]; // Data initially selected.
+
+    container.html = () => {};
+    container.find = (elem) => DropdownItem(elem);
+
+    // We essentially create fake Jquery functions
+    // whose return value are stored in objects so that
+    // they can be later asserted with expected values.
+    function DropdownItem(element) {
+        const temp = {};
+
+        function length() {
+            if (element) {
+                return true;
+            }
+            return false;
+        }
+
+        function find(tag) {
+            return ListItem(tag, temp);
+        }
+
+        function addClass(cls) {
+            temp.appended_class = cls;
+        }
+
+        temp.element = element;
+        return {
+            length: length(),
+            find,
+            addClass,
+        };
+    }
+
+    function ListItem(element, temp) {
+        function expectOne() {
+            data_rendered.push(temp);
+            return ListItem(element, temp);
+        }
+
+        function prepend(data) {
+            temp.prepended_data = data.html();
+        }
+
+        return {
+            expectOne,
+            prepend,
+        };
+    }
+
+    const widget = ListWidget.create(container, list, {
+        name: "replace-list",
+        modifier: (item) => `<li data-value="${item.value}">${item.name}</li>\n`,
+        multiselect: {
+            selected_items: data,
+        },
+        filter: {
+            element: filter_element,
+            predicate: () => true,
+        },
+        simplebar_container: scroll_container,
+    });
+
+    const expected_value = [
+        {
+            element: 'li[data-value = "one"]',
+            appended_class: "checked",
+            prepended_data: "<i>",
+        },
+    ];
+
+    assert.deepEqual(expected_value, data_rendered);
+
+    // Reset the variable and re execute the `widget.render` method.
+    data_rendered = [];
+
+    // Making sure!
+    assert.deepEqual(data_rendered, []);
+
+    widget.hard_redraw();
+
+    // Expect the `data_rendered` array to be same again.
+    assert.deepEqual(expected_value, data_rendered);
+});

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import _ from "lodash";
+import tippy from "tippy.js";
 
 import render_dropdown_list from "../templates/settings/dropdown_list.hbs";
 
@@ -303,6 +304,9 @@ MultiSelectDropdownListWidget.prototype.render_button_text = function (elem, lim
     const items_selected = this.data_selected.length;
     let text = "";
 
+    // Destroy the tooltip once the button text reloads.
+    this.destroy_tooltip();
+
     if (items_selected === 0) {
         this.render_default_text(elem);
         return;
@@ -311,6 +315,7 @@ MultiSelectDropdownListWidget.prototype.render_button_text = function (elem, lim
         text = data_selected.map((data) => data.name).toString();
     } else {
         text = $t({defaultMessage: "{items_selected} selected"}, {items_selected});
+        this.render_tooltip();
     }
 
     elem.text(text);
@@ -410,6 +415,27 @@ MultiSelectDropdownListWidget.prototype.remove_check_mark = function (element) {
         element.removeClass("checked");
         this.data_selected.splice(index, 1);
     }
+};
+
+// Render the tooltip once the text changes to `n` selected.
+MultiSelectDropdownListWidget.prototype.render_tooltip = function () {
+    const elem = $(`#${CSS.escape(this.container_id)}`);
+    const selected_items = this.data.filter((item) => this.checked_items.includes(item.value));
+
+    tippy(elem[0], {
+        content: selected_items.map((item) => item.name).join(", "),
+        placement: "top",
+    });
+};
+
+MultiSelectDropdownListWidget.prototype.destroy_tooltip = function () {
+    const elem = $(`#${CSS.escape(this.container_id)}`);
+    const tippy_instance = elem[0]._tippy;
+    if (!tippy_instance) {
+        return;
+    }
+
+    tippy_instance.destroy();
 };
 
 MultiSelectDropdownListWidget.prototype.dropdown_focus_events = function () {

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -5,7 +5,7 @@ import render_dropdown_list from "../templates/settings/dropdown_list.hbs";
 import * as blueslip from "./blueslip";
 import * as ListWidget from "./list_widget";
 
-export const DropdownListWidget = function ({
+export function DropdownListWidget({
     widget_name,
     data,
     default_text,
@@ -15,153 +15,179 @@ export const DropdownListWidget = function ({
     value,
     on_update = () => {},
 }) {
-    const container_id = `${widget_name}_widget`;
-    const value_id = `id_${widget_name}`;
+    // Initializing values
+    this.widget_name = widget_name;
+    this.data = data;
+    this.default_text = default_text;
+    this.render_text = render_text;
+    this.null_value = null_value;
+    this.include_current_item = include_current_item;
+    this.initial_value = value;
+    this.on_update = on_update;
+
+    this.container_id = `${widget_name}_widget`;
+    this.value_id = `id_${widget_name}`;
+
     if (value === undefined) {
-        value = null_value;
+        this.initial_value = null_value;
         blueslip.warn("dropdown-list-widget: Called without a default value; using null value");
     }
 
-    const render_default_text = (elem) => {
-        elem.text(default_text);
-        elem.addClass("text-warning");
-        elem.closest(".input-group").find(".dropdown_list_reset_button:enabled").hide();
-    };
+    // Setting up dropdown_list_widget
+    this.setup();
+}
 
-    const render = (value) => {
-        $(`#${CSS.escape(container_id)} #${CSS.escape(value_id)}`).data("value", value);
+DropdownListWidget.prototype.render_default_text = function (elem) {
+    elem.text(this.default_text);
+    elem.addClass("text-warning");
+    elem.closest(".input-group").find(".dropdown_list_reset_button:enabled").hide();
+};
 
-        const elem = $(`#${CSS.escape(container_id)} #${CSS.escape(widget_name)}_name`);
+DropdownListWidget.prototype.render = function (value) {
+    $(`#${CSS.escape(this.container_id)} #${CSS.escape(this.value_id)}`).data("value", value);
 
-        if (!value || value === null_value) {
-            render_default_text(elem);
-            return;
-        }
+    const elem = $(`#${CSS.escape(this.container_id)} #${CSS.escape(this.widget_name)}_name`);
 
-        // Happy path
-        const item = data.find((x) => x.value === value.toString());
+    if (!value || value === this.null_value) {
+        this.render_default_text(elem);
+        return;
+    }
 
-        if (item === undefined) {
-            render_default_text(elem);
-            return;
-        }
+    // Happy path
+    const item = this.data.find((x) => x.value === value.toString());
 
-        const text = render_text(item.name);
-        elem.text(text);
-        elem.removeClass("text-warning");
-        elem.closest(".input-group").find(".dropdown_list_reset_button:enabled").show();
-    };
+    if (item === undefined) {
+        this.render_default_text(elem);
+        return;
+    }
 
-    const update = (value) => {
-        render(value);
-        on_update(value);
-    };
+    const text = this.render_text(item.name);
+    elem.text(text);
+    elem.removeClass("text-warning");
+    elem.closest(".input-group").find(".dropdown_list_reset_button:enabled").show();
+};
 
-    const register_event_handlers = () => {
-        $(`#${CSS.escape(container_id)} .dropdown-list-body`).on(
-            "click keypress",
-            ".list_item",
-            function (e) {
-                const setting_elem = $(this).closest(`.${CSS.escape(widget_name)}_setting`);
-                if (e.type === "keypress") {
-                    if (e.key === "Enter") {
-                        setting_elem.find(".dropdown-menu").dropdown("toggle");
-                    } else {
-                        return;
-                    }
+DropdownListWidget.prototype.update = function (value) {
+    this.render(value);
+    this.on_update(value);
+};
+
+DropdownListWidget.prototype.register_event_handlers = function () {
+    $(`#${CSS.escape(this.container_id)} .dropdown-list-body`).on(
+        "click keypress",
+        ".list_item",
+        (e) => {
+            const setting_elem = $(e.currentTarget).closest(
+                `.${CSS.escape(this.widget_name)}_setting`,
+            );
+            if (e.type === "keypress") {
+                if (e.key === "Enter") {
+                    setting_elem.find(".dropdown-menu").dropdown("toggle");
+                } else {
+                    return;
                 }
-                const value = $(this).attr("data-value");
-                update(value);
-            },
-        );
-        $(`#${CSS.escape(container_id)} .dropdown_list_reset_button`).on("click", (e) => {
-            update(null_value);
-            e.preventDefault();
-        });
-    };
-
-    const setup = () => {
-        // populate the dropdown
-        const dropdown_list_body = $(
-            `#${CSS.escape(container_id)} .dropdown-list-body`,
-        ).expectOne();
-        const search_input = $(`#${CSS.escape(container_id)} .dropdown-search > input[type=text]`);
-        const dropdown_toggle = $(`#${CSS.escape(container_id)} .dropdown-toggle`);
-        const get_data = (data) => {
-            if (include_current_item) {
-                return data;
             }
-            return data.filter((x) => x.value !== value.toString());
-        };
+            const value = $(e.currentTarget).attr("data-value");
+            this.update(value);
+        },
+    );
+    $(`#${CSS.escape(this.container_id)} .dropdown_list_reset_button`).on("click", (e) => {
+        this.update(this.null_value);
+        e.preventDefault();
+    });
+};
 
-        ListWidget.create(dropdown_list_body, get_data(data), {
-            name: `${CSS.escape(widget_name)}_list`,
-            modifier(item) {
-                return render_dropdown_list({item});
-            },
-            filter: {
-                element: search_input,
-                predicate(item, value) {
-                    return item.name.toLowerCase().includes(value);
-                },
-            },
-            simplebar_container: $(`#${CSS.escape(container_id)} .dropdown-list-wrapper`),
-        });
-        $(`#${CSS.escape(container_id)} .dropdown-search`).on("click", (e) => {
-            e.stopPropagation();
-        });
-
-        dropdown_toggle.on("click", () => {
-            search_input.val("").trigger("input");
-        });
-
-        dropdown_toggle.on("focus", (e) => {
-            // On opening a Bootstrap Dropdown, the parent element receives focus.
-            // Here, we want our search input to have focus instead.
-            e.preventDefault();
-            // This function gets called twice when focusing the
-            // dropdown, and only in the second call is the input
-            // field visible in the DOM; so the following visibility
-            // check ensures we wait for the second call to focus.
-            if (dropdown_list_body.is(":visible")) {
-                search_input.trigger("focus");
-            }
-        });
-
-        search_input.on("keydown", (e) => {
-            const {key, keyCode, which} = e;
-            const navigation_keys = ["ArrowUp", "ArrowDown", "Escape"];
-            if (!navigation_keys.includes(key)) {
-                return;
-            }
-            e.preventDefault();
-            e.stopPropagation();
-
-            // We pass keyCode instead of key here because the outdated
-            // bootstrap library we have at static/third/ still uses the
-            // deprecated keyCode & which properties.
-            const custom_event = new $.Event("keydown.dropdown.data-api", {keyCode, which});
-            dropdown_toggle.trigger(custom_event);
-        });
-
-        render(value);
-        register_event_handlers();
-    };
-
-    const get_value = () => {
-        let val = $(`#${CSS.escape(container_id)} #${CSS.escape(value_id)}`).data("value");
-        if (val === null) {
-            val = "";
+DropdownListWidget.prototype.setup_dropdown_widget = function (data) {
+    const dropdown_list_body = $(
+        `#${CSS.escape(this.container_id)} .dropdown-list-body`,
+    ).expectOne();
+    const search_input = $(`#${CSS.escape(this.container_id)} .dropdown-search > input[type=text]`);
+    const get_data = () => {
+        if (this.include_current_item) {
+            return data;
         }
-        return val;
+        return data.filter((x) => x.value !== this.value.toString());
     };
 
-    // Run setup() automatically on initialization.
-    setup();
+    ListWidget.create(dropdown_list_body, get_data(data), {
+        name: `${CSS.escape(this.widget_name)}_list`,
+        modifier(item) {
+            return render_dropdown_list({item});
+        },
+        filter: {
+            element: search_input,
+            predicate(item, value) {
+                return item.name.toLowerCase().includes(value);
+            },
+        },
+        simplebar_container: $(`#${CSS.escape(this.container_id)} .dropdown-list-wrapper`),
+    });
+};
 
-    return {
-        render,
-        value: get_value,
-        update,
-    };
+// Sets the focus to the ListWidget input once the dropdown button is clicked.
+DropdownListWidget.prototype.dropdown_toggle_click_handler = function () {
+    const dropdown_toggle = $(`#${CSS.escape(this.container_id)} .dropdown-toggle`);
+    const search_input = $(`#${CSS.escape(this.container_id)} .dropdown-search > input[type=text]`);
+
+    dropdown_toggle.on("click", () => {
+        search_input.val("").trigger("input");
+    });
+};
+
+DropdownListWidget.prototype.setup = function () {
+    // populate the dropdown
+    const dropdown_list_body = $(
+        `#${CSS.escape(this.container_id)} .dropdown-list-body`,
+    ).expectOne();
+    const search_input = $(`#${CSS.escape(this.container_id)} .dropdown-search > input[type=text]`);
+    const dropdown_toggle = $(`#${CSS.escape(this.container_id)} .dropdown-toggle`);
+
+    this.setup_dropdown_widget(this.data);
+
+    $(`#${CSS.escape(this.container_id)} .dropdown-search`).on("click", (e) => {
+        e.stopPropagation();
+    });
+
+    this.dropdown_toggle_click_handler();
+
+    dropdown_toggle.on("focus", (e) => {
+        // On opening a Bootstrap Dropdown, the parent element receives focus.
+        // Here, we want our search input to have focus instead.
+        e.preventDefault();
+        // This function gets called twice when focusing the
+        // dropdown, and only in the second call is the input
+        // field visible in the DOM; so the following visibility
+        // check ensures we wait for the second call to focus.
+        if (dropdown_list_body.is(":visible")) {
+            search_input.trigger("focus");
+        }
+    });
+
+    search_input.on("keydown", (e) => {
+        const {key, keyCode, which} = e;
+        const navigation_keys = ["ArrowUp", "ArrowDown", "Escape"];
+        if (!navigation_keys.includes(key)) {
+            return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+
+        // We pass keyCode instead of key here because the outdated
+        // bootstrap library we have at static/third/ still uses the
+        // deprecated keyCode & which properties.
+        const custom_event = new $.Event("keydown.dropdown.data-api", {keyCode, which});
+        dropdown_toggle.trigger(custom_event);
+    });
+
+    this.render(this.initial_value);
+    this.register_event_handlers();
+};
+
+// Returns the updated value
+DropdownListWidget.prototype.value = function () {
+    let val = $(`#${CSS.escape(this.container_id)} #${CSS.escape(this.value_id)}`).data("value");
+    if (val === null) {
+        val = "";
+    }
+    return val;
 };

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -134,6 +134,67 @@ DropdownListWidget.prototype.dropdown_toggle_click_handler = function () {
     });
 };
 
+DropdownListWidget.prototype.dropdown_focus_events = function () {
+    const search_input = $(`#${CSS.escape(this.container_id)} .dropdown-search > input[type=text]`);
+    const dropdown_menu = $(`.${CSS.escape(this.widget_name)}_setting .dropdown-menu`);
+
+    const dropdown_elements = () => {
+        const dropdown_list_body = $(
+            `#${CSS.escape(this.container_id)} .dropdown-list-body`,
+        ).expectOne();
+
+        return dropdown_list_body.children().find("a");
+    };
+
+    // Rest of the key handlers are supported by our
+    // bootstrap library.
+    dropdown_menu.on("keydown", (e) => {
+        function trigger_element_focus(element) {
+            e.preventDefault();
+            e.stopPropagation();
+            element.trigger("focus");
+        }
+
+        switch (e.key) {
+            case "ArrowDown": {
+                switch (e.target) {
+                    case dropdown_elements().last()[0]:
+                        trigger_element_focus(search_input);
+                        break;
+                    case search_input[0]:
+                        trigger_element_focus(dropdown_elements().first());
+                        break;
+                }
+
+                break;
+            }
+            case "ArrowUp": {
+                switch (e.target) {
+                    case dropdown_elements().first()[0]:
+                        trigger_element_focus(search_input);
+                        break;
+                    case search_input[0]:
+                        trigger_element_focus(dropdown_elements().last());
+                }
+
+                break;
+            }
+            case "Tab": {
+                switch (e.target) {
+                    case search_input[0]:
+                        trigger_element_focus(dropdown_elements().first());
+                        break;
+                    case dropdown_elements().last()[0]:
+                        trigger_element_focus(search_input);
+                        break;
+                }
+
+                break;
+            }
+        }
+    });
+};
+
 DropdownListWidget.prototype.setup = function () {
     // populate the dropdown
     const dropdown_list_body = $(
@@ -163,21 +224,7 @@ DropdownListWidget.prototype.setup = function () {
         }
     });
 
-    search_input.on("keydown", (e) => {
-        const {key, keyCode, which} = e;
-        const navigation_keys = ["ArrowUp", "ArrowDown", "Escape"];
-        if (!navigation_keys.includes(key)) {
-            return;
-        }
-        e.preventDefault();
-        e.stopPropagation();
-
-        // We pass keyCode instead of key here because the outdated
-        // bootstrap library we have at static/third/ still uses the
-        // deprecated keyCode & which properties.
-        const custom_event = new $.Event("keydown.dropdown.data-api", {keyCode, which});
-        dropdown_toggle.trigger(custom_event);
-    });
+    this.dropdown_focus_events();
 
     this.render(this.initial_value);
     this.register_event_handlers();

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -1,8 +1,10 @@
 import $ from "jquery";
+import _ from "lodash";
 
 import render_dropdown_list from "../templates/settings/dropdown_list.hbs";
 
 import * as blueslip from "./blueslip";
+import {$t} from "./i18n";
 import * as ListWidget from "./list_widget";
 
 export function DropdownListWidget({
@@ -235,6 +237,317 @@ DropdownListWidget.prototype.value = function () {
     let val = $(`#${CSS.escape(this.container_id)} #${CSS.escape(this.value_id)}`).data("value");
     if (val === null) {
         val = "";
+    }
+    return val;
+};
+
+export function MultiSelectDropdownListWidget({
+    widget_name,
+    data,
+    default_text,
+    null_value = null,
+    on_update = () => {},
+    on_close,
+    value,
+    limit,
+}) {
+    // A widget mostly similar to `DropdownListWidget` but
+    // used in cases of multiple dropdown selection.
+
+    // Initializing values specific to `MultiSelectDropdownListWidget`.
+    this.limit = limit;
+    this.on_close = on_close;
+
+    // Important thing to note is that this needs to be maintained as
+    // a reference type and not to deep clone it/assign it to a
+    // different variable, so that it can be later referenced within
+    // `list_widget` as well. The way we manage dropdown elements are
+    // essentially by just modifying the values in `data_selected` variable.
+    this.data_selected = []; // Populate the dropdown values selected by user.
+
+    DropdownListWidget.call(this, {
+        widget_name,
+        data,
+        default_text,
+        null_value,
+        on_update,
+        value,
+    });
+
+    if (limit === undefined) {
+        this.limit = 2;
+        blueslip.warn(
+            "Multiselect dropdown-list-widget: Called without limit value; using 2 as the limit",
+        );
+    }
+
+    this.initialize_dropdown_values();
+}
+
+MultiSelectDropdownListWidget.prototype = Object.create(DropdownListWidget.prototype);
+
+MultiSelectDropdownListWidget.prototype.initialize_dropdown_values = function () {
+    // Stop the execution if value parameter is undefined and null_value is passed.
+    if (!this.initial_value || this.initial_value === this.null_value) {
+        return;
+    }
+    const elem = $(`#${CSS.escape(this.container_id)} #${CSS.escape(this.widget_name)}_name`);
+
+    // Push values from initial valued array to `data_selected`.
+    this.data_selected.push(...this.initial_value);
+    this.render_button_text(elem, this.limit);
+};
+
+// Set the button text as per the selected data.
+MultiSelectDropdownListWidget.prototype.render_button_text = function (elem, limit) {
+    const items_selected = this.data_selected.length;
+    let text = "";
+
+    if (items_selected === 0) {
+        this.render_default_text(elem);
+        return;
+    } else if (limit >= items_selected) {
+        const data_selected = this.data.filter((data) => this.data_selected.includes(data.value));
+        text = data_selected.map((data) => data.name).toString();
+    } else {
+        text = $t({defaultMessage: "{items_selected} selected"}, {items_selected});
+    }
+
+    elem.text(text);
+    elem.removeClass("text-warning");
+    elem.closest(".input-group").find(".dropdown_list_reset_button:enabled").show();
+};
+
+// Override the DrodownListWidget `render` function.
+MultiSelectDropdownListWidget.prototype.render = function (value) {
+    const elem = $(`#${CSS.escape(this.container_id)} #${CSS.escape(this.widget_name)}_name`);
+
+    if (!value || value === this.null_value) {
+        this.render_default_text(elem);
+        return;
+    }
+    this.render_button_text(elem, this.limit);
+};
+
+MultiSelectDropdownListWidget.prototype.dropdown_toggle_click_handler = function () {
+    const dropdown_toggle = $(`#${CSS.escape(this.container_id)} .dropdown-toggle`);
+    const search_input = $(`#${CSS.escape(this.container_id)} .dropdown-search > input[type=text]`);
+
+    dropdown_toggle.on("click", () => {
+        this.reset_dropdown_items();
+        search_input.val("").trigger("input");
+    });
+};
+
+// Cases where a user presses any dropdown item but accidentally closes
+// the dropdown list.
+MultiSelectDropdownListWidget.prototype.reset_dropdown_items = function () {
+    // Clear the data selected and stop the execution once the user has
+    // pressed the `reset` button.
+    if (this.is_reset) {
+        this.data_selected.splice(0, this.data_selected.length);
+        return;
+    }
+
+    const original_items = this.checked_items ? this.checked_items : this.initial_value;
+    const items_added = _.difference(this.data_selected, original_items);
+
+    // Removing the unnecessary items from dropdown.
+    for (const val of items_added) {
+        const index = this.data_selected.indexOf(val);
+        if (index > -1) {
+            this.data_selected.splice(index, 1);
+        }
+    }
+
+    // Items that are removed in dropdown but should have been a part of it
+    const items_removed = _.difference(original_items, this.data_selected);
+    this.data_selected.push(...items_removed);
+};
+
+// Override the DrodownListWidget `setup_dropdown_widget` function.
+MultiSelectDropdownListWidget.prototype.setup_dropdown_widget = function (data) {
+    const dropdown_list_body = $(
+        `#${CSS.escape(this.container_id)} .dropdown-list-body`,
+    ).expectOne();
+    const search_input = $(`#${CSS.escape(this.container_id)} .dropdown-search > input[type=text]`);
+
+    ListWidget.create(dropdown_list_body, data, {
+        name: `${CSS.escape(this.widget_name)}_list`,
+        modifier(item) {
+            return render_dropdown_list({item});
+        },
+        multiselect: {
+            selected_items: this.data_selected,
+        },
+        filter: {
+            element: search_input,
+            predicate(item, value) {
+                return item.name.toLowerCase().includes(value);
+            },
+        },
+        simplebar_container: $(`#${CSS.escape(this.container_id)} .dropdown-list-wrapper`),
+    });
+};
+
+// Add the check mark to dropdown element passed.
+MultiSelectDropdownListWidget.prototype.add_check_mark = function (element) {
+    const value = element.attr("data-value");
+    const link_elem = element.find("a").expectOne();
+    link_elem.prepend($("<i>", {class: "fa fa-check"}));
+    element.addClass("checked");
+    this.data_selected.push(value);
+};
+
+// Remove the check mark from dropdown element.
+MultiSelectDropdownListWidget.prototype.remove_check_mark = function (element) {
+    const icon = element.find("i").expectOne();
+    const value = element.attr("data-value");
+    const index = this.data_selected.indexOf(value);
+
+    if (index > -1) {
+        icon.remove();
+        element.removeClass("checked");
+        this.data_selected.splice(index, 1);
+    }
+};
+
+MultiSelectDropdownListWidget.prototype.dropdown_focus_events = function () {
+    // Main keydown event handler which transfers the focus from one child element
+    // to another.
+
+    const search_input = $(`#${CSS.escape(this.container_id)} .dropdown-search > input[type=text]`);
+    const dropdown_menu = $(`.${CSS.escape(this.widget_name)}_setting .dropdown-menu`);
+    const filter_button = $(`#${CSS.escape(this.container_id)} .multiselect_btn`);
+
+    const dropdown_elements = () => {
+        const dropdown_list_body = $(
+            `#${CSS.escape(this.container_id)} .dropdown-list-body`,
+        ).expectOne();
+
+        return dropdown_list_body.children().find("a");
+    };
+
+    dropdown_menu.on("keydown", (e) => {
+        function trigger_element_focus(element) {
+            e.preventDefault();
+            e.stopPropagation();
+            element.trigger("focus");
+        }
+
+        switch (e.key) {
+            case "ArrowDown": {
+                switch (e.target) {
+                    case dropdown_elements().last()[0]:
+                        trigger_element_focus(filter_button);
+                        break;
+                    case $(`#${CSS.escape(this.container_id)} .multiselect_btn`)[0]:
+                        trigger_element_focus(search_input);
+                        break;
+                    case search_input[0]:
+                        trigger_element_focus(dropdown_elements().first());
+                        break;
+                }
+
+                break;
+            }
+            case "ArrowUp": {
+                switch (e.target) {
+                    case dropdown_elements().first()[0]:
+                        trigger_element_focus(search_input);
+                        break;
+                    case search_input[0]:
+                        trigger_element_focus(filter_button);
+                        break;
+                    case $(`#${CSS.escape(this.container_id)} .multiselect_btn`)[0]:
+                        trigger_element_focus(dropdown_elements().last());
+                        break;
+                }
+
+                break;
+            }
+            case "Tab": {
+                switch (e.target) {
+                    case search_input[0]:
+                        trigger_element_focus(dropdown_elements().first());
+                        break;
+                    case filter_button[0]:
+                        trigger_element_focus(search_input);
+                        break;
+                }
+
+                break;
+            }
+        }
+    });
+};
+
+// Override the `register_event_handlers` function.
+MultiSelectDropdownListWidget.prototype.register_event_handlers = function () {
+    const dropdown_list_body = $(
+        `#${CSS.escape(this.container_id)} .dropdown-list-body`,
+    ).expectOne();
+
+    dropdown_list_body.on("click keypress", ".list_item", (e) => {
+        if (e.type === "keypress" && e.key !== "Enter") {
+            return;
+        }
+
+        const element = $(e.target.closest("li"));
+        if (element.hasClass("checked")) {
+            this.remove_check_mark(element);
+        } else {
+            this.add_check_mark(element);
+        }
+
+        e.stopPropagation();
+    });
+
+    $(`#${CSS.escape(this.container_id)} .dropdown_list_reset_button`).on("click", (e) => {
+        // Default back the values.
+        this.is_reset = true;
+        this.checked_items = undefined;
+
+        this.update(this.null_value);
+        e.preventDefault();
+    });
+
+    $(`#${CSS.escape(this.container_id)} .multiselect_btn`).on("click", (e) => {
+        e.preventDefault();
+
+        // Set the value to `false` to end the scope of the
+        // `reset` button.
+        this.is_reset = false;
+        // We deep clone the values of `data_selected` to a new
+        // variable. This is so because arrays are reference types
+        // and modifying the parent array can change the values
+        // within the child array. Here, `checked_items` copies over the
+        // value and not just the reference.
+        this.checked_items = _.cloneDeep(this.data_selected);
+        this.update(this.data_selected);
+
+        // Cases when the user wants to pass a successful event after
+        // the dropdown is closed.
+        if (this.on_close) {
+            e.stopPropagation();
+            const setting_elem = $(e.currentTarget).closest(
+                `.${CSS.escape(this.widget_name)}_setting`,
+            );
+            setting_elem.find(".dropdown-menu").dropdown("toggle");
+
+            this.on_close();
+        }
+    });
+};
+
+// Returns array of values selected by user.
+MultiSelectDropdownListWidget.prototype.value = function () {
+    let val = this.checked_items;
+    // Cases taken care of -
+    // - User never pressed the filter button -> We return the initial value.
+    // - User pressed the `reset` button -> We return an empty array.
+    if (val === undefined) {
+        val = this.is_reset ? [] : this.initial_value;
     }
     return val;
 };

--- a/static/js/list_widget.js
+++ b/static/js/list_widget.js
@@ -190,6 +190,24 @@ export function create($container, list, opts) {
         }
     };
 
+    // Used in case of Multiselect DropdownListWidget to retain
+    // previously checked items even after widget redraws.
+    widget.retain_selected_items = function () {
+        const items = opts.multiselect;
+
+        if (items.selected_items) {
+            const data = items.selected_items;
+            for (const value of data) {
+                const list_item = $container.find(`li[data-value = "${value}"]`);
+                if (list_item.length) {
+                    const link_elem = list_item.find("a").expectOne();
+                    list_item.addClass("checked");
+                    link_elem.prepend($("<i>", {class: "fa fa-check"}));
+                }
+            }
+        }
+    };
+
     // Reads the provided list (in the scope directly above)
     // and renders the next block of messages automatically
     // into the specified container.
@@ -223,6 +241,10 @@ export function create($container, list, opts) {
 
         $container.append($(html));
         meta.offset += load_count;
+
+        if (opts.multiselect) {
+            widget.retain_selected_items();
+        }
 
         if (opts.callback_after_render) {
             opts.callback_after_render();

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -15,7 +15,7 @@ import * as composebox_typeahead from "./composebox_typeahead";
 import * as condense from "./condense";
 import * as confirm_dialog from "./confirm_dialog";
 import * as dialog_widget from "./dialog_widget";
-import {DropdownListWidget as dropdown_list_widget} from "./dropdown_list_widget";
+import {DropdownListWidget} from "./dropdown_list_widget";
 import * as echo from "./echo";
 import * as giphy from "./giphy";
 import {$t, $t_html} from "./i18n";
@@ -441,7 +441,7 @@ function edit_message(row, raw_content) {
     const copy_message = row.find(".copy_message");
 
     if (is_stream_editable) {
-        stream_widget = dropdown_list_widget(opts);
+        stream_widget = new DropdownListWidget(opts);
     }
     stream_bar.decorate(message.stream, stream_header_colorblock, false);
 

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -10,7 +10,7 @@ import * as avatar from "./avatar";
 import * as bot_data from "./bot_data";
 import * as channel from "./channel";
 import {csrf_token} from "./csrf";
-import {DropdownListWidget as dropdown_list_widget} from "./dropdown_list_widget";
+import {DropdownListWidget} from "./dropdown_list_widget";
 import {$t} from "./i18n";
 import * as loading from "./loading";
 import * as overlays from "./overlays";
@@ -440,7 +440,7 @@ export function set_up() {
             default_text: $t({defaultMessage: "No owner"}),
             value: bot.owner_id,
         };
-        const owner_widget = dropdown_list_widget(opts);
+        const owner_widget = new DropdownListWidget(opts);
 
         const service = bot_data.get_services(bot_id)[0];
         if (bot.bot_type.toString() === OUTGOING_WEBHOOK_BOT_TYPE) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -9,7 +9,7 @@ import * as blueslip from "./blueslip";
 import * as channel from "./channel";
 import * as confirm_dialog from "./confirm_dialog";
 import {csrf_token} from "./csrf";
-import {DropdownListWidget as dropdown_list_widget} from "./dropdown_list_widget";
+import {DropdownListWidget} from "./dropdown_list_widget";
 import {$t, $t_html} from "./i18n";
 import * as loading from "./loading";
 import * as overlays from "./overlays";
@@ -638,17 +638,17 @@ export function init_dropdown_widgets() {
         render_text: (x) => `#${x}`,
         null_value: -1,
     };
-    notifications_stream_widget = dropdown_list_widget({
+    notifications_stream_widget = new DropdownListWidget({
         widget_name: "realm_notifications_stream_id",
         value: page_params.realm_notifications_stream_id,
         ...notification_stream_options,
     });
-    signup_notifications_stream_widget = dropdown_list_widget({
+    signup_notifications_stream_widget = new DropdownListWidget({
         widget_name: "realm_signup_notifications_stream_id",
         value: page_params.realm_signup_notifications_stream_id,
         ...notification_stream_options,
     });
-    default_code_language_widget = dropdown_list_widget({
+    default_code_language_widget = new DropdownListWidget({
         widget_name: "realm_default_code_block_language",
         data: Object.keys(pygments_data.langs).map((x) => ({
             name: x,

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -10,7 +10,7 @@ import * as bot_data from "./bot_data";
 import * as channel from "./channel";
 import * as confirm_dialog from "./confirm_dialog";
 import * as dialog_widget from "./dialog_widget";
-import {DropdownListWidget as dropdown_list_widget} from "./dropdown_list_widget";
+import {DropdownListWidget} from "./dropdown_list_widget";
 import {$t, $t_html} from "./i18n";
 import * as ListWidget from "./list_widget";
 import * as loading from "./loading";
@@ -652,7 +652,7 @@ function handle_bot_form(tbody, status_field) {
             };
             // Note: Rendering this is quite expensive in
             // organizations with 10Ks of users.
-            owner_widget = dropdown_list_widget(opts);
+            owner_widget = new DropdownListWidget(opts);
         }
 
         dialog_widget.launch({

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -13,7 +13,7 @@ import * as browser_history from "./browser_history";
 import * as channel from "./channel";
 import * as compose_actions from "./compose_actions";
 import * as confirm_dialog from "./confirm_dialog";
-import {DropdownListWidget as dropdown_list_widget} from "./dropdown_list_widget";
+import {DropdownListWidget} from "./dropdown_list_widget";
 import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
 import * as message_edit from "./message_edit";
@@ -379,7 +379,7 @@ function build_move_topic_to_stream_popover(e, current_stream_id, topic_name) {
 
     $("#move-a-topic-modal-holder").html(render_move_topic_to_stream(args));
 
-    stream_widget = dropdown_list_widget(opts);
+    stream_widget = new DropdownListWidget(opts);
     stream_header_colorblock = $("#move_topic_modal .topic_stream_edit_header").find(
         ".stream_header_colorblock",
     );

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1613,6 +1613,12 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
         }
     }
 
+    button.multiselect_btn {
+        /* Matches the dropdown input margin so as to keep it aligned */
+        margin-left: 9px;
+        margin-top: 4px;
+    }
+
     a.dropdown_list_reset_button {
         /* Prevent night mode from overriding background. */
         background: unset !important;

--- a/static/templates/settings/dropdown_list_widget.hbs
+++ b/static/templates/settings/dropdown_list_widget.hbs
@@ -15,6 +15,12 @@
             </li>
             <div class="dropdown-list-wrapper" data-simplebar>
                 <span class="dropdown-list-body"></span>
+                {{#if filter_button_text }}
+                <button class="button rounded small sea-green multiselect_btn" tabindex="0">
+                    <i class="fa fa-filter" aria-hidden="true"></i>
+                    {{filter_button_text}}
+                </button>
+                {{/if}}
             </div>
         </ul>
     </span>


### PR DESCRIPTION
Added support for Multiselect Dropdown List Widget (`MLDW` ) by using prototypal inheritance which inherits from the existing `dropdown_list_widget`.

Essentially adopted a cleaner methodology than using `if`/`else` ladders within the `dropdown_list_widget` itself (#17674). 

<strong>TODOs:</strong>
##### Major
- [x] Implement a better way to add check marks to dropdown items. Since, the current methodology interpolates unescaped text into HTML.
- [x] Handle scenarios where user triggers the `Reset` button with `MLDW`. 
- [x] Add tooltip to `MLDW` button displaying all the items checked by user (if the items checked exceeds the `limit`). 

##### Minor

- [x] Add node tests for <code>MLDW</code>.
- [x] Fix failing `list_widget` node tests to regain coverage.
- [x] Improve overall styling.
- [x] Better commit messages (obviously!)


<strong>Usage:</strong>

Initial prototype when implemented in `Move Topic` dropdown as an example!
```js
const opts = {
  widget_name: "select_stream",
  data: streams_list,
  default_text: $t({ defaultMessage: "No streams" }),
  include_current_item: false,
  value: [current_stream_id.toString()], // Defines the existing items that should be present in dropdown.
  limit: 3, // Maximum items to display in button.
};
```

Corresponding template: 

```hbs
{{> dropdown_list_widget
  widget_name="select_stream"
  filter_button_text = (t 'Filter')
  list_placeholder=(t 'Filter streams')}}
```

Yields: 

![mldw](https://user-images.githubusercontent.com/53977614/122947013-73b9a200-d397-11eb-8214-6034727af067.gif)
