### PR TITLE
user_settings: Create _legacy dicts for existing settings.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5082,7 +5082,7 @@ def do_change_notification_settings(
         send_event(user_profile.realm, legacy_event, [user_profile.id])
 
 
-def do_set_user_display_setting(
+def do_change_user_setting(
     user_profile: UserProfile, setting_name: str, setting_value: Union[bool, str, int]
 ) -> None:
     if setting_name == "timezone":

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1443,11 +1443,8 @@ def check_user_settings_update(
     assert isinstance(setting_name, str)
     if setting_name == "timezone":
         assert isinstance(value, str)
-    elif setting_name in UserProfile.property_types:
-        setting_type = UserProfile.property_types[setting_name]
-        assert isinstance(value, setting_type)
     else:
-        setting_type = UserProfile.notification_setting_types[setting_name]
+        setting_type = UserProfile.property_types[setting_name]
         assert isinstance(value, setting_type)
 
     if setting_name == "default_language":

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -515,13 +515,13 @@ def fetch_initial_state_data(
         state["stop_words"] = read_stop_words()
 
     if want("update_display_settings") and not user_settings_object:
-        for prop in UserProfile.property_types:
+        for prop in UserProfile.display_settings_legacy:
             state[prop] = getattr(settings_user, prop)
         state["emojiset_choices"] = UserProfile.emojiset_choices()
         state["timezone"] = settings_user.timezone
 
     if want("update_global_notifications") and not user_settings_object:
-        for notification in UserProfile.notification_setting_types:
+        for notification in UserProfile.notification_settings_legacy:
             state[notification] = getattr(settings_user, notification)
         state["available_notification_sounds"] = get_available_notification_sounds()
 
@@ -530,8 +530,6 @@ def fetch_initial_state_data(
 
         for prop in UserProfile.property_types:
             state["user_settings"][prop] = getattr(settings_user, prop)
-        for notification in UserProfile.notification_setting_types:
-            state["user_settings"][notification] = getattr(settings_user, notification)
 
         state["user_settings"]["emojiset_choices"] = UserProfile.emojiset_choices()
         state["user_settings"]["timezone"] = settings_user.timezone
@@ -1112,20 +1110,16 @@ def apply_event(
         state["realm_playgrounds"] = event["realm_playgrounds"]
     elif event["type"] == "update_display_settings":
         if event["setting_name"] != "timezone":
-            assert event["setting_name"] in UserProfile.property_types
+            assert event["setting_name"] in UserProfile.display_settings_legacy
         state[event["setting_name"]] = event["setting"]
     elif event["type"] == "update_global_notifications":
-        assert event["notification_name"] in UserProfile.notification_setting_types
+        assert event["notification_name"] in UserProfile.notification_settings_legacy
         state[event["notification_name"]] = event["setting"]
     elif event["type"] == "user_settings":
-        # timezone setting is not included in property_types or
-        # notification_setting_types dicts, because this setting
-        # is not a part of UserBaseSettings class.
+        # timezone setting is not included in property_types dict because
+        # this setting is not a part of UserBaseSettings class.
         if event["property"] != "timezone":
-            assert (
-                event["property"] in UserProfile.property_types
-                or event["property"] in UserProfile.notification_setting_types
-            )
+            assert event["property"] in UserProfile.property_types
         state[event["property"]] = event["value"]
         state["user_settings"][event["property"]] = event["value"]
     elif event["type"] == "invites_changed":

--- a/zerver/lib/zcommand.py
+++ b/zerver/lib/zcommand.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 from django.utils.translation import gettext as _
 
-from zerver.lib.actions import do_set_user_display_setting
+from zerver.lib.actions import do_change_user_setting
 from zerver.lib.exceptions import JsonableError
 from zerver.models import UserProfile
 
@@ -18,7 +18,7 @@ def process_zcommands(content: str, user_profile: UserProfile) -> Dict[str, Any]
                 switch_command=switch_command,
             )
         )
-        do_set_user_display_setting(
+        do_change_user_setting(
             user_profile=user_profile, setting_name=setting, setting_value=setting_value
         )
         return msg

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1362,8 +1362,7 @@ class UserBaseSettings(models.Model):
     # Whether or not the user wants to sync their drafts.
     enable_drafts_synchronization = models.BooleanField(default=True)
 
-    # Define the types of the various automatically managed properties
-    property_types = dict(
+    display_settings_legacy = dict(
         color_scheme=int,
         default_language=str,
         default_view=str,
@@ -1380,7 +1379,7 @@ class UserBaseSettings(models.Model):
         twenty_four_hour_time=bool,
     )
 
-    notification_setting_types = dict(
+    notification_settings_legacy = dict(
         enable_desktop_notifications=bool,
         enable_digest_emails=bool,
         enable_login_emails=bool,
@@ -1402,6 +1401,13 @@ class UserBaseSettings(models.Model):
         realm_name_in_notifications=bool,
         presence_enabled=bool,
     )
+
+    notification_setting_types = {
+        **notification_settings_legacy
+    }  # Add new notifications settings here.
+
+    # Define the types of the various automatically managed properties
+    property_types = {**display_settings_legacy, **notification_setting_types}
 
     class Meta:
         abstract = True

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -49,6 +49,7 @@ from zerver.lib.actions import (
     do_change_subscription_property,
     do_change_user_delivery_email,
     do_change_user_role,
+    do_change_user_setting,
     do_create_default_stream_group,
     do_create_multiuse_invite_link,
     do_create_user,
@@ -82,7 +83,6 @@ from zerver.lib.actions import (
     do_set_realm_notifications_stream,
     do_set_realm_property,
     do_set_realm_signup_notifications_stream,
-    do_set_user_display_setting,
     do_set_zoom_token,
     do_unmute_topic,
     do_unmute_user,
@@ -2061,7 +2061,7 @@ class NormalActionsTest(BaseAction):
 
     def test_display_setting_event_not_sent(self) -> None:
         events = self.verify_action(
-            lambda: do_set_user_display_setting(
+            lambda: do_change_user_setting(
                 self.user_profile,
                 "default_view",
                 "all_messages",
@@ -2169,7 +2169,7 @@ class RealmPropertyActionTest(BaseAction):
 
 
 class UserDisplayActionTest(BaseAction):
-    def do_set_user_display_settings_test(self, setting_name: str) -> None:
+    def do_change_user_settings_test(self, setting_name: str) -> None:
         """Test updating each setting in UserProfile.property_types dict."""
 
         test_changes: Dict[str, Any] = dict(
@@ -2195,19 +2195,19 @@ class UserDisplayActionTest(BaseAction):
 
         for value in values:
             events = self.verify_action(
-                lambda: do_set_user_display_setting(self.user_profile, setting_name, value),
+                lambda: do_change_user_setting(self.user_profile, setting_name, value),
                 num_events=num_events,
             )
 
             check_user_settings_update("events[0]", events[0])
             check_update_display_settings("events[1]", events[1])
 
-    def test_set_user_display_settings(self) -> None:
+    def test_change_user_settings(self) -> None:
         for prop in UserProfile.property_types:
             # Notification settings have a separate test suite, which
             # handles their separate legacy event type.
             if prop not in UserProfile.notification_settings_legacy:
-                self.do_set_user_display_settings_test(prop)
+                self.do_change_user_settings_test(prop)
 
     def test_set_user_timezone(self) -> None:
         values = ["America/Denver", "Pacific/Pago_Pago", "Pacific/Galapagos", ""]
@@ -2215,7 +2215,7 @@ class UserDisplayActionTest(BaseAction):
 
         for value in values:
             events = self.verify_action(
-                lambda: do_set_user_display_setting(self.user_profile, "timezone", value),
+                lambda: do_change_user_setting(self.user_profile, "timezone", value),
                 num_events=num_events,
             )
 
@@ -2347,7 +2347,7 @@ class SubscribeActionTest(BaseAction):
 
 class DraftActionTest(BaseAction):
     def do_enable_drafts_synchronization(self, user_profile: UserProfile) -> None:
-        do_set_user_display_setting(user_profile, "enable_drafts_synchronization", True)
+        do_change_user_setting(user_profile, "enable_drafts_synchronization", True)
 
     def test_draft_create_event(self) -> None:
         self.do_enable_drafts_synchronization(self.user_profile)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2204,7 +2204,10 @@ class UserDisplayActionTest(BaseAction):
 
     def test_set_user_display_settings(self) -> None:
         for prop in UserProfile.property_types:
-            self.do_set_user_display_settings_test(prop)
+            # Notification settings have a separate test suite, which
+            # handles their separate legacy event type.
+            if prop not in UserProfile.notification_settings_legacy:
+                self.do_set_user_display_settings_test(prop)
 
     def test_set_user_timezone(self) -> None:
         values = ["America/Denver", "Pacific/Pago_Pago", "Pacific/Galapagos", ""]

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -13,10 +13,10 @@ from markdown import Markdown
 from zerver.lib.actions import (
     change_user_is_active,
     do_add_alert_words,
+    do_change_user_setting,
     do_create_realm,
     do_remove_realm_emoji,
     do_set_realm_property,
-    do_set_user_display_setting,
 )
 from zerver.lib.alert_words import get_alert_word_automaton
 from zerver.lib.camo import get_camo_url
@@ -436,7 +436,7 @@ class MarkdownTest(ZulipTestCase):
                 if test.get("translate_emoticons", False):
                     # Create a userprofile and send message with it.
                     user_profile = self.example_user("othello")
-                    do_set_user_display_setting(user_profile, "translate_emoticons", True)
+                    do_change_user_setting(user_profile, "translate_emoticons", True)
                     msg = Message(sender=user_profile, sending_client=get_client("test"))
                     rendering_result = render_markdown(msg, test["input"])
                     converted = rendering_result.rendered_content
@@ -1219,7 +1219,7 @@ class MarkdownTest(ZulipTestCase):
 
     def test_no_translate_emoticons_if_off(self) -> None:
         user_profile = self.example_user("othello")
-        do_set_user_display_setting(user_profile, "translate_emoticons", False)
+        do_change_user_setting(user_profile, "translate_emoticons", False)
         msg = Message(sender=user_profile, sending_client=get_client("test"))
 
         content = ":)"

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -319,7 +319,7 @@ class ChangeSettingsTest(ZulipTestCase):
             )
             self.assert_json_error(result, "Your Zulip password is managed in LDAP")
 
-    def do_test_change_user_display_setting(self, setting_name: str) -> None:
+    def do_test_change_user_setting(self, setting_name: str) -> None:
 
         test_changes: Dict[str, Any] = dict(
             default_language="de",
@@ -366,14 +366,19 @@ class ChangeSettingsTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         self.assertNotEqual(getattr(user_profile, setting_name), invalid_value)
 
-    def test_change_user_display_setting(self) -> None:
+    def test_change_user_setting(self) -> None:
         """Test updating each non-boolean setting in UserProfile property_types"""
         user_settings = (
-            s for s in UserProfile.property_types if UserProfile.property_types[s] is not bool
+            s
+            for s in UserProfile.property_types
+            if UserProfile.property_types[s] is not bool
+            # Legacy notification settings have a separate test suite, though
+            # we can likely merge that test suite with this one in the future.
+            and s not in UserProfile.notification_settings_legacy
         )
         for setting in user_settings:
-            self.do_test_change_user_display_setting(setting)
-        self.do_test_change_user_display_setting("timezone")
+            self.do_test_change_user_setting(setting)
+        self.do_test_change_user_setting("timezone")
 
     def do_change_emojiset(self, emojiset: str) -> HttpResponse:
         self.login("hamlet")

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -38,9 +38,9 @@ from zerver.lib.actions import (
     do_activate_mirror_dummy_user,
     do_change_full_name,
     do_change_password,
+    do_change_user_setting,
     do_create_realm,
     do_create_user,
-    do_set_user_display_setting,
     lookup_default_stream_groups,
 )
 from zerver.lib.email_validation import email_allowed_for_realm, validate_email_not_already_in_realm
@@ -420,7 +420,7 @@ def accounts_register(
             do_activate_mirror_dummy_user(user_profile, acting_user=user_profile)
             do_change_password(user_profile, password)
             do_change_full_name(user_profile, full_name, user_profile)
-            do_set_user_display_setting(user_profile, "timezone", timezone)
+            do_change_user_setting(user_profile, "timezone", timezone)
             # TODO: When we clean up the `do_activate_mirror_dummy_user` code path,
             # make it respect invited_as_admin / is_realm_admin.
 

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -24,8 +24,8 @@ from zerver.lib.actions import (
     do_change_notification_settings,
     do_change_password,
     do_change_user_delivery_email,
+    do_change_user_setting,
     do_regenerate_api_key,
-    do_set_user_display_setting,
     do_start_email_change_process,
     get_available_notification_sounds,
 )
@@ -266,7 +266,7 @@ def json_change_settings(
     }
     for k, v in list(request_settings.items()):
         if v is not None and getattr(user_profile, k) != v:
-            do_set_user_display_setting(user_profile, k, v)
+            do_change_user_setting(user_profile, k, v)
 
     req_vars = {
         k: v for k, v in list(locals().items()) if k in user_profile.notification_setting_types
@@ -277,7 +277,7 @@ def json_change_settings(
             do_change_notification_settings(user_profile, k, v, acting_user=user_profile)
 
     if timezone is not None and user_profile.timezone != timezone:
-        do_set_user_display_setting(user_profile, "timezone", timezone)
+        do_change_user_setting(user_profile, "timezone", timezone)
 
     # TODO: Do this more generally.
     from zerver.lib.request import RequestNotes

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -259,7 +259,11 @@ def json_change_settings(
             check_change_full_name(user_profile, full_name, user_profile)
 
     # Loop over user_profile.property_types
-    request_settings = {k: v for k, v in list(locals().items()) if k in user_profile.property_types}
+    request_settings = {
+        k: v
+        for k, v in list(locals().items())
+        if k in user_profile.property_types and k not in user_profile.notification_setting_types
+    }
     for k, v in list(request_settings.items()):
         if v is not None and getattr(user_profile, k) != v:
             do_set_user_display_setting(user_profile, k, v)


### PR DESCRIPTION
Since 84742a0, all settings are sent in `user_settings`
dictionary which were previously sent inline with other
fields in /register response. We want to be able to
distinguish the previous legacy settings from the new
ones we'll add by storing them all in `property_types`
which can used to aggregate all the settings to be sent
in `user_settings` dictionary and the `_legacy` ones
could be used to send them inline with other values
if client doesn't have `user_settings_object` client
capability.

See https://chat.zulip.org/#narrow/stream/378-api-design/topic/user.20settings.20response.20in.20.2Fregister
to understand this better.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->
automated tests
