### PR TITLE
Patch for None Type as message.rendered_content in 0257_fix_has_link_attribute.py

### DIFF
--- a/zerver/migrations/0257_fix_has_link_attribute.py
+++ b/zerver/migrations/0257_fix_has_link_attribute.py
@@ -13,9 +13,9 @@ BATCH_SIZE = 1000
 def process_batch(apps: StateApps, id_start: int, id_end: int, last_id: int) -> None:
     Message = apps.get_model('zerver', 'Message')
     for message in Message.objects.filter(id__gte=id_start, id__lte=id_end).order_by("id"):
-        if message.rendered_content == "":
+        if message.rendered_content in ["", None]:
             # There have been bugs in the past that made it possible
-            # for a message to have "" as its rendered_content; we
+            # for a message to have "" or None as its rendered_content; we
             # need to skip those because lxml won't process them.
             #
             # They should safely already have the correct state


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
During upgradation from *v2.0.x* to *v2.1.x* it is noted that, it is somehow possible for the `message.rendered_content` to get the value **None** just like the way it gets an empty string (""). This should be immediately patched since it breaks migration, and thereby the whole upgradation. Not only with v2.1.x but this patch is applicable to **all greater versions** doing similar migration.

**Testing plan:** <!-- How have you tested? -->

Tested by running `./manage.py migrate` with `pdb`. Screenshots are attached.

**Current Zulip Version**
```shell
cat version.py
ZULIP_VERSION = "2.0.8"
...
```

**Next Zulip Version**
```shell
# cat version
2.1.0
```

**OS**
```shell
$ cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.04
DISTRIB_CODENAME=bionic
DISTRIB_DESCRIPTION="Ubuntu 18.04.2 LTS"
```

**Postgres Version:**
```shell
postgres (PostgreSQL) 10.17 (Ubuntu 10.17-0ubuntu0.18.04.1)
```

**Server Status:**
```shell
supervisorctl status
process-fts-updates                                             STOPPED   Aug 03 06:04 AM
zulip-django                                                    STOPPED   Aug 03 06:04 AM
zulip-senders:zulip_events_message_sender-0                     STOPPED   Aug 03 06:04 AM
zulip-senders:zulip_events_message_sender-1                     STOPPED   Aug 03 06:04 AM
zulip-senders:zulip_events_message_sender-2                     STOPPED   Aug 03 06:04 AM
zulip-senders:zulip_events_message_sender-3                     STOPPED   Aug 03 06:04 AM
zulip-thumbor                                                   STOPPED   Aug 03 06:04 AM
zulip-tornado                                                   STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_deliver_enqueued_emails                     STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_deliver_scheduled_messages                  STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_deferred_work                        STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_digest_emails                        STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_email_mirror                         STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_email_senders                        STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_embed_links                          STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_embedded_bots                        STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_error_reports                        STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_feedback_messages                    STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_invites                              STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_missedmessage_email_senders          STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_missedmessage_emails                 STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_missedmessage_mobile_notifications   STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_outgoing_webhooks                    STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_signups                              STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_slow_queries                         STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_user_activity                        STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_user_activity_interval               STOPPED   Aug 03 06:04 AM
zulip-workers:zulip_events_user_presence                        STOPPED   Aug 03 06:04 AM
```

**CPU Spec:**
```shell
Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
CPU(s):              4
On-line CPU(s) list: 0-3
Thread(s) per core:  1
Core(s) per socket:  4
Socket(s):           1
NUMA node(s):        1
Vendor ID:           GenuineIntel
CPU family:          6
Model:               85
Model name:          DO-Premium-Intel
Stepping:            4
CPU MHz:             2494.084
BogoMIPS:            4988.16
Virtualization:      VT-x
Hypervisor vendor:   KVM
Virtualization type: full
L1d cache:           32K
L1i cache:           32K
L2 cache:            4096K
NUMA node0 CPU(s):   0-3
```

**Execution and Full Error Log from `./manage.py shell`:**

