### PR TITLE
settings: Use correct object in notification settings template.

### DIFF
--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -137,7 +137,7 @@
         {{#each notification_settings.other_email_settings}}
         {{> settings_checkbox
           setting_name=this
-          is_checked=(lookup ../user_settings this)
+          is_checked=(lookup ../settings_object this)
           label=(lookup ../settings_label this)
           prefix=../prefix}}
         {{/each}}


### PR DESCRIPTION
In commit 40f4316, we changed the code to pass user settings
with settings_object variable, but this change was missed
during rebasing.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

 <!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
