### PR TITLE
docs: Update links for other repository branch renames

### DIFF
--- a/docs/contributing/gsoc-ideas.md
+++ b/docs/contributing/gsoc-ideas.md
@@ -391,7 +391,7 @@ CSS](https://github.com/zulip/zulip/).
   being built into Zulip.  And then for built-in bots, one should be able to click a few
   buttons of configuration on the web to set them up and include them in
   your organization.  We've developed a number of example bots
-  in the (`zulip_bots`](https://github.com/zulip/python-zulip-api/tree/master/zulip_bots)
+  in the [`zulip_bots`](https://github.com/zulip/python-zulip-api/tree/main/zulip_bots)
   PyPI package.
   **Skills recommended**: Python and JavaScript/CSS, plus devops
   skills (Linux deployment, Docker, Puppet etc.) are all useful here.

--- a/docs/contributing/zulipbot-usage.md
+++ b/docs/contributing/zulipbot-usage.md
@@ -90,5 +90,5 @@ assignee(s) if they are still working on the issue.
 If you wish to help develop and contribute to **@zulipbot**, check out the
 [zulip/zulipbot](https://github.com/zulip/zulipbot) repository on GitHub and read
 the project's [contributing
-guidelines](https://github.com/zulip/zulipbot/blob/master/.github/CONTRIBUTING.md#contributing) for
+guidelines](https://github.com/zulip/zulipbot/blob/main/.github/CONTRIBUTING.md#contributing) for
 more information.

--- a/docs/documentation/api.md
+++ b/docs/documentation/api.md
@@ -259,7 +259,7 @@ above.
    bindings don't have a dedicated method for a specific API call,
    you may either use `client.call_endpoint` or add a dedicated
    function to the [zulip PyPI
-   package](https://github.com/zulip/python-zulip-api/tree/master/zulip).
+   package](https://github.com/zulip/python-zulip-api/tree/main/zulip).
    Ultimately, the goal is for every endpoint to be documented the
    latter way, but it's useful to be able to write working
    documentation for an endpoint that isn't supported by
@@ -312,7 +312,7 @@ above.
    in `zerver/openapi/zulip.yaml`, which mentions the API feature level
    at which they were added.
 
-[javascript-examples]: https://github.com/zulip/zulip-js/tree/master/examples
+[javascript-examples]: https://github.com/zulip/zulip-js/tree/main/examples
 
 ## Why a custom system?
 

--- a/docs/subsystems/events-system.md
+++ b/docs/subsystems/events-system.md
@@ -138,7 +138,7 @@ soon as it attempted to send them to the client; if that specific HTTP
 response didn't reach the client due to a network TCP failure, then
 those events could be lost).
 
-[api-bindings-code]: https://github.com/zulip/python-zulip-api/blob/master/zulip/zulip/__init__.py
+[api-bindings-code]: https://github.com/zulip/python-zulip-api/blob/main/zulip/zulip/__init__.py
 
 The queue servers are a very high-traffic system, processing at a
 minimum one request for every message delivered to every Zulip client.

--- a/docs/subsystems/widgets.md
+++ b/docs/subsystems/widgets.md
@@ -240,7 +240,7 @@ the **zform** to the client rendering it.
 
 
 First,
-[here](https://github.com/zulip/python-zulip-api/blob/master/zulip_bots/zulip_bots/bots/trivia_quiz/trivia_quiz.py)
+[here](https://github.com/zulip/python-zulip-api/blob/main/zulip_bots/zulip_bots/bots/trivia_quiz/trivia_quiz.py)
 is the code that produces the JSON.
 
 ``` py

--- a/templates/zerver/api/deploying-bots.md
+++ b/templates/zerver/api/deploying-bots.md
@@ -192,7 +192,7 @@ running it manually.
 
     * Edit the `<>` sections according to your preferences.
 
-[supervisord-config-file]: https://raw.githubusercontent.com/zulip/python-zulip-api/master/zulip_botserver/zulip-botserver-supervisord.conf
+[supervisord-config-file]: https://raw.githubusercontent.com/zulip/python-zulip-api/main/zulip_botserver/zulip-botserver-supervisord.conf
 
 1. Update *supervisord* to read the configuration file:
 

--- a/templates/zerver/api/non-webhook-integrations.md
+++ b/templates/zerver/api/non-webhook-integrations.md
@@ -8,7 +8,7 @@ them. Zulip supports several other types of integrations.
    (examples: SVN, Git), where we can get the service to call our integration
    (by shelling out or otherwise), passing in the required data.  Our preferred
    model for these is to ship these integrations in the
-   [Zulip Python API distribution](https://github.com/zulip/python-zulip-api/tree/master/zulip),
+   [Zulip Python API distribution](https://github.com/zulip/python-zulip-api/tree/main/zulip),
    within the `integrations` directory there.
 
 1. **Plugin integrations** (examples:

--- a/templates/zerver/api/running-bots.md
+++ b/templates/zerver/api/running-bots.md
@@ -7,7 +7,7 @@ to messages in Zulip.
 
 This guide will show you how to run an existing Zulip bot
 found in [zulip_bots/bots](
-https://github.com/zulip/python-zulip-api/tree/master/zulip_bots/zulip_bots/bots).
+https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots).
 
 You'll need:
 

--- a/templates/zerver/api/writing-bots.md
+++ b/templates/zerver/api/writing-bots.md
@@ -114,7 +114,7 @@ we have a little tool to help you out: `zulip-terminal`
 * [Install all requirements](#installing-a-development-version-of-the-zulip-bots-package).
 
 * Run `zulip-terminal` to test one of the bots in
-  [`zulip_bots/bots`](https://github.com/zulip/python-zulip-api/tree/master/zulip_bots/zulip_bots/bots).
+  [`zulip_bots/bots`](https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots).
 
 Example invocations are below:
 
@@ -374,7 +374,7 @@ every call to `put` and `get`, respectively.
 
 Bots, like most software that you want to work, should have unit tests. In this section,
 we detail our framework for writing unit tests for bots. We require that bots in the main
-[`python-zulip-api`](https://github.com/zulip/python-zulip-api/tree/master/zulip_bots/zulip_bots/bots)
+[`python-zulip-api`](https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots)
 repository include a reasonable set of unit tests, so that future developers can easily
 refactor them.
 
@@ -385,7 +385,7 @@ refactor them.
 ### A simple example
 
  Let's have a look at a simple test suite for the [`helloworld`](
- https://github.com/zulip/python-zulip-api/tree/master/zulip_bots/zulip_bots/bots/helloworld)
+ https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots/helloworld)
  bot.
 
 ```python
@@ -419,7 +419,7 @@ The best way to learn about bot tests is to read all the existing tests in the
 Once you have written a test suite, you want to verify that everything works as expected.
 
 * To test a bot in [Zulip's bot directory](
-  https://github.com/zulip/python-zulip-api/tree/master/zulip_bots/zulip_bots/bots):
+  https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots):
   `tools/test-bots <botname>`
 
 * To run all bot tests: `tools/test-bots`
@@ -429,13 +429,13 @@ Once you have written a test suite, you want to verify that everything works as 
 This section shows advanced testing techniques for more complicated bots that have
 configuration files or interact with third-party APIs.
 *The code for the bot testing library can be found [here](
- https://github.com/zulip/python-zulip-api/blob/master/zulip_bots/zulip_bots/test_lib.py).*
+ https://github.com/zulip/python-zulip-api/blob/main/zulip_bots/zulip_bots/test_lib.py).*
 
 
 #### Testing bots with config files
 
 Some bots, such as [Giphy](
-https://github.com/zulip/python-zulip-api/tree/master/zulip_bots/zulip_bots/bots/giphy),
+https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots/giphy),
 support or require user configuration options to control how the bot works.
 
 To test such a bot, you can use the following pattern:
@@ -449,7 +449,7 @@ system and gives your test "dummy data" instead.
 #### Testing bots with internet access
 
 Some bots, such as [Giphy](
-https://github.com/zulip/python-zulip-api/tree/master/zulip_bots/zulip_bots/bots/giphy),
+https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots/giphy),
 depend on a third-party service, such as the Giphy web app, in order to work. Because
 we want our test suite to be reliable and not add load to these third-party APIs, tests
 for these services need to have "test fixtures": sample HTTP request/response pairs to
@@ -476,7 +476,7 @@ fixtures:
 }
 ```
 For an example, check out the [giphy bot](
-https://github.com/zulip/python-zulip-api/tree/master/zulip_bots/zulip_bots/bots/giphy).
+https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots/giphy).
 
 *Tip: You can use [requestbin](https://requestbin.com/) or a similar
 tool to capture payloads from the service your bot is interacting
@@ -484,7 +484,7 @@ with.*
 
 #### Examples
 
-Check out our [bots](https://github.com/zulip/python-zulip-api/tree/master/zulip_bots/zulip_bots/bots)
+Check out our [bots](https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots)
 to see examples of bot tests.
 
 ## Common problems

--- a/templates/zerver/help/custom-certificates.md
+++ b/templates/zerver/help/custom-certificates.md
@@ -108,4 +108,4 @@ server. You'll need to get a certificate file (should end in `.crt` or
 
 
 
-[linux]: https://chromium.googlesource.com/chromium/src.git/+/master/docs/linux/cert_management.md
+[linux]: https://chromium.googlesource.com/chromium/src.git/+/main/docs/linux/cert_management.md

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -174,7 +174,7 @@ paths:
           description: |
             The highest event ID in this queue that you've received and
             wish to acknowledge. See the [code for
-            `call_on_each_event`](https://github.com/zulip/python-zulip-api/blob/master/zulip/zulip/__init__.py)
+            `call_on_each_event`](https://github.com/zulip/python-zulip-api/blob/main/zulip/zulip/__init__.py)
             in the [zulip Python
             module](https://github.com/zulip/python-zulip-api) for an
             example implementation of correctly processing each event

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -787,7 +787,7 @@ def login_page(
         # context_data attribute. This attribute doesn't exist otherwise. It is
         # added in SimpleTemplateResponse class, which is a derived class of
         # HttpResponse. See django.template.response.SimpleTemplateResponse,
-        # https://github.com/django/django/blob/master/django/template/response.py#L19.
+        # https://github.com/django/django/blob/2.0/django/template/response.py#L19
         update_login_page_context(request, template_response.context_data)
 
     assert isinstance(template_response, HttpResponse)

--- a/zerver/webhooks/trello/doc.md
+++ b/zerver/webhooks/trello/doc.md
@@ -57,7 +57,7 @@ Get Zulip notifications from your Trello boards!
 
 1. You can delete `zulip_trello.py` from your computer if you'd like.
 
-[2]: https://raw.githubusercontent.com/zulip/python-zulip-api/master/zulip/integrations/trello/zulip_trello.py
+[2]: https://raw.githubusercontent.com/zulip/python-zulip-api/main/zulip/integrations/trello/zulip_trello.py
 
 {!congrats.md!}
 


### PR DESCRIPTION
GitHub redirects these, but we should use the canonical URLs.