### PR TITLE
refactor: Move "send button" related code from `compose_validate.js`  to `compose.js`.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -546,7 +546,7 @@ test_ui("finish", ({override}) => {
     })();
 
     (function test_when_compose_validation_succeed() {
-        $("#compose-textarea").hide();
+        // Testing successfully sending of a message.
         $("#compose .undo_markdown_preview").show();
         $("#compose .preview_message_area").show();
         $("#compose .markdown_preview").hide();
@@ -564,11 +564,35 @@ test_ui("finish", ({override}) => {
             send_message_called = true;
         });
         assert.ok(compose.finish());
+        assert.equal($("#sending-indicator").text(), "translated: Sending...");
         assert.ok($("#compose-textarea").visible());
         assert.ok(!$("#compose .undo_markdown_preview").visible());
         assert.ok(!$("#compose .preview_message_area").visible());
         assert.ok($("#compose .markdown_preview").visible());
         assert.ok(send_message_called);
+        assert.ok(compose_finished_event_checked);
+
+        // Testing successful scheduling of message.
+        $("#compose .undo_markdown_preview").show();
+        $("#compose .preview_message_area").show();
+        $("#compose .markdown_preview").hide();
+        $("#compose-textarea").val("foobarfoobar");
+        compose_state.set_message_type("stream");
+        override(compose_state, "stream_name", () => "social");
+        override(people, "get_by_user_id", () => []);
+        compose_finished_event_checked = false;
+        let schedule_message = false;
+        override(reminder, "schedule_message", () => {
+            schedule_message = true;
+        });
+        reminder.is_deferred_delivery = () => true;
+        assert.ok(compose.finish());
+        assert.equal($("#sending-indicator").text(), "translated: Scheduling...");
+        assert.ok($("#compose-textarea").visible());
+        assert.ok(!$("#compose .undo_markdown_preview").visible());
+        assert.ok(!$("#compose .preview_message_area").visible());
+        assert.ok($("#compose .markdown_preview").visible());
+        assert.ok(schedule_message);
         assert.ok(compose_finished_event_checked);
     })();
 });

--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -13,7 +13,6 @@ set_global("document", {location: {}});
 const channel = mock_esm("../../static/js/channel");
 const compose_actions = mock_esm("../../static/js/compose_actions");
 const compose_state = zrequire("compose_state");
-const reminder = mock_esm("../../static/js/reminder");
 const ui_util = mock_esm("../../static/js/ui_util");
 
 const compose_pm_pill = zrequire("compose_pm_pill");
