### PR TITLE
Add 'Nobody' option to invite_to_realm_policy.

### DIFF
--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -259,3 +259,11 @@ run_test("using_dark_theme", () => {
     page_params.color_scheme = settings_config.color_scheme_values.day.code;
     assert.equal(settings_data.using_dark_theme(), false);
 });
+
+run_test("user_can_invite_others_to_realm_nobody_case", () => {
+    page_params.is_admin = true;
+    page_params.is_guest = false;
+    page_params.realm_invite_to_realm_policy =
+        settings_config.invite_to_realm_policy_values.nobody.code;
+    assert.equal(settings_data.user_can_invite_others_to_realm(), false);
+});

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -130,6 +130,34 @@ export const common_policy_values = {
     },
 };
 
+export const invite_to_realm_policy_values = {
+    nobody: {
+        order: 1,
+        code: 6,
+        description: $t({defaultMessage: "Nobody"}),
+    },
+    by_admins_only: {
+        order: 2,
+        code: 2,
+        description: $t({defaultMessage: "Admins"}),
+    },
+    by_moderators_only: {
+        order: 3,
+        code: 4,
+        description: $t({defaultMessage: "Admins and moderators"}),
+    },
+    by_full_members: {
+        order: 4,
+        code: 3,
+        description: $t({defaultMessage: "Admins and full members"}),
+    },
+    by_members: {
+        order: 5,
+        code: 1,
+        description: $t({defaultMessage: "Admins and members"}),
+    },
+};
+
 export const private_message_policy_values = {
     by_anyone: {
         order: 1,

--- a/static/js/settings_data.js
+++ b/static/js/settings_data.js
@@ -137,6 +137,12 @@ function user_has_permission(policy_value) {
 }
 
 export function user_can_invite_others_to_realm() {
+    if (
+        page_params.realm_invite_to_realm_policy ===
+        settings_config.invite_to_realm_policy_values.nobody.code
+    ) {
+        return false;
+    }
     return user_has_permission(page_params.realm_invite_to_realm_policy);
 }
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -45,6 +45,7 @@ export function maybe_disable_widgets() {
     if (page_params.is_admin) {
         $("#deactivate_realm_button").prop("disabled", true);
         $("#org-message-retention").find("input, select").prop("disabled", true);
+        $("#id_realm_invite_to_realm_policy").prop("disabled", true);
         return;
     }
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -104,6 +104,9 @@ export function get_organization_settings_options() {
     options.common_message_policy_values = get_sorted_options_list(
         settings_config.common_message_policy_values,
     );
+    options.invite_to_realm_policy_values = get_sorted_options_list(
+        settings_config.invite_to_realm_policy_values,
+    );
     return options;
 }
 

--- a/static/js/settings_ui.js
+++ b/static/js/settings_ui.js
@@ -73,10 +73,25 @@ export function do_settings_change(
 //   string id of setting.
 // * disable_on_uncheck is boolean, true if sub setting should be disabled
 //   when main setting unchecked.
-export function disable_sub_setting_onchange(is_checked, sub_setting_id, disable_on_uncheck) {
+export function disable_sub_setting_onchange(
+    is_checked,
+    sub_setting_id,
+    disable_on_uncheck,
+    include_label,
+) {
     if ((is_checked && disable_on_uncheck) || (!is_checked && !disable_on_uncheck)) {
         $(`#${CSS.escape(sub_setting_id)}`).prop("disabled", false);
+        if (include_label) {
+            $(`#${CSS.escape(sub_setting_id)}_label`)
+                .parent()
+                .removeClass("control-label-disabled");
+        }
     } else if ((is_checked && !disable_on_uncheck) || (!is_checked && disable_on_uncheck)) {
         $(`#${CSS.escape(sub_setting_id)}`).prop("disabled", true);
+        if (include_label) {
+            $(`#${CSS.escape(sub_setting_id)}_label`)
+                .parent()
+                .addClass("control-label-disabled");
+        }
     }
 }

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -10,7 +10,7 @@
                 <div class="input-group">
                     <label for="realm_invite_to_realm_policy" class="dropdown-title">{{t "Who can invite users to this organization" }}</label>
                     <select name="realm_invite_to_realm_policy" id="id_realm_invite_to_realm_policy" class="prop-element" data-setting-widget-type="number">
-                        {{> dropdown_options_widget option_values=common_policy_values}}
+                        {{> dropdown_options_widget option_values=invite_to_realm_policy_values}}
                     </select>
                     {{> settings_checkbox
                       setting_name="realm_invite_required"

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -8,7 +8,9 @@
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
-                    <label for="realm_invite_to_realm_policy" class="dropdown-title">{{t "Who can invite users to this organization" }}</label>
+                    <label for="realm_invite_to_realm_policy" class="dropdown-title">{{t "Who can invite users to this organization" }}
+                        <i class="fa fa-info-circle settings-info-icon realm_message_retention_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can change this setting.' }}"></i>
+                    </label>
                     <select name="realm_invite_to_realm_policy" id="id_realm_invite_to_realm_policy" class="prop-element" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=invite_to_realm_policy_values}}
                     </select>

--- a/templates/zerver/help/invite-new-users.md
+++ b/templates/zerver/help/invite-new-users.md
@@ -121,10 +121,13 @@ and reusable invitation links expire 10 days after they are sent.
 
 ## Change who can send invitations
 
+{!owner-only.md!}
+
 By default, all members can invite new users to join your Zulip
 organization. However, you can restrict the permission to invite new
 users to other sets of roles:
 
+* Nobody
 * Organization administrators
 * Organization administrators and moderators
 * Organization administrators and all members

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -256,6 +256,7 @@ class Realm(models.Model):
     POLICY_FULL_MEMBERS_ONLY = 3
     POLICY_MODERATORS_ONLY = 4
     POLICY_EVERYONE = 5
+    POLICY_NOBODY = 6
 
     COMMON_POLICY_TYPES = [
         POLICY_MEMBERS_ONLY,
@@ -270,6 +271,14 @@ class Realm(models.Model):
         POLICY_FULL_MEMBERS_ONLY,
         POLICY_MODERATORS_ONLY,
         POLICY_EVERYONE,
+    ]
+
+    INVITE_TO_REALM_POLICY_TYPES = [
+        POLICY_MEMBERS_ONLY,
+        POLICY_ADMINS_ONLY,
+        POLICY_FULL_MEMBERS_ONLY,
+        POLICY_MODERATORS_ONLY,
+        POLICY_NOBODY,
     ]
 
     DEFAULT_COMMUNITY_TOPIC_EDITING_LIMIT_SECONDS = 259200
@@ -1743,10 +1752,13 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
         ]:
             raise AssertionError("Invalid policy")
 
+        policy_value = getattr(self.realm, policy_name)
+        if policy_value == Realm.POLICY_NOBODY:
+            return False
+
         if self.is_realm_admin:
             return True
 
-        policy_value = getattr(self.realm, policy_name)
         if policy_value == Realm.POLICY_ADMINS_ONLY:
             return False
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8859,6 +8859,7 @@ paths:
                           * 2 = Administrators only
                           * 3 = Full members only
                           * 4 = Moderators only
+                          * 6 = Nobody
 
                           **Changes**: New in Zulip 4.0 (feature level 50) replacing the
                           previous `realm_invite_by_admins_only` boolean.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3358,19 +3358,6 @@ paths:
                                       type: boolean
                                       description: |
                                         Whether an invitation is required to join this organization.
-                                    invite_to_realm_policy:
-                                      type: integer
-                                      description: |
-                                        Policy for [who can invite new users](/help/invite-new-users#change-who-can-send-invitations)
-                                        to join the organization:
-
-                                        * 1 = Members only
-                                        * 2 = Administrators only
-                                        * 3 = Full members only
-                                        * 4 = Moderators only
-
-                                        **Changes**: New in Zulip 4.0 (feature level 50) replacing the
-                                        previous `invite_by_admins_only` boolean.
                                     inline_image_preview:
                                       type: boolean
                                       description: |

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2045,7 +2045,7 @@ class RealmPropertyActionTest(BaseAction):
             ],
             default_code_block_language=["python", "javascript"],
             message_content_delete_limit_seconds=[1000, 1100, 1200],
-            invite_to_realm_policy=[4, 3, 2, 1],
+            invite_to_realm_policy=[6, 4, 3, 2, 1],
             move_messages_between_streams_policy=[4, 3, 2, 1],
         )
 

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -778,7 +778,7 @@ class RealmAPITest(ZulipTestCase):
                 Realm.GIPHY_RATING_OPTIONS["r"]["id"],
             ],
             message_content_delete_limit_seconds=[1000, 1100, 1200],
-            invite_to_realm_policy=Realm.COMMON_POLICY_TYPES,
+            invite_to_realm_policy=Realm.INVITE_TO_REALM_POLICY_TYPES,
             move_messages_between_streams_policy=Realm.COMMON_POLICY_TYPES,
         )
 

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -868,6 +868,18 @@ class RealmAPITest(ZulipTestCase):
         self.assertEqual(realm.allow_message_deleting, True)
         self.assertEqual(realm.message_content_delete_limit_seconds, 600)
 
+    def test_change_invite_to_realm_policy_by_owners_only(self) -> None:
+        self.login("iago")
+        req = {"invite_to_realm_policy": Realm.POLICY_ADMINS_ONLY}
+        result = self.client_patch("/json/realm", req)
+        self.assert_json_error(result, "Must be an organization owner")
+
+        self.login("desdemona")
+        result = self.client_patch("/json/realm", req)
+        self.assert_json_success(result)
+        realm = get_realm("zulip")
+        self.assertEqual(realm.invite_to_realm_policy, Realm.POLICY_ADMINS_ONLY)
+
 
 class ScrubRealmTest(ZulipTestCase):
     def test_scrub_realm(self) -> None:

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -150,6 +150,9 @@ def update_realm(
             message_retention_days_raw, Realm.MESSAGE_RETENTION_SPECIAL_VALUES_MAP
         )
 
+    if invite_to_realm_policy is not None and not user_profile.is_realm_owner:
+        raise OrganizationOwnerRequired()
+
     # The user of `locals()` here is a bit of a code smell, but it's
     # restricted to the elements present in realm.property_types.
     #

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -53,7 +53,7 @@ def update_realm(
     ),
     invite_required: Optional[bool] = REQ(json_validator=check_bool, default=None),
     invite_to_realm_policy: Optional[int] = REQ(
-        json_validator=check_int_in(Realm.COMMON_POLICY_TYPES), default=None
+        json_validator=check_int_in(Realm.INVITE_TO_REALM_POLICY_TYPES), default=None
     ),
     name_changes_disabled: Optional[bool] = REQ(json_validator=check_bool, default=None),
     email_changes_disabled: Optional[bool] = REQ(json_validator=check_bool, default=None),


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
There are following commits -
- Remove `invite_to_realm_policy` from `update_dict` schema (#18697).
- Add `Nobody` option to `invite_to_realm_policy` in backend.
- Add `Nobody` option to `invite_to_realm_policy` in frontend.
- Allow only owners to change `invite_to_realm_policy` setting.
- Handle special cases when there cannot be a certain combination of values of `invite_required` and `invite_to_realm_policy`. (Explained in detail in commit message)
- A prep commit for UI changes related to above commit.
- Updated the docs accordingly.

**Testing plan:** <!-- How have you tested? --> Updated tests and also tested manually in dev server.


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
