### PR TITLE
compose: Fix compose box getting close on copying code.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -828,10 +828,17 @@ export function initialize() {
         }
 
         if (compose_state.composing()) {
-            if ($(e.target).closest("a").length > 0) {
+            if (
+                $(e.target).closest("a").length > 0 ||
+                $(e.target).closest(".copy_codeblock").length > 0
+            ) {
                 // Refocus compose message text box if one clicks an external
-                // link/url to view something else while composing a message
-                // See issue #4331 for more details
+                // link/url to view something else while composing a message.
+                // See issue #4331 for more details.
+                //
+                // We do the same when copying a code block, since the
+                // most likely next action within Zulip is to paste it
+                // into compose and modify it.
                 $("#compose-textarea").trigger("focus");
                 return;
             } else if (


### PR DESCRIPTION
This commit adds an exception in click-handlers.js so that
when mouse clicks on .copy-codeblock, the composebox is not
closed.

Fixes #19130

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested this manually on chrome browser.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![copy-bug](https://user-images.githubusercontent.com/56730716/124794950-2fb8c680-df6d-11eb-8b12-a2da9e4e827f.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
@alya FYI