### PR TITLE
markdown: Document built-in preprocessor priorities.

### DIFF
--- a/zerver/lib/markdown/preprocessor_priorities.py
+++ b/zerver/lib/markdown/preprocessor_priorities.py
@@ -1,6 +1,7 @@
 # Note that in the Markdown preprocessor registry, the highest
 # numeric value is considered the highest priority, so the dict
 # below is ordered from highest-to-lowest priority.
+# Priorities for the built-in preprocessors are commented out.
 PREPROCESSOR_PRIORITES = {
     "generate_parameter_description": 535,
     "generate_response_description": 531,
@@ -10,9 +11,12 @@ PREPROCESSOR_PRIORITES = {
     "generate_return_values": 510,
     "generate_api_arguments": 505,
     "include": 500,
+    # "include_wrapper": 500,
     "help_relative_links": 475,
     "setting": 450,
+    # "normalize_whitespace": 30,
     "fenced_code_block": 25,
+    # "html_block": 20,
     "tabbed_sections": -500,
     "nested_code_blocks": -500,
     "emoticon_translations": -505,


### PR DESCRIPTION
#19810 

Added 3 new preprocessor priorities by inspecting `md_engine.preprocessors._priority` when running `./tools/test-backend zerver.tests.test_email_notifications`. I suspect there are more priorities to be added here (which I could not find), hence the **WIP** prefix.