### PR TITLE
Status emoji follow up.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -87,6 +87,7 @@ const message_store = zrequire("message_store");
 const people = zrequire("people");
 const starred_messages = zrequire("starred_messages");
 const user_status = zrequire("user_status");
+const compose_pm_pill = zrequire("compose_pm_pill");
 
 const emoji = zrequire("../shared/js/emoji");
 
@@ -934,6 +935,7 @@ run_test("user_status", ({override}) => {
     {
         const stub = make_stub();
         override(activity, "redraw_user", stub.f);
+        override(compose_pm_pill, "get_user_ids", () => [event.user_id]);
         dispatch(event);
         assert.equal(stub.num_calls, 1);
         const args = stub.get_args("user_id");

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -9,7 +9,9 @@ import * as attachments_ui from "./attachments_ui";
 import * as blueslip from "./blueslip";
 import * as bot_data from "./bot_data";
 import * as compose from "./compose";
+import * as compose_actions from "./compose_actions";
 import * as compose_fade from "./compose_fade";
+import * as compose_pm_pill from "./compose_pm_pill";
 import * as composebox_typeahead from "./composebox_typeahead";
 import * as emoji_picker from "./emoji_picker";
 import * as giphy from "./giphy";
@@ -710,6 +712,11 @@ export function dispatch_normal_event(event) {
                     status_text: event.status_text,
                 });
                 activity.redraw_user(event.user_id);
+
+                // Update the status text in compose box placeholder when opened to self.
+                if (compose_pm_pill.get_user_ids().includes(event.user_id)) {
+                    compose_actions.update_placeholder_text();
+                }
             }
 
             if (event.emoji_name !== undefined) {

--- a/static/styles/user_status.css
+++ b/static/styles/user_status.css
@@ -29,22 +29,29 @@
         .status_emoji_wrapper {
             height: 20px;
             width: 22px;
-            padding: 6px 8px 2px 8px;
+            padding: 8px 8px 1px 8px;
             border-right: 1px solid;
             border-color: inherit;
             cursor: pointer;
             .selected_emoji {
-                width: 18px;
-                height: 18px;
+                width: 20px;
+                height: 20px;
                 top: 50%;
                 transform: translateY(-50%);
                 cursor: pointer;
             }
+
+            /* For custom emojis and smiley icon to take full width. */
+            img.selected_emoji,
+            .smiley_icon {
+                min-width: 20px;
+            }
+
             .smiley_icon {
                 display: block;
                 font-size: 18px;
                 position: relative;
-                top: 1px;
+                top: -2px;
                 left: 2px;
                 &:hover {
                     text-decoration: none;

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -84,13 +84,15 @@
         <li class="user_info_status_text">
             <span id="status_message">
                 {{status_text}}
-                {{#if status_emoji_info.emoji_alt_code}}
-                    <div class="emoji_alt_code">&nbsp:{{status_emoji_info.emoji_name}}:</div>
-                {{else}}
-                    {{#if status_emoji_info.url}}
-                    <img src="{{status_emoji_info.url}}" class="emoji status_emoji" />
+                {{#if status_emoji_info}}
+                    {{#if status_emoji_info.emoji_alt_code}}
+                        <div class="emoji_alt_code">&nbsp:{{status_emoji_info.emoji_name}}:</div>
                     {{else}}
-                    <div class="emoji status_emoji emoji-{{status_emoji_info.emoji_code}}"></div>
+                        {{#if status_emoji_info.url}}
+                        <img src="{{status_emoji_info.url}}" class="emoji status_emoji" />
+                        {{else}}
+                        <div class="emoji status_emoji emoji-{{status_emoji_info.emoji_code}}"></div>
+                        {{/if}}
                     {{/if}}
                 {{/if}}
                 {{#if is_me}}(<a tabindex="0" class="clear_status">{{#tr}}clear{{/tr}}</a>){{/if}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- [x] Fix the emoji alignment issue in the set user status modal.
- [x] Allow keyboard navigation in emoji picker of set user status modal.
- [x] Fix the custom emoji not showing up.
- [x] Fix status text not updating until clicking when compose box is opened to self.


**Testing plan:** <!-- How have you tested? -->
Tested localy.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Before | After
--- | ---
![before_house_emoji](https://user-images.githubusercontent.com/63820270/128127430-20b2244f-85e8-4431-9183-28f9c9f2b7b1.png) | ![after_house_emoji](https://user-images.githubusercontent.com/63820270/128127435-48db7462-7f5e-4974-ba00-ccfbc3d15243.png)
![before_hurt_emoji](https://user-images.githubusercontent.com/63820270/128127547-f91e7046-3009-4919-bc3f-e0c41d183bf3.png) | ![after_hurt_emoji](https://user-images.githubusercontent.com/63820270/128127541-f05f72de-e2f4-423a-a881-ca1328b4976c.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
