### PR TITLE
puppet: Move backup time earlier, from 10am to 7pm America/Los_Angeles.

### DIFF
--- a/puppet/zulip/manifests/postgresql_backups.pp
+++ b/puppet/zulip/manifests/postgresql_backups.pp
@@ -43,7 +43,7 @@ class zulip::postgresql_backups {
     ensure      => present,
     command     => '/usr/local/bin/pg_backup_and_purge',
     environment => 'PATH=/bin:/usr/bin:/usr/local/bin',
-    hour        => 5,
+    hour        => 2,
     minute      => 0,
     target      => 'postgres',
     user        => 'postgres',


### PR DESCRIPTION
This is less likely to overlap with common evening deploy times.
