### PR TITLE
api: Remove '/users/me/enter-sends' endpoint and use '/settings' endpoint instead.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1098,13 +1098,13 @@ test("initialize", ({override, mock_template}) => {
 
     $("#compose-send-button").fadeOut = noop;
     $("#compose-send-button").fadeIn = noop;
-    let channel_post_called = false;
-    override(channel, "post", (params) => {
-        assert.equal(params.url, "/json/users/me/enter-sends");
+    let channel_patch_called = false;
+    override(channel, "patch", (params) => {
+        assert.equal(params.url, "/json/settings");
         assert.equal(params.idempotent, true);
         assert.deepEqual(params.data, {enter_sends: page_params.enter_sends});
 
-        channel_post_called = true;
+        channel_patch_called = true;
     });
     $("#enter_sends").is = () => false;
     $("#enter_sends").trigger("click");
@@ -1128,7 +1128,7 @@ test("initialize", ({override, mock_template}) => {
     assert.ok(stream_typeahead_called);
     assert.ok(subject_typeahead_called);
     assert.ok(pm_recipient_typeahead_called);
-    assert.ok(channel_post_called);
+    assert.ok(channel_patch_called);
     assert.ok(compose_textarea_typeahead_called);
 });
 

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -1093,8 +1093,8 @@ export function initialize() {
         // press Enter to send.
         $("#compose-textarea").trigger("focus");
 
-        return channel.post({
-            url: "/json/users/me/enter-sends",
+        return channel.patch({
+            url: "/json/settings",
             idempotent: true,
             data: {enter_sends: page_params.enter_sends},
         });

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -11,6 +11,12 @@ below features are supported.
 
 ## Changes in Zulip 5.0
 
+**Feature level 81**
+
+* `POST /users/me/enter-sends` has been removed. The `enter_sends`
+  setting is now edited using the normal [`PATCH
+  /settings`](/api/update-settings) endpoint.
+
 **Feature level 80**
 
 * [`PATCH /settings`](/api/update-settings): The

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 80
+API_FEATURE_LEVEL = 81
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10387,6 +10387,17 @@ paths:
           schema:
             type: boolean
           example: true
+        - name: enter_sends
+          in: query
+          description: |
+            Whether pressing Enter in the compose box sends a message
+            (or saves a message edit).
+
+            **Changes**: Before Zulip 5.0 (feature level 81), this setting was managed by
+            the `POST /users/me/enter-sends` endpoint, with the same parameter format.
+          schema:
+            type: boolean
+          example: true
       responses:
         "200":
           description: Success

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1530,7 +1530,6 @@ class TestHumanUsersOnlyDecorator(ZulipTestCase):
         post_endpoints = [
             "/api/v1/users/me/apns_device_token",
             "/api/v1/users/me/android_gcm_reg_id",
-            "/api/v1/users/me/enter-sends",
             "/api/v1/users/me/hotspots",
             "/api/v1/users/me/presence",
             "/api/v1/users/me/tutorial_status",

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -15,23 +15,6 @@ from zerver.models import UserProfile, get_user_profile_by_api_key
 
 
 class ChangeSettingsTest(ZulipTestCase):
-    # DEPRECATED, to be deleted after all uses of check_for_toggle_param
-    # are converted into check_for_toggle_param_patch.
-    def check_for_toggle_param(self, pattern: str, param: str) -> None:
-        self.login("hamlet")
-        user_profile = self.example_user("hamlet")
-        json_result = self.client_post(pattern, {param: orjson.dumps(True).decode()})
-        self.assert_json_success(json_result)
-        # refetch user_profile object to correctly handle caching
-        user_profile = self.example_user("hamlet")
-        self.assertEqual(getattr(user_profile, param), True)
-
-        json_result = self.client_post(pattern, {param: orjson.dumps(False).decode()})
-        self.assert_json_success(json_result)
-        # refetch user_profile object to correctly handle caching
-        user_profile = self.example_user("hamlet")
-        self.assertEqual(getattr(user_profile, param), False)
-
     # TODO: requires method consolidation, right now, there's no alternative
     # for check_for_toggle_param for PATCH.
     def check_for_toggle_param_patch(self, pattern: str, param: str) -> None:
@@ -192,7 +175,7 @@ class ChangeSettingsTest(ZulipTestCase):
             self.check_for_toggle_param_patch("/json/settings", display_setting)
 
     def test_enter_sends_setting(self) -> None:
-        self.check_for_toggle_param("/json/users/me/enter-sends", "enter_sends")
+        self.check_for_toggle_param_patch("/json/settings", "enter_sends")
 
     def test_wrong_old_password(self) -> None:
         self.login("hamlet")

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -154,6 +154,7 @@ def json_change_settings(
     desktop_icon_count_display: Optional[int] = REQ(json_validator=check_int, default=None),
     realm_name_in_notifications: Optional[bool] = REQ(json_validator=check_bool, default=None),
     presence_enabled: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    enter_sends: Optional[bool] = REQ(json_validator=check_bool, default=None),
 ) -> HttpResponse:
     # We can't use REQ for this widget because
     # get_available_language_codes requires provisioning to be
@@ -260,6 +261,9 @@ def json_change_settings(
     if timezone is not None and user_profile.timezone != timezone:
         do_set_user_display_setting(user_profile, "timezone", timezone)
 
+    if enter_sends is not None and user_profile.enter_sends != enter_sends:
+        do_change_enter_sends(user_profile, enter_sends)
+
     # TODO: Do this more generally.
     from zerver.lib.request import get_request_notes
 
@@ -322,14 +326,3 @@ def regenerate_api_key(request: HttpRequest, user_profile: UserProfile) -> HttpR
         api_key=new_api_key,
     )
     return json_success(json_result)
-
-
-@human_users_only
-@has_request_variables
-def change_enter_sends(
-    request: HttpRequest,
-    user_profile: UserProfile,
-    enter_sends: bool = REQ(json_validator=check_bool),
-) -> HttpResponse:
-    do_change_enter_sends(user_profile, enter_sends)
-    return json_success()

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -179,7 +179,6 @@ from zerver.views.user_groups import (
     update_user_group_backend,
 )
 from zerver.views.user_settings import (
-    change_enter_sends,
     confirm_email_change,
     delete_avatar_backend,
     json_change_settings,
@@ -381,14 +380,6 @@ v1_api_and_json_patterns = [
     rest_path("user_groups/<int:user_group_id>/members", POST=update_user_group_backend),
     # users/me -> zerver.views.user_settings
     rest_path("users/me/api_key/regenerate", POST=regenerate_api_key),
-    rest_path(
-        "users/me/enter-sends",
-        POST=(
-            change_enter_sends,
-            # This endpoint should be folded into user settings
-            {"intentionally_undocumented"},
-        ),
-    ),
     rest_path("users/me/avatar", POST=set_avatar_backend, DELETE=delete_avatar_backend),
     # users/me/hotspots -> zerver.views.hotspots
     rest_path(


### PR DESCRIPTION
We remove the '/users/me/enter-sends' endpoint and 'enter_sends' setting will now be edited
using the '/settings' endpoint.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


 <!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
