### PR TITLE
webhooks/slack_incoming: Update regex to correctly convert emphasis.

### DIFF
--- a/zerver/webhooks/slack_incoming/fixtures/actions.json
+++ b/zerver/webhooks/slack_incoming/fixtures/actions.json
@@ -5,7 +5,7 @@
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": "Danny Torrence left the following review for your property:"
+        "text": "Danny Torrence left the following _review_ for your property:"
       }
     },
     {

--- a/zerver/webhooks/slack_incoming/tests.py
+++ b/zerver/webhooks/slack_incoming/tests.py
@@ -34,7 +34,7 @@ Hello, world.
     def test_message_with_actions(self) -> None:
         expected_topic = "C1H9RESGL"
         expected_message = """
-Danny Torrence left the following review for your property:
+Danny Torrence left the following *review* for your property:
 
 [Overlook Hotel](https://google.com) \n :star: \n Doors had too many axe holes, guest in room 237 was far too rowdy, whole place felt stuck in the 1920s.
 [Haunted hotel image](https://is5-ssl.mzstatic.com/image/thumb/Purple3/v4/d3/72/5c/d3725c8f-c642-5d69-1904-aa36e4297885/source/256x256bb.jpg)

--- a/zerver/webhooks/slack_incoming/view.py
+++ b/zerver/webhooks/slack_incoming/view.py
@@ -99,5 +99,5 @@ def replace_formatting(text: str) -> str:
     text = re.sub(r"([^\w])\*(?!\s+)([^\*^\n]+)(?<!\s)\*([^\w])", r"\1**\2**\3", text)
 
     # Slack uses _text_ for emphasis, whereas Zulip interprets that as nothing
-    text = re.sub(r"([^\w])[_](?!\s+)([^\_\^\n]+)(?<!\s)[_]([^\w])", r"\1**\2**\3", text)
+    text = re.sub(r"([^\w])[_](?!\s+)([^\_\^\n]+)(?<!\s)[_]([^\w])", r"\1*\2*\3", text)
     return text


### PR DESCRIPTION
This was a bug where we were converting `_text_` to` **text**`. For emphasis, we use the `*text*` format.


**Testing plan:** <!-- How have you tested? -->

A Test case is modified to check this conversion.
