### PR TITLE
node_tests: Import templates.js only once for all tests.

### DIFF
--- a/frontend_tests/node_tests/i18n.js
+++ b/frontend_tests/node_tests/i18n.js
@@ -20,6 +20,10 @@ page_params.translation_data = {
         "<p>Le canal <b>{stream_name}</b> n'existe pas.</p><p>Gérez vos abonnements <z-link>sur votre page canaux</z-link>.</p>",
 };
 
+// Re-register Zulip extensions so extensions registered previously with
+// mocked i18n.ts do not interefere with following tests.
+require("../../static/js/templates");
+
 // All of our other tests stub out i18n activity;
 // here we do a quick sanity check on the engine itself.
 // `i18n.js` initializes FormatJS and is imported by

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -67,6 +67,8 @@ function short_tb(tb) {
     return lines.splice(0, i + 1).join("\n") + "\n(...)\n";
 }
 
+require("../../static/js/templates"); // register Zulip extensions
+
 function run_one_module(file) {
     zjquery.clear_initialize_function();
     zjquery.clear_all_elements();
@@ -80,11 +82,6 @@ test.set_verbose(files.length === 1);
 
 try {
     for (const file of files) {
-        // register Zulip extensions before each test file; this is
-        // necessary because of how we mock i18n for every module
-        // except for the i18n test suite.
-        require("../../static/js/templates");
-
         namespace.start();
         namespace.set_global("window", window);
         namespace.set_global("to_$", () => window);


### PR DESCRIPTION
Reverts 55b2b1c with a better fix.

Closes: #19934

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
Ran node tests
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
