### PR TITLE
puppet: Catch when a comma is left out of puppet_classes.

### DIFF
--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -34,6 +34,11 @@ Exec { path => "/usr/sbin:/usr/bin:/sbin:/bin" }
 """
 
 for pclass in re.split(r"\s*,\s*", config.get("machine", "puppet_classes")):
+    if " " in pclass:
+        print(
+            f"The `machine.puppet_classes` setting in {args.config} must be comma-separated, not space-separated!"
+        )
+        sys.exit(1)
     puppet_config += f"include {pclass}\n"
 
 # We use the Puppet configuration from the same Zulip checkout as this script


### PR DESCRIPTION
With two space-separated classes in `puppet_classes`, the second one
is silently ignored.  With three of more, puppet generates the
following very opaque error message:

```
Error: Could not parse for environment production: This
Name has no effect. A value was produced and then forgotten (one or
more preceding expressions may have the wrong form)
```

Catch when this has happened, and give an error message to the user.

Fixes #18992.

**Testing plan:** Test applied.

-----

Another option is to split on `\s*,\s*|\s+` and thus make this just DTRT.  This is the only place that we actually parse the list of values, so it's not like this would make things notably more complex.