### PR TITLE
Revert "validator: Add generic check_or."

### DIFF
--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -582,15 +582,3 @@ def check_string_or_int(var_name: str, val: object) -> Union[str, int]:
         return val
 
     raise ValidationError(_("{var_name} is not a string or integer").format(var_name=var_name))
-
-
-def check_or(sub_validator1: Validator[Any], sub_validator2: Validator[Any]) -> Validator[Any]:
-    def f(var_name: str, val: object) -> Validator[Any]:
-        try:
-            return sub_validator1(var_name, val)
-        except ValidationError:
-            pass
-
-        return sub_validator2(var_name, val)
-
-    return f

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -70,7 +70,6 @@ from zerver.lib.validator import (
     check_int_in,
     check_list,
     check_none_or,
-    check_or,
     check_short_string,
     check_string,
     check_string_fixed_length,
@@ -991,25 +990,6 @@ class ValidatorTestCase(ZulipTestCase):
         x = None
         with self.assertRaisesRegex(ValidationError, r"x is not a string or integer"):
             check_string_or_int("x", x)
-
-    def test_check_or(self) -> None:
-        x: Any = "valid"
-        check_or(check_string_in(["valid"]), check_url)("x", x)
-
-        x = "http://zulip-bots.example.com/"
-        check_or(check_string_in(["valid"]), check_url)("x", x)
-
-        x = "invalid"
-        with self.assertRaisesRegex(ValidationError, r"x is not a URL"):
-            check_or(check_string_in(["valid"]), check_url)("x", x)
-
-        x = "http://127.0.0"
-        with self.assertRaisesRegex(ValidationError, r"x is not a URL"):
-            check_or(check_string_in(["valid"]), check_url)("x", x)
-
-        x = 1
-        with self.assertRaisesRegex(ValidationError, r"x is not a string"):
-            check_or(check_string_in(["valid"]), check_url)("x", x)
 
 
 class DeactivatedRealmTest(ZulipTestCase):


### PR DESCRIPTION
This reverts commit cd93d0967f0ddad61414fb8fff7445e4efcbd3a3.

This `check_or` is redundant with `check_union`; it gives a misleading error message for the non-matching case; and it has no type safety.

Cc @seiwailai @ligmitz.