### PR TITLE
css: Set standard outline color for focusable elements.

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -585,4 +585,10 @@ div.overlay {
         background-color: hsl(240, 41%, 50%);
         box-shadow: 0 1px 4px hsl(0, 0%, 0%, 0.3);
     }
+
+    &:focus {
+        background-color: hsl(240, 41%, 50%);
+        box-shadow: 0 1px 4px 0 hsl(235, 18%, 7%);
+        outline: none;
+    }
 }

--- a/static/styles/components.css
+++ b/static/styles/components.css
@@ -42,11 +42,6 @@
                 background-repeat: no-repeat;
             }
 
-            &:focus ~ span {
-                outline: 1px dotted;
-                outline: -webkit-focus-ring-color auto 5px;
-            }
-
             &:disabled ~ span {
                 opacity: 0.5;
                 cursor: not-allowed;

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -1076,6 +1076,10 @@ body.night-mode {
     .auto-select:focus {
         outline-color: hsl(0, 0%, 67%);
     }
+
+    .animated-purple-button:focus {
+        box-shadow: 0 1px 4px 0 hsl(0, 0%, 100%, 0.666);
+    }
 }
 
 @supports (-moz-appearance: none) {

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -171,7 +171,7 @@ body.night-mode {
     }
 
     /* do not turn the .message_header .stream_label text dark on hover because they're
-on a dark background, and don't change the dark labels dark either. */
+       on a dark background, and don't change the dark labels dark either. */
     .message_header:not(.dark_background)
         a.stream_label:not(.dark_background):hover {
         color: hsl(212, 28%, 18%);
@@ -1068,8 +1068,13 @@ on a dark background, and don't change the dark labels dark either. */
         }
     }
 
-    a:not(:active):focus {
-        outline-color: hsl(0, 0%, 100%);
+    a:not(:active):focus,
+    button:focus,
+    .new-style label.checkbox input[type="checkbox"]:focus ~ span,
+    i.fa:focus,
+    i.zulip-icon:focus,
+    .auto-select:focus {
+        outline-color: hsl(0, 0%, 67%);
     }
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -424,7 +424,12 @@ label {
 }
 
 /* Bootstrap's focus outline uses -webkit-focus-ring-color which doesn't exist in Firefox */
-a:not(:active):focus {
+a:not(:active):focus,
+button:focus,
+.new-style label.checkbox input[type="checkbox"]:focus ~ span,
+i.fa:focus,
+i.zulip-icon:focus,
+.auto-select:focus {
     outline: 2px solid hsl(215, 47%, 50%);
     /* TODO: change solid to auto once the Chromium bug #1105822 is fixed */
 }


### PR DESCRIPTION
Fixes #19198

We set blue outline color in day mode and light gray outline colour
in night mode. This removes the different outline colours users
in different platforms / desktop app.
