### PR TITLE
outgoing-webhook: Catch jsonable error in fail_with_message.

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -210,7 +210,10 @@ def fail_with_message(event: Dict[str, Any], failure_message: str) -> None:
     message_info = event["message"]
     content = "Failure! " + failure_message
     response_data = dict(content=content)
-    send_response_message(bot_id=bot_id, message_info=message_info, response_data=response_data)
+    try:
+        send_response_message(bot_id=bot_id, message_info=message_info, response_data=response_data)
+    except JsonableError:
+        pass
 
 
 def get_message_url(event: Dict[str, Any]) -> str:

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -265,7 +265,10 @@ def notify_bot_owner(
         display_recipient=[dict(email=bot_owner.email)],
     )
     response_data = dict(content=notification_message)
-    send_response_message(bot_id=bot_id, message_info=message_info, response_data=response_data)
+    try:
+        send_response_message(bot_id=bot_id, message_info=message_info, response_data=response_data)
+    except JsonableError:
+        pass
 
 
 def request_retry(event: Dict[str, Any], failure_message: Optional[str] = None) -> None:


### PR DESCRIPTION
Currently if the server timeouts on hitting a url, the fail_with_message
sends a message to the recipients. But if the bot gets deactivated
just after the failure happened, the fail_with_message returns a
JsonableError from send_response_message. This error piles up
till the queue handler. Hence catch the error in fail_with_message.

Fixes #19101.

**Testing plan:** <!-- How have you tested? -->
I am not sure how to reproduce the behaviour in a test to deactivate the bot after the timeout response, hence added no-coverage to the block for now. 

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
