### PR TITLE
settings: Fix bug of empty subsection heading being visible.

### DIFF
--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -65,10 +65,21 @@ function update_desktop_icon_count_display(settings_panel) {
     }
 }
 
-export function set_enable_digest_emails_visibility(container) {
+export function set_enable_digest_emails_visibility(settings_panel) {
+    const container = $(settings_panel.container);
+    const for_realm_settings = settings_panel.for_realm_settings;
+
     if (page_params.realm_digest_emails_enabled) {
+        if (for_realm_settings) {
+            container.find(".other_email_notifications").show();
+            return;
+        }
         container.find(".enable_digest_emails_label").parent().show();
     } else {
+        if (for_realm_settings) {
+            container.find(".other_email_notifications").hide();
+            return;
+        }
         container.find(".enable_digest_emails_label").parent().hide();
     }
 }
@@ -145,7 +156,7 @@ export function set_up(settings_panel) {
         settings_object.email_notifications_batching_period_seconds,
     );
 
-    set_enable_digest_emails_visibility(container);
+    set_enable_digest_emails_visibility(settings_panel);
     if (!for_realm_settings) {
         set_enable_marketing_emails_visibility();
         rerender_ui();

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -18,6 +18,7 @@ import * as realm_icon from "./realm_icon";
 import * as realm_logo from "./realm_logo";
 import * as settings_config from "./settings_config";
 import * as settings_notifications from "./settings_notifications";
+import * as settings_realm_user_settings_defaults from "./settings_realm_user_settings_defaults";
 import * as settings_ui from "./settings_ui";
 import * as stream_settings_data from "./stream_settings_data";
 import * as ui_report from "./ui_report";
@@ -378,10 +379,10 @@ function update_dependent_subsettings(property_name) {
             break;
         case "realm_digest_emails_enabled":
             settings_notifications.set_enable_digest_emails_visibility(
-                $("#user-notification-settings"),
+                settings_notifications.user_settings_panel,
             );
             settings_notifications.set_enable_digest_emails_visibility(
-                $("#realm-user-default-settings"),
+                settings_realm_user_settings_defaults.realm_default_settings_panel,
             );
             set_digest_emails_weekday_visibility();
             break;


### PR DESCRIPTION
We should also hide the 'Other emails' heading in realm-level
defaults section when digest emails organization setting is
disabled because there is no other setting in this subsection
after we removed the enable_login_emails setting in d1732fb.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![digest-subsection](https://user-images.githubusercontent.com/35494118/135436064-e0b123ca-a7d4-45ca-9c2f-8d84a28dbd52.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
