### PR TITLE
github: Ignore CodeQL analysis in private repos.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   CodeQL:
+    if: ${{!github.event.repository.private}}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
CodeQL only runs in public repos; private forks will otherwise error
their CI runs.
