### PR TITLE
Add tab design for separating stream settings into different categories.

### DIFF
--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -26,6 +26,11 @@ mock_esm("../../static/js/list_widget", {
 mock_esm("../../static/js/stream_color", {
     set_colorpicker_color: noop,
 });
+mock_esm("../../static/js/components", {
+    toggle: () => ({
+        get: () => [],
+    }),
+});
 
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
@@ -35,6 +40,7 @@ const stream_pill = zrequire("stream_pill");
 const user_groups = zrequire("user_groups");
 const user_group_pill = zrequire("user_group_pill");
 const user_pill = zrequire("user_pill");
+const stream_ui_updates = zrequire("stream_ui_updates");
 
 const jill = {
     email: "jill@zulip.com",
@@ -282,6 +288,9 @@ test_ui("subscriber_pills", ({override, mock_template}) => {
 
     let fake_this = $subscription_settings;
     let event = {target: fake_this};
+
+    override(stream_ui_updates, "update_toggler_for_sub", noop);
+    override(stream_ui_updates, "update_add_subscriptions_elements", noop);
     stream_row_handler.call(fake_this, event);
     assert.ok(template_rendered);
     assert.ok(input_typeahead_called);

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -3,6 +3,7 @@ import $ from "jquery";
 import render_change_stream_info_modal from "../templates/change_stream_info_modal.hbs";
 import render_settings_deactivation_stream_modal from "../templates/confirm_dialog/confirm_deactivate_stream.hbs";
 import render_unsubscribe_private_stream_modal from "../templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs";
+import render_stream_description from "../templates/stream_description.hbs";
 import render_stream_member_list_entry from "../templates/stream_member_list_entry.hbs";
 import render_stream_subscription_request_result from "../templates/stream_subscription_request_result.hbs";
 import render_subscription_settings from "../templates/subscription_settings.hbs";
@@ -221,9 +222,10 @@ export function update_stream_name(sub, new_name) {
 export function update_stream_description(sub) {
     const stream_settings = settings_for_sub(sub);
     stream_settings.find("input.description").val(sub.description);
-    stream_settings
-        .find(".sub-stream-description")
-        .html(util.clean_user_content_links(sub.rendered_description));
+    const html = render_stream_description({
+        rendered_description: util.clean_user_content_links(sub.rendered_description),
+    });
+    stream_settings.find(".stream-description").html(html);
 }
 
 export function invite_user_to_stream(user_ids, sub, success, failure) {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -182,7 +182,7 @@ export function open_edit_panel_for_row(stream_row) {
     const sub = get_sub_for_target(stream_row);
 
     $(".stream-row.active").removeClass("active");
-    subs.show_subs_pane.settings();
+    subs.show_subs_pane.settings(sub.name);
     $(stream_row).addClass("active");
     setup_subscriptions_stream_hash(sub);
     setup_stream_settings(stream_row);

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -11,6 +11,7 @@ import render_subscription_stream_privacy_modal from "../templates/subscription_
 import * as blueslip from "./blueslip";
 import * as browser_history from "./browser_history";
 import * as channel from "./channel";
+import * as components from "./components";
 import * as confirm_dialog from "./confirm_dialog";
 import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
@@ -39,6 +40,8 @@ import * as user_pill from "./user_pill";
 import * as util from "./util";
 
 export let pill_widget;
+export let toggler;
+export let select_tab = "personal_settings";
 
 function setup_subscriptions_stream_hash(sub) {
     const hash = hash_util.stream_edit_uri(sub);
@@ -154,7 +157,9 @@ function set_stream_message_retention_setting_dropdown(stream) {
 }
 
 function get_stream_id(target) {
-    const row = $(target).closest(".stream-row, .subscription_settings, .save-button");
+    const row = $(target).closest(
+        ".stream-row, .stream_settings_header, .subscription_settings, .save-button",
+    );
     return Number.parseInt(row.attr("data-stream-id"), 10);
 }
 
@@ -180,7 +185,7 @@ export function open_edit_panel_for_row(stream_row) {
     subs.show_subs_pane.settings();
     $(stream_row).addClass("active");
     setup_subscriptions_stream_hash(sub);
-    show_settings_for(stream_row);
+    setup_stream_settings(stream_row);
 }
 
 export function open_edit_panel_empty() {
@@ -525,7 +530,10 @@ export function show_settings_for(node) {
         stream_post_policy_values: stream_data.stream_post_policy_values,
         message_retention_text: get_retention_policy_text_for_subscription_type(sub),
     });
-    ui.get_content_element($(".subscriptions .right .settings")).html(html);
+    ui.get_content_element($("#stream_settings")).html(html);
+
+    $("#stream_settings .tab-container").prepend(toggler.get());
+    stream_ui_updates.update_toggler_for_sub(sub);
 
     const sub_settings = settings_for_sub(sub);
 
@@ -535,6 +543,24 @@ export function show_settings_for(node) {
     sub_settings.addClass("show");
 
     show_subscription_settings(sub);
+}
+
+export function setup_stream_settings(node) {
+    toggler = components.toggle({
+        child_wants_focus: true,
+        values: [
+            {label: $t({defaultMessage: "General"}), key: "general_settings"},
+            {label: $t({defaultMessage: "Personal"}), key: "personal_settings"},
+            {label: $t({defaultMessage: "Subscribers"}), key: "subscriber_settings"},
+        ],
+        callback(name, key) {
+            $(".stream_section").hide();
+            $("." + key).show();
+            select_tab = key;
+        },
+    });
+
+    show_settings_for(node);
 }
 
 function stream_is_muted_changed(e) {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -642,11 +642,11 @@ function get_message_retention_days_from_sub(sub) {
 function change_stream_privacy(e) {
     e.stopPropagation();
 
-    const stream_id = $(e.target).data("stream-id");
-    const sub = sub_store.get(stream_id);
     const data = {};
-    const stream_privacy_status = $(".stream-privacy-status");
-    stream_privacy_status.hide();
+    const stream_id = $(e.target).data("stream-id");
+    const url = "/json/streams/" + stream_id;
+    const status_element = $(".stream_permission_change_info");
+    const sub = sub_store.get(stream_id);
 
     const privacy_setting = $("#stream_privacy_modal input[name=privacy]:checked").val();
     const stream_post_policy = Number.parseInt(
@@ -696,25 +696,13 @@ function change_stream_privacy(e) {
         data.message_retention_days = JSON.stringify(message_retention_days);
     }
 
-    $(".stream_change_property_info").hide();
+    overlays.close_modal("#stream_privacy_modal");
 
     if (Object.keys(data).length === 0) {
-        overlays.close_modal("#stream_privacy_modal");
         return;
     }
 
-    channel.patch({
-        url: "/json/streams/" + stream_id,
-        data,
-        success() {
-            overlays.close_modal("#stream_privacy_modal");
-            // The rest will be done by update stream event we will get.
-        },
-        error(xhr) {
-            ui_report.error($t_html({defaultMessage: "Failed"}), xhr, stream_privacy_status);
-            $("#change-stream-privacy-button").text($t({defaultMessage: "Try again"}));
-        },
-    });
+    settings_ui.do_settings_change(channel.patch, url, data, status_element);
 }
 
 export function archive_stream(stream_id, alert_element, stream_row) {

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -50,6 +50,26 @@ export function initialize_cant_subscribe_popover(sub) {
     );
 }
 
+export function update_toggler_for_sub(sub) {
+    if (!stream_edit.is_sub_settings_active(sub)) {
+        return;
+    }
+    if (sub.subscribed) {
+        stream_edit.toggler.enable_tab("personal_settings");
+        stream_edit.toggler.goto(stream_edit.select_tab);
+    } else {
+        if (stream_edit.select_tab === "personal_settings") {
+            // Go to the general settings tab, if the user is not
+            // subscribed. Also preserve the previous selected tab,
+            // to render next time a stream row is selected.
+            stream_edit.toggler.goto("general_settings");
+        } else {
+            stream_edit.toggler.goto(stream_edit.select_tab);
+        }
+        stream_edit.toggler.disable_tab("personal_settings");
+    }
+}
+
 export function update_settings_button_for_sub(sub) {
     // This is for the Subscribe/Unsubscribe button in the right panel.
     const settings_button = subs.settings_button_for_sub(sub);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -39,20 +39,20 @@ import * as util from "./util";
 
 export const show_subs_pane = {
     nothing_selected() {
-        $(".stream-info-title, .settings, #stream-creation").hide();
-        $("#stream_settings_title, .nothing-selected").show();
+        $(".settings, #stream-creation").hide();
+        $(".nothing-selected").show();
         $("#subscription_overlay .stream-info-title").text($t({defaultMessage: "Stream settings"}));
     },
     settings(stream_name) {
-        $(".stream-info-title, .settings, #stream-creation").hide();
-        $("#stream_settings_title, .settings").show();
+        $(".settings, #stream-creation").hide();
+        $(".settings").show();
         $("#subscription_overlay .stream-info-title").text(
             $t({defaultMessage: "Settings for #{stream_name}"}, {stream_name}),
         );
     },
     create_stream() {
-        $(".stream-info-title, .nothing-selected, .settings, #stream-creation").hide();
-        $("#add_new_stream_title, #stream-creation").show();
+        $(".nothing-selected, .settings, #stream-creation").hide();
+        $("#stream-creation").show();
         $("#subscription_overlay .stream-info-title").text($t({defaultMessage: "Create stream"}));
     },
 };

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -288,6 +288,7 @@ export function update_settings_for_subscribed(slim_sub) {
 
     if (is_sub_already_present(sub)) {
         update_left_panel_row(sub);
+        stream_ui_updates.update_toggler_for_sub(sub);
         stream_ui_updates.update_stream_row_in_settings_tab(sub);
         stream_ui_updates.update_settings_button_for_sub(sub);
         stream_ui_updates.update_change_stream_privacy_settings(sub);
@@ -314,6 +315,7 @@ export function update_settings_for_unsubscribed(slim_sub) {
     const sub = stream_settings_data.get_sub_for_settings(slim_sub);
     update_left_panel_row(sub);
     stream_ui_updates.update_subscribers_list(sub);
+    stream_ui_updates.update_toggler_for_sub(sub);
     stream_ui_updates.update_settings_button_for_sub(sub);
     stream_ui_updates.update_regular_sub_settings(sub);
     stream_ui_updates.update_change_stream_privacy_settings(sub);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -41,14 +41,19 @@ export const show_subs_pane = {
     nothing_selected() {
         $(".stream-info-title, .settings, #stream-creation").hide();
         $("#stream_settings_title, .nothing-selected").show();
+        $("#subscription_overlay .stream-info-title").text($t({defaultMessage: "Stream settings"}));
     },
-    settings() {
+    settings(stream_name) {
         $(".stream-info-title, .settings, #stream-creation").hide();
         $("#stream_settings_title, .settings").show();
+        $("#subscription_overlay .stream-info-title").text(
+            $t({defaultMessage: "Settings for #{stream_name}"}, {stream_name}),
+        );
     },
     create_stream() {
         $(".stream-info-title, .nothing-selected, .settings, #stream-creation").hide();
         $("#add_new_stream_title, #stream-creation").show();
+        $("#subscription_overlay .stream-info-title").text($t({defaultMessage: "Create stream"}));
     },
 };
 

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -818,6 +818,32 @@
         margin: 20px;
     }
 
+    .stream_settings_header {
+        white-space: nowrap;
+        display: flex;
+        margin-left: 15px;
+
+        .tab-container {
+            .ind-tab {
+                padding: 3px 4px;
+                width: 80px;
+            }
+        }
+
+        .button-group {
+            padding-top: 5px;
+            margin-left: auto;
+            margin-right: 15px;
+
+            .subscribe-button,
+            #preview-stream-button,
+            .deactivate {
+                margin-right: 3px;
+                text-decoration: none;
+            }
+        }
+    }
+
     .stream-header {
         white-space: nowrap;
 
@@ -844,9 +870,6 @@
             float: right;
             margin-top: -5px;
 
-            .subscribe-button,
-            #preview-stream-button,
-            #open_stream_info_modal,
             .deactivate {
                 margin-right: 3px;
                 text-decoration: none;
@@ -925,6 +948,10 @@
         height: calc(100% - 45px);
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
+
+        .tab-container {
+            padding-top: 5px;
+        }
     }
 
     .subscription_settings {
@@ -1048,6 +1075,10 @@
     .search-container {
         text-align: center;
     }
+
+    #subscription_overlay .stream_settings_header {
+        flex-wrap: wrap;
+    }
 }
 
 /* Note that this block has settings_page CSS as well, and thus needs
@@ -1119,7 +1150,7 @@
 @media (width < $sm_min) {
     #subscription_overlay .subscription_settings .button-group {
         display: block;
-        float: unset;
+        float: right;
         margin-top: 10px;
     }
 
@@ -1136,6 +1167,19 @@
         display: block;
         max-width: max-content;
         white-space: nowrap;
+    }
+}
+
+@media (width <= 500px) {
+    #subscription_overlay .stream_settings_header {
+        display: block;
+        text-align: center;
+        margin-left: 0;
+        .tab-container {
+            .ind-tab {
+                width: 85px;
+            }
+        }
     }
 }
 

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -1016,7 +1016,7 @@
             padding: 5px 0;
 
             input[type="radio"] {
-                margin: 0 0 1px 0;
+                margin: 3.5px 0 1px 0;
             }
 
             &:last-of-type {

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -200,10 +200,10 @@
     color: hsl(0, 100%, 50%);
 }
 
-.sub_settings_title {
-    line-height: 30px;
+.stream_setting_subsection_title {
+    font-size: 1.5em;
+    line-height: 1.5;
     margin: 10px 0 0 0;
-    font-size: 16px;
 }
 
 .new-stream-name,
@@ -966,8 +966,10 @@
         }
     }
 
-    #personal_settings_label_container {
-        margin-bottom: 5px;
+    #personal-stream-settings {
+        .stream_change_property_status {
+            margin: 9px auto 3px 3px;
+        }
     }
 
     .loading_indicator_text {

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -201,6 +201,7 @@
 }
 
 .stream_setting_subsection_title {
+    display: inline-block;
     font-size: 1.5em;
     line-height: 1.5;
     margin: 10px 0 0 0;
@@ -843,7 +844,8 @@
         }
     }
 
-    .stream-header {
+    .stream-header,
+    .stream_setting_subsection_header {
         white-space: nowrap;
 
         .stream-name {
@@ -867,7 +869,6 @@
 
         .button-group {
             float: right;
-            margin-top: -5px;
 
             .deactivate {
                 margin-right: 3px;
@@ -924,10 +925,13 @@
 
     .subscription-type {
         margin-bottom: 10px;
-        opacity: 0.5;
 
         .subscription-type-text {
             display: inline;
+            ul {
+                margin: 0 0 10px 14px;
+                list-style-type: unset;
+            }
         }
 
         b {
@@ -1149,10 +1153,16 @@
 }
 
 @media (width < $sm_min) {
-    #subscription_overlay .subscription_settings .button-group {
-        display: block;
-        float: right;
-        margin-top: 10px;
+    #subscription_overlay .subscription_settings {
+        .button-group {
+            display: block;
+            float: right;
+            margin-top: 10px;
+        }
+
+        .stream-header .button-group {
+            margin-top: -5px;
+        }
     }
 
     #subscription_overlay .subscription_settings .stream_change_property_info {

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -844,8 +844,7 @@
         }
     }
 
-    .stream-header,
-    .stream_setting_subsection_header {
+    .stream-header {
         white-space: nowrap;
 
         .stream-name {
@@ -908,6 +907,20 @@
         .no-description {
             font-style: italic;
             color: hsl(0, 0%, 67%);
+        }
+    }
+
+    .stream_setting_subsection_header {
+        display: flex;
+
+        .stream_permission_change_info {
+            margin: 12px auto 0 3px;
+        }
+
+        .button-group {
+            display: inline;
+            margin-left: auto;
+            align-self: center;
         }
     }
 
@@ -1056,6 +1069,12 @@
     }
 }
 
+#stream_privacy_modal .modal-body {
+    .grey-box {
+        margin-bottom: 20px;
+    }
+}
+
 @media (width < $lg_min) {
     .subscriptions-container {
         max-width: 95%;
@@ -1190,6 +1209,14 @@
             .ind-tab {
                 width: 85px;
             }
+        }
+    }
+
+    #subscription_overlay .stream_setting_subsection_header {
+        display: block;
+
+        .stream_permission_change_info {
+            margin: 12px auto 0 3px;
         }
     }
 }

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -759,7 +759,6 @@
     }
 }
 
-#subscription_overlay .stream-description .sub-stream-description:empty::after,
 .stream-row .sub-info-box .description:empty::after {
     content: attr(data-no-description);
     font-style: italic;

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -222,7 +222,7 @@
 
     .subscriber_list_container {
         position: relative;
-        max-height: 300px;
+        max-height: 100%;
         overflow: auto;
         text-align: left;
         -webkit-overflow-scrolling: touch;

--- a/static/templates/stream_description.hbs
+++ b/static/templates/stream_description.hbs
@@ -1,0 +1,9 @@
+{{#if rendered_description}}
+<span class="sub-stream-description rendered_markdown">
+    {{rendered_markdown rendered_description}}
+</span>
+{{else}}
+<span class="sub-stream-description no-description">
+    {{t "This stream does not yet have a description." }}
+</span>
+{{/if}}

--- a/static/templates/stream_types.hbs
+++ b/static/templates/stream_types.hbs
@@ -6,8 +6,8 @@
         </h4>
         {{#each stream_privacy_policy_values}}
         <div class="radio-input-parent">
-            <input type="radio" name="privacy" value="{{ this.code }}" {{#if (eq this.code ../stream_privacy_policy) }}checked{{/if}} />
             <label class="radio">
+                <input type="radio" name="privacy" value="{{ this.code }}" {{#if (eq this.code ../stream_privacy_policy) }}checked{{/if}} />
                 <b>{{ this.name }}:</b> {{ this.description }}
             </label>
         </div>
@@ -20,8 +20,8 @@
         </h4>
         {{#each stream_post_policy_values}}
         <div class="radio-input-parent">
-            <input type="radio" name="stream-post-policy" value="{{ this.code }}" {{#if (eq this.code ../stream_post_policy) }}checked{{/if}} />
             <label class="radio">
+                <input type="radio" name="stream-post-policy" value="{{ this.code }}" {{#if (eq this.code ../stream_post_policy) }}checked{{/if}} />
                 {{ this.description }}
             </label>
         </div>

--- a/static/templates/stream_types.hbs
+++ b/static/templates/stream_types.hbs
@@ -37,9 +37,9 @@
         {{> settings/upgrade_tip_widget}}
 
         <div class="input-group inline-block message-retention-setting-group">
-            <label for="stream_message_retention_setting" class="dropdown-title">{{t "Message retention period" }}
+            <div class="dropdown-title">{{t "Message retention period" }}
                 <i class="fa fa-info-circle settings-info-icon stream_message_retention_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can change stream message retention policy.' }}"></i>
-            </label>
+            </div>
             <select name="stream_message_retention_setting"
               class="stream_message_retention_setting" class="prop-element"
               {{#if disable_message_retention_setting}}disabled{{/if}}>

--- a/static/templates/subscription_members.hbs
+++ b/static/templates/subscription_members.hbs
@@ -1,9 +1,9 @@
 {{#render_subscribers}}
 <div class="subscriber_list_settings_container" {{#unless can_access_subscribers}}style="display: none"{{/unless}}>
     <div class="subscriber_list_settings">
-        <label class="sub_settings_title float-left">
+        <h3 class="stream_setting_subsection_title float-left">
             {{t "Stream membership" }}
-        </label>
+        </h3>
         <div class="subscriber-search float-right">
             <input type="text" class="search" placeholder="{{t 'Search subscribers' }}" />
         </div>

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -47,22 +47,20 @@
             </div>
             {{/with}}
             <div class="stream-email-box" {{#unless sub.email_address}}style="display: none;"{{/unless}}>
-                <label class="sub_settings_title">
+                <h3 class="stream_setting_subsection_title">
                     {{t "Email address" }}
                     {{> help_link_widget link="/help/message-a-stream-by-email" }}
-                </label>
+                </h3>
                 <div class="stream-email">
                     <span class="email-address">{{sub.email_address}}</span>
                 </div>
             </div>
         </div>
 
-        <div class="personal_settings stream_section collapse {{#sub.subscribed}}in{{/sub.subscribed}}">
-            <div id="personal_settings_label_container">
-                <label class="sub_settings_title inline-block">
-                    {{t "Personal settings" }}
-                </label>
-                <div id="stream_change_property_status{{sub.stream_id}}" class="alert-notification"></div>
+        <div id="personal-stream-settings" class="personal_settings stream_section collapse {{#sub.subscribed}}in{{/sub.subscribed}}">
+            <div class="subsection-header">
+                <h3 class="stream_setting_subsection_title inline-block">{{t "Personal settings" }}</h3>
+                <div id="stream_change_property_status{{sub.stream_id}}" class="stream_change_property_status alert-notification"></div>
             </div>
             <div class="subscription-config">
                 <ul class="grey-box">

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -33,9 +33,9 @@
                 </div>
             </div>
             <div class="stream-description">
-                <span class="sub-stream-description rendered_markdown" data-no-description="{{t 'No description.' }}">
-                    {{rendered_markdown rendered_description}}
-                </span>
+                {{> stream_description
+                  rendered_description=rendered_description
+                  }}
             </div>
             <div class="subscription-type">
                 <div class="subscription-type-text">

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -46,6 +46,15 @@
                 <a class="change-stream-privacy" {{#unless can_change_stream_permissions}}style="display: none;"{{/unless}}>[{{t "Change" }}]</a>
             </div>
             {{/with}}
+            <div class="stream-email-box" {{#unless sub.email_address}}style="display: none;"{{/unless}}>
+                <label class="sub_settings_title">
+                    {{t "Email address" }}
+                    {{> help_link_widget link="/help/message-a-stream-by-email" }}
+                </label>
+                <div class="stream-email">
+                    <span class="email-address">{{sub.email_address}}</span>
+                </div>
+            </div>
         </div>
 
         <div class="personal_settings stream_section collapse {{#sub.subscribed}}in{{/sub.subscribed}}">
@@ -81,15 +90,6 @@
         </div>
 
         <div class="subscriber_settings stream_section">
-            <div class="stream-email-box" {{#unless sub.email_address}}style="display: none;"{{/unless}}>
-                <label class="sub_settings_title">
-                    {{t "Email address" }}
-                    {{> help_link_widget link="/help/message-a-stream-by-email" }}
-                </label>
-                <div class="stream-email">
-                    <span class="email-address">{{sub.email_address}}</span>
-                </div>
-            </div>
             {{#with sub}}
             <div class="subscription-members-setting">
                 {{> subscription_members}}

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -42,6 +42,7 @@
                     {{t "Stream permissions" }}
                 </h3>
                 {{#if can_change_stream_permissions}}
+                <div class="stream_permission_change_info alert-notification"></div>
                 <div class="button-group">
                     <a class="change-stream-privacy button rounded small btn-warning" role="button">
                         <i class="fa fa-pencil" aria-hidden="true"></i>

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -1,7 +1,22 @@
+<div class="stream_settings_header" data-stream-id="{{sub.stream_id}}">
+    <div class="tab-container"></div>
+    {{#with sub}}
+    <div class="button-group">
+        <div class="sub_unsub_button_wrapper inline-block">
+            <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}}title="{{t 'Toggle subscription'}} (S)" {{else}}disabled="disabled"{{/if}}>
+                {{#if subscribed }}{{#tr}}Unsubscribe{{/tr}}{{else}}{{#tr}}Subscribe{{/tr}}{{/if}}</button>
+        </div>
+        <a href="{{preview_url}}" class="button small rounded" id="preview-stream-button" role="button" title="{{t 'View stream'}} (V)" {{#unless should_display_preview_button }}style="display: none"{{/unless}}><i class="fa fa-eye"></i></a>
+        {{#if is_realm_admin}}
+        <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Archive stream'}}"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
+        {{/if}}
+    </div>
+    {{/with}}
+</div>
 <div class="subscription_settings" data-stream-id="{{sub.stream_id}}">
     <div class="inner-box">
 
-        <div class="general_settings">
+        <div class="general_settings stream_section">
             {{#with sub}}
             <div class="stream-header">
                 {{> subscription_privacy
@@ -15,14 +30,6 @@
                     <button id="open_stream_info_modal" class="button rounded small btn-warning" title="{{t 'Change stream info' }}">
                         <i class="fa fa-pencil" aria-hidden="true"></i>
                     </button>
-                    <div class="sub_unsub_button_wrapper inline-block">
-                        <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}}title="{{t 'Toggle subscription'}} (S)" {{else}}disabled="disabled"{{/if}}>
-                            {{#if subscribed }}{{#tr}}Unsubscribe{{/tr}}{{else}}{{#tr}}Subscribe{{/tr}}{{/if}}</button>
-                    </div>
-                    <a href="{{preview_url}}" class="button small rounded" id="preview-stream-button" role="button" title="{{t 'View stream'}} (V)" {{#unless should_display_preview_button }}style="display: none"{{/unless}}><i class="fa fa-eye"></i></a>
-                    {{#if is_realm_admin}}
-                    <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Archive stream for everyone'}}"> <i class="fa fa-archive" aria-hidden="true"></i></button>
-                    {{/if}}
                 </div>
             </div>
             <div class="stream-description">
@@ -41,7 +48,7 @@
             {{/with}}
         </div>
 
-        <div class="personal_settings collapse {{#sub.subscribed}}in{{/sub.subscribed}}">
+        <div class="personal_settings stream_section collapse {{#sub.subscribed}}in{{/sub.subscribed}}">
             <div id="personal_settings_label_container">
                 <label class="sub_settings_title inline-block">
                     {{t "Personal settings" }}
@@ -73,7 +80,7 @@
             </div>
         </div>
 
-        <div class="subscriber_settings">
+        <div class="subscriber_settings stream_section">
             <div class="stream-email-box" {{#unless sub.email_address}}style="display: none;"{{/unless}}>
                 <label class="sub_settings_title">
                     {{t "Email address" }}

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -37,13 +37,24 @@
                   rendered_description=rendered_description
                   }}
             </div>
+            <div class="stream_setting_subsection_header">
+                <h3 class="stream_setting_subsection_title">
+                    {{t "Stream permissions" }}
+                </h3>
+                {{#if can_change_stream_permissions}}
+                <div class="button-group">
+                    <a class="change-stream-privacy button rounded small btn-warning" role="button">
+                        <i class="fa fa-pencil" aria-hidden="true"></i>
+                    </a>
+                </div>
+                {{/if}}
+            </div>
             <div class="subscription-type">
                 <div class="subscription-type-text">
                     {{> subscription_type
                       stream_post_policy_values=../stream_post_policy_values
                       message_retention_text=../message_retention_text}}
                 </div>
-                <a class="change-stream-privacy" {{#unless can_change_stream_permissions}}style="display: none;"{{/unless}}>[{{t "Change" }}]</a>
             </div>
             {{/with}}
             <div class="stream-email-box" {{#unless sub.email_address}}style="display: none;"{{/unless}}>

--- a/static/templates/subscription_table_body.hbs
+++ b/static/templates/subscription_table_body.hbs
@@ -29,7 +29,6 @@
             </div>
             <div class="right">
                 <div class="display-type">
-                    <div id="add_new_stream_title" class="stream-info-title">{{t 'Create stream' }}</div>
                     <div id="stream_settings_title" class="stream-info-title">{{t 'Stream settings' }}</div>
                 </div>
                 <div class="nothing-selected">

--- a/static/templates/subscription_table_body.hbs
+++ b/static/templates/subscription_table_body.hbs
@@ -43,7 +43,7 @@
                     </span>
                     {{/if}}
                 </div>
-                <div class="settings" data-simplebar data-simplebar-auto-hide="false">
+                <div id="stream_settings" class="settings" data-simplebar data-simplebar-auto-hide="false">
                     {{!-- edit stream here --}}
                 </div>
                 {{> stream_creation_form }}

--- a/static/templates/subscription_type.hbs
+++ b/static/templates/subscription_type.hbs
@@ -2,8 +2,7 @@
     {{#if invite_only}}
     <li>
         {{#tr}}
-            This is a <z-icon></z-icon> <b>private stream</b>. Only people who have been invited can access its content, but any member of the stream can invite others.
-            {{#*inline "z-icon"}}<span class="fa fa-lock" aria-hidden="true"></span>{{/inline}}
+        This is a <b>private stream</b>. Only people who have been invited can access its content, but any member of the stream can invite others.
         {{/tr}}
     </li>
     <li>
@@ -14,15 +13,13 @@
     {{else if is_web_public}}
     <li>
         {{#tr}}
-            This is a <z-icon></z-icon> <b>web public stream</b>. Any member of the organization can join without an invitation and anyone on the internet can read the content published.
-            {{#*inline "z-icon"}}<i class="fa fa-globe" aria-hidden="true"></i>{{/inline}}
+        This is a <b>web public stream</b>. Any member of the organization can join without an invitation and anyone on the internet can read the content published.
         {{/tr}}
     </li>
     {{else}}
     <li>
         {{#tr}}
-            This is a <z-icon></z-icon> <b>public stream</b>. Any member of the organization can join without an invitation.
-            {{#*inline "z-icon"}}<i class="hash" aria-hidden="true"></i>{{/inline}}
+        This is a <b>public stream</b>. Any member of the organization can join without an invitation.
         {{/tr}}
     </li>
     {{/if}}

--- a/static/templates/subscription_type.hbs
+++ b/static/templates/subscription_type.hbs
@@ -1,29 +1,45 @@
-{{#if invite_only}}
-    {{#tr}}
-        This is a <z-icon></z-icon> <b>private stream</b>. Only people who have been invited can access its content, but any member of the stream can invite others.
-        {{#*inline "z-icon"}}<span class="fa fa-lock" aria-hidden="true"></span>{{/inline}}
-    {{/tr}}
-    {{#if history_public_to_subscribers}}{{t 'New members can view complete message history.' }}
-    {{else}}{{t 'New members can only see messages sent after they join.' }}
-    {{/if}}
+<ul>
+    {{#if invite_only}}
+    <li>
+        {{#tr}}
+            This is a <z-icon></z-icon> <b>private stream</b>. Only people who have been invited can access its content, but any member of the stream can invite others.
+            {{#*inline "z-icon"}}<span class="fa fa-lock" aria-hidden="true"></span>{{/inline}}
+        {{/tr}}
+    </li>
+    <li>
+        {{#if history_public_to_subscribers}}{{t 'New members can view complete message history.' }}
+        {{else}}{{t 'New members can only see messages sent after they join.' }}
+        {{/if}}
+    </li>
     {{else if is_web_public}}
-    {{#tr}}
-        This is a <z-icon></z-icon> <b>web public stream</b>. Any member of the organization can join without an invitation and anyone on the internet can read the content published.
-        {{#*inline "z-icon"}}<i class="fa fa-globe" aria-hidden="true"></i>{{/inline}}
-    {{/tr}}
-{{else}}
-    {{#tr}}
-        This is a <z-icon></z-icon> <b>public stream</b>. Any member of the organization can join without an invitation.
-        {{#*inline "z-icon"}}<i class="hash" aria-hidden="true"></i>{{/inline}}
-    {{/tr}}
-{{/if}}
-{{#if (eq stream_post_policy stream_post_policy_values.admins.code)}}
-{{t 'Only organization administrators can post.'}}
-{{else if (eq stream_post_policy stream_post_policy_values.moderators.code)}}
-{{t 'Only organization administrators and moderators can post.'}}
-{{else if (eq stream_post_policy stream_post_policy_values.non_new_members.code)}}
-{{t 'Only organization full members can post.'}}
-{{else}}
-{{t 'All stream members can post.'}}
-{{/if}}
-{{message_retention_text}}
+    <li>
+        {{#tr}}
+            This is a <z-icon></z-icon> <b>web public stream</b>. Any member of the organization can join without an invitation and anyone on the internet can read the content published.
+            {{#*inline "z-icon"}}<i class="fa fa-globe" aria-hidden="true"></i>{{/inline}}
+        {{/tr}}
+    </li>
+    {{else}}
+    <li>
+        {{#tr}}
+            This is a <z-icon></z-icon> <b>public stream</b>. Any member of the organization can join without an invitation.
+            {{#*inline "z-icon"}}<i class="hash" aria-hidden="true"></i>{{/inline}}
+        {{/tr}}
+    </li>
+    {{/if}}
+    <li>
+        {{#if (eq stream_post_policy stream_post_policy_values.admins.code)}}
+        {{t 'Only organization administrators can post.'}}
+        {{else if (eq stream_post_policy stream_post_policy_values.moderators.code)}}
+        {{t 'Only organization administrators and moderators can post.'}}
+        {{else if (eq stream_post_policy stream_post_policy_values.non_new_members.code)}}
+        {{t 'Only organization full members can post.'}}
+        {{else}}
+        {{t 'All stream members can post.'}}
+        {{/if}}
+    </li>
+    {{#if message_retention_text}}
+    <li>
+        {{message_retention_text}}
+    </li>
+    {{/if}}
+</ul>


### PR DESCRIPTION
Fixes: #14906
A follow up on #18872.

From https://github.com/zulip/zulip/pull/18872#issuecomment-870984616 following things have been implemented exactly:

On the common tabs system:
- [x]  Change the "Stream settings" in the top-left corner to use the Settings for #{stream_name}, and use the same font size we use for that area in "Manage streams" (but probably not small caps). We will likely want to iterate on this further after merging, but we should display clearly which stream is selected somewhere in the right side region.
On the "Subscribers" tab:

- [x] Move the "Email address" block to the bottom of "General", since that's where it belongs.
- [x] Change the users region to fill the full height of the page, rather than being fixed height.

On the "General" tab:

- [x] Show text like "This stream does not have a description configured" if no description is set.
- [x] Replace the "This is a public stream. Any member of the organization can join without an invitation.Only organization administrators can post." text, which now feels weirdly compressed given all the available space, with something that explains each value on a line by itself in a normal font size. A bulleted list might work as a first pass; we should try that and see if we need to do something harder.

**Few points whose implementation were tweaked to have a good design**
- [x] Change the title to "Subscribers" from "Stream membership". [For this we don't have enough space on the row containing tab widget, and increasing width for tab by `npx` will increase width of tab container by `3*npx` so it is not feasible.]. To solve it to some extent I have improved the title (**Stream membership**) in the content of that tab to be more clearly noticeable.
- [x] Make the design identical to how a normal "settings / organization settings" page works, i.e. remove the box, dividers, etc. 
[This was looking odd like few settings are scattered, so current UI for this looks way more clean, so I didn't do much here apart from improving display of **Personal Settings** title.]
![Untitled](https://user-images.githubusercontent.com/63504956/124813907-02771300-df83-11eb-81cc-6c0589a5221c.png)
**GIFs or screenshots:** 
![demo](https://user-images.githubusercontent.com/63504956/124800383-33e7e280-df73-11eb-9b04-87e6db8064a1.gif)
