### PR TITLE
narrow: Do not mark messages as read in mentioned narrow.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -170,7 +170,7 @@ test("basics", () => {
     operators = [{operator: "is", operand: "mentioned"}];
     filter = new Filter(operators);
     assert.ok(!filter.contains_only_private_messages());
-    assert.ok(filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
     assert.ok(!filter.has_operator("search"));
     assert.ok(filter.can_apply_locally());
     assert.ok(filter.is_personal_filter());
@@ -250,11 +250,7 @@ function assert_not_mark_read_with_is_operands(additional_operators_to_test) {
 
     is_operator = [{operator: "is", operand: "mentioned"}];
     filter = new Filter(additional_operators_to_test.concat(is_operator));
-    if (additional_operators_to_test.length === 0) {
-        assert.ok(filter.can_mark_messages_read());
-    } else {
-        assert.ok(!filter.can_mark_messages_read());
-    }
+    assert.ok(!filter.can_mark_messages_read());
 
     is_operator = [{operator: "is", operand: "mentioned", negated: true}];
     filter = new Filter(additional_operators_to_test.concat(is_operator));

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -453,10 +453,6 @@ export class Filter {
             return true;
         }
 
-        if (_.isEqual(term_types, ["is-mentioned"])) {
-            return true;
-        }
-
         if (_.isEqual(term_types, ["is-resolved"])) {
             return true;
         }
@@ -494,15 +490,20 @@ export class Filter {
         // can_mark_messages_read tests the following filters:
         // stream, stream + topic,
         // is: private, pm-with:,
-        // is: mentioned, is: resolved
+        // is: resolved
         if (this.can_mark_messages_read()) {
             return true;
         }
         // that leaves us with checking:
         // is: starred
         // (which can_mark_messages_read_does not check as starred messages are always read)
+        // is: mentioned
+        // We don't mark messages as read when in mentioned narrow.
         const term_types = this.sorted_term_types();
 
+        if (_.isEqual(term_types, ["is-mentioned"])) {
+            return true;
+        }
         if (_.isEqual(term_types, ["is-starred"])) {
             return true;
         }


### PR DESCRIPTION
The current behaviour marks messages as read when in mentioned
narrow. This is not the ideal behaviour, hence do not mark them
as read.

Fixes #19098.

**Testing plan:** <!-- How have you tested? -->
Manual testing, frontend tests.
