### PR TITLE
request: Create ZulipRequestNotes to manage extra attributes we added to HttpRequest.

### DIFF
--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -170,7 +170,7 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
         "settings_path": settings_path,
         "secrets_path": secrets_path,
         "settings_comments_path": settings_comments_path,
-        "platform": request.client_name,
+        "platform": get_request_notes(request).client_name,
         "allow_search_engine_indexing": allow_search_engine_indexing,
         "landing_page_navbar_message": settings.LANDING_PAGE_NAVBAR_MESSAGE,
         "default_page_params": default_page_params,

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -809,14 +809,14 @@ def internal_notify_view(is_tornado_view: bool) -> Callable[[ViewFuncT], ViewFun
         ) -> HttpResponse:
             if not authenticate_notify(request):
                 raise AccessDeniedError()
-            is_tornado_request = hasattr(request, "_tornado_handler")
+            request_notes = get_request_notes(request)
+            is_tornado_request = request_notes.tornado_handler is not None
             # These next 2 are not security checks; they are internal
             # assertions to help us find bugs.
             if is_tornado_view and not is_tornado_request:
                 raise RuntimeError("Tornado notify view called with no Tornado handler")
             if not is_tornado_view and is_tornado_request:
                 raise RuntimeError("Django notify view called with Tornado handler")
-            request_notes = get_request_notes(request)
             request_notes.requestor_for_logs = "internal"
             return view_func(request, *args, **kwargs)
 

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -84,10 +84,11 @@ def update_user_activity(
     if request.META["PATH_INFO"] == "/json/users/me/presence":
         return
 
+    request_notes = get_request_notes(request)
     if query is not None:
         pass
-    elif hasattr(request, "_query"):
-        query = request._query
+    elif request_notes.query is not None:
+        query = request_notes.query
     else:
         query = request.META["PATH_INFO"]
 
@@ -112,7 +113,7 @@ def require_post(func: ViewFuncT) -> ViewFuncT:
                 request.path,
                 extra={"status_code": 405, "request": request},
             )
