### PR TITLE
Add a UI option for entering a custom notification batching period

### DIFF
--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -563,6 +563,10 @@ export const email_notifications_batching_period_values = [
         value: 60 * 60 * 24 * 7,
         description: $t({defaultMessage: "1 week"}),
     },
+    {
+        value: "custom_period",
+        description: $t({defaultMessage: "N minutes"}),
+    },
 ];
 
 const email_message_notification_settings = [

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -173,25 +173,30 @@ export function update_page(settings_panel) {
     const container = $(settings_panel.container);
     const settings_object = settings_panel.settings_object;
     for (const setting of settings_config.all_notification_settings) {
-        if (
-            setting === "enable_offline_push_notifications" &&
-            !page_params.realm_push_notifications_enabled
-        ) {
-            // If push notifications are disabled at the realm level,
-            // we should just leave the checkbox always off.
-            continue;
-        } else if (setting === "desktop_icon_count_display") {
-            update_desktop_icon_count_display(settings_panel);
-            continue;
-        } else if (
-            setting === "notification_sound" ||
-            setting === "email_notifications_batching_period_seconds"
-        ) {
-            container.find(`.setting_${CSS.escape(setting)}`).val(settings_object[setting]);
-            continue;
+        switch (setting) {
+            case "enable_offline_push_notifications": {
+                if (!page_params.realm_push_notifications_enabled) {
+                    // If push notifications are disabled at the realm level,
+                    // we should just leave the checkbox always off.
+                    break;
+                }
+                container.find(`.${CSS.escape(setting)}`).prop("checked", settings_object[setting]);
+                break;
+            }
+            case "desktop_icon_count_display": {
+                update_desktop_icon_count_display(settings_panel);
+                break;
+            }
+            case "notification_sound":
+            case "email_notifications_batching_period_seconds": {
+                container.find(`.setting_${CSS.escape(setting)}`).val(settings_object[setting]);
+                break;
+            }
+            default: {
+                container.find(`.${CSS.escape(setting)}`).prop("checked", settings_object[setting]);
+                break;
+            }
         }
-
-        container.find(`.${CSS.escape(setting)}`).prop("checked", settings_object[setting]);
     }
     rerender_ui();
 }

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -65,10 +65,30 @@ function update_desktop_icon_count_display(settings_panel) {
     }
 }
 
+function set_notification_batching_ui(container, setting_seconds, force_custom) {
+    const select_elem = container.find(".setting_email_notifications_batching_period_seconds");
+    const edit_elem = container.find(".email_notification_batching_period_edit_minutes");
+    const valid_period_values = settings_config.email_notifications_batching_period_values.map(
+        (x) => x.value,
+    );
+
+    // We display the custom widget if either the user just selected
+    // custom_period, or the current value cannot be represented with
+    // the existing set of values.
+    if (force_custom || !valid_period_values.includes(setting_seconds)) {
+        const setting_minutes = setting_seconds / 60;
+        select_elem.val("custom_period");
+        edit_elem.val(setting_minutes);
+        edit_elem.parent().show();
+    } else {
+        select_elem.val(setting_seconds);
+        edit_elem.parent().hide();
+    }
+}
+
 export function set_enable_digest_emails_visibility(settings_panel) {
     const container = $(settings_panel.container);
     const for_realm_settings = settings_panel.for_realm_settings;
-
     if (page_params.realm_digest_emails_enabled) {
         if (for_realm_settings) {
             container.find(".other_email_notifications").show();
@@ -123,10 +143,8 @@ export function set_up(settings_panel) {
         }
     });
 
-    const email_notifications_batching_period_dropdown = container.find(
-        ".setting_email_notifications_batching_period_seconds",
-    );
-    email_notifications_batching_period_dropdown.val(
+    set_notification_batching_ui(
+        container,
         settings_object.email_notifications_batching_period_seconds,
     );
 
@@ -148,10 +166,29 @@ export function set_up(settings_panel) {
             stream_edit.stream_setting_changed(e, true);
             return;
         }
-        const setting_name = input_elem.attr("name");
+        let setting_name = input_elem.attr("name");
+        let setting_value = settings_org.get_input_element_value(this);
+
+        if (setting_name === "email_notifications_batching_period_seconds") {
+            if (input_elem.val() === "custom_period") {
+                set_notification_batching_ui(
+                    container,
+                    settings_object.email_notifications_batching_period_seconds,
+                    true,
+                );
+                return;
+            }
+            set_notification_batching_ui(container, setting_value);
+        } else if (setting_name === "email_notification_batching_period_edit_minutes") {
+            // This field is in minutes, but the actual setting is seconds
+            setting_value = setting_value * 60;
+            set_notification_batching_ui(container, setting_value);
+            setting_name = "email_notifications_batching_period_seconds";
+        }
+
         change_notification_setting(
             setting_name,
-            settings_org.get_input_element_value(this),
+            setting_value,
             input_elem.closest(".subsection-parent").find(".alert-notification"),
         );
     });
@@ -187,8 +224,11 @@ export function update_page(settings_panel) {
                 update_desktop_icon_count_display(settings_panel);
                 break;
             }
-            case "notification_sound":
             case "email_notifications_batching_period_seconds": {
+                set_notification_batching_ui(container, settings_object[setting]);
+                break;
+            }
+            case "notification_sound": {
                 container.find(`.setting_${CSS.escape(setting)}`).val(settings_object[setting]);
                 break;
             }

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -119,16 +119,27 @@
             {{> settings_save_discard_widget section_name="email-message-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
 
-        <label for="email_notifications_batching_period">
-            {{t "Delay before sending message notification emails" }}
-        </label>
+        <div class="input-group form-horizontal">
 
-        <div class="input-group">
+            <label for="email_notifications_batching_period">
+                {{t "Delay before sending message notification emails" }}
+            </label>
             <select name="email_notifications_batching_period_seconds" class="setting_email_notifications_batching_period_seconds prop-element" data-setting-widget-type="number">
                 {{#each email_notifications_batching_period_values}}
                 <option value="{{ this.value }}">{{ this.description }}</option>
                 {{/each}}
             </select>
+            <div class="dependent-inline-block">
+                <label for="email_notification_batching_period_edit_minutes" class="inline-block">
+                    {{t 'N' }}:
+                </label>
+                <input type="text"
+                  name="email_notification_batching_period_edit_minutes"
+                  class="email_notification_batching_period_edit_minutes admin-realm-time-limit-input prop-element"
+                  data-setting-widget-type="number"
+                  autocomplete="off"
+                  value="{{ email_notifications_batching_period_seconds }}"/>
+            </div>
         </div>
 
         {{#each notification_settings.email_message_notification_settings}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Issue 19713: PR #19576 added a settings option for selecting a notification batching period. We want to extend that UI option with the ability to select a custom period. I have attempted to replicate the behavior of the custom retention days setting in the organization permissions settings panel.

**Testing plan:** <!-- How have you tested? -->
Tested on my local development environment using Chrome. Here is a GIF of the UI change:
**GIFs or screenshots:** 
![batch_seconds](https://user-images.githubusercontent.com/5497482/136802151-78562639-ee21-42a2-8ee6-c3504b2c2a74.gif)