### PR TITLE
filter: Show typeahead suggestions if search query has search filters.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -944,15 +944,17 @@ test("parse", () => {
 
     string = "text stream:foo more text";
     operators = [
+        {operator: "search", operand: "text"},
         {operator: "stream", operand: "foo"},
-        {operator: "search", operand: "text more text"},
+        {operator: "search", operand: "more text"},
     ];
     _test();
 
     string = "text streams:public more text";
     operators = [
+        {operator: "search", operand: "text"},
         {operator: "streams", operand: "public"},
-        {operator: "search", operand: "text more text"},
+        {operator: "search", operand: "more text"},
     ];
     _test();
 
@@ -973,15 +975,17 @@ test("parse", () => {
 
     string = ":stream: stream:foo :emoji: are cool";
     operators = [
+        {operator: "search", operand: ":stream:"},
         {operator: "stream", operand: "foo"},
-        {operator: "search", operand: ":stream: :emoji: are cool"},
+        {operator: "search", operand: ":emoji: are cool"},
     ];
     _test();
 
     string = ":stream: stream:foo -:emoji: are cool";
     operators = [
+        {operator: "search", operand: ":stream:"},
         {operator: "stream", operand: "foo"},
-        {operator: "search", operand: ":stream: -:emoji: are cool"},
+        {operator: "search", operand: "-:emoji: are cool"},
     ];
     _test();
 

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -982,6 +982,6 @@ test("multiple_operators_without_pills", () => {
     query = "abc is:alerted sender:ted@zulip.com";
     base_query = "";
     suggestions = get_suggestions(base_query, query);
-    expected = ["is:alerted sender:ted@zulip.com abc"];
+    expected = ["abc is:alerted sender:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 });

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -292,7 +292,7 @@ export class Filter {
     // Parse a string into a list of operators (see below).
     static parse(str) {
         const operators = [];
-        const search_term = [];
+        let search_term = [];
         let negated;
         let operator;
         let operand;
@@ -304,6 +304,7 @@ export class Filter {
                 const _operand = search_term.join(" ");
                 term = {operator, operand: _operand, negated: false};
                 operators.push(term);
+                search_term = [];
             }
         }
 
@@ -339,12 +340,16 @@ export class Filter {
                     search_term.push(token);
                     continue;
                 }
+                // If any search query was present and it is followed by some other filters
+                // then we must add that search filter in its current position in the
+                // operators list. This is done so that the last active filter is correctly
+                // detected by the `get_search_result` function (in search_suggestions.js).
+                maybe_add_search_terms();
                 term = {negated, operator, operand};
                 operators.push(term);
             }
         }
 
-        // NB: Callers of 'parse' can assume that the 'search' operator is last.
         maybe_add_search_terms();
         return operators;
     }

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -298,6 +298,15 @@ export class Filter {
         let operand;
         let term;
 
+        function maybe_add_search_terms() {
+            if (search_term.length > 0) {
+                operator = "search";
+                const _operand = search_term.join(" ");
+                term = {operator, operand: _operand, negated: false};
+                operators.push(term);
+            }
+        }
+
         // Match all operands that either have no spaces, or are surrounded by
         // quotes, preceded by an optional operator that may have a space after it.
         const matches = str.match(/([^\s:]+: ?)?("[^"]+"?|\S+)/g);
@@ -336,12 +345,7 @@ export class Filter {
         }
 
         // NB: Callers of 'parse' can assume that the 'search' operator is last.
-        if (search_term.length > 0) {
-            operator = "search";
-            operand = search_term.join(" ");
-            term = {operator, operand, negated: false};
-            operators.push(term);
-        }
+        maybe_add_search_terms();
         return operators;
     }
 


### PR DESCRIPTION
In message header search bar, users didn't use to get any typeahead
suggestions if a normal filter follows search filter.

E.g.: query => foo bar stream:D

In the above case, users didn't use to get any typeahead suggestions.
This was because we had set that the callers of 'parse' function can
assume that the 'search' operator is present in the last in the query.
Because of which `get_search_result` function (in search_suggestion.js)
didn't use to show any typeahead suggestions as it used to assume that
the latest typed query is for search filters.

Fixes part of #19435.

**Testing plan:** <!-- How have you tested? -->

Modified existing test cases.


