### PR TITLE
compose: Fix overlaping expand-compose icon.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -116,7 +116,7 @@
 
     .pm_recipient {
         margin-left: 5px;
-        margin-right: 20px;
+        margin-right: 35px;
         display: flex;
         width: 100%;
     }


### PR DESCRIPTION
The expand-compose icon currently overlaps with the
recipient input field of private message compose box.
Reduce the size of the division to fix overlap.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![WhatsApp Image 2021-07-14 at 15 12 07](https://user-images.githubusercontent.com/55033316/125602633-21e48a13-7c55-41a5-9f27-213513ddb933.jpeg)
![WhatsApp Image 2021-07-14 at 15 11 48](https://user-images.githubusercontent.com/55033316/125602672-3ed7c2de-2ea4-49a1-8094-91c68c0ac7d6.jpeg)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
