### PR TITLE
sentry: Set environment from `machine.deploy_type` config.

### DIFF
--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -1185,4 +1185,4 @@ SENTRY_DSN = os.environ.get("SENTRY_DSN", SENTRY_DSN)
 if SENTRY_DSN:
     from .sentry import setup_sentry
 
-    setup_sentry(SENTRY_DSN)
+    setup_sentry(SENTRY_DSN, get_config("machine", "deploy_type", "development"))

--- a/zproject/config.py
+++ b/zproject/config.py
@@ -9,7 +9,6 @@ config_file.read("/etc/zulip/zulip.conf")
 
 # Whether this instance of Zulip is running in a production environment.
 PRODUCTION = config_file.has_option("machine", "deploy_type")
-STAGING = config_file.get("machine", "deploy_type", fallback="") == "staging"
 DEVELOPMENT = not PRODUCTION
 
 secrets_file = configparser.RawConfigParser()

--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, Optional
 
 import sentry_sdk
 from django.utils.translation import override as override_language
-from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.integrations.redis import RedisIntegration
@@ -59,7 +58,7 @@ def add_context(event: "Event", hint: "Hint") -> Optional["Event"]:
     return event
 
 
-def setup_sentry(dsn: Optional[str], *integrations: Integration) -> None:
+def setup_sentry(dsn: Optional[str]) -> None:
     if not dsn:
         return
     if PRODUCTION:
@@ -77,7 +76,6 @@ def setup_sentry(dsn: Optional[str], *integrations: Integration) -> None:
             DjangoIntegration(),
             RedisIntegration(),
             SqlalchemyIntegration(),
-            *integrations,
         ],
         before_send=add_context,
         # Because we strip the email/username from the Sentry data

--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -11,8 +11,6 @@ from sentry_sdk.utils import capture_internal_exceptions
 from version import ZULIP_VERSION
 from zerver.lib.request import get_request_notes
 
-from .config import PRODUCTION, STAGING
-
 if TYPE_CHECKING:
     from sentry_sdk._types import Event, Hint
 
@@ -58,16 +56,9 @@ def add_context(event: "Event", hint: "Hint") -> Optional["Event"]:
     return event
 
 
-def setup_sentry(dsn: Optional[str]) -> None:
+def setup_sentry(dsn: Optional[str], environment: str) -> None:
     if not dsn:
         return
-    if PRODUCTION:
-        if STAGING:
-            environment = "staging"
-        else:
-            environment = "production"
-    else:
-        environment = "development"
     sentry_sdk.init(
         dsn=dsn,
         environment=environment,


### PR DESCRIPTION
This allows for greater flexibility in values for "environment," and
avoids having to have duplicate definitions of STAGING in
`zproject/config.py` and `zproject/default_settings.py` (due to import
order restrictions).

It does overload the "deploy type" concept somewhat.

Follow-up to #19185.
