### PR TITLE
api_docs: Mention special value of realm_message_retention_days feild.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -530,6 +530,9 @@ No changes; feature level used for Zulip 3.0 release.
 * `GET /invites`: Now encodes the user ID of the person who created
    the invitation as `invited_by_user_id`, replacing the previous
    `ref` field (which had that user's Zulip display email address).
+* [`POST /register`](/api/register-queue): The encoding of an
+  unlimited `realm_message_retention_days` in the response was changed
+  from `null` to `-1`.
 
 **Feature level 21**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10065,11 +10065,14 @@ paths:
                           Present if `realm` is present in `fetch_event_types`.
 
                           The default [message retention policy](/help/message-retention-policy)
-                          for this organization.  Pass `"unlimited"` to request that messages
-                          by retained forever (the default).
+                          for this organization. It can have one special value:
 
-                          **Changes**: Prior to Zulip 5.0 (feature level 91), no limit was encoded
-                          by passing `"forever"`.
+                          * `-1` denoting that the messages will be retained forever for this realm, by default.
+
+                          **Changes**: Prior to Zulip 3.0 (feature level 22), no limit was
+                          encoded as `null` instead of `-1`. Clients can correctly handle all
+                          server versions by treating both `-1` and `null` as indicating
+                          unlimited message retention.
                       realm_name:
                         type: string
                         description: |


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR improves the API documentation to indicate that the `realm_message_retention_days` field can have a special value, similar to its stream counterpart and also explains how the special value changed over different server versions.

Related discussion: https://chat.zulip.org/#narrow/stream/378-api-design/topic/realm_message_retention_days
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
