### PR TITLE
Show _OR_ during login only when other methods are available.

### DIFF
--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -68,7 +68,7 @@ page can be easily identified in it's respective JavaScript file -->
                                 <button class="full-width" type="submit">{{ _('Sign up') }}</button>
                             </form>
 
-                            {% if any_social_backend_enabled %}
+                            {% if page_params.external_authentication_methods|length > 0 %}
                             <div class="or"><span>{{ _('OR') }}</span></div>
                             {% endif %}
                         {% endif %}

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -104,7 +104,7 @@ page can be easily identified in it's respective JavaScript file. -->
                             </button>
                         </form>
 
-                        {% if any_social_backend_enabled %}
+                        {% if page_params.external_authentication_methods|length > 0 %}
                         <div class="or"><span>{{ _('OR') }}</span></div>
                         {% endif %}
 

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -23,7 +23,6 @@ from zerver.lib.subdomains import get_subdomain
 from zerver.models import Realm, UserProfile, get_realm
 from zproject.backends import (
     AUTH_BACKEND_NAME_MAP,
-    any_social_backend_enabled,
     auth_enabled_helper,
     get_external_method_dicts,
     password_auth_enabled,
@@ -198,7 +197,6 @@ def login_context(request: HttpRequest) -> Dict[str, Any]:
         "realm_description": realm_description,
         "require_email_format_usernames": require_email_format_usernames(realm),
         "password_auth_enabled": password_auth_enabled(realm),
-        "any_social_backend_enabled": any_social_backend_enabled(realm),
         "two_factor_authentication_enabled": settings.TWO_FACTOR_AUTHENTICATION_ENABLED,
     }
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -79,9 +79,9 @@ from zproject.backends import (
     ExternalAuthResult,
     ZulipLDAPAuthBackend,
     ZulipLDAPExceptionNoMatchingLDAPUser,
-    any_social_backend_enabled,
     email_auth_enabled,
     email_belongs_to_ldap,
+    get_external_method_dicts,
     ldap_auth_enabled,
     password_auth_enabled,
 )
@@ -370,8 +370,8 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
                 return_data=return_data,
             )
             if user_profile is None:
-                can_use_different_backend = email_auth_enabled(realm) or any_social_backend_enabled(
-                    realm
+                can_use_different_backend = email_auth_enabled(realm) or (
+                    len(get_external_method_dicts(realm)) > 0
                 )
                 if settings.LDAP_APPEND_DOMAIN:
                     # In LDAP_APPEND_DOMAIN configurations, we don't allow making a non-LDAP account

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -161,15 +161,6 @@ def saml_auth_enabled(realm: Optional[Realm] = None) -> bool:
     return auth_enabled_helper(["SAML"], realm)
 
 
-def any_social_backend_enabled(realm: Optional[Realm] = None) -> bool:
-    """Used by the login page process to determine whether to show the
-    'OR' for login with Google"""
-    social_backend_names = [
-        social_auth_subclass.auth_backend_name for social_auth_subclass in EXTERNAL_AUTH_METHODS
-    ]
-    return auth_enabled_helper(social_backend_names, realm)
-
-
 def require_email_format_usernames(realm: Optional[Realm] = None) -> bool:
     if ldap_auth_enabled(realm):
         if settings.LDAP_EMAIL_ATTR or settings.LDAP_APPEND_DOMAIN:


### PR DESCRIPTION
There might be good reasons to have other external authentication
methods such as SAML configured, but none of them is available. This
happens for example when you already enable SAML so that Zulip is able
to generate the metadata in XML format, but you haven't configured an
IdP yet. This commit makes sure that the phrase _OR_ is only shown on
the login page when there are actually other authentication methods
available. When they are just configured, but not available yet, the
page looks like as if no other authentication methods would be
configured.

**Testing plan:**

Manually tested in Firefox

**GIFs or screenshots:** 

You can see Zulip in the original/broken state here: https://ibb.co/x3rR7Qm

With the commit, it looks like this: https://ibb.co/Fbg82PV
