### PR TITLE
exceptions: Use `raise JsonableError` in place of `return json_error`.

### DIFF
--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -25,8 +25,8 @@ from zerver.lib.actions import (
     do_scrub_realm,
     do_send_realm_reactivation_email,
 )
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.realm_icon import realm_icon_url
-from zerver.lib.response import json_error
 from zerver.lib.subdomains import get_subdomain_from_hostname
 from zerver.models import MultiuseInvite, PreregistrationUser, Realm, UserProfile, get_realm
 from zerver.views.invite import get_invitee_emails_set
@@ -110,7 +110,7 @@ def support(request: HttpRequest) -> HttpResponse:
         if "csrfmiddlewaretoken" in keys:
             keys.remove("csrfmiddlewaretoken")
         if len(keys) != 2:
-            return json_error(_("Invalid parameters"))
+            raise JsonableError(_("Invalid parameters"))
 
         realm_id = request.POST.get("realm_id")
         realm = Realm.objects.get(id=realm_id)

--- a/docs/subsystems/logging.md
+++ b/docs/subsystems/logging.md
@@ -32,9 +32,8 @@ infrastructure needed by our error reporting system:
 * A nice framework for filtering passwords and other important user
   data from the exception details, which we use in
   `zerver/filters.py`.
-* Middleware for handling `JsonableError`, our system for allowing
-  code anywhere in Django to report an API-facing `json_error` from
-  anywhere in a view code path.
+* Middleware for handling `JsonableError`, which is our standard
+  system for API code to return a JSON-format HTTP error response.
 
 Since 500 errors in any Zulip server are usually a problem the server
 administrator should investigate and/or report upstream, we have this

--- a/docs/tutorials/life-of-a-request.md
+++ b/docs/tutorials/life-of-a-request.md
@@ -193,9 +193,9 @@ This is covered in good detail in the [writing views doc](writing-views.md).
 ## Results are given as JSON
 
 Our API works on JSON requests and responses. Every API endpoint should
-return `json_error` in the case of an error, which gives a JSON string:
+`raise JsonableError` in the case of an error, which gives a JSON string:
 
