### PR TITLE
compose: Add alert for resolved topic.

### DIFF
--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -18,6 +18,7 @@ const ui_util = mock_esm("../../static/js/ui_util");
 
 const compose_pm_pill = zrequire("compose_pm_pill");
 const compose_validate = zrequire("compose_validate");
+const message_edit = zrequire("message_edit");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const settings_config = zrequire("settings_config");
@@ -754,4 +755,54 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
     compose_validate.warn_if_mentioning_unsubscribed_user(mentioned);
     assert.equal($("#compose_invite_users").visible(), true);
     assert.ok(looked_for_existing);
+});
+
+test_ui("test clear_topic_resolved_warning", () => {
+    $("#compose_resolved_topic").show();
+    $("#compose-send-status").show();
+
+    compose_validate.clear_topic_resolved_warning();
+
+    assert.ok(!$("#compose_resolved_topic").visible());
+    assert.ok(!$("#compose-send-status").visible());
+});
+
+test_ui("test warn_if_topic_resolved", ({override, mock_template}) => {
+    override(settings_data, "user_can_move_messages_between_streams", () => true);
+
+    mock_template("compose_resolved_topic.hbs", false, (context) => {
+        assert.ok(context.can_move_topic);
+        assert.ok(context.topic_name.startsWith(message_edit.RESOLVED_TOPIC_PREFIX));
+        return "fake-compose_resolved_topic";
+    });
+
+    const sub = {
+        stream_id: 111,
+        name: "random",
+    };
+    stream_data.add_sub(sub);
+
+    // The error message area where it is shown
+    const error_area = $("#compose_resolved_topic");
+    error_area.html("");
+
+    compose_state.set_message_type("stream");
+    compose_state.stream_name("Do not exist");
+    compose_state.topic(message_edit.RESOLVED_TOPIC_PREFIX + "hello");
+
+    // Do not show a warning if stream name does not exist
+    compose_validate.warn_if_topic_resolved();
+    assert.ok(!error_area.visible());
+
+    compose_state.stream_name("random");
+
+    // Show the warning now as stream also exists
+    compose_validate.warn_if_topic_resolved();
+    assert.ok(error_area.visible());
+
+    compose_state.topic("hello");
+
+    // The warning will be cleared now
+    compose_validate.warn_if_topic_resolved();
+    assert.ok(!error_area.visible());
 });

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -17,6 +17,7 @@ import * as giphy from "./giphy";
 import {$t, $t_html} from "./i18n";
 import * as loading from "./loading";
 import * as markdown from "./markdown";
+import * as message_edit from "./message_edit";
 import * as notifications from "./notifications";
 import {page_params} from "./page_params";
 import * as people from "./people";
@@ -95,6 +96,7 @@ function update_fade() {
     }
 
     const msg_type = compose_state.get_message_type();
+    compose_validate.warn_if_topic_resolved();
     compose_fade.set_focused_recipient(msg_type);
     compose_fade.update_all();
 }
