### PR TITLE
drafts: Fix buggy "Saved as draft" notice flashing on send.

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -156,7 +156,8 @@ function draft_notify() {
     setTimeout(remove_instance, 1500);
 }
 
-export function update_draft() {
+export function update_draft(opts = {}) {
+    const no_notify = opts.no_notify || false;
     const draft = snapshot_message();
 
     if (draft === undefined) {
@@ -174,7 +175,9 @@ export function update_draft() {
         // We don't save multiple drafts of the same message;
         // just update the existing draft.
         draft_model.editDraft(draft_id, draft);
-        draft_notify();
+        if (!no_notify) {
+            draft_notify();
+        }
         return draft_id;
     }
 
@@ -182,7 +185,9 @@ export function update_draft() {
     // one.
     const new_draft_id = draft_model.addDraft(draft);
     $("#compose-textarea").data("draft-id", new_draft_id);
-    draft_notify();
+    if (!no_notify) {
+        draft_notify();
+    }
 
     return new_draft_id;
 }

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -237,9 +237,12 @@ export function try_deliver_locally(message_request) {
         return undefined;
     }
 
-    // Only saving in draft for locally echoed message
-    // This draft will be cleared after successfull message
-    const draft_id = drafts.update_draft();
+    // Save a locally echoed message in drafts, so it cannot be
+    // lost. It will be cleared if the message is sent successfully.
+    // We ask the drafts system to not notify the user, since they'd
+    // be quite distracting in the very common case that the message
+    // sends normally.
+    const draft_id = drafts.update_draft({no_notify: true});
     message_request.draft_id = draft_id;
 
     // Now that we've committed to delivering the message locally, we


### PR DESCRIPTION
This fixes a bug introduced in
459ce92109fb6f06008d71c8a94b480ad1e58286, where "Saved as draft" would
flicker every time you send a message that was locally echoed.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
