### PR TITLE
Add `ignored_paramters_unsupported` to response of `/settings` endpoint and remove existing `full_name` and `account_email`.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -17,6 +17,9 @@ below features are supported.
   which is a list of parameters that were ignored by the endpoint,
   to the response object.
 
+* `PATCH /settings`: Removed `full_name` and `account_email` fields
+  from the response object.
+
 **Feature level 77**
 
 * [`GET /events`](/api/get-events): Removed `recipient_id` and

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -11,6 +11,12 @@ below features are supported.
 
 ## Changes in Zulip 5.0
 
+**Feature level 78**
+
+* `PATCH /settings`: Added `ignored_parameters_unsupported` field,
+  which is a list of parameters that were ignored by the endpoint,
+  to the response object.
+
 **Feature level 77**
 
 * [`GET /events`](/api/get-events): Removed `recipient_id` and

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 77
+API_FEATURE_LEVEL = 78
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -103,8 +103,8 @@ class EmailChangeTestCase(ZulipTestCase):
         url = "/json/settings"
         self.assert_length(mail.outbox, 0)
         result = self.client_patch(url, data)
+        self.assert_json_success(result)
         self.assert_length(mail.outbox, 1)
-        self.assert_in_success_response(["Check your email for a confirmation link."], result)
         email_message = mail.outbox[0]
         self.assertEqual(
             email_message.subject,
@@ -127,7 +127,7 @@ class EmailChangeTestCase(ZulipTestCase):
 
         # Now confirm trying to change your email back doesn't throw an immediate error
         result = self.client_patch(url, {"email": "hamlet@zulip.com"})
-        self.assert_in_success_response(["Check your email for a confirmation link."], result)
+        self.assert_json_success(result)
 
     def test_unauthorized_email_change(self) -> None:
         data = {"email": "hamlet-new@zulip.com"}
@@ -149,7 +149,7 @@ class EmailChangeTestCase(ZulipTestCase):
         self.login("iago")
         url = "/json/settings"
         result = self.client_patch(url, data)
-        self.assert_in_success_response(["Check your email for a confirmation link."], result)
+        self.assert_json_success(result)
 
     def test_email_change_already_taken(self) -> None:
         data = {"email": "cordelia@zulip.com"}
@@ -170,7 +170,7 @@ class EmailChangeTestCase(ZulipTestCase):
         self.assert_length(mail.outbox, 0)
         result = self.client_patch(url, data)
         self.assert_length(mail.outbox, 1)
-        self.assert_in_success_response(["Check your email for a confirmation link."], result)
+        self.assert_json_success(result)
         email_message = mail.outbox[0]
         self.assertEqual(
             email_message.subject,

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -171,7 +171,7 @@ class RealmTest(ZulipTestCase):
         self.login("iago")
         url = "/json/settings"
         result = self.client_patch(url, data)
-        self.assert_in_success_response(['"full_name":"New Iago"'], result)
+        self.assert_json_success(result)
 
     def test_do_deactivate_realm_clears_user_realm_cache(self) -> None:
         """The main complicated thing about deactivating realm names is

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -15,9 +15,6 @@ from zerver.models import UserProfile, get_user_profile_by_api_key
 
 
 class ChangeSettingsTest(ZulipTestCase):
-    def check_well_formed_change_settings_response(self, result: Dict[str, Any]) -> None:
-        self.assertIn("full_name", result)
-
     # DEPRECATED, to be deleted after all uses of check_for_toggle_param
     # are converted into check_for_toggle_param_patch.
     def check_for_toggle_param(self, pattern: str, param: str) -> None:
@@ -68,8 +65,6 @@ class ChangeSettingsTest(ZulipTestCase):
             ),
         )
         self.assert_json_success(json_result)
-        result = orjson.loads(json_result.content)
-        self.check_well_formed_change_settings_response(result)
 
         user.refresh_from_db()
         self.assertEqual(user.full_name, "Foo Bar")

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -409,6 +409,17 @@ class ChangeSettingsTest(ZulipTestCase):
                 result = self.client_post("/json/users/me/avatar", {"f1": fp1})
             self.assert_json_error(result, "Avatar changes are disabled in this organization.", 400)
 
+    def test_invalid_setting_name(self) -> None:
+        self.login("hamlet")
+
+        # Now try an invalid setting name
+        json_result = self.client_patch("/json/settings", dict(invalid_setting="value"))
+        self.assert_json_success(json_result)
+
+        result = orjson.loads(json_result.content)
+        self.assertIn("ignored_parameters_unsupported", result)
+        self.assertEqual(result["ignored_parameters_unsupported"], ["invalid_setting"])
+
 
 class UserChangesTest(ZulipTestCase):
     def test_update_api_key(self) -> None:

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -173,6 +173,17 @@ def json_change_settings(
             # Note that check_change_full_name strips the passed name automatically
             result["full_name"] = check_change_full_name(user_profile, full_name, user_profile)
 
+    # TODO: Do this more generally.
+    from zerver.lib.request import get_request_notes
+
+    request_notes = get_request_notes(request)
+    for req_var in request.POST:
+        if req_var not in request_notes.processed_parameters:
+            request_notes.ignored_parameters.add(req_var)
+
+    if len(request_notes.ignored_parameters) > 0:
+        result["ignored_parameters_unsupported"] = list(request_notes.ignored_parameters)
+
     return json_success(result)
 
 

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -162,7 +162,6 @@ def json_change_settings(
             raise JsonableError(e.message)
 
         do_start_email_change_process(user_profile, new_email)
-        result["account_email"] = _("Check your email for a confirmation link. ")
 
     if user_profile.full_name != full_name and full_name.strip() != "":
         if name_changes_disabled(user_profile.realm) and not user_profile.is_realm_admin:
@@ -171,7 +170,7 @@ def json_change_settings(
             pass
         else:
             # Note that check_change_full_name strips the passed name automatically
-            result["full_name"] = check_change_full_name(user_profile, full_name, user_profile)
+            check_change_full_name(user_profile, full_name, user_profile)
 
     # TODO: Do this more generally.
     from zerver.lib.request import get_request_notes


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit adds `ignored_parameters_unsupported` to response.
- Second commit removes `full_name` and `account_email` from response.
 <!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
