### PR TITLE
install: Remove /dev/null redirect for zulip-puppet-apply

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -397,8 +397,7 @@ id -u zulip &>/dev/null || useradd -m zulip --home-dir /home/zulip
 if [ -n "$NO_OVERWRITE_SETTINGS" ] && [ -e "/etc/zulip/zulip.conf" ]; then
     "$ZULIP_PATH"/scripts/zulip-puppet-apply --noop \
         --write-catalog-summary \
-        --classfile=/var/lib/puppet/classes.txt \
-        >/dev/null
+        --classfile=/var/lib/puppet/classes.txt
 else
     # Write out more than we need, and remove sections that are not
     # applicable to the classes that are actually necessary.
@@ -421,8 +420,7 @@ EOF
 
     "$ZULIP_PATH"/scripts/zulip-puppet-apply --noop \
         --write-catalog-summary \
-        --classfile=/var/lib/puppet/classes.txt \
-        >/dev/null
+        --classfile=/var/lib/puppet/classes.txt
 
     # We only need the PostgreSQL version setting on database hosts; but
     # we don't know if this is a database host until we have the catalog summary.


### PR DESCRIPTION
The usual output from this command looks like

```
Notice: Compiled catalog for localhost in environment production in 2.33 seconds
Notice: /Stage[main]/Zulip::Apt_repository/Exec[setup_apt_repo]/returns: current_value 'notrun', should be ['0'] (noop)
Notice: Class[Zulip::Apt_repository]: Would have triggered 'refresh' from 1 event
Notice: Stage[main]: Would have triggered 'refresh' from 1 event
Notice: Applied catalog in 1.20 seconds
```

which doesn’t seem abnormally alarming, and hiding it makes failures harder to diagnose.