### PR TITLE
compose: Restyle compose send button with logo colours.

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -563,3 +563,22 @@ div.overlay {
         display: unset;
     }
 }
+
+.animated-purple-button {
+    color: hsl(0, 0%, 100%);
+    transition: all 80ms linear;
+    box-shadow: none;
+    /* This color just passes WCAG AA */
+    background-color: hsl(240, 96%, 68%);
+    cursor: pointer;
+    border: none;
+    border-radius: 4px;
+    text-align: center;
+    white-space: nowrap;
+
+    &:hover {
+        /* This color passes WCAG AAA */
+        background-color: hsl(240, 41%, 50%);
+        box-shadow: 0 1px 4px hsl(0, 0%, 0%, 0.3);
+    }
+}

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -359,20 +359,12 @@ input.recipient_box {
        this element appears before its proper position in the DOM and is configured
        to float right, so that tabbing from the compose box goes here and then
        to the message controls to its left, to ensure "Tab then Enter" sends messages. */
-    border-radius: 4px;
     padding-top: 3px;
     padding-bottom: 3px;
     margin-bottom: 0;
     font-weight: 600;
-    border: 1px solid hsl(170, 68%, 41%);
-    background-color: hsl(170, 48%, 54%);
-    color: hsl(0, 0%, 100%);
     float: right;
     font-size: 0.9em;
-
-    &:focus {
-        box-shadow: 0 0 10px hsl(170, 48%, 54%), 0 0 5px hsl(170, 48%, 54%);
-    }
 }
 
 #send_controls {

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -91,7 +91,7 @@
                             </div>
                             <div class="drag"></div>
                             <div id="below-compose-content">
-                                <button type="submit" id="compose-send-button" class="button small send_message" title="{{t 'Send' }} (Ctrl + Enter)">{{t 'Send' }}</button>
+                                <button type="submit" id="compose-send-button" class="button small send_message animated-purple-button" title="{{t 'Send' }} (Ctrl + Enter)">{{t 'Send' }}</button>
                                 {{> compose_control_buttons }}
                                 <span id="sending-indicator"></span>
                                 <div id="send_controls" class="new-style">


### PR DESCRIPTION
Previous sea-green colour didn't meet the WCAG AA standard
guidelines for color contrast. This changes meets WCAG AAA
standard.
<img width="900" alt="Screenshot 2021-06-24 at 3 32 25 PM" src="https://user-images.githubusercontent.com/25124304/123244284-64566800-d501-11eb-9650-5358ebf0f47f.png">
**onhover**:
<img width="900" alt="Screenshot 2021-06-24 at 3 32 40 PM" src="https://user-images.githubusercontent.com/25124304/123244307-6caea300-d501-11eb-85f1-a246a9d76eb5.png">
