### PR TITLE
popover: Adjust spacing between checkboxes in topic edit UI

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -9,13 +9,6 @@
     justify-content: center;
 }
 
-/* Inserting this collapsed row between two flex items will make
- * the flex item that comes after it break to a new row */
-.break-row {
-    flex-basis: 100%;
-    height: 0;
-}
-
 .hide {
     display: none;
 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1581,11 +1581,15 @@ div.focused_table {
     white-space: nowrap;
 
     label.checkbox {
-        margin-right: 0 !important;
-
+        /* Place the checkboxes on their own lines. */
+        display: block;
         input {
             margin: 0;
             vertical-align: baseline;
+        }
+
+        & + label.checkbox {
+            margin-top: 10px;
         }
     }
 
@@ -1593,10 +1597,6 @@ div.focused_table {
         display: inline-block;
         margin-right: 10px;
     }
-}
-
-.topic_move_breadcrumb_messages {
-    margin-top: 10px !important;
 }
 
 .message_length_controller {

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -23,7 +23,6 @@
                         <span></span>
                         {{t "Send notification to new topic" }}
                     </label>
-                    <div class="break-row"></div> <!-- break -->
                     <label class="checkbox">
                         <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
                         <span></span>

--- a/static/templates/move_topic_to_stream.hbs
+++ b/static/templates/move_topic_to_stream.hbs
@@ -28,7 +28,6 @@
                         <span></span>
                         {{t "Send notification to new topic" }}
                     </label>
-                    <br/>
                     <label class="checkbox">
                         <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
                         <span></span>


### PR DESCRIPTION
Issue #19947

After adding vertical space between the checkboxes:

![image](https://user-images.githubusercontent.com/75037620/137324579-66087b65-237e-4bd1-9ba7-2fc4eb312e14.png)

![image](https://user-images.githubusercontent.com/75037620/137324716-8c18be10-b992-4a69-8aef-58edc47b7c3b.png)

This issue is the follow up issue for issue #19875.

I made the following changes in `static/styles/zulip.css` :

- Changed overall top margin from `10px` to `0px` in `.topic_move_breadcrumb_messages` and `.message_edit_breadcrumb_messages`.
- Added top margin of `10px` to each checkbox labels.