### PR TITLE
logo: Compute realm-logo url in frontend only.

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -50,6 +50,7 @@ import * as people from "./people";
 import * as pm_conversations from "./pm_conversations";
 import * as popover_menus from "./popover_menus";
 import * as presence from "./presence";
+import * as realm_logo from "./realm_logo";
 import * as realm_playground from "./realm_playground";
 import * as recent_topics_util from "./recent_topics_util";
 import * as reload from "./reload";
@@ -462,6 +463,7 @@ export function initialize_everything() {
     const user_status_params = pop_fields("user_status");
     const i18n_params = pop_fields("language_list");
 
+    realm_logo.rerender();
     i18n.initialize(i18n_params);
     tippyjs.initialize();
     popover_menus.initialize();

--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -2,7 +2,7 @@
     <nav class="header-main rightside-userlist" id="top_navbar">
         <div class="column-left">
             <a class="brand no-style" href="#">
-                <img id="realm-logo" src="{{ navbar_logo_url }}" alt="" class="nav-logo no-drag"/>
+                <img id="realm-logo" src="" alt="" class="nav-logo no-drag"/>
             </a>
         </div>
         <div class="column-middle" id="navbar-middle">

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -11,14 +11,8 @@ from django.http import HttpResponse
 from django.utils.timezone import now as timezone_now
 
 from corporate.models import Customer, CustomerPlan
-from zerver.lib.actions import (
-    change_user_is_active,
-    do_change_logo_source,
-    do_change_plan_type,
-    do_create_user,
-)
+from zerver.lib.actions import change_user_is_active, do_change_plan_type, do_create_user
 from zerver.lib.compatibility import LAST_SERVER_UPGRADE_TIME, is_outdated_server
-from zerver.lib.events import add_realm_logo_fields
 from zerver.lib.home import (
     get_billing_info,
     get_furthest_read_time,
@@ -39,7 +33,6 @@ from zerver.models import (
     get_system_bot,
     get_user,
 )
-from zerver.views.home import compute_navbar_logo_url
 from zerver.worker.queue_processors import UserActivityWorker
 
 logger_string = "zulip.soft_deactivation"
@@ -859,73 +852,6 @@ class HomeTest(ZulipTestCase):
         self.assertEqual(result.status_code, 302)
         path = urllib.parse.urlparse(result["Location"]).path
         self.assertEqual(path, "/")
-
-    def test_compute_navbar_logo_url(self) -> None:
-        user_profile = self.example_user("hamlet")
-
-        page_params = {"color_scheme": user_profile.COLOR_SCHEME_NIGHT}
-        add_realm_logo_fields(page_params, user_profile.realm)
-        self.assertEqual(
-            compute_navbar_logo_url(page_params), "/static/images/logo/zulip-org-logo.svg?version=0"
-        )
-
-        page_params = {"color_scheme": user_profile.COLOR_SCHEME_LIGHT}
-        add_realm_logo_fields(page_params, user_profile.realm)
-        self.assertEqual(
-            compute_navbar_logo_url(page_params), "/static/images/logo/zulip-org-logo.svg?version=0"
-        )
-
-        do_change_logo_source(
-            user_profile.realm, Realm.LOGO_UPLOADED, night=False, acting_user=user_profile
-        )
-        page_params = {"color_scheme": user_profile.COLOR_SCHEME_NIGHT}
-        add_realm_logo_fields(page_params, user_profile.realm)
-        self.assertEqual(
-            compute_navbar_logo_url(page_params),
-            f"/user_avatars/{user_profile.realm_id}/realm/logo.png?version=2",
-        )
-
-        page_params = {"color_scheme": user_profile.COLOR_SCHEME_LIGHT}
-        add_realm_logo_fields(page_params, user_profile.realm)
-        self.assertEqual(
-            compute_navbar_logo_url(page_params),
-            f"/user_avatars/{user_profile.realm_id}/realm/logo.png?version=2",
-        )
-
-        do_change_logo_source(
-            user_profile.realm, Realm.LOGO_UPLOADED, night=True, acting_user=user_profile
-        )
-        page_params = {"color_scheme": user_profile.COLOR_SCHEME_NIGHT}
-        add_realm_logo_fields(page_params, user_profile.realm)
-        self.assertEqual(
-            compute_navbar_logo_url(page_params),
-            f"/user_avatars/{user_profile.realm_id}/realm/night_logo.png?version=2",
-        )
-
-        page_params = {"color_scheme": user_profile.COLOR_SCHEME_LIGHT}
-        add_realm_logo_fields(page_params, user_profile.realm)
-        self.assertEqual(
-            compute_navbar_logo_url(page_params),
-            f"/user_avatars/{user_profile.realm_id}/realm/logo.png?version=2",
-        )
-
-        # This configuration isn't super supported in the UI and is a
-        # weird choice, but we have a test for it anyway.
-        do_change_logo_source(
-            user_profile.realm, Realm.LOGO_DEFAULT, night=False, acting_user=user_profile
-        )
-        page_params = {"color_scheme": user_profile.COLOR_SCHEME_NIGHT}
-        add_realm_logo_fields(page_params, user_profile.realm)
-        self.assertEqual(
-            compute_navbar_logo_url(page_params),
-            f"/user_avatars/{user_profile.realm_id}/realm/night_logo.png?version=2",
-        )
-
-        page_params = {"color_scheme": user_profile.COLOR_SCHEME_LIGHT}
-        add_realm_logo_fields(page_params, user_profile.realm)
-        self.assertEqual(
-            compute_navbar_logo_url(page_params), "/static/images/logo/zulip-org-logo.svg?version=0"
-        )
 
     @override_settings(SERVER_UPGRADE_NAG_DEADLINE_DAYS=365)
     def test_is_outdated_server(self) -> None:

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -1,6 +1,6 @@
 import logging
 import secrets
-from typing import Any, Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
@@ -97,17 +97,6 @@ def update_last_reminder(user_profile: Optional[UserProfile]) -> None:
         # eliminated that as a useful concept for non-bot users.
         user_profile.last_reminder = None
         user_profile.save(update_fields=["last_reminder"])
-
-
-def compute_navbar_logo_url(page_params: Dict[str, Any]) -> str:
-    if (
-        page_params["color_scheme"] == 2
-        and page_params["realm_night_logo_source"] != Realm.LOGO_DEFAULT
-    ):
-        navbar_logo_url = page_params["realm_night_logo_url"]
-    else:
-        navbar_logo_url = page_params["realm_logo_url"]
-    return navbar_logo_url
 
 
 def home(request: HttpRequest) -> HttpResponse:
@@ -209,8 +198,6 @@ def home_real(request: HttpRequest) -> HttpResponse:
 
     user_permission_info = get_user_permission_info(user_profile)
 
-    navbar_logo_url = compute_navbar_logo_url(page_params)
-
     response = render(
         request,
         "zerver/app/index.html",
@@ -225,7 +212,6 @@ def home_real(request: HttpRequest) -> HttpResponse:
             "is_admin": user_permission_info.is_realm_admin,
             "is_guest": user_permission_info.is_guest,
             "color_scheme": user_permission_info.color_scheme,
-            "navbar_logo_url": navbar_logo_url,
             "embedded": narrow_stream is not None,
             "max_file_upload_size_mib": settings.MAX_FILE_UPLOAD_SIZE,
         },


### PR DESCRIPTION
This PR fixes the bug of always showing day-mode realm logo when color scheme display
setting is set to automatic but the OS setting is dark theme. This is because we cannot check
the OS setting on backend and we need to set the logo url accordingly in frontend only.
So, we remove the logo url computation from backend completely and instead compute it in
the frontend only.

Fixes #18778.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? --> Tested manually in chrome.


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
