### PR TITLE
Show  ignored deactivated users when they are being added to streams.

### DIFF
--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -337,4 +337,13 @@ test_ui("subscriber_pills", ({override, mock_template}) => {
     stream_pill.get_user_ids = () => peer_data.get_subscribers(denmark.stream_id);
     expected_user_ids = potential_denmark_stream_subscribers.concat(fred.user_id);
     add_subscribers_handler(event);
+
+    function is_person_active(user_id) {
+        return user_id === mark.user_id;
+    }
+    // Deactivated user_id is not included in request.
+    override(user_pill, "get_user_ids", () => [mark.user_id, fred.user_id]);
+    override(people, "is_person_active", is_person_active);
+    expected_user_ids = [mark.user_id];
+    add_subscribers_handler(event);
 });

--- a/static/templates/stream_subscription_info.hbs
+++ b/static/templates/stream_subscription_info.hbs
@@ -1,3 +1,7 @@
+{{#if message}}
+{{message}}
+<br />
+{{/if}}
 {{#each subscribed_users}}
     {{#if @first}}
     {{t "Successfully subscribed users:" }}

--- a/static/templates/stream_subscription_info.hbs
+++ b/static/templates/stream_subscription_info.hbs
@@ -2,16 +2,20 @@
 {{message}}
 <br />
 {{/if}}
-{{#each subscribed_users}}
-    {{#if @first}}
-    {{t "Successfully subscribed users:" }}
-    {{/if}}
-    <a data-user-id="{{user_id}}" class="view_user_profile">{{full_name}}</a>{{#unless @last}},{{else}}.{{/unless}}
-{{/each}}
-<br />
-{{#each already_subscribed_users}}
-    {{#if @first}}
-    {{t "Already subscribed users:" }}
-    {{/if}}
-    <a data-user-id="{{user_id}}" class="view_user_profile">{{full_name}}</a>{{#unless @last}},{{else}}.{{/unless}}
-{{/each}}
+{{#if subscribed_users}}
+    {{#each subscribed_users}}
+        {{#if @first}}
+        {{t "Successfully subscribed users:" }}
+        {{/if}}
+        <a data-user-id="{{user_id}}" class="view_user_profile">{{full_name}}</a>{{#unless @last}},{{else}}.{{/unless}}
+    {{/each}}
+    <br />
+{{/if}}
+{{#if already_subscribed_users}}
+    {{#each already_subscribed_users}}
+        {{#if @first}}
+        {{t "Already subscribed users:" }}
+        {{/if}}
+        <a data-user-id="{{user_id}}" class="view_user_profile">{{full_name}}</a>{{#unless @last}},{{else}}.{{/unless}}
+    {{/each}}
+{{/if}}

--- a/static/templates/stream_subscription_info.hbs
+++ b/static/templates/stream_subscription_info.hbs
@@ -18,4 +18,13 @@
         {{/if}}
         <a data-user-id="{{user_id}}" class="view_user_profile">{{full_name}}</a>{{#unless @last}},{{else}}.{{/unless}}
     {{/each}}
+    <br />
+{{/if}}
+{{#if ignored_deactivated_users}}
+    {{#each ignored_deactivated_users}}
+        {{#if @first}}
+        {{t "Ignored deactivated users:" }}
+        {{/if}}
+        <a data-user-id="{{user_id}}" class="view_user_profile">{{full_name}}</a>{{#unless @last}},{{else}}.{{/unless}}
+    {{/each}}
 {{/if}}


### PR DESCRIPTION
Partially addresses #18949.
Related discussion: [https://chat.zulip.org/#narrow/stream/2-general/topic/Not.20authorized.20to.20execute.20queries.3F](https://chat.zulip.org/#narrow/stream/2-general/topic/Not.20authorized.20to.20execute.20queries.3F)

**Testing plan:** Adding new cases in stream-edit node tests.


**GIFs or screenshots:** 
![deactivated_user_info](https://user-images.githubusercontent.com/63504956/122972302-9eaef080-d3ad-11eb-8501-bac2efec9d61.gif)

