### PR TITLE
changelog: Fix typo occurred during rebasing in 45f6c8d27ffeb.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -11,7 +11,6 @@ below features are supported.
 
 ## Changes in Zulip 5.0
 
-=======
 **Feature level 90**
 
 * We no longer include `sender_ids` in the `streams` section of


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


<!-- How have you tested? -->


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
