### PR TITLE
tests: Use assertion to enforce None-checks in tests.

### DIFF
--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -240,6 +240,7 @@ class TestProcessCountStat(AnalyticsTestCase):
         self, stat: CountStat, end_time: datetime, state: int = FillState.DONE
     ) -> None:
         fill_state = FillState.objects.filter(property=stat.property).first()
+        assert fill_state is not None
         self.assertEqual(fill_state.end_time, end_time)
         self.assertEqual(fill_state.state, state)
 

--- a/zerver/lib/sessions.py
+++ b/zerver/lib/sessions.py
@@ -71,14 +71,14 @@ def delete_all_deactivated_user_sessions() -> None:
 
 
 def set_expirable_session_var(
-    session: Session, var_name: str, var_value: Any, expiry_seconds: int
+    session: SessionBase, var_name: str, var_value: Any, expiry_seconds: int
 ) -> None:
     expire_at = datetime_to_timestamp(timezone_now() + timedelta(seconds=expiry_seconds))
     session[var_name] = {"value": var_value, "expire_at": expire_at}
 
 
 def get_expirable_session_var(
-    session: Session, var_name: str, default_value: Any = None, delete: bool = False
+    session: SessionBase, var_name: str, default_value: Any = None, delete: bool = False
 ) -> Any:
     if var_name not in session:
         return default_value

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1613,7 +1613,9 @@ class MigrationsTestCase(ZulipTestCase):  # nocoverage
 
     @property
     def app(self) -> str:
-        return apps.get_containing_app_config(type(self).__module__).name
+        app_config = apps.get_containing_app_config(type(self).__module__)
+        assert app_config is not None
+        return app_config.name
 
     migrate_from: Optional[str] = None
     migrate_to: Optional[str] = None

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -288,8 +288,10 @@ class TestRealmAuditLog(ZulipTestCase):
             modified_user=user,
             modified_stream=stream,
         )
+        modified_stream = subscription_creation_logs[0].modified_stream
+        assert modified_stream is not None
         self.assertEqual(subscription_creation_logs.count(), 1)
-        self.assertEqual(subscription_creation_logs[0].modified_stream.id, stream.id)
+        self.assertEqual(modified_stream.id, stream.id)
         self.assertEqual(subscription_creation_logs[0].modified_user, user)
 
         bulk_remove_subscriptions([user], [stream], get_client("website"), acting_user=acting_user)
@@ -300,8 +302,10 @@ class TestRealmAuditLog(ZulipTestCase):
             modified_user=user,
             modified_stream=stream,
         )
+        modified_stream = subscription_deactivation_logs[0].modified_stream
+        assert modified_stream is not None
         self.assertEqual(subscription_deactivation_logs.count(), 1)
-        self.assertEqual(subscription_deactivation_logs[0].modified_stream.id, stream.id)
+        self.assertEqual(modified_stream.id, stream.id)
         self.assertEqual(subscription_deactivation_logs[0].modified_user, user)
 
     def test_realm_activation(self) -> None:
@@ -495,11 +499,11 @@ class TestRealmAuditLog(ZulipTestCase):
             acting_user=user,
             event_time__gte=test_start,
         )
+        audit_log = audit_entries.first()
+        assert audit_log is not None
         self.assert_length(audit_entries, 1)
         self.assertEqual(icon_source, realm.icon_source)
-        self.assertEqual(
-            audit_entries.first().extra_data, "{'icon_source': 'G', 'icon_version': 2}"
-        )
+        self.assertEqual(audit_log.extra_data, "{'icon_source': 'G', 'icon_version': 2}")
 
     def test_change_subscription_property(self) -> None:
         user = self.example_user("hamlet")

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1310,6 +1310,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase):
         else:
             self.assertEqual(result.status_code, 302)
         confirmation = Confirmation.objects.all().last()
