### PR TITLE
portico: Clean up /for/open-source.

### DIFF
--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -42,6 +42,22 @@ html {
     }
 }
 
+.bottom-text-large {
+    text-align: center;
+    margin-top: 20px;
+    font-weight: 500;
+    font-size: 1.2em;
+
+    a {
+        color: hsl(164, 100%, 23%);
+
+        &:hover {
+            text-decoration: none;
+            color: hsl(156, 62%, 61%);
+        }
+    }
+}
+
 .grey {
     color: hsl(0, 0%, 67%);
 }

--- a/templates/zerver/for-open-source.html
+++ b/templates/zerver/for-open-source.html
@@ -50,6 +50,9 @@
         <h1>
             <a href="/plans">Zulip Standard</a> is free for open-source projects!
         </h1>
+        <div class="bottom-text-large">
+            <p>Join the hundreds of open-source projects we sponsor.</p>
+        </div>
         <div class="hero-buttons center">
             <a href="/new/" class="button">
                 {{ _('Create organization') }}

--- a/templates/zerver/for/open-source.md
+++ b/templates/zerver/for/open-source.md
@@ -1,104 +1,12 @@
-[Zulip Standard](/plans) is free for open-source communities! To join the
-hundreds of open-source projects we sponsor, you can request sponsorship
-from your organization's
-[billing page](/accounts/go/?next=/upgrade%23sponsorship), or contact us at
-[sales@zulip.com](mailto:sales@zulip.com) to check whether your organization
-qualifies.
-
-
-------------------------------------------
-
-The Zulip core developers have decades of combined experience leading
-and growing open source communities. We use Zulip to fashion the
-day-to-day experience of being a part of our project. No other chat
-product comes close to Zulip in facilitating contributor engagement,
-facilitating inclusion, and making efficient use of everyone’s time.
-
-If you haven’t read [why Zulip](/why-zulip), read that first.  The
-challenges with the Slack/Discord/IRC model discussed there are even
-more important for open source projects:
-
-* Open source contributors are scattered all over the world and in
-  every time zone.  Traditional open source communication tools like
-  email, forums, and issue trackers work well in this context, because
-  you can communicate effectively asynchronously.  A Slack community
-  is a bad experience if you’re rarely online at the same time as most
-  other members, and a result, Slack represents a huge regression in
-  the global inclusivity of open source projects.
-* Most contributors and potential contributors have other fulltime
-  obligations and can only spend a few hours a week on an open source
-  project.  Because catching up on history in an active Slack
-  organization is a huge waste of time, these part-time community
-  members cannot efficiently use their time participating in an active
-  Slack.  So either they don’t participate in the Slack, or they do,
-  and their other contributions to the project suffer.
-* Maintainers are busy people and almost uniformly report that they
-  wish they had more time to do focus work on their project.  Because
-  active participation in Slack fundamentally requires constant
-  interruptions, maintainers end up making unpleasant choices between
-  participating in the Slack community (limiting their ability to do
-  focus work) or ignoring the Slack community (leaving it effectively
-  without their input and potentially unmoderated).
-* Writing to a busy Slack channel often means interrupting another existing
-  conversation. This makes it harder for newer and shyer members to jump into
-  the community. Often this disproportionately affects groups already
-  underrepresented in open source communities.
-* The lack of organization in Slack message history (and its 10K
-  message history limit) mean that users asking for help cannot
-  effectively do self-service support.  This results in the community
-  answering a lot of duplicate questions.
-
-The overall effect is that Slack is a poor communication tool for
-projects that want to have an inclusive, global, open source community
-and effectively retain volunteer contributors.
-
-------------------------------------------
-
-Zulip’s topic-based threading model solves these problems:
-
-* Contributors in any time zone can send messages and expect to get a
-  reply and have an effective (potentially asynchronous) conversation
-  with the rest of the community.
-* Zulip’s topic-based theading helps include part-time contributors in
-  two major ways.  First, they can easily browse what conversations
-  happened while they were away from the community, and prioritize
-  which conversations to read now, skip, or read later (e.g. on the
-  weekend).  Second, Zulip makes it easy for them to have public
-  conversations with participation from maintainers and other
-  contributors (potentially split over hours, days, or weeks as
-  needed), allowing them to fully participate in the work of the
-  community.
-* Maintainers can effectively participate in a Zulip community without
-  being continuously online.  Using Zulip’s [keyboard
-  shortcuts](/help/keyboard-shortcuts), it’s extremely efficient to
-  inspect every potentially relevant thread and reply wherever one’s
-  feedback is useful, and replying hours after a question was asked is
-  still a good contributor experience.  As a result, maintainers can
-  do multi-hour sessions of focus work while still being available to
-  their community.
-* Every contributor has their own space to start a conversation (we
-  recommend new contributors start a topic with their name as the
-  topic). Asking a question never has to be an interruption of another
-  conversation.
-
-You can see this in action in our own
-[chat.zulip.org](/developer-community/) community, which sends
-thousands of messages a week.  We often get feedback from contributors
-around the world that they love how responsive Zulip’s project leaders
-are in public Zulip conversations.  We are able to achieve this
-despite the project leaders collectively spending only a few hours a
-day managing the community and spending most of their time integrating
-improvements into Zulip.
-
-Many communities that migrated from Slack, IRC, or Gitter to Zulip
-tell us that Zulip helped them manage and grow an inclusive, healthy
-open source community in a similar way.  We hope Zulip can help your
-community succeed too!
-
-------------------------------------------
-
 Below, we’ve collected a list of [Zulip features](/features) that are
