### PR TITLE
settings: Fix live update of notification sound dropdown.

### DIFF
--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -139,6 +139,10 @@ export function update_page() {
         } else if (setting === "desktop_icon_count_display") {
             update_desktop_icon_count_display();
             continue;
+        } else if (setting === "notification_sound") {
+            $("#user-notification-settings .setting_notification_sound").val(
+                user_settings.notification_sound,
+            );
         }
 
         $("#user-notification-settings")


### PR DESCRIPTION
This PR fixes the live update of notification sound
setting dropdown. We already update the notification sound
source to play the correct sound after changing the setting.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


 <!-- How have you tested? -->


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