+        assert confirmation is not None
         confirmation_key = confirmation.confirmation_key
         if expect_confirm_registration_page:
             self.assert_in_success_response(["do_confirm/" + confirmation_key], result)
@@ -1495,6 +1496,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase):
         multiuse_obj.streams.set(streams)
         create_confirmation_link(multiuse_obj, Confirmation.MULTIUSE_INVITE)
         multiuse_confirmation = Confirmation.objects.all().last()
+        assert multiuse_confirmation is not None
         multiuse_object_key = multiuse_confirmation.confirmation_key
         account_data_dict = self.get_account_data_dict(email=email, name=name)
 
@@ -3927,6 +3929,7 @@ class GoogleAuthBackendTest(SocialAuthBase):
         result = self.get_log_into_subdomain(data)
         self.assertEqual(result.status_code, 302)
         confirmation = Confirmation.objects.all().first()
+        assert confirmation is not None
         confirmation_key = confirmation.confirmation_key
         self.assertIn("do_confirm/" + confirmation_key, result.url)
         result = self.client_get(result.url)
@@ -3962,6 +3965,7 @@ class GoogleAuthBackendTest(SocialAuthBase):
             result.content.decode("utf-8"),
         )[0]
         confirmation = Confirmation.objects.all().first()
+        assert confirmation is not None
         confirmation_key = confirmation.confirmation_key
         self.assertIn("do_confirm/" + confirmation_key, url)
         result = self.client_get(url)
@@ -4008,6 +4012,7 @@ class GoogleAuthBackendTest(SocialAuthBase):
         multiuse_obj.streams.set(streams)
         create_confirmation_link(multiuse_obj, Confirmation.MULTIUSE_INVITE)
         multiuse_confirmation = Confirmation.objects.all().last()
+        assert multiuse_confirmation is not None
         multiuse_object_key = multiuse_confirmation.confirmation_key
 
         data["multiuse_object_key"] = multiuse_object_key
@@ -4015,6 +4020,7 @@ class GoogleAuthBackendTest(SocialAuthBase):
         self.assertEqual(result.status_code, 302)
 
         confirmation = Confirmation.objects.all().last()
+        assert confirmation is not None
         confirmation_key = confirmation.confirmation_key
         self.assertIn("do_confirm/" + confirmation_key, result.url)
         result = self.client_get(result.url)
@@ -6233,6 +6239,7 @@ class TestMaybeSendToRegistration(ZulipTestCase):
             )
             self.assertEqual(result.status_code, 302)
             confirmation = Confirmation.objects.all().first()
+            assert confirmation is not None
             confirmation_key = confirmation.confirmation_key
             self.assertIn("do_confirm/" + confirmation_key, result.url)
             self.assertEqual(PreregistrationUser.objects.all().count(), 1)
@@ -6264,6 +6271,7 @@ class TestMaybeSendToRegistration(ZulipTestCase):
             result = maybe_send_to_registration(request, email, is_signup=True)
             self.assertEqual(result.status_code, 302)
             confirmation = Confirmation.objects.all().first()
+            assert confirmation is not None
             confirmation_key = confirmation.confirmation_key
             self.assertIn("do_confirm/" + confirmation_key, result.url)
             self.assertEqual(PreregistrationUser.objects.all().count(), 1)

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -150,7 +150,9 @@ class CacheWithKeyDecoratorTest(ZulipTestCase):
             except UserProfile.DoesNotExist:
                 return None
 
-        last_user_id = UserProfile.objects.last().id
+        last_user = UserProfile.objects.last()
+        assert last_user is not None
+        last_user_id = last_user.id
         with queries_captured() as queries:
             result = get_user_function_can_return_none(last_user_id + 1)
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1534,7 +1534,9 @@ class NormalActionsTest(BaseAction):
         )
         check_realm_playgrounds("events[0]", events[0])
 
