### PR TITLE
move_topic/message_edit: Toggle checkbox by clicking it's label as well.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -832,10 +832,10 @@ export function save_message_row_edit(row) {
         const selected_topic_propagation =
             row.find("select.message_edit_topic_propagate").val() || "change_later";
         const send_notification_to_old_thread = row
-            .find("#id_send_notification_to_old_thread")
+            .find(".send_notification_to_old_thread")
             .is(":checked");
         const send_notification_to_new_thread = row
-            .find("#id_send_notification_to_new_thread")
+            .find(".send_notification_to_new_thread")
             .is(":checked");
         request.propagate_mode = selected_topic_propagation;
         request.send_notification_to_old_thread = send_notification_to_old_thread;

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -9,6 +9,13 @@
     justify-content: center;
 }
 
+/* Inserting this collapsed row between two flex items will make
+ * the flex item that comes after it break to a new row */
+.break-row {
+    flex-basis: 100%;
+    height: 0;
+}
+
 .hide {
     display: none;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2544,11 +2544,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
         border-radius: 1px 4px 4px 1px !important;
     }
 
-    /* Remove the bottom margin from the notification checkboxes */
-    .message_edit_breadcrumb_messages .input-group {
-        margin-bottom: 0;
-    }
-
     .stream_header_colorblock {
         margin-bottom: 20px;
     }

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -18,16 +18,17 @@
                 <i class="fa fa-angle-right" aria-hidden="true" {{#unless is_stream_editable}}style="display:none"{{/unless}}></i>
                 <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" autocomplete="off" />
                 <div class="message_edit_breadcrumb_messages"  style='display:none;'>
-                    {{> settings/settings_checkbox
-                      setting_name="send_notification_to_new_thread"
-                      prefix="id_"
-                      is_checked=notify_new_thread
-                      label=(t 'Send notification to new topic')}}
-                    {{> settings/settings_checkbox
-                      setting_name="send_notification_to_old_thread"
-                      prefix="id_"
-                      is_checked=notify_old_thread
-                      label=(t 'Send notification to old topic')}}
+                    <label class="checkbox">
+                        <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />
+                        <span></span>
+                    </label>
+                    <label for="send_notification_to_new_thread">{{t "Send notification to new topic" }}</label>
+                    <div class="break-row"></div> <!-- break -->
+                    <label class="checkbox">
+                        <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
+                        <span></span>
+                    </label>
+                    <label for="send_notification_to_old_thread">{{t "Send notification to old topic" }}</label>
                 </div>
                 <select class='message_edit_topic_propagate' style='display:none;'>
                     <option selected="selected" value="change_later"> {{t "Change later messages to this topic" }}</option>

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -21,14 +21,14 @@
                     <label class="checkbox">
                         <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />
                         <span></span>
+                        {{t "Send notification to new topic" }}
                     </label>
-                    <label for="send_notification_to_new_thread">{{t "Send notification to new topic" }}</label>
                     <div class="break-row"></div> <!-- break -->
                     <label class="checkbox">
                         <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
                         <span></span>
+                        {{t "Send notification to old topic" }}
                     </label>
-                    <label for="send_notification_to_old_thread">{{t "Send notification to old topic" }}</label>
                 </div>
                 <select class='message_edit_topic_propagate' style='display:none;'>
                     <option selected="selected" value="change_later"> {{t "Change later messages to this topic" }}</option>

--- a/static/templates/move_topic_to_stream.hbs
+++ b/static/templates/move_topic_to_stream.hbs
@@ -26,13 +26,13 @@
                     <label class="checkbox">
                         <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />
                         <span></span>
+                        {{t "Send notification to new topic" }}
                     </label>
-                    <label for="send_notification_to_new_thread">{{t "Send notification to new topic" }}</label>
                     <label class="checkbox">
                         <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
                         <span></span>
+                        {{t "Send notification to old topic" }}
                     </label>
-                    <label for="send_notification_to_old_thread">{{t "Send notification to old topic" }}</label>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
This pr consists of 3 commit as follows: 

Commit 4a3671c: Reverts the commit 54a1c73c7888f6fd398eb17cebe15bd60520a6c7.
This is because, commit f094933 handles the same scenario in a much cleaner way and without the need of `settings_checkbox` partial. (As it is specifically designed to handle organization checkboxes).

Commit f094933: As explained above, implements the same feature in a much simpler way than 54a1c73c7888f6fd398eb17cebe15bd60520a6c7(My bad).

Commit f6aa8d8: Similar to above commit, which handles the same feature in case of "Move topic" modal. 

Would be great if @timabbott can take a look!