### PR TITLE
notification_data: Use `acting_user_id` as variable name, not `sender_id`.

### DIFF
--- a/docs/subsystems/sending-messages.md
+++ b/docs/subsystems/sending-messages.md
@@ -59,8 +59,8 @@ number of purposes:
      to just do the check for whether a notification should be
      generated, and then put an event into an appropriate
      [queue](../subsystems/queuing.md) to actually send the message.
-     See `maybe_enqueue_notifications` and related code for this part
-     of the logic.
+     See `maybe_enqueue_notifications` and `zerver/lib/notification_data.py` for
+     this part of the logic.
    * Splicing user-dependent data (E.g. `flags` such as when the user
    was `mentioned`) into the events.
    * Handling the [local echo details](#local-echo).

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -48,21 +48,24 @@ class UserMessageNotificationsData:
     # `enable_offline_email_notifications` settings (for PMs and mentions), but currently they
     # don't.
 
-    def is_notifiable(self, private_message: bool, sender_id: int, idle: bool) -> bool:
+    # For these functions, acting_user_id is the user sent a message
+    # (or edited a message) triggering the event for which we need to
+    # determine notifiability.
+    def is_notifiable(self, private_message: bool, acting_user_id: int, idle: bool) -> bool:
         return self.is_email_notifiable(
-            private_message, sender_id, idle
-        ) or self.is_push_notifiable(private_message, sender_id, idle)
+            private_message, acting_user_id, idle
+        ) or self.is_push_notifiable(private_message, acting_user_id, idle)
 
-    def is_push_notifiable(self, private_message: bool, sender_id: int, idle: bool) -> bool:
-        return self.get_push_notification_trigger(private_message, sender_id, idle) is not None
+    def is_push_notifiable(self, private_message: bool, acting_user_id: int, idle: bool) -> bool:
+        return self.get_push_notification_trigger(private_message, acting_user_id, idle) is not None
 
     def get_push_notification_trigger(
-        self, private_message: bool, sender_id: int, idle: bool
+        self, private_message: bool, acting_user_id: int, idle: bool
     ) -> Optional[str]:
         if not idle and not self.online_push_enabled:
             return None
 
-        if self.user_id == sender_id:
+        if self.user_id == acting_user_id:
             return None
 
         if self.sender_is_muted:
@@ -79,16 +82,18 @@ class UserMessageNotificationsData:
         else:
             return None
 
-    def is_email_notifiable(self, private_message: bool, sender_id: int, idle: bool) -> bool:
-        return self.get_email_notification_trigger(private_message, sender_id, idle) is not None
+    def is_email_notifiable(self, private_message: bool, acting_user_id: int, idle: bool) -> bool:
+        return (
+            self.get_email_notification_trigger(private_message, acting_user_id, idle) is not None
+        )
 
     def get_email_notification_trigger(
-        self, private_message: bool, sender_id: int, idle: bool
+        self, private_message: bool, acting_user_id: int, idle: bool
     ) -> Optional[str]:
         if not idle:
             return None
 
