### PR TITLE
Add onSuccess listener to copy clipboards.

### DIFF
--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -100,7 +100,9 @@ function test_ui(label, f) {
         page_params.is_admin = false;
         page_params.realm_email_address_visibility = 3;
         page_params.custom_profile_fields = [];
-        override(popovers, "clipboard_enable", noop);
+        override(popovers, "clipboard_enable", () => ({
+            on: noop,
+        }));
         popovers.clear_for_testing();
         popovers.register_click_handlers();
         f({override, mock_template});

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -19,7 +19,6 @@ import {media_breakpoints_num} from "./css_variables";
 import * as emoji_picker from "./emoji_picker";
 import * as hash_util from "./hash_util";
 import * as hotspots from "./hotspots";
-import {$t} from "./i18n";
 import * as message_edit from "./message_edit";
 import * as message_flags from "./message_flags";
 import * as message_lists from "./message_lists";
@@ -282,18 +281,6 @@ export function initialize() {
         message_edit.end_message_row_edit(row);
         e.stopPropagation();
         popovers.hide_all();
-    });
-    $("body").on("click", ".copy_message", function (e) {
-        const row = $(this).closest(".message_row");
-        message_edit.end_message_row_edit(row);
-        row.find(".alert-msg").text($t({defaultMessage: "Copied!"}));
-        row.find(".alert-msg").css("display", "block");
-        row.find(".alert-msg").delay(1000).fadeOut(300);
-        if ($(".tooltip").is(":visible")) {
-            $(".tooltip").hide();
-        }
-        e.preventDefault();
-        e.stopPropagation();
     });
     $("body").on("click", "a", function () {
         if (document.activeElement === this) {

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -321,10 +321,20 @@ function timer_text(seconds_left) {
     return $t({defaultMessage: "{seconds} sec to edit"}, {seconds: seconds.toString()});
 }
 
-function create_copy_to_clipboard_handler(source, message_id) {
-    new ClipboardJS(source, {
+function create_copy_to_clipboard_handler(row, source, message_id) {
+    const clipboard = new ClipboardJS(source, {
         target: () =>
             document.querySelector(`#edit_form_${CSS.escape(message_id)} .message_edit_content`),
+    });
+
+    clipboard.on("success", () => {
+        end_message_row_edit(row);
+        row.find(".alert-msg").text($t({defaultMessage: "Copied!"}));
+        row.find(".alert-msg").css("display", "block");
+        row.find(".alert-msg").delay(1000).fadeOut(300);
+        if ($(".tooltip").is(":visible")) {
+            $(".tooltip").hide();
+        }
     });
 }
 
@@ -417,7 +427,7 @@ function edit_message(row, raw_content) {
         case editability_types.NO:
             message_edit_content.attr("readonly", "readonly");
             message_edit_topic.attr("readonly", "readonly");
-            create_copy_to_clipboard_handler(copy_message[0], message.id);
+            create_copy_to_clipboard_handler(row, copy_message[0], message.id);
             break;
         case editability_types.NO_LONGER:
             // You can currently only reach this state in non-streams. If that
@@ -426,13 +436,13 @@ function edit_message(row, raw_content) {
             // row.find('input.message_edit_topic') as well.
             message_edit_content.attr("readonly", "readonly");
             message_edit_countdown_timer.text($t({defaultMessage: "View source"}));
-            create_copy_to_clipboard_handler(copy_message[0], message.id);
+            create_copy_to_clipboard_handler(row, copy_message[0], message.id);
             break;
         case editability_types.TOPIC_ONLY:
             message_edit_content.attr("readonly", "readonly");
             // Hint why you can edit the topic but not the message content
             message_edit_countdown_timer.text($t({defaultMessage: "Topic editing only"}));
-            create_copy_to_clipboard_handler(copy_message[0], message.id);
+            create_copy_to_clipboard_handler(row, copy_message[0], message.id);
             break;
         case editability_types.FULL: {
             copy_message.remove();

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1173,11 +1173,10 @@ export function register_click_handlers() {
         e.preventDefault();
     });
 
-    clipboard_enable(".copy_link");
-
-    $("body").on("click", ".copy_link", function (e) {
+    clipboard_enable(".copy_link").on("success", (e) => {
         hide_actions_popover();
-        const message_id = $(this).attr("data-message-id");
+        // e.trigger returns the DOM element triggering the copy action
+        const message_id = e.trigger.getAttribute("data-message-id");
         const row = $(`[zid='${CSS.escape(message_id)}']`);
         row.find(".alert-msg")
             .text($t({defaultMessage: "Copied!"}))
@@ -1190,9 +1189,6 @@ export function register_click_handlers() {
             // We unfocus this so keyboard shortcuts, etc., will work again.
             $(":focus").trigger("blur");
         }, 0);
-
-        e.stopPropagation();
-        e.preventDefault();
     });
 
     clipboard_enable(".copy_mention_syntax");

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -97,7 +97,7 @@
     {{/if}}
 
     <li>
-        <a href="#" class="copy_link" data-message-id="{{message_id}}" data-clipboard-text="{{ conversation_time_uri }}">
+        <a class="copy_link" data-message-id="{{message_id}}" data-clipboard-text="{{ conversation_time_uri }}">
             <i class="fa fa-link" aria-hidden="true"></i> {{t "Copy link to message" }}
         </a>
     </li>


### PR DESCRIPTION
Covers: 
-  [x] : Copy message option
-  [x] : Copy link option

Fixes #19019.

**Testing plan:** <!-- How have you tested? -->
Manual testing

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
No changes expected.
