### PR TITLE
compose: Fix compose fade not updating on deleting user pill.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -89,7 +89,7 @@ export function clear_preview_area() {
     $("#compose .markdown_preview").show();
 }
 
-function update_fade() {
+export function update_fade() {
     if (!compose_state.composing()) {
         return;
     }

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -3,6 +3,7 @@ import $ from "jquery";
 import render_input_pill from "../templates/input_pill.hbs";
 
 import * as blueslip from "./blueslip";
+import * as compose from "./compose";
 import * as ui_util from "./ui_util";
 
 // See https://zulip.readthedocs.io/en/latest/subsystems/input-pills.html
@@ -355,6 +356,8 @@ export function create(opts) {
 
             funcs.removePill(id);
             $next.trigger("focus");
+
+            compose.update_fade();
         });
 
         store.$parent.on("click", function (e) {


### PR DESCRIPTION
This commit makes the compose.update_fade as an exported
function and adds the listener to update the fade manually
as deleting the pill was not calling this functions.

Fixes #18865

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested this manually and with node tests.
Try testing as @alya  mentioned in the issue description.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
