### PR TITLE
topics: Fix translation issue with moved topic notifications.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -35,6 +35,7 @@ from django.db.models.query import QuerySet
 from django.utils.html import escape
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 from django.utils.translation import override as override_language
 from psycopg2.extras import execute_values
 from psycopg2.sql import SQL
@@ -6489,11 +6490,13 @@ def do_update_message(
         # Notify users that the topic was moved.
         old_thread_notification_string = None
         if send_notification_to_old_thread:
-            old_thread_notification_string = _("This topic was moved by {user} to {new_location}")
+            old_thread_notification_string = gettext_lazy(
+                "This topic was moved by {user} to {new_location}"
+            )
 
         new_thread_notification_string = None
         if send_notification_to_new_thread:
-            new_thread_notification_string = _(
+            new_thread_notification_string = gettext_lazy(
                 "This topic was moved here from {old_location} by {user}"
             )
 

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -2049,6 +2049,10 @@ class EditMessageTest(EditMessageTestCase):
     def test_mark_topic_as_resolved(self) -> None:
         self.login("iago")
         admin_user = self.example_user("iago")
+        # Set the user's translation language to German to test that
+        # it is overridden by the realm's default language.
+        admin_user.default_language = "de"
+        admin_user.save()
         stream = self.make_stream("new")
         self.subscribe(admin_user, stream.name)
         original_topic = "topic 1"
@@ -2077,6 +2081,7 @@ class EditMessageTest(EditMessageTestCase):
                 "topic": resolved_topic,
                 "propagate_mode": "change_all",
             },
+            HTTP_ACCEPT_LANGUAGE="de",
         )
 
         self.assert_json_success(result)


### PR DESCRIPTION
Since the calls to the translation function `_()` are made outside of the `send_message_moved_breadcrumbs` function, these calls are thus outside of the `with override_language` block and are translated incorrectly.

This commit refactors the function to make sure that the translation happens in the right block of code.

@timabbott FYI :)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
