### PR TITLE
markdown: Change timezone to time zone in <time> tooltip.

### DIFF
--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -278,7 +278,7 @@ run_test("timestamp", ({mock_template}) => {
     assert.equal($timestamp.html(), '<i class="fa fa-clock-o"></i>\nThu, Jan 1 1970, 12:00 AM\n');
     assert.equal(
         $timestamp.attr("data-tippy-content"),
-        "Everyone sees this in their own timezone.\n<br/>\nYour time zone: UTC\n",
+        "Everyone sees this in their own time zone.\n<br/>\nYour time zone: UTC\n",
     );
     assert.equal($timestamp_invalid.text(), "never-been-set");
 });

--- a/static/templates/markdown_time_tooltip.hbs
+++ b/static/templates/markdown_time_tooltip.hbs
@@ -1,3 +1,3 @@
-{{t 'Everyone sees this in their own timezone.' }}
+{{t 'Everyone sees this in their own time zone.' }}
 <br/>
 {{t 'Your time zone:' }} {{ tz_offset_str }}


### PR DESCRIPTION
This makes it consistent with the second line.
https://chat.zulip.org/#narrow/stream/6-frontend/topic/.3Ctime.3E.20widget.20tooltip.2E/near/1227423
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/44665669/124874016-d68c7980-dfe4-11eb-841a-c0085027d950.png)
![image](https://user-images.githubusercontent.com/44665669/124874057-e015e180-dfe4-11eb-81ca-d5d6e9cc9b77.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
