### PR TITLE
stream_ui: Fix subscription button out of sync.

### DIFF
--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -94,7 +94,7 @@ export function settings_button_for_sub(sub) {
     // We don't do expectOne() here, because this button is only
     // visible if the user has that stream selected in the streams UI.
     return $(
-        `.subscription_settings[data-stream-id='${CSS.escape(sub.stream_id)}'] .subscribe-button`,
+        `.stream_settings_header[data-stream-id='${CSS.escape(sub.stream_id)}'] .subscribe-button`,
     );
 }
 


### PR DESCRIPTION
cb4797e3b7c4c0364e23125f677a2498ba71be14 rearranged the stream templates
but didn't change the selector for the subscibe button.

Fixes #19290

![stream_sync](https://user-images.githubusercontent.com/58626718/126436124-8a1cfbd6-43c2-467d-9113-be4f370fb41e.gif)
