### PR TITLE
delete_realm: Allow deletion of realms with empty customers.

### DIFF
--- a/zerver/management/commands/delete_realm.py
+++ b/zerver/management/commands/delete_realm.py
@@ -33,10 +33,17 @@ realms used for testing; consider using deactivate_realm instead."""
             # Deleting a Realm object also deletes associating billing
             # metadata in an invariant-violating way, so we should
             # never use this tool for a realm with billing setup.
-            from corporate.models import get_customer_by_realm
+            from corporate.models import CustomerPlan, get_customer_by_realm
 
-            if get_customer_by_realm(realm):
-                raise CommandError("This realm has had a billing relationship associated with it!")
+            customer = get_customer_by_realm(realm)
+            if customer:
+                if (
+                    customer.stripe_customer_id
+                    or CustomerPlan.objects.filter(customer=customer).count() > 0
+                ):
+                    raise CommandError(
+                        "This realm has had a billing relationship associated with it!"
+                    )
 
         print(
             "This command will \033[91mPERMANENTLY DELETE\033[0m all data for this realm.  "


### PR DESCRIPTION
This is effectively a step closer to what was proposed in
https://github.com/zulip/zulip/pull/18678#discussion_r644490540 when
this code was written in #18678.

If the Customer object has neither of a Stripe id, nor any historical
plans, then there's no real billing association contained in the
existence of the Customer object, and it's safe to delete.