### PR TITLE
emoji: Remove octopus override

### DIFF
--- a/static/js/emojisets.js
+++ b/static/js/emojisets.js
@@ -2,8 +2,6 @@ import google_blob_sheet from "emoji-datasource-google-blob/img/google/sheets-25
 import google_sheet from "emoji-datasource-google/img/google/sheets-256/64.png";
 import twitter_sheet from "emoji-datasource-twitter/img/twitter/sheets-256/64.png";
 
-import octopus_url from "../generated/emoji/images-google-64/1f419.png";
-
 import {user_settings} from "./user_settings";
 
 import google_blob_css from "!style-loader?injectType=lazyStyleTag!css-loader!../generated/emoji-styles/google-blob-sprite.css";
@@ -42,12 +40,4 @@ export async function select(name) {
 
 export function initialize() {
     select(user_settings.emojiset);
-
-    // Load the octopus image in the background, so that the browser
-    // will cache it for later use.  Note that we hardcode the octopus
-    // emoji to the old Google one because it's better.
-    //
-    // TODO: We should probably just make this work just like the Zulip emoji.
-    const octopus_image = new Image();
-    octopus_image.src = octopus_url;
 }

--- a/tools/setup/emoji/build_emoji
+++ b/tools/setup/emoji/build_emoji
@@ -60,13 +60,6 @@ span.emoji
     overflow: hidden;
 }}
 
-.emoji-1f419
-{{
-    background-image: url(../emoji/images-google-64/1f419.png) !important;
-    background-position: 0% 0% !important;
-    background-size: contain !important;
-}}
-
 {emoji_positions}
 """
 
@@ -309,12 +302,6 @@ def setup_emoji_farms(cache_path: str, emoji_data: List[Dict[str, Any]]) -> None
         zulip_image = os.path.join(ZULIP_PATH, "static", "assets", "zulip-emoji")
         for f in os.listdir(zulip_image):
             shutil.copy2(os.path.join(zulip_image, f), target_emoji_farm, follow_symlinks=False)
-
-        # We hardcode octopus emoji image to Google emoji set's old
-        # "cute octopus" image. Copy it to the emoji farms.
-        input_img_file = os.path.join(EMOJI_SCRIPT_DIR_PATH, "1f419.png")
-        output_img_file = os.path.join(cache_path, "images-" + emojiset + "-64", "1f419.png")
-        shutil.copyfile(input_img_file, output_img_file)
 
         generate_sprite_css_files(cache_path, emoji_data, emojiset, alt_name, fallback_emoji_data)
 


### PR DESCRIPTION
There’s no objective reason to override this emoji. Organizations that really want to enforce a specific octopus can configure it as a custom emoji.

(This has no visible effect for users of the Google classic emoji set, which was the default until last week (#19672).)