### PR TITLE
webhooks/stripe: Verify webhook signatures in incoming payloads.

### DIFF
--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -58,9 +58,9 @@ def api_stripe_webhook(
     sig_header = request.META["HTTP_STRIPE_SIGNATURE"]
     try:
         stripe.Webhook.construct_event(request.body, sig_header, get_secret("stripe_api_endpoint"))
-    except ValueError as e:
+    except ValueError:
         return HttpResponse(status=400)
-    except stripe.error.SignatureVerificationError as e:
+    except stripe.error.SignatureVerificationError:
         return HttpResponse(status=400)
 
     try:


### PR DESCRIPTION
Solves issue #19774

**Testing plan:**
I have used stripe cli tool for testing by sending test payloads. 
I implemented the code before it assigns the `topic` and `body` from the payload. It would first check the `HTTP_STRIPE_SIGNATURE` from the request and check it with the `stripe.Webhook.construct_event`. If the signatures are not verified it would return status code `400`  else  it  would  return  `200` status code 