### PR TITLE
import_realm: Match file uploads relative path with LocalUploadBackend.

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import multiprocessing
 import os
+import random
 import secrets
 import shutil
 from mimetypes import guess_type
@@ -773,14 +774,16 @@ def import_uploads(
             relative_path = os.path.join(str(record["realm_id"]), "realm", icon_name)
             record["last_modified"] = timestamp
         else:
-            # Should be kept in sync with its equivalent in zerver/lib/uploads in the
-            # function 'upload_message_file'.
+            # Should be kept in sync with its equivalent in
+            # zerver/lib/upload.py in the function 'upload_message_file'.
+            # In particular the one in LocalUploadBackend.
             # This relative_path is basically the new location of the file,
             # which will later be copied from its original location as
             # specified in record["s3_path"].
             relative_path = "/".join(
                 [
                     str(record["realm_id"]),
+                    format(random.randint(0, 255), "x"),
                     secrets.token_urlsafe(18),
                     sanitize_name(os.path.basename(record["path"])),
                 ]

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -797,7 +797,10 @@ class LocalUploadBackend(ZulipUploadBackend):
         user_profile: UserProfile,
         target_realm: Optional[Realm] = None,
     ) -> str:
-        # Split into 256 subdirectories to prevent directories from getting too big
+        # If this function is changed, make sure to also change the
+        # relative_path calculation in the function import_uploads in
+        # zerver/lib/import_realm.py.
+        # Split into 256 subdirectories to prevent directories from getting too big.
         path = "/".join(
             [
                 str(user_profile.realm_id),


### PR DESCRIPTION
Otherwise, if the import zip file has lots of file uploads, it will
flood the upload folder with too many directories. We should limit the
number to be at most 256, just like in LocalUploadBackend.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
