### PR TITLE
portico: Reduce header font size to 11px on small screens.

### DIFF
--- a/static/js/portico/header.js
+++ b/static/js/portico/header.js
@@ -46,4 +46,14 @@ $(() => {
             $this.closest("ul .dropdown").removeClass("show");
         }
     });
+
+    $("body").on("click", ".hamburger-portico, .cross-portico", (e) => {
+        // Having a class which only works on mobile widths avoids it from still working when user resizes the window.
+        $(".portico-header .top-links .portico_nav_dropdown").toggleClass("show_mobile");
+        $(".portico-header .top-links .cross-portico").toggleClass("show_mobile");
+        $(".portico-header .top-links .hamburger-portico").toggleClass("hide_mobile");
+
+        e.preventDefault();
+        e.stopPropagation();
+    });
 });

--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -242,9 +242,9 @@ nav {
 
     .hamburger {
         display: none;
-        fill: hsl(0, 0%, 100%);
         cursor: pointer;
         margin-top: 3px;
+        font-size: 30px;
     }
 
     .content {

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -1790,3 +1790,67 @@ label.label-title {
         text-decoration: underline;
     }
 }
+
+.portico-header {
+    padding: 15px 0;
+
+    .hamburger-portico {
+        display: none;
+        cursor: pointer;
+        font-size: 25px;
+    }
+
+    .portico_nav_dropdown {
+        display: inline-block;
+        li {
+            display: inline;
+            list-style: none;
+        }
+    }
+
+    .cross-portico {
+        display: none;
+        font-size: 20px;
+        color: hsl(0, 0%, 27%);
+        cursor: pointer;
+    }
+
+    @media (width <= 768px) {
+        .show_mobile {
+            display: block !important;
+        }
+
+        .hide_mobile {
+            display: none !important;
+        }
+
+        .hamburger-portico {
+            display: inline-block;
+        }
+
+        .top-links .portico_nav_dropdown {
+            display: none;
+            list-style: none;
+            background: hsl(43, 30%, 95%);
+            width: 100vw;
+            position: absolute;
+            left: 0;
+            top: 43px;
+            margin: 0;
+            text-align: center;
+            box-shadow: 0 2px 4px 0 hsla(0, 0%, 0%, 0.1);
+
+            li {
+                display: block;
+                margin: 5px 0;
+                text-align: center;
+
+                a {
+                    padding: 5px;
+                    width: 100%;
+                }
+            }
+        }
+
+    }
+}

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -980,7 +980,7 @@ input#terminal:checked ~ #tab-terminal {
     color: hsl(207, 89%, 54%);
 }
 
