### PR TITLE
Fix bugs related to hash changes in settings overlay.

### DIFF
--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -242,12 +242,12 @@ function do_hashchange_overlay(old_hash) {
     const is_hashchange_internal =
         settings_hashes.has(base) && settings_hashes.has(old_base) && overlays.settings_open();
     if (is_hashchange_internal) {
-        settings_toggle.highlight_toggle(base);
         if (base === "settings") {
             settings_panel_menu.normal_settings.activate_section_or_default(section);
         } else {
             settings_panel_menu.org_settings.activate_section_or_default(section);
         }
+        settings_toggle.highlight_toggle(base);
         return;
     }
 

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -243,7 +243,11 @@ function do_hashchange_overlay(old_hash) {
         settings_hashes.has(base) && settings_hashes.has(old_base) && overlays.settings_open();
     if (is_hashchange_internal) {
         settings_toggle.highlight_toggle(base);
-        settings_panel_menu.normal_settings.activate_section_or_default(section);
+        if (base === "settings") {
+            settings_panel_menu.normal_settings.activate_section_or_default(section);
+        } else {
+            settings_panel_menu.org_settings.activate_section_or_default(section);
+        }
         return;
     }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- The first commit fixes the bug of incorrect hash and left sidebar when changing hash from `#settings/profile` to
`#organization/organization-permissions`. Explained in detail in commit message and also added GIF below for
description of bug.
- The second commit changes the order of function calling to avoid extra `hashchange` events. Explained in detail in commit message and also added GIF below for showing the `hashchanged` events.

**Testing plan:** <!-- How have you tested? -->Manually tested.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Bug in changing hash
![hash-bug](https://user-images.githubusercontent.com/35494118/124177565-0c55cd80-dace-11eb-97ab-22ceca2e8550.gif)

Behavior after fix in first commit
![hash-fix](https://user-images.githubusercontent.com/35494118/124177559-0b24a080-dace-11eb-890d-89b7b946e62c.gif)

`hashchange` events before changing order of function calls.
![toggle-bug](https://user-images.githubusercontent.com/35494118/124177535-05c75600-dace-11eb-8e04-25cb3d2284e3.gif)

`hashchange` events before changing order of function calls in the second commit.
![toggle-fix](https://user-images.githubusercontent.com/35494118/124177547-095add00-dace-11eb-9caa-495c956f53be.gif)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
