### PR TITLE
api: Return zulip_merge_base alongside zulip_version.

### DIFF
--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -520,6 +520,7 @@ exports.fixtures = {
     restart: {
         type: "restart",
         zulip_version: "4.0-dev+git",
+        zulip_merge_base: "",
         zulip_feature_level: 55,
         server_generation: 2,
         immediate: true,

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -11,6 +11,16 @@ below features are supported.
 
 ## Changes in Zulip 5.0
 
+**Feature level 88**
+
+* [`POST /register`](/api/register-queue): Added `zulip_merge_base`
+  field to the response.
+* [`GET /events`](/api/get-events): Added new `zulip_merge_base`
+  field to the `restart` event.
+* [`GET /server_settings`](/api/get-server-settings): Added
+  `zulip_merge_base` to the responses which can be used to
+  make "About Zulip" widgets in clients.
+
 **Feature level 87**
 
 * [`PATCH /settings`](/api/update-settings): Added a new

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 87
+API_FEATURE_LEVEL = 88
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1169,6 +1169,7 @@ restart_event = event_dict_type(
     required_keys=[
         ("type", Equals("restart")),
         ("zulip_version", str),
+        ("zulip_merge_base", str),
         ("zulip_feature_level", int),
         ("server_generation", int),
         ("immediate", bool),

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Collection, Dict, Iterable, Optional, Sequence
 from django.conf import settings
 from django.utils.translation import gettext as _
 
-from version import API_FEATURE_LEVEL, ZULIP_VERSION
+from version import API_FEATURE_LEVEL, ZULIP_MERGE_BASE, ZULIP_VERSION
 from zerver.lib.actions import (
     default_stream_groups_to_dicts_sorted,
     do_get_streams,
@@ -135,6 +135,7 @@ def fetch_initial_state_data(
     # Show the version info unconditionally.
     state["zulip_version"] = ZULIP_VERSION
     state["zulip_feature_level"] = API_FEATURE_LEVEL
+    state["zulip_merge_base"] = ZULIP_MERGE_BASE
 
     if want("alert_words"):
         state["alert_words"] = [] if user_profile is None else user_alert_words(user_profile)

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -8,7 +8,6 @@ from django.http import HttpRequest
 from django.utils import translation
 from two_factor.utils import default_device
 
-from version import ZULIP_MERGE_BASE
 from zerver.context_processors import get_apps_page_url
 from zerver.lib.events import do_events_register
 from zerver.lib.i18n import (
@@ -214,8 +213,6 @@ def build_page_params_for_home_page_load(
         # There is no event queue for spectators since
         # events support for spectators is not implemented yet.
         no_event_queue=user_profile is None,
-        # Required for about_zulip.hbs
-        zulip_merge_base=ZULIP_MERGE_BASE,
     )
 
     for field_name in register_ret.keys():

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3240,6 +3240,14 @@ paths:
                                     [register](/api/register-queue) responses.
 
                                     **Changes**: New in Zulip 4.0 (feature level 59).
+                                zulip_merge_base:
+                                  type: string
+                                  description: |
+                                    The Zulip merge base number, in the format where this appears
+                                    in the [server_settings](/api/get-server-settings) and
+                                    [register](/api/register-queue) responses.
+
+                                    **Changes**: New in Zulip 5.0 (feature level 87).
                                 zulip_feature_level:
                                   type: integer
                                   description: |
@@ -3272,7 +3280,8 @@ paths:
                                   "server_generation": 1619334181,
                                   "type": "restart",
                                   "zulip_feature_level": 57,
-                                  "zulip_version": "4.0-dev+git",
+                                  "zulip_version": "5.0-dev-1650-gc3fd37755f",
+                                  "zulip_merge_base": "5.0-dev-1646-gea6b21cd8c",
                                 }
                             - type: object
                               additionalProperties: false
@@ -8248,7 +8257,23 @@ paths:
                       zulip_version:
                         type: string
                         description: |
-                          The server's version.
+                          The server's version number.  This is often a release version number,
+                          like `2.1.7`. But for a server running a [version from Git][git-release],
+                          it will be a Git reference to the commit, like `5.0-dev-1650-gc3fd37755f`.
+
+                          [git-release]: https://zulip.readthedocs.io/en/latest/overview/release-lifecycle.html#git-versions
+                      zulip_merge_base:
+                        type: string
+                        description: |
+                          The `git merge-base` between `zulip_verson` and official branches
+                          in the public
+                          [Zulip server and web app repository](https://github.com/zulip/zulip),
+                          in the same format as `zulip_version`. This will equal
+                          `zulip_version` if the server is not running a fork of the Zulip server.
+
+                          This will be `""` if the server does not know its `merge-base`.
+
+                          **Changes**: New in Zulip 5.0 (feature level 88).
                       alert_words:
                         type: array
                         description: |
@@ -10237,7 +10262,8 @@ paths:
                           },
                         "result": "success",
                         "zulip_feature_level": 2,
-                        "zulip_version": "2.1.0",
+                        "zulip_version": "5.0-dev-1650-gc3fd37755f",
+                        "zulip_merge_base": "5.0-dev-1646-gea6b21cd8c",
                       }
   /server_settings:
     get:
@@ -10380,10 +10406,6 @@ paths:
                               type: string
                               description: |
                                 URL to be used to initiate account registration using this method.
-                      zulip_version:
-                        type: string
-                        description: |
-                          The version of Zulip running in the server.
                       zulip_feature_level:
                         type: integer
                         description: |
@@ -10397,6 +10419,26 @@ paths:
 
                           **Changes**.  New in Zulip 3.0.  We recommend using an implied value
                           of 0 for Zulip servers that do not send this field.
+                      zulip_version:
+                        type: string
+                        description: |
+                          The server's version number.  This is often a release version number,
+                          like `2.1.7`. But for a server running a [version from Git][git-release],
+                          it will be a Git reference to the commit, like `5.0-dev-1650-gc3fd37755f`.
+
+                          [git-release]: https://zulip.readthedocs.io/en/latest/overview/release-lifecycle.html#git-versions
+                      zulip_merge_base:
+                        type: string
+                        description: |
+                          The `git merge-base` between `zulip_verson` and official branches
+                          in the public
+                          [Zulip server and web app repository](https://github.com/zulip/zulip),
+                          in the same format as `zulip_version`. This will equal
+                          `zulip_version` if the server is not running a fork of the Zulip server.
+
+                          This will be `""` if unavailable.
+
+                          **Changes**: New in Zulip 5.0 (feature level 88).
                       push_notifications_enabled:
                         type: boolean
                         description: |
@@ -10457,7 +10499,8 @@ paths:
                             "google": true,
                             "saml": true,
                           },
-                        "zulip_version": "2.0.6+git",
+                        "zulip_version": "5.0-dev-1650-gc3fd37755f",
+                        "zulip_merge_base": "5.0-dev-1646-gea6b21cd8c",
                         "push_notifications_enabled": false,
                         "msg": "",
                         "is_incompatible": false,

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -4547,6 +4547,7 @@ class FetchAuthBackends(ZulipTestCase):
                     ("require_email_format_usernames", check_bool),
                     ("realm_uri", check_string),
                     ("zulip_version", check_string),
+                    ("zulip_merge_base", check_string),
                     ("zulip_feature_level", check_int),
                     ("push_notifications_enabled", check_bool),
                     ("msg", check_string),

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.utils.timezone import now as timezone_now
 
-from version import API_FEATURE_LEVEL, ZULIP_VERSION
+from version import API_FEATURE_LEVEL, ZULIP_MERGE_BASE, ZULIP_VERSION
 from zerver.lib.actions import (
     check_send_message,
     do_change_user_role,
@@ -889,6 +889,7 @@ class RestartEventsTest(ZulipTestCase):
             dict(
                 type="restart",
                 zulip_version=ZULIP_VERSION,
+                zulip_merge_base=ZULIP_MERGE_BASE,
                 zulip_feature_level=API_FEATURE_LEVEL,
                 server_generation=settings.SERVER_GENERATION,
                 immediate=True,

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -36,7 +36,7 @@ from django.conf import settings
 from django.utils.translation import gettext as _
 from typing_extensions import TypedDict
 
-from version import API_FEATURE_LEVEL, ZULIP_VERSION
+from version import API_FEATURE_LEVEL, ZULIP_MERGE_BASE, ZULIP_VERSION
 from zerver.decorator import cachify
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import MessageDict
@@ -584,6 +584,7 @@ def send_restart_events(immediate: bool = False) -> None:
     event: Dict[str, Any] = dict(
         type="restart",
         zulip_version=ZULIP_VERSION,
+        zulip_merge_base=ZULIP_MERGE_BASE,
         zulip_feature_level=API_FEATURE_LEVEL,
         server_generation=settings.SERVER_GENERATION,
     )

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -30,7 +30,7 @@ from confirmation.models import (
     create_confirmation_link,
     get_object_from_key,
 )
-from version import API_FEATURE_LEVEL, ZULIP_VERSION
+from version import API_FEATURE_LEVEL, ZULIP_MERGE_BASE, ZULIP_VERSION
 from zerver.context_processors import get_realm_from_request, login_context, zulip_default_context
 from zerver.decorator import do_login, log_view_func, process_client, require_post
 from zerver.forms import (
@@ -910,6 +910,7 @@ def api_get_server_settings(request: HttpRequest) -> HttpResponse:
     result = dict(
         authentication_methods=get_auth_backends_data(request),
         zulip_version=ZULIP_VERSION,
+        zulip_merge_base=ZULIP_MERGE_BASE,
         zulip_feature_level=API_FEATURE_LEVEL,
         push_notifications_enabled=push_notifications_enabled(),
         is_incompatible=check_server_incompatibility(request),


### PR DESCRIPTION
Return zulip_merge_base alongside zulip_version
in `/register`, `/event` and `/server_settings`
endpoint so that the value can be used by other
clients.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
