### PR TITLE
stream settings: Use buddy list logic for filtering users in stream setting subscriber list.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -454,20 +454,11 @@ function show_subscription_settings(sub) {
         },
         filter: {
             element: $(`[data-stream-id='${CSS.escape(stream_id)}'] .search`),
-            predicate(item, value) {
-                const person = item;
+            predicate(person, value) {
+                const matcher = people.build_person_matcher(value);
+                const match = matcher(person);
 
-                if (person) {
-                    if (
-                        person.email.toLocaleLowerCase().includes(value) &&
-                        settings_data.show_email()
-                    ) {
-                        return true;
-                    }
-                    return person.full_name.toLowerCase().includes(value);
-                }
-
-                return false;
+                return match;
             },
         },
         simplebar_container: $(".subscriber_list_container"),


### PR DESCRIPTION
Our logic for filtering subscribed users in stream setting was
buggy and gave irrelevant filters based on email matching.

We correct it by using same logic as we use for filtering in
buddy list.
Follow up for: #19156.
