### PR TITLE
sponsorship: Fix alignment of inputs in sponsorship form.

### DIFF
--- a/static/styles/portico/billing.css
+++ b/static/styles/portico/billing.css
@@ -288,3 +288,13 @@ input[name="licenses"]::-webkit-inner-spin-button {
 input[name="licenses"] {
     appearance: textfield;
 }
+
+#sponsorship-form {
+    input {
+        box-sizing: border-box;
+        height: 30px;
+    }
+    textarea {
+        box-sizing: border-box;
+    }
+}


### PR DESCRIPTION
All the inputs of form has 'width: 100%' property but then
also the width of inputs were different because of box-sizing
property. The select input had 'box-sizing: border-box' style
but the others did not, so this commit adds this style to
the other inputs - text type input and the textarea input to
fix the alignments of input.

Adding 'box-sizing: border-box' changes the actual height of
the normal text type input because the default input height
of 20px set by bootstrap now includes padding and border also,
so we add 'height: 30px' style to make its height same as the
select input.

Fixes #19332.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2021-07-21 15-06-49](https://user-images.githubusercontent.com/35494118/126467531-dcb495f0-e042-4857-8d84-cf370dcd33e5.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
