### PR TITLE
buddy list: Always include "me" in the list.

### DIFF
--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -461,6 +461,19 @@ test("bulk_data_hacks", () => {
     assert.equal(user_ids.length, 700);
 });
 
+test("always show me", ({override}) => {
+    const present_user_ids = [];
+    override(presence, "get_user_ids", () => present_user_ids);
+    assert.deepEqual(buddy_data.get_filtered_and_sorted_user_ids(""), [me.user_id]);
+
+    // Make sure we didn't mutate the list passed to us.
+    assert.deepEqual(present_user_ids, []);
+
+    // try to make us show twice
+    present_user_ids.push(me.user_id);
+    assert.deepEqual(buddy_data.get_filtered_and_sorted_user_ids(""), [me.user_id]);
+});
+
 test("user_status", () => {
     user_status.initialize({user_status: []});
     set_presence(me.user_id, "active");

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -363,6 +363,12 @@ function get_filtered_user_id_list(user_filter_text) {
         // users who have been idle more than three weeks.  When the
         // filter text is blank, we show only those recently active users.
         base_user_id_list = presence.get_user_ids();
+
+        // Always include ourselves, even if we're "unavailable".
+        const my_user_id = people.my_current_user_id();
+        if (!base_user_id_list.includes(my_user_id)) {
+            base_user_id_list = [my_user_id, ...base_user_id_list];
+        }
     }
 
     const user_ids = filter_user_ids(user_filter_text, base_user_id_list);


### PR DESCRIPTION
If a user sets themselves to unavailable, or otherwise
drops out of our presence data, we should still show
them at the top of their own buddy list.

See https://chat.zulip.org/#narrow/stream/137-feedback/topic/Users.20Sidebar/near/1220135
for more context.

I believe this change makes sense as a defensive
fallback, but it's quite possible that we may
want to change the server to record presence info
about users who are "unavailable" and then only
send that info to them (and not their peers).
