### PR TITLE
Remove Markdown mangling to convert upload URLs from relative to absolute and back to relative

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -394,9 +394,7 @@ test_ui("send_message", ({override}) => {
             stub_state.reify_message_id_checked += 1;
         });
 
-        // Setting message content with a host server link and we will assert
-        // later that this has been converted to a relative link.
-        $("#compose-textarea").val("[foobar](https://foo.com/user_uploads/123456)");
+        $("#compose-textarea").val("[foobar](/user_uploads/123456)");
         $("#compose-textarea").trigger("blur");
         $("#compose-send-status").show();
         $("#compose-send-button").prop("disabled", true);

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -54,15 +54,6 @@ test("feature_check", ({override}) => {
     assert.ok(!upload_button.hasClass("notdisplayed"));
 });
 
-test("make_upload_absolute", () => {
-    let uri = "/user_uploads/5/d4/6lSlfIPIg9nDI2Upj0Mq_EbE/kerala.png";
-    const expected_uri = "https://foo.com/user_uploads/5/d4/6lSlfIPIg9nDI2Upj0Mq_EbE/kerala.png";
-    assert.equal(upload.make_upload_absolute(uri), expected_uri);
-
-    uri = "https://foo.com/user_uploads/5/d4/6lSlfIPIg9nDI2Upj0Mq_EbE/alappuzha.png";
-    assert.equal(upload.make_upload_absolute(uri), uri);
-});
-
 test("get_item", () => {
     assert.equal(upload.get_item("textarea", {mode: "compose"}), $("#compose-textarea"));
     assert.equal(
@@ -532,7 +523,7 @@ test("uppy_events", ({override}) => {
         assert.equal(old_syntax, "[translated: Uploading copenhagen.png…]()");
         assert.equal(
             new_syntax,
-            "[copenhagen.png](https://foo.com/user_uploads/4/cb/rue1c-MlMUjDAUdkRrEM4BTJ/copenhagen.png)",
+            "[copenhagen.png](/user_uploads/4/cb/rue1c-MlMUjDAUdkRrEM4BTJ/copenhagen.png)",
         );
         assert.equal(textarea, $("#compose-textarea"));
     });

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -54,19 +54,6 @@ import * as zcommand from "./zcommand";
 
 let uppy;
 
-export const uploads_domain = document.location.protocol + "//" + document.location.host;
-export const uploads_path = "/user_uploads";
-
-export const uploads_re = new RegExp(
-    "\\]\\(" + uploads_domain + "(" + uploads_path + "[^\\)]+)\\)",
-    "g",
-);
-
-function make_uploads_relative(content) {
-    // Rewrite uploads in Markdown links back to domain-relative form
-    return content.replace(uploads_re, "]($1)");
-}
-
 export function compute_show_video_chat_button() {
     const available_providers = page_params.realm_available_video_chat_providers;
     if (page_params.realm_video_chat_provider === available_providers.disabled.id) {
@@ -144,12 +131,10 @@ export function create_message_object() {
         topic = empty_topic_placeholder();
     }
 
-    const content = make_uploads_relative(compose_state.message_content());
-
     // Changes here must also be kept in sync with echo.try_deliver_locally
     const message = {
         type: compose_state.get_message_type(),
-        content,
+        content: compose_state.message_content(),
         sender_id: page_params.user_id,
         queue_id: page_params.queue_id,
         stream: "",

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -11,14 +11,6 @@ import {csrf_token} from "./csrf";
 import {$t} from "./i18n";
 import {page_params} from "./page_params";
 
-export function make_upload_absolute(uri) {
-    if (uri.startsWith(compose.uploads_path)) {
-        // Rewrite the URI to a usable link
-        return compose.uploads_domain + uri;
-    }
-    return uri;
-}
-
 // Show the upload button only if the browser supports it.
 export function feature_check(upload_button) {
     if (window.XMLHttpRequest && new window.XMLHttpRequest().upload) {
@@ -255,8 +247,7 @@ export function setup_upload(config) {
         if (config.mode === "compose" && !compose_state.composing()) {
             compose_actions.start("stream");
         }
-        const absolute_uri = make_upload_absolute(uri);
-        const filename_uri = "[" + filename + "](" + absolute_uri + ")";
+        const filename_uri = "[" + filename + "](" + uri + ")";
         compose_ui.replace_syntax(
             get_translated_status(file),
             filename_uri,

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -3,7 +3,6 @@ import ProgressBar from "@uppy/progress-bar";
 import XHRUpload from "@uppy/xhr-upload";
 import $ from "jquery";
 
-import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
 import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";


### PR DESCRIPTION
This feature is not useful and poorly implemented. These are the last few commits from #15979; see discussion there.