### PR TITLE
tooltip: Improve tooltip visibility for message control buttons.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -119,6 +119,9 @@ export function initialize() {
 
     delegate("body", {
         target: ".message_control_button",
+        // This ensures that the tooltip doesn't
+        // hide by the selected message blue border.
+        appendTo: () => document.body,
         // Add some additional delay when they open
         // so that regular users don't have to see
         // them unless they want to.


### PR DESCRIPTION
This change ensures that the tooltip doesn't hide by the
selected message blue border.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

| Before | After |
| --- | --- |
| ![Screenshot from 2021-07-09 03-44-34](https://user-images.githubusercontent.com/67277428/124998316-d1bdd900-e069-11eb-8855-6c1abce73887.png) | ![Screenshot from 2021-07-09 03-43-52](https://user-images.githubusercontent.com/67277428/124998337-daaeaa80-e069-11eb-8726-1c5e39d281b3.png) |