### PR TITLE
Use do.oneclick.zulip.dev domain for digital ocean one click test droplets

### DIFF
--- a/tools/oneclickapps/prepare_digital_ocean_one_click_app_release.py
+++ b/tools/oneclickapps/prepare_digital_ocean_one_click_app_release.py
@@ -51,7 +51,7 @@ def set_api_request_retry_limits(api_object: digitalocean.baseapi.BaseAPI) -> No
 
 
 def create_droplet(
-    name: str, ssh_keys: List[str], image: str = "ubuntu-18-04-x64"
+    name: str, ssh_keys: List[str], image: str = "ubuntu-20-04-x64"
 ) -> digitalocean.Droplet:
     droplet = digitalocean.Droplet(
         token=manager.token,

--- a/tools/oneclickapps/prepare_digital_ocean_one_click_app_release.py
+++ b/tools/oneclickapps/prepare_digital_ocean_one_click_app_release.py
@@ -11,7 +11,7 @@ from requests.packages.urllib3.util.retry import Retry
 
 manager = digitalocean.Manager(token=os.environ["DIGITALOCEAN_API_KEY"])
 zulip_client = zulip.Client()
-TEST_DROPLET_SUBDOMAIN = "oneclicktest"
+TEST_DROPLET_SUBDOMAIN = "do"
 
 
 def generate_ssh_keys() -> None:
@@ -85,7 +85,7 @@ def create_snapshot(droplet: digitalocean.Droplet, snapshot_name: str) -> None:
 
 
 def create_dns_records(droplet: digitalocean.Droplet) -> None:
-    domain = digitalocean.Domain(token=manager.token, name="zulipdev.org")
+    domain = digitalocean.Domain(token=manager.token, name="oneclick.zulip.dev")
     set_api_request_retry_limits(domain)
     domain.load()
 
@@ -93,7 +93,7 @@ def create_dns_records(droplet: digitalocean.Droplet) -> None:
     for record in domain.get_records():
         if (
             record.name in oneclick_test_app_record_names
-            and record.domain == "zulipdev.org"
+            and record.domain == "oneclick.zulip.dev"
             and record.type == "A"
         ):
             record.destroy()
@@ -155,5 +155,5 @@ if __name__ == "__main__":
     test_droplet = create_droplet(test_droplet_name, manager.get_all_sshkeys(), image=snapshot.id)
     create_dns_records(test_droplet)
     send_message(
-        f"Test droplet `{test_droplet_name}` created. SSH as root to {TEST_DROPLET_SUBDOMAIN}.zulipdev.org for testing."
+        f"Test droplet `{test_droplet_name}` created. SSH as root to {TEST_DROPLET_SUBDOMAIN}.oneclick.zulip.dev for testing."
     )


### PR DESCRIPTION
We used to use oneclicktest.zulipdev.org as the domain for the one click app test droplet created by the GitHub action. But since we moved to a diffrent team account in DigitalOcean for the vendor portal, we can no longer create subdomains on zulipdev.org from the action since that domain is not added to the new team account.

From now on, we would be using do.oneclick.zulip.dev as the domain the test droplet. oneclick.zulip.dev has been added to the new team account in digital ocean.

Also upgrade the base image of the DigitalOcean one click app to ubuntu-20-04-x64.

I don't think there are any other changes necessary.

I have triiggered a release from my fork to make sure that the action works correctly.

https://github.com/hackerkid/zulip/runs/3227705312?check_suite_focus=true

Can be merged after

 

- [x] The action succeeds
- [x]  Verify that you can SSH into the test droplet.
- [x] Exit the installation. Run the https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/99-img-check.sh. Make sure there are no errrors. except the SSH key error.
- [x]  Exit the droplet and SSH again. Then fill the details asked by installer and make sure the installer succeeds
- [x]  Create an organiozation using the link generated by the installer and make sure basic things like the sending messages work correctly.
- [x]  Make sure that the image is there in the account. It should be since the test droplet is created from that.
- [x]  Verify that the droplet is on Ubuntu 20 and also ensure that the pricing is 10$/month.