### PR TITLE
message_edit: Replace checkboxes with `settings_checkbox` partial. 

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -832,10 +832,10 @@ export function save_message_row_edit(row) {
         const selected_topic_propagation =
             row.find("select.message_edit_topic_propagate").val() || "change_later";
         const send_notification_to_old_thread = row
-            .find(".send_notification_to_old_thread")
+            .find("#id_send_notification_to_old_thread")
             .is(":checked");
         const send_notification_to_new_thread = row
-            .find(".send_notification_to_new_thread")
+            .find("#id_send_notification_to_new_thread")
             .is(":checked");
         request.propagate_mode = selected_topic_propagation;
         request.send_notification_to_old_thread = send_notification_to_old_thread;

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -9,13 +9,6 @@
     justify-content: center;
 }
 
-/* Inserting this collapsed row between two flex items will make
- * the flex item that comes after it break to a new row */
-.break-row {
-    flex-basis: 100%;
-    height: 0;
-}
-
 .hide {
     display: none;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2544,6 +2544,11 @@ div.topic_edit_spinner .loading_indicator_spinner {
         border-radius: 1px 4px 4px 1px !important;
     }
 
+    /* Remove the bottom margin from the notification checkboxes */
+    .message_edit_breadcrumb_messages .input-group {
+        margin-bottom: 0;
+    }
+
     .stream_header_colorblock {
         margin-bottom: 20px;
     }

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -18,17 +18,16 @@
                 <i class="fa fa-angle-right" aria-hidden="true" {{#unless is_stream_editable}}style="display:none"{{/unless}}></i>
                 <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" autocomplete="off" />
                 <div class="message_edit_breadcrumb_messages"  style='display:none;'>
-                    <label class="checkbox">
-                        <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />
-                        <span></span>
-                    </label>
-                    <label for="send_notification_to_new_thread">{{t "Send notification to new topic" }}</label>
-                    <div class="break-row"></div> <!-- break -->
-                    <label class="checkbox">
-                        <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
-                        <span></span>
-                    </label>
-                    <label for="send_notification_to_old_thread">{{t "Send notification to old topic" }}</label>
+                    {{> settings/settings_checkbox
+                      setting_name="send_notification_to_new_thread"
+                      prefix="id_"
+                      is_checked=notify_new_thread
+                      label=(t 'Send notification to new topic')}}
+                    {{> settings/settings_checkbox
+                      setting_name="send_notification_to_old_thread"
+                      prefix="id_"
+                      is_checked=notify_old_thread
+                      label=(t 'Send notification to old topic')}}
                 </div>
                 <select class='message_edit_topic_propagate' style='display:none;'>
                     <option selected="selected" value="change_later"> {{t "Change later messages to this topic" }}</option>


### PR DESCRIPTION
CZO conversation: https://chat.zulip.org/#narrow/stream/9-issues/topic/Message.20edit.20checkboxes.

Basically, added a feature that supports the selection of message edit `send_notification` checkboxes by clicking over it's corresponding label as well (The similar case as in organization checkboxes).

<strong>Screenshot</strong>

![checkboxes](https://user-images.githubusercontent.com/53977614/126505024-15cc5ede-494c-4109-bbc0-8b75b8292c29.gif)

