### PR TITLE
compose: Fix the color or expand/collapse compose box in night mode.

### DIFF
--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -403,6 +403,8 @@ on a dark background, and don't change the dark labels dark either. */
         border-right-color: hsl(235, 18%, 7%);
     }
 
+    .expand_composebox_button,
+    .collapse_composebox_button,
     #message_edit_tooltip,
     .clear_search_button,
     .clear_search_button:focus,
@@ -423,6 +425,8 @@ on a dark background, and don't change the dark labels dark either. */
         color: hsl(236, 33%, 80%);
     }
 
+    .expand_composebox_button:hover,
+    .collapse_composebox_button:hover,
     #message_edit_tooltip:hover,
     .clear_search_button:hover,
     #message_view_header .search_icon:hover,


### PR DESCRIPTION
Follow-up: #17667

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested hover effect also.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/56730716/124866934-dab39980-dfda-11eb-98b2-7ea8134cb432.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
