### PR TITLE
test-js-with-puppeteer: Remove bogus CHROMIUM_EXECUTABLE variable

### DIFF
--- a/tools/test-js-with-puppeteer
+++ b/tools/test-js-with-puppeteer
@@ -22,7 +22,6 @@ os.environ["PUPPETEER_TESTS"] = "1"
 # which we do verify in some tests.
 os.environ["LC_ALL"] = "C.UTF-8"
 
-os.environ["CHROMIUM_EXECUTABLE"] = os.path.join(ZULIP_PATH, "node_modules/.bin/chromium")
 os.environ.pop("http_proxy", "")
 os.environ.pop("https_proxy", "")
 


### PR DESCRIPTION
This environment variable is not a thing and has never been a thing, while the path it purportedly pointed to does not exist and has never existed.  It appears to have been inexplicably both cargo-culted and renamed from `test-js-with-casper`.