### PR TITLE
emoji: Change default emojiset from Google classic to Twitter.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1211,7 +1211,7 @@ class UserBaseSettings(models.Model):
         (TEXT_EMOJISET, "Plain text"),
     )
     emojiset: str = models.CharField(
-        default=GOOGLE_BLOB_EMOJISET, choices=EMOJISET_CHOICES, max_length=20
+        default=TWITTER_EMOJISET, choices=EMOJISET_CHOICES, max_length=20
     )
 
     ### Notifications settings. ###


### PR DESCRIPTION
This is a step towards updating our emoji to support newer Unicode
emojis (#19371).

**Testing plan:** Created new user, they had the default emoji set correctly.