### PR TITLE
downloads: Serve desktop downloads from desktop-download.zulip.com.

### DIFF
--- a/zerver/lib/github.py
+++ b/zerver/lib/github.py
@@ -50,7 +50,7 @@ def get_latest_github_release_download_link_for_platform(platform: str) -> str:
         if latest_version[0] in ["v", "V"]:
             latest_version = latest_version[1:]
         setup_file = PLATFORM_TO_SETUP_FILE[platform].format(version=latest_version)
-        link = f"https://github.com/zulip/zulip-desktop/releases/download/v{latest_version}/{setup_file}"
+        link = f"https://desktop-download.zulip.com/v{latest_version}/{setup_file}"
         if verify_release_download_link(link):
             return link
     return "https://github.com/zulip/zulip-desktop/releases/latest"

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -537,7 +537,7 @@ class AppsPageTest(ZulipTestCase):
         self.assertIn("Apps for every platform.", html)
 
     def test_app_download_link_view(self) -> None:
-        return_value = "https://github.com/zulip/zulip-desktop/releases/download/v5.4.3/Zulip-Web-Setup-5.4.3.exe"
+        return_value = "https://desktop-download.zulip.com/v5.4.3/Zulip-Web-Setup-5.4.3.exe"
         with mock.patch(
             "zerver.views.portico.get_latest_github_release_download_link_for_platform",
             return_value=return_value,

--- a/zerver/tests/test_github.py
+++ b/zerver/tests/test_github.py
@@ -20,32 +20,32 @@ class GitHubTestCase(ZulipTestCase):
 
         responses.add(
             responses.HEAD,
-            "https://github.com/zulip/zulip-desktop/releases/download/v5.4.3/Zulip-Web-Setup-5.4.3.exe",
+            "https://desktop-download.zulip.com/v5.4.3/Zulip-Web-Setup-5.4.3.exe",
             status=302,
         )
         self.assertEqual(
             get_latest_github_release_download_link_for_platform("windows"),
-            "https://github.com/zulip/zulip-desktop/releases/download/v5.4.3/Zulip-Web-Setup-5.4.3.exe",
+            "https://desktop-download.zulip.com/v5.4.3/Zulip-Web-Setup-5.4.3.exe",
         )
 
         responses.add(
             responses.HEAD,
-            "https://github.com/zulip/zulip-desktop/releases/download/v5.4.3/Zulip-5.4.3-x86_64.AppImage",
+            "https://desktop-download.zulip.com/v5.4.3/Zulip-5.4.3-x86_64.AppImage",
             status=302,
         )
         self.assertEqual(
             get_latest_github_release_download_link_for_platform("linux"),
-            "https://github.com/zulip/zulip-desktop/releases/download/v5.4.3/Zulip-5.4.3-x86_64.AppImage",
+            "https://desktop-download.zulip.com/v5.4.3/Zulip-5.4.3-x86_64.AppImage",
         )
 
         responses.add(
             responses.HEAD,
-            "https://github.com/zulip/zulip-desktop/releases/download/v5.4.3/Zulip-5.4.3-x64.dmg",
+            "https://desktop-download.zulip.com/v5.4.3/Zulip-5.4.3-x64.dmg",
             status=302,
         )
         self.assertEqual(
             get_latest_github_release_download_link_for_platform("mac"),
-            "https://github.com/zulip/zulip-desktop/releases/download/v5.4.3/Zulip-5.4.3-x64.dmg",
+            "https://desktop-download.zulip.com/v5.4.3/Zulip-5.4.3-x64.dmg",
         )
 
         api_url = "https://api.github.com/repos/zulip/zulip-desktop/releases/latest"
@@ -67,7 +67,7 @@ class GitHubTestCase(ZulipTestCase):
             json={"tag_name": "5.4.4"},
             status=200,
         )
-        download_link = "https://github.com/zulip/zulip-desktop/releases/download/v5.4.4/Zulip-5.4.4-x86_64.AppImage"
+        download_link = "https://desktop-download.zulip.com/v5.4.4/Zulip-5.4.4-x86_64.AppImage"
         responses.add(responses.HEAD, download_link, status=404)
         cache_delete("download_link:linux")
         with self.assertLogs(logger_string, level="ERROR") as error_log:


### PR DESCRIPTION
This makes them work for sites which block github.com.

