### PR TITLE
styles: Fix line-height of delete button of image-upload-widget.

### DIFF
--- a/static/styles/image_upload_widget.css
+++ b/static/styles/image_upload_widget.css
@@ -32,6 +32,7 @@
         top: 10px;
         right: 10px;
         z-index: 99;
+        line-height: 20px;
     }
 
     .image-delete-button:hover {


### PR DESCRIPTION
This commit fixes the bug with the delete button of both profile
picture and realm-logo buttons. The button was shifted downwards
and was caused due to line height change in 5d64c21c3855.

Found the correct value of 20px by checking the line-height in
one test organization on zulipchat.com where the button position
looks correct.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


 <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before
![Screenshot from 2021-06-24 22-34-10](https://user-images.githubusercontent.com/35494118/123308070-d8fcc700-d540-11eb-9963-09e3f3f3b34f.png)
![Screenshot from 2021-06-24 22-33-44](https://user-images.githubusercontent.com/35494118/123308100-e3b75c00-d540-11eb-80d8-ee58fee63768.png)

After
![Screenshot from 2021-06-24 22-55-37](https://user-images.githubusercontent.com/35494118/123308125-e9ad3d00-d540-11eb-9151-338e0d1895c7.png)
![Screenshot from 2021-06-24 22-55-32](https://user-images.githubusercontent.com/35494118/123308137-ec0f9700-d540-11eb-8de8-77b8ee22b348.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
