### PR TITLE
table-sticky-headers: Add `z-index` CSS property to table headers.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -255,6 +255,7 @@ td .button {
     .table-sticky-headers th {
         position: sticky;
         top: 0;
+        z-index: 1;
     }
 
     .table-striped {


### PR DESCRIPTION
Added a `z-index` CSS property having value of `1` to `table-sticky-headers` class which resolves all such cases where the table contents started to overlap with the table headings. 

<strong>Previously</strong>: <a href = 'https://user-images.githubusercontent.com/53977614/122544441-712f1380-d04a-11eb-9a92-622b9992ffe6.gif'>#18906(description)</a>

<strong>Currently</strong>:
![nonoverlap](https://user-images.githubusercontent.com/53977614/124168294-926c1700-dac2-11eb-96fa-2ddfc2e3f5d5.gif)

Fixes #18906.
