### PR TITLE
Fix loading indicator in night mode.

### DIFF
--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -225,3 +225,25 @@ test_message_policy(
     "realm_edit_topic_policy",
     settings_data.user_can_edit_topic_of_any_message,
 );
+
+run_test("using_dark_theme", () => {
+    page_params.color_scheme = settings_config.color_scheme_values.night.code;
+    assert.equal(settings_data.using_dark_theme(), true);
+
+    page_params.color_scheme = settings_config.color_scheme_values.automatic.code;
+
+    window.matchMedia = (query) => {
+        assert.equal(query, "(prefers-color-scheme: dark)");
+        return {matches: true};
+    };
+    assert.equal(settings_data.using_dark_theme(), true);
+
+    window.matchMedia = (query) => {
+        assert.equal(query, "(prefers-color-scheme: dark)");
+        return {matches: false};
+    };
+    assert.equal(settings_data.using_dark_theme(), false);
+
+    page_params.color_scheme = settings_config.color_scheme_values.day.code;
+    assert.equal(settings_data.using_dark_theme(), false);
+});

--- a/static/js/confirm_dialog.js
+++ b/static/js/confirm_dialog.js
@@ -40,12 +40,14 @@ export function hide_confirm_dialog_spinner() {
     $(".confirm_dialog_submit_button .loader").hide();
     $(".confirm_dialog_submit_button span").show();
     $(".confirm_dialog_submit_button").prop("disabled", false);
+    $("#confirm_dialog_modal .close-modal-btn").prop("disabled", false);
 }
 
 export function show_confirm_dialog_spinner() {
     $(".confirm_dialog_submit_button .loader").css("display", "inline-block");
     $(".confirm_dialog_submit_button span").hide();
     $(".confirm_dialog_submit_button").prop("disabled", true);
+    $("#confirm_dialog_modal .close-modal-btn").prop("disabled", true);
     if (!settings_data.using_dark_theme()) {
         $(".confirm_dialog_submit_button object").on("load", function () {
             const doc = this.getSVGDocument();

--- a/static/js/confirm_dialog.js
+++ b/static/js/confirm_dialog.js
@@ -5,6 +5,7 @@ import render_confirm_dialog_heading from "../templates/confirm_dialog_heading.h
 
 import * as blueslip from "./blueslip";
 import * as overlays from "./overlays";
+import * as settings_data from "./settings_data";
 
 /*
     Look for confirm_dialog in settings_user_groups
@@ -45,11 +46,13 @@ export function show_confirm_dialog_spinner() {
     $(".confirm_dialog_submit_button .loader").css("display", "inline-block");
     $(".confirm_dialog_submit_button span").hide();
     $(".confirm_dialog_submit_button").prop("disabled", true);
-    $(".confirm_dialog_submit_button object").on("load", function () {
-        const doc = this.getSVGDocument();
-        const $svg = $(doc).find("svg");
-        $svg.find("rect").css("fill", "#000");
-    });
+    if (!settings_data.using_dark_theme()) {
+        $(".confirm_dialog_submit_button object").on("load", function () {
+            const doc = this.getSVGDocument();
+            const $svg = $(doc).find("svg");
+            $svg.find("rect").css("fill", "#000");
+        });
+    }
 }
 
 export function launch(conf) {

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -203,11 +203,13 @@ export function show_message_edit_spinner(row) {
     row.find(".message_edit_save span").hide();
     row.find(".message_edit_save").addClass("disable-btn");
     row.find(".message_edit_cancel").addClass("disable-btn");
-    row.find("object").on("load", function () {
-        const doc = this.getSVGDocument();
-        const $svg = $(doc).find("svg");
-        $svg.find("rect").css("fill", "#000");
-    });
+    if (!settings_data.using_dark_theme()) {
+        row.find("object").on("load", function () {
+            const doc = this.getSVGDocument();
+            const $svg = $(doc).find("svg");
+            $svg.find("rect").css("fill", "#000");
+        });
+    }
 }
 
 export function show_topic_edit_spinner(row) {

--- a/static/js/realm_logo.js
+++ b/static/js/realm_logo.js
@@ -2,7 +2,7 @@ import $ from "jquery";
 
 import * as channel from "./channel";
 import {page_params} from "./page_params";
-import * as settings_config from "./settings_config";
+import * as settings_data from "./settings_data";
 import * as upload_widget from "./upload_widget";
 
 export function build_realm_logo_widget(upload_function, is_night) {
@@ -82,14 +82,7 @@ export function rerender() {
         );
     }
 
-    if (
-        (page_params.color_scheme === settings_config.color_scheme_values.night.code &&
-            page_params.realm_night_logo_source !== "D") ||
-        (page_params.color_scheme === settings_config.color_scheme_values.automatic.code &&
-            page_params.realm_night_logo_source !== "D" &&
-            window.matchMedia &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-    ) {
+    if (settings_data.using_dark_theme() && page_params.realm_night_logo_source !== "D") {
         $("#realm-logo").attr("src", page_params.realm_night_logo_url);
     } else {
         $("#realm-logo").attr("src", page_params.realm_logo_url);

--- a/static/js/settings_data.js
+++ b/static/js/settings_data.js
@@ -158,3 +158,18 @@ export function user_can_edit_topic_of_any_message() {
     }
     return user_has_permission(page_params.realm_edit_topic_policy);
 }
+
+export function using_dark_theme() {
+    if (page_params.color_scheme === settings_config.color_scheme_values.night.code) {
+        return true;
+    }
+
+    if (
+        page_params.color_scheme === settings_config.color_scheme_values.automatic.code &&
+        window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches
+    ) {
+        return true;
+    }
+    return false;
+}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit is for extracting the code for checking night mode setting.
- Second commit fixes the loading indicator in night mode for message edit button.
- Third commit fixes the loading indicator in night mode for confirm dialog.
- Fourth commit is for disabling cancel button while loading in confirm dialog.

 <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![edit-night](https://user-images.githubusercontent.com/35494118/124917640-af986c80-e011-11eb-87e2-12db20d5b1cd.gif)
![confirm-night](https://user-images.githubusercontent.com/35494118/124917644-b1fac680-e011-11eb-9dd2-a0532bd1d17e.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
