### PR TITLE
Remove uses of VERSION_CODENAME and bullseye hack

### DIFF
--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -24,8 +24,6 @@ class zulip::profile::base {
         /^9\.[0-9]*$/  => 'stretch',
         /^10\.[0-9]*$/ => 'buster',
         /^11\.[0-9]*$/ => 'bullseye',
-        # This next line is temporary until bullseye releases.
-        /bullseye\/sid/ => 'bullseye',
         # Ubuntu releases
         '12.04' => 'precise',
         '14.04' => 'trusty',

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -220,8 +220,8 @@ case "$os_id$os_version_id" in
 Unsupported OS release: $os_id $os_version_id
 
 Zulip in production is supported only on:
- - Debian 11 "bullseye" (beta)
  - Debian 10 "buster"
+ - Debian 11 "bullseye" (beta)
  - Ubuntu 18.04 LTS "bionic"
  - Ubuntu 20.04 LTS "focal"
 

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -426,11 +426,6 @@ def parse_os_release() -> Dict[str, str]:
                 continue
             k, v = line.split("=", 1)
             [distro_info[k]] = shlex.split(v)
-    if distro_info["PRETTY_NAME"] == "Debian GNU/Linux bullseye/sid":
-        # This hack can be removed once bullseye releases and reports
-        # its VERSION_ID in /etc/os-release.
-        distro_info["VERSION_CODENAME"] = "bullseye"
-        distro_info["VERSION_ID"] = "11"
     return distro_info
 
 

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -412,8 +412,9 @@ def parse_os_release() -> Dict[str, str]:
      'PRETTY_NAME': 'Ubuntu 18.04.3 LTS',
     }
 
