### PR TITLE
css: Fixed padding in alert messages.

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -546,6 +546,10 @@ div.overlay {
     }
 }
 
+.alert p {
+    margin-bottom: 2.5px;
+}
+
 .white_zulip_icon_without_text {
     display: inline-block;
     background-image: url(../../static/images/logo/white-zulip-logo-without-text.svg);

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -379,6 +379,7 @@ on a dark background, and don't change the dark labels dark either. */
     .dropdown .dropdown-menu li.divider,
     .popover hr,
     hr {
+        height: 1px;
         color: hsl(212, 28%, 18%);
         opacity: 0.2;
     }

--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -40,6 +40,15 @@
         margin-top: 0;
     }
 
+    /* Changing visibility of hr in light-mode */
+
+    hr {
+        height: 2px;
+        background-color: hsl(214, 13%, 89%);
+        color: hsl(214, 13%, 89%);
+        opacity: 1;
+    }
+
     /* Headings: We need to make sure our headings are less prominent than our sender names styling. */
     h1,
     h2,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This PR is for issue #19153.

**Testing plan:** <!-- How have you tested? -->

I have created a new selector as `.alert p` in `app_components.css` and given it `padding of 2.5px`.
I have tested it manually. And would like to see if my changes were sufficient enough.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

> Before:

![before](https://user-images.githubusercontent.com/74018438/126761710-b8435953-8960-4af7-8bef-65c0982c807d.png)

> After:

![after](https://user-images.githubusercontent.com/74018438/126761751-f40e7f8a-cb81-46b3-b46b-f02e9919e06a.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
