### PR TITLE
Remove realm-level default of `enable_login_emails` setting.

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -62,12 +62,10 @@ function get_realm_level_notification_settings(options) {
         realm_user_settings_defaults,
     );
 
-    // We remove enable_marketing_emails setting from all_notification_settings, since there is no
-    // realm-level default of this setting.
-    all_notifications_settings.settings.other_email_settings = [
-        "enable_digest_emails",
-        "enable_login_emails",
-    ];
+    // We remove enable_marketing_emails and enable_login_emails
+    // setting from all_notification_settings, since there are no
+    // realm-level defaults for these setting.
+    all_notifications_settings.settings.other_email_settings = ["enable_digest_emails"];
 
     options.general_settings = all_notifications_settings.general_settings;
     options.notification_settings = all_notifications_settings.settings;

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -406,9 +406,6 @@ export const realm_user_settings_defaults_labels = {
         defaultMessage: "Send mobile notifications even if user is online (useful for testing)",
     }),
     enable_digest_emails: $t({defaultMessage: "Send digest emails when user is away"}),
-    enable_login_emails: $t({
-        defaultMessage: "Send email notifications for new logins to the account",
-    }),
 
     realm_presence_enabled: $t({defaultMessage: "Display availability to other users when online"}),
     realm_enter_sends: $t({defaultMessage: "Enter sends when composing a message"}),

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -78,7 +78,7 @@ export function set_up(settings_panel) {
             const data = {};
             data[setting] = JSON.stringify($(this).prop("checked"));
 
-            if (["left_side_userlist"].includes(setting)) {
+            if (["left_side_userlist"].includes(setting) && !for_realm_settings) {
                 change_display_setting(
                     data,
                     settings_panel,

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -46,7 +46,7 @@
         </table>
     </div>
 
-    <div class="desktop_notifications m-10 inline-block subsection-parent">
+    <div class="desktop_notifications m-10 subsection-parent">
 
         <h3 class="inline-block">{{t "Desktop message notifications" }}</h3>
         <div class="alert-notification"></div>
@@ -91,7 +91,7 @@
         </div>
     </div>
 
-    <div class="mobile_notifications m-10 inline-block subsection-parent">
+    <div class="mobile_notifications m-10 subsection-parent">
 
         <h3 class="inline-block">{{t "Mobile message notifications" }}</h3>
         <div class="alert-notification"></div>
@@ -106,7 +106,7 @@
         {{/each}}
     </div>
 
-    <div class="email_message_notifications m-10 inline-block subsection-parent">
+    <div class="email_message_notifications m-10 subsection-parent">
 
         <h3 class="inline-block">{{t "Email message notifications" }}</h3>
         <div class="alert-notification"></div>
@@ -132,7 +132,7 @@
         {{/each}}
     </div>
 
-    <div class="other_email_notifications m-10 inline-block subsection-parent">
+    <div class="other_email_notifications m-10 subsection-parent">
 
         <h3 class="inline-block">{{t "Other emails" }}</h3>
         <div class="alert-notification"></div>

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -29,7 +29,9 @@ def copy_default_settings(
     #
     # Note that this function will do at least one save() on target_profile.
     for settings_name in UserBaseSettings.property_types:
-        if settings_name == "default_language" and isinstance(settings_source, RealmUserDefault):
+        if settings_name in ["default_language", "enable_login_emails"] and isinstance(
+            settings_source, RealmUserDefault
+        ):
             continue
         value = getattr(settings_source, settings_name)
         setattr(target_profile, settings_name, value)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7767,13 +7767,6 @@ paths:
           schema:
             type: boolean
           example: true
-        - name: enable_login_emails
-          in: query
-          description: |
-            Enable email notifications for new logins to account.
-          schema:
-            type: boolean
-          example: true
         - name: message_content_in_email_notifications
           in: query
           description: |

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -913,7 +913,7 @@ class RealmAPITest(ZulipTestCase):
             # duplicate code. default_language is currently present in Realm table also and thus
             # is updated using '/realm' endpoint, but this will be removed in future and the
             # settings in RealmUserDefault table will be used.
-            if prop in ["default_language", "enable_marketing_emails"]:
+            if prop in ["default_language", "enable_login_emails", "enable_marketing_emails"]:
                 continue
             self.do_test_realm_default_setting_update_api(prop)
 

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -326,7 +326,8 @@ def update_realm_user_settings_defaults(
     ),
     enable_online_push_notifications: Optional[bool] = REQ(json_validator=check_bool, default=None),
     enable_digest_emails: Optional[bool] = REQ(json_validator=check_bool, default=None),
-    enable_login_emails: Optional[bool] = REQ(json_validator=check_bool, default=None),
+    # enable_login_emails is not included here, because we don't want
+    # security-related settings to be controlled by organization administrators.
     # enable_marketing_emails is not included here, since we don't at
     # present allow organizations to customize this. (The user's selection
     # in the signup form takes precedence over RealmUserDefault).


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit is a simple fix to not show reload message incorrectly.
- Second commit is a prep commit to fix `inline-block` used incorrectly. There is no change in UI due to this.
- Second commit is to remove realm-level default of `enable_login_emails` setting.
 <!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
