### PR TITLE
auth: Redirect password reset page to /accounts/go when required

### DIFF
--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -3,6 +3,7 @@ import secrets
 import urllib
 from functools import wraps
 from typing import Any, Dict, List, Mapping, Optional, cast
+from urllib.parse import urlencode
 
 import jwt
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
@@ -959,6 +960,12 @@ def logout_then_login(request: HttpRequest, **kwargs: Any) -> HttpResponse:
 
 
 def password_reset(request: HttpRequest) -> HttpResponse:
+    if is_subdomain_root_or_alias(request) and settings.ROOT_DOMAIN_LANDING_PAGE:
+        redirect_url = add_query_to_redirect_url(
+            reverse("realm_redirect"), urlencode({"next": reverse("password_reset")})
+        )
+        return HttpResponseRedirect(redirect_url)
+
     response = DjangoPasswordResetView.as_view(
         template_name="zerver/reset.html",
         form_class=ZulipPasswordResetForm,


### PR DESCRIPTION
Fixes https://sentry.io/organizations/zulip/issues/2560055985/events/479c289ccc9545329c05996973454ed2/?project=5303926

If a user opens /accounts/password/reset opens from the root domain or a root alias when root landing page is enabled, we don't redirect to /accounts/go currently. Instead we show the password reset form. We should instead redirect the user to /accounts/go with the next param set to password reset page.

I have tested that the new setup works in local dev environment. Plus unittests are added to enforce this in test suite as well.