### PR TITLE
docs: Remove do-release-upgrade -d option

### DIFF
--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -273,12 +273,8 @@ instructions for other supported platforms.
 
     ```
     sudo -i # Or otherwise get a root shell
-    do-release-upgrade -d
+    do-release-upgrade
     ```
-
-    The `-d` option to `do-release-upgrade` is required because Ubuntu
-    20.04 is new; it will stop being necessary once the first point
-    release update of Ubuntu 20.04 LTS is released.
 
     When `do-release-upgrade` asks you how to upgrade configuration
     files for services that Zulip manages like Redis, PostgreSQL,


### PR DESCRIPTION
It has not been necessary since Ubuntu 20.04.1 was released in August.