### PR TITLE
Use `unlimited` instead of `forever` to set the message retention setting to retain messages forever.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -810,7 +810,7 @@ export function build_page() {
                     "#id_realm_message_retention_setting",
                 ).val();
                 if (message_retention_setting_value === "retain_forever") {
-                    data.message_retention_days = JSON.stringify("forever");
+                    data.message_retention_days = JSON.stringify("unlimited");
                 } else {
                     data.message_retention_days = JSON.stringify(
                         get_input_element_value($("#id_realm_message_retention_days")),

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -151,7 +151,7 @@ function set_stream_message_retention_setting_dropdown(stream) {
     if (stream.message_retention_days === null) {
         value = "realm_default";
     } else if (stream.message_retention_days === settings_config.retain_message_forever) {
-        value = "forever";
+        value = "unlimited";
     }
 
     $(".stream_message_retention_setting").val(value);
@@ -637,7 +637,7 @@ function get_message_retention_days_from_sub(sub) {
         return "realm_default";
     }
     if (sub.message_retention_days === -1) {
-        return "forever";
+        return "unlimited";
     }
     return sub.message_retention_days;
 }

--- a/static/templates/stream_settings/stream_types.hbs
+++ b/static/templates/stream_settings/stream_types.hbs
@@ -44,7 +44,7 @@
               class="stream_message_retention_setting" class="prop-element"
               {{#if disable_message_retention_setting}}disabled{{/if}}>
                 <option value="realm_default">{{#tr}}Use organization level settings {org_level_message_retention_setting}{{/tr}}</option>
-                <option value="forever">{{t 'Retain forever' }}</option>
+                <option value="unlimited">{{t 'Retain forever' }}</option>
                 <option value="retain_for_period">{{t 'Retain for N days after posting' }}</option>
             </select>
 

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -11,6 +11,13 @@ below features are supported.
 
 ## Changes in Zulip 5.0
 
+**Feature level 91**
+
+* `PATCH /realm`, [`PATCH /streams/{stream_id}`](/api/update-stream):
+  These endpoints now accept `"unlimited"` for `message_retention_days`,
+  replacing `"forever"` as the way to encode a retention policy where
+  messages are not automatically deleted.
+
 **Feature level 90**
 
 * [`POST /register`](/api/register-queue): The `unread_msgs` section

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 90
+API_FEATURE_LEVEL = 91
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -404,7 +404,7 @@ class Realm(models.Model):
     )
 
     MESSAGE_RETENTION_SPECIAL_VALUES_MAP = {
-        "forever": -1,
+        "unlimited": -1,
     }
     # For old messages being automatically deleted
     message_retention_days: int = models.IntegerField(null=False, default=-1)
@@ -2063,7 +2063,7 @@ class Stream(models.Model):
     # Value -1 means "disable retention policy for this stream unconditionally".
     # Non-negative values have the natural meaning of "archive messages older than <value> days".
     MESSAGE_RETENTION_SPECIAL_VALUES_MAP = {
-        "forever": -1,
+        "unlimited": -1,
         "realm_default": None,
     }
     message_retention_days: Optional[int] = models.IntegerField(null=True, default=None)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3475,12 +3475,6 @@ paths:
                                       type: boolean
                                       description: |
                                         Whether [topics are required](/help/require-topics) for messages in this organization.
-                                    message_retention_days:
-                                      type: integer
-                                      description: |
-                                        The default [message retention policy](/help/message-retention-policy)
-                                        for this organization.  Pass `"forever"` to request that messages
-                                        by retained forever (the default).
                                     realm_name:
                                       type: string
                                       description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10051,8 +10051,11 @@ paths:
                           Present if `realm` is present in `fetch_event_types`.
 
                           The default [message retention policy](/help/message-retention-policy)
-                          for this organization.  Pass `"forever"` to request that messages
+                          for this organization.  Pass `"unlimited"` to request that messages
                           by retained forever (the default).
+
+                          **Changes**: Prior to Zulip 5.0 (feature level 91), no limit was encoded
+                          by passing `"forever"`.
                       realm_name:
                         type: string
                         description: |
@@ -14548,9 +14551,13 @@ components:
         values are supported:
 
         * "realm_default" => Return to the organization-level setting.
-        * "forever" => Retain messages forever.
+        * "unlimited" => Retain messages forever.
 
-        **Changes**: New in Zulip 3.0 (feature level 17).
+        **Changes**: Prior to Zulip 5.0 (feature level 91), retaining
+        messages forever was encoded using `"forever"` instead of
+        `"unlimited"`.
+
+        New in Zulip 3.0 (feature level 17).
       schema:
         oneOf:
           - type: string

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -644,7 +644,7 @@ class RealmTest(ZulipTestCase):
         result = self.client_patch("/json/realm", req)
         self.assert_json_error(result, "Bad value for 'message_retention_days': -1")
 
-        req = dict(message_retention_days=orjson.dumps("forever").decode())
+        req = dict(message_retention_days=orjson.dumps("unlimited").decode())
         result = self.client_patch("/json/realm", req)
         self.assert_json_success(result)
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1204,7 +1204,7 @@ class StreamAdminTest(ZulipTestCase):
         with self.tornado_redirected_to_list(events, expected_num_events=1):
             result = self.client_patch(
                 f"/json/streams/{stream.id}",
-                {"message_retention_days": orjson.dumps("forever").decode()},
+                {"message_retention_days": orjson.dumps("unlimited").decode()},
             )
         self.assert_json_success(result)
         event = events[0]["event"]


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR updates both the stream-level and realm-level message retention setting to
use `unlimited` instead of `forever` to set the message retention setting to retain messages forever.
 <!-- How have you tested? -->


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