@@ -113,7 +112,6 @@ test_ui("validate_stream_message_address_info", ({mock_template}) => {
 
 test_ui("validate", ({override, mock_template}) => {
     override(compose_actions, "update_placeholder_text", () => {});
-    override(reminder, "is_deferred_delivery", () => false);
 
     function initialize_pm_pill() {
         $.clear_all_elements();
@@ -144,17 +142,13 @@ test_ui("validate", ({override, mock_template}) => {
     initialize_pm_pill();
     assert.ok(!compose_validate.validate());
     assert.ok(!$("#sending-indicator").visible());
-    assert.ok(!$("#compose-send-button").is_focused());
     assert.equal($("#compose-send-button").prop("disabled"), false);
     assert.equal(
         $("#compose-error-msg").html(),
         $t_html({defaultMessage: "You have nothing to send!"}),
     );
 
-    reminder.is_deferred_delivery = () => true;
     compose_validate.validate();
-    assert.equal($("#sending-indicator").text(), "translated: Scheduling...");
-    reminder.is_deferred_delivery = () => {};
 
     add_content_to_compose_box();
     let zephyr_checked = false;
@@ -312,8 +306,6 @@ test_ui("test_wildcard_mention_allowed", () => {
 });
 
 test_ui("validate_stream_message", ({override, mock_template}) => {
-    override(reminder, "is_deferred_delivery", () => false);
-
     // This test is in kind of continuation to test_validate but since it is
     // primarily used to get coverage over functions called from validate()
     // we are separating it up in different test. Though their relative position
@@ -362,9 +354,7 @@ test_ui("validate_stream_message", ({override, mock_template}) => {
     );
 });
 
-test_ui("test_validate_stream_message_post_policy_admin_only", ({override}) => {
-    override(reminder, "is_deferred_delivery", () => false);
-
+test_ui("test_validate_stream_message_post_policy_admin_only", () => {
     // This test is in continuation with test_validate but it has been separated out
     // for better readability. Their relative position of execution should not be changed.
     // Although the position with respect to test_validate_stream_message does not matter
@@ -401,9 +391,7 @@ test_ui("test_validate_stream_message_post_policy_admin_only", ({override}) => {
     );
 });
 
-test_ui("test_validate_stream_message_post_policy_moderators_only", ({override}) => {
-    override(reminder, "is_deferred_delivery", () => false);
-
+test_ui("test_validate_stream_message_post_policy_moderators_only", () => {
     page_params.is_admin = false;
     page_params.is_moderator = false;
     page_params.is_guest = false;
@@ -440,9 +428,7 @@ test_ui("test_validate_stream_message_post_policy_moderators_only", ({override})
     );
 });
 
-test_ui("test_validate_stream_message_post_policy_full_members_only", ({override}) => {
-    override(reminder, "is_deferred_delivery", () => false);
-
+test_ui("test_validate_stream_message_post_policy_full_members_only", () => {
     page_params.is_admin = false;
     page_params.is_guest = true;
     const sub = {
@@ -499,10 +485,8 @@ test_ui("test_check_overflow_text", () => {
     assert.ok(!textarea.hasClass("over_limit"));
 });
 
-test_ui("test_message_overflow", ({override}) => {
+test_ui("test_message_overflow", () => {
     page_params.max_message_length = 10000;
-
-    override(reminder, "is_deferred_delivery", () => false);
 
     const sub = {
         stream_id: 101,

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -266,6 +266,11 @@ export function enter_with_preview_open() {
     }
 }
 
+function show_sending_indicator(whats_happening) {
+    $("#sending-indicator").text(whats_happening);
+    $("#sending-indicator").show();
+}
+
 export function finish() {
     clear_preview_area();
     clear_invites();
@@ -283,6 +288,12 @@ export function finish() {
         return undefined;
     }
 
+    $("#compose-send-button").prop("disabled", true).trigger("blur");
+    if (reminder.is_deferred_delivery(message_content)) {
+        show_sending_indicator($t({defaultMessage: "Scheduling..."}));
+    } else {
+        show_sending_indicator($t({defaultMessage: "Sending..."}));
+    }
     if (!compose_validate.validate()) {
         // If the message failed validation, hide the sending indicator.
         $("#sending-indicator").hide();

--- a/static/js/compose_validate.js
+++ b/static/js/compose_validate.js
@@ -8,11 +8,10 @@ import * as channel from "./channel";
 import * as compose_error from "./compose_error";
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
-import {$t, $t_html} from "./i18n";
+import {$t_html} from "./i18n";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as people from "./people";
-import * as reminder from "./reminder";
 import * as settings_config from "./settings_config";
 import * as stream_data from "./stream_data";
 import * as util from "./util";
@@ -46,11 +45,6 @@ export function clear_all_everyone_warnings() {
     $("#compose-all-everyone").hide();
     $("#compose-all-everyone").empty();
     $("#compose-send-status").hide();
-}
-
-function show_sending_indicator(whats_happening) {
-    $("#sending-indicator").text(whats_happening);
-    $("#sending-indicator").show();
 }
 
 function show_announce_warnings(stream_id) {
@@ -513,14 +507,7 @@ export function warn_for_text_overflow_when_tries_to_send() {
 }
 
 export function validate() {
-    $("#compose-send-button").prop("disabled", true).trigger("blur");
     const message_content = compose_state.message_content();
-    if (reminder.is_deferred_delivery(message_content)) {
-        show_sending_indicator($t({defaultMessage: "Scheduling..."}));
-    } else {
-        show_sending_indicator($t({defaultMessage: "Sending..."}));
-    }
-
     if (/^\s*$/.test(message_content)) {
         // Avoid showing an error message when "enter sends" is enabled,
         // as it is more likely that the user has hit "Enter" accidentally.


### PR DESCRIPTION
This commit moves "send button" related code from
`compose_validate.js` to `compose.js` as it makes more
sense there.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
