### PR TITLE
Rename system group examples and restrict mentioning system user groups.

### DIFF
--- a/zerver/lib/mention.py
+++ b/zerver/lib/mention.py
@@ -101,7 +101,7 @@ class MentionData:
         user_group_names = possible_user_group_mentions(content)
         if user_group_names:
             for group in UserGroup.objects.filter(
-                realm_id=realm_id, name__in=user_group_names
+                realm_id=realm_id, name__in=user_group_names, is_system_group=False
             ).prefetch_related("usergroupmembership_set"):
                 self.user_group_name_info[group.name.lower()] = group
                 self.user_group_members[group.id] = [

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -825,33 +825,6 @@ class TestMissedMessages(ZulipTestCase):
         for text in expected_email_include:
             self.assertIn(text, self.normalize_string(mail.outbox[0].body))
 
-    def test_system_user_group_mention_sends_email(self) -> None:
-        hamlet = self.example_user("hamlet")
-        cordelia = self.example_user("cordelia")
-        othello = self.example_user("othello")
-
-        hamlet_and_cordelia = create_user_group(
-            "hamlet_and_cordelia", [hamlet, cordelia], get_realm("zulip"), is_system_group=True
-        )
-        user_group_mentioned_message_id = self.send_stream_message(
-            othello, "Denmark", "@*hamlet_and_cordelia*"
-        )
-
-        handle_missedmessage_emails(
-            hamlet.id,
-            [
-                {
-                    "message_id": user_group_mentioned_message_id,
-                    "trigger": "mentioned",
-                    "mentioned_user_group_id": hamlet_and_cordelia.id,
-                },
-            ],
-        )
-        self.assertIn(
-            "Othello, the Moor of Venice: @*hamlet_and_cordelia* -- ",
-            self.normalize_string(mail.outbox[0].body),
-        )
-
     def test_realm_name_in_notifications(self) -> None:
         # Test with realm_name_in_notifications for hamlet disabled.
         self._realm_name_in_missed_message_email_subject(False)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit renames the system group in api docs.
- Second commit renames the system group used in tests.
- Third commit adds restriction on mentioning system groups.

Follow-up of #19536.

 <!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
