### PR TITLE
saml: Don't raise AssertionError if no name is provided in SAMLResponse.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1845,9 +1845,13 @@ class SAMLAuthBackendTest(SocialAuthBase):
         with {email}, {first_name}, {last_name} placeholders, that can
         be filled out with the data we want.
         """
-        name_parts = name.split(" ")
-        first_name = name_parts[0]
-        last_name = name_parts[1]
+        if name:
+            name_parts = name.split(" ")
+            first_name = name_parts[0]
+            last_name = name_parts[1]
+        else:
+            first_name = ""
+            last_name = ""
 
         extra_attrs = ""
         for extra_attr_name, extra_attr_values in extra_attributes.items():
@@ -1876,6 +1880,29 @@ class SAMLAuthBackendTest(SocialAuthBase):
 
     def get_account_data_dict(self, email: str, name: str) -> Dict[str, Any]:
         return dict(email=email, name=name)
+
+    def test_auth_registration_with_no_name_provided(self) -> None:
+        """
+        The SAMLResponse may not actually provide name values, which is considered
+        unexpected behavior for most social backends, but SAML is an exception. The
+        signup flow should proceed normally, without pre-filling the name in the
+        registration form.
+        """
+        email = "newuser@zulip.com"
+        subdomain = "zulip"
+        realm = get_realm("zulip")
+        account_data_dict = self.get_account_data_dict(email=email, name="")
+        result = self.social_auth_test(account_data_dict, subdomain=subdomain, is_signup=True)
+        self.stage_two_of_registration(
+            result,
+            realm,
+            subdomain,
+            email,
+            "",
+            "Full Name",
+            skip_registration_form=False,
+            expect_full_name_prepopulated=False,
+        )
 
     def test_social_auth_no_key(self) -> None:
         """

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1430,11 +1430,16 @@ def social_associate_user_helper(
     full_name = kwargs["details"].get("fullname")
     first_name = kwargs["details"].get("first_name")
     last_name = kwargs["details"].get("last_name")
-    if all(name is None for name in [full_name, first_name, last_name]) and backend.name != "apple":
-        # Apple authentication provides the user's name only the very first time a user tries to log in.
+    if all(name is None for name in [full_name, first_name, last_name]) and backend.name not in [
+        "apple",
+        "saml",
+    ]:
+        # (1) Apple authentication provides the user's name only the very first time a user tries to log in.
         # So if the user aborts login or otherwise is doing this the second time,
-        # we won't have any name data. So, this case is handled with the code below
-        # setting full name to empty string.
+        # we won't have any name data.
+        # (2) Some IdPs may not send any name value if the user doesn't have them set in the IdP's directory.
+        #
+        # The name will just default to the empty string in the code below.
 
         # We need custom code here for any social auth backends
         # that don't provide name details feature.


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/31-production-help/topic/SAML.2Fkeycloak.20configuration/near/1224852 for context

This is an acceptable edge case for SAML and shouldn't raise any errors.