### PR TITLE
Display which user group was mentioned in email/push notifications.

### DIFF
--- a/templates/zerver/emails/missed_message.source.html
+++ b/templates/zerver/emails/missed_message.source.html
@@ -26,7 +26,11 @@
 <div class="email-preferences">
     &mdash;<br />
     {% if mention %}
+    {% if mentioned_user_group_name %}
+    {% trans %}You are receiving this because @{{ mentioned_user_group_name }} was mentioned in {{ realm_name }}.{% endtrans %}<br />
+    {% else %}
     {% trans %}You are receiving this because you were mentioned in {{ realm_name }}.{% endtrans %}<br />
+    {% endif %}
     {% elif stream_email_notify %}
     {% trans %}You are receiving this because you have email notifications enabled for this stream.{% endtrans %}<br />
     {% endif %}

--- a/templates/zerver/emails/missed_message.txt
+++ b/templates/zerver/emails/missed_message.txt
@@ -22,7 +22,11 @@ See {{ alert_notif_url }} for more details.
 
 --
 {% if mention %}
+{% if mentioned_user_group_name %}
+{% trans %}You are receiving this because @{{ mentioned_user_group_name }} was mentioned in {{ realm_name }}.{% endtrans %}
+{% else %}
 {% trans %}You are receiving this because you were mentioned in {{ realm_name }}.{% endtrans %}
+{% endif %}
 {% elif stream_email_notify %}
 {% trans %}You are receiving this because you have email notifications enabled for this stream.{% endtrans %}
 {% endif %}

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -96,6 +96,7 @@ class SendMessageRequest:
     sender_queue_id: Optional[str]
     realm: Realm
     mention_data: MentionData
+    mentioned_user_groups_map: Dict[int, int]
     active_user_ids: Set[int]
     online_push_user_ids: Set[int]
     stream_push_user_ids: Set[int]

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -565,7 +565,8 @@ def get_gcm_alert(message: Message) -> str:
         message.trigger == "mentioned" or message.trigger == "wildcard_mentioned"
     ):
         return f"New mention from {sender_str}"
-    else:  # message.is_stream_message() and message.trigger == 'stream_push_notify'
+    else:
+        assert message.is_stream_message() and message.trigger == "stream_push_notify"
         return f"New stream message from {sender_str} in {get_display_recipient(message.recipient)}"
 
 

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1355,6 +1355,7 @@ Output:
             acting_user_id=acting_user_id,
             private_message=kwargs.get("private_message", False),
             stream_name=kwargs.get("stream_name", None),
+            mentioned_user_group_id=kwargs.get("mentioned_user_group_id", None),
             idle=kwargs.get("idle", True),
             already_notified=kwargs.get(
                 "already_notified", {"email_notified": False, "push_notified": False}


### PR DESCRIPTION
Fixes: #13080

This is a reworked version of #15011