### PR TITLE
docs: Set X-Forwarded-Proto in nginx example

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -332,6 +332,7 @@ server {
 
         location / {
                 proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header        X-Forwarded-Proto $scheme;
                 proxy_set_header        Host $http_host;
                 proxy_http_version      1.1;
                 proxy_buffering         off;


### PR DESCRIPTION
The current example for nginx doesn't set the X-Forwarded-Proto header.
This header is used by django to build URLs. When nginx is used as a
reverse proxy to terminate TLS then django might use http instead of
https when constructing URLs pointing towards the Zulip server such as
for example the SAML metadata.

**Testing plan:**

Manually tested

**GIFs or screenshots:**

No UI changes