### PR TITLE
portico: Add comparison checkboxes to /for/education. [WIP]

### DIFF
--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -927,13 +927,18 @@ nav {
 }
 
 /* -- compare css -- */
-.compare {
+.compare,
+.compare-education {
     background: linear-gradient(
         198deg,
         hsl(170deg 34% 47%),
         hsl(146deg 31% 60%)
     );
     color: hsl(0, 0%, 100%);
+
+    .table-container {
+        overflow-x: auto;
+    }
 
     .gradients .gradient.white-fade {
         background: none;
@@ -944,21 +949,20 @@ nav {
     }
 
     .padded-content {
-        width: 900px;
+        max-width: 900px;
         margin: 0 auto;
         position: relative; /* To place the content on top of gradients. */
         z-index: 2;
     }
 
     table {
+        min-width: 550px;
         padding: 33px;
         border: 20px solid transparent;
         width: 100%;
         text-align: left;
         border-collapse: collapse;
-
         font-weight: 400;
-
         color: hsla(0, 0%, 100%, 0.8);
 
         thead th {
@@ -1004,7 +1008,8 @@ nav {
 
             &:nth-of-type(3),
             &:nth-of-type(4),
-            &:nth-of-type(5) {
+            &:nth-of-type(5),
+            &:nth-of-type(6) {
                 width: 18%;
                 background-color: hsl(162, 67%, 25%);
             }
@@ -1031,7 +1036,8 @@ nav {
 
             &:nth-of-type(3),
             &:nth-of-type(4),
-            &:nth-of-type(5) {
+            &:nth-of-type(5),
+            &:nth-of-type(6) {
                 background-color: hsl(162, 44%, 38%);
             }
 
@@ -1087,6 +1093,27 @@ nav {
 
         a {
             color: hsl(170, 47%, 73%);
+        }
+    }
+}
+
+.compare-education {
+    color: hsl(0, 0%, 0%);
+    background: none;
+
+    table {
+        min-width: 650px;
+
+        .number {
+            font-weight: 800;
+
+            &.one {
+                color: hsl(0, 0%, 100%, 0.4);
+            }
+        }
+
+        td:first-of-type {
+            padding: 10px 10px 10px 0;
         }
     }
 }

--- a/templates/zerver/compare-education.html
+++ b/templates/zerver/compare-education.html
@@ -1,0 +1,131 @@
+<div class="compare-education">
+    <div class="padded-content">
+        <div class="text-header">
+            <div class="text-content">
+                <h1 class="center"><span>Zulip: The most complete communication hub for your class.</span></h1>
+            </div>
+        </div>
+
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Feature</th>
+                        <th >Zulip</th>
+                        <th class="normal">Slack</th>
+                        <th class="normal">Discord</th>
+                        <th class="normal">Piazza</th>
+                        <th class="normal">CampusWire</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Rich, modern chat</td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                    </tr>
+                    <tr>
+                        <td>Apps for every platform</td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                    </tr>
+                    <tr>
+                        <td>Self-hosting option for full control over data</td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                    </tr>
+                    <tr>
+                        <td>Dedicated account</td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                    </tr>
+                    <tr>
+                        <td>Topic-based threading</td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                    </tr>
+                    <tr>
+                        <td>Resolve topics/questions</td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                    </tr>
+                    <tr>
+                        <td>Move topics/questions</td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                    </tr>
+                    <tr>
+                        <td>Native LaTeX support</td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                    </tr>
+                    <tr>
+                        <td>Built-in spoilers</td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                    </tr>
+                    <tr>
+                        <td>Emoji reactions</td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                    </tr>
+                    <tr>
+                        <td>@-mention groups</td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                    </tr>
+                    <tr>
+                        <td>Scales to 10,000s of users</td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                    </tr>
+                    <tr>
+                        <td># supported languages</td>
+                        <td class="number">17</td>
+                        <td class="number">13</td>
+                        <td class="number">30</td>
+                        <td class="number one">1</td>
+                        <td class="number one">1</td>
+                    </tr>
+
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/templates/zerver/compare.html
+++ b/templates/zerver/compare.html
@@ -6,76 +6,77 @@
                 <h1 class="center"><span>Zulip: The most complete team chat solution.</span></h1>
             </div>
         </div>
-
-        <table>
-            <thead>
-                <tr>
-                    <th>Feature</th>
-                    <th class="uniform">Zulip</th>
-                    <th class="normal uniform">Slack</th>
-                    <th class="normal uniform">Mattermost</th>
-                    <th class="normal uniform">Discord</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>Apps for every platform</td>
-                    <td class="yes"></td>
-                    <td class="yes"></td>
-                    <td class="yes"></td>
-                    <td class="yes"></td>
-                </tr>
-                <tr>
-                    <td>Hundreds of integrations</td>
-                    <td class="yes"></td>
-                    <td class="yes"></td>
-                    <td class="yes"></td>
-                    <td class="no"></td>
-                </tr>
-                <tr>
-                    <td>Self hosting available</td>
-                    <td class="yes"></td>
-                    <td class="no"></td>
-                    <td class="yes"></td>
-                    <td class="no"></td>
-                </tr>
-                <tr>
-                    <td>Emoji reactions</td>
-                    <td class="yes"></td>
-                    <td class="yes"></td>
-                    <td class="yes"></td>
-                    <td class="yes"></td>
-                </tr>
-                <tr>
-                    <td>Markdown formatting</td>
-                    <td class="yes"></td>
-                    <td class="no"></td>
-                    <td class="yes"></td>
-                    <td class="yes"></td>
-                </tr>
-                <tr>
-                    <td>Topic-based threading</td>
-                    <td class="yes"></td>
-                    <td class="no"></td>
-                    <td class="no"></td>
-                    <td class="no"></td>
-                </tr>
-                <tr>
-                    <td>Lightning-fast search</td>
-                    <td class="yes"></td>
-                    <td class="no"></td>
-                    <td class="no"></td>
-                    <td class="no"></td>
-                </tr>
-                <tr>
-                    <td>Free and open source</td>
-                    <td class="yes"></td>
-                    <td class="no"></td>
-                    <td>Open core *</td>
-                    <td class="no"></td>
-                </tr>
-            </tbody>
-        </table>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Feature</th>
+                        <th class="uniform">Zulip</th>
+                        <th class="normal uniform">Slack</th>
+                        <th class="normal uniform">Mattermost</th>
+                        <th class="normal uniform">Discord</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Apps for every platform</td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                    </tr>
+                    <tr>
+                        <td>Hundreds of integrations</td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                    </tr>
+                    <tr>
+                        <td>Self hosting available</td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                    </tr>
+                    <tr>
+                        <td>Emoji reactions</td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                    </tr>
+                    <tr>
+                        <td>Markdown formatting</td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="yes"></td>
+                        <td class="yes"></td>
+                    </tr>
+                    <tr>
+                        <td>Topic-based threading</td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                    </tr>
+                    <tr>
+                        <td>Lightning-fast search</td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                        <td class="no"></td>
+                    </tr>
+                    <tr>
+                        <td>Free and open source</td>
+                        <td class="yes"></td>
+                        <td class="no"></td>
+                        <td>Open core *</td>
+                        <td class="no"></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
         <p class="terms">
             <span class="term">
                 * Mattermost Team is open source, but many features

--- a/templates/zerver/for-education.html
+++ b/templates/zerver/for-education.html
@@ -184,7 +184,7 @@
                 <ul>
                     <li>
                         <div class="list-content">
-                            Zulip Cloud is built with <a href="/privacy/">privacy</a> and <a href="/security/">security</a> in mind.
+                            Zulip Cloud is built with <a href="/privacy/">privacy</a> and <a href="/security/">security</a> in mind. We will never sell data or ads.
                         </div>
                     </li>
                     <li><div class="list-content">Zulip is <a href="https://github.com/zulip">100% open source</a>. We work hard to make it <a href="https://zulip.readthedocs.io/en/latest/production/install.html">easy to set up</a> and run a self-hosted Zulip installation, where you have full control of the data.</div></li>
@@ -344,6 +344,7 @@
         </p>
     </div>
 
+    {% include "zerver/compare-education.html" %}
 
 </div>
 


### PR DESCRIPTION
portico: Add comparison checkboxes to /for/education.

@amanagr , I hacked the css `compare` class to:
- Add one more column
- Remove the gradient background
- Make the heading black rather than white

Could you please do a cleanup pass to fix it up?

1. Add margin to the leftmost column text; currently "Self-hosting option for full control over data" looks bad.
2. Give the leftmost column a bit more space, so that "Topic-based threading. Avoid duplicate questions." fits on 2 lines.
2. Check what's up with the column widths -- the rightmost two look much closer together to me.
3. Improve the look of the numbers in the bottom row. They should probably be bigger, and we should try making the 1's green-ish the way that the X's are.
4. Do any refactoring that should happen to fix the fact that I copy-pasted a bunch of code. :)

Thanks!


**Testing plan:** <!-- How have you tested? -->
manual

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screen Shot 2021-08-04 at 11 59 22 PM](https://user-images.githubusercontent.com/2090066/128305755-5ae0661e-2d6d-49bb-a79a-ffe6a6fae076.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
