### PR TITLE
templates: Fix footer links on /plans

### DIFF
--- a/templates/zerver/compare.html
+++ b/templates/zerver/compare.html
@@ -1,5 +1,4 @@
 <div class="compare">
-    {% include 'zerver/gradients.html' %}
     <div class="padded-content">
         <div class="text-header">
             <div class="text-content">


### PR DESCRIPTION
The footer was being covered by a bunch of invisible divs, rendering most of the links non-functional.