### PR TITLE
api: Bump feature level to 82.

### DIFF
--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 81
+API_FEATURE_LEVEL = 82
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump


### PR DESCRIPTION
Bump api feature level to 82 as
after changes in 5db4fe865224a18bb11e0f3e67e0f7fe9f52665e.

@abhijeetbodas2001 FYI.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
