### PR TITLE
composebox_typeahead: Remove redundant options from the `/` typeahead

### DIFF
--- a/docs/subsystems/slash-commands.md
+++ b/docs/subsystems/slash-commands.md
@@ -6,7 +6,7 @@ and both these terms are often user interchangeably.
 
 Currently supported slash commands are:
 
-- `/day` and `/night` to change the UI theme
+- `/light` and `/dark` to change the UI theme
 - `/ping` to ping to server and get back the time for the round
   trip. Mainly for testing.
 - `/fluid-width` and `/fixed-width` to toggle that setting
@@ -28,8 +28,8 @@ basically just acks the client. The client then computes
 the round trip time and shows a little message above
 the compose box that the user can see and then dismiss.
 
-For commands like "/day" and "/night", the server does
-a little bit of logic to toggle the user's night mode
+For commands like "/light" and "/dark", the server does
+a little bit of logic to toggle the user's dark mode
 setting, and this is largely done inside `zcommand.py`.
 The server sends a very basic response, and then
 the client actually changes the display colors. The

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -154,12 +154,26 @@ const emoji_list = Array.from(emojis_by_name.values(), (emoji_dict) => {
 
 const me_slash = {
     name: "me",
+    aliases: "",
     text: "translated: /me is excited (Display action text)",
 };
 
 const my_slash = {
     name: "my",
+    aliases: "",
     text: "translated: /my (Test)",
+};
+
+const dark_slash = {
+    name: "dark",
+    aliases: "night",
+    text: "translated: /dark (Toggle dark mode)",
+};
+
+const light_slash = {
+    name: "light",
+    aliases: "day",
+    text: "translated: /light (Toggle light mode)",
 };
 
 const sweden_stream = {
@@ -483,6 +497,30 @@ test("content_typeahead_selected", ({override}) => {
     fake_this.completing = "slash";
     actual_value = ct.content_typeahead_selected.call(fake_this, me_slash);
     expected_value = "/me ";
+    assert.equal(actual_value, expected_value);
+
+    fake_this.query = "/da";
+    fake_this.completing = "slash";
+    actual_value = ct.content_typeahead_selected.call(fake_this, dark_slash);
+    expected_value = "/dark ";
+    assert.equal(actual_value, expected_value);
+
+    fake_this.query = "/ni";
+    fake_this.completing = "slash";
+    actual_value = ct.content_typeahead_selected.call(fake_this, dark_slash);
+    expected_value = "/dark ";
+    assert.equal(actual_value, expected_value);
+
+    fake_this.query = "/li";
+    fake_this.completing = "slash";
+    actual_value = ct.content_typeahead_selected.call(fake_this, light_slash);
+    expected_value = "/light ";
+    assert.equal(actual_value, expected_value);
+
+    fake_this.query = "/da";
+    fake_this.completing = "slash";
+    actual_value = ct.content_typeahead_selected.call(fake_this, light_slash);
+    expected_value = "/light ";
     assert.equal(actual_value, expected_value);
 
     // stream
@@ -946,6 +984,11 @@ test("initialize", ({override, mock_template}) => {
         fake_this = {completing: "slash", token: "m"};
         actual_value = sort_items(fake_this, [my_slash, me_slash]);
         expected_value = [me_slash, my_slash];
+        assert.deepEqual(actual_value, expected_value);
+
+        fake_this = {completing: "slash", token: "da"};
+        actual_value = sort_items(fake_this, [dark_slash, light_slash]);
+        expected_value = [dark_slash, light_slash];
         assert.deepEqual(actual_value, expected_value);
 
         fake_this = {completing: "stream", token: "de"};
@@ -1520,6 +1563,10 @@ test("typeahead_results", () => {
 
     // Autocomplete by slash commands.
     assert_slash_matches("me", [me_slash]);
+    assert_slash_matches("dark", [dark_slash]);
+    assert_slash_matches("night", [dark_slash]);
+    assert_slash_matches("light", [light_slash]);
+    assert_slash_matches("day", [light_slash]);
 
     // Autocomplete stream by stream name or stream description.
     assert_stream_matches("den", [denmark_stream, sweden_stream]);

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -118,7 +118,7 @@ function get_slash_matcher(query) {
     query = typeahead.clean_query_lowercase(query);
 
     return function (item) {
-        return typeahead.query_matches_source_attrs(query, item, ["name"], " ");
+        return typeahead.query_matches_source_attrs(query, item, ["name", "aliases"], " ");
     };
 }
 
@@ -393,40 +393,39 @@ function should_show_custom_query(query, items) {
 
 export const slash_commands = [
     {
-        text: $t({defaultMessage: "/dark (Toggle night mode)"}),
+        text: $t({defaultMessage: "/dark (Toggle dark mode)"}),
         name: "dark",
-    },
-    {
-        text: $t({defaultMessage: "/day (Toggle day mode)"}),
-        name: "day",
+        aliases: "night",
     },
     {
         text: $t({defaultMessage: "/fixed-width (Toggle fixed width mode)"}),
         name: "fixed-width",
+        aliases: "",
     },
     {
         text: $t({defaultMessage: "/fluid-width (Toggle fluid width mode)"}),
         name: "fluid-width",
+        aliases: "",
     },
     {
-        text: $t({defaultMessage: "/light (Toggle day mode)"}),
+        text: $t({defaultMessage: "/light (Toggle light mode)"}),
         name: "light",
+        aliases: "day",
     },
     {
         text: $t({defaultMessage: "/me is excited (Display action text)"}),
         name: "me",
-    },
-    {
-        text: $t({defaultMessage: "/night (Toggle night mode)"}),
-        name: "night",
+        aliases: "",
     },
     {
         text: $t({defaultMessage: "/poll Where should we go to lunch today? (Create a poll)"}),
         name: "poll",
+        aliases: "",
     },
     {
         text: $t({defaultMessage: "/todo (Create a todo list)"}),
         name: "todo",
+        aliases: "",
     },
 ];
 

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -52,11 +52,11 @@ export const color_scheme_values = {
     },
     night: {
         code: 2,
-        description: $t({defaultMessage: "Night mode"}),
+        description: $t({defaultMessage: "Dark mode"}),
     },
     day: {
         code: 3,
-        description: $t({defaultMessage: "Day mode"}),
+        description: $t({defaultMessage: "Light mode"}),
     },
 };
 

--- a/static/js/zcommand.js
+++ b/static/js/zcommand.js
@@ -74,8 +74,8 @@ export function enter_day_mode() {
                         command: "/night",
                     });
                 },
-                title_text: $t({defaultMessage: "Day mode"}),
-                undo_button_text: $t({defaultMessage: "Night"}),
+                title_text: $t({defaultMessage: "Light mode"}),
+                undo_button_text: $t({defaultMessage: "Dark mode"}),
             });
         },
     });
@@ -96,8 +96,8 @@ export function enter_night_mode() {
                         command: "/day",
                     });
                 },
