### PR TITLE
popovers: Add link in profile popover groups tab to open groups settings.

### DIFF
--- a/static/js/user_profile.js
+++ b/static/js/user_profile.js
@@ -154,6 +154,8 @@ export function show_user_profile(user) {
         profile_data,
         user_avatar: "avatar/" + user.email + "/medium",
         is_me: people.is_current_user(user.email),
+        is_admin: page_params.is_admin,
+        is_guest: page_params.is_guest,
         date_joined: dateFormat.format(parseISO(user.date_joined)),
         last_seen: buddy_data.user_last_seen_time_status(user.user_id),
         show_email: settings_data.show_email(),
@@ -298,6 +300,10 @@ export function register_click_handlers() {
     /* These click handlers are implemented as just deep links to the
      * relevant part of the Zulip UI, so we don't want preventDefault,
      * but we do want to close the modal when you click them. */
+    $("body").on("click", "#user-profile-modal .manage_user_group", () => {
+        hide_user_profile();
+    });
+
     $("body").on("click", "#user-profile-modal #name #edit-button", () => {
         hide_user_profile();
     });

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -453,6 +453,13 @@ ul {
             }
         }
     }
+
+    p.manage_user_group {
+        padding-left: 10px;
+        a {
+            text-decoration: none;
+        }
+    }
 }
 
 @media (width < $md_min) {

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -81,6 +81,18 @@
             </div>
 
             <div class="tabcontent" id="user-profile-groups-tab">
+                {{#unless is_guest}}
+                <p class="manage_user_group">
+                    <a href="#organization/user-groups-admin">
+                        <i class="fa fa-cog" aria-hidden="true"></i>
+                        {{#if is_admin}}
+                        {{t 'Manage user groups'}}
+                        {{else}}
+                        {{t 'View user groups'}}
+                        {{/if}}
+                    </a>
+                </p>
+                {{/unless}}
                 <div class="subscription-group-list">
                     <table class="user-group-list" data-empty="{{t 'No user group subscriptions.'}}"></table>
                 </div>


### PR DESCRIPTION
These changes will help users or administrators to access or change groups settings from user profile popover itself, to facilitate the users if they want to perceive more information about the groups.
Added a link "Manage user groups" if the user is a administrator and "View user groups" if the user is a normal user in Profile Popover groups tab to open Organization settings > User groups overlay.

__Screenshots:__
![image](https://user-images.githubusercontent.com/33193638/123539727-a5948500-d758-11eb-8e9f-2293b332f6a4.png)
 
Fixes #18880.