### PR TITLE
login: Fix hash being lost with redirects.

### DIFF
--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -131,12 +131,15 @@ $(() => {
     // Code in this block will be executed when the user is at login page
     // i.e. login.html is rendered.
     if ($("[data-page-id='login-page']").length > 0 && window.location.hash.slice(0, 1) === "#") {
-        /* We append the location.hash to the formaction so that URL can be
-        preserved after user is logged in. See this:
-        https://stackoverflow.com/questions/5283395/url-hash-is-persisting-between-redirects */
-        const email_formaction = $("#login_form").attr("action");
-        $("#login_form").attr("action", email_formaction + "/" + window.location.hash);
-        $(".social_login_form input[name='next']").attr("value", "/" + window.location.hash);
+        // All next inputs have the same value when the page is
+        // rendered, so it's OK that this selector gets N elements.
+        const next_value = $("input[name='next']").attr("value");
+
+        // We need to add `window.location.hash` to the `next`
+        // property, since the server doesn't receive URL fragments
+        // (and thus could not have included them when rendering a
+        // redirect to this page).
+        $("input[name='next']").attr("value", next_value + window.location.hash);
     }
 
     $("#send_confirm").validate({


### PR DESCRIPTION
This fixes the following flow being broken:

* You start on
  http://zulipdev.com:9991/accounts/go/?next=/upgrade%23sponsorship
  (which we link to from e.g. /plans/)

* The form on that page has
  `action=/accounts/go/?next=%2Fupgrade%23sponsorship`, i.e. it has correctly
  URL-encoded the `next `value.

* You enter a realm name and hit submit.

* That redirects you to
  `http://realm-26.zulipdev.com:9991/upgrade#sponsorship`, would is
  correct if you are already logged in.

* However, if you're not logged in, `/upgrade` will serve a redirect
  to the login page, landing you at
  `http://realm-26.zulipdev.com:9991/devlogin/?next=/upgrade/#sponsorship`.
  This page works.  But in production, it would instead be:
  `http://realm-26.zulipdev.com:9991/login/?next=/upgrade/#sponsorship`.
  On this page, password login works but social login does not.
  Note that the `next=` value is no longer URL-encoded, and thus is
  parsed by the browser as `?next=/upgrade` + a hash of
  `#sponsorship`.

* If you now login with Google auth, you find yourself on
  `http://realm-26.zulipdev.com:9991/#sponsorship` (no /upgrade).

The root cause was that we have a bit of JavaScript in signup.js and
dev-login.js that is intended to handle this; but it was broken for
the social login case for unknown legacy reasons.

This bug appears to date from the original
b62bdde3034bb618365ba8e3160f34fc5b928d2f which introduced `next`
support for social backends in the first place.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
