### PR TITLE
invites: Update error message when max limit for the day is reached.

### DIFF
--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -109,6 +109,7 @@ function submit_invitation_form() {
                     is_invitee_deactivated,
                     license_limit_reached: arr.license_limit_reached,
                     has_billing_access: page_params.is_owner || page_params.is_billing_admin,
+                    daily_limit_reached: arr.daily_limit_reached,
                 });
                 ui_report.message(error_response, invite_status, "alert-warning");
                 invitee_emails_group.addClass("warning");

--- a/static/templates/invitation_failed_error.hbs
+++ b/static/templates/invitation_failed_error.hbs
@@ -1,4 +1,11 @@
 <p id="invitation_error_message">{{ error_message }}</p>
+{{#if daily_limit_reached}}
+    {{#tr}}
+        Please <z-link-support>contact support</z-link-support> for an exception or <z-link-invite-help>add users with a reusable invite link</z-link-invite-help>.
+        {{#*inline "z-link-support"}}<a href="https://zulip.com/help/contact-support">{{> @partial-block}}</a>{{/inline}}
+        {{#*inline "z-link-invite-help"}}<a href="https://zulip.com/help/invite-new-users#send-invitations">{{> @partial-block}}</a>{{/inline}}
+    {{/tr}}
+{{/if}}
 <ul>
     {{#each error_list}}
     <li>{{this}}</li>

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -7017,16 +7017,19 @@ def estimate_recent_invites(realms: Collection[Realm], *, days: int) -> int:
 def check_invite_limit(realm: Realm, num_invitees: int) -> None:
     """Discourage using invitation emails as a vector for carrying spam."""
     msg = _(
-        "You do not have enough remaining invites for today. "
-        "Please contact {email} to have your limit raised. "
-        "No invitations were sent."
-    ).format(email=settings.ZULIP_ADMINISTRATOR)
+        "To protect users, Zulip limits the number of invitations you can send in one day. Because you have reached the limit, no invitations were sent."
+    )
     if not settings.OPEN_REALM_CREATION:
         return
 
     recent_invites = estimate_recent_invites([realm], days=1)
     if num_invitees + recent_invites > realm.max_invites:
-        raise InvitationError(msg, [], sent_invitations=False)
+        raise InvitationError(
+            msg,
+            [],
+            sent_invitations=False,
+            daily_limit_reached=True,
+        )
 
     default_max = settings.INVITES_DEFAULT_REALM_DAILY_MAX
     newrealm_age = datetime.timedelta(days=settings.INVITES_NEW_REALM_DAYS)
@@ -7049,7 +7052,12 @@ def check_invite_limit(realm: Realm, num_invitees: int) -> None:
     for days, count in settings.INVITES_NEW_REALM_LIMIT_DAYS:
         recent_invites = estimate_recent_invites(new_realms, days=days)
         if num_invitees + recent_invites > count:
-            raise InvitationError(msg, [], sent_invitations=False)
+            raise InvitationError(
+                msg,
+                [],
+                sent_invitations=False,
+                daily_limit_reached=True,
+            )
 
 
 def do_invite_users(

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -360,7 +360,12 @@ class ZephyrMessageAlreadySentException(Exception):
 
 class InvitationError(JsonableError):
     code = ErrorCode.INVITATION_FAILED
-    data_fields = ["errors", "sent_invitations", "license_limit_reached"]
+    data_fields = [
+        "errors",
+        "sent_invitations",
+        "license_limit_reached",
+        "daily_limit_reached",
+    ]
 
     def __init__(
         self,
@@ -368,11 +373,13 @@ class InvitationError(JsonableError):
         errors: List[Tuple[str, str, bool]],
         sent_invitations: bool,
         license_limit_reached: bool = False,
+        daily_limit_reached: bool = False,
     ) -> None:
         self._msg: str = msg
         self.errors: List[Tuple[str, str, bool]] = errors
         self.sent_invitations: bool = sent_invitations
         self.license_limit_reached: bool = license_limit_reached
+        self.daily_limit_reached: bool = daily_limit_reached
 
 
 class AccessDeniedError(JsonableError):

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1123,7 +1123,7 @@ class InviteUserTest(InviteUserBase):
                 return result
 
         result = try_invite()
-        self.assert_json_error_contains(result, "enough remaining invites")
+        self.assert_json_error_contains(result, "reached the limit")
 
         # Next show that aggregate limits expire once the realm is old
         # enough.
@@ -1624,9 +1624,7 @@ earl-test@zulip.com""",
         invitee_emails = ", ".join(str(i) for i in range(get_realm("zulip").max_invites - 1))
         self.assert_json_error(
             self.invite(invitee_emails, ["Denmark"]),
-            "You do not have enough remaining invites for today. "
-            "Please contact desdemona+admin@zulip.com to have your limit raised. "
-            "No invitations were sent.",
+            "To protect users, Zulip limits the number of invitations you can send in one day. Because you have reached the limit, no invitations were sent.",
         )
 
     def test_missing_or_invalid_params(self) -> None:


### PR DESCRIPTION
This PR updates the error message returned when the maximum
invite limit for the day is reached to mention that the user can
use multi-use invite link. We show this part only on the frontend
linking to the help page because we cannot use links with proper
format in backend.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2021-09-21 22-24-10](https://user-images.githubusercontent.com/35494118/134214752-4e633380-86a0-443d-a455-4be2e0fc312f.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
