### PR TITLE
upgrade: Modify upgrade scripts to handle failure.

### DIFF
--- a/scripts/setup/install
+++ b/scripts/setup/install
@@ -6,7 +6,7 @@
 
 set -e
 if [ "$EUID" -ne 0 ]; then
-    echo "Error: The installation script must be run as root" >&2
+    echo "Error: The installation script must be run as root." >&2
     exit 1
 fi
 umask 022

--- a/scripts/upgrade-zulip
+++ b/scripts/upgrade-zulip
@@ -1,2 +1,26 @@
 #!/usr/bin/env bash
+#
+# This is a thin wrapper around the upgrade script (scripts/lib/upgrade-zulip).
+# This wrapper exists to log output to /var/log/zulip/upgrade.log for debugging.
+
+set -e
+
+if [ "$EUID" -ne 0 ]; then
+    basename=$(basename "$0")
+    echo "Error: $basename must be run as root." >&2
+    exit 1
+fi
+
 "$(dirname "$0")/lib/upgrade-zulip" "$@" 2>&1 | tee -a /var/log/zulip/upgrade.log
+failed=${PIPESTATUS[0]}
+
+if [ "$failed" -ne 0 ]; then
+    echo -e '\033[0;31m'
+    echo "Zulip upgrade failed (exit code $failed)!"
+    echo
+    echo -n "The upgrade process is designed to be idempotent, so you can retry "
+    echo -n "after resolving whatever issue caused the failure (there should be a traceback above). "
+    echo -n "A log of this installation is available in /var/log/zulip/upgrade.log"
+    echo -e '\033[0m'
+    exit "$failed"
+fi

--- a/scripts/upgrade-zulip-from-git
+++ b/scripts/upgrade-zulip-from-git
@@ -1,2 +1,26 @@
 #!/usr/bin/env bash
+#
+# This is a thin wrapper around the upgrade-from-git script (scripts/lib/upgrade-zulip-from-git).
+# This wrapper exists to log output to /var/log/zulip/upgrade.log for debugging.
+
+set -e
+
+if [ "$EUID" -ne 0 ]; then
+    basename=$(basename "$0")
+    echo "Error: $basename must be run as root." >&2
+    exit 1
+fi
+
 "$(dirname "$0")/lib/upgrade-zulip-from-git" "$@" 2>&1 | tee -a /var/log/zulip/upgrade.log
+failed=${PIPESTATUS[0]}
+
+if [ "$failed" -ne 0 ]; then
+    echo -e '\033[0;31m'
+    echo "Zulip upgrade failed (exit code $failed)!"
+    echo
+    echo -n "The upgrade process is designed to be idempotent, so you can retry "
+    echo -n "after resolving whatever issue caused the failure (there should be a traceback above). "
+    echo -n "A log of this installation is available in /var/log/zulip/upgrade.log"
+    echo -e '\033[0m'
+    exit "$failed"
+fi


### PR DESCRIPTION
The current `upgrade-zulip` and `upgrade-zulip-from-git`
bash scripts exit with a zero status even if the
upgrade commands exit with a non-zero status.
Hence add `set -e` command which exits the script with
the same status as the non-zero command.

For pipe commands however, the net status of a command
is the status of the last command, hence if the other parts
fail, the net status is only determined by the last command.
This is the case with our main /lib/upgrade-zulip* command
in the scripts whose status is determined by the `tee` command
instead. Hence add a small condition to get the status of the
actual upgrade command and exit the script if it fails with
a non-zero command.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

Tested with adding an additional upgrade run to production-install check in production-suite.
