### PR TITLE
help_docs: Fix improper indentation for ordered lists.

### DIFF
--- a/static/styles/portico/markdown.css
+++ b/static/styles/portico/markdown.css
@@ -102,11 +102,6 @@
         left: calc(30px);
     }
 
-    ul,
-    ol {
-        margin-left: 30px;
-    }
-
     li {
         line-height: 150%;
     }
@@ -191,6 +186,14 @@
 
         ol li p:not(:first-child) {
             display: block;
+        }
+
+        & > ol {
+            margin: 15px 10px;
+
+            & > li {
+                margin: 5px 0;
+            }
         }
 
         i.zulip-icon {

--- a/templates/zerver/help/saml-authentication.md
+++ b/templates/zerver/help/saml-authentication.md
@@ -10,6 +10,7 @@ Zulip with various common SAML identity providers.
 
 1. Make sure you have created your organization. We'll assume its URL is
    `https://<subdomain>.zulipchat.com` in the instructions below.
+
 1. Set up SAML authentication by following
    [Okta's documentation](https://developer.okta.com/docs/guides/saml-application-setup/overview/).
    Specify:
@@ -20,28 +21,36 @@ Zulip with various common SAML identity providers.
      * Set 'Email` for "Application username format".
      * Provide "Attribute statements" of `email` to `user.email`,
        `first_name` to `user.firstName`, and `last_name` to `user.lastName`.
+
 1. Assign the appropriate accounts in the "Assignments" tab. These are the users
    that will be able to log in to your Zulip organization.
+
 1. Send the following information to us at support@zulip.com:
      * The URL of your zulipchat-hosted organization.
      * The "Identity Provider metadata" provided by Okta for the application.
      * The name "X" that will be displayed on the "Log in with X" button in Zulip.
      * Optionally you can also send us an icon that should be shown on the button.
+
 1. We will take care of the server-side setup and let you know as soon as it's ready.
 
 ## Configure SAML with OneLogin
 
 1. Make sure you have created your organization. We'll assume its URL is
    `https://<subdomain>.zulipchat.com` in the instructions below.
+
 1. Navigate to the OneLogin Applications page, and click "Add App".
+
 1. Search for the "SAML Test Connector (IdP w/ attr w/ sign response)" app and select it.
+
 1. Set a name and logo according to your preferences and click "Save". This doesn't affect anything in Zulip,
    but will be shown on your OneLogin Applications page.
+
 1. Go to the "Configuration" section:
     * Leave the `RelayState` field empty.
     * Set `https://zulip.com` as the Audience.
     * Set `https://<subdomain>.zulipchat.com/complete/saml/` as the Recipient, ACS URL
       and ACS URL Validator.
+
 1. Go to the "Parameters" section. Ignore the pre-configured parameters that are already there
    and add custom ones to match the following screenshot:
 
@@ -55,6 +64,7 @@ Zulip with various common SAML identity providers.
      * The issuer URL from the "SSO" section. It contains Identity Provider metadata that we will need.
      * The name "X" that will be displayed on the "Log in with X" button in Zulip.
      * Optionally you can also send us an icon that should be shown on the button.
+
 1. We will take care of the server-side setup and let you know as soon as it's ready.
 
 ## Related articles


### PR DESCRIPTION
On our Markdown help docs, ordered lists that aren't encapsulated
in tabs don't have custom CSS that tells them how to display
themselves with proper indentation. An example of a doc that has
this issue is /help/saml-authentication. This commit adds some CSS
that targets such ordered lists.

@timabbott FYI :)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
