### PR TITLE
settings: Fix the sticky behavior of saving indicator.

### DIFF
--- a/static/js/settings_ui.js
+++ b/static/js/settings_ui.js
@@ -37,7 +37,7 @@ export function do_settings_change(
     const spinner = $(status_element).expectOne();
     spinner.fadeTo(0, 1);
     loading.make_indicator(spinner, {text: strings.saving});
-    const remove_after = sticky ? null : 1000;
+    const remove_after = sticky ? undefined : 1000;
     const appear_after = 500;
 
     request_method({


### PR DESCRIPTION
We want the saving indicator to be sticky in the cases
where we ask user to reload after changing settings.
This used to work correctly before 9e08c6db936, as
'if(remove_after)' returned false if remove_after was
null, but the condition was changed in 9e08c6db936
to 'if(remove_after !== undefined)' and thus the
condition returned true when remove_after was null.

This PR change the remove_after value to undefined
for sticky cases.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![sticky](https://user-images.githubusercontent.com/35494118/133319516-0ece2589-b4f1-4242-9d70-b25d2a8ffebd.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
