### PR TITLE
docs: Adjust phrasing of "From your desktop, click on the gear...".

### DIFF
--- a/templates/zerver/help/include/go-to-stream-via-all-streams.md
+++ b/templates/zerver/help/include/go-to-stream-via-all-streams.md
@@ -1,4 +1,5 @@
-1. From your desktop, click on the gear (<i class="fa fa-cog"></i>) in the upper right corner.
+1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the upper
+   right corner of the web or desktop app.
 
 1. Select **Manage streams**.
 

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -27,8 +27,8 @@ gear_info = {
 }
 
 gear_instructions = """
-1. From your desktop, click on the **gear**
-   (<i class="fa fa-cog"></i>) in the upper right corner.
+1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the upper
+   right corner of the web or desktop app.
 
 1. Select {item}.
 """
@@ -48,8 +48,8 @@ stream_info = {
 }
 
 stream_instructions_no_link = """
-1. From your desktop, click on the **gear**
-   (<i class="fa fa-cog"></i>) in the upper right corner.
+1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the upper
+   right corner of the web or desktop app.
 
 1. Click **Manage streams**.
 """

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -91,8 +91,8 @@ link_mapping = {
 }
 
 settings_markdown = """
-1. From your desktop, click on the **gear**
-   (<i class="fa fa-cog"></i>) in the upper right corner.
+1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the upper
+   right corner of the web or desktop app.
 
 1. Select **{setting_type_name}**.
 


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/19-documentation/topic/.22From.20your.20.20desktop.2C.20click.20on.20the.20gear.22.20phrasing

We actually mean the main Zulip UI here, so "from your desktop" sounds
potentially misleading. It seems better to just remove the phrase, as it
isn't enlightening on where the gear is (main Zulip UI) and only risks
confusion that it's the users main desktop screen.
