### PR TITLE
stream settings: Add whitespace before disabled attribute.

### DIFF
--- a/static/templates/stream_settings/stream_settings_checkbox.hbs
+++ b/static/templates/stream_settings/stream_settings_checkbox.hbs
@@ -6,7 +6,8 @@
     <label class="checkbox">
         <input id="{{setting_name}}_{{stream_id}}" name="{{setting_name}}"
           class="sub_setting_control" type="checkbox"
-          {{#if is_checked}}checked{{/if}}{{#if is_disabled}}disabled="disabled"{{/if}} />
+          {{#if is_checked}}checked{{/if}}
+          {{#if is_disabled}}disabled="disabled"{{/if}} />
         <span></span>
     </label>
     <label class="subscription-control-label" for="{{setting_name}}_{{stream_id}}">{{label}}</label>


### PR DESCRIPTION
Fixes #19641. There was no whitespace between the 'checked' and 'disabled'
attribute, leading to muted checked checkboxes being neither checked nor
disabled (since `checkeddisabled='disabled'` didn't do anything).
This bug was introduced in 747e797.

![attributes before the change](https://user-images.githubusercontent.com/5634097/133476260-e01e6bf2-156f-4742-a26e-23425c6febae.png)

This change adds a new line before the disabled template code, so that both
the checked and disabled attributes are added properly.

Tested manually to ensure the following cases didn't change when reopening
the stream settings view:

* unchecked disabled checkboxes
* checked enabled checkboxes
* checked disabled checkboxes

![UI on page load after the change](https://user-images.githubusercontent.com/5634097/133475954-ac4f3d6f-3e7c-41d0-b587-9f7d189d8a7e.png)
