### PR TITLE
puppet: Ensure psycopg2 is installed before running process_fts_updates.

### DIFF
--- a/puppet/zulip/manifests/process_fts_updates.pp
+++ b/puppet/zulip/manifests/process_fts_updates.pp
@@ -28,7 +28,7 @@ class zulip::process_fts_updates {
 
   file { "${zulip::common::supervisor_conf_dir}/zulip_db.conf":
     ensure  => file,
-    require => Package[supervisor],
+    require => [Package[supervisor], Package['python3-psycopg2']],
     owner   => 'root',
     group   => 'root',
     mode    => '0644',


### PR DESCRIPTION
Not having the package installed will cause startup failures in
`process_fts_updates`; ensure that we've installed the package before
we potentially start the service.

**Testing plan:** Untested; see https://github.com/zulip/zulip/pull/19228#issuecomment-880250576