@@ -471,6 +473,27 @@ export function initialize() {
         event.preventDefault();
 
         $("#compose-send-status").hide();
+    });
+
+    $("#compose_resolved_topic").on("click", ".compose_unresolve_topic", (event) => {
+        event.preventDefault();
+
+        const target = $(event.target).parents(".compose_resolved_topic");
+        const stream_name = target.attr("data-stream-name");
+        const topic_name = target.attr("data-topic-name");
+
+        const stream_id = stream_data.get_sub(stream_name).stream_id;
+
+        message_edit.with_first_message_id(stream_id, topic_name, (message_id) => {
+            message_edit.toggle_resolve_topic(message_id, topic_name);
+            compose_validate.clear_topic_resolved_warning();
+        });
+    });
+
+    $("#compose_resolved_topic").on("click", ".compose_resolved_topic_close", (event) => {
+        event.preventDefault();
+
+        compose_validate.clear_topic_resolved_warning();
     });
 
     $("#compose_invite_users").on("click", ".compose_invite_link", (event) => {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -106,6 +106,7 @@ function clear_box() {
     compose.clear_invites();
 
     // TODO: Better encapsulate at-mention warnings.
+    compose_validate.clear_topic_resolved_warning();
     compose_validate.clear_all_everyone_warnings();
     compose_validate.clear_announce_warnings();
     compose.clear_private_stream_alert();
@@ -273,6 +274,9 @@ export function start(msg_type, opts) {
 
     // Show either stream/topic fields or "You and" field.
     show_box(msg_type, opts);
+
+    // Show a warning if topic is resolved
+    compose_validate.warn_if_topic_resolved();
 
     // Reset the `max-height` property of `compose-textarea` so that the
     // compose-box do not cover the last messages of the current stream
@@ -447,6 +451,7 @@ export function on_topic_narrow() {
     // See #3300 for context--a couple users specifically asked for
     // this convenience.
     compose_state.topic(narrow_state.topic());
+    compose_validate.warn_if_topic_resolved();
     compose_fade.set_focused_recipient("stream");
     compose_fade.update_message_list();
     $("#compose-textarea").trigger("focus").trigger("select");

--- a/static/js/compose_validate.js
+++ b/static/js/compose_validate.js
@@ -5,12 +5,14 @@ import render_compose_announce from "../templates/compose_announce.hbs";
 import render_compose_invite_users from "../templates/compose_invite_users.hbs";
 import render_compose_not_subscribed from "../templates/compose_not_subscribed.hbs";
 import render_compose_private_stream_alert from "../templates/compose_private_stream_alert.hbs";
+import render_compose_resolved_topic from "../templates/compose_resolved_topic.hbs";
 
 import * as channel from "./channel";
 import * as compose_error from "./compose_error";
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
 import {$t_html} from "./i18n";
+import * as message_edit from "./message_edit";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as people from "./people";
@@ -160,6 +162,40 @@ export function warn_if_mentioning_unsubscribed_user(mentioned) {
         }
 
         error_area.show();
+    }
+}
+
+export function clear_topic_resolved_warning() {
+    $("#compose_resolved_topic").hide();
+    $("#compose_resolved_topic").empty();
+    $("#compose-send-status").hide();
+}
+
+export function warn_if_topic_resolved() {
+    const stream_name = compose_state.stream_name();
+    const topic_name = compose_state.topic();
+
+    const sub = stream_data.get_sub(stream_name);
+
+    if (sub && topic_name.startsWith(message_edit.RESOLVED_TOPIC_PREFIX)) {
+        const error_area = $("#compose_resolved_topic");
+
+        if (error_area.html()) {
+            clear_topic_resolved_warning(); // This warning already exists
+        }
+
+        const context = {
+            stream_name,
+            topic_name,
+            can_move_topic: settings_data.user_can_move_messages_between_streams(),
+        };
+
+        const new_row = render_compose_resolved_topic(context);
+        error_area.append(new_row);
+
+        error_area.show();
+    } else {
+        clear_topic_resolved_warning();
     }
 }
 

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -1103,3 +1103,40 @@ export function move_topic_containing_message_to_stream(
         },
     });
 }
+
+export function with_first_message_id(stream_id, topic_name, success_cb, error_cb) {
+    // The API endpoint for editing messages to change their
+    // content, topic, or stream requires a message ID.
+    //
+    // Because we don't have full data in the browser client, it's
+    // possible that we might display a topic in the left sidebar
+    // (and thus expose the UI for moving its topic to another
+    // stream) without having a message ID that is definitely
+    // within the topic.  (The comments in stream_topic_history.js
+    // discuss the tricky issues around message deletion that are
+    // involved here).
+    //
+    // To ensure this option works reliably at a small latency
+    // cost for a rare operation, we just ask the server for the
+    // latest message ID in the topic.
+    const data = {
+        anchor: "newest",
+        num_before: 1,
+        num_after: 0,
+        narrow: JSON.stringify([
+            {operator: "stream", operand: stream_id},
+            {operator: "topic", operand: topic_name},
+        ]),
+    };
+
+    channel.get({
+        url: "/json/messages",
+        data,
+        idempotent: true,
+        success(data) {
+            const message_id = data.messages[0].id;
+            success_cb(message_id);
+        },
+        error_cb,
+    });
+}

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -5,6 +5,7 @@ import {all_messages_data} from "./all_messages_data";
 import * as channel from "./channel";
 import * as compose_fade from "./compose_fade";
 import * as compose_state from "./compose_state";
+import * as compose_validate from "./compose_validate";
 import * as condense from "./condense";
 import * as huddle_data from "./huddle_data";
 import * as message_edit from "./message_edit";
@@ -218,6 +219,7 @@ export function update_messages(events) {
             ) {
                 changed_compose = true;
                 compose_state.topic(new_topic);
+                compose_validate.warn_if_topic_resolved();
                 compose_fade.set_focused_recipient("stream");
             }
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -573,43 +573,6 @@ export function register_stream_handlers() {
     });
 }
 
