### PR TITLE
worker: Make MissedMessageWorker not be lossy.

### DIFF
--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -13,7 +13,7 @@ import tempfile
 import time
 import urllib
 from abc import ABC, abstractmethod
-from collections import defaultdict, deque
+from collections import deque
 from email.message import EmailMessage
 from functools import wraps
 from threading import Lock, Timer
@@ -37,7 +37,7 @@ import orjson
 import sentry_sdk
 from django.conf import settings
 from django.core.mail.backends.smtp import EmailBackend
-from django.db import connection
+from django.db import connection, transaction
 from django.db.models import F
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
@@ -93,6 +93,7 @@ from zerver.models import (
     PreregistrationUser,
     Realm,
     RealmAuditLog,
+    ScheduledMessageNotificationEmail,
     UserMessage,
     UserProfile,
     filter_to_valid_prereg_users,
@@ -561,17 +562,9 @@ class MissedMessageWorker(QueueProcessingWorker):
     #
     # The timer is running whenever; we poll at most every TIMER_FREQUENCY
     # seconds, to avoid excessive activity.
-    #
-    # TODO: Since this process keeps events in memory for up to 2
-    # minutes, it now will lose approximately BATCH_DURATION worth of
-    # missed_message emails whenever it is restarted as part of a
-    # server restart.  We should probably add some sort of save/reload
-    # mechanism for that case.
     TIMER_FREQUENCY = 5
     BATCH_DURATION = 120
     timer_event: Optional[Timer] = None
-    events_by_recipient: Dict[int, List[Dict[str, Any]]] = defaultdict(list)
-    batch_start_by_recipient: Dict[int, float] = {}
 
     # This lock protects access to all of the data structures declared
     # above.  A lock is required because maybe_send_batched_emails, as
@@ -589,11 +582,29 @@ class MissedMessageWorker(QueueProcessingWorker):
         with self.lock:
             logging.debug("Received missedmessage_emails event: %s", event)
 
-            # When we process an event, just put it into the queue and ensure we have a timer going.
-            user_profile_id = event["user_profile_id"]
-            if user_profile_id not in self.batch_start_by_recipient:
-                self.batch_start_by_recipient[user_profile_id] = time.time()
-            self.events_by_recipient[user_profile_id].append(event)
+            # When we consume an event, check if there are existing pending emails
+            # for that user, and if so use the same scheduled timestamp.
+            user_profile_id: int = event["user_profile_id"]
+            batch_duration = datetime.timedelta(seconds=self.BATCH_DURATION)
+
+            with transaction.atomic():
+                try:
+                    pending_email = ScheduledMessageNotificationEmail.objects.filter(
+                        user_profile_id=user_profile_id
+                    )[0]
+                    scheduled_timestamp = pending_email.scheduled_timestamp
+                except IndexError:
+                    scheduled_timestamp = timezone_now() + batch_duration
+
+                entry = ScheduledMessageNotificationEmail(
+                    user_profile_id=user_profile_id,
+                    message_id=event["message_id"],
+                    trigger=event["trigger"],
+                    scheduled_timestamp=scheduled_timestamp,
+                )
+                if "mentioned_user_group_id" in event:
+                    entry.mentioned_user_group_id = event["mentioned_user_group_id"]
+                entry.save()
 
             self.ensure_timer()
 
@@ -615,25 +626,44 @@ class MissedMessageWorker(QueueProcessingWorker):
             # is active.
             self.timer_event = None
 
-            current_time = time.time()
-            for user_profile_id, timestamp in list(self.batch_start_by_recipient.items()):
-                if current_time - timestamp < self.BATCH_DURATION:
-                    continue
-                events = self.events_by_recipient[user_profile_id]
-                logging.info(
-                    "Batch-processing %s missedmessage_emails events for user %s",
-                    len(events),
-                    user_profile_id,
-                )
-                handle_missedmessage_emails(user_profile_id, events)
-                del self.events_by_recipient[user_profile_id]
-                del self.batch_start_by_recipient[user_profile_id]
+            current_time = timezone_now()
+
+            with transaction.atomic():
+                events_to_process = ScheduledMessageNotificationEmail.objects.filter(
+                    scheduled_timestamp__lte=current_time
+                ).select_related()
+
+                # Batch the entries by user
+                events_by_recipient: Dict[int, List[Dict[str, Any]]] = {}
+                for event in events_to_process:
+                    entry = dict(
+                        user_profile_id=event.user_profile_id,
+                        message_id=event.message_id,
+                        trigger=event.trigger,
+                        mentioned_user_group_id=event.mentioned_user_group_id,
+                    )
+                    if event.user_profile_id in events_by_recipient:
+                        events_by_recipient[event.user_profile_id].append(entry)
+                    else:
+                        events_by_recipient[event.user_profile_id] = [entry]
+
+                for user_profile_id in events_by_recipient.keys():
+                    events: List[Dict[str, Any]] = events_by_recipient[user_profile_id]
+
+                    logging.info(
+                        "Batch-processing %s missedmessage_emails events for user %s",
+                        len(events),
+                        user_profile_id,
+                    )
+                    handle_missedmessage_emails(user_profile_id, events)
+
+                events_to_process.delete()
 
             # By only restarting the timer if there are actually events in
             # the queue, we ensure this queue processor is idle when there
             # are no missed-message emails to process.  This avoids
             # constant CPU usage when there is no work to do.
-            if len(self.batch_start_by_recipient) > 0:
+            if ScheduledMessageNotificationEmail.objects.exists():
                 self.ensure_timer()
 
 


### PR DESCRIPTION
Previously, we stored up to 2 minutes worth of email events in memory
before processing them. So, if the server were to go down we would lose
those events.

To fix this, we store the events in the database.

This is a prep change for allowing users to set custom grace period for
email notifications, since the bug noted above could aggravated if with
longer grace periods.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
