### PR TITLE
Log authentication attempts via username+password backends

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -574,8 +574,11 @@ Output:
 
     def assert_login_failure(self, email: str, password: str) -> None:
         realm = get_realm("zulip")
+        request = HttpRequest()
+        request.session = self.client.session
         self.assertFalse(
             self.client.login(
+                request=request,
                 username=email,
                 password=password,
                 realm=realm,

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -136,6 +136,7 @@ if not PUPPETEER_TESTS:
 
     set_loglevel("zulip.requests", "CRITICAL")
     set_loglevel("zulip.management", "CRITICAL")
+    set_loglevel("zulip.auth", "WARNING")
     set_loglevel("django.request", "ERROR")
     set_loglevel("django_auth_ldap", "WARNING")
     set_loglevel("fakeldap", "ERROR")


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/191-kandra-support/topic/Tracking.20authentication.20attempts.20to.20Zulip

Example logline:
```
2021-09-01 18:16:19.994 INFO [zulip.auth.email] Authentication attempt from 172.17.0.1: subdomain=zulip;username=hamlet@zulip.com;outcome=failed;return_data={}
```
