### PR TITLE
refactor: Change `maybe_enqueue_notifications` to take in notifications dataclass instance.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -6612,7 +6612,7 @@ def get_active_presence_idle_user_ids(
         # for them if they were indeed idle. Only including those users in the calculation below is a
         # very important optimization for open communities with many inactive users.
         if user_data.is_notifiable(is_private_message, sender_id, idle=True) or alerted:
-            user_ids.add(user_data.id)
+            user_ids.add(user_data.user_id)
 
     return filter_presence_idle_user_ids(user_ids)
 

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -4,7 +4,7 @@ from typing import Collection, Set
 
 @dataclass
 class UserMessageNotificationsData:
-    id: int
+    user_id: int
     flags: Collection[str]
     mentioned: bool
     online_push_enabled: bool
@@ -34,7 +34,7 @@ class UserMessageNotificationsData:
             user_id in wildcard_mention_user_ids and "wildcard_mentioned" in flags
         )
         return cls(
-            id=user_id,
+            user_id=user_id,
             flags=flags,
             mentioned=("mentioned" in flags),
             online_push_enabled=(user_id in online_push_user_ids),
@@ -57,7 +57,7 @@ class UserMessageNotificationsData:
         if not idle and not self.online_push_enabled:
             return False
 
-        if self.id == sender_id:
+        if self.user_id == sender_id:
             return False
 
         if self.sender_is_muted:
@@ -74,7 +74,7 @@ class UserMessageNotificationsData:
         if not idle:
             return False
 
-        if self.id == sender_id:
+        if self.user_id == sender_id:
             return False
 
         if self.sender_is_muted:

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Collection, Set
+from typing import Collection, Optional, Set
 
 
 @dataclass
@@ -54,35 +54,53 @@ class UserMessageNotificationsData:
         ) or self.is_push_notifiable(private_message, sender_id, idle)
 
     def is_push_notifiable(self, private_message: bool, sender_id: int, idle: bool) -> bool:
+        return self.get_push_notification_trigger(private_message, sender_id, idle) is not None
+
+    def get_push_notification_trigger(
+        self, private_message: bool, sender_id: int, idle: bool
+    ) -> Optional[str]:
         if not idle and not self.online_push_enabled:
-            return False
+            return None
 
         if self.user_id == sender_id:
-            return False
+            return None
 
         if self.sender_is_muted:
-            return False
+            return None
 
-        return (
-            private_message
-            or self.mentioned
-            or self.wildcard_mention_notify
-            or self.stream_push_notify
-        )
+        if private_message:
+            return "private_message"
+        elif self.mentioned:
+            return "mentioned"
+        elif self.wildcard_mention_notify:
+            return "wildcard_mentioned"
+        elif self.stream_push_notify:
+            return "stream_push_notify"
+        else:
+            return None
 
     def is_email_notifiable(self, private_message: bool, sender_id: int, idle: bool) -> bool:
+        return self.get_email_notification_trigger(private_message, sender_id, idle) is not None
+
+    def get_email_notification_trigger(
+        self, private_message: bool, sender_id: int, idle: bool
+    ) -> Optional[str]:
         if not idle:
-            return False
+            return None
 
         if self.user_id == sender_id:
-            return False
+            return None
 
         if self.sender_is_muted:
-            return False
+            return None
 
-        return (
-            private_message
-            or self.mentioned
-            or self.wildcard_mention_notify
-            or self.stream_email_notify
-        )
+        if private_message:
+            return "private_message"
+        elif self.mentioned:
+            return "mentioned"
+        elif self.wildcard_mention_notify:
+            return "wildcard_mentioned"
+        elif self.stream_email_notify:
+            return "stream_email_notify"
+        else:
+            return None

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1337,26 +1337,28 @@ Output:
             sender_is_muted=kwargs.get("sender_is_muted", False),
         )
 
-    def get_maybe_enqueue_notifications_parameters(self, **kwargs: Any) -> Dict[str, Any]:
+    def get_maybe_enqueue_notifications_parameters(
+        self, *, message_id: int, user_id: int, sender_id: int, **kwargs: Any
+    ) -> Dict[str, Any]:
         """
         Returns a dictionary with the passed parameters, after filling up the
         missing data with default values, for testing what was passed to the
         `maybe_enqueue_notifications` method.
         """
