### PR TITLE
Merge settings api

### DIFF
--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -289,7 +289,14 @@ class OpenAPIArgumentsTest(ZulipTestCase):
 
     # Endpoints where the documentation is currently failing our
     # consistency tests.  We aim to keep this list empty.
-    buggy_documentation_endpoints: Set[str] = set([])
+    buggy_documentation_endpoints: Set[str] = {
+        # These endpoints were merged with the main /settings
+        # endpoint, and exist for temporary backwards-compatibility;
+        # as a result their documentation reflects the state before
+        # they were removed.
+        "/settings/display",
+        "/settings/notifications",
+    }
 
     def convert_regex_to_url_pattern(self, regex_pattern: str) -> str:
         """Convert regular expressions style URL patterns to their

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -322,16 +322,6 @@ class ChangeSettingsTest(ZulipTestCase):
             )
             self.assert_json_error(result, "Your Zulip password is managed in LDAP")
 
-    def test_changing_nothing_returns_error(self) -> None:
-        """
-        We need to supply at least one non-empty parameter
-        to this API, or it should fail.  (Eventually, we should
-        probably use a patch interface for these changes.)
-        """
-        self.login("hamlet")
-        result = self.client_patch("/json/settings", dict(old_password="ignored"))
-        self.assert_json_error(result, "Please fill out all fields.")
-
     def do_test_change_user_display_setting(self, setting_name: str) -> None:
 
         test_changes: Dict[str, Any] = dict(

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -97,9 +97,6 @@ def json_change_settings(
     old_password: str = REQ(default=""),
     new_password: str = REQ(default=""),
 ) -> HttpResponse:
-    if not (full_name or new_password or email):
-        raise JsonableError(_("Please fill out all fields."))
-
     if new_password != "":
         return_data: Dict[str, Any] = {}
         if email_belongs_to_ldap(user_profile.realm, user_profile.delivery_email):

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -87,6 +87,10 @@ def confirm_email_change(request: HttpRequest, confirmation_key: str) -> HttpRes
     return render(request, "confirmation/confirm_email_change.html", context=ctx)
 
 
+emojiset_choices = {emojiset["key"] for emojiset in UserProfile.emojiset_choices()}
+default_view_options = ["recent_topics", "all_messages"]
+
+
 @human_users_only
 @has_request_variables
 def json_change_settings(
@@ -96,7 +100,74 @@ def json_change_settings(
     email: str = REQ(default=""),
     old_password: str = REQ(default=""),
     new_password: str = REQ(default=""),
+    twenty_four_hour_time: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    dense_mode: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    starred_message_counts: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    fluid_layout_width: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    high_contrast_mode: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    color_scheme: Optional[int] = REQ(
+        json_validator=check_int_in(UserProfile.COLOR_SCHEME_CHOICES), default=None
+    ),
+    translate_emoticons: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    default_language: Optional[str] = REQ(default=None),
+    default_view: Optional[str] = REQ(
+        str_validator=check_string_in(default_view_options), default=None
+    ),
+    left_side_userlist: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    emojiset: Optional[str] = REQ(str_validator=check_string_in(emojiset_choices), default=None),
+    demote_inactive_streams: Optional[int] = REQ(
+        json_validator=check_int_in(UserProfile.DEMOTE_STREAMS_CHOICES), default=None
+    ),
+    timezone: Optional[str] = REQ(
+        str_validator=check_string_in(pytz.all_timezones_set), default=None
+    ),
+    enable_stream_desktop_notifications: Optional[bool] = REQ(
+        json_validator=check_bool, default=None
+    ),
+    enable_stream_email_notifications: Optional[bool] = REQ(
+        json_validator=check_bool, default=None
+    ),
+    enable_stream_push_notifications: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    enable_stream_audible_notifications: Optional[bool] = REQ(
+        json_validator=check_bool, default=None
+    ),
+    wildcard_mentions_notify: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    notification_sound: Optional[str] = REQ(default=None),
+    enable_desktop_notifications: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    enable_sounds: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    enable_offline_email_notifications: Optional[bool] = REQ(
+        json_validator=check_bool, default=None
+    ),
+    enable_offline_push_notifications: Optional[bool] = REQ(
+        json_validator=check_bool, default=None
+    ),
+    enable_online_push_notifications: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    enable_digest_emails: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    enable_login_emails: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    enable_marketing_emails: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    message_content_in_email_notifications: Optional[bool] = REQ(
+        json_validator=check_bool, default=None
+    ),
+    pm_content_in_desktop_notifications: Optional[bool] = REQ(
+        json_validator=check_bool, default=None
+    ),
+    desktop_icon_count_display: Optional[int] = REQ(json_validator=check_int, default=None),
+    realm_name_in_notifications: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    presence_enabled: Optional[bool] = REQ(json_validator=check_bool, default=None),
 ) -> HttpResponse:
+    # We can't use REQ for this widget because
+    # get_available_language_codes requires provisioning to be
+    # complete.
+    if default_language is not None and default_language not in get_available_language_codes():
+        raise JsonableError(_("Invalid default_language"))
+
+    if (
+        notification_sound is not None
+        and notification_sound not in get_available_notification_sounds()
+        and notification_sound != "none"
+    ):
+        raise JsonableError(_("Invalid notification sound '{}'").format(notification_sound))
+
     if new_password != "":
         return_data: Dict[str, Any] = {}
         if email_belongs_to_ldap(user_profile.realm, user_profile.delivery_email):
@@ -173,107 +244,14 @@ def json_change_settings(
             # Note that check_change_full_name strips the passed name automatically
             result["full_name"] = check_change_full_name(user_profile, full_name, user_profile)
 
-    return json_success(result)
-
-
-emojiset_choices = {emojiset["key"] for emojiset in UserProfile.emojiset_choices()}
-default_view_options = ["recent_topics", "all_messages"]
-
-
-@human_users_only
-@has_request_variables
-def update_display_settings_backend(
-    request: HttpRequest,
-    user_profile: UserProfile,
-    twenty_four_hour_time: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    dense_mode: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    starred_message_counts: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    fluid_layout_width: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    high_contrast_mode: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    color_scheme: Optional[int] = REQ(
-        json_validator=check_int_in(UserProfile.COLOR_SCHEME_CHOICES), default=None
-    ),
-    translate_emoticons: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    default_language: Optional[str] = REQ(default=None),
-    default_view: Optional[str] = REQ(
-        str_validator=check_string_in(default_view_options), default=None
-    ),
-    left_side_userlist: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    emojiset: Optional[str] = REQ(str_validator=check_string_in(emojiset_choices), default=None),
-    demote_inactive_streams: Optional[int] = REQ(
-        json_validator=check_int_in(UserProfile.DEMOTE_STREAMS_CHOICES), default=None
-    ),
-    timezone: Optional[str] = REQ(
-        str_validator=check_string_in(pytz.all_timezones_set), default=None
-    ),
-) -> HttpResponse:
-
-    # We can't use REQ for this widget because
-    # get_available_language_codes requires provisioning to be
-    # complete.
-    if default_language is not None and default_language not in get_available_language_codes():
-        raise JsonableError(_("Invalid default_language"))
-
+    # Loop over user_profile.property_types
     request_settings = {k: v for k, v in list(locals().items()) if k in user_profile.property_types}
-    result: Dict[str, Any] = {}
     for k, v in list(request_settings.items()):
         if v is not None and getattr(user_profile, k) != v:
             do_set_user_display_setting(user_profile, k, v)
             result[k] = v
 
-    return json_success(result)
-
-
-@human_users_only
-@has_request_variables
-def json_change_notify_settings(
-    request: HttpRequest,
-    user_profile: UserProfile,
-    enable_stream_desktop_notifications: Optional[bool] = REQ(
-        json_validator=check_bool, default=None
-    ),
-    enable_stream_email_notifications: Optional[bool] = REQ(
-        json_validator=check_bool, default=None
-    ),
-    enable_stream_push_notifications: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    enable_stream_audible_notifications: Optional[bool] = REQ(
-        json_validator=check_bool, default=None
-    ),
-    wildcard_mentions_notify: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    notification_sound: Optional[str] = REQ(default=None),
-    enable_desktop_notifications: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    enable_sounds: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    enable_offline_email_notifications: Optional[bool] = REQ(
-        json_validator=check_bool, default=None
-    ),
-    enable_offline_push_notifications: Optional[bool] = REQ(
-        json_validator=check_bool, default=None
-    ),
-    enable_online_push_notifications: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    enable_digest_emails: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    enable_login_emails: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    enable_marketing_emails: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    message_content_in_email_notifications: Optional[bool] = REQ(
-        json_validator=check_bool, default=None
-    ),
-    pm_content_in_desktop_notifications: Optional[bool] = REQ(
-        json_validator=check_bool, default=None
-    ),
-    desktop_icon_count_display: Optional[int] = REQ(json_validator=check_int, default=None),
-    realm_name_in_notifications: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    presence_enabled: Optional[bool] = REQ(json_validator=check_bool, default=None),
-) -> HttpResponse:
-    result = {}
-
-    # Stream notification settings.
-
-    if (
-        notification_sound is not None
-        and notification_sound not in get_available_notification_sounds()
-        and notification_sound != "none"
-    ):
-        raise JsonableError(_("Invalid notification sound '{}'").format(notification_sound))
-
+    # Loop over user_profile.notification_settings_types
     req_vars = {
         k: v for k, v in list(locals().items()) if k in user_profile.notification_setting_types
     }

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -182,11 +182,9 @@ from zerver.views.user_settings import (
     change_enter_sends,
     confirm_email_change,
     delete_avatar_backend,
-    json_change_notify_settings,
     json_change_settings,
     regenerate_api_key,
     set_avatar_backend,
-    update_display_settings_backend,
 )
 from zerver.views.users import (
     add_bot_backend,
@@ -414,8 +412,10 @@ v1_api_and_json_patterns = [
     ),
     # settings -> zerver.views.user_settings
     rest_path("settings", PATCH=json_change_settings),
-    rest_path("settings/display", PATCH=update_display_settings_backend),
-    rest_path("settings/notifications", PATCH=json_change_notify_settings),
+    # These next two are legacy aliases for /settings, from before
+    # we merged the endpoints.
+    rest_path("settings/display", PATCH=json_change_settings),
+    rest_path("settings/notifications", PATCH=json_change_settings),
     # users/me/alert_words -> zerver.views.alert_words
     rest_path(
         "users/me/alert_words",


### PR DESCRIPTION
settings: Merge settings API endpoints.

This API change removes unnecessary complexity from a client that
wants to change a user's personal settings, and also saves developers
from needing to make decisions about what sort of setting something is
at the API level.

We preserve the old settings endpoints as mapping to the same function
as the new one for backwards-compatibility.

TODOs include:
* Manual testing.
* Adjusting the API documentation.
* Changing the webapp to use the post-migration endpoint.
* As followup work, merging the `property_types` and `notification_settings_types`
  lists to a single list, and potentially deduplicating tests and the like.
