### PR TITLE
Use additional characters as separators for stream filtering

### DIFF
--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -38,6 +38,38 @@ const weaving = {
     stream_id: 5,
     pin_to_top: false,
 };
+const stream_underscore = {
+    subscribed: true,
+    name: "stream_underscore",
+    stream_id: 6,
+    pin_to_top: true,
+};
+const stream_dash = {
+    subscribed: true,
+    name: "stream-dash",
+    stream_id: 7,
+    pin_to_top: false,
+};
+const stream_slash = {
+    subscribed: true,
+    name: "stream/slash",
+    stream_id: 8,
+    pin_to_top: false,
+};
+const stream_space = {
+    subscribed: true,
+    name: "stream space",
+    stream_id: 9,
+    pin_to_top: false,
+};
+
+const stream_space_dash_underscore_slash = {
+    subscribed: true,
+    name: "stream space-dash_underscore/slash",
+    stream_id: 10,
+    pin_to_top: false,
+};
+
 
 function sort_groups(query) {
     const streams = stream_data.subscribed_stream_ids();
@@ -113,4 +145,43 @@ test("basics", ({override}) => {
     assert.deepEqual(sorted.pinned_streams, []);
     assert.deepEqual(sorted.normal_streams, [fast_tortoise.stream_id]);
     assert.deepEqual(sorted.dormant_streams, []);
+});
+
+run_test("sort_groups", () => {
+    stream_data.add_sub(stream_underscore);
+    stream_data.add_sub(stream_dash);
+    stream_data.add_sub(stream_slash);
+    stream_data.add_sub(stream_space);
+    stream_data.add_sub(stream_space_dash_underscore_slash);
+    const streams = stream_data.subscribed_stream_ids();
+    assert.deepEqual(stream_sort.sort_groups(streams, "under"), {
+        same_as_before: false,
+        pinned_streams: [6],
+        normal_streams: [10],
+        dormant_streams: []
+    })
+    assert.deepEqual(stream_sort.sort_groups(streams, "dash"), {
+        same_as_before: false,
+        pinned_streams: [],
+        normal_streams: [10, 7],
+        dormant_streams: []
+    })
+    assert.deepEqual(stream_sort.sort_groups(streams, "slash"), {
+        same_as_before: false,
+        pinned_streams: [],
+        normal_streams: [10, 8],
+        dormant_streams: []
+    })
+    assert.deepEqual(stream_sort.sort_groups(streams, "space"), {
+        same_as_before: false,
+        pinned_streams: [],
+        normal_streams: [9, 10],
+        dormant_streams: []
+    })
+    assert.deepEqual(stream_sort.sort_groups(streams, "stream-d"), {
+        same_as_before: false,
+        pinned_streams: [],
+        normal_streams: [7],
+        dormant_streams: []
+    })
 });

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -70,7 +70,6 @@ const stream_space_dash_underscore_slash = {
     pin_to_top: false,
 };
 
-
 function sort_groups(query) {
     const streams = stream_data.subscribed_stream_ids();
     return stream_sort.sort_groups(streams, query);
@@ -158,30 +157,30 @@ run_test("sort_groups", () => {
         same_as_before: false,
         pinned_streams: [6],
         normal_streams: [10],
-        dormant_streams: []
-    })
+        dormant_streams: [],
+    });
     assert.deepEqual(stream_sort.sort_groups(streams, "dash"), {
         same_as_before: false,
         pinned_streams: [],
         normal_streams: [10, 7],
-        dormant_streams: []
-    })
+        dormant_streams: [],
+    });
     assert.deepEqual(stream_sort.sort_groups(streams, "slash"), {
         same_as_before: false,
         pinned_streams: [],
         normal_streams: [10, 8],
-        dormant_streams: []
-    })
+        dormant_streams: [],
+    });
     assert.deepEqual(stream_sort.sort_groups(streams, "space"), {
         same_as_before: false,
         pinned_streams: [],
         normal_streams: [9, 10],
-        dormant_streams: []
-    })
+        dormant_streams: [],
+    });
     assert.deepEqual(stream_sort.sort_groups(streams, "stream-d"), {
         same_as_before: false,
         pinned_streams: [],
         normal_streams: [7],
-        dormant_streams: []
-    })
+        dormant_streams: [],
+    });
 });

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -9,6 +9,39 @@ const {run_test} = require("../zjsunit/test");
 
 set_global("document", {});
 const util = zrequire("util");
