### PR TITLE
Revert "request: Refactor to record rate limit data using ZulipRequestNotes."

### DIFF
--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -540,9 +540,8 @@ class RateLimitMiddleware(MiddlewareMixin):
             return response
 
         # Add X-RateLimit-*** headers
-        ratelimits_applied = get_request_notes(request).ratelimits_applied
-        if len(ratelimits_applied) > 0:
-            self.set_response_headers(response, ratelimits_applied)
+        if hasattr(request, "_ratelimits_applied"):
+            self.set_response_headers(response, request._ratelimits_applied)
 
         return response
 

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -238,10 +238,10 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         # Add to this new HttpRequest logging data from the processing of
         # the original request; we will need these for logging.
         request_notes.log_data = old_request_notes.log_data
-        if request_notes.rate_limit is not None:
-            request_notes.rate_limit = old_request_notes.rate_limit
         if request_notes.requestor_for_logs is not None:
             request_notes.requestor_for_logs = old_request_notes.requestor_for_logs
+        if hasattr(request, "_rate_limit"):
+            request._rate_limit = old_request._rate_limit
         request.user = old_request.user
         request_notes.client = old_request_notes.client
         request_notes.client_name = old_request_notes.client_name

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -259,11 +259,12 @@ def rate_limit_authentication_by_username(request: HttpRequest, username: str) -
 
 
 def auth_rate_limiting_already_applied(request: HttpRequest) -> bool:
-    request_notes = get_request_notes(request)
+    if not hasattr(request, "_ratelimits_applied"):
+        return False
 
     return any(
         isinstance(r.entity, RateLimitedAuthenticationByUsername)
-        for r in request_notes.ratelimits_applied
+        for r in request._ratelimits_applied
     )
 
 


### PR DESCRIPTION
This reverts commit 3f9a5e1e17f0e5f50430300dfcf6e0cce11e899b, providing a temporary fix before finding a way to rewrite it without memory leak.

[chat](https://chat.zulip.org/#narrow/stream/3-backend/topic/HttpRequest.20-.3E.20ZulipHttpRequest.20conversion/near/1232467)