### PR TITLE
icons: Set font-display: block for icon font

### DIFF
--- a/static/assets/icons/template.hbs
+++ b/static/assets/icons/template.hbs
@@ -5,6 +5,7 @@
     src: {{{src}}};
     font-weight: normal;
     font-style: normal;
+    font-display: block;
 }
 
 i{{baseSelector}} {


### PR DESCRIPTION
It’s not helpful for the browser to substitute another font for the icon font while it’s loading.

This suppresses a warning from the Lighthouse performance analyzer.