### PR TITLE
Revert "request: Move tornado_handler to ZulipRequestNotes."

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -811,14 +811,14 @@ def internal_notify_view(is_tornado_view: bool) -> Callable[[ViewFuncT], ViewFun
         ) -> HttpResponse:
             if not authenticate_notify(request):
                 raise AccessDeniedError()
-            request_notes = get_request_notes(request)
-            is_tornado_request = request_notes.tornado_handler is not None
+            is_tornado_request = hasattr(request, "_tornado_handler")
             # These next 2 are not security checks; they are internal
             # assertions to help us find bugs.
             if is_tornado_view and not is_tornado_request:
                 raise RuntimeError("Tornado notify view called with no Tornado handler")
             if not is_tornado_view and is_tornado_request:
                 raise RuntimeError("Django notify view called with Tornado handler")
+            request_notes = get_request_notes(request)
             request_notes.requestor_for_logs = "internal"
             return view_func(request, *args, **kwargs)
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -310,7 +310,8 @@ class HostRequestMock(HttpRequest):
             self.POST[key] = str(post_data[key])
             self.method = "POST"
 
-        self._tornado_handler = DummyHandler()
+        if tornado_handler is not None:
+            self._tornado_handler = tornado_handler
         self._log_data: Dict[str, Any] = {}
         if meta_data is None:
             self.META = {"PATH_INFO": "test"}
@@ -324,7 +325,6 @@ class HostRequestMock(HttpRequest):
         request_notes_map[self] = ZulipRequestNotes(
             client_name="",
             log_data={},
-            tornado_handler=tornado_handler,
             client=get_client(client_name) if client_name is not None else None,
         )
 

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1482,7 +1482,7 @@ class TestInternalNotifyView(ZulipTestCase):
             with self.assertRaises(RuntimeError):
                 self.internal_notify(True, request)
 
-        get_request_notes(request).tornado_handler = DummyHandler()
+        request._tornado_handler = DummyHandler()
         with self.settings(SHARED_SECRET=secret):
             self.assertTrue(authenticate_notify(request))
             self.assertEqual(self.internal_notify(True, request), self.BORING_RESULT)

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -111,12 +111,9 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         signals.request_started.send(sender=self.__class__)
         request = WSGIRequest(environ)
 
-        # We do the import during runtime to avoid cyclic dependency
-        from zerver.lib.request import get_request_notes
-
         # Provide a way for application code to access this handler
         # given the HttpRequest object.
-        get_request_notes(request).tornado_handler = self
+        request._tornado_handler = self
 
         return request
 

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -109,9 +109,7 @@ def get_events_backend(
         raise JsonableError(_("User not authorized for this query"))
 
     # Extract the Tornado handler from the request
-    tornado_handler = get_request_notes(request).tornado_handler
-    assert tornado_handler is not None
-    handler: AsyncDjangoHandler = tornado_handler
+    handler: AsyncDjangoHandler = request._tornado_handler
 
     if user_client is None:
         valid_user_client = get_request_notes(request).client


### PR DESCRIPTION
This reverts commit 5167a93229cb4d52ef87b95d8c3bf4093ed2f275.
This is part of the experimental fix to the memory leakage problem brought in #19112.

DO NOT MERGE YET; this doesn't fix the problem.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