-        parameters: Dict[str, Any] = dict(
-            private_message=False,
-            mentioned=False,
-            wildcard_mention_notify=False,
-            stream_push_notify=False,
-            stream_email_notify=False,
-            stream_name=None,
-            online_push_enabled=False,
-            idle=True,
-            already_notified={"email_notified": False, "push_notified": False},
+        user_notifications_data = self.create_user_notifications_data_object(
+            user_id=user_id, **kwargs
         )
-
-        # Values from `kwargs` will replace those from `parameters`
-        return {**parameters, **kwargs}
+        return dict(
+            user_data=user_notifications_data,
+            message_id=message_id,
+            sender_id=sender_id,
+            private_message=kwargs.get("private_message", False),
+            stream_name=kwargs.get("stream_name", None),
+            idle=kwargs.get("idle", True),
+            already_notified=kwargs.get(
+                "already_notified", {"email_notified": False, "push_notified": False}
+            ),
+        )
 
 
 class WebhookTestCase(ZulipTestCase):

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1323,9 +1323,11 @@ Output:
 
         self.assert_length(lst, expected_num_events)
 
-    def create_user_notifications_data_object(self, **kwargs: Any) -> UserMessageNotificationsData:
+    def create_user_notifications_data_object(
+        self, *, user_id: int, **kwargs: Any
+    ) -> UserMessageNotificationsData:
         return UserMessageNotificationsData(
-            id=kwargs.get("id", self.example_user("hamlet").id),
+            user_id=user_id,
             flags=kwargs.get("flags", []),
             mentioned=kwargs.get("mentioned", False),
             online_push_enabled=kwargs.get("online_push_enabled", False),

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -245,28 +245,26 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             self.assert_json_success(result)
 
         def assert_maybe_enqueue_notifications_call_args(
-            args_list: Collection[Any],
+            args_dict: Collection[Any],
             user_profile_id: int,
             message_id: int,
             **kwargs: Union[bool, Dict[str, bool], Optional[str]],
         ) -> None:
             kwargs = self.get_maybe_enqueue_notifications_parameters(**kwargs)
-            self.assertEqual(
-                args_list,
-                (
-                    user_profile_id,
-                    message_id,
-                    kwargs["private_message"],
-                    kwargs["mentioned"],
-                    kwargs["wildcard_mention_notify"],
-                    kwargs["stream_push_notify"],
-                    kwargs["stream_email_notify"],
-                    kwargs["stream_name"],
-                    kwargs["online_push_enabled"],
-                    kwargs["idle"],
-                    kwargs["already_notified"],
-                ),
+            expected_args_dict = dict(
+                user_profile_id=user_profile_id,
+                message_id=message_id,
+                private_message=kwargs["private_message"],
+                mentioned=kwargs["mentioned"],
+                wildcard_mention_notify=kwargs["wildcard_mention_notify"],
+                stream_push_notify=kwargs["stream_push_notify"],
+                stream_email_notify=kwargs["stream_email_notify"],
+                stream_name=kwargs["stream_name"],
+                online_push_enabled=kwargs["online_push_enabled"],
+                idle=kwargs["idle"],
+                already_notified=kwargs["already_notified"],
             )
+            self.assertEqual(args_dict, expected_args_dict)
 
         client_descriptor = allocate_event_queue()
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
@@ -283,10 +281,10 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             # Now verify that we called the appropriate enqueue function
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
-            args_list = mock_enqueue.call_args_list[0][0]
+            args_dict = mock_enqueue.call_args_list[0][1]
 
             assert_maybe_enqueue_notifications_call_args(
-                args_list=args_list,
+                args_dict=args_dict,
                 user_profile_id=user_profile.id,
                 message_id=msg_id,
                 stream_name="Denmark",
@@ -301,10 +299,10 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
-            args_list = mock_enqueue.call_args_list[0][0]
+            args_dict = mock_enqueue.call_args_list[0][1]
 
             assert_maybe_enqueue_notifications_call_args(
-                args_list=args_list,
+                args_dict=args_dict,
                 user_profile_id=user_profile.id,
                 message_id=msg_id,
                 private_message=True,
@@ -321,10 +319,10 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
-            args_list = mock_enqueue.call_args_list[0][0]
+            args_dict = mock_enqueue.call_args_list[0][1]
 
             assert_maybe_enqueue_notifications_call_args(
-                args_list=args_list,
+                args_dict=args_dict,
                 user_profile_id=user_profile.id,
                 message_id=msg_id,
                 mentioned=True,
@@ -340,10 +338,10 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
-            args_list = mock_enqueue.call_args_list[0][0]
+            args_dict = mock_enqueue.call_args_list[0][1]
 
             assert_maybe_enqueue_notifications_call_args(
-                args_list=args_list,
+                args_dict=args_dict,
                 user_profile_id=user_profile.id,
                 message_id=msg_id,
                 wildcard_mention_notify=True,
@@ -360,10 +358,10 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
-            args_list = mock_enqueue.call_args_list[0][0]
+            args_dict = mock_enqueue.call_args_list[0][1]
 
             assert_maybe_enqueue_notifications_call_args(
-                args_list=args_list,
+                args_dict=args_dict,
                 user_profile_id=user_profile.id,
                 message_id=msg_id,
                 stream_name="Denmark",
@@ -381,10 +379,10 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
-            args_list = mock_enqueue.call_args_list[0][0]
+            args_dict = mock_enqueue.call_args_list[0][1]
 
             assert_maybe_enqueue_notifications_call_args(
-                args_list=args_list,
+                args_dict=args_dict,
                 user_profile_id=user_profile.id,
                 message_id=msg_id,
                 stream_name="Denmark",
@@ -406,10 +404,10 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
-            args_list = mock_enqueue.call_args_list[0][0]
+            args_dict = mock_enqueue.call_args_list[0][1]
 
             assert_maybe_enqueue_notifications_call_args(
-                args_list=args_list,
+                args_dict=args_dict,
                 user_profile_id=user_profile.id,
                 message_id=msg_id,
                 wildcard_mention_notify=True,
@@ -430,10 +428,10 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
-            args_list = mock_enqueue.call_args_list[0][0]
+            args_dict = mock_enqueue.call_args_list[0][1]
 
             assert_maybe_enqueue_notifications_call_args(
-                args_list=args_list,
+                args_dict=args_dict,
                 user_profile_id=user_profile.id,
                 message_id=msg_id,
                 stream_push_notify=True,
@@ -453,10 +451,10 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
-            args_list = mock_enqueue.call_args_list[0][0]
+            args_dict = mock_enqueue.call_args_list[0][1]
 
             assert_maybe_enqueue_notifications_call_args(
-                args_list=args_list,
+                args_dict=args_dict,
                 user_profile_id=user_profile.id,
                 message_id=msg_id,
                 stream_push_notify=False,
@@ -484,10 +482,10 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
-            args_list = mock_enqueue.call_args_list[0][0]
+            args_dict = mock_enqueue.call_args_list[0][1]
 
             assert_maybe_enqueue_notifications_call_args(
-                args_list=args_list,
+                args_dict=args_dict,
                 user_profile_id=user_profile.id,
                 message_id=msg_id,
                 stream_name="Denmark",
@@ -508,10 +506,10 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
-            args_list = mock_enqueue.call_args_list[0][0]
+            args_dict = mock_enqueue.call_args_list[0][1]
 
             assert_maybe_enqueue_notifications_call_args(
-                args_list=args_list,
+                args_dict=args_dict,
                 user_profile_id=user_profile.id,
                 message_id=msg_id,
                 stream_name="Denmark",

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -105,7 +105,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         cordelia_calls = [
             call_args
             for call_args in m.call_args_list
-            if call_args[1]["user_profile_id"] == cordelia.id
+            if call_args[1]["user_data"].user_id == cordelia.id
         ]
 
         if expect_short_circuit:
@@ -184,10 +184,13 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         info = notification_message_data["info"]
 
         cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
         expected_enqueue_kwargs = self.get_maybe_enqueue_notifications_parameters(
-            user_profile_id=cordelia.id,
+            user_id=cordelia.id,
+            sender_id=hamlet.id,
             message_id=message_id,
             mentioned=True,
+            flags=["mentioned"],
             stream_name="Scotland",
             already_notified={},
         )
@@ -295,6 +298,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
 
     def test_online_push_enabled_for_fully_present_mentioned_user(self) -> None:
         cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
 
         # Simulate Cordelia is FULLY present, not just in term of
         # browser activity, but also in terms of her client descriptors.
@@ -312,10 +316,12 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         info = notification_message_data["info"]
 
         expected_enqueue_kwargs = self.get_maybe_enqueue_notifications_parameters(
-            user_profile_id=cordelia.id,
+            user_id=cordelia.id,
+            sender_id=hamlet.id,
             message_id=message_id,
             mentioned=True,
             stream_name="Scotland",
+            flags=["mentioned"],
             online_push_enabled=True,
             idle=False,
             already_notified={},
@@ -329,6 +335,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
 
     def test_online_push_enabled_for_fully_present_boring_user(self) -> None:
         cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
 
         # Simulate Cordelia is FULLY present, not just in term of
         # browser activity, but also in terms of her client descriptors.
@@ -346,7 +353,8 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         info = notification_message_data["info"]
 
         expected_enqueue_kwargs = self.get_maybe_enqueue_notifications_parameters(
-            user_profile_id=cordelia.id,
+            user_id=cordelia.id,
+            sender_id=hamlet.id,
             message_id=message_id,
             stream_name="Scotland",
             online_push_enabled=True,
@@ -381,9 +389,11 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         info = notification_message_data["info"]
 
         expected_enqueue_kwargs = self.get_maybe_enqueue_notifications_parameters(
-            user_profile_id=cordelia.id,
+            user_id=cordelia.id,
             message_id=message_id,
+            sender_id=self.example_user("hamlet").id,
             mentioned=True,
+            flags=["mentioned"],
             stream_name="Scotland",
             already_notified={},
         )
@@ -395,6 +405,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
 
     def test_updates_with_wildcard_mention(self) -> None:
         cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
 
         # We will simulate that the user still has a an active client,
         # but they don't have UserPresence rows, so we will still
@@ -411,9 +422,11 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         info = notification_message_data["info"]
 
         expected_enqueue_kwargs = self.get_maybe_enqueue_notifications_parameters(
-            user_profile_id=cordelia.id,
+            user_id=cordelia.id,
+            sender_id=hamlet.id,
             message_id=message_id,
             wildcard_mention_notify=True,
+            flags=["wildcard_mentioned"],
             stream_name="Scotland",
             already_notified={},
         )
@@ -450,6 +463,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
 
     def test_updates_with_stream_mention_of_fully_present_user(self) -> None:
         cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
 
         # Simulate Cordelia is FULLY present, not just in term of
         # browser activity, but also in terms of her client descriptors.
@@ -466,9 +480,11 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         info = notification_message_data["info"]
 
         expected_enqueue_kwargs = self.get_maybe_enqueue_notifications_parameters(
-            user_profile_id=cordelia.id,
+            user_id=cordelia.id,
+            sender_id=hamlet.id,
             message_id=message_id,
             mentioned=True,
+            flags=["mentioned"],
             stream_name="Scotland",
             idle=False,
             already_notified={},

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -23,8 +23,8 @@ class MissedMessageTest(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         othello = self.example_user("othello")
         user_data_objects = [
-            self.create_user_notifications_data_object(id=hamlet.id),
-            self.create_user_notifications_data_object(id=othello.id),
+            self.create_user_notifications_data_object(user_id=hamlet.id),
+            self.create_user_notifications_data_object(user_id=othello.id),
         ]
         message_type = "private"
 

--- a/zerver/tests/test_muting_users.py
+++ b/zerver/tests/test_muting_users.py
@@ -312,7 +312,7 @@ class MutedUsersTests(ZulipTestCase):
             self.assert_json_success(result)
             m.assert_called_once()
             # `maybe_enqueue_notificaions` was called for Hamlet after message edit mentioned him.
-            self.assertEqual(m.call_args_list[0][1]["user_profile_id"], hamlet.id)
+            self.assertEqual(m.call_args_list[0][1]["user_data"].user_id, hamlet.id)
 
         # Hamlet mutes Cordelia.
         self.login("hamlet")

--- a/zerver/tests/test_notification_data.py
+++ b/zerver/tests/test_notification_data.py
@@ -3,46 +3,53 @@ from zerver.lib.test_classes import ZulipTestCase
 
 class TestNotificationData(ZulipTestCase):
     def test_is_push_notifiable(self) -> None:
+        user_id = self.example_user("hamlet").id
         sender_id = self.example_user("cordelia").id
 
         # Boring case
-        user_data = self.create_user_notifications_data_object()
+        user_data = self.create_user_notifications_data_object(user_id=user_id)
         self.assertFalse(
             user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
         )
 
         # Notifiable cases for PMs, mentions, stream notifications
-        user_data = self.create_user_notifications_data_object()
+        user_data = self.create_user_notifications_data_object(user_id=user_id)
         self.assertTrue(
             user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=True)
         )
 
-        user_data = self.create_user_notifications_data_object(flags=["mentioned"], mentioned=True)
+        user_data = self.create_user_notifications_data_object(
+            user_id=user_id, flags=["mentioned"], mentioned=True
+        )
         self.assertTrue(
             user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
         )
 
         user_data = self.create_user_notifications_data_object(
-            flags=["wildcard_mentioned"], wildcard_mention_notify=True
+            user_id=user_id, flags=["wildcard_mentioned"], wildcard_mention_notify=True
         )
         self.assertTrue(
             user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
         )
 
-        user_data = self.create_user_notifications_data_object(stream_push_notify=True)
+        user_data = self.create_user_notifications_data_object(
+            user_id=user_id, stream_push_notify=True
+        )
         self.assertTrue(
             user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
         )
 
         # Now, test the `online_push_enabled` property
         # Test no notifications when not idle
-        user_data = self.create_user_notifications_data_object()
+        user_data = self.create_user_notifications_data_object(user_id=user_id)
         self.assertFalse(
             user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=False)
         )
 
         # Test notifications are sent when not idle but `online_push_enabled = True`
-        user_data = self.create_user_notifications_data_object(online_push_enabled=True)
+        user_data = self.create_user_notifications_data_object(
+            user_id=user_id, online_push_enabled=True
+        )
         self.assertTrue(
             user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=False)
         )
@@ -51,6 +58,7 @@ class TestNotificationData(ZulipTestCase):
         # We just want to test the early (False) return patterns in these special cases:
         # Message sender is muted.
         user_data = self.create_user_notifications_data_object(
+            user_id=user_id,
             sender_is_muted=True,
             flags=["mentioned", "wildcard_mentioned"],
             wildcard_mention_notify=True,
@@ -64,7 +72,7 @@ class TestNotificationData(ZulipTestCase):
 
         # Message sender is the user the object corresponds to.
         user_data = self.create_user_notifications_data_object(
-            id=sender_id,
+            user_id=sender_id,
             sender_is_muted=False,
             flags=["mentioned", "wildcard_mentioned"],
             wildcard_mention_notify=True,
@@ -77,39 +85,44 @@ class TestNotificationData(ZulipTestCase):
         )
 
     def test_is_email_notifiable(self) -> None:
+        user_id = self.example_user("hamlet").id
         sender_id = self.example_user("cordelia").id
 
         # Boring case
-        user_data = self.create_user_notifications_data_object()
+        user_data = self.create_user_notifications_data_object(user_id=user_id)
         self.assertFalse(
             user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
         )
 
         # Notifiable cases for PMs, mentions, stream notifications
-        user_data = self.create_user_notifications_data_object()
+        user_data = self.create_user_notifications_data_object(user_id=user_id)
         self.assertTrue(
             user_data.is_email_notifiable(private_message=True, sender_id=sender_id, idle=True)
         )
 
-        user_data = self.create_user_notifications_data_object(flags=["mentioned"], mentioned=True)
+        user_data = self.create_user_notifications_data_object(
+            user_id=user_id, flags=["mentioned"], mentioned=True
+        )
         self.assertTrue(
             user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
         )
 
         user_data = self.create_user_notifications_data_object(
-            flags=["wildcard_mentioned"], wildcard_mention_notify=True
+            user_id=user_id, flags=["wildcard_mentioned"], wildcard_mention_notify=True
         )
         self.assertTrue(
             user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
         )
 
-        user_data = self.create_user_notifications_data_object(stream_email_notify=True)
+        user_data = self.create_user_notifications_data_object(
+            user_id=user_id, stream_email_notify=True
+        )
         self.assertTrue(
             user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
         )
 
         # Test no notifications when not idle
-        user_data = self.create_user_notifications_data_object()
+        user_data = self.create_user_notifications_data_object(user_id=user_id)
         self.assertFalse(
             user_data.is_email_notifiable(private_message=True, sender_id=sender_id, idle=False)
         )
@@ -118,6 +131,7 @@ class TestNotificationData(ZulipTestCase):
         # We just want to test the early (False) return patterns in these special cases:
         # Message sender is muted.
         user_data = self.create_user_notifications_data_object(
+            user_id=user_id,
             sender_is_muted=True,
             flags=["mentioned", "wildcard_mentioned"],
             wildcard_mention_notify=True,
@@ -131,7 +145,7 @@ class TestNotificationData(ZulipTestCase):
 
         # Message sender is the user the object corresponds to.
         user_data = self.create_user_notifications_data_object(
-            id=sender_id,
+            user_id=sender_id,
             sender_is_muted=False,
             flags=["mentioned", "wildcard_mentioned"],
             wildcard_mention_notify=True,
@@ -146,8 +160,9 @@ class TestNotificationData(ZulipTestCase):
     def test_is_notifiable(self) -> None:
         # This is just for coverage purposes. We've already tested all scenarios above,
         # and `is_notifiable` is a simple OR of the email and push functions.
+        user_id = self.example_user("hamlet").id
         sender_id = self.example_user("cordelia").id
-        user_data = self.create_user_notifications_data_object()
+        user_data = self.create_user_notifications_data_object(user_id=user_id)
         self.assertTrue(
             user_data.is_notifiable(private_message=True, sender_id=sender_id, idle=True)
         )

--- a/zerver/tests/test_notification_data.py
+++ b/zerver/tests/test_notification_data.py
@@ -8,32 +8,65 @@ class TestNotificationData(ZulipTestCase):
 
         # Boring case
         user_data = self.create_user_notifications_data_object(user_id=user_id)
+        self.assertEqual(
+            user_data.get_push_notification_trigger(
+                private_message=False, sender_id=sender_id, idle=True
+            ),
+            None,
+        )
         self.assertFalse(
             user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
         )
 
-        # Notifiable cases for PMs, mentions, stream notifications
+        # Private message
         user_data = self.create_user_notifications_data_object(user_id=user_id)
+        self.assertEqual(
+            user_data.get_push_notification_trigger(
+                private_message=True, sender_id=sender_id, idle=True
+            ),
+            "private_message",
+        )
         self.assertTrue(
             user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=True)
         )
 
+        # Mention
         user_data = self.create_user_notifications_data_object(
             user_id=user_id, flags=["mentioned"], mentioned=True
         )
+        self.assertEqual(
+            user_data.get_push_notification_trigger(
+                private_message=False, sender_id=sender_id, idle=True
+            ),
+            "mentioned",
+        )
         self.assertTrue(
             user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
         )
 
+        # Wildcard mention
         user_data = self.create_user_notifications_data_object(
             user_id=user_id, flags=["wildcard_mentioned"], wildcard_mention_notify=True
         )
+        self.assertEqual(
+            user_data.get_push_notification_trigger(
+                private_message=False, sender_id=sender_id, idle=True
+            ),
+            "wildcard_mentioned",
+        )
         self.assertTrue(
             user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
         )
 
+        # Stream notification
         user_data = self.create_user_notifications_data_object(
             user_id=user_id, stream_push_notify=True
+        )
+        self.assertEqual(
+            user_data.get_push_notification_trigger(
+                private_message=False, sender_id=sender_id, idle=True
+            ),
+            "stream_push_notify",
         )
         self.assertTrue(
             user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
@@ -42,6 +75,12 @@ class TestNotificationData(ZulipTestCase):
         # Now, test the `online_push_enabled` property
         # Test no notifications when not idle
         user_data = self.create_user_notifications_data_object(user_id=user_id)
+        self.assertEqual(
+            user_data.get_push_notification_trigger(
+                private_message=True, sender_id=sender_id, idle=False
+            ),
+            None,
+        )
         self.assertFalse(
             user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=False)
         )
@@ -49,6 +88,12 @@ class TestNotificationData(ZulipTestCase):
         # Test notifications are sent when not idle but `online_push_enabled = True`
         user_data = self.create_user_notifications_data_object(
             user_id=user_id, online_push_enabled=True
+        )
+        self.assertEqual(
+            user_data.get_push_notification_trigger(
+                private_message=True, sender_id=sender_id, idle=False
+            ),
+            "private_message",
         )
         self.assertTrue(
             user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=False)
@@ -66,6 +111,12 @@ class TestNotificationData(ZulipTestCase):
             stream_email_notify=True,
             stream_push_notify=True,
         )
+        self.assertEqual(
+            user_data.get_push_notification_trigger(
+                private_message=True, sender_id=sender_id, idle=True
+            ),
+            None,
+        )
         self.assertFalse(
             user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=True)
         )
@@ -80,6 +131,12 @@ class TestNotificationData(ZulipTestCase):
             stream_email_notify=True,
             stream_push_notify=True,
         )
+        self.assertEqual(
+            user_data.get_push_notification_trigger(
+                private_message=True, sender_id=sender_id, idle=True
+            ),
+            None,
+        )
         self.assertFalse(
             user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=True)
         )
@@ -90,32 +147,65 @@ class TestNotificationData(ZulipTestCase):
 
         # Boring case
         user_data = self.create_user_notifications_data_object(user_id=user_id)
+        self.assertEqual(
+            user_data.get_email_notification_trigger(
+                private_message=False, sender_id=sender_id, idle=True
+            ),
+            None,
+        )
         self.assertFalse(
             user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
         )
 
-        # Notifiable cases for PMs, mentions, stream notifications
+        # Private message
         user_data = self.create_user_notifications_data_object(user_id=user_id)
+        self.assertEqual(
+            user_data.get_email_notification_trigger(
+                private_message=True, sender_id=sender_id, idle=True
+            ),
+            "private_message",
+        )
         self.assertTrue(
             user_data.is_email_notifiable(private_message=True, sender_id=sender_id, idle=True)
         )
 
+        # Mention
         user_data = self.create_user_notifications_data_object(
             user_id=user_id, flags=["mentioned"], mentioned=True
         )
+        self.assertEqual(
+            user_data.get_email_notification_trigger(
+                private_message=False, sender_id=sender_id, idle=True
+            ),
+            "mentioned",
+        )
         self.assertTrue(
             user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
         )
 
+        # Wildcard mention
         user_data = self.create_user_notifications_data_object(
             user_id=user_id, flags=["wildcard_mentioned"], wildcard_mention_notify=True
         )
+        self.assertEqual(
+            user_data.get_email_notification_trigger(
+                private_message=False, sender_id=sender_id, idle=True
+            ),
+            "wildcard_mentioned",
+        )
         self.assertTrue(
             user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
         )
 
+        # Stream notification
         user_data = self.create_user_notifications_data_object(
             user_id=user_id, stream_email_notify=True
+        )
+        self.assertEqual(
+            user_data.get_email_notification_trigger(
+                private_message=False, sender_id=sender_id, idle=True
+            ),
+            "stream_email_notify",
         )
         self.assertTrue(
             user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
@@ -123,6 +213,12 @@ class TestNotificationData(ZulipTestCase):
 
         # Test no notifications when not idle
         user_data = self.create_user_notifications_data_object(user_id=user_id)
+        self.assertEqual(
+            user_data.get_email_notification_trigger(
+                private_message=True, sender_id=sender_id, idle=False
+            ),
+            None,
+        )
         self.assertFalse(
             user_data.is_email_notifiable(private_message=True, sender_id=sender_id, idle=False)
         )
@@ -139,6 +235,12 @@ class TestNotificationData(ZulipTestCase):
             stream_email_notify=True,
             stream_push_notify=True,
         )
+        self.assertEqual(
+            user_data.get_email_notification_trigger(
+                private_message=True, sender_id=sender_id, idle=True
+            ),
+            None,
+        )
         self.assertFalse(
             user_data.is_email_notifiable(private_message=True, sender_id=sender_id, idle=True)
         )
@@ -152,6 +254,12 @@ class TestNotificationData(ZulipTestCase):
             mentioned=True,
             stream_email_notify=True,
             stream_push_notify=True,
+        )
+        self.assertEqual(
+            user_data.get_email_notification_trigger(
+                private_message=True, sender_id=sender_id, idle=True
+            ),
+            None,
         )
         self.assertFalse(
             user_data.is_email_notifiable(private_message=True, sender_id=sender_id, idle=True)

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -767,17 +767,17 @@ def missedmessage_hook(
             email_notified=internal_data.get("email_notified", False),
         )
         maybe_enqueue_notifications(
-            user_profile_id,
-            message_id,
-            private_message,
-            mentioned,
-            wildcard_mention_notify,
-            stream_push_notify,
-            stream_email_notify,
-            stream_name,
-            online_push_enabled,
-            idle,
-            already_notified,
+            user_profile_id=user_profile_id,
+            message_id=message_id,
+            private_message=private_message,
+            mentioned=mentioned,
+            wildcard_mention_notify=wildcard_mention_notify,
+            stream_push_notify=stream_push_notify,
+            stream_email_notify=stream_email_notify,
+            stream_name=stream_name,
+            online_push_enabled=online_push_enabled,
+            idle=idle,
+            already_notified=already_notified,
         )
 
 
@@ -793,6 +793,7 @@ def receiver_is_off_zulip(user_profile_id: int) -> bool:
 
 
 def maybe_enqueue_notifications(
+    *,
     user_profile_id: int,
     message_id: int,
     private_message: bool,
@@ -984,17 +985,17 @@ def process_message_event(
 
         extra_user_data[user_profile_id]["internal_data"].update(
             maybe_enqueue_notifications(
-                user_profile_id,
-                message_id,
-                private_message,
-                user_notifications_data.mentioned,
-                user_notifications_data.wildcard_mention_notify,
-                user_notifications_data.stream_push_notify,
-                user_notifications_data.stream_email_notify,
-                stream_name,
-                user_notifications_data.online_push_enabled,
-                idle,
-                {},
+                user_profile_id=user_profile_id,
+                message_id=message_id,
+                private_message=private_message,
+                mentioned=user_notifications_data.mentioned,
+                wildcard_mention_notify=user_notifications_data.wildcard_mention_notify,
+                stream_push_notify=user_notifications_data.stream_push_notify,
+                stream_email_notify=user_notifications_data.stream_email_notify,
+                stream_name=stream_name,
+                online_push_enabled=user_notifications_data.online_push_enabled,
+                idle=idle,
+                already_notified={},
             )
         )
 

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -969,7 +969,7 @@ def process_message_event(
         # Remove fields sent through other pipes to save some space.
         internal_data = asdict(user_notifications_data)
         internal_data.pop("flags")
-        internal_data.pop("id")
+        internal_data.pop("user_id")
         extra_user_data[user_profile_id] = dict(internal_data=internal_data)
 
         # If the message isn't notifiable had the user been idle, then the user
@@ -1199,10 +1199,10 @@ def maybe_enqueue_notifications_for_message_update(
         # model.
         return
 
-    idle = presence_idle or receiver_is_off_zulip(user_data.id)
+    idle = presence_idle or receiver_is_off_zulip(user_data.user_id)
 
     maybe_enqueue_notifications(
-        user_profile_id=user_data.id,
+        user_profile_id=user_data.user_id,
         message_id=message_id,
         private_message=private_message,
         mentioned=user_data.mentioned,

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -809,16 +809,9 @@ def maybe_enqueue_notifications(
 
     if user_data.is_push_notifiable(private_message, sender_id, idle):
         notice = build_offline_notification(user_data.user_id, message_id)
-        if private_message:
-            notice["trigger"] = "private_message"
-        elif user_data.mentioned:
-            notice["trigger"] = "mentioned"
-        elif user_data.wildcard_mention_notify:
-            notice["trigger"] = "wildcard_mentioned"
-        elif user_data.stream_push_notify:
-            notice["trigger"] = "stream_push_notify"
-        else:
-            raise AssertionError("Unknown notification trigger!")
+        notice["trigger"] = user_data.get_push_notification_trigger(
+            private_message, sender_id, idle
+        )
         notice["stream_name"] = stream_name
         if not already_notified.get("push_notified"):
             queue_json_publish("missedmessage_mobile_notifications", notice)
@@ -830,16 +823,9 @@ def maybe_enqueue_notifications(
     # above.
     if user_data.is_email_notifiable(private_message, sender_id, idle):
         notice = build_offline_notification(user_data.user_id, message_id)
-        if private_message:
-            notice["trigger"] = "private_message"
-        elif user_data.mentioned:
-            notice["trigger"] = "mentioned"
-        elif user_data.wildcard_mention_notify:
-            notice["trigger"] = "wildcard_mentioned"
-        elif user_data.stream_email_notify:
-            notice["trigger"] = "stream_email_notify"
-        else:
-            raise AssertionError("Unknown notification trigger!")
+        notice["trigger"] = user_data.get_email_notification_trigger(
+            private_message, sender_id, idle
+        )
         notice["stream_name"] = stream_name
         if not already_notified.get("email_notified"):
             queue_json_publish("missedmessage_emails", notice, lambda notice: None)


### PR DESCRIPTION
Followup to #18853 and #18951.