### PR TITLE
user docs: Document public vs. private stream creation permissions.

### DIFF
--- a/templates/zerver/help/configure-who-can-create-streams.md
+++ b/templates/zerver/help/configure-who-can-create-streams.md
@@ -2,25 +2,35 @@
 
 {!admin-only.md!}
 
-By default, anyone other than guests can create new streams. However, you can restrict stream
-creation to:
+Zulip allows you to separately control permissions for creating public and private streams.
+You can restrict stream creation to:
 
 * Organization administrators
 * Organization administrators and moderators
-* Organization administrators and all members
 * Organization administrators and [full members](/help/restrict-permissions-of-new-members)
+* Organization administrators and all members
 
 For corporations and other entities with controlled access, we highly
-recommend keeping stream creation open. A typical Zulip organization with
-heavy use has as many streams as users.
+recommend keeping stream creation open. Open organizations may choose to be
+less permissive, especially with public streams.
 
 ### Manage who can create streams
 
 {start_tabs}
 
+{tab|public-streams}
+
 {settings_tab|organization-permissions}
 
-2. Under **Stream permissions**, configure **Who can create streams**.
+2. Under **Stream permissions**, configure **Who can create public streams**.
+
+{!save-changes.md!}
+
+{tab|private-streams}
+
+{settings_tab|organization-permissions}
+
+2. Under **Stream permissions**, configure **Who can create private streams**.
 
 {!save-changes.md!}
 

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -74,6 +74,8 @@ TAB_SECTION_LABELS = {
     "via-recent-topics": "Via recent topics",
     "via-left-sidebar": "Via left sidebar",
     "instructions-for-all-platforms": "Instructions for all platforms",
+    "public-streams": "Public streams",
+    "private-streams": "Private streams",
 }
 
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Follow-up to #17066.

**Testing plan:** <!-- How have you tested? -->
Manual

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<img width="832" alt="Screen Shot 2021-10-06 at 3 25 41 PM" src="https://user-images.githubusercontent.com/2090066/136292130-9b0e79b8-c68c-4193-a60a-25711aa470a6.png">

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
