### PR TITLE
Refactor display settings code to use a single handler.

### DIFF
--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -20,7 +20,7 @@
     </div>
     {{/unless}}
 
-    <div class="display-settings {{#if for_realm_settings}}org-subsection-parent{{/if}}">
+    <div class="display-settings {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
         <div class="subsection-header">
             <h3>{{t "Display settings" }}</h3>
             {{> settings_save_discard_widget section_name="display-settings" show_only_indicator=(not for_realm_settings) }}
@@ -62,7 +62,7 @@
         </div>
     </div>
 
-    <div class="time-settings {{#if for_realm_settings}}org-subsection-parent{{/if}}">
+    <div class="time-settings {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
         <div class="subsection-header">
             <h3>{{t "Time settings" }}</h3>
             {{> settings_save_discard_widget section_name="time-settings" show_only_indicator=(not for_realm_settings) }}
@@ -78,7 +78,7 @@
         </div>
     </div>
 
-    <div class="emoji-settings {{#if for_realm_settings}}org-subsection-parent{{/if}}">
+    <div class="emoji-settings {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
         <div class="subsection-header">
             <h3 class="light">{{t "Emoji settings" }}</h3>
             {{> settings_save_discard_widget section_name="emoji-settings" show_only_indicator=(not for_realm_settings) }}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit is a small fix to remove unnecessary check for `for_realm_settings`.
- Second commit is the main refactor commit.
 <!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
