### PR TITLE
authentication: Fix placeholder realms for redirects.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1096,7 +1096,7 @@ def do_change_realm_subdomain(
     # deactivated. We are creating a deactivated realm using old subdomain and setting
     # it's deactivated redirect to new_subdomain so that we can tell the users that
     # the realm has been moved to a new subdomain.
-    placeholder_realm = do_create_realm(old_subdomain, "placeholder-realm")
+    placeholder_realm = do_create_realm(old_subdomain, realm.name)
     do_deactivate_realm(placeholder_realm, acting_user=None)
     do_add_deactivated_redirect(placeholder_realm, realm.uri)
 


### PR DESCRIPTION
The name of the new realm created as a tombstone after renaming
a realm's subdomain is the constant 'placeholder-realm'.
This PR replaces it with the original realm name.
Fixes: #19677

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/19677

**Testing plan:** <!-- How have you tested? -->
I have tested it manually by creating and renaming new realms. I have also tested it through the automated tests.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/76661350/132481536-768c306d-b7de-4f8b-b5b9-018c64d79d12.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
