### PR TITLE
UI: Fix x button alignment in feedback widget.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -226,9 +226,9 @@ p.n-margin {
     }
 
     .exit-me {
-        font-size: 30pt;
+        font-size: 20pt;
         font-weight: 200;
-        margin: 5px 0 0 10px;
+        margin: 0 0 0 10px;
         cursor: pointer;
     }
 }


### PR DESCRIPTION
https://github.com/zulip/zulip/issues/19251


![Screen Shot 2021-07-31 at 2 42 47 PM](https://user-images.githubusercontent.com/54130092/127753110-295872f7-5d3e-44a6-a2e1-5c18a83852a5.png)


The issue was fixed by decreasing font size and aligning the the .exit-me class up.