### PR TITLE
ui_init: Fix "Error: Unknown user_id in get_by_user_id: 0".

### DIFF
--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -147,6 +147,13 @@ function test_policy(label, policy, validation_func) {
         page_params.is_guest = false;
         assert.equal(validation_func(), true);
 
+        page_params.is_spectator = true;
+        page_params[policy] = settings_config.common_policy_values.by_members.code;
+        assert.equal(validation_func(), false);
+
+        page_params.is_spectator = false;
+        assert.equal(validation_func(), true);
+
         page_params[policy] = settings_config.common_policy_values.by_full_members.code;
         page_params.user_id = 30;
         isaac.date_joined = new Date(Date.now());

--- a/static/js/settings_data.js
+++ b/static/js/settings_data.js
@@ -3,6 +3,7 @@ import * as settings_config from "./settings_config";
 
 let user_join_date;
 export function initialize(current_user_join_date) {
+    // We keep the `user_join_date` undefined if the user is a spectator
     user_join_date = current_user_join_date;
 }
 
@@ -103,6 +104,10 @@ export function user_can_change_logo() {
 function user_has_permission(policy_value) {
     if (page_params.is_admin) {
         return true;
+    }
+
+    if (page_params.is_spectator) {
+        return false;
     }
 
     if (page_params.is_guest) {

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -499,7 +499,11 @@ export function initialize_everything() {
     popover_menus.initialize();
 
     people.initialize(page_params.user_id, people_params);
-    settings_data.initialize(people.get_by_user_id(page_params.user_id).date_joined);
+
+    if (!page_params.is_spectator) {
+        const user = people.get_by_user_id(page_params.user_id);
+        settings_data.initialize(user.date_joined);
+    }
 
     // These components must be initialized early, because other
     // modules' initialization has not been audited for whether they


### PR DESCRIPTION
For spectators (logged view), we send user_id=0 via page_params.

The people module does not know about this user ID, and so throws the
exception. Earlier `people.get_by_user_id` was not called on page load,
but only when determining settings permissions with `settings_data.user_has_permission`.

But 231c536cad3d9c33cd32fb2b12af54d037fad959 made it so that that function
is always called, so we need to handle the spectator case explicitly.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
