### PR TITLE
push_notifications: Hide "error" level messages from aioapns.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -74,6 +74,10 @@ def get_apns_context() -> Optional[APNsContext]:
     # import time.
     import aioapns
 
+    # aioapns logs at "error" level for every non-successful request,
+    # which fills the logs; see https://github.com/Fatal1ty/aioapns/issues/15
+    logging.getLogger("aioapns").setLevel(logging.CRITICAL)
+
     if settings.APNS_CERT_FILE is None:
         return None
 


### PR DESCRIPTION
Work around Fatal1ty/aioapns#15, by silencing error-level logging from
the aioapns logger.  We deal with the results of failed
send_notification calls by examining the `result.description` and
handling them; the extra logging message merely clutters the Sentry
logs.

**Testing plan:** Untested.
