### PR TITLE
compose: Fix compose-preview size in expanded mode.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -605,4 +605,10 @@ a.compose_control_button.hide {
         max-height: none !important;
         flex: 1;
     }
+
+    #preview_message_area {
+        max-height: none;
+        height: 1.5em;
+        flex: 1;
+    }
 }


### PR DESCRIPTION
The CSS properties used to make the `#compose-textarea` full-size
were missing for the `#preview_message_area`, thus, it was just
getting to the height as specified in the `max-height` property
of `#preview_compose_box`.

Adding the missing CSS properties resolved the problem, but only
for not-too-long messages. For very-long messages, the preview
message area was overflowing the parent container (attaining the
maximum height possible according to the content, due to the absence
of max-height), which led to the controls below compose-box to
disappear.

Adding an additional property of `height: 1.5em` solved this problem,
as if a height lower than min-height is set to an element, it attains
its min-height.

Tested manually on my Ubuntu Development environment.

Fixes: #19243.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

**Without height property**
![Screenshot from 2021-07-20 01-01-27](https://user-images.githubusercontent.com/39924567/126216582-3eb6f196-b647-4b95-9109-82c399758467.png)


**With height property**
![Screenshot from 2021-07-20 01-02-32](https://user-images.githubusercontent.com/39924567/126217255-16255bf0-6747-475b-a83b-a763cc4f2ea9.png)


