### PR TITLE
help: Add a related link to the "Configure..." article

### DIFF
--- a/templates/zerver/help/configure-message-editing-and-deletion.md
+++ b/templates/zerver/help/configure-message-editing-and-deletion.md
@@ -83,5 +83,6 @@ streams.  You can configure which roles have permission to do so:
 
 * [Disable message edit history](/help/disable-message-edit-history)
 * [Configure message retention policy](/help/message-retention-policy)
+* [Move content to another stream](/help/move-content-to-another-stream)
 * [Rename a topic](/help/rename-a-topic)
 * [Restrict topic editing](/help/configure-who-can-edit-topics)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

As mentioned in #18953, I'm adding this change to add a new link to the "Related articles" section, so users can follow to
the new `Move content to another stream` article.

**Testing plan:** <!-- How have you tested? -->

Generate the docs locally, and run a local webserver

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
