### PR TITLE
Fix race condition in scheduled_emails

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1214,7 +1214,7 @@ def do_deactivate_user(
         change_user_is_active(user_profile, False)
 
         delete_user_sessions(user_profile)
-        clear_scheduled_emails([user_profile.id])
+        clear_scheduled_emails(user_profile.id)
 
         event_time = timezone_now()
         RealmAuditLog.objects.create(
@@ -5036,7 +5036,7 @@ def do_change_notification_settings(
 
     # Disabling digest emails should clear a user's email queue
     if name == "enable_digest_emails" and not value:
-        clear_scheduled_emails([user_profile.id], ScheduledEmail.DIGEST)
+        clear_scheduled_emails(user_profile.id, ScheduledEmail.DIGEST)
 
     user_profile.save(update_fields=[name])
     event = {

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -363,7 +363,7 @@ def send_future_email(
                 assert to_emails is not None
                 assert len(to_emails) == 1
                 email.address = parseaddr(to_emails[0])[1]
-            email.save()
+                email.save()
         except Exception as e:
             email.delete()
             raise e

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -416,23 +416,20 @@ def clear_scheduled_invitation_emails(email: str) -> None:
 
 
 @transaction.atomic(savepoint=False)
-def clear_scheduled_emails(user_ids: List[int], email_type: Optional[int] = None) -> None:
+def clear_scheduled_emails(user_id: int, email_type: Optional[int] = None) -> None:
     # We need to obtain a FOR UPDATE lock on the selected rows to keep a concurrent
     # execution of this function (or something else) from deleting them before we access
     # the .users attribute.
-    items = ScheduledEmail.objects.filter(users__in=user_ids).select_for_update()
+    items = ScheduledEmail.objects.filter(users__in=[user_id]).select_for_update()
     if email_type is not None:
         items = items.filter(type=email_type)
 
-    deduplicated_items = {}
     for item in items:
-        deduplicated_items[item.id] = item
-    for item in deduplicated_items.values():
         # Now we want a FOR UPDATE lock on the item.users rows
         # to prevent a concurrent transaction from mutating them
         # simultaneously.
         item.users.all().select_for_update()
-        item.users.remove(*user_ids)
+        item.users.remove(user_id)
         if item.users.all().count() == 0:
             # Due to our transaction holding the row lock we have a guarantee
             # that the obtained COUNT is accurate, thus we can reliably use it

--- a/zerver/management/commands/deliver_scheduled_emails.py
+++ b/zerver/management/commands/deliver_scheduled_emails.py
@@ -36,9 +36,11 @@ Usage: ./manage.py deliver_scheduled_emails
         while True:
             found_rows = False
             with transaction.atomic():
-                email_jobs_to_deliver = ScheduledEmail.objects.filter(
-                    scheduled_timestamp__lte=timezone_now()
-                ).select_for_update()
+                email_jobs_to_deliver = (
+                    ScheduledEmail.objects.filter(scheduled_timestamp__lte=timezone_now())
+                    .prefetch_related("users")
+                    .select_for_update()
+                )
                 if email_jobs_to_deliver:
                     found_rows = True
                     for job in email_jobs_to_deliver:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -774,7 +774,7 @@ class LoginTest(ZulipTestCase):
         with queries_captured() as queries, cache_tries_captured() as cache_tries:
             self.register(self.nonreg_email("test"), "test")
         # Ensure the number of queries we make is not O(streams)
-        self.assert_length(queries, 89)
+        self.assert_length(queries, 87)
 
         # We can probably avoid a couple cache hits here, but there doesn't
         # seem to be any O(N) behavior.  Some of the cache hits are related

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -771,7 +771,7 @@ class QueryCountTest(ZulipTestCase):
                         acting_user=None,
                     )
 
-        self.assert_length(queries, 84)
+        self.assert_length(queries, 82)
         self.assert_length(cache_tries, 27)
 
         peer_add_events = [event for event in events if event["event"].get("op") == "peer_add"]

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1392,7 +1392,7 @@ class ActivateTest(ZulipTestCase):
         assert email is not None and email.users is not None
         self.assertEqual(email.users.count(), 2)
 
-    def test_clear_scheduled_emails_with_multiple_user_ids(self) -> None:
+    def test_clear_schedule_emails(self) -> None:
         hamlet = self.example_user("hamlet")
         iago = self.example_user("iago")
         send_future_email(
@@ -1402,20 +1402,7 @@ class ActivateTest(ZulipTestCase):
             delay=datetime.timedelta(hours=1),
         )
         self.assertEqual(ScheduledEmail.objects.count(), 1)
-        clear_scheduled_emails([hamlet.id, iago.id])
-        self.assertEqual(ScheduledEmail.objects.count(), 0)
-
-    def test_clear_schedule_emails_with_one_user_id(self) -> None:
-        hamlet = self.example_user("hamlet")
-        iago = self.example_user("iago")
-        send_future_email(
-            "zerver/emails/followup_day1",
-            iago.realm,
-            to_user_ids=[hamlet.id, iago.id],
-            delay=datetime.timedelta(hours=1),
-        )
-        self.assertEqual(ScheduledEmail.objects.count(), 1)
-        clear_scheduled_emails([hamlet.id])
+        clear_scheduled_emails(hamlet.id)
         self.assertEqual(ScheduledEmail.objects.count(), 1)
         self.assertEqual(ScheduledEmail.objects.filter(users=hamlet).count(), 0)
         self.assertEqual(ScheduledEmail.objects.filter(users=iago).count(), 1)

--- a/zerver/views/unsubscribe.py
+++ b/zerver/views/unsubscribe.py
@@ -39,7 +39,7 @@ def do_missedmessage_unsubscribe(user_profile: UserProfile) -> None:
 
 
 def do_welcome_unsubscribe(user_profile: UserProfile) -> None:
-    clear_scheduled_emails([user_profile.id], ScheduledEmail.WELCOME)
+    clear_scheduled_emails(user_profile.id, ScheduledEmail.WELCOME)
 
 
 def do_digest_unsubscribe(user_profile: UserProfile) -> None:


### PR DESCRIPTION
**Testing plan:** 

```python3
se = ScheduledEmail.objects.create(realm=get_realm('zulip'), scheduled_timestamp=timezone_now(), type=EMAIL_TYPES["followup_day1"])
se.users.add(1);
```

Leaving that window open, run:
```
zulip=> delete from zerver_scheduledemail_users;
DELETE 1
zulip=> delete from zerver_scheduledemail;
DELETE 1
```

```python3
se.save()
```

Django will execute:
```sql
INSERT INTO "zerver_scheduledemail" ("scheduled_timestamp", "data", "realm_id", "address", "type") VALUES ('2021-08-17T01:29:21.256728+00:00'::timestamptz, '', 2, NULL, 1) RETURNING "zerver_scheduledemail"."id"
INSERT INTO "zerver_scheduledemail_users" ("scheduledemail_id", "userprofile_id") VALUES (4, 1) ON CONFLICT DO NOTHING
UPDATE "zerver_scheduledemail" SET "scheduled_timestamp" = '2021-08-17T01:29:21.256728+00:00'::timestamptz, "data" = '', "realm_id" = 2, "address" = NULL, "type" = 1 WHERE "zerver_scheduledemail"."id" = 4
INSERT INTO "zerver_scheduledemail" ("id", "scheduled_timestamp", "data", "realm_id", "address", "type") VALUES (4, '2021-08-17T01:29:21.256728+00:00'::timestamptz, '', 2, NULL, 1) RETURNING "zerver_scheduledemail"."id"
```

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
