### PR TITLE
Reformat timestamp tooltip content.

### DIFF
--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -221,33 +221,21 @@ run_test("absolute_time_24_hour", () => {
 
 run_test("get_full_datetime", () => {
     const time = new Date(1495141973000); // 2017/5/18 9:12:53 PM (UTC+0)
-    let expected_date = "Thursday, May 18, 2017";
-    let expected_time = "9:12:53 PM Coordinated Universal Time";
-    assert.deepEqual(timerender.get_full_datetime(time), {
-        date: expected_date,
-        time: expected_time,
-    });
+    let expected = "translated: 5/18/2017 at 9:12:53 PM UTC";
+    assert.equal(timerender.get_full_datetime(time), expected);
 
     // test 24 hour time setting.
     page_params.twenty_four_hour_time = true;
-    expected_time = "21:12:53 Coordinated Universal Time";
-    assert.deepEqual(timerender.get_full_datetime(time), {
-        date: expected_date,
-        time: expected_time,
-    });
+    expected = "translated: 5/18/2017 at 21:12:53 UTC";
+    assert.equal(timerender.get_full_datetime(time), expected);
 
-    // Test year not shown if current.
-    const current_year = new Date().getFullYear();
-    time.setFullYear(current_year);
-    expected_date = time.toLocaleDateString(undefined, {
-        weekday: "long",
-        month: "long",
-        day: "numeric",
-    });
-    assert.deepEqual(timerender.get_full_datetime(time), {
-        date: expected_date,
-        time: expected_time,
-    });
+    page_params.twenty_four_hour_time = false;
+
+    // Test the GMT[+-]x:y logic.
+    process.env.TZ = "Asia/Kolkata";
+    expected = "translated: 5/19/2017 at 2:42:53 AM (UTC+5.5)";
+    assert.equal(timerender.get_full_datetime(time), expected);
+    delete process.env.TZ;
 });
 
 run_test("last_seen_status_from_date", () => {

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -150,7 +150,6 @@ export function initialize() {
 
     delegate("body", {
         target: ".message_time",
-        allowHTML: true,
         placement: "top",
         appendTo: () => document.body,
         onShow(instance) {
@@ -158,8 +157,7 @@ export function initialize() {
             const row = time_elem.closest(".message_row");
             const message = message_lists.current.get(rows.id(row));
             const time = new Date(message.timestamp * 1000);
-            const full_datetime = timerender.get_full_datetime(time);
-            instance.setContent(full_datetime.date + "<br/>" + full_datetime.time);
+            instance.setContent(timerender.get_full_datetime(time));
         },
         onHidden(instance) {
             instance.destroy();

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -166,7 +166,6 @@ export function initialize() {
 
     delegate("body", {
         target: ".recipient_row_date > span",
-        allowHTML: true,
         placement: "top",
         appendTo: () => document.body,
         onHidden(instance) {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
 Reformats to a format like: `5/19/17, 2:42:53 AM IST (UTC+5.5)` as suggested in https://github.com/zulip/zulip/pull/18856#discussion_r659098020.

One thing to note here is, I didn't use `at` as suggested(`{date} at {time}`) to keep it nicer in all languages. For example, `.toLocaleTimeString(undefined, options)` returns ` ١٢:١٥:٣٠` when user's locale is 'ar-EG'. In such cases showing `at` in English would be odd and literal translations for 'at' in different languages might not fit there.

So, this PR uses `.toLocaleString` which adds a `,` after date part for English based locales.

**Testing plan:** <!-- How have you tested? -->
Automated tests plus a bit of manual testing.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/44665669/123554500-ee226180-d79d-11eb-9423-f43fbb852d0f.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
