### PR TITLE
Stop forking django-auth-ldap

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -42,10 +42,7 @@ mypy-boto3-s3
 defusedxml
 
 # Needed for LDAP support
-# Using our fork for the feature of searching users by email.
-# https://github.com/django-auth-ldap/django-auth-ldap/pull/150 for monitoring
-# progress on merging this upstream.
-https://github.com/zulip/django-auth-ldap/archive/e26d0ef2a7ff77ab3fdd7b6578a76081f780778c.zip#egg=django-auth-ldap==2.0.0zulip1
+django-auth-ldap
 
 # Django extension providing bitfield support
 django-bitfield

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -391,8 +391,9 @@ django[argon2]==3.2.6 \
     #   django-phonenumber-field
     #   django-sendfile2
     #   django-two-factor-auth
-https://github.com/zulip/django-auth-ldap/archive/e26d0ef2a7ff77ab3fdd7b6578a76081f780778c.zip#egg=django-auth-ldap==2.0.0zulip1 \
-    --hash=sha256:1a104fdb5085ef9340996ae82d4b302f99c39c5d9d60d4ae55bcc7c1f58cb65e
+django-auth-ldap==3.0.0 \
+    --hash=sha256:19ee19034f344d9efd07ed88d3187e256ec33ae39d6a47222083b89f7d35c5f6 \
+    --hash=sha256:1f2d5c562d9ba9a5e9a64099ae9798e1a63840a11afe4d1c4a9c74121f066eaa
     # via -r requirements/common.in
 django-bitfield==2.1.0 \
     --hash=sha256:158f1056e22cce450d0a49633ea77bfd84b85a2294b1ef03faa775a485f4065d \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -242,8 +242,9 @@ django[argon2]==3.2.6 \
     #   django-phonenumber-field
     #   django-sendfile2
     #   django-two-factor-auth
-https://github.com/zulip/django-auth-ldap/archive/e26d0ef2a7ff77ab3fdd7b6578a76081f780778c.zip#egg=django-auth-ldap==2.0.0zulip1 \
-    --hash=sha256:1a104fdb5085ef9340996ae82d4b302f99c39c5d9d60d4ae55bcc7c1f58cb65e
+django-auth-ldap==3.0.0 \
+    --hash=sha256:19ee19034f344d9efd07ed88d3187e256ec33ae39d6a47222083b89f7d35c5f6 \
+    --hash=sha256:1f2d5c562d9ba9a5e9a64099ae9798e1a63840a11afe4d1c4a9c74121f066eaa
     # via -r requirements/common.in
 django-bitfield==2.1.0 \
     --hash=sha256:158f1056e22cce450d0a49633ea77bfd84b85a2294b1ef03faa775a485f4065d \

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 93
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "155.1"
+PROVISION_VERSION = "156.0"


### PR DESCRIPTION
Motivated by https://chat.zulip.org/#narrow/stream/3-backend/topic/Non-upgradable.20Python.20requirements/near/1249331

Till now, we've been forking django-auth-ldap at
https://github.com/zulip/django-auth-ldap to put the
LDAPReverseEmailSearch feature in it, hoping to get it merged
upstream in https://github.com/django-auth-ldap/django-auth-ldap/pull/150

The efforts to get it merged have stalled for now however and we don't
want to be on the fork forever, so this commit puts the email search
feature as a clumsy workaround inside our codebase and switches to using
the latest upstream release instead of the fork.
