### PR TITLE
user docs: Add documentation for configuring new user defaults.

### DIFF
--- a/static/templates/settings/organization_user_settings_defaults.hbs
+++ b/static/templates/settings/organization_user_settings_defaults.hbs
@@ -1,6 +1,10 @@
 <div id="realm-user-default-settings" class="settings-section" data-name="organization-level-user-defaults">
     <div class="tip">
-        {{t "Configure the default personal preference settings for new users joining your organization." }}
+        {{#tr}}
+            Configure the <z-link>default personal preference settings</z-link>
+            for new users joining your organization.
+            {{#*inline "z-link"}}<a href="/help/configure-default-new-user-settings" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
+        {{/tr}}
     </div>
     {{> display_settings prefix="realm_" for_realm_settings=true}}
 

--- a/templates/zerver/help/configure-default-new-user-settings.md
+++ b/templates/zerver/help/configure-default-new-user-settings.md
@@ -1,0 +1,40 @@
+# Configure default settings for new users
+
+{!admin-only.md!}
+
+Organization administrators can configure the default values of
+personal preference settings for new users joining the
+organization. This can help seemlessly customize the Zulip experience
+to match how the organization in question is using Zulip.
+
+Existing users' preferences cannot be modified by administrators, and
+users will be able to customize their own settings once they
+join. Administrators can customize defaults for all personal
+preference settings, including the following:
+
+* Display settings, including:
+    * Default view ([Recent topics](/help/recent-topics) vs. [All messages](/help/reading-strategies#all-messages))
+    * [Light mode vs. dark mode](/help/night-mode)
+    * [Emoji theme](/help/emoji-and-emoticons#change-your-emoji-set)
+* Notification settings, including:
+    * [What types of messages trigger notifications][default-notifications]
+    * [Configurations for email notifications](/help/configure-message-notification-emails)
+
+[default-notifications]: /help/stream-notifications#set-default-notifications-for-all-streams
+
+## How to configure default settings for new users
+
+{start_tabs}
+
+{settings_tab|default-user-settings}
+
+2. Review all settings and adjust as needed.
+
+{end_tabs}
+
+## Related articles
+
+* [Setting up your organization](/help/getting-your-organization-started-with-zulip)
+* [Customize settings for new users](/help/customize-settings-for-new-users)
+* [Set default streams for new users](/help/set-default-streams-for-new-users)
+* [Invite users to join](/help/invite-users-to-join)

--- a/templates/zerver/help/customize-settings-for-new-users.md
+++ b/templates/zerver/help/customize-settings-for-new-users.md
@@ -5,6 +5,5 @@
 ## Related articles
 
 * [Setting up your organization](/help/getting-your-organization-started-with-zulip)
-* [Set default streams for new users](/help/set-default-streams-for-new-users)
 * [Invite users to join](/help/invite-users-to-join)
 * [Getting started with Zulip](/help/getting-started-with-zulip)

--- a/templates/zerver/help/include/customize-settings-for-new-users.md
+++ b/templates/zerver/help/include/customize-settings-for-new-users.md
@@ -1,8 +1,10 @@
 Customize settings for new users to get them off to a great start.
 
 * [Add custom profile fields](/help/add-custom-profile-fields).
+* [Configure default new user settings][default-user-settings].
 * [Set default streams for new users](/help/set-default-streams-for-new-users).
 * [Set the default language for new users][change-default-language],
   if it should be something other than US English.
 
 [change-default-language]: /help/change-the-default-language-for-your-organization
+[default-user-settings]: /help/configure-default-new-user-settings

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -146,6 +146,7 @@
 * [Allow anyone to join](/help/allow-anyone-to-join-without-an-invitation)
 * [Deactivate or reactivate a user](/help/deactivate-or-reactivate-a-user)
 * [Add custom profile fields](/help/add-custom-profile-fields)
+* [Configure default new user settings](/help/configure-default-new-user-settings)
 * [Set default language for new users](/help/change-the-default-language-for-your-organization)
 * [User groups](/help/user-groups)
 * [Restrict visibility of email addresses](/help/restrict-visibility-of-email-addresses)

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -46,6 +46,11 @@ link_mapping = {
         "Organization permissions",
         "/#organization/organization-permissions",
     ],
+    "default-user-settings": [
+        "Manage organization",
+        "Default user settings",
+        "/#organization/organization-level-user-defaults",
+    ],
     "emoji-settings": ["Manage organization", "Custom emoji", "/#organization/emoji-settings"],
     "auth-methods": [
         "Manage organization",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3889,8 +3889,10 @@ paths:
                               additionalProperties: false
                               description: |
                                 Event sent to all users in a Zulip organization when the
-                                default settings for new users of the organization
-                                (realm) have changed.
+                                [default settings for new users][new-user-defaults]
+                                of the organization (realm) have changed.
+
+                                [new-user-defaults]: /help/configure-default-new-user-settings
 
                                 **Changes**: New in Zulip 5.0 (feature level 95).
                               properties:
@@ -7524,9 +7526,9 @@ paths:
       tags: ["server_and_organizations"]
       x-requires-administrator: true
       description: |
-        Change the the default/initial values of
-        [personal preference settings](/api/update-settings) for new users
-        created in the organization.
+        Change the [default values of settings][new-user-defaults] for new users
+        joining the organization. Essentially all
+        [personal preference settings](/api/update-settings) are supported.
 
         `PATCH {{ api_url }}/v1/realm/user_settings_defaults`
 
@@ -7541,6 +7543,8 @@ paths:
         settings for existing users in any way.
 
         **Changes**: New in Zulip 5.0 (feature level 96).
+
+        [new-user-defaults]: /help/configure-default-new-user-settings
       x-curl-examples-parameters:
         oneOf:
           - type: include


### PR DESCRIPTION
Also remove a redundant link on customize-settings-for-new-users page.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
manual

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<img width="822" alt="Screen Shot 2021-09-20 at 11 54 51 AM" src="https://user-images.githubusercontent.com/2090066/134058477-10ef281a-3739-42f8-befe-6ae7eb5e1fcd.png">
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
