### PR TITLE
Add UI for realm-level default of `enter_sends` and `presence_enabled` settings.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -1012,4 +1012,18 @@ run_test("realm_user_settings_defaults", ({override}) => {
     dispatch(event);
     assert_same(realm_user_settings_defaults.notification_sound, "ding");
     assert_same(called, true);
+
+    const presence_enabled_elem = $.create(".presence_enabled");
+    $("#realm-user-default-settings").set_find_results(".presence_enabled", presence_enabled_elem);
+    called = false;
+    presence_enabled_elem.prop = (property, value) => {
+        assert_same(property, "checked");
+        assert_same(value, false);
+        called = true;
+    };
+    event = event_fixtures.realm_user_settings_defaults__presence_enabled;
+    realm_user_settings_defaults.presence_enabled = true;
+    dispatch(event);
+    assert_same(realm_user_settings_defaults.presence_enabled, false);
+    assert_same(called, true);
 });

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -802,6 +802,11 @@ run_test("user_settings", ({override}) => {
     dispatch(event);
     assert_same(user_settings.enter_sends, true);
 
+    event = event_fixtures.user_settings__presence_enabled;
+    user_settings.presence_enabled = true;
+    dispatch(event);
+    assert_same(user_settings.presence_enabled, false);
+
     {
         event = event_fixtures.user_settings__enable_stream_audible_notifications;
         const stub = make_stub();

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -818,6 +818,13 @@ exports.fixtures = {
         value: true,
     },
 
+    user_settings__presence_enabled: {
+        type: "user_settings",
+        op: "update",
+        property: "presence_enabled",
+        value: false,
+    },
+
     user_settings__starred_message_counts: {
         type: "user_settings",
         op: "update",

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -532,6 +532,13 @@ exports.fixtures = {
         value: "ding",
     },
 
+    realm_user_settings_defaults__presence_enabled: {
+        type: "realm_user_settings_defaults",
+        op: "update",
+        property: "presence_enabled",
+        value: false,
+    },
+
     restart: {
         type: "restart",
         zulip_version: "4.0-dev+git",

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -407,6 +407,10 @@ export function dispatch_normal_event(event) {
                     realm_user_settings_defaults,
                     true,
                 );
+            } else {
+                container_elem
+                    .find(`.${CSS.escape(event.property)}`)
+                    .prop("checked", realm_user_settings_defaults[event.property]);
             }
 
             if (event.property === "emojiset") {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -406,9 +406,7 @@ export function dispatch_normal_event(event) {
                 );
             } else if (settings_config.all_notification_settings.includes(event.property)) {
                 settings_notifications.update_page(
-                    container_elem,
-                    realm_user_settings_defaults,
-                    true,
+                    settings_realm_user_settings_defaults.realm_default_settings_panel,
                 );
             } else {
                 container_elem
@@ -594,11 +592,7 @@ export function dispatch_normal_event(event) {
         case "user_settings": {
             if (settings_config.all_notification_settings.includes(event.property)) {
                 notifications.handle_global_notification_updates(event.property, event.value);
-                settings_notifications.update_page(
-                    $("#user-notification-settings"),
-                    user_settings,
-                    false,
-                );
+                settings_notifications.update_page(settings_notifications.user_settings_panel);
                 // TODO: This should also do a refresh of the stream_edit UI
                 // if it's currently displayed, possibly reusing some code
                 // from stream_events.js

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -701,6 +701,11 @@ export function dispatch_normal_event(event) {
                 compose.toggle_enter_sends_ui();
                 break;
             }
+            if (event.property === "presence_enabled") {
+                user_settings.presence_enabled = event.value;
+                $("#user_presence_enabled").prop("checked", user_settings.presence_enabled);
+                break;
+            }
             settings_display.update_page(container_elem, user_settings);
             break;
         }

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -51,6 +51,7 @@ import * as settings_notifications from "./settings_notifications";
 import * as settings_org from "./settings_org";
 import * as settings_playgrounds from "./settings_playgrounds";
 import * as settings_profile_fields from "./settings_profile_fields";
+import * as settings_realm_user_settings_defaults from "./settings_realm_user_settings_defaults";
 import * as settings_streams from "./settings_streams";
 import * as settings_user_groups from "./settings_user_groups";
 import * as settings_users from "./settings_users";
@@ -400,7 +401,9 @@ export function dispatch_normal_event(event) {
 
             const container_elem = $("#realm-user-default-settings");
             if (display_settings_list.includes(event.property)) {
-                settings_display.update_page(container_elem, realm_user_settings_defaults);
+                settings_display.update_page(
+                    settings_realm_user_settings_defaults.realm_default_settings_panel,
+                );
             } else if (settings_config.all_notification_settings.includes(event.property)) {
                 settings_notifications.update_page(
                     container_elem,
@@ -415,8 +418,7 @@ export function dispatch_normal_event(event) {
 
             if (event.property === "emojiset") {
                 settings_display.report_emojiset_change(
-                    container_elem,
-                    realm_user_settings_defaults,
+                    settings_realm_user_settings_defaults.realm_default_settings_panel,
                 );
             } else if (event.property === "notification_sound") {
                 notifications.update_notification_sound_source(
@@ -620,7 +622,6 @@ export function dispatch_normal_event(event) {
                 "starred_message_counts",
             ];
 
-            const container_elem = $("#user-display-settings");
             if (user_display_settings.includes(event.property)) {
                 user_settings[event.property] = event.value;
             }
@@ -685,7 +686,7 @@ export function dispatch_normal_event(event) {
                 // reload.
             }
             if (event.property === "emojiset") {
-                settings_display.report_emojiset_change(container_elem, user_settings);
+                settings_display.report_emojiset_change(settings_display.user_settings_panel);
 
                 // Rerender the whole message list UI
                 message_lists.home.rerender();
@@ -706,7 +707,7 @@ export function dispatch_normal_event(event) {
                 $("#user_presence_enabled").prop("checked", user_settings.presence_enabled);
                 break;
             }
-            settings_display.update_page(container_elem, user_settings);
+            settings_display.update_page(settings_display.user_settings_panel);
             break;
         }
 

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -694,7 +694,7 @@ export function set_up() {
             channel.patch,
             "/json/settings",
             data,
-            $(".privacy-setting-status").expectOne(),
+            $("#account-settings .privacy-setting-status").expectOne(),
         );
     });
 }

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -409,6 +409,8 @@ export const realm_user_settings_defaults_labels = {
     enable_login_emails: $t({
         defaultMessage: "Send email notifications for new logins to the account",
     }),
+
+    realm_presence_enabled: $t({defaultMessage: "Display availability to other users when online"}),
 };
 
 // NOTIFICATIONS

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -411,6 +411,7 @@ export const realm_user_settings_defaults_labels = {
     }),
 
     realm_presence_enabled: $t({defaultMessage: "Display availability to other users when online"}),
+    realm_enter_sends: $t({defaultMessage: "Enter sends when composing a message"}),
 };
 
 // NOTIFICATIONS

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -14,6 +14,8 @@ import * as stream_settings_data from "./stream_settings_data";
 import * as unread_ui from "./unread_ui";
 import {user_settings} from "./user_settings";
 
+export const user_settings_panel = {};
+
 function rerender_ui() {
     const unmatched_streams_table = $("#stream-specific-notify-table");
     if (unmatched_streams_table.length === 0) {
@@ -52,11 +54,13 @@ function change_notification_setting(setting, value, status_element, url) {
     settings_ui.do_settings_change(channel.patch, url, data, status_element);
 }
 
-function update_desktop_icon_count_display(container, settings_object, for_realm_settings) {
+function update_desktop_icon_count_display(settings_panel) {
+    const container = $(settings_panel.container);
+    const settings_object = settings_panel.settings_object;
     container
         .find(".setting_desktop_icon_count_display")
         .val(settings_object.desktop_icon_count_display);
-    if (!for_realm_settings) {
+    if (!settings_panel.for_realm_settings) {
         unread_ui.update_unread_counts();
     }
 }
@@ -78,13 +82,12 @@ export function set_enable_marketing_emails_visibility() {
     }
 }
 
-export function set_up(container, settings_object, for_realm_settings) {
-    let patch_url = "/json/settings";
-    let notification_sound_elem = $("#user-notification-sound-audio");
-    if (for_realm_settings) {
-        patch_url = "/json/realm/user_settings_defaults";
-        notification_sound_elem = $("#realm-default-notification-sound-audio");
-    }
+export function set_up(settings_panel) {
+    const container = $(settings_panel.container);
+    const settings_object = settings_panel.settings_object;
+    const patch_url = settings_panel.patch_url;
+    const notification_sound_elem = $(settings_panel.notification_sound_elem);
+    const for_realm_settings = settings_panel.for_realm_settings;
 
     container.find(".notification-settings-form").on("change", "input, select", function (e) {
         e.preventDefault();
@@ -103,7 +106,7 @@ export function set_up(container, settings_object, for_realm_settings) {
         );
     });
 
-    update_desktop_icon_count_display(container, settings_object, for_realm_settings);
+    update_desktop_icon_count_display(settings_panel);
 
     if (!for_realm_settings) {
         container.find(".send_test_notification").on("click", () => {
@@ -149,7 +152,9 @@ export function set_up(container, settings_object, for_realm_settings) {
     }
 }
 
-export function update_page(container, settings_object, for_realm_settings) {
+export function update_page(settings_panel) {
+    const container = $(settings_panel.container);
+    const settings_object = settings_panel.settings_object;
     for (const setting of settings_config.all_notification_settings) {
         if (
             setting === "enable_offline_push_notifications" &&
@@ -159,7 +164,7 @@ export function update_page(container, settings_object, for_realm_settings) {
             // we should just leave the checkbox always off.
             continue;
         } else if (setting === "desktop_icon_count_display") {
-            update_desktop_icon_count_display(container, settings_object, for_realm_settings);
+            update_desktop_icon_count_display(settings_panel);
             continue;
         } else if (
             setting === "notification_sound" ||
@@ -172,4 +177,12 @@ export function update_page(container, settings_object, for_realm_settings) {
         container.find(`.${CSS.escape(setting)}`).prop("checked", settings_object[setting]);
     }
     rerender_ui();
+}
+
+export function initialize() {
+    user_settings_panel.container = "#user-notification-settings";
+    user_settings_panel.settings_object = user_settings;
+    user_settings_panel.patch_url = "/json/settings";
+    user_settings_panel.notification_sound_elem = "#user-notification-sound-audio";
+    user_settings_panel.for_realm_settings = false;
 }

--- a/static/js/settings_realm_user_settings_defaults.js
+++ b/static/js/settings_realm_user_settings_defaults.js
@@ -1,9 +1,11 @@
 import $ from "jquery";
 
+import * as channel from "./channel";
 import {page_params} from "./page_params";
 import {realm_user_settings_defaults} from "./realm_user_settings_defaults";
 import * as settings_display from "./settings_display";
 import * as settings_notifications from "./settings_notifications";
+import * as settings_ui from "./settings_ui";
 
 export function maybe_disable_widgets() {
     if (!page_params.is_admin) {
@@ -20,5 +22,19 @@ export function set_up() {
     const container = $("#realm-user-default-settings");
     settings_display.set_up(container, realm_user_settings_defaults, true);
     settings_notifications.set_up(container, realm_user_settings_defaults, true);
+
+    container.find(".presence_enabled").on("change", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const data = {presence_enabled: container.find(".presence_enabled").prop("checked")};
+        settings_ui.do_settings_change(
+            channel.patch,
+            "/json/realm/user_settings_defaults",
+            data,
+            container.find(".privacy-setting-status").expectOne(),
+        );
+    });
+
     maybe_disable_widgets();
 }

--- a/static/js/settings_realm_user_settings_defaults.js
+++ b/static/js/settings_realm_user_settings_defaults.js
@@ -23,7 +23,7 @@ export function maybe_disable_widgets() {
 export function set_up() {
     const container = $(realm_default_settings_panel.container);
     settings_display.set_up(realm_default_settings_panel);
-    settings_notifications.set_up(container, realm_user_settings_defaults, true);
+    settings_notifications.set_up(realm_default_settings_panel);
 
     container.find(".presence_enabled").on("change", (e) => {
         e.preventDefault();
@@ -58,5 +58,7 @@ export function initialize() {
     realm_default_settings_panel.container = "#realm-user-default-settings";
     realm_default_settings_panel.settings_object = realm_user_settings_defaults;
     realm_default_settings_panel.patch_url = "/json/realm/user_settings_defaults";
+    realm_default_settings_panel.notification_sound_elem =
+        "#realm-default-notification-sound-audio";
     realm_default_settings_panel.for_realm_settings = true;
 }

--- a/static/js/settings_realm_user_settings_defaults.js
+++ b/static/js/settings_realm_user_settings_defaults.js
@@ -7,6 +7,8 @@ import * as settings_display from "./settings_display";
 import * as settings_notifications from "./settings_notifications";
 import * as settings_ui from "./settings_ui";
 
+export const realm_default_settings_panel = {};
+
 export function maybe_disable_widgets() {
     if (!page_params.is_admin) {
         $(".organization-box [data-name='organization-level-user-defaults']")
@@ -19,8 +21,8 @@ export function maybe_disable_widgets() {
     }
 }
 export function set_up() {
-    const container = $("#realm-user-default-settings");
-    settings_display.set_up(container, realm_user_settings_defaults, true);
+    const container = $(realm_default_settings_panel.container);
+    settings_display.set_up(realm_default_settings_panel);
     settings_notifications.set_up(container, realm_user_settings_defaults, true);
 
     container.find(".presence_enabled").on("change", (e) => {
@@ -50,4 +52,11 @@ export function set_up() {
     });
 
     maybe_disable_widgets();
+}
+
+export function initialize() {
+    realm_default_settings_panel.container = "#realm-user-default-settings";
+    realm_default_settings_panel.settings_object = realm_user_settings_defaults;
+    realm_default_settings_panel.patch_url = "/json/realm/user_settings_defaults";
+    realm_default_settings_panel.for_realm_settings = true;
 }

--- a/static/js/settings_realm_user_settings_defaults.js
+++ b/static/js/settings_realm_user_settings_defaults.js
@@ -36,5 +36,18 @@ export function set_up() {
         );
     });
 
+    container.find(".enter_sends").on("change", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const data = {enter_sends: container.find(".enter_sends").prop("checked")};
+        settings_ui.do_settings_change(
+            channel.patch,
+            "/json/realm/user_settings_defaults",
+            data,
+            container.find(".other-setting-status").expectOne(),
+        );
+    });
+
     maybe_disable_widgets();
 }

--- a/static/js/settings_sections.js
+++ b/static/js/settings_sections.js
@@ -1,5 +1,3 @@
-import $ from "jquery";
-
 import * as alert_words_ui from "./alert_words_ui";
 import * as attachments_ui from "./attachments_ui";
 import * as blueslip from "./blueslip";
@@ -20,7 +18,6 @@ import * as settings_realm_user_settings_defaults from "./settings_realm_user_se
 import * as settings_streams from "./settings_streams";
 import * as settings_user_groups from "./settings_user_groups";
 import * as settings_users from "./settings_users";
-import {user_settings} from "./user_settings";
 
 const load_func_dict = new Map(); // group -> function
 const loaded_groups = new Set();
@@ -58,7 +55,7 @@ export function initialize() {
         settings_display.set_up(settings_display.user_settings_panel);
     });
     load_func_dict.set("notifications", () => {
-        settings_notifications.set_up($("#user-notification-settings"), user_settings);
+        settings_notifications.set_up(settings_notifications.user_settings_panel);
     });
     load_func_dict.set("your-bots", settings_bots.set_up);
     load_func_dict.set("alert-words", alert_words_ui.set_up_alert_words);

--- a/static/js/settings_sections.js
+++ b/static/js/settings_sections.js
@@ -55,7 +55,7 @@ export function initialize() {
     // personal
     load_func_dict.set("your-account", settings_account.set_up);
     load_func_dict.set("display-settings", () => {
-        settings_display.set_up($("#user-display-settings"), user_settings, false);
+        settings_display.set_up(settings_display.user_settings_panel);
     });
     load_func_dict.set("notifications", () => {
         settings_notifications.set_up($("#user-notification-settings"), user_settings);

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -17,7 +17,6 @@ import * as stream_list from "./stream_list";
 import * as stream_muting from "./stream_muting";
 import * as stream_settings_ui from "./stream_settings_ui";
 import * as sub_store from "./sub_store";
-import {user_settings} from "./user_settings";
 
 // In theory, this function should apply the account-level defaults,
 // however, they are only called after a manual override, so
@@ -55,11 +54,7 @@ export function update_property(stream_id, property, value, other_values) {
         case "email_notifications":
         case "wildcard_mentions_notify":
             update_stream_setting(sub, value, property);
-            settings_notifications.update_page(
-                $("#user-notification-settings"),
-                user_settings,
-                false,
-            );
+            settings_notifications.update_page(settings_notifications.user_settings_panel);
             break;
         case "name":
             stream_settings_ui.update_stream_name(sub, value);

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -70,6 +70,7 @@ import * as settings from "./settings";
 import * as settings_data from "./settings_data";
 import * as settings_display from "./settings_display";
 import * as settings_panel_menu from "./settings_panel_menu";
+import * as settings_realm_user_settings_defaults from "./settings_realm_user_settings_defaults";
 import * as settings_sections from "./settings_sections";
 import * as settings_toggle from "./settings_toggle";
 import * as spoilers from "./spoilers";
@@ -602,6 +603,7 @@ export function initialize_everything() {
     giphy.initialize();
     presence.initialize(presence_params);
     settings_display.initialize();
+    settings_realm_user_settings_defaults.initialize();
     settings_panel_menu.initialize();
     settings_sections.initialize();
     settings_toggle.initialize();

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -69,6 +69,7 @@ import * as server_events from "./server_events";
 import * as settings from "./settings";
 import * as settings_data from "./settings_data";
 import * as settings_display from "./settings_display";
+import * as settings_notifications from "./settings_notifications";
 import * as settings_panel_menu from "./settings_panel_menu";
 import * as settings_realm_user_settings_defaults from "./settings_realm_user_settings_defaults";
 import * as settings_sections from "./settings_sections";
@@ -603,6 +604,7 @@ export function initialize_everything() {
     giphy.initialize();
     presence.initialize(presence_params);
     settings_display.initialize();
+    settings_notifications.initialize();
     settings_realm_user_settings_defaults.initialize();
     settings_panel_menu.initialize();
     settings_sections.initialize();

--- a/static/templates/settings/organization_user_settings_defaults.hbs
+++ b/static/templates/settings/organization_user_settings_defaults.hbs
@@ -16,4 +16,14 @@
           help_link="/help/status-and-availability"
           prefix="realm_"}}
     </div>
+
+    <div class="form-horizontal" class="other_settings">
+        <h3 class="inline-block">{{t "Other settings" }}</h3>
+        <div class="alert-notification other-setting-status"></div>
+        {{> settings_checkbox
+          setting_name="enter_sends"
+          is_checked=settings_object.enter_sends
+          label=settings_label.realm_enter_sends
+          prefix="realm_"}}
+    </div>
 </div>

--- a/static/templates/settings/organization_user_settings_defaults.hbs
+++ b/static/templates/settings/organization_user_settings_defaults.hbs
@@ -5,4 +5,15 @@
     {{> display_settings prefix="realm_" for_realm_settings=true}}
 
     {{> notification_settings prefix="realm_" for_realm_settings=true}}
+
+    <div class="form-horizontal" class="privacy_settings">
+        <h3 class="inline-block">{{t "Privacy settings" }}</h3>
+        <div class="alert-notification privacy-setting-status"></div>
+        {{> settings_checkbox
+          setting_name="presence_enabled"
+          is_checked=settings_object.presence_enabled
+          label=settings_label.realm_presence_enabled
+          help_link="/help/status-and-availability"
+          prefix="realm_"}}
+    </div>
 </div>

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -118,6 +118,7 @@ IGNORED_PHRASES = [
     # SPECIAL CASES
     # Enter is usually capitalized
     r"Press Enter to send",
+    r"Send message on pressing Enter",
     # Because topics usually are lower-case, this would look weird if it were capitalized
     r"more topics",
     # For consistency with "more topics"


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit is a minor prep commit.
- Next two commits are actual commits for adding the UI and JS code.
- Last commit is to add live update for existing user `presence_enabled` setting.

 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2021-09-17 17-21-14](https://user-images.githubusercontent.com/35494118/133778286-f78293a8-8946-4761-9a20-8076551b4c1e.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
