### PR TITLE
Add WSGIApplicationGroup config to Apache SSO example

### DIFF
--- a/puppet/zulip/files/apache/sites/zulip-sso.example
+++ b/puppet/zulip/files/apache/sites/zulip-sso.example
@@ -38,6 +38,7 @@ Listen 127.0.0.1:8888
 	WSGIScriptAlias / /home/zulip/deployments/current/zproject/wsgi.py
 	WSGIDaemonProcess zulip threads=5 user=zulip python-path=/home/zulip/deployments/current/
 	WSGIProcessGroup zulip
+	WSGIApplicationGroup %{GLOBAL}
 
 	ErrorLog ${APACHE_LOG_DIR}/zulip_auth_error.log
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This PR "fixes" issue https://github.com/zulip/zulip/issues/19924


**Testing plan:** <!-- How have you tested? -->

Since the Apache SSO is not deployed automatically but by hand automated testing not necessary/possible.

Change was tested on our prod instance since login was broken.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
