### PR TITLE
Added a "Skip navigation" link on the /help and /api route

### DIFF
--- a/docs/git/using.md
+++ b/docs/git/using.md
@@ -48,6 +48,7 @@ from Zulip's main repositories.
 projects. With Zulip, because we don't use merge commits, you'll want to avoid
 it. Rather than using `git pull`, which by default is a shortcut for `git fetch
 && git merge FETCH_HEAD` ([docs][gitbook-git-pull]), you should use `git fetch`
+
 and then `git rebase`.
 
 First, [fetch][gitbook-fetch] changes from Zulip's upstream repository you

--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -6,11 +6,12 @@ import * as common from "../common";
 import * as google_analytics from "./google-analytics";
 import {activate_correct_tab} from "./tabbed-instructions";
 
+
+
 function registerCodeSection($codeSection) {
     const $li = $codeSection.find("ul.nav li");
     const $blocks = $codeSection.find(".blocks div");
 	const $skiplink = $codeSection.find(".skip-link");
-	console.log("Here");
 	$skiplink.addClass("active");
 
     $li.on("click", function () {
@@ -26,7 +27,7 @@ function registerCodeSection($codeSection) {
     $li.on("keydown", (e) => {
         if (e.key === "Enter") {
             e.target.click();
-        }
+		}
     });
 }
 
@@ -54,10 +55,11 @@ function highlight_current_article() {
 }
 
 function render_code_sections() {
-    $(".code-section").each(function () {
+	if(parent.location.hash !== "") parent.location.hash = "";
+	$(".code-section").each(function () {
         activate_correct_tab($(this));
         registerCodeSection($(this));
-    });
+	});
 
     highlight_current_article();
 
@@ -119,7 +121,7 @@ new SimpleBar($(".sidebar")[0]);
 
 $(".sidebar a").on("click", function (e) {
     const path = $(this).attr("href");
-    const path_dir = path.split("/")[1];
+	const path_dir = path.split("/")[1];
     const current_dir = window.location.pathname.split("/")[1];
 
     // Do not block redirecting to external URLs
@@ -183,5 +185,4 @@ window.addEventListener("popstate", () => {
 });
 
 $("body").addClass("noscroll");
-
 $(".highlighted")[0].scrollIntoView({block: "center"});

--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -11,6 +11,8 @@ import {activate_correct_tab} from "./tabbed-instructions";
 function registerCodeSection($codeSection) {
     const $li = $codeSection.find("ul.nav li");
     const $blocks = $codeSection.find(".blocks div");
+	
+	// Activating skip-link 
 	const $skiplink = $codeSection.find(".skip-link");
 	$skiplink.addClass("active");
 
@@ -55,7 +57,7 @@ function highlight_current_article() {
 }
 
 function render_code_sections() {
-	if(parent.location.hash !== "") parent.location.hash = "";
+	if(parent.location.hash !== "") parent.location.hash = ""; // Removing the hash after the string
 	$(".code-section").each(function () {
         activate_correct_tab($(this));
         registerCodeSection($(this));

--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -9,6 +9,9 @@ import {activate_correct_tab} from "./tabbed-instructions";
 function registerCodeSection($codeSection) {
     const $li = $codeSection.find("ul.nav li");
     const $blocks = $codeSection.find(".blocks div");
+	const $skiplink = $codeSection.find(".skip-link");
+	console.log("Here");
+	$skiplink.addClass("active");
 
     $li.on("click", function () {
         const language = this.dataset.language;
@@ -47,7 +50,7 @@ function highlight_current_article() {
     // Highlight current article link and the heading of the same
     article.closest("ul").css("display", "block");
     article.addClass("highlighted");
-    article.attr("tabindex", "-1");
+    article.attr("tabindex", "1");
 }
 
 function render_code_sections() {

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -237,12 +237,10 @@ html {
             font-weight: 400;
             line-height: 1.8;
             cursor: pointer;
-
             a {
                 color: inherit;
                 display: block;
             	padding: 1px 4px;
-
 			}
         }
 

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -235,14 +235,15 @@ html {
             list-style-type: none;
             font-size: 0.95em;
             font-weight: 400;
-            line-height: 1.7;
-
+            line-height: 1.8;
             cursor: pointer;
 
             a {
                 color: inherit;
                 display: block;
-            }
+            	padding: 1px 4px;
+
+			}
         }
 
         a {
@@ -701,6 +702,33 @@ input.text-error {
 .portico-page-container .portico-header .dropdown-pill .realm-name {
     margin-left: -3px;
 }
+
+.skip-link {
+	background: #68b190 ;
+	top : -100px;
+	left : 300px;
+	position : absolute;
+	margin-left: 5px;
+	overflow : hidden;
+	border-radius : 6px;
+	padding : 6px 10px;
+	cursor : pointer;
+	color : #ffffff;
+	font-size : 18px;
+	font-weight: bold;
+	outline : 5px auto #40966e;
+	&:focus{
+		z-index : 5000;
+		transition : ease-in-out 0.3s;
+		top : -3px;
+		width : auto;
+		height : 25px;
+		outline : 5px auto #40966e;	
+		color : #FFFFFF;
+	}
+
+}
+
 
 .app {
     width: 100%;

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -22,13 +22,12 @@
     </svg>
 
     <div class="markdown">
-        <div class="content">
+		<div class="content" id="skip-link-nav">
             {{ render_markdown_path(article, api_uri_context) }}
-
-            <div id="footer" class="documentation-footer">
-                <hr />
-                <p>We're here to help! Email us at <a href="mailto:{{ support_email }}">{{ support_email }}</a> with questions, feedback, or feature requests.</p>
-            </div>
+        <div id="footer" class="documentation-footer">
+            <hr />
+            <p>We're here to help! Email us at <a href="mailto:{{ support_email }}">{{ support_email }}</a> with questions, feedback, or feature requests.</p>
+        </div>
         </div>
     </div>
 </div>

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -24,10 +24,10 @@
     <div class="markdown">
 		<div class="content" id="skip-link-nav">
             {{ render_markdown_path(article, api_uri_context) }}
-        <div id="footer" class="documentation-footer">
-            <hr />
-            <p>We're here to help! Email us at <a href="mailto:{{ support_email }}">{{ support_email }}</a> with questions, feedback, or feature requests.</p>
-        </div>
+        	<div id="footer" class="documentation-footer">
+            	<hr />
+            	<p>We're here to help! Email us at <a href="mailto:{{ support_email }}">{{ support_email }}</a> with questions, feedback, or feature requests.</p>
+        	</div>
         </div>
     </div>
 </div>

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -1,7 +1,12 @@
 <div class="header portico-header">
     <div class="header-main" id="top_navbar">
         
-		<!-- Adding skip link for better navigation and less scrolling -->
+		<!-- 
+	  	Adding skip link for better navigation and less scrolling 
+		On the press of tab a button will appear and on the press of enter 
+		it will take to the top of the page.
+		in /help and /api
+		-->
 		{% if page_is_help_center or page_is_api_center %}
 		<a class="skip-link" href="#skip-link-nav" tabindex="0">Skip To Main Content </a>	
 		{% endif %}

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -1,8 +1,14 @@
 <div class="header portico-header">
     <div class="header-main" id="top_navbar">
-        <div class="float-left">
+        
+		<!-- Adding skip link for better navigation and less scrolling -->
+		{% if page_is_help_center or page_is_api_center %}
+		<a class="skip-link" href='#skip-link-nav' tabindex="0">Skip To Main Content </a>
+		{% endif %}
+
+		<div class="float-left">
             {% if custom_logo_url %}
-            <a class="brand logo" href="{{ root_domain_uri }}/"><img draggable="false" src="{{ custom_logo_url }}" class="portico-logo" alt="{{ _('Zulip') }}" content="Zulip" /></a>
+			<a class="brand logo" href="{{ root_domain_uri }}/"><img draggable="false" src="{{ custom_logo_url }}" class="portico-logo" alt="{{ _('Zulip') }}"  content="Zulip" /></a>
             {% else %}
             <div class="brand logo">
                 <a href="{{ root_domain_uri }}/">
@@ -12,7 +18,7 @@
                 </a>
 
                 {% if page_is_help_center %}
-                <span class="light"> | <a href="{{ root_domain_uri }}/help/">{{ doc_root_title }}</a></span>
+				<span class="light"> | <a tabindex="-1" href="{{ root_domain_uri }}/help/">{{ doc_root_title }}</a></span>
                 {% endif %}
                 {% if page_is_api_center %}
                 <span class="light"> | <a href="{{ root_domain_uri }}/api/">{{ doc_root_title }}</a></span>

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -3,7 +3,7 @@
         
 		<!-- Adding skip link for better navigation and less scrolling -->
 		{% if page_is_help_center or page_is_api_center %}
-		<a class="skip-link" href='#skip-link-nav' tabindex="0">Skip To Main Content </a>
+		<a class="skip-link" href="#skip-link-nav" tabindex="0">Skip To Main Content </a>	
 		{% endif %}
 
 		<div class="float-left">


### PR DESCRIPTION
PR for the issue #15948 

**I have added the following changes.**
- When pressed tab the button appears from the top
- And when we press enter, it takes us to top of the page.
- I have remove the hash in URL after we press enter.

Please review the commit and suggest the changes. This is my first issue.

![image](https://user-images.githubusercontent.com/51414879/129312684-1259ca76-7203-4b32-bd57-c48e8852898c.png)
