### PR TITLE
Allow only owners to change `Joining the organization` settings.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -46,7 +46,8 @@ export function maybe_disable_widgets() {
     if (page_params.is_admin) {
         $("#deactivate_realm_button").prop("disabled", true);
         $("#org-message-retention").find("input, select").prop("disabled", true);
-        $("#id_realm_invite_to_realm_policy").prop("disabled", true);
+        $("#org-join").find("input, select").prop("disabled", true);
+        $("#id_realm_invite_required_label").parent().addClass("control-label-disabled");
         return;
     }
 

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -4,6 +4,7 @@
         <div id="org-join" class="org-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Joining the organization" }}</h3>
+                <i class="fa fa-info-circle settings-info-icon realm_message_retention_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can change these settings.' }}"></i>
                 {{> settings_save_discard_widget section_name="org-join" }}
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
@@ -14,7 +15,6 @@
                       is_checked=realm_invite_required
                       label=admin_settings_label.realm_invite_required}}
                     <label for="realm_invite_to_realm_policy" class="dropdown-title">{{t "Who can invite users to this organization" }}
-                        <i class="fa fa-info-circle settings-info-icon realm_message_retention_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can change this setting.' }}"></i>
                     </label>
                     <select name="realm_invite_to_realm_policy" id="id_realm_invite_to_realm_policy" class="prop-element" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=invite_to_realm_policy_values}}
@@ -30,7 +30,7 @@
                     </select>
                     <div class="dependent-block">
                         <p id="allowed_domains_label" class="inline-block"></p>