-        if self.user_id == sender_id:
+        if self.user_id == acting_user_id:
             return None
 
         if self.sender_is_muted:

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1339,7 +1339,7 @@ Output:
         )
 
     def get_maybe_enqueue_notifications_parameters(
-        self, *, message_id: int, user_id: int, sender_id: int, **kwargs: Any
+        self, *, message_id: int, user_id: int, acting_user_id: int, **kwargs: Any
     ) -> Dict[str, Any]:
         """
         Returns a dictionary with the passed parameters, after filling up the
@@ -1352,7 +1352,7 @@ Output:
         return dict(
             user_data=user_notifications_data,
             message_id=message_id,
-            sender_id=sender_id,
+            acting_user_id=acting_user_id,
             private_message=kwargs.get("private_message", False),
             stream_name=kwargs.get("stream_name", None),
             idle=kwargs.get("idle", True),

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1350,7 +1350,7 @@ Output:
             user_id=user_id, **kwargs
         )
         return dict(
-            user_data=user_notifications_data,
+            user_notifications_data=user_notifications_data,
             message_id=message_id,
             acting_user_id=acting_user_id,
             private_message=kwargs.get("private_message", False),

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -31,7 +31,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         # This test is for verifying whether `maybe_enqueue_notifications` returns the
         # `already_notified` data correctly.
         params = self.get_maybe_enqueue_notifications_parameters(
-            message_id=1, user_id=1, sender_id=2
+            message_id=1, user_id=1, acting_user_id=2
         )
 
         with mock_queue_publish(
@@ -160,7 +160,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         ) -> None:
             expected_args_dict = self.get_maybe_enqueue_notifications_parameters(
                 user_id=user_profile.id,
-                sender_id=iago.id,
+                acting_user_id=iago.id,
                 message_id=message_id,
                 **kwargs,
             )

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -187,7 +187,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         expected_enqueue_kwargs = self.get_maybe_enqueue_notifications_parameters(
             user_id=cordelia.id,
-            sender_id=hamlet.id,
+            acting_user_id=hamlet.id,
             message_id=message_id,
             mentioned=True,
             flags=["mentioned"],
@@ -317,7 +317,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
 
         expected_enqueue_kwargs = self.get_maybe_enqueue_notifications_parameters(
             user_id=cordelia.id,
-            sender_id=hamlet.id,
+            acting_user_id=hamlet.id,
             message_id=message_id,
             mentioned=True,
             stream_name="Scotland",
@@ -354,7 +354,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
 
         expected_enqueue_kwargs = self.get_maybe_enqueue_notifications_parameters(
             user_id=cordelia.id,
-            sender_id=hamlet.id,
+            acting_user_id=hamlet.id,
             message_id=message_id,
             stream_name="Scotland",
             online_push_enabled=True,
@@ -391,7 +391,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         expected_enqueue_kwargs = self.get_maybe_enqueue_notifications_parameters(
             user_id=cordelia.id,
             message_id=message_id,
-            sender_id=self.example_user("hamlet").id,
+            acting_user_id=self.example_user("hamlet").id,
             mentioned=True,
             flags=["mentioned"],
             stream_name="Scotland",
@@ -423,7 +423,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
 
         expected_enqueue_kwargs = self.get_maybe_enqueue_notifications_parameters(
             user_id=cordelia.id,
-            sender_id=hamlet.id,
+            acting_user_id=hamlet.id,
             message_id=message_id,
             wildcard_mention_notify=True,
             flags=["wildcard_mentioned"],
@@ -481,7 +481,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
 
         expected_enqueue_kwargs = self.get_maybe_enqueue_notifications_parameters(
             user_id=cordelia.id,
-            sender_id=hamlet.id,
+            acting_user_id=hamlet.id,
             message_id=message_id,
             mentioned=True,
             flags=["mentioned"],

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -105,7 +105,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         cordelia_calls = [
             call_args
             for call_args in m.call_args_list
-            if call_args[1]["user_data"].user_id == cordelia.id
+            if call_args[1]["user_notifications_data"].user_id == cordelia.id
         ]
 
         if expect_short_circuit:

--- a/zerver/tests/test_muting_users.py
+++ b/zerver/tests/test_muting_users.py
@@ -312,7 +312,7 @@ class MutedUsersTests(ZulipTestCase):
             self.assert_json_success(result)
             m.assert_called_once()
             # `maybe_enqueue_notificaions` was called for Hamlet after message edit mentioned him.
-            self.assertEqual(m.call_args_list[0][1]["user_data"].user_id, hamlet.id)
+            self.assertEqual(m.call_args_list[0][1]["user_notifications_data"].user_id, hamlet.id)
 
         # Hamlet mutes Cordelia.
         self.login("hamlet")

--- a/zerver/tests/test_notification_data.py
+++ b/zerver/tests/test_notification_data.py
@@ -4,30 +4,34 @@ from zerver.lib.test_classes import ZulipTestCase
 class TestNotificationData(ZulipTestCase):
     def test_is_push_notifiable(self) -> None:
         user_id = self.example_user("hamlet").id
-        sender_id = self.example_user("cordelia").id
+        acting_user_id = self.example_user("cordelia").id
 
         # Boring case
         user_data = self.create_user_notifications_data_object(user_id=user_id)
         self.assertEqual(
             user_data.get_push_notification_trigger(
-                private_message=False, sender_id=sender_id, idle=True
+                private_message=False, acting_user_id=acting_user_id, idle=True
             ),
             None,
         )
         self.assertFalse(
-            user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
+            user_data.is_push_notifiable(
+                private_message=False, acting_user_id=acting_user_id, idle=True
+            )
         )
 
         # Private message
         user_data = self.create_user_notifications_data_object(user_id=user_id)
         self.assertEqual(
             user_data.get_push_notification_trigger(
-                private_message=True, sender_id=sender_id, idle=True
+                private_message=True, acting_user_id=acting_user_id, idle=True
             ),
             "private_message",
         )
         self.assertTrue(
-            user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=True)
+            user_data.is_push_notifiable(
+                private_message=True, acting_user_id=acting_user_id, idle=True
+            )
         )
 
         # Mention
@@ -36,12 +40,14 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(
-                private_message=False, sender_id=sender_id, idle=True
+                private_message=False, acting_user_id=acting_user_id, idle=True
             ),
             "mentioned",
         )
         self.assertTrue(
-            user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
+            user_data.is_push_notifiable(
+                private_message=False, acting_user_id=acting_user_id, idle=True
+            )
         )
 
         # Wildcard mention
@@ -50,12 +56,14 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(
-                private_message=False, sender_id=sender_id, idle=True
+                private_message=False, acting_user_id=acting_user_id, idle=True
             ),
             "wildcard_mentioned",
         )
         self.assertTrue(
-            user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
+            user_data.is_push_notifiable(
+                private_message=False, acting_user_id=acting_user_id, idle=True
+            )
         )
 
         # Stream notification
@@ -64,12 +72,14 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(
-                private_message=False, sender_id=sender_id, idle=True
+                private_message=False, acting_user_id=acting_user_id, idle=True
             ),
             "stream_push_notify",
         )
         self.assertTrue(
-            user_data.is_push_notifiable(private_message=False, sender_id=sender_id, idle=True)
+            user_data.is_push_notifiable(
+                private_message=False, acting_user_id=acting_user_id, idle=True
+            )
         )
 
         # Now, test the `online_push_enabled` property
@@ -77,12 +87,14 @@ class TestNotificationData(ZulipTestCase):
         user_data = self.create_user_notifications_data_object(user_id=user_id)
         self.assertEqual(
             user_data.get_push_notification_trigger(
-                private_message=True, sender_id=sender_id, idle=False
+                private_message=True, acting_user_id=acting_user_id, idle=False
             ),
             None,
         )
         self.assertFalse(
-            user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=False)
+            user_data.is_push_notifiable(
+                private_message=True, acting_user_id=acting_user_id, idle=False
+            )
         )
 
         # Test notifications are sent when not idle but `online_push_enabled = True`
@@ -91,12 +103,14 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(
-                private_message=True, sender_id=sender_id, idle=False
+                private_message=True, acting_user_id=acting_user_id, idle=False
             ),
             "private_message",
         )
         self.assertTrue(
-            user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=False)
+            user_data.is_push_notifiable(
+                private_message=True, acting_user_id=acting_user_id, idle=False
+            )
         )
 
         # The following are hypothetical cases, since a private message can never have `stream_push_notify = True`.
@@ -113,17 +127,19 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(
-                private_message=True, sender_id=sender_id, idle=True
+                private_message=True, acting_user_id=acting_user_id, idle=True
             ),
             None,
         )
         self.assertFalse(
-            user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=True)
+            user_data.is_push_notifiable(
+                private_message=True, acting_user_id=acting_user_id, idle=True
+            )
         )
 
         # Message sender is the user the object corresponds to.
         user_data = self.create_user_notifications_data_object(
-            user_id=sender_id,
+            user_id=acting_user_id,
             sender_is_muted=False,
             flags=["mentioned", "wildcard_mentioned"],
             wildcard_mention_notify=True,
@@ -133,40 +149,46 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(
-                private_message=True, sender_id=sender_id, idle=True
+                private_message=True, acting_user_id=acting_user_id, idle=True
             ),
             None,
         )
         self.assertFalse(
-            user_data.is_push_notifiable(private_message=True, sender_id=sender_id, idle=True)
+            user_data.is_push_notifiable(
+                private_message=True, acting_user_id=acting_user_id, idle=True
+            )
         )
 
     def test_is_email_notifiable(self) -> None:
         user_id = self.example_user("hamlet").id
-        sender_id = self.example_user("cordelia").id
+        acting_user_id = self.example_user("cordelia").id
 
         # Boring case
         user_data = self.create_user_notifications_data_object(user_id=user_id)
         self.assertEqual(
             user_data.get_email_notification_trigger(
-                private_message=False, sender_id=sender_id, idle=True
+                private_message=False, acting_user_id=acting_user_id, idle=True
             ),
             None,
         )
         self.assertFalse(
-            user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
+            user_data.is_email_notifiable(
+                private_message=False, acting_user_id=acting_user_id, idle=True
+            )
         )
 
         # Private message
         user_data = self.create_user_notifications_data_object(user_id=user_id)
         self.assertEqual(
             user_data.get_email_notification_trigger(
-                private_message=True, sender_id=sender_id, idle=True
+                private_message=True, acting_user_id=acting_user_id, idle=True
             ),
             "private_message",
         )
         self.assertTrue(
-            user_data.is_email_notifiable(private_message=True, sender_id=sender_id, idle=True)
+            user_data.is_email_notifiable(
+                private_message=True, acting_user_id=acting_user_id, idle=True
+            )
         )
 
         # Mention
@@ -175,12 +197,14 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(
-                private_message=False, sender_id=sender_id, idle=True
+                private_message=False, acting_user_id=acting_user_id, idle=True
             ),
             "mentioned",
         )
         self.assertTrue(
-            user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
+            user_data.is_email_notifiable(
+                private_message=False, acting_user_id=acting_user_id, idle=True
+            )
         )
 
         # Wildcard mention
@@ -189,12 +213,14 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(
-                private_message=False, sender_id=sender_id, idle=True
+                private_message=False, acting_user_id=acting_user_id, idle=True
             ),
             "wildcard_mentioned",
         )
         self.assertTrue(
-            user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
+            user_data.is_email_notifiable(
+                private_message=False, acting_user_id=acting_user_id, idle=True
+            )
         )
 
         # Stream notification
@@ -203,24 +229,28 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(
-                private_message=False, sender_id=sender_id, idle=True
+                private_message=False, acting_user_id=acting_user_id, idle=True
             ),
             "stream_email_notify",
         )
         self.assertTrue(
-            user_data.is_email_notifiable(private_message=False, sender_id=sender_id, idle=True)
+            user_data.is_email_notifiable(
+                private_message=False, acting_user_id=acting_user_id, idle=True
+            )
         )
 
         # Test no notifications when not idle
         user_data = self.create_user_notifications_data_object(user_id=user_id)
         self.assertEqual(
             user_data.get_email_notification_trigger(
-                private_message=True, sender_id=sender_id, idle=False
+                private_message=True, acting_user_id=acting_user_id, idle=False
             ),
             None,
         )
         self.assertFalse(
-            user_data.is_email_notifiable(private_message=True, sender_id=sender_id, idle=False)
+            user_data.is_email_notifiable(
+                private_message=True, acting_user_id=acting_user_id, idle=False
+            )
         )
 
         # The following are hypothetical cases, since a private message can never have `stream_email_notify = True`.
@@ -237,17 +267,19 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(
-                private_message=True, sender_id=sender_id, idle=True
+                private_message=True, acting_user_id=acting_user_id, idle=True
             ),
             None,
         )
         self.assertFalse(
-            user_data.is_email_notifiable(private_message=True, sender_id=sender_id, idle=True)
+            user_data.is_email_notifiable(
+                private_message=True, acting_user_id=acting_user_id, idle=True
+            )
         )
 
         # Message sender is the user the object corresponds to.
         user_data = self.create_user_notifications_data_object(
-            user_id=sender_id,
+            user_id=acting_user_id,
             sender_is_muted=False,
             flags=["mentioned", "wildcard_mentioned"],
             wildcard_mention_notify=True,
@@ -257,20 +289,22 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(
-                private_message=True, sender_id=sender_id, idle=True
+                private_message=True, acting_user_id=acting_user_id, idle=True
             ),
             None,
         )
         self.assertFalse(
-            user_data.is_email_notifiable(private_message=True, sender_id=sender_id, idle=True)
+            user_data.is_email_notifiable(
+                private_message=True, acting_user_id=acting_user_id, idle=True
+            )
         )
 
     def test_is_notifiable(self) -> None:
         # This is just for coverage purposes. We've already tested all scenarios above,
         # and `is_notifiable` is a simple OR of the email and push functions.
         user_id = self.example_user("hamlet").id
-        sender_id = self.example_user("cordelia").id
+        acting_user_id = self.example_user("cordelia").id
         user_data = self.create_user_notifications_data_object(user_id=user_id)
         self.assertTrue(
-            user_data.is_notifiable(private_message=True, sender_id=sender_id, idle=True)
+            user_data.is_notifiable(private_message=True, acting_user_id=acting_user_id, idle=True)
         )

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -767,7 +767,7 @@ def missedmessage_hook(
             email_notified=internal_data.get("email_notified", False),
         )
         maybe_enqueue_notifications(
-            user_data=user_notifications_data,
+            user_notifications_data=user_notifications_data,
             acting_user_id=sender_id,
             message_id=message_id,
             private_message=private_message,
@@ -790,7 +790,7 @@ def receiver_is_off_zulip(user_profile_id: int) -> bool:
 
 def maybe_enqueue_notifications(
     *,
-    user_data: UserMessageNotificationsData,
+    user_notifications_data: UserMessageNotificationsData,
     acting_user_id: int,
     message_id: int,
     private_message: bool,
@@ -807,9 +807,9 @@ def maybe_enqueue_notifications(
     """
     notified: Dict[str, bool] = {}
 