-        last_id = RealmPlayground.objects.last().id
+        last_realm_playground = RealmPlayground.objects.last()
+        assert last_realm_playground is not None
+        last_id = last_realm_playground.id
         realm_playground = access_playground_by_id(self.user_profile.realm, last_id)
         events = self.verify_action(
             lambda: do_remove_realm_playground(self.user_profile.realm, realm_playground)
@@ -1951,6 +1953,7 @@ class NormalActionsTest(BaseAction):
         audit_log_entry = RealmAuditLog.objects.filter(
             event_type=RealmAuditLog.REALM_EXPORTED
         ).first()
+        assert audit_log_entry is not None
         events = self.verify_action(
             lambda: self.client_delete(f"/json/export/realm/{audit_log_entry.id}"),
             state_change_expected=False,

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -250,6 +250,7 @@ class TestFullStack(ZulipTestCase):
         # especially if there's risk of similar objects existing
         # (E.g. a message sent to that topic earlier in the test).
         row = UserStatus.objects.last()
+        assert row is not None
         self.assertEqual(row.user_profile_id, cordelia.id)
         self.assertEqual(row.status_text, "on vacation")
 

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -622,6 +622,7 @@ class ImportExportTest(ZulipTestCase):
 
         realm_emoji = RealmEmoji.objects.get(realm=realm)
         realm_emoji.delete()
+        assert message is not None
         full_data = self._export_realm(realm, consent_message_id=message.id)
         realm_emoji.save()
 
@@ -699,6 +700,7 @@ class ImportExportTest(ZulipTestCase):
         )
 
         # Third huddle is not exported since none of the members gave consent
+        assert huddle_a is not None and huddle_b is not None
         huddle_recipients = Recipient.objects.filter(
             type_id__in=[huddle_a.id, huddle_b.id], type=Recipient.HUDDLE
         )
@@ -806,10 +808,12 @@ class ImportExportTest(ZulipTestCase):
 
         # data to test import of muted topic
         stream = get_stream("Verona", original_realm)
+        recipient = stream.recipient
+        assert recipient is not None
         add_topic_mute(
             user_profile=sample_user,
             stream_id=stream.id,
-            recipient_id=stream.recipient.id,
+            recipient_id=recipient.id,
             topic_name="Verona2",
         )
 

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -509,6 +509,7 @@ class TestExport(ZulipTestCase):
             content="Outbox emoji for export",
         )
         message = Message.objects.last()
+        assert message is not None
         do_add_reaction(
             self.example_user("iago"), message, "outbox", "1f4e4", Reaction.UNICODE_EMOJI
         )

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -74,9 +74,9 @@ def get_sqlalchemy_query_params(query: ClauseElement) -> Dict[str, object]:
     return comp.params
 
 
-def get_recipient_id_for_stream_name(realm: Realm, stream_name: str) -> str:
+def get_recipient_id_for_stream_name(realm: Realm, stream_name: str) -> Optional[str]:
     stream = get_stream(stream_name, realm)
-    return stream.recipient.id
+    return stream.recipient.id if stream.recipient is not None else None
 
 
 def mute_stream(realm: Realm, user_profile: str, stream_name: str) -> None:
@@ -3277,6 +3277,7 @@ class GetOldMessagesTest(ZulipTestCase):
         self.assert_length(queries, 1)
 
         stream = get_stream("Scotland", realm)
+        assert stream.recipient is not None
         recipient_id = stream.recipient.id
         cond = f"AND NOT (recipient_id = {recipient_id} AND upper(subject) = upper('golf'))"
         self.assertIn(cond, queries[0]["sql"])

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -374,6 +374,7 @@ class FixUnreadTests(ZulipTestCase):
         def mute_topic(stream_name: str, topic_name: str) -> None:
             stream = get_stream(stream_name, realm)
             recipient = stream.recipient
