### PR TITLE
recent_topics: Handle no rows case on `r` keypress.

### DIFF
--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -256,8 +256,16 @@ function format_topic(topic_data) {
         // We display only 10 extra senders in tooltips,
         // and just display remaining number of senders.
         const remaining_senders = extra_sender_ids.length - MAX_EXTRA_SENDERS;
+        // Pluralization syntax from:
+        // https://formatjs.io/docs/core-concepts/icu-syntax/#plural-format
         displayed_other_names.push(
-            $t({defaultMessage: `and {remaining_senders} other(s).`}, {remaining_senders}),
+            $t(
+                {
+                    defaultMessage:
+                        "and {remaining_senders, plural, one {1 other} other {# others}}.",
+                },
+                {remaining_senders},
+            ),
         );
     }
     const other_sender_names = displayed_other_names.join("<br/>");

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -154,6 +154,10 @@ export function get_focused_row_message() {
     if (is_table_focused()) {
         const recent_topic_id_prefix_len = "recent_topic:".length;
         const topic_rows = $("#recent_topics_table table tbody tr");
+        if (topic_rows.length === 0) {
+            return undefined;
+        }
+
         const topic_row = topic_rows.eq(row_focus);
         const topic_id = topic_row.attr("id").slice(recent_topic_id_prefix_len);
         const topic_last_msg_id = topics.get(topic_id).last_msg_id;


### PR DESCRIPTION
When there are no rows for user to reply on `r` keypress,
we open compose box with everything empty.

Traceback:
![image](https://user-images.githubusercontent.com/25124304/132461059-043280b2-6731-4d8f-9d7a-1f0341482344.png)
