### PR TITLE
server-settings: Raise error if request realm is deactivated.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 5.0
 
+**Feature level 113**
+
+* [`GET /server_settings`](/api/get-server-settings): The endpoint
+  now returns an error when requesting a deactivated realm.
+
 **Feature level 112**
 
 * [`GET /events`](/api/get-events): Updated `update_message` event type

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 112
+API_FEATURE_LEVEL = 113
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -31,6 +31,7 @@ class ErrorCode(Enum):
     RATE_LIMIT_HIT = auto()
     USER_DEACTIVATED = auto()
     REALM_DEACTIVATED = auto()
+    REALM_MOVED = auto()
     PASSWORD_AUTH_DISABLED = auto()
     PASSWORD_RESET_REQUIRED = auto()
     AUTHENTICATION_FAILED = auto()
@@ -271,12 +272,37 @@ class UserDeactivatedError(AuthenticationFailedError):
         return _("Account is deactivated")
 
 
-class RealmDeactivatedError(AuthenticationFailedError):
+class RealmDeactivatedError(JsonableError):
     code: ErrorCode = ErrorCode.REALM_DEACTIVATED
+    http_status_code = 404
+
+    def __init__(self) -> None:
+        pass
 
     @staticmethod
     def msg_format() -> str:
         return _("This organization has been deactivated")
+
+
+class RealmMovedError(JsonableError):
+    # This is a variation of RealmDeactivatedError
+    # when the deactivated realm has been moved to a different url.
+    code: ErrorCode = ErrorCode.REALM_MOVED
+    http_status_code = 404
+
+    def __init__(self, moved_to_url: str) -> None:
+        self.moved_to_url = moved_to_url
+
+    @staticmethod
+    def msg_format() -> str:
+        return _("This organization has been moved to new hosting")
+
+    @property
+    def data(self) -> Dict[str, Any]:
+        data_dict = super().data
+        data_dict["moved_to_url"] = self.moved_to_url
+
+        return data_dict
 
 
 class PasswordAuthDisabledError(AuthenticationFailedError):

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11900,6 +11900,20 @@ paths:
                             },
                           ],
                       }
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/RealmDeactivatedError"
+                      - description: |
+                          A typical failed json response when the requested realm has been deactivated
+                  - allOf:
+                      - $ref: "#/components/schemas/RealmMovedError"
+                      - description: |
+                          A typical failed json response when the requested realm has been moved to a different hosting
   /settings:
     patch:
       operationId: update-settings
@@ -13323,7 +13337,15 @@ paths:
               schema:
                 oneOf:
                   - $ref: "#/components/schemas/UserDeactivatedError"
+        "404":
+          description: |
+            Not Found.
+          content:
+            application/json:
+              schema:
+                oneOf:
                   - $ref: "#/components/schemas/RealmDeactivatedError"
+                  - $ref: "#/components/schemas/RealmMovedError"
         "429":
           description: |
             Rate limit exceeded.
@@ -15156,8 +15178,25 @@ components:
 
             **Changes**: These errors used the HTTP 403 status code
             before Zulip 5.0 (feature level 76).
+            This error returns a 404 status code after Zulip 5.0 (feature level 113).
 
             A typical failed json response for when user's organization is deactivated:
+    RealmMovedError:
+      allOf:
+        - $ref: "#/components/schemas/CodedError"
+        - example:
+            {
+              "code": "REALM_MOVED",
+              "msg": "This organization has been moved to new hosting",
+              "result": "error",
+              "moved_to_url": "http://realm-abc.com:9991",
+            }
+          description: |
+            ## Realm moved
+
+            **Changes**: New in Zulip 5.0 (feature level 113).
+
+            A typical failed json response when the request organization has been moved to a different hosting:
 
   ###################
   # Shared responses

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1030,7 +1030,7 @@ class DeactivatedRealmTest(ZulipTestCase):
             },
         )
         self.assert_json_error_contains(
-            result, "This organization has been deactivated", status_code=401
+            result, "This organization has been deactivated", status_code=404
         )
 
         result = self.api_post(
@@ -1062,7 +1062,7 @@ class DeactivatedRealmTest(ZulipTestCase):
         realm.save()
         result = self.client_post("/json/fetch_api_key", {"password": test_password})
         self.assert_json_error_contains(
-            result, "This organization has been deactivated", status_code=401
+            result, "This organization has been deactivated", status_code=404
         )
 
     def test_webhook_deactivated_realm(self) -> None:
@@ -1077,7 +1077,7 @@ class DeactivatedRealmTest(ZulipTestCase):
         data = self.webhook_fixture_data("jira", "created_v2")
         result = self.client_post(url, data, content_type="application/json")
         self.assert_json_error_contains(
-            result, "This organization has been deactivated", status_code=401
+            result, "This organization has been deactivated", status_code=404
         )
 
 
@@ -1641,7 +1641,7 @@ class TestAuthenticatedJsonPostViewDecorator(ZulipTestCase):
         self.assert_json_error_contains(
             self._do_test(user_profile),
             "This organization has been deactivated",
-            status_code=401,
+            status_code=404,
         )
         do_reactivate_realm(user_profile.realm)
 

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -54,6 +54,7 @@ from zerver.lib.exceptions import (
     PasswordResetRequiredError,
     RateLimited,
     RealmDeactivatedError,
+    RealmMovedError,
     UserDeactivatedError,
 )
 from zerver.lib.mobile_auth_otp import otp_encrypt_api_key
@@ -936,6 +937,14 @@ def check_server_incompatibility(request: HttpRequest) -> bool:
 @csrf_exempt
 def api_get_server_settings(request: HttpRequest) -> HttpResponse:
     # Log which client is making this request.
+
+    realm = get_realm_from_request(request)
+    if realm is not None and realm.deactivated:
+        if realm.deactivated_redirect:
+            raise RealmMovedError(realm.deactivated_redirect)
+        else:
+            raise RealmDeactivatedError()
+
     process_client(request, request.user, skip_update_user_activity=True)
     result = dict(
         authentication_methods=get_auth_backends_data(request),


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
When the realm in the request is deactivated, raise RealmDeactivatedError
along with redirect_domain for the realm in the response if any.

Fixes #19347.
**Testing plan:** <!-- How have you tested? -->
Manual Testing and automated tests.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
