### PR TITLE
Fix feature levels and documentation in zulip.yaml.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3308,7 +3308,7 @@ paths:
                                     in the [server_settings](/api/get-server-settings) and
                                     [register](/api/register-queue) responses.
 
-                                    **Changes**: New in Zulip 5.0 (feature level 87).
+                                    **Changes**: New in Zulip 5.0 (feature level 88).
                                 zulip_feature_level:
                                   type: integer
                                   description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10745,8 +10745,9 @@ paths:
                           Whether the user setting for [sending on pressing Enter](/help/enable-enter-to-send)
                           in the compose box is enabled.
 
-                          **Changes**: Deprecated in Zulip 5.0 (feature level 87), clients should
-                          use `user_settings` dictionary instead.
+                          **Changes**: Deprecated in Zulip 5.0 (feature level 89). Clients
+                          connecting to newer servers should declare the `user_settings_object`
+                          client capability and process the `user_settings` event type instead.
                           Prior to Zulip 5.0 (feature level 84) this field was present
                           in response if 'realm_user' was present in `fetch_event_types`, not
                           `update_display_settings`.


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit fixes the feature level of `zulip_merge_base`.
- Second commit fixes the `Changes` entry for `enter_sends`.

 <!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