-    VERSION_CODENAME (e.g. 'bionic') is nice and human-readable, but
-    we avoid using it, as it is not available on RHEL-based platforms.
+    VERSION_CODENAME (e.g. 'bionic') is nice and readable to Ubuntu
+    developers, but we avoid using it, as it is not available on
+    RHEL-based platforms.
     """
     distro_info = {}  # type: Dict[str, str]
     with open("/etc/os-release") as fp:

--- a/tools/ci/Dockerfile.prod.template
+++ b/tools/ci/Dockerfile.prod.template
@@ -10,14 +10,9 @@ FROM {base_image}
 RUN sudo rm -rf /var/lib/rabbitmq/mnesia/*
 
 # The bionic hack used in production suite
-RUN if [ -f /etc/os-release ]; then \
-    . /etc/os-release \
-    && os_codename=$VERSION_CODENAME \
-    && if [ "$os_codename" = "bionic" ]; then \
+RUN if (. /etc/os-release && [ "$ID $VERSION_ID" = 'ubuntu 18.04' ]); then \
       sudo sed -i '/^bind/s/bind.*/bind 0.0.0.0/' /etc/redis/redis.conf; \
-    fi; \
-  fi
-
+    fi
 
 # Download the release tarball, start rabbitmq server and install the server
 RUN cd $(mktemp -d) \

--- a/tools/ci/production-install
+++ b/tools/ci/production-install
@@ -65,9 +65,12 @@ if [ -f /etc/os-release ]; then
 
     os_info="$(
         . /etc/os-release
-        printf '%s\n' "$VERSION_CODENAME"
+        printf '%s\n' "$ID" "$VERSION_ID"
     )"
-    { read -r os_version_codename || true; } <<<"$os_info"
+    {
+        read -r os_id
+        read -r os_version_id
+    } <<<"$os_info"
 fi
 
 if ! apt-get dist-upgrade -y "${APT_OPTIONS[@]}"; then
@@ -76,7 +79,7 @@ if ! apt-get dist-upgrade -y "${APT_OPTIONS[@]}"; then
 fi
 
 # Pin to PostgreSQL 10 on Bionic, so we can test upgrading it
-if [ "$os_version_codename" = "bionic" ]; then
+if [ "$os_id $os_version_id" = 'ubuntu 18.04' ]; then
     export POSTGRESQL_VERSION=10
 fi
 
@@ -89,7 +92,7 @@ else
     "$ZULIP_PATH"/scripts/setup/install --self-signed-cert --hostname 127.0.0.1 --email circleci@example.com --postgresql-database-user zulipcustomuser --postgresql-database-name zulipcustomdb
 fi
 
-if [ "$os_version_codename" = "bionic" ]; then
+if [ "$os_id $os_version_id" = 'ubuntu 18.04' ]; then
     if [ "$(crudini --get /etc/zulip/zulip.conf postgresql version)" != "10" ]; then
         echo "Installer did not install the PostgreSQL 10 that we asked for!"
         exit 1

--- a/tools/ci/production-install
+++ b/tools/ci/production-install
@@ -47,36 +47,19 @@ tar -xf /tmp/zulip-server-test.tar.gz -C "$ZULIP_PATH" --strip-components=1
 APT_OPTIONS=(-o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold')
 apt-get update
 
-if [ -f /etc/os-release ]; then
-    # This is a temporary hack to test Debian Bullseye systems as
-    # though Bullseye was already released, so we don't need to
-    # change all of our scripts to parse bullseye/sid.
-    check_pretty_name="$(
-        . /etc/os-release
-        printf '%s\n' "$PRETTY_NAME"
-    )"
-    { read -r pretty_name; } <<<"$check_pretty_name"
-
-    if [ "$pretty_name" = "Debian GNU/Linux bullseye/sid" ]; then
-        echo "VERSION_CODENAME=bullseye" | tee -a >>/etc/os-release
-        echo "VERSION_ID=\"11\"" | tee -a >>/etc/os-release
-    fi
-    # End hack
-
-    os_info="$(
-        . /etc/os-release
-        printf '%s\n' "$ID" "$VERSION_ID"
-    )"
-    {
-        read -r os_id
-        read -r os_version_id
-    } <<<"$os_info"
-fi
-
 if ! apt-get dist-upgrade -y "${APT_OPTIONS[@]}"; then
     echo "\`apt-get dist-upgrade\`: Failure occurred while trying to perform distribution upgrade, Retrying..."
     apt-get dist-upgrade -y "${APT_OPTIONS[@]}"
 fi
+
+os_info="$(
+    . /etc/os-release
+    printf '%s\n' "$ID" "$VERSION_ID"
+)"
+{
+    read -r os_id
+    read -r os_version_id
+} <<<"$os_info"
 
 # Pin to PostgreSQL 10 on Bionic, so we can test upgrading it
 if [ "$os_id $os_version_id" = 'ubuntu 18.04' ]; then

--- a/tools/ci/production-verify
+++ b/tools/ci/production-verify
@@ -12,13 +12,13 @@ NOREPLY_EMAIL_ADDRESS = 'noreply@circleci.example.com'
 ALLOWED_HOSTS = []
 EOF
 
-if [ -f /etc/os-release ]; then
-    os_info="$(
-        . /etc/os-release
-        printf '%s\n' "$VERSION_CODENAME"
-    )"
-    { read -r os_version_codename || true; } <<<"$os_info"
-fi
+os_info="$(
+    . /etc/os-release
+    printf '%s\n' "$ID"
+)"
+{
+    read -r os_id
+} <<<"$os_info"
 
 check_header() {
     sed -i -e 's|Length: [0-9]\+\( ([0-9.]\+K)\)\?|Length: <Length>|' -e "s|{nginx_version_string}|$nginx_version|g" "$success_header_file"
@@ -74,7 +74,7 @@ nginx_version="$(nginx -v 2>&1 | awk '{print $3, $4}' | xargs)"
 
 # Simplify the diff by getting replacing 4-5 digit length numbers with <Length>.
 sed -i 's|Length: [0-9]\+\( ([0-9.]\+K)\)\?|Length: <Length>|' /tmp/http-headers-processed
-if [ "$os_version_codename" = "buster" ] || [ "$os_version_codename" = "bullseye" ]; then
+if [ "$os_id" = debian ]; then
     success_header_file="/tmp/success-http-headers.template.debian.txt"
     check_header
 else

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -199,7 +199,7 @@ elif "debian" in os_families():
     # additional dependency for postgresql-13-pgdg-pgroonga.
     #
     # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895037
-    if distro_info["VERSION_CODENAME"] == "bullseye":
+    if vendor == "debian" and os_version == "11":
         DEBIAN_DEPENDECIES.remove("libappindicator1")
         DEBIAN_DEPENDECIES.append("libgroonga0")
 


### PR DESCRIPTION
base-files 11.1 marked bullseye as Debian 11 in /etc/os-release.

(I rebuilt and pushed `zulip/ci:bullseye`.)