### PR TITLE
mark-unread: Add prep commits for JS unread.js module.

### DIFF
--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -510,31 +510,49 @@ test("mentions", () => {
         unread: true,
     };
 
+    const muted_direct_mention_message = {
+        id: 17,
+        type: "stream",
+        stream_id: muted_stream_id,
+        topic: "lunch",
+        mentioned: true,
+        mentioned_me_directly: true,
+        unread: true,
+    };
+
     unread.process_loaded_messages([
         already_read_message,
         mention_me_message,
         mention_all_message,
         muted_mention_all_message,
+        muted_direct_mention_message,
     ]);
 
     counts = unread.get_counts();
-    assert.equal(counts.mentioned_message_count, 2);
+    assert.equal(counts.mentioned_message_count, 3);
     assert.deepEqual(unread.get_msg_ids_for_mentions(), [
         mention_me_message.id,
         mention_all_message.id,
+        muted_direct_mention_message.id,
     ]);
     assert.deepEqual(unread.get_all_msg_ids(), [
         mention_me_message.id,
         mention_all_message.id,
         muted_mention_all_message.id,
     ]);
-    test_notifiable_count(counts.home_unread_messages, 2);
+    test_notifiable_count(counts.home_unread_messages, 3);
 
     unread.mark_as_read(mention_me_message.id);
     unread.mark_as_read(mention_all_message.id);
+    unread.mark_as_read(muted_direct_mention_message.id);
     counts = unread.get_counts();
     assert.equal(counts.mentioned_message_count, 0);
     test_notifiable_count(counts.home_unread_messages, 0);
+
+    // redundantly read a message to make sure nothing explodes
+    unread.mark_as_read(muted_direct_mention_message.id);
+    counts = unread.get_counts();
+    assert.equal(counts.mentioned_message_count, 0);
 });
 
 test("mention updates", () => {

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -99,6 +99,7 @@ test("changing_topics", () => {
         unread: true,
     };
 
+    assert.deepEqual(unread.get_read_message_ids([15, 16]), [15, 16]);
     assert.deepEqual(unread.get_unread_message_ids([15, 16]), []);
     assert.deepEqual(unread.get_unread_messages([message, other_message]), []);
 
@@ -111,6 +112,7 @@ test("changing_topics", () => {
     unread.process_loaded_messages([message, other_message]);
 
     assert.deepEqual(unread.get_all_msg_ids(), [15, 16]);
+    assert.deepEqual(unread.get_read_message_ids([15, 16]), []);
     assert.deepEqual(unread.get_unread_message_ids([15, 16]), [15, 16]);
     assert.deepEqual(unread.get_unread_messages([message, other_message]), [
         message,

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -211,20 +211,20 @@ class UnreadTopicCounter {
             const topic = obj.topic;
             const unread_message_ids = obj.unread_message_ids;
 
-            for (const msg_id of unread_message_ids) {
-                this.add(stream_id, topic, msg_id);
+            for (const message_id of unread_message_ids) {
+                this.add({message_id, stream_id, topic});
             }
         }
     }
 
-    add(stream_id, topic, msg_id) {
+    add({message_id, stream_id, topic}) {
         this.bucketer.add({
             bucket_key: stream_id,
-            item_id: msg_id,
+            item_id: message_id,
             add_callback(per_stream_bucketer) {
                 per_stream_bucketer.add({
                     bucket_key: topic,
-                    item_id: msg_id,
+                    item_id: message_id,
                 });
             },
         });
@@ -419,7 +419,11 @@ export function update_unread_topics(msg, event) {
 
     unread_topic_counter.delete(msg.id);
 
-    unread_topic_counter.add(new_stream_id || msg.stream_id, new_topic || msg.topic, msg.id);
+    unread_topic_counter.add({
+        message_id: msg.id,
+        stream_id: new_stream_id || msg.stream_id,
+        topic: new_topic || msg.topic,
+    });
 }
 
 export function process_loaded_messages(messages) {
@@ -457,7 +461,11 @@ function process_unread_message(message) {
     }
 
     if (message.type === "stream") {
-        unread_topic_counter.add(message.stream_id, message.topic, message.id);
+        unread_topic_counter.add({
+            message_id: message.id,
+            stream_id: message.stream_id,
+            topic: message.topic,
+        });
     }
 
     update_message_for_mention(message);

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -397,6 +397,10 @@ export function message_unread(message) {
     return message.unread;
 }
 
+export function get_read_message_ids(message_ids) {
+    return message_ids.filter((message_id) => !unread_messages.has(message_id));
+}
+
 export function get_unread_message_ids(message_ids) {
     return message_ids.filter((message_id) => unread_messages.has(message_id));
 }

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -426,7 +426,16 @@ export function update_unread_topics(msg, event) {
 export function process_loaded_messages(messages) {
     for (const message of messages) {
         if (message.unread) {
-            process_unread_message(message);
+            process_unread_message({
+                display_recipient: message.display_recipient,
+                id: message.id,
+                mentioned: message.mentioned,
+                mentioned_me_directly: message.mentioned_me_directly,
+                stream_id: message.stream_id,
+                topic: message.topic,
+                type: message.type,
+                unread: true,
+            });
         }
     }
 }

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -425,22 +425,28 @@ export function update_unread_topics(msg, event) {
 
 export function process_loaded_messages(messages) {
     for (const message of messages) {
-        if (!message.unread) {
-            continue;
+        if (message.unread) {
+            process_unread_message(message);
         }
-
-        unread_messages.add(message.id);
-
-        if (message.type === "private") {
-            unread_pm_counter.add(message);
-        }
-
-        if (message.type === "stream") {
-            unread_topic_counter.add(message.stream_id, message.topic, message.id);
-        }
-
-        update_message_for_mention(message);
     }
+}
+
+function process_unread_message(message) {
+    // The `message` here just needs to require certain fields. For example,
+    // the "message" may actually be constructed from a Zulip event that doesn't
+    // include fields like "content".  The caller must verify that the message
+    // is actually unread--we don't defend against that.
+    unread_messages.add(message.id);
+
+    if (message.type === "private") {
+        unread_pm_counter.add(message);
+    }
+
+    if (message.type === "stream") {
+        unread_topic_counter.add(message.stream_id, message.topic, message.id);
+    }
+
+    update_message_for_mention(message);
 }
 
 export function update_message_for_mention(message) {


### PR DESCRIPTION
These commits set us up to do mark-as-unread more easily.  In particular, we want to make it easy to process mark-as-unread events (which don't have full messages) with the same functions that now deal with "real" messages.

I think some of this work will also help us for an eventual TS migration, as I try to pass more narrow, less opaque types around.