-            if request.error_format == "JSON":
+            if get_request_notes(request).error_format == "JSON":
                 return json_method_not_allowed(["POST"])
             else:
                 return TemplateResponse(
@@ -442,7 +443,7 @@ def do_login(request: HttpRequest, user_profile: UserProfile) -> None:
 def log_view_func(view_func: ViewFuncT) -> ViewFuncT:
     @wraps(view_func)
     def _wrapped_view_func(request: HttpRequest, *args: object, **kwargs: object) -> HttpResponse:
-        request._query = view_func.__name__
+        get_request_notes(request).query = view_func.__name__
         return view_func(request, *args, **kwargs)
 
     return cast(ViewFuncT, _wrapped_view_func)  # https://github.com/python/mypy/issues/1927

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -92,11 +92,12 @@ def update_user_activity(
     else:
         query = request.META["PATH_INFO"]
 
+    assert request_notes.client is not None
     event = {
         "query": query,
         "user_profile_id": user_profile.id,
         "time": datetime_to_timestamp(timezone_now()),
-        "client_id": request.client.id,
+        "client_id": request_notes.client.id,
     }
     queue_json_publish("user_activity", event, lambda event: None)
 
@@ -181,8 +182,11 @@ def process_client(
     skip_update_user_activity: bool = False,
     query: Optional[str] = None,
 ) -> None:
+    request_notes = get_request_notes(request)
     if client_name is None:
-        client_name = request.client_name
+        client_name = request_notes.client_name
+
+    assert client_name is not None
 
     # We could check for a browser's name being "Mozilla", but
     # e.g. Opera and MobileSafari don't set that, and it seems
@@ -192,7 +196,7 @@ def process_client(
         # the Zulip desktop apps be themselves.
         client_name = "website"
 
-    request.client = get_client(client_name)
+    request_notes.client = get_client(client_name)
     if not skip_update_user_activity and user_profile.is_authenticated:
         update_user_activity(request, user_profile, query)
 
@@ -788,7 +792,8 @@ def client_is_exempt_from_rate_limiting(request: HttpRequest) -> bool:
 
     # Don't rate limit requests from Django that come from our own servers,
     # and don't rate-limit dev instances
-    return (request.client and request.client.name.lower() == "internal") and (
+    client = get_request_notes(request).client
+    return (client is not None and client.name.lower() == "internal") and (
         is_local_addr(request.META["REMOTE_ADDR"]) or settings.DEBUG_RATE_LIMITING
     )
 

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -16,6 +16,7 @@ from zerver.lib.i18n import (
     get_language_list,
     get_language_translation_data,
 )
+from zerver.lib.request import get_request_notes
 from zerver.models import Message, Realm, Stream, UserProfile
 from zerver.views.message_flags import get_latest_update_message_flag_activity
 
@@ -138,9 +139,11 @@ def build_page_params_for_home_page_load(
     }
 
     if user_profile is not None:
+        client = get_request_notes(request).client
+        assert client is not None
         register_ret = do_events_register(
             user_profile,
-            request.client,
+            client,
             apply_markdown=True,
             client_gravatar=True,
             slim_presence=True,

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -10,6 +10,8 @@ from django.conf import settings
 from django.http import HttpRequest
 from django.utils import translation
 
+from zerver.lib.request import get_request_notes
+
 
 @lru_cache()
 def get_language_list() -> List[Dict[str, Any]]:
@@ -62,6 +64,6 @@ def get_and_set_request_language(
     # something reasonable will happen in logged-in portico pages.
     # We accomplish that by setting a flag on the request which signals
     # to LocaleMiddleware to set the cookie on the response.
-    request._set_language = translation.get_language()
+    get_request_notes(request).set_language = translation.get_language()
 
     return request_language

--- a/zerver/lib/logging_util.py
+++ b/zerver/lib/logging_util.py
@@ -276,9 +276,13 @@ class ZulipWebhookFormatter(ZulipFormatter):
                 )
 
         header_message = header_text if header_text else None
+        from zerver.lib.request import get_request_notes
+
+        client = get_request_notes(request).client
+        assert client is not None
 
         setattr(record, "user", f"{request.user.delivery_email} ({request.user.realm.string_id})")
-        setattr(record, "client", request.client.name)
+        setattr(record, "client", client.name)
         setattr(record, "url", request.META.get("PATH_INFO", None))
         setattr(record, "content_type", request.content_type)
         setattr(record, "custom_headers", header_message)

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -43,6 +43,7 @@ from zerver.lib.avatar import avatar_url
 from zerver.lib.cache import get_cache_backend
 from zerver.lib.db import Params, ParamsT, Query, TimeTrackingCursor
 from zerver.lib.integrations import WEBHOOK_INTEGRATIONS
+from zerver.lib.request import ZulipRequestNotes, request_notes_map
 from zerver.lib.upload import LocalUploadBackend, S3UploadBackend
 from zerver.models import (
     Client,
@@ -319,6 +320,10 @@ class HostRequestMock(HttpRequest):
         self._body = b""
         self.content_type = ""
         self.client_name = ""
+
+        request_notes_map[self] = ZulipRequestNotes(
+            log_data={},
+        )
 
     @property
     def body(self) -> bytes:

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -29,6 +29,7 @@ import ldap
 import orjson
 from boto3.resources.base import ServiceResource
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.db.migrations.state import StateApps
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.http.request import QueryDict
@@ -58,6 +59,7 @@ from zerver.models import (
 )
 from zerver.tornado.handlers import AsyncDjangoHandler, allocate_handler_id
 from zerver.worker import queue_processors
+from zilencer.models import RemoteZulipServer
 from zproject.backends import ExternalAuthDataDict, ExternalAuthResult
 
 if TYPE_CHECKING:
@@ -289,10 +291,11 @@ class HostRequestMock(HttpRequest):
     def __init__(
         self,
         post_data: Dict[str, Any] = {},
-        user_profile: Optional[UserProfile] = None,
+        user_profile: Optional[Union[UserProfile, AnonymousUser, RemoteZulipServer]] = None,
         host: str = settings.EXTERNAL_HOST,
         client_name: Optional[str] = None,
         meta_data: Optional[Dict[str, Any]] = None,
+        tornado_handler: Optional[AsyncDjangoHandler] = DummyHandler(),
     ) -> None:
         self.host = host
         self.GET = QueryDict(mutable=True)
@@ -323,7 +326,7 @@ class HostRequestMock(HttpRequest):
 
         request_notes_map[self] = ZulipRequestNotes(
             log_data={},
-            tornado_handler=DummyHandler(),
+            tornado_handler=tornado_handler,
         )
 
     @property

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -30,7 +30,8 @@ import orjson
 from boto3.resources.base import ServiceResource
 from django.conf import settings
 from django.db.migrations.state import StateApps
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.http.request import QueryDict
 from django.test import override_settings
 from django.urls import URLResolver
 from moto import mock_s3
@@ -280,7 +281,7 @@ class DummyHandler(AsyncDjangoHandler):
         allocate_handler_id(self)
 
 
-class HostRequestMock:
+class HostRequestMock(HttpRequest):
     """A mock request object where get_host() works.  Useful for testing
     routes that use Zulip's subdomains feature"""
 
@@ -290,9 +291,10 @@ class HostRequestMock:
         user_profile: Optional[UserProfile] = None,
         host: str = settings.EXTERNAL_HOST,
         client_name: Optional[str] = None,
+        meta_data: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.host = host
-        self.GET: Dict[str, Any] = {}
+        self.GET = QueryDict(mutable=True)
         self.method = ""
         if client_name is not None:
             self.client = get_client(client_name)
@@ -301,19 +303,30 @@ class HostRequestMock:
         # though of course the HTTP API would do so.  Ideally, we'd
         # get rid of this abstraction entirely and just use the HTTP
         # API directly, but while it exists, we need this code
-        self.POST: Dict[str, Any] = {}
+        self.POST = QueryDict(mutable=True)
         for key in post_data:
             self.POST[key] = str(post_data[key])
             self.method = "POST"
 
         self._tornado_handler = DummyHandler()
         self._log_data: Dict[str, Any] = {}
-        self.META = {"PATH_INFO": "test"}
+        if meta_data is None:
+            self.META = {"PATH_INFO": "test"}
+        else:
+            self.META = meta_data
         self.path = ""
         self.user = user_profile
-        self.body = ""
+        self._body = b""
         self.content_type = ""
         self.client_name = ""
+
+    @property
+    def body(self) -> bytes:
+        return super().body
+
+    @body.setter
+    def body(self, val: bytes) -> None:
+        self._body = val
 
     def get_host(self) -> str:
         return self.host

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -323,6 +323,7 @@ class HostRequestMock(HttpRequest):
 
         request_notes_map[self] = ZulipRequestNotes(
             log_data={},
+            tornado_handler=DummyHandler(),
         )
 
     @property

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -300,8 +300,6 @@ class HostRequestMock(HttpRequest):
         self.host = host
         self.GET = QueryDict(mutable=True)
         self.method = ""
-        if client_name is not None:
-            self.client = get_client(client_name)
 
         # Convert any integer parameters passed into strings, even
         # though of course the HTTP API would do so.  Ideally, we'd
@@ -322,11 +320,12 @@ class HostRequestMock(HttpRequest):
         self.user = user_profile
         self._body = b""
         self.content_type = ""
-        self.client_name = ""
 
         request_notes_map[self] = ZulipRequestNotes(
+            client_name="",
             log_data={},
             tornado_handler=tornado_handler,
+            client=get_client(client_name) if client_name is not None else None,
         )
 
     @property

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -49,8 +49,10 @@ from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator, validate_email
 from django.utils.translation import gettext as _
 
-from zerver.lib.request import JsonableError, ResultT
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.types import ProfileFieldData, Validator
+
+ResultT = TypeVar("ResultT")
 
 
 def check_string(var_name: str, val: object) -> str:

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -394,9 +394,9 @@ class LogRequests(MiddlewareMixin):
         remote_ip = request.META["REMOTE_ADDR"]
 
         # Get the requestor's identifier and client, if available.
-        try:
-            requestor_for_logs = request._requestor_for_logs
-        except Exception:
+        request_notes = get_request_notes(request)
+        requestor_for_logs = request_notes.requestor_for_logs
+        if requestor_for_logs is None:
             if hasattr(request, "user") and hasattr(request.user, "format_requestor_for_logs"):
                 requestor_for_logs = request.user.format_requestor_for_logs()
             else:
@@ -413,7 +413,6 @@ class LogRequests(MiddlewareMixin):
             content = response.content
             content_iter = None
 
-        request_notes = get_request_notes(request)
         assert request_notes.log_data is not None
         write_log_line(
             request_notes.log_data,

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -351,7 +351,7 @@ class LogRequests(MiddlewareMixin):
             # Avoid re-initializing request_notes.log_data if it's already there.
             return
 
-        request.client_name, request.client_version = parse_client(request)
+        request_notes.client_name, request_notes.client_version = parse_client(request)
         request_notes.log_data = {}
         record_request_start_data(request_notes.log_data)
 
@@ -401,10 +401,6 @@ class LogRequests(MiddlewareMixin):
                 requestor_for_logs = request.user.format_requestor_for_logs()
             else:
                 requestor_for_logs = "unauth@{}".format(get_subdomain(request) or "root")
-        try:
-            client = request.client.name
-        except Exception:
-            client = request.client_name
 
         if response.streaming:
             content_iter = response.streaming_content
@@ -413,15 +409,15 @@ class LogRequests(MiddlewareMixin):
             content = response.content
             content_iter = None
 
-        assert request_notes.log_data is not None
+        assert request_notes.client_name is not None and request_notes.log_data is not None
         write_log_line(
             request_notes.log_data,
             request.path,
             request.method,
             remote_ip,
             requestor_for_logs,
-            client,
-            client_version=request.client_version,
+            request_notes.client_name,
+            client_version=request_notes.client_version,
             status_code=response.status_code,
             error_content=content,
             error_content_iter=content_iter,

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -577,10 +577,12 @@ class HostDomainMiddleware(MiddlewareMixin):
 
         subdomain = get_subdomain(request)
         if subdomain != Realm.SUBDOMAIN_FOR_ROOT_DOMAIN:
+            request_notes = get_request_notes(request)
             try:
-                request.realm = get_realm(subdomain)
+                request_notes.realm = get_realm(subdomain)
             except Realm.DoesNotExist:
                 return render(request, "zerver/invalid_realm.html", status=404)
+            request_notes.has_fetched_realm = True
         return None
 
 

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -544,8 +544,9 @@ class RateLimitMiddleware(MiddlewareMixin):
             return response
 
         # Add X-RateLimit-*** headers
-        if hasattr(request, "_ratelimits_applied"):
-            self.set_response_headers(response, request._ratelimits_applied)
+        ratelimits_applied = get_request_notes(request).ratelimits_applied
+        if len(ratelimits_applied) > 0:
+            self.set_response_headers(response, ratelimits_applied)
 
         return response
 

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -135,11 +135,7 @@ class DecoratorTestCase(ZulipTestCase):
         ) -> int:
             return x + x
 
-        class Request:
-            GET: Dict[str, str] = {}
-            POST: Dict[str, str] = {}
-
-        request = Request()
+        request = HostRequestMock()
 
         request.POST = dict(bogus="5555")
         with self.assertRaises(RequestVariableMissingError):
@@ -174,11 +170,7 @@ class DecoratorTestCase(ZulipTestCase):
         ) -> int:
             return sum(numbers)
 
-        class Request:
-            GET: Dict[str, str] = {}
-            POST: Dict[str, str] = {}
-
-        request = Request()
+        request = HostRequestMock()
 
         with self.assertRaises(RequestVariableMissingError):
             get_total(request)
@@ -209,11 +201,7 @@ class DecoratorTestCase(ZulipTestCase):
         ) -> int:
             return sum(numbers)
 
-        class Request:
-            GET: Dict[str, str] = {}
-            POST: Dict[str, str] = {}
-
-        request = Request()
+        request = HostRequestMock()
 
         with self.assertRaises(RequestVariableMissingError):
             get_total(request)
@@ -239,11 +227,7 @@ class DecoratorTestCase(ZulipTestCase):
         ) -> str:
             return value[1:-1]
 
-        class Request:
-            GET: Dict[str, str] = {}
-            POST: Dict[str, str] = {}
-
-        request = Request()
+        request = HostRequestMock()
 
         with self.assertRaises(RequestVariableMissingError):
             get_middle_characters(request)
@@ -577,17 +561,12 @@ class RateLimitTestCase(ZulipTestCase):
         return mock.patch("logging.error", side_effect=TestLoggingErrorException)
 
     def test_internal_local_clients_skip_rate_limiting(self) -> None:
-        class Client:
-            name = "internal"
+        META = {"REMOTE_ADDR": "127.0.0.1"}
+        user = AnonymousUser()
 
-        class Request:
-            client = Client()
-            META = {"REMOTE_ADDR": "127.0.0.1"}
-            user = AnonymousUser()
+        request = HostRequestMock(client_name="internal", user_profile=user, meta_data=META)
 
-        req = Request()
-
-        def f(req: Any) -> str:
+        def f(request: Any) -> str:
             return "some value"
 
         f = rate_limit()(f)
@@ -596,21 +575,16 @@ class RateLimitTestCase(ZulipTestCase):
                 "zerver.decorator.rate_limit_ip"
             ) as rate_limit_ip_mock:
                 with self.errors_disallowed():
-                    self.assertEqual(f(req), "some value")
+                    self.assertEqual(f(request), "some value")
 
         self.assertFalse(rate_limit_ip_mock.called)
         self.assertFalse(rate_limit_user_mock.called)
 
     def test_debug_clients_skip_rate_limiting(self) -> None:
-        class Client:
-            name = "internal"
+        META = {"REMOTE_ADDR": "3.3.3.3"}
+        user = AnonymousUser()
 
-        class Request:
-            client = Client()
-            META = {"REMOTE_ADDR": "3.3.3.3"}
-            user = AnonymousUser()
-
-        req = Request()
+        req = HostRequestMock(client_name="internal", user_profile=user, meta_data=META)
 
         def f(req: Any) -> str:
             return "some value"
@@ -628,15 +602,10 @@ class RateLimitTestCase(ZulipTestCase):
         self.assertFalse(rate_limit_user_mock.called)
 
     def test_rate_limit_setting_of_false_bypasses_rate_limiting(self) -> None:
-        class Client:
-            name = "external"
+        META = {"REMOTE_ADDR": "3.3.3.3"}
+        user = self.example_user("hamlet")
 
-        class Request:
-            client = Client()
-            META = {"REMOTE_ADDR": "3.3.3.3"}
-            user = self.example_user("hamlet")
-
-        req = Request()
+        req = HostRequestMock(client_name="external", user_profile=user, meta_data=META)
 
         def f(req: Any) -> str:
             return "some value"
@@ -653,15 +622,10 @@ class RateLimitTestCase(ZulipTestCase):
         self.assertFalse(rate_limit_user_mock.called)
 
     def test_rate_limiting_happens_in_normal_case(self) -> None:
-        class Client:
-            name = "external"
+        META = {"REMOTE_ADDR": "3.3.3.3"}
+        user = self.example_user("hamlet")
 
-        class Request:
-            client = Client()
-            META = {"REMOTE_ADDR": "3.3.3.3"}
-            user = self.example_user("hamlet")
-
-        req = Request()
+        req = HostRequestMock(client_name="external", user_profile=user, meta_data=META)
 
         def f(req: Any) -> str:
             return "some value"
@@ -683,16 +647,9 @@ class RateLimitTestCase(ZulipTestCase):
             hostname="demo.example.com",
             last_updated=timezone_now(),
         )
+        META = {"REMOTE_ADDR": "3.3.3.3"}
 
-        class Client:
-            name = "external"
-
-        class Request:
-            client = Client()
-            META = {"REMOTE_ADDR": "3.3.3.3"}
-            user = server
-
-        req = Request()
+        req = HostRequestMock(client_name="external", user_profile=server, meta_data=META)
 
         def f(req: Any) -> str:
             return "some value"
@@ -706,15 +663,10 @@ class RateLimitTestCase(ZulipTestCase):
         self.assertTrue(rate_limit_mock.called)
 
     def test_rate_limiting_happens_by_ip_if_unauthed(self) -> None:
-        class Client:
-            name = "external"
+        META = {"REMOTE_ADDR": "3.3.3.3"}
+        user = AnonymousUser()
 
-        class Request:
-            client = Client()
-            META = {"REMOTE_ADDR": "3.3.3.3"}
-            user = AnonymousUser()
-
-        req = Request()
+        req = HostRequestMock(client_name="external", user_profile=user, meta_data=META)
 
         def f(req: Any) -> str:
             return "some value"
@@ -1510,21 +1462,16 @@ class TestValidateApiKey(ZulipTestCase):
 class TestInternalNotifyView(ZulipTestCase):
     BORING_RESULT = "boring"
 
-    class Request:
-        def __init__(self, POST: Dict[str, Any], META: Dict[str, Any]) -> None:
-            self.POST = POST
-            self.META = META
-            self.method = "POST"
-
     def internal_notify(self, is_tornado: bool, req: HttpRequest) -> HttpResponse:
         boring_view = lambda req: self.BORING_RESULT
         return internal_notify_view(is_tornado)(boring_view)(req)
 
     def test_valid_internal_requests(self) -> None:
         secret = "random"
-        request: HttpRequest = self.Request(
-            POST=dict(secret=secret),
-            META=dict(REMOTE_ADDR="127.0.0.1"),
+        request = HostRequestMock(
+            post_data=dict(secret=secret),
+            meta_data=dict(REMOTE_ADDR="127.0.0.1"),
+            tornado_handler=None,
         )
 
         with self.settings(SHARED_SECRET=secret):
@@ -1546,28 +1493,28 @@ class TestInternalNotifyView(ZulipTestCase):
 
     def test_internal_requests_with_broken_secret(self) -> None:
         secret = "random"
-        req = self.Request(
-            POST=dict(secret=secret),
-            META=dict(REMOTE_ADDR="127.0.0.1"),
+        request = HostRequestMock(
+            post_data=dict(secret=secret),
+            meta_data=dict(REMOTE_ADDR="127.0.0.1"),
         )
 
         with self.settings(SHARED_SECRET="broken"):
-            self.assertFalse(authenticate_notify(req))
+            self.assertFalse(authenticate_notify(request))
             with self.assertRaises(AccessDeniedError) as context:
-                self.internal_notify(True, req)
+                self.internal_notify(True, request)
             self.assertEqual(context.exception.http_status_code, 403)
 
     def test_external_requests(self) -> None:
         secret = "random"
-        req = self.Request(
-            POST=dict(secret=secret),
-            META=dict(REMOTE_ADDR="3.3.3.3"),
+        request = HostRequestMock(
+            post_data=dict(secret=secret),
+            meta_data=dict(REMOTE_ADDR="3.3.3.3"),
         )
 
         with self.settings(SHARED_SECRET=secret):
-            self.assertFalse(authenticate_notify(req))
+            self.assertFalse(authenticate_notify(request))
             with self.assertRaises(AccessDeniedError) as context:
-                self.internal_notify(True, req)
+                self.internal_notify(True, request)
             self.assertEqual(context.exception.http_status_code, 403)
 
     def test_is_local_address(self) -> None:
@@ -1808,32 +1755,32 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
         def test_view(request: HttpRequest) -> HttpResponse:
             return HttpResponse("Success")
 
-        request = HttpRequest()
-        request.META["SERVER_NAME"] = "localhost"
-        request.META["SERVER_PORT"] = 80
-        request.META["PATH_INFO"] = ""
-        request.user = hamlet = self.example_user("hamlet")
-        request.user.is_verified = lambda: False
-        request.client_name = ""
+        meta_data = {
+            "SERVER_NAME": "localhost",
+            "SERVER_PORT": 80,
+            "PATH_INFO": "",
+        }
+        user = hamlet = self.example_user("hamlet")
+        user.is_verified = lambda: False
         self.login_user(hamlet)
+        request = HostRequestMock(
+            client_name="", user_profile=user, meta_data=meta_data, host="zulip.testserver"
+        )
         request.session = self.client.session
-        request.get_host = lambda: "zulip.testserver"
 
         response = test_view(request)
         content = getattr(response, "content")
         self.assertEqual(content.decode(), "Success")
 
         with self.settings(TWO_FACTOR_AUTHENTICATION_ENABLED=True):
-            request = HttpRequest()
-            request.META["SERVER_NAME"] = "localhost"
-            request.META["SERVER_PORT"] = 80
-            request.META["PATH_INFO"] = ""
-            request.user = hamlet = self.example_user("hamlet")
-            request.user.is_verified = lambda: False
-            request.client_name = ""
+            user = hamlet = self.example_user("hamlet")
+            user.is_verified = lambda: False
             self.login_user(hamlet)
+            request = HostRequestMock(
+                client_name="", user_profile=user, meta_data=meta_data, host="zulip.testserver"
+            )
             request.session = self.client.session
-            request.get_host = lambda: "zulip.testserver"
+            assert type(request.user) is UserProfile
             self.create_default_device(request.user)
 
             response = test_view(request)
@@ -1851,16 +1798,19 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
             return HttpResponse("Success")
 
         with self.settings(TWO_FACTOR_AUTHENTICATION_ENABLED=True):
-            request = HttpRequest()
-            request.META["SERVER_NAME"] = "localhost"
-            request.META["SERVER_PORT"] = 80
-            request.META["PATH_INFO"] = ""
-            request.user = hamlet = self.example_user("hamlet")
-            request.user.is_verified = lambda: True
-            request.client_name = ""
+            meta_data = {
+                "SERVER_NAME": "localhost",
+                "SERVER_PORT": 80,
+                "PATH_INFO": "",
+            }
+            user = hamlet = self.example_user("hamlet")
+            user.is_verified = lambda: True
             self.login_user(hamlet)
+            request = HostRequestMock(
+                client_name="", user_profile=user, meta_data=meta_data, host="zulip.testserver"
+            )
             request.session = self.client.session
-            request.get_host = lambda: "zulip.testserver"
+            assert type(request.user) is UserProfile
             self.create_default_device(request.user)
 
             response = test_view(request)

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -49,6 +49,7 @@ from zerver.lib.request import (
     RequestConfusingParmsError,
     RequestVariableConversionError,
     RequestVariableMissingError,
+    get_request_notes,
     has_request_variables,
 )
 from zerver.lib.response import json_response, json_success
@@ -1521,27 +1522,27 @@ class TestInternalNotifyView(ZulipTestCase):
 
     def test_valid_internal_requests(self) -> None:
         secret = "random"
-        req: HttpRequest = self.Request(
+        request: HttpRequest = self.Request(
             POST=dict(secret=secret),
             META=dict(REMOTE_ADDR="127.0.0.1"),
         )
 
         with self.settings(SHARED_SECRET=secret):
-            self.assertTrue(authenticate_notify(req))
-            self.assertEqual(self.internal_notify(False, req), self.BORING_RESULT)
-            self.assertEqual(req._requestor_for_logs, "internal")
+            self.assertTrue(authenticate_notify(request))
+            self.assertEqual(self.internal_notify(False, request), self.BORING_RESULT)
+            self.assertEqual(get_request_notes(request).requestor_for_logs, "internal")
 
             with self.assertRaises(RuntimeError):
-                self.internal_notify(True, req)
+                self.internal_notify(True, request)
 
-        req._tornado_handler = "set"
+        request._tornado_handler = "set"
         with self.settings(SHARED_SECRET=secret):
-            self.assertTrue(authenticate_notify(req))
-            self.assertEqual(self.internal_notify(True, req), self.BORING_RESULT)
-            self.assertEqual(req._requestor_for_logs, "internal")
+            self.assertTrue(authenticate_notify(request))
+            self.assertEqual(self.internal_notify(True, request), self.BORING_RESULT)
+            self.assertEqual(get_request_notes(request).requestor_for_logs, "internal")
 
             with self.assertRaises(RuntimeError):
-                self.internal_notify(False, req)
+                self.internal_notify(False, request)
 
     def test_internal_requests_with_broken_secret(self) -> None:
         secret = "random"

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -264,12 +264,12 @@ class DecoratorTestCase(ZulipTestCase):
             return payload
 
         request = HostRequestMock()
-        request.body = "notjson"
+        request.body = b"notjson"
         with self.assertRaises(JsonableError) as cm:
             get_payload(request)
         self.assertEqual(str(cm.exception), "Malformed JSON")
 
-        request.body = '{"a": "b"}'
+        request.body = b'{"a": "b"}'
         self.assertEqual(get_payload(request), {"a": "b"})
 
     def logger_output(self, output_string: str, type: str, logger: str) -> str:
@@ -340,7 +340,7 @@ class DecoratorTestCase(ZulipTestCase):
 
         with self.assertLogs("zulip.zerver.webhooks", level="INFO") as log:
             with self.assertRaisesRegex(Exception, "raised by webhook function"):
-                request.body = "{}"
+                request.body = b"{}"
                 request.content_type = "application/json"
                 my_webhook_raises_exception(request)
 
@@ -349,7 +349,7 @@ class DecoratorTestCase(ZulipTestCase):
 
         with self.assertLogs("zulip.zerver.webhooks", level="INFO") as log:
             with self.assertRaisesRegex(Exception, "raised by webhook function"):
-                request.body = "notjson"
+                request.body = b"notjson"
                 request.content_type = "text/plain"
                 my_webhook_raises_exception(request)
 
@@ -358,7 +358,7 @@ class DecoratorTestCase(ZulipTestCase):
         # exception raised in the webhook function should be re-raised
         with self.assertLogs("zulip.zerver.webhooks", level="ERROR") as log:
             with self.assertRaisesRegex(Exception, "raised by webhook function"):
-                request.body = "invalidjson"
+                request.body = b"invalidjson"
                 request.content_type = "application/json"
                 request.META["HTTP_X_CUSTOM_HEADER"] = "custom_value"
                 my_webhook_raises_exception(request)
@@ -371,7 +371,7 @@ class DecoratorTestCase(ZulipTestCase):
         exception_msg = "The 'test_event' event isn't currently supported by the ClientName webhook"
         with self.assertLogs("zulip.zerver.webhooks.unsupported", level="ERROR") as log:
             with self.assertRaisesRegex(UnsupportedWebhookEventType, exception_msg):
-                request.body = "invalidjson"
+                request.body = b"invalidjson"
                 request.content_type = "application/json"
                 request.META["HTTP_X_CUSTOM_HEADER"] = "custom_value"
                 my_webhook_raises_exception_unsupported_event(request)
@@ -487,7 +487,7 @@ class DecoratorLoggingTestCase(ZulipTestCase):
         request.method = "POST"
         request.host = "zulip.testserver"
 
-        request.body = "{}"
+        request.body = b"{}"
         request.content_type = "text/plain"
 
         with mock.patch("zerver.decorator.webhook_logger.exception") as mock_exception:
@@ -508,7 +508,7 @@ class DecoratorLoggingTestCase(ZulipTestCase):
         request.method = "POST"
         request.host = "zulip.testserver"
 
-        request.body = "{}"
+        request.body = b"{}"
         request.content_type = "text/plain"
 
         with mock.patch(
@@ -534,7 +534,7 @@ class DecoratorLoggingTestCase(ZulipTestCase):
         request.method = "POST"
         request.host = "zulip.testserver"
 
-        request.body = "{}"
+        request.body = b"{}"
         request.content_type = "application/json"
 
         with mock.patch("zerver.decorator.webhook_logger.exception") as mock_exception:

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -54,7 +54,7 @@ from zerver.lib.request import (
 )
 from zerver.lib.response import json_response, json_success
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import HostRequestMock
+from zerver.lib.test_helpers import DummyHandler, HostRequestMock
 from zerver.lib.user_agent import parse_user_agent
 from zerver.lib.users import get_api_key
 from zerver.lib.utils import generate_api_key, has_api_key_format
@@ -1535,7 +1535,7 @@ class TestInternalNotifyView(ZulipTestCase):
             with self.assertRaises(RuntimeError):
                 self.internal_notify(True, request)
 
-        request._tornado_handler = "set"
+        get_request_notes(request).tornado_handler = DummyHandler()
         with self.settings(SHARED_SECRET=secret):
             self.assertTrue(authenticate_notify(request))
             self.assertEqual(self.internal_notify(True, request), self.BORING_RESULT)

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -237,8 +237,8 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         request_notes.log_data = old_request_notes.log_data
         if request_notes.rate_limit is not None:
             request_notes.rate_limit = old_request_notes.rate_limit
-        if hasattr(request, "_requestor_for_logs"):
-            request._requestor_for_logs = old_request._requestor_for_logs
+        if request_notes.requestor_for_logs is not None:
+            request_notes.requestor_for_logs = old_request_notes.requestor_for_logs
         request.user = old_request.user
         request.client = old_request.client
         request.client_name = old_request.client_name

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -111,9 +111,12 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         signals.request_started.send(sender=self.__class__)
         request = WSGIRequest(environ)
 
+        # We do the import during runtime to avoid cyclic dependency
+        from zerver.lib.request import get_request_notes
+
         # Provide a way for application code to access this handler
         # given the HttpRequest object.
-        request._tornado_handler = self
+        get_request_notes(request).tornado_handler = self
 
         return request
 

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -250,7 +250,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         # request/middleware system to run unmodified while avoiding
         # running expensive things like Zulip's authentication code a
         # second time.
-        request.saved_response = json_response(
+        request_notes.saved_response = json_response(
             res_type=result_dict["result"], data=result_dict, status=self.get_status()
         )
 

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -235,8 +235,8 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         # Add to this new HttpRequest logging data from the processing of
         # the original request; we will need these for logging.
         request_notes.log_data = old_request_notes.log_data
-        if hasattr(request, "_rate_limit"):
-            request._rate_limit = old_request._rate_limit
+        if request_notes.rate_limit is not None:
+            request_notes.rate_limit = old_request_notes.rate_limit
         if hasattr(request, "_requestor_for_logs"):
             request._requestor_for_logs = old_request._requestor_for_logs
         request.user = old_request.user

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -243,9 +243,9 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         if request_notes.requestor_for_logs is not None:
             request_notes.requestor_for_logs = old_request_notes.requestor_for_logs
         request.user = old_request.user
-        request.client = old_request.client
-        request.client_name = old_request.client_name
-        request.client_version = old_request.client_version
+        request_notes.client = old_request_notes.client
+        request_notes.client_name = old_request_notes.client_name
+        request_notes.client_version = old_request_notes.client_version
 
         # The saved_response attribute, if present, causes
         # rest_dispatch to return the response immediately before

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -109,7 +109,9 @@ def get_events_backend(
         raise JsonableError(_("User not authorized for this query"))
 
     # Extract the Tornado handler from the request
-    handler: AsyncDjangoHandler = request._tornado_handler
+    tornado_handler = get_request_notes(request).tornado_handler
+    assert tornado_handler is not None
+    handler: AsyncDjangoHandler = tornado_handler
 
     if user_client is None:
         valid_user_client = request.client

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -114,7 +114,8 @@ def get_events_backend(
     handler: AsyncDjangoHandler = tornado_handler
 
     if user_client is None:
-        valid_user_client = request.client
+        valid_user_client = get_request_notes(request).client
+        assert valid_user_client is not None
     else:
         valid_user_client = user_client
 

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -50,7 +50,7 @@ def get_events_internal(
     request: HttpRequest, user_profile_id: int = REQ(json_validator=check_int)
 ) -> HttpResponse:
     user_profile = get_user_profile_by_id(user_profile_id)
-    request._requestor_for_logs = user_profile.format_requestor_for_logs()
+    get_request_notes(request).requestor_for_logs = user_profile.format_requestor_for_logs()
     process_client(request, user_profile, client_name="internal")
     return get_events_backend(request, user_profile)
 

--- a/zerver/views/archive.py
+++ b/zerver/views/archive.py
@@ -6,6 +6,7 @@ from django.template import loader
 
 from zerver.lib.avatar import get_gravatar_url
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.request import get_request_notes
 from zerver.lib.response import json_success
 from zerver.lib.streams import access_web_public_stream
 from zerver.lib.timestamp import datetime_to_timestamp
@@ -29,7 +30,9 @@ def archive(request: HttpRequest, stream_id: int, topic_name: str) -> HttpRespon
         )
 
     try:
-        stream = access_web_public_stream(stream_id, request.realm)
+        realm = get_request_notes(request).realm
+        assert realm is not None
+        stream = access_web_public_stream(stream_id, realm)
     except JsonableError:
         return get_response([], False, "")
 
@@ -75,7 +78,9 @@ def archive(request: HttpRequest, stream_id: int, topic_name: str) -> HttpRespon
 
 def get_web_public_topics_backend(request: HttpRequest, stream_id: int) -> HttpResponse:
     try:
-        stream = access_web_public_stream(stream_id, request.realm)
+        realm = get_request_notes(request).realm
+        assert realm is not None
+        stream = access_web_public_stream(stream_id, realm)
     except JsonableError:
         return json_success(dict(topics=[]))
 

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -53,7 +53,7 @@ from zerver.lib.mobile_auth_otp import otp_encrypt_api_key
 from zerver.lib.push_notifications import push_notifications_enabled
 from zerver.lib.pysa import mark_sanitized
 from zerver.lib.realm_icon import realm_icon_url
-from zerver.lib.request import REQ, JsonableError, has_request_variables
+from zerver.lib.request import REQ, JsonableError, get_request_notes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.sessions import set_expirable_session_var
 from zerver.lib.subdomains import get_subdomain, is_subdomain_root_or_alias
@@ -354,7 +354,7 @@ def finish_mobile_flow(request: HttpRequest, user_profile: UserProfile, otp: str
 
     # Mark this request as having a logged-in user for our server logs.
     process_client(request, user_profile)
-    request._requestor_for_logs = user_profile.format_requestor_for_logs()
+    get_request_notes(request).requestor_for_logs = user_profile.format_requestor_for_logs()
 
     return response
 
@@ -859,7 +859,7 @@ def api_fetch_api_key(
 
     # Mark this request as having a logged-in user for our server logs.
     process_client(request, user_profile)
-    request._requestor_for_logs = user_profile.format_requestor_for_logs()
+    get_request_notes(request).requestor_for_logs = user_profile.format_requestor_for_logs()
 
     api_key = get_api_key(user_profile)
     return json_success({"api_key": api_key, "email": user_profile.delivery_email})

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -13,7 +13,7 @@ from django.views.generic import TemplateView
 from zerver.context_processors import zulip_default_context
 from zerver.decorator import add_google_analytics_context
 from zerver.lib.integrations import CATEGORIES, INTEGRATIONS, HubotIntegration, WebhookIntegration
-from zerver.lib.request import REQ, has_request_variables
+from zerver.lib.request import REQ, get_request_notes, has_request_variables
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.templates import render_markdown_path
 from zerver.models import Realm
@@ -168,10 +168,11 @@ class MarkdownDirectoryView(ApiURLView):
                 context["OPEN_GRAPH_TITLE"] = f"{article_title} ({title_base})"
             else:
                 context["OPEN_GRAPH_TITLE"] = title_base
-            self.request.placeholder_open_graph_description = (
+            request_notes = get_request_notes(self.request)
+            request_notes.placeholder_open_graph_description = (
                 f"REPLACMENT_OPEN_GRAPH_DESCRIPTION_{int(2**24 * random.random())}"
             )
-            context["OPEN_GRAPH_DESCRIPTION"] = self.request.placeholder_open_graph_description
+            context["OPEN_GRAPH_DESCRIPTION"] = request_notes.placeholder_open_graph_description
 
         context["sidebar_index"] = sidebar_index
         # An "article" might require the api_uri_context to be rendered

--- a/zerver/views/events_register.py
+++ b/zerver/views/events_register.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext as _
 
 from zerver.lib.events import do_events_register
 from zerver.lib.exceptions import JsonableError
-from zerver.lib.request import REQ, has_request_variables
+from zerver.lib.request import REQ, get_request_notes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.validator import check_bool, check_dict, check_list, check_string
 from zerver.models import Stream, UserProfile
@@ -79,9 +79,12 @@ def events_register_backend(
     if client_capabilities is None:
         client_capabilities = {}
 
+    client = get_request_notes(request).client
+    assert client is not None
+
     ret = do_events_register(
         user_profile,
-        request.client,
+        client,
         apply_markdown,
         client_gravatar,
         slim_presence,

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -14,6 +14,7 @@ from zerver.forms import ToSForm
 from zerver.lib.actions import do_change_tos_version, realm_user_count
 from zerver.lib.compatibility import is_outdated_desktop_app, is_unsupported_browser
 from zerver.lib.home import build_page_params_for_home_page_load, get_user_permission_info
+from zerver.lib.request import get_request_notes
 from zerver.lib.streams import access_stream_by_name
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.utils import statsd
@@ -189,7 +190,9 @@ def home_real(request: HttpRequest) -> HttpResponse:
         needs_tutorial=needs_tutorial,
     )
 
-    request._log_data["extra"] = "[{}]".format(queue_id)
+    log_data = get_request_notes(request).log_data
+    assert log_data is not None
+    log_data["extra"] = "[{}]".format(queue_id)
 
     csp_nonce = secrets.token_hex(24)
 

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -12,6 +12,7 @@ from zerver.lib.actions import check_update_message, do_delete_messages
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.html_diff import highlight_html_differences
 from zerver.lib.message import access_message
+from zerver.lib.request import get_request_notes
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import LEGACY_PREV_TOPIC, REQ_topic
@@ -117,7 +118,9 @@ def update_message_backend(
     )
 
     # Include the number of messages changed in the logs
-    request._log_data["extra"] = f"[{number_changed}]"
+    log_data = get_request_notes(request).log_data
+    assert log_data is not None
+    log_data["extra"] = f"[{number_changed}]"
 
     return json_success()
 

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -38,6 +38,7 @@ from zerver.lib.addressee import get_user_profiles, get_user_profiles_by_ids
 from zerver.lib.exceptions import ErrorCode, JsonableError, MissingAuthenticationError
 from zerver.lib.message import get_first_visible_message_id, messages_for_ids
 from zerver.lib.narrow import is_web_public_compatible, is_web_public_narrow
+from zerver.lib.request import get_request_notes
 from zerver.lib.response import json_success
 from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
 from zerver.lib.streams import (
@@ -1043,7 +1044,9 @@ def get_messages_backend(
                 verbose_operators.append("is:" + term["operand"])
             else:
                 verbose_operators.append(term["operator"])
-        request._log_data["extra"] = "[{}]".format(",".join(verbose_operators))
+        log_data = get_request_notes(request).log_data
+        assert log_data is not None
+        log_data["extra"] = "[{}]".format(",".join(verbose_operators))
 
     sa_conn = get_sqlalchemy_connection()
 

--- a/zerver/views/message_flags.py
+++ b/zerver/views/message_flags.py
@@ -37,9 +37,10 @@ def update_message_flags(
     flag: str = REQ(),
 ) -> HttpResponse:
     request_notes = get_request_notes(request)
+    assert request_notes.client is not None
     assert request_notes.log_data is not None
 
-    count = do_update_message_flags(user_profile, request.client, operation, flag, messages)
+    count = do_update_message_flags(user_profile, request_notes.client, operation, flag, messages)
 
     target_count_str = str(len(messages))
     log_data_str = f"[{operation} {flag}/{target_count_str}] actually {count}"
@@ -50,8 +51,9 @@ def update_message_flags(
 
 @has_request_variables
 def mark_all_as_read(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
-    count = do_mark_all_as_read(user_profile, request.client)
     request_notes = get_request_notes(request)
+    assert request_notes.client is not None
+    count = do_mark_all_as_read(user_profile, request_notes.client)
 
     log_data_str = f"[{count} updated]"
     assert request_notes.log_data is not None

--- a/zerver/views/message_flags.py
+++ b/zerver/views/message_flags.py
@@ -10,6 +10,7 @@ from zerver.lib.actions import (
     do_update_message_flags,
 )
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.request import get_request_notes
 from zerver.lib.response import json_success
 from zerver.lib.streams import access_stream_by_id
 from zerver.lib.topic import user_message_exists_for_topic
@@ -35,12 +36,14 @@ def update_message_flags(
     operation: str = REQ("op"),
     flag: str = REQ(),
 ) -> HttpResponse:
+    request_notes = get_request_notes(request)
+    assert request_notes.log_data is not None
 
     count = do_update_message_flags(user_profile, request.client, operation, flag, messages)
 
     target_count_str = str(len(messages))
     log_data_str = f"[{operation} {flag}/{target_count_str}] actually {count}"
-    request._log_data["extra"] = log_data_str
+    request_notes.log_data["extra"] = log_data_str
 
     return json_success({"result": "success", "messages": messages, "msg": ""})
 
@@ -48,9 +51,11 @@ def update_message_flags(
 @has_request_variables
 def mark_all_as_read(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
     count = do_mark_all_as_read(user_profile, request.client)
+    request_notes = get_request_notes(request)
 
     log_data_str = f"[{count} updated]"
-    request._log_data["extra"] = log_data_str
+    assert request_notes.log_data is not None
+    request_notes.log_data["extra"] = log_data_str
 
     return json_success({"result": "success", "msg": ""})
 
@@ -63,7 +68,9 @@ def mark_stream_as_read(
     count = do_mark_stream_messages_as_read(user_profile, stream.recipient_id)
 
     log_data_str = f"[{count} updated]"
-    request._log_data["extra"] = log_data_str
+    log_data = get_request_notes(request).log_data
+    assert log_data is not None
+    log_data["extra"] = log_data_str
 
     return json_success({"result": "success", "msg": ""})
 
@@ -90,6 +97,8 @@ def mark_topic_as_read(
     count = do_mark_stream_messages_as_read(user_profile, stream.recipient_id, topic_name)
 
     log_data_str = f"[{count} updated]"
-    request._log_data["extra"] = log_data_str
+    log_data = get_request_notes(request).log_data
+    assert log_data is not None
+    log_data["extra"] = log_data_str
 
     return json_success({"result": "success", "msg": ""})

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -20,6 +20,7 @@ from zerver.lib.actions import (
 )
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import render_markdown
+from zerver.lib.request import get_request_notes
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import convert_to_UTC
 from zerver.lib.topic import REQ_topic
@@ -52,13 +53,16 @@ def create_mirrored_message_users(
         for email in recipients:
             referenced_users.add(email.lower())
 
-    if request.client.name == "zephyr_mirror":
+    client = get_request_notes(request).client
+    assert client is not None
+
+    if client.name == "zephyr_mirror":
         user_check = same_realm_zephyr_user
         fullname_function = compute_mit_user_fullname
-    elif request.client.name == "irc_mirror":
+    elif client.name == "irc_mirror":
         user_check = same_realm_irc_user
         fullname_function = compute_irc_user_fullname
-    elif request.client.name in ("jabber_mirror", "JabberMirror"):
+    elif client.name in ("jabber_mirror", "JabberMirror"):
         user_check = same_realm_jabber_user
         fullname_function = compute_jabber_user_fullname
     else:
@@ -221,7 +225,8 @@ def send_message_backend(
     # `yes` to accepting `true` like all of our normal booleans.
     forged = forged_str is not None and forged_str in ["yes", "true"]
 
-    client = request.client
+    client = get_request_notes(request).client
+    assert client is not None
     can_forge_sender = request.user.can_forge_sender
     if forged and not can_forge_sender:
         raise JsonableError(_("User not authorized for this query"))
@@ -324,7 +329,9 @@ def render_message_backend(
     message = Message()
     message.sender = user_profile
     message.content = content
-    message.sending_client = request.client
+    client = get_request_notes(request).client
+    assert client is not None
+    message.sending_client = client
 
     rendering_result = render_markdown(message, content, realm=user_profile.realm)
     return json_success({"rendered": rendering_result.rendered_content})

--- a/zerver/views/report.py
+++ b/zerver/views/report.py
@@ -14,7 +14,7 @@ from zerver.context_processors import get_valid_realm_from_request
 from zerver.decorator import human_users_only
 from zerver.lib.markdown import privacy_clean_markdown
 from zerver.lib.queue import queue_json_publish
-from zerver.lib.request import REQ, has_request_variables
+from zerver.lib.request import REQ, get_request_notes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.storage import static_path
 from zerver.lib.unminify import SourceMap
@@ -54,7 +54,9 @@ def report_send_times(
     if displayed > 0:
         displayed_str = str(displayed)
 
-    request._log_data[
+    log_data = get_request_notes(request).log_data
+    assert log_data is not None
+    log_data[
         "extra"
     ] = f"[{time}ms/{received_str}ms/{displayed_str}ms/echo:{locally_echoed}/diff:{rendered_content_disparity}]"
 
@@ -79,7 +81,9 @@ def report_narrow_times(
     initial_free: int = REQ(converter=to_non_negative_int),
     network: int = REQ(converter=to_non_negative_int),
 ) -> HttpResponse:
-    request._log_data["extra"] = f"[{initial_core}ms/{initial_free}ms/{network}ms]"
+    log_data = get_request_notes(request).log_data
+    assert log_data is not None
+    log_data["extra"] = f"[{initial_core}ms/{initial_free}ms/{network}ms]"
     realm = get_valid_realm_from_request(request)
     base_key = statsd_key(realm.string_id, clean_periods=True)
     statsd.timing(f"narrow.initial_core.{base_key}", initial_core)
@@ -95,7 +99,9 @@ def report_unnarrow_times(
     initial_core: int = REQ(converter=to_non_negative_int),
     initial_free: int = REQ(converter=to_non_negative_int),
 ) -> HttpResponse:
-    request._log_data["extra"] = f"[{initial_core}ms/{initial_free}ms]"
+    log_data = get_request_notes(request).log_data
+    assert log_data is not None
+    log_data["extra"] = f"[{initial_core}ms/{initial_free}ms]"
     realm = get_valid_realm_from_request(request)
     base_key = statsd_key(realm.string_id, clean_periods=True)
     statsd.timing(f"unnarrow.initial_core.{base_key}", initial_core)

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -50,7 +50,7 @@ from zerver.lib.exceptions import (
     OrganizationOwnerRequired,
     ResourceNotFoundError,
 )
-from zerver.lib.request import REQ, has_request_variables
+from zerver.lib.request import REQ, get_request_notes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.retention import parse_message_retention_days
 from zerver.lib.streams import (
@@ -404,8 +404,10 @@ def remove_subscriptions_backend(
         people_to_unsub = {user_profile}
 
     result: Dict[str, List[str]] = dict(removed=[], not_removed=[])
+    client = get_request_notes(request).client
+    assert client is not None
     (removed, not_subscribed) = bulk_remove_subscriptions(
-        people_to_unsub, streams, request.client, acting_user=user_profile
+        people_to_unsub, streams, client, acting_user=user_profile
     )
 
     for (subscriber, removed_stream) in removed:

--- a/zerver/webhooks/dialogflow/view.py
+++ b/zerver/webhooks/dialogflow/view.py
@@ -5,7 +5,7 @@ from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.actions import check_send_private_message
-from zerver.lib.request import REQ, has_request_variables
+from zerver.lib.request import REQ, get_request_notes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.models import UserProfile, get_user
 
@@ -35,5 +35,7 @@ def api_dialogflow_webhook(
         body = f"{status} - {error_status}"
 
     receiving_user = get_user(email, user_profile.realm)
-    check_send_private_message(user_profile, request.client, receiving_user, body)
+    client = get_request_notes(request).client
+    assert client is not None
+    check_send_private_message(user_profile, client, receiving_user, body)
     return json_success()

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext as _
 from zerver.decorator import webhook_view
 from zerver.lib.actions import check_send_stream_message
 from zerver.lib.exceptions import JsonableError
-from zerver.lib.request import REQ, has_request_variables
+from zerver.lib.request import REQ, get_request_notes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.models import UserProfile
 
@@ -34,5 +34,7 @@ def api_slack_webhook(
         subject = _("Message from Slack")
 
     content = ZULIP_MESSAGE_TEMPLATE.format(message_sender=user_name, text=text)
-    check_send_stream_message(user_profile, request.client, stream, subject, content)
+    client = get_request_notes(request).client
+    assert client is not None
+    check_send_stream_message(user_profile, client, stream, subject, content)
     return json_success()

--- a/zerver/webhooks/teamcity/view.py
+++ b/zerver/webhooks/teamcity/view.py
@@ -10,7 +10,7 @@ from zerver.lib.actions import (
     check_send_private_message,
     send_rate_limited_pm_notification_to_bot_owner,
 )
-from zerver.lib.request import REQ, has_request_variables
+from zerver.lib.request import REQ, get_request_notes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress
 from zerver.lib.webhooks.common import check_send_webhook_message
@@ -137,7 +137,9 @@ def api_teamcity_webhook(
             return json_success()
 
         body = f"Your personal build for {body}"
-        check_send_private_message(user_profile, request.client, teamcity_user, body)
+        client = get_request_notes(request).client
+        assert client is not None
+        check_send_private_message(user_profile, client, teamcity_user, body)
 
         return json_success()
 

--- a/zerver/webhooks/yo/view.py
+++ b/zerver/webhooks/yo/view.py
@@ -5,7 +5,7 @@ from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.actions import check_send_private_message
-from zerver.lib.request import REQ, has_request_variables
+from zerver.lib.request import REQ, get_request_notes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.models import UserProfile, get_user
 
@@ -22,5 +22,7 @@ def api_yo_app_webhook(
 ) -> HttpResponse:
     body = f"Yo from {username}"
     receiving_user = get_user(email, user_profile.realm)
-    check_send_private_message(user_profile, request.client, receiving_user, body)
+    client = get_request_notes(request).client
+    assert client is not None
+    check_send_private_message(user_profile, client, receiving_user, body)
     return json_success()

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -278,7 +278,9 @@ def rate_limit_auth(auth_func: AuthFuncT, *args: Any, **kwargs: Any) -> Optional
 
     request = args[1]
     username = kwargs["username"]
-    if not hasattr(request, "client") or not client_is_exempt_from_rate_limiting(request):
+    if get_request_notes(request).client is None or not client_is_exempt_from_rate_limiting(
+        request
+    ):
         # Django cycles through enabled authentication backends until one succeeds,
         # or all of them fail. If multiple backends are tried like this, we only want
         # to execute rate_limit_authentication_* once, on the first attempt:

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -70,7 +70,7 @@ from zerver.lib.email_validation import email_allowed_for_realm, validate_email_
 from zerver.lib.mobile_auth_otp import is_valid_otp
 from zerver.lib.rate_limiter import RateLimitedObject
 from zerver.lib.redis_utils import get_dict_from_redis, get_redis_client, put_dict_in_redis
-from zerver.lib.request import JsonableError
+from zerver.lib.request import JsonableError, get_request_notes
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.users import check_full_name, validate_user_custom_profile_field
 from zerver.models import (
@@ -259,12 +259,11 @@ def rate_limit_authentication_by_username(request: HttpRequest, username: str) -
 
 
 def auth_rate_limiting_already_applied(request: HttpRequest) -> bool:
-    if not hasattr(request, "_ratelimits_applied"):
-        return False
+    request_notes = get_request_notes(request)
 
     return any(
         isinstance(r.entity, RateLimitedAuthenticationByUsername)
-        for r in request._ratelimits_applied
+        for r in request_notes.ratelimits_applied
     )
 
 

--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -52,8 +52,8 @@ def add_context(event: "Event", hint: "Hint") -> Optional["Event"]:
         request = get_current_request()
         if request:
             request_notes = get_request_notes(request)
-            if hasattr(request, "client"):
-                event["tags"]["client"] = request.client.name
+            if request_notes.client is not None:
+                event["tags"]["client"] = request_notes.client.name
             if request_notes.realm is not None:
                 event["tags"].setdefault("realm", request_notes.realm.string_id)
     return event

--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -10,6 +10,7 @@ from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from sentry_sdk.utils import capture_internal_exceptions
 
 from version import ZULIP_VERSION
+from zerver.lib.request import get_request_notes
 
 from .config import PRODUCTION, STAGING
 
@@ -50,10 +51,11 @@ def add_context(event: "Event", hint: "Hint") -> Optional["Event"]:
 
         request = get_current_request()
         if request:
+            request_notes = get_request_notes(request)
             if hasattr(request, "client"):
                 event["tags"]["client"] = request.client.name
-            if hasattr(request, "realm"):
-                event["tags"].setdefault("realm", request.realm.string_id)
+            if request_notes.realm is not None:
+                event["tags"].setdefault("realm", request_notes.realm.string_id)
     return event
 
 


### PR DESCRIPTION
This is still a WIP;

TODO:

- [x] Split the commits
- [x] Mirgrate `Request` in `zerver/tests/test_mirror_users.py` from `namedtuple` to something else that supports `weakref`
- [x] Find a better way to access `ZulipRequestData` than `get_or_create_request_data` while guarantee that the mapping supports tests that do not go through the middleware
- [x] Figure a way to not defining `Optional` fields in `ZulipRequestData` to save assertions

prep PR for #18777