### PR TITLE
links: Change chat.zulip.org to /developer-community wherever required

### DIFF
--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -28,7 +28,7 @@ Look at the surrounding code, or a similar part of the project, and try
 to do the same thing. If you think the other code has actively bad
 style, fix it (in a separate commit).
 
-When in doubt, ask in [The Zulip developer community](https://zulip.com/developer-community/).
+When in doubt, ask in [The Zulip developer community](https://zulip.com/developer-community/#narrow/stream/49-development-help).
 
 ## Lint tools
 

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -28,7 +28,7 @@ Look at the surrounding code, or a similar part of the project, and try
 to do the same thing. If you think the other code has actively bad
 style, fix it (in a separate commit).
 
-When in doubt, ask in [chat.zulip.org](https://chat.zulip.org).
+When in doubt, ask in [The Zulip developer community](https://zulip.com/developer-community/).
 
 ## Lint tools
 

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -28,7 +28,7 @@ Look at the surrounding code, or a similar part of the project, and try
 to do the same thing. If you think the other code has actively bad
 style, fix it (in a separate commit).
 
-When in doubt, ask in [The Zulip developer community](https://zulip.com/developer-community/#narrow/stream/49-development-help).
+When in doubt, ask in [the Zulip developer community](https://zulip.com/developer-community/#narrow/stream/49-development-help).
 
 ## Lint tools
 

--- a/docs/contributing/gsoc-ideas.md
+++ b/docs/contributing/gsoc-ideas.md
@@ -170,14 +170,14 @@ projects. We usually decide who will mentor which projects based in
 part on who is a good fit for the needs of each student as well as
 technical expertise as well as who has available time during the
 summer. You can reach us via
-[#GSoC](https://chat.zulip.org/#narrow/stream/14-GSoC) on [the Zulip
+[#GSoC](https://chat.zulip.org/#narrow/stream/14-GSoC) on [The Zulip
 development community server](https://zulip.com/developer-community/),
 (compose a new stream message with your name as the topic).
 
 Zulip operates under group mentorship. That means you should
-generally post in public streams on chat.zulip.org, not send private
+generally post in public streams on [The Zulip developer community](https://zulip.com/developer-community/), not send private
 messages, for assistance. Our preferred approach is to just post in
-an appropriate public stream on chat.zulip.org and someone will help
+an appropriate public stream on [The Zulip developer community](https://zulip.com/developer-community/) and someone will help
 you. We list the Zulip contributors who are experts for various
 projects by name below; they will likely be able to provide you with
 the best feedback on your proposal (feel free to @-mention them in
@@ -198,8 +198,7 @@ make sure you don't make the same mistakes next time).
 Once you have several PRs merged (or at least one significant PR
 merged), you can start discussing with the Zulip development community
 the project you'd like to do, and developing a specific project plan.
-We recommend discussing what you're thinking in public streams on
-chat.zulip.org, so it's easy to get quick feedback from whoever is
+We recommend discussing what you're thinking in public streams on [The Zulip developer community](https://zulip.com/developer-community/), so it's easy to get quick feedback from whoever is
 online.
 
 ## Project ideas
@@ -588,7 +587,7 @@ Where should you publish your draft? We prefer Dropbox Paper or
 Google Docs, since those platforms allow people to look at the text
 without having to log in or download a particular app, and you can
 update the draft as you improve your idea. In either case, you should
-post the draft for feedback in chat.zulip.org.
+post the draft for feedback in [The Zulip developer community](https://zulip.com/developer-community/).
 
 Rough is fine! The ideal first draft to get feedback from the
 community on should include primarily (1) links to your contributions

--- a/docs/contributing/gsoc-ideas.md
+++ b/docs/contributing/gsoc-ideas.md
@@ -175,7 +175,7 @@ development community server](https://zulip.com/developer-community/),
 (compose a new stream message with your name as the topic).
 
 Zulip operates under group mentorship. That means you should
-generally post in public streams on [The Zulip developer community](https://zulip.com/developer-community/), not send private
+generally post in public streams on the [Zulip developer community](https://zulip.com/developer-community/), not send private
 messages, for assistance. Our preferred approach is to just post in
 an appropriate public stream on [The Zulip developer community](https://zulip.com/developer-community/) and someone will help
 you. We list the Zulip contributors who are experts for various
@@ -587,7 +587,8 @@ Where should you publish your draft? We prefer Dropbox Paper or
 Google Docs, since those platforms allow people to look at the text
 without having to log in or download a particular app, and you can
 update the draft as you improve your idea. In either case, you should
-post the draft for feedback in [The Zulip developer community](https://zulip.com/developer-community/).
+post the draft for feedback in [The Zulip developer community]
+(https://zulip.com/developer-community/).
 
 Rough is fine! The ideal first draft to get feedback from the
 community on should include primarily (1) links to your contributions

--- a/docs/contributing/gsoc-ideas.md
+++ b/docs/contributing/gsoc-ideas.md
@@ -126,8 +126,7 @@ application deadline.
 
 We are more interested in candidates if we see them submitting good
 contributions to Zulip projects, helping other applicants on GitHub
-and on
-[chat.zulip.org](https://zulip.com/developer-community/),
+and on [the Zulip development community server](https://zulip.com/developer-community/),
 learning from our suggestions,
 [trying to solve their own obstacles and then asking well-formed
 questions](https://blogs.akamai.com/2013/10/you-must-try-and-then-you-must-ask.html),
@@ -170,14 +169,14 @@ projects. We usually decide who will mentor which projects based in
 part on who is a good fit for the needs of each student as well as
 technical expertise as well as who has available time during the
 summer. You can reach us via
-[#GSoC](https://chat.zulip.org/#narrow/stream/14-GSoC) on [The Zulip
-development community server](https://zulip.com/developer-community/),
+[#GSoC](https://chat.zulip.org/#narrow/stream/14-GSoC) on
+[the Zulip development community server](https://zulip.com/developer-community/),
 (compose a new stream message with your name as the topic).
 
 Zulip operates under group mentorship. That means you should
-generally post in public streams on the [Zulip developer community](https://zulip.com/developer-community/), not send private
+generally post in public streams on [the Zulip developer community](https://zulip.com/developer-community/), not send private
 messages, for assistance. Our preferred approach is to just post in
-an appropriate public stream on [The Zulip developer community](https://zulip.com/developer-community/) and someone will help
+an appropriate public stream on [the Zulip developer community](https://zulip.com/developer-community/) and someone will help
 you. We list the Zulip contributors who are experts for various
 projects by name below; they will likely be able to provide you with
 the best feedback on your proposal (feel free to @-mention them in
@@ -198,8 +197,7 @@ make sure you don't make the same mistakes next time).
 Once you have several PRs merged (or at least one significant PR
 merged), you can start discussing with the Zulip development community
 the project you'd like to do, and developing a specific project plan.
-We recommend discussing what you're thinking in public streams on [The Zulip developer community](https://zulip.com/developer-community/), so it's easy to get quick feedback from whoever is
-online.
+We recommend discussing what you're thinking in public streams on [the Zulip developer community](https://zulip.com/developer-community/), so it's easy to get quick feedback from whoever is online.
 
 ## Project ideas
 
@@ -587,8 +585,7 @@ Where should you publish your draft? We prefer Dropbox Paper or
 Google Docs, since those platforms allow people to look at the text
 without having to log in or download a particular app, and you can
 update the draft as you improve your idea. In either case, you should
-post the draft for feedback in [The Zulip developer community]
-(https://zulip.com/developer-community/).
+post the draft for feedback in [the Zulip developer community](https://zulip.com/developer-community/).
 
 Rough is fine! The ideal first draft to get feedback from the
 community on should include primarily (1) links to your contributions

--- a/docs/contributing/summer-with-zulip.md
+++ b/docs/contributing/summer-with-zulip.md
@@ -34,7 +34,7 @@ materials](https://developers.google.com/open-source/gsoc/resources/manual).
 - Mentors and students should stay in close contact, both with each other and
   the rest of the Zulip community. We recommend the following:
 
-  - Daily checkins on #checkins on [The Zulip developer community](https://zulip.com/developer-community/); ideally at some time of day
+  - Daily checkins on #checkins on [the Zulip developer community](https://zulip.com/developer-community/); ideally at some time of day
     you can both be online, but when not possible, async is better than nothing!
 
     - We prefer checkins in public streams, since it makes easier for
@@ -54,7 +54,7 @@ materials](https://developers.google.com/open-source/gsoc/resources/manual).
     need help learning, and time-saving tricks.
 
   - If you need feedback from the community / decisions made, ask in the
-    appropriate public stream on [The Zulip developer community](https://zulip.com/developer-community/). Often
+    appropriate public stream on [the Zulip developer community](https://zulip.com/developer-community/). Often
     someone can provide important context that you need to succeed in your
     project.
 

--- a/docs/contributing/summer-with-zulip.md
+++ b/docs/contributing/summer-with-zulip.md
@@ -34,7 +34,7 @@ materials](https://developers.google.com/open-source/gsoc/resources/manual).
 - Mentors and students should stay in close contact, both with each other and
   the rest of the Zulip community. We recommend the following:
 
-  - Daily checkins on #checkins on chat.zulip.org; ideally at some time of day
+  - Daily checkins on #checkins on [The Zulip developer community](https://zulip.com/developer-community/); ideally at some time of day
     you can both be online, but when not possible, async is better than nothing!
 
     - We prefer checkins in public streams, since it makes easier for
@@ -54,7 +54,7 @@ materials](https://developers.google.com/open-source/gsoc/resources/manual).
     need help learning, and time-saving tricks.
 
   - If you need feedback from the community / decisions made, ask in the
-    appropriate public stream on [chat.zulip.org](https://chat.zulip.org). Often
+    appropriate public stream on [The Zulip developer community](https://zulip.com/developer-community/). Often
     someone can provide important context that you need to succeed in your
     project.
 

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -279,7 +279,7 @@ likely only a few lines of changes to `tools/lib/provision.py` and
 `scripts/lib/setup-apt-repo` if you'd like to do it yourself and
 submit a pull request, or you can ask for help in
 [#development help](https://chat.zulip.org/#narrow/stream/49-development-help)
-on chat.zulip.org, and a core team member can help guide you through
+on [The Zulip developer community](https://zulip.com/developer-community/), and a core team member can help guide you through
 adding support for the platform.
 
 ## Installing on Cloud9

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -279,7 +279,7 @@ likely only a few lines of changes to `tools/lib/provision.py` and
 `scripts/lib/setup-apt-repo` if you'd like to do it yourself and
 submit a pull request, or you can ask for help in
 [#development help](https://chat.zulip.org/#narrow/stream/49-development-help)
-on [The Zulip developer community](https://zulip.com/developer-community/), and a core team member can help guide you through
+on [the Zulip developer community](https://zulip.com/developer-community/), and a core team member can help guide you through
 adding support for the platform.
 
 ## Installing on Cloud9

--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -194,7 +194,7 @@ installing Zulip with a dedicated database server.
   accounts) per (1M messages to public streams).
 
 - **Example:** When
-  [The Zulip developer community](https://zulip.com/developer-community/)
+  [the Zulip developer community](https://zulip.com/developer-community/)
   had 12K user accounts (~300 daily actives) and 800K messages of
   history (400K to public streams), it was a default configuration
   single-server installation with 16GB of RAM, 4 cores (essentially

--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -193,8 +193,8 @@ installing Zulip with a dedicated database server.
   subscribed (like on chat.zulip.org), add 20GB per (1000 user
   accounts) per (1M messages to public streams).
 
-- **Example:** When the
-  [chat.zulip.org](https://zulip.com/developer-community/) community server
+- **Example:** When
+  [The Zulip developer community](https://zulip.com/developer-community/)
   had 12K user accounts (~300 daily actives) and 800K messages of
   history (400K to public streams), it was a default configuration
   single-server installation with 16GB of RAM, 4 cores (essentially

--- a/docs/production/settings.md
+++ b/docs/production/settings.md
@@ -33,7 +33,7 @@ to each new major release.
 
 Since Zulip's settings file is a Python script, there are a number of
 other things that one can configure that are not documented; ask on
-[The Zulip developer community](https://zulip.com/developer-community/)
+[the Zulip developer community](https://zulip.com/developer-community/)
 if there's something you'd like to do but can't figure out how to.
 
 ## Specific settings

--- a/docs/production/settings.md
+++ b/docs/production/settings.md
@@ -33,7 +33,7 @@ to each new major release.
 
 Since Zulip's settings file is a Python script, there are a number of
 other things that one can configure that are not documented; ask on
-[chat.zulip.org](https://zulip.com/developer-community/)
+[The Zulip developer community](https://zulip.com/developer-community/)
 if there's something you'd like to do but can't figure out how to.
 
 ## Specific settings

--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -531,7 +531,7 @@ modified version of Zulip, please be responsible about communicating
 that fact:
 
 - Ideally, you'd reproduce the issue in an unmodified version (e.g. on
-  [chat.zulip.org](https://zulip.com/developer-community/) or
+  [The Zulip developer community](https://zulip.com/developer-community/) or
   [zulip.com](https://zulip.com)).
 - Where that is difficult or you think it's very unlikely your changes
   are related to the issue, just mention your changes in the issue report.

--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -531,7 +531,7 @@ modified version of Zulip, please be responsible about communicating
 that fact:
 
 - Ideally, you'd reproduce the issue in an unmodified version (e.g. on
-  [The Zulip developer community](https://zulip.com/developer-community/) or
+  [the Zulip developer community](https://zulip.com/developer-community/) or
   [zulip.com](https://zulip.com)).
 - Where that is difficult or you think it's very unlikely your changes
   are related to the issue, just mention your changes in the issue report.

--- a/docs/subsystems/performance.md
+++ b/docs/subsystems/performance.md
@@ -34,7 +34,7 @@ of load profiles:
   etc. have large numbers of users, many of whom are idle. (Many of
   the others likely stopped by to ask a question, got it answered, and
   then didn't need the community again for the next year). Our own
-  [The Zulip developer community](https://zulip.com/developer-community/) is a good
+  [Zulip developer community](https://zulip.com/developer-community/) is a good
   example for this, with more than 15K total user accounts, of which
   only several hundred have logged in during the last few weeks.
   Zulip has many important optimizations, including [soft

--- a/docs/subsystems/performance.md
+++ b/docs/subsystems/performance.md
@@ -34,7 +34,7 @@ of load profiles:
   etc. have large numbers of users, many of whom are idle. (Many of
   the others likely stopped by to ask a question, got it answered, and
   then didn't need the community again for the next year). Our own
-  [chat.zulip.org](https://zulip.com/developer-community/) is a good
+  [The Zulip developer community](https://zulip.com/developer-community/) is a good
   example for this, with more than 15K total user accounts, of which
   only several hundred have logged in during the last few weeks.
   Zulip has many important optimizations, including [soft

--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -556,7 +556,7 @@ in. For example in this case of `mandatory_topics` it will lie in
 "Other settings" (`other_settings`) subsection.
 
 _If you're not sure in which section your feature belongs, it's
-better to discuss it in the [community](https://chat.zulip.org/)
+better to discuss it in [The Zulip developer community](https://zulip.com/developer-community/)
 before implementing it._
 
 Note that some settings, like `realm_msg_edit_limit_setting`,

--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -556,7 +556,7 @@ in. For example in this case of `mandatory_topics` it will lie in
 "Other settings" (`other_settings`) subsection.
 
 _If you're not sure in which section your feature belongs, it's
-better to discuss it in [The Zulip developer community](https://zulip.com/developer-community/)
+better to discuss it in [the Zulip developer community](https://zulip.com/developer-community/)
 before implementing it._
 
 Note that some settings, like `realm_msg_edit_limit_setting`,

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -62,12 +62,10 @@ function get_realm_level_notification_settings(options) {
         realm_user_settings_defaults,
     );
 
-    // We remove enable_marketing_emails setting from all_notification_settings, since there is no
-    // realm-level default of this setting.
-    all_notifications_settings.settings.other_email_settings = [
-        "enable_digest_emails",
-        "enable_login_emails",
-    ];
+    // We remove enable_marketing_emails and enable_login_emails
+    // setting from all_notification_settings, since there are no
+    // realm-level defaults for these setting.
+    all_notifications_settings.settings.other_email_settings = ["enable_digest_emails"];
 
     options.general_settings = all_notifications_settings.general_settings;
     options.notification_settings = all_notifications_settings.settings;

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -182,6 +182,14 @@ export function create_message_object() {
 }
 
 export function clear_compose_box() {
+    /* Before clearing the compose box, we reset it to the
+     * default/normal size. Note that for locally echoed messages, we
+     * will have already done this action before echoing the message
+     * to avoid the compose box triggering "new message out of view"
+     * notifications incorrectly. */
+    if (compose_ui.is_full_size()) {
+        compose_ui.make_compose_box_original_size();
+    }
     $("#compose-textarea").val("").trigger("focus");
     compose_validate.check_overflow_text();
     $("#compose-textarea").removeData("draft-id");

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -4,6 +4,7 @@ import * as alert_words from "./alert_words";
 import {all_messages_data} from "./all_messages_data";
 import * as blueslip from "./blueslip";
 import * as compose from "./compose";
+import * as compose_ui from "./compose_ui";
 import * as drafts from "./drafts";
 import * as local_message from "./local_message";
 import * as markdown from "./markdown";
@@ -240,6 +241,18 @@ export function try_deliver_locally(message_request) {
     // This draft will be cleared after successfull message
     const draft_id = drafts.update_draft();
     message_request.draft_id = draft_id;
+
+    // Now that we've committed to delivering the message locally, we
+    // shrink the compose-box if it is in the full-screen state. This
+    // would have happened anyway in clear_compose_box, however, we
+    // need to this operation before inserting the local message into
+    // the feed. Otherwise, the out-of-view notification will be
+    // always triggered on the top of compose-box, regardless of
+    // whether the message would be visible after shrinking compose,
+    // because compose occludes the whole screen.
+    if (compose_ui.is_full_size()) {
+        compose_ui.make_compose_box_original_size();
+    }
 
     const message = insert_local_message(message_request, local_id_float);
     return message;

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -406,9 +406,6 @@ export const realm_user_settings_defaults_labels = {
         defaultMessage: "Send mobile notifications even if user is online (useful for testing)",
     }),
     enable_digest_emails: $t({defaultMessage: "Send digest emails when user is away"}),
-    enable_login_emails: $t({
-        defaultMessage: "Send email notifications for new logins to the account",
-    }),
 
     realm_presence_enabled: $t({defaultMessage: "Display availability to other users when online"}),
     realm_enter_sends: $t({defaultMessage: "Enter sends when composing a message"}),

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -78,7 +78,7 @@ export function set_up(settings_panel) {
             const data = {};
             data[setting] = JSON.stringify($(this).prop("checked"));
 
-            if (["left_side_userlist"].includes(setting)) {
+            if (["left_side_userlist"].includes(setting) && !for_realm_settings) {
                 change_display_setting(
                     data,
                     settings_panel,

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -46,7 +46,7 @@
         </table>
     </div>
 
-    <div class="desktop_notifications m-10 inline-block subsection-parent">
+    <div class="desktop_notifications m-10 subsection-parent">
 
         <h3 class="inline-block">{{t "Desktop message notifications" }}</h3>
         <div class="alert-notification"></div>
@@ -91,7 +91,7 @@
         </div>
     </div>
 
-    <div class="mobile_notifications m-10 inline-block subsection-parent">
+    <div class="mobile_notifications m-10 subsection-parent">
 
         <h3 class="inline-block">{{t "Mobile message notifications" }}</h3>
         <div class="alert-notification"></div>
@@ -106,7 +106,7 @@
         {{/each}}
     </div>
 
-    <div class="email_message_notifications m-10 inline-block subsection-parent">
+    <div class="email_message_notifications m-10 subsection-parent">
 
         <h3 class="inline-block">{{t "Email message notifications" }}</h3>
         <div class="alert-notification"></div>
@@ -132,7 +132,7 @@
         {{/each}}
     </div>
 
-    <div class="other_email_notifications m-10 inline-block subsection-parent">
+    <div class="other_email_notifications m-10 subsection-parent">
 
         <h3 class="inline-block">{{t "Other emails" }}</h3>
         <div class="alert-notification"></div>

--- a/templates/zerver/api/client-libraries.md
+++ b/templates/zerver/api/client-libraries.md
@@ -33,7 +33,7 @@ writing new ones.  If you actively maintain a Zulip language binding
 and would like it to be listed here (or would like to collaborate with
 us in making it an official library), post in [this
 topic][integrations-thread] on
-[chat.zulip.org](/developer-community/) or submit a pull request
+[The Zulip developer community](https://zulip.com/developer-community/) or submit a pull request
 [updating this
 page](https://zulip.readthedocs.io/en/latest/documentation/api.html).
 

--- a/templates/zerver/api/client-libraries.md
+++ b/templates/zerver/api/client-libraries.md
@@ -33,9 +33,8 @@ writing new ones.  If you actively maintain a Zulip language binding
 and would like it to be listed here (or would like to collaborate with
 us in making it an official library), post in [this
 topic][integrations-thread] on
-[The Zulip developer community](https://zulip.com/developer-community/) or submit a pull request
-[updating this
-page](https://zulip.readthedocs.io/en/latest/documentation/api.html).
+[the Zulip developer community](https://zulip.com/developer-community/) or submit a pull request
+[updating this page](https://zulip.readthedocs.io/en/latest/documentation/api.html).
 
 [integrations-thread]: https://chat.zulip.org/#narrow/stream/127-integrations/topic/API.20client.20libraries/
 

--- a/templates/zerver/api/running-bots.md
+++ b/templates/zerver/api/running-bots.md
@@ -12,7 +12,7 @@ https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots).
 You'll need:
 
 * An account in a Zulip organization
-  (e.g. [chat.zulip.org](/developer-community/),
+  (e.g. [The Zulip developer community](https://zulip.com/developer-community/),
   `<yourSubdomain>.zulipchat.com`, or a Zulip organization on your own
   [development](https://zulip.readthedocs.io/en/latest/development/overview.html) or
   [production](https://zulip.readthedocs.io/en/latest/production/install.html) server).

--- a/templates/zerver/emails/find_team.source.html
+++ b/templates/zerver/emails/find_team.source.html
@@ -5,6 +5,8 @@
 {% endblock %}
 
 {% block content %}
+<p>{{ _("Thanks for your request!") }}</p>
+
 <p>{% trans %}Your email address {{ email }} has accounts with the following Zulip organizations hosted by <a href="{{ external_host }}">{{ external_host }}</a>:{% endtrans %}</p>
 
 <ul>

--- a/templates/zerver/emails/find_team.txt
+++ b/templates/zerver/emails/find_team.txt
@@ -1,3 +1,5 @@
+{{ _("Thanks for your request!") }}
+
 {% trans -%}
 Your email address {{ email }} has accounts with the following Zulip organizations hosted by {{ external_host }}:
 {%- endtrans %}

--- a/templates/zerver/for/communities.md
+++ b/templates/zerver/for/communities.md
@@ -116,8 +116,7 @@ Zulip’s topic-based threading model solves the problems described above:
 
 ## Try Zulip today!
 
-You can see Zulip in action in our own [chat.zulip.org
-community](/developer-community/), which sends
+You can see Zulip in action in [The Zulip developer community](https://zulip.com/developer-community/), which sends
 thousands of messages a week. We often get feedback from contributors
 around the world that they love how responsive Zulip’s project leaders
 are in public Zulip conversations. We are able to achieve this despite

--- a/templates/zerver/for/communities.md
+++ b/templates/zerver/for/communities.md
@@ -116,7 +116,7 @@ Zulip’s topic-based threading model solves the problems described above:
 
 ## Try Zulip today!
 
-You can see Zulip in action in [The Zulip developer community](https://zulip.com/developer-community/), which sends
+You can see Zulip in action in [the Zulip developer community](https://zulip.com/developer-community/), which sends
 thousands of messages a week. We often get feedback from contributors
 around the world that they love how responsive Zulip’s project leaders
 are in public Zulip conversations. We are able to achieve this despite

--- a/templates/zerver/help/contact-support.md
+++ b/templates/zerver/help/contact-support.md
@@ -3,7 +3,7 @@
 General and technical support for Zulip is available through three
 channels:
 
-* [chat.zulip.org][chat-zulip-org], the Zulip development community.
+* [The Zulip developer community](https://zulip.com/developer-community/).
   Depending on the time of day/week of your query and the complexity
   of your question, you may get complete responses immediately or up
   to a couple days later, but Zulip's threading makes it easy for us
@@ -17,7 +17,7 @@ channels:
   app](https://github.com/zulip/zulip-mobile/issues/new), [desktop
   app](https://github.com/zulip/zulip-desktop/issues/new). If you
   aren't able to provide a clear bug report or are otherwise
-  uncertain, it can be helpful to discuss in chat.zulip.org first to
+  uncertain, it can be helpful to discuss in [The Zulip developer community](https://zulip.com/developer-community/) first to
   help create a better GitHub issue.
 * We don't offer phone support except as part of enterprise contracts.
 

--- a/templates/zerver/help/contact-support.md
+++ b/templates/zerver/help/contact-support.md
@@ -3,7 +3,7 @@
 General and technical support for Zulip is available through three
 channels:
 
-* [The Zulip developer community](https://zulip.com/developer-community/).
+* [The Zulip developer community](https://zulip.developer-community/).
   Depending on the time of day/week of your query and the complexity
   of your question, you may get complete responses immediately or up
   to a couple days later, but Zulip's threading makes it easy for us
@@ -17,15 +17,15 @@ channels:
   app](https://github.com/zulip/zulip-mobile/issues/new), [desktop
   app](https://github.com/zulip/zulip-desktop/issues/new). If you
   aren't able to provide a clear bug report or are otherwise
-  uncertain, it can be helpful to discuss in [The Zulip developer community](https://zulip.com/developer-community/) first to
-  help create a better GitHub issue.
-* We don't offer phone support except as part of enterprise contracts.
+  uncertain, it can be helpful to discuss in 
+  [the Zulip developer community](https://zulip.com/developer-community/) first to help create a better GitHub issue.
+* We don't offer phone support except as part of enterprise    contracts.
 
 We love hearing feedback! Please reach out if you have feedback,
 questions, or just want to brainstorm how to make Zulip work for your
 organization.
 
-[chat-zulip-org]: /developer-community/
+[The Zulip developer community]: /developer-community/
 
 ## Billing and commercial questions
 

--- a/tools/provision
+++ b/tools/provision
@@ -1,4 +1,4 @@
-chat.zulip.org#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # Use this script to provision dependencies for your Zulip installation.
 # This script is idempotent, so it can be restarted at any time, and it

--- a/tools/provision
+++ b/tools/provision
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+chat.zulip.org#!/usr/bin/env bash
 
 # Use this script to provision dependencies for your Zulip installation.
 # This script is idempotent, so it can be restarted at any time, and it

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -29,7 +29,9 @@ def copy_default_settings(
     #
     # Note that this function will do at least one save() on target_profile.
     for settings_name in UserBaseSettings.property_types:
-        if settings_name == "default_language" and isinstance(settings_source, RealmUserDefault):
+        if settings_name in ["default_language", "enable_login_emails"] and isinstance(
+            settings_source, RealmUserDefault
+        ):
             continue
         value = getattr(settings_source, settings_name)
         setattr(target_profile, settings_name, value)

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -24,7 +24,7 @@ from zerver.lib.cache import (
     to_dict_cache_key_id,
 )
 from zerver.lib.display_recipient import bulk_fetch_display_recipients
-from zerver.lib.exceptions import JsonableError
+from zerver.lib.exceptions import JsonableError, MissingAuthenticationError
 from zerver.lib.markdown import MessageRenderingResult, markdown_convert, topic_links
 from zerver.lib.markdown import version as markdown_version
 from zerver.lib.mention import MentionData
@@ -33,6 +33,7 @@ from zerver.lib.stream_subscription import (
     get_subscribed_stream_recipient_ids_for_user,
     num_subscribers_for_stream_id,
 )
+from zerver.lib.streams import get_web_public_streams_queryset
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import DB_TOPIC_NAME, MESSAGE__TOPIC, TOPIC_LINKS, TOPIC_NAME
 from zerver.lib.topic_mutes import build_topic_mute_checker, topic_is_muted
@@ -707,6 +708,48 @@ def access_message(
     if has_message_access(user_profile, message, has_user_message=user_message is not None):
         return (message, user_message)
     raise JsonableError(_("Invalid message(s)"))
+
+
+def access_web_public_message(
+    realm: Realm,
+    message_id: int,
+) -> Message:
+    """Access control method for unauthenticated requests interacting
+    with a message in web public streams.
+    """
+
+    # We throw a MissingAuthenticationError for all errors in this
+    # code path, to avoid potentially leaking information on whether a
+    # message with the provided ID exists on the server if the client
+    # shouldn't have access to it.
+    if not realm.web_public_streams_enabled():
+        raise MissingAuthenticationError()
+
+    try:
+        message = Message.objects.select_related().get(id=message_id)
+    except Message.DoesNotExist:
+        raise MissingAuthenticationError()
+
+    if not message.is_stream_message():
+        raise MissingAuthenticationError()
+
+    queryset = get_web_public_streams_queryset(realm)
+    try:
+        stream = queryset.get(id=message.recipient.type_id)
+    except Stream.DoesNotExist:
+        raise MissingAuthenticationError()
+
+    # These should all have been enforced by the code in
+    # get_web_public_streams_queryset
+    assert stream.is_web_public
+    assert not stream.deactivated
+    assert not stream.invite_only
+    assert stream.history_public_to_subscribers
+
+    # Now that we've confirmed this message was sent to the target
+    # web-public stream, we can return it as having been successfully
+    # accessed.
+    return message
 
 
 def has_message_access(

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -399,15 +399,20 @@ def get_public_streams_queryset(realm: Realm) -> "QuerySet[Stream]":
 
 
 def get_web_public_streams_queryset(realm: Realm) -> "QuerySet[Stream]":
-    # In theory, is_web_public=True implies invite_only=False and
-    # history_public_to_subscribers=True, but it's safer to include
-    # this in the query.
+    # This should match the include_web_public code path in do_get_streams.
     return Stream.objects.filter(
         realm=realm,
+        is_web_public=True,
+        # In theory, nothing conflicts with allowing web-public access
+        # to deactivated streams.  However, we should offer a way to
+        # review archived streams and adjust their settings before
+        # allowing that configuration to exist.
         deactivated=False,
+        # In theory, is_web_public=True implies invite_only=False and
+        # history_public_to_subscribers=True, but it's safer to include
+        # these in the query.
         invite_only=False,
         history_public_to_subscribers=True,
-        is_web_public=True,
     )
 
 

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1329,7 +1329,7 @@ Output:
         # so mypy doesn't allow assigning lst.append to process_notification
         # So explicitly change parameter name to 'notice' to work around this problem
         with mock.patch(
-            "zerver.tornado.django_api.process_notification", lambda notice: lst.append(notice)
+            "zerver.tornado.event_queue.process_notification", lambda notice: lst.append(notice)
         ):
             # Some `send_event` calls need to be executed only after the current transaction
             # commits (using `on_commit` hooks). Because the transaction in Django tests never

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -582,15 +582,3 @@ def check_string_or_int(var_name: str, val: object) -> Union[str, int]:
         return val
 
     raise ValidationError(_("{var_name} is not a string or integer").format(var_name=var_name))
-
-
-def check_or(sub_validator1: Validator[Any], sub_validator2: Validator[Any]) -> Validator[Any]:
-    def f(var_name: str, val: object) -> Validator[Any]:
-        try:
-            return sub_validator1(var_name, val)
-        except ValidationError:
-            pass
-
-        return sub_validator2(var_name, val)
-
-    return f

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -874,7 +874,9 @@ class Realm(models.Model):
         if not self.web_public_streams_enabled():
             return False
 
-        return Stream.objects.filter(realm=self, is_web_public=True).exists()
+        from zerver.lib.streams import get_web_public_streams_queryset
+
+        return get_web_public_streams_queryset(self).exists()
 
 
 post_save.connect(flush_realm, sender=Realm)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7767,13 +7767,6 @@ paths:
           schema:
             type: boolean
           example: true
-        - name: enable_login_emails
-          in: query
-          description: |
-            Enable email notifications for new logins to account.
-          schema:
-            type: boolean
-          example: true
         - name: message_content_in_email_notifications
           in: query
           description: |

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -70,7 +70,6 @@ from zerver.lib.validator import (
     check_int_in,
     check_list,
     check_none_or,
-    check_or,
     check_short_string,
     check_string,
     check_string_fixed_length,
@@ -991,25 +990,6 @@ class ValidatorTestCase(ZulipTestCase):
         x = None
         with self.assertRaisesRegex(ValidationError, r"x is not a string or integer"):
             check_string_or_int("x", x)
-
-    def test_check_or(self) -> None:
-        x: Any = "valid"
-        check_or(check_string_in(["valid"]), check_url)("x", x)
-
-        x = "http://zulip-bots.example.com/"
-        check_or(check_string_in(["valid"]), check_url)("x", x)
-
-        x = "invalid"
-        with self.assertRaisesRegex(ValidationError, r"x is not a URL"):
-            check_or(check_string_in(["valid"]), check_url)("x", x)
-
-        x = "http://127.0.0"
-        with self.assertRaisesRegex(ValidationError, r"x is not a URL"):
-            check_or(check_string_in(["valid"]), check_url)("x", x)
-
-        x = 1
-        with self.assertRaisesRegex(ValidationError, r"x is not a string"):
-            check_or(check_string_in(["valid"]), check_url)("x", x)
 
 
 class DeactivatedRealmTest(ZulipTestCase):

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -913,7 +913,7 @@ class RealmAPITest(ZulipTestCase):
             # duplicate code. default_language is currently present in Realm table also and thus
             # is updated using '/realm' endpoint, but this will be removed in future and the
             # settings in RealmUserDefault table will be used.
-            if prop in ["default_language", "enable_marketing_emails"]:
+            if prop in ["default_language", "enable_login_emails", "enable_marketing_emails"]:
                 continue
             self.do_test_realm_default_setting_update_api(prop)
 

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -1,16 +1,18 @@
 import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import orjson
+from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError, transaction
 from django.http import HttpRequest, HttpResponse
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
+from zerver.context_processors import get_valid_realm_from_request
 from zerver.lib.actions import check_update_message, do_delete_messages
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.html_diff import highlight_html_differences
-from zerver.lib.message import access_message
+from zerver.lib.message import access_message, access_web_public_message
 from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_timestamp
@@ -168,8 +170,14 @@ def delete_message_backend(
 @has_request_variables
 def json_fetch_raw_message(
     request: HttpRequest,
-    user_profile: UserProfile,
+    maybe_user_profile: Union[UserProfile, AnonymousUser],
     message_id: int = REQ(converter=to_non_negative_int, path_only=True),
 ) -> HttpResponse:
-    (message, user_message) = access_message(user_profile, message_id)
+
+    if not maybe_user_profile.is_authenticated:
+        realm = get_valid_realm_from_request(request)
+        message = access_web_public_message(realm, message_id)
+    else:
+        (message, user_message) = access_message(maybe_user_profile, message_id)
+
     return json_success({"raw_content": message.content})

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -326,7 +326,8 @@ def update_realm_user_settings_defaults(
     ),
     enable_online_push_notifications: Optional[bool] = REQ(json_validator=check_bool, default=None),
     enable_digest_emails: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    enable_login_emails: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    # enable_login_emails is not included here, because we don't want
+    # security-related settings to be controlled by organization administrators.
     # enable_marketing_emails is not included here, since we don't at
     # present allow organizations to customize this. (The user's selection
     # in the signup form takes precedence over RealmUserDefault).

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -324,7 +324,7 @@ v1_api_and_json_patterns = [
     ),
     rest_path(
         "messages/<int:message_id>",
-        GET=json_fetch_raw_message,
+        GET=(json_fetch_raw_message, {"allow_anonymous_user_web"}),
         PATCH=update_message_backend,
         DELETE=delete_message_backend,
     ),


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is focused on changing chat.zulip.org to /developer-community wherever required.
Fixes: #19827

**Testing plan:** <!-- How have you tested? -->
Manually

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
