### PR TITLE
puppeteer_test: Improve how we select the typeahead element.

### DIFF
--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -482,8 +482,11 @@ class CommonUtils {
         await this.clear_and_type(page, field_selector, str);
         const entry = await page.waitForXPath(
             `//*[@class="typeahead dropdown-menu" and contains(@style, "display: block")]//li[contains(normalize-space(), "${item}")]//a`,
+            {visible: true},
         );
-        await entry!.click();
+        await page.evaluate((entry) => {
+            entry.click();
+        }, entry);
     }
 
     async wait_for_modal_to_close(page: Page): Promise<void> {

--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -326,7 +326,7 @@
       }
 
       this.$menu
-        .on('click', this.click.bind(this))
+        .on('click', 'li', this.click.bind(this))
         .on('mouseenter', 'li', this.mouseenter.bind(this))
     }
 
@@ -428,6 +428,14 @@
   , click: function (e) {
       e.stopPropagation()
       e.preventDefault()
+      // The original bootstrap code expected `mouseenter` to be called
+      // to set the active element before `select()`.
+      // Since select() selects the element with the active class, if
+      // we trigger a click from JavaScript (or with a mobile touchscreen),
+      // this won't work. So we need to set the active element ourselves,
+      // and the simplest way to do that is to just call the `mouseenter`
+      // handler here.
+      this.mouseenter(e)
       this.select(e)
     }
 


### PR DESCRIPTION
Our typeahead system is very sensitive, a simple internal
focus can hide it. This leads to occasional failure on the
puppeteer test.

This commit tries to solve it by clicking via javascript
instead of manual puppeteer click.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
