### PR TITLE
settings: Move presence-enabled setting to 'Account & privacy'.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -681,4 +681,19 @@ export function set_up() {
             $(".timezone-setting-status").expectOne(),
         );
     });
+
+    $("#presence_enabled").val(page_params.presence_enabled);
+
+    $("#presence_enabled").on("change", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const data = {presence_enabled: $("#presence_enabled").prop("checked")};
+        settings_ui.do_settings_change(
+            channel.patch,
+            "/json/settings/notifications",
+            data,
+            $(".privacy-setting-status").expectOne(),
+        );
+    });
 }

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -387,13 +387,10 @@ const email_notification_settings = [
     "enable_marketing_emails",
 ];
 
-const presence_notification_settings = ["presence_enabled"];
-
 const other_notification_settings = desktop_notification_settings.concat(
     ["desktop_icon_count_display"],
     mobile_notification_settings,
     email_notification_settings,
-    presence_notification_settings,
     ["notification_sound"],
 );
 
@@ -441,7 +438,6 @@ export const all_notifications = () => ({
         desktop_notification_settings,
         mobile_notification_settings,
         email_notification_settings,
-        presence_notification_settings,
     },
     show_push_notifications_tooltip: {
         push_notifications: !page_params.realm_push_notifications_enabled,

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -597,7 +597,8 @@ input[type="checkbox"] {
 
     .alert-notification.custom-field-status,
     .alert-notification.full-name-status,
-    .alert-notification.timezone-setting-status {
+    .alert-notification.timezone-setting-status,
+    .alert-notification.presence-setting-status {
         padding-top: 0;
         padding-bottom: 0;
         margin-top: 0;

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -102,7 +102,8 @@
                 {{> settings_checkbox
                   setting_name="presence_enabled"
                   is_checked=page_params.presence_enabled
-                  label=settings_label.presence_enabled}}
+                  label=settings_label.presence_enabled
+                  help_link="/help/status-and-availability"}}
             </div>
         </div>
 

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -95,6 +95,17 @@
             </div>
         </div>
 
+        <div class="form-horizontal" id="privacy_settings_box">
+            <h3 class="inline-block">{{t "Privacy" }}</h3>
+            <div class="alert-notification privacy-setting-status"></div>
+            <div class="input-group">
+                {{> settings_checkbox
+                  setting_name="presence_enabled"
+                  is_checked=page_params.presence_enabled
+                  label=settings_label.presence_enabled}}
+            </div>
+        </div>
+
         <hr class="settings_separator" />
 
         <div class="form-horizontal" id="api_key_button_box">

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -106,15 +106,6 @@
               label=(lookup ../settings_label this)}}
             {{/each}}
 
-            <h5>{{t "Presence" }}</h5>
-
-            {{#each notification_settings.presence_notification_settings}}
-            {{> settings_checkbox
-              setting_name=this
-              is_checked=(lookup ../page_params this)
-              label=(lookup ../settings_label this)}}
-            {{/each}}
-
         </div>
     </form>
 </div>

--- a/templates/zerver/help/status-and-availability.md
+++ b/templates/zerver/help/status-and-availability.md
@@ -77,10 +77,9 @@ the UI will be frozen as the time you enabled this setting.
 
 {start_tabs}
 
-{settings_tab|notifications}
+{settings_tab|account-and-privacy}
 
-1. Under **Other notification settings**, in the **Presence**
-   subsection, toggle **Display my availability to other users**.
+1. Under **Privacy**, toggle **Display my availability to other users**.
 
 {end_tabs}
 


### PR DESCRIPTION
The presence setting is more suited in 'Account & privacy'
section as it is not related to notifications in anyway
and resembles privacy of user by allowing user to hide
his status of being online.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


<!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![presence-setting](https://user-images.githubusercontent.com/35494118/124180442-d0bd0280-dad1-11eb-977d-a657cb47aeb4.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
