### PR TITLE
js: Remove ancient IE createTextRange API

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -181,8 +181,7 @@ export function initialize() {
         // on the other hand, on mobile it should be done with a long tap.
     } else {
         $("#main_div").on("longtap", ".messagebox", function (e) {
-            // find the correct selection API for the browser.
-            const sel = window.getSelection ? window.getSelection() : document.selection;
+            const sel = window.getSelection();
             // if one matches, remove the current selections.
             // after a longtap that is valid, there should be no text selected.
             if (sel) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -117,20 +117,12 @@ export function get_active_data() {
 }
 
 function selectText(element) {
-    let range;
-    let sel;
-    if (window.getSelection) {
-        sel = window.getSelection();
-        range = document.createRange();
-        range.selectNodeContents(element);
+    const sel = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(element);
 
-        sel.removeAllRanges();
-        sel.addRange(range);
-    } else if (document.body.createTextRange) {
-        range = document.body.createTextRange();
-        range.moveToElementText(element);
-        range.select();
-    }
+    sel.removeAllRanges();
+    sel.addRange(range);
 }
 
 function should_list_all_streams() {

--- a/static/js/ui_util.js
+++ b/static/js/ui_util.js
@@ -11,19 +11,12 @@ export function change_tab_to(tabname) {
 export function place_caret_at_end(el) {
     el.focus();
 
-    if (window.getSelection !== undefined && document.createRange !== undefined) {
-        const range = document.createRange();
-        range.selectNodeContents(el);
-        range.collapse(false);
-        const sel = window.getSelection();
-        sel.removeAllRanges();
-        sel.addRange(range);
-    } else if (document.body.createTextRange !== undefined) {
-        const textRange = document.body.createTextRange();
-        textRange.moveToElementText(el);
-        textRange.collapse(false);
-        textRange.select();
-    }
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    range.collapse(false);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
 }
 
 export function blur_active_element() {


### PR DESCRIPTION
This only existed up through IE 8.

https://developer.mozilla.org/en-US/docs/Web/API/TextRange