### PR TITLE
webhooks/clubhouse: Ignore label removals for story batch updates.

### DIFF
--- a/zerver/webhooks/clubhouse/fixtures/story_update_everything_at_once_skip_removed_labels.json
+++ b/zerver/webhooks/clubhouse/fixtures/story_update_everything_at_once_skip_removed_labels.json
@@ -1,0 +1,233 @@
+{
+  "id": "60723fdc-2c6d-4b31-b160-ef4d438dc5bc",
+  "changed_at": "2021-04-11T00:16:28.845Z",
+  "version": "v1",
+  "member_id": "6071752f-e16e-4f79-b41e-7c78b76aa4bd",
+  "actions": [
+    {
+      "id": 17,
+      "entity_type": "story",
+      "action": "update",
+      "name": "asd4",
+      "story_type": "bug",
+      "app_url": "https://app.clubhouse.io/pig208/story/17",
+      "changes": {
+        "story_type": {
+          "new": "bug",
+          "old": "feature"
+        },
+        "epic_id": {
+          "new": 23,
+          "old": 29
+        },
+        "requested_by_id": {
+          "new": "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae",
+          "old": "6071752f-e16e-4f79-b41e-7c78b76aa4bd"
+        },
+        "label_ids": {
+          "removes": [
+            8
+          ]
+        },
+        "group_id": {
+          "new": "6071adb0-641f-46c4-b5e1-4945dae399ea",
+          "old": "6071752f-ece0-4772-854c-05a9666c480f"
+        },
+        "workflow_state_id": {
+          "new": 500000010,
+          "old": 500000006
+        },
+        "follower_ids": {
+          "adds": [
+            "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae"
+          ]
+        },
+        "owner_ids": {
+          "adds": [
+            "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae"
+          ]
+        },
+        "position": {
+          "new": 42147811328,
+          "old": 32147483648
+        },
+        "project_id": {
+          "new": 28,
+          "old": 2
+        },
+        "deadline": {
+          "new": "2021-04-12T16:00:00Z",
+          "old": "2021-04-11T16:00:00Z"
+        }
+      }
+    },
+    {
+      "id": 26,
+      "entity_type": "story",
+      "action": "update",
+      "name": "new1",
+      "story_type": "bug",
+      "app_url": "https://app.clubhouse.io/pig208/story/26",
+      "changes": {
+        "story_type": {
+          "new": "bug",
+          "old": "feature"
+        },
+        "epic_id": {
+          "new": 23,
+          "old": 29
+        },
+        "requested_by_id": {
+          "new": "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae",
+          "old": "6071752f-e16e-4f79-b41e-7c78b76aa4bd"
+        },
+        "label_ids": {
+          "removes": [
+            8
+          ]
+        },
+        "group_id": {
+          "new": "6071adb0-641f-46c4-b5e1-4945dae399ea",
+          "old": "6071752f-ece0-4772-854c-05a9666c480f"
+        },
+        "workflow_state_id": {
+          "new": 500000010,
+          "old": 500000006
+        },
+        "follower_ids": {
+          "adds": [
+            "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae"
+          ]
+        },
+        "owner_ids": {
+          "adds": [
+            "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae"
+          ]
+        },
+        "position": {
+          "new": 42147942400,
+          "old": 32147680256
+        },
+        "project_id": {
+          "new": 28,
+          "old": 2
+        },
+        "deadline": {
+          "new": "2021-04-12T16:00:00Z",
+          "old": "2021-04-11T16:00:00Z"
+        }
+      }
+    },
+    {
+      "id": 27,
+      "entity_type": "story",
+      "action": "update",
+      "name": "new2",
+      "story_type": "bug",
+      "app_url": "https://app.clubhouse.io/pig208/story/27",
+      "changes": {
+        "story_type": {
+          "new": "bug",
+          "old": "feature"
+        },
+        "epic_id": {
+          "new": 23,
+          "old": 29
+        },
+        "requested_by_id": {
+          "new": "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae",
+          "old": "6071752f-e16e-4f79-b41e-7c78b76aa4bd"
+        },
+        "label_ids": {
+          "removes": [
+            8
+          ]
+        },
+        "group_id": {
+          "new": "6071adb0-641f-46c4-b5e1-4945dae399ea",
+          "old": "6071752f-ece0-4772-854c-05a9666c480f"
+        },
+        "workflow_state_id": {
+          "new": 500000010,
+          "old": 500000006
+        },
+        "follower_ids": {
+          "adds": [
+            "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae"
+          ]
+        },
+        "owner_ids": {
+          "adds": [
+            "60723f5f-28ca-4ec2-a3a2-37b2dc5606ae"
+          ]
+        },
+        "position": {
+          "new": 42147876864,
+          "old": 32147614720
+        },
+        "project_id": {
+          "new": 28,
+          "old": 2
+        },
+        "deadline": {
+          "new": "2021-04-12T16:00:00Z",
+          "old": "2021-04-11T16:00:00Z"
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "id": "6071752f-ece0-4772-854c-05a9666c480f",
+      "entity_type": "group",
+      "name": "Team 1"
+    },
+    {
+      "id": 500000010,
+      "entity_type": "workflow-state",
+      "name": "Ready for Review",
+      "type": "started"
+    },
+    {
+      "id": 500000006,
+      "entity_type": "workflow-state",
+      "name": "In Development",
+      "type": "started"
+    },
+    {
+      "id": 8,
+      "entity_type": "label",
+      "name": "low priority",
+      "app_url": "https://app.clubhouse.io/pig208/label/8"
+    },
+    {
+      "id": 23,
+      "entity_type": "epic",
+      "name": "testeipc",
+      "app_url": "https://app.clubhouse.io/pig208/epic/23"
+    },
+    {
+      "id": 2,
+      "entity_type": "project",
+      "name": "Product Development",
+      "app_url": "https://app.clubhouse.io/pig208/project/2"
+    },
+    {
+      "id": "6071adb0-641f-46c4-b5e1-4945dae399ea",
+      "entity_type": "group",
+      "name": "team2"
+    },
+    {
+      "id": 29,
+      "entity_type": "epic",
+      "name": "epic",
+      "app_url": "https://app.clubhouse.io/pig208/epic/29"
+    },
+    {
+      "id": 28,
+      "entity_type": "project",
+      "name": "test2",
+      "app_url": "https://app.clubhouse.io/pig208/project/28"
+    }
+  ]
+}

--- a/zerver/webhooks/clubhouse/tests.py
+++ b/zerver/webhooks/clubhouse/tests.py
@@ -334,6 +334,48 @@ class ClubhouseWebhookTest(WebhookTestCase):
         self.assertEqual(check_send_webhook_message_mock.call_args_list, expected_list)
 
     @patch("zerver.webhooks.clubhouse.view.check_send_webhook_message")
+    def test_story_update_batch_skip_removed_labels(
+        self, check_send_webhook_message_mock: MagicMock
+    ) -> None:
+        payload = self.get_body("story_update_everything_at_once_skip_removed_labels")
+        self.client_post(self.url, payload, content_type="application/json")
+        expected_message = "The story [{name}]({url}) was moved from Epic **epic** to **testeipc**, Project **Product Development** to **test2**, and changed from type **feature** to **bug** (In Development -> Ready for Review)."
+        request, user_profile = (
+            check_send_webhook_message_mock.call_args_list[0][0][0],
+            check_send_webhook_message_mock.call_args_list[0][0][1],
+        )
+        expected_list = [
+            call(
+                request,
+                user_profile,
+                "asd4",
+                expected_message.format(
+                    name="asd4", url="https://app.clubhouse.io/pig208/story/17"
+                ),
+                "story_update_batch",
+            ),
+            call(
+                request,
+                user_profile,
+                "new1",
+                expected_message.format(
+                    name="new1", url="https://app.clubhouse.io/pig208/story/26"
+                ),
+                "story_update_batch",
+            ),
+            call(
+                request,
+                user_profile,
+                "new2",
+                expected_message.format(
+                    name="new2", url="https://app.clubhouse.io/pig208/story/27"
+                ),
+                "story_update_batch",
+            ),
+        ]
+        self.assertEqual(check_send_webhook_message_mock.call_args_list, expected_list)
+
+    @patch("zerver.webhooks.clubhouse.view.check_send_webhook_message")
     def test_story_update_batch_each_with_one_change(
         self, check_send_webhook_message_mock: MagicMock
     ) -> None:

--- a/zerver/webhooks/clubhouse/view.py
+++ b/zerver/webhooks/clubhouse/view.py
@@ -562,16 +562,19 @@ def get_story_update_batch_body(payload: Dict[str, Any], action: Dict[str, Any])
         )
 
     if "label_ids" in changes:
-        last_change = "label"
-        labels = get_story_joined_label_list(payload, action, changes["label_ids"].get("adds"))
-        templates.append(
-            STORY_UPDATE_BATCH_ADD_REMOVE_TEMPLATE.format(
-                operation="{} added".format("was" if len(templates) == 0 else "and"),
-                entity="the new label{plural} {labels}".format(
-                    plural="s" if len(changes["label_ids"]) > 1 else "", labels=labels
-                ),
+        label_ids_added = changes["label_ids"].get("adds")
+        # If this is a payload for when no label is added, ignore it
+        if label_ids_added is not None:
+            last_change = "label"
+            labels = get_story_joined_label_list(payload, action, label_ids_added)
+            templates.append(
+                STORY_UPDATE_BATCH_ADD_REMOVE_TEMPLATE.format(
+                    operation="{} added".format("was" if len(templates) == 0 else "and"),
+                    entity="the new label{plural} {labels}".format(
+                        plural="s" if len(changes["label_ids"]) > 1 else "", labels=labels
+                    ),
+                )
             )
-        )
 
     if "workflow_state_id" in changes:
         last_change = "state"


### PR DESCRIPTION
9ac55a8cf6644afcffeca36d217818045fad06df introduced support for
batch updates to stories. However, that commit didn't skip label
removals, as we already do in non-batch story payloads. This led
to an exception for batch story update payloads where labels were
removed but none were added.

@timabbott FYI :)
