### PR TITLE
do_update_embedded_data: Remove unnecessary transaction.atomic.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5869,8 +5869,6 @@ def update_to_dict_cache(
     return message_ids
 
 
-# We use transaction.atomic to support select_for_update in the attachment codepath.
-@transaction.atomic
 def do_update_embedded_data(
     user_profile: UserProfile,
     message: Message,

--- a/zerver/tests/test_queue.py
+++ b/zerver/tests/test_queue.py
@@ -103,8 +103,9 @@ class TestQueueImplementation(ZulipTestCase):
         assert not message
 
     @override_settings(USING_RABBITMQ=True)
-    def tearDown(self) -> None:
+    def setUp(self) -> None:
         queue_client = get_queue_client()
         assert queue_client.channel
-        queue_client.channel.queue_purge("test_suite")
-        super().tearDown()
+        if "test_suite" in queue_client.queues:
+            queue_client.channel.queue_purge("test_suite")
+        super().setUp()


### PR DESCRIPTION
There isn't any attachments code involved here.
This was added in c93f1d4, probably accidentally.

The first commit is kinda unrelated, but I think is an improvement nonetheless.