### PR TITLE
landing_page: Fix overflowing text on firefox in plans container.

### DIFF
--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -2836,6 +2836,7 @@ nav {
     color: hsl(0, 0%, 53%);
 
     text-align: left;
+    white-space: nowrap;
 }
 
 .pricing-model .pricing-container .bottom .button {


### PR DESCRIPTION
This usually happens due to different defaults set by
different browsers for certain properties.
after:
![before](https://user-images.githubusercontent.com/25124304/136601370-6c7e7bb1-04dd-4e6a-ba66-6e6f862ee6f0.png)
before:
![after](https://user-images.githubusercontent.com/25124304/136601397-18baa488-0577-461c-8364-8cd83c9f395f.png)
