### PR TITLE
test_stripe: Convert NamedTuple to dataclass.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -4,6 +4,7 @@ import os
 import random
 import re
 import sys
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from functools import wraps
@@ -13,7 +14,6 @@ from typing import (
     Dict,
     List,
     Mapping,
-    NamedTuple,
     Optional,
     Sequence,
     Tuple,
@@ -2834,7 +2834,8 @@ class StripeTest(StripeTestCase):
                 invoices = self.create_invoices(customer, num_invoices)
             return realm, customer, plan, invoices
 
-        class Row(NamedTuple):
+        @dataclass
+        class Row:
             realm: Realm
             expected_plan_type: int
             plan: Optional[CustomerPlan]


### PR DESCRIPTION
The locally defined `NamedTuple` was triggering a mypy caching bug (python/mypy#10913), and we don’t use the tuple behavior anyway.

Context: #15132, https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/lint/near/1242223

@hackerkid FYI.