+            assert recipient is not None
 
             add_topic_mute(
                 user_profile=user,
@@ -573,6 +574,7 @@ class GetUnreadMsgsTest(ZulipTestCase):
         realm = user_profile.realm
         stream = get_stream(stream_name, realm)
         recipient = stream.recipient
+        assert recipient is not None
 
         add_topic_mute(
             user_profile=user_profile,

--- a/zerver/tests/test_muting_topics.py
+++ b/zerver/tests/test_muting_topics.py
@@ -25,6 +25,7 @@ class MutedTopicsTests(ZulipTestCase):
 
         mock_date_muted = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
 
+        assert recipient is not None
         add_topic_mute(
             user_profile=user,
             stream_id=stream.id,
@@ -56,6 +57,7 @@ class MutedTopicsTests(ZulipTestCase):
         self.assertEqual(user_ids, set())
 
         def mute_topic_for_user(user: UserProfile) -> None:
+            assert recipient is not None
             add_topic_mute(
                 user_profile=user,
                 stream_id=stream.id,
@@ -123,6 +125,7 @@ class MutedTopicsTests(ZulipTestCase):
         ]
         mock_date_muted = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
 
+        assert recipient is not None
         for data in payloads:
             add_topic_mute(
                 user_profile=user,
@@ -146,6 +149,7 @@ class MutedTopicsTests(ZulipTestCase):
 
         stream = get_stream("Verona", realm)
         recipient = stream.recipient
+        assert recipient is not None
         add_topic_mute(
             user_profile=user,
             stream_id=stream.id,

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -454,7 +454,9 @@ class AnalyticsBouncerTest(BouncerTestCase):
 
         self.add_mock_response()
         # Send any existing data over, so that we can start the test with a "clean" slate
-        audit_log_max_id = RealmAuditLog.objects.all().order_by("id").last().id
+        audit_log = RealmAuditLog.objects.all().order_by("id").last()
+        assert audit_log is not None
+        audit_log_max_id = audit_log.id
         send_analytics_to_remote_server()
         self.assertTrue(responses.assert_call_count(ANALYTICS_STATUS_URL, 1))
         remote_audit_log_count = RemoteRealmAuditLog.objects.count()
@@ -712,6 +714,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
         )
         send_analytics_to_remote_server()
         remote_log_entry = RemoteRealmAuditLog.objects.order_by("id").last()
+        assert remote_log_entry is not None
         self.assertEqual(remote_log_entry.server.uuid, self.server_uuid)
         self.assertEqual(remote_log_entry.remote_id, log_entry.id)
         self.assertEqual(remote_log_entry.event_time, self.TIME_ZERO)

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -207,6 +207,7 @@ class RealmTest(ZulipTestCase):
         realm_audit_log = RealmAuditLog.objects.filter(
             event_type=RealmAuditLog.REALM_SUBDOMAIN_CHANGED, acting_user=iago
         ).last()
+        assert realm_audit_log is not None
         expected_extra_data = {"old_subdomain": "zulip", "new_subdomain": "newzulip"}
         self.assertEqual(realm_audit_log.extra_data, str(expected_extra_data))
         self.assertEqual(realm_audit_log.acting_user, iago)
@@ -283,6 +284,7 @@ class RealmTest(ZulipTestCase):
         self.assertTrue(realm.deactivated)
         create_confirmation_link(realm, Confirmation.REALM_REACTIVATION)
         confirmation = Confirmation.objects.last()
+        assert confirmation is not None
         self.assertEqual(confirmation.content_object, realm)
         self.assertEqual(confirmation.realm, realm)
 
@@ -575,6 +577,7 @@ class RealmTest(ZulipTestCase):
         realm_audit_log = RealmAuditLog.objects.filter(
             event_type=RealmAuditLog.REALM_PLAN_TYPE_CHANGED
         ).last()
+        assert realm_audit_log is not None
         expected_extra_data = {"old_value": Realm.SELF_HOSTED, "new_value": Realm.STANDARD}
         self.assertEqual(realm_audit_log.extra_data, str(expected_extra_data))
         self.assertEqual(realm_audit_log.acting_user, iago)

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -68,6 +68,7 @@ class RealmEmojiTest(ZulipTestCase):
         self.assert_json_success(result)
         self.assertEqual(200, result.status_code)
         realm_emoji = RealmEmoji.objects.get(name="my_emoji")
+        assert realm_emoji.author is not None
         self.assertEqual(realm_emoji.author.email, email)
 
         result = self.client_get("/json/realm/emoji")
@@ -99,6 +100,7 @@ class RealmEmojiTest(ZulipTestCase):
         self.assert_json_success(result)
         self.assertEqual(200, result.status_code)
         realm_emoji = RealmEmoji.objects.get(name="smile")
+        assert realm_emoji is not None and realm_emoji.author is not None
         self.assertEqual(realm_emoji.author.email, email)
 
     def test_realm_emoji_repr(self) -> None:

--- a/zerver/tests/test_realm_export.py
+++ b/zerver/tests/test_realm_export.py
@@ -61,6 +61,7 @@ class RealmExportTest(ZulipTestCase):
         audit_log_entry = RealmAuditLog.objects.filter(
             event_type=RealmAuditLog.REALM_EXPORTED
         ).first()
+        assert audit_log_entry is not None
         self.assertEqual(audit_log_entry.acting_user_id, admin.id)
 
         # Test that the file is hosted, and the contents are as expected.
@@ -126,6 +127,7 @@ class RealmExportTest(ZulipTestCase):
         audit_log_entry = RealmAuditLog.objects.filter(
             event_type=RealmAuditLog.REALM_EXPORTED
         ).first()
+        assert audit_log_entry is not None
         self.assertEqual(audit_log_entry.acting_user_id, admin.id)
 
         # Test that the file is hosted, and the contents are as expected.

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -602,6 +602,7 @@ class MoveMessageToArchiveGeneral(MoveMessageToArchiveBase):
         self._verify_archive_data(msg_ids, usermsg_ids)
 
         archive_transaction = ArchiveTransaction.objects.last()
+        assert archive_transaction is not None
         self.assertEqual(archive_transaction.realm, realm)
 
     def test_stream_messages_archiving(self) -> None:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1179,6 +1179,7 @@ class InviteUserTest(InviteUserBase):
         self.assert_json_success(result)
 
         prereg_user = PreregistrationUser.objects.get(email=mirror_user.email)
+        assert prereg_user.referred_by is not None and inviter is not None
         self.assertEqual(
             prereg_user.referred_by.email,
             inviter.email,
@@ -1790,6 +1791,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
 
         obj = Confirmation.objects.get(confirmation_key=find_key_by_email(email))
         prereg_user = obj.content_object
+        assert prereg_user is not None
         prereg_user.email = "invalid.email"
         prereg_user.save()
 
@@ -1930,6 +1932,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         registration_key = url.split("/")[-1]
 
         conf = Confirmation.objects.filter(confirmation_key=registration_key).first()
+        assert conf is not None
         conf.date_sent -= datetime.timedelta(weeks=3)
         conf.save()
 
@@ -2140,6 +2143,7 @@ class InvitationsTestCase(InviteUserBase):
         multiuse_invite_two = MultiuseInvite.objects.create(referred_by=othello, realm=realm)
         create_confirmation_link(multiuse_invite_two, Confirmation.MULTIUSE_INVITE)
         confirmation = Confirmation.objects.last()
+        assert confirmation is not None
         confirmation.date_sent = expired_datetime
         confirmation.save()
 
@@ -2432,6 +2436,7 @@ class InvitationsTestCase(InviteUserBase):
 
     def test_accessing_invites_in_another_realm(self) -> None:
         inviter = UserProfile.objects.exclude(realm=get_realm("zulip")).first()
+        assert inviter is not None
         prereg_user = PreregistrationUser.objects.create(
             email="email", referred_by=inviter, realm=inviter.realm
         )
@@ -2460,6 +2465,7 @@ class InvitationsTestCase(InviteUserBase):
         )
         self.assertEqual(result.status_code, 200)
         confirmation = Confirmation.objects.get(confirmation_key=registration_key)
+        assert confirmation.content_object is not None
         prereg_user = confirmation.content_object
         self.assertEqual(prereg_user.status, 0)
 
@@ -3934,6 +3940,7 @@ class UserSignUpTest(InviteUserBase):
                 form.errors["email"][0],
             )
             last_message = Message.objects.last()
+            assert last_message is not None
             self.assertIn(
                 f"A new member ({self.nonreg_email('test')}) was unable to join your organization because all Zulip",
                 last_message.content,
@@ -4735,7 +4742,7 @@ class UserSignUpTest(InviteUserBase):
         stream_name = "Rome"
         realm = get_realm("zulip")
         stream = get_stream(stream_name, realm)
-        default_streams = get_default_streams_for_realm(realm)
+        default_streams = get_default_streams_for_realm(realm.id)
         default_streams_name = [stream.name for stream in default_streams]
         self.assertNotIn(stream_name, default_streams_name)
 
@@ -4818,6 +4825,7 @@ class UserSignUpTest(InviteUserBase):
             key = find_key_by_email(email)
             confirmation = Confirmation.objects.get(confirmation_key=key)
             prereg_user = confirmation.content_object
+            assert prereg_user is not None
             prereg_user.realm_creation = True
             prereg_user.save()
 
@@ -4950,6 +4958,7 @@ class UserSignUpTest(InviteUserBase):
 
         result = self.client_post("/devtools/register_user/")
         user_profile = UserProfile.objects.all().order_by("id").last()
+        assert user_profile is not None
 
         self.assertEqual(result.status_code, 302)
         self.assertEqual(user_profile.delivery_email, email)
@@ -4971,6 +4980,7 @@ class UserSignUpTest(InviteUserBase):
         self.assertEqual(result["Location"], f"http://{string_id}.testserver")
 
         user_profile = UserProfile.objects.all().order_by("id").last()
+        assert user_profile is not None
         self.assert_logged_in_user_id(user_profile.id)
 
 

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -39,6 +39,7 @@ class UserGroupTestCase(ZulipTestCase):
     def test_user_groups_in_realm_serialized(self) -> None:
         realm = get_realm("zulip")
         user_group = UserGroup.objects.first()
+        assert user_group is not None
         membership = UserGroupMembership.objects.filter(user_group=user_group)
         membership = membership.values_list("user_profile_id", flat=True)
         empty_user_group = create_user_group("newgroup", [], realm)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1388,6 +1388,7 @@ class ActivateTest(ZulipTestCase):
             ScheduledEmail.objects.filter(users__in=[hamlet, iago]).distinct().count(), 1
         )
         email = ScheduledEmail.objects.all().first()
+        assert email is not None and email.users is not None
         self.assertEqual(email.users.count(), 2)
 
     def test_clear_scheduled_emails_with_multiple_user_ids(self) -> None:
@@ -1455,6 +1456,7 @@ class ActivateTest(ZulipTestCase):
         )
         self.assertEqual(ScheduledEmail.objects.count(), 1)
         email = ScheduledEmail.objects.all().first()
+        assert email is not None
         email.users.remove(*to_user_ids)
 
         with self.assertLogs("zulip.send_email", level="INFO") as info_log:
@@ -1497,6 +1499,7 @@ class RecipientInfoTest(ZulipTestCase):
 
         stream = get_stream(stream_name, realm)
         recipient = stream.recipient
+        assert recipient is not None
 
         stream_topic = StreamTopicTarget(
             stream_id=stream.id,


### PR DESCRIPTION
This fixes a batch of mypy errors of the following format:
'Item "None" of "Optional[Something]" has no attribute "abc"

Since we have already been recklessly using these attritbutes
in the tests, adding assertions beforehand is justified presuming
that they oughtn't to be None.

This counts as a part of #18777.