### PR TITLE
templates: Add missing tabnabbing protection for target="_blank" links

### DIFF
--- a/static/templates/default_language_modal.hbs
+++ b/static/templates/default_language_modal.hbs
@@ -16,7 +16,7 @@
                 Zulip's translations are contributed by our amazing community of volunteer
                 translators. If you'd like to help, see the
                 <z-link>Zulip translation guidelines</z-link>.
-                {{#*inline "z-link"}}<a target="_blank" href="{{guidelines_link}}">{{> @partial-block}}</a>{{/inline}}
+                {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="https://zulip.readthedocs.io/en/latest/translating/translating.html">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         </p>
         <div>

--- a/static/templates/gear_menu.hbs
+++ b/static/templates/gear_menu.hbs
@@ -91,7 +91,7 @@
             {{/if}}
             {{#if page_params.promote_sponsoring_zulip }}
             <li role="presentation">
-                <a href="https://github.com/sponsors/zulip" target="_blank" role="menuitem">
+                <a href="https://github.com/sponsors/zulip" target="_blank" rel="noopener noreferrer" role="menuitem">
                     <i class="fa fa-heart" aria-hidden="true"></i> {{t 'Support Zulip' }}
                 </a>
             </li>

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -14,7 +14,7 @@
                 </button>
             </div>
 
-            {{> ../default_language_modal language_list=language_list_dbl_col guidelines_link="https://zulip.readthedocs.io/en/latest/translating/translating.html"}}
+            {{> ../default_language_modal language_list=language_list_dbl_col}}
         </div>
 
         <div id="user-display-settings">


### PR DESCRIPTION
These links were introduced in #17369 and #17499. Cc @amanagr, @hackerkid; please remember that https://web.dev/external-anchors-use-rel-noopener/ is important for security.