### PR TITLE
fix: apidocs: send-message: use topic instead of deprecated subject

### DIFF
--- a/templates/zerver/api/send-message.md
+++ b/templates/zerver/api/send-message.md
@@ -18,7 +18,7 @@ curl -X POST {{ api_url }}/v1/messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     --data-urlencode type=stream \
     --data-urlencode to=Denmark \
-    --data-urlencode subject=Castle \
+    --data-urlencode topic=Castle \
     --data-urlencode 'content=I come not, friends, to steal away your hearts.'
 
 # For private messages
@@ -37,7 +37,7 @@ the command-line, providing the message content via STDIN.
 
 ```bash
 # For stream messages
-zulip-send --stream Denmark --subject Castle \
+zulip-send --stream Denmark --topic Castle \
     --user othello-bot@example.com --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
 
 # For private messages
@@ -52,7 +52,7 @@ If you'd like, you can also provide the message on the command-line with the
 
 
 ```bash
-zulip-send --stream Denmark --subject Castle \
+zulip-send --stream Denmark --topic Castle \
     --message 'I come not, friends, to steal away your hearts.' \
     --user othello-bot@example.com --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
 ```


### PR DESCRIPTION
Hello!
In my understanding, the API docs are partially autogenerated.
It seems that the curl and zulip-send examples are hardcoded in the template files, so I am editing the template directly.

NOTE: I updated both the curl and zulip-send example, but I am sure only of the curl one. I don't know if zulip-send is kept up to date.