### PR TITLE
Added support for Fedora 34

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -16,7 +16,7 @@ that's running one of:
 * Ubuntu 20.04 Focal, 18.04 Bionic
 * Debian 10 Buster, 11 Bullseye (beta)
 * CentOS 7 (beta)
-* Fedora 33 (beta)
+* Fedora 33 and 34 (beta)
 * RHEL 7 (beta)
 
 You can just run the Zulip provision script on your machine.

--- a/scripts/lib/setup-yum-repo
+++ b/scripts/lib/setup-yum-repo
@@ -53,7 +53,7 @@ elif [ "$is_rhel" = true ]; then
     yum localinstall -y https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-latest-x86_64/pgdg-redhat10-10-2.noarch.rpm
     yum localinstall -y https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm
 else
-    # TODO only fedora33 for now
+    # TODO make the postgres version a variable.
     PGVER=13
-    dnf install -y "https://download.postgresql.org/pub/repos/yum/reporpms/F-33-x86_64/pgdg-fedora-repo-latest.noarch.rpm"
+    dnf install -y "https://download.postgresql.org/pub/repos/yum/reporpms/F-$RHVER-x86_64/pgdg-fedora-repo-latest.noarch.rpm"
 fi

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -107,6 +107,8 @@ elif vendor == "neon" and os_version == "20.04":  # KDE Neon
     POSTGRESQL_VERSION = "12"
 elif vendor == "fedora" and os_version == "33":
     POSTGRESQL_VERSION = "13"
+elif vendor == "fedora" and os_version == "34":
+    POSTGRESQL_VERSION = "13"
 elif vendor == "rhel" and os_version.startswith("7."):
     POSTGRESQL_VERSION = "10"
 elif vendor == "centos" and os_version == "7":


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This PR is for Issue #19306 . I have added support for Fedora 34.

**Changes:**
I have made changes in the `provision.py` file and `setup-yum-repo` file.

**Testing plan:** <!-- How have you tested? -->
This was tested on my local system which is based on Fedora 34 (kernel - `kernel-5.12.15-300.fc34.x86_64`). It works perfectly as per my knowledge.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
