### PR TITLE
embed_links: Interrupt consume() function on worker timeout.

### DIFF
--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -115,6 +115,16 @@ class WorkerTimeoutException(Exception):
         return f"Timed out after {self.limit * self.event_count} seconds processing {self.event_count} events"
 
 
+class InterruptConsumeException(Exception):
+    """
+    This exception is to be thrown inside event consume function
+    if the intention is to simply interrupt the processing
+    of the current event and normally continue the work of the queue.
+    """
+
+    pass
+
+
 class WorkerDeclarationException(Exception):
     pass
 
@@ -341,6 +351,11 @@ class QueueProcessingWorker(ABC):
         raise WorkerTimeoutException(limit, len(events))
 
     def _handle_consume_exception(self, events: List[Dict[str, Any]], exception: Exception) -> None:
+        if isinstance(exception, InterruptConsumeException):
+            # The exception signals that no further error handling
+            # is needed and the worker can proceed.
+            return
+
         with configure_scope() as scope:
             scope.set_context(
                 "events",
@@ -775,6 +790,7 @@ class FetchLinksEmbedData(QueueProcessingWorker):
             event["message_id"],
             event["urls"],
         )
+        raise InterruptConsumeException
 
 
 @assign_queue("outgoing_webhooks")


### PR DESCRIPTION
Addressing the bug pointed out by @alexmv in https://github.com/zulip/zulip/pull/19138#issuecomment-875090966. Regardless of the direction we want to proceed in, based on the other concerns raised in that comment, this is a clear bug that we should merge a fix for.

This fixes a bug introduced in 95b46549e19bf8a3ebe240914b9514ec94542fe2
which made the worker simply log a warning about the timeout and then
continue consume()ing the event that should have also been interrupted.

The idea here is to introduce an exception which can be used to
interrupt the consume() process without triggering the regular handling
of exceptions that happens in _handle_consume_exception.
