### PR TITLE
recipient_row: Shift topic edit form code to the above of external link.

### DIFF
--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -30,6 +30,10 @@
                 </a>
                 <!-- The missing whitespace on the next line is a hack; ideally, would be user-select: none. -->
             </span><span class="recipient_bar_controls no-select">
+                <span class="topic_edit hidden-for-spectators">
+                    <span class="topic_edit_form" id="{{id}}"></span>
+                </span>
+
                 {{! exterior links (e.g. to a trac ticket) }}
                 {{#each topic_links}}
                 <a href="{{this.url}}" target="_blank" rel="noopener noreferrer" class="no-underline">
@@ -45,10 +49,6 @@
                     <i class="fa fa-pencil on_hover_topic_edit recipient_bar_icon hidden-for-spectators" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} data-tippy-content="{{t 'Edit topic'}}" role="button" tabindex="0" aria-label="{{t 'Edit topic' }}"></i>
                     {{/if}}
                 {{/if}}
-
-                <span class="topic_edit hidden-for-spectators">
-                    <span class="topic_edit_form" id="{{id}}"></span>
-                </span>
 
                 {{#if topic_is_resolved}}
                     <i class="fa fa-check on_hover_topic_unresolve recipient_bar_icon" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as unresolved' }}" role="button" tabindex="0" aria-label="{{t 'Mark as unresolved' }}"></i>


### PR DESCRIPTION
When editing a topic name (and the topic name has some link
in it) through the recipient bar, the external link icon
overlaps with the stream name. Shifting the code now
ensures that the external link icon would appear to the
right of the topic edit form box.

Also see: https://chat.zulip.org/#narrow/stream/9-issues/topic/topic.20edit.20recipient.20bar



**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

| Before | After |
| --- | --- |
| ![Screenshot from 2021-07-08 20-06-58](https://user-images.githubusercontent.com/67277428/124943429-1b86cf00-e02a-11eb-95ad-f6f543d2800f.png) | ![Screenshot from 2021-07-08 20-01-22](https://user-images.githubusercontent.com/67277428/124943467-23df0a00-e02a-11eb-85bf-2d2f6164e169.png) |


