### PR TITLE
Add UI for realm-level defaults of notification settings.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -992,7 +992,8 @@ run_test("server_event_dispatch_op_errors", ({override}) => {
 
 run_test("realm_user_settings_defaults", ({override}) => {
     override(settings_display, "update_page", noop);
-    const event = event_fixtures.realm_user_settings_defaults__emojiset;
+    override(settings_notifications, "update_page", noop);
+    let event = event_fixtures.realm_user_settings_defaults__emojiset;
     realm_user_settings_defaults.emojiset = "text";
     let called = false;
     settings_display.report_emojiset_change = () => {
@@ -1000,5 +1001,15 @@ run_test("realm_user_settings_defaults", ({override}) => {
     };
     dispatch(event);
     assert_same(realm_user_settings_defaults.emojiset, "google");
+    assert_same(called, true);
+
+    event = event_fixtures.realm_user_settings_defaults__notification_sound;
+    realm_user_settings_defaults.notification_sound = "zulip";
+    called = false;
+    notifications.update_notification_sound_source = () => {
+        called = true;
+    };
+    dispatch(event);
+    assert_same(realm_user_settings_defaults.notification_sound, "ding");
     assert_same(called, true);
 });

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -525,6 +525,13 @@ exports.fixtures = {
         value: "google",
     },
 
+    realm_user_settings_defaults__notification_sound: {
+        type: "realm_user_settings_defaults",
+        op: "update",
+        property: "notification_sound",
+        value: "ding",
+    },
+
     restart: {
         type: "restart",
         zulip_version: "4.0-dev+git",

--- a/frontend_tests/node_tests/settings_config.js
+++ b/frontend_tests/node_tests/settings_config.js
@@ -22,13 +22,19 @@ run_test("all_notifications", () => {
     // is passed. In this case, we articulate that with
     // wildcard_mentions_notify being undefined, which will be
     // the case, if a wrong setting_name is passed.
-    assert.throws(settings_config.all_notifications, {
-        name: "TypeError",
-        message: "Incorrect setting_name passed: wildcard_mentions_notify",
-    });
+    let error_message;
+    let error_name;
+    try {
+        settings_config.all_notifications(user_settings);
+    } catch (error) {
+        error_name = error.name;
+        error_message = error.message;
+    }
+    assert.equal(error_name, "TypeError");
+    assert.equal(error_message, "Incorrect setting_name passed: wildcard_mentions_notify");
 
     user_settings.wildcard_mentions_notify = false;
-    const notifications = settings_config.all_notifications();
+    const notifications = settings_config.all_notifications(user_settings);
 
     assert.deepEqual(notifications.general_settings, [
         {

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -37,6 +37,9 @@ mock_esm("../../static/js/settings_org", {
 mock_esm("../../static/js/settings_profile_fields", {
     maybe_disable_widgets() {},
 });
+mock_esm("../../static/js/settings_realm_user_settings_defaults", {
+    maybe_disable_widgets() {},
+});
 mock_esm("../../static/js/settings_streams", {
     maybe_disable_widgets() {},
 });

--- a/frontend_tests/puppeteer_tests/settings.ts
+++ b/frontend_tests/puppeteer_tests/settings.ts
@@ -365,16 +365,17 @@ async function test_notifications_section(page: Page): Promise<void> {
     // At the beginning, "PMs, mentions, and alerts"(checkbox name=enable_sounds) audio will be on
     // and "Streams"(checkbox name=enable_stream_audible_notifications) audio will be off by default.
 
-    const notification_sound_enabled = ".setting_notification_sound:enabled";
+    const notification_sound_enabled =
+        "#user-notification-settings .setting_notification_sound:enabled";
     await page.waitForSelector(notification_sound_enabled, {visible: true});
 
-    await common.fill_form(page, ".notification-settings-form", {
+    await common.fill_form(page, "#user-notification-settings .notification-settings-form", {
         enable_stream_audible_notifications: true,
         enable_sounds: false,
     });
     await page.waitForSelector(notification_sound_enabled, {visible: true});
 
-    await common.fill_form(page, ".notification-settings-form", {
+    await common.fill_form(page, "#user-notification-settings .notification-settings-form", {
         enable_stream_audible_notifications: true,
     });
     /*

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -58,6 +58,24 @@ function insert_tip_box() {
         .prepend(tip_box);
 }
 
+function get_realm_level_notification_settings(options) {
+    const all_notifications_settings = settings_config.all_notifications(
+        realm_user_settings_defaults,
+    );
+
+    // We remove enable_marketing_emails setting from all_notification_settings, since there is no
+    // realm-level default of this setting.
+    all_notifications_settings.settings.other_email_settings = [
+        "enable_digest_emails",
+        "enable_login_emails",
+    ];
+
+    options.general_settings = all_notifications_settings.general_settings;
+    options.notification_settings = all_notifications_settings.settings;
+    options.show_push_notifications_tooltip =
+        all_notifications_settings.show_push_notifications_tooltip;
+}
+
 export function build_page() {
     const options = {
         custom_profile_field_types: page_params.custom_profile_field_types,
@@ -129,7 +147,13 @@ export function build_page() {
         default_view_values: settings_config.default_view_values,
         settings_object: realm_user_settings_defaults,
         display_settings: settings_config.get_all_display_settings(),
-        settings_label: settings_config.display_settings_labels,
+        settings_label: settings_config.realm_user_settings_defaults_labels,
+        desktop_icon_count_display_values: settings_config.desktop_icon_count_display_values,
+        enable_sound_select:
+            realm_user_settings_defaults.enable_sounds ||
+            realm_user_settings_defaults.enable_stream_audible_notifications,
+        email_notifications_batching_period_values:
+            settings_config.email_notifications_batching_period_values,
     };
 
     if (options.realm_logo_source !== "D" && options.realm_night_logo_source === "D") {
@@ -143,6 +167,8 @@ export function build_page() {
         options.giphy_help_link =
             "https://zulip.readthedocs.io/en/latest/production/giphy-gif-integration.html";
     }
+
+    get_realm_level_notification_settings(options);
 
     const rendered_admin_tab = render_admin_tab(options);
     $("#settings_content .organization-box").html(rendered_admin_tab);

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -97,7 +97,7 @@ export function initialize() {
     );
 }
 
-function update_notification_sound_source(container_elem, settings_object) {
+export function update_notification_sound_source(container_elem, settings_object) {
     const notification_sound = settings_object.notification_sound;
     const audio_file_without_extension = "/static/audio/notification_sounds/" + notification_sound;
     container_elem

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -17,6 +17,7 @@ import * as narrow_state from "./narrow_state";
 import * as navigate from "./navigate";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import {realm_user_settings_defaults} from "./realm_user_settings_defaults";
 import * as settings_config from "./settings_config";
 import * as spoilers from "./spoilers";
 import * as stream_data from "./stream_data";
@@ -90,6 +91,10 @@ export function initialize() {
         });
 
     update_notification_sound_source($("#user-notification-sound-audio"), user_settings);
+    update_notification_sound_source(
+        $("#realm-default-notification-sound-audio"),
+        realm_user_settings_defaults,
+    );
 }
 
 function update_notification_sound_source(container_elem, settings_object) {

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -89,13 +89,12 @@ export function initialize() {
             window_focused = false;
         });
 
-    update_notification_sound_source();
+    update_notification_sound_source($("#user-notification-sound-audio"), user_settings);
 }
 
-function update_notification_sound_source() {
-    const notification_sound = user_settings.notification_sound;
+function update_notification_sound_source(container_elem, settings_object) {
+    const notification_sound = settings_object.notification_sound;
     const audio_file_without_extension = "/static/audio/notification_sounds/" + notification_sound;
-    const container_elem = $("#user-notification-sound-audio");
     container_elem
         .find(".notification-sound-source-ogg")
         .attr("src", `${audio_file_without_extension}.ogg`);
@@ -739,6 +738,6 @@ export function handle_global_notification_updates(notification_name, setting) {
 
     if (notification_name === "notification_sound") {
         // Change the sound source with the new page `notification_sound`.
-        update_notification_sound_source();
+        update_notification_sound_source($("#user-notification-sound-audio"), user_settings);
     }
 }

--- a/static/js/realm_user_settings_defaults.ts
+++ b/static/js/realm_user_settings_defaults.ts
@@ -1,4 +1,4 @@
-type RealmDefaultSettingsType = {
+export type RealmDefaultSettingsType = {
     color_scheme: number;
     default_language: string;
     default_view: string;

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -401,11 +401,22 @@ export function dispatch_normal_event(event) {
             const container_elem = $("#realm-user-default-settings");
             if (display_settings_list.includes(event.property)) {
                 settings_display.update_page(container_elem, realm_user_settings_defaults);
+            } else if (settings_config.all_notification_settings.includes(event.property)) {
+                settings_notifications.update_page(
+                    container_elem,
+                    realm_user_settings_defaults,
+                    true,
+                );
             }
 
             if (event.property === "emojiset") {
                 settings_display.report_emojiset_change(
                     container_elem,
+                    realm_user_settings_defaults,
+                );
+            } else if (event.property === "notification_sound") {
+                notifications.update_notification_sound_source(
+                    $("#realm-default-notification-sound-audio"),
                     realm_user_settings_defaults,
                 );
             }
@@ -576,7 +587,11 @@ export function dispatch_normal_event(event) {
         case "user_settings": {
             if (settings_config.all_notification_settings.includes(event.property)) {
                 notifications.handle_global_notification_updates(event.property, event.value);
-                settings_notifications.update_page($("#user-notification-settings"), user_settings);
+                settings_notifications.update_page(
+                    $("#user-notification-settings"),
+                    user_settings,
+                    false,
+                );
                 // TODO: This should also do a refresh of the stream_edit UI
                 // if it's currently displayed, possibly reusing some code
                 // from stream_events.js

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -576,7 +576,7 @@ export function dispatch_normal_event(event) {
         case "user_settings": {
             if (settings_config.all_notification_settings.includes(event.property)) {
                 notifications.handle_global_notification_updates(event.property, event.value);
-                settings_notifications.update_page();
+                settings_notifications.update_page($("#user-notification-settings"), user_settings);
                 // TODO: This should also do a refresh of the stream_edit UI
                 // if it's currently displayed, possibly reusing some code
                 // from stream_events.js

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -45,33 +45,11 @@ $("body").ready(() => {
 function setup_settings_label() {
     settings_label = {
         // settings_notification
-        enable_online_push_notifications: $t({
-            defaultMessage: "Send mobile notifications even if I'm online (useful for testing)",
-        }),
-        pm_content_in_desktop_notifications: $t({
-            defaultMessage: "Include content of private messages in desktop notifications",
-        }),
-        desktop_icon_count_display: $t({
-            defaultMessage: "Unread count summary (appears in desktop sidebar and browser tab)",
-        }),
-        enable_digest_emails: $t({defaultMessage: "Send digest emails when I'm away"}),
-        enable_login_emails: $t({
-            defaultMessage: "Send email notifications for new logins to my account",
-        }),
-        enable_marketing_emails: $t({
-            defaultMessage: "Send me Zulip's low-traffic newsletter (a few emails a year)",
-        }),
-        message_content_in_email_notifications: $t({
-            defaultMessage: "Include message content in message notification emails",
-        }),
-        realm_name_in_notifications: $t({
-            defaultMessage: "Include organization name in subject of message notification emails",
-        }),
         presence_enabled: $t({
             defaultMessage: "Display my availability to other users when online",
         }),
 
-        // display settings
+        ...settings_config.notification_settings_labels,
         ...settings_config.display_settings_labels,
     };
 }

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -100,13 +100,13 @@ export function build_page() {
         color_scheme_values: settings_config.color_scheme_values,
         default_view_values: settings_config.default_view_values,
         twenty_four_hour_time_values: settings_config.twenty_four_hour_time_values,
-        general_settings: settings_config.all_notifications().general_settings,
-        notification_settings: settings_config.all_notifications().settings,
+        general_settings: settings_config.all_notifications(user_settings).general_settings,
+        notification_settings: settings_config.all_notifications(user_settings).settings,
         email_notifications_batching_period_values:
             settings_config.email_notifications_batching_period_values,
         desktop_icon_count_display_values: settings_config.desktop_icon_count_display_values,
         show_push_notifications_tooltip:
-            settings_config.all_notifications().show_push_notifications_tooltip,
+            settings_config.all_notifications(user_settings).show_push_notifications_tooltip,
         display_settings: settings_config.get_all_display_settings(),
         user_can_change_name: settings_data.user_can_change_name(),
         user_can_change_avatar: settings_data.user_can_change_avatar(),

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -2,7 +2,7 @@ import Handlebars from "handlebars/runtime";
 
 import {$t, $t_html} from "./i18n";
 import {page_params} from "./page_params";
-import {user_settings} from "./user_settings";
+import type {UserSettingsType} from "./user_settings";
 
 /*
     This file contains translations between the integer values used in
@@ -404,7 +404,8 @@ export const stream_specific_notification_settings = [
     "wildcard_mentions_notify",
 ];
 
-type PageParamsItem = keyof typeof user_settings;
+type SettingsObjectType = UserSettingsType;
+type PageParamsItem = keyof SettingsObjectType;
 export const stream_notification_settings: PageParamsItem[] = [
     "enable_stream_desktop_notifications",
     "enable_stream_audible_notifications",
@@ -495,6 +496,7 @@ type NotificationSettingCheckbox = {
 
 export function get_notifications_table_row_data(
     notify_settings: PageParamsItem[],
+    settings_object: SettingsObjectType,
 ): NotificationSettingCheckbox[] {
     return general_notifications_table_labels.realm.map((column, index) => {
         const setting_name = notify_settings[index];
@@ -506,7 +508,7 @@ export function get_notifications_table_row_data(
             };
         }
 
-        const checked = user_settings[setting_name];
+        const checked = settings_object[setting_name];
         if (typeof checked !== "boolean") {
             throw new TypeError(`Incorrect setting_name passed: ${setting_name}`);
         }
@@ -537,16 +539,20 @@ export interface AllNotifications {
     };
 }
 
-export const all_notifications = (): AllNotifications => ({
+export const all_notifications = (settings_object: SettingsObjectType): AllNotifications => ({
     general_settings: [
         {
             label: $t({defaultMessage: "Streams"}),
-            notification_settings: get_notifications_table_row_data(stream_notification_settings),
+            notification_settings: get_notifications_table_row_data(
+                stream_notification_settings,
+                settings_object,
+            ),
         },
         {
             label: $t({defaultMessage: "PMs, mentions, and alerts"}),
             notification_settings: get_notifications_table_row_data(
                 pm_mention_notification_settings,
+                settings_object,
             ),
         },
     ],

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -372,9 +372,9 @@ export const display_settings_labels = {
     ),
 };
 
-export const realm_user_settings_defaults_labels = {
+export const notification_settings_labels = {
     enable_online_push_notifications: $t({
-        defaultMessage: "Send mobile notifications even if user is online (useful for testing)",
+        defaultMessage: "Send mobile notifications even if I'm online (useful for testing)",
     }),
     pm_content_in_desktop_notifications: $t({
         defaultMessage: "Include content of private messages in desktop notifications",
@@ -382,9 +382,12 @@ export const realm_user_settings_defaults_labels = {
     desktop_icon_count_display: $t({
         defaultMessage: "Unread count summary (appears in desktop sidebar and browser tab)",
     }),
-    enable_digest_emails: $t({defaultMessage: "Send digest emails when user is away"}),
+    enable_digest_emails: $t({defaultMessage: "Send digest emails when I'm away"}),
     enable_login_emails: $t({
-        defaultMessage: "Send email notifications for new logins to the account",
+        defaultMessage: "Send email notifications for new logins to my account",
+    }),
+    enable_marketing_emails: $t({
+        defaultMessage: "Send me Zulip's low-traffic newsletter (a few emails a year)",
     }),
     message_content_in_email_notifications: $t({
         defaultMessage: "Include message content in message notification emails",
@@ -392,7 +395,20 @@ export const realm_user_settings_defaults_labels = {
     realm_name_in_notifications: $t({
         defaultMessage: "Include organization name in subject of message notification emails",
     }),
+};
+
+export const realm_user_settings_defaults_labels = {
+    ...notification_settings_labels,
     ...display_settings_labels,
+
+    /* Overrides to remove "I" from labels for the realm-level versions of these labels. */
+    enable_online_push_notifications: $t({
+        defaultMessage: "Send mobile notifications even if user is online (useful for testing)",
+    }),
+    enable_digest_emails: $t({defaultMessage: "Send digest emails when user is away"}),
+    enable_login_emails: $t({
+        defaultMessage: "Send email notifications for new logins to the account",
+    }),
 };
 
 // NOTIFICATIONS

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -2,6 +2,7 @@ import Handlebars from "handlebars/runtime";
 
 import {$t, $t_html} from "./i18n";
 import {page_params} from "./page_params";
+import type {RealmDefaultSettingsType} from "./realm_user_settings_defaults";
 import type {UserSettingsType} from "./user_settings";
 
 /*
@@ -371,6 +372,29 @@ export const display_settings_labels = {
     ),
 };
 
+export const realm_user_settings_defaults_labels = {
+    enable_online_push_notifications: $t({
+        defaultMessage: "Send mobile notifications even if user is online (useful for testing)",
+    }),
+    pm_content_in_desktop_notifications: $t({
+        defaultMessage: "Include content of private messages in desktop notifications",
+    }),
+    desktop_icon_count_display: $t({
+        defaultMessage: "Unread count summary (appears in desktop sidebar and browser tab)",
+    }),
+    enable_digest_emails: $t({defaultMessage: "Send digest emails when user is away"}),
+    enable_login_emails: $t({
+        defaultMessage: "Send email notifications for new logins to the account",
+    }),
+    message_content_in_email_notifications: $t({
+        defaultMessage: "Include message content in message notification emails",
+    }),
+    realm_name_in_notifications: $t({
+        defaultMessage: "Include organization name in subject of message notification emails",
+    }),
+    ...display_settings_labels,
+};
+
 // NOTIFICATIONS
 
 export const general_notifications_table_labels = {
@@ -404,7 +428,7 @@ export const stream_specific_notification_settings = [
     "wildcard_mentions_notify",
 ];
 
-type SettingsObjectType = UserSettingsType;
+type SettingsObjectType = UserSettingsType | RealmDefaultSettingsType;
 type PageParamsItem = keyof SettingsObjectType;
 export const stream_notification_settings: PageParamsItem[] = [
     "enable_stream_desktop_notifications",

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -478,7 +478,7 @@ const other_notification_settings = desktop_notification_settings.concat(
     ["desktop_icon_count_display"],
     mobile_notification_settings,
     email_notification_settings,
-    ["email_notifications_batching_period"],
+    ["email_notifications_batching_period_seconds"],
     ["notification_sound"],
 );
 

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -75,6 +75,7 @@ export function set_enable_marketing_emails_visibility() {
 
 export function set_up(container, settings_object) {
     const patch_url = "/json/settings";
+    const notification_sound_elem = $("#user-notification-sound-audio");
     container.find(".notification-settings-form").on("change", "input, select", function (e) {
         e.preventDefault();
         e.stopPropagation();
@@ -102,7 +103,7 @@ export function set_up(container, settings_object) {
 
     container.find(".play_notification_sound").on("click", () => {
         if (settings_object.notification_sound !== "none") {
-            $("#user-notification-sound-audio")[0].play();
+            notification_sound_elem[0].play();
         }
     });
 

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -44,10 +44,10 @@ function rerender_ui() {
     }
 }
 
-function change_notification_setting(setting, value, status_element) {
+function change_notification_setting(setting, value, status_element, url) {
     const data = {};
     data[setting] = value;
-    settings_ui.do_settings_change(channel.patch, "/json/settings", data, status_element);
+    settings_ui.do_settings_change(channel.patch, url, data, status_element);
 }
 
 function update_desktop_icon_count_display() {
@@ -78,6 +78,7 @@ export function set_enable_marketing_emails_visibility() {
 
 export function set_up() {
     const container = $("#user-notification-settings");
+    const patch_url = "/json/settings";
     container.on("change", "input, select", function (e) {
         e.preventDefault();
         e.stopPropagation();
@@ -91,6 +92,7 @@ export function set_up() {
             setting_name,
             settings_org.get_input_element_value(this),
             input_elem.closest(".subsection-parent").find(".alert-notification"),
+            patch_url,
         );
     });
 

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -12,7 +12,6 @@ import * as settings_ui from "./settings_ui";
 import * as stream_edit from "./stream_edit";
 import * as stream_settings_data from "./stream_settings_data";
 import * as unread_ui from "./unread_ui";
-import {user_settings} from "./user_settings";
 
 function rerender_ui() {
     const unmatched_streams_table = $("#stream-specific-notify-table");
@@ -50,17 +49,14 @@ function change_notification_setting(setting, value, status_element, url) {
     settings_ui.do_settings_change(channel.patch, url, data, status_element);
 }
 
-function update_desktop_icon_count_display() {
-    const container = $("#user-notification-settings");
-    const settings_object = user_settings;
+function update_desktop_icon_count_display(container, settings_object) {
     container
         .find(".setting_desktop_icon_count_display")
         .val(settings_object.desktop_icon_count_display);
     unread_ui.update_unread_counts();
 }
 
-export function set_enable_digest_emails_visibility() {
-    const container = $("#user-notification-settings");
+export function set_enable_digest_emails_visibility(container) {
     if (page_params.realm_digest_emails_enabled) {
         container.find(".enable_digest_emails_label").parent().show();
     } else {
@@ -77,10 +73,8 @@ export function set_enable_marketing_emails_visibility() {
     }
 }
 
-export function set_up() {
-    const container = $("#user-notification-settings");
+export function set_up(container, settings_object) {
     const patch_url = "/json/settings";
-    const settings_object = user_settings;
     container.find(".notification-settings-form").on("change", "input, select", function (e) {
         e.preventDefault();
         e.stopPropagation();
@@ -98,7 +92,7 @@ export function set_up() {
         );
     });
 
-    update_desktop_icon_count_display();
+    update_desktop_icon_count_display(container, settings_object);
 
     container.find(".send_test_notification").on("click", () => {
         notifications.send_test_notification(
@@ -135,14 +129,12 @@ export function set_up() {
         settings_object.email_notifications_batching_period_seconds,
     );
 
-    set_enable_digest_emails_visibility();
+    set_enable_digest_emails_visibility(container);
     set_enable_marketing_emails_visibility();
     rerender_ui();
 }
 
-export function update_page() {
-    const container = $("#user-notification-settings");
-    const settings_object = user_settings;
+export function update_page(container, settings_object) {
     for (const setting of settings_config.all_notification_settings) {
         if (
             setting === "enable_offline_push_notifications" &&
@@ -152,7 +144,7 @@ export function update_page() {
             // we should just leave the checkbox always off.
             continue;
         } else if (setting === "desktop_icon_count_display") {
-            update_desktop_icon_count_display();
+            update_desktop_icon_count_display(container, settings_object);
             continue;
         } else if (
             setting === "notification_sound" ||

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -81,7 +81,7 @@ export function set_up() {
     const container = $("#user-notification-settings");
     const patch_url = "/json/settings";
     const settings_object = user_settings;
-    container.on("change", "input, select", function (e) {
+    container.find(".notification-settings-form").on("change", "input, select", function (e) {
         e.preventDefault();
         e.stopPropagation();
         const input_elem = $(e.currentTarget);

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -124,7 +124,9 @@ export function set_up() {
         }
     });
 
-    const email_notifications_batching_period_dropdown = $("#email_notifications_batching_period");
+    const email_notifications_batching_period_dropdown = container.find(
+        ".setting_email_notifications_batching_period_seconds",
+    );
     email_notifications_batching_period_dropdown.val(
         user_settings.email_notifications_batching_period_seconds,
     );

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -149,7 +149,7 @@ export function set_up(container, settings_object, for_realm_settings) {
     }
 }
 
-export function update_page(container, settings_object) {
+export function update_page(container, settings_object, for_realm_settings) {
     for (const setting of settings_config.all_notification_settings) {
         if (
             setting === "enable_offline_push_notifications" &&
@@ -159,7 +159,7 @@ export function update_page(container, settings_object) {
             // we should just leave the checkbox always off.
             continue;
         } else if (setting === "desktop_icon_count_display") {
-            update_desktop_icon_count_display(container, settings_object);
+            update_desktop_icon_count_display(container, settings_object, for_realm_settings);
             continue;
         } else if (
             setting === "notification_sound" ||

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -51,9 +51,10 @@ function change_notification_setting(setting, value, status_element) {
 }
 
 function update_desktop_icon_count_display() {
-    $("#user-notification-settings .setting_desktop_icon_count_display").val(
-        user_settings.desktop_icon_count_display,
-    );
+    const container = $("#user-notification-settings");
+    container
+        .find(".setting_desktop_icon_count_display")
+        .val(user_settings.desktop_icon_count_display);
     unread_ui.update_unread_counts();
 }
 
@@ -77,7 +78,7 @@ export function set_enable_marketing_emails_visibility() {
 
 export function set_up() {
     const container = $("#user-notification-settings");
-    $("#user-notification-settings").on("change", "input, select", function (e) {
+    container.on("change", "input, select", function (e) {
         e.preventDefault();
         e.stopPropagation();
         const input_elem = $(e.currentTarget);
@@ -134,6 +135,7 @@ export function set_up() {
 }
 
 export function update_page() {
+    const container = $("#user-notification-settings");
     for (const setting of settings_config.all_notification_settings) {
         if (
             setting === "enable_offline_push_notifications" &&
@@ -146,14 +148,10 @@ export function update_page() {
             update_desktop_icon_count_display();
             continue;
         } else if (setting === "notification_sound") {
-            $("#user-notification-settings .setting_notification_sound").val(
-                user_settings.notification_sound,
-            );
+            container.find(".setting_notification_sound").val(user_settings.notification_sound);
         }
 
-        $("#user-notification-settings")
-            .find(`.${CSS.escape(setting)}`)
-            .prop("checked", user_settings[setting]);
+        container.find(`.${CSS.escape(setting)}`).prop("checked", user_settings[setting]);
     }
     rerender_ui();
 }

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -52,11 +52,13 @@ function change_notification_setting(setting, value, status_element, url) {
     settings_ui.do_settings_change(channel.patch, url, data, status_element);
 }
 
-function update_desktop_icon_count_display(container, settings_object) {
+function update_desktop_icon_count_display(container, settings_object, for_realm_settings) {
     container
         .find(".setting_desktop_icon_count_display")
         .val(settings_object.desktop_icon_count_display);
-    unread_ui.update_unread_counts();
+    if (!for_realm_settings) {
+        unread_ui.update_unread_counts();
+    }
 }
 
 export function set_enable_digest_emails_visibility(container) {
@@ -76,9 +78,14 @@ export function set_enable_marketing_emails_visibility() {
     }
 }
 
-export function set_up(container, settings_object) {
-    const patch_url = "/json/settings";
-    const notification_sound_elem = $("#user-notification-sound-audio");
+export function set_up(container, settings_object, for_realm_settings) {
+    let patch_url = "/json/settings";
+    let notification_sound_elem = $("#user-notification-sound-audio");
+    if (for_realm_settings) {
+        patch_url = "/json/realm/user_settings_defaults";
+        notification_sound_elem = $("#realm-default-notification-sound-audio");
+    }
+
     container.find(".notification-settings-form").on("change", "input, select", function (e) {
         e.preventDefault();
         e.stopPropagation();
@@ -96,13 +103,15 @@ export function set_up(container, settings_object) {
         );
     });
 
-    update_desktop_icon_count_display(container, settings_object);
+    update_desktop_icon_count_display(container, settings_object, for_realm_settings);
 
-    container.find(".send_test_notification").on("click", () => {
-        notifications.send_test_notification(
-            $t({defaultMessage: "This is what a Zulip notification looks like."}),
-        );
-    });
+    if (!for_realm_settings) {
+        container.find(".send_test_notification").on("click", () => {
+            notifications.send_test_notification(
+                $t({defaultMessage: "This is what a Zulip notification looks like."}),
+            );
+        });
+    }
 
     container.find(".play_notification_sound").on("click", () => {
         if (settings_object.notification_sound !== "none") {
@@ -134,8 +143,10 @@ export function set_up(container, settings_object) {
     );
 
     set_enable_digest_emails_visibility(container);
-    set_enable_marketing_emails_visibility();
-    rerender_ui();
+    if (!for_realm_settings) {
+        set_enable_marketing_emails_visibility();
+        rerender_ui();
+    }
 }
 
 export function update_page(container, settings_object) {

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -12,6 +12,7 @@ import * as settings_ui from "./settings_ui";
 import * as stream_edit from "./stream_edit";
 import * as stream_settings_data from "./stream_settings_data";
 import * as unread_ui from "./unread_ui";
+import {user_settings} from "./user_settings";
 
 function rerender_ui() {
     const unmatched_streams_table = $("#stream-specific-notify-table");
@@ -31,7 +32,9 @@ function rerender_ui() {
                 stream,
                 stream_specific_notification_settings:
                     settings_config.stream_specific_notification_settings,
-                is_disabled: settings_config.all_notifications().show_push_notifications_tooltip,
+                is_disabled:
+                    settings_config.all_notifications(user_settings)
+                        .show_push_notifications_tooltip,
             }),
         );
     }

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -52,9 +52,10 @@ function change_notification_setting(setting, value, status_element, url) {
 
 function update_desktop_icon_count_display() {
     const container = $("#user-notification-settings");
+    const settings_object = user_settings;
     container
         .find(".setting_desktop_icon_count_display")
-        .val(user_settings.desktop_icon_count_display);
+        .val(settings_object.desktop_icon_count_display);
     unread_ui.update_unread_counts();
 }
 
@@ -79,6 +80,7 @@ export function set_enable_marketing_emails_visibility() {
 export function set_up() {
     const container = $("#user-notification-settings");
     const patch_url = "/json/settings";
+    const settings_object = user_settings;
     container.on("change", "input, select", function (e) {
         e.preventDefault();
         e.stopPropagation();
@@ -105,13 +107,13 @@ export function set_up() {
     });
 
     container.find(".play_notification_sound").on("click", () => {
-        if (user_settings.notification_sound !== "none") {
+        if (settings_object.notification_sound !== "none") {
             $("#user-notification-sound-audio")[0].play();
         }
     });
 
     const notification_sound_dropdown = container.find(".setting_notification_sound");
-    notification_sound_dropdown.val(user_settings.notification_sound);
+    notification_sound_dropdown.val(settings_object.notification_sound);
 
     container.find(".enable_sounds, .enable_stream_audible_notifications").on("change", () => {
         if (
@@ -130,7 +132,7 @@ export function set_up() {
         ".setting_email_notifications_batching_period_seconds",
     );
     email_notifications_batching_period_dropdown.val(
-        user_settings.email_notifications_batching_period_seconds,
+        settings_object.email_notifications_batching_period_seconds,
     );
 
     set_enable_digest_emails_visibility();
@@ -140,6 +142,7 @@ export function set_up() {
 
 export function update_page() {
     const container = $("#user-notification-settings");
+    const settings_object = user_settings;
     for (const setting of settings_config.all_notification_settings) {
         if (
             setting === "enable_offline_push_notifications" &&
@@ -155,11 +158,11 @@ export function update_page() {
             setting === "notification_sound" ||
             setting === "email_notifications_batching_period_seconds"
         ) {
-            container.find(`.setting_${CSS.escape(setting)}`).val(user_settings[setting]);
+            container.find(`.setting_${CSS.escape(setting)}`).val(settings_object[setting]);
             continue;
         }
 
-        container.find(`.${CSS.escape(setting)}`).prop("checked", user_settings[setting]);
+        container.find(`.${CSS.escape(setting)}`).prop("checked", settings_object[setting]);
     }
     rerender_ui();
 }

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -149,8 +149,12 @@ export function update_page() {
         } else if (setting === "desktop_icon_count_display") {
             update_desktop_icon_count_display();
             continue;
-        } else if (setting === "notification_sound") {
-            container.find(".setting_notification_sound").val(user_settings.notification_sound);
+        } else if (
+            setting === "notification_sound" ||
+            setting === "email_notifications_batching_period_seconds"
+        ) {
+            container.find(`.setting_${CSS.escape(setting)}`).val(user_settings[setting]);
+            continue;
         }
 
         container.find(`.${CSS.escape(setting)}`).prop("checked", user_settings[setting]);

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -381,7 +381,9 @@ function update_dependent_subsettings(property_name) {
             set_message_content_in_email_notifications_visiblity();
             break;
         case "realm_digest_emails_enabled":
-            settings_notifications.set_enable_digest_emails_visibility();
+            settings_notifications.set_enable_digest_emails_visibility(
+                $("#user-notification-settings"),
+            );
             set_digest_emails_weekday_visibility();
             break;
     }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -384,6 +384,9 @@ function update_dependent_subsettings(property_name) {
             settings_notifications.set_enable_digest_emails_visibility(
                 $("#user-notification-settings"),
             );
+            settings_notifications.set_enable_digest_emails_visibility(
+                $("#realm-user-default-settings"),
+            );
             set_digest_emails_weekday_visibility();
             break;
     }

--- a/static/js/settings_realm_user_settings_defaults.js
+++ b/static/js/settings_realm_user_settings_defaults.js
@@ -1,9 +1,22 @@
 import $ from "jquery";
 
+import {page_params} from "./page_params";
 import {realm_user_settings_defaults} from "./realm_user_settings_defaults";
 import * as settings_display from "./settings_display";
 
+export function maybe_disable_widgets() {
+    if (!page_params.is_admin) {
+        $(".organization-box [data-name='organization-level-user-defaults']")
+            .find("input, select")
+            .prop("disabled", true);
+
+        $(".organization-box [data-name='organization-level-user-defaults']")
+            .find(".play_notification_sound")
+            .addClass("control-label-disabled");
+    }
+}
 export function set_up() {
     const container = $("#realm-user-default-settings");
     settings_display.set_up(container, realm_user_settings_defaults, true);
+    maybe_disable_widgets();
 }

--- a/static/js/settings_realm_user_settings_defaults.js
+++ b/static/js/settings_realm_user_settings_defaults.js
@@ -3,6 +3,7 @@ import $ from "jquery";
 import {page_params} from "./page_params";
 import {realm_user_settings_defaults} from "./realm_user_settings_defaults";
 import * as settings_display from "./settings_display";
+import * as settings_notifications from "./settings_notifications";
 
 export function maybe_disable_widgets() {
     if (!page_params.is_admin) {
@@ -18,5 +19,6 @@ export function maybe_disable_widgets() {
 export function set_up() {
     const container = $("#realm-user-default-settings");
     settings_display.set_up(container, realm_user_settings_defaults, true);
+    settings_notifications.set_up(container, realm_user_settings_defaults, true);
     maybe_disable_widgets();
 }

--- a/static/js/settings_sections.js
+++ b/static/js/settings_sections.js
@@ -57,7 +57,9 @@ export function initialize() {
     load_func_dict.set("display-settings", () => {
         settings_display.set_up($("#user-display-settings"), user_settings, false);
     });
-    load_func_dict.set("notifications", settings_notifications.set_up);
+    load_func_dict.set("notifications", () => {
+        settings_notifications.set_up($("#user-notification-settings"), user_settings);
+    });
     load_func_dict.set("your-bots", settings_bots.set_up);
     load_func_dict.set("alert-words", alert_words_ui.set_up_alert_words);
     load_func_dict.set("uploaded-files", attachments_ui.set_up_attachments);

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -485,7 +485,8 @@ export function is_notification_setting(setting_label) {
 
 export function stream_settings(sub) {
     const settings_labels = settings_config.general_notifications_table_labels.stream;
-    const check_realm_setting = settings_config.all_notifications().show_push_notifications_tooltip;
+    const check_realm_setting =
+        settings_config.all_notifications(user_settings).show_push_notifications_tooltip;
 
     const settings = Object.keys(settings_labels).map((setting) => {
         const ret = {

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -17,6 +17,7 @@ import * as stream_list from "./stream_list";
 import * as stream_muting from "./stream_muting";
 import * as stream_settings_ui from "./stream_settings_ui";
 import * as sub_store from "./sub_store";
+import {user_settings} from "./user_settings";
 
 // In theory, this function should apply the account-level defaults,
 // however, they are only called after a manual override, so
@@ -54,7 +55,7 @@ export function update_property(stream_id, property, value, other_values) {
         case "email_notifications":
         case "wildcard_mentions_notify":
             update_stream_setting(sub, value, property);
-            settings_notifications.update_page();
+            settings_notifications.update_page($("#user-notification-settings"), user_settings);
             break;
         case "name":
             stream_settings_ui.update_stream_name(sub, value);

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -55,7 +55,11 @@ export function update_property(stream_id, property, value, other_values) {
         case "email_notifications":
         case "wildcard_mentions_notify":
             update_stream_setting(sub, value, property);
-            settings_notifications.update_page($("#user-notification-settings"), user_settings);
+            settings_notifications.update_page(
+                $("#user-notification-settings"),
+                user_settings,
+                false,
+            );
             break;
         case "name":
             stream_settings_ui.update_stream_name(sub, value);

--- a/static/js/user_events.js
+++ b/static/js/user_events.js
@@ -18,6 +18,7 @@ import * as settings_config from "./settings_config";
 import * as settings_linkifiers from "./settings_linkifiers";
 import * as settings_org from "./settings_org";
 import * as settings_profile_fields from "./settings_profile_fields";
+import * as settings_realm_user_settings_defaults from "./settings_realm_user_settings_defaults";
 import * as settings_streams from "./settings_streams";
 import * as settings_users from "./settings_users";
 
@@ -86,6 +87,7 @@ export const update_person = function update(person) {
             settings_org.maybe_disable_widgets();
             settings_profile_fields.maybe_disable_widgets();
             settings_streams.maybe_disable_widgets();
+            settings_realm_user_settings_defaults.maybe_disable_widgets();
         }
 
         if (

--- a/static/js/user_settings.ts
+++ b/static/js/user_settings.ts
@@ -1,4 +1,4 @@
-type UserSettingsType = {
+export type UserSettingsType = {
     color_scheme: number;
     default_language: string;
     default_view: string;

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -51,7 +51,9 @@
         <h3 class="inline-block">{{t "Desktop message notifications" }}</h3>
         <div class="alert-notification"></div>
 
+        {{#unless for_realm_settings}}
         <p><a class="send_test_notification">{{t "Test desktop notification" }}</a></p>
+        {{/unless}}
 
         {{#each notification_settings.desktop_notification_settings}}
         {{> settings_checkbox

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -114,7 +114,7 @@
         </label>
 
         <div class="input-group">
-            <select name="email_notifications_batching_period_seconds" id="email_notifications_batching_period" data-setting-widget-type="number">
+            <select name="email_notifications_batching_period_seconds" class="setting_email_notifications_batching_period_seconds" data-setting-widget-type="number">
                 {{#each email_notifications_batching_period_values}}
                 <option value="{{ this.value }}">{{ this.description }}</option>
                 {{/each}}

--- a/static/templates/settings/organization_user_settings_defaults.hbs
+++ b/static/templates/settings/organization_user_settings_defaults.hbs
@@ -3,4 +3,6 @@
         {{t "Configure the default personal preference settings for new users joining your organization." }}
     </div>
     {{> display_settings prefix="realm_" for_realm_settings=true}}
+
+    {{> notification_settings prefix="realm_" for_realm_settings=true}}
 </div>

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -208,6 +208,10 @@
         <source class="notification-sound-source-ogg" type="audio/ogg" />
         <source class="notification-sound-source-mp3" type="audio/mpeg" />
     </audio>
+    <audio id="realm-default-notification-sound-audio">
+        <source class="notification-sound-source-ogg" type="audio/ogg" />
+        <source class="notification-sound-source-mp3" type="audio/mpeg" />
+    </audio>
     <div id="login-to-access-modal-holder"></div>
 </div>
 {% endblock %}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Commit summary -
- First commit is to disable the settings for non-admins.
- Next six commits are small refactors with one being to fix the existing live update code. (Explained in detail in commit messages).
- Next commit is the major refactor to modify functions in `settings_notifications.js` to accept container element and settings obejct as parameters.
- Next commit is to refactor `settings_config.all_notification_settings` to accept settings object as parameter.
- Last two commits actually add the UI for notification settings and the code for live update of these settings.
<!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2021-09-16 23-23-46](https://user-images.githubusercontent.com/35494118/133661175-4812aa99-62f2-44fe-846f-8c2d658b3e8c.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
