### PR TITLE
populate_db: Fix naive datetime RuntimeWarning

### DIFF
--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -478,14 +478,14 @@ class Command(BaseCommand):
                 recipient=None,
                 topic="Release Notes",
                 content="Release 4.0 will contain ...",
-                last_edit_time=datetime.now(),
+                last_edit_time=timezone_now(),
             )
             Draft.objects.create(
                 user_profile=iago,
                 recipient=None,
                 topic="Release Notes",
                 content="Release 4.0 will contain many new features such as ... ",
-                last_edit_time=datetime.now(),
+                last_edit_time=timezone_now(),
             )
 
             desdemona = get_user_by_delivery_email("desdemona@zulip.com", zulip_realm)


### PR DESCRIPTION
Fixes these warnings from populate_db:

```
/srv/zulip-py3-venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1419: RuntimeWarning: DateTimeField Draft.last_edit_time received a naive datetime (2021-09-10 23:33:15.063608) while time zone support is active.
  RuntimeWarning)
/srv/zulip-py3-venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1419: RuntimeWarning: DateTimeField Draft.last_edit_time received a naive datetime (2021-09-10 23:33:15.065517) while time zone support is active.
  RuntimeWarning)
```

introduced by commit 472c55a1ff4611d163a1284277ae6042538858b1 (#18074, cc @Hypro999).