### PR TITLE
topic_edit_form: Restyle topic edit save button with logo colours.

### DIFF
--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -1066,16 +1066,6 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     .small_square_button {
-        &.small_square_check {
-            background-color: hsl(166, 35%, 52%);
-            color: hsl(0, 0%, 90%);
-
-            &:hover {
-                background-color: hsl(156, 30%, 45%);
-                color: hsl(0, 0%, 95%);
-            }
-        }
-
         &.small_square_x {
             background-color: hsl(0, 0%, 95%);
             color: hsl(0, 0%, 42%);

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2282,16 +2282,6 @@ div.floating_recipient {
         outline: none;
     }
 
-    &.small_square_check {
-        background-color: hsl(166, 35%, 57%);
-        color: hsl(0, 0%, 95%);
-
-        &:hover {
-            background-color: hsl(156, 30%, 50%);
-            color: hsl(0, 0%, 100%);
-        }
-    }
-
     &.small_square_x {
         background-color: hsl(0, 0%, 100%);
         color: hsl(0, 0%, 47%);

--- a/static/templates/topic_edit_form.hbs
+++ b/static/templates/topic_edit_form.hbs
@@ -3,7 +3,7 @@
 <form id="topic_edit_form" class="form-horizontal">
     <input type="text" value="" class="inline_topic_edit header-v" id="inline_topic_edit"
       autocomplete="off" />
-    <button type="button" class="topic_edit_save small_square_button small_square_check"><i class="fa fa-check" aria-hidden="true"></i></button>
+    <button type="button" class="topic_edit_save small_square_button animated-purple-button"><i class="fa fa-check" aria-hidden="true"></i></button>
     <button type="button" class="topic_edit_cancel small_square_button small_square_x"><i class="fa fa-remove" aria-hidden="true"></i></button>
     <div class="alert alert-error edit_error" style="display: none"></div>
     <div class="topic_edit_spinner"></div>


### PR DESCRIPTION
Similar to what mentioned in 2e196fd5d396c621ab69f2f2a15f65f3fa5c2662
previous sea-green colour didn't meet the WCAG AA standard
guidelines for color contrast. This changes meets WCAG AAA
standard.
