### PR TITLE
docs: Migrate from recommonmark to MyST-Parser

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@
 # serve to show the default.
 import os
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -30,7 +30,13 @@ from version import ZULIP_VERSION
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions: List[str] = []
+extensions = [
+    "myst_parser",
+]
+
+myst_enable_extensions = [
+    "colon_fence",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -293,8 +299,6 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
 
-from recommonmark.transform import AutoStructify
-
 # The suffix(es) of source filenames. You can specify multiple suffix
 # as a dictionary mapping file extensions to file types
 # https://www.sphinx-doc.org/en/master/usage/markdown.html
@@ -303,39 +307,11 @@ source_suffix = {
     ".md": "markdown",
 }
 
-# Temporary workaround to remove multiple build warnings caused by upstream bug.
-# See https://github.com/zulip/zulip/issues/13263 for details.
-from commonmark.node import Node
-from recommonmark.parser import CommonMarkParser
-
-
-class CustomCommonMarkParser(CommonMarkParser):
-    def visit_document(self, node: Node) -> None:
-        pass
+suppress_warnings = [
+    "myst.header",
+]
 
 
 def setup(app: Any) -> None:
-
-    app.add_source_parser(CustomCommonMarkParser)
-    app.add_config_value(
-        "recommonmark_config",
-        {
-            "enable_eval_rst": True,
-            # Turn off recommonmark features we aren't using.
-            "enable_auto_doc_ref": False,
-            "auto_toc_tree_section": None,
-            "enable_auto_toc_tree": False,
-            "enable_math": False,
-            "enable_inline_math": False,
-            "url_resolver": lambda x: x,
-        },
-        True,
-    )
-
-    # Enable `eval_rst`, and any other features enabled in recommonmark_config.
-    # Docs: https://recommonmark.readthedocs.io/en/latest/auto_structify.html
-    # (But NB those docs are for master, not latest release.)
-    app.add_transform(AutoStructify)
-
     # overrides for wide tables in RTD theme
     app.add_css_file("theme_overrides.css")  # path relative to _static

--- a/docs/development/request-remote.md
+++ b/docs/development/request-remote.md
@@ -1,4 +1,4 @@
-```eval_rst
+```{eval-rst}
 :orphan:
 ```
 

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -26,12 +26,11 @@ If you are using a [remote server](../development/remote.md), see
 the
 [section on creating appropriate user accounts](../development/remote.html#setting-up-user-accounts).
 
-```eval_rst
-.. warning::
-    There is no supported uninstallation process with this
-    method.  If you want that, use the Vagrant environment, where you can
-    just do ``vagrant destroy`` to clean up the development environment.
-```
+:::{warning}
+There is no supported uninstallation process with this
+method.  If you want that, use the Vagrant environment, where you can
+just do `vagrant destroy` to clean up the development environment.
+:::
 
 Start by [cloning your fork of the Zulip repository][zulip-rtd-git-cloning]
 and [connecting the Zulip upstream repository][zulip-rtd-git-connect]:
@@ -120,11 +119,10 @@ installation method described here.
    ./tools/run-dev.py
    ```
 
-   ```eval_rst
-   .. note::
-       If you shut down WSL, after starting it again, you will have to manually start
-       the services using ``./tools/wsl/start_services``.
-   ```
+   :::{note}
+   If you shut down WSL, after starting it again, you will have to manually start
+   the services using `./tools/wsl/start_services`.
+   :::
 
 1. If you are facing problems or you see error messages after running `./tools/run-dev.py`,
    you can try running `./tools/provision` again.
@@ -217,12 +215,11 @@ expected.
    Make sure you note down this down. This is where your zulip development web
    server can be accessed.
 
-   ```eval_rst
-   .. important::
-      The output of the above command changes every time you restart the Vagrant
-      development machine. Thus, it will have to be run every time you bring one up.
-      This quirk is one reason this method is marked experimental.
-   ```
+   :::{important}
+   The output of the above command changes every time you restart the Vagrant
+   development machine. Thus, it will have to be run every time you bring one up.
+   This quirk is one reason this method is marked experimental.
+   :::
 
 1. You should now be able to start the Zulip development server.
 

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -30,7 +30,7 @@ the
 .. warning::
     There is no supported uninstallation process with this
     method.  If you want that, use the Vagrant environment, where you can
-    just do `vagrant destroy` to clean up the development environment.
+    just do ``vagrant destroy`` to clean up the development environment.
 ```
 
 Start by [cloning your fork of the Zulip repository][zulip-rtd-git-cloning]

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -162,10 +162,9 @@ Debian](https://docs.docker.com/install/linux/docker-ce/debian/).
 
 #### Windows 10
 
-```eval_rst
-.. note::
-    We recommend using `WSL 2 for Windows development <../development/setup-advanced.html#installing-directly-on-windows-10-with-wsl-2>`_.
-```
+:::{note}
+We recommend using [WSL 2 for Windows development](../development/setup-advanced.html#installing-directly-on-windows-10-with-wsl-2).
+:::
 
 1. Install [Git for Windows][git-bash], which installs *Git BASH*.
 2. Install [VirtualBox][vbox-dl] (latest).

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -754,8 +754,8 @@ default: SSH auth method: private key
 default: Error: Connection timeout. Retrying...
 default: Error: Connection timeout. Retrying...
 default: Error: Connection timeout. Retrying...
-
 ```
+
 A likely cause is that hardware virtualization is not enabled for your
 computer. This must be done via your computer's BIOS settings. Look for a
 setting called VT-x (Intel) or (AMD-V).

--- a/docs/git/troubleshooting.md
+++ b/docs/git/troubleshooting.md
@@ -72,14 +72,13 @@ $ git reset --hard 13bea0e
 HEAD is now at 13bea0e test commit for docs.
 ```
 
-```eval_rst
-.. important::
-    ``git reset --hard <commit>`` will discard all changes in your
-    working directory and index since the commit you're resetting to with
-    ``<commit>``. *This is the main way you can lose work in Git*. If you need
-    to keep any changes that are in your working directory or that you have
-    committed, use ``git reset --merge <commit>`` instead.
-```
+:::{important}
+`git reset --hard <commit>` will discard all changes in your
+working directory and index since the commit you're resetting to with
+`<commit>`. *This is the main way you can lose work in Git*. If you need
+to keep any changes that are in your working directory or that you have
+committed, use `git reset --merge <commit>` instead.
+:::
 
 You can also use the relative reflog `HEAD@{1}` instead of the commit hash,
 just keep in mind that this changes as you run git commands.

--- a/docs/git/using.md
+++ b/docs/git/using.md
@@ -413,7 +413,6 @@ hint: Updates were rejected because the tip of your current branch is behind
 hint: its remote counterpart. Integrate the remote changes (e.g.
 hint: 'git pull ...') before pushing again.
 hint: See the 'Note about fast-forwards' in 'git push --help' for details.
-
 ```
 
 Re-running the command with `+<branch>` allows the push to continue by
@@ -429,7 +428,6 @@ Total 12 (delta 8), reused 0 (delta 0)
 remote: Resolving deltas: 100% (8/8), completed with 2 local objects.
 To git@github.com:christi3k/zulip.git
  + 2d49e2d...bfb2433 1754-docs-add-git-workflow -> 1754-docs-add-git-workflow (forced update)
-
 ```
 
 This is perfectly okay to do on your own feature branches, especially if you're

--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -35,6 +35,9 @@ Each of these requires one to a handful of lines of configuration in
 `settings.py`, as well as a secret in `zulip-secrets.conf`.  Details
 are documented in your `settings.py`.
 
+```eval_rst
+.. _ldap:
+```
 ## LDAP (including Active Directory)
 
 Zulip supports retrieving information about users via LDAP, and
@@ -490,10 +493,6 @@ If you're hosting multiple organizations and thus using the
 authenticate the user to when they visit your SSO URL from the IdP.
 (If the organization is on the root domain, use the empty string:
 `{"subdomain": ""}`.).
-
-```eval_rst
-.. _ldap:
-```
 
 ### Restricting access to specific organizations
 

--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -362,9 +362,9 @@ it as follows:
 
       The `Entity ID` should match the value of
       `SOCIAL_AUTH_SAML_SP_ENTITY_ID` computed in the Zulip settings.
-       You can get the correct value by running the following:
+      You can get the correct value by running the following:
       `/home/zulip/deployments/current/scripts/get-django-setting
-       SOCIAL_AUTH_SAML_SP_ENTITY_ID`.
+      SOCIAL_AUTH_SAML_SP_ENTITY_ID`.
 
     * **SSO URL**:
       `https://yourzulipdomain.example.com/complete/saml/`.  This is

--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -35,9 +35,7 @@ Each of these requires one to a handful of lines of configuration in
 `settings.py`, as well as a secret in `zulip-secrets.conf`.  Details
 are documented in your `settings.py`.
 
-```eval_rst
-.. _ldap:
-```
+(ldap)=
 ## LDAP (including Active Directory)
 
 Zulip supports retrieving information about users via LDAP, and
@@ -315,12 +313,11 @@ organization list with multiple maps, that contain a map with an attribute, and 
 value for that attribute. If for any of the attribute maps, all user's
 LDAP attributes match what is configured, access is granted.
 
-```eval_rst
-.. warning::
-    Restricting access using these mechanisms only affects authentication via LDAP,
-    and won't prevent users from accessing the organization using any other
-    authentication backends that are enabled for the organization.
-```
+:::{warning}
+Restricting access using these mechanisms only affects authentication via LDAP,
+and won't prevent users from accessing the organization using any other
+authentication backends that are enabled for the organization.
+:::
 
 ### Troubleshooting
 

--- a/docs/production/email-gateway.md
+++ b/docs/production/email-gateway.md
@@ -29,14 +29,13 @@ polling option is convenient for testing/developing this feature
 because it doesn't require a public IP address or setting up MX
 records in DNS.
 
-```eval_rst
-.. note::
-    Incoming emails are rate-limited, with the following limits:
+:::{note}
+Incoming emails are rate-limited, with the following limits:
 
-    * 50 emails per minute.
-    * 120 emails per 5 minutes.
-    * 600 emails per hour.
-```
+* 50 emails per minute.
+* 120 emails per 5 minutes.
+* 600 emails per hour.
+:::
 
 ## Local delivery setup
 

--- a/docs/production/email-gateway.md
+++ b/docs/production/email-gateway.md
@@ -30,13 +30,13 @@ because it doesn't require a public IP address or setting up MX
 records in DNS.
 
 ```eval_rst
-   .. note::
-       Incoming emails are rate-limited, with the following limits:
+.. note::
+    Incoming emails are rate-limited, with the following limits:
 
-       * 50 emails per minute.
-       * 120 emails per 5 minutes.
-       * 600 emails per hour.
-   ```
+    * 50 emails per minute.
+    * 120 emails per 5 minutes.
+    * 600 emails per hour.
+```
 
 ## Local delivery setup
 

--- a/docs/production/expensive-migrations.md
+++ b/docs/production/expensive-migrations.md
@@ -1,4 +1,4 @@
-```eval_rst
+```{eval-rst}
 :orphan:
 ```
 

--- a/docs/production/install-existing-server.md
+++ b/docs/production/install-existing-server.md
@@ -1,4 +1,4 @@
-```eval_rst
+```{eval-rst}
 :orphan:
 ```
 

--- a/docs/production/install.md
+++ b/docs/production/install.md
@@ -121,9 +121,7 @@ server.
 
 [realm-admin-docs]: https://zulip.com/help/getting-your-organization-started-with-zulip
 
-```eval_rst
-.. _installer-details:
-```
+(installer-details)=
 ## Details: What the installer does
 
 The install script does several things:

--- a/docs/production/maintain-secure-upgrade.md
+++ b/docs/production/maintain-secure-upgrade.md
@@ -1,4 +1,4 @@
-```eval_rst
+```{eval-rst}
 :orphan:
 ```
 

--- a/docs/production/multiple-organizations.md
+++ b/docs/production/multiple-organizations.md
@@ -1,4 +1,4 @@
-```eval_rst
+```{eval-rst}
 :orphan:
 ```
 

--- a/docs/production/password-strength.md
+++ b/docs/production/password-strength.md
@@ -1,4 +1,4 @@
-```eval_rst
+```{eval-rst}
 :orphan:
 ```
 

--- a/docs/production/troubleshooting.md
+++ b/docs/production/troubleshooting.md
@@ -144,15 +144,14 @@ problems and how to resolve them:
 
 ### Restrict unattended upgrades
 
-```eval_rst
-.. important::
-    We recommend that you disable or limit Ubuntu's unattended-upgrades
-    to skip some server packages.  With unattended upgrades enabled but
-    not limited, the moment a new PostgreSQL release is published, your
-    Zulip server will have its PostgreSQL server upgraded (and thus
-    restarted).  If you do disable unattended-upgrades, do not forget to
-    regularly install apt upgrades manually!
-```
+:::{important}
+We recommend that you disable or limit Ubuntu's unattended-upgrades
+to skip some server packages.  With unattended upgrades enabled but
+not limited, the moment a new PostgreSQL release is published, your
+Zulip server will have its PostgreSQL server upgraded (and thus
+restarted).  If you do disable unattended-upgrades, do not forget to
+regularly install apt upgrades manually!
+:::
 
 Restarting one of the system services that Zulip uses (PostgreSQL,
 memcached, Redis, or Rabbitmq) will drop the connections that

--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -212,12 +212,11 @@ the version corresponding to the `restart-server` path you call.
 
 ## Preserving local changes to service configuration files
 
-```eval_rst
-.. warning::
-    If you have modified service configuration files installed by
-    Zulip (e.g. the nginx configuration), the Zulip upgrade process will
-    overwrite your configuration when it does the ``puppet apply``.
-```
+:::{warning}
+If you have modified service configuration files installed by
+Zulip (e.g. the nginx configuration), the Zulip upgrade process will
+overwrite your configuration when it does the `puppet apply`.
+:::
 
 You can test whether this will happen assuming no upstream changes to
 the configuration using `scripts/zulip-puppet-apply` (without the

--- a/docs/production/upload-backends.md
+++ b/docs/production/upload-backends.md
@@ -127,7 +127,6 @@ need a block like this:
     "Action": "s3:GetObject",
     "Resource": "arn:aws:s3:::BUCKET_NAME_HERE/*"
 }
-
 ```
 
 The file-uploads bucket should not be world-readable.  See the

--- a/docs/production/upload-backends.md
+++ b/docs/production/upload-backends.md
@@ -44,24 +44,24 @@ as world-readable, whereas the "uploaded files" one is not.
    setting to your default AWS region's code (e.g. `"eu-central-1"`).
 
 1. You will need to configure `nginx` to direct requests for uploaded
-    files to the Zulip server (which will then serve a redirect to the
-    appropriate place in S3), rather than serving them directly.
+   files to the Zulip server (which will then serve a redirect to the
+   appropriate place in S3), rather than serving them directly.
 
-    With Zulip 1.9.0 and newer, you can do this automatically with the
-    following commands run as root:
+   With Zulip 1.9.0 and newer, you can do this automatically with the
+   following commands run as root:
 
-    ```
-    crudini --set /etc/zulip/zulip.conf application_server no_serve_uploads true
-    /home/zulip/deployments/current/scripts/zulip-puppet-apply
-    ```
+   ```
+   crudini --set /etc/zulip/zulip.conf application_server no_serve_uploads true
+   /home/zulip/deployments/current/scripts/zulip-puppet-apply
+   ```
 
-    (The first line will update your `/etc/zulip/zulip.conf`).
+   (The first line will update your `/etc/zulip/zulip.conf`).
 
-    With older Zulip, you need to edit
-    `/etc/nginx/sites-available/zulip-enterprise` to comment out the
-    `nginx` configuration block for `/user_avatars` and the `include
-    /etc/nginx/zulip-include/uploads.route` line and then reload the
-    `nginx` service (`service nginx reload`).
+   With older Zulip, you need to edit
+   `/etc/nginx/sites-available/zulip-enterprise` to comment out the
+   `nginx` configuration block for `/user_avatars` and the `include
+   /etc/nginx/zulip-include/uploads.route` line and then reload the
+   `nginx` service (`service nginx reload`).
 
 1. Finally, restart the Zulip server so that your settings changes
    take effect

--- a/docs/subsystems/performance.md
+++ b/docs/subsystems/performance.md
@@ -83,20 +83,16 @@ substantial oscillation within a 24 hour period), we expect the rough
 sense of them (as well as the list of important endpoints) is not
 likely to vary dramatically over time.
 
-``` eval_rst
-=======================   ============  ==============  ===============
-Endpoint                  Average time  Request volume  Average impact
-=======================   ============  ==============  ===============
-POST /users/me/presence   25ms          36%             9000
-GET /messages             70ms          3%              2100
-GET /                     300ms         0.3%            900
-GET /events               2ms           44%             880
-GET /user_uploads/*       12ms          5%              600
-POST /messages/flags      25ms          1.5%            375
-POST /messages            40ms          0.5%            200
-POST /users/me/*          50ms          0.04%           20
-=======================   ============  ==============  ===============
-```
+Endpoint                | Average time | Request volume | Average impact
+----------------------- | ------------ | -------------- | --------------
+POST /users/me/presence | 25ms         | 36%            | 9000
+GET /messages           | 70ms         | 3%             | 2100
+GET /                   | 300ms        | 0.3%           | 900
+GET /events             | 2ms          | 44%            | 880
+GET /user_uploads/*     | 12ms         | 5%             | 600
+POST /messages/flags    | 25ms         | 1.5%           | 375
+POST /messages          | 40ms         | 0.5%           | 200
+POST /users/me/*        | 50ms         | 0.04%          | 20
 
 The "Average impact" above is computed by multiplying request volume
 by average time; this tells you roughly that endpoint's **relative**

--- a/docs/testing/linters.md
+++ b/docs/testing/linters.md
@@ -60,15 +60,14 @@ note are:
 Finally, you can rely on our continuous integration setup to run linters for you,
 but it is good practice to run lint checks locally.
 
-```eval_rst
-.. important::
-    We provide a
-    `Git pre-commit hook <../git/zulip-tools.html#set-up-git-repo-script>`_
-    that can automatically run ``tools/lint`` on just the files that
-    changed (in a few 100ms) whenever you make a commit.  This can save
-    you a lot of time, by automatically detecting linter errors as you
-    make them.
-```
+:::{important}
+We provide a
+[Git pre-commit hook](../git/zulip-tools.html#set-up-git-repo-script)
+that can automatically run `tools/lint` on just the files that
+changed (in a few 100ms) whenever you make a commit.  This can save
+you a lot of time, by automatically detecting linter errors as you
+make them.
+:::
 
 **Note:** The linters only check files that git tracks. Remember to `git add`
 new files before running lint checks.

--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -156,12 +156,11 @@ show up in the message pane.  And, finally, you should make sure
 that no messages outside the narrow show up in Cordelia's view.
 
 
-```eval_rst
-.. important::
-    Make sure that Cordelia is subscribed to Verona but not
-    subscribed to Denmark; if not, you should use different streams
-    for your testing.
-```
+:::{important}
+Make sure that Cordelia is subscribed to Verona but not
+subscribed to Denmark; if not, you should use different streams
+for your testing.
+:::
 
 When testing narrows, you want to have Hamlet send the same message
 several times in a row, while cycling Cordelia through various narrows.

--- a/docs/translating/translating.md
+++ b/docs/translating/translating.md
@@ -29,14 +29,13 @@ progress, reporting problematic strings, etc.
 project on Transifex](https://www.transifex.com/zulip/zulip/), requesting access
 to any languages that you'd like to contribute to (or add new ones).
 
-   ```eval_rst
-   .. note::
-       Unless you plan to contribute country-specific translations, do not
-       select a country-specific language in the **Languages** menu when you sign
-       up. E.g. use **English (United Kingdom)** if you plan to translate Zulip
-       into UK English, but select **Russian** rather than **Russian (Russia)** for
-       general Russian translations.
-   ```
+   :::{note}
+   Unless you plan to contribute country-specific translations, do not
+   select a country-specific language in the **Languages** menu when you sign
+   up. E.g. use **English (United Kingdom)** if you plan to translate Zulip
+   into UK English, but select **Russian** rather than **Russian (Russia)** for
+   general Russian translations.
+   :::
 
 1. Wait for a maintainer to approve your Transifex access; this
    usually takes less than a day. You should then be able to access

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ module = [
     "pyinotify.*",
     "pyoembed.*",
     "pyuca.*",
-    "recommonmark.*",
     "requests_oauthlib.*",
     "scrapy.*",
     "social_core.*",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -60,6 +60,7 @@ attrs==21.2.0 \
     # via
     #   automat
     #   jsonschema
+    #   markdown-it-py
     #   openapi-core
     #   semgrep
     #   service-identity
@@ -237,10 +238,6 @@ colorama==0.4.4 \
     --hash=sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b \
     --hash=sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2
     # via semgrep
-commonmark==0.9.1 \
-    --hash=sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60 \
-    --hash=sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9
-    # via recommonmark
 constantly==15.1.0 \
     --hash=sha256:586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35 \
     --hash=sha256:dd2fa9d6b1a51a83f0d7dd76293d734046aa176e384bf6e33b7e44880eb37c5d
@@ -427,7 +424,7 @@ docutils==0.16 \
     --hash=sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af \
     --hash=sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc
     # via
-    #   recommonmark
+    #   myst-parser
     #   sphinx
     #   sphinx-rtd-theme
 ecdsa==0.17.0 \
@@ -539,6 +536,7 @@ jinja2==3.0.1 \
     # via
     #   -r requirements/common.in
     #   moto
+    #   myst-parser
     #   sphinx
 jmespath==0.10.0 \
     --hash=sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9 \
@@ -707,6 +705,12 @@ markdown==3.3.4 \
 markdown-include==0.6.0 \
     --hash=sha256:6f5d680e36f7780c7f0f61dca53ca581bd50d1b56137ddcd6353efafa0c3e4a2
     # via -r requirements/common.in
+markdown-it-py==1.1.0 \
+    --hash=sha256:36be6bb3ad987bfdb839f5ba78ddf094552ca38ccbd784ae4f74a4e1419fc6e3 \
+    --hash=sha256:98080fc0bc34c4f2bcf0846a096a9429acbd9d5d8e67ed34026c03c61c464389
+    # via
+    #   mdit-py-plugins
+    #   myst-parser
 markupsafe==2.0.1 \
     --hash=sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298 \
     --hash=sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64 \
@@ -759,6 +763,10 @@ matrix-client==0.3.2 \
     --hash=sha256:2855a2614a177db66f9bc3ba38cbd2876041456f663c334f72a160ab6bb11c49 \
     --hash=sha256:dce3ccb8665df0d519f08e07a16e6d3f9fab3a947df4b7a7c4bb26573d68f2d5
     # via zulip
+mdit-py-plugins==0.2.8 \
+    --hash=sha256:1833bf738e038e35d89cb3a07eb0d227ed647ce7dd357579b65343740c6d249c \
+    --hash=sha256:5991cef645502e80a5388ec4fc20885d2313d4871e8b8e320ca2de14ac0c015f
+    # via myst-parser
 more-itertools==8.8.0 \
     --hash=sha256:2cf89ec599962f2ddc4d568a05defc40e0a587fbc10d5989713638864c36be4d \
     --hash=sha256:83f0308e05477c68f56ea3a888172c78ed5d5b3c282addb67508e7ba6c8f813a
@@ -809,6 +817,10 @@ mypy-extensions==0.4.3 \
     #   black
     #   mypy
     #   typing-inspect
+myst-parser==0.15.1 \
+    --hash=sha256:7c3c78a36c4bc30ce6a67933ebd800a880c8d81f1688fad5c2ebd82cddbc1603 \
+    --hash=sha256:e8baa9959dac0bcf0f3ea5fc32a1a28792959471d8a8094e3ed5ee0de9733ade
+    # via -r requirements/docs.in
 oauthlib==3.1.1 \
     --hash=sha256:42bf6354c2ed8c6acb54d971fce6f88193d97297e18602a3a886603f9d7730cc \
     --hash=sha256:8f0215fcc533dd8dd1bee6f4c412d4f0cd7297307d43ac61666389e3bc3198a3
@@ -1276,6 +1288,7 @@ pyyaml==5.4.1 \
     # via
     #   libcst
     #   moto
+    #   myst-parser
     #   openapi-spec-validator
 qrcode==6.1 \
     --hash=sha256:3996ee560fc39532910603704c82980ff6d4d5d629f9c3f25f34174ce8606cf5 \
@@ -1285,10 +1298,6 @@ queuelib==1.6.1 \
     --hash=sha256:631d067c9be57e395c382d680d3653ca1452cd29e8da25c5e8d94b5c0c528c31 \
     --hash=sha256:90ee30ebb0b57112606358b63c09a681bbb9a7dd1120af09c836b475504cea85
     # via scrapy
-recommonmark==0.7.1 \
-    --hash=sha256:1b1db69af0231efce3fa21b94ff627ea33dee7079a01dd0a7f8482c3da148b3f \
-    --hash=sha256:bdb4db649f2222dcd8d2d844f0006b958d627f732415d399791ee436a3686d67
-    # via -r requirements/docs.in
 redis==3.5.3 \
     --hash=sha256:0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2 \
     --hash=sha256:432b788c4530cfe16d8d943a09d40ca6c16149727e4afe8c2c9d5580c59d9f24
@@ -1486,7 +1495,7 @@ sphinx==3.5.4 \
     --hash=sha256:2320d4e994a191f4b4be27da514e46b3d6b420f2ff895d064f52415d342461e8
     # via
     #   -r requirements/docs.in
-    #   recommonmark
+    #   myst-parser
     #   sphinx-rtd-theme
 sphinx-rtd-theme==0.5.2 \
     --hash=sha256:32bd3b5d13dc8186d7a42fc816a23d32e83a4827d7d9882948e7b837c232da5a \
@@ -1760,6 +1769,7 @@ typing-extensions==3.10.0.0 \
     #   botocore-stubs
     #   importlib-metadata
     #   libcst
+    #   markdown-it-py
     #   mypy
     #   mypy-boto3-s3
     #   pyre-check

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -12,4 +12,4 @@ sphinx<4  # https://github.com/readthedocs/sphinx_rtd_theme/issues/1159
 sphinx-rtd-theme
 
 # Needed to build Markdown docs
-recommonmark
+myst-parser

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,6 +11,10 @@ alabaster==0.7.12 \
     --hash=sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359 \
     --hash=sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02
     # via sphinx
+attrs==21.2.0 \
+    --hash=sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1 \
+    --hash=sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb
+    # via markdown-it-py
 babel==2.9.1 \
     --hash=sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9 \
     --hash=sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0
@@ -23,15 +27,11 @@ chardet==4.0.0 \
     --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa \
     --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5
     # via requests
-commonmark==0.9.1 \
-    --hash=sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60 \
-    --hash=sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9
-    # via recommonmark
 docutils==0.16 \
     --hash=sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af \
     --hash=sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc
     # via
-    #   recommonmark
+    #   myst-parser
     #   sphinx
     #   sphinx-rtd-theme
 idna==2.10 \
@@ -45,7 +45,15 @@ imagesize==1.2.0 \
 jinja2==3.0.1 \
     --hash=sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4 \
     --hash=sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4
-    # via sphinx
+    # via
+    #   myst-parser
+    #   sphinx
+markdown-it-py==1.1.0 \
+    --hash=sha256:36be6bb3ad987bfdb839f5ba78ddf094552ca38ccbd784ae4f74a4e1419fc6e3 \
+    --hash=sha256:98080fc0bc34c4f2bcf0846a096a9429acbd9d5d8e67ed34026c03c61c464389
+    # via
+    #   mdit-py-plugins
+    #   myst-parser
 markupsafe==2.0.1 \
     --hash=sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298 \
     --hash=sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64 \
@@ -82,6 +90,14 @@ markupsafe==2.0.1 \
     --hash=sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51 \
     --hash=sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872
     # via jinja2
+mdit-py-plugins==0.2.8 \
+    --hash=sha256:1833bf738e038e35d89cb3a07eb0d227ed647ce7dd357579b65343740c6d249c \
+    --hash=sha256:5991cef645502e80a5388ec4fc20885d2313d4871e8b8e320ca2de14ac0c015f
+    # via myst-parser
+myst-parser==0.15.1 \
+    --hash=sha256:7c3c78a36c4bc30ce6a67933ebd800a880c8d81f1688fad5c2ebd82cddbc1603 \
+    --hash=sha256:e8baa9959dac0bcf0f3ea5fc32a1a28792959471d8a8094e3ed5ee0de9733ade
+    # via -r requirements/docs.in
 packaging==21.0 \
     --hash=sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7 \
     --hash=sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14
@@ -98,10 +114,37 @@ pytz==2021.1 \
     --hash=sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da \
     --hash=sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798
     # via babel
-recommonmark==0.7.1 \
-    --hash=sha256:1b1db69af0231efce3fa21b94ff627ea33dee7079a01dd0a7f8482c3da148b3f \
-    --hash=sha256:bdb4db649f2222dcd8d2d844f0006b958d627f732415d399791ee436a3686d67
-    # via -r requirements/docs.in
+pyyaml==5.4.1 \
+    --hash=sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf \
+    --hash=sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696 \
+    --hash=sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393 \
+    --hash=sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77 \
+    --hash=sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922 \
+    --hash=sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5 \
+    --hash=sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8 \
+    --hash=sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10 \
+    --hash=sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc \
+    --hash=sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018 \
+    --hash=sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e \
+    --hash=sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253 \
+    --hash=sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347 \
+    --hash=sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183 \
+    --hash=sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541 \
+    --hash=sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb \
+    --hash=sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185 \
+    --hash=sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc \
+    --hash=sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db \
+    --hash=sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa \
+    --hash=sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46 \
+    --hash=sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122 \
+    --hash=sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b \
+    --hash=sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63 \
+    --hash=sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df \
+    --hash=sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc \
+    --hash=sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247 \
+    --hash=sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6 \
+    --hash=sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0
+    # via myst-parser
 requests==2.25.1 \
     --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804 \
     --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e
@@ -115,7 +158,7 @@ sphinx==3.5.4 \
     --hash=sha256:2320d4e994a191f4b4be27da514e46b3d6b420f2ff895d064f52415d342461e8
     # via
     #   -r requirements/docs.in
-    #   recommonmark
+    #   myst-parser
     #   sphinx-rtd-theme
 sphinx-rtd-theme==0.5.2 \
     --hash=sha256:32bd3b5d13dc8186d7a42fc816a23d32e83a4827d7d9882948e7b837c232da5a \
@@ -145,6 +188,11 @@ sphinxcontrib-serializinghtml==1.1.5 \
     --hash=sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd \
     --hash=sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952
     # via sphinx
+typing-extensions==3.10.0.0 \
+    --hash=sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497 \
+    --hash=sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342 \
+    --hash=sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84
+    # via markdown-it-py
 urllib3==1.26.6 \
     --hash=sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4 \
     --hash=sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 92
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "153.14"
+PROVISION_VERSION = "154.0"


### PR DESCRIPTION
Recommonmark is [no longer maintained](https://github.com/readthedocs/recommonmark#readme), and [MyST-Parser](https://myst-parser.readthedocs.io/) is much more complete.

**Testing plan:** `tools/build-docs --clean`