### PR TITLE
docs: Add doc root links to sidebar.

### DIFF
--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -170,7 +170,7 @@ html {
             border-bottom: 1px solid hsla(0, 0, 100%, 0.6);
 
             &:not(:first-of-type) {
-                margin-top: 20px;
+                margin-top: 0;
             }
 
             &:first-of-type,
@@ -180,6 +180,7 @@ html {
 
             &.home-link {
                 font-size: 1em;
+                margin-top: 20px;
                 margin-bottom: 17px;
 
                 a::before {

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -11,6 +11,7 @@
     <div class="sidebar">
         <div class="content">
             <h1><a href="https://zulip.com" class="no-underline">Zulip homepage</a></h1>
+            <h1><a href="{{ doc_root }}" class="no-underline">{{ doc_root_title }} home</a></h1>
             {{ render_markdown_path(sidebar_index, api_uri_context) }}
             <h1 class="home-link"><a href="/" class="no-underline">Back to Zulip</a></h1>
         </div>


### PR DESCRIPTION
A recent commit (5a94bfcb88bffc245c159dc896eb5ab873461805)
introduced a couple of regressions:

* The part of help.js that highlights the active page in the
  sidebar raised an exception on /help and /api since there
  was nothing to highlight for the doc roots in the sidebar
  anymore.
* Moving the doc root links to the header after the logo made
  it such that on narrow mobile widths, there was no way to get
  to the doc root since the links in the header were truncated.

@timabbott FYI :) Huge thanks to @andersk for reporting these!
