### PR TITLE
import_realm: Fix stream `rendered_description` not being set while importing a realm.

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -920,8 +920,6 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
     re_map_foreign_keys(data, "zerver_stream", "realm", related_table="realm")
     # Handle rendering of stream descriptions for import from non-Zulip
     for stream in data["zerver_stream"]:
-        if "rendered_description" in stream:
-            continue
         stream["rendered_description"] = render_stream_description(stream["description"])
     bulk_import_model(data, Stream)
 


### PR DESCRIPTION
While importing a realm, the stream dictionaries in data['zerver_stream']
already contains the field named `rendered_description`, which is set to
`""`. This lead the code to assume that the stream rendered_description
was already set, due to which, it was not setting the rendered_description
field for any stream.