### PR TITLE
settings_checkbox: Fix incorrect line wrapping in mobile view.

### DIFF
--- a/static/templates/settings/settings_checkbox.hbs
+++ b/static/templates/settings/settings_checkbox.hbs
@@ -5,7 +5,7 @@
           id="{{prefix}}{{setting_name}}" {{#if is_checked}}checked="checked"{{/if}} />
         <span></span>
     </label>
-    <label for="{{prefix}}{{setting_name}}" class="inline-block" id="{{prefix}}{{setting_name}}_label">
+    <label for="{{prefix}}{{setting_name}}" class="inline" id="{{prefix}}{{setting_name}}_label">
         {{label}}
         {{#if help_link}}
         {{> ../help_link_widget link=help_link }}


### PR DESCRIPTION
The issue was text label has `display: inline-block`
property which caused it to go to a new line in smaller
width screens.

This PR fixes it by changing its display property to `inline`.

Fixes #19075.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested it in different width screens.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  --> 


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/63820270/124175712-918bb300-dacb-11eb-8aa3-379dac6b824a.png) | ![after](https://user-images.githubusercontent.com/63820270/124175591-699c4f80-dacb-11eb-8a2c-b312aa77ed02.png)




