### PR TITLE
quote-and-reply: Add tests for caret position.

### DIFF
--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const autosize = require("autosize");
 
 const {$t} = require("../zjsunit/i18n");
-const {set_global, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 
@@ -15,9 +15,17 @@ set_global("document", {
     },
 });
 
+mock_esm("../../static/js/message_lists", {
+    current: {},
+});
+
 const compose_ui = zrequire("compose_ui");
 const people = zrequire("people");
 const user_status = zrequire("user_status");
+const hash_util = mock_esm("../../static/js/hash_util");
+const channel = mock_esm("../../static/js/channel");
+const compose_actions = zrequire("compose_actions");
+const message_lists = zrequire("message_lists");
 
 const alice = {
     email: "alice@zulip.com",
@@ -240,5 +248,94 @@ run_test("compute_placeholder_text", () => {
     assert.equal(
         compose_ui.compute_placeholder_text(opts),
         $t({defaultMessage: "Message Alice, Bob"}),
+    );
+});
+
+run_test("quote_and_reply", ({override}) => {
+    const selected_message = {
+        type: "stream",
+        stream: "devel",
+        topic: "python",
+        sender_full_name: "Steve Stephenson",
+        sender_id: 90,
+    };
+
+    override(
+        hash_util,
+        "by_conversation_and_time_uri",
+        () => "https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado",
+    );
+
+    override(message_lists.current, "selected_message", () => selected_message);
+    override(message_lists.current, "selected_id", () => 100);
+
+    let success_function;
+    override(channel, "get", (opts) => {
+        success_function = opts.success;
+    });
+
+    // zjquery does not simulate caret handling, so we provide
+    // our own versions of val() and caret()
+    let textarea_val = "";
+    let textarea_caret_pos;
+
+    $("#compose-textarea").val = function (...args) {
+        if (args.length === 0) {
+            return textarea_val;
+        }
+
+        textarea_val = args[0];
+        textarea_caret_pos = textarea_val.length;
+
+        return this;
+    };
+
+    $("#compose-textarea").caret = function (arg) {
+        if (arg === 0) {
+            textarea_caret_pos = 0;
+            return this;
+        }
+        if (arg === undefined) {
+            return textarea_caret_pos;
+        }
+        if (typeof arg !== "string") {
+            console.info(arg);
+            throw new Error("We expected the actual code to pass in a string.");
+        }
+
+        const before = textarea_val.slice(0, textarea_caret_pos);
+        const after = textarea_val.slice(textarea_caret_pos);
+
+        textarea_val = before + arg + after;
+        textarea_caret_pos += arg.length;
+        return this;
+    };
+
+    function set_compose_content_with_caret(content) {
+        const caret_position = content.indexOf("%");
+        content = content.slice(0, caret_position) + content.slice(caret_position + 1); // remove the "%"
+        textarea_val = content;
+        textarea_caret_pos = caret_position;
+        $("#compose-textarea").trigger("focus");
+    }
+
+    function get_compose_content_with_caret() {
+        const content =
+            textarea_val.slice(0, textarea_caret_pos) +
+            "%" +
+            textarea_val.slice(textarea_caret_pos); // insert the "%"
+        return content;
+    }
+
+    set_compose_content_with_caret("hello %there"); // "%" is used to encode/display position of focus before change
+    compose_actions.quote_and_reply();
+    assert.equal(get_compose_content_with_caret(), "[Quoting…]\n%hello there");
+
+    success_function({
+        raw_content: "Testing caret position",
+    });
+    assert.equal(
+        get_compose_content_with_caret(),
+        "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n```quote\nTesting caret position\n```\nhello there%",
     );
 });


### PR DESCRIPTION
(This was modified by @showell to introduce the
vars for textarea_val and textarea_caret_pos.)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