-function with_first_message_id(stream_id, topic_name, success_cb, error_cb) {
-    // The API endpoint for editing messages to change their
-    // content, topic, or stream requires a message ID.
-    //
-    // Because we don't have full data in the browser client, it's
-    // possible that we might display a topic in the left sidebar
-    // (and thus expose the UI for moving its topic to another
-    // stream) without having a message ID that is definitely
-    // within the topic.  (The comments in stream_topic_history.js
-    // discuss the tricky issues around message deletion that are
-    // involved here).
-    //
-    // To ensure this option works reliably at a small latency
-    // cost for a rare operation, we just ask the server for the
-    // latest message ID in the topic.
-    const data = {
-        anchor: "newest",
-        num_before: 1,
-        num_after: 0,
-        narrow: JSON.stringify([
-            {operator: "stream", operand: stream_id},
-            {operator: "topic", operand: topic_name},
-        ]),
-    };
-
-    channel.get({
-        url: "/json/messages",
-        data,
-        idempotent: true,
-        success(data) {
-            const message_id = data.messages[0].id;
-            success_cb(message_id);
-        },
-        error_cb,
-    });
-}
-
 export function register_topic_handlers() {
     // Mute the topic
     $("body").on("click", ".sidebar-popover-mute-topic", (e) => {
@@ -684,7 +647,7 @@ export function register_topic_handlers() {
         const topic_row = $(e.currentTarget);
         const stream_id = Number.parseInt(topic_row.attr("data-stream-id"), 10);
         const topic_name = topic_row.attr("data-topic-name");
-        with_first_message_id(stream_id, topic_name, (message_id) => {
+        message_edit.with_first_message_id(stream_id, topic_name, (message_id) => {
             message_edit.toggle_resolve_topic(message_id, topic_name);
         });
 
@@ -743,7 +706,7 @@ export function register_topic_handlers() {
         }
 
         message_edit.show_topic_move_spinner();
-        with_first_message_id(
+        message_edit.with_first_message_id(
             current_stream_id,
             old_topic_name,
             (message_id) => {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -240,6 +240,7 @@
     display: none;
 }
 
+.compose_resolved_topic,
 .compose_invite_user,
 .compose_private_stream_alert,
 .compose-all-everyone,
@@ -256,6 +257,7 @@
     right: 10px;
 }
 
+.compose_resolved_topic_close,
 .compose_invite_close,
 .compose_private_stream_alert_close {
     display: inline-block;
@@ -264,6 +266,7 @@
     width: 10px;
 }
 
+.compose_resolved_topic_user_controls,
 .compose-all-everyone-controls,
 .compose-announce-controls,
 .compose_invite_user_controls,

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -48,6 +48,7 @@
             <span class="compose-send-status-close">&times;</span>
             <span id="compose-error-msg"></span>
         </div>
+        <div id="compose_resolved_topic" class="alert home-error-bar"></div>
         <div id="compose_invite_users" class="alert home-error-bar"></div>
         <div id="compose-all-everyone" class="alert home-error-bar"></div>
         <div id="compose-announce" class="alert home-error-bar"></div>

--- a/static/templates/compose_resolved_topic.hbs
+++ b/static/templates/compose_resolved_topic.hbs
@@ -1,0 +1,9 @@
+<div class="compose_resolved_topic" data-stream-name="{{stream_name}}" data-topic-name="{{topic_name}}">
+    <p>{{#tr}} You are sending a message to a resolved topic. You can send as-is or unresolve the topic first. {{/tr}}</p>
+    <div class="compose_resolved_topic_user_controls">
+        {{#if can_move_topic}}
+        <button class="btn btn-warning compose_unresolve_topic" >{{t "Unresolve topic" }}</button>
+        {{/if}}
+        <button type="button" class="compose_resolved_topic_close close">&times;</button>
+    </div>
+</div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#18751

**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
I am currently stuck at:
1. When I change the URL, or say click on some other topic, the `input change` listener is not called. How the topic is changed, etc, so manually add the function there. [**Fixed**]

A gif to show what I am talking about where I am stuck.
![resolve_toppic](https://user-images.githubusercontent.com/56730716/127218942-d2d4ef25-a5ce-4b8a-a9f8-ade1446a2e18.gif)
