### PR TITLE
ci: Use apt-get -y in production-upgrade test

### DIFF
--- a/tools/ci/production-upgrade
+++ b/tools/ci/production-upgrade
@@ -16,8 +16,8 @@ set -x
 # * For rabbitmq-server, we likely need to do this to work around the
 # hostname changing on reboot causing RabbitMQ to not boot.
 # * For supervisor, we don't understand why it doesn't start properly.
-sudo apt-get remove rabbitmq-server supervisor && sudo apt-get purge rabbitmq-server supervisor
-sudo apt-get install rabbitmq-server supervisor
+sudo apt-get -y purge rabbitmq-server supervisor
+sudo apt-get -y install rabbitmq-server supervisor
 
 # Start the postgresql service.
 sudo service postgresql start


### PR DESCRIPTION
We currently configure `APT::Get::Assume-Yes` in our custom Docker image, but this is the only place we rely on it (outside of the `Dockerfile` itself), and it’s better not to.

Also `apt-get remove && apt-get purge` is the same as just `apt-get purge`.