### PR TITLE
gitlint: Update commit title regex to catch incorrect casing.

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -4,7 +4,7 @@ ignore=title-trailing-punctuation, body-min-length, body-is-missing
 extra-path=tools/lib/gitlint-rules.py
 
 [title-match-regex]
-regex=^(.+:\ )?[A-Z].+\.$
+regex=^(([A-Z][^:]+\.)|([a-z].+:\ [A-Z].+\.))$
 
 [title-max-length]
 line-length=76


### PR DESCRIPTION
In #19763, the linter didn't catch that I had an uppercase letter
before the colon and a lowercase letter after the colon. Zulip prefers the
opposite casing.

Instead of "Stream settings: add whitespace before disabled attribute."
the commit title should have been but "stream settings: Add whitespace
before disabled attribute."

This change updates the gitlint regex to catch this, so that reviewers
don't have to manually comment on this.

Zulip discussion
[here](https://chat.zulip.org/#narrow/stream/9-issues/topic/gitlint/near/1255638).

Testing:

1. used https://regex101.com to ensure only the last two of these messages
were allowed:

```
Capital not allowed here: Second part has capital as it should.

Capital not allowed here: and this part should have had one.

no capital is good here: but this part should have had one.

no capital is good here: Second part has capital as it should.

No colon just a capitalized sentence, this is allowed.
```

2. Ran the regex over the last 5000 commit messages with
`git log --pretty='format:%s' -n 5000 | grep -Ev`
