### PR TITLE
recent_topics: Load older messages when scrolling is completed.

### DIFF
--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -329,7 +329,8 @@ export function maybe_load_older_messages(opts) {
 
     do_backfill({
         msg_list,
-        num_before: consts.backward_batch_size,
+        num_before: opts.num_before || consts.backward_batch_size,
+        cont: opts.cont,
     });
 }
 

--- a/static/js/message_scroll.js
+++ b/static/js/message_scroll.js
@@ -28,15 +28,29 @@ let loading_newer_messages_indicator_showing = false;
 
 export function show_loading_older() {
     if (!loading_older_messages_indicator_showing) {
+        // Narrowed view indicators.
         loading.make_indicator($("#loading_older_messages_indicator"), {abs_positioned: true});
-        loading_older_messages_indicator_showing = true;
         floating_recipient_bar.hide();
+
+        // Recent topics indicators.
+        $("#recent_topics_table .bottom-messages-logo").show();
+        loading.make_indicator($("#recent_topics_loading_messages_indicator"), {
+            abs_positioned: true,
+        });
+
+        loading_older_messages_indicator_showing = true;
     }
 }
 
 export function hide_loading_older() {
     if (loading_older_messages_indicator_showing) {
+        // Narrowed view indicators.
         loading.destroy_indicator($("#loading_older_messages_indicator"));
+
+        // Recent topics indicators.
+        $("#recent_topics_table .bottom-messages-logo").hide();
+        loading.destroy_indicator($("#recent_topics_loading_messages_indicator"));
+
         loading_older_messages_indicator_showing = false;
     }
 }

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -78,6 +78,9 @@
         .table_fix_head table {
             /* To keep border properties to the thead th. */
             border-collapse: separate;
+        }
+
+        .bottom_whitespace {
             /* For visual reasons, in a message feed, we require a large
              * bottom_whitespace to make it convenient to display new
              * messages as they come in and prevent occluding the last
@@ -88,7 +91,7 @@
              * overlap content. Add some more margin so that user
              * can clearly see the end of the topics.
              */
-            margin-bottom: 100px;
+            height: 120px;
         }
 
         #recent_topics_filter_buttons {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2195,13 +2195,15 @@ div.floating_recipient {
 }
 
 #loading_older_messages_indicator_box_container,
-#loading_newer_messages_indicator_box_container {
+#loading_newer_messages_indicator_box_container,
+#recent_topics_loading_messages_indicator_box_container {
     position: absolute;
     left: 50%;
 }
 
 #loading_older_messages_indicator_box,
-#loading_newer_messages_indicator_box {
+#loading_newer_messages_indicator_box,
+#recent_topics_loading_messages_indicator_box {
     position: relative;
     left: -50%;
     top: -43px;

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -21,4 +21,13 @@
         </thead>
         <tbody class="required-text" data-empty="{{t 'No topics match your current filter.' }}"></tbody>
     </table>
+    <div class="bottom_whitespace">
+        <div class="bottom-messages-logo">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 773.12 773.12">
+                <circle cx="386.56" cy="386.56" r="386.56"/>
+                <path d="M566.66 527.25c0 33.03-24.23 60.05-53.84 60.05H260.29c-29.61 0-53.84-27.02-53.84-60.05 0-20.22 9.09-38.2 22.93-49.09l134.37-120c2.5-2.14 5.74 1.31 3.94 4.19l-49.29 98.69c-1.38 2.76.41 6.16 3.25 6.16h191.18c29.61 0 53.83 27.03 53.83 60.05zm0-281.39c0 20.22-9.09 38.2-22.93 49.09l-134.37 120c-2.5 2.14-5.74-1.31-3.94-4.19l49.29-98.69c1.38-2.76-.41-6.16-3.25-6.16H260.29c-29.61 0-53.84-27.02-53.84-60.05s24.23-60.05 53.84-60.05h252.54c29.61 0 53.83 27.02 53.83 60.05z"/>
+            </svg>
+        </div>
+        <div id="recent_topics_loading_messages_indicator"></div>
+    </div>
 </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes: #18461 

**Testing plan:** <!-- How have you tested? -->
`./manage.py populate_db --num-messages=10000`

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->




https://user-images.githubusercontent.com/63820270/125824660-0e785c6e-13d1-47f0-8c31-9ab1e00a6005.mov










<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
