### PR TITLE
settings_overlay: Change privacy icon to a lock

### DIFF
--- a/static/templates/settings_overlay.hbs
+++ b/static/templates/settings_overlay.hbs
@@ -16,7 +16,7 @@
                     <div class="text">{{t "Profile" }}</div>
                 </li>
                 <li tabindex="0" data-section="account-and-privacy">
-                    <i class="icon fa fa-user" aria-hidden="true"></i>
+                    <i class="icon fa fa-lock" aria-hidden="true"></i>
                     <div class="text">{{t "Account & privacy" }}</div>
                 </li>
                 <li tabindex="0" data-section="display-settings">


### PR DESCRIPTION
Fixes #19737

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
Manual testing.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![lock-icon](https://user-images.githubusercontent.com/61168867/133192145-6c3d8c6a-e595-4d16-9554-659890c85c10.PNG)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
