### PR TITLE
tippy: Fix blueslip error on edit history timestamp hover.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -147,7 +147,7 @@ export function initialize() {
     });
 
     delegate("body", {
-        target: ".message_time",
+        target: ".message_table .message_time",
         appendTo: () => document.body,
         onShow(instance) {
             const time_elem = $(instance.reference);


### PR DESCRIPTION
The timestamp in edit history ui also has .message_time.
We had a tippy hover event attached to .message_time
whose code assumes it to belong to an actual message
which caused an error on hovering the message timestamp
in edit history.

This commit fixes it by making the selector more specific.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Checked the error didn't occur after the change.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
