### PR TITLE
openapi: Render all responses of an operation.

### DIFF
--- a/docs/documentation/api.md
+++ b/docs/documentation/api.md
@@ -182,12 +182,11 @@ must have a `post` HTTP method defined.
 If you've already followed the steps in the [Usage examples](#usage-examples)
 section, this part should be fairly trivial.
 
-You can use the following Markdown directive to render the fixtures
-defined in the OpenAPI `zulip.yaml` for a given endpoint and status
-code:
+You can use the following Markdown directive to render all the fixtures
+defined in the OpenAPI `zulip.yaml` for a given endpoint
 
 ```
-{generate_code_example|/messages/render:post|fixture(200)}
+{generate_code_example|/messages/render:post|fixture}
 ```
 
 ## Step by step guide

--- a/templates/zerver/api/api-doc-template.md
+++ b/templates/zerver/api/api-doc-template.md
@@ -30,6 +30,4 @@
 
 #### Example response
 
-{generate_code_example|API_ENDPOINT_NAME|fixture(200)}
-
-{generate_code_example|API_ENDPOINT_NAME|fixture(400)}
+{generate_code_example|API_ENDPOINT_NAME|fixture}

--- a/templates/zerver/api/mark-all-as-read.md
+++ b/templates/zerver/api/mark-all-as-read.md
@@ -28,9 +28,7 @@
 
 #### Example response
 
-{generate_code_example|/mark_all_as_read:post|fixture(200)}
-
-{generate_code_example|/mark_all_as_read:post|fixture(400)}
+{generate_code_example|/mark_all_as_read:post|fixture}
 
 {generate_api_title(/mark_stream_as_read:post)}
 
@@ -64,9 +62,7 @@
 
 #### Example response
 
-{generate_code_example|/mark_stream_as_read:post|fixture(200)}
-
-{generate_code_example|/mark_stream_as_read:post|fixture(400)}
+{generate_code_example|/mark_stream_as_read:post|fixture}
 
 # Mark messages in a topic as read
 {generate_api_title(/mark_topic_as_read:post)}
@@ -101,6 +97,4 @@
 
 #### Example response
 
-{generate_code_example|/mark_topic_as_read:post|fixture(200)}
-
-{generate_code_example|/mark_topic_as_read:post|fixture(400)}
+{generate_code_example|/mark_topic_as_read:post|fixture}

--- a/templates/zerver/api/outgoing-webhooks.md
+++ b/templates/zerver/api/outgoing-webhooks.md
@@ -46,7 +46,7 @@ settings][settings].
 
 ## Outgoing webhook format
 
-{generate_code_example|/zulip-outgoing-webhook:post|fixture(200)}
+{generate_code_example|/zulip-outgoing-webhook:post|fixture}
 
 ### Fields documentation
 

--- a/templates/zerver/api/rest-error-handling.md
+++ b/templates/zerver/api/rest-error-handling.md
@@ -17,13 +17,7 @@ translated into French if the user has a French locale).
 Each endpoint documents its own unique errors; below, we document
 errors common to many endpoints:
 
-{generate_code_example|/rest-error-handling:post|fixture(400)}
-
-{generate_code_example|/rest-error-handling:post|fixture(401)}
-
-{generate_code_example|/rest-error-handling:post|fixture(403)}
-
-{generate_code_example|/rest-error-handling:post|fixture(429)}
+{generate_code_example|/rest-error-handling:post|fixture}
 
 The `retry-after` paremeter in the response indicates how many seconds
 the client must wait before making additional requests.

--- a/templates/zerver/api/send-message.md
+++ b/templates/zerver/api/send-message.md
@@ -76,6 +76,4 @@ file.
 
 #### Example response
 
-{generate_code_example|/messages:post|fixture(200)}
-
-{generate_code_example|/messages:post|fixture(400)}
+{generate_code_example|/messages:post|fixture}

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -451,14 +451,12 @@ class APICodeExamplesPreprocessor(Preprocessor):
                     language, options = parse_language_and_options(match.group(2))
                     function = match.group(3)
                     key = match.group(4)
-                    argument = match.group(6)
                     if self.api_url is None:
                         raise AssertionError("Cannot render curl API examples without API URL set.")
                     options["api_url"] = self.api_url
 
                     if key == "fixture":
-                        if argument:
-                            text = self.render_fixture(function, name=argument)
+                        text = self.render_fixture(function)
                     elif key == "example":
                         path, method = function.rsplit(":", 1)
                         if language in ADMIN_CONFIG_LANGUAGES and check_requires_administrator(
@@ -484,9 +482,9 @@ class APICodeExamplesPreprocessor(Preprocessor):
                 done = True
         return lines
 
-    def render_fixture(self, function: str, name: str) -> List[str]:
+    def render_fixture(self, function: str) -> List[str]:
         path, method = function.rsplit(":", 1)
-        return generate_openapi_fixture(path, method, name)
+        return generate_openapi_fixture(path, method)
 
 
 class APIDescriptionPreprocessor(Preprocessor):


### PR DESCRIPTION
The current system requires specifying all the status
codes that we want to render along with the operation,
but the primary use case just needs the responses of
all the status codes, and not just one.

This commit modifies the Markdown extesnion to render
all the responses of all status codes of a specified
operation.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