-.login-page {
+.login-page.new-style {
     text-align: center;
 
     .alert {
@@ -989,6 +989,21 @@ input#terminal:checked ~ #tab-terminal {
         margin-top: -30px;
         margin-bottom: 15px;
         text-align: center;
+    }
+
+    @media (width <= 425px) {
+        .white-box {
+            width: calc(100% - 80px);
+
+            .form-inline {
+                width: 280px;
+            }
+        }
+
+        button.full-width,
+        button.login-social-button {
+            width: 280px;
+        }
     }
 }
 
@@ -1016,6 +1031,10 @@ input.new-organization-button {
     /* plus input padding. */
     width: calc(300px - -28px);
     margin-bottom: 10px;
+
+    @media (width <= 425px) {
+        width: 280px;
+    }
 
     .direct-label {
         margin-top: 50px;
@@ -1791,7 +1810,7 @@ label.label-title {
     }
 }
 
-.portico-header {
+.header.portico-header {
     padding: 15px 0;
 
     .hamburger-portico {
@@ -1802,6 +1821,7 @@ label.label-title {
 
     .portico_nav_dropdown {
         display: inline-block;
+
         li {
             display: inline;
             list-style: none;
@@ -1851,6 +1871,5 @@ label.label-title {
                 }
             }
         }
-
     }
 }

--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -18,6 +18,12 @@ html {
 .white-box {
     position: relative;
     padding: 30px;
+
+    @media (width <= 768px) {
+        padding: 30px 20px;
+    }
+
+    margin: auto;
     min-width: 0;
 
     background-color: hsl(0, 0%, 100%);
@@ -468,6 +474,10 @@ html {
             &:focus {
                 border: 1px solid hsl(0, 0%, 53%);
             }
+
+            @media (width <= 425px) {
+                padding: 10px 0 10px 12px;
+            }
         }
 
         input[type="email"] {
@@ -549,11 +559,16 @@ html {
     }
 
     .lead {
+        padding-top: 50px;
         margin: 0;
     }
 
     .inline-block {
         text-align: left;
+
+        @media (width <= 425px) {
+            text-align: center;
+        }
     }
 
     .contact-admin p.invite-hint {
@@ -1220,7 +1235,6 @@ button#register_auth_button_gitlab {
     .app-main.goto-account-page-container,
     .app-main.forgot-password-container {
         display: inline-block;
-        padding: 20px;
         width: calc(100% - 40px);
     }
 

--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -163,6 +163,6 @@
         </ul>
         <div class="clear-float"></div>
     </div>
-    <svg height="32px" class="hamburger" style="enable-background:new 0 0 32 32;" version="1.1" viewBox="0 0 32 32" width="32px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M4,10h24c1.104,0,2-0.896,2-2s-0.896-2-2-2H4C2.896,6,2,6.896,2,8S2.896,10,4,10z M28,14H4c-1.104,0-2,0.896-2,2  s0.896,2,2,2h24c1.104,0,2-0.896,2-2S29.104,14,28,14z M28,22H4c-1.104,0-2,0.896-2,2s0.896,2,2,2h24c1.104,0,2-0.896,2-2  S29.104,22,28,22z"/></svg>
+    <i class="fa fa-bars hamburger"></i>
 </nav>
 {% endif %}

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -25,30 +25,47 @@
         </div>
 
         <div class="float-right top-links">
-            {% if user_is_authenticated %}
-                {% include 'zerver/portico-header-dropdown.html' %}
-            {% else %}
-                {% if login_link_disabled %}
-                {% elif not only_sso %}
-                <a href="{{login_url}}">{{ _('Log in') }}</a>
-                {% endif %}
-            {% endif %}
+            <i class="fa fa-bars hamburger-portico"></i>
+            <div class="cross-portico"><i class="fa fa-remove"></i></div>
 
-            {% if register_link_disabled %}
-            {% elif only_sso %}
-                <a href="{{ url('login-sso') }}">{{ _('Log in') }}</a>
-            {% else %}
+            <ul class="portico_nav_dropdown">
                 {% if user_is_authenticated %}
+                    <li>
+                        {% include 'zerver/portico-header-dropdown.html' %}
+                    </li>
                 {% else %}
-                <a href="{{ url('register') }}">{{ _('Sign up') }}</a>
+                    {% if login_link_disabled %}
+                    {% elif not only_sso %}
+                    <li>
+                        <a href="{{login_url}}">{{ _('Log in') }}</a>
+                    </li>
+                    {% endif %}
                 {% endif %}
-            {% endif %}
 
-            {% if find_team_link_disabled %}
-            {% else %}
-            <a href="{{ root_domain_uri }}/accounts/find/">Find accounts</a>
-            <a href="{{ root_domain_uri }}/new">New organization</a>
-            {% endif %}
+                {% if register_link_disabled %}
+                {% elif only_sso %}
+                    <li>
+                        <a href="{{ url('login-sso') }}">{{ _('Log in') }}</a>
+                    </li>
+                {% else %}
+                    {% if user_is_authenticated %}
+                    {% else %}
+                    <li>
+                        <a href="{{ url('register') }}">{{ _('Sign up') }}</a>
+                    </li>
+                    {% endif %}
+                {% endif %}
+
+                {% if find_team_link_disabled %}
+                {% else %}
+                <li>
+                    <a href="{{ root_domain_uri }}/accounts/find/">Find accounts</a>
+                </li>
+                <li>
+                    <a href="{{ root_domain_uri }}/new">New organization</a>
+                </li>
+                {% endif %}
+            </ul>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This allows us fit the navbar links in the header, which avoids
them overflowing into next line.

The numbers were calculated on a hit and trial basis.
