### PR TITLE
name_restrictions: Reserve ‘mg’ and ‘front-mail’

### DIFF
--- a/zerver/lib/name_restrictions.py
+++ b/zerver/lib/name_restrictions.py
@@ -43,6 +43,8 @@ ZULIP_RESERVED_SUBDOMAINS = {
     "testing",
     "nagios",
     "nginx",
+    "mg",
+    "front-mail",
     # website pages
     "server",
     "client",


### PR DESCRIPTION
front-mail.zulipchat.com only has an MX record for Front and will not work as a Zulip organization.