-    if user_data.is_push_notifiable(private_message, acting_user_id, idle):
-        notice = build_offline_notification(user_data.user_id, message_id)
-        notice["trigger"] = user_data.get_push_notification_trigger(
+    if user_notifications_data.is_push_notifiable(private_message, acting_user_id, idle):
+        notice = build_offline_notification(user_notifications_data.user_id, message_id)
+        notice["trigger"] = user_notifications_data.get_push_notification_trigger(
             private_message, acting_user_id, idle
         )
         notice["stream_name"] = stream_name
@@ -821,9 +821,9 @@ def maybe_enqueue_notifications(
     # mention.  Eventually, we'll add settings to allow email
     # notifications to match the model of push notifications
     # above.
-    if user_data.is_email_notifiable(private_message, acting_user_id, idle):
-        notice = build_offline_notification(user_data.user_id, message_id)
-        notice["trigger"] = user_data.get_email_notification_trigger(
+    if user_notifications_data.is_email_notifiable(private_message, acting_user_id, idle):
+        notice = build_offline_notification(user_notifications_data.user_id, message_id)
+        notice["trigger"] = user_notifications_data.get_email_notification_trigger(
             private_message, acting_user_id, idle
         )
         notice["stream_name"] = stream_name
@@ -963,7 +963,7 @@ def process_message_event(
 
         extra_user_data[user_profile_id]["internal_data"].update(
             maybe_enqueue_notifications(
-                user_data=user_notifications_data,
+                user_notifications_data=user_notifications_data,
                 acting_user_id=sender_id,
                 message_id=message_id,
                 private_message=private_message,
@@ -1131,7 +1131,7 @@ def process_message_update_event(
         )
 
         maybe_enqueue_notifications_for_message_update(
-            user_data=user_notifications_data,
+            user_notifications_data=user_notifications_data,
             message_id=message_id,
             acting_user_id=acting_user_id,
             private_message=(stream_name is None),
@@ -1148,7 +1148,7 @@ def process_message_update_event(
 
 
 def maybe_enqueue_notifications_for_message_update(
-    user_data: UserMessageNotificationsData,
+    user_notifications_data: UserMessageNotificationsData,
     message_id: int,
     acting_user_id: int,
     private_message: bool,
@@ -1156,7 +1156,7 @@ def maybe_enqueue_notifications_for_message_update(
     presence_idle: bool,
     prior_mentioned: bool,
 ) -> None:
-    if user_data.sender_is_muted:
+    if user_notifications_data.sender_is_muted:
         # Never send notifications if the sender has been muted
         return
 
@@ -1181,7 +1181,7 @@ def maybe_enqueue_notifications_for_message_update(
         # without extending the UserMessage data model.
         return
 
-    if user_data.stream_push_notify or user_data.stream_email_notify:
+    if user_notifications_data.stream_push_notify or user_notifications_data.stream_email_notify:
         # Currently we assume that if this flag is set to True, then
         # the user already was notified about the earlier message,
         # so we short circuit.  We may handle this more rigorously
@@ -1189,10 +1189,10 @@ def maybe_enqueue_notifications_for_message_update(
         # model.
         return
 
-    idle = presence_idle or receiver_is_off_zulip(user_data.user_id)
+    idle = presence_idle or receiver_is_off_zulip(user_notifications_data.user_id)
 
     maybe_enqueue_notifications(
-        user_data=user_data,
+        user_notifications_data=user_notifications_data,
         message_id=message_id,
         acting_user_id=acting_user_id,
         private_message=private_message,


### PR DESCRIPTION
Followup to #18969 