### PR TITLE
Refactor html in failed message action buttons.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -140,14 +140,7 @@ export function initialize() {
                 const edit_button = elem.find("i.edit_content_button");
                 content = edit_button.attr("data-tippy-content");
             }
-            if (content === undefined) {
-                // If content is still undefined it is because content
-                // is specified on inner i tags and is handled by our
-                // general tippy-zulip-tooltip class. So we return
-                // false here to avoid showing an extra empty tooltip
-                // for such cases.
-                return false;
-            }
+
             instance.setContent(content);
             return true;
         },

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -919,8 +919,6 @@ td.pointer {
         /* error icon width is 11px, gap between icons equals 28px - 2*11px = 6px */
         width: 30px;
         cursor: pointer;
-        font-weight: bold;
-        color: hsl(0, 100%, 50%);
         position: relative;
         vertical-align: middle;
 
@@ -928,6 +926,12 @@ td.pointer {
             display: inline-block;
 
             animation: rotate 1s infinite linear;
+        }
+
+        .failed_message_action {
+            opacity: 1 !important;
+            color: hsl(0, 100%, 50%);
+            font-weight: bold;
         }
     }
 
@@ -957,7 +961,9 @@ td.pointer {
     border: none;
 
     &:hover .message_controls,
-    &:focus-within .message_controls {
+    &:focus-within .message_controls,
+    &:hover .message_failed,
+    &:focus-within .message_failed {
         .empty-star:hover {
             cursor: pointer;
         }

--- a/static/templates/message_controls.hbs
+++ b/static/templates/message_controls.hbs
@@ -15,9 +15,14 @@
     </div>
     {{/unless}}
 
-    <div class="message_failed message_control_button {{#unless msg.failed_request}}notvisible{{/unless}}">
-        <i class="fa fa-refresh refresh-failed-message tippy-zulip-tooltip" data-tippy-content="{{t 'Retry' }}" aria-label="{{t 'Retry' }}" role="button" tabindex="0"></i>
-        <i class="fa fa-times-circle remove-failed-message tippy-zulip-tooltip" data-tippy-content="{{t 'Cancel' }}" aria-label="{{t 'Cancel' }}" role="button" tabindex="0"></i>
+    <div class="message_failed {{#unless msg.failed_request}}notvisible{{/unless}}">
+        <div class="message_control_button failed_message_action" data-tippy-content="{{t 'Retry' }}">
+            <i class="fa fa-refresh refresh-failed-message" aria-label="{{t 'Retry' }}" role="button" tabindex="0"></i>
+        </div>
+
+        <div class="message_control_button failed_message_action" data-tippy-content="{{t 'Cancel' }}">
+            <i class="fa fa-times-circle remove-failed-message" aria-label="{{t 'Cancel' }}" role="button" tabindex="0"></i>
+        </div>
     </div>
 
     {{#unless msg/locally_echoed}}


### PR DESCRIPTION
https://github.com/zulip/zulip/pull/18515#issuecomment-845569371


**Testing plan:** Manualy


**GIFs or screenshots:** 
![failed_message](https://user-images.githubusercontent.com/63504956/126039429-ff62a607-2e12-4345-a208-07544be59640.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
