### PR TITLE
user_status: Show change status modal when clicked on emoji in buddy list.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -970,14 +970,23 @@ export function register_click_handlers() {
         e.preventDefault();
     });
 
-    $("body").on("click", ".update_status_text", (e) => {
+    function open_user_status_modal(e) {
         hide_all();
 
         user_status_ui.open_user_status_modal();
 
         e.stopPropagation();
         e.preventDefault();
-    });
+    }
+
+    $("body").on("click", ".update_status_text", open_user_status_modal);
+
+    // Clicking on one's own status emoji should open the user status modal.
+    $("#user_presences").on(
+        "click",
+        ".user_sidebar_entry_me .status_emoji",
+        open_user_status_modal,
+    );
 
     $("body").on("click", ".info_popover_actions .sidebar-popover-mute-user", (e) => {
         const user_id = elem_to_user_id($(e.target).parents("ul"));

--- a/static/templates/user_presence_row.hbs
+++ b/static/templates/user_presence_row.hbs
@@ -1,4 +1,4 @@
-<li data-user-id="{{user_id}}" class="user_sidebar_entry {{#if num_unread}} user-with-count {{/if}} narrow-filter {{#if faded}} user-fade {{/if}}">
+<li data-user-id="{{user_id}}" class="user_sidebar_entry {{#if is_current_user}}user_sidebar_entry_me {{/if}}{{#if num_unread}} user-with-count {{/if}} narrow-filter {{#if faded}} user-fade {{/if}}">
     <div class="selectable_sidebar_block">
         <span class="{{user_circle_class}} user_circle"></span>
         <a class="user-presence-link"


### PR DESCRIPTION
Fixes #19506

(For some reason, directly passing the selector to the existing handler doesn't work)

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![clicking_emoji_brings_status](https://user-images.githubusercontent.com/58626718/128338558-0ec39d3b-74a5-4be6-81ed-8b2a5b19c6f7.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
