### PR TITLE
Change the loading indicator of message edit to be inside the button.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -192,17 +192,22 @@ export function update_message_topic_editing_pencil() {
 }
 
 export function hide_message_edit_spinner(row) {
-    const spinner = row.find(".message_edit_spinner");
-    loading.destroy_indicator(spinner);
-    $(".message_edit_form .message_edit_save").show();
-    $(".message_edit_form .message_edit_cancel").show();
+    row.find(".loader").hide();
+    row.find(".message_edit_save span").show();
+    row.find(".message_edit_save").removeClass("disable-btn");
+    row.find(".message_edit_cancel").removeClass("disable-btn");
 }
 
 export function show_message_edit_spinner(row) {
-    const spinner = row.find(".message_edit_spinner");
-    loading.make_indicator(spinner);
-    $(".message_edit_form .message_edit_save").hide();
-    $(".message_edit_form .message_edit_cancel").hide();
+    row.find(".loader").css("display", "inline-block");
+    row.find(".message_edit_save span").hide();
+    row.find(".message_edit_save").addClass("disable-btn");
+    row.find(".message_edit_cancel").addClass("disable-btn");
+    row.find("object").on("load", function () {
+        const doc = this.getSVGDocument();
+        const $svg = $(doc).find("svg");
+        $svg.find("rect").css("fill", "#000");
+    });
 }
 
 export function show_topic_edit_spinner(row) {

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -656,7 +656,7 @@ export function end_message_row_edit(row) {
     const message = message_lists.current.get(rows.id(row));
     if (message !== undefined && currently_editing_messages.has(message.id)) {
         const scroll_by = currently_editing_messages.get(message.id).scrolled_by;
-        message_viewport.scrollTop(message_viewport.scrollTop() - scroll_by);
+        const original_scrollTop = message_viewport.scrollTop();
 
         // Clean up resize event listeners
         const listeners = currently_editing_messages.get(message.id).listeners;
@@ -671,6 +671,7 @@ export function end_message_row_edit(row) {
 
         currently_editing_messages.delete(message.id);
         message_lists.current.hide_edit_message(row);
+        message_viewport.scrollTop(original_scrollTop - scroll_by);
 
         compose.abort_video_callbacks(message.id);
     }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1468,6 +1468,25 @@ div.focused_table {
     align-items: baseline;
 }
 
+.message_edit_save .loader {
+    display: none;
+    vertical-align: top;
+    position: relative;
+    height: 28px;
+    margin-top: -10px;
+    top: 6px;
+    width: 30px;
+}
+
+.edit-controls {
+    .btn-wrapper {
+        cursor: not-allowed;
+    }
+    .disable-btn {
+        pointer-events: none;
+    }
+}
+
 .topic_edit {
     display: none;
     line-height: 22px;

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -54,8 +54,15 @@
         <div class="message_edit_spinner"></div>
         <div class="controls edit-controls">
             {{#if is_editable}}
-                <button type="button" class="button small rounded sea-green message_edit_save">{{t "Save" }}</button>
-                <button type="button" class="button small rounded message_edit_cancel">{{t "Cancel" }}</button>
+                <div class="btn-wrapper inline-block">
+                    <button type="button" class="button small rounded sea-green message_edit_save">
+                        <object class="loader" type="image/svg+xml" data="/static/images/loader.svg"></object>
+                        <span>{{t "Save" }}</span>
+                    </button>
+                </div>
+                <div class="btn-wrapper inline-block">
+                    <button type="button" class="button small rounded message_edit_cancel">{{t "Cancel" }}</button>
+                </div>
                 {{#if is_content_editable}}
                 <div class="message-edit-feature-group">
                     {{> compose_control_buttons }}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit changes the loading indicator to be inside the button and disable the buttons.
- Second commit fixes the bug when there is scrolling just after clicking on save, although it is rarely visible.

**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![message-edit](https://user-images.githubusercontent.com/35494118/124362888-89f81580-dc55-11eb-86ae-dbf65fd69752.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
