### PR TITLE
topics: Fix translation issue with resolve topic notifications.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5885,15 +5885,14 @@ def maybe_send_resolve_topic_notifications(
     if old_topic.lstrip(RESOLVED_TOPIC_PREFIX) != new_topic.lstrip(RESOLVED_TOPIC_PREFIX):
         return
 
-    if new_topic.startswith(RESOLVED_TOPIC_PREFIX) and not old_topic.startswith(
+    topic_resolved: bool = new_topic.startswith(RESOLVED_TOPIC_PREFIX) and not old_topic.startswith(
         RESOLVED_TOPIC_PREFIX
-    ):
-        notification_string = _("{user} has marked this topic as resolved.")
-    elif old_topic.startswith(RESOLVED_TOPIC_PREFIX) and not new_topic.startswith(
+    )
+    topic_unresolved: bool = old_topic.startswith(
         RESOLVED_TOPIC_PREFIX
-    ):
-        notification_string = _("{user} has marked this topic as unresolved.")
-    else:
+    ) and not new_topic.startswith(RESOLVED_TOPIC_PREFIX)
+
+    if not topic_resolved and not topic_unresolved:
         # If there's some other weird topic that does not toggle the
         # state of "topic starts with RESOLVED_TOPIC_PREFIX", we do
         # nothing. Any other logic could result in cases where we send
@@ -5912,6 +5911,11 @@ def maybe_send_resolve_topic_notifications(
     sender = get_system_bot(settings.NOTIFICATION_BOT, user_profile.realm_id)
     user_mention = f"@_**{user_profile.full_name}|{user_profile.id}**"
     with override_language(stream.realm.default_language):
+        if topic_resolved:
+            notification_string = _("{user} has marked this topic as resolved.")
+        elif topic_unresolved:
+            notification_string = _("{user} has marked this topic as unresolved.")
+
         internal_send_stream_message(
             sender,
             stream,


### PR DESCRIPTION
In maybe_send_resolve_topic_notifications, since the calls to the translation function `_()` are made outside of the `override_language` block, the strings are not translated correctly.

This commit refactors the function to make sure that the translation happens in the right block of code.

@timabbott @gnprice FYI :)


<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
