### PR TITLE
Add UI for realm-level defaults of user display settings.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -7,7 +7,11 @@ const {make_stub} = require("../zjsunit/stub");
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
 const $ = require("../zjsunit/zjquery");
-const {page_params, user_settings} = require("../zjsunit/zpage_params");
+const {
+    page_params,
+    realm_user_settings_defaults,
+    user_settings,
+} = require("../zjsunit/zpage_params");
 
 const noop = () => {};
 
@@ -984,4 +988,17 @@ run_test("server_event_dispatch_op_errors", ({override}) => {
     override(settings_user_groups, "reload", noop);
     blueslip.expect("error", "Unexpected event type user_group/other");
     server_events_dispatch.dispatch_normal_event({type: "user_group", op: "other"});
+});
+
+run_test("realm_user_settings_defaults", ({override}) => {
+    override(settings_display, "update_page", noop);
+    const event = event_fixtures.realm_user_settings_defaults__emojiset;
+    realm_user_settings_defaults.emojiset = "text";
+    let called = false;
+    settings_display.report_emojiset_change = () => {
+        called = true;
+    };
+    dispatch(event);
+    assert_same(realm_user_settings_defaults.emojiset, "google");
+    assert_same(called, true);
 });

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -518,6 +518,13 @@ exports.fixtures = {
         },
     },
 
