### PR TITLE
notifications: Fix unnecessary wildcard mention notifications.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1344,9 +1344,10 @@ Output:
             pm_push_notify=kwargs.get("pm_push_notify", False),
             mention_email_notify=kwargs.get("mention_email_notify", False),
             mention_push_notify=kwargs.get("mention_push_notify", False),
+            wildcard_mention_email_notify=kwargs.get("wildcard_mention_email_notify", False),
+            wildcard_mention_push_notify=kwargs.get("wildcard_mention_push_notify", False),
             stream_email_notify=kwargs.get("stream_email_notify", False),
             stream_push_notify=kwargs.get("stream_push_notify", False),
-            wildcard_mention_notify=kwargs.get("wildcard_mention_notify", False),
             sender_is_muted=kwargs.get("sender_is_muted", False),
         )
 

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -420,7 +420,8 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             user_id=cordelia.id,
             acting_user_id=hamlet.id,
             message_id=message_id,
-            wildcard_mention_notify=True,
+            wildcard_mention_email_notify=True,
+            wildcard_mention_push_notify=True,
             already_notified={},
         )
         self.assertEqual(info["enqueue_kwargs"], expected_enqueue_kwargs)

--- a/zerver/tests/test_notification_data.py
+++ b/zerver/tests/test_notification_data.py
@@ -37,7 +37,7 @@ class TestNotificationData(ZulipTestCase):
 
         # Wildcard mention
         user_data = self.create_user_notifications_data_object(
-            user_id=user_id, wildcard_mention_notify=True
+            user_id=user_id, wildcard_mention_push_notify=True
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(acting_user_id=acting_user_id, idle=True),
@@ -79,11 +79,12 @@ class TestNotificationData(ZulipTestCase):
         user_data = self.create_user_notifications_data_object(
             user_id=user_id,
             sender_is_muted=True,
-            wildcard_mention_notify=True,
             pm_push_notify=True,
             pm_email_notify=True,
             mention_push_notify=True,
             mention_email_notify=True,
+            wildcard_mention_push_notify=True,
+            wildcard_mention_email_notify=True,
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(acting_user_id=acting_user_id, idle=True),
@@ -94,11 +95,12 @@ class TestNotificationData(ZulipTestCase):
         # Message sender is the user the object corresponds to.
         user_data = self.create_user_notifications_data_object(
             user_id=acting_user_id,
-            wildcard_mention_notify=True,
             pm_push_notify=True,
             pm_email_notify=True,
             mention_push_notify=True,
             mention_email_notify=True,
+            wildcard_mention_push_notify=True,
+            wildcard_mention_email_notify=True,
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(acting_user_id=acting_user_id, idle=True),
@@ -140,7 +142,7 @@ class TestNotificationData(ZulipTestCase):
 
         # Wildcard mention
         user_data = self.create_user_notifications_data_object(
-            user_id=user_id, wildcard_mention_notify=True
+            user_id=user_id, wildcard_mention_email_notify=True
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(acting_user_id=acting_user_id, idle=True),
@@ -173,11 +175,12 @@ class TestNotificationData(ZulipTestCase):
         user_data = self.create_user_notifications_data_object(
             user_id=user_id,
             sender_is_muted=True,
-            wildcard_mention_notify=True,
             pm_push_notify=True,
             pm_email_notify=True,
             mention_push_notify=True,
             mention_email_notify=True,
+            wildcard_mention_push_notify=True,
+            wildcard_mention_email_notify=True,
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(acting_user_id=acting_user_id, idle=True),
@@ -188,11 +191,12 @@ class TestNotificationData(ZulipTestCase):
         # Message sender is the user the object corresponds to.
         user_data = self.create_user_notifications_data_object(
             user_id=acting_user_id,
-            wildcard_mention_notify=True,
             pm_push_notify=True,
             pm_email_notify=True,
             mention_push_notify=True,
             mention_email_notify=True,
+            wildcard_mention_push_notify=True,
+            wildcard_mention_email_notify=True,
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(acting_user_id=acting_user_id, idle=True),

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -762,9 +762,10 @@ def missedmessage_hook(
             pm_email_notify=internal_data.get("pm_email_notify", False),
             mention_push_notify=internal_data.get("mention_push_notify", False),
             mention_email_notify=internal_data.get("mention_email_notify", False),
+            wildcard_mention_push_notify=internal_data.get("wildcard_mention_push_notify", False),
+            wildcard_mention_email_notify=internal_data.get("wildcard_mention_email_notify", False),
             stream_push_notify=internal_data.get("stream_push_notify", False),
             stream_email_notify=internal_data.get("stream_email_notify", False),
-            wildcard_mention_notify=internal_data.get("wildcard_mention_notify", False),
             # Since one is by definition idle, we don't need to check online_push_enabled
             online_push_enabled=False,
         )


### PR DESCRIPTION
This fixes a bug where email notifications were sent for wildcard
mentions even if the `enable_offline_email_notifications` setting was
turned off.
This was because the `notification_data` class incorrectly considered
`wildcard_mentions_notify` as an indeoendent setting, instead of a wrapper
around `enable_offline_email_notifications` and `enable_offline_push_notifications`.

Also add a test for this case.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
