### PR TITLE
popovers: Fix alignment in `Move topic` menu

### DIFF
--- a/static/templates/move_topic_to_stream.hbs
+++ b/static/templates/move_topic_to_stream.hbs
@@ -28,6 +28,7 @@
                         <span></span>
                         {{t "Send notification to new topic" }}
                     </label>
+                    <br/>
                     <label class="checkbox">
                         <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
                         <span></span>


### PR DESCRIPTION
Issue #19875

![image](https://user-images.githubusercontent.com/75037620/136805894-4b152c2d-c8f6-41bd-867d-d6ab904490f9.png)

I moved the second option on new line using `<br/>` in `static/templates/move_topic_to_stream.hbs`.
Please check if this requires any change.