### PR TITLE
setup_venv: Skip virtualenv’s automatic download of setuptools

### DIFF
--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -330,7 +330,7 @@ def do_setup_virtualenv(venv_path: str, requirements_file: str) -> None:
     if not try_to_copy_venv(venv_path, new_packages):
         # Create new virtualenv.
         run_as_root(["mkdir", "-p", venv_path])
-        run_as_root(["virtualenv", "-p", "python3", venv_path])
+        run_as_root(["virtualenv", "-p", "python3", "--no-download", venv_path])
         run_as_root(["chown", "-R", f"{os.getuid()}:{os.getgid()}", venv_path])
         create_log_entry(get_logfile_name(venv_path), "", set(), new_packages)
 


### PR DESCRIPTION
It recently started failing on Debian 10 (buster). We immediately follow this by replacing these packages with our own versions from pip.txt, anyway.

(This will probably need to be backported to 4.x.)