### PR TITLE
docs: Update client.md for the request notes change.

### DIFF
--- a/docs/subsystems/client.md
+++ b/docs/subsystems/client.md
@@ -27,11 +27,12 @@ ZulipIntegrationName/1.2 so that they are categorized properly.
 
 The `webhook_view` auth decorator, used for most incoming
 webhooks, accepts the name of the integration as an argument and uses
-it to generate a client name that it adds to the `request` (Django
+it to generate a client name that it adds to the `request_notes`
+object that can be accessed with the `request` (Django
 [HttpRequest](https://docs.djangoproject.com/en/1.8/ref/request-response/#django.http.HttpRequest))
-object as `request.client`.
+object via `zerver.lib.request.get_request_notes(request)`.
 
-In most integrations, `request.client` is then passed to
-`check_send_stream_message`, where it is used to keep track of which client
+In most integrations, `request_notes.client` is then passed to
+`check_send_webhook_message`, where it is used to keep track of which client
 sent the message (which in turn is used by analytics). For more
 information, see [the incoming webhook walkthrough](https://zulip.com/api/incoming-webhooks-walkthrough).


### PR DESCRIPTION
`request.client` is no longer valid since the ZulipRequestNotes change.
This update the documentation to reflect that. And it also makes it
recommend `check_send_webhook_message` in favor of
`check_send_stream_message`.