### PR TITLE
portico: Change Zulip Standard link on UCSD case study.

### DIFF
--- a/templates/zerver/for/ucsd-case-study.md
+++ b/templates/zerver/for/ucsd-case-study.md
@@ -22,7 +22,7 @@ threaded model (which I find sorely lacking in other chat apps), and
 the TeX integration.”
 
 From Spring 2020 through Spring 2021, the [Zulip
-Standard](/plans/) plan was free for all educators,
+Standard](/for/education/#feature-pricing) plan was free for all educators,
 as we did our part to help make the transition to online education a
 little easier. Having set up Zulip Cloud for his three graduate-level
 courses, Kiran felt confident in the communication platform, and was


### PR DESCRIPTION
I think it's better for the Zulip Standard link from the UCSD case study to point to Zulip Standard for Education.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
manual
