### PR TITLE
Add setter and test for realm_owner

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1716,6 +1716,15 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
     def is_realm_owner(self) -> bool:
         return self.role == UserProfile.ROLE_REALM_OWNER
 
+    @is_realm_owner.setter
+    def is_realm_owner(self, value: bool) -> None:
+        if value:
+            self.role = UserProfile.ROLE_REALM_OWNER
+        elif self.role == UserProfile.ROLE_REALM_OWNER:
+            # We need to be careful to not accidentally change
+            # ROLE_GUEST to ROLE_MEMBER here.
+            self.role = UserProfile.ROLE_MEMBER
+
     @property
     def is_guest(self) -> bool:
         return self.role == UserProfile.ROLE_GUEST
@@ -1732,6 +1741,15 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
     @property
     def is_moderator(self) -> bool:
         return self.role == UserProfile.ROLE_MODERATOR
+
+    @is_moderator.setter
+    def is_moderator(self, value: bool) -> None:
+        if value:
+            self.role = UserProfile.ROLE_MODERATOR
+        elif self.role == UserProfile.ROLE_MODERATOR:
+            # We need to be careful to not accidentally change
+            # ROLE_GUEST to ROLE_MEMBER here.
+            self.role = UserProfile.ROLE_MEMBER
 
     @property
     def is_incoming_webhook(self) -> bool:

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -95,6 +95,14 @@ class PermissionTest(ZulipTestCase):
         self.assertEqual(user_profile.is_guest, False)
         self.assertEqual(user_profile.role, UserProfile.ROLE_REALM_ADMINISTRATOR)
 
+        user_profile.is_realm_owner = False
+        self.assertEqual(user_profile.is_realm_owner, False)
+        self.assertEqual(user_profile.role, UserProfile.ROLE_REALM_ADMINISTRATOR)
+
+        user_profile.is_moderator = False
+        self.assertEqual(user_profile.is_moderator, False)
+        self.assertEqual(user_profile.role, UserProfile.ROLE_REALM_ADMINISTRATOR)
+
         user_profile.is_realm_admin = False
         self.assertEqual(user_profile.is_realm_admin, False)
         self.assertEqual(user_profile.role, UserProfile.ROLE_MEMBER)
@@ -109,6 +117,22 @@ class PermissionTest(ZulipTestCase):
 
         user_profile.is_guest = False
         self.assertEqual(user_profile.is_guest, False)
+        self.assertEqual(user_profile.role, UserProfile.ROLE_MEMBER)
+
+        user_profile.is_realm_owner = True
+        self.assertEqual(user_profile.is_realm_owner, True)
+        self.assertEqual(user_profile.role, UserProfile.ROLE_REALM_OWNER)
+
+        user_profile.is_realm_owner = False
+        self.assertEqual(user_profile.is_realm_owner, False)
+        self.assertEqual(user_profile.role, UserProfile.ROLE_MEMBER)
+
+        user_profile.is_moderator = True
+        self.assertEqual(user_profile.is_moderator, True)
+        self.assertEqual(user_profile.role, UserProfile.ROLE_MODERATOR)
+
+        user_profile.is_moderator = False
+        self.assertEqual(user_profile.is_moderator, False)
         self.assertEqual(user_profile.role, UserProfile.ROLE_MEMBER)
 
     def test_get_admin_users(self) -> None:


### PR DESCRIPTION
Adds setter for realm_owner in response to https://github.com/zulip/zulip/issues/18677.

Adds automated tests in test_users similar to those already in place for the setters is_realm_admin and is_guest.

