### PR TITLE
Bulk delete drafts

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -556,6 +556,14 @@ test("format_drafts", ({override_rewire, mock_template}) => {
     ];
 
     $("#drafts_table").append = noop;
+    $(".removed-drafts").width = noop;
+    $(".drafts-header").width = noop;
+    $(".drafts-header").height = noop;
+    $(".delete-drafts-button").width = noop;
+    $(".drafts-header").css = noop;
+    $(".select-drafts-button").css = noop;
+    $(".delete-drafts-button").css = noop;
+    $(".drafts-list")[0] = noop;
 
     const draft_model = drafts.draft_model;
     const ls = localstorage();
@@ -587,11 +595,24 @@ test("format_drafts", ({override_rewire, mock_template}) => {
     override_rewire(drafts, "set_initial_element", noop);
 
     $.create("#drafts_table .draft-row", {children: []});
+    let checkbox = $.create(".mark-draft");
+    checkbox.filter = () => [];
     drafts.launch();
 
     $.clear_all_elements();
     $.create("#drafts_table .draft-row", {children: []});
+    checkbox = $.create(".mark-draft");
+    checkbox.filter = () => [];
     $("#draft_overlay").css = () => {};
+    $("#drafts_table").append = noop;
+    $(".removed-drafts").width = noop;
+    $(".drafts-header").width = noop;
+    $(".drafts-header").height = noop;
+    $(".delete-drafts-button").width = noop;
+    $(".drafts-header").css = noop;
+    $(".select-drafts-button").css = noop;
+    $(".delete-drafts-button").css = noop;
+    $(".drafts-list")[0] = noop;
 
     sub_store.get = function (stream_id) {
         assert.equal(stream_id, 30);
@@ -700,6 +721,9 @@ test("filter_drafts", ({override_rewire, mock_template}) => {
     ];
 
     $("#drafts_table").append = noop;
+    $(".drafts-list")[0] = noop;
+    $(".select-drafts-button").css = noop;
+    $(".delete-drafts-button").css = noop;
 
     const draft_model = drafts.draft_model;
     const ls = localstorage();
@@ -738,5 +762,7 @@ test("filter_drafts", ({override_rewire, mock_template}) => {
     compose_state.private_message_recipient(aaron.email);
 
     $.create("#drafts_table .draft-row", {children: []});
+    const checkbox = $.create(".mark-draft");
+    checkbox.filter = () => [];
     drafts.launch();
 });

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -601,6 +601,7 @@ export function launch() {
             });
         }
         update_rendered_drafts(narrow_drafts.length > 0, other_drafts.length > 0);
+        update_bulk_delete_ui();
     }
 
     function setup_event_handlers() {
@@ -620,6 +621,35 @@ export function launch() {
             const $draft_row = $(this).closest(".draft-row");
 
             remove_draft($draft_row);
+
+            update_bulk_delete_ui();
+        });
+
+        $(".draft_controls .mark-draft").on("change", () => {
+            update_bulk_delete_ui();
+        });
+
+        $(".select-drafts-button").on("click", () => {
+            const $unchecked_checkboxes = $(".mark-draft").filter(function () {
+                return !this.checked;
+            });
+            const check_boxes = $unchecked_checkboxes.length > 0;
+            $(".drafts-list")
+                .find(".draft-row")
+                .each(function () {
+                    $(this).find(".mark-draft").prop("checked", check_boxes);
+                });
+            update_bulk_delete_ui();
+        });
+
+        $(".delete-drafts-button").on("click", () => {
+            $(".drafts-list")
+                .find(".mark-draft:checked")
+                .closest(".draft-row")
+                .each(function () {
+                    remove_draft($(this));
+                });
+            update_bulk_delete_ui();
         });
     }
 
@@ -641,6 +671,46 @@ export function launch() {
     open_overlay();
     set_initial_element(formatted_narrow_drafts.concat(formatted_other_drafts));
     setup_event_handlers();
+}
+
+function update_bulk_delete_ui() {
+    if ($(".drafts-list")[0].scrollHeight > $(".drafts-list")[0].clientHeight) {
+        $(".select-drafts-button").css("right", "35px");
+        $(".delete-drafts-button").css("right", "190px");
+    } else {
+        $(".select-drafts-button").css("right", "23px");
+        $(".delete-drafts-button").css("right", "178px");
+    }
+
+    const $unchecked_checkboxes = $(".mark-draft").filter(function () {
+        return !this.checked;
+    });
+    const $checked_checkboxes = $(".mark-draft").filter(function () {
+        return this.checked;
+    });
+    if ($checked_checkboxes.length > 0) {
+        if ($unchecked_checkboxes.length === 0) {
+            $(".delete-drafts-button").prop("disabled", false);
+            $(".select-drafts-button .select-state-indicator")
+                .addClass("fa-check-square")
+                .removeClass("fa-square-o");
+        } else {
+            $(".delete-drafts-button").prop("disabled", false);
+            $(".select-drafts-button .select-state-indicator")
+                .addClass("fa-square-o")
+                .removeClass("fa-check-square");
+        }
+    } else {
+        if ($unchecked_checkboxes.length > 0) {
+            $(".delete-drafts-button").prop("disabled", true);
+            $(".select-drafts-button .select-state-indicator")
+                .addClass("fa-square-o")
+                .removeClass("fa-check-square");
+        } else {
+            $(".delete-drafts-button").hide();
+            $(".select-drafts-button").hide();
+        }
+    }
 }
 
 function activate_element(elem) {

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -158,6 +158,37 @@ export function initialize() {
     });
 
     delegate("body", {
+        target: ".mark-draft-tooltip",
+        delay: [400, 20],
+        appendTo: () => document.body,
+        onShow(instance) {
+            let content = "Select draft";
+            const $elem = $(instance.reference);
+            if ($($elem).parent().find(".mark-draft").is(":checked")) {
+                content = "Deselect draft";
+            }
+
+            instance.setContent(content);
+            return true;
+        },
+    });
+
+    delegate("body", {
+        target: ".delete-drafts-tooltip-wrapper",
+        appendTo: () => document.body,
+        onShow(instance) {
+            let content = "Delete all selected drafts";
+            const $elem = $(instance.reference);
+            if ($($elem).find(".delete-drafts-button").is(":disabled")) {
+                content = "No drafts selected";
+            }
+
+            instance.setContent(content);
+            return true;
+        },
+    });
+
+    delegate("body", {
         target: ".message_control_button",
         // This ensures that the tooltip doesn't
         // hide by the selected message blue border.

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -813,6 +813,12 @@
     .modal-bg .modal-header {
         border-color: hsla(0, 0%, 0%, 0.2);
         background-color: hsla(0, 0%, 0%, 0.2);
+
+        .delete-drafts-button {
+            background-color: hsl(357, 32%, 14%);
+            border-color: hsl(357, 52%, 57%);
+            color: hsl(357, 52%, 57%);
+        }
     }
 
     .table-striped tbody tr:nth-child(odd) td {
@@ -848,6 +854,12 @@
     .draft-row .message_header_private_message .message_label_clickable {
         padding: 4px 6px 3px;
         color: inherit;
+    }
+
+    .draft-row .draft-info-box label.checkbox {
+        input[type="checkbox"]:not(:checked) ~ span {
+            opacity: 1;
+        }
     }
 
     .nav-list > li > a,

--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -52,6 +52,56 @@
             justify-content: space-between;
             align-items: flex-end;
 
+            .select-drafts-button {
+                flex-basis: auto;
+                flex-shrink: 0;
+                width: 153px;
+                height: 38px;
+                margin-left: 5px;
+
+                .fa-check-square {
+                    position: relative;
+                    font-size: 20px;
+                    top: 3px;
+                    left: 6px;
+                }
+
+                .fa-square-o {
+                    position: relative;
+                    font-size: 20px;
+                    top: 3px;
+                    left: 6px;
+                }
+
+                .button-text {
+                    font-size: 14px;
+                    padding-left: 8px;
+                    padding-top: 2.5px;
+                    float: left;
+                }
+
+                .select-state-indicator {
+                    padding-left: 5px;
+                    padding-right: 8px;
+                }
+            }
+
+            .delete-drafts-tooltip-wrapper {
+                margin-left: auto;
+            }
+
+            .delete-drafts-button {
+                height: 38px;
+                padding-top: 9px;
+                color: hsl(357, 52%, 57%);
+                border-color: hsl(357, 52%, 57%);
+                background-color: hsl(357, 52%, 90%);
+                opacity: 0.7;
+
+                &:hover {
+                    opacity: 1;
+                }
+            }
         }
     }
 
@@ -128,6 +178,9 @@
 
         .draft_controls {
             display: inline-block;
+            padding-top: 10px;
+            padding-right: 10px;
+            float: right;
             font-size: 0.9em;
 
             [data-tippy-root] {
@@ -150,6 +203,19 @@
                 cursor: pointer;
                 margin-left: 5px;
                 color: hsl(357, 52%, 57%);
+                opacity: 0.7;
+
+                &:hover {
+                    opacity: 1;
+                }
+            }
+        }
+
+        label.checkbox {
+            top: 2px;
+            left: 10px;
+
+            input[type="checkbox"]:not(:checked) ~ span {
                 opacity: 0.7;
 
                 &:hover {

--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -18,9 +18,8 @@
     }
 
     .drafts-header {
-        padding-top: 4px;
-        padding-bottom: 8px;
-        text-align: center;
+        padding: 4px 25px 8px;
+        text-align: left;
         border-bottom: 1px solid hsl(0, 0%, 87%);
 
         h1 {
@@ -46,6 +45,13 @@
                 font-weight: 600;
                 cursor: pointer;
             }
+        }
+
+        .header-body {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+
         }
     }
 

--- a/static/templates/draft.hbs
+++ b/static/templates/draft.hbs
@@ -35,6 +35,10 @@
                         <div class="draft_controls">
                             <i class="fa fa-pencil fa-lg restore-draft tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Restore draft' }} (Enter)"></i>
                             <i class="fa fa-trash-o fa-lg delete-draft tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Delete draft' }} (Backspace)"></i>
+                            <label class="checkbox">
+                                <input type="checkbox" class="mark-draft" aria-hidden="true"/>
+                                <span class="mark-draft-tooltip"></span>
+                            </label>
                         </div>
                     </div>
                     <div class="message_content rendered_markdown restore-draft" title="{{t 'Restore draft' }}">{{rendered_markdown content}}</div>

--- a/static/templates/draft_table_body.hbs
+++ b/static/templates/draft_table_body.hbs
@@ -12,8 +12,16 @@
                         <br />
                         {{#tr}}Drafts older than <strong>{draft_lifetime}</strong> days are automatically removed.{{/tr}}
                         <br />
-                        {{t "Pro tip: You can use 'd' to open your drafts."}}
                     </div>
+                    <div class="delete-drafts-tooltip-wrapper">
+                        <button class="button small rounded delete-drafts-button" type="button" name="button">
+                            <div class="fa fa-trash-o fa-lg" aria-hidden="true"></div>
+                        </button>
+                    </div>
+                    <button class="button small rounded select-drafts-button" type="button" name="button">
+                        <span class="button-text">Select all drafts</span>
+                        <div class="fa fa-square-o select-state-indicator" aria-hidden="true"></div>
+                    </button>
                 </div>
             </div>
             <div class="drafts-list">

--- a/static/templates/draft_table_body.hbs
+++ b/static/templates/draft_table_body.hbs
@@ -6,10 +6,14 @@
                 <div class="exit">
                     <span class="exit-sign">&times;</span>
                 </div>
-                <div class="removed-drafts">
-                    {{#tr}}Drafts are not synced to other devices and browsers.{{/tr}}
-                    <br />
-                    {{#tr}}Drafts older than <strong>{draft_lifetime}</strong> days are automatically removed.{{/tr}}
+                <div class="header-body">
+                    <div class="removed-drafts">
+                        {{#tr}}Drafts are not synced to other devices and browsers.{{/tr}}
+                        <br />
+                        {{#tr}}Drafts older than <strong>{draft_lifetime}</strong> days are automatically removed.{{/tr}}
+                        <br />
+                        {{t "Pro tip: You can use 'd' to open your drafts."}}
+                    </div>
                 </div>
             </div>
             <div class="drafts-list">


### PR DESCRIPTION
Resolves zulip/zulip#19360

A added the possibility to bulk-delete drafts (instead of having to delete each one individually):
![bulk-delete_all](https://user-images.githubusercontent.com/74348920/140652397-0bda523c-a906-4e2e-bfde-ea04de3b34c2.gif)

It is also possible to mark the drafts individually or to unselect all drafts:
![bulk-delete_markManually](https://user-images.githubusercontent.com/74348920/140652465-f6a0f256-e5ce-4fad-9322-f935c1d53b03.gif)

And you can unselect specifc drafts so you can delete all except those drafts:
![bulk-delete_notAll](https://user-images.githubusercontent.com/74348920/140652552-6a6c2aa2-e782-41ab-9a9c-98229edb4791.gif)

Testing:
Manually, might need some formal tests in frontend_tests/node_tests or frontend_tests/puppeteer_tests