### PR TITLE
slash commands: Remove /settings command.

### DIFF
--- a/docs/subsystems/slash-commands.md
+++ b/docs/subsystems/slash-commands.md
@@ -10,7 +10,6 @@ Currently supported slash commands are:
 - `/ping` to ping to server and get back the time for the round
 trip. Mainly for testing.
 - `/fluid-width` and `/fixed-width` to toggle that setting
-- `/settings` to open the settings page
 
 It is important to distinguish slash commands from the
 [widget system](/subsystems/widgets.md). Slash commands essentially

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -161,11 +161,6 @@ const my_slash = {
     text: "translated: /my (Test)",
 };
 
-const settings_slash = {
-    name: "settings",
-    text: "translated: /settings (Load settings menu)",
-};
-
 const sweden_stream = {
     name: "Sweden",
     description: "Cold, mountains and home decor.",
@@ -1518,7 +1513,6 @@ test("typeahead_results", () => {
 
     // Autocomplete by slash commands.
     assert_slash_matches("me", [me_slash]);
-    assert_slash_matches("settings", [settings_slash]);
 
     // Autocomplete stream by stream name or stream description.
     assert_stream_matches("den", [denmark_stream, sweden_stream]);

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -409,10 +409,6 @@ export const slash_commands = [
         name: "poll",
     },
     {
-        text: $t({defaultMessage: "/settings (Load settings menu)"}),
-        name: "settings",
-    },
-    {
         text: $t({defaultMessage: "/todo (Create a todo list)"}),
         name: "todo",
     },

--- a/static/js/zcommand.js
+++ b/static/js/zcommand.js
@@ -2,7 +2,6 @@ import $ from "jquery";
 
 import marked from "../third/marked/lib/marked";
 
-import * as browser_history from "./browser_history";
 import * as channel from "./channel";
 import * as common from "./common";
 import * as feedback_widget from "./feedback_widget";
@@ -186,11 +185,6 @@ export function process(message_content) {
 
     if (content === "/fixed-width") {
         enter_fixed_mode();
-        return true;
-    }
-
-    if (content === "/settings") {
-        browser_history.go_to_location("settings/your-account");
         return true;
     }
 


### PR DESCRIPTION
It's easy enough for power keyboard users to just use "g"
to get to settings, and it's certainly easier for
mouse users to just go to the menu.
