### PR TITLE
management: Rename clear_auth_rate_limit_history command.

### DIFF
--- a/zerver/management/commands/reset_authentication_attempt_count.py
+++ b/zerver/management/commands/reset_authentication_attempt_count.py
@@ -15,7 +15,7 @@ class Command(ZulipBaseCommand):
 
     def handle(self, *args: Any, **options: Any) -> None:
         if not options["username"]:
-            self.print_help("./manage.py", "clear_auth_rate_limit_history")
+            self.print_help("./manage.py", "reset_authentication_attempt_count")
             raise CommandError("Please enter a username")
 
         username = options["username"]


### PR DESCRIPTION
@alexmv Suggested a better name in https://github.com/zulip/zulip/pull/19586#issuecomment-902314266