### PR TITLE
Changed chat.zulip.org to /developer-community wherever required

### DIFF
--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -28,7 +28,7 @@ Look at the surrounding code, or a similar part of the project, and try
 to do the same thing. If you think the other code has actively bad
 style, fix it (in a separate commit).
 
-When in doubt, ask in [chat.zulip.org](https://chat.zulip.org).
+When in doubt, ask in [The Zulip developer community](https://zulip.com/developer-community/).
 
 ## Lint tools
 

--- a/docs/contributing/gsoc-ideas.md
+++ b/docs/contributing/gsoc-ideas.md
@@ -170,14 +170,14 @@ projects. We usually decide who will mentor which projects based in
 part on who is a good fit for the needs of each student as well as
 technical expertise as well as who has available time during the
 summer. You can reach us via
-[#GSoC](https://chat.zulip.org/#narrow/stream/14-GSoC) on [the Zulip
+[#GSoC](https://chat.zulip.org/#narrow/stream/14-GSoC) on [The Zulip
 development community server](https://zulip.com/developer-community/),
 (compose a new stream message with your name as the topic).
 
 Zulip operates under group mentorship. That means you should
-generally post in public streams on chat.zulip.org, not send private
+generally post in public streams on [The Zulip developer community](https://zulip.com/developer-community/), not send private
 messages, for assistance. Our preferred approach is to just post in
-an appropriate public stream on chat.zulip.org and someone will help
+an appropriate public stream on [The Zulip developer community](https://zulip.com/developer-community/) and someone will help
 you. We list the Zulip contributors who are experts for various
 projects by name below; they will likely be able to provide you with
 the best feedback on your proposal (feel free to @-mention them in
@@ -198,8 +198,7 @@ make sure you don't make the same mistakes next time).
 Once you have several PRs merged (or at least one significant PR
 merged), you can start discussing with the Zulip development community
 the project you'd like to do, and developing a specific project plan.
-We recommend discussing what you're thinking in public streams on
-chat.zulip.org, so it's easy to get quick feedback from whoever is
+We recommend discussing what you're thinking in public streams on [The Zulip developer community](https://zulip.com/developer-community/), so it's easy to get quick feedback from whoever is
 online.
 
 ## Project ideas
@@ -588,7 +587,7 @@ Where should you publish your draft? We prefer Dropbox Paper or
 Google Docs, since those platforms allow people to look at the text
 without having to log in or download a particular app, and you can
 update the draft as you improve your idea. In either case, you should
-post the draft for feedback in chat.zulip.org.
+post the draft for feedback in [The Zulip developer community](https://zulip.com/developer-community/).
 
 Rough is fine! The ideal first draft to get feedback from the
 community on should include primarily (1) links to your contributions

--- a/docs/contributing/summer-with-zulip.md
+++ b/docs/contributing/summer-with-zulip.md
@@ -34,7 +34,7 @@ materials](https://developers.google.com/open-source/gsoc/resources/manual).
 - Mentors and students should stay in close contact, both with each other and
   the rest of the Zulip community. We recommend the following:
 
-  - Daily checkins on #checkins on chat.zulip.org; ideally at some time of day
+  - Daily checkins on #checkins on [The Zulip developer community](https://zulip.com/developer-community/); ideally at some time of day
     you can both be online, but when not possible, async is better than nothing!
 
     - We prefer checkins in public streams, since it makes easier for
@@ -54,7 +54,7 @@ materials](https://developers.google.com/open-source/gsoc/resources/manual).
     need help learning, and time-saving tricks.
 
   - If you need feedback from the community / decisions made, ask in the
-    appropriate public stream on [chat.zulip.org](https://chat.zulip.org). Often
+    appropriate public stream on [The Zulip developer community](https://zulip.com/developer-community/). Often
     someone can provide important context that you need to succeed in your
     project.
 

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -279,7 +279,7 @@ likely only a few lines of changes to `tools/lib/provision.py` and
 `scripts/lib/setup-apt-repo` if you'd like to do it yourself and
 submit a pull request, or you can ask for help in
 [#development help](https://chat.zulip.org/#narrow/stream/49-development-help)
-on chat.zulip.org, and a core team member can help guide you through
+on [The Zulip developer community](https://zulip.com/developer-community/), and a core team member can help guide you through
 adding support for the platform.
 
 ## Installing on Cloud9

--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -193,8 +193,8 @@ installing Zulip with a dedicated database server.
   subscribed (like on chat.zulip.org), add 20GB per (1000 user
   accounts) per (1M messages to public streams).
 
-- **Example:** When the
-  [chat.zulip.org](https://zulip.com/developer-community/) community server
+- **Example:** When 
+  [The Zulip developer community](https://zulip.com/developer-community/)
   had 12K user accounts (~300 daily actives) and 800K messages of
   history (400K to public streams), it was a default configuration
   single-server installation with 16GB of RAM, 4 cores (essentially

--- a/docs/production/settings.md
+++ b/docs/production/settings.md
@@ -33,7 +33,7 @@ to each new major release.
 
 Since Zulip's settings file is a Python script, there are a number of
 other things that one can configure that are not documented; ask on
-[chat.zulip.org](https://zulip.com/developer-community/)
+[The Zulip developer community](https://zulip.com/developer-community/)
 if there's something you'd like to do but can't figure out how to.
 
 ## Specific settings

--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -531,7 +531,7 @@ modified version of Zulip, please be responsible about communicating
 that fact:
 
 - Ideally, you'd reproduce the issue in an unmodified version (e.g. on
-  [chat.zulip.org](https://zulip.com/developer-community/) or
+  [The Zulip developer community](https://zulip.com/developer-community/) or
   [zulip.com](https://zulip.com)).
 - Where that is difficult or you think it's very unlikely your changes
   are related to the issue, just mention your changes in the issue report.

--- a/docs/subsystems/performance.md
+++ b/docs/subsystems/performance.md
@@ -34,7 +34,7 @@ of load profiles:
   etc. have large numbers of users, many of whom are idle. (Many of
   the others likely stopped by to ask a question, got it answered, and
   then didn't need the community again for the next year). Our own
-  [chat.zulip.org](https://zulip.com/developer-community/) is a good
+  [The Zulip developer community](https://zulip.com/developer-community/) is a good
   example for this, with more than 15K total user accounts, of which
   only several hundred have logged in during the last few weeks.
   Zulip has many important optimizations, including [soft

--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -556,7 +556,7 @@ in. For example in this case of `mandatory_topics` it will lie in
 "Other settings" (`other_settings`) subsection.
 
 _If you're not sure in which section your feature belongs, it's
-better to discuss it in the [community](https://chat.zulip.org/)
+better to discuss it in [The Zulip developer community](https://zulip.com/developer-community/)
 before implementing it._
 
 Note that some settings, like `realm_msg_edit_limit_setting`,

--- a/templates/zerver/api/client-libraries.md
+++ b/templates/zerver/api/client-libraries.md
@@ -33,7 +33,7 @@ writing new ones.  If you actively maintain a Zulip language binding
 and would like it to be listed here (or would like to collaborate with
 us in making it an official library), post in [this
 topic][integrations-thread] on
-[chat.zulip.org](/developer-community/) or submit a pull request
+[The Zulip developer community](https://zulip.com/developer-community/) or submit a pull request
 [updating this
 page](https://zulip.readthedocs.io/en/latest/documentation/api.html).
 

--- a/templates/zerver/api/running-bots.md
+++ b/templates/zerver/api/running-bots.md
@@ -12,7 +12,7 @@ https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots).
 You'll need:
 
 * An account in a Zulip organization
-  (e.g. [chat.zulip.org](/developer-community/),
+  (e.g. [The Zulip developer community](https://zulip.com/developer-community/),
   `<yourSubdomain>.zulipchat.com`, or a Zulip organization on your own
   [development](https://zulip.readthedocs.io/en/latest/development/overview.html) or
   [production](https://zulip.readthedocs.io/en/latest/production/install.html) server).

--- a/templates/zerver/for/communities.md
+++ b/templates/zerver/for/communities.md
@@ -116,8 +116,7 @@ Zulip’s topic-based threading model solves the problems described above:
 
 ## Try Zulip today!
 
-You can see Zulip in action in our own [chat.zulip.org
-community](/developer-community/), which sends
+You can see Zulip in action in [The Zulip developer community](https://zulip.com/developer-community/), which sends
 thousands of messages a week. We often get feedback from contributors
 around the world that they love how responsive Zulip’s project leaders
 are in public Zulip conversations. We are able to achieve this despite

--- a/templates/zerver/help/contact-support.md
+++ b/templates/zerver/help/contact-support.md
@@ -3,7 +3,7 @@
 General and technical support for Zulip is available through three
 channels:
 
-* [chat.zulip.org][chat-zulip-org], the Zulip development community.
+* [The Zulip developer community](https://zulip.com/developer-community/).
   Depending on the time of day/week of your query and the complexity
   of your question, you may get complete responses immediately or up
   to a couple days later, but Zulip's threading makes it easy for us
@@ -17,7 +17,7 @@ channels:
   app](https://github.com/zulip/zulip-mobile/issues/new), [desktop
   app](https://github.com/zulip/zulip-desktop/issues/new). If you
   aren't able to provide a clear bug report or are otherwise
-  uncertain, it can be helpful to discuss in chat.zulip.org first to
+  uncertain, it can be helpful to discuss in [The Zulip developer community](https://zulip.com/developer-community/) first to
   help create a better GitHub issue.
 * We don't offer phone support except as part of enterprise contracts.
 

--- a/tools/provision
+++ b/tools/provision
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+chat.zulip.org#!/usr/bin/env bash
 
 # Use this script to provision dependencies for your Zulip installation.
 # This script is idempotent, so it can be restarted at any time, and it


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is focused on changing `chat.zulip.org` to `/developer-community` wherever required.
This PR is for the the issue: #19827 

**Testing plan:** <!-- How have you tested? -->
Manually

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
