### PR TITLE
bootstrap-awscli: Remove executable bit.

### DIFF
--- a/tools/setup/bootstrap-aws-installer
+++ b/tools/setup/bootstrap-aws-installer
@@ -41,7 +41,7 @@ export DEBIAN_FRONTEND=noninteractive
     apt-get -qy autoclean
 )
 
-# The following line gets subbed in with the contents of bootstrap-awscli
+# The following line gets subbed in with the contents of bootstrap-awscli.sh
 AWS=
 
 # Set up AWS so we can use the role credentials we were started with, which give secrets access

--- a/tools/setup/bootstrap-awscli.sh
+++ b/tools/setup/bootstrap-awscli.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 
 AWS_CLI_VERSION="2.0.30"
 AWS_CLI_SHA="7ee475f22c1b35cc9e53affbf96a9ffce91706e154a9441d0d39cbf8366b718e"

--- a/tools/setup/install-aws-server
+++ b/tools/setup/install-aws-server
@@ -31,7 +31,7 @@ set -x
 
 cd "$(dirname "$0")"
 
-source ./bootstrap-awscli
+source ./bootstrap-awscli.sh
 
 zulip_install_config_file="$HOME/.zulip-install-server.conf"
 if [ ! -f "$zulip_install_config_file" ]; then
@@ -105,7 +105,7 @@ BOOTDATA=$(mktemp)
     echo "REPO_URL=$REPO_URL"
     echo "BRANCH=$BRANCH"
     echo "SSH_SECRET_ID=$SSH_SECRET_ID"
-    sed '/^AWS=/ r ./bootstrap-awscli' bootstrap-aws-installer
+    sed '/^AWS=/ r ./bootstrap-awscli.sh' bootstrap-aws-installer
 } >>"$BOOTDATA"
 
 TAG_ROLE_NAMES=$(echo "$ROLES" | perl -pe 's/\w+::profile::(\w+)/$1/g')


### PR DESCRIPTION
Even though this looks like an independently runnable script, it should not be run independently: a SHA-256 mismatch will fail to stop the script, unless it was sourced from another script that has `set -e`.

**Testing plan:** Not tested.

Cc @alexmv.