### PR TITLE
stream_create: Avoid re-initialization of event handlers.

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -314,8 +314,6 @@ export function show_new_stream_modal() {
         html_selector: (user) => $(`#${CSS.escape("user_checkbox_" + user.user_id)}`),
     });
 
-    create_handlers_for_users(add_people_container);
-
     // Make the options default to the same each time:
     // public, "announce stream" on.
     $("#make-invite-only input:radio[value=public]").prop("checked", true);
@@ -394,7 +392,7 @@ export function create_handlers_for_users(container) {
         $("#copy-from-stream-expand-collapse .toggle").toggleClass("fa-caret-right fa-caret-down");
     });
 
-    $("#stream-checkboxes label.checkbox").on("change", (e) => {
+    container.on("change", "#stream-checkboxes label.checkbox", (e) => {
         e.preventDefault();
         const elem = $(e.target).closest("[data-stream-id]");
         const stream_id = Number.parseInt(elem.attr("data-stream-id"), 10);
@@ -405,6 +403,11 @@ export function create_handlers_for_users(container) {
 }
 
 export function set_up_handlers() {
+    // Sets up all the event handlers concerning the `People to add`
+    // section in Create stream UI.
+    const people_to_add_holder = $("#people_to_add").expectOne();
+    create_handlers_for_users(people_to_add_holder);
+
     const container = $("#stream-creation").expectOne();
 
     container.on("change", "#make-invite-only input", update_announce_stream_state);

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -331,7 +331,7 @@ export function show_new_stream_modal() {
     clear_error_display();
 }
 
-export function create_handlers_for_users(container) {
+function create_handlers_for_users(container) {
     // container should be $('#people_to_add')...see caller to verify
     function update_checked_state_for_users(value, users) {
         // Update the all_users backing data structure for


### PR DESCRIPTION
Everytime, the user presses the "Create stream" button in "Manage streams" UI, the `create_handlers_for_users` function used to initialize which lead to multiple events being binded over a single element.

In case #19255, upon reopening the "Manage stream" UI, the click event for "Copy from stream" triggered twice.
This lead to the dropdown closing itself again as the `.toggle()` method is executed twice.

<details>
<summary>Bug</summary>

![bug](https://user-images.githubusercontent.com/53977614/125835226-c1384c74-222c-4f39-814c-92ac2cdc1181.gif)
</details>
(The function is triggered twice here. Suppose, I reopen the "Manage stream" UI - the function is triggered thrice then!)


<br/>
<br/>


<details>
<summary>Fixed screenshot</summary>

![bug-fixed](https://user-images.githubusercontent.com/53977614/125833713-15b3576f-fedf-4649-94c0-ca06670f9d0b.gif)
</details>


Fixes #19255. 