![call_command](https://user-images.githubusercontent.com/44225503/128201753-226000a3-bd18-4832-8ee1-543d2f0ea96c.jpeg)


```shell
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-06ee02f79eef> in <module>
----> 1 call_command("migrate")

~/deployments/2021-08-04-12-00-02/zulip-py3-venv/lib/python3.6/site-packages/django/core/management/__init__.py in call_command(command_name, 
*args, **options)
    129         defaults['skip_checks'] = True
    130
--> 131     return command.execute(*args, **defaults)
    132
    133

~/deployments/2021-08-04-12-00-02/zulip-py3-venv/lib/python3.6/site-packages/django/core/management/base.py in execute(self, *args, **options)
    328             if self.requires_migrations_checks:
    329                 self.check_migrations()
--> 330             output = self.handle(*args, **options)
    331             if output:
    332                 if self.output_transaction:

~/deployments/2021-08-04-12-00-02/zulip-py3-venv/lib/python3.6/site-packages/django/core/management/commands/migrate.py in handle(self, *args, **options)
    202         post_migrate_state = executor.migrate(
    203             targets, plan=plan, state=pre_migrate_state.clone(), fake=fake,
--> 204             fake_initial=fake_initial,
    205         )
    206         # post_migrate signals have access to all models. Ensure that all models

~/deployments/2021-08-04-12-00-02/zulip-py3-venv/lib/python3.6/site-packages/django/db/migrations/executor.py in migrate(self, targets, plan, state, fake, fake_initial)
    113                 # The resulting state should still include applied migrations.
    114                 state = self._create_project_state(with_applied_migrations=True)
--> 115             state = self._migrate_all_forwards(state, plan, full_plan, fake=fake, fake_initial=fake_initial)
    116         else:
    117             # No need to check for `elif all_backwards` here, as that condition
~/deployments/2021-08-04-12-00-02/zulip-py3-venv/lib/python3.6/site-packages/django/db/migrations/executor.py in _migrate_all_forwards(self, state, plan, full_plan, fake, fake_initial)
    143                     if self.progress_callback:
    144                         self.progress_callback("render_success")
--> 145                 state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
    146                 migrations_to_run.remove(migration)
    147

~/deployments/2021-08-04-12-00-02/zulip-py3-venv/lib/python3.6/site-packages/django/db/migrations/executor.py in apply_migration(self, state, migration, fake, fake_initial)
    242                 # Alright, do it normally
    243                 with self.connection.schema_editor(atomic=migration.atomic) as schema_editor:
--> 244                     state = migration.apply(state, schema_editor)
    245         # For replacement migrations, record individual statuses
    246         if migration.replaces:

~/deployments/2021-08-04-12-00-02/zulip-py3-venv/lib/python3.6/site-packages/django/db/migrations/migration.py in apply(self, project_state, schema_editor, collect_sql)
    127             else:
    128                 # Normal behaviour
--> 129                 operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
    130         return project_state
    131

~/deployments/2021-08-04-12-00-02/zulip-py3-venv/lib/python3.6/site-packages/django/db/migrations/operations/special.py in database_forwards(self, app_label, schema_editor, from_state, to_state)
    191             # We could try to override the global cache, but then people will still
    192             # use direct imports, so we go with a documentation approach instead.
--> 193             self.code(from_state.apps, schema_editor)
    194
    195     def database_backwards(self, app_label, schema_editor, from_state, to_state):

~/deployments/2021-08-04-12-00-02/zerver/migrations/0257_fix_has_link_attribute.py in fix_has_link(apps, schema_editor)
     71     id_range_upper_bound = 0 + BATCH_SIZE
     72     while id_range_upper_bound <= last_id:
---> 73         process_batch(apps, id_range_lower_bound, id_range_upper_bound, last_id)
     74
     75         id_range_lower_bound = id_range_upper_bound + 1

~/deployments/2021-08-04-12-00-02/zerver/migrations/0257_fix_has_link_attribute.py in process_batch(apps, id_start, id_end, last_id)
     33         # For has_link and has_image, we need to parse the messages.
     34         # Links are simple -- look for a link in the message.
---> 35         lxml_obj = lxml.html.fromstring(message.rendered_content)
     36         has_link = False
     37         for link in lxml_obj.xpath("//a"):

~/deployments/2021-08-04-12-00-02/zulip-py3-venv/lib/python3.6/site-packages/lxml/html/__init__.py in fromstring(html, base_url, parser, **kw)
    872         is_full_html = _looks_like_full_html_bytes(html)
    873     else:
--> 874         is_full_html = _looks_like_full_html_unicode(html)
    875     doc = document_fromstring(html, parser=parser, base_url=base_url, **kw)
    876     if is_full_html:

TypeError: expected string or bytes-like object
```


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

**Error Log and pdb inspection:**

![migrate_starting](https://user-images.githubusercontent.com/44225503/128200734-f711a6d2-2b08-46fe-bd59-355a40c91aef.jpeg)
![migrate2](https://user-images.githubusercontent.com/44225503/128200760-8887431d-58d5-4eaf-bd66-93fab22760ef.jpeg)
![migrate3](https://user-images.githubusercontent.com/44225503/128200779-f0ab58c8-626e-49a2-9870-e5f24140634b.jpeg)

**Value of `html` variable in `/home/zulip/deployments/next/zulip-py3-venv/lib/python3.6/site-packages/lxml/html/__init__.py`**

![finalp](https://user-images.githubusercontent.com/44225503/128201126-75c07591-5a62-42bc-a553-b9d20ac5cee8.jpeg)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
