### PR TITLE
about_zulip: Indicate the copy icon to be clickable.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2659,6 +2659,10 @@ select.inline_select_topic_edit {
     .about-zulip-logo img {
         height: 40px;
     }
+
+    i.fa-copy {
+        cursor: pointer;
+    }
 }
 
 /* This max-width must be synced with message_viewport.is_narrow */


### PR DESCRIPTION
Added a minor commit which indicates the `about_zulip` copy icon to be a clickable element by setting a CSS property of `cursor` having value `pointer`. 

<strong>Screenshot</strong>

![about_zulip_pointer](https://user-images.githubusercontent.com/53977614/125338305-a559d380-e36d-11eb-93b5-fb1fd25722b0.png)
