### PR TITLE
find_accounts: Thank the user for their request in the email.

### DIFF
--- a/templates/zerver/emails/find_team.source.html
+++ b/templates/zerver/emails/find_team.source.html
@@ -5,6 +5,8 @@
 {% endblock %}
 
 {% block content %}
+<p>{{ _("Thanks for your request!") }}</p>
+
 <p>{% trans %}Your email address {{ email }} has accounts with the following Zulip organizations hosted by <a href="{{ external_host }}">{{ external_host }}</a>:{% endtrans %}</p>
 
 <ul>

--- a/templates/zerver/emails/find_team.txt
+++ b/templates/zerver/emails/find_team.txt
@@ -1,3 +1,5 @@
+{{ _("Thanks for your request!") }}
+
 {% trans -%}
 Your email address {{ email }} has accounts with the following Zulip organizations hosted by {{ external_host }}:
 {%- endtrans %}


### PR DESCRIPTION
A recent commit removed the "Thanks for you request!" at the start
of the find accounts email. As Alya Abbott pointed out, this line
actually helps us point out to the user that they are the ones who
requested the email in the first place, lowering the chances that
they'll misinterpret it as spam.

This is a follow-up to issue #19659.

@timabbott @alya FYI :)

Screenshots
![with_images](https://user-images.githubusercontent.com/7251823/134706379-ced9611b-1c91-44a9-ac2d-cb4d0990f732.PNG)
![text_only](https://user-images.githubusercontent.com/7251823/134706380-9395a8b4-bb8e-417e-92e4-1d608132c33b.PNG)
:
