### PR TITLE
LDAP: Support alternative attributes to userAccountControl for deactivating users.

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -212,17 +212,23 @@ corresponding LDAP attribute is `linkedinProfile` then you just need
 to add `'custom_profile_field__linkedin_profile': 'linkedinProfile'`
 to the `AUTH_LDAP_USER_ATTR_MAP`.
 
-#### Automatically deactivating users with Active Directory
+#### Automatically deactivating users
 
 Zulip supports synchronizing the
-disabled/deactivated status of users from Active Directory. You can
-configure this by uncommenting the sample line
+disabled/deactivated status of users. If you're using Active Directory,
+you can configure this by uncommenting the sample line
 `"userAccountControl": "userAccountControl",` in
 `AUTH_LDAP_USER_ATTR_MAP` (and restarting the Zulip server). Zulip
 will then treat users that are disabled via the "Disable Account"
 feature in Active Directory as deactivated in Zulip.
 
-Users disabled in active directory will be immediately unable to log in
+If you're using a different LDAP server which uses a boolean attribute
+which is `TRUE` or `YES` for users that should be deactivated and `FALSE`
+or `NO` otherwise. You can configure a mapping for `deactivated` in
+`AUTH_LDAP_USER_ATTR_MAP`. For example, `"deactivated": "nsAccountLock",` is a correct mapping for a
+[FreeIPA](https://www.freeipa.org/) LDAP database.
+
+Disabled users will be immediately unable to log in
 to Zulip, since Zulip queries the LDAP/Active Directory server on
 every login attempt. The user will be fully deactivated the next time
 your `manage.py sync_ldap_user_data` cron job runs (at which point

--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -194,14 +194,14 @@ run of `manage.py sync_ldap_user_data`.
 
 #### Synchronizing avatars
 
-Starting with Zulip 2.0, Zulip supports syncing LDAP / Active
+Zulip supports syncing LDAP / Active
 Directory profile pictures (usually available in the `thumbnailPhoto`
 or `jpegPhoto` attribute in LDAP) by configuring the `avatar` key in
 `AUTH_LDAP_USER_ATTR_MAP`.
 
 #### Synchronizing custom profile fields
 
-Starting with Zulip 2.0, Zulip supports syncing
+Zulip supports syncing
 [custom profile fields][custom-profile-fields] from LDAP / Active
 Directory. To configure this, you first need to
 [configure some custom profile fields][custom-profile-fields] for your
@@ -214,7 +214,7 @@ to the `AUTH_LDAP_USER_ATTR_MAP`.
 
 #### Automatically deactivating users with Active Directory
 
-Starting with Zulip 2.0, Zulip supports synchronizing the
+Zulip supports synchronizing the
 disabled/deactivated status of users from Active Directory. You can
 configure this by uncommenting the sample line
 `"userAccountControl": "userAccountControl",` in
@@ -236,7 +236,7 @@ for details on the various `userAccountControl` flags.
 
 #### Deactivating non-matching users
 
-Starting with Zulip 2.0, Zulip supports automatically deactivating
+Zulip supports automatically deactivating
 users if they are not found by the `AUTH_LDAP_USER_SEARCH` query
 (either because the user is no longer in LDAP/Active Directory, or
 because the user no longer matches the query). This feature is

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -239,6 +239,9 @@ AUTH_LDAP_USER_ATTR_MAP = {
     ## who are disabled in LDAP/Active Directory (and reactivate users who are not).
     ## See docs for usage details and precise semantics.
     # "userAccountControl": "userAccountControl",
+    ## Alternatively, you can map "deactivated" to a boolean attribute
+    ## that is "TRUE" for deactivated users and "FALSE" otherwise.
+    # "deactivated": "nsAccountLock",
     ## Restrict access to organizations using an LDAP attribute.
     ## See https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#restricting-ldap-user-access-to-specific-organizations
     # "org_membership": "department",


### PR DESCRIPTION
Fixes #17456

Implements the approach from https://github.com/zulip/zulip/issues/17456#issuecomment-841569742

@andreas-bulling  Would you be up for testing this?