### PR TITLE
search_icon: Polish hover effects.

### DIFF
--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -93,7 +93,7 @@ function bind_title_area_handlers() {
         e.stopPropagation();
     });
 
-    $("#message_view_header span:nth-last-child(2)").on("click", (e) => {
+    $("#message_view_header .navbar-click-opens-search").on("click", (e) => {
         if (document.getSelection().type === "Range") {
             // Allow copy/paste to work normally without interference.
             return;

--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -111,10 +111,10 @@ function bind_title_area_handlers() {
     // with whether search is being opened or not.
     $("#message_view_header .narrow_description > a")
         .on("mouseenter", () => {
-            $("#message_view_header .search_closed").addClass("search_icon_hover_highlight");
+            $("#message_view_header .search_closed").css("opacity", 0.5);
         })
         .on("mouseleave", () => {
-            $("#message_view_header .search_closed").removeClass("search_icon_hover_highlight");
+            $("#message_view_header .search_closed").css("opacity", "");
         });
 }
 

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -419,9 +419,7 @@ body.night-mode {
     .clear_search_button:active,
     .clear_search_button:disabled:hover,
     #user-groups .save-instructions,
-    #searchbox_legacy .search_icon,
     #searchbox_legacy .search_button,
-    #searchbox .search_icon,
     #searchbox .search_button,
     .close,
     #user_presences li:hover .user-list-sidebar-menu-icon,
@@ -436,9 +434,7 @@ body.night-mode {
     .collapse_composebox_button:hover,
     #message_edit_tooltip:hover,
     .clear_search_button:hover,
-    #searchbox_legacy .search_icon:hover,
     #searchbox_legacy .search_button:hover,
-    #searchbox .search_icon:hover,
     #searchbox .search_button:hover,
     .close:hover {
         color: hsl(0, 0%, 100%);

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -341,10 +341,6 @@ body.night-mode {
         }
     }
 
-    #message_view_header .navbar-click-opens-search:hover + .search_closed {
-        color: hsl(0, 0%, 100%);
-    }
-
     #message_view_header .stream {
         color: hsl(236, 33%, 90%);
     }
@@ -423,7 +419,6 @@ body.night-mode {
     .clear_search_button:active,
     .clear_search_button:disabled:hover,
     #user-groups .save-instructions,
-    #message_view_header .search_icon,
     #searchbox_legacy .search_icon,
     #searchbox_legacy .search_button,
     #searchbox .search_icon,
@@ -441,7 +436,6 @@ body.night-mode {
     .collapse_composebox_button:hover,
     #message_edit_tooltip:hover,
     .clear_search_button:hover,
-    #message_view_header .search_icon:hover,
     .search_icon_hover_highlight,
     #searchbox_legacy .search_icon:hover,
     #searchbox_legacy .search_button:hover,

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -419,8 +419,6 @@ body.night-mode {
     .clear_search_button:active,
     .clear_search_button:disabled:hover,
     #user-groups .save-instructions,
-    #searchbox_legacy .search_button,
-    #searchbox .search_button,
     .close,
     #user_presences li:hover .user-list-sidebar-menu-icon,
     li.top_left_all_messages:hover .all-messages-sidebar-menu-icon,
@@ -434,8 +432,6 @@ body.night-mode {
     .collapse_composebox_button:hover,
     #message_edit_tooltip:hover,
     .clear_search_button:hover,
-    #searchbox_legacy .search_button:hover,
-    #searchbox .search_button:hover,
     .close:hover {
         color: hsl(0, 0%, 100%);
     }

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -436,7 +436,6 @@ body.night-mode {
     .collapse_composebox_button:hover,
     #message_edit_tooltip:hover,
     .clear_search_button:hover,
-    .search_icon_hover_highlight,
     #searchbox_legacy .search_icon:hover,
     #searchbox_legacy .search_button:hover,
     #searchbox .search_icon:hover,

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -341,7 +341,7 @@ body.night-mode {
         }
     }
 
-    #message_view_header span:nth-last-child(2):hover + .search_closed {
+    #message_view_header .navbar-click-opens-search:hover + .search_closed {
         color: hsl(0, 0%, 100%);
     }
 

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -199,6 +199,12 @@
             cursor: pointer;
         }
     }
+
+    /* hovering over the userlist-header creates the same highlight effect as hovering over the user_filter_icon */
+    &:hover > #user_filter_icon {
+        opacity: 1;
+        cursor: pointer;
+    }
 }
 
 #keyboard-icon {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1905,7 +1905,8 @@ div.focused_table {
         height: 30px;
         text-align: center;
         padding: 4px;
-        color: hsl(0, 0%, 80%);
+        color: inherit;
+        opacity: 0.5;
         font-size: 18px;
         box-shadow: none;
         text-shadow: none;
@@ -1913,7 +1914,7 @@ div.focused_table {
     }
 
     .search_button:hover {
-        color: hsl(0, 0%, 0%);
+        opacity: 1;
     }
 
     .search_button:disabled {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1923,17 +1923,11 @@ div.focused_table {
     .search_icon {
         position: absolute;
         height: 100%;
-        color: hsl(0, 0%, 80%);
         text-decoration: none;
         padding: 0 10px;
         font-size: 20px;
         z-index: 5;
         left: 0;
-    }
-
-    .search_icon:hover {
-        color: hsl(0, 0%, 0%);
-        text-decoration: none;
     }
 
     #search_arrows {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1831,7 +1831,7 @@ div.focused_table {
         /* Provide the visual cue that clicking this will work as expected. */
         cursor: pointer;
         &:hover + .search_closed {
-            color: hsl(0, 0%, 0%);
+            opacity: 1;
         }
     }
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1931,7 +1931,6 @@ div.focused_table {
         left: 0;
     }
 
-    .search_icon_hover_highlight,
     .search_icon:hover {
         color: hsl(0, 0%, 0%);
         text-decoration: none;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds polish to the hover effects on search_icons and makes minor refactors.
These can be considered prep commits for implementing the message_view_header  extended description.
The last commit here improves the hover effect on the right sidebar, addressing half of what is leftover in #14931, the remaining would need to be done in a separate PR.

**Testing plan:** <!-- How have you tested? -->
Manually tested, GIFs attached.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before - Day mode:
![](https://user-images.githubusercontent.com/33805964/136176948-e6efd2c8-1eac-4c95-bc10-2c468e831fe5.gif)

Before - Night mode:
![](https://user-images.githubusercontent.com/33805964/136178263-4263dbf0-b29e-4829-8a8e-4bc3ea107504.gif)


After - Day mode:
![](https://user-images.githubusercontent.com/33805964/136179254-8b75336e-7479-4b92-8332-3d6c60c269b7.gif)

After - Night mode:
![](https://user-images.githubusercontent.com/33805964/136179755-4492d3ea-d317-46ef-954b-070b9baecd67.gif)


There is an almost unnoticeable difference (#7b818e vs #7f8694) between the color of the icons when the search bar is open in night mode, probably caused by the darker background of the search bar interacting with the 0.5 opacity.
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
