### PR TITLE
users: Remove redundant `compute_show_invites` function.

### DIFF
--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -7,6 +7,7 @@ import {$t} from "./i18n";
 import * as message_viewport from "./message_viewport";
 import * as navigate from "./navigate";
 import {page_params} from "./page_params";
+import * as settings_data from "./settings_data";
 
 /*
 For various historical reasons there isn't one
@@ -98,7 +99,10 @@ export function update_org_settings_menu_item() {
 }
 
 export function initialize() {
-    const rendered_gear_menu = render_gear_menu({page_params});
+    const rendered_gear_menu = render_gear_menu({
+        ...page_params,
+        can_invite_others_to_realm: settings_data.user_can_invite_others_to_realm(),
+    });
     $("#navbar-buttons").html(rendered_gear_menu);
     update_org_settings_menu_item();
 

--- a/static/templates/gear_menu.hbs
+++ b/static/templates/gear_menu.hbs
@@ -104,7 +104,7 @@
             </li>
             {{/if}}
             <li class="divider" role="presentation"></li>
-            {{#if page_params.show_invites}}
+            {{#if can_invite_others_to_realm}}
             <li role="presentation">
                 <a href="#invite" role="menuitem">
                     <i class="fa fa-user-plus" aria-hidden="true"></i> {{t 'Invite users' }}

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -16,7 +16,6 @@ from zerver.lib.i18n import (
     get_language_list,
     get_language_translation_data,
 )
-from zerver.lib.users import compute_show_invites
 from zerver.models import Message, Realm, Stream, UserProfile
 from zerver.views.message_flags import get_latest_update_message_flag_activity
 
@@ -179,7 +178,6 @@ def build_page_params_for_home_page_load(
 
     two_fa_enabled = settings.TWO_FACTOR_AUTHENTICATION_ENABLED and user_profile is not None
     billing_info = get_billing_info(user_profile)
-    show_invites = compute_show_invites(user_profile)
     user_permission_info = get_user_permission_info(user_profile)
 
     # Pass parameters to the client-side JavaScript code.
@@ -206,7 +204,6 @@ def build_page_params_for_home_page_load(
         show_billing=billing_info.show_billing,
         promote_sponsoring_zulip=promote_sponsoring_zulip_in_realm(realm),
         show_plans=billing_info.show_plans,
-        show_invites=show_invites,
         show_webathena=user_permission_info.show_webathena,
         # Adding two_fa_enabled as condition saves us 3 queries when
         # 2FA is not enabled.

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -349,16 +349,6 @@ def validate_user_custom_profile_data(
             raise JsonableError(error.message)
 
 
-def compute_show_invites(user_profile: Optional[UserProfile]) -> bool:
-    if user_profile is None:
-        return False
-
-    if user_profile.is_guest:
-        return False
-
-    return user_profile.can_invite_others_to_realm()
-
-
 def can_access_delivery_email(user_profile: UserProfile) -> bool:
     realm = user_profile.realm
     if realm.email_address_visibility == Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS:

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -21,7 +21,6 @@ from zerver.lib.home import (
 from zerver.lib.soft_deactivation import do_soft_deactivate_users
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import get_user_messages, override_settings, queries_captured
-from zerver.lib.users import compute_show_invites
 from zerver.models import (
     DefaultStream,
     Realm,
@@ -214,7 +213,6 @@ class HomeTest(ZulipTestCase):
         "server_timestamp",
         "settings_send_digest_emails",
         "show_billing",
-        "show_invites",
         "show_plans",
         "show_webathena",
         "starred_message_counts",
@@ -1040,33 +1038,3 @@ class HomeTest(ZulipTestCase):
 
         page_params = self._get_page_params(result)
         self.assertEqual(page_params["default_language"], "es")
-
-    def test_compute_show_invites_and_add_streams_admin(self) -> None:
-        user = self.example_user("iago")
-
-        realm = user.realm
-        realm.invite_to_realm_policy = Realm.POLICY_ADMINS_ONLY
-        realm.save()
-
-        show_invites = compute_show_invites(user)
-        self.assertEqual(show_invites, True)
-
-    def test_compute_show_invites_and_add_streams_require_admin(self) -> None:
-        user = self.example_user("hamlet")
-
-        realm = user.realm
-        realm.invite_to_realm_policy = Realm.POLICY_ADMINS_ONLY
-        realm.save()
-
-        show_invites = compute_show_invites(user)
-        self.assertEqual(show_invites, False)
-
-    def test_compute_show_invites_and_add_streams_guest(self) -> None:
-        user = self.example_user("polonius")
-
-        show_invites = compute_show_invites(user)
-        self.assertEqual(show_invites, False)
-
-    def test_compute_show_invites_and_add_streams_unauthenticated(self) -> None:
-        show_invites = compute_show_invites(None)
-        self.assertEqual(show_invites, False)


### PR DESCRIPTION
Added context in commit message body. 

(Follow up of #19048)