### PR TITLE
left-sidebar: Add support for showing resolve-topic-prefix.

### DIFF
--- a/frontend_tests/node_tests/topic_list_data.js
+++ b/frontend_tests/node_tests/topic_list_data.js
@@ -62,7 +62,14 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         });
     }
     for (const i of _.range(7)) {
-        add_topic_message("topic " + i, 1000 + i);
+        let topic_name;
+        // All odd topics are resolved.
+        if (i % 2) {
+            topic_name = "✔ topic ";
+        } else {
+            topic_name = "topic ";
+        }
+        add_topic_message(topic_name + i, 1000 + i);
     }
 
     override(narrow_state, "topic", () => "topic 6");
@@ -76,11 +83,25 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         is_active_topic: true,
         is_muted: false,
         is_zero: true,
+        resolved: false,
+        resolved_topic_prefix: "✔ ",
+        topic_display_name: "topic 6",
         topic_name: "topic 6",
         unread: 0,
         url: "#narrow/stream/556-general/topic/topic.206",
     });
 
+    assert.deepEqual(list_info.items[1], {
+        is_active_topic: false,
+        is_muted: false,
+        is_zero: true,
+        resolved: true,
+        resolved_topic_prefix: "✔ ",
+        topic_display_name: "topic 5",
+        topic_name: "✔ topic 5",
+        unread: 0,
+        url: "#narrow/stream/556-general/topic/.E2.9C.94.20topic.205",
+    });
     // If we zoom in, our results based on topic filter.
     // If topic search input is empty, we show all 7 topics.
 

--- a/static/js/topic_list_data.js
+++ b/static/js/topic_list_data.js
@@ -1,4 +1,5 @@
 import * as hash_util from "./hash_util";
+import * as message_edit from "./message_edit";
 import * as muted_topics from "./muted_topics";
 import * as narrow_state from "./narrow_state";
 import * as stream_topic_history from "./stream_topic_history";
@@ -31,6 +32,12 @@ export function get_list_info(stream_id, zoomed) {
         const num_unread = unread.num_unread_for_topic(stream_id, topic_name);
         const is_active_topic = active_topic === topic_name.toLowerCase();
         const is_topic_muted = muted_topics.is_topic_muted(stream_id, topic_name);
+        const resolved = topic_name.startsWith(message_edit.RESOLVED_TOPIC_PREFIX);
+        let topic_display_name = topic_name;
+
+        if (resolved) {
+            topic_display_name = topic_display_name.replace(message_edit.RESOLVED_TOPIC_PREFIX, "");
+        }
 
         if (!zoomed) {
             function should_show_topic(topics_selected) {
@@ -91,11 +98,14 @@ export function get_list_info(stream_id, zoomed) {
 
         const topic_info = {
             topic_name,
+            topic_display_name,
             unread: num_unread,
             is_zero: num_unread === 0,
             is_muted: is_topic_muted,
             is_active_topic,
             url: hash_util.by_stream_topic_uri(stream_id, topic_name),
+            resolved,
+            resolved_topic_prefix: message_edit.RESOLVED_TOPIC_PREFIX,
         };
 
         items.push(topic_info);

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -7,6 +7,7 @@ $left_col_size: 19px;
 /* The full topic indentation includes 4px of indent in addition to
    the above (and another 5px of padding not measured here) */
 $topic_indent: calc($far_left_gutter_size + $left_col_size + 4px);
+$topic_resolve_width: 13px;
 
 #left-sidebar {
     #user-list {
@@ -102,7 +103,7 @@ li.show-more-topics {
                 padding-top: 2px;
                 padding-right: 0;
                 padding-bottom: 2px;
-                padding-left: $topic_indent;
+                padding-left: calc($topic_indent - $topic_resolve_width);
 
                 &.filter-topics {
                     padding-bottom: 0;
@@ -330,6 +331,14 @@ li.top_left_recent_topics {
 .topic-box {
     padding-left: 5px;
     margin-right: 30px;
+}
+
+.sidebar-topic-check {
+    display: flex;
+    align-items: center;
+    min-width: $topic_resolve_width;
+    font-size: 15px;
+    height: 20px;
 }
 
 .conversation-partners,

--- a/static/templates/topic_list_item.hbs
+++ b/static/templates/topic_list_item.hbs
@@ -1,7 +1,12 @@
 <li class='bottom_left_row {{#if is_active_topic}}active-sub-filter{{/if}} {{#if is_zero}}zero-topic-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} topic-list-item' data-topic-name='{{topic_name}}'>
     <span class='topic-box'>
+        <span class="sidebar-topic-check">
+            {{#if resolved}}
+            {{resolved_topic_prefix}}
+            {{/if}}
+        </span>
         <a href='{{url}}' class="topic-name" title="{{topic_name}}">
-            {{topic_name}}
+            {{topic_display_name}}
         </a>
         <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
             {{unread}}


### PR DESCRIPTION
We currently have the resolved topics prefix shown as part of
the topic name in the left sidebar. However this causes inconsistency
while showing topic names. Hence this adds support for showing the
prefix in the cutter to the left of the topic name.

Fixes #18989.

**Testing plan:** <!-- How have you tested? -->
Manual testing, frontend tests.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Peek 2021-07-01 13-49](https://user-images.githubusercontent.com/55033316/124101218-c1f83080-da7c-11eb-8653-e5d2155143ea.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
