### PR TITLE
hashchange: Don't narrow to default_view on `#reload`.

### DIFF
--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -188,7 +188,6 @@ run_test("hash_interactions", ({override}) => {
         [message_viewport, "stop_auto_scrolling"],
     ]);
 
-    override(recent_topics_ui, "show", () => {});
     window.location.hash = "#all_messages";
 
     helper.clear_events();
@@ -247,6 +246,15 @@ run_test("hash_interactions", ({override}) => {
         [overlays, "close_for_hash_change"],
         [subs, "launch"],
     ]);
+
+    recent_topics_ui_shown = false;
+    window.location.hash = "#reload:send_after_reload=0...";
+
+    helper.clear_events();
+    window_stub.trigger("hashchange");
+    helper.assert_events([]);
+    // If it's reload hash it shouldn't show the default view.
+    assert.equal(recent_topics_ui_shown, false);
 
     window.location.hash = "#keyboard-shortcuts/whatever";
 

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -128,6 +128,7 @@ function do_hashchange_normal(from_reload) {
     // Even if the URL bar says #%41%42%43%44, the value here will
     // be #ABCD.
     const hash = window.location.hash.split("/");
+
     switch (hash[0]) {
         case "#narrow": {
             maybe_hide_recent_topics();
@@ -311,6 +312,13 @@ function hashchanged(from_reload, e) {
     const was_internal_change = browser_history.save_old_hash();
 
     if (was_internal_change) {
+        return undefined;
+    }
+
+    // TODO: Migrate the `#reload` syntax to use slashes as separators
+    // so that this can be part of the main switch statement.
+    if (window.location.hash.startsWith("#reload")) {
+        // We don't want to change narrow if app is undergoing reload.
         return undefined;
     }
 


### PR DESCRIPTION
When hash changes to `#reload...` before a reload, the app
tries to show default_view since there is no `case` handled for
it. We don't change any narrow in the case of `#relaod...`
hashchange.

easy to test by cherry-picking 1e376e5d857aa1d95b55cadd2f1ac18df3b17d4d