### PR TITLE
Clean up a bunch of unnecessarily hard-coded user ids in tests

### DIFF
--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1967,7 +1967,7 @@ class MarkdownTest(ZulipTestCase):
         # incorrect(as it uses hamlet's id) so it should not be able
         # to use that data for creating a valid mention.
 
-        content = f"@**King Hamlet|10** and @**aaron|{hamlet.id}**"
+        content = f"@**King Hamlet|{hamlet.id}** and @**aaron|{hamlet.id}**"
         rendering_result = render_markdown(msg, content)
         self.assertEqual(
             rendering_result.rendered_content,

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -195,8 +195,8 @@ class WorkerTest(ZulipTestCase):
                 self.assertEqual(
                     info_logs.output,
                     [
-                        "INFO:root:Batch-processing 3 missedmessage_emails events for user 10",
-                        "INFO:root:Batch-processing 1 missedmessage_emails events for user 12",
+                        f"INFO:root:Batch-processing 3 missedmessage_emails events for user {hamlet.id}",
+                        f"INFO:root:Batch-processing 1 missedmessage_emails events for user {othello.id}",
                     ],
                 )
 

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -104,11 +104,11 @@ class ReactionEmojiTest(ZulipTestCase):
                 "emoji_code": "1f642",
                 "reaction_type": "unicode_emoji",
                 "user": {
-                    "email": "user10@zulip.testserver",
-                    "id": 10,
+                    "email": f"user{sender.id}@zulip.testserver",
+                    "id": sender.id,
                     "full_name": "King Hamlet",
                 },
-                "user_id": 10,
+                "user_id": sender.id,
             }
         ]
         self.assertEqual(expected_reaction_data, message["reactions"])

--- a/zerver/tests/test_sessions.py
+++ b/zerver/tests/test_sessions.py
@@ -103,7 +103,8 @@ class TestSessions(ZulipTestCase):
         with self.assertLogs(level="INFO") as info_logs:
             delete_all_deactivated_user_sessions()
         self.assertEqual(
-            info_logs.output, ["INFO:root:Deactivating session for deactivated user 8"]
+            info_logs.output,
+            [f"INFO:root:Deactivating session for deactivated user {user_profile_3.id}"],
         )
         result = self.client_get("/")
         self.check_rendered_spectator(result)

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -405,10 +405,11 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         # Then, try having a user who didn't receive the message try to publish it, and fail
         body = f"Illegal message ...[zulip.txt](http://{host}/user_uploads/" + d1_path_id + ")"
+        cordelia = self.example_user("cordelia")
         with self.assertLogs(level="WARNING") as warn_log:
-            self.send_stream_message(self.example_user("cordelia"), "Denmark", body, "test")
+            self.send_stream_message(cordelia, "Denmark", body, "test")
         self.assertTrue(
-            "WARNING:root:User 8 tried to share upload" in warn_log.output[0]
+            f"WARNING:root:User {cordelia.id} tried to share upload" in warn_log.output[0]
             and "but lacks permission" in warn_log.output[0]
         )
         self.assertEqual(Attachment.objects.get(path_id=d1_path_id).messages.count(), 1)


### PR DESCRIPTION
  These are really prep commit for #17520 but should be worth merging independently