### PR TITLE
[4.x] upgrade-zulip-from-git: Run git fetch with --prune

### DIFF
--- a/scripts/lib/upgrade-zulip-from-git
+++ b/scripts/lib/upgrade-zulip-from-git
@@ -81,7 +81,9 @@ try:
         )
 
     logging.info("Fetching the latest commits")
-    subprocess.check_call(["git", "fetch", "-q", "--tags", "--all"], preexec_fn=su_to_zulip)
+    subprocess.check_call(
+        ["git", "fetch", "--prune", "--quiet", "--tags", "--all"], preexec_fn=su_to_zulip
+    )
 
     # Generate the deployment directory via git worktree from our local repository.
     subprocess.check_call(


### PR DESCRIPTION
This prevents upgrading to an obsolete version of a branch that has been deleted or renamed.

Backport of #19650.