### PR TITLE
user docs: Fix missing tab name on /help/getting-your-organization-started-with-zulip.

### DIFF
--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -57,6 +57,7 @@ TAB_DISPLAY_NAMES = {
     "mm-gitlab-omnibus": "GitLab Omnibus",
     "send-email-invitations": "Send email invitations",
     "share-an-invite-link": "Share an invite link",
+    "require-invitations": "Require invitations",
     "allow-anyone-to-join": "Allow anyone to join",
     "restrict-by-email-domain": "Restrict by email domain",
     "zoom": "Zoom",


### PR DESCRIPTION
Could we add a linter test or something to make this problem easier to catch?

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
manual

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:
![Screen Shot 2021-09-22 at 1 12 00 AM](https://user-images.githubusercontent.com/2090066/134307080-94be7fc4-bc58-4bad-ad5b-f74c683759de.png)

After:
![Screen Shot 2021-09-22 at 1 12 11 AM](https://user-images.githubusercontent.com/2090066/134307091-d2debfa7-ac09-48a0-98d4-6156857215f5.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
