### PR TITLE
Revert "time_widget: Make the generated time string more readable."

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -1,4 +1,4 @@
-import {format} from "date-fns";
+import {formatISO} from "date-fns";
 import ConfirmDatePlugin from "flatpickr/dist/plugins/confirmDate/confirmDate";
 import $ from "jquery";
 import _ from "lodash";
@@ -778,7 +778,7 @@ const show_flatpickr = (element, callback, default_timestamp) => {
         plugins: [new ConfirmDatePlugin({})],
         positionElement: element,
         dateFormat: "Z",
-        formatDate: (date) => format(date, "yyyy-MM-dd|HH:mm:ss|'UTC'xxx"),
+        formatDate: (date) => formatISO(date),
     });
     const container = $($(instance.innerContainer).parent());
     container.on("click", ".flatpickr-calendar", (e) => {

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -346,14 +346,7 @@ function handleEmoji(emoji_name) {
 function handleTimestamp(time) {
     let timeobject;
     if (Number.isNaN(Number(time))) {
-        // Check if the time string is of the new more-readable format.
-        if (time.includes("|UTC")) {
-            // Remove and replace the non-standard characters with the ISO ones.
-            const standard_format_time = time.replace("|UTC", "").replace(/\|/g, "T");
-            timeobject = new Date(standard_format_time);
-        } else {
-            timeobject = new Date(time); // not a Unix timestamp
-        }
+        timeobject = new Date(time); // not a Unix timestamp
     } else {
         // JavaScript dates are in milliseconds, Unix timestamps are in seconds
         timeobject = new Date(time * 1000);

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1369,13 +1369,7 @@ class Timestamp(markdown.inlinepatterns.Pattern):
         time_input_string = match.group("time")
         timestamp = None
         try:
-            # Check if the time string is of the new more-readable format.
-            if "|UTC" in time_input_string:
-                # Remove and replace the non-standard characters with the ISO ones.
-                standard_format_time = time_input_string.replace("|", "T", 1).replace("|UTC", "")
-                timestamp = dateutil.parser.parse(standard_format_time, tzinfos=common_timezones)
-            else:
-                timestamp = dateutil.parser.parse(time_input_string, tzinfos=common_timezones)
+            timestamp = dateutil.parser.parse(time_input_string, tzinfos=common_timezones)
         except ValueError:
             try:
                 timestamp = datetime.datetime.fromtimestamp(float(time_input_string))

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -791,19 +791,6 @@
       "text_content": "Let's meet at 1496701800."
     },
     {
-      "name": "timestamp_new_format",
-      "input": "<time:2021-08-02|14:03:00|UTC+05:30>",
-      "expected_output": "<p><time datetime=\"2021-08-02T08:33:00Z\">2021-08-02|14:03:00|UTC+05:30</time></p>",
-      "text_content": "2021-08-02|14:03:00|UTC+05:30"
-    },
-    {
-      "name": "timestamp_without_utc",
-      "input": "<time:2021-08-02|14:03:00|+05:30>",
-      "expected_output": "<p><span class=\"timestamp-error\">Invalid time format: 2021-08-02|14:03:00|+05:30</span></p>",
-      "marked_expected_output": "<p><span>2021-08-02|14:03:00|+05:30</span></p>",
-      "text_content": "Invalid time format: 2021-08-02|14:03:00|+05:30"
-    },
-    {
       "name": "tex_inline",
       "input": "$$1 \\oplus 0 = 1$$",
       "expected_output": "<p><span class=\"katex\"><span class=\"katex-mathml\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\"><semantics><mrow><mn>1</mn><mo>⊕</mo><mn>0</mn><mo>=</mo><mn>1</mn></mrow><annotation encoding=\"application/x-tex\">1 \\oplus 0 = 1</annotation></semantics></math></span><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:0.72777em;vertical-align:-0.08333em;\"></span><span class=\"mord\">1</span><span class=\"mspace\" style=\"margin-right:0.2222222222222222em;\"></span><span class=\"mbin\">⊕</span><span class=\"mspace\" style=\"margin-right:0.2222222222222222em;\"></span></span><span class=\"base\"><span class=\"strut\" style=\"height:0.64444em;vertical-align:0em;\"></span><span class=\"mord\">0</span><span class=\"mspace\" style=\"margin-right:0.2777777777777778em;\"></span><span class=\"mrel\">=</span><span class=\"mspace\" style=\"margin-right:0.2777777777777778em;\"></span></span><span class=\"base\"><span class=\"strut\" style=\"height:0.64444em;vertical-align:0em;\"></span><span class=\"mord\">1</span></span></span></span></p>"


### PR DESCRIPTION
This reverts commit 1965584eeccfd79ee6de37fd07bf712a93831e95.

This syntax has a bad interaction with table syntax and needs to be rethought.

Context: https://chat.zulip.org/#narrow/stream/6-frontend/topic/.3Ctime.3E.20formatting.20in.20compose.20box/near/1242667