### PR TITLE
css: Alert message padding

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -546,6 +546,10 @@ div.overlay {
     }
 }
 
+.alert p {
+    margin-bottom: 2.5px;
+}
+
 .white_zulip_icon_without_text {
     display: inline-block;
     background-image: url(../../static/images/logo/white-zulip-logo-without-text.svg);


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This PR is for `issue #19153`. 

**Testing plan:** <!-- How have you tested? -->

I have changed padding of p tags in alert using `.alert p` in the `app_components.css` file.
I have tested it manually.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

> Before: 

![before](https://user-images.githubusercontent.com/74018438/126769148-e0cd1887-cba6-4690-8ab0-d7c0239fb120.png)

> After:

![after](https://user-images.githubusercontent.com/74018438/126769176-e983f8d4-d3ed-42b2-aae6-2537091ffdb1.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
