### PR TITLE
Change alignment of items in general tab of profile modal.

### DIFF
--- a/static/js/user_profile.js
+++ b/static/js/user_profile.js
@@ -156,6 +156,7 @@ export function show_user_profile(user) {
         is_me: people.is_current_user(user.email),
         date_joined: dateFormat.format(parseISO(user.date_joined)),
         last_seen: buddy_data.user_last_seen_time_status(user.user_id),
+        user_circle_class: buddy_data.get_user_circle_class(user.user_id),
         show_email: settings_data.show_email(),
         user_time: people.get_user_time(user.user_id),
         user_type: people.get_user_type(user.user_id),

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -318,6 +318,14 @@ ul {
         }
     }
 
+    #profile-tab {
+        margin: 0 -5px 0 5px;
+        .general-info {
+            display: flex;
+            justify-content: space-between;
+        }
+    }
+
     hr {
         border: 1px solid hsl(0, 0%, 93%);
         margin: 5px 0;

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -312,10 +312,6 @@ ul {
         .default-field {
             margin-bottom: 5px;
         }
-
-        #user-type {
-            margin-bottom: 15px;
-        }
     }
 
     #profile-tab {
@@ -323,6 +319,16 @@ ul {
         .general-info {
             display: flex;
             justify-content: space-between;
+
+            .user_circle {
+                width: 8px;
+                height: 8px;
+                position: relative;
+                top: 1px;
+                margin-right: 1px;
+                float: none;
+                display: inline-block;
+            }
         }
     }
 

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -15,30 +15,32 @@
         <div id="tab-toggle" class="center"></div>
         <div class="tab-data">
             <div class="tabcontent active" id="profile-tab">
-                <div id="avatar" {{#if user_is_guest}} class="guest-avatar" {{/if}}
-                  style="background-image: url('{{user_avatar}}');"></div>
-                <div id="default-section">
-                    {{#if show_email}}
-                    <div id="email" class="default-field">
-                        <span class="name">{{#tr}}Email{{/tr}}</span>
-                        <span class="value">{{email}}</span>
+                <div class="general-info">
+                    <div id="default-section">
+                        {{#if show_email}}
+                        <div id="email" class="default-field">
+                            <span class="name">{{#tr}}Email{{/tr}}</span>
+                            <span class="value">{{email}}</span>
+                        </div>
+                        {{/if}}
+                        <div id="date-joined" class="default-field">
+                            <span class="name">{{#tr}}Joined{{/tr}}</span>
+                            <span class="value">{{date_joined}}</span>
+                        </div>
+                        <div id="user-type" class="default-field">
+                            <span class="name">{{#tr}}Role{{/tr}}</span>
+                            <span class="value">{{user_type}}</span>
+                        </div>
+                        <span class="value">{{last_seen}}</span>
+                        {{#if user_time}}
+                        <div class="default-field">
+                            <span class="name">{{#tr}}Local time{{/tr}}</span>
+                            <span class="value">{{user_time}}</span>
+                        </div>
+                        {{/if}}
                     </div>
-                    {{/if}}
-                    <div id="date-joined" class="default-field">
-                        <span class="name">{{#tr}}Joined{{/tr}}</span>
-                        <span class="value">{{date_joined}}</span>
-                    </div>
-                    <div id="user-type" class="default-field">
-                        <span class="name">{{#tr}}Role{{/tr}}</span>
-                        <span class="value">{{user_type}}</span>
-                    </div>
-                    <span class="value">{{last_seen}}</span>
-                    {{#if user_time}}
-                    <div class="default-field">
-                        <span class="name">{{#tr}}Local time{{/tr}}</span>
-                        <span class="value">{{user_time}}</span>
-                    </div>
-                    {{/if}}
+                    <div id="avatar" {{#if user_is_guest}} class="guest-avatar" {{/if}}
+                      style="background-image: url('{{user_avatar}}');"></div>
                 </div>
                 <div id="content">
                     {{#each profile_data}}

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -31,7 +31,12 @@
                             <span class="name">{{#tr}}Role{{/tr}}</span>
                             <span class="value">{{user_type}}</span>
                         </div>
-                        <span class="value">{{last_seen}}</span>
+                        <div class="default-field">
+                            <span class="name">{{#tr}}Presence{{/tr}}</span>
+                            <span class="value">
+                                <span class="{{user_circle_class}} user_circle"></span>{{last_seen}}
+                            </span>
+                        </div>
                         {{#if user_time}}
                         <div class="default-field">
                             <span class="name">{{#tr}}Local time{{/tr}}</span>


### PR DESCRIPTION
Related conversation: https://chat.zulip.org/#narrow/stream/101-design/topic/user.20Profile.20modal
I think we can improve on how we show presence here. I'll mention idea for that in above linked thread on chat.zulip.org, and probably add a commit for that.

**GIFs or screenshots:**
![profile](https://user-images.githubusercontent.com/63504956/128309347-c944b650-79b5-4b2a-9a9b-ace6299a14b4.gif)

