### PR TITLE
rate_limit: Rate limit the /accounts/find/ endpoint.

### DIFF
--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -190,7 +190,7 @@ class RateLimitTests(ZulipTestCase):
         with self.settings(OPEN_REALM_CREATION=True):
             add_ratelimit_rule(1, 5, domain="create_realm_by_ip")
             try:
-                RateLimitedIPAddr("127.0.0.1").clear_history()
+                RateLimitedIPAddr("127.0.0.1", domain="create_realm_by_ip").clear_history()
                 self.do_test_hit_ratelimits(
                     lambda: self.client_post("/new/", {"email": "new@zulip.com"}),
                     assert_func=assert_func,

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -155,6 +155,8 @@ class RateLimitTests(ZulipTestCase):
         for i in range(6):
             with mock.patch("time.time", return_value=(start_time + i * 0.1)):
                 result = request_func()
+            if i < 5:
+                self.assertNotEqual(result.status_code, 429)
 
         assert_func(result)
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -711,6 +711,17 @@ def find_account(request: HttpRequest) -> HttpResponse:
         form = FindMyTeamForm(request.POST)
         if form.is_valid():
             emails = form.cleaned_data["emails"]
+            for i in range(len(emails)):
+                try:
+                    rate_limit_request_by_ip(request, domain="find_account_by_ip")
+                except RateLimited as e:
+                    assert e.secs_to_freedom is not None
+                    return render(
+                        request,
+                        "zerver/rate_limit_exceeded.html",
+                        context={"retry_after": int(e.secs_to_freedom)},
+                        status=429,
+                    )
 
             # Django doesn't support __iexact__in lookup with EmailField, so we have
             # to use Qs to get around that without needing to do multiple queries.

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -387,6 +387,9 @@ RATE_LIMITING_RULES = {
     "create_realm_by_ip": [
         (1800, 5),
     ],
+    "find_account_by_ip": [
+        (3600, 10),
+    ],
     "password_reset_form_by_email": [
         (3600, 2),  # 2 reset emails per hour
         (86400, 5),  # 5 per day

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -265,6 +265,7 @@ RATE_LIMITING_RULES: Dict[str, List[Tuple[int, int]]] = {
     "api_by_remote_server": [],
     "authenticate_by_username": [],
     "create_realm_by_ip": [],
+    "find_account_by_ip": [],
     "password_reset_form_by_email": [],
 }
 


### PR DESCRIPTION
Closes #19287

This endpoint allows submitting multiple addresses so we need to "weigh"
the rate limit more heavily the more emails are submitted. Clearly e.g.
a request triggering emails to 2 addresses should weigh twice as much as
a request doing that for just 1 address.