+const stream_data = zrequire("stream_data");
+const sub_store = zrequire("sub_store")
+
+const stream_underscore = {
+    subscribed: true,
+    name: "stream_underscore",
+    stream_id: 1,
+    pin_to_top: true,
+};
+const stream_dash = {
+    subscribed: true,
+    name: "stream-dash",
+    stream_id: 2,
+    pin_to_top: false,
+};
+const stream_slash = {
+    subscribed: true,
+    name: "stream/slash",
+    stream_id: 3,
+    pin_to_top: false,
+};
+const stream_space = {
+    subscribed: true,
+    name: "stream space",
+    stream_id: 4,
+    pin_to_top: false,
+};
+const stream_space_dash_underscore_slash = {
+    subscribed: true,
+    name: "stream space-dash_underscore/slash",
+    stream_id: 5,
+    pin_to_top: false,
+};
 
 run_test("CachedValue", () => {
     let x = 5;
@@ -296,4 +329,19 @@ run_test("clean_user_content_links", () => {
             "<a>unsafe</a> " +
             '<a href="/#fragment" title="http://zulip.zulipdev.com/#fragment">fragment</a>',
     );
+});
+
+run_test("filter_by_word_prefix_match", () => {
+    stream_data.add_sub(stream_underscore);
+    stream_data.add_sub(stream_dash);
+    stream_data.add_sub(stream_slash);
+    stream_data.add_sub(stream_space);
+    stream_data.add_sub(stream_space_dash_underscore_slash);
+    const streams = stream_data.subscribed_stream_ids();
+    const stream_id_to_name = (stream) => sub_store.get(stream).name;
+    assert.deepEqual(util.filter_by_word_prefix_match(streams, "under", stream_id_to_name), [1, 5])
+    assert.deepEqual(util.filter_by_word_prefix_match(streams, "dash", stream_id_to_name), [2, 5])
+    assert.deepEqual(util.filter_by_word_prefix_match(streams, "slash", stream_id_to_name), [3, 5])
+    assert.deepEqual(util.filter_by_word_prefix_match(streams, "space", stream_id_to_name), [4, 5])
+    assert.deepEqual(util.filter_by_word_prefix_match(streams, "stream-d", stream_id_to_name), [2])
 });

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -10,7 +10,7 @@ const {run_test} = require("../zjsunit/test");
 set_global("document", {});
 const util = zrequire("util");
 const stream_data = zrequire("stream_data");
-const sub_store = zrequire("sub_store")
+const sub_store = zrequire("sub_store");
 
 const stream_underscore = {
     subscribed: true,
@@ -339,9 +339,9 @@ run_test("filter_by_word_prefix_match", () => {
     stream_data.add_sub(stream_space_dash_underscore_slash);
     const streams = stream_data.subscribed_stream_ids();
     const stream_id_to_name = (stream) => sub_store.get(stream).name;
-    assert.deepEqual(util.filter_by_word_prefix_match(streams, "under", stream_id_to_name), [1, 5])
-    assert.deepEqual(util.filter_by_word_prefix_match(streams, "dash", stream_id_to_name), [2, 5])
-    assert.deepEqual(util.filter_by_word_prefix_match(streams, "slash", stream_id_to_name), [3, 5])
-    assert.deepEqual(util.filter_by_word_prefix_match(streams, "space", stream_id_to_name), [4, 5])
-    assert.deepEqual(util.filter_by_word_prefix_match(streams, "stream-d", stream_id_to_name), [2])
+    assert.deepEqual(util.filter_by_word_prefix_match(streams, "under", stream_id_to_name), [1, 5]);
+    assert.deepEqual(util.filter_by_word_prefix_match(streams, "dash", stream_id_to_name), [2, 5]);
+    assert.deepEqual(util.filter_by_word_prefix_match(streams, "slash", stream_id_to_name), [3, 5]);
+    assert.deepEqual(util.filter_by_word_prefix_match(streams, "space", stream_id_to_name), [4, 5]);
+    assert.deepEqual(util.filter_by_word_prefix_match(streams, "stream-d", stream_id_to_name), [2]);
 });

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -322,7 +322,7 @@ export function filter_by_word_prefix_match(items, search_term, item_to_text) {
     const filtered_items = items.filter((item) =>
         search_terms.some((search_term) => {
             const lower_name = item_to_text(item).toLowerCase();
-            const cands = lower_name.split(" ");
+            const cands = lower_name.split(/[\s-_\/]+/);
             cands.push(lower_name);
             return cands.some((name) => name.startsWith(search_term));
         }),

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -322,7 +322,7 @@ export function filter_by_word_prefix_match(items, search_term, item_to_text) {
     const filtered_items = items.filter((item) =>
         search_terms.some((search_term) => {
             const lower_name = item_to_text(item).toLowerCase();
-            const cands = lower_name.split(/[\s-_\/]+/);
+            const cands = lower_name.split(/[\s-_/]+/);
             cands.push(lower_name);
             return cands.some((name) => name.startsWith(search_term));
         }),


### PR DESCRIPTION
It is common to use several separators in addition to spaces between words in stream names. At present, searching in the sidebar for a word in the latter part of the stream name using such a separator will not find the stream. E.g. if a stream is called "foo-bar", searching for "bar" will not find it.

To make it easier for users to find the streams they are looking for, the left sidebar stream filter should use the following additional characters as word separators:

-, _, /

This is already being done by Zulip Terminal.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes [#19700 ](https://github.com/zulip/zulip/issues/19700)

**Testing plan:** <!-- How have you tested? -->
Manual testing

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="131" alt="slash" src="https://user-images.githubusercontent.com/33564446/132956561-88381b02-9b3e-4d96-b59b-e9d67bc18ebe.PNG">
<img width="124" alt="space" src="https://user-images.githubusercontent.com/33564446/132956562-325007c1-218f-4025-8838-197660a91c85.PNG">
<img width="128" alt="dash" src="https://user-images.githubusercontent.com/33564446/132956565-832e8db7-37cb-4b3b-85d8-2cf9c15a44ac.PNG">
<img width="135" alt="underscore" src="https://user-images.githubusercontent.com/33564446/132956596-c8137bda-292d-449e-bb68-499c9f1fa017.PNG">

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
