### PR TITLE
message_editing : Fix topic edit propagate option cut-off

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1531,6 +1531,7 @@ div.focused_table {
 
 #message_edit_topic {
     margin: 0 5px 5px 0;
+    width: auto;
 }
 
 .message_edit_header {
@@ -1554,8 +1555,7 @@ div.focused_table {
 }
 
 .message_edit_topic_propagate {
-    display: inline-block;
-    width: 300px;
+    width: auto;
     margin-bottom: 5px !important;
     max-width: 100%;
 }
@@ -2571,8 +2571,9 @@ div.topic_edit_spinner .loading_indicator_spinner {
         border-radius: 1px 4px 4px 1px !important;
     }
 
+    .dropdown-list-widget,
     .stream_header_colorblock {
-        margin-bottom: 20px;
+        margin-bottom: 10px;
     }
 
     textarea {

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -29,12 +29,12 @@
                         {{t "Send notification to old topic" }}
                     </label>
                 </div>
-                <select class='message_edit_topic_propagate' style='display:none;'>
-                    <option selected="selected" value="change_later"> {{t "Change later messages to this topic" }}</option>
-                    <option value="change_one"> {{t "Change only this message topic" }}</option>
-                    <option value="change_all"> {{t "Change previous and following messages to this topic" }}</option>
-                </select>
             </div>
+            <select class='message_edit_topic_propagate' style='display:none;'>
+                <option selected="selected" value="change_later"> {{t "Change later messages to this topic" }}</option>
+                <option value="change_one"> {{t "Change only this message topic" }}</option>
+                <option value="change_all"> {{t "Change previous and following messages to this topic" }}</option>
+            </select>
         </div>
     </div>
     {{/if}}


### PR DESCRIPTION
In the topic changing UI, the 'Change later messages to this topic'
and other options in the drop down were cut off
when selected in some languages.
This commit makes the selection box width adjust
appropriately according to the length of the text.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes https://github.com/zulip/zulip/issues/19739

**Testing plan:** <!-- How have you tested? -->
Manually

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="423" alt="russian" src="https://user-images.githubusercontent.com/76661350/133410937-d389c617-332d-4026-96a4-e8878b05c30d.png">
<img width="482" alt="english" src="https://user-images.githubusercontent.com/76661350/133410958-1f69a200-dc35-4e1c-93a2-47866f73252d.png">

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
