### PR TITLE
Move `enter_sends` setting to `property_types`.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1096,8 +1096,7 @@ test("initialize", ({override, mock_template}) => {
 
     // select_on_focus()
 
-    $("#compose-send-button").fadeOut = noop;
-    $("#compose-send-button").fadeIn = noop;
+    override(compose, "toggle_enter_sends_ui", noop);
     let channel_patch_called = false;
     override(channel, "patch", (params) => {
         assert.equal(params.url, "/json/settings");

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -24,6 +24,7 @@ const activity = mock_esm("../../static/js/activity");
 const alert_words_ui = mock_esm("../../static/js/alert_words_ui");
 const attachments_ui = mock_esm("../../static/js/attachments_ui");
 const bot_data = mock_esm("../../static/js/bot_data");
+const compose = mock_esm("../../static/js/compose");
 const composebox_typeahead = mock_esm("../../static/js/composebox_typeahead");
 const emoji_picker = mock_esm("../../static/js/emoji_picker");
 const hotspots = mock_esm("../../static/js/hotspots");
@@ -64,7 +65,6 @@ const ui = mock_esm("../../static/js/ui");
 const unread_ops = mock_esm("../../static/js/unread_ops");
 const user_events = mock_esm("../../static/js/user_events");
 const user_groups = mock_esm("../../static/js/user_groups");
-mock_esm("../../static/js/compose");
 mock_esm("../../static/js/giphy");
 
 const electron_bridge = set_global("electron_bridge", {});
@@ -788,6 +788,13 @@ run_test("update_display_settings", ({override}) => {
         assert.equal(stub.num_calls, 1);
         assert_same(page_params.demote_inactive_streams, 2);
     }
+
+    override(compose, "toggle_enter_sends_ui", noop);
+
+    event = event_fixtures.update_display_settings__enter_sends;
+    page_params.enter_sends = false;
+    dispatch(event);
+    assert_same(page_params.enter_sends, true);
 });
 
 run_test("update_global_notifications", ({override}) => {

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -691,6 +691,13 @@ exports.fixtures = {
         user: test_user.email,
     },
 
+    update_display_settings__enter_sends: {
+        type: "update_display_settings",
+        setting_name: "enter_sends",
+        setting: true,
+        user: test_user.email,
+    },
+
     update_display_settings__fluid_layout_width: {
         type: "update_display_settings",
         setting_name: "fluid_layout_width",

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -124,6 +124,15 @@ export function empty_topic_placeholder() {
     return $t({defaultMessage: "(no topic)"});
 }
 
+export function toggle_enter_sends_ui() {
+    const send_button = $("#compose-send-button");
+    if (page_params.enter_sends) {
+        send_button.fadeOut();
+    } else {
+        send_button.fadeIn();
+    }
+}
+
 export function create_message_object() {
     // Topics are optional, and we provide a placeholder if one isn't given.
     let topic = compose_state.topic();

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -1085,13 +1085,8 @@ export function initialize() {
     $("form#send_message_form").on("keyup", handle_keyup);
 
     $("#enter_sends").on("click", () => {
-        const send_button = $("#compose-send-button");
         page_params.enter_sends = $("#enter_sends").is(":checked");
-        if (page_params.enter_sends) {
-            send_button.fadeOut();
-        } else {
-            send_button.fadeIn();
-        }
+        compose.toggle_enter_sends_ui();
 
         // Refocus in the content box so you can continue typing or
         // press Enter to send.

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -627,6 +627,12 @@ export function dispatch_normal_event(event) {
                     message_list.narrowed.rerender();
                 }
             }
+            if (event.setting_name === "enter_sends") {
+                page_params.enter_sends = event.setting;
+                $("#enter_sends").prop("checked", page_params.enter_sends);
+                compose.toggle_enter_sends_ui();
+                break;
+            }
             settings_display.update_page();
             break;
         }

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -11,6 +11,12 @@ below features are supported.
 
 ## Changes in Zulip 5.0
 
+**Feature level 84**
+
+* [`POST /register`](/api/register-queue): The `enter_sends` setting
+  is now sent when `update_display_setting` is present in
+  `fetch_event_types` instead of `realm_user`.
+
 **Feature level 83**
 
 * * [`POST /register`](/api/register-queue): The `cross_realm_bots`

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 83
+API_FEATURE_LEVEL = 84
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5039,11 +5039,6 @@ def do_change_notification_settings(
     send_event(user_profile.realm, event, [user_profile.id])
 
 
-def do_change_enter_sends(user_profile: UserProfile, enter_sends: bool) -> None:
-    user_profile.enter_sends = enter_sends
-    user_profile.save(update_fields=["enter_sends"])
-
-
 def do_set_user_display_setting(
     user_profile: UserProfile, setting_name: str, setting_value: Union[bool, str, int]
 ) -> None:

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -384,7 +384,6 @@ def fetch_initial_state_data(
         state["is_guest"] = settings_user.is_guest
         state["is_billing_admin"] = settings_user.is_billing_admin
         state["user_id"] = settings_user.id
-        state["enter_sends"] = settings_user.enter_sends
         state["email"] = settings_user.email
         state["delivery_email"] = settings_user.delivery_email
         state["full_name"] = settings_user.full_name
@@ -502,10 +501,6 @@ def fetch_initial_state_data(
 
     if want("update_display_settings"):
         for prop in UserProfile.property_types:
-            if prop == "enter_sends":
-                # This will be removed when we make the API change to
-                # move this to the update_display_settings event type.
-                continue
             state[prop] = getattr(settings_user, prop)
         state["emojiset_choices"] = UserProfile.emojiset_choices()
         state["timezone"] = settings_user.timezone

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -502,6 +502,10 @@ def fetch_initial_state_data(
 
     if want("update_display_settings"):
         for prop in UserProfile.property_types:
+            if prop == "enter_sends":
+                # This will be removed when we make the API change to
+                # move this to the update_display_settings event type.
+                continue
             state[prop] = getattr(settings_user, prop)
         state["emojiset_choices"] = UserProfile.emojiset_choices()
         state["timezone"] = settings_user.timezone

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1351,6 +1351,7 @@ class UserBaseSettings(models.Model):
         demote_inactive_streams=int,
         dense_mode=bool,
         emojiset=str,
+        enter_sends=bool,
         fluid_layout_width=bool,
         high_contrast_mode=bool,
         left_side_userlist=bool,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9579,10 +9579,14 @@ paths:
                       enter_sends:
                         type: boolean
                         description: |
-                          Present if `realm_user` is present in `fetch_event_types`.
+                          Present if `update_display_settings` is present in `fetch_event_types`.
 
                           Whether the user setting for [sending on pressing Enter](/help/enable-enter-to-send)
                           in the compose box is enabled.
+
+                          **Changes**: Prior to Zulip 5.0 (feature level 84) this field was present
+                          in response if 'realm_user' was present in `fetch_event_types`, not
+                          `update_display_settings`.
                       user_id:
                         type: integer
                         description: |

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -198,9 +198,6 @@ class ChangeSettingsTest(ZulipTestCase):
         for display_setting in boolean_settings:
             self.check_for_toggle_param_patch("/json/settings", display_setting)
 
-    def test_enter_sends_setting(self) -> None:
-        self.check_for_toggle_param_patch("/json/settings", "enter_sends")
-
     def test_wrong_old_password(self) -> None:
         self.login("hamlet")
         result = self.client_patch(

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -21,7 +21,6 @@ from zerver.decorator import human_users_only
 from zerver.lib.actions import (
     check_change_full_name,
     do_change_avatar_fields,
-    do_change_enter_sends,
     do_change_notification_settings,
     do_change_password,
     do_change_user_delivery_email,
@@ -274,9 +273,6 @@ def json_change_settings(
 
     if timezone is not None and user_profile.timezone != timezone:
         do_set_user_display_setting(user_profile, "timezone", timezone)
-
-    if enter_sends is not None and user_profile.enter_sends != enter_sends:
-        do_change_enter_sends(user_profile, enter_sends)
 
     # TODO: Do this more generally.
     from zerver.lib.request import get_request_notes


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit moves `enter_sends` setting to property_types`.
- Second commit changes the events code to include `enter_sends` in `register` response if `update_display_settings` is present in `fetch_event_types`. (I was not sure if we need this change or we need previous behavior, so have kept this as different commit for now we can squash the commits if we want to merge both).

<!-- How have you tested? -->


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
