### PR TITLE
landing_page: Fix anchor links on landing pages.

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -144,7 +144,9 @@ if (window.location.pathname === "/help/") {
 // Remove ID attributes from sidebar links so they don't conflict with index page anchor links
 $(".help .sidebar h1, .help .sidebar h2, .help .sidebar h3").removeAttr("id");
 
-// Scroll to anchor link when clicked
+// Scroll to anchor link when clicked. Note that landing-page.js has a
+// similar function; this file and landing-page.js are never included
+// on the same page.
 $(document).on(
     "click",
     ".markdown .content h1, .markdown .content h2, .markdown .content h3",

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -246,3 +246,10 @@ $(() => {
         }
     });
 });
+
+// Scroll to anchor link when clicked. Note that help.js has a similar
+// function; this file and help.js are never included on the same
+// page.
+$(document).on("click", ".markdown h1, .markdown h2, .markdown h3", function () {
+    window.location.hash = $(this).attr("id");
+});


### PR DESCRIPTION
As it turns out, anchor links on headings only worked on our /help
and /api pages but were broken everywhere else. This commit adds
the required JS to scroll properly when an anchor link on any of
our various landing pages is clicked. We use similar code to
accomplish this in help.js.

Fixes #19349.

@alya @timabbott FYI :)