### PR TITLE
apidocs: Display response codes in example responses.

### DIFF
--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -1736,6 +1736,10 @@ label.label-title {
     color: hsl(176, 46.4%, 41%);
 }
 
+.response-title {
+    display: inline;
+}
+
 .desktop-redirect-box {
     text-align: center;
 

--- a/templates/zerver/api/api-doc-template.md
+++ b/templates/zerver/api/api-doc-template.md
@@ -28,6 +28,6 @@
 
 {generate_response_description(API_ENDPOINT_NAME)}
 
-#### Example response
+#### Example responses
 
 {generate_code_example|API_ENDPOINT_NAME|fixture}

--- a/templates/zerver/api/mark-all-as-read.md
+++ b/templates/zerver/api/mark-all-as-read.md
@@ -26,7 +26,7 @@
 
 {generate_response_description(/mark_all_as_read:post)}
 
-#### Example response
+#### Example responses
 
 {generate_code_example|/mark_all_as_read:post|fixture}
 
@@ -60,7 +60,7 @@
 
 {generate_response_description(/mark_all_as_read:post)}
 
-#### Example response
+#### Example responses
 
 {generate_code_example|/mark_stream_as_read:post|fixture}
 
@@ -95,6 +95,6 @@
 
 {generate_response_description(/mark_all_as_read:post)}
 
-#### Example response
+#### Example responses
 
 {generate_code_example|/mark_topic_as_read:post|fixture}

--- a/templates/zerver/api/send-message.md
+++ b/templates/zerver/api/send-message.md
@@ -74,6 +74,6 @@ file.
 
 {generate_response_description(/messages:post)}
 
-#### Example response
+#### Example responses
 
 {generate_code_example|/messages:post|fixture}

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -273,12 +273,20 @@ def generate_openapi_fixture(endpoint: str, method: str) -> List[str]:
             )
         else:
             subschema_count = 1
+
         for subschema_index in range(subschema_count):
             if subschema_count != 1:
                 subschema_status_code = status_code + "_" + str(subschema_index)
             else:
                 subschema_status_code = status_code
             fixture_dict = get_openapi_fixture(endpoint, method, subschema_status_code)
+            if status_code == "200":
+                status_string = "Success"
+            else:
+                status_string = "Error"
+            response_title = fixture_dict.get("code", status_string).replace("_", " ").title()
+            rendered_title = f"<div><h4 class='response-title'>{response_title}</h4><span class='api-field-type'>&ensp;HTTP {status_code} response</span></div>"
+            fixture.append(rendered_title)
             fixture_description = (
                 get_openapi_fixture_description(endpoint, method, subschema_status_code).strip()
                 + ":"
@@ -286,7 +294,6 @@ def generate_openapi_fixture(endpoint: str, method: str) -> List[str]:
             fixture_json = json.dumps(
                 fixture_dict, indent=4, sort_keys=True, separators=(",", ": ")
             )
-
             fixture.extend(fixture_description.splitlines())
             fixture.append("``` json")
             fixture.extend(fixture_json.splitlines())

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12792,16 +12792,12 @@ components:
         - $ref: "#/components/schemas/JsonError"
         - example: {"msg": "Invalid API key", "result": "error"}
           description: |
-            ## Invalid API key
-
             A typical failed JSON response for when the API key is invalid
     MissingArgumentError:
       allOf:
         - $ref: "#/components/schemas/CodedErrorBase"
         - additionalProperties: false
           description: |
-            ## Missing request parameter(s)
-
             A typical failed JSON response for when a required request parameter
             is not supplied
           properties:
@@ -12829,8 +12825,6 @@ components:
               "result": "error",
             }
           description: |
-            ## User not authorized for query
-
             A typical failed JSON response for when the user is not authorized for
             a query
     UserDeactivatedError:
@@ -12843,8 +12837,6 @@ components:
               "result": "error",
             }
           description: |
-            ## User account deactivated
-
             **Changes**: These errors used the HTTP 403 status code
               before Zulip 5.0 (feature level 76).
 
@@ -12860,8 +12852,6 @@ components:
               "retry-after": 28.706807374954224,
             }
           description: |
-            ## Rate limit exceeded
-
             A typical failed JSON response for when a rate limit is exceeded:
     RealmDeactivatedError:
       allOf:
@@ -12873,8 +12863,6 @@ components:
               "result": "error",
             }
           description: |
-            ## Realm deactivated
-
             **Changes**: These errors used the HTTP 403 status code
               before Zulip 5.0 (feature level 76).
 


### PR DESCRIPTION
Currently, the examples response don't show response
codes anywhere, which is already existing and important
information. This commit adds the same.
![Screenshot from 2021-07-08 21-21-25](https://user-images.githubusercontent.com/56172924/124953570-e7fc7280-e032-11eb-9f53-54e8155d70e1.png)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
