### PR TITLE
filter: Filter out muted topics in `message_in_home`.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -13,6 +13,7 @@ const message_store = mock_esm("../../static/js/message_store");
 const stream_data = zrequire("stream_data");
 const people = zrequire("people");
 const {Filter} = zrequire("../js/filter");
+const muted_topics = zrequire("muted_topics");
 
 const me = {
     email: "me@example.com",
@@ -629,9 +630,13 @@ test("predicate_basics", () => {
     assert.ok(!predicate({type: "stream", topic: "foo"}));
 
     const unknown_stream_id = 999;
+    const muted_topic = "A muted topic";
+    muted_topics.add_muted_topic(stream_id, muted_topic);
     predicate = get_predicate([["in", "home"]]);
     assert.ok(!predicate({stream_id: unknown_stream_id, stream: "unknown"}));
     assert.ok(predicate({type: "private"}));
+    assert.ok(!predicate({stream_id, topic: muted_topic}));
+    muted_topics.remove_muted_topic(stream_id, muted_topic); // Reset
 
     with_field(page_params, "narrow_stream", "kiosk", () => {
         assert.ok(predicate({stream: "kiosk"}));

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -5,6 +5,7 @@ import {$t} from "./i18n";
 import * as message_edit from "./message_edit";
 import * as message_parser from "./message_parser";
 import * as message_store from "./message_store";
+import * as muted_topics from "./muted_topics";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as stream_data from "./stream_data";
@@ -63,8 +64,11 @@ function message_in_home(message) {
         return true;
     }
 
-    // We don't display muted streams in 'All messages' view
-    return !stream_data.is_muted(message.stream_id);
+    // We don't display muted streams and topics in 'All messages' view
+    return !(
+        stream_data.is_muted(message.stream_id) ||
+        muted_topics.is_topic_muted(message.stream_id, message.topic)
+    );
 }
 
 function message_matches_search_term(message, operator, operand) {


### PR DESCRIPTION
Following the backend logic, here also we filter out
muted topics so that we don't display muted topics
in `All messages` view.

This commit will also act as a prep commit for #16943.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->

A new test case is added.