### PR TITLE
realm_logo: Rename realm_logo.rerender to realm_logo.render.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -410,7 +410,7 @@ run_test("realm settings", ({override}) => {
     assert_same(page_params.realm_icon_url, "icon.png");
     assert_same(page_params.realm_icon_source, "U");
 
-    override(realm_logo, "rerender", noop);
+    override(realm_logo, "render", noop);
 
     event = event_fixtures.realm__update_dict__logo;
     dispatch(event);
@@ -708,7 +708,7 @@ run_test("update_display_settings", ({override}) => {
         assert_same(secs, 300);
     };
 
-    override(realm_logo, "rerender", noop);
+    override(realm_logo, "render", noop);
 
     {
         const stub = make_stub();

--- a/static/js/realm_logo.js
+++ b/static/js/realm_logo.js
@@ -63,7 +63,7 @@ function change_logo_delete_button(logo_source, logo_delete_button, file_input) 
     }
 }
 
-export function rerender() {
+export function render() {
     const file_input = $("#realm-day-logo-upload-widget .image_file_input");
     const night_file_input = $("#realm-night-logo-upload-widget .realm-logo-file-input");
     $("#realm-day-logo-upload-widget .image-block").attr("src", page_params.realm_logo_url);

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -263,12 +263,12 @@ export function dispatch_normal_event(event) {
                         case "logo":
                             page_params.realm_logo_url = event.data.logo_url;
                             page_params.realm_logo_source = event.data.logo_source;
-                            realm_logo.rerender();
+                            realm_logo.render();
                             break;
                         case "night_logo":
                             page_params.realm_night_logo_url = event.data.night_logo_url;
                             page_params.realm_night_logo_source = event.data.night_logo_source;
-                            realm_logo.rerender();
+                            realm_logo.render();
                             break;
                         default:
                             blueslip.error(
@@ -590,13 +590,13 @@ export function dispatch_normal_event(event) {
                 setTimeout(() => {
                     if (event.setting === settings_config.color_scheme_values.night.code) {
                         night_mode.enable();
-                        realm_logo.rerender();
+                        realm_logo.render();
                     } else if (event.setting === settings_config.color_scheme_values.day.code) {
                         night_mode.disable();
-                        realm_logo.rerender();
+                        realm_logo.render();
                     } else {
                         night_mode.default_preference_checker();
-                        realm_logo.rerender();
+                        realm_logo.render();
                     }
                     $("body").fadeIn(300);
                 }, 300);

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -509,7 +509,7 @@ export function initialize_everything() {
     settings.initialize();
     compose.initialize();
     initialize_navbar();
-    realm_logo.rerender();
+    realm_logo.render();
 
     message_lists.initialize();
     alert_words.initialize(alert_words_params);


### PR DESCRIPTION
As realm_logo.rerender is now used for initial rendering of
logo as well in c8849f8, so we rename this function from
rerender to render.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


<!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