-                        {{#if is_admin }}
+                        {{#if is_owner }}
                         <a id="show_realm_domains_modal" role="button">{{t "[Configure]" }}</a>
                         {{/if}}
                     </div>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -1,7 +1,7 @@
 <div id="organization-permissions" data-name="organization-permissions" class="settings-section">
     <form class="form-horizontal admin-realm-form org-permissions-form">
 
-        <div id="org-org-join" class="org-subsection-parent">
+        <div id="org-join" class="org-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Joining the organization" }}</h3>
                 {{> settings_save_discard_widget section_name="org-join" }}

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,16 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 6.0
 
+**Feature level 143**
+
+* `PATCH /realm`: The `disallow_disposable_email_addresses`,
+  `emails_restricted_to_domains`, `invite_required`, and
+  `waiting_period_threshold` settings can no longer be changed by
+  organization administrators who are not owners.
+* `PATCH /realm/domains`, `POST /realm/domains`, `DELETE
+  /realm/domains`: Organization administrators who are not owners can
+  no longer access these endpoints.
+
 **Feature level 142**
 
 * [`GET users/me/subscriptions`](/api/get-subscriptions), [`GET

--- a/templates/zerver/help/join-a-zulip-organization.md
+++ b/templates/zerver/help/join-a-zulip-organization.md
@@ -2,7 +2,7 @@
 
 By default, Zulip organizations require an invitation to join.
 
-Organization administrators can also allow anyone to join without an
+Organization owners can also allow anyone to join without an
 invitation, and/or restrict user email addresses to a company domain. See
 [inviting new users](/help/invite-new-users).
 

--- a/templates/zerver/help/restrict-account-creation.md
+++ b/templates/zerver/help/restrict-account-creation.md
@@ -1,6 +1,6 @@
 # Restrict account creation
 
-{!admin-only.md!}
+{!owner-only.md!}
 
 Each Zulip account is associated with an email address. If your organization
 allows multiple authentication methods, it doesn't matter which one is used to

--- a/templates/zerver/help/restrict-permissions-of-new-members.md
+++ b/templates/zerver/help/restrict-permissions-of-new-members.md
@@ -1,6 +1,6 @@
 # Restrict permissions of new members
 
-{!admin-only.md!}
+{!owner-only.md!}
 
 In large Zulip organizations where
 [anyone can join](/help/restrict-account-creation#set-whether-invitations-are-required-to-join), it can

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 142
+API_FEATURE_LEVEL = 143
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -1376,6 +1376,7 @@ class RealmAPITest(ZulipTestCase):
         bool_tests: List[bool] = [False, True]
         test_values: Dict[str, Any] = dict(
             invite_to_realm_policy=[Realm.POLICY_MEMBERS_ONLY, Realm.POLICY_ADMINS_ONLY],
+            waiting_period_threshold=[10, 20],
         )
 
         vals = test_values.get(setting_name)
@@ -1404,6 +1405,7 @@ class RealmAPITest(ZulipTestCase):
         self.do_test_changing_settings_by_owners_only("invite_required")
         self.do_test_changing_settings_by_owners_only("emails_restricted_to_domains")
         self.do_test_changing_settings_by_owners_only("disallow_disposable_email_addresses")
+        self.do_test_changing_settings_by_owners_only("waiting_period_threshold")
 
     def test_enable_spectator_access_for_limited_plan_realms(self) -> None:
         self.login("iago")

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -1402,6 +1402,8 @@ class RealmAPITest(ZulipTestCase):
     def test_changing_user_joining_settings_require_owners(self) -> None:
         self.do_test_changing_settings_by_owners_only("invite_to_realm_policy")
         self.do_test_changing_settings_by_owners_only("invite_required")
+        self.do_test_changing_settings_by_owners_only("emails_restricted_to_domains")
+        self.do_test_changing_settings_by_owners_only("disallow_disposable_email_addresses")
 
     def test_enable_spectator_access_for_limited_plan_realms(self) -> None:
         self.login("iago")

--- a/zerver/tests/test_realm_domains.py
+++ b/zerver/tests/test_realm_domains.py
@@ -29,17 +29,17 @@ class RealmDomainTest(ZulipTestCase):
         ]
         self.assertEqual(received, expected)
 
-    def test_not_realm_admin(self) -> None:
-        self.login("hamlet")
+    def test_not_realm_owner(self) -> None:
+        self.login("iago")
         result = self.client_post("/json/realm/domains")
-        self.assert_json_error(result, "Must be an organization administrator")
+        self.assert_json_error(result, "Must be an organization owner")
         result = self.client_patch("/json/realm/domains/15")
-        self.assert_json_error(result, "Must be an organization administrator")
+        self.assert_json_error(result, "Must be an organization owner")
         result = self.client_delete("/json/realm/domains/15")
-        self.assert_json_error(result, "Must be an organization administrator")
+        self.assert_json_error(result, "Must be an organization owner")
 
     def test_create_realm_domain(self) -> None:
-        self.login("iago")
+        self.login("desdemona")
         data = {
             "domain": "",
             "allow_subdomains": orjson.dumps(True).decode(),
@@ -65,9 +65,7 @@ class RealmDomainTest(ZulipTestCase):
         mit_user_profile = self.mit_user("sipbtest")
         self.login_user(mit_user_profile)
 
-        do_change_user_role(
-            mit_user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None
-        )
+        do_change_user_role(mit_user_profile, UserProfile.ROLE_REALM_OWNER, acting_user=None)
 
         result = self.client_post(
             "/json/realm/domains", info=data, HTTP_HOST=mit_user_profile.realm.host
@@ -75,7 +73,7 @@ class RealmDomainTest(ZulipTestCase):
         self.assert_json_success(result)
 
     def test_patch_realm_domain(self) -> None:
-        self.login("iago")
+        self.login("desdemona")
         realm = get_realm("zulip")
         RealmDomain.objects.create(realm=realm, domain="acme.com", allow_subdomains=False)
         data = {
@@ -96,7 +94,7 @@ class RealmDomainTest(ZulipTestCase):
         self.assert_json_error(result, "No entry found for domain non-existent.com.")
 
     def test_delete_realm_domain(self) -> None:
-        self.login("iago")
+        self.login("desdemona")
         realm = get_realm("zulip")
         RealmDomain.objects.create(realm=realm, domain="acme.com")
         result = self.client_delete("/json/realm/domains/non-existent.com")

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -187,6 +187,9 @@ def update_realm(
     ) and not user_profile.is_realm_owner:
         raise OrganizationOwnerRequired()
 
+    if waiting_period_threshold is not None and not user_profile.is_realm_owner:
+        raise OrganizationOwnerRequired()
+
     if enable_spectator_access:
         realm.ensure_not_on_limited_plan()
 

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -177,7 +177,9 @@ def update_realm(
             message_retention_days_raw, Realm.MESSAGE_RETENTION_SPECIAL_VALUES_MAP
         )
 
-    if invite_to_realm_policy is not None and not user_profile.is_realm_owner:
+    if (
+        invite_to_realm_policy is not None or invite_required is not None
+    ) and not user_profile.is_realm_owner:
         raise OrganizationOwnerRequired()
 
     if enable_spectator_access:

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -182,6 +182,11 @@ def update_realm(
     ) and not user_profile.is_realm_owner:
         raise OrganizationOwnerRequired()
 
+    if (
+        emails_restricted_to_domains is not None or disallow_disposable_email_addresses is not None
+    ) and not user_profile.is_realm_owner:
+        raise OrganizationOwnerRequired()
+
     if enable_spectator_access:
         realm.ensure_not_on_limited_plan()
 

--- a/zerver/views/realm_domains.py
+++ b/zerver/views/realm_domains.py
@@ -7,7 +7,7 @@ from zerver.actions.realm_domains import (
     do_change_realm_domain,
     do_remove_realm_domain,
 )
-from zerver.decorator import require_realm_admin
+from zerver.decorator import require_realm_owner
 from zerver.lib.domains import validate_domain
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
@@ -21,7 +21,7 @@ def list_realm_domains(request: HttpRequest, user_profile: UserProfile) -> HttpR
     return json_success(request, data={"domains": domains})
 
 
-@require_realm_admin
+@require_realm_owner
 @has_request_variables
 def create_realm_domain(
     request: HttpRequest,
@@ -44,7 +44,7 @@ def create_realm_domain(
     return json_success(request, data={"new_domain": [realm_domain.id, realm_domain.domain]})
 
 
-@require_realm_admin
+@require_realm_owner
 @has_request_variables
 def patch_realm_domain(
     request: HttpRequest,
@@ -60,7 +60,7 @@ def patch_realm_domain(
     return json_success(request)
 
 
-@require_realm_admin
+@require_realm_owner
 @has_request_variables
 def delete_realm_domain(
     request: HttpRequest, user_profile: UserProfile, domain: str


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First four commits are to restrict changing of individual settings from backend. Have done frontend changes separately as we can simply disable the all the inputs in section using a single collector.
- Next is a commit for fixing typo.
- Then the two commits are for frontend and docs changes.

 <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
This is how the settings look after being disabled for an admin-
![Screenshot from 2021-07-29 17-15-22](https://user-images.githubusercontent.com/35494118/127496609-65bc7fd3-d596-4016-a0e6-87f1955f19b4.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
