### PR TITLE
minor: Add `z-index` to `message_time` class.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -865,6 +865,10 @@ td.pointer {
     /* Disable blue link styling for the message timestamp link. */
     color: hsl(0, 0%, 20%);
     transition: background-color 1.5s ease-in, color 1.5s ease-in;
+
+    a& {
+        z-index: 1;
+    }
 }
 
 /* The way this overrides the menus with a background-color and a high


### PR DESCRIPTION
This fixes the issue of the timestamp in a message not
being clickable at smaller widths.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

**Before**
![message_time_hover_works](https://user-images.githubusercontent.com/58626718/128638532-ba8b06ab-ce0b-4db6-bb82-9ab8a2b1273c.gif)

**After**
![message_time_hover_does_not_work](https://user-images.githubusercontent.com/58626718/128638524-0aa20cbe-90e3-4e6a-b7b8-d45bfa438464.gif)