### PR TITLE
django-stubs: Fix typing for mypy errors discovered with django-stubs.

### DIFF
--- a/zerver/filters.py
+++ b/zerver/filters.py
@@ -7,7 +7,9 @@ from django.views.debug import SafeExceptionReporterFilter
 
 class ZulipExceptionReporterFilter(SafeExceptionReporterFilter):
     def get_post_parameters(self, request: HttpRequest) -> Dict[str, Any]:
-        filtered_post = SafeExceptionReporterFilter.get_post_parameters(self, request).copy()
+        post_data = SafeExceptionReporterFilter.get_post_parameters(self, request)
+        assert isinstance(post_data, dict)
+        filtered_post = post_data.copy()
         filtered_vars = [
             "content",
             "secret",

--- a/zerver/filters.py
+++ b/zerver/filters.py
@@ -1,12 +1,12 @@
 import re
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from django.http import HttpRequest
 from django.views.debug import SafeExceptionReporterFilter
 
 
 class ZulipExceptionReporterFilter(SafeExceptionReporterFilter):
-    def get_post_parameters(self, request: HttpRequest) -> Dict[str, Any]:
+    def get_post_parameters(self, request: Optional[HttpRequest]) -> Dict[str, Any]:
         post_data = SafeExceptionReporterFilter.get_post_parameters(self, request)
         assert isinstance(post_data, dict)
         filtered_post = post_data.copy()

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2924,7 +2924,7 @@ def check_update_message(
     message_id: int,
     stream_id: Optional[int] = None,
     topic_name: Optional[str] = None,
-    propagate_mode: Optional[str] = "change_one",
+    propagate_mode: str = "change_one",
     send_notification_to_old_thread: bool = True,
     send_notification_to_new_thread: bool = True,
     content: Optional[str] = None,

--- a/zerver/lib/avatar_hash.py
+++ b/zerver/lib/avatar_hash.py
@@ -24,6 +24,7 @@ def user_avatar_hash(uid: str) -> str:
     # The salt probably doesn't serve any purpose now.  In the past we
     # used a hash of the email address, not the user ID, and we salted
     # it in order to make the hashing scheme different from Gravatar's.
+    assert settings.AVATAR_SALT is not None
     user_key = uid + settings.AVATAR_SALT
     return make_safe_digest(user_key, hashlib.sha1)
 

--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Collection, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Any, Collection, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
 
 from django.db.models import Model
 
@@ -97,7 +97,7 @@ def bulk_create_users(
 
 
 def bulk_set_users_or_streams_recipient_fields(
-    model: Model,
+    model: Type[Model],
     objects: Union[Collection[UserProfile], Collection[Stream]],
     recipients: Optional[Iterable[Recipient]] = None,
 ) -> None:

--- a/zerver/lib/fix_unreads.py
+++ b/zerver/lib/fix_unreads.py
@@ -1,13 +1,10 @@
 import logging
 import time
-from typing import Callable, List, TypeVar
-
-from psycopg2.extensions import cursor
-from psycopg2.sql import SQL
-
-CursorObj = TypeVar("CursorObj", bound=cursor)
+from typing import Callable, List
 
 from django.db import connection
+from django.db.backends.utils import CursorWrapper
+from psycopg2.sql import SQL
 
 from zerver.models import UserProfile
 
@@ -23,7 +20,7 @@ logger.setLevel(logging.WARNING)
 
 
 def build_topic_mute_checker(
-    cursor: CursorObj, user_profile: UserProfile
+    cursor: CursorWrapper, user_profile: UserProfile
 ) -> Callable[[int, str], bool]:
     """
     This function is similar to the function of the same name
@@ -52,7 +49,7 @@ def build_topic_mute_checker(
     return is_muted
 
 
-def update_unread_flags(cursor: CursorObj, user_message_ids: List[int]) -> None:
+def update_unread_flags(cursor: CursorWrapper, user_message_ids: List[int]) -> None:
     query = SQL(
         """
         UPDATE zerver_usermessage
@@ -72,7 +69,7 @@ def get_timing(message: str, f: Callable[[], None]) -> None:
     logger.info("elapsed time: %.03f\n", elapsed)
 
 
-def fix_unsubscribed(cursor: CursorObj, user_profile: UserProfile) -> None:
+def fix_unsubscribed(cursor: CursorWrapper, user_profile: UserProfile) -> None:
 
     recipient_ids = []
 

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -234,6 +234,7 @@ def build_page_params_for_home_page_load(
             page_params["narrow_topic"] = narrow_topic
         page_params["narrow"] = [dict(operator=term[0], operand=term[1]) for term in narrow]
         page_params["max_message_id"] = max_message_id
+        assert isinstance(page_params["user_settings"], dict)
         page_params["user_settings"]["enable_desktop_notifications"] = False
 
     page_params["translation_data"] = get_language_translation_data(request_language)

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -827,6 +827,7 @@ def import_uploads(
                 ExtraArgs={"ContentType": content_type, "Metadata": metadata},
             )
         else:
+            assert settings.LOCAL_UPLOADS_DIR is not None
             if processing_avatars or processing_emojis or processing_realm_icons:
                 file_path = os.path.join(settings.LOCAL_UPLOADS_DIR, "avatars", relative_path)
             else:

--- a/zerver/lib/management.py
+++ b/zerver/lib/management.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from django.conf import settings
 from django.core.exceptions import MultipleObjectsReturned
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand, CommandError, CommandParser
 
 from zerver.models import Client, Realm, UserProfile, get_client
 
@@ -33,8 +33,8 @@ def check_config() -> None:
 class ZulipBaseCommand(BaseCommand):
 
     # Fix support for multi-line usage
-    def create_parser(self, *args: Any, **kwargs: Any) -> ArgumentParser:
-        parser = super().create_parser(*args, **kwargs)
+    def create_parser(self, prog_name: str, subcommand: str, **kwargs: Any) -> CommandParser:
+        parser = super().create_parser(prog_name, subcommand, **kwargs)
         parser.formatter_class = RawTextHelpFormatter
         return parser
 

--- a/zerver/lib/migrate.py
+++ b/zerver/lib/migrate.py
@@ -1,14 +1,12 @@
 import time
-from typing import List, TypeVar
+from typing import List
 
-from psycopg2.extensions import cursor
+from django.db.backends.utils import CursorWrapper
 from psycopg2.sql import SQL, Composable, Identifier
-
-CursorObj = TypeVar("CursorObj", bound=cursor)
 
 
 def do_batch_update(
-    cursor: CursorObj,
+    cursor: CursorWrapper,
     table: str,
     assignments: List[Composable],
     batch_size: int = 10000,

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -105,6 +105,7 @@ def send_initial_pms(user: UserProfile) -> None:
 def send_welcome_bot_response(send_request: SendMessageRequest) -> None:
     welcome_bot = get_system_bot(settings.WELCOME_BOT, send_request.message.sender.realm_id)
     human_recipient_id = send_request.message.sender.recipient_id
+    assert human_recipient_id is not None
     if Message.objects.filter(sender=welcome_bot, recipient_id=human_recipient_id).count() < 2:
         content = (
             _("Congratulations on your first reply!") + " "

--- a/zerver/lib/presence.py
+++ b/zerver/lib/presence.py
@@ -2,7 +2,7 @@ import datetime
 import itertools
 import time
 from collections import defaultdict
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, Mapping, Sequence, Set
 
 from django.utils.timezone import now as timezone_now
 
@@ -11,7 +11,7 @@ from zerver.models import PushDeviceToken, Realm, UserPresence, UserProfile, que
 
 
 def get_status_dicts_for_rows(
-    all_rows: List[Dict[str, Any]], mobile_user_ids: Set[int], slim_presence: bool
+    all_rows: Sequence[Mapping[str, Any]], mobile_user_ids: Set[int], slim_presence: bool
 ) -> Dict[str, Dict[str, Any]]:
 
     # Note that datetime values have sub-second granularity, which is
@@ -46,7 +46,7 @@ def get_status_dicts_for_rows(
 
 
 def get_modern_user_info(
-    presence_rows: List[Dict[str, Any]], mobile_user_ids: Set[int]
+    presence_rows: Sequence[Mapping[str, Any]], mobile_user_ids: Set[int]
 ) -> Dict[str, Any]:
 
     active_timestamp = None
@@ -76,7 +76,7 @@ def get_modern_user_info(
 
 
 def get_legacy_user_info(
-    presence_rows: List[Dict[str, Any]], mobile_user_ids: Set[int]
+    presence_rows: Sequence[Mapping[str, Any]], mobile_user_ids: Set[int]
 ) -> Dict[str, Any]:
 
     # The format of data here is for legacy users of our API,

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -6,7 +6,7 @@ import logging
 import re
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 import gcm
 import lxml.html
@@ -26,6 +26,7 @@ from zerver.lib.remote_server import send_json_to_push_bouncer, send_to_push_bou
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.user_groups import access_user_group_by_id
 from zerver.models import (
+    AbstractPushDeviceToken,
     ArchivedMessage,
     Message,
     NotificationTriggers,
@@ -149,7 +150,7 @@ def send_apple_push_notification(
 
     if remote:
         assert settings.ZILENCER_ENABLED
-        DeviceTokenClass = RemotePushDeviceToken
+        DeviceTokenClass: Type[AbstractPushDeviceToken] = RemotePushDeviceToken
     else:
         DeviceTokenClass = PushDeviceToken
 
@@ -336,7 +337,7 @@ def send_android_push_notification(
 
     if remote:
         assert settings.ZILENCER_ENABLED
-        DeviceTokenClass = RemotePushDeviceToken
+        DeviceTokenClass: Type[AbstractPushDeviceToken] = RemotePushDeviceToken
     else:
         DeviceTokenClass = PushDeviceToken
 

--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -17,7 +17,7 @@ from pika.channel import Channel
 from pika.spec import Basic
 from tornado import ioloop
 
-from zerver.lib.utils import statsd
+from zerver.lib.utils import assert_is_not_none, statsd
 
 MAX_REQUEST_RETRIES = 3
 ChannelT = TypeVar("ChannelT", Channel, BlockingChannel)
@@ -50,7 +50,9 @@ class QueueClient(Generic[ChannelT], metaclass=ABCMeta):
         raise NotImplementedError
 
     def _get_parameters(self) -> pika.ConnectionParameters:
-        credentials = pika.PlainCredentials(settings.RABBITMQ_USERNAME, settings.RABBITMQ_PASSWORD)
+        credentials = pika.PlainCredentials(
+            settings.RABBITMQ_USERNAME, assert_is_not_none(settings.RABBITMQ_PASSWORD)
+        )
 
         # With BlockingConnection, we are passed
         # self.rabbitmq_heartbeat=0, which asks to explicitly disable

--- a/zerver/lib/remote_server.py
+++ b/zerver/lib/remote_server.py
@@ -45,6 +45,7 @@ def send_to_push_bouncer(
       vs. client-side errors like an invalid token.
 
     """
+    assert settings.PUSH_NOTIFICATION_BOUNCER_URL is not None
     url = urllib.parse.urljoin(
         settings.PUSH_NOTIFICATION_BOUNCER_URL, "/api/v1/remotes/" + endpoint
     )

--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -29,7 +29,7 @@
 import logging
 import time
 from datetime import timedelta
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, Union
 
 from django.conf import settings
 from django.db import connection, transaction
@@ -92,7 +92,7 @@ models_with_message_key: List[Dict[str, Any]] = [
 
 @transaction.atomic(savepoint=False)
 def move_rows(
-    base_model: Model,
+    base_model: Type[Model],
     raw_query: SQL,
     *,
     src_db_table: Optional[str] = None,

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -297,6 +297,7 @@ class HostRequestMock(HttpRequest):
         client_name: Optional[str] = None,
         meta_data: Optional[Dict[str, Any]] = None,
         tornado_handler: Optional[AsyncDjangoHandler] = DummyHandler(),
+        path: str = "",
     ) -> None:
         self.host = host
         self.GET = QueryDict(mutable=True)
@@ -315,7 +316,7 @@ class HostRequestMock(HttpRequest):
             self.META = {"PATH_INFO": "test"}
         else:
             self.META = meta_data
-        self.path = ""
+        self.path = path
         self.user = user_profile
         self._body = b""
         self.content_type = ""

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -297,7 +297,7 @@ class Runner(DiscoverRunner):
         self.shallow_tested_templates: Set[str] = set()
         template_rendered.connect(self.on_template_rendered)
 
-    def get_resultclass(self) -> Type[TestResult]:
+    def get_resultclass(self) -> Optional[Type[TextTestResult]]:
         return TextTestResult
 
     def on_template_rendered(self, sender: Any, context: Dict[str, Any], **kwargs: Any) -> None:

--- a/zerver/management/commands/add_users_to_streams.py
+++ b/zerver/management/commands/add_users_to_streams.py
@@ -17,7 +17,7 @@ class Command(ZulipBaseCommand):
             "-s", "--streams", required=True, help="A comma-separated list of stream names."
         )
 
-    def handle(self, **options: Any) -> None:
+    def handle(self, *args: Any, **options: Any) -> None:
         realm = self.get_realm(options)
         assert realm is not None  # Should be ensured by parser
 

--- a/zerver/management/commands/backup.py
+++ b/zerver/management/commands/backup.py
@@ -5,6 +5,7 @@ from argparse import ArgumentParser, RawTextHelpFormatter
 from typing import Any
 
 from django.conf import settings
+from django.core.management.base import CommandParser
 from django.db import connection
 from django.utils.timezone import now as timezone_now
 
@@ -16,8 +17,8 @@ from zerver.logging_handlers import try_git_describe
 
 class Command(ZulipBaseCommand):
     # Fix support for multi-line usage strings
-    def create_parser(self, *args: Any, **kwargs: Any) -> ArgumentParser:
-        parser = super().create_parser(*args, **kwargs)
+    def create_parser(self, prog_name: str, subcommand: str, **kwargs: Any) -> CommandParser:
+        parser = super().create_parser(prog_name, subcommand, **kwargs)
         parser.formatter_class = RawTextHelpFormatter
         return parser
 

--- a/zerver/management/commands/compilemessages.py
+++ b/zerver/management/commands/compilemessages.py
@@ -12,7 +12,7 @@ from django.core.management.base import CommandParser
 from django.core.management.commands import compilemessages
 from django.utils.translation import gettext as _
 from django.utils.translation import override as override_language
-from django.utils.translation.trans_real import to_language
+from django.utils.translation import to_language
 from pyuca import Collator
 
 

--- a/zerver/management/commands/makemessages.py
+++ b/zerver/management/commands/makemessages.py
@@ -37,9 +37,9 @@ import json
 import os
 import re
 import subprocess
-from argparse import ArgumentParser
 from typing import Any, Collection, Dict, Iterator, List, Mapping
 
+from django.core.management.base import CommandParser
 from django.core.management.commands import makemessages
 from django.template.base import BLOCK_TAG_END, BLOCK_TAG_START
 from django.utils.translation import template
@@ -80,7 +80,7 @@ class Command(makemessages.Command):
     for func, tag in tags:
         xgettext_options += [f'--keyword={func}:1,"{tag}"']
 
-    def add_arguments(self, parser: ArgumentParser) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         parser.add_argument(
             "--frontend-source",

--- a/zerver/management/commands/register_server.py
+++ b/zerver/management/commands/register_server.py
@@ -30,7 +30,7 @@ class Command(ZulipBaseCommand):
             help="Automatically rotate your server's zulip_org_key",
         )
 
-    def handle(self, **options: Any) -> None:
+    def handle(self, *args: Any, **options: Any) -> None:
         if not settings.DEVELOPMENT:
             check_config()
 

--- a/zerver/management/commands/remove_users_from_stream.py
+++ b/zerver/management/commands/remove_users_from_stream.py
@@ -18,7 +18,7 @@ class Command(ZulipBaseCommand):
             parser, all_users_help="Remove all users in realm from this stream."
         )
 
-    def handle(self, **options: Any) -> None:
+    def handle(self, *args: Any, **options: Any) -> None:
         realm = self.get_realm(options)
         assert realm is not None  # Should be ensured by parser
         user_profiles = self.get_users(options, realm)

--- a/zerver/management/commands/restore_messages.py
+++ b/zerver/management/commands/restore_messages.py
@@ -49,7 +49,7 @@ To restore a specific ArchiveTransaction:
             "(Does not restore manually deleted messages.)",
         )
 
-    def handle(self, **options: Any) -> None:
+    def handle(self, *args: Any, **options: Any) -> None:
         realm = self.get_realm(options)
         if realm:
             restore_data_from_archive_by_realm(realm)

--- a/zerver/management/commands/runtornado.py
+++ b/zerver/management/commands/runtornado.py
@@ -47,8 +47,10 @@ class Command(BaseCommand):
             help="[port number or ipaddr:port]",
         )
 
-    def handle(self, addrport: str, **options: bool) -> None:
+    def handle(self, *args: Any, **options: Any) -> None:
         interactive_debug_listen()
+        addrport = options["addrport"]
+        assert isinstance(addrport, str)
 
         import django
         from tornado import httpserver

--- a/zerver/management/commands/runtornado.py
+++ b/zerver/management/commands/runtornado.py
@@ -44,9 +44,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "addrport",
-            nargs="?",
-            help="[optional port number or ipaddr:port]\n "
-            "(use multiple ports to start multiple servers)",
+            help="[port number or ipaddr:port]",
         )
 
     def handle(self, addrport: str, **options: bool) -> None:

--- a/zerver/management/commands/send_to_email_mirror.py
+++ b/zerver/management/commands/send_to_email_mirror.py
@@ -3,7 +3,7 @@ import email
 import email.policy
 import os
 from email.message import EmailMessage
-from typing import Optional
+from typing import Any, Optional
 
 import orjson
 from django.conf import settings
@@ -54,7 +54,7 @@ Example:
 
         self.add_realm_args(parser, help="Specify which realm to connect to; default is zulip")
 
-    def handle(self, **options: Optional[str]) -> None:
+    def handle(self, *args: Any, **options: Optional[str]) -> None:
         if options["fixture"] is None:
             self.print_help("./manage.py", "send_to_email_mirror")
             raise CommandError

--- a/zerver/management/commands/send_webhook_fixture_message.py
+++ b/zerver/management/commands/send_webhook_fixture_message.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import orjson
 from django.conf import settings
@@ -61,7 +61,7 @@ approach shown above.
             )
         return standardize_headers(custom_headers_dict)
 
-    def handle(self, **options: Optional[str]) -> None:
+    def handle(self, *args: Any, **options: Optional[str]) -> None:
         if options["fixture"] is None or options["url"] is None:
             self.print_help("./manage.py", "send_webhook_fixture_message")
             raise CommandError
@@ -84,7 +84,7 @@ approach shown above.
                 json,
                 content_type="application/json",
                 HTTP_HOST=realm.host,
-                **headers,
+                extra=headers,
             )
         else:
             result = client.post(

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -75,6 +75,7 @@ from zerver.models import (
 
 
 def destroy_uploads() -> None:
+    assert settings.LOCAL_UPLOADS_DIR is not None
     if os.path.exists(settings.LOCAL_UPLOADS_DIR):
         shutil.rmtree(settings.LOCAL_UPLOADS_DIR)
 
@@ -833,6 +834,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
                 fp_path = os.path.split(fp_path_id)[0]
                 response = self.client_get(uri)
                 _get_sendfile.cache_clear()
+                assert settings.LOCAL_UPLOADS_DIR is not None
                 test_run, worker = os.path.split(os.path.dirname(settings.LOCAL_UPLOADS_DIR))
                 self.assertEqual(
                     response["X-Accel-Redirect"],
@@ -1679,6 +1681,7 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
             emoji_file_name=file_name,
         )
 
+        assert settings.LOCAL_UPLOADS_DIR is not None
         file_path = os.path.join(settings.LOCAL_UPLOADS_DIR, "avatars", emoji_path)
         with get_test_image_file("img.png") as image_file, open(
             file_path + ".original", "rb"

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -46,6 +46,7 @@ from zerver.lib.test_helpers import (
 from zerver.lib.topic_mutes import add_topic_mute
 from zerver.lib.upload import upload_avatar_image
 from zerver.lib.users import Accounts, access_user_by_id, get_accounts_for_email, user_ids_to_users
+from zerver.lib.utils import assert_is_not_none
 from zerver.models import (
     CustomProfileField,
     InvalidFakeEmailDomain,
@@ -324,7 +325,7 @@ class PermissionTest(ZulipTestCase):
             "zerver.lib.events.request_event_queue", return_value=None
         ) as mock_request_event_queue:
             with self.assertRaises(JsonableError):
-                result = do_events_register(user, get_client("website"), client_gravatar=True)
+                do_events_register(user, get_client("website"), client_gravatar=True)
             self.assertEqual(mock_request_event_queue.call_args_list[0][0][3], False)
 
         # client_gravatar is still turned off for admins.  In theory,
@@ -1410,7 +1411,7 @@ class ActivateTest(ZulipTestCase):
         )
         self.assertEqual(ScheduledEmail.objects.count(), 1)
         email = ScheduledEmail.objects.all().first()
-        deliver_scheduled_emails(email)
+        deliver_scheduled_emails(assert_is_not_none(email))
         from django.core.mail import outbox
 
         self.assert_length(outbox, 1)
@@ -1741,7 +1742,7 @@ class BulkUsersTest(ZulipTestCase):
         """
         self.assertIn(
             "gravatar.com",
-            get_hamlet_avatar(client_gravatar=False),
+            assert_is_not_none(get_hamlet_avatar(client_gravatar=False)),
         )
 
 

--- a/zerver/tests/test_webhooks_common.py
+++ b/zerver/tests/test_webhooks_common.py
@@ -3,6 +3,7 @@ from typing import Dict
 from unittest.mock import MagicMock, patch
 
 from django.http import HttpRequest
+from django.http.response import HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.actions import do_rename_stream
@@ -61,11 +62,11 @@ class WebhooksCommonTestCase(ZulipTestCase):
 
     def test_notify_bot_owner_on_invalid_json(self) -> None:
         @webhook_view("ClientName", notify_bot_owner_on_invalid_json=False)
-        def my_webhook_no_notify(request: HttpRequest, user_profile: UserProfile) -> None:
+        def my_webhook_no_notify(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
             raise InvalidJSONError("Malformed JSON")
 
         @webhook_view("ClientName", notify_bot_owner_on_invalid_json=True)
-        def my_webhook_notify(request: HttpRequest, user_profile: UserProfile) -> None:
+        def my_webhook_notify(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
             raise InvalidJSONError("Malformed JSON")
 
         webhook_bot_email = "webhook-bot@zulip.com"

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -172,6 +172,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
                 # Mark this handler ID as finished for Zulip's own tracking.
                 clear_handler_by_id(self.handler_id)
 
+                assert isinstance(response, HttpResponse)
                 self.write_django_response_as_tornado_response(response)
         finally:
             # Tell Django that we're done processing this request on
@@ -261,6 +262,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
             # Explicitly mark requests as varying by cookie, since the
             # middleware will not have seen a session access
             patch_vary_headers(response, ("Cookie",))
+            assert isinstance(response, HttpResponse)
             self.write_django_response_as_tornado_response(response)
         finally:
             # Tell Django we're done processing this request

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -98,7 +98,7 @@ def update_message_backend(
     message_id: int = REQ(converter=to_non_negative_int, path_only=True),
     stream_id: Optional[int] = REQ(converter=to_non_negative_int, default=None),
     topic_name: Optional[str] = REQ_topic(),
-    propagate_mode: Optional[str] = REQ(
+    propagate_mode: str = REQ(
         default="change_one", str_validator=check_string_in(PROPAGATE_MODE_VALUES)
     ),
     send_notification_to_old_thread: bool = REQ(default=True, json_validator=check_bool),

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -1,4 +1,5 @@
 from django.http import HttpRequest
+from django.http.response import HttpResponse
 from django.utils.translation import gettext as _
 
 from zerver.decorator import webhook_view
@@ -22,7 +23,7 @@ def api_slack_webhook(
     channel_name: str = REQ(),
     stream: str = REQ(default="slack"),
     channels_map_to_topics: str = REQ(default="1"),
-) -> HttpRequest:
+) -> HttpResponse:
 
     if channels_map_to_topics not in list(VALID_OPTIONS.values()):
         raise JsonableError(_("Error: channels_map_to_topics parameter other than 0 or 1"))

--- a/zilencer/management/commands/add_new_realm.py
+++ b/zilencer/management/commands/add_new_realm.py
@@ -9,7 +9,7 @@ from zerver.models import Realm, UserProfile
 class Command(ZulipBaseCommand):
     help = """Add a new realm and initial user for manual testing of the onboarding process."""
 
-    def handle(self, **options: Any) -> None:
+    def handle(self, *args: Any, **options: Any) -> None:
         string_id = "realm{:02}".format(Realm.objects.filter(string_id__startswith="realm").count())
         realm = do_create_realm(string_id, string_id)
 

--- a/zilencer/management/commands/add_new_user.py
+++ b/zilencer/management/commands/add_new_user.py
@@ -15,7 +15,7 @@ and will otherwise fall back to the zulip realm."""
     def add_arguments(self, parser: CommandParser) -> None:
         self.add_realm_args(parser)
 
-    def handle(self, **options: Any) -> None:
+    def handle(self, *args: Any, **options: Any) -> None:
         realm = self.get_realm(options)
         if realm is None:
             realm = (

--- a/zilencer/management/commands/add_remote_server.py
+++ b/zilencer/management/commands/add_remote_server.py
@@ -17,7 +17,10 @@ class Command(ZulipBaseCommand):
         )
         group.add_argument("--email", "-e", required=True, help="a contact email address")
 
-    def handle(self, uuid: str, key: str, hostname: str, email: str, **options: Any) -> None:
+    def handle(self, *args: Any, **options: Any) -> None:
         RemoteZulipServer.objects.create(
-            uuid=uuid, api_key=key, hostname=hostname, contact_email=email
+            uuid=options["uuid"],
+            api_key=options["key"],
+            hostname=options["hostname"],
+            contact_email=options["email"],
         )

--- a/zilencer/management/commands/calculate_first_visible_message_id.py
+++ b/zilencer/management/commands/calculate_first_visible_message_id.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Iterable
 
 from django.core.management.base import CommandParser
 
@@ -24,7 +24,7 @@ class Command(ZulipBaseCommand):
         target_realm = self.get_realm(options)
 
         if target_realm is None:
-            realms = Realm.objects.all()
+            realms: Iterable[Realm] = Realm.objects.all()
         else:
             realms = [target_realm]
 

--- a/zilencer/management/commands/profile_request.py
+++ b/zilencer/management/commands/profile_request.py
@@ -1,12 +1,16 @@
 import cProfile
 import logging
 import tempfile
+from os import path
 from typing import Any, Dict
 
+from django.contrib.sessions.backends.base import SessionBase
 from django.core.management.base import CommandParser
 from django.http import HttpRequest, HttpResponse
 
 from zerver.lib.management import ZulipBaseCommand
+from zerver.lib.request import get_request_notes
+from zerver.lib.test_helpers import HostRequestMock
 from zerver.middleware import LogRequests
 from zerver.models import UserMessage, UserProfile
 from zerver.views.message_fetch import get_messages_backend

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -301,7 +301,7 @@ class ZulipAuthMixin:
     """
 
     name = "undefined"
-    _logger = None
+    _logger: Optional[logging.Logger] = None
 
     @property
     def logger(self) -> logging.Logger:

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -192,8 +192,6 @@ MIDDLEWARE = (
     "zerver.middleware.FinalizeOpenGraphDescription",
 )
 
-ANONYMOUS_USER_ID = None
-
 AUTH_USER_MODEL = "zerver.UserProfile"
 
 TEST_RUNNER = "zerver.lib.test_runner.Runner"

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -3,7 +3,6 @@ import sys
 import time
 import warnings
 from copy import deepcopy
-from pathlib import PosixPath
 from typing import Any, Dict, List, Tuple, Union
 from urllib.parse import urljoin
 
@@ -165,7 +164,7 @@ ALLOWED_HOSTS += REALM_HOSTS.values()
 
 
 class TwoFactorLoader(app_directories.Loader):
-    def get_dirs(self) -> List[PosixPath]:
+    def get_dirs(self) -> List[Union[bytes, str]]:
         dirs = super().get_dirs()
         return [d for d in dirs if d.match("two_factor/*")]
 

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -65,7 +65,7 @@ AUTH_LDAP_ALWAYS_UPDATE_USER = False
 # Detailed docs in zproject/dev_settings.py.
 FAKE_LDAP_MODE: Optional[str] = None
 FAKE_LDAP_NUM_USERS = 8
-AUTH_LDAP_ADVANCED_REALM_ACCESS_CONTROL = None
+AUTH_LDAP_ADVANCED_REALM_ACCESS_CONTROL: Optional[Dict[str, Any]] = None
 
 # Social auth; we support providing values for some of these
 # settings in zulip-secrets.conf instead of settings.py in development.
@@ -138,8 +138,8 @@ DEFAULT_AVATAR_URI = "/static/images/default-avatar.png"
 DEFAULT_LOGO_URI = "/static/images/logo/zulip-org-logo.svg"
 S3_AVATAR_BUCKET = ""
 S3_AUTH_UPLOADS_BUCKET = ""
-S3_REGION = None
-S3_ENDPOINT_URL = None
+S3_REGION: Optional[str] = None
+S3_ENDPOINT_URL: Optional[str] = None
 LOCAL_UPLOADS_DIR: Optional[str] = None
 MAX_FILE_UPLOAD_SIZE = 25
 

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -160,7 +160,7 @@ THUMBNAIL_IMAGES = True
 SEARCH_PILLS_ENABLED = bool(os.getenv("SEARCH_PILLS_ENABLED", False))
 
 BILLING_ENABLED = True
-LANDING_PAGE_NAVBAR_MESSAGE = None
+LANDING_PAGE_NAVBAR_MESSAGE: Optional[str] = None
 
 # Test custom TOS template rendering
 TERMS_OF_SERVICE = "corporate/terms.md"
@@ -175,4 +175,4 @@ USE_X_FORWARDED_PORT = True
 # Override the default SAML entity ID
 SOCIAL_AUTH_SAML_SP_ENTITY_ID = "http://localhost:9991"
 
-MEMCACHED_USERNAME = None
+MEMCACHED_USERNAME: Optional[str] = None

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -4,7 +4,8 @@ from urllib.parse import urlsplit
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib.staticfiles.views import serve as staticfiles_serve
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest
+from django.http.response import FileResponse
 from django.urls import path
 from django.views.generic import TemplateView
 from django.views.static import serve
@@ -110,7 +111,7 @@ if use_prod_static:
     ]
 else:
 
-    def serve_static(request: HttpRequest, path: str) -> HttpResponse:
+    def serve_static(request: HttpRequest, path: str) -> FileResponse:
         response = staticfiles_serve(request, path)
         response["Access-Control-Allow-Origin"] = "*"
         return response

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import ldap
 from django_auth_ldap.config import LDAPSearch
@@ -215,7 +215,7 @@ BIG_BLUE_BUTTON_URL = "https://bbb.example.com/bigbluebutton/"
 # By default two factor authentication is disabled in tests.
 # Explicitly set this to True within tests that must have this on.
 TWO_FACTOR_AUTHENTICATION_ENABLED = False
-PUSH_NOTIFICATION_BOUNCER_URL = None
+PUSH_NOTIFICATION_BOUNCER_URL: Optional[str] = None
 
 THUMBNAIL_IMAGES = True
 
@@ -269,4 +269,4 @@ RATE_LIMITING_RULES: Dict[str, List[Tuple[int, int]]] = {
     "password_reset_form_by_email": [],
 }
 
-FREE_TRIAL_DAYS = None
+FREE_TRIAL_DAYS: Optional[int] = None

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -1,4 +1,5 @@
 import os
+from typing import List, Union
 
 from django.conf import settings
 from django.conf.urls import include
@@ -10,6 +11,7 @@ from django.contrib.auth.views import (
     PasswordResetDoneView,
 )
 from django.urls import path
+from django.urls.resolvers import URLPattern, URLResolver
 from django.utils.module_loading import import_string
 from django.views.generic import RedirectView, TemplateView
 
@@ -634,7 +636,7 @@ i18n_urls = [
 ]
 
 # Make a copy of i18n_urls so that they appear without prefix for english
-urls = list(i18n_urls)
+urls: List[Union[URLPattern, URLResolver]] = list(i18n_urls)
 
 # Include the dual-use patterns twice
 urls += [


### PR DESCRIPTION
This fixes some typing errors found with `django-stubs` for the management scripts, `test_push_notifications.py` and `zproject/*.py`.

This is a part of #18777.

There are some remaining errors related to the django `Manager[T]` and
the `List[T]` type that we use to annotate the `Manage[T]` objects.

There are also errors that need to be fixed in the `django-stubs` project.


**Testing plan:** <!-- How have you tested? -->
This has been tested with mypy.