### PR TITLE
docs: Add skip navigation link in /help and /api.

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -9,6 +9,8 @@ import {activate_correct_tab} from "./tabbed-instructions";
 function registerCodeSection($codeSection) {
     const $li = $codeSection.find("ul.nav li");
     const $blocks = $codeSection.find(".blocks div");
+    const $skiplink = $codeSection.find(".skip-link");
+    $skiplink.addClass("active");
 
     $li.on("click", function () {
         const language = this.dataset.language;
@@ -47,10 +49,14 @@ function highlight_current_article() {
     // Highlight current article link and the heading of the same
     $article.closest("ul").css("display", "block");
     $article.addClass("highlighted");
-    $article.attr("tabindex", "-1");
+    $article.attr("tabindex", "1");
 }
 
 function render_code_sections() {
+    // Removing #skip-link-nav hash from the url
+    if (parent.location.hash !== "") {
+        parent.location.hash = "";
+    }
     $(".code-section").each(function () {
         activate_correct_tab($(this));
         registerCodeSection($(this));
@@ -180,5 +186,4 @@ window.addEventListener("popstate", () => {
 });
 
 $("body").addClass("noscroll");
-
 $(".highlighted")[0].scrollIntoView({block: "center"});

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -209,13 +209,12 @@ html {
             list-style-type: none;
             font-size: 0.95em;
             font-weight: 400;
-            line-height: 1.7;
-
+            line-height: 1.8;
             cursor: pointer;
-
             a {
                 color: inherit;
                 display: block;
+                padding: 1px 4px;
             }
         }
 
@@ -607,6 +606,29 @@ input.text-error {
 
 .portico-page-container .portico-header .dropdown-pill .realm-name {
     margin-left: -3px;
+}
+
+.skip-link {
+    background: hsl(153, 32%, 55%);
+    top: -100px;
+    left: 300px;
+    position: absolute;
+    overflow: hidden;
+    border-radius: 6px;
+    padding: 6px 10px;
+    color: hsl(0, 0%, 98%);
+    font-size: 18px;
+    font-weight: bold;
+    outline: 5px auto hsl(152, 40%, 42%);
+    &:focus {
+        z-index: 5000;
+        transition: ease-in-out 0.3s;
+        top: -3px;
+        width: auto;
+        height: 25px;
+        outline: 5px auto hsl(152, 40%, 42%);
+        color: hsl(0, 0%, 98%);
+    }
 }
 
 .app {

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -32,7 +32,7 @@
     </svg>
 
     <div class="markdown">
-        <div class="content">
+        <div class="content" id="skip-link-nav">
             {% if page_is_policy_center %}
             {{ render_markdown_path(article, pure_markdown=True) }}
             {% else %}
@@ -41,7 +41,8 @@
 
             <div id="footer" class="documentation-footer">
                 <hr />
-                <p>We're here to help! Email us at <a href="mailto:{{ support_email }}">{{ support_email }}</a> with questions, feedback, or feature requests.</p>
+                <p>We're here to help! Email us at <a href="mailto:{{ support_email }}">{{ support_email }}</a> with questions,
+                    feedback, or feature requests.</p>
             </div>
         </div>
     </div>

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -1,5 +1,16 @@
 <div class="header portico-header">
     <div class="header-main" id="top_navbar">
+
+        <!--
+        Adding skip link for better navigation and less scrolling
+        On the press of tab a button will appear and on the press of enter
+        it will take to the top of the page.
+        in /help and /api
+        -->
+        {% if page_is_help_center or page_is_api_center %}
+        <a class="skip-link" href="#skip-link-nav" tabindex="0">Skip To Main Content </a>
+        {% endif %}
+
         <div class="float-left">
             {% if custom_logo_url %}
             <a class="brand logo" href="{{ root_domain_uri }}/"><img draggable="false" src="{{ custom_logo_url }}" class="portico-logo" alt="{{ _('Zulip') }}" content="Zulip" /></a>
@@ -12,7 +23,7 @@
                 </a>
 
                 {% if page_is_help_center %}
-                <span class="light"> | <a href="{{ root_domain_uri }}/help/">{{ doc_root_title }}</a></span>
+                <span class="light"> | <a tabindex="-1" href="{{ root_domain_uri }}/help/">{{ doc_root_title }}</a></span>
                 {% endif %}
                 {% if page_is_api_center %}
                 <span class="light"> | <a href="{{ root_domain_uri }}/api/">{{ doc_root_title }}</a></span>


### PR DESCRIPTION
PR for the issue #15948 

**I have added the following changes.**
- When pressed tab the button appears from the top
- And when we press enter, it takes us to top of the page.
- I have remove the hash in URL after we press enter.

I have made a skip-nav-link class and set the tab index of button to 0 and in css I have added the animations. So when the tab is pressed the button makes transition from the top.

Please review the commit and suggest the changes. This is my first issue.

![image](https://user-images.githubusercontent.com/51414879/129312684-1259ca76-7203-4b32-bd57-c48e8852898c.png)
