### PR TITLE
Migrate `left_sidebar` and `right_sidebar` to handlebars.

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -7,6 +7,7 @@ import * as emoji from "../shared/js/emoji";
 import * as fenced_code from "../shared/js/fenced_code";
 import render_edit_content_button from "../templates/edit_content_button.hbs";
 import render_left_sidebar from "../templates/left_sidebar.hbs";
+import render_right_sidebar from "../templates/right_sidebar.hbs";
 
 import * as about_zulip from "./about_zulip";
 import * as activity from "./activity";
@@ -63,6 +64,7 @@ import * as search from "./search";
 import * as search_pill_widget from "./search_pill_widget";
 import * as sent_messages from "./sent_messages";
 import * as server_events from "./server_events";
+import * as settings_data from "./settings_data";
 import * as settings_display from "./settings_display";
 import * as settings_panel_menu from "./settings_panel_menu";
 import * as settings_sections from "./settings_sections";
@@ -137,6 +139,14 @@ function initialize_left_sidebar() {
     });
 
     $("#left-sidebar-container").html(rendered_sidebar);
+}
+
+function initialize_right_sidebar() {
+    const rendered_sidebar = render_right_sidebar({
+        can_invite_others_to_realm: settings_data.user_can_invite_others_to_realm(),
+    });
+
+    $("#right-sidebar-container").html(rendered_sidebar);
 }
 
 export function initialize_kitchen_sink_stuff() {
@@ -483,6 +493,7 @@ export function initialize_everything() {
     // expect DOM elements to always exist (As that did before these
     // modules were migrated from Django templates to handlebars).
     initialize_left_sidebar();
+    initialize_right_sidebar();
     compose.initialize();
 
     message_lists.initialize();

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -6,6 +6,7 @@ import generated_pygments_data from "../generated/pygments_data.json";
 import * as emoji from "../shared/js/emoji";
 import * as fenced_code from "../shared/js/fenced_code";
 import render_edit_content_button from "../templates/edit_content_button.hbs";
+import render_left_sidebar from "../templates/left_sidebar.hbs";
 
 import * as about_zulip from "./about_zulip";
 import * as activity from "./activity";
@@ -128,6 +129,14 @@ function message_hover(message_row) {
         msg_id: id,
     };
     message_row.find(".edit_content").html(render_edit_content_button(args));
+}
+
+function initialize_left_sidebar() {
+    const rendered_sidebar = render_left_sidebar({
+        is_guest: page_params.is_guest,
+    });
+
+    $("#left-sidebar-container").html(rendered_sidebar);
 }
 
 export function initialize_kitchen_sink_stuff() {
@@ -468,11 +477,14 @@ export function initialize_everything() {
     i18n.initialize(i18n_params);
     tippyjs.initialize();
     popover_menus.initialize();
-    // We need to initialize compose early, because other modules'
-    // initialization expects `#compose` to be already present in the
-    // DOM, dating from when the compose area was part of the backend
-    // template.
+
+    // These components must be initialized early, because other
+    // modules' initialization has not been audited for whether they
+    // expect DOM elements to always exist (As that did before these
+    // modules were migrated from Django templates to handlebars).
+    initialize_left_sidebar();
     compose.initialize();
+
     message_lists.initialize();
     alert_words.initialize(alert_words_params);
     emojisets.initialize();

--- a/static/templates/left_sidebar.hbs
+++ b/static/templates/left_sidebar.hbs
@@ -1,26 +1,26 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
     <div class="narrows_panel">
         <ul id="global_filters" class="filters">
-            {# Special-case this link so we don't actually go to page top. #}
-            <li class="top_left_all_messages top_left_row" title="{{ _('All messages') }} (a)">
+            {{!-- Special-case this link so we don't actually go to page top. --}}
+            <li class="top_left_all_messages top_left_row" title="{{t 'All messages' }} (a)">
                 <a href="#all_messages" class="home-link">
                     <span class="filter-icon">
                         <i class="fa fa-align-left" aria-hidden="true"></i>
                     </span>
-                    {#- squash whitespace -#}
-                    <span>{{ _('All messages') }}</span>
+                    {{~!-- squash whitespace --~}}
+                    <span>{{t 'All messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
                 <span class="arrow all-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_private_messages">
-                <div class="private_messages_header top_left_row" title="{{ _('Private messages') }} (P)">
+                <div class="private_messages_header top_left_row" title="{{t 'Private messages' }} (P)">
                     <a href="#narrow/is/private">
                         <span class="filter-icon">
                             <i class="fa fa-envelope" aria-hidden="true"></i>
                         </span>
-                        {#- squash whitespace -#}
-                        <span>{{ _('Private messages') }}</span>
+                        {{~!-- squash whitespace --~}}
+                        <span>{{t 'Private messages' }}</span>
                         <span class="unread_count"></span>
                     </a>
                 </div>
@@ -32,8 +32,8 @@
                     <span class="filter-icon">
                         <i class="fa fa-at" aria-hidden="true"></i>
                     </span>
-                    {#- squash whitespace -#}
-                    <span>{{ _('Mentions') }}</span>
+                    {{~!-- squash whitespace --~}}
+                    <span>{{t 'Mentions' }}</span>
                     <span class="unread_count"></span>
                 </a>
             </li>
@@ -42,46 +42,46 @@
                     <span class="filter-icon">
                         <i class="fa fa-star" aria-hidden="true"></i>
                     </span>
-                    {#- squash whitespace -#}
-                    <span>{{ _('Starred messages') }}</span>
+                    {{~!-- squash whitespace --~}}
+                    <span>{{t 'Starred messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
                 <span class="arrow starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_recent_topics top_left_row" title="{{ _('Recent topics') }} (t)">
+            <li class="top_left_recent_topics top_left_row" title="{{t 'Recent topics' }} (t)">
                 <a href="#recent_topics">
                     <span class="filter-icon">
                         <i class="fa fa-clock-o" aria-hidden="true"></i>
                     </span>
-                    {#- squash whitespace -#}
-                    <span>{{ _('Recent topics') }}</span>
+                    {{~!-- squash whitespace --~}}
+                    <span>{{t 'Recent topics' }}</span>
                 </a>
             </li>
         </ul>
         <div id="streams_list" class="zoom-out">
-            <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title tippy-zulip-tooltip" data-tippy-content="{{ _('Filter streams') }} (q)">{{ _('STREAMS') }}</h4>
-                <span class="tippy-zulip-tooltip streams_inline_cog_wrapper hidden-for-spectators" data-tippy-content="{{ _('Add streams') }}" data-tippy-placement="top">
+            <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title tippy-zulip-tooltip" data-tippy-content="{{t 'Filter streams' }} (q)">{{t 'STREAMS' }}</h4>
+                <span class="tippy-zulip-tooltip streams_inline_cog_wrapper hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}" data-tippy-placement="top">
                     <i id="streams_inline_cog" class='fa fa-plus' aria-hidden="true" ></i>
                 </span>
-                <i class="streams_filter_icon fa fa-filter tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{ _('Filter streams') }} (q)" data-tippy-placement="top"></i>
+                <i class="streams_filter_icon fa fa-filter tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Filter streams' }} (q)" data-tippy-placement="top"></i>
                 <div class="input-append notdisplayed stream_search_section">
-                    <input class="stream-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{ _('Filter streams') }}" />
+                    <input class="stream-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{t 'Filter streams' }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>
                 </div>
             </div>
             <div id="topics_header">
-                <a href="" class="show-all-streams"> <i class="fa fa-chevron-left" aria-hidden="true"></i>{{ _('Back to streams') }}</a>
+                <a href="" class="show-all-streams"> <i class="fa fa-chevron-left" aria-hidden="true"></i>{{t 'Back to streams' }}</a>
             </div>
             <div id="stream-filters-container" class="scrolling_list" data-simplebar>
                 <ul id="stream_filters" class="filters"></ul>
             </div>
-            {% if show_add_streams %}
+            {{#unless is_guest }}
             <div id="add-stream-link">
-                <a href="#streams/all"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Subscribe to more streams') }}</a>
+                <a href="#streams/all"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{t 'Subscribe to more streams' }}</a>
             </div>
-            {% endif %}
+            {{/unless}}
         </div>
     </div>
 </div>

--- a/static/templates/right_sidebar.hbs
+++ b/static/templates/right_sidebar.hbs
@@ -3,14 +3,14 @@
         <div id="user-list">
             <div id="userlist-header">
                 <h4 class='sidebar-title tippy-zulip-tooltip'
-                  id='userlist-title' data-tippy-content="{{ _('Search people') }} (w)">{{ _('USERS') }}</h4>
+                  id='userlist-title' data-tippy-content="{{t 'Search people' }} (w)">{{t 'USERS' }}</h4>
                 <i id="user_filter_icon" class="fa fa-search tippy-zulip-tooltip"
-                  aria-hidden="true" aria-label="{{ _('Search people') }}"
-                  data-tippy-content="{{ _('Search people') }} (w)">
+                  aria-hidden="true" aria-label="{{t 'Search people' }}"
+                  data-tippy-content="{{t 'Search people' }} (w)">
                 </i>
             </div>
             <div class="input-append notdisplayed" id="user_search_section">
-                <input class="user-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{ _('Search people') }}" />
+                <input class="user-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{t 'Search people' }}" />
                 <button type="button" class="btn clear_search_button" id="clear_search_people_button">
                     <i class="fa fa-remove" aria-hidden="true"></i>
                 </button>
@@ -21,11 +21,11 @@
             </div>
         </div>
         <div class="right-sidebar-shortcuts">
-            {% if show_invites %}
-            <a id="invite-user-link" href="#invite"><i class="fa fa-user-plus" aria-hidden="true"></i>{{ _('Invite more users') }}</a>
-            {% endif %}
+            {{#if can_invite_others_to_realm}}
+            <a id="invite-user-link" href="#invite"><i class="fa fa-user-plus" aria-hidden="true"></i>{{t 'Invite more users' }}</a>
+            {{/if}}
             <a id="sidebar-keyboard-shortcuts" data-overlay-trigger="keyboard-shortcuts">
-                <i class="fa fa-keyboard-o fa-2x tippy-zulip-tooltip" id="keyboard-icon" data-tippy-allowHtml="true" data-tippy-content="{{ _('Keyboard shortcuts') }} <span class='hotkey-hint'>(?)</span>"></i>
+                <i class="fa fa-keyboard-o fa-2x tippy-zulip-tooltip" id="keyboard-icon" data-tippy-allowHtml="true" data-tippy-content="{{t 'Keyboard shortcuts' }} <span class='hotkey-hint'>(?)</span>"></i>
             </a>
         </div>
     </div>

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -129,8 +129,7 @@
                 </div>
             </div><!--/tab-content-->
         </div>
-        <div class="column-right">
-            {% include "zerver/app/right_sidebar.html" %}
+        <div class="column-right" id="right-sidebar-container">
         </div><!--/right sidebar-->
     </div><!--/row-->
     <div class="informational-overlays overlay new-style" data-overlay="informationalOverlays" aria-hidden="true">

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -90,8 +90,7 @@
         <div class="alert alert_sidebar alert-error home-error-bar" id="reloading-application"></div>
     </div>
     <div class="app-main">
-        <div class="column-left">
-            {% include "zerver/app/left_sidebar.html" %}
+        <div class="column-left" id="left-sidebar-container">
         </div>
         <div class="column-middle">
             <div class="column-middle-inner tab-content">

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -16,7 +16,7 @@ from zerver.lib.i18n import (
     get_language_list,
     get_language_translation_data,
 )
-from zerver.lib.users import compute_show_invites_and_add_streams
+from zerver.lib.users import compute_show_invites
 from zerver.models import Message, Realm, Stream, UserProfile
 from zerver.views.message_flags import get_latest_update_message_flag_activity
 
@@ -179,7 +179,7 @@ def build_page_params_for_home_page_load(
 
     two_fa_enabled = settings.TWO_FACTOR_AUTHENTICATION_ENABLED and user_profile is not None
     billing_info = get_billing_info(user_profile)
-    show_invites, _ = compute_show_invites_and_add_streams(user_profile)
+    show_invites = compute_show_invites(user_profile)
     user_permission_info = get_user_permission_info(user_profile)
 
     # Pass parameters to the client-side JavaScript code.

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -1,7 +1,7 @@
 import re
 import unicodedata
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -349,14 +349,14 @@ def validate_user_custom_profile_data(
             raise JsonableError(error.message)
 
 
-def compute_show_invites_and_add_streams(user_profile: Optional[UserProfile]) -> Tuple[bool, bool]:
+def compute_show_invites(user_profile: Optional[UserProfile]) -> bool:
     if user_profile is None:
-        return False, False
+        return False
 
     if user_profile.is_guest:
-        return False, False
+        return False
 
-    return user_profile.can_invite_others_to_realm(), True
+    return user_profile.can_invite_others_to_realm()
 
 
 def can_access_delivery_email(user_profile: UserProfile) -> bool:

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -246,7 +246,6 @@ class HomeTest(ZulipTestCase):
         # Keep this list sorted!!!
         html_bits = [
             "start the conversation",
-            "Keyboard shortcuts",
             "Loading...",
             # Verify that the app styles get included
             "app-stubentry.js",
@@ -395,12 +394,6 @@ class HomeTest(ZulipTestCase):
         ):
             result = self.client_get("/", dict(**kwargs))
         return result
-
-    def assertInHomePage(self, string: str) -> bool:
-        return self.assertIn(string, self._get_home_page().content.decode("utf-8"))
-
-    def assertNotInHomePage(self, string: str) -> bool:
-        return self.assertNotIn(string, self._get_home_page().content.decode("utf-8"))
 
     def _sanity_check(self, result: HttpResponse) -> None:
         """
@@ -686,33 +679,6 @@ class HomeTest(ZulipTestCase):
         self.assertEqual(page_params["narrow_stream"], stream_name)
         self.assertEqual(page_params["narrow"], [dict(operator="stream", operand=stream_name)])
         self.assertEqual(page_params["max_message_id"], -1)
-
-    def test_invites_by_admins_only(self) -> None:
-        user_profile = self.example_user("hamlet")
-
-        realm = user_profile.realm
-        realm.invite_to_realm_policy = Realm.POLICY_ADMINS_ONLY
-        realm.save()
-
-        self.login_user(user_profile)
-        self.assertFalse(user_profile.is_realm_admin)
-        self.assertNotInHomePage("Invite more users")
-
-        user_profile.role = UserProfile.ROLE_REALM_ADMINISTRATOR
-        user_profile.save()
-        self.assertInHomePage("Invite more users")
-
-    def test_show_invites_for_guest_users(self) -> None:
-        user_profile = self.example_user("polonius")
-
-        realm = user_profile.realm
-        realm.invite_to_realm_policy = Realm.POLICY_MEMBERS_ONLY
-        realm.save()
-
-        self.login_user(user_profile)
-        self.assertFalse(user_profile.is_realm_admin)
-        self.assertEqual(get_realm("zulip").invite_to_realm_policy, Realm.POLICY_MEMBERS_ONLY)
-        self.assertNotInHomePage("Invite more users")
 
     def test_get_billing_info(self) -> None:
         user = self.example_user("desdemona")

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -21,7 +21,7 @@ from zerver.lib.home import (
 from zerver.lib.soft_deactivation import do_soft_deactivate_users
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import get_user_messages, override_settings, queries_captured
-from zerver.lib.users import compute_show_invites_and_add_streams
+from zerver.lib.users import compute_show_invites
 from zerver.models import (
     DefaultStream,
     Realm,
@@ -248,7 +248,6 @@ class HomeTest(ZulipTestCase):
             "start the conversation",
             "Keyboard shortcuts",
             "Loading...",
-            "Filter streams",
             # Verify that the app styles get included
             "app-stubentry.js",
             "data-params",
@@ -1083,9 +1082,8 @@ class HomeTest(ZulipTestCase):
         realm.invite_to_realm_policy = Realm.POLICY_ADMINS_ONLY
         realm.save()
 
-        show_invites, show_add_streams = compute_show_invites_and_add_streams(user)
+        show_invites = compute_show_invites(user)
         self.assertEqual(show_invites, True)
-        self.assertEqual(show_add_streams, True)
 
     def test_compute_show_invites_and_add_streams_require_admin(self) -> None:
         user = self.example_user("hamlet")
@@ -1094,18 +1092,15 @@ class HomeTest(ZulipTestCase):
         realm.invite_to_realm_policy = Realm.POLICY_ADMINS_ONLY
         realm.save()
 
-        show_invites, show_add_streams = compute_show_invites_and_add_streams(user)
+        show_invites = compute_show_invites(user)
         self.assertEqual(show_invites, False)
-        self.assertEqual(show_add_streams, True)
 
     def test_compute_show_invites_and_add_streams_guest(self) -> None:
         user = self.example_user("polonius")
 
-        show_invites, show_add_streams = compute_show_invites_and_add_streams(user)
+        show_invites = compute_show_invites(user)
         self.assertEqual(show_invites, False)
-        self.assertEqual(show_add_streams, False)
 
     def test_compute_show_invites_and_add_streams_unauthenticated(self) -> None:
-        show_invites, show_add_streams = compute_show_invites_and_add_streams(None)
+        show_invites = compute_show_invites(None)
         self.assertEqual(show_invites, False)
-        self.assertEqual(show_add_streams, False)

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -16,7 +16,6 @@ from zerver.lib.compatibility import is_outdated_desktop_app, is_unsupported_bro
 from zerver.lib.home import build_page_params_for_home_page_load, get_user_permission_info
 from zerver.lib.streams import access_stream_by_name
 from zerver.lib.subdomains import get_subdomain
-from zerver.lib.users import compute_show_invites
 from zerver.lib.utils import statsd
 from zerver.models import PreregistrationUser, Realm, Stream, UserProfile
 from zerver.views.portico import hello_view
@@ -190,8 +189,6 @@ def home_real(request: HttpRequest) -> HttpResponse:
         needs_tutorial=needs_tutorial,
     )
 
-    show_invites = compute_show_invites(user_profile)
-
     request._log_data["extra"] = "[{}]".format(queue_id)
 
     csp_nonce = secrets.token_hex(24)
@@ -206,7 +203,6 @@ def home_real(request: HttpRequest) -> HttpResponse:
             "page_params": page_params,
             "csp_nonce": csp_nonce,
             "search_pills_enabled": settings.SEARCH_PILLS_ENABLED,
-            "show_invites": show_invites,
             "is_owner": user_permission_info.is_realm_owner,
             "is_admin": user_permission_info.is_realm_admin,
             "is_guest": user_permission_info.is_guest,

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -16,7 +16,7 @@ from zerver.lib.compatibility import is_outdated_desktop_app, is_unsupported_bro
 from zerver.lib.home import build_page_params_for_home_page_load, get_user_permission_info
 from zerver.lib.streams import access_stream_by_name
 from zerver.lib.subdomains import get_subdomain
-from zerver.lib.users import compute_show_invites_and_add_streams
+from zerver.lib.users import compute_show_invites
 from zerver.lib.utils import statsd
 from zerver.models import PreregistrationUser, Realm, Stream, UserProfile
 from zerver.views.portico import hello_view
@@ -190,7 +190,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
         needs_tutorial=needs_tutorial,
     )
 
-    show_invites, show_add_streams = compute_show_invites_and_add_streams(user_profile)
+    show_invites = compute_show_invites(user_profile)
 
     request._log_data["extra"] = "[{}]".format(queue_id)
 
@@ -207,7 +207,6 @@ def home_real(request: HttpRequest) -> HttpResponse:
             "csp_nonce": csp_nonce,
             "search_pills_enabled": settings.SEARCH_PILLS_ENABLED,
             "show_invites": show_invites,
-            "show_add_streams": show_add_streams,
             "is_owner": user_permission_info.is_realm_owner,
             "is_admin": user_permission_info.is_realm_admin,
             "is_guest": user_permission_info.is_guest,


### PR DESCRIPTION
Added a couple of commits to migrate the `left_sidebar.html` (8ba6d0a) and `right_sidebar.html` (9c28c91) to handlebars.
The templates (`left_sidebar.hbs` and `right_sidebar.hbs`) are then rendered using `ui_init.js`. 

Fixes parts of #18792. 