### PR TITLE
bots: Remove the need to debounce for dispatching bot events.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -433,7 +433,7 @@ run_test("realm_bot add", ({override}) => {
     const bot_stub = make_stub();
     const admin_stub = make_stub();
     override(bot_data, "add", bot_stub.f);
-    override(settings_bots, "eventually_render_bots", () => {});
+    override(settings_bots, "render_bots", () => {});
     override(settings_users, "update_bot_data", admin_stub.f);
     dispatch(event);
 
@@ -449,7 +449,7 @@ run_test("realm_bot remove", ({override}) => {
     const bot_stub = make_stub();
     const admin_stub = make_stub();
     override(bot_data, "deactivate", bot_stub.f);
-    override(settings_bots, "eventually_render_bots", () => {});
+    override(settings_bots, "render_bots", () => {});
     override(settings_users, "update_bot_data", admin_stub.f);
     dispatch(event);
 
@@ -471,7 +471,7 @@ run_test("realm_bot update", ({override}) => {
     const bot_stub = make_stub();
     const admin_stub = make_stub();
     override(bot_data, "update", bot_stub.f);
-    override(settings_bots, "eventually_render_bots", () => {});
+    override(settings_bots, "render_bots", () => {});
     override(settings_users, "update_bot_data", admin_stub.f);
 
     dispatch(event);

--- a/frontend_tests/puppeteer_tests/settings.ts
+++ b/frontend_tests/puppeteer_tests/settings.ts
@@ -106,6 +106,7 @@ async function test_webhook_bot_creation(page: Page): Promise<void> {
         payload_url: "http://hostname.example.com/bots/followup",
     });
 
+    await page.waitForSelector("#create_bot_button", {visible: true});
     await page.click("#create_bot_button");
 
     const bot_email = "1-bot@zulip.testserver";

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -300,13 +300,13 @@ export function dispatch_normal_event(event) {
             switch (event.op) {
                 case "add":
                     bot_data.add(event.bot);
-                    settings_bots.eventually_render_bots();
+                    settings_bots.render_bots();
                     settings_users.update_bot_data(event.bot.user_id);
                     break;
                 case "remove":
                     bot_data.deactivate(event.bot.user_id);
                     event.bot.is_active = false;
-                    settings_bots.eventually_render_bots();
+                    settings_bots.render_bots();
                     settings_users.update_bot_data(event.bot.user_id);
                     break;
                 case "delete":
@@ -314,7 +314,7 @@ export function dispatch_normal_event(event) {
                     break;
                 case "update":
                     bot_data.update(event.bot.user_id, event.bot);
-                    settings_bots.eventually_render_bots();
+                    settings_bots.render_bots();
                     settings_users.update_bot_data(event.bot.user_id);
                     break;
                 default:

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -1,6 +1,5 @@
 import ClipboardJS from "clipboard";
 import $ from "jquery";
-import _ from "lodash";
 
 import render_bot_avatar_row from "../templates/settings/bot_avatar_row.hbs";
 import render_edit_bot from "../templates/settings/edit_bot.hbs";
@@ -85,7 +84,7 @@ export function type_id_to_string(type_id) {
     return page_params.bot_types.find((bot_type) => bot_type.type_id === type_id).name;
 }
 
-function render_bots() {
+export function render_bots() {
     $("#active_bots_list").empty();
     $("#inactive_bots_list").empty();
 
@@ -110,30 +109,7 @@ function render_bots() {
         focus_tab.add_a_new_bot_tab();
         return;
     }
-
-    if ($("#bots_lists_navbar .add-a-new-bot-tab").hasClass("active")) {
-        $("#add-a-new-bot-form").show();
-        $("#active_bots_list").hide();
-        $("#inactive_bots_list").hide();
-    } else if ($("#bots_lists_navbar .active-bots-tab").hasClass("active")) {
-        $("#add-a-new-bot-form").hide();
-        $("#active_bots_list").show();
-        $("#inactive_bots_list").hide();
-    } else {
-        $("#add-a-new-bot-form").hide();
-        $("#active_bots_list").hide();
-        $("#inactive_bots_list").show();
-    }
 }
-
-// The reason we debounce this call is very wonky. I just moved it
-// from bot_data.js as part of breaking dependencies. Basically, it
-// allows the server response to win the race against events.
-// TODO: Organize the code so that we clear loading spinners and
-//       switch tabs within the UI when the event comes in.
-export const eventually_render_bots = _.debounce(() => {
-    render_bots();
-}, 50);
 
 export function generate_zuliprc_uri(bot_id) {
     const bot = bot_data.get(bot_id);
@@ -267,6 +243,9 @@ export function set_up() {
         );
     });
 
+    // This needs to come before render_bots() in case the user
+    // has no active bots
+    focus_tab.active_bots_tab();
     render_bots();
 
     $.validator.addMethod(
@@ -345,8 +324,7 @@ export function set_up() {
                     $("#create_bot_button").show();
                     $("#create_interface_type").val(GENERIC_INTERFACE);
                     create_avatar_widget.clear();
-                    $("#bots_lists_navbar .add-a-new-bot-tab").removeClass("active");
-                    $("#bots_lists_navbar .active-bots-tab").addClass("active");
+                    focus_tab.active_bots_tab();
                 },
                 error(xhr) {
                     $("#bot_table_error").text(JSON.parse(xhr.responseText).msg).show();


### PR DESCRIPTION
We rely on calling eventually_render_bots from the event handling
code path for bot events to both updating the list and switching
the tab.

Now we decouple the logic and make render_bots take care of
rendering the list of bots only and switch the tab upon calling
the success handler of creating the bot. #17743

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
