### PR TITLE
docs: Add documentation for bullseye support.

### DIFF
--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -6,6 +6,7 @@ To run a Zulip server, you will need:
 - A supported OS:
   - Ubuntu 20.04 Focal
   - Ubuntu 18.04 Bionic
+  - Debian 11 Bullseye
   - Debian 10 Buster
 - At least 2GB RAM, and 10GB disk space
   - If you expect 100+ users: 4GB RAM, and 2 CPUs
@@ -29,10 +30,10 @@ can't support you, but
 
 #### Operating system
 
-Ubuntu 20.04 Focal, 18.04 Bionic, and Debian 10 Buster are supported
-for running Zulip in production. 64-bit is recommended. We recommend
-installing on the newest supported OS release you're comfortable with,
-to save a bit of future work [upgrading the operating
+Ubuntu 20.04 Focal, 18.04 Bionic, Debian 11 Bullseye, and Debian 10 Buster
+are supported for running Zulip in production. 64-bit is recommended.
+We recommend installing on the newest supported OS release you're
+comfortable with, to save a bit of future work [upgrading the operating
 system][upgrade-os].
 
 If you're using Ubuntu, the

--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -405,6 +405,14 @@ instructions for other supported platforms.
    Bionic](#upgrading-from-ubuntu-16-04-xenial-to-18-04-bionic), so
    that you are running a supported operating system.
 
+### Upgrading from Debian Buster to Debian Bullseye
+
+We expect to have documentation for the upgrade from Buster to Bullseye
+available soon
+([Follow the discussion on Zulip Developer Community][bullseye-discussion-thread]).
+
+[bullseye-discussion-thread]: https://chat.zulip.org/#narrow/stream/3-backend/topic/Upgrade.20to.20bullseye
+
 ### Upgrading from Debian Stretch to Debian Buster
 
 1. Upgrade your server to the latest Zulip `2.1.x` release. You can

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -221,7 +221,7 @@ Unsupported OS release: $os_id $os_version_id
 
 Zulip in production is supported only on:
  - Debian 10 "buster"
- - Debian 11 "bullseye" (beta)
+ - Debian 11 "bullseye"
  - Ubuntu 18.04 LTS "bionic"
  - Ubuntu 20.04 LTS "focal"
 


### PR DESCRIPTION
The support for bullseye was added in #17951
but it was not documented as bullseye was
frozen and did not have proper configuration
files, hence wasn't documented.

Since now bullseye is released as a stable
version, it's support can be documented.