### PR TITLE
saml: Set requestedAuthnContext to False in prod_settings_template.

### DIFF
--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -449,6 +449,17 @@ SOCIAL_AUTH_SAML_SECURITY_CONFIG: Dict[str, Any] = {
     ## set this to True to enable signing of SAMLRequests using the
     ## private key.
     "authnRequestsSigned": False,
+    ## If you'd like the Zulip server to request that the IdP limit user identity
+    ## verification to a specific set of authentication contexts, you can do this
+    ## by changing the requestedAuthnContext parameter to a list of specific
+    ## Authentication Context Classes that you want to include in the AuthnContext. E.g.:
+    ##
+    # "requestedAuthnContext": ["urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
+    #                           "urn:oasis:names:tc:SAML:2.0:ac:classes:X509"],
+    ##
+    ## For details on this, see https://github.com/onelogin/python3-saml#settings
+    ## and https://docs.oasis-open.org/security/saml/v2.0/saml-authn-context-2.0-os.pdf
+    "requestedAuthnContext": False,
 }
 
 ## These SAML settings you likely won't need to modify.

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -444,6 +444,8 @@ SOCIAL_AUTH_SAML_ENABLED_IDPS: Dict[str, Any] = {
     },
 }
 
+# More complete documentation of the configurable security settings
+# are available in the "security" part of https://github.com/onelogin/python3-saml#settings.
 SOCIAL_AUTH_SAML_SECURITY_CONFIG: Dict[str, Any] = {
     ## If you've set up the optional private and public server keys,
     ## set this to True to enable signing of SAMLRequests using the
@@ -457,7 +459,7 @@ SOCIAL_AUTH_SAML_SECURITY_CONFIG: Dict[str, Any] = {
     # "requestedAuthnContext": ["urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
     #                           "urn:oasis:names:tc:SAML:2.0:ac:classes:X509"],
     ##
-    ## For details on this, see https://github.com/onelogin/python3-saml#settings
+    ## For details on this, see the aforementioned python3-saml documentation
     ## and https://docs.oasis-open.org/security/saml/v2.0/saml-authn-context-2.0-os.pdf
     "requestedAuthnContext": False,
 }


### PR DESCRIPTION
AuthnContextClassRef tells the IdP what forms of authentication the user
should use on the IdP's server for us to be okay with it. I don't think
there's a reason for us to enforce anything here and it should be up to
the IdP's configuration to handle authentication how it wants.

The default AuthnContextClassRef only allows PasswordProtectedTransport,
causing the IdP to e.g. reject authentication with Yubikey in AzureAD
SAML - which can be confusing for folks setting up SAML and is just not
necessary.
