### PR TITLE
sentry: Set environment to `staging` on staging hosts.

### DIFF
--- a/zproject/config.py
+++ b/zproject/config.py
@@ -9,6 +9,7 @@ config_file.read("/etc/zulip/zulip.conf")
 
 # Whether this instance of Zulip is running in a production environment.
 PRODUCTION = config_file.has_option("machine", "deploy_type")
+STAGING = config_file.get("machine", "deploy_type", fallback="") == "staging"
 DEVELOPMENT = not PRODUCTION
 
 secrets_file = configparser.RawConfigParser()

--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -11,7 +11,7 @@ from sentry_sdk.utils import capture_internal_exceptions
 
 from version import ZULIP_VERSION
 
-from .config import PRODUCTION
+from .config import PRODUCTION, STAGING
 
 if TYPE_CHECKING:
     from sentry_sdk._types import Event, Hint
@@ -60,9 +60,16 @@ def add_context(event: "Event", hint: "Hint") -> Optional["Event"]:
 def setup_sentry(dsn: Optional[str], *integrations: Integration) -> None:
     if not dsn:
         return
+    if PRODUCTION:
+        if STAGING:
+            environment = "staging"
+        else:
+            environment = "production"
+    else:
+        environment = "development"
     sentry_sdk.init(
         dsn=dsn,
-        environment="production" if PRODUCTION else "development",
+        environment=environment,
         release=ZULIP_VERSION,
         integrations=[
             DjangoIntegration(),


### PR DESCRIPTION
Splitting exceptions out between staging and production provides
useful filtering.

----

Alternately, we could use `deploy_type` as the Sentry environment, but that seems like overloading things.  Or we could have a separate `sentry.environment` property in `zulip.conf` but that seems like overkill.