### PR TITLE
message_edit: Fix bug when multiple message edit forms are opened.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -37,7 +37,6 @@ import * as upload from "./upload";
 const currently_editing_messages = new Map();
 let currently_deleting_messages = [];
 let currently_topic_editing_messages = [];
-let stream_widget;
 const currently_echoing_messages = new Map();
 export const RESOLVED_TOPIC_PREFIX = "✔ ";
 
@@ -352,6 +351,7 @@ function create_copy_to_clipboard_handler(row, source, message_id) {
 }
 
 function edit_message(row, raw_content) {
+    let stream_widget;
     row.find(".message_reactions").hide();
     condense.hide_message_expander(row);
     condense.hide_message_condenser(row);
@@ -807,7 +807,8 @@ export function save_message_row_edit(row) {
         topic_changed = new_topic !== old_topic && new_topic.trim() !== "";
 
         if (can_edit_stream) {
-            new_stream_id = Number.parseInt(stream_widget.value(), 10);
+            const dropdown_list_widget_value_elem = $(`#id_select_move_stream_${message_id}`);
+            new_stream_id = Number.parseInt(dropdown_list_widget_value_elem.data("value"), 10);
             stream_changed = new_stream_id !== old_stream_id;
         }
     }


### PR DESCRIPTION
There is a bug when multiple message edit forms are opened at the
same time where undefined value of stream_id is sent to the server.
This happens because a global variable stream_widget is used to get
the id of stream selected in dropdown and value of stream_widget
variable keeps on changing when we open multiple message edit forms.
Thus, stream_widget can have the dropdown widget of already closed
edit form resulting in undefined value of stream id.

This PR changes the save_message_row_edit function to access
the dropdown element directly using message id instead of using
stream_widget.value() and thus we always use the correct dropdown
element to get the stream id.

We also move the stream_widget variable to be inside edit_message
function instead of being global variable for the module.

Fixes #19663.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


 <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![msg-edit](https://user-images.githubusercontent.com/35494118/132389545-2b03bae9-1abc-468d-b89d-0ab7aa7590c4.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
