### PR TITLE
settings: Show correct email in user-info form.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -522,9 +522,19 @@ function handle_human_form(tbody, status_field) {
             return;
         }
 
+        let user_email = settings_data.email_for_user_settings(person);
+        if (!user_email) {
+            // When email_address_visibility is "Nobody", we still
+            // want to show the fake email address in the edit form.
+            //
+            // We may in the future want to just hide the form field
+            // for this situation, once we display user IDs.
+            user_email = person.email;
+        }
+
         const html_body = render_admin_human_form({
             user_id,
-            email: person.email,
+            email: user_email,
             full_name: person.full_name,
             user_role_values: settings_config.user_role_values,
             disable_role_dropdown: person.is_owner && !page_params.is_owner,


### PR DESCRIPTION
This PR fixes the bug of showing custom email to admin in
the user-info form even when email_address_visibility is set
to admins only.
This commit fixes it to show the correct email according to
email_address_visibility values.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


 <!-- How have you tested? -->


**GIFs or screenshots:**
![email-bug](https://user-images.githubusercontent.com/35494118/125266726-b8e04c80-e323-11eb-89cc-46ad0ed844a8.gif)
 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
