### PR TITLE
compose: Fix compose top-right buttons misalignment.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -227,6 +227,7 @@
         border: 0;
         padding: 0;
         margin-left: 4px;
+        vertical-align: unset;
 
         &:hover {
             opacity: 1;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Bootstrap set the `vertical-align` property of all button elements to `middle`, which seems to be causing this problem.

**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

**Before**
![Screenshot from 2021-07-16 02-19-49](https://user-images.githubusercontent.com/39924567/125857977-d78583e1-06ce-435b-b09d-11bfcf3c40f7.png)


**After**
![Screenshot from 2021-07-16 02-29-49](https://user-images.githubusercontent.com/39924567/125858002-753538c5-f906-4ffd-9281-bd635b75b585.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