+    realm_user_settings_defaults__emojiset: {
+        type: "realm_user_settings_defaults",
+        op: "update",
+        property: "emojiset",
+        value: "google",
+    },
+
     restart: {
         type: "restart",
         zulip_version: "4.0-dev+git",

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -102,6 +102,8 @@ try {
         require("../../static/js/page_params");
         namespace.mock_esm("../../static/js/user_settings", zpage_params);
         require("../../static/js/user_settings");
+        namespace.mock_esm("../../static/js/realm_user_settings_defaults", zpage_params);
+        require("../../static/js/realm_user_settings_defaults");
 
         run_one_module(file);
 

--- a/frontend_tests/zjsunit/zpage_params.js
+++ b/frontend_tests/zjsunit/zpage_params.js
@@ -1,6 +1,7 @@
 "use strict";
 
 exports.page_params = {};
+exports.realm_user_settings_defaults = {};
 exports.user_settings = {};
 
 exports.reset = () => {
@@ -12,6 +13,11 @@ exports.reset = () => {
     for (const field in exports.user_settings) {
         if (Object.prototype.hasOwnProperty.call(exports.user_settings, field)) {
             delete exports.user_settings[field];
+        }
+    }
+    for (const field in exports.realm_user_settings_defaults) {
+        if (Object.prototype.hasOwnProperty.call(exports.realm_user_settings_defaults, field)) {
+            delete exports.realm_user_settings_defaults[field];
         }
     }
 };

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -6,6 +6,7 @@ import render_settings_organization_settings_tip from "../templates/settings/org
 import {$t, language_list} from "./i18n";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
+import {realm_user_settings_defaults} from "./realm_user_settings_defaults";
 import * as settings from "./settings";
 import * as settings_bots from "./settings_bots";
 import * as settings_config from "./settings_config";
@@ -123,6 +124,12 @@ export function build_page() {
         can_edit_user_groups: settings_data.user_can_edit_user_groups(),
         policy_values: settings_config.common_policy_values,
         ...settings_org.get_organization_settings_options(),
+        demote_inactive_streams_values: settings_config.demote_inactive_streams_values,
+        color_scheme_values: settings_config.color_scheme_values,
+        default_view_values: settings_config.default_view_values,
+        settings_object: realm_user_settings_defaults,
+        display_settings: settings_config.get_all_display_settings(),
+        settings_label: settings_config.display_settings_labels,
     };
 
     if (options.realm_logo_source !== "D" && options.realm_night_logo_source === "D") {

--- a/static/js/realm_user_settings_defaults.ts
+++ b/static/js/realm_user_settings_defaults.ts
@@ -1,0 +1,42 @@
+type RealmDefaultSettingsType = {
+    color_scheme: number;
+    default_language: string;
+    default_view: string;
+    desktop_icon_count_display: number;
+    demote_inactive_streams: number;
+    dense_mode: boolean;
+    email_notifications_batching_period_seconds: number;
+    emojiset: string;
+    enable_desktop_notifications: boolean;
+    enable_digest_emails: boolean;
+    enable_drafts_synchronization: boolean;
+    enable_login_emails: boolean;
+    enable_marketing_emails: boolean;
+    enable_offline_push_notifications: boolean;
+    enable_offline_email_notifications: boolean;
+    enable_online_push_notifications: boolean;
+    enable_sounds: boolean;
+    enable_stream_audible_notifications: boolean;
+    enable_stream_desktop_notifications: boolean;
+    enable_stream_email_notifications: boolean;
+    enable_stream_push_notifications: boolean;
+    enter_sends: boolean;
+    fluid_layout_width: boolean;
+    high_contrast_mode: boolean;
+    left_side_userlist: boolean;
+    message_content_in_email_notifications: boolean;
+    notification_sound: string;
+    pm_content_in_desktop_notifications: boolean;
+    presence_enabled: boolean;
+    realm_name_in_notifications: boolean;
+    starred_message_counts: boolean;
+    translate_emoticons: boolean;
+    twenty_four_hour_time: boolean;
+    wildcard_mentions_notify: boolean;
+};
+
+export let realm_user_settings_defaults = {} as RealmDefaultSettingsType;
+
+export function initialize(params: Record<string, RealmDefaultSettingsType>): void {
+    realm_user_settings_defaults = params.realm_user_settings_defaults;
+}

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -36,6 +36,7 @@ import * as reactions from "./reactions";
 import * as realm_icon from "./realm_icon";
 import * as realm_logo from "./realm_logo";
 import * as realm_playground from "./realm_playground";
+import {realm_user_settings_defaults} from "./realm_user_settings_defaults";
 import * as reload from "./reload";
 import * as scroll_bar from "./scroll_bar";
 import * as settings_account from "./settings_account";
@@ -380,6 +381,36 @@ export function dispatch_normal_event(event) {
                 }
             }
             break;
+
+        case "realm_user_settings_defaults": {
+            realm_user_settings_defaults[event.property] = event.value;
+
+            const display_settings_list = [
+                "color_scheme",
+                "default_view",
+                "demote_inactive_streams",
+                "dense_mode",
+                "emojiset",
+                "fluid_layout_width",
+                "high_contrast_mode",
+                "left_side_userlist",
+                "translate_emoticons",
+                "starred_message_counts",
+            ];
+
+            const container_elem = $("#realm-user-default-settings");
+            if (display_settings_list.includes(event.property)) {
+                settings_display.update_page(container_elem, realm_user_settings_defaults);
+            }
+
+            if (event.property === "emojiset") {
+                settings_display.report_emojiset_change(
+                    container_elem,
+                    realm_user_settings_defaults,
+                );
+            }
+            break;
+        }
 
         case "realm_user":
             switch (event.op) {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -568,6 +568,8 @@ export function dispatch_normal_event(event) {
                 "translate_emoticons",
                 "starred_message_counts",
             ];
+
+            const container_elem = $("#user-display-settings");
             if (user_display_settings.includes(event.property)) {
                 user_settings[event.property] = event.value;
             }
@@ -632,7 +634,7 @@ export function dispatch_normal_event(event) {
                 // reload.
             }
             if (event.property === "emojiset") {
-                settings_display.report_emojiset_change();
+                settings_display.report_emojiset_change(container_elem, user_settings);
 
                 // Rerender the whole message list UI
                 message_lists.home.rerender();
@@ -648,7 +650,7 @@ export function dispatch_normal_event(event) {
                 compose.toggle_enter_sends_ui();
                 break;
             }
-            settings_display.update_page();
+            settings_display.update_page(container_elem, user_settings);
             break;
         }
 

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -111,7 +111,7 @@ export function build_page() {
         user_can_change_name: settings_data.user_can_change_name(),
         user_can_change_avatar: settings_data.user_can_change_avatar(),
         user_role_text: people.get_user_type(page_params.user_id),
-        default_language_name: settings_display.default_language_name,
+        default_language_name: settings_display.user_default_language_name,
         language_list_dbl_col: get_language_list_columns(user_settings.default_language),
         settings_object: user_settings,
     });

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1,5 +1,4 @@
 import {parseISO} from "date-fns";
-import Handlebars from "handlebars/runtime";
 import $ from "jquery";
 
 import timezones from "../generated/timezones.json";
@@ -73,19 +72,7 @@ function setup_settings_label() {
         }),
 
         // display settings
-        dense_mode: $t({defaultMessage: "Dense mode"}),
-        fluid_layout_width: $t({defaultMessage: "Use full width on wide screens"}),
-        high_contrast_mode: $t({defaultMessage: "High contrast mode"}),
-        left_side_userlist: $t({
-            defaultMessage: "Show user list on left sidebar in narrow windows",
-        }),
-        starred_message_counts: $t({defaultMessage: "Show counts for starred messages"}),
-        twenty_four_hour_time: $t({defaultMessage: "Time format"}),
-        translate_emoticons: new Handlebars.SafeString(
-            $t_html({
-                defaultMessage: "Convert emoticons before sending (<code>:)</code> becomes 😃)",
-            }),
-        ),
+        ...settings_config.display_settings_labels,
     };
 }
 

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -192,12 +192,12 @@ export function update_bot_settings_tip() {
     let tip_text;
     if (current_permission === permission_type.admins_only.code) {
         tip_text = $t({
-            defaultMessage: "Only organization administrators can add bots to this organization",
+            defaultMessage: "Only organization administrators can add bots to this organization.",
         });
     } else if (current_permission === permission_type.restricted.code) {
-        tip_text = $t({defaultMessage: "Only organization administrators can add generic bots"});
+        tip_text = $t({defaultMessage: "Only organization administrators can add generic bots."});
     } else {
-        tip_text = $t({defaultMessage: "Anyone in this organization can add bots"});
+        tip_text = $t({defaultMessage: "Anyone in this organization can add bots."});
     }
     $(".bot-settings-tip").text(tip_text);
 }

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -1,4 +1,6 @@
-import {$t} from "./i18n";
+import Handlebars from "handlebars/runtime";
+
+import {$t, $t_html} from "./i18n";
 import {page_params} from "./page_params";
 import {user_settings} from "./user_settings";
 