-particularly useful to open source communities.
+particularly useful to open source communities. We also recommend
+checking out [Zulip for communities](/for/communities) to learn how
+Zulip empowers welcoming communities by making it easy to participate
+on your own time.
+
+<br />
+<blockquote class="twitter-tweet"><p lang="en" dir="ltr">When we made the switch to <a href="https://twitter.com/zulip?ref_src=twsrc%5Etfw">@zulip</a> a few months ago for chat, never in my wildest dreams did I imagine it was going to become the beating heart of the community, and so quickly. It&#39;s a game changer. 🧑‍💻🗨️👩‍💻</p>&mdash; Dan Allen (@mojavelinux) <a href="https://twitter.com/mojavelinux/status/1409702273400201217?ref_src=twsrc%5Etfw">June 29, 2021</a></blockquote>
+<br />
 
 ### Moderation suite.
 
@@ -125,6 +33,10 @@ username and password.
 Import your existing organization from [Slack](/help/import-from-slack),
 [Mattermost](/help/import-from-mattermost), or
 [Gitter](/help/import-from-gitter).
+
+<br />
+<blockquote class="twitter-tweet" data-cards="hidden"><p lang="en" dir="ltr">We just moved the Lichess team (~100 persons) to <a href="https://twitter.com/zulip?ref_src=twsrc%5Etfw">@zulip</a>, and I&#39;m loving it. The topics in particular make it vastly superior to slack &amp; discord, when it comes to dealing with many conversations.<br>Zulip is also open-source! <a href="https://t.co/lxHjf3YPMe">https://t.co/lxHjf3YPMe</a></p>&mdash; Thibault D (@ornicar) <a href="https://twitter.com/ornicar/status/1412672302601457664?ref_src=twsrc%5Etfw">July 7, 2021</a></blockquote>
+<br />
 
 ### Collaborate on code and formulas
 
@@ -160,6 +72,13 @@ your organization.
 Get events from GitHub, Travis CI, Jira, and
 [hundreds of other tools](/integrations) right in Zulip. Topics give each
 issue its own place for discussion.
+
+>  “Wikimedia uses Zulip for its participation in open source
+>  mentoring programs. Zulip’s threaded discussions help busy
+>  organization administrators and mentors stay in close communication
+>  with students during all phases of the programs.”
+
+> — Srishti Sethi, Developer Advocate, Wikimedia Foundation
 
 ### Mirror IRC, Matrix, or Slack.
 
@@ -221,3 +140,15 @@ feature requests from paying customers.
 So if there’s something we could improve to make Zulip the obvious
 choice either for you or your community, [contact
 us](/help/contact-support) and we'll do what we can to help!
+
+>  “I highly recommend Zulip to other communities. We’re coming from
+>  Freenode as our only real-time communication so the difference is
+>  night and day. Slack is a no-go for many due to not being FLOSS,
+>  and I’m concerned about vendor lock-in if they were to stop being
+>  so generous. Slack’s threading model is much worse than Zulip’s
+>  IMO. The streams/topics flow is an incredibly intuitive way to keep
+>  track of everything that is going on.”
+
+> — RJ Ryan, Mixxx Developer
+
+<script async src="https://platform.twitter.com/widgets.js"></script>


### PR DESCRIPTION
- Remove essay portion and link to /for/communities instead.
- Copy over relevant quotes from /for/communities.
- Move "Join the hundreds of open-source projects we sponsor."

Please review the css addition and change the implementation if there's a better approach.

**Testing plan:** <!-- How have you tested? -->
Manual.
