### PR TITLE
compose: Fix expanded compose un-collapsible in presence of navbar_alerts.

### DIFF
--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -407,18 +407,52 @@ run_test("quote_and_reply", ({override}) => {
     );
 });
 
+run_test("set_compose_box_top", () => {
+    $(".header").set_height(40);
+
+    const padding_bottom = 10;
+    $(".header").css = (arg) => {
+        assert.equal(arg, "paddingBottom");
+        return padding_bottom;
+    };
+
+    let compose_top = "";
+    $("#compose").css = (arg, val) => {
+        assert.equal(arg, "top");
+        compose_top = val;
+    };
+
+    $("#navbar_alerts_wrapper").set_height(0);
+    compose_ui.set_compose_box_top(true);
+    assert.equal(compose_top, "50px");
+
+    $("#navbar_alerts_wrapper").set_height(45);
+    compose_ui.set_compose_box_top(true);
+    assert.equal(compose_top, "95px");
+
+    compose_ui.set_compose_box_top(false);
+    assert.equal(compose_top, "");
+});
+
 run_test("test_compose_height_changes", ({override}) => {
     let autosize_destroyed = false;
     override(autosize, "destroy", () => {
         autosize_destroyed = true;
     });
 
+    let compose_box_top_set = false;
+    override(compose_ui, "set_compose_box_top", (set_top) => {
+        compose_box_top_set = set_top;
+    });
+
     compose_ui.make_compose_box_full_size();
     assert.ok($("#compose").hasClass("compose-fullscreen"));
     assert.ok(compose_ui.is_full_size());
     assert.ok(autosize_destroyed);
+    assert.ok(compose_box_top_set);
 
     compose_ui.make_compose_box_original_size();
     assert.ok(!$("#compose").hasClass("compose-fullscreen"));
     assert.ok(!compose_ui.is_full_size());
+    assert.ok(!compose_box_top_set);
 });

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -144,6 +144,23 @@ export function wrap_text_with_markdown(textarea, prefix, suffix) {
     }
 }
 
+export function set_compose_box_top(set_top) {
+    if (set_top) {
+        // As `#compose` has `position: fixed` property, we cannot
+        // make the compose-box to attain the correct height just by
+        // using CSS. If that wasn't the case, we could have somehow
+        // refactored the HTML so as to consider only the space below
+        // below the `#navbar_alerts` as `height: 100%` of `#compose`.
+        const compose_top =
+            $("#navbar_alerts_wrapper").height() +
+            $(".header").height() +
+            Number.parseInt($(".header").css("paddingBottom"), 10);
+        $("#compose").css("top", compose_top + "px");
+    } else {
+        $("#compose").css("top", "");
+    }
+}
+
 export function make_compose_box_full_size() {
     set_full_size(true);
 
@@ -152,6 +169,9 @@ export function make_compose_box_full_size() {
     autosize.destroy($("#compose-textarea"));
 
     $("#compose").addClass("compose-fullscreen");
+
+    // Set the `top` property of compose-box.
+    set_compose_box_top(true);
 
     $(".collapse_composebox_button").show();
     $(".expand_composebox_button").hide();
@@ -162,6 +182,9 @@ export function make_compose_box_original_size() {
     set_full_size(false);
 
     $("#compose").removeClass("compose-fullscreen");
+
+    // Unset the `top` property of compose-box.
+    set_compose_box_top(false);
 
     // Again initialise the compose textarea as it was destroyed
     // when compose box was made full screen

--- a/static/js/navbar_alerts.js
+++ b/static/js/navbar_alerts.js
@@ -9,6 +9,7 @@ import render_navbar_alert_wrapper from "../templates/navbar_alerts/navbar_alert
 import render_profile_incomplete_alert_content from "../templates/navbar_alerts/profile_incomplete.hbs";
 import render_server_needs_upgrade_alert_content from "../templates/navbar_alerts/server_needs_upgrade.hbs";
 
+import * as compose_ui from "./compose_ui";
 import {localstorage} from "./localstorage";
 import * as notifications from "./notifications";
 import {page_params} from "./page_params";
@@ -29,6 +30,12 @@ export function resize_app() {
         $(".header").height() +
         Number.parseInt($(".header").css("paddingBottom"), 10);
     $("#floating_recipient_bar").css("top", frb_top + "px");
+
+    // If the compose-box is in expanded state,
+    // reset its height as well.
+    if (compose_ui.is_full_size()) {
+        compose_ui.set_compose_box_top(true);
+    }
 }
 
 const show_step = function ($process, step) {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -586,12 +586,10 @@ a.compose_control_button.hide {
 }
 
 #compose.compose-fullscreen {
-    height: 100%;
     z-index: 99;
 
     #compose-container {
-        margin-top: 50px;
-        height: calc(100% - 50px);
+        height: 100%;
     }
 
     .message_comp {


### PR DESCRIPTION
The distance of compose-box from the top is hardcoded in the existing
code as `50px`, which only considers the height of the `.header`, plus the
padding-bottom of the header. This results in a bug where the top bar of
compose-box gets hidden behind the header if navbar_alerts is also present
in the view.

This commit calculates the top distance of the compose-box dynamically,
whenever the compose-box is opened and set the `top` property of the
compose-box accordingly.

Tested on my Ubuntu development environment.

Fixes: #19249.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2021-07-16 01-07-15](https://user-images.githubusercontent.com/39924567/125847299-2f5879d4-be9a-4b78-a8b7-f5133ca17106.png)