-                title_text: $t({defaultMessage: "Night mode"}),
-                undo_button_text: $t({defaultMessage: "Day"}),
+                title_text: $t({defaultMessage: "Dark mode"}),
+                undo_button_text: $t({defaultMessage: "Light mode"}),
             });
         },
     });

--- a/templates/zerver/help/include/set-up-your-account.md
+++ b/templates/zerver/help/include/set-up-your-account.md
@@ -7,7 +7,7 @@
   [edit your profile information](https://zulip.com/help/edit-your-profile) to tell others
   about yourself.
 - [Review your display settings](/help/review-your-settings#review-your-display-settings).
-  You can [switch between day and night mode](/help/night-mode),
+  You can [switch between light and dark mode](/help/night-mode),
   [pick your favorite emoji theme](/help/emoji-and-emoticons#change-your-emoji-set),
   [change your language](/help/change-your-language), and make other tweaks to your Zulip experience.
 - [Browse and subscribe to streams](/help/browse-and-subscribe-to-streams).

--- a/templates/zerver/help/night-mode.md
+++ b/templates/zerver/help/night-mode.md
@@ -1,6 +1,6 @@
-# Night mode
+# Dark mode
 
-Zulip provides both a light theme and a night theme, which is great
+Zulip provides both a light theme and a dark theme, which is great
 for working in a dark space.
 
 ## Manage color theme
@@ -16,6 +16,6 @@ for working in a dark space.
 The default is **Automatic**, which detects which theme to use based
 on the color scheme used by your operating system.
 
-You can also specify **Night mode** or **Day mode** if you'd like
+You can also specify **Dark mode** or **Light mode** if you'd like
 Zulip to use the same color scheme regardless of your operating system
 configuration.

--- a/zerver/lib/zcommand.py
+++ b/zerver/lib/zcommand.py
@@ -34,22 +34,22 @@ def process_zcommands(content: str, user_profile: UserProfile) -> Dict[str, Any]
         return {}
     elif command == "night":
         if user_profile.color_scheme == UserProfile.COLOR_SCHEME_NIGHT:
-            return dict(msg="You are still in night mode.")
+            return dict(msg="You are still in dark mode.")
         return dict(
             msg=change_mode_setting(
-                command=command,
-                switch_command="day",
+                command="dark",
+                switch_command="light",
                 setting="color_scheme",
                 setting_value=UserProfile.COLOR_SCHEME_NIGHT,
             )
         )
     elif command == "day":
         if user_profile.color_scheme == UserProfile.COLOR_SCHEME_LIGHT:
-            return dict(msg="You are still in day mode.")
+            return dict(msg="You are still in light mode.")
         return dict(
             msg=change_mode_setting(
-                command=command,
-                switch_command="night",
+                command="light",
+                switch_command="dark",
                 setting="color_scheme",
                 setting_value=UserProfile.COLOR_SCHEME_LIGHT,
             )

--- a/zerver/tests/test_zcommand.py
+++ b/zerver/tests/test_zcommand.py
@@ -30,11 +30,11 @@ class ZcommandTest(ZulipTestCase):
         payload = dict(command="/night")
         result = self.client_post("/json/zcommand", payload)
         self.assert_json_success(result)
-        self.assertIn("Changed to night", result.json()["msg"])
+        self.assertIn("Changed to dark mode", result.json()["msg"])
 
         result = self.client_post("/json/zcommand", payload)
         self.assert_json_success(result)
-        self.assertIn("still in night mode", result.json()["msg"])
+        self.assertIn("still in dark mode", result.json()["msg"])
 
     def test_day_zcommand(self) -> None:
         self.login("hamlet")
@@ -45,11 +45,11 @@ class ZcommandTest(ZulipTestCase):
         payload = dict(command="/day")
         result = self.client_post("/json/zcommand", payload)
         self.assert_json_success(result)
-        self.assertIn("Changed to day", result.json()["msg"])
+        self.assertIn("Changed to light mode", result.json()["msg"])
 
         result = self.client_post("/json/zcommand", payload)
         self.assert_json_success(result)
-        self.assertIn("still in day mode", result.json()["msg"])
+        self.assertIn("still in light mode", result.json()["msg"])
 
     def test_fluid_zcommand(self) -> None:
         self.login("hamlet")


### PR DESCRIPTION
Fixes #18318
Removes the `/day` and `/night` options from the typeahead menu while still allowing the commands to be used. Typing `/day` and `/night` will now suggest `/light` and `/dark`, respectively. Also changes the display settings to use `Light mode`/`Dark mode`. Finally, changes the `Dark mode` and `Light mode` popups that appear after using the corresponding command.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
Manual testing, node tests, and backend tests.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
New slash typeahead without the `/day` and `/night` options
![slash-typeahead](https://user-images.githubusercontent.com/61168867/133723391-0e24b540-e84b-46a8-83a3-18e55e047694.png)

`/day` typeahead
![day-slash](https://user-images.githubusercontent.com/61168867/133723169-a20d9a75-aebc-4086-8237-2b16926ea93b.png)

`/night` typeahead
![night-slash](https://user-images.githubusercontent.com/61168867/133723187-962fb68b-bd65-483c-890c-dc87e698b68c.png)

`/da` typeahead (which can either be `/day` or `/dark`)
![da-slash](https://user-images.githubusercontent.com/61168867/133723211-2882c617-627e-4b2c-b780-0fbe8e88802c.png)

New personal settings menu (display settings)
![color-scheme](https://user-images.githubusercontent.com/61168867/133723287-c2ebb113-684d-4e9e-945b-efd043088c6e.png)

Popups after using `/light` or `/day`
![light-command](https://user-images.githubusercontent.com/61168867/133726230-4589c031-7e18-4a09-871f-27e287bf8e5a.png)
![already-light](https://user-images.githubusercontent.com/61168867/133726283-a621eb8e-caf5-42b2-8001-704f0006fdbd.png)

Popups after using `/dark` or `/night`
![dark-command](https://user-images.githubusercontent.com/61168867/133726312-1411691b-8e80-4c5c-bad7-ca7713de51f8.png)
![already-dark](https://user-images.githubusercontent.com/61168867/133726634-afdda160-9b12-40ab-a79f-a069ce00f9bf.png)

<!-- Also be sure to make
 clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
