### PR TITLE
markdown/tabbed_sections: Raise exception for missing tab name.

### DIFF
--- a/templates/zerver/tests/markdown/test_tabbed_sections_missing_tabs.md
+++ b/templates/zerver/tests/markdown/test_tabbed_sections_missing_tabs.md
@@ -1,0 +1,11 @@
+# Heading
+
+{start_tabs}
+{tab|ios}
+iOS instructions
+
+{tab|minix}
+
+Minix instructions. We expect an exception because the minix tab doesn't have a declared label.
+
+{end_tabs}

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -38,7 +38,7 @@ DIV_TAB_CONTENT_TEMPLATE = """
 
 # If adding new entries here, also check if you need to update
 # tabbed-instructions.js
-TAB_DISPLAY_NAMES = {
+TAB_SECTION_LABELS = {
     "desktop-web": "Desktop/Web",
     "ios": "iOS",
     "android": "Android",
@@ -138,7 +138,7 @@ class TabbedSectionsPreprocessor(Preprocessor):
         li_elements = []
         for tab in tab_section["tabs"]:
             li = NAV_LIST_ITEM_TEMPLATE.format(
-                data_language=tab.get("tab_name"), name=TAB_DISPLAY_NAMES.get(tab.get("tab_name"))
+                data_language=tab.get("tab_name"), name=TAB_SECTION_LABELS.get(tab.get("tab_name"))
             )
             li_elements.append(li)
         return NAV_BAR_TEMPLATE.format(tabs="\n".join(li_elements))

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -73,6 +73,7 @@ TAB_SECTION_LABELS = {
     "not-stream": "From other views",
     "via-recent-topics": "Via recent topics",
     "via-left-sidebar": "Via left sidebar",
+    "instructions-for-all-platforms": "Instructions for all platforms",
 }
 
 
@@ -97,7 +98,10 @@ class TabbedSectionsPreprocessor(Preprocessor):
             else:
                 tab_class = "no-tabs"
                 tab_section["tabs"] = [
-                    {"tab_name": "null_tab", "start": tab_section["start_tabs_index"]}
+                    {
+                        "tab_name": "instructions-for-all-platforms",
+                        "start": tab_section["start_tabs_index"],
+                    }
                 ]
             nav_bar = self.generate_nav_bar(tab_section)
             content_blocks = self.generate_content_blocks(tab_section, lines)

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -27,7 +27,7 @@ NAV_BAR_TEMPLATE = """
 """.strip()
 
 NAV_LIST_ITEM_TEMPLATE = """
-<li data-language="{data_language}" tabindex="0">{name}</li>
+<li data-language="{data_language}" tabindex="0">{label}</li>
 """.strip()
 
 DIV_TAB_CONTENT_TEMPLATE = """
@@ -141,10 +141,16 @@ class TabbedSectionsPreprocessor(Preprocessor):
     def generate_nav_bar(self, tab_section: Dict[str, Any]) -> str:
         li_elements = []
         for tab in tab_section["tabs"]:
-            li = NAV_LIST_ITEM_TEMPLATE.format(
-                data_language=tab.get("tab_name"), name=TAB_SECTION_LABELS.get(tab.get("tab_name"))
-            )
+            tab_name = tab.get("tab_name")
+            tab_label = TAB_SECTION_LABELS.get(tab_name)
+            if tab_label is None:
+                raise ValueError(
+                    f"Tab '{tab_name}' is not present in TAB_SECTION_LABELS in zerver/lib/markdown/tabbed_sections.py"
+                )
+
+            li = NAV_LIST_ITEM_TEMPLATE.format(data_language=tab_name, label=tab_label)
             li_elements.append(li)
+
         return NAV_BAR_TEMPLATE.format(tabs="\n".join(li_elements))
 
     def parse_tabs(self, lines: List[str]) -> Optional[Dict[str, Any]]:

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -76,10 +76,10 @@ header
 <p>
   <div class="code-section no-tabs" markdown="1">
     <ul class="nav">
-      <li data-language="null_tab" tabindex="0">None</li>
+      <li data-language="instructions-for-all-platforms" tabindex="0">Instructions for all platforms</li>
     </ul>
     <div class="blocks">
-      <div data-language="null_tab" markdown="1"></p>
+      <div data-language="instructions-for-all-platforms" markdown="1"></p>
         <p>Instructions for all platforms</p>
       <p></div>
     </div>

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -92,6 +92,15 @@ footer
         expected_html_sans_whitespace = expected_html.replace(" ", "").replace("\n", "")
         self.assertEqual(content_sans_whitespace, expected_html_sans_whitespace)
 
+    def test_markdown_tabbed_sections_missing_tabs(self) -> None:
+        template = get_template("tests/test_markdown.html")
+        context = {
+            "markdown_test_file": "zerver/tests/markdown/test_tabbed_sections_missing_tabs.md",
+        }
+        expected_regex = "^Tab 'minix' is not present in TAB_SECTION_LABELS in zerver/lib/markdown/tabbed_sections.py$"
+        with self.assertRaisesRegex(ValueError, expected_regex):
+            template.render(context)
+
     def test_markdown_nested_code_blocks(self) -> None:
         template = get_template("tests/test_markdown.html")
         context = {


### PR DESCRIPTION
- Have checked that ./tools/test-help-documentation failed after reverting  #19807 

- In case of a tab_section with no tabs, currently a single tab with the name 'null_tab' gets added. Have added the display name 'None' for 'null_tab', to keep in line with the existing behavior.

Fixes #19822 
