### PR TITLE
message_view_header: Make subscription count tooltip open downwards.

### DIFF
--- a/static/templates/message_view_header.hbs
+++ b/static/templates/message_view_header.hbs
@@ -2,7 +2,7 @@
 <a class="stream" href="{{stream_settings_link}}">
     {{> navbar_icon_and_title }}
 </a>
-<a class="sub_count no-style tippy-zulip-tooltip" data-tippy-content="{{sub_count_tooltip_text}}" href="{{stream_settings_link}}">
+<a class="sub_count no-style tippy-zulip-tooltip" data-tippy-content="{{sub_count_tooltip_text}}" data-tippy-placement="bottom" href="{{stream_settings_link}}">
     <i class="fa fa-user-o"></i>{{formatted_sub_count}}
 </a>
 <span class="narrow_description rendered_markdown">


### PR DESCRIPTION
This causes it to not cover up the stream description. See CZO thread:
https://chat.zulip.org/#narrow/stream/137-feedback/topic/users.20subscribed.20tooltip.20direction

**Testing plan:** Manually tested

**GIFs or screenshots:** 

![light mode screenshot](https://user-images.githubusercontent.com/5001092/124400093-ddf60f00-dcd4-11eb-8759-dc2fc4f66dc1.png)

![dark mode screenshot](https://user-images.githubusercontent.com/5001092/124400101-e6e6e080-dcd4-11eb-9c9c-76c45e58b5b5.png)
