### PR TITLE
message: Improve the UI for long messages.

### DIFF
--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -115,7 +115,7 @@ the hotkeys too:
   - click on the star button in the right column
   - use 'Ctrl + S' to star a message
 - Message length
-  - send a long message and see if '[More]' appears
+  - send a long message and see if '[More]' button appears
   - click on the 'more' or 'collapse' link
   - use i to collapse/expand a message irrespective of message length
 - use 'v' to show all images in the thread

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -120,6 +120,11 @@ export function initialize() {
             return true;
         }
 
+        // Button to expand or condense long messages.
+        if ($target.is("button.message_expander") || $target.is("button.message_condenser")) {
+            return true;
+        }
+
         // Inline image and twitter previews.
         if ($target.is("img.message_inline_image") || $target.is("img.twitter-avatar")) {
             return true;

--- a/static/js/condense.js
+++ b/static/js/condense.js
@@ -20,14 +20,16 @@ This library implements two related, similar concepts:
 
 const _message_content_height_cache = new Map();
 
-function show_more_link($row) {
-    $row.find(".message_condenser").hide();
-    $row.find(".message_expander").show();
+function show_more_link(row) {
+    row.find(".expand_condense_buttons_wrapper").show();
+    row.find(".message_condenser").hide();
+    row.find(".message_expander").show();
 }
 
-function show_condense_link($row) {
-    $row.find(".message_expander").hide();
-    $row.find(".message_condenser").show();
+function show_condense_link(row) {
+    row.find(".expand_condense_buttons_wrapper").show();
+    row.find(".message_expander").hide();
+    row.find(".message_condenser").show();
 }
 
 function condense_row($row) {
@@ -42,45 +44,47 @@ function uncondense_row($row) {
     show_condense_link($row);
 }
 
-export function uncollapse($row) {
-    // Uncollapse a message, restoring the condensed message [More] or
-    // [Show less] link if necessary.
-    const message = message_lists.current.get(rows.id($row));
+export function uncollapse(row) {
+    // Uncollapse a message, restoring the condensed message 'Show more' or
+    // 'Show less' button if necessary.
+    const message = message_lists.current.get(rows.id(row));
     message.collapsed = false;
     message_flags.save_uncollapsed(message);
 
-    const process_row = function process_row($row) {
-        const $content = $row.find(".message_content");
-        $content.removeClass("collapsed");
+    const process_row = function process_row(row) {
+        const content = row.find(".message_content");
+        const expand_condense_buttons_wrapper = row.find(".expand_condense_buttons_wrapper");
+        content.removeClass("collapsed");
 
         if (message.condensed === true) {
             // This message was condensed by the user, so re-show the
-            // [More] link.
-            condense_row($row);
+            // 'Show more' button.
+            condense_row(row);
         } else if (message.condensed === false) {
             // This message was un-condensed by the user, so re-show the
-            // [Show less] link.
-            uncondense_row($row);
-        } else if ($content.hasClass("could-be-condensed")) {
+            // 'Show less' button.
+            uncondense_row(row);
+        } else if (content.hasClass("could-be-condensed")) {
             // By default, condense a long message.
-            condense_row($row);
+            condense_row(row);
         } else {
-            // This was a short message, no more need for a [More] link.
-            $row.find(".message_expander").hide();
+            // This was a short message, no more need for a 'Show more' button.
+            row.find(".message_expander").hide();
+            expand_condense_buttons_wrapper.hide();
         }
     };
 
     // We also need to collapse this message in the home view
-    const $home_row = message_lists.home.get_row(rows.id($row));
+    const $home_row = message_lists.home.get_row(rows.id(row));
 
-    process_row($row);
+    process_row(row);
     process_row($home_row);
 }
 
-export function collapse($row) {
+export function collapse(row) {
     // Collapse a message, hiding the condensed message [More] or
     // [Show less] link if necessary.
-    const message = message_lists.current.get(rows.id($row));
+    const message = message_lists.current.get(rows.id(row));
     message.collapsed = true;
 
     if (message.locally_echoed) {
@@ -99,9 +103,9 @@ export function collapse($row) {
     };
 
     // We also need to collapse this message in the home view
-    const $home_row = message_lists.home.get_row(rows.id($row));
+    const $home_row = message_lists.home.get_row(rows.id(row));
 
-    process_row($row);
+    process_row(row);
     process_row($home_row);
 }
 
@@ -116,7 +120,7 @@ export function toggle_collapse(message) {
     // This function implements a multi-way toggle, to try to do what
     // the user wants for messages:
     //
-    // * If the message is currently showing any [More] link, either
+    // * If the message is currently showing 'Show more' button, either
     //   because it was previously condensed or collapsed, fully display it.
     // * If the message is fully visible, either because it's too short to
     //   condense or because it's already uncondensed, collapse it
@@ -199,6 +203,7 @@ export function condense_and_collapse(elems) {
 
     for (const elem of elems) {
         const $content = $(elem).find(".message_content");
+        const $expand_condense_buttons_wrapper = $(elem).find(".expand_condense_buttons_wrapper");
 
         if ($content.length !== 1) {
             // We could have a "/me did this" message or something
@@ -222,8 +227,10 @@ export function condense_and_collapse(elems) {
         if (long_message) {
             // All long messages are flagged as such.
             $content.addClass("could-be-condensed");
+            $expand_condense_buttons_wrapper.show();
         } else {
             $content.removeClass("could-be-condensed");
+            $expand_condense_buttons_wrapper.hide();
         }
 
         // If message.condensed is defined, then the user has manually
@@ -246,10 +253,11 @@ export function condense_and_collapse(elems) {
             $(elem).find(".message_expander").hide();
         }
 
-        // Completely hide the message and replace it with a [More]
-        // link if the user has collapsed it.
+        // Completely hide the message and replace it with a 'Show More'
+        // button if the user has collapsed it.
         if (message.collapsed) {
             $content.addClass("collapsed");
+            $expand_condense_buttons_wrapper.show();
             $(elem).find(".message_expander").show();
         }
     }

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -271,7 +271,7 @@ export function handler() {
     }
     resize_page_components();
 
-    // Re-compute and display/remove [More] links to messages
+    // Re-compute and display/remove 'Show more'/'Show less' button to messages
     condense.condense_and_collapse($(".message_table .message_row"));
 
     // This function might run onReady (if we're in a narrow window),

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -242,6 +242,13 @@ body.dark-theme {
         background-color: hsl(208, 17%, 29%);
     }
 
+    .private-message .expand_condense_buttons_wrapper {
+        .message_expander,
+        .message_condenser {
+            background-color: hsl(208, 17%, 29%);
+        }
+    }
+
     /* do not turn the .message_header .stream_label text dark on hover because they're
        on a dark background, and don't change the dark labels dark either. */
     .message_header:not(.dark_background)
@@ -354,6 +361,13 @@ body.dark-theme {
         .emoji-popover-category-tabs
         .emoji-popover-tab-item.active {
         background-color: hsla(0, 0%, 0%, 0.5);
+    }
+
+    .expand_condense_buttons_wrapper {
+        .message_expander,
+        .message_condenser {
+            background-color: hsl(212, 28%, 18%);
+        }
     }
 
     .new-style .tab-switcher .ind-tab.selected,

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1265,6 +1265,13 @@ td.pointer {
         background-color: hsla(192, 19%, 75%, 0.2);
         box-shadow: inset 2px 0 0 0 hsl(0, 0%, 27%), -1px 0 0 0 hsl(0, 0%, 27%);
     }
+
+    .expand_condense_buttons_wrapper {
+        .message_expander,
+        .message_condenser {
+            background-color: hsl(192, 20%, 95%);
+        }
+    }
 }
 
 .message-header-contents {
@@ -1477,6 +1484,12 @@ div.focused_table {
     display: block;
     position: relative;
     overflow: hidden;
+    /* We are using very high value here to imitate an infinite value so that
+    we can enable collapse/expand animation. */
+    max-height: 1000vh;
+    transition: max-height 0.5s ease-in-out, mask-size 0.3s ease-in-out;
+    mask-image: none;
+    mask-size: 200% 200%;
 
     &:empty {
         display: none;
@@ -1486,12 +1499,22 @@ div.focused_table {
         max-height: 8.5em;
         min-height: 0;
         overflow: hidden;
+        mask-image: linear-gradient(to bottom, hsl(0, 0%, 100%), transparent);
+        mask-size: 60% 101%;
+
+        ~ .expand_condense_buttons_wrapper {
+            margin: -20px 0 20px;
+        }
     }
 
     &.collapsed {
         max-height: 0;
         min-height: 0;
         overflow: hidden;
+
+        ~ .expand_condense_buttons_wrapper {
+            margin: 12px 0;
+        }
     }
 }
 
@@ -1631,19 +1654,30 @@ div.focused_table {
     }
 }
 
-.message_length_controller {
+.topic_move_breadcrumb_messages {
+    margin-top: 10px !important;
+}
+
+.expand_condense_buttons_wrapper {
     display: none;
-    text-align: center;
-    color: hsl(200, 100%, 40%);
+    height: 25px;
+    position: relative;
+    margin: 12px 0;
+    transition: margin-top 0.5s ease-in-out, margin-bottom 0.5s ease-in-out;
 
-    /* to match .message_content */
-    margin-left: 5px;
-    margin-right: 35px;
-    /* to make message-uncollapse easier */
-    margin-top: 10px;
-
-    &:hover {
-        text-decoration: underline;
+    .message_expander,
+    .message_condenser {
+        display: none;
+        position: absolute;
+        left: 50%;
+        text-align: center;
+        color: inherit;
+        background-color: hsl(0, 0%, 100%);
+        width: 100px;
+        border-radius: 10px;
+        border: solid 1px hsl(215, 47%, 50%);
+        font-size: 13px;
+        font-weight: 400;
     }
 }
 

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -55,9 +55,10 @@
 <div class="message_edit">
     <div class="message_edit_form"></div>
 </div>
-<div class="message_expander message_length_controller" title="{{t 'Expand message (-)' }}">{{t "[More…]" }}</div>
-<div class="message_condenser message_length_controller" title="{{t 'Show less' }} (-)">[{{t "Show less" }}]</div>
-
+<div class="expand_condense_buttons_wrapper message_length_controller">
+    <button type="button" class="message_expander" title="{{t 'Show more' }} (-)">{{t "Show more" }}</button>
+    <button type="button"class="message_condenser" title="{{t 'Show less' }} (-)">{{t "Show less" }}</button>
+</div>
 {{#unless is_hidden}}
 <div class="message_reactions">{{> message_reactions }}</div>
 {{/unless}}


### PR DESCRIPTION
This PR makes the following changes to improve the UI:

* Rename `[More]` and [Show less]` link with `Show
More` and `Show less` buttons.

* Added fade effect when the message is condensed.

Fixes: #19157

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Test locally. 
Also with `-` shortcut key.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

https://user-images.githubusercontent.com/63820270/126137932-08678a9f-1002-4501-b449-91b114a80f79.mov



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
