### PR TITLE
api: Return user IDs, not display emails, in subscribers endpoints.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -11,6 +11,15 @@ below features are supported.
 
 ## Changes in Zulip 5.0
 
+**Feature level 79**
+
+* [`GET /users/me/subscriptions`](/api/get-subscriptions): The
+  `subscribers` field now returns user IDs if `include_subscribers` is
+  passed. Previously, this endpoint returned user display email
+  addresses in this field.
+* `GET /streams/{stream_id}/members`: This endpoint now returns user
+  IDs. Previously, it returned display email addresses.
+
 **Feature level 78**
 
 * `PATCH /settings`: Added `ignored_parameters_unsupported` field,

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 78
+API_FEATURE_LEVEL = 79
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3650,12 +3650,9 @@ def get_subscribers_query(stream: Stream, requesting_user: Optional[UserProfile]
     return get_active_subscriptions_for_stream_id(stream.id, include_deactivated_users=False)
 
 
-def get_subscriber_emails(
-    stream: Stream, requesting_user: Optional[UserProfile] = None
-) -> List[str]:
+def get_subscriber_ids(stream: Stream, requesting_user: Optional[UserProfile] = None) -> List[str]:
     subscriptions_query = get_subscribers_query(stream, requesting_user)
-    subscriptions = subscriptions_query.values("user_profile__email")
-    return [subscription["user_profile__email"] for subscription in subscriptions]
+    return subscriptions_query.values_list("user_profile_id", flat=True)
 
 
 def send_subscription_add_events(
@@ -6630,26 +6627,8 @@ def gather_subscriptions(
         user_profile,
         include_subscribers=include_subscribers,
     )
-
     subscribed = helper_result.subscriptions
     unsubscribed = helper_result.unsubscribed
-
-    if include_subscribers:
-        user_ids = set()
-        for subs in [subscribed, unsubscribed]:
-            for sub in subs:
-                if "subscribers" in sub:
-                    for subscriber in sub["subscribers"]:
-                        user_ids.add(subscriber)
-        email_dict = get_emails_from_user_ids(list(user_ids))
-
-        for subs in [subscribed, unsubscribed]:
-            for sub in subs:
-                if "subscribers" in sub:
-                    sub["subscribers"] = sorted(
-                        email_dict[user_id] for user_id in sub["subscribers"]
-                    )
-
     return (subscribed, unsubscribed)
 
 

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -561,10 +561,16 @@ def test_user_not_authorized_error(nonadmin_client: Client) -> None:
     validate_against_openapi_schema(result, "/rest-error-handling", "post", "400_2")
 
 
+@openapi_test_function("/streams/{stream_id}/members:get")
 def get_subscribers(client: Client) -> None:
+    ensure_users([11, 26], ["iago", "newbie"])
 
+    # {code_example|start}
+    # Get the subscribers to a stream
     result = client.get_subscribers(stream="new stream")
-    assert result["subscribers"] == ["iago@zulip.com", "newbie@zulip.com"]
+    print(result)
+    # {code_example|end}
+    assert result["subscribers"] == [11, 26]
 
 
 def get_user_agent(client: Client) -> None:

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -40,7 +40,7 @@ from zerver.lib.actions import (
     do_send_messages,
     gather_subscriptions,
     get_default_streams_for_realm,
-    get_subscriber_emails,
+    get_subscriber_ids,
     internal_prep_private_message,
     internal_prep_stream_message,
 )
@@ -676,9 +676,9 @@ def get_subscribers_backend(
         stream_id,
         allow_realm_admin=True,
     )
-    subscribers = get_subscriber_emails(stream, user_profile)
+    subscribers = get_subscriber_ids(stream, user_profile)
 
-    return json_success({"subscribers": subscribers})
+    return json_success({"subscribers": list(subscribers)})
 
 
 # By default, lists all streams that the user has access to --


### PR DESCRIPTION
Sometime in the deep past, Zulip the GET /users/me/subscriptions
endpoint started returning subscribers.  We noticed this and made it
optional via the include_subscribers parameter in
1af72a2745e974e67d1cdc6e8af4134c37d4551e, however, we didn't notice
that they were being returned as emails rather than user IDs.

We migrated the core /register code paths to use subscriber IDs years
ago; this change completes that for the endpoints we forgot about.

The documentation allowed this error because we apparently had no
tests for this code path that used the actual API.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
