### PR TITLE
find_team: Send one email per email address, not per organization.

### DIFF
--- a/templates/zerver/emails/find_team.source.html
+++ b/templates/zerver/emails/find_team.source.html
@@ -5,19 +5,13 @@
 {% endblock %}
 
 {% block content %}
-<p>{% trans %}Hi {{ user_name }},{% endtrans %}</p>
+<p>{% trans %}Your email address {{ email }} has accounts with the following Zulip organizations hosted by <a href="{{ external_host }}">{{ external_host }}</a>:{% endtrans %}</p>
 
-<p>{% trans %}You can log in to your Zulip organization, {{ realm_name }}, at the following link:{% endtrans %}</p>
-
-<table width="100%" border="0" cellspacing="0" cellpadding="0">
-    <tr>
-        <td align="center">
-            <a href="{{ realm_uri }}">{{ realm_uri }}</a>
-        </td>
-    </tr>
-</table>
-
-<p>{% trans %}The email address associated with your account is {{ email }}.{% endtrans %}</p>
+<ul>
+    {% for realm in realms %}
+    <li><a href="{{ realm.uri }}">{{ realm.name }} ({{ realm.host }})</a></li>
+    {% endfor %}
+</ul>
 
 <p>{% trans %}If you have trouble logging in, please contact Zulip support by replying to this email.{% endtrans %}</p>
 

--- a/templates/zerver/emails/find_team.subject.txt
+++ b/templates/zerver/emails/find_team.subject.txt
@@ -1,1 +1,1 @@
-{{ _("Your Zulip login page") }}
+{{ _("Your Zulip accounts") }}

--- a/templates/zerver/emails/find_team.txt
+++ b/templates/zerver/emails/find_team.txt
@@ -1,16 +1,11 @@
 {% trans -%}
-Hi {{ user_name }},
+Your email address {{ email }} has accounts with the following Zulip organizations hosted by {{ external_host }}:
 {%- endtrans %}
 
 
-{% trans -%}
-You can log in to your Zulip organization, {{ realm_name }}, at the following link:
-{%- endtrans %}
-
-    {{ realm_uri }}
-
-{% trans %}The email address associated with your account is {{ email }}.{% endtrans %}
-
+{% for realm in realms %}
+* {{ realm.name }}: {{ realm.uri }}
+{% endfor %}
 
 {% trans %}If you have trouble logging in, please contact Zulip support by replying to this email.{% endtrans %}
 

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 98
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "161.1"
+PROVISION_VERSION = "162.0"

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -5440,8 +5440,13 @@ class TestFindMyTeam(ZulipTestCase):
         self.assertIn("cordeliA@zulip.com", content)
         from django.core.mail import outbox
 
-        # 3 = 1 + 2 -- Cordelia gets an email each for the "zulip" and "lear" realms.
-        self.assert_length(outbox, 3)
+        self.assert_length(outbox, 2)
+        iago_message = outbox[1]
+        cordelia_message = outbox[0]
+        self.assertIn("Zulip Dev", iago_message.body)
+        self.assertNotIn("Lear & Co", iago_message.body)
+        self.assertIn("Zulip Dev", cordelia_message.body)
+        self.assertIn("Lear & Co", cordelia_message.body)
 
     def test_find_team_ignore_invalid_email(self) -> None:
         result = self.client_post(

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -1,6 +1,6 @@
 import logging
 import urllib
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode
 
 from django.conf import settings
@@ -716,8 +716,6 @@ def accounts_home_from_multiuse_invite(request: HttpRequest, confirmation_key: s
 def find_account(
     request: HttpRequest, raw_emails: Optional[str] = REQ("emails", default=None)
 ) -> HttpResponse:
-    from zerver.context_processors import common_context
-
     url = reverse("find_account")
 
     emails: List[str] = []
@@ -743,17 +741,32 @@ def find_account(
             for email in emails:
                 emails_q |= Q(delivery_email__iexact=email)
 
-            for user in UserProfile.objects.filter(
+            user_profiles = UserProfile.objects.filter(
                 emails_q, is_active=True, is_bot=False, realm__deactivated=False
-            ):
-                context = common_context(user)
-                context.update(
-                    email=user.delivery_email,
-                )
+            )
+
+            # We organize the data in preparation for sending exactly
+            # one outgoing email per provided email address, with each
+            # email listing all of the accounts that email address has
+            # with the current Zulip server.
+            context: Dict[str, Dict[str, Any]] = {}
+            for user in user_profiles:
+                key = user.delivery_email.lower()
+                context.setdefault(key, {})
+                context[key].setdefault("realms", [])
+                context[key]["realms"].append(user.realm)
+                context[key]["external_host"] = settings.EXTERNAL_HOST
+                # This value will end up being the last user ID among
+                # matching accounts; since it's only used for minor
+                # details like language, that arbitrary choice is OK.
+                context[key]["to_user_id"] = user.id
+
+            for delivery_email, realm_context in context.items():
+                realm_context["email"] = delivery_email
                 send_email(
                     "zerver/emails/find_team",
-                    to_user_ids=[user.id],
-                    context=context,
+                    to_user_ids=[realm_context["to_user_id"]],
+                    context=realm_context,
                     from_address=FromAddress.SUPPORT,
                     request=request,
                 )


### PR DESCRIPTION
Fixes #19659.

@timabbott FYI :)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
