### PR TITLE
push_notifications: Fix APNs message generation

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -156,7 +156,8 @@ def send_apple_push_notification(
         DeviceTokenClass = PushDeviceToken
 
     logger.info("APNs: Sending notification for user %d to %d devices", user_id, len(devices))
-    message = {"aps": modernize_apns_payload(payload_data)}
+    payload_data = modernize_apns_payload(payload_data).copy()
+    message = {**payload_data.pop("custom", {}), "aps": payload_data}
     retries_left = APNS_MAX_RETRIES
     for device in devices:
         # TODO obviously this should be made to actually use the async


### PR DESCRIPTION
This emulates the previous PyAPNs2 behavior of moving the contents of the `custom` key to top level.

**Testing plan:** Tested on staging.