### PR TITLE
recent_topics: Set focus to filter button after click.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -409,6 +409,7 @@ export function initialize() {
         recent_topics_ui.change_focused_element($(e.target), "click");
         recent_topics_ui.set_filter(e.currentTarget.dataset.filter);
         recent_topics_ui.update_filters_view();
+        recent_topics_ui.revive_current_focus();
     });
 
     $("body").on("click", "td.recent_topic_stream", (e) => {

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -162,7 +162,7 @@ export function get_focused_row_message() {
     return undefined;
 }
 
-function revive_current_focus() {
+export function revive_current_focus() {
     // After re-render, the current_focus_elem is no longer linked
     // to the focused element, this function attempts to revive the
     // link and focus to the element prior to the rerender.


### PR DESCRIPTION
Since, the filter button is replaced with a different button
after click, the `current_focus_elem` points at incorrect
element. `revive_current_focus` follows a good
method to locate the filter button, hence
we use it to correct the element `current_focus_elem` points at.

reported https://chat.zulip.org/#narrow/stream/101-design/topic/Recent.20topic.20dropdown/near/1249504