### PR TITLE
user_groups: Hide system user groups from UI.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -257,6 +257,7 @@ const hamletcharacters = {
     id: 1,
     description: "Characters of Hamlet",
     members: new Set([100, 104]),
+    is_system_group: false,
 };
 
 const backend = {
@@ -264,6 +265,7 @@ const backend = {
     id: 2,
     description: "Backend team",
     members: new Set([]),
+    is_system_group: false,
 };
 
 const call_center = {
@@ -271,6 +273,7 @@ const call_center = {
     id: 3,
     description: "folks working in support",
     members: new Set([]),
+    is_system_group: false,
 };
 
 const make_emoji = (emoji_dict) => ({

--- a/frontend_tests/node_tests/user_groups.js
+++ b/frontend_tests/node_tests/user_groups.js
@@ -14,6 +14,7 @@ run_test("user_groups", () => {
         name: "Students",
         id: 0,
         members: new Set([1, 2]),
+        is_system_group: false,
     };
 
     const params = {};
@@ -29,11 +30,13 @@ run_test("user_groups", () => {
         description: "foo",
         id: 1,
         members: new Set([3]),
+        is_system_group: false,
     };
     const all = {
         name: "Everyone",
         id: 2,
         members: new Set([1, 2, 3]),
+        is_system_group: false,
     };
 
     user_groups.add(admins);

--- a/static/js/user_groups.ts
+++ b/static/js/user_groups.ts
@@ -7,6 +7,7 @@ type UserGroup = {
     id: number;
     name: string;
     members: Set<number>;
+    is_system_group: boolean;
 };
 
 // The members field is a number array which we convert
@@ -33,6 +34,7 @@ export function add(user_group_raw: UserGroupRaw): void {
         id: user_group_raw.id,
         name: user_group_raw.name,
         members: new Set(user_group_raw.members),
+        is_system_group: user_group_raw.is_system_group,
     };
 
     user_group_name_dict.set(user_group.name, user_group);
@@ -71,7 +73,8 @@ export function get_user_group_from_name(name: string): UserGroup | undefined {
 }
 
 export function get_realm_user_groups(): UserGroup[] {
-    return Array.from(user_group_by_id_dict.values()).sort((a, b) => a.id - b.id);
+    const user_groups = Array.from(user_group_by_id_dict.values()).sort((a, b) => a.id - b.id);
+    return user_groups.filter((group) => !group.is_system_group);
 }
 
 export function is_member_of(user_group_id: number, user_id: number): boolean {


### PR DESCRIPTION
We do not have any system user groups as of
now, but this commit is just a prep commit
to prevent any change in user-facing pages
to avoid confusion till this feature is
completed.

This change was initially made in 6117c38,
but it was reverted in 1543775a due to merge
conflicts with the typescript migration of
user_groups.js.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

<!-- How have you tested? -->
 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
