### PR TITLE
landing-page: Fix mobile scrolling bug when sidebar is toggled.

### DIFF
--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -174,16 +174,19 @@ const events = function () {
             setTimeout(() => {
                 $("nav ul").removeClass("show");
                 $("nav ul").css("transform", "");
+                $("body").removeClass("noscroll");
             }, 500);
         }
 
         if ($("nav ul.show") && !$e.closest("nav ul.show").length && !$e.is("nav ul.show")) {
             $("nav ul").removeClass("show");
+            $("body").removeClass("noscroll");
         }
     });
 
     $(".hamburger").on("click", (e) => {
         $("nav ul").addClass("show");
+        $("body").addClass("noscroll");
         e.stopPropagation();
     });
 


### PR DESCRIPTION
On mobile, when the sidebar is toggled, the following three issues
are encountered:
- When none of the sidebar menus are expanded, the sidebar has no
  scrollbar, which is expected. But if you scroll, the background
  content scrolls, which is a bug.
- When some of the sidebar menus are expanded such that the content
  overflows and is "scrollable", once you get to the end of the
  sidebar content, the background content keeps scrolling in a weird
  way.
- If the mobile screen is wide enough, if you scroll the sidebar
  content, it scrolls as expected. But if you move the pointer to
  the side of the background content that is still visible, you
  can scroll the background content even though it should be fixed.

This commit fixes all of the above issues.

@timabbott @alya FYI :) This has been tested on browserstack.