### PR TITLE
puppet: Add a bare-bones zulipbot profile.

### DIFF
--- a/puppet/zulip_ops/manifests/profile/zulipbot_zulip_org.pp
+++ b/puppet/zulip_ops/manifests/profile/zulipbot_zulip_org.pp
@@ -1,0 +1,8 @@
+class zulip_ops::profile::zulipbot_zulip_org {
+  include zulip_ops::profile::base
+  zulip_ops::firewall_allow { 'http': }
+  zulip_ops::firewall_allow { 'https': }
+
+  # TODO: This does not do any configuration of zulipbot itself, or of
+  # caddy.
+}


### PR DESCRIPTION
This sets up the firewalls appropriate for zulipbot, but does not
automate any of the configuration of zulipbot itself.

**Testing plan:** Untested.
