### PR TITLE
message_edit: Show indicators for max message length limits.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -199,7 +199,9 @@
     }
 }
 
-#compose_limit_indicator {
+#compose_limit_indicator,
+.message_edit_limit_indicator {
+    position: relative;
     margin-right: 8px;
     font-size: 12px;
     color: hsl(39, 100%, 50%);
@@ -209,6 +211,11 @@
         color: hsl(0, 76%, 65%);
         font-weight: bold;
     }
+}
+
+#compose_limit_indicator {
+    top: 3px;
+    float: right;
 }
 
 #compose {
@@ -369,7 +376,10 @@ textarea.new_message_textarea {
     margin-bottom: 0;
     resize: vertical !important;
     margin-top: 5px;
+}
 
+.message_edit_content,
+textarea.new_message_textarea {
     @keyframes flash {
         0% {
             box-shadow: none;

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -41,7 +41,7 @@
     <div class="control-group no-margin">
         <div class="controls edit-controls">
             {{> copy_message_button message_id=this.message_id}}
-            <textarea class="message_edit_content" maxlength="10000">{{content}}</textarea>
+            <textarea class="message_edit_content">{{content}}</textarea>
             <div class="scrolling_list preview_message_area" id="preview_message_area_{{message_id}}" style="display:none;">
                 <div class="markdown_preview_spinner"></div>
                 <div class="preview_content rendered_markdown"></div>
@@ -71,6 +71,7 @@
             {{/if}}
             {{#if has_been_editable}}
             <div class="message-edit-timer-control-group">
+                <span class="message_edit_limit_indicator"></span>
                 <span class="message_edit_countdown_timer"></span>
                 <span>
                     <i id="message_edit_tooltip" class="tippy-zulip-tooltip message_edit_tooltip fa fa-question-circle" aria-hidden="true"


### PR DESCRIPTION
This commit is in continuation to the PR #18871 for adding indicators that will tell the user when he or she exceeds the allowed maximum limit while composing a message.

Part of #15909

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
Tested this manually for now.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/56730716/128573152-02304ba3-7701-4e19-b07f-93ffad9dbc9a.png)


Currently I am seeing a way to make the code same for both, by using same function if possible.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
