### PR TITLE
email_mirror: Downgrade a couple ZulipEmailForwardErrors.

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -147,12 +147,12 @@ def get_usable_missed_message_address(address: str) -> MissedMessageEmailAddress
             - timedelta(seconds=MissedMessageEmailAddress.EXPIRY_SECONDS),
         )
     except MissedMessageEmailAddress.DoesNotExist:
-        raise ZulipEmailForwardError("Missed message address expired or doesn't exist.")
+        raise ZulipEmailForwardUserError("Missed message address expired or doesn't exist.")
 
     if not mm_address.is_usable():
         # Technical, this also checks whether the event is expired,
         # but that case is excluded by the logic above.
-        raise ZulipEmailForwardError("Missed message address out of uses.")
+        raise ZulipEmailForwardUserError("Missed message address out of uses.")
 
     return mm_address
 

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -17,6 +17,7 @@ from zerver.lib.actions import (
 )
 from zerver.lib.email_mirror_helpers import (
     ZulipEmailForwardError,
+    ZulipEmailForwardUserError,
     decode_email_address,
     get_email_gateway_message_string_from_address,
 )
@@ -197,10 +198,6 @@ def construct_zulip_body(
 
 
 ## Sending the Zulip ##
-
-
-class ZulipEmailForwardUserError(ZulipEmailForwardError):
-    pass
 
 
 def send_zulip(sender: UserProfile, stream: Stream, topic: str, content: str) -> None:

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -492,7 +492,7 @@ def process_message(message: EmailMessage, rcpt_to: Optional[str] = None) -> Non
             process_stream_message(to, message)
     except ZulipEmailForwardUserError as e:
         # TODO: notify sender of error, retry if appropriate.
-        logger.warning(e.args[0])
+        logger.info(e.args[0])
     except ZulipEmailForwardError as e:
         log_and_report(message, e.args[0], to)
 

--- a/zerver/lib/email_mirror_helpers.py
+++ b/zerver/lib/email_mirror_helpers.py
@@ -27,6 +27,10 @@ class ZulipEmailForwardError(Exception):
     pass
 
 
+class ZulipEmailForwardUserError(ZulipEmailForwardError):
+    pass
+
+
 def get_email_gateway_message_string_from_address(address: str) -> str:
     pattern_parts = [re.escape(part) for part in settings.EMAIL_GATEWAY_PATTERN.split("%s")]
     if settings.EMAIL_GATEWAY_EXTRA_PATTERN_HACK:

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -733,10 +733,10 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
         incoming_valid_message["To"] = stream_to_address
         incoming_valid_message["Reply-to"] = self.example_email("othello")
 
-        with self.assertLogs(logger_name, level="WARNING") as m:
+        with self.assertLogs(logger_name, level="INFO") as m:
             process_message(incoming_valid_message)
         self.assertEqual(
-            m.output, [f"WARNING:{logger_name}:Email has no nonempty body sections; ignoring."]
+            m.output, [f"INFO:{logger_name}:Email has no nonempty body sections; ignoring."]
         )
 
     def test_receive_stream_email_messages_no_textual_body(self) -> None:
@@ -761,13 +761,13 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
         incoming_valid_message["To"] = stream_to_address
         incoming_valid_message["Reply-to"] = self.example_email("othello")
 
-        with self.assertLogs(logger_name, level="WARNING") as m:
+        with self.assertLogs(logger_name, level="INFO") as m:
             process_message(incoming_valid_message)
         self.assertEqual(
             m.output,
             [
                 f"WARNING:{logger_name}:Content types: ['multipart/mixed', 'image/png']",
-                f"WARNING:{logger_name}:Unable to find plaintext or HTML message body",
+                f"INFO:{logger_name}:Unable to find plaintext or HTML message body",
             ],
         )
 


### PR DESCRIPTION
These errors may occur in the course of normal operations, and
shouldn't generate a message in the error logs.
