### PR TITLE
portico: Add use case buttons to top & bottom of /why-zulip. [WIP]

### DIFF
--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -2115,7 +2115,7 @@ nav {
     margin-top: 0;
 }
 
-.portico-landing.hello .call-to-action-bottom .button {
+.portico-landing.hello .call-to-action-bottom .styled-button {
     display: table;
     margin: 20px auto 0;
     padding: 10px 20px;

--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -702,6 +702,10 @@ nav {
 .portico-landing.hello {
     background-color: transparent;
     color: hsl(219, 23%, 33%);
+
+    .hero-buttons {
+        margin-top: 40px;
+    }
 }
 
 .portico-landing.hello .hero {
@@ -2112,6 +2116,10 @@ nav {
 .portico-landing.hello .call-to-action-bottom {
     position: relative;
     padding: 50px 100px 0;
+
+    @media (width <= 768px) {
+        padding: 50px 10px 0;
+    }
     margin-top: 0;
 }
 
@@ -2331,6 +2339,10 @@ nav {
 
 .portico-landing.why-page .hero {
     padding: 200px 50px 100px;
+
+    @media (width < 900px) {
+        padding: 200px 0 100px;
+    }
 
     &.empty-hero {
         padding: 50px 50px 70px;
@@ -4531,4 +4543,66 @@ nav {
 
 .mirror-image {
     transform: scaleX(-1);
+}
+
+.why-zulip {
+    .discounts-section {
+        margin: 30px;
+
+        h1 {
+            font-weight: 700 !important;
+            font-size: 26px !important;
+        }
+    }
+}
+
+.portico-landing.why-page .hero.why-zulip {
+    padding-bottom: 120px;
+
+    .bg-dimmer {
+        background-color: hsla(224, 52%, 12%, 0.85);
+    }
+
+    .padded-content {
+        padding-top: 0;
+        padding-bottom: 10px;
+    }
+
+    @media (width <= 768px) {
+        .register-buttons {
+            display: none;
+        }
+    }
+
+    .discounts-section .register-buttons a {
+        color: hsl(169, 71%, 64%);
+
+        &:hover {
+            color: hsl(0, 0%, 100%);
+        }
+    }
+}
+
+.why-zulip,
+.hello {
+    .register-buttons {
+        max-width: 800px;
+        margin: auto;
+        margin-top: 30px;
+
+        a {
+            min-height: 40px;
+            padding: 7px 0;
+        }
+    }
+
+    @media (width <= 768px) {
+        .register-buttons {
+            a {
+                margin: 10px calc(5vw - 10px);
+                width: clamp(130px, 40vw, 200px);
+                font-size: 13px;
+            }
+        }
+    }
 }

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -531,20 +531,23 @@
     </div>
 
     <div class="padded-content call-to-action-bottom">
-        <h1>Experience Zulip today!</h1>
-        {% if root_domain_landing_page %}
-        <a href="{{ url('plans') }}" class="download-button styled-button button green">
-            {{ _('See plans and pricing') }}
-        </a>
-        {% endif %}
+        <h1>Learn how Zulip can help your organization!</h1>
+        <div class="register-buttons">
+            <a href="/for/companies" class="register-now button">Companies</a>
+            <a href="/for/open-source" class="register-now button">Open source</a>
+            <a href="/for/education" class="register-now button">Education</a>
+            <a href="/for/events" class="register-now button">Events and Conferences</a>
+            <a href="/for/research" class="register-now button">Research</a>
+            <a href="/for/communities" class="register-now button">Communities</a>
+        </div>
         {% if register_link_disabled %}
         {% elif only_sso %}
         <a href="{{ url('login-sso') }}" class="styled-button button green">
             {{ _('Log in now') }}
         </a>
         {% else %}
-        <a href="{{ url('register') }}" class="styled-button button green">
-            {{ _('Sign up now') }}
+        <a href="/plans" class="styled-button button green">
+            {{ _('See plans and pricing') }}
         </a>
         {% endif %}
         <div class="zulip-octopus"></div>

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -533,17 +533,17 @@
     <div class="padded-content call-to-action-bottom">
         <h1>Experience Zulip today!</h1>
         {% if root_domain_landing_page %}
-        <a href="{{ url('plans') }}" class="download-button button green">
+        <a href="{{ url('plans') }}" class="download-button styled-button button green">
             {{ _('See plans and pricing') }}
         </a>
         {% endif %}
         {% if register_link_disabled %}
         {% elif only_sso %}
-        <a href="{{ url('login-sso') }}" class="button green">
+        <a href="{{ url('login-sso') }}" class="styled-button button green">
             {{ _('Log in now') }}
         </a>
         {% else %}
-        <a href="{{ url('register') }}" class="button green">
+        <a href="{{ url('register') }}" class="styled-button button green">
             {{ _('Sign up now') }}
         </a>
         {% endif %}

--- a/templates/zerver/why-zulip.html
+++ b/templates/zerver/why-zulip.html
@@ -21,14 +21,30 @@
         <div class="bg-dimmer"></div>
         <div class="content">
             <h1 class="center">Why Zulip?</h1>
-            <p></p>
         </div>
     </div>
+
 
     <div class="main">
         <div class="padded-content">
             <div class="inner-content markdown">
                 {{ render_markdown_path('zerver/why-zulip.md') }}
+            </div>
+        </div>
+    </div>
+
+    <div class="why-zulip">
+        <div class="discounts-section">
+            <header>
+                <h2>Learn how Zulip can help your organization!</h2>
+            </header>
+            <div class="register-buttons">
+                <a href="/for/companies" class="register-now button">Companies</a>
+                <a href="/for/open-source" class="register-now button">Open source</a>
+                <a href="/for/education" class="register-now button">Education</a>
+                <a href="/for/events" class="register-now button">Events and Conferences</a>
+                <a href="/for/research" class="register-now button">Research</a>
+                <a href="/for/communities" class="register-now button">Communities</a>
             </div>
         </div>
     </div>

--- a/templates/zerver/why-zulip.md
+++ b/templates/zerver/why-zulip.md
@@ -154,11 +154,3 @@ transform how your organization communicates:
 > experienced with Skype and Slack.
 >
 > &mdash;Grahame Grieve, founder, FHIR health care standards body
-
-## Further reading
-
-- [Zulip features](/features)
-- [Plans and pricing](/plans)
-- [Zulip for companies](/for/companies)
-- [Zulip for open source organizations](/for/open-source)
-- [Zulip for communities](/for/communities)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Add buttons linking to use-case specific pages on /why-zulip.

@amanagr could you please do a CSS/layout pass on this? Things we should do the following:

1. Convert the button layout into two rows of three (Companies, Open Source and Education in top row).
2. Change button text so that the second line is the same font weight as the first.
3. Change the "Learn how Zulip can help your organization!" font to the h1 font in class="bottom-register-buttons".
4. I'm not sure, but maybe we can make the buttons a bit smaller, since most of them only have one line of text?

Thanks!

**Testing plan:** <!-- How have you tested? -->
manual
