### PR TITLE
stream_type_icon: Add icon to rendered messages

### DIFF
--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -146,6 +146,7 @@ function populate_group_from_message_container(group, message_container) {
         group.background_color = stream_data.get_color(message_container.msg.stream);
         group.color_class = color_class.get_css_class(group.background_color);
         group.invite_only = stream_data.get_invite_only(message_container.msg.stream);
+        group.is_web_public = stream_data.get_is_web_public(message_container.msg.stream);
         group.topic = message_container.msg.topic;
         group.match_topic = util.get_match_topic(message_container.msg);
         group.stream_url = message_container.stream_url;

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -560,6 +560,14 @@ export function get_invite_only(stream_name) {
     return sub.invite_only;
 }
 
+export function get_is_web_public(stream_name) {
+    const sub = get_sub(stream_name);
+    if (sub === undefined) {
+        return false;
+    }
+    return sub.is_web_public;
+}
+
 export function set_realm_default_streams(realm_default_streams) {
     default_stream_ids.clear();
 

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -62,9 +62,6 @@
                     <div id="stream-message">
                         <div class="stream-selection-header-colorblock message_header_stream left_part"></div>
                         <div class="right_part">
-                            <span id="compose-lock-icon">
-                                <i class="fa fa-lock" title="{{t 'This is a private stream' }}" aria-hidden="true"></i>
-                            </span>
                             <input type="text" class="recipient_box" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="30" value="" placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Stream' }}" />
                             <i class="fa fa-angle-right" aria-hidden="true"></i>
                             <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="60" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -10,6 +10,11 @@
                 {{! invite only lock }}
                 {{#if invite_only}}
                 <i class="fa fa-lock invite-stream-icon" title="{{t 'This is a private stream' }}" aria-label="{{t 'This is a private stream' }}"></i>
+                {{! web public globe }}
+                {{else if is_web_public}}
+                <i class="fa fa-globe invite-stream-icon" title="{{t 'This is a global stream' }} aria-label="{{t 'This is a global stream' }}"></i>
+                {{else}}
+                <span class="hashtag invite-stream-icon"></span>
                 {{/if}}
                 {{display_recipient}}</a>
 


### PR DESCRIPTION
Pass is_web_public to message template exactly as invite_only is passed

fixes #19058 

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#19058 


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
before: 
![image](https://user-images.githubusercontent.com/45676445/124339395-441b4e80-db7c-11eb-8bad-65972fe35f0c.png)

after: 
![image](https://user-images.githubusercontent.com/45676445/124339409-5bf2d280-db7c-11eb-8081-e7dc3548d135.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
