### PR TITLE
Rate limit the /new/ endpoint

### DIFF
--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -26,7 +26,7 @@ from confirmation.models import (
     validate_key,
 )
 from zerver.context_processors import get_realm_from_request, login_context
-from zerver.decorator import do_login, require_post
+from zerver.decorator import do_login, rate_limit_request_by_ip, require_post
 from zerver.forms import (
     FindMyTeamForm,
     HomepageForm,
@@ -588,6 +588,8 @@ def create_realm(request: HttpRequest, creation_key: Optional[str] = None) -> Ht
     if request.method == "POST":
         form = RealmCreationForm(request.POST)
         if form.is_valid():
+            rate_limit_request_by_ip(request, domain="create_realm_by_ip")
+
             email = form.cleaned_data["email"]
             activation_url = prepare_activation_url(email, request, realm_creation=True)
             if key_record is not None and key_record.presume_email_valid:

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -384,6 +384,9 @@ RATE_LIMITING_RULES = {
     "authenticate_by_username": [
         (1800, 5),  # 5 login attempts within 30 minutes
     ],
+    "create_realm_by_ip": [
+        (1800, 5),
+    ],
     "password_reset_form_by_email": [
         (3600, 2),  # 2 reset emails per hour
         (86400, 5),  # 5 per day

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -264,6 +264,7 @@ RATE_LIMITING_RULES: Dict[str, List[Tuple[int, int]]] = {
     "api_by_ip": [],
     "api_by_remote_server": [],
     "authenticate_by_username": [],
+    "create_realm_by_ip": [],
     "password_reset_form_by_email": [],
 }
 


### PR DESCRIPTION
Addressing a piece of #19287. This only covers one endpoint, but the others can be done with a similar approach, so it seems to make sense to decide on whether the approach is fine and then do the other endpoints.

Also the conversation in https://github.com/zulip/zulip/pull/16190#discussion_r670707718 is relevant here - @alexmv With this approach we would start using `domain` rather than removing it, does that seem right? Alternatively, we could still get rid of `domain` and instead define separate `RateLimitedSomething` classes per endpoint - but that seems worse and the `domain` concept was probably made with this kind of scenario in mind