### PR TITLE
compose: Collapse compose-box after sending message.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -182,6 +182,14 @@ export function create_message_object() {
 }
 
 export function clear_compose_box() {
+    /* Before clearing the compose box, we reset it to the
+     * default/normal size. Note that for locally echoed messages, we
+     * will have already done this action before echoing the message
+     * to avoid the compose box triggering "new message out of view"
+     * notifications incorrectly. */
+    if (compose_ui.is_full_size()) {
+        compose_ui.make_compose_box_original_size();
+    }
     $("#compose-textarea").val("").trigger("focus");
     compose_validate.check_overflow_text();
     $("#compose-textarea").removeData("draft-id");

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -4,6 +4,7 @@ import * as alert_words from "./alert_words";
 import {all_messages_data} from "./all_messages_data";
 import * as blueslip from "./blueslip";
 import * as compose from "./compose";
+import * as compose_ui from "./compose_ui";
 import * as drafts from "./drafts";
 import * as local_message from "./local_message";
 import * as markdown from "./markdown";
@@ -240,6 +241,18 @@ export function try_deliver_locally(message_request) {
     // This draft will be cleared after successfull message
     const draft_id = drafts.update_draft();
     message_request.draft_id = draft_id;
+
+    // Now that we've committed to delivering the message locally, we
+    // shrink the compose-box if it is in the full-screen state. This
+    // would have happened anyway in clear_compose_box, however, we
+    // need to this operation before inserting the local message into
+    // the feed. Otherwise, the out-of-view notification will be
+    // always triggered on the top of compose-box, regardless of
+    // whether the message would be visible after shrinking compose,
+    // because compose occludes the whole screen.
+    if (compose_ui.is_full_size()) {
+        compose_ui.make_compose_box_original_size();
+    }
 
     const message = insert_local_message(message_request, local_id_float);
     return message;


### PR DESCRIPTION
Currently, after sending a message from the full-sized compose-box,
the compose-box remains in expanded state covering the entire middle
part. Instead, it should collapse back to the original state after
the message is sent.

The compose-box is collapsed right before the message is sent and
not in `do_post_send_tasks` because in the latter case, the compose-
box collapses after the message has rendered locally, due to which
the out-of-view notification stays on top of the compose-box even if
the sent message is in the view (the notification initially shows up
as the new message was out-of-view when it was first rendered due to
the full-sized compose-box). Also, in the latter case, scroll animation
does not take place when the new message is added in the stream.

Tested on my Ubuntu development environment, by sending empty message,
valid message and slash commands. The compose-box only collapsed on
sending valid messages.

Part of: #19353

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

On putting `collapse_compose_box` in `do_post_send_tasks`:
![Screenshot from 2021-09-23 23-06-14](https://user-images.githubusercontent.com/39924567/134556706-8c01cb3f-a7e2-4c71-9c05-1c520cc90638.png)

