### PR TITLE
recent_topics_timestamp: Fix tooltip.

### DIFF
--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -116,10 +116,7 @@ mock_esm("../../static/js/stream_list", {
 mock_esm("../../static/js/timerender", {
     last_seen_status_from_date: () => "Just now",
 
-    get_full_datetime: () => ({
-        date: "date",
-        time: "time",
-    }),
+    get_full_datetime: () => "date at time",
 });
 mock_esm("../../static/js/sub_store", {
     get: (stream) => {
@@ -292,7 +289,7 @@ function generate_topic_data(topic_info_array) {
             invite_only: false,
             is_web_public: true,
             last_msg_time: "Just now",
-            full_last_msg_date_time: "date time",
+            full_last_msg_date_time: "date at time",
             senders: [1, 2],
             stream: "stream" + stream_id,
             stream_color: "",

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -278,7 +278,7 @@ function format_topic(topic_data) {
         muted,
         topic_muted,
         participated: topic_data.participated,
-        full_last_msg_date_time: full_datetime.date + " " + full_datetime.time,
+        full_last_msg_date_time: full_datetime,
     };
 }
 


### PR DESCRIPTION
d779a1c tweaked `get_full_datetime` to return a string instead
of a {date, time} object. This function is used for recent topics
too but wasn't fixed to use the string.

This resulted in showing 'undefined undefined' in tooltip.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
verified manually

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/44665669/124346059-52a84b00-dbfa-11eb-9b2c-a9cbb1ce38bc.png)
![image](https://user-images.githubusercontent.com/44665669/124346067-62279400-dbfa-11eb-9967-f708ed701ad2.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
