### PR TITLE
billing: Edit helper text on sponsorship application

### DIFF
--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -164,7 +164,7 @@ run_test("initialize", ({override}) => {
     helpers.update_discount_details("event");
     assert.equal(
         $("#sponsorship-discount-details").text(),
-        "Zulip Cloud Standard is free for academic conferences and most nonprofit events.",
+        "Zulip Cloud Standard is free for academic conferences and most non-profit events.",
     );
     helpers.update_discount_details("education");
     assert.equal(
@@ -174,12 +174,12 @@ run_test("initialize", ({override}) => {
     helpers.update_discount_details("nonprofit");
     assert.equal(
         $("#sponsorship-discount-details").text(),
-        "Zulip Cloud Standard is discounted 85%+ for registered nonprofits.",
+        "Zulip Cloud Standard is discounted 85%+ for registered non-profits.",
     );
     helpers.update_discount_details("other");
     assert.equal(
         $("#sponsorship-discount-details").text(),
-        "Your organization may be eligible for a discount on Zulip Standard. Generally, use cases where the users are not your employees are eligible for discounts.",
+        "Your organization may be eligible for a discount on Zulip Cloud Standard. Organizations whose members are not employees are generally eligible.",
     );
 });
 

--- a/static/js/billing/helpers.js
+++ b/static/js/billing/helpers.js
@@ -89,15 +89,15 @@ export function update_charged_amount(prices, schedule) {
 
 export function update_discount_details(organization_type) {
     let discount_notice =
-        "Your organization may be eligible for a discount on Zulip Standard. Generally, use cases where the users are not your employees are eligible for discounts.";
+        "Your organization may be eligible for a discount on Zulip Cloud Standard. Organizations whose members are not employees are generally eligible.";
     const discount_details = {
         opensource: "Zulip Cloud Standard is free for open-source projects.",
         research: "Zulip Cloud Standard is free for academic research.",
-        nonprofit: "Zulip Cloud Standard is discounted 85%+ for registered nonprofits.",
-        event: "Zulip Cloud Standard is free for academic conferences and most nonprofit events.",
+        nonprofit: "Zulip Cloud Standard is discounted 85%+ for registered non-profits.",
+        event: "Zulip Cloud Standard is free for academic conferences and most non-profit events.",
         education: "Zulip Cloud Standard is discounted 85% for education.",
         education_nonprofit:
-            "Zulip Cloud Standard is discounted 90% for education nonprofits with online purchase.",
+            "Zulip Cloud Standard is discounted 90% for education non-profits with online purchase.",
     };
     if (discount_details[organization_type]) {
         discount_notice = discount_details[organization_type];


### PR DESCRIPTION
* nonprofit -> non-profit, since we were being inconsistent about it. Cf. [this reference]( https://www.claxonmarketing.com/2016/02/24/nonprofit-vs-non-profit-does-a-hyphen-make-a-difference/) for choosing the version with a dash. Our landing page uses the dashed form.
* Edit pass on default helper text to use more user-oriented language.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Manual testing.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="898" alt="Screen Shot 2021-07-19 at 11 21 20 AM" src="https://user-images.githubusercontent.com/2090066/126208147-41364bd1-45fa-4167-bee6-cdd3a3a54459.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
