### PR TITLE
css: Fixed hr visibility in day mode

### DIFF
--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -40,6 +40,11 @@
         margin-top: 0;
     }
 
+    hr {
+        border-bottom: 1px solid hsl(0, 0%, 87%);
+        border-top: 1px solid hsl(0, 0%, 87%);
+    }
+
     /* Headings: We need to make sure our headings are less prominent than our sender names styling. */
     h1,
     h2,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is for resolving issue #19261.  After getting a positive review I will make the final commit and remove the comments.


**Testing plan:** <!-- How have you tested? -->

> I made changes to `bootstrap.css` for the day mode `<hr>` tag.
> I have tested it manually.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![Screenshot from 2021-07-22 01-11-45](https://user-images.githubusercontent.com/74018438/126550057-34b65c03-f683-466e-8f3f-15f61cb230c3.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
