### PR TITLE
fetch-contributor-data: Normalize names to NFC

### DIFF
--- a/tools/fetch-contributor-data
+++ b/tools/fetch-contributor-data
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import sys
+import unicodedata
 from datetime import date
 from random import randrange
 from time import sleep
@@ -141,7 +142,9 @@ def update_contributor_data_file() -> None:
 
                 name = contributor.get("name")
                 if name is not None:
-                    contributor_username_to_data[username]["name"] = name
+                    contributor_username_to_data[username]["name"] = unicodedata.normalize(
+                        "NFC", name
+                    )
 
     # remove duplicate contributions count
     # find commits at the time of split and subtract from zulip-server

--- a/tools/fetch-contributor-data
+++ b/tools/fetch-contributor-data
@@ -3,32 +3,28 @@
 Fetch contributors data from GitHub using their API, convert it to structured
 JSON data for the /team page contributors section.
 """
+import argparse
+import json
+import logging
 import os
 import sys
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from scripts.lib.setup_path import setup_path
-
-setup_path()
-
-import argparse
-import logging
 from datetime import date
 from random import randrange
 from time import sleep
 from typing import Dict, List, Optional, Union
 
-from typing_extensions import TypedDict
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from scripts.lib.setup_path import setup_path
 
+setup_path()
 os.environ["DJANGO_SETTINGS_MODULE"] = "zproject.settings"
+
 import django
-
-django.setup()
-
-import json
-
 import requests
 from django.conf import settings
+from typing_extensions import TypedDict
+
+django.setup()
 
 from zerver.lib.avatar_hash import gravatar_hash
 from zproject.config import get_secret


### PR DESCRIPTION
Fixes an (admittedly picky) HTML validator warning on https://zulip.com/team/.

**Testing plan:** Ran `tools/fetch-contributor-data; tools/test-help-documentation --skip-external-links`