### PR TITLE
Revert "compose: Convert pasted url to named link."

### DIFF
--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -306,19 +306,6 @@ export function paste_handler_converter(paste_html) {
     return markdown_text;
 }
 
-// https://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url
-function isValidHttpUrl(string) {
-    let url;
-
-    try {
-        url = new URL(string);
-    } catch {
-        return false;
-    }
-
-    return url.protocol === "http:" || url.protocol === "https:";
-}
-
 export function paste_handler(event) {
     const clipboardData = event.originalEvent.clipboardData;
     if (!clipboardData) {
@@ -331,20 +318,6 @@ export function paste_handler(event) {
     }
 
     if (clipboardData.getData) {
-        const paste_text = clipboardData.getData("text");
-        if (paste_text && isValidHttpUrl(paste_text) && document.getSelection().type === "Range") {
-            event.preventDefault();
-            event.stopPropagation();
-
-            const textarea = $(this);
-            const prefix = "[";
-            const suffix = "](" + paste_text + ")";
-            compose_ui.wrap_text_with_markdown(textarea, prefix, suffix);
-            compose_ui.autosize_textarea(textarea);
-
-            return;
-        }
-
         const paste_html = clipboardData.getData("text/html");
         if (paste_html && page_params.development_environment) {
             const text = paste_handler_converter(paste_html);


### PR DESCRIPTION
This reverts commit 5a61c9bb145df2db410431f7e5801712d7612ee1 (#18849), which had a number of bugs:

* It had a poor interaction with Ctrl+Shift+L resulting in double link formatting.
* It didn’t work at all in Firefox.
* It didn’t check whether what you’re pasting into is even a compose box.
* On pasting into the message edit box, it would throw `Error: Cannot read property 'text' of undefined`.

See https://chat.zulip.org/#narrow/stream/6-frontend/topic/Linkify.20on.20Paste.20.2318849/near/1227452. Cc @Signior-X.