### PR TITLE
Remove unnecessary use of `notification_setting_types`.

### DIFF
--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -21,10 +21,6 @@ def copy_user_settings(source_profile: UserProfile, target_profile: UserProfile)
         value = getattr(source_profile, settings_name)
         setattr(target_profile, settings_name, value)
 
-    for settings_name in UserProfile.notification_setting_types:
-        value = getattr(source_profile, settings_name)
-        setattr(target_profile, settings_name, value)
-
     setattr(target_profile, "full_name", source_profile.full_name)
     setattr(target_profile, "enter_sends", source_profile.enter_sends)
     setattr(target_profile, "timezone", source_profile.timezone)

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -22,7 +22,6 @@ def copy_user_settings(source_profile: UserProfile, target_profile: UserProfile)
         setattr(target_profile, settings_name, value)
 
     setattr(target_profile, "full_name", source_profile.full_name)
-    setattr(target_profile, "enter_sends", source_profile.enter_sends)
     setattr(target_profile, "timezone", source_profile.timezone)
     target_profile.save()
 

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1470,7 +1470,7 @@ def check_update_global_notifications(
     desired_val: Union[bool, int, str],
 ) -> None:
     """
-    See UserProfile.notification_setting_types for
+    See UserProfile.notification_settings_legacy for
     more details.
     """
     _check_update_global_notifications(var_name, event)
@@ -1479,7 +1479,7 @@ def check_update_global_notifications(
     assert setting == desired_val
 
     assert isinstance(setting_name, str)
-    setting_type = UserProfile.notification_setting_types[setting_name]
+    setting_type = UserProfile.notification_settings_legacy[setting_name]
     assert isinstance(setting, setting_type)
 
 

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -557,9 +557,6 @@ class FetchInitialStateDataTest(ZulipTestCase):
         for prop in UserProfile.property_types:
             self.assertNotIn(prop, result)
             self.assertIn(prop, result["user_settings"])
-        for prop in UserProfile.notification_setting_types:
-            self.assertNotIn(prop, result)
-            self.assertIn(prop, result["user_settings"])
 
         result = fetch_initial_state_data(
             user_profile=hamlet,
@@ -567,9 +564,6 @@ class FetchInitialStateDataTest(ZulipTestCase):
         )
         self.assertIn("user_settings", result)
         for prop in UserProfile.property_types:
-            self.assertIn(prop, result)
-            self.assertIn(prop, result["user_settings"])
-        for prop in UserProfile.notification_setting_types:
             self.assertIn(prop, result)
             self.assertIn(prop, result["user_settings"])
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
First two commits are to remove unnecessary use of `notification_setting_types`.
Third commit is to remove unnecessary setattr statement.
Explained in detail in commit messages.
 <!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
