### PR TITLE
muting_ui: Fix bug with same name of function parameter and a file.

### DIFF
--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -45,9 +45,9 @@ export function rerender_for_muted_topic(old_muted_topics) {
     }
 }
 
-export function handle_topic_updates(muted_topics) {
+export function handle_topic_updates(muted_topics_list) {
     const old_muted_topics = muted_topics.get_muted_topics();
-    muted_topics.set_muted_topics(muted_topics);
+    muted_topics.set_muted_topics(muted_topics_list);
     stream_popover.hide_topic_popover();
     unread_ui.update_unread_counts();
     rerender_for_muted_topic(old_muted_topics);


### PR DESCRIPTION
The parameter passed to 'handle_topic_updates' is 'muted_topics'
and there is also a javascript file with same name.
So 'muted_topics.get_muted_topics' gives error, and this commit
fixes this by changing the parametr name to 'muted_topics_list'.

This was introduced in  5f74e78beeac0a.

Reported by Aman in https://chat.zulip.org/#narrow/stream/6-frontend/topic/mute.20migration.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? --> Tested manually in dev server.


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
