### PR TITLE
stream settings: Fix scroll issue in subscriber list in stream settings.

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -223,7 +223,8 @@
 
     .subscriber_list_container {
         position: relative;
-        max-height: 100%;
+        /* 2*45px (settings header) + 38px(tab-container row) + 20px (margin for .inner-box) + 134px (add user input and search widget area) = 282px */
+        max-height: calc(95vh - 282px);
         overflow: auto;
         text-align: left;
         -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
As we want subscriber list to occupy rest of available space
in the tab, we use relative units (vh) and calc to set the
max-height property dynamically without losing scroll behavior
for stream list.

Follow up for #19156.


**Testing plan:** Tested with 100 extra users created using `./manage.py populate_db --extra-users=100`.


**GIFs or screenshots:** 
![subcribers_list](https://user-images.githubusercontent.com/63504956/125073189-36fce300-e0d9-11eb-97d8-5abb033f306a.gif)
