### PR TITLE
webpack: Increase Node.js heap size on low-memory systems

### DIFF
--- a/tools/webpack
+++ b/tools/webpack
@@ -11,7 +11,11 @@ os.chdir(os.path.join(os.path.dirname(__file__), ".."))
 def build_for_prod_or_puppeteer(quiet: bool) -> NoReturn:
     """Builds for production, writing the output to disk"""
 
-    webpack_args = ["node", "node_modules/.bin/webpack-cli", "--mode=production"]
+    webpack_args = ["node"]
+    with open("/proc/meminfo") as meminfo:
+        if int(next(meminfo).split()[1]) < 3 * 1024 * 1024:
+            webpack_args += ["--max-old-space-size=1536"]
+    webpack_args += ["node_modules/.bin/webpack-cli", "--mode=production"]
     if quiet:
         webpack_args += ["--stats=errors-only"]
     os.execvp(webpack_args[0], webpack_args)


### PR DESCRIPTION
On a 2 GiB, 1 CPU system, webpack would hit the Node.js heap limit (which is half of physical memory up to 4 GiB, on 64-bit systems).

**Testing plan:** `tools/webpack`