### PR TITLE
copy_code_button: Attach tooltip to body to avoid overlap with parent.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -178,7 +178,7 @@ export function initialize() {
     });
 
     delegate("body", {
-        target: ".rendered_markdown time",
+        target: [".rendered_markdown time", ".rendered_markdown .copy_codeblock"],
         allowHTML: true,
         appendTo: () => document.body,
         onHidden(instance) {

--- a/static/templates/copy_code_button.hbs
+++ b/static/templates/copy_code_button.hbs
@@ -1,3 +1,3 @@
-<button class="btn pull-left copy_button_base copy_codeblock tippy-zulip-tooltip" data-tippy-content="{{t 'Copy code' }}" aria-label="{{t 'Copy code' }}">
+<button class="btn pull-left copy_button_base copy_codeblock" data-tippy-content="{{t 'Copy code' }}" aria-label="{{t 'Copy code' }}">
     {{> copy_to_clipboard_svg }}
 </button>


### PR DESCRIPTION
Having tooltip `appendTo` to parent causes it to be trimmed by
the size of parent container if the parent doesn't have enough
size to include the tooltip. To fix this, we append tooltip
to `document.body`.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Issue.20with.20code.20snippet.20.20-.20web

Fixed:
<img width="477" alt="Screenshot 2021-10-01 at 7 20 05 AM" src="https://user-images.githubusercontent.com/25124304/135553261-c4c294bd-07db-4843-9ac9-57cdcae742fe.png">

