### PR TITLE
api: Default `client_gravatar` to `true`.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -11,6 +11,14 @@ below features are supported.
 
 ## Changes in Zulip 5.0
 
+**Feature level 92**
+
+* [`GET /messages`](/api/get-messages), [`POST
+  /register`](/api/register-queue), [`GET /users`](/api/get-users),
+  [`GET /users/{user_id}`](/api/get-user), [`GET
+  /users/{email}`](/api/get-user-by-email): The `client_gravatar`
+  parameter now defaults to `true`.
+
 **Feature level 91**
 
 * `PATCH /realm`, [`PATCH /streams/{stream_id}`](/api/update-stream):
@@ -178,7 +186,7 @@ below features are supported.
 
 * [`GET /users`](/api/get-users), [`GET /users/{user_id}`](/api/get-user),
   [`GET /users/{email}`](/api/get-user-by-email) and
-  [`GET /users/me`](/api/get-own-user): Added `is_billing_admin` field to
+  [`GET /users/me`](/api/get-own-Added): is `user_billing_admin` field to
   returned user objects.
 * [`GET /events`](/api/get-events): Added `is_billing_admin` field to
   user objects sent in `realm_user` events.

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 91
+API_FEATURE_LEVEL = 92
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -229,7 +229,7 @@ def get_members(client: Client) -> None:
 
     # {code_example|start}
     # You may pass the `client_gravatar` query parameter as follows:
-    result = client.get_members({"client_gravatar": True})
+    result = client.get_members({"client_gravatar": False})
     # {code_example|end}
 
     validate_against_openapi_schema(result, "/users", "get", "200")

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14370,10 +14370,13 @@ components:
         since gravatar URLs are long, random strings and thus do not
         compress well. The `client_gravatar` field is set to `true` if
         clients can compute their own gravatars.
+
+        **Changes**: The default value of this parameter was `false`
+        prior to Zulip 5.0 (feature level 92).
       schema:
         type: boolean
-        default: false
-      example: true
+        default: true
+      example: false
     RequiredContent:
       name: content
       in: query

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -1662,7 +1662,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
         self.send_personal_message(hamlet, self.example_user("iago"))
 
-        result = self.get_and_check_messages({})
+        result = self.get_and_check_messages(dict(client_gravatar=orjson.dumps(False).decode()))
         message = result["messages"][0]
         self.assertIn("gravatar.com", message["avatar_url"])
 

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -900,7 +900,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
             "    --data-urlencode num_before=4 \\",
             "    --data-urlencode num_after=8 \\",
             '    --data-urlencode \'narrow=[{"operand": "Denmark", "operator": "stream"}]\' \\',
-            "    --data-urlencode client_gravatar=true \\",
+            "    --data-urlencode client_gravatar=false \\",
             "    --data-urlencode apply_markdown=false \\",
             "    --data-urlencode use_first_unread_anchor=true",
             "```",

--- a/zerver/views/events_register.py
+++ b/zerver/views/events_register.py
@@ -37,7 +37,7 @@ def events_register_backend(
     request: HttpRequest,
     user_profile: UserProfile,
     apply_markdown: bool = REQ(default=False, json_validator=check_bool),
-    client_gravatar: bool = REQ(default=False, json_validator=check_bool),
+    client_gravatar: bool = REQ(default=True, json_validator=check_bool),
     slim_presence: bool = REQ(default=False, json_validator=check_bool),
     all_public_streams: Optional[bool] = REQ(default=None, json_validator=check_bool),
     include_subscribers: bool = REQ(default=False, json_validator=check_bool),

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -950,7 +950,7 @@ def get_messages_backend(
     use_first_unread_anchor_val: bool = REQ(
         "use_first_unread_anchor", json_validator=check_bool, default=False
     ),
-    client_gravatar: bool = REQ(json_validator=check_bool, default=False),
+    client_gravatar: bool = REQ(json_validator=check_bool, default=True),
     apply_markdown: bool = REQ(json_validator=check_bool, default=True),
 ) -> HttpResponse:
     anchor = parse_anchor_value(anchor_val, use_first_unread_anchor_val)

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -527,13 +527,13 @@ def get_members_backend(
     user_profile: UserProfile,
     user_id: Optional[int] = None,
     include_custom_profile_fields: bool = REQ(json_validator=check_bool, default=False),
-    client_gravatar: bool = REQ(json_validator=check_bool, default=False),
+    client_gravatar: bool = REQ(json_validator=check_bool, default=True),
 ) -> HttpResponse:
     """
-    The client_gravatar field here is set to True if clients can compute
-    their own gravatars, which saves us bandwidth.  We want to eventually
-    make this the default behavior, but we have old clients that expect
-    the server to compute this for us.
+    The client_gravatar field here is set to True by default assuming that clients
+    can compute their own gravatars, which saves bandwidth. This is more important of
+    an optimization than it might seem because gravatar URLs contain MD5 hashes that
+    compress very poorly compared to other data.
     """
     realm = user_profile.realm
     if realm.email_address_visibility != Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE:
@@ -650,7 +650,7 @@ def get_user_by_email(
     user_profile: UserProfile,
     email: str,
     include_custom_profile_fields: bool = REQ(json_validator=check_bool, default=False),
-    client_gravatar: bool = REQ(json_validator=check_bool, default=False),
+    client_gravatar: bool = REQ(json_validator=check_bool, default=True),
 ) -> HttpResponse:
     realm = user_profile.realm
 


### PR DESCRIPTION
Default `client_gravatar` to `true` for all
endpoints passing the parameter to avoid
extra payload.

Fixes #11214.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
