### PR TITLE
notifications: Remove unused fields in notices.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -912,10 +912,6 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
 
     if user_message is not None:
         # If the user has read the message already, don't push-notify.
-        #
-        # TODO: It feels like this is already handled when things are
-        # put in the queue; maybe we should centralize this logic with
-        # the `zerver/tornado/event_queue.py` logic?
         if user_message.flags.read or user_message.flags.active_mobile_push_notification:
             return
 

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1363,7 +1363,6 @@ Output:
             message_id=message_id,
             acting_user_id=acting_user_id,
             private_message=kwargs.get("private_message", False),
-            stream_name=kwargs.get("stream_name", None),
             mentioned_user_group_id=kwargs.get("mentioned_user_group_id", None),
             idle=kwargs.get("idle", True),
             already_notified=kwargs.get(

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -63,7 +63,6 @@ class MissedMessageNotificationsTest(ZulipTestCase):
                 acting_user_id=2,
                 user_id=3,
                 private_message=False,
-                stream_name="Denmark",
                 flags=["mentioned"],
                 mentioned=True,
                 mentioned_user_group_id=33,
@@ -72,11 +71,9 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             self.assertTrue(mock_queue_json_publish.call_count, 2)
 
             push_notice = mock_queue_json_publish.call_args_list[0][0][1]
-            self.assertEqual(push_notice["stream_name"], "Denmark")
             self.assertEqual(push_notice["mentioned_user_group_id"], 33)
 
             email_notice = mock_queue_json_publish.call_args_list[1][0][1]
-            self.assertEqual(email_notice["stream_name"], "Denmark")
             self.assertEqual(email_notice["mentioned_user_group_id"], 33)
 
     def tornado_call(
@@ -212,7 +209,6 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             assert_maybe_enqueue_notifications_call_args(
                 args_dict=args_dict,
                 message_id=msg_id,
-                stream_name="Denmark",
                 already_notified={"email_notified": False, "push_notified": False},
             )
         destroy_event_queue(client_descriptor.event_queue.id)
@@ -250,7 +246,6 @@ class MissedMessageNotificationsTest(ZulipTestCase):
                 message_id=msg_id,
                 flags=["mentioned"],
                 mentioned=True,
-                stream_name="Denmark",
                 already_notified={"email_notified": True, "push_notified": True},
             )
         destroy_event_queue(client_descriptor.event_queue.id)
@@ -269,7 +264,6 @@ class MissedMessageNotificationsTest(ZulipTestCase):
                 message_id=msg_id,
                 flags=["wildcard_mentioned"],
                 wildcard_mention_notify=True,
-                stream_name="Denmark",
                 already_notified={"email_notified": True, "push_notified": True},
             )
         destroy_event_queue(client_descriptor.event_queue.id)
@@ -288,7 +282,6 @@ class MissedMessageNotificationsTest(ZulipTestCase):
                 args_dict=args_dict,
                 flags=["wildcard_mentioned"],
                 message_id=msg_id,
-                stream_name="Denmark",
                 already_notified={"email_notified": False, "push_notified": False},
             )
         destroy_event_queue(client_descriptor.event_queue.id)
@@ -309,7 +302,6 @@ class MissedMessageNotificationsTest(ZulipTestCase):
                 args_dict=args_dict,
                 message_id=msg_id,
                 flags=["wildcard_mentioned"],
-                stream_name="Denmark",
                 already_notified={"email_notified": False, "push_notified": False},
             )
         destroy_event_queue(client_descriptor.event_queue.id)
@@ -335,7 +327,6 @@ class MissedMessageNotificationsTest(ZulipTestCase):
                 message_id=msg_id,
                 flags=["wildcard_mentioned"],
                 wildcard_mention_notify=True,
-                stream_name="Denmark",
                 already_notified={"email_notified": True, "push_notified": True},
             )
         destroy_event_queue(client_descriptor.event_queue.id)
@@ -363,7 +354,6 @@ class MissedMessageNotificationsTest(ZulipTestCase):
                 message_id=msg_id,
                 flags=["mentioned"],
                 mentioned=True,
-                stream_name="Denmark",
                 mentioned_user_group_id=hamlet_and_cordelia.id,
                 already_notified={"email_notified": True, "push_notified": True},
             )
@@ -386,7 +376,6 @@ class MissedMessageNotificationsTest(ZulipTestCase):
                 message_id=msg_id,
                 stream_push_notify=True,
                 stream_email_notify=False,
-                stream_name="Denmark",
                 already_notified={"email_notified": False, "push_notified": True},
             )
         destroy_event_queue(client_descriptor.event_queue.id)
@@ -408,7 +397,6 @@ class MissedMessageNotificationsTest(ZulipTestCase):
                 message_id=msg_id,
                 stream_push_notify=False,
                 stream_email_notify=True,
-                stream_name="Denmark",
                 already_notified={"email_notified": True, "push_notified": False},
             )
         destroy_event_queue(client_descriptor.event_queue.id)
@@ -436,7 +424,6 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             assert_maybe_enqueue_notifications_call_args(
                 args_dict=args_dict,
                 message_id=msg_id,
-                stream_name="Denmark",
                 already_notified={"email_notified": False, "push_notified": False},
             )
         destroy_event_queue(client_descriptor.event_queue.id)
@@ -459,7 +446,6 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             assert_maybe_enqueue_notifications_call_args(
                 args_dict=args_dict,
                 message_id=msg_id,
-                stream_name="Denmark",
                 already_notified={"email_notified": False, "push_notified": False},
             )
         destroy_event_queue(client_descriptor.event_queue.id)

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -191,7 +191,6 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             message_id=message_id,
             mentioned=True,
             flags=["mentioned"],
-            stream_name="Scotland",
             already_notified={},
         )
 
@@ -320,7 +319,6 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             acting_user_id=hamlet.id,
             message_id=message_id,
             mentioned=True,
-            stream_name="Scotland",
             flags=["mentioned"],
             online_push_enabled=True,
             idle=False,
@@ -356,7 +354,6 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             user_id=cordelia.id,
             acting_user_id=hamlet.id,
             message_id=message_id,
-            stream_name="Scotland",
             online_push_enabled=True,
             idle=False,
             already_notified={},
@@ -394,7 +391,6 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             acting_user_id=self.example_user("hamlet").id,
             mentioned=True,
             flags=["mentioned"],
-            stream_name="Scotland",
             already_notified={},
         )
         self.assertEqual(info["enqueue_kwargs"], expected_enqueue_kwargs)
@@ -427,7 +423,6 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             message_id=message_id,
             wildcard_mention_notify=True,
             flags=["wildcard_mentioned"],
-            stream_name="Scotland",
             already_notified={},
         )
         self.assertEqual(info["enqueue_kwargs"], expected_enqueue_kwargs)
@@ -485,7 +480,6 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             message_id=message_id,
             mentioned=True,
             flags=["mentioned"],
-            stream_name="Scotland",
             idle=False,
             already_notified={},
         )


### PR DESCRIPTION
* `stream_name`
This field is actually redundant. The email/push notifications handlers
don't use that field from the dict, and they anyways query for the
message, so we're safe in deleting this field, even if in the future
we end up needing the stream name.

* `type` and `timestamp`
These are totally unused by the handlers, and aren't sent to push clients
either.