### PR TITLE
compose: Open typeahead immediately when @ is entered.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1197,18 +1197,18 @@ test("begins_typeahead", ({override}) => {
     assert_stream_list(":tada: #foo");
     assert_typeahead_equals("#foo\n~~~py", lang_list);
 
-    assert_typeahead_equals("@", false);
-    assert_typeahead_equals("@_", false);
-    assert_typeahead_equals(" @", false);
-    assert_typeahead_equals(" @_", false);
+    assert_typeahead_equals("@", all_mentions);
+    assert_typeahead_equals("@_", people_only);
+    assert_typeahead_equals(" @", all_mentions);
+    assert_typeahead_equals(" @_", people_only);
     assert_typeahead_equals("test @**o", all_mentions);
     assert_typeahead_equals("test @_**o", people_only);
     assert_typeahead_equals("test @*o", all_mentions);
     assert_typeahead_equals("test @_*k", people_only);
     assert_typeahead_equals("test @*h", all_mentions);
     assert_typeahead_equals("test @_*h", people_only);
-    assert_typeahead_equals("test @", false);
-    assert_typeahead_equals("test @_", false);
+    assert_typeahead_equals("test @", all_mentions);
+    assert_typeahead_equals("test @_", people_only);
     assert_typeahead_equals("test no@o", false);
     assert_typeahead_equals("test no@_k", false);
     assert_typeahead_equals("@ ", false);

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -354,7 +354,7 @@ function filter_mention_name(current_token) {
     } else if (current_token.startsWith("*")) {
         current_token = current_token.slice(1);
     }
-    if (current_token.length < 1 || current_token.lastIndexOf("*") !== -1) {
+    if (current_token.length < 0 || current_token.lastIndexOf("*") !== -1) {
         return false;
     }
 
@@ -648,7 +648,7 @@ export function get_candidates(query) {
             current_token = current_token.slice(1);
         }
         current_token = filter_mention_name(current_token);
-        if (!current_token) {
+        if (!current_token && current_token !== "") {
             this.completing = null;
             return false;
         }


### PR DESCRIPTION
'filter_mention_name' in 'composebox_typeahead.js' now also
accepts since there is no charater after @. Now it will return
an empty string which will be rejected by if block in
get_candidates, hence changes were made to let the empty string pass.

Changes were made to  node tests becuase now '@', '@\_', ' @' and
' @\_' (and similar cases with a string before), won't return false

Fixes #19142.

**GIFs or screenshots:** 
Before: 

![mention-before](https://user-images.githubusercontent.com/49791933/124820386-0a3ab580-df8b-11eb-9452-d24d511f9977.gif)

After: 

![mention-after](https://user-images.githubusercontent.com/49791933/124820418-16267780-df8b-11eb-811d-9cb761f9c6fc.gif)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