-`{'result': 'error', 'msg': <some error message>}`
+`{'result': 'error', 'msg': <some error message>, 'code': 'BAD_REQUEST'}`
 
 in a
 [HTTP response](https://docs.djangoproject.com/en/1.8/ref/request-response/)

--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -437,7 +437,7 @@ can be handled at the beginning of `update_realm`.
     if default_language is not None and default_language not in get_available_language_codes():
         raise JsonableError(_("Invalid language '%s'" % (default_language,)))
     if description is not None and len(description) > 100:
-        return json_error(_("Realm description cannot exceed 100 characters."))
+        raise JsonableError(_("Realm description cannot exceed 100 characters."))
     # ...
 
 The code in `update_realm` loops through the `property_types` dictionary

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -452,7 +452,7 @@ def human_users_only(view_func: ViewFuncT) -> ViewFuncT:
     @wraps(view_func)
     def _wrapped_view_func(request: HttpRequest, *args: object, **kwargs: object) -> HttpResponse:
         if request.user.is_bot:
-            return json_error(_("This endpoint does not accept bot requests."))
+            raise JsonableError(_("This endpoint does not accept bot requests."))
         return view_func(request, *args, **kwargs)
 
     return cast(ViewFuncT, _wrapped_view_func)  # https://github.com/python/mypy/issues/1927
@@ -549,7 +549,7 @@ def require_member_or_admin(view_func: ViewFuncT) -> ViewFuncT:
         if user_profile.is_guest:
             raise JsonableError(_("Not allowed for guest users"))
         if user_profile.is_bot:
-            return json_error(_("This endpoint does not accept bot requests."))
+            raise JsonableError(_("This endpoint does not accept bot requests."))
         return view_func(request, user_profile, *args, **kwargs)
 
     return cast(ViewFuncT, _wrapped_view_func)  # https://github.com/python/mypy/issues/1927
@@ -624,7 +624,7 @@ def authenticated_rest_api_view(
                 auth_type, credentials = request.META["HTTP_AUTHORIZATION"].split()
                 # case insensitive per RFC 1945
                 if auth_type.lower() != "basic":
-                    return json_error(_("This endpoint requires HTTP basic authentication."))
+                    raise JsonableError(_("This endpoint requires HTTP basic authentication."))
                 role, api_key = base64.b64decode(credentials).decode("utf-8").split(":")
             except ValueError:
                 return json_unauthorized(_("Invalid authorization header for basic auth"))

--- a/zerver/lib/error_notify.py
+++ b/zerver/lib/error_notify.py
@@ -9,7 +9,8 @@ from django.utils.translation import gettext as _
 
 from zerver.filters import clean_data_from_query_parameters
 from zerver.lib.actions import internal_send_stream_message
-from zerver.lib.response import json_error, json_success
+from zerver.lib.exceptions import JsonableError
+from zerver.lib.response import json_success
 from zerver.models import get_stream, get_system_bot
 
 
@@ -199,5 +200,5 @@ def do_report_error(type: str, report: Dict[str, Any]) -> HttpResponse:
     elif type == "server":
         notify_server_error(report)
     else:
-        return json_error(_("Invalid type parameter"))
+        raise JsonableError(_("Invalid type parameter"))
     return json_success()

--- a/zerver/tests/test_integrations_dev_panel.py
+++ b/zerver/tests/test_integrations_dev_panel.py
@@ -220,6 +220,7 @@ class TestIntegrationsDevPanel(ZulipTestCase):
                 "message": {
                     "msg": "Unknown WordPress webhook action: WordPress action",
                     "result": "error",
+                    "code": "BAD_REQUEST",
                 },
                 "fixture_name": "user_register.txt",
                 "status_code": 400,
@@ -228,6 +229,7 @@ class TestIntegrationsDevPanel(ZulipTestCase):
                 "message": {
                     "msg": "Unknown WordPress webhook action: WordPress action",
                     "result": "error",
+                    "code": "BAD_REQUEST",
                 },
                 "fixture_name": "publish_post_no_data_provided.txt",
                 "status_code": 400,
@@ -236,6 +238,7 @@ class TestIntegrationsDevPanel(ZulipTestCase):
                 "message": {
                     "msg": "Unknown WordPress webhook action: WordPress action",
                     "result": "error",
+                    "code": "BAD_REQUEST",
                 },
                 "fixture_name": "unknown_action_no_data.txt",
                 "status_code": 400,
@@ -244,6 +247,7 @@ class TestIntegrationsDevPanel(ZulipTestCase):
                 "message": {
                     "msg": "Unknown WordPress webhook action: WordPress action",
                     "result": "error",
+                    "code": "BAD_REQUEST",
                 },
                 "fixture_name": "publish_page.txt",
                 "status_code": 400,
@@ -252,6 +256,7 @@ class TestIntegrationsDevPanel(ZulipTestCase):
                 "message": {
                     "msg": "Unknown WordPress webhook action: WordPress action",
                     "result": "error",
+                    "code": "BAD_REQUEST",
                 },
                 "fixture_name": "unknown_action_no_hook_provided.txt",
                 "status_code": 400,
@@ -260,6 +265,7 @@ class TestIntegrationsDevPanel(ZulipTestCase):
                 "message": {
                     "msg": "Unknown WordPress webhook action: WordPress action",
                     "result": "error",
+                    "code": "BAD_REQUEST",
                 },
                 "fixture_name": "publish_post_type_not_provided.txt",
                 "status_code": 400,
@@ -268,6 +274,7 @@ class TestIntegrationsDevPanel(ZulipTestCase):
                 "message": {
                     "msg": "Unknown WordPress webhook action: WordPress action",
                     "result": "error",
+                    "code": "BAD_REQUEST",
                 },
                 "fixture_name": "wp_login.txt",
                 "status_code": 400,
@@ -276,6 +283,7 @@ class TestIntegrationsDevPanel(ZulipTestCase):
                 "message": {
                     "msg": "Unknown WordPress webhook action: WordPress action",
                     "result": "error",
+                    "code": "BAD_REQUEST",
                 },
                 "fixture_name": "publish_post.txt",
                 "status_code": 400,

--- a/zerver/tests/test_realm_export.py
+++ b/zerver/tests/test_realm_export.py
@@ -184,8 +184,9 @@ class RealmExportTest(ZulipTestCase):
             )
         RealmAuditLog.objects.bulk_create(exports)
 
-        result = export_realm(self.client_post, admin)
-        self.assert_json_error(result, "Exceeded rate limit.")
+        with self.assertRaises(JsonableError) as error:
+            export_realm(self.client_post, admin)
+        self.assertEqual(str(error.exception), "Exceeded rate limit.")
 
     def test_upload_and_message_limit(self) -> None:
         admin = self.example_user("iago")

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -822,7 +822,7 @@ def api_fetch_api_key(
 
     realm = get_realm_from_request(request)
     if realm is None:
-        return json_error(_("Invalid subdomain"))
+        raise JsonableError(_("Invalid subdomain"))
 
     if not ldap_auth_enabled(realm=realm):
         # In case we don't authenticate against LDAP, check for a valid
@@ -945,12 +945,12 @@ def json_fetch_api_key(
 ) -> HttpResponse:
     realm = get_realm_from_request(request)
     if realm is None:
-        return json_error(_("Invalid subdomain"))
+        raise JsonableError(_("Invalid subdomain"))
     if password_auth_enabled(user_profile.realm):
         if not authenticate(
             request=request, username=user_profile.delivery_email, password=password, realm=realm
         ):
-            return json_error(_("Your username or password is incorrect."))
+            raise JsonableError(_("Your username or password is incorrect."))
 
     api_key = get_api_key(user_profile)
     return json_success({"api_key": api_key, "email": user_profile.delivery_email})

--- a/zerver/views/compatibility.py
+++ b/zerver/views/compatibility.py
@@ -2,7 +2,8 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
 from zerver.lib.compatibility import find_mobile_os, version_lt
-from zerver.lib.response import json_error, json_success
+from zerver.lib.exceptions import JsonableError
+from zerver.lib.response import json_success
 from zerver.lib.user_agent import parse_user_agent
 
 # Zulip Mobile release 16.2.96 was made 2018-08-22.  It fixed a
@@ -14,16 +15,16 @@ android_min_app_version = "16.2.96"
 
 def check_global_compatibility(request: HttpRequest) -> HttpResponse:
     if request.META.get("HTTP_USER_AGENT") is None:
-        return json_error(_("User-Agent header missing from request"))
+        raise JsonableError(_("User-Agent header missing from request"))
 
     # This string should not be tagged for translation, since old
     # clients are checking for an extra string.
     legacy_compatibility_error_message = "Client is too old"
     user_agent = parse_user_agent(request.META["HTTP_USER_AGENT"])
     if user_agent["name"] == "ZulipInvalid":
-        return json_error(legacy_compatibility_error_message)
+        raise JsonableError(legacy_compatibility_error_message)
     if user_agent["name"] == "ZulipMobile":
         user_os = find_mobile_os(request.META["HTTP_USER_AGENT"])
         if user_os == "android" and version_lt(user_agent["version"], android_min_app_version):
-            return json_error(legacy_compatibility_error_message)
+            raise JsonableError(legacy_compatibility_error_message)
     return json_success()

--- a/zerver/views/development/dev_login.py
+++ b/zerver/views/development/dev_login.py
@@ -103,7 +103,7 @@ def api_dev_fetch_api_key(request: HttpRequest, username: str = REQ()) -> HttpRe
     validate_login_email(username)
     realm = get_realm_from_request(request)
     if realm is None:
-        return json_error(_("Invalid subdomain"))
+        raise JsonableError(_("Invalid subdomain"))
     return_data: Dict[str, bool] = {}
     user_profile = authenticate(dev_auth_username=username, realm=realm, return_data=return_data)
     if return_data.get("inactive_realm"):

--- a/zerver/views/development/integrations.py
+++ b/zerver/views/development/integrations.py
@@ -6,6 +6,7 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.test import Client
 
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.integrations import WEBHOOK_INTEGRATIONS
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_error, json_success
@@ -104,7 +105,7 @@ def check_send_webhook_fixture_message(
     try:
         custom_headers_dict = orjson.loads(custom_headers)
     except orjson.JSONDecodeError as ve:
-        return json_error(f"Custom HTTP headers are not in a valid JSON format. {ve}")  # nolint
+        raise JsonableError(f"Custom HTTP headers are not in a valid JSON format. {ve}")  # nolint
 
     response = send_webhook_fixture_message(url, body, is_json, custom_headers_dict)
     if response.status_code == 200:

--- a/zerver/views/email_mirror.py
+++ b/zerver/views/email_mirror.py
@@ -2,8 +2,9 @@ from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import internal_notify_view
 from zerver.lib.email_mirror import mirror_email_message
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 
 
 @internal_notify_view(False)
@@ -15,5 +16,5 @@ def email_mirror_message(
 ) -> HttpResponse:
     result = mirror_email_message(rcpt_to, msg_base64)
     if result["status"] == "error":
-        return json_error(result["msg"])
+        raise JsonableError(result["msg"])
     return json_success()

--- a/zerver/views/events_register.py
+++ b/zerver/views/events_register.py
@@ -4,8 +4,9 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
 from zerver.lib.events import do_events_register
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.validator import check_bool, check_dict, check_list, check_string
 from zerver.models import Stream, UserProfile
 
@@ -70,7 +71,7 @@ def events_register_backend(
     queue_lifespan_secs: int = REQ(converter=int, default=0, documentation_pending=True),
 ) -> HttpResponse:
     if all_public_streams and not user_profile.can_access_public_streams():
-        return json_error(_("User not authorized for this query"))
+        raise JsonableError(_("User not authorized for this query"))
 
     all_public_streams = _default_all_public_streams(user_profile, all_public_streams)
     narrow = _default_narrow(user_profile, narrow)

--- a/zerver/views/hotspots.py
+++ b/zerver/views/hotspots.py
@@ -3,9 +3,10 @@ from django.utils.translation import gettext as _
 
 from zerver.decorator import human_users_only
 from zerver.lib.actions import do_mark_hotspot_as_read
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.hotspots import ALL_HOTSPOTS
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.models import UserProfile
 
 
@@ -15,6 +16,6 @@ def mark_hotspot_as_read(
     request: HttpRequest, user: UserProfile, hotspot: str = REQ()
 ) -> HttpResponse:
     if hotspot not in ALL_HOTSPOTS:
-        return json_error(_("Unknown hotspot: {}").format(hotspot))
+        raise JsonableError(_("Unknown hotspot: {}").format(hotspot))
     do_mark_hotspot_as_read(user, hotspot)
     return json_success()

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -15,7 +15,7 @@ from zerver.lib.actions import (
 )
 from zerver.lib.exceptions import OrganizationOwnerRequired
 from zerver.lib.request import REQ, JsonableError, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.streams import access_stream_by_id
 from zerver.lib.validator import check_int, check_list
 from zerver.models import MultiuseInvite, PreregistrationUser, Stream, UserProfile
@@ -44,7 +44,7 @@ def invite_users_backend(
         # be handled by the decorator above.
         raise JsonableError(_("Insufficient permission"))
     if invite_as not in PreregistrationUser.INVITE_AS.values():
-        return json_error(_("Must be invited as an valid type of user"))
+        raise JsonableError(_("Must be invited as an valid type of user"))
     check_if_owner_required(invite_as, user_profile)
     if (
         invite_as
@@ -54,11 +54,11 @@ def invite_users_backend(
         ]
         and not user_profile.is_realm_admin
     ):
-        return json_error(_("Must be an organization administrator"))
+        raise JsonableError(_("Must be an organization administrator"))
     if not invitee_emails_raw:
-        return json_error(_("You must specify at least one email address."))
+        raise JsonableError(_("You must specify at least one email address."))
     if not stream_ids:
-        return json_error(_("You must specify at least one stream for invitees to join."))
+        raise JsonableError(_("You must specify at least one stream for invitees to join."))
 
     invitee_emails = get_invitee_emails_set(invitee_emails_raw)
 
@@ -67,7 +67,7 @@ def invite_users_backend(
         try:
             (stream, sub) = access_stream_by_id(user_profile, stream_id)
         except JsonableError:
-            return json_error(
+            raise JsonableError(
                 _("Stream does not exist with id: {}. No invites were sent.").format(stream_id)
             )
         streams.append(stream)
@@ -174,7 +174,7 @@ def generate_multiuse_invite_backend(
         try:
             (stream, sub) = access_stream_by_id(user_profile, stream_id)
         except JsonableError:
-            return json_error(_("Invalid stream id {}. No invites were sent.").format(stream_id))
+            raise JsonableError(_("Invalid stream id {}. No invites were sent.").format(stream_id))
         streams.append(stream)
 
     invite_link = do_create_multiuse_invite_link(user_profile, invite_as, streams)

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -12,7 +12,7 @@ from zerver.lib.actions import check_update_message, do_delete_messages
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.html_diff import highlight_html_differences
 from zerver.lib.message import access_message
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import LEGACY_PREV_TOPIC, REQ_topic
 from zerver.lib.validator import check_bool, check_string_in, to_non_negative_int
@@ -74,7 +74,7 @@ def get_message_edit_history(
     message_id: int = REQ(converter=to_non_negative_int, path_only=True),
 ) -> HttpResponse:
     if not user_profile.realm.allow_edit_history:
-        return json_error(_("Message edit history is disabled in this organization"))
+        raise JsonableError(_("Message edit history is disabled in this organization"))
     message, ignored_user_message = access_message(user_profile, message_id)
 
     # Extract the message edit history from the message

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -38,7 +38,7 @@ from zerver.lib.addressee import get_user_profiles, get_user_profiles_by_ids
 from zerver.lib.exceptions import ErrorCode, JsonableError, MissingAuthenticationError
 from zerver.lib.message import get_first_visible_message_id, messages_for_ids
 from zerver.lib.narrow import is_web_public_compatible, is_web_public_narrow
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
 from zerver.lib.streams import (
     can_access_stream_history_by_id,
@@ -946,7 +946,7 @@ def get_messages_backend(
 ) -> HttpResponse:
     anchor = parse_anchor_value(anchor_val, use_first_unread_anchor_val)
     if num_before + num_after > MAX_MESSAGES_PER_FETCH:
-        return json_error(
+        raise JsonableError(
             _("Too many messages requested (maximum {}).").format(
                 MAX_MESSAGES_PER_FETCH,
             )

--- a/zerver/views/muting.py
+++ b/zerver/views/muting.py
@@ -6,8 +6,9 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
 from zerver.lib.actions import do_mute_topic, do_mute_user, do_unmute_topic, do_unmute_user
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.streams import (
     access_stream_by_id,
     access_stream_by_name,
@@ -36,7 +37,7 @@ def mute_topic(
         (stream, sub) = access_stream_by_id(user_profile, stream_id)
 
     if topic_is_muted(user_profile, stream.id, topic_name):
-        return json_error(_("Topic already muted"))
+        raise JsonableError(_("Topic already muted"))
 
     do_mute_topic(user_profile, stream, topic_name, date_muted)
     return json_success()
@@ -54,7 +55,7 @@ def unmute_topic(
         stream = access_stream_for_unmute_topic_by_id(user_profile, stream_id, error)
 
     if not topic_is_muted(user_profile, stream.id, topic_name):
-        return json_error(error)
+        raise JsonableError(error)
 
     do_unmute_topic(user_profile, stream, topic_name)
     return json_success()
@@ -91,13 +92,13 @@ def update_muted_topic(
 
 def mute_user(request: HttpRequest, user_profile: UserProfile, muted_user_id: int) -> HttpResponse:
     if user_profile.id == muted_user_id:
-        return json_error(_("Cannot mute self"))
+        raise JsonableError(_("Cannot mute self"))
 
     muted_user = access_user_by_id(user_profile, muted_user_id, allow_bots=False, for_admin=False)
     date_muted = timezone_now()
 
     if get_mute_object(user_profile, muted_user) is not None:
-        return json_error(_("User already muted"))
+        raise JsonableError(_("User already muted"))
 
     do_mute_user(user_profile, muted_user, date_muted)
     return json_success()
@@ -110,7 +111,7 @@ def unmute_user(
     mute_object = get_mute_object(user_profile, muted_user)
 
     if mute_object is None:
-        return json_error(_("User is not muted"))
+        raise JsonableError(_("User is not muted"))
 
     do_unmute_user(mute_object)
     return json_success()

--- a/zerver/views/presence.py
+++ b/zerver/views/presence.py
@@ -10,7 +10,7 @@ from zerver.decorator import human_users_only
 from zerver.lib.actions import do_update_user_status, update_user_presence
 from zerver.lib.presence import get_presence_for_user, get_presence_response
 from zerver.lib.request import REQ, JsonableError, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.validator import check_bool, check_capped_string
 from zerver.models import (
@@ -37,14 +37,14 @@ def get_presence_backend(
             email = user_id_or_email
             target = get_active_user(email, user_profile.realm)
     except UserProfile.DoesNotExist:
-        return json_error(_("No such user"))
+        raise JsonableError(_("No such user"))
 
     if target.is_bot:
-        return json_error(_("Presence is not supported for bot users."))
+        raise JsonableError(_("Presence is not supported for bot users."))
 
     presence_dict = get_presence_for_user(target.id)
     if len(presence_dict) == 0:
-        return json_error(
+        raise JsonableError(
             _("No presence data for {user_id_or_email}").format(user_id_or_email=user_id_or_email)
         )
 
@@ -73,7 +73,7 @@ def update_user_status_backend(
         status_text = status_text.strip()
 
     if (away is None) and (status_text is None):
-        return json_error(_("Client did not pass any new values."))
+        raise JsonableError(_("Client did not pass any new values."))
 
     do_update_user_status(
         user_profile=user_profile,

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -21,7 +21,7 @@ from zerver.lib.actions import (
 from zerver.lib.exceptions import OrganizationOwnerRequired
 from zerver.lib.i18n import get_available_language_codes
 from zerver.lib.request import REQ, JsonableError, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.retention import parse_message_retention_days
 from zerver.lib.streams import access_stream_by_id
 from zerver.lib.validator import (
@@ -131,15 +131,15 @@ def update_realm(
         if not user_profile.is_realm_owner:
             raise OrganizationOwnerRequired()
         if True not in list(authentication_methods.values()):
-            return json_error(_("At least one authentication method must be enabled."))
+            raise JsonableError(_("At least one authentication method must be enabled."))
     if video_chat_provider is not None and video_chat_provider not in {
         p["id"] for p in Realm.VIDEO_CHAT_PROVIDERS.values()
     }:
-        return json_error(_("Invalid video_chat_provider {}").format(video_chat_provider))
+        raise JsonableError(_("Invalid video_chat_provider {}").format(video_chat_provider))
     if giphy_rating is not None and giphy_rating not in {
         p["id"] for p in Realm.GIPHY_RATING_OPTIONS.values()
     }:
-        return json_error(_("Invalid giphy_rating {}").format(giphy_rating))
+        raise JsonableError(_("Invalid giphy_rating {}").format(giphy_rating))
 
     message_retention_days: Optional[int] = None
     if message_retention_days_raw is not None:

--- a/zerver/views/realm_emoji.py
+++ b/zerver/views/realm_emoji.py
@@ -6,7 +6,7 @@ from zerver.decorator import require_member_or_admin
 from zerver.lib.actions import check_add_realm_emoji, do_remove_realm_emoji
 from zerver.lib.emoji import check_emoji_admin, check_valid_emoji_name
 from zerver.lib.request import REQ, JsonableError, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.models import RealmEmoji, UserProfile
 
 
@@ -28,12 +28,12 @@ def upload_emoji(
     if RealmEmoji.objects.filter(
         realm=user_profile.realm, name=emoji_name, deactivated=False
     ).exists():
-        return json_error(_("A custom emoji with this name already exists."))
+        raise JsonableError(_("A custom emoji with this name already exists."))
     if len(request.FILES) != 1:
-        return json_error(_("You must upload exactly one file."))
+        raise JsonableError(_("You must upload exactly one file."))
     emoji_file = list(request.FILES.values())[0]
     if (settings.MAX_EMOJI_FILE_SIZE_MIB * 1024 * 1024) < emoji_file.size:
-        return json_error(
+        raise JsonableError(
             _("Uploaded file is larger than the allowed limit of {} MiB").format(
                 settings.MAX_EMOJI_FILE_SIZE_MIB,
             )
@@ -41,7 +41,7 @@ def upload_emoji(
 
     realm_emoji = check_add_realm_emoji(user_profile.realm, emoji_name, user_profile, emoji_file)
     if realm_emoji is None:
-        return json_error(_("Image file upload failed."))
+        raise JsonableError(_("Image file upload failed."))
     return json_success()
 
 

--- a/zerver/views/realm_icon.py
+++ b/zerver/views/realm_icon.py
@@ -5,8 +5,9 @@ from django.utils.translation import gettext as _
 
 from zerver.decorator import require_realm_admin
 from zerver.lib.actions import do_change_icon_source
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.realm_icon import realm_icon_url
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.upload import upload_icon_image
 from zerver.lib.url_encoding import add_query_arg_to_redirect_url
 from zerver.models import UserProfile
@@ -16,11 +17,11 @@ from zerver.models import UserProfile
 def upload_icon(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
 
     if len(request.FILES) != 1:
-        return json_error(_("You must upload exactly one icon."))
+        raise JsonableError(_("You must upload exactly one icon."))
 
     icon_file = list(request.FILES.values())[0]
     if (settings.MAX_ICON_FILE_SIZE_MIB * 1024 * 1024) < icon_file.size:
-        return json_error(
+        raise JsonableError(
             _("Uploaded file is larger than the allowed limit of {} MiB").format(
                 settings.MAX_ICON_FILE_SIZE_MIB,
             )

--- a/zerver/views/realm_linkifiers.py
+++ b/zerver/views/realm_linkifiers.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext as _
 
 from zerver.decorator import require_realm_admin
 from zerver.lib.actions import do_add_linkifier, do_remove_linkifier, do_update_linkifier
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_error, json_success
 from zerver.models import RealmFilter, UserProfile, linkifiers_for_realm
@@ -41,7 +42,7 @@ def delete_linkifier(
     try:
         do_remove_linkifier(realm=user_profile.realm, id=filter_id)
     except RealmFilter.DoesNotExist:
-        return json_error(_("Linkifier not found."))
+        raise JsonableError(_("Linkifier not found."))
     return json_success()
 
 
@@ -63,6 +64,6 @@ def update_linkifier(
         )
         return json_success()
     except RealmFilter.DoesNotExist:
-        return json_error(_("Linkifier not found."))
+        raise JsonableError(_("Linkifier not found."))
     except ValidationError as e:
         return json_error(e.messages[0], data={"errors": dict(e)})

--- a/zerver/views/realm_logo.py
+++ b/zerver/views/realm_logo.py
@@ -5,9 +5,10 @@ from django.utils.translation import gettext as _
 
 from zerver.decorator import require_realm_admin
 from zerver.lib.actions import do_change_logo_source
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.realm_logo import get_realm_logo_url
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.upload import upload_logo_image
 from zerver.lib.url_encoding import add_query_arg_to_redirect_url
 from zerver.lib.validator import check_bool
@@ -22,10 +23,10 @@ def upload_logo(
     user_profile.realm.ensure_not_on_limited_plan()
 
     if len(request.FILES) != 1:
-        return json_error(_("You must upload exactly one logo."))
+        raise JsonableError(_("You must upload exactly one logo."))
     logo_file = list(request.FILES.values())[0]
     if (settings.MAX_LOGO_FILE_SIZE_MIB * 1024 * 1024) < logo_file.size:
-        return json_error(
+        raise JsonableError(
             _("Uploaded file is larger than the allowed limit of {} MiB").format(
                 settings.MAX_LOGO_FILE_SIZE_MIB,
             )

--- a/zerver/views/storage.py
+++ b/zerver/views/storage.py
@@ -10,7 +10,8 @@ from zerver.lib.bot_storage import (
     remove_bot_storage,
     set_bot_storage,
 )
-from zerver.lib.response import json_error, json_success
+from zerver.lib.exceptions import JsonableError
+from zerver.lib.response import json_success
 from zerver.lib.validator import check_dict, check_list, check_string
 from zerver.models import UserProfile
 
@@ -24,7 +25,7 @@ def update_storage(
     try:
         set_bot_storage(user_profile, list(storage.items()))
     except StateError as e:  # nocoverage
-        return json_error(str(e))
+        raise JsonableError(str(e))
     return json_success()
 
 
@@ -39,7 +40,7 @@ def get_storage(
     try:
         storage = {key: get_bot_storage(user_profile, key) for key in keys}
     except StateError as e:
-        return json_error(str(e))
+        raise JsonableError(str(e))
     return json_success({"storage": storage})
 
 
@@ -54,5 +55,5 @@ def remove_storage(
     try:
         remove_bot_storage(user_profile, keys)
     except StateError as e:
-        return json_error(str(e))
+        raise JsonableError(str(e))
     return json_success()

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -148,7 +148,7 @@ def add_default_stream(
 ) -> HttpResponse:
     (stream, sub) = access_stream_by_id(user_profile, stream_id)
     if stream.invite_only:
-        return json_error(_("Private streams cannot be made default."))
+        raise JsonableError(_("Private streams cannot be made default."))
     do_add_default_stream(stream)
     return json_success()
 
@@ -180,7 +180,7 @@ def update_default_stream_group_info(
     new_description: Optional[str] = REQ(default=None),
 ) -> None:
     if not new_group_name and not new_description:
-        return json_error(_('You must pass "new_description" or "new_group_name".'))
+        raise JsonableError(_('You must pass "new_description" or "new_group_name".'))
 
     group = access_default_stream_group_by_id(user_profile.realm, group_id)
     if new_group_name is not None:
@@ -210,7 +210,7 @@ def update_default_stream_group_streams(
     elif op == "remove":
         do_remove_streams_from_default_stream_group(user_profile.realm, group, streams)
     else:
-        return json_error(_('Invalid value for "op". Specify one of "add" or "remove".'))
+        raise JsonableError(_('Invalid value for "op". Specify one of "add" or "remove".'))
     return json_success()
 
 
@@ -278,7 +278,7 @@ def update_stream_backend(
     if new_name is not None:
         new_name = new_name.strip()
         if stream.name == new_name:
-            return json_error(_("Stream already has that name!"))
+            raise JsonableError(_("Stream already has that name!"))
         if stream.name.lower() != new_name.lower():
             # Check that the stream name is available (unless we are
             # are only changing the casing of the stream name).
@@ -301,7 +301,7 @@ def update_stream_backend(
         default_stream_ids = {s.id for s in get_default_streams_for_realm(stream.realm_id)}
         (stream, sub) = access_stream_by_id(user_profile, stream_id)
         if is_private and stream.id in default_stream_ids:
-            return json_error(_("Default streams cannot be made private."))
+            raise JsonableError(_("Default streams cannot be made private."))
         do_change_stream_invite_only(stream, is_private, history_public_to_subscribers)
     return json_success()
 
@@ -340,7 +340,7 @@ def update_subscriptions_backend(
     add: Sequence[Mapping[str, str]] = REQ(json_validator=add_subscriptions_schema, default=[]),
 ) -> HttpResponse:
     if not add and not delete:
-        return json_error(_('Nothing to do. Specify at least one of "add" or "delete".'))
+        raise JsonableError(_('Nothing to do. Specify at least one of "add" or "delete".'))
 
     thunks = [
         lambda: add_subscriptions_backend(request, user_profile, streams_raw=add),
@@ -498,7 +498,7 @@ def add_subscriptions_backend(
         user_profile, existing_streams
     )
     if len(unauthorized_streams) > 0 and authorization_errors_fatal:
-        return json_error(
+        raise JsonableError(
             _("Unable to access stream ({stream_name}).").format(
                 stream_name=unauthorized_streams[0].name,
             )
@@ -508,7 +508,7 @@ def add_subscriptions_backend(
 
     if len(principals) > 0:
         if realm.is_zephyr_mirror_realm and not all(stream.invite_only for stream in streams):
-            return json_error(
+            raise JsonableError(
                 _("You can only invite other Zephyr mirroring users to private streams.")
             )
         if not user_profile.can_subscribe_other_users():
@@ -865,16 +865,16 @@ def update_subscription_properties_backend(
         value = change["value"]
 
         if property not in property_converters:
-            return json_error(_("Unknown subscription property: {}").format(property))
+            raise JsonableError(_("Unknown subscription property: {}").format(property))
 
         (stream, sub) = access_stream_by_id(user_profile, stream_id)
         if sub is None:
-            return json_error(_("Not subscribed to stream id {}").format(stream_id))
+            raise JsonableError(_("Not subscribed to stream id {}").format(stream_id))
 
         try:
             value = property_converters[property](property, value)
         except ValidationError as error:
-            return json_error(error.message)
+            raise JsonableError(error.message)
 
         do_change_subscription_property(
             user_profile, sub, stream, property, value, acting_user=user_profile

--- a/zerver/views/submessage.py
+++ b/zerver/views/submessage.py
@@ -8,7 +8,7 @@ from zerver.decorator import REQ, has_request_variables
 from zerver.lib.actions import do_add_submessage, verify_submessage_sender
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import access_message
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.validator import check_int, validate_poll_data, validate_todo_data
 from zerver.lib.widget import get_widget_type
 from zerver.models import UserProfile
@@ -35,7 +35,7 @@ def process_submessage(
     try:
         widget_data = orjson.loads(content)
     except orjson.JSONDecodeError:
-        return json_error(_("Invalid json for submessage"))
+        raise JsonableError(_("Invalid json for submessage"))
 
     widget_type = get_widget_type(message_id=message.id)
 

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -5,7 +5,8 @@ from django.utils.translation import gettext as _
 
 from zerver.decorator import REQ, has_request_variables
 from zerver.lib.actions import check_send_typing_notification, do_send_stream_typing_notification
-from zerver.lib.response import json_error, json_success
+from zerver.lib.exceptions import JsonableError
+from zerver.lib.response import json_success
 from zerver.lib.streams import access_stream_by_id, access_stream_for_send_message
 from zerver.lib.validator import check_int, check_list, check_string_in
 from zerver.models import UserProfile
@@ -28,14 +29,14 @@ def send_notification_backend(
     to_length = len(notification_to)
 
     if to_length == 0:
-        return json_error(_("Empty 'to' list"))
+        raise JsonableError(_("Empty 'to' list"))
 
     if message_type == "stream":
         if to_length > 1:
-            return json_error(_("Cannot send to multiple streams"))
+            raise JsonableError(_("Cannot send to multiple streams"))
 
         if topic is None:
-            return json_error(_("Missing topic"))
+            raise JsonableError(_("Missing topic"))
 
         stream_id = notification_to[0]
         # Verify that the user has access to the stream and has

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -14,7 +14,7 @@ from zerver.lib.actions import (
 )
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.user_groups import (
     access_user_group_by_id,
     get_memberships_of_users,
@@ -58,7 +58,7 @@ def edit_user_group(
     description: str = REQ(default=""),
 ) -> HttpResponse:
     if not (name or description):
-        return json_error(_("No new data supplied"))
+        raise JsonableError(_("No new data supplied"))
 
     user_group = access_user_group_by_id(user_group_id, user_profile)
 
@@ -93,7 +93,7 @@ def update_user_group_backend(
     add: Sequence[int] = REQ(json_validator=check_list(check_int), default=[]),
 ) -> HttpResponse:
     if not add and not delete:
-        return json_error(_('Nothing to do. Specify at least one of "add" or "delete".'))
+        raise JsonableError(_('Nothing to do. Specify at least one of "add" or "delete".'))
 
     thunks = [
         lambda: add_members_to_group_backend(

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -32,7 +32,7 @@ from zerver.lib.email_validation import email_allowed_for_realm
 from zerver.lib.exceptions import CannotDeactivateLastUserError, OrganizationOwnerRequired
 from zerver.lib.integrations import EMBEDDED_BOTS
 from zerver.lib.request import REQ, JsonableError, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.streams import access_stream_by_id, access_stream_by_name, subscribed_to_stream
 from zerver.lib.types import Validator
 from zerver.lib.upload import upload_avatar_image
@@ -96,7 +96,7 @@ def deactivate_user_backend(
     if target.is_realm_owner and not user_profile.is_realm_owner:
         raise OrganizationOwnerRequired()
     if check_last_owner(target):
-        return json_error(_("Cannot deactivate the only organization owner"))
+        raise JsonableError(_("Cannot deactivate the only organization owner"))
     return _deactivate_user_profile_backend(request, user_profile, target)
 
 
@@ -182,7 +182,7 @@ def update_user_backend(
             raise OrganizationOwnerRequired()
 
         if target.role == UserProfile.ROLE_REALM_OWNER and check_last_owner(user_profile):
-            return json_error(
+            raise JsonableError(
                 _("The owner permission cannot be removed from the only organization owner.")
             )
         do_change_user_role(target, role, acting_user=user_profile)
@@ -278,11 +278,11 @@ def patch_bot_backend(
         try:
             owner = get_user_profile_by_id_in_realm(bot_owner_id, user_profile.realm)
         except UserProfile.DoesNotExist:
-            return json_error(_("Failed to change owner, no such user"))
+            raise JsonableError(_("Failed to change owner, no such user"))
         if not owner.is_active:
-            return json_error(_("Failed to change owner, user is deactivated"))
+            raise JsonableError(_("Failed to change owner, user is deactivated"))
         if owner.is_bot:
-            return json_error(_("Failed to change owner, bots can't own other bots"))
+            raise JsonableError(_("Failed to change owner, bots can't own other bots"))
 
         previous_owner = bot.bot_owner
         if previous_owner != owner:
@@ -321,7 +321,7 @@ def patch_bot_backend(
         avatar_source = UserProfile.AVATAR_FROM_USER
         do_change_avatar_fields(bot, avatar_source, acting_user=user_profile)
     else:
-        return json_error(_("You may only upload one file at a time"))
+        raise JsonableError(_("You may only upload one file at a time"))
 
     json_result = dict(
         full_name=bot.full_name,
@@ -384,7 +384,7 @@ def add_bot_backend(
     try:
         email = f"{short_name}@{user_profile.realm.get_bot_domain()}"
     except InvalidFakeEmailDomain:
-        return json_error(
+        raise JsonableError(
             _(
                 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
                 "Please contact your server administrator."
@@ -394,16 +394,16 @@ def add_bot_backend(
 
     if bot_type == UserProfile.EMBEDDED_BOT:
         if not settings.EMBEDDED_BOTS_ENABLED:
-            return json_error(_("Embedded bots are not enabled."))
+            raise JsonableError(_("Embedded bots are not enabled."))
         if service_name not in [bot.name for bot in EMBEDDED_BOTS]:
-            return json_error(_("Invalid embedded bot name."))
+            raise JsonableError(_("Invalid embedded bot name."))
 
     if not form.is_valid():
         # We validate client-side as well
-        return json_error(_("Bad name or username"))
+        raise JsonableError(_("Bad name or username"))
     try:
         get_user_by_delivery_email(email, user_profile.realm)
-        return json_error(_("Username already in use"))
+        raise JsonableError(_("Username already in use"))
     except UserProfile.DoesNotExist:
         pass
 
@@ -419,7 +419,7 @@ def add_bot_backend(
     if len(request.FILES) == 0:
         avatar_source = UserProfile.AVATAR_FROM_GRAVATAR
     elif len(request.FILES) != 1:
-        return json_error(_("You may only upload one file at a time"))
+        raise JsonableError(_("You may only upload one file at a time"))
     else:
         avatar_source = UserProfile.AVATAR_FROM_USER
 
@@ -569,12 +569,12 @@ def create_user_backend(
     full_name_raw: str = REQ("full_name"),
 ) -> HttpResponse:
     if not user_profile.can_create_users:
-        return json_error(_("User not authorized for this query"))
+        raise JsonableError(_("User not authorized for this query"))
 
     full_name = check_full_name(full_name_raw)
     form = CreateUserForm({"full_name": full_name, "email": email})
     if not form.is_valid():
-        return json_error(_("Bad name or username"))
+        raise JsonableError(_("Bad name or username"))
 
     # Check that the new user's email address belongs to the admin's realm
     # (Since this is an admin API, we don't require the user to have been
@@ -583,24 +583,24 @@ def create_user_backend(
     try:
         email_allowed_for_realm(email, user_profile.realm)
     except DomainNotAllowedForRealmError:
-        return json_error(
+        raise JsonableError(
             _("Email '{email}' not allowed in this organization").format(
                 email=email,
             )
         )
     except DisposableEmailError:
-        return json_error(_("Disposable email addresses are not allowed in this organization"))
+        raise JsonableError(_("Disposable email addresses are not allowed in this organization"))
     except EmailContainsPlusError:
-        return json_error(_("Email addresses containing + are not allowed."))
+        raise JsonableError(_("Email addresses containing + are not allowed."))
 
     try:
         get_user_by_delivery_email(email, user_profile.realm)
-        return json_error(_("Email '{}' already in use").format(email))
+        raise JsonableError(_("Email '{}' already in use").format(email))
     except UserProfile.DoesNotExist:
         pass
 
     if not check_password_strength(password):
-        return json_error(PASSWORD_TOO_WEAK_ERROR)
+        raise JsonableError(PASSWORD_TOO_WEAK_ERROR)
 
     target_user = do_create_user(email, password, realm, full_name, acting_user=user_profile)
     return json_success({"user_id": target_user.id})

--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -25,7 +25,7 @@ from zerver.decorator import REQ, has_request_variables, zulip_login_required
 from zerver.lib.actions import do_set_zoom_token
 from zerver.lib.exceptions import ErrorCode, JsonableError
 from zerver.lib.pysa import mark_sanitized
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.url_encoding import add_query_arg_to_redirect_url, add_query_to_redirect_url
 from zerver.lib.validator import check_dict, check_string
@@ -212,7 +212,7 @@ def join_bigbluebutton(
     checksum: str = REQ(),
 ) -> HttpResponse:
     if settings.BIG_BLUE_BUTTON_URL is None or settings.BIG_BLUE_BUTTON_SECRET is None:
-        return json_error(_("Big Blue Button is not configured."))
+        raise JsonableError(_("Big Blue Button is not configured."))
     else:
         try:
             response = requests.get(
@@ -230,14 +230,14 @@ def join_bigbluebutton(
             )
             response.raise_for_status()
         except requests.RequestException:
-            return json_error(_("Error connecting to the Big Blue Button server."))
+            raise JsonableError(_("Error connecting to the Big Blue Button server."))
 
         payload = ElementTree.fromstring(response.text)
         if payload.find("messageKey").text == "checksumError":
-            return json_error(_("Error authenticating to the Big Blue Button server."))
+            raise JsonableError(_("Error authenticating to the Big Blue Button server."))
 
         if payload.find("returncode").text != "SUCCESS":
-            return json_error(_("Big Blue Button server returned an unexpected error."))
+            raise JsonableError(_("Big Blue Button server returned an unexpected error."))
 
         join_params = urlencode(  # type: ignore[type-var] # https://github.com/python/typeshed/issues/4234
             {

--- a/zerver/webhooks/freshstatus/view.py
+++ b/zerver/webhooks/freshstatus/view.py
@@ -6,7 +6,8 @@ from django.utils.translation import ugettext as _
 
 from zerver.decorator import REQ, has_request_variables, webhook_view
 from zerver.lib.actions import send_rate_limited_pm_notification_to_bot_owner
-from zerver.lib.response import json_error, json_success
+from zerver.lib.exceptions import JsonableError
+from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress
 from zerver.lib.webhooks.common import check_send_webhook_message, get_setup_webhook_message
 from zerver.models import UserProfile
@@ -84,7 +85,7 @@ def api_freshstatus_webhook(
         ).strip()
         send_rate_limited_pm_notification_to_bot_owner(user_profile, user_profile.realm, message)
 
-        return json_error(_("Invalid payload"))
+        raise JsonableError(_("Invalid payload"))
 
     check_send_webhook_message(request, user_profile, subject, body)
     return json_success()

--- a/zerver/webhooks/front/view.py
+++ b/zerver/webhooks/front/view.py
@@ -4,8 +4,9 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
 from zerver.decorator import webhook_view
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -143,7 +144,7 @@ def api_front_webhook(
 
     event = payload["type"]
     if event not in EVENT_FUNCTION_MAPPER:
-        return json_error(_("Unknown webhook request"))
+        raise JsonableError(_("Unknown webhook request"))
 
     topic = payload["conversation"]["id"]
     body = get_body_based_on_event(event)(payload)

--- a/zerver/webhooks/ifttt/view.py
+++ b/zerver/webhooks/ifttt/view.py
@@ -4,8 +4,9 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
 from zerver.decorator import webhook_view
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -23,10 +24,10 @@ def api_iftt_app_webhook(
     if topic is None:
         topic = payload.get("subject")  # Backwards-compatibility
         if topic is None:
-            return json_error(_("Topic can't be empty"))
+            raise JsonableError(_("Topic can't be empty"))
 
     if content is None:
-        return json_error(_("Content can't be empty"))
+        raise JsonableError(_("Content can't be empty"))
 
     check_send_webhook_message(request, user_profile, topic, content)
     return json_success()

--- a/zerver/webhooks/librato/view.py
+++ b/zerver/webhooks/librato/view.py
@@ -6,8 +6,9 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
 from zerver.decorator import webhook_view
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -169,7 +170,7 @@ def api_librato_webhook(
         attachments = []
 
     if not attachments and not payload:
-        return json_error(_("Malformed JSON input"))
+        raise JsonableError(_("Malformed JSON input"))
 
     message_handler = LibratoWebhookHandler(payload, attachments)
     topic = message_handler.generate_topic()
@@ -177,7 +178,7 @@ def api_librato_webhook(
     try:
         content = message_handler.handle()
     except Exception as e:
-        return json_error(str(e))
+        raise JsonableError(str(e))
 
     check_send_webhook_message(request, user_profile, topic, content)
     return json_success()

--- a/zerver/webhooks/newrelic/view.py
+++ b/zerver/webhooks/newrelic/view.py
@@ -5,8 +5,9 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
 from zerver.decorator import webhook_view
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.webhooks.common import check_send_webhook_message, unix_milliseconds_to_timestamp
 from zerver.models import UserProfile
 
@@ -46,7 +47,7 @@ def api_newrelic_webhook(
 
     unix_time = payload.get("timestamp", None)
     if unix_time is None:
-        return json_error(_("The newrelic webhook requires timestamp in milliseconds"))
+        raise JsonableError(_("The newrelic webhook requires timestamp in milliseconds"))
 
     info["iso_timestamp"] = unix_milliseconds_to_timestamp(unix_time, "newrelic")
 
@@ -62,7 +63,7 @@ def api_newrelic_webhook(
     elif "closed" in info["status"]:
         content = DEFAULT_TEMPLATE.format(**info)
     else:
-        return json_error(
+        raise JsonableError(
             _("The newrelic webhook requires current_state be in [open|acknowledged|closed]")
         )
 

--- a/zerver/webhooks/pivotal/view.py
+++ b/zerver/webhooks/pivotal/view.py
@@ -8,9 +8,9 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
 from zerver.decorator import webhook_view
-from zerver.lib.exceptions import UnsupportedWebhookEventType
+from zerver.lib.exceptions import JsonableError, UnsupportedWebhookEventType
 from zerver.lib.request import has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -176,7 +176,7 @@ def api_pivotal_webhook(request: HttpRequest, user_profile: UserProfile) -> Http
         subject, content = api_pivotal_webhook_v5(request, user_profile)
 
     if not content:
-        return json_error(_("Unable to handle Pivotal payload"))
+        raise JsonableError(_("Unable to handle Pivotal payload"))
 
     check_send_webhook_message(request, user_profile, subject, content)
     return json_success()

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -3,8 +3,9 @@ from django.utils.translation import gettext as _
 
 from zerver.decorator import webhook_view
 from zerver.lib.actions import check_send_stream_message
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.models import UserProfile
 
 ZULIP_MESSAGE_TEMPLATE = "**{message_sender}**: `{text}`"
@@ -24,7 +25,7 @@ def api_slack_webhook(
 ) -> HttpRequest:
 
     if channels_map_to_topics not in list(VALID_OPTIONS.values()):
-        return json_error(_("Error: channels_map_to_topics parameter other than 0 or 1"))
+        raise JsonableError(_("Error: channels_map_to_topics parameter other than 0 or 1"))
 
     if channels_map_to_topics == VALID_OPTIONS["SHOULD_BE_MAPPED"]:
         subject = f"channel: {channel_name}"

--- a/zerver/webhooks/uptimerobot/view.py
+++ b/zerver/webhooks/uptimerobot/view.py
@@ -5,7 +5,8 @@ from django.utils.translation import ugettext as _
 
 from zerver.decorator import REQ, has_request_variables, webhook_view
 from zerver.lib.actions import send_rate_limited_pm_notification_to_bot_owner
-from zerver.lib.response import json_error, json_success
+from zerver.lib.exceptions import JsonableError
+from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
@@ -46,7 +47,7 @@ def api_uptimerobot_webhook(
         ).strip()
         send_rate_limited_pm_notification_to_bot_owner(user_profile, user_profile.realm, message)
 
-        return json_error(_("Invalid payload"))
+        raise JsonableError(_("Invalid payload"))
 
     check_send_webhook_message(request, user_profile, subject, body)
     return json_success()

--- a/zerver/webhooks/wordpress/view.py
+++ b/zerver/webhooks/wordpress/view.py
@@ -3,8 +3,9 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
 from zerver.decorator import webhook_view
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -46,7 +47,7 @@ def api_wordpress_webhook(
         data = WP_LOGIN_TEMPLATE.format(name=user_login)
 
     else:
-        return json_error(_("Unknown WordPress webhook action: {}").format(hook))
+        raise JsonableError(_("Unknown WordPress webhook action: {}").format(hook))
 
     topic = "WordPress notification"
 

--- a/zerver/webhooks/zabbix/view.py
+++ b/zerver/webhooks/zabbix/view.py
@@ -5,7 +5,8 @@ from django.utils.translation import gettext as _
 
 from zerver.decorator import REQ, has_request_variables, webhook_view
 from zerver.lib.actions import send_rate_limited_pm_notification_to_bot_owner
-from zerver.lib.response import json_error, json_success
+from zerver.lib.exceptions import JsonableError
+from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
@@ -45,7 +46,7 @@ def api_zabbix_webhook(
         ).strip()
         send_rate_limited_pm_notification_to_bot_owner(user_profile, user_profile.realm, message)
 
-        return json_error(_("Invalid payload"))
+        raise JsonableError(_("Invalid payload"))
 
     check_send_webhook_message(request, user_profile, subject, body)
     return json_success()

--- a/zerver/webhooks/zapier/view.py
+++ b/zerver/webhooks/zapier/view.py
@@ -4,8 +4,9 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
 from zerver.decorator import webhook_view
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -35,10 +36,10 @@ def api_zapier_webhook(
     if topic is None:
         topic = payload.get("subject")  # Backwards-compatibility
         if topic is None:
-            return json_error(_("Topic can't be empty"))
+            raise JsonableError(_("Topic can't be empty"))
 
     if content is None:
-        return json_error(_("Content can't be empty"))
+        raise JsonableError(_("Content can't be empty"))
 
     check_send_webhook_message(request, user_profile, topic, content)
     return json_success()

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -19,7 +19,7 @@ from zerver.lib.push_notifications import (
     send_apple_push_notification,
 )
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.validator import (
     check_bool,
     check_capped_string,
@@ -147,7 +147,7 @@ def unregister_remote_push_device(
         token=token, kind=token_kind, user_id=user_id, server=server
     ).delete()
     if deleted[0] == 0:
-        return json_error(err_("Token does not exist"))
+        raise JsonableError(err_("Token does not exist"))
 
     return json_success()
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is a follow-up PR for [chat](https://chat.zulip.org/#narrow/stream/3-backend/topic/The.20Difference.20.22return.20json_error.22.20and.20.22raise.20JsonableError.22).

It replaces the usage of `return json_error` by `raise JsonableError` when the argument passed is only a translated string literal/variable.

**Testing plan:** <!-- How have you tested? -->
Tested by passing backend tests and zulint.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
