### PR TITLE
Fix behavior of PM list with deactivated users

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -48,6 +48,7 @@ const render_compose_private_stream_alert = mock_template("compose_private_strea
 
 const compose_closed_ui = zrequire("compose_closed_ui");
 const compose_fade = zrequire("compose_fade");
+const compose_pm_pill = zrequire("compose_pm_pill");
 const compose_state = zrequire("compose_state");
 const compose = zrequire("compose");
 const echo = zrequire("echo");
@@ -614,6 +615,7 @@ test_ui("finish", ({override}) => {
         $("#compose-textarea").val("foobarfoobar");
         compose_state.set_message_type("private");
         override(compose_state, "private_message_recipient", () => "bob@example.com");
+        override(compose_pm_pill, "get_user_ids", () => []);
 
         let compose_finished_event_checked = false;
         $(document).on("compose_finished.zulip", () => {

--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -37,6 +37,10 @@ run_test("pills", ({override}) => {
         full_name: "Hamlet",
     };
 
+    people.add_active_user(othello);
+    people.add_active_user(iago);
+    people.add_active_user(hamlet);
+
     people.get_realm_users = () => [iago, othello, hamlet];
 
     const recipient_stub = $("#private_message_recipient");
@@ -113,6 +117,18 @@ run_test("pills", ({override}) => {
             assert.equal(res.user_id, iago.user_id);
             assert.equal(res.display_value, iago.full_name);
         })();
+
+        (function test_deactivated_pill() {
+            people.deactivate(iago);
+            get_by_email_called = false;
+            const res = handler(iago.email, pills.items());
+            assert.ok(get_by_email_called);
+            assert.equal(typeof res, "object");
+            assert.equal(res.user_id, iago.user_id);
+            assert.equal(res.display_value, iago.full_name + " (deactivated)");
+            assert.ok(res.deactivated);
+            people.add_active_user(iago);
+        })();
     }
 
     function input_pill_stub(opts) {
@@ -152,7 +168,9 @@ run_test("pills", ({override}) => {
 
     const persons = [othello, iago, hamlet];
     const items = compose_pm_pill.filter_taken_users(persons);
-    assert.deepEqual(items, [{email: "iago@zulip.com", user_id: 2, full_name: "Iago"}]);
+    assert.deepEqual(items, [
+        {email: "iago@zulip.com", user_id: 2, full_name: "Iago", is_moderator: false},
+    ]);
 
     test_create_item(create_item_handler);
 

--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -213,6 +213,13 @@ test_ui("validate", ({override}) => {
     compose_state.private_message_recipient("bob@example.com");
     assert.ok(compose.validate());
 
+    people.deactivate(bob);
+    assert.ok(!compose.validate());
+    assert.equal(
+        $("#compose-error-msg").html(),
+        $t_html({defaultMessage: "You cannot send messages to deactivated users."}),
+    );
+
     page_params.realm_is_zephyr_mirror_realm = true;
     assert.ok(compose.validate());
     page_params.realm_is_zephyr_mirror_realm = false;

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -312,7 +312,7 @@ test_people("basics", () => {
     assert.equal(people.get_non_active_human_ids().length, 1);
     assert.equal(people.get_active_human_count(), 1);
     assert.equal(people.is_active_user_for_popover(isaac.user_id), false);
-    assert.equal(people.is_valid_email_for_compose(isaac.email), false);
+    assert.equal(people.is_valid_email_for_compose(isaac.email), true);
 
     people.add_active_user(bot_botson);
     assert.equal(people.is_active_user_for_popover(bot_botson.user_id), true);
@@ -1077,7 +1077,7 @@ test_people("initialize", () => {
     assert.ok(people.is_cross_realm_email("bot@example.com"));
     assert.ok(people.is_valid_email_for_compose("bot@example.com"));
     assert.ok(people.is_valid_email_for_compose("alice@example.com"));
-    assert.ok(!people.is_valid_email_for_compose("retiree@example.com"));
+    assert.ok(people.is_valid_email_for_compose("retiree@example.com"));
     assert.ok(!people.is_valid_email_for_compose("totally-bogus-username@example.com"));
     assert.ok(people.is_valid_bulk_emails_for_compose(["bot@example.com", "alice@example.com"]));
     assert.ok(!people.is_valid_bulk_emails_for_compose(["not@valid.com", "alice@example.com"]));

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -121,6 +121,10 @@ test_ui("populate_user_groups", ({override}) => {
         full_name: "Bob",
     };
 
+    people.add_active_user(iago);
+    people.add_active_user(alice);
+    people.add_active_user(bob);
+
     people.get_realm_users = () => [iago, alice, bob];
 
     user_groups.get_realm_user_groups = () => [realm_user_group];
@@ -320,6 +324,18 @@ test_ui("populate_user_groups", ({override}) => {
             assert.equal(typeof res, "object");
             assert.equal(res.user_id, bob.user_id);
             assert.equal(res.display_value, bob.full_name);
+        })();
+
+        (function test_deactivated_pill() {
+            people.deactivate(bob);
+            get_by_email_called = false;
+            const res = handler(bob.email, pills.items());
+            assert.ok(get_by_email_called);
+            assert.equal(typeof res, "object");
+            assert.equal(res.user_id, bob.user_id);
+            assert.equal(res.display_value, bob.full_name + " (deactivated)");
+            assert.ok(res.deactivated);
+            people.add_active_user(bob);
         })();
     }
 

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -62,6 +62,12 @@ run_test("narrowing", ({override}) => {
     top_left_corner.handle_narrow_activated(filter);
     assert.ok(!pm_expanded);
 
+    pm_expanded = false;
+    people.deactivate(alice);
+    filter = new Filter([{operator: "pm-with", operand: "alice@example.com"}]);
+    top_left_corner.handle_narrow_activated(filter);
+    assert.ok(pm_expanded);
+
     filter = new Filter([{operator: "is", operand: "mentioned"}]);
     top_left_corner.handle_narrow_activated(filter);
     assert.ok($(".top_left_mentions").hasClass("active-filter"));

--- a/frontend_tests/node_tests/user_pill.js
+++ b/frontend_tests/node_tests/user_pill.js
@@ -32,6 +32,7 @@ const isaac_item = {
     display_value: "Isaac Newton",
     type: "user",
     user_id: isaac.user_id,
+    deactivated: false,
     img_src: `/avatar/${isaac.user_id}&s=50`,
 };
 

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -102,6 +102,7 @@ export function create(opts) {
                 id: payload.id,
                 display_value: item.display_value,
                 has_image,
+                deactivated: item.deactivated,
             };
 
             if (has_image) {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -730,7 +730,10 @@ export function is_valid_email_for_compose(email) {
     if (!person) {
         return false;
     }
-    return active_user_dict.has(person.user_id);
+
+    // we allow deactivated users in compose so that
+    // one can attempt to reply to threads that contained them.
+    return true;
 }
 
 export function is_valid_bulk_emails_for_compose(emails) {

--- a/static/js/user_pill.js
+++ b/static/js/user_pill.js
@@ -48,7 +48,14 @@ export function create_item_from_email(email, current_items) {
         user_id: user.user_id,
         email: user.email,
         img_src: avatar_url,
+        deactivated: false,
     };
+
+    // We pass deactivated true for a deactivated user
+    if (!people.is_person_active(user.user_id)) {
+        item.deactivated = true;
+        item.display_value = user.full_name + " (deactivated)";
+    }
 
     return item;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1627,6 +1627,10 @@ div.focused_table {
     }
 }
 
+.deactivated-pill {
+    background-color: hsl(0, 86%, 86%) !important;
+}
+
 #message_view_header {
     z-index: 2;
     float: left;

--- a/static/templates/input_pill.hbs
+++ b/static/templates/input_pill.hbs
@@ -1,4 +1,4 @@
-<div class='pill' data-id='{{ id }}' tabindex=0>
+<div class='pill {{#if deactivated}} deactivated-pill {{/if}}' data-id='{{ id }}' tabindex=0>
     {{#if has_image}}
     <img class="pill-image" src="{{img_src}}" />
     {{/if}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #13766
Follow-up PR #13795 
Rebase the PR and tested properly.
1. Allowing deactivated users pill in the compose box. thus prevents pm-list from collapsing.
2. Showing the deactivated user pill in red.
3. Showing compose error with deactivated user detail.

**Testing plan:** <!-- How have you tested? -->
Tested properly with node tests. Also tested manually as mentioned in the issue.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
When you try to send a message to a deactivated user.
![image](https://user-images.githubusercontent.com/56730716/123335937-cf845680-d562-11eb-9720-38def6db28d2.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
