### PR TITLE
test_script: Use alphabetically first matches in find_js_test_files

### DIFF
--- a/tools/lib/test_script.py
+++ b/tools/lib/test_script.py
@@ -105,12 +105,10 @@ def add_provision_check_override_param(parser: ArgumentParser) -> None:
 def find_js_test_files(test_dir: str, files: Iterable[str]) -> List[str]:
     test_files = []
     for file in files:
-        for file_name in os.listdir(test_dir):
-            if file_name.startswith(file):
-                file = file_name
-                break
-        if not os.path.exists(file):
-            file = os.path.join(test_dir, file)
+        file = min(
+            (file_name for file_name in os.listdir(test_dir) if file_name.startswith(file)),
+            default=os.path.join(test_dir, file),
+        )
         test_files.append(os.path.abspath(file))
 
     if not test_files:


### PR DESCRIPTION
Otherwise the behavior depends on the filesystem order.