### PR TITLE
landing_page: Fix top navigation dropdowns for mobile screens. 

### DIFF
--- a/static/js/portico/header.js
+++ b/static/js/portico/header.js
@@ -6,41 +6,39 @@ $(() => {
         return false;
     });
 
+    const is_touchscreen = window.matchMedia("(hover: none)").matches;
+
     $("body").on("click", (e) => {
         const $this = $(e.target);
+        const dropdown_is_shown = $this.closest("ul .dropdown").hasClass("show");
+        const dropdown_label_was_clicked = $this.closest(".dropdown .dropdown-label").length > 0;
+        const logged_in_pill_was_clicked = $this.closest(".dropdown .dropdown-pill").length > 0;
+        const clicked_outside_dropdown_content =
+            !$this.is(".dropdown ul") && $this.closest(".dropdown ul").length === 0;
 
-        if (
-            $this.closest(".dropdown .dropdown-label").length > 0 &&
-            !$this.closest("ul .dropdown").hasClass("show") &&
-            window.matchMedia("(max-width: 686px)").matches
-        ) {
+        if (dropdown_label_was_clicked && !dropdown_is_shown && is_touchscreen) {
             $this.closest("ul .dropdown").addClass("show");
-        } else if (
-            $this.closest(".dropdown .dropdown-pill").length > 0 &&
-            !$this.closest("ul .dropdown").hasClass("show")
-        ) {
+        } else if (logged_in_pill_was_clicked && !dropdown_is_shown) {
             $this.closest("ul .dropdown").addClass("show");
-        } else if (!$this.is(".dropdown ul") && $this.closest(".dropdown ul").length === 0) {
+        } else if (clicked_outside_dropdown_content) {
             $this.closest("ul .dropdown").removeClass("show");
         }
     });
 
     $(".nav-dropdown").on("mouseover", (e) => {
         const $this = $(e.target);
-        if (
-            !$this.closest("ul .dropdown").hasClass("show") &&
-            window.matchMedia("(min-width: 687px)").matches
-        ) {
+        const dropdown_is_shown = $this.closest("ul .dropdown").hasClass("show");
+
+        if (!dropdown_is_shown && !is_touchscreen) {
             $this.closest("ul .dropdown").addClass("show");
         }
     });
 
     $(".nav-dropdown").on("mouseout", (e) => {
         const $this = $(e.target);
-        if (
-            $this.closest("ul .dropdown").hasClass("show") &&
-            window.matchMedia("(min-width: 687px)").matches
-        ) {
+        const dropdown_is_shown = $this.closest("ul .dropdown").hasClass("show");
+
+        if (dropdown_is_shown && !is_touchscreen) {
             $this.closest("ul .dropdown").removeClass("show");
         }
     });


### PR DESCRIPTION
A recent PR introduced a bug where navigation dropdowns on the landing page would not open for tablet screens. This commit fixes that by increasing the width we use to determine when to switch to click-to-open (as opposed to hover-to-open) for our top-level navigation dropdowns.

@timabbott @alya FYI :)