### PR TITLE
docs: Update links for zulip-mobile branch rename

### DIFF
--- a/docs/development/using.md
+++ b/docs/development/using.md
@@ -97,4 +97,4 @@ for mobile development][mobile-dev-server].
 [django-runserver]: https://docs.djangoproject.com/en/1.8/ref/django-admin/#runserver-port-or-address-port
 [new-feature-tutorial]: ../tutorials/new-feature-tutorial.md
 [testing-docs]: ../testing/testing.md
-[mobile-dev-server]: https://github.com/zulip/zulip-mobile/blob/master/docs/howto/dev-server.md#using-a-dev-version-of-the-server
+[mobile-dev-server]: https://github.com/zulip/zulip-mobile/blob/main/docs/howto/dev-server.md#using-a-dev-version-of-the-server

--- a/static/shared/README.md
+++ b/static/shared/README.md
@@ -22,4 +22,4 @@ Note that the deployment cycles are different:
 To update the version of @zulip/shared on NPM, see the
 [instructions][publishing-shared] in the mobile repo.
 
-[publishing-shared]: https://github.com/zulip/zulip-mobile/blob/master/docs/howto/shared.md#publishing-zulipshared-to-npm
+[publishing-shared]: https://github.com/zulip/zulip-mobile/blob/main/docs/howto/shared.md#publishing-zulipshared-to-npm


### PR DESCRIPTION
GitHub redirects these, but we should use the canonical URLs.