### PR TITLE
ci: Remove unnecessary steps from production upgrade script.

### DIFF
--- a/tools/ci/production-upgrade
+++ b/tools/ci/production-upgrade
@@ -11,13 +11,12 @@ set -x
 # need to do some preparatory steps. It is a goal to delete these
 # steps.
 
-# Reinstall rabbitmq-server and supervisor.
+# Reinstall rabbitmq-server.
 #
 # * For rabbitmq-server, we likely need to do this to work around the
 # hostname changing on reboot causing RabbitMQ to not boot.
-# * For supervisor, we don't understand why it doesn't start properly.
-sudo apt-get -y purge rabbitmq-server supervisor
-sudo apt-get -y install rabbitmq-server supervisor
+sudo apt-get -y purge rabbitmq-server
+sudo apt-get -y install rabbitmq-server
 
 # Start the postgresql service.
 sudo service postgresql start
@@ -29,20 +28,8 @@ if ! sudo service rabbitmq-server start; then
     sudo service rabbitmq-server start
 fi
 
-# Apply puppet (still on the previous release the container was
-# installed with).  This should leave us with a working copy of Zulip
-# running a previous release.
-sudo /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
-
-# Stopping nginx service started by above command.
-#
-# This is a workaround for an unexpected `Unable to stop
-# Service[nginx]` error in the puppet apply step of upgrade otherwise.
-if ! sudo service nginx stop; then
-    echo
-    echo "Stoping nginx failed. Trying again:"
-    sudo service nginx stop
-fi
+# Start the supervisor
+sudo service supervisor start
 
 # Zulip releases before 2.1.8/3.5/4.4 have a bug in their
 # `upgrade-zulip` scripts, resulting in them exiting with status 0


### PR DESCRIPTION
This removes some steps which are no longer necessary to be run
in the production upgrade script. The steps were used due to
errors related to supervisor failing to restart which was resolved
in the commit 08c39a738826fe517570027fafa27eb24e9a3f30.

Noticed this while working on #19228. These steps can be removed
and I don't think they are going to affect the errors in the verify-production
step much. While we figure out the issue with that PR, I guess its safe to do this step
anyways.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
