### PR TITLE
portico: Add general info at the top of /for/education.

### DIFF
--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -4189,7 +4189,9 @@ nav {
         text-align: center;
         font-weight: bolder;
         opacity: 0.9;
+    }
 
+    .hero {
         a {
             color: hsl(170, 76%, 64%);
         }
@@ -4337,5 +4339,16 @@ nav {
         font-size: 25px;
         font-weight: 500;
         opacity: 0.8;
+    }
+}
+
+.feature-intro {
+    max-width: 800px;
+    margin: 50px auto 0;
+    padding: 0 4vw 0;
+
+    h1 {
+        font-size: 36px;
+        font-weight: 600;
     }
 }

--- a/templates/zerver/for-education.html
+++ b/templates/zerver/for-education.html
@@ -22,11 +22,11 @@
         <div class="bg-dimmer"></div>
         <div class="content">
             <h1 class="center">Teach a course with Zulip.</h1>
-            <p>Online, in-person, and anything in between</p>
+            <p>Online, in-person, and anything in between. <br/><a href="#feature-pricing">Free</a> for most classes!</p>
         </div>
         <div class="hero-text">
             Learn how <a href="/case-studies/tum/">Technical University of Munich</a> and
-            <br /><a href="/case-studies/ucsd/">University of California San Diego</a> are using Zulip!
+            <br /><a href="/case-studies/ucsd/">University of California San Diego</a> are using Zulip.
         </div>
         <div class="hero-buttons center">
             <a href="/new/" class="button">
@@ -39,6 +39,13 @@
                 {{ _('Self-host Zulip') }}
             </a>
         </div>
+    </div>
+
+    <div class="feature-intro">
+        <h1 class="center"> Make Zulip the communication hub for your class. </h1>
+        <p>
+            <a href="/hello">Zulip</a> is the only <a href="/features">modern team chat app</a> that is <a href="/why-zulip">ideal</a> for both live and asynchronous conversations. Post lecture notes and announcements, answer students’ questions, and coordinate with teaching staff all in one place.
+        </p>
     </div>
 
     <div class="feature-container">

--- a/templates/zerver/for-events.html
+++ b/templates/zerver/for-events.html
@@ -40,6 +40,12 @@
         </div>
     </div>
 
+    <div class="feature-intro">
+        <h1 class="center"> Make Zulip the communication hub for your event. </h1>
+        <p>
+            <a href="/hello">Zulip</a> is the only <a href="/features">modern team chat app</a> that is <a href="/why-zulip">ideal</a> for both live and asynchronous conversations. Post presentations and announcements, host Q&A sessions, and coordinate among organizers.
+        </p>
+    </div>
 
     <div class="feature-container">
         <div class="feature-half">

--- a/templates/zerver/for-research.html
+++ b/templates/zerver/for-research.html
@@ -40,6 +40,13 @@
         </div>
     </div>
 
+    <div class="feature-intro">
+        <h1 class="center"> Make Zulip the communication hub for your research community. </h1>
+        <p>
+            <a href="/hello">Zulip</a> is the only <a href="/features">modern team chat app</a> that is <a href="/why-zulip">ideal</a> for both live and asynchronous conversations. Coordinate with collaborators, post questions and ideas, and learn from others in your field.
+        </p>
+    </div>
+
     <div class="feature-container">
         <div class="feature-half">
             <div class="feature-text">

--- a/templates/zerver/for-research.html
+++ b/templates/zerver/for-research.html
@@ -149,7 +149,7 @@
                     Powerful formatting
                 </h1>
                 <ul>
-                    <li><div class="list-content">Teaching technical topics? <a href="/help/format-your-message-using-markdown#latex">Type LaTeX</a> directly into your Zulip message, and see it beautifully rendered.</div></li>
+                    <li><div class="list-content"><a href="/help/format-your-message-using-markdown#latex">Type LaTeX</a> directly into your Zulip message, and see it beautifully rendered.</div></li>
                     <li><div class="list-content"><a href="/help/code-blocks">Zulip
                     code blocks</a> come with syntax highlighting for over 250 languages, and integrated <a href="/help/code-blocks#code-playgrounds">code playgrounds.</a></div></li>
                     <li><div class="list-content">Structure your points with bulleted and numbered <a href="/help/format-your-message-using-markdown#lists">lists</a>.</div></li>


### PR DESCRIPTION
Add text to the top of /for/education to make it stand on its own.

The CSS needs to be fixed.
- Vertical spacing is off.
- "Free" link in the hero looks bad.
- Maybe the couple of lines of text would look better centered?
- I used classes from the end part, so the class names don't make sense for the new section up top.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Manual testing.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="1427" alt="Screen Shot 2021-07-22 at 9 20 06 PM" src="https://user-images.githubusercontent.com/2090066/126736974-b7a84caa-209c-467e-931a-12f4aaa728ae.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
