### PR TITLE
login_to_access: Rename module to `spectators`.

### DIFF
--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -44,8 +44,8 @@ const emoji_picker = mock_esm("../../static/js/emoji_picker", {
 });
 const message_lists = mock_esm("../../static/js/message_lists");
 const message_store = mock_esm("../../static/js/message_store");
-const login_to_access = mock_esm("../../static/js/login_to_access", {
-    show() {},
+const spectators = mock_esm("../../static/js/spectators", {
+    login_to_access() {},
 });
 
 message_lists.current = {
@@ -914,7 +914,7 @@ test("process_reaction_click", ({override}) => {
     // Test spectator cannot react.
     page_params.is_spectator = true;
     let stub = make_stub();
-    login_to_access.show = stub.f;
+    spectators.login_to_access = stub.f;
     reactions.process_reaction_click(message.id, "unicode_emoji,1f642");
     let args = stub.get_args("args").args;
     assert.equal(args, undefined);

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -15,7 +15,6 @@ import * as compose_validate from "./compose_validate";
 import * as drafts from "./drafts";
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
-import * as login_to_access from "./login_to_access";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as narrow_state from "./narrow_state";
@@ -26,6 +25,7 @@ import * as recent_topics_ui from "./recent_topics_ui";
 import * as recent_topics_util from "./recent_topics_util";
 import * as reload_state from "./reload_state";
 import * as resize from "./resize";
+import * as spectators from "./spectators";
 import * as stream_bar from "./stream_bar";
 import * as stream_data from "./stream_data";
 import * as unread_ops from "./unread_ops";
@@ -216,7 +216,7 @@ export function update_placeholder_text() {
 
 export function start(msg_type, opts) {
     if (page_params.is_spectator) {
-        login_to_access.show();
+        spectators.login_to_access();
         return;
     }
 

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -9,7 +9,6 @@ import * as floating_recipient_bar from "./floating_recipient_bar";
 import * as hash_util from "./hash_util";
 import * as info_overlay from "./info_overlay";
 import * as invite from "./invite";
-import * as login_to_access from "./login_to_access";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as narrow from "./narrow";
@@ -22,6 +21,7 @@ import * as search from "./search";
 import * as settings from "./settings";
 import * as settings_panel_menu from "./settings_panel_menu";
 import * as settings_toggle from "./settings_toggle";
+import * as spectators from "./spectators";
 import * as stream_settings_ui from "./stream_settings_ui";
 import * as top_left_corner from "./top_left_corner";
 import * as ui_util from "./ui_util";
@@ -335,7 +335,7 @@ function hashchanged(from_reload, e) {
     }
 
     if (page_params.is_spectator && !is_hash_web_public_compatible) {
-        login_to_access.show();
+        spectators.login_to_access();
         return undefined;
     }
 

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -8,11 +8,11 @@ import * as blueslip from "./blueslip";
 import * as channel from "./channel";
 import * as emoji_picker from "./emoji_picker";
 import {$t} from "./i18n";
-import * as login_to_access from "./login_to_access";
 import * as message_lists from "./message_lists";
 import * as message_store from "./message_store";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import * as spectators from "./spectators";
 import {user_settings} from "./user_settings";
 
 export const view = {}; // function namespace
@@ -114,7 +114,7 @@ export function process_reaction_click(message_id, local_id) {
     if (page_params.is_spectator) {
         // Spectators can't react, since they don't have accounts.  We
         // stop here to avoid a confusing reaction local echo.
-        login_to_access.show();
+        spectators.login_to_access();
         return;
     }
 

--- a/static/js/spectators.js
+++ b/static/js/spectators.js
@@ -12,7 +12,7 @@ import render_login_to_access_modal from "../templates/login_to_access.hbs";
 import * as hash_util from "./hash_util";
 import {page_params} from "./page_params";
 
-export function show() {
+export function login_to_access() {
     // Hide all overlays, popover and go back to the previous hash if the
     // hash has changed.
     let login_link;

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -84,7 +84,7 @@ EXEMPT_FILES = {
     "static/js/loading.ts",
     "static/js/local_message.js",
     "static/js/localstorage.js",
-    "static/js/login_to_access.js",
+    "static/js/spectators.js",
     "static/js/message_edit.js",
     "static/js/message_edit_history.js",
     "static/js/message_events.js",


### PR DESCRIPTION
This allows us to call spectators.login_to_access which
is more clear for what it does.
