### PR TITLE
notifications: Add safeties to prevent incorrect notifications.

### DIFF
--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -569,6 +569,10 @@ def handle_missedmessage_emails(
         # Never email bot users.
         return
 
+    if not user_profile.enable_offline_email_notifications:
+        # BUG: Investigate why it's possible to get here.
+        return  # nocoverage
+
     # Note: This query structure automatically filters out any
     # messages that were permanently deleted, since those would now be
     # in the ArchivedMessage table, not the Message table.

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -896,6 +896,17 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
         return
     user_profile = get_user_profile_by_id(user_profile_id)
 
+    if user_profile.is_bot:
+        # BUG: Investigate why it's possible to get here.
+        return  # nocoverage
+
+    if not (
+        user_profile.enable_offline_push_notifications
+        or user_profile.enable_online_push_notifications
+    ):
+        # BUG: Investigate why it's possible to get here.
+        return  # nocoverage
+
     try:
         (message, user_message) = access_message(user_profile, missed_message["message_id"])
     except JsonableError:


### PR DESCRIPTION
de04f0ad6770 changed now notifications recipients were calculated, in
a manner that caused them to be sent when they should not have been.
ac70a2d2e1b2 was supposed to resolve this, but appears to have been
insufficient, as all three of these cases have been observed to still
happen.

Add safety checks immediately before notification, until the
underlying logic error can be sussed out.

**Testing plan:** Deployed in production.
