### PR TITLE
Slack import: Use Python ZipFile to unzip.

### DIFF
--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -4,6 +4,7 @@ import random
 import secrets
 import shutil
 import subprocess
+import zipfile
 from collections import defaultdict
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Type, TypeVar
 
@@ -1290,7 +1291,8 @@ def do_convert_data(original_path: str, output_dir: str, token: str, threads: in
         if not os.path.exists(slack_data_dir):
             os.makedirs(slack_data_dir)
 
-        subprocess.check_call(["unzip", "-q", original_path, "-d", slack_data_dir])
+        with zipfile.ZipFile(original_path) as zipObj:
+            zipObj.extractall(slack_data_dir)
     elif os.path.isdir(original_path):
         slack_data_dir = original_path
     else:


### PR DESCRIPTION
This should handle the case when non-ASCII Unicode folder names are
created on Windows.

Fixes #19899.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
