### PR TITLE
favicon: Fix embedded number font for Webpack 5 asset modules

### DIFF
--- a/static/js/favicon.js
+++ b/static/js/favicon.js
@@ -3,8 +3,7 @@ import $ from "jquery";
 import render_favicon_svg from "../templates/favicon.svg.hbs";
 
 import * as blueslip from "./blueslip";
-
-import favicon_font_url from "!url-loader!font-subset-loader2?glyphs=0123456789KMGT∞!source-sans/TTF/SourceSans3-Bold.ttf";
+import favicon_font_url from "./favicon_font_url!=!url-loader!font-subset-loader2?glyphs=0123456789KMGT∞!source-sans/TTF/SourceSans3-Bold.ttf";
 
 let favicon_state;
 


### PR DESCRIPTION
**Testing plan:** `require('./static/js/favicon').update_favicon(12, 3)` in browser console.