### PR TITLE
composebox_typeahead: Prevent default actions only after triggering the focus.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -216,8 +216,7 @@ function handle_keydown(e) {
                 // which does not make <button>s tab-accessible by default
                 // (even if we were to set tabindex=0).
                 if (!should_enter_send(e)) {
-                    $("#compose-send-button").trigger("focus");
-                    e.preventDefault();
+                    nextFocus = $("#compose-send-button");
                 }
             } else {
                 // Enter

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -236,9 +236,6 @@ function handle_keydown(e) {
                 handle_enter($("#compose-textarea"), e);
             }
         } else if (on_stream || on_topic || on_pm) {
-            // Prevent the form from submitting
-            e.preventDefault();
-
             // We are doing the focusing on keyup to not abort the typeahead.
             if (on_stream) {
                 nextFocus = $("#stream_message_recipient_topic");
@@ -259,6 +256,9 @@ function handle_keyup(e) {
     ) {
         nextFocus.trigger("focus");
         nextFocus = false;
+
+        // Prevent the form from submitting
+        e.preventDefault();
     }
 }
 


### PR DESCRIPTION
In this case, we need to prevent the default actions
only after triggering the focus of the selected element.

This was known to cause a bug where after starting a new
topic, if one presses the tab key, then focus was not shifted
from the topic input box to the compose box. This commit fixes
that bug.

See: https://chat.zulip.org/#narrow/stream/9-issues/topic/tab.20key.20not.20working.20from.20topic.20input.20box/near/1235022.


**Testing plan:** <!-- How have you tested? -->

Tested manually on Chrome and Mozilla.
