### PR TITLE
docs: Add /help/ page about Zulip Cloud org data deletion.

### DIFF
--- a/templates/zerver/help/delete-all-organization-data.md
+++ b/templates/zerver/help/delete-all-organization-data.md
@@ -1,0 +1,12 @@
+# Delete your organization's data
+
+Upon request by all owners of an organization hosted on Zulip Cloud,
+we can delete all organization data, including user accounts and information
+as well as messages. Please note that we have to preserve:
+
+* Old logs related to the organization
+* Billing history (if any)
+* The support ticket for handling your deletion request and related internal communications
+
+If you'd like us to delete your organization's data, contact [support@zulip.com](mailto:support@zulip.com).
+

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -122,6 +122,7 @@
 * [Export your organization](/help/export-your-organization)
 * [Change organization URL](/help/change-organization-url)
 * [Deactivate your organization](/help/deactivate-your-organization)
+* [Delete your organization's data](/help/delete-all-organization-data)
 * [GDPR compliance](/help/gdpr-compliance)
 
 ## Organization settings


### PR DESCRIPTION
It was mentioned a while back that we should write a help page about, so here's a short first draft.