### PR TITLE
request: Weaken ZulipRequestNotes.tornado_handler reference

### DIFF
--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -62,7 +62,9 @@ class ZulipRequestNotes:
     error_format: Optional[str] = None
     placeholder_open_graph_description: Optional[str] = None
     saved_response: Optional[HttpResponse] = None
-    tornado_handler: Optional["handlers.AsyncDjangoHandler"] = None
+    # tornado_handler is a weak reference to work around a memory leak
+    # in WeakKeyDictionary (https://bugs.python.org/issue44680).
+    tornado_handler: Optional["weakref.ReferenceType[handlers.AsyncDjangoHandler]"] = None
     processed_parameters: Set[str] = field(default_factory=set)
     ignored_parameters: Set[str] = field(default_factory=set)
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import time
+import weakref
 from contextlib import contextmanager
 from functools import wraps
 from typing import (
@@ -310,7 +311,6 @@ class HostRequestMock(HttpRequest):
             self.POST[key] = str(post_data[key])
             self.method = "POST"
 
-        self._tornado_handler = DummyHandler()
         self._log_data: Dict[str, Any] = {}
         if meta_data is None:
             self.META = {"PATH_INFO": "test"}
@@ -324,7 +324,7 @@ class HostRequestMock(HttpRequest):
         request_notes_map[self] = ZulipRequestNotes(
             client_name="",
             log_data={},
-            tornado_handler=tornado_handler,
+            tornado_handler=None if tornado_handler is None else weakref.ref(tornado_handler),
             client=get_client(client_name) if client_name is not None else None,
         )
 

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -540,8 +540,9 @@ class RateLimitMiddleware(MiddlewareMixin):
             return response
 
         # Add X-RateLimit-*** headers
-        if hasattr(request, "_ratelimits_applied"):
-            self.set_response_headers(response, request._ratelimits_applied)
+        ratelimits_applied = get_request_notes(request).ratelimits_applied
+        if len(ratelimits_applied) > 0:
+            self.set_response_headers(response, ratelimits_applied)
 
         return response
 

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -1,5 +1,6 @@
 import logging
 import urllib
+import weakref
 from typing import Any, Dict, List
 
 import tornado.web
@@ -116,7 +117,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
 
         # Provide a way for application code to access this handler
         # given the HttpRequest object.
-        get_request_notes(request).tornado_handler = self
+        get_request_notes(request).tornado_handler = weakref.ref(self)
 
         return request
 

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -238,10 +238,10 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         # Add to this new HttpRequest logging data from the processing of
         # the original request; we will need these for logging.
         request_notes.log_data = old_request_notes.log_data
+        if request_notes.rate_limit is not None:
+            request_notes.rate_limit = old_request_notes.rate_limit
         if request_notes.requestor_for_logs is not None:
             request_notes.requestor_for_logs = old_request_notes.requestor_for_logs
-        if hasattr(request, "_rate_limit"):
-            request._rate_limit = old_request._rate_limit
         request.user = old_request.user
         request_notes.client = old_request_notes.client
         request_notes.client_name = old_request_notes.client_name

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -19,7 +19,6 @@ from zerver.lib.validator import (
 from zerver.models import Client, UserProfile, get_client, get_user_profile_by_id
 from zerver.tornado.event_queue import fetch_events, get_client_descriptor, process_notification
 from zerver.tornado.exceptions import BadEventQueueIdError
-from zerver.tornado.handlers import AsyncDjangoHandler
 
 
 @internal_notify_view(True)
@@ -111,7 +110,8 @@ def get_events_backend(
     # Extract the Tornado handler from the request
     tornado_handler = get_request_notes(request).tornado_handler
     assert tornado_handler is not None
-    handler: AsyncDjangoHandler = tornado_handler
+    handler = tornado_handler()
+    assert handler is not None
 
     if user_client is None:
         valid_user_client = get_request_notes(request).client

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -260,12 +260,11 @@ def rate_limit_authentication_by_username(request: HttpRequest, username: str) -
 
 
 def auth_rate_limiting_already_applied(request: HttpRequest) -> bool:
-    if not hasattr(request, "_ratelimits_applied"):
-        return False
+    request_notes = get_request_notes(request)
 
     return any(
         isinstance(r.entity, RateLimitedAuthenticationByUsername)
-        for r in request._ratelimits_applied
+        for r in request_notes.ratelimits_applied
     )
 
 


### PR DESCRIPTION
This prevents a memory leak arising from Python’s inability to collect a reference cycle from a `WeakKeyDictionary` value to its key (https://bugs.python.org/issue44680).

Context: #19112, #19282, https://chat.zulip.org/#narrow/stream/3-backend/topic/HttpRequest.20-.3E.20ZulipHttpRequest.20conversion/near/1232467. Cc @PIG208.

**Testing plan:** Being tested on chat.zulip.org.