### PR TITLE
recipient_bar: Change CSS of unresolve topic icon to that of resolve icon.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1311,7 +1311,6 @@ td.pointer {
     opacity: 0.7;
 }
 
-.on_hover_topic_unresolve,
 .on_hover_topic_unmute {
     opacity: 0.7;
 
@@ -1321,6 +1320,7 @@ td.pointer {
     }
 }
 
+.on_hover_topic_unresolve,
 .on_hover_topic_resolve,
 .on_hover_topic_mute {
     opacity: 0.2;


### PR DESCRIPTION
It is very unlikely that one may want to unresolve
a topic. Topic resolving button should look the
same in whatever state it is.

See: https://chat.zulip.org/#narrow/stream/101-design/topic/closing.2Fsolving.20a.20topic.20.28.2311154.29/near/1228906