### PR TITLE
[WIP] compose: Render stream icons according to stream type(public/private).

### DIFF
--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -134,7 +134,7 @@ export const update_elements = (content) => {
                 // undefined.  Otherwise, display the current stream name.
                 let stream_icon = "#";
                 if (stream_data.get_invite_only(stream_name)) {
-                    stream_icon = "<i class='fa fa-lock' aria-hidden='true'></i>";
+                    stream_icon = $("<i>", {class: "fa fa-lock"});
                 }
                 $(this).html(stream_icon + " " + stream_name);
             }

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -132,7 +132,11 @@ export const update_elements = (content) => {
                 // If the stream has been deleted,
                 // stream_data.maybe_get_stream_name might return
                 // undefined.  Otherwise, display the current stream name.
-                $(this).text("#" + stream_name);
+                let stream_icon = "#";
+                if (stream_data.get_invite_only(stream_name)) {
+                    stream_icon = "<i class='fa fa-lock' aria-hidden='true'></i>";
+                }
+                $(this).html(stream_icon + " " + stream_name);
             }
         }
     });
@@ -148,7 +152,11 @@ export const update_elements = (content) => {
                 // stream_data.maybe_get_stream_name might return
                 // undefined.  Otherwise, display the current stream name.
                 const text = $(this).text();
-                $(this).text("#" + stream_name + text.slice(text.indexOf(" > ")));
+                let stream_icon = "#";
+                if (stream_data.get_invite_only(stream_name)) {
+                    stream_icon = "<i class='fa fa-lock' aria-hidden='true'></i>";
+                }
+                $(this).html(stream_icon + " " + stream_name + text.slice(text.indexOf(" > ")));
             }
         }
     });


### PR DESCRIPTION
Probably unsafe due to use of .html method(I'm not sure).

My question is, is this the right(and safe) way to proceed? Is there some other method which I can use to display the html for icon? 

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
[issue #19058](https://github.com/zulip/zulip/issues/19058l)

I am able to achieve this:

![image](https://user-images.githubusercontent.com/49791933/125041679-a57c7980-e0b6-11eb-8de5-45fe2f87b79b.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
