### PR TITLE
Fix alignment of x button in image view menu

### DIFF
--- a/static/styles/lightbox.css
+++ b/static/styles/lightbox.css
@@ -43,7 +43,7 @@
 
         color: hsla(0, 0%, 100%, 0.8);
         font-size: 2rem;
-        margin: 24px 20px 0 0;
+        margin: 11px 20px 0 0;
 
         transform: scaleY(0.75);
         font-weight: 300;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #19711

**Testing plan:** <!-- How have you tested? -->
I tested the UI change on different screen sizes by inspecting the page and changing the window size.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
This is what the image view menu buttons look like now.
![fixed_image_view](https://user-images.githubusercontent.com/61168867/132939842-53b98d7a-9b51-4451-83a1-fa7336bef570.PNG)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
