### PR TITLE
smokescreen: Default to only listening on 127.0.0.1.

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -254,6 +254,11 @@ To use Smokescreen:
     port = 4750
     ```
 
+1. If you intend to also make the Smokescreen install available to
+   other hosts, set `listen_address` in the same block.  Note that you
+   must control access to the Smokescreen port if you do this, as
+   failing to do so opens a public HTTP proxy!
+
 1. As root, run
    `/home/zulip/deployments/current/scripts/zulip-puppet-apply`.  This
    will compile and install Smokescreen, reconfigure services to use
@@ -665,3 +670,8 @@ proxy](#using-an-outgoing-http-proxy).
 #### `port`
 
 The TCP port of the HTTP `CONNECT` proxy on the host specified above.
+
+#### `listen_address`
+
+The IP address that Smokescreen should bind to and listen on.
+Defaults to `127.0.0.1`.

--- a/puppet/zulip/manifests/profile/smokescreen.pp
+++ b/puppet/zulip/manifests/profile/smokescreen.pp
@@ -42,6 +42,7 @@ class zulip::profile::smokescreen {
     notify  => Service[supervisor],
   }
 
+  $listen_address = zulipconf('http_proxy', 'listen_address', '127.0.0.1')
   file { "${zulip::common::supervisor_conf_dir}/smokescreen.conf":
     ensure  => file,
     require => [

--- a/puppet/zulip/templates/supervisor/smokescreen.conf.erb
+++ b/puppet/zulip/templates/supervisor/smokescreen.conf.erb
@@ -1,5 +1,5 @@
 [program:smokescreen]
-command=/usr/local/bin/smokescreen-<%= @version %>
+command=/usr/local/bin/smokescreen-<%= @version %> --listen-ip <%= @listen_address %>
 priority=15
 autostart=true
 autorestart=true


### PR DESCRIPTION
This prevents Smokescreen from acting as an open proxy.

Fixes #19214.

**Testing plan:** Applied to a test prod deployment.

Should get cherry-picked back to 4.x.