### PR TITLE
search_icon: Fix contrast color of icon

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1641,10 +1641,12 @@ div.focused_table {
 }
 
 .search_icon {
-    color: hsl(0, 0%, 80%);
+    /* These rules match the .dropdown-toggle CSS for the gear menu. */
+    color: inherit;
+    opacity: 0.5;
     text-decoration: none;
     &:hover {
-        color: hsl(0, 0%, 0%);
+        opacity: 1;
     }
 }
 


### PR DESCRIPTION
Add same color inherit/opacity that settings cog has

fixes #19053

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#19053


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/45676445/124206747-f1756000-dab1-11eb-96ad-6859bb85116a.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
