### PR TITLE
compose: Add trigger for new private message.

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -200,6 +200,17 @@ test("start", ({override}) => {
     assert.equal(compose_state.get_message_type(), "private");
     assert.ok(compose_state.composing());
 
+    // Triggered by new private message
+    opts = {
+        trigger: "new private message",
+    };
+
+    start("private", opts);
+
+    assert.equal(compose_state.private_message_recipient(), "");
+    assert.equal(compose_state.get_message_type(), "private");
+    assert.ok(compose_state.composing());
+
     // Cancel compose.
     let pill_cleared;
     compose_pm_pill.clear = () => {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -223,7 +223,11 @@ export function start(msg_type, opts) {
     // If we are invoked by a compose hotkey (c or x) or new topic
     // button, do not assume that we know what the message's topic or
     // PM recipient should be.
-    if (opts.trigger === "compose_hotkey" || opts.trigger === "new topic button") {
+    if (
+        opts.trigger === "compose_hotkey" ||
+        opts.trigger === "new topic button" ||
+        opts.trigger === "new private message"
+    ) {
         opts.topic = "";
         opts.private_message_recipient = "";
     }

--- a/static/js/compose_closed_ui.js
+++ b/static/js/compose_closed_ui.js
@@ -116,7 +116,7 @@ export function initialize() {
     });
 
     $("body").on("click", ".compose_private_button", () => {
-        compose_actions.start("private");
+        compose_actions.start("private", {trigger: "new private message"});
     });
 
     $("body").on("click", ".compose_reply_button", () => {


### PR DESCRIPTION
This commit adds a new trigger for compose.start that is
"new private message". It will clear the message recipients
whenever compose.start is called with this trigger.

This solves the bug, when a person is in a PM narrow and
clicks the new private message button, it opens the
composebox with the recipients filled out with whoever
you're narrowed to, rather than opening a new, blank PM.

CZO link for the issue
https://chat.zulip.org/#narrow/stream/9-issues/topic/.22New.20private.20message.22.20isn't/near/1222712

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested this manually and with node tests. Also added tests for this.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![new_private_message](https://user-images.githubusercontent.com/56730716/124453544-1a913b80-dda5-11eb-8d73-2c8bab363fa9.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

@timabbott @WesleyAC FYI