### PR TITLE
UI setting for invitation expiration time

### DIFF
--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -1,5 +1,6 @@
 import autosize from "autosize";
 import ClipboardJS from "clipboard";
+import {addDays} from "date-fns";
 import $ from "jquery";
 
 import copy_invite_link from "../templates/copy_invite_link.hbs";
@@ -33,6 +34,7 @@ function reset_error_messages() {
 
 function get_common_invitation_data() {
     const invite_as = Number.parseInt($("#invite_as").val(), 10);
+    const expires_in = Number.parseFloat($("#expires_in").val());
     const stream_ids = [];
     $("#invite-stream-checkboxes input:checked").each(function () {
         const stream_id = Number.parseInt($(this).val(), 10);
@@ -42,6 +44,7 @@ function get_common_invitation_data() {
         csrfmiddlewaretoken: $('input[name="csrfmiddlewaretoken"]').attr("value"),
         invite_as,
         stream_ids: JSON.stringify(stream_ids),
+        invite_expires_in_days: expires_in,
     };
     return data;
 }
@@ -192,12 +195,22 @@ export function launch() {
     });
 }
 
+function valid_to() {
+    const time_valid = Number.parseFloat($("#expires_in").val());
+    if (!time_valid) {
+        return $t({defaultMessage: "Never expires"});
+    }
+    const valid_to = addDays(new Date(), time_valid);
+    return $t({defaultMessage: "Expires on {date}"}, {date: valid_to.toLocaleDateString()});
+}
+
 export function initialize() {
     const rendered = render_invite_user({
         is_admin: page_params.is_admin,
         is_owner: page_params.is_owner,
         development_environment: page_params.development_environment,
         invite_as_options: settings_config.user_role_values,
+        expires_in_options: settings_config.expires_in_values,
     });
 
     $(".app").append(rendered);
@@ -236,5 +249,10 @@ export function initialize() {
         $("#multiuse_radio_section").hide();
         $("#invite-method-choice").show();
         reset_error_messages();
+    });
+
+    $("#expires_on").text(valid_to());
+    $("#expires_in").on("change", () => {
+        $("#expires_on").text(valid_to());
     });
 }

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -417,6 +417,41 @@ export const user_role_values = {
     },
 };
 
+export const expires_in_values = {
+    // Backend support for this configuration is not available yet.
+    // hour: {
+    //     value: 1,
+    //     description: $t({defaultMessage: "1 hour"}),
+    //     default: false,
+    // },
+    day: {
+        value: 1,
+        description: $t({defaultMessage: "1 day"}),
+        default: false,
+    },
+    threeDays: {
+        value: 3,
+        description: $t({defaultMessage: "3 days"}),
+        default: false,
+    },
+    tenDays: {
+        value: 10,
+        description: $t({defaultMessage: "10 days"}),
+        default: true,
+    },
+    thirtyDays: {
+        value: 30,
+        description: $t({defaultMessage: "30 days"}),
+        default: false,
+    },
+    // Backend support for this configuration is not available yet.
+    // never: {
+    //     value: "never",
+    //     description: $t({defaultMessage: "Never expires"}),
+    //     default: false,
+    // }
+};
+
 const user_role_array = Object.values(user_role_values);
 export const user_role_map = new Map(user_role_array.map((role) => [role.code, role.description]));
 

--- a/static/templates/invite_user.hbs
+++ b/static/templates/invite_user.hbs
@@ -30,6 +30,17 @@
                     </div>
                 </div>
                 <div class="input-group">
+                    <label for="expires_in">{{t "Invitation expires after" }}</label>
+                    <div>
+                        <select id="expires_in">
+                            {{#each expires_in_options}}
+                            <option {{#if this.default }}selected{{/if}} name="expires_in" value="{{this.value}}">{{this.description}}</option>
+                            {{/each}}
+                        </select>
+                    </div>
+                    <p id="expires_on"></p>
+                </div>
+                <div class="input-group">
                     <label for="invite_as">{{t "User(s) join as" }}
                         <a href="/help/roles-and-permissions" target="_blank" rel="noopener noreferrer">
                             <i class="fa fa-question-circle-o" aria-hidden="true"></i>


### PR DESCRIPTION
Add a UI for invite expiration time, supported options are 1 day, 3
days, 10 days and 30 days.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
fixes #19680 

**Testing plan:** <!-- How have you tested? -->
Tests that have been done (besides automatic tests):
- Backend receives correct value.
- Noted that backend does not support the use of "1 hour" or "never" this is because it is built around days and not hours. I suggest that this should be fixed in a separate issue and I have commented out the options "1 hour" and "never" in the frontend.
- Noted that invitation emails are hard coded with the phrase "This invitation expires in two days." I suggest that this also gets its own issue.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/65904251/133414167-351d3881-16a6-4107-a422-693ea65a5dbd.png)

![image](https://user-images.githubusercontent.com/65904251/133414445-9463f47a-6666-4281-825e-ceee572c7e1e.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
