### PR TITLE
webhooks: Make github webhook support event filtering system.

### DIFF
--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -18,6 +18,7 @@ class GitHubWebhookTest(WebhookTestCase):
     STREAM_NAME = "github"
     URL_TEMPLATE = "/api/v1/external/github?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "github"
+    VIEW_FUNCTION_NAME = "api_github_webhook"
 
     def test_ping_event(self) -> None:
         expected_message = "GitHub webhook has been successfully configured by TomaszKolek."

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -672,8 +672,10 @@ IGNORED_TEAM_ACTIONS = [
     "removed_from_repository",
 ]
 
+ALL_EVENT_TYPES = list(EVENT_FUNCTION_MAPPER.keys())
 
-@webhook_view("GitHub", notify_bot_owner_on_invalid_json=True)
+
+@webhook_view("GitHub", notify_bot_owner_on_invalid_json=True, all_event_types=ALL_EVENT_TYPES)
 @has_request_variables
 def api_github_webhook(
     request: HttpRequest,
@@ -709,7 +711,7 @@ def api_github_webhook(
     )
     body = body_function(helper)
 
-    check_send_webhook_message(request, user_profile, subject, body)
+    check_send_webhook_message(request, user_profile, subject, body, event)
     return json_success()
 
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is a follow-up for #19059 and for #18392. We experimentally add support to the event filtering system for the github webhook.

**Testing plan:** <!-- How have you tested? -->
It is being tested manually through running the testcase with the filtering arguments applied in the template URL.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
