### PR TITLE
Implement generic zulip notes

### DIFF
--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -17,7 +17,7 @@ from version import (
 from zerver.lib.exceptions import InvalidSubdomainError
 from zerver.lib.realm_description import get_realm_rendered_description, get_realm_text_description
 from zerver.lib.realm_icon import get_realm_icon_url
-from zerver.lib.request import get_request_notes
+from zerver.lib.request import RequestNotes
 from zerver.lib.send_email import FromAddress
 from zerver.lib.subdomains import get_subdomain
 from zerver.models import Realm, UserProfile, get_realm
@@ -50,7 +50,7 @@ def common_context(user: UserProfile) -> Dict[str, Any]:
 
 
 def get_realm_from_request(request: HttpRequest) -> Optional[Realm]:
-    request_notes = get_request_notes(request)
+    request_notes = RequestNotes.get_notes(request)
     if hasattr(request, "user") and hasattr(request.user, "realm"):
         return request.user.realm
     if not request_notes.has_fetched_realm:
@@ -59,7 +59,7 @@ def get_realm_from_request(request: HttpRequest) -> Optional[Realm]:
         # need to do duplicate queries on the same realm while
         # processing a single request.
         subdomain = get_subdomain(request)
-        request_notes = get_request_notes(request)
+        request_notes = RequestNotes.get_notes(request)
         try:
             request_notes.realm = get_realm(subdomain)
         except Realm.DoesNotExist:
@@ -169,7 +169,7 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
         "settings_path": settings_path,
         "secrets_path": secrets_path,
         "settings_comments_path": settings_comments_path,
-        "platform": get_request_notes(request).client_name,
+        "platform": RequestNotes.get_notes(request).client_name,
         "allow_search_engine_indexing": allow_search_engine_indexing,
         "landing_page_navbar_message": settings.LANDING_PAGE_NAVBAR_MESSAGE,
         "default_page_params": default_page_params,

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -15,7 +15,7 @@ from zerver.lib.i18n import (
     get_language_list,
     get_language_translation_data,
 )
-from zerver.lib.request import get_request_notes
+from zerver.lib.request import RequestNotes
 from zerver.models import Message, Realm, Stream, UserProfile
 from zerver.views.message_flags import get_latest_update_message_flag_activity
 
@@ -139,7 +139,7 @@ def build_page_params_for_home_page_load(
     }
 
     if user_profile is not None:
-        client = get_request_notes(request).client
+        client = RequestNotes.get_notes(request).client
         assert client is not None
         register_ret = do_events_register(
             user_profile,

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.http import HttpRequest
 from django.utils import translation
 
-from zerver.lib.request import get_request_notes
+from zerver.lib.request import RequestNotes
 
 
 @lru_cache()
@@ -64,6 +64,6 @@ def get_and_set_request_language(
     # something reasonable will happen in logged-in portico pages.
     # We accomplish that by setting a flag on the request which signals
     # to LocaleMiddleware to set the cookie on the response.
-    get_request_notes(request).set_language = translation.get_language()
+    RequestNotes.get_notes(request).set_language = translation.get_language()
 
     return request_language

--- a/zerver/lib/logging_util.py
+++ b/zerver/lib/logging_util.py
@@ -276,9 +276,9 @@ class ZulipWebhookFormatter(ZulipFormatter):
                 )
 
         header_message = header_text if header_text else None
-        from zerver.lib.request import get_request_notes
+        from zerver.lib.request import RequestNotes
 
-        client = get_request_notes(request).client
+        client = RequestNotes.get_notes(request).client
         assert client is not None
 
         setattr(record, "user", f"{request.user.delivery_email} ({request.user.realm.string_id})")

--- a/zerver/lib/notes.py
+++ b/zerver/lib/notes.py
@@ -1,0 +1,46 @@
+import weakref
+from abc import ABCMeta, abstractmethod
+from typing import Any, ClassVar, Generic, MutableMapping, TypeVar
+
+_KeyT = TypeVar("_KeyT")
+_DataT = TypeVar("_DataT")
+
+
+class BaseNotes(Generic[_KeyT, _DataT], metaclass=ABCMeta):
+    """This class defines a generic type-safe mechanism for associating
+    additional data with an object (without modifying the original
+    object via subclassing or monkey-patching).
+
+    It was originally designed to avoid monkey-patching the Django
+    HttpRequest object, to which we want to associate computed state
+    (e.g. parsed state computed from the User-Agent) so that it's
+    available in code paths that receive the HttpRequest object.
+
+    The implementation uses a WeakKeyDictionary, so that the notes
+    object will be garbage-collected when the original object no
+    longer has other references (avoiding memory leaks).
+
+    We still need to be careful to avoid any of the attributes of
+    _NoteT having points to the original object, as that can create a
+    cyclic reference cycle that the Python garbage collect may not
+    handle correctly.
+    """
+
+    __notes_map: ClassVar[MutableMapping[Any, Any]] = weakref.WeakKeyDictionary()
+
+    @classmethod
+    def get_notes(cls, key: _KeyT) -> _DataT:
+        try:
+            return cls.__notes_map[key]
+        except KeyError:
+            cls.__notes_map[key] = cls.init_notes()
+            return cls.__notes_map[key]
+
+    @classmethod
+    def set_notes(cls, key: _KeyT, notes: _DataT) -> None:
+        cls.__notes_map[key] = notes
+
+    @classmethod
+    @abstractmethod
+    def init_notes(cls) -> _DataT:
+        ...

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -548,7 +548,9 @@ def initialize_push_notifications() -> None:
         )
 
 
-def get_gcm_alert(message: Message, mentioned_user_group_name: Optional[str] = None) -> str:
+def get_gcm_alert(
+    message: Message, trigger: str, mentioned_user_group_name: Optional[str] = None
+) -> str:
     """
     Determine what alert string to display based on the missed messages.
     """
@@ -556,23 +558,23 @@ def get_gcm_alert(message: Message, mentioned_user_group_name: Optional[str] = N
     display_recipient = get_display_recipient(message.recipient)
     if (
         message.recipient.type == Recipient.HUDDLE
-        and message.trigger == NotificationTriggers.PRIVATE_MESSAGE
+        and trigger == NotificationTriggers.PRIVATE_MESSAGE
     ):
         return f"New private group message from {sender_str}"
     elif (
         message.recipient.type == Recipient.PERSONAL
-        and message.trigger == NotificationTriggers.PRIVATE_MESSAGE
+        and trigger == NotificationTriggers.PRIVATE_MESSAGE
     ):
         return f"New private message from {sender_str}"
-    elif message.is_stream_message() and message.trigger == NotificationTriggers.MENTION:
+    elif message.is_stream_message() and trigger == NotificationTriggers.MENTION:
         if mentioned_user_group_name is None:
             return f"{sender_str} mentioned you in #{display_recipient}"
         else:
             return f"{sender_str} mentioned @{mentioned_user_group_name} in #{display_recipient}"
-    elif message.is_stream_message() and message.trigger == NotificationTriggers.WILDCARD_MENTION:
+    elif message.is_stream_message() and trigger == NotificationTriggers.WILDCARD_MENTION:
         return f"{sender_str} mentioned everyone in #{display_recipient}"
     else:
-        assert message.is_stream_message() and message.trigger == NotificationTriggers.STREAM_PUSH
+        assert message.is_stream_message() and trigger == NotificationTriggers.STREAM_PUSH
         return f"New stream message from {sender_str} in #{display_recipient}"
 
 
@@ -718,19 +720,22 @@ def get_apns_alert_title(message: Message) -> str:
 
 
 def get_apns_alert_subtitle(
-    user_profile: UserProfile, message: Message, mentioned_user_group_name: Optional[str] = None
+    user_profile: UserProfile,
+    message: Message,
+    trigger: str,
+    mentioned_user_group_name: Optional[str] = None,
 ) -> str:
     """
     On an iOS notification, this is the second bolded line.
     """
-    if message.trigger == NotificationTriggers.MENTION:
+    if trigger == NotificationTriggers.MENTION:
         if mentioned_user_group_name is not None:
             return _("{full_name} mentioned @{user_group_name}:").format(
                 full_name=message.sender.full_name, user_group_name=mentioned_user_group_name
             )
         else:
             return _("{full_name} mentioned you:").format(full_name=message.sender.full_name)
-    elif message.trigger == NotificationTriggers.WILDCARD_MENTION:
+    elif trigger == NotificationTriggers.WILDCARD_MENTION:
         return _("{full_name} mentioned everyone:").format(full_name=message.sender.full_name)
     elif message.recipient.type == Recipient.PERSONAL:
         return ""
@@ -769,6 +774,7 @@ def get_apns_badge_count_future(
 def get_message_payload_apns(
     user_profile: UserProfile,
     message: Message,
+    trigger: str,
     mentioned_user_group_id: Optional[int] = None,
     mentioned_user_group_name: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -787,7 +793,7 @@ def get_message_payload_apns(
             "alert": {
                 "title": get_apns_alert_title(message),
                 "subtitle": get_apns_alert_subtitle(
-                    user_profile, message, mentioned_user_group_name
+                    user_profile, message, trigger, mentioned_user_group_name
                 ),
                 "body": content,
             },
@@ -801,6 +807,7 @@ def get_message_payload_apns(
 def get_message_payload_gcm(
     user_profile: UserProfile,
     message: Message,
+    trigger: str,
     mentioned_user_group_id: Optional[int] = None,
     mentioned_user_group_name: Optional[str] = None,
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
@@ -813,7 +820,7 @@ def get_message_payload_gcm(
         content, truncated = truncate_content(get_mobile_push_content(message.rendered_content))
         data.update(
             event="message",
-            alert=get_gcm_alert(message, mentioned_user_group_name),
+            alert=get_gcm_alert(message, trigger, mentioned_user_group_name),
             zulip_message_id=message.id,  # message_id is reserved for CCS
             time=datetime_to_timestamp(message.date_sent),
             content=content,
@@ -944,7 +951,7 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
             )
             return
 
-    message.trigger = missed_message["trigger"]
+    trigger = missed_message["trigger"]
     mentioned_user_group_name = None
     mentioned_user_group_id = missed_message.get("mentioned_user_group_id")
 
@@ -955,10 +962,10 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
         mentioned_user_group_name = user_group.name
 
     apns_payload = get_message_payload_apns(
-        user_profile, message, mentioned_user_group_id, mentioned_user_group_name
+        user_profile, message, trigger, mentioned_user_group_id, mentioned_user_group_name
     )
     gcm_payload, gcm_options = get_message_payload_gcm(
-        user_profile, message, mentioned_user_group_id, mentioned_user_group_name
+        user_profile, message, trigger, mentioned_user_group_id, mentioned_user_group_name
     )
     logger.info("Sending push notifications to mobile clients for user %s", user_profile_id)
 

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -42,10 +42,10 @@ class RateLimitedObject(ABC):
         )
 
     def rate_limit_request(self, request: HttpRequest) -> None:
-        from zerver.lib.request import get_request_notes
+        from zerver.lib.request import RequestNotes
 
         ratelimited, time = self.rate_limit()
-        request_notes = get_request_notes(request)
+        request_notes = RequestNotes.get_notes(request)
 
         request_notes.ratelimits_applied.append(
             RateLimitResult(

--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -14,7 +14,7 @@ from zerver.decorator import (
     process_as_post,
 )
 from zerver.lib.exceptions import MissingAuthenticationError
-from zerver.lib.request import get_request_notes
+from zerver.lib.request import RequestNotes
 from zerver.lib.response import json_method_not_allowed
 from zerver.lib.types import ViewFuncT
 
@@ -66,7 +66,7 @@ def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
     etc, as that is where we route HTTP verbs to target functions.
     """
     supported_methods: Dict[str, Any] = {}
-    request_notes = get_request_notes(request)
+    request_notes = RequestNotes.get_notes(request)
     if request_notes.saved_response is not None:
         # For completing long-polled Tornado requests, we skip the
         # view function logic and just return the response.

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -45,7 +45,8 @@ from zerver.lib.avatar import avatar_url
 from zerver.lib.cache import get_cache_backend
 from zerver.lib.db import Params, ParamsT, Query, TimeTrackingCursor
 from zerver.lib.integrations import WEBHOOK_INTEGRATIONS
-from zerver.lib.request import ZulipRequestNotes, request_notes_map
+from zerver.lib.notes import BaseNotes
+from zerver.lib.request import RequestNotes
 from zerver.lib.upload import LocalUploadBackend, S3UploadBackend
 from zerver.models import (
     Client,
@@ -320,12 +321,16 @@ class HostRequestMock(HttpRequest):
         self.user = user_profile
         self._body = b""
         self.content_type = ""
+        BaseNotes[str, str].get_notes
 
-        request_notes_map[self] = ZulipRequestNotes(
-            client_name="",
-            log_data={},
-            tornado_handler=None if tornado_handler is None else weakref.ref(tornado_handler),
-            client=get_client(client_name) if client_name is not None else None,
+        RequestNotes.set_notes(
+            self,
+            RequestNotes(
+                client_name="",
+                log_data={},
+                tornado_handler=None if tornado_handler is None else weakref.ref(tornado_handler),
+                client=get_client(client_name) if client_name is not None else None,
+            ),
         )
 
     @property

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -14,7 +14,7 @@ from zerver.lib.actions import (
     send_rate_limited_pm_notification_to_bot_owner,
 )
 from zerver.lib.exceptions import ErrorCode, JsonableError, StreamDoesNotExistError
-from zerver.lib.request import REQ, get_request_notes, has_request_variables
+from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.send_email import FromAddress
 from zerver.lib.timestamp import timestamp_to_datetime
 from zerver.lib.validator import check_list, check_string
@@ -107,7 +107,7 @@ def check_send_webhook_message(
         ):
             return
 
-    client = get_request_notes(request).client
+    client = RequestNotes.get_notes(request).client
     assert client is not None
     if stream is None:
         assert user_profile.bot_owner is not None

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -47,9 +47,9 @@ from zerver.lib.initial_password import initial_password
 from zerver.lib.request import (
     REQ,
     RequestConfusingParmsError,
+    RequestNotes,
     RequestVariableConversionError,
     RequestVariableMissingError,
-    get_request_notes,
     has_request_variables,
 )
 from zerver.lib.response import json_response, json_success
@@ -1428,19 +1428,19 @@ class TestInternalNotifyView(ZulipTestCase):
                 orjson.loads(self.internal_notify(False, request).content).get("msg"),
                 self.BORING_RESULT,
             )
-            self.assertEqual(get_request_notes(request).requestor_for_logs, "internal")
+            self.assertEqual(RequestNotes.get_notes(request).requestor_for_logs, "internal")
 
             with self.assertRaises(RuntimeError):
                 self.internal_notify(True, request)
 
-        get_request_notes(request).tornado_handler = DummyHandler()
+        RequestNotes.get_notes(request).tornado_handler = DummyHandler()
         with self.settings(SHARED_SECRET=secret):
             self.assertTrue(authenticate_notify(request))
             self.assertEqual(
                 orjson.loads(self.internal_notify(True, request).content).get("msg"),
                 self.BORING_RESULT,
             )
-            self.assertEqual(get_request_notes(request).requestor_for_logs, "internal")
+            self.assertEqual(RequestNotes.get_notes(request).requestor_for_logs, "internal")
 
             with self.assertRaises(RuntimeError):
                 self.internal_notify(False, request)

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1574,7 +1574,6 @@ class TestGetAPNsPayload(PushNotificationTest):
         stream = Stream.objects.filter(name="Verona").get()
         message = self.get_message(Recipient.STREAM, stream.id)
         payload = get_message_payload_apns(self.sender, message, NotificationTriggers.STREAM_PUSH)
-        message.stream_name = "Verona"
         expected = {
             "alert": {
                 "title": "#Verona > Test topic",
@@ -1605,7 +1604,6 @@ class TestGetAPNsPayload(PushNotificationTest):
         stream = Stream.objects.filter(name="Verona").get()
         message = self.get_message(Recipient.STREAM, stream.id)
         payload = get_message_payload_apns(user_profile, message, NotificationTriggers.MENTION)
-        message.stream_name = "Verona"
         expected = {
             "alert": {
                 "title": "#Verona > Test topic",
@@ -1639,7 +1637,6 @@ class TestGetAPNsPayload(PushNotificationTest):
         payload = get_message_payload_apns(
             user_profile, message, NotificationTriggers.MENTION, user_group.id, user_group.name
         )
-        message.stream_name = "Verona"
         expected = {
             "alert": {
                 "title": "#Verona > Test topic",
@@ -1674,7 +1671,6 @@ class TestGetAPNsPayload(PushNotificationTest):
         payload = get_message_payload_apns(
             user_profile, message, NotificationTriggers.WILDCARD_MENTION
         )
-        message.stream_name = "Verona"
         expected = {
             "alert": {
                 "title": "#Verona > Test topic",
@@ -1844,7 +1840,6 @@ class TestGetGCMPayload(PushNotificationTest):
     def test_get_message_payload_gcm_stream_notifications(self) -> None:
         stream = Stream.objects.get(name="Denmark")
         message = self.get_message(Recipient.STREAM, stream.id)
-        message.stream_name = "Denmark"
         hamlet = self.example_user("hamlet")
         payload, gcm_options = get_message_payload_gcm(
             hamlet, message, NotificationTriggers.STREAM_PUSH
@@ -1882,7 +1877,6 @@ class TestGetGCMPayload(PushNotificationTest):
     def test_get_message_payload_gcm_redacted_content(self) -> None:
         stream = Stream.objects.get(name="Denmark")
         message = self.get_message(Recipient.STREAM, stream.id)
-        message.stream_name = "Denmark"
         hamlet = self.example_user("hamlet")
         payload, gcm_options = get_message_payload_gcm(
             hamlet, message, NotificationTriggers.STREAM_PUSH

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -47,7 +47,7 @@ def finish_handler(
     try:
         # We do the import during runtime to avoid cyclic dependency
         # with zerver.lib.request
-        from zerver.lib.request import get_request_notes
+        from zerver.lib.request import RequestNotes
         from zerver.middleware import async_request_timer_restart
 
         # We call async_request_timer_restart here in case we are
@@ -56,7 +56,7 @@ def finish_handler(
         handler = get_handler_by_id(handler_id)
         request = handler._request
         async_request_timer_restart(request)
-        log_data = get_request_notes(request).log_data
+        log_data = RequestNotes.get_notes(request).log_data
         assert log_data is not None
         if len(contents) != 1:
             log_data["extra"] = f"[{event_queue_id}/1]"
@@ -113,11 +113,11 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         request = WSGIRequest(environ)
 
         # We do the import during runtime to avoid cyclic dependency
-        from zerver.lib.request import get_request_notes
+        from zerver.lib.request import RequestNotes
 
         # Provide a way for application code to access this handler
         # given the HttpRequest object.
-        get_request_notes(request).tornado_handler = weakref.ref(self)
+        RequestNotes.get_notes(request).tornado_handler = weakref.ref(self)
 
         return request
 
@@ -228,12 +228,12 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         # HttpResponse with all Django middleware run.
         request = self.convert_tornado_request_to_django_request()
 
-        # We import get_request_notes during runtime to avoid
+        # We import RequestNotes during runtime to avoid
         # cyclic import
-        from zerver.lib.request import get_request_notes
+        from zerver.lib.request import RequestNotes
 
-        request_notes = get_request_notes(request)
-        old_request_notes = get_request_notes(old_request)
+        request_notes = RequestNotes.get_notes(request)
+        old_request_notes = RequestNotes.get_notes(old_request)
 
         # Add to this new HttpRequest logging data from the processing of
         # the original request; we will need these for logging.

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -54,7 +54,7 @@ from zerver.lib.mobile_auth_otp import otp_encrypt_api_key
 from zerver.lib.push_notifications import push_notifications_enabled
 from zerver.lib.pysa import mark_sanitized
 from zerver.lib.realm_icon import realm_icon_url
-from zerver.lib.request import REQ, get_request_notes, has_request_variables
+from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.sessions import set_expirable_session_var
 from zerver.lib.subdomains import get_subdomain, is_subdomain_root_or_alias
@@ -358,7 +358,7 @@ def finish_mobile_flow(request: HttpRequest, user_profile: UserProfile, otp: str
 
     # Mark this request as having a logged-in user for our server logs.
     process_client(request, user_profile)
-    get_request_notes(request).requestor_for_logs = user_profile.format_requestor_for_logs()
+    RequestNotes.get_notes(request).requestor_for_logs = user_profile.format_requestor_for_logs()
 
     return response
 
@@ -866,7 +866,7 @@ def api_fetch_api_key(
 
     # Mark this request as having a logged-in user for our server logs.
     process_client(request, user_profile)
-    get_request_notes(request).requestor_for_logs = user_profile.format_requestor_for_logs()
+    RequestNotes.get_notes(request).requestor_for_logs = user_profile.format_requestor_for_logs()
 
     api_key = get_api_key(user_profile)
     return json_success({"api_key": api_key, "email": user_profile.delivery_email})

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -13,7 +13,7 @@ from django.views.generic import TemplateView
 from zerver.context_processors import zulip_default_context
 from zerver.decorator import add_google_analytics_context
 from zerver.lib.integrations import CATEGORIES, INTEGRATIONS, HubotIntegration, WebhookIntegration
-from zerver.lib.request import REQ, get_request_notes, has_request_variables
+from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.templates import render_markdown_path
 from zerver.models import Realm
@@ -168,7 +168,7 @@ class MarkdownDirectoryView(ApiURLView):
                 context["OPEN_GRAPH_TITLE"] = f"{article_title} ({title_base})"
             else:
                 context["OPEN_GRAPH_TITLE"] = title_base
-            request_notes = get_request_notes(self.request)
+            request_notes = RequestNotes.get_notes(self.request)
             request_notes.placeholder_open_graph_description = (
                 f"REPLACMENT_OPEN_GRAPH_DESCRIPTION_{int(2**24 * random.random())}"
             )

--- a/zerver/views/events_register.py
+++ b/zerver/views/events_register.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext as _
 
 from zerver.lib.events import do_events_register
 from zerver.lib.exceptions import JsonableError
-from zerver.lib.request import REQ, get_request_notes, has_request_variables
+from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.validator import check_bool, check_dict, check_list, check_string
 from zerver.models import Stream, UserProfile
@@ -80,7 +80,7 @@ def events_register_backend(
     if client_capabilities is None:
         client_capabilities = {}
 
-    client = get_request_notes(request).client
+    client = RequestNotes.get_notes(request).client
     assert client is not None
 
     ret = do_events_register(

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -14,7 +14,7 @@ from zerver.forms import ToSForm
 from zerver.lib.actions import do_change_tos_version, realm_user_count
 from zerver.lib.compatibility import is_outdated_desktop_app, is_unsupported_browser
 from zerver.lib.home import build_page_params_for_home_page_load, get_user_permission_info
-from zerver.lib.request import get_request_notes
+from zerver.lib.request import RequestNotes
 from zerver.lib.streams import access_stream_by_name
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.utils import statsd
@@ -192,7 +192,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
         needs_tutorial=needs_tutorial,
     )
 
-    log_data = get_request_notes(request).log_data
+    log_data = RequestNotes.get_notes(request).log_data
     assert log_data is not None
     log_data["extra"] = f"[{queue_id}]"
 

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -11,7 +11,7 @@ from zerver.lib.actions import check_update_message, do_delete_messages
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.html_diff import highlight_html_differences
 from zerver.lib.message import access_message
-from zerver.lib.request import REQ, get_request_notes, has_request_variables
+from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import LEGACY_PREV_TOPIC, REQ_topic
@@ -117,7 +117,7 @@ def update_message_backend(
     )
 
     # Include the number of messages changed in the logs
-    log_data = get_request_notes(request).log_data
+    log_data = RequestNotes.get_notes(request).log_data
     assert log_data is not None
     log_data["extra"] = f"[{number_changed}]"
 

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -37,7 +37,7 @@ from zerver.lib.addressee import get_user_profiles, get_user_profiles_by_ids
 from zerver.lib.exceptions import ErrorCode, JsonableError, MissingAuthenticationError
 from zerver.lib.message import get_first_visible_message_id, messages_for_ids
 from zerver.lib.narrow import is_web_public_compatible, is_web_public_narrow
-from zerver.lib.request import REQ, get_request_notes, has_request_variables
+from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
 from zerver.lib.streams import (
@@ -1040,7 +1040,7 @@ def get_messages_backend(
                 verbose_operators.append("is:" + term["operand"])
             else:
                 verbose_operators.append(term["operator"])
-        log_data = get_request_notes(request).log_data
+        log_data = RequestNotes.get_notes(request).log_data
         assert log_data is not None
         log_data["extra"] = "[{}]".format(",".join(verbose_operators))
 

--- a/zerver/views/message_flags.py
+++ b/zerver/views/message_flags.py
@@ -9,7 +9,7 @@ from zerver.lib.actions import (
     do_update_message_flags,
 )
 from zerver.lib.exceptions import JsonableError
-from zerver.lib.request import REQ, get_request_notes, has_request_variables
+from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.streams import access_stream_by_id
 from zerver.lib.topic import user_message_exists_for_topic
@@ -35,7 +35,7 @@ def update_message_flags(
     operation: str = REQ("op"),
     flag: str = REQ(),
 ) -> HttpResponse:
-    request_notes = get_request_notes(request)
+    request_notes = RequestNotes.get_notes(request)
     assert request_notes.client is not None
     assert request_notes.log_data is not None
 
@@ -50,7 +50,7 @@ def update_message_flags(
 
 @has_request_variables
 def mark_all_as_read(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
-    request_notes = get_request_notes(request)
+    request_notes = RequestNotes.get_notes(request)
     assert request_notes.client is not None
     count = do_mark_all_as_read(user_profile, request_notes.client)
 
@@ -69,7 +69,7 @@ def mark_stream_as_read(
     count = do_mark_stream_messages_as_read(user_profile, stream.recipient_id)
 
     log_data_str = f"[{count} updated]"
-    log_data = get_request_notes(request).log_data
+    log_data = RequestNotes.get_notes(request).log_data
     assert log_data is not None
     log_data["extra"] = log_data_str
 
@@ -98,7 +98,7 @@ def mark_topic_as_read(
     count = do_mark_stream_messages_as_read(user_profile, stream.recipient_id, topic_name)
 
     log_data_str = f"[{count} updated]"
-    log_data = get_request_notes(request).log_data
+    log_data = RequestNotes.get_notes(request).log_data
     assert log_data is not None
     log_data["extra"] = log_data_str
 

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -19,7 +19,7 @@ from zerver.lib.actions import (
 )
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import render_markdown
-from zerver.lib.request import REQ, get_request_notes, has_request_variables
+from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import convert_to_UTC
 from zerver.lib.topic import REQ_topic
@@ -53,7 +53,7 @@ def create_mirrored_message_users(
         for email in recipients:
             referenced_users.add(email.lower())
 
-    client = get_request_notes(request).client
+    client = RequestNotes.get_notes(request).client
     assert client is not None
 
     if client.name == "zephyr_mirror":
@@ -226,7 +226,7 @@ def send_message_backend(
     # `yes` to accepting `true` like all of our normal booleans.
     forged = forged_str is not None and forged_str in ["yes", "true"]
 
-    client = get_request_notes(request).client
+    client = RequestNotes.get_notes(request).client
     assert client is not None
     can_forge_sender = user_profile.can_forge_sender
     if forged and not can_forge_sender:
@@ -330,7 +330,7 @@ def render_message_backend(
     message = Message()
     message.sender = user_profile
     message.content = content
-    client = get_request_notes(request).client
+    client = RequestNotes.get_notes(request).client
     assert client is not None
     message.sending_client = client
 

--- a/zerver/views/presence.py
+++ b/zerver/views/presence.py
@@ -11,7 +11,7 @@ from zerver.lib.actions import do_update_user_status, update_user_presence
 from zerver.lib.emoji import check_emoji_request, emoji_name_to_emoji_code
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.presence import get_presence_for_user, get_presence_response
-from zerver.lib.request import REQ, get_request_notes, has_request_variables
+from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.validator import check_bool, check_capped_string
@@ -114,7 +114,7 @@ def update_user_status_backend(
         assert emoji_type is not None
         check_emoji_request(user_profile.realm, emoji_name, emoji_code, emoji_type)
 
-    client = get_request_notes(request).client
+    client = RequestNotes.get_notes(request).client
     assert client is not None
     do_update_user_status(
         user_profile=user_profile,
@@ -143,7 +143,7 @@ def update_active_status_backend(
     if status_val is None:
         raise JsonableError(_("Invalid status: {}").format(status))
     elif user_profile.presence_enabled:
-        client = get_request_notes(request).client
+        client = RequestNotes.get_notes(request).client
         assert client is not None
         update_user_presence(user_profile, client, timezone_now(), status_val, new_user_input)
 

--- a/zerver/views/report.py
+++ b/zerver/views/report.py
@@ -14,7 +14,7 @@ from zerver.context_processors import get_valid_realm_from_request
 from zerver.decorator import human_users_only
 from zerver.lib.markdown import privacy_clean_markdown
 from zerver.lib.queue import queue_json_publish
-from zerver.lib.request import REQ, get_request_notes, has_request_variables
+from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.storage import static_path
 from zerver.lib.unminify import SourceMap
@@ -54,7 +54,7 @@ def report_send_times(
     if displayed > 0:
         displayed_str = str(displayed)
 
-    log_data = get_request_notes(request).log_data
+    log_data = RequestNotes.get_notes(request).log_data
     assert log_data is not None
     log_data[
         "extra"
@@ -81,7 +81,7 @@ def report_narrow_times(
     initial_free: int = REQ(converter=to_non_negative_int),
     network: int = REQ(converter=to_non_negative_int),
 ) -> HttpResponse:
-    log_data = get_request_notes(request).log_data
+    log_data = RequestNotes.get_notes(request).log_data
     assert log_data is not None
     log_data["extra"] = f"[{initial_core}ms/{initial_free}ms/{network}ms]"
     realm = get_valid_realm_from_request(request)
@@ -99,7 +99,7 @@ def report_unnarrow_times(
     initial_core: int = REQ(converter=to_non_negative_int),
     initial_free: int = REQ(converter=to_non_negative_int),
 ) -> HttpResponse:
-    log_data = get_request_notes(request).log_data
+    log_data = RequestNotes.get_notes(request).log_data
     assert log_data is not None
     log_data["extra"] = f"[{initial_core}ms/{initial_free}ms]"
     realm = get_valid_realm_from_request(request)

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -276,9 +276,9 @@ def json_change_settings(
         do_set_user_display_setting(user_profile, "timezone", timezone)
 
     # TODO: Do this more generally.
-    from zerver.lib.request import get_request_notes
+    from zerver.lib.request import RequestNotes
 
-    request_notes = get_request_notes(request)
+    request_notes = RequestNotes.get_notes(request)
     for req_var in request.POST:
         if req_var not in request_notes.processed_parameters:
             request_notes.ignored_parameters.add(req_var)

--- a/zerver/webhooks/dialogflow/view.py
+++ b/zerver/webhooks/dialogflow/view.py
@@ -5,7 +5,7 @@ from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.actions import check_send_private_message
-from zerver.lib.request import REQ, get_request_notes, has_request_variables
+from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.models import UserProfile, get_user
 
@@ -35,7 +35,7 @@ def api_dialogflow_webhook(
         body = f"{status} - {error_status}"
 
     receiving_user = get_user(email, user_profile.realm)
-    client = get_request_notes(request).client
+    client = RequestNotes.get_notes(request).client
     assert client is not None
     check_send_private_message(user_profile, client, receiving_user, body)
     return json_success()

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext as _
 from zerver.decorator import webhook_view
 from zerver.lib.actions import check_send_stream_message
 from zerver.lib.exceptions import JsonableError
-from zerver.lib.request import REQ, get_request_notes, has_request_variables
+from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.models import UserProfile
 
@@ -35,7 +35,7 @@ def api_slack_webhook(
         subject = _("Message from Slack")
 
     content = ZULIP_MESSAGE_TEMPLATE.format(message_sender=user_name, text=text)
-    client = get_request_notes(request).client
+    client = RequestNotes.get_notes(request).client
     assert client is not None
     check_send_stream_message(user_profile, client, stream, subject, content)
     return json_success()

--- a/zerver/webhooks/teamcity/view.py
+++ b/zerver/webhooks/teamcity/view.py
@@ -10,7 +10,7 @@ from zerver.lib.actions import (
     check_send_private_message,
     send_rate_limited_pm_notification_to_bot_owner,
 )
-from zerver.lib.request import REQ, get_request_notes, has_request_variables
+from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress
 from zerver.lib.webhooks.common import check_send_webhook_message
@@ -137,7 +137,7 @@ def api_teamcity_webhook(
             return json_success()
 
         body = f"Your personal build for {body}"
-        client = get_request_notes(request).client
+        client = RequestNotes.get_notes(request).client
         assert client is not None
         check_send_private_message(user_profile, client, teamcity_user, body)
 

--- a/zerver/webhooks/yo/view.py
+++ b/zerver/webhooks/yo/view.py
@@ -5,7 +5,7 @@ from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.actions import check_send_private_message
-from zerver.lib.request import REQ, get_request_notes, has_request_variables
+from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.models import UserProfile, get_user
 
@@ -22,7 +22,7 @@ def api_yo_app_webhook(
 ) -> HttpResponse:
     body = f"Yo from {username}"
     receiving_user = get_user(email, user_profile.realm)
-    client = get_request_notes(request).client
+    client = RequestNotes.get_notes(request).client
     assert client is not None
     check_send_private_message(user_profile, client, receiving_user, body)
     return json_success()

--- a/zilencer/management/commands/profile_request.py
+++ b/zilencer/management/commands/profile_request.py
@@ -8,7 +8,7 @@ from django.core.management.base import CommandParser
 from django.http import HttpRequest, HttpResponse
 
 from zerver.lib.management import ZulipBaseCommand
-from zerver.lib.request import get_request_notes
+from zerver.lib.request import RequestNotes
 from zerver.lib.test_helpers import HostRequestMock
 from zerver.middleware import LogRequests
 from zerver.models import UserMessage
@@ -55,6 +55,6 @@ class Command(ZulipBaseCommand):
             path="/",
         )
         mock_request.session = MockSession()
-        get_request_notes(mock_request).log_data = None
+        RequestNotes.get_notes(mock_request).log_data = None
 
         profile_request(mock_request)

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -71,7 +71,7 @@ from zerver.lib.exceptions import JsonableError
 from zerver.lib.mobile_auth_otp import is_valid_otp
 from zerver.lib.rate_limiter import RateLimitedObject
 from zerver.lib.redis_utils import get_dict_from_redis, get_redis_client, put_dict_in_redis
-from zerver.lib.request import get_request_notes
+from zerver.lib.request import RequestNotes
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.users import check_full_name, validate_user_custom_profile_field
 from zerver.models import (
@@ -251,7 +251,7 @@ def rate_limit_authentication_by_username(request: HttpRequest, username: str) -
 
 
 def auth_rate_limiting_already_applied(request: HttpRequest) -> bool:
-    request_notes = get_request_notes(request)
+    request_notes = RequestNotes.get_notes(request)
 
     return any(
         isinstance(r.entity, RateLimitedAuthenticationByUsername)
@@ -270,7 +270,7 @@ def rate_limit_auth(auth_func: AuthFuncT, *args: Any, **kwargs: Any) -> Optional
 
     request = args[1]
     username = kwargs["username"]
-    if get_request_notes(request).client is None or not client_is_exempt_from_rate_limiting(
+    if RequestNotes.get_notes(request).client is None or not client_is_exempt_from_rate_limiting(
         request
     ):
         # Django cycles through enabled authentication backends until one succeeds,

--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -22,7 +22,7 @@ def add_context(event: "Event", hint: "Hint") -> Optional["Event"]:
             return None
     from django.conf import settings
 
-    from zerver.lib.request import get_current_request, get_request_notes
+    from zerver.lib.request import RequestNotes, get_current_request
     from zerver.models import get_user_profile_by_id
 
     with capture_internal_exceptions():
@@ -47,7 +47,7 @@ def add_context(event: "Event", hint: "Hint") -> Optional["Event"]:
 
         request = get_current_request()
         if request:
-            request_notes = get_request_notes(request)
+            request_notes = RequestNotes.get_notes(request)
             if request_notes.client is not None:
                 event["tags"]["client"] = request_notes.client.name
             if request_notes.realm is not None:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
The motive of adding `BaseNotes` was to support monokey patching
temporary attributes to objects (such as `.trigger` on `Message`) when
working on the django-stubs migration in #18777.

**Testing plan:** <!-- How have you tested? -->
This has been tested with existing test suites.