### PR TITLE
email_mirror: Add subject to message body when its too long.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -153,6 +153,10 @@ def truncate_topic(topic: str) -> str:
     return truncate_content(topic, MAX_TOPIC_NAME_LENGTH, "...")
 
 
+def prepend_topic_to_content(topic: str, content: str) -> str:
+    return f"Subject: {topic}\n{content}"
+
+
 def messages_for_ids(
     message_ids: List[int],
     user_message_flags: Dict[int, List[str]],


### PR DESCRIPTION
When the length of the email subject exceeds MAX_TOPIC_NAME_LENGTH,
the topic name for the the message gets truncated. This prepends the
full subject of the email to the zulip message body in such cases,
given that the message being sent is the first one under the topic.
Fixes #10539 

**Testing plan:** <!-- How have you tested? -->
Added a unit test for it. The fix would be manually tested after deployment.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
