### PR TITLE
Replace remaining logging mocks with assertLogs.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1104,7 +1104,9 @@ Output:
         """
         with self.settings(ERROR_BOT=None), mock.patch(
             "zerver.lib.markdown.timeout", side_effect=subprocess.CalledProcessError(1, [])
-        ), mock.patch("zerver.lib.markdown.markdown_logger"):
+        ), self.assertLogs(
+            level="ERROR"
+        ):  # For markdown_logger.exception
             yield
 
     def create_default_device(

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -475,11 +475,11 @@ class DecoratorLoggingTestCase(ZulipTestCase):
         request.body = b"{}"
         request.content_type = "text/plain"
 
-        with mock.patch("zerver.decorator.webhook_logger.exception") as mock_exception:
+        with self.assertLogs("zulip.zerver.webhooks") as logger:
             with self.assertRaisesRegex(Exception, "raised by webhook function"):
                 my_webhook_raises_exception(request)
 
-        mock_exception.assert_called_with("raised by webhook function", stack_info=True)
+        self.assertIn("raised by webhook function", logger.output[0])
 
     def test_authenticated_rest_api_view_logging_unsupported_event(self) -> None:
         @authenticated_rest_api_view(webhook_client_name="ClientName")

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -35,9 +35,11 @@ class SlowQueryTest(ZulipTestCase):
 
     def test_slow_query_log(self) -> None:
         self.log_data["time_started"] = time.time() - self.SLOW_QUERY_TIME
-        with patch("zerver.middleware.slow_query_logger") as mock_slow_query_logger, patch(
-            "zerver.middleware.logger"
-        ) as mock_normal_logger:
+        with self.assertLogs(
+            "zulip.slow_queries", level="INFO"
+        ) as slow_query_logger, self.assertLogs(
+            "zulip.requests", level="INFO"
+        ) as middleware_normal_logger:
 
             write_log_line(
                 self.log_data,
@@ -47,12 +49,11 @@ class SlowQueryTest(ZulipTestCase):
                 requestor_for_logs="unknown",
                 client_name="?",
             )
-            mock_slow_query_logger.info.assert_called_once()
-            mock_normal_logger.info.assert_called_once()
+            self.assert_length(middleware_normal_logger.output, 1)
+            self.assert_length(slow_query_logger.output, 1)
 
-            logged_line = mock_slow_query_logger.info.call_args_list[0][0][0]
             self.assertRegex(
-                logged_line,
+                slow_query_logger.output[0],
                 r"123\.456\.789\.012 GET     200 10\.\ds .* \(unknown via \?\)",
             )
 

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -118,10 +118,6 @@ def clear_database() -> None:
     Session.objects.all().delete()
 
 
-# Suppress spammy output from the push notifications logger
-push_notifications_logger.disabled = True
-
-
 def subscribe_users_to_streams(realm: Realm, stream_dict: Dict[str, Dict[str, Any]]) -> None:
     subscriptions_to_add = []
     event_time = timezone_now()
@@ -273,6 +269,9 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options: Any) -> None:
+        # Suppress spammy output from the push notifications logger
+        push_notifications_logger.disabled = True
+
         if options["percent_huddles"] + options["percent_personals"] > 100:
             self.stderr.write("Error!  More than 100% of messages allocated.\n")
             return
@@ -898,6 +897,8 @@ class Command(BaseCommand):
 
             mark_all_messages_as_read()
             self.stdout.write("Successfully populated test database.\n")
+
+        push_notifications_logger.disabled = False
 
 
 def mark_all_messages_as_read() -> None:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Closes #15331

I think this completes the migration of logging mocks to `assertLogs`. The ones left are either used to assert a logging call isn't made, or some sort of strategic mocking like [this](https://github.com/zulip/zulip/blob/master/zerver/tests/test_decorators.py#L561), or somehow necessary for eg. [to check `stack_info` is set `True`](https://github.com/zulip/zulip/blob/master/zerver/webhooks/github/tests.py#L485).


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
