### PR TITLE
Embed links queue - only log a warning instead of an exception if the worker times out

### DIFF
--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -288,9 +288,7 @@ class QueueProcessingWorker(ABC):
                 try:
                     signal.signal(
                         signal.SIGALRM,
-                        functools.partial(
-                            self.timer_expired, self.MAX_CONSUME_SECONDS, len(events)
-                        ),
+                        functools.partial(self.timer_expired, self.MAX_CONSUME_SECONDS, events),
                     )
                     try:
                         signal.alarm(self.MAX_CONSUME_SECONDS * len(events))
@@ -337,8 +335,10 @@ class QueueProcessingWorker(ABC):
         consume_func = lambda events: self.consume(events[0])
         self.do_consume(consume_func, [event])
 
-    def timer_expired(self, limit: int, event_count: int, signal: int, frame: FrameType) -> None:
-        raise WorkerTimeoutException(limit, event_count)
+    def timer_expired(
+        self, limit: int, events: List[Dict[str, Any]], signal: int, frame: FrameType
+    ) -> None:
+        raise WorkerTimeoutException(limit, len(events))
 
     def _handle_consume_exception(self, events: List[Dict[str, Any]], exception: Exception) -> None:
         with configure_scope() as scope:

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -763,6 +763,19 @@ class FetchLinksEmbedData(QueueProcessingWorker):
             )
             do_update_embedded_data(message.sender, message, message.content, rendering_result)
 
+    def timer_expired(
+        self, limit: int, events: List[Dict[str, Any]], signal: int, frame: FrameType
+    ) -> None:
+        assert len(events) == 1
+        event = events[0]
+
+        logging.warning(
+            "Timed out after %s seconds while fetching URLs for message %s: %s",
+            limit,
+            event["message_id"],
+            event["urls"],
+        )
+
 
 @assign_queue("outgoing_webhooks")
 class OutgoingWebhookWorker(QueueProcessingWorker):


### PR DESCRIPTION
Discussion in https://chat.zulip.org/#narrow/stream/3-backend/topic/error.3A.20.22Timed.20out.20after.2030.20seconds.20processing.201.20events.22/near/1210121

Tested manually with `manage.py process_queue` in the dev environment