### PR TITLE
webhooks: Support configuring destination stream by id.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2680,6 +2680,20 @@ def check_send_stream_message(
     return do_send_messages([message])[0]
 
 
+def check_send_stream_message_by_id(
+    sender: UserProfile,
+    client: Client,
+    stream_id: int,
+    topic: str,
+    body: str,
+    realm: Optional[Realm] = None,
+) -> int:
+    addressee = Addressee.for_stream_id(stream_id, topic)
+    message = check_message(sender, client, addressee, body, realm)
+
+    return do_send_messages([message])[0]
+
+
 def check_send_private_message(
     sender: UserProfile, client: Client, receiving_user: UserProfile, body: str
 ) -> int:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
[chat](https://chat.zulip.org/#narrow/stream/127-integrations/topic/Webhook.20using.20stream.20ID)

**Testing plan:** <!-- How have you tested? -->
Tests added as `WebhookURLConfigurationTestCase`.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