@@ -352,6 +354,22 @@ export const user_role_values = {
 
 const user_role_array = Object.values(user_role_values);
 export const user_role_map = new Map(user_role_array.map((role) => [role.code, role.description]));
+
+export const display_settings_labels = {
+    dense_mode: $t({defaultMessage: "Dense mode"}),
+    fluid_layout_width: $t({defaultMessage: "Use full width on wide screens"}),
+    high_contrast_mode: $t({defaultMessage: "High contrast mode"}),
+    left_side_userlist: $t({
+        defaultMessage: "Show user list on left sidebar in narrow windows",
+    }),
+    starred_message_counts: $t({defaultMessage: "Show counts for starred messages"}),
+    twenty_four_hour_time: $t({defaultMessage: "Time format"}),
+    translate_emoticons: new Handlebars.SafeString(
+        $t_html({
+            defaultMessage: "Convert emoticons before sending (<code>:)</code> becomes 😃)",
+        }),
+    ),
+};
 
 // NOTIFICATIONS
 

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -14,10 +14,10 @@ const meta = {
     loaded: false,
 };
 
-export let default_language_name;
+export let user_default_language_name;
 
 export function set_default_language_name(name) {
-    default_language_name = name;
+    user_default_language_name = name;
 }
 
 function change_display_setting(data, container, url, status_element, success_msg_html, sticky) {
@@ -38,12 +38,10 @@ function change_display_setting(data, container, url, status_element, success_ms
     settings_ui.do_settings_change(channel.patch, url, data, $status_el, opts);
 }
 
-export function set_up() {
+export function set_up(container, settings_object) {
     meta.loaded = true;
-    const container = $("#user-display-settings");
     const language_modal_elem = "#user_default_language_modal";
     const patch_url = "/json/settings";
-    const settings_object = user_settings;
 
     container.find(".display-settings-status").hide();
 
@@ -181,18 +179,16 @@ export function set_up() {
     });
 }
 
-export async function report_emojiset_change() {
+export async function report_emojiset_change(container, settings_object) {
     // TODO: Clean up how this works so we can use
     // change_display_setting.  The challenge is that we don't want to
     // report success before the server_events request returns that
     // causes the actual sprite sheet to change.  The current
     // implementation is wrong, though, in that it displays the UI
     // update in all active browser windows.
-
-    const settings_object = user_settings;
     await emojisets.select(settings_object.emojiset);
 
-    const spinner = $("#user-display-settings").find(".emoji-settings-status");
+    const spinner = container.find(".emoji-settings-status");
     if (spinner.length) {
         loading.destroy_indicator(spinner);
         ui_report.success(
@@ -204,9 +200,9 @@ export async function report_emojiset_change() {
     }
 }
 
-export function update_page() {
-    const container = $("#user-display-settings");
-    const settings_object = user_settings;
+export function update_page(container, settings_object) {
+    const default_language_name = user_default_language_name;
+
     container.find(".left_side_userlist").prop("checked", settings_object.left_side_userlist);
     container.find(".default_language_name").text(default_language_name);
     container.find(".translate_emoticons").prop("checked", settings_object.translate_emoticons);
@@ -221,6 +217,6 @@ export function update_page() {
 }
 
 export function initialize() {
-    const language_name = get_language_name(user_settings.default_language);
-    set_default_language_name(language_name);
+    const user_language_name = get_language_name(user_settings.default_language);
+    set_default_language_name(user_language_name);
 }

--- a/static/js/settings_realm_user_settings_defaults.js
+++ b/static/js/settings_realm_user_settings_defaults.js
@@ -1,0 +1,9 @@
+import $ from "jquery";
+
+import {realm_user_settings_defaults} from "./realm_user_settings_defaults";
+import * as settings_display from "./settings_display";
+
+export function set_up() {
+    const container = $("#realm-user-default-settings");
+    settings_display.set_up(container, realm_user_settings_defaults, true);
+}

--- a/static/js/settings_sections.js
+++ b/static/js/settings_sections.js
@@ -1,3 +1,5 @@
+import $ from "jquery";
+
 import * as alert_words_ui from "./alert_words_ui";
 import * as attachments_ui from "./attachments_ui";
 import * as blueslip from "./blueslip";
@@ -17,6 +19,7 @@ import * as settings_profile_fields from "./settings_profile_fields";
 import * as settings_streams from "./settings_streams";
 import * as settings_user_groups from "./settings_user_groups";
 import * as settings_users from "./settings_users";
+import {user_settings} from "./user_settings";
 
 const load_func_dict = new Map(); // group -> function
 const loaded_groups = new Set();
@@ -50,7 +53,9 @@ export function get_group(section) {
 export function initialize() {
     // personal
     load_func_dict.set("your-account", settings_account.set_up);
-    load_func_dict.set("display-settings", settings_display.set_up);
+    load_func_dict.set("display-settings", () => {
+        settings_display.set_up($("#user-display-settings"), user_settings);
+    });
     load_func_dict.set("notifications", settings_notifications.set_up);
     load_func_dict.set("your-bots", settings_bots.set_up);
     load_func_dict.set("alert-words", alert_words_ui.set_up_alert_words);

--- a/static/js/settings_sections.js
+++ b/static/js/settings_sections.js
@@ -16,6 +16,7 @@ import * as settings_notifications from "./settings_notifications";
 import * as settings_org from "./settings_org";
 import * as settings_playgrounds from "./settings_playgrounds";
 import * as settings_profile_fields from "./settings_profile_fields";
+import * as settings_realm_user_settings_defaults from "./settings_realm_user_settings_defaults";
 import * as settings_streams from "./settings_streams";
 import * as settings_user_groups from "./settings_user_groups";
 import * as settings_users from "./settings_users";
@@ -54,7 +55,7 @@ export function initialize() {
     // personal
     load_func_dict.set("your-account", settings_account.set_up);
     load_func_dict.set("display-settings", () => {
-        settings_display.set_up($("#user-display-settings"), user_settings);
+        settings_display.set_up($("#user-display-settings"), user_settings, false);
     });
     load_func_dict.set("notifications", settings_notifications.set_up);
     load_func_dict.set("your-bots", settings_bots.set_up);
@@ -75,6 +76,10 @@ export function initialize() {
     load_func_dict.set("user-groups-admin", settings_user_groups.set_up);
     load_func_dict.set("profile-field-settings", settings_profile_fields.set_up);
     load_func_dict.set("data-exports-admin", settings_exports.set_up);
+    load_func_dict.set(
+        "organization-level-user-defaults",
+        settings_realm_user_settings_defaults.set_up,
+    );
 }
 
 export function load_settings_section(section) {

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -56,6 +56,7 @@ import * as popover_menus from "./popover_menus";
 import * as presence from "./presence";
 import * as realm_logo from "./realm_logo";
 import * as realm_playground from "./realm_playground";
+import * as realm_user_settings_defaults from "./realm_user_settings_defaults";
 import * as recent_topics_util from "./recent_topics_util";
 import * as reload from "./reload";
 import * as resize from "./resize";
@@ -515,12 +516,14 @@ export function initialize_everything() {
     const user_status_params = pop_fields("user_status");
     const i18n_params = pop_fields("language_list");
     const user_settings_params = pop_fields("user_settings");
+    const realm_settings_defaults_params = pop_fields("realm_user_settings_defaults");
 
     i18n.initialize(i18n_params);
     tippyjs.initialize();
     popover_menus.initialize();
 
     initialize_user_settings(user_settings_params);
+    realm_user_settings_defaults.initialize(realm_settings_defaults_params);
     people.initialize(page_params.user_id, people_params);
 
     let date_joined;

--- a/static/templates/settings/admin_tab.hbs
+++ b/static/templates/settings/admin_tab.hbs
@@ -9,6 +9,8 @@
 
 {{> organization_permissions_admin }}
 
+{{> organization_user_settings_defaults }}
+
 {{> emoji_settings_admin }}
 
 {{> user_list_admin }}

--- a/static/templates/settings/organization_user_settings_defaults.hbs
+++ b/static/templates/settings/organization_user_settings_defaults.hbs
@@ -1,0 +1,6 @@
+<div id="realm-user-default-settings" class="settings-section" data-name="organization-level-user-defaults">
+    <div class="tip">
+        {{t "Configure the default personal preference settings for new users joining your organization." }}
+    </div>
+    {{> display_settings prefix="realm_" for_realm_settings=true}}
+</div>

--- a/static/templates/settings_overlay.hbs
+++ b/static/templates/settings_overlay.hbs
@@ -75,6 +75,13 @@
                     <i class="locked fa fa-lock" title="{{t 'Only organization administrators can edit these settings.' }}"></i>
                     {{/unless}}
                 </li>
+                <li class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-level-user-defaults">
+                    <i class="icon fa fa-cog" aria-hidden="true"></i>
+                    <div class="text">{{t "Default user settings" }}</div>
+                    {{#unless is_admin}}
+                    <i class="locked fa fa-lock" title="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                    {{/unless}}
+                </li>
                 <li tabindex="0" data-section="emoji-settings">
                     <i class="icon fa fa-smile-o" aria-hidden="true"></i>
                     <div class="text">{{t "Custom emoji" }}</div>

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -115,6 +115,7 @@ EXEMPT_FILES = {
     "static/js/realm_icon.js",
     "static/js/realm_logo.js",
     "static/js/realm_playground.js",
+    "static/js/realm_user_settings_defaults.ts",
     "static/js/recent_topics_ui.js",
     "static/js/recent_topics_util.js",
     "static/js/reload.js",

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -142,6 +142,7 @@ EXEMPT_FILES = {
     "static/js/settings_org.js",
     "static/js/settings_panel_menu.js",
     "static/js/settings_profile_fields.js",
+    "static/js/settings_realm_user_settings_defaults.js",
     "static/js/settings_sections.js",
     "static/js/settings_streams.js",
     "static/js/settings_toggle.js",


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Commit summary -
- First two commits are to hide certain settings in realm-default section.
- Next four commits are prep commits to extract `settings_display.js` such that we can avoid duplication of code.
- Next commit is to add `realm_user_settings_defaults` module similar to `user_settings` module.
- Last commit is to add UI and javascript logic for realm-level defaults of display settings.
 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2021-09-12 23-12-59](https://user-images.githubusercontent.com/35494118/132997572-5ba077a7-7fc4-4063-9f0e-e23904349f3b.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
