### PR TITLE
quote-and-reply: Quote part of a message

### DIFF
--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -340,8 +340,10 @@ run_test("quote_and_reply", ({override}) => {
         $("#compose-textarea").trigger("blur");
     }
 
+    const opts = {};
+
     set_compose_content_with_caret("hello %there"); // "%" is used to encode/display position of focus before change
-    compose_actions.quote_and_reply();
+    compose_actions.quote_and_reply(opts);
     assert.equal(get_compose_content_with_caret(), "hello \n[Quoting…]\n%there");
 
     success_function({
@@ -357,7 +359,7 @@ run_test("quote_and_reply", ({override}) => {
     // If the caret is initially positioned at 0, it should not
     // add a newline before the quoted message.
     set_compose_content_with_caret("%hello there");
-    compose_actions.quote_and_reply();
+    compose_actions.quote_and_reply(opts);
     assert.equal(get_compose_content_with_caret(), "[Quoting…]\n%hello there");
 
     success_function({
@@ -380,7 +382,7 @@ run_test("quote_and_reply", ({override}) => {
     // If the compose-box is close, or open with no content while
     // quoting a message, the quoted message should be placed
     // at the beginning of compose-box.
-    compose_actions.quote_and_reply();
+    compose_actions.quote_and_reply(opts);
     assert.equal(get_compose_content_with_caret(), "[Quoting…]\n%");
 
     success_function({
@@ -398,7 +400,7 @@ run_test("quote_and_reply", ({override}) => {
     // newlines), the compose-box should re-open and thus the quoted
     // message should start from the beginning of compose-box.
     set_compose_content_with_caret("  \n\n \n %");
-    compose_actions.quote_and_reply();
+    compose_actions.quote_and_reply(opts);
     assert.equal(get_compose_content_with_caret(), "[Quoting…]\n%");
 
     success_function({

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -354,7 +354,7 @@ run_test("misc", () => {
     assert_mapping("u", popovers, "show_sender_info");
     assert_mapping("i", popovers, "open_message_menu");
     assert_mapping(":", reactions, "open_reactions_popover", true);
-    assert_mapping(">", compose_actions, "quote_and_reply");
+    assert_mapping(">", compose_actions, "quote_selected_text_and_reply");
     assert_mapping("e", message_edit, "start");
 });
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -897,7 +897,7 @@ export function process_hotkey(e, hotkey) {
             condense.toggle_collapse(msg);
             return true;
         case "compose_quote_reply": // > : respond to selected message with quote
-            compose_actions.quote_and_reply({trigger: "hotkey"});
+            compose_actions.quote_selected_text_and_reply({trigger: "hotkey"});
             return true;
         case "edit_message": {
             const row = message_lists.current.get_row(msg.id);

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1052,7 +1052,7 @@ export function register_click_handlers() {
         // message in the current message list (and
         // compose_actions.respond_to_message doesn't take a message
         // argument).
-        compose_actions.quote_and_reply({trigger: "popover respond"});
+        compose_actions.quote_selected_text_and_reply({trigger: "popover respond"});
         hide_actions_popover();
         e.stopPropagation();
         e.preventDefault();


### PR DESCRIPTION
Fixes #19712, Fixes #8951
Continues the work of [PR #18850](https://github.com/zulip/zulip/pull/18850) and [PR #15235](https://github.com/zulip/zulip/pull/15235)
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
Manual testing.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Quote and reply using the `>` hotkey.
![quote_hotkey](https://user-images.githubusercontent.com/61168867/133024215-2a50a3b8-491e-4a45-9c3e-6a9368df5056.gif)

Quote and reply using the menu option.
![quote_menu](https://user-images.githubusercontent.com/61168867/133024240-69b61ba1-d699-4aa4-a691-64403903ed10.gif)


Summary
- When nothing is highlighted, fully quote the currently selected message
- When part of a message is highlighted, quote only the highlighted text
- If the user highlights multiple messages, same behavior as nothing highlighted
- The `quote-and-reply` menu option has the same behavior as the `>` hotkey

Issues
- Formatting is not preserved when quoting only part of a message

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->