### PR TITLE
[WIP] Issue #18757 Tabbed compose preview

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -488,20 +488,20 @@ test_ui("enter_with_preview_open", ({override}) => {
     compose_state.stream_name("social");
 
     $("#compose-textarea").val("message me");
-    $("#compose-textarea").hide();
-    $("#compose .undo_markdown_preview").show();
-    $("#compose .preview_message_area").show();
-    $("#compose .markdown_preview").hide();
+    // Simulates the same UI interaction that ought to cause the desired outcome
+    // instead of manually show/hiding everything
+    $("#stream-message .markdown_preview").trigger("click");
+
     page_params.enter_sends = true;
     let send_message_called = false;
     override(compose, "send_message", () => {
         send_message_called = true;
     });
     compose.enter_with_preview_open();
+    // TODO figure out why both #compose-textarea and #compose .preview_message_area
+    // are coming back as `false`.
     assert.ok($("#compose-textarea").visible());
-    assert.ok(!$("#compose .undo_markdown_preview").visible());
     assert.ok(!$("#compose .preview_message_area").visible());
-    assert.ok($("#compose .markdown_preview").visible());
     assert.ok(send_message_called);
 
     page_params.enter_sends = false;

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -175,6 +175,7 @@ export function create_message_object() {
 }
 
 export function clear_compose_box() {
+    $("#stream-message .undo_markdown_preview").trigger("click");
     $("#compose-textarea").val("").trigger("focus");
     compose_validate.check_overflow_text();
     drafts.delete_active_draft();
@@ -258,6 +259,7 @@ export function enter_with_preview_open() {
         finish();
     } else {
         // Otherwise, we return to the compose box and focus it
+        $("#stream-message .markdown_preview").trigger("click");
         $("#compose-textarea").trigger("focus");
     }
 }

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -87,11 +87,7 @@ export function clear_private_stream_alert() {
 }
 
 export function clear_preview_area() {
-    $("#compose-textarea").show();
-    $("#compose .undo_markdown_preview").hide();
-    $("#compose .preview_message_area").hide();
     $("#compose .preview_content").empty();
-    $("#compose .markdown_preview").show();
 }
 
 function update_fade() {
@@ -815,10 +811,6 @@ export function initialize() {
     $("#compose").on("click", ".markdown_preview", (e) => {
         e.preventDefault();
         const content = $("#compose-textarea").val();
-        $("#compose-textarea").hide();
-        $("#compose .markdown_preview").hide();
-        $("#compose .undo_markdown_preview").show();
-        $("#compose .preview_message_area").show();
 
         render_and_show_preview(
             $("#compose .markdown_preview_spinner"),

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -3,6 +3,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    padding: 4px 4px 8px 4px;
 
     .new_message_button {
         margin-left: 4px;
@@ -61,8 +62,6 @@
 /* Main geometry for this element is in zulip.css */
 #compose-content {
     border-top: 1px solid hsla(0, 0%, 0%, 0.07);
-    transition: background-color 200ms linear;
-    padding: 4px 4px 8px 4px;
     border-left: 1px solid hsl(0, 0%, 93%);
     border-right: 1px solid hsl(0, 0%, 93%);
     height: 100%;
@@ -76,7 +75,7 @@
 
 .message_comp {
     display: none;
-    padding: 10px 10px 8px 5px;
+    background-color: hsl(0, 0%, 93%);
 }
 
 .autocomplete_secondary {
@@ -88,24 +87,19 @@
 }
 
 .compose_table {
-    height: 100%;
-    display: flex;
-    flex-flow: column;
-
-    .nav {
+    .nav-tabs {
         margin-bottom: 0;
-
-        > li:last-child {
-            margin-right: 20px;
-        }
+        padding: 0 8px 0 9px;
     }
 
-    .stream-selection-header-colorblock {
-        &.message_header_private_message {
-            border-radius: 3px 0 0 3px;
-            border-bottom: 0;
-            background-color: hsl(0, 0%, 27%);
-        }
+    .nav-tabs > li:last-child {
+        margin-right: 28px;
+    }
+
+    .stream-selection-header-colorblock.message_header_private_message {
+        border-radius: 3px 0 0 3px;
+        border-bottom: 0;
+        background-color: hsl(0, 0%, 27%);
     }
 
     .receiving_streams {
@@ -177,13 +171,14 @@
     .messagebox {
         /* normally 5px 14px; pull in the right and bottom a bit */
         cursor: default;
-        padding: 0;
         background: none;
         box-shadow: none;
         border: none;
         height: 100%;
         display: flex;
         flex-flow: column;
+        background-color: hsl(0, 0%, 100%);
+        padding: 4px 9px 16px 9px;
     }
 
     .message_content {
@@ -229,7 +224,8 @@
 
 #compose_top_right {
     position: absolute;
-    right: 0;
+    top: 0;
+    right: 8px;
     float: right;
 
     button {
@@ -337,8 +333,8 @@ div[id^="message-edit-send-status"],
 
     .close {
         position: absolute;
-        right: 8px;
         top: 4px;
+        right: 8px;
         font-size: 17px;
         font-weight: bold;
         color: hsl(0, 0%, 0%);
@@ -350,6 +346,10 @@ div[id^="message-edit-send-status"],
 .compose-notifications-content {
     padding: 4px 22px 4px 22px;
     text-align: center;
+}
+
+.composition-alerts {
+    padding: 4px 14px 0 9px;
 }
 
 .composition-area {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -92,6 +92,14 @@
     display: flex;
     flex-flow: column;
 
+    .nav {
+        margin-bottom: 0;
+
+        > li:last-child {
+            margin-right: 20px;
+        }
+    }
+
     .stream-selection-header-colorblock {
         &.message_header_private_message {
             border-radius: 3px 0 0 3px;
@@ -100,17 +108,23 @@
         }
     }
 
-    .right_part {
+    .receiving_streams {
         padding: 0;
         display: flex;
-        align-items: center;
-        width: 100%;
+        align-items: stretch;
+        flex: 1 1 auto;
 
         .fa-angle-right {
             font-size: 0.9em;
             -webkit-text-stroke: 0.05em;
             position: relative;
             margin: 0 5px;
+        }
+
+        .stream-info {
+            flex: 1 1 auto;
+            display: flex;
+            align-items: center;
         }
     }
 
@@ -443,6 +457,7 @@ input.recipient_box {
 #stream-message,
 #private-message {
     display: flex;
+    align-items: center;
 }
 
 #private-message {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -93,7 +93,7 @@
     }
 
     .nav-tabs > li:last-child {
-        margin-right: 28px;
+        margin-right: 36px; /* Makes space for the close and expand buttons */
     }
 
     .stream-selection-header-colorblock.message_header_private_message {
@@ -240,6 +240,11 @@
 
         &:hover {
             opacity: 1;
+        }
+
+        &.expand_composebox_button,
+        &.collapse_composebox_button {
+            margin-top: -6px;
         }
     }
 }

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -223,11 +223,21 @@ on a dark background, and don't change the dark labels dark either. */
         color: inherit;
     }
 
-    .nav-tabs {
+    #send_message_form .messagebox {
+        background-color: hsl(212, 28%, 18%);
+    }
+
+    .message_comp {
+        background-color: hsla(0, 0%, 0%, 0.1);
+    }
+
+    .message_comp .nav-tabs {
         border-bottom-color: hsla(0, 0%, 0%, 0.2);
 
-        > li > a:hover {
+        > li:not(.active) > a:hover {
             color: hsl(200, 79%, 66%);
+            background: none;
+            border: 1px solid transparent;
         }
 
         > li.active > a {

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -223,6 +223,21 @@ on a dark background, and don't change the dark labels dark either. */
         color: inherit;
     }
 
+    .nav-tabs {
+        border-bottom-color: hsla(0, 0%, 0%, 0.2);
+
+        > li > a:hover {
+            color: hsl(200, 79%, 66%);
+        }
+
+        > li.active > a {
+            background-color: hsl(212, 28%, 18%);
+            color: inherit;
+            border-color: hsla(0, 0%, 0%, 0.2);
+            border-bottom-color: hsl(212, 28%, 18%);
+        }
+    }
+
     select option {
         background-color: hsl(212, 28%, 18%);
         color: hsl(236, 33%, 90%);

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -44,16 +44,18 @@
         </div>
     </div>
     <div class="message_comp">
-        <div class="alert" id="compose-send-status">
-            <span class="compose-send-status-close">&times;</span>
-            <span id="compose-error-msg"></span>
+        <div class="composition-alerts">
+            <div class="alert" id="compose-send-status">
+                <span class="compose-send-status-close">&times;</span>
+                <span id="compose-error-msg"></span>
+            </div>
+            <div id="compose_invite_users" class="alert home-error-bar"></div>
+            <div id="compose-all-everyone" class="alert home-error-bar"></div>
+            <div id="compose-announce" class="alert home-error-bar"></div>
+            <div id="compose_not_subscribed" class="alert home-error-bar"></div>
+            <div id="compose_private_stream_alert" class="alert home-error-bar"></div>
+            <div id="out-of-view-notification" class="notification-alert"></div>
         </div>
-        <div id="compose_invite_users" class="alert home-error-bar"></div>
-        <div id="compose-all-everyone" class="alert home-error-bar"></div>
-        <div id="compose-announce" class="alert home-error-bar"></div>
-        <div id="compose_not_subscribed" class="alert home-error-bar"></div>
-        <div id="compose_private_stream_alert" class="alert home-error-bar"></div>
-        <div id="out-of-view-notification" class="notification-alert"></div>
         <div class="composition-area">
             <div id="compose_top_right">
                 <button type="button" class="expand_composebox_button fa fa-angle-up" aria-label="{{t 'Expand compose' }}" tabindex=0 title="{{t 'Expand compose' }}"></button>
@@ -65,7 +67,7 @@
                 <div class="compose_table">
                     <ul id="stream-message" class="nav nav-tabs" role="tablist">
                         <div class="receiving_streams">
-                                <div class="stream-selection-header-colorblock message_header_stream"></div>
+                            <div class="stream-selection-header-colorblock message_header_stream"></div>
                             <div class="stream-info">
                                 <span id="compose-lock-icon">
                                     <i class="fa fa-lock" title="{{t 'This is a private stream' }}" aria-hidden="true"></i>
@@ -119,6 +121,18 @@
                                     </label>
                                 </div>
                                 <span id="compose_limit_indicator"></span>
+                            </div>
+                        </div>
+                        <div class="drag"></div>
+                        <div id="below-compose-content">
+                            <button type="submit" id="compose-send-button" class="button small send_message" title="{{t 'Send' }} (Ctrl + Enter)">{{t 'Send' }}</button>
+                            {{> compose_control_buttons }}
+                            <span id="sending-indicator"></span>
+                            <div id="send_controls" class="new-style">
+                                <label id="enter-sends-label" class="compose_checkbox_label checkbox">
+                                    <input type="checkbox" id="enter_sends" />
+                                    <span></span>{{t 'Press Enter to send' }}
+                                </label>
                             </div>
                         </div>
                     </div>

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -63,22 +63,30 @@
             <form id="send_message_form" action="/json/messages" method="post">
                 {{ csrf_input }}
                 <div class="compose_table">
-                    <div id="stream-message">
-                        <div class="stream-selection-header-colorblock message_header_stream left_part"></div>
-                        <div class="right_part">
-                            <span id="compose-lock-icon">
-                                <i class="fa fa-lock" title="{{t 'This is a private stream' }}" aria-hidden="true"></i>
-                            </span>
-                            <input type="text" class="recipient_box" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="30" value="" placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Stream' }}" />
-                            <i class="fa fa-angle-right" aria-hidden="true"></i>
-                            <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="60" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
+                    <ul id="stream-message" class="nav nav-tabs" role="tablist">
+                        <div class="receiving_streams">
+                                <div class="stream-selection-header-colorblock message_header_stream"></div>
+                            <div class="stream-info">
+                                <span id="compose-lock-icon">
+                                    <i class="fa fa-lock" title="{{t 'This is a private stream' }}" aria-hidden="true"></i>
+                                </span>
+                                <input type="text" class="recipient_box" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="30" value="" placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Stream' }}" />
+                                <i class="fa fa-angle-right" aria-hidden="true"></i>
+                                <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="60" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
+                            </div>
                         </div>
-                    </div>
+                        <li role="presentation" class="preview-toggle">
+                            <a href="#preview" class="markdown_preview" aria-controls="preview" role="tab" data-toggle="tab">Preview</a>
+                        </li>
+                        <li role="presentation" class="preview-toggle active">
+                            <a href="#write" class="undo_markdown_preview" aria-controls="write" role="tab" data-toggle="tab">Write</a>
+                        </li>
+                    </ul>
                     <div id="private-message">
                         <div class="to_text">
                             <span>{{t 'To' }}:</span>
                         </div>
-                        <div class="right_part">
+                        <div class="receiving_streams">
                             <div class="pm_recipient">
                                 <div class="pill-container" data-before="{{t 'You and' }}">
                                     <div class="input" contenteditable="true" id="private_message_recipient" data-no-recipients-text="{{t 'Add one or more users' }}" data-some-recipients-text="{{t 'Add another user...' }}"></div>
@@ -88,10 +96,16 @@
                     </div>
                     <div class="messagebox-wrapper">
                         <div class="messagebox">
-                            <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
-                            <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area" style="display:none;">
-                                <div class="markdown_preview_spinner"></div>
-                                <div class="preview_content rendered_markdown"></div>
+                            <div class="tab-content">
+                                <div role="tabpanel" class="tab-pane active" id="write">
+                                    <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
+                                </div>
+                                <div role="tabpanel" class="tab-pane" id="preview">
+                                    <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area">
+                                        <div class="markdown_preview_spinner"></div>
+                                        <div class="preview_content rendered_markdown"></div>
+                                    </div>
+                                </div>
                             </div>
                             <div class="drag"></div>
                             <div id="below-compose-content">

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -109,19 +109,6 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="drag"></div>
-                            <div id="below-compose-content">
-                                <button type="submit" id="compose-send-button" class="button small send_message animated-purple-button" title="{{t 'Send' }} (Ctrl + Enter)">{{t 'Send' }}</button>
-                                {{> compose_control_buttons }}
-                                <span id="sending-indicator"></span>
-                                <div id="send_controls" class="new-style">
-                                    <label id="enter-sends-label" class="compose_checkbox_label checkbox">
-                                        <input type="checkbox" id="enter_sends" />
-                                        <span></span>{{t 'Press Enter to send' }}
-                                    </label>
-                                </div>
-                                <span id="compose_limit_indicator"></span>
-                            </div>
                         </div>
                         <div class="drag"></div>
                         <div id="below-compose-content">

--- a/static/templates/compose_control_buttons.hbs
+++ b/static/templates/compose_control_buttons.hbs
@@ -2,8 +2,6 @@
 {{#if file_upload_enabled }}
 <a role="button" class="compose_control_button compose_upload_file fa fa-paperclip notdisplayed" aria-label="{{t 'Upload files' }}" tabindex=0 data-tippy-content="{{t 'Upload files' }}"></a>
 {{/if}}
-<a role="button" class="markdown_preview compose_control_button fa fa-eye" aria-label="{{t 'Preview' }}" tabindex=0 data-tippy-content="{{t 'Preview' }}"></a>
-<a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"></a>
 <a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"></a>
 <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 data-tippy-content="{{t 'Add emoji' }}"></a>
 <a role="button" class="compose_control_button compose_giphy_link {{#unless giphy_enabled }} hide {{/unless}}" aria-label="{{t 'Add GIF' }}" data-tippy-content="{{t 'Add GIF' }}">


### PR DESCRIPTION
The preview vs write toggle button is now two tabs on the top right of
the compose area.

Known issues:
- It does add a little vertical height with the default Bootstrap styling. Could be modified.
- The colored stripe to the right of the stream name disappeared and I'm not sure why

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/18757

**Testing plan:** <!-- How have you tested? -->
- I tried with light and dark mode (are there other stylesheets?)
- TODO test with DMs
- TODO test with not-Chrome (haven't looked at what the browser SLA is yet)


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="932" alt="Screen Shot 2021-06-29 at 00 03 53" src="https://user-images.githubusercontent.com/689247/123752361-918e7780-d86d-11eb-9bd7-01a08f18d542.png">

<img width="911" alt="Screen Shot 2021-06-29 at 00 04 17" src="https://user-images.githubusercontent.com/689247/123752384-94896800-d86d-11eb-95be-1f8bf83bc4cd.png">

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
