### PR TITLE
Update the labels of settings dropdown to specify moderators and fix some width related issues.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -737,13 +737,13 @@ test("test get_organization_settings_options", () => {
             key: "by_full_members",
             order: 3,
             code: 3,
-            description: $t({defaultMessage: "Admins and full members"}),
+            description: $t({defaultMessage: "Admins, moderators and full members"}),
         },
         {
             key: "by_members",
             order: 4,
             code: 1,
-            description: $t({defaultMessage: "Admins and members"}),
+            description: $t({defaultMessage: "Admins, moderators and members"}),
         },
     ];
     assert.deepEqual(sorted_common_policy_values, expected_common_policy_values);
@@ -759,12 +759,12 @@ test("test get_sorted_options_list", () => {
         by_members: {
             order: 2,
             code: 1,
-            description: $t({defaultMessage: "Admins and members"}),
+            description: $t({defaultMessage: "Admins, moderators and members"}),
         },
         by_full_members: {
             order: 1,
             code: 3,
-            description: $t({defaultMessage: "Admins and full members"}),
+            description: $t({defaultMessage: "Admins, moderators and full members"}),
         },
     };
     let expected_option_values = [
@@ -772,13 +772,13 @@ test("test get_sorted_options_list", () => {
             key: "by_full_members",
             order: 1,
             code: 3,
-            description: $t({defaultMessage: "Admins and full members"}),
+            description: $t({defaultMessage: "Admins, moderators and full members"}),
         },
         {
             key: "by_members",
             order: 2,
             code: 1,
-            description: $t({defaultMessage: "Admins and members"}),
+            description: $t({defaultMessage: "Admins, moderators and members"}),
         },
         {
             key: "by_admins_only",
@@ -796,11 +796,11 @@ test("test get_sorted_options_list", () => {
         },
         by_members: {
             code: 2,
-            description: $t({defaultMessage: "Admins and members"}),
+            description: $t({defaultMessage: "Admins, moderators and members"}),
         },
         by_full_members: {
             code: 3,
-            description: $t({defaultMessage: "Admins and full members"}),
+            description: $t({defaultMessage: "Admins, moderators and full members"}),
         },
     };
     expected_option_values = [
@@ -812,12 +812,12 @@ test("test get_sorted_options_list", () => {
         {
             key: "by_full_members",
             code: 3,
-            description: $t({defaultMessage: "Admins and full members"}),
+            description: $t({defaultMessage: "Admins, moderators and full members"}),
         },
         {
             key: "by_members",
             code: 2,
-            description: $t({defaultMessage: "Admins and members"}),
+            description: $t({defaultMessage: "Admins, moderators and members"}),
         },
     ];
     assert.deepEqual(settings_org.get_sorted_options_list(option_values_2), expected_option_values);

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -164,12 +164,12 @@ export const bot_creation_policy_values = {
     },
     everyone: {
         code: 1,
-        description: $t({defaultMessage: "Admins and members"}),
+        description: $t({defaultMessage: "Admins, moderators and members"}),
     },
     restricted: {
         code: 2,
         description: $t({
-            defaultMessage: "Admins and members, but only admins can add generic bots",
+            defaultMessage: "Admins, moderators and members, but only admins can add generic bots",
         }),
     },
 };

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -97,7 +97,7 @@ export const get_all_display_settings = (): DisplaySettings => ({
 export const email_address_visibility_values = {
     everyone: {
         code: 1,
-        description: $t({defaultMessage: "Admins, members, and guests"}),
+        description: $t({defaultMessage: "Admins, moderators, members and guests"}),
     },
     // // Backend support for this configuration is not available yet.
     // admins_and_members: {
@@ -132,12 +132,12 @@ export const common_policy_values = {
     by_full_members: {
         order: 3,
         code: 3,
-        description: $t({defaultMessage: "Admins and full members"}),
+        description: $t({defaultMessage: "Admins, moderators and full members"}),
     },
     by_members: {
         order: 4,
         code: 1,
-        description: $t({defaultMessage: "Admins and members"}),
+        description: $t({defaultMessage: "Admins, moderators and members"}),
     },
 };
 
@@ -160,12 +160,12 @@ export const invite_to_realm_policy_values = {
     by_full_members: {
         order: 4,
         code: 3,
-        description: $t({defaultMessage: "Admins and full members"}),
+        description: $t({defaultMessage: "Admins, moderators and full members"}),
     },
     by_members: {
         order: 5,
         code: 1,
-        description: $t({defaultMessage: "Admins and members"}),
+        description: $t({defaultMessage: "Admins, moderators and members"}),
     },
 };
 
@@ -173,7 +173,7 @@ export const private_message_policy_values = {
     by_anyone: {
         order: 1,
         code: 1,
-        description: $t({defaultMessage: "Admins, members, and guests"}),
+        description: $t({defaultMessage: "Admins, moderators, members and guests"}),
     },
     disabled: {
         order: 2,
@@ -186,17 +186,17 @@ export const wildcard_mention_policy_values = {
     by_everyone: {
         order: 1,
         code: 1,
-        description: $t({defaultMessage: "Admins, members and guests"}),
+        description: $t({defaultMessage: "Admins, moderators, members and guests"}),
     },
     by_members: {
         order: 2,
         code: 2,
-        description: $t({defaultMessage: "Admins and members"}),
+        description: $t({defaultMessage: "Admins, moderators and members"}),
     },
     by_full_members: {
         order: 3,
         code: 3,
-        description: $t({defaultMessage: "Admins and full members"}),
+        description: $t({defaultMessage: "Admins, moderators and full members"}),
     },
     by_moderators_only: {
         order: 4,
@@ -228,17 +228,17 @@ export const common_message_policy_values = {
     by_everyone: {
         order: 1,
         code: 5,
-        description: $t({defaultMessage: "Admins, members and guests"}),
+        description: $t({defaultMessage: "Admins, moderators, members and guests"}),
     },
     by_members: {
         order: 2,
         code: 1,
-        description: $t({defaultMessage: "Admins and members"}),
+        description: $t({defaultMessage: "Admins, moderators and members"}),
     },
     by_full_members: {
         order: 3,
         code: 3,
-        description: $t({defaultMessage: "Admins and full members"}),
+        description: $t({defaultMessage: "Admins, moderators and full members"}),
     },
     by_moderators_only: {
         order: 4,

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1560,7 +1560,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     vertical-align: center;
 }
 
-/* These have enough space for "Admins, moderators and full members" in German. */
+/* These have enough space for all the options in German. */
 .setting_desktop_icon_count_display,
 #id_realm_waiting_period_setting,
 #id_realm_create_stream_policy,
@@ -1572,7 +1572,9 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 #id_realm_wildcard_mention_policy,
 #id_realm_move_messages_between_streams_policy,
 #id_realm_invite_to_realm_policy,
-#id_realm_edit_topic_policy {
+#id_realm_edit_topic_policy,
+#id_realm_msg_edit_limit_setting,
+#id_realm_msg_delete_limit_setting {
     width: 325px;
 }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1571,7 +1571,8 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 #id_realm_email_address_visibility,
 #id_realm_wildcard_mention_policy,
 #id_realm_move_messages_between_streams_policy,
-#id_realm_invite_to_realm_policy {
+#id_realm_invite_to_realm_policy,
+#id_realm_edit_topic_policy {
     width: 325px;
 }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1560,7 +1560,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     vertical-align: center;
 }
 
-/* These have enough space for "Admins and full members" in German. */
+/* These have enough space for "Admins, moderators and full members" in German. */
 .setting_desktop_icon_count_display,
 #id_realm_waiting_period_setting,
 #id_realm_create_stream_policy,
@@ -1572,7 +1572,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 #id_realm_wildcard_mention_policy,
 #id_realm_move_messages_between_streams_policy,
 #id_realm_invite_to_realm_policy {
-    width: 250px;
+    width: 325px;
 }
 
 #id_realm_bot_creation_policy,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- Specify moderators in the options of various setting dropdowns.
- Two commits for increasing the width of dropdowns to have enough space for options even after translation.

Fixes #19562.
<!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
