### PR TITLE
portico: Clarify annual pricing on /for/education.

### DIFF
--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -2646,7 +2646,7 @@ nav {
 }
 
 .pricing-model .pricing-container .text-content {
-    margin: 20px;
+    margin: 18px;
 }
 
 .pricing-model .padded-content .text-header .text-content h1 {
@@ -2716,7 +2716,7 @@ nav {
     content: "$";
     position: relative;
     vertical-align: top;
-    top: 4px;
+    top: 7px;
     left: -3px;
 
     font-size: 2rem;
@@ -2731,12 +2731,13 @@ nav {
     font-size: 3.5em;
     font-weight: 600;
     line-height: 0.8;
+    margin-top: 4px;
 }
 
 .pricing-model .pricing-container .bottom .details {
     display: inline-block;
     vertical-align: top;
-    margin-left: 15px;
+    margin-left: 8px;
     margin-top: 4px;
 
     font-size: 0.9em;
@@ -2747,7 +2748,7 @@ nav {
 }
 
 .pricing-model .pricing-container .bottom .button {
-    margin-top: 20px;
+    margin-top: 24px;
     display: block;
     text-align: center;
 
@@ -2877,7 +2878,7 @@ nav {
     text-align: center;
 
     &.multi-line {
-        padding: 0 0 30px 0;
+        padding: 5px 0 25px 0;
     }
 }
 

--- a/templates/zerver/for-education.html
+++ b/templates/zerver/for-education.html
@@ -287,6 +287,8 @@
                                         <div class="details">
                                             per user per month
                                             <br />
+                                            with annual billing discount
+                                            <br />
                                             $1.20/month billed monthly
                                         </div>
                                     </div>
@@ -295,6 +297,8 @@
                                         <div class="price">0<span class="price-cents">.67</span></div>
                                         <div class="details">
                                             per user per month
+                                            <br />
+                                            with annual billing discount
                                             <br />
                                             $0.80/month billed monthly
                                         </div>

--- a/templates/zerver/plans.html
+++ b/templates/zerver/plans.html
@@ -80,6 +80,8 @@
                                         <div class="details">
                                             per user per month
                                             <br />
+                                            with annual billing discount
+                                            <br />
                                             $8/month billed monthly
                                         </div>
                                     </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Adds "(upfront)") to the line describing annual pricing on /for/education.

@amanagr , assuming we're happy with this change, could you also make the same change on /plans? I tried, but it didn't quite fit, and I gave up on making the CSS work.

**Testing plan:** <!-- How have you tested? -->
Manual.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="320" alt="Screen Shot 2021-07-23 at 5 07 01 PM" src="https://user-images.githubusercontent.com/2090066/126851473-d030864a-b3de-49fb-b934-c5411e2a5e88.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
