### PR TITLE
puppeteer: remove test_not_delete_draft_on_sending().

### DIFF
--- a/frontend_tests/puppeteer_tests/drafts.ts
+++ b/frontend_tests/puppeteer_tests/drafts.ts
@@ -241,21 +241,6 @@ async function test_save_draft_by_reloading(page: Page): Promise<void> {
     );
 }
 
-async function test_not_delete_draft_on_sending(page: Page): Promise<void> {
-    await page.click("#drafts_table .message_row.private-message .restore-draft");
-    await wait_for_drafts_to_dissapear(page);
-    await page.waitForSelector("#private-message", {visible: true});
-    await common.ensure_enter_does_not_send(page);
-    await page.waitForSelector("#compose-send-button", {visible: true});
-    await page.click("#compose-send-button");
-
-    await page.waitForSelector(drafts_button_in_compose, {visible: true});
-    await page.click(drafts_button_in_compose);
-    await wait_for_drafts_to_appear(page);
-    const drafts_count = await get_drafts_count(page);
-    assert.strictEqual(drafts_count, 2, "Draft got cleared on sending.");
-}
-
 async function drafts_test(page: Page): Promise<void> {
     await common.log_in(page);
     await page.click(".top_left_all_messages");
@@ -275,7 +260,6 @@ async function drafts_test(page: Page): Promise<void> {
     await test_restore_private_message_draft(page);
     await test_delete_draft(page);
     await test_save_draft_by_reloading(page);
-    await test_not_delete_draft_on_sending(page);
 }
 
 common.run_test(drafts_test);


### PR DESCRIPTION
This test was `assert`ing the draft is not getting cleared
as soon as sending, which is desired behaviour to some extent
because we don't want to delete it until we receive a confirmation
from the server, but given the right amount of delay (or very
low network latency), the draft will be cleared. This inconsistency
was causing failures.

We could better test this with a node test. A node test was
already added in #18827.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
