### PR TITLE
analytics: Use user IDs to get user activity summaries.

### DIFF
--- a/analytics/tests/test_activity_views.py
+++ b/analytics/tests/test_activity_views.py
@@ -46,9 +46,10 @@ class ActivityTest(ZulipTestCase):
 
         self.assert_length(queries, 8)
 
+        iago = self.example_user("iago")
         flush_per_request_caches()
         with queries_captured() as queries:
-            result = self.client_get("/user_activity/iago@zulip.com/")
+            result = self.client_get(f"/user_activity/{iago.id}/")
             self.assertEqual(result.status_code, 200)
 
-        self.assert_length(queries, 4)
+        self.assert_length(queries, 5)

--- a/analytics/urls.py
+++ b/analytics/urls.py
@@ -27,7 +27,7 @@ i18n_urlpatterns: List[Union[URLPattern, URLResolver]] = [
     path("activity", get_installation_activity),
     path("activity/support", support, name="support"),
     path("realm_activity/<realm_str>/", get_realm_activity),
-    path("user_activity/<email>/", get_user_activity),
+    path("user_activity/<user_profile_id>/", get_user_activity),
     path("stats/realm/<realm_str>/", stats_for_realm),
     path("stats/installation", stats_for_installation),
     path("stats/remote/<int:remote_server_id>/installation", stats_for_remote_installation),

--- a/analytics/views/realm_activity.py
+++ b/analytics/views/realm_activity.py
@@ -41,7 +41,7 @@ def get_user_activity_records_for_realm(realm: str, is_bot: bool) -> QuerySet:
 
 def realm_user_summary_table(
     all_records: List[QuerySet], admin_emails: Set[str]
-) -> Tuple[Dict[str, Dict[str, Any]], str]:
+) -> Tuple[Dict[str, Any], str]:
     user_records = {}
 
     def by_email(record: QuerySet) -> str:
@@ -68,7 +68,7 @@ def realm_user_summary_table(
 
     rows = []
     for email, user_summary in user_records.items():
-        email_link = user_activity_link(email)
+        email_link = user_activity_link(email, user_summary["user_profile_id"])
         sent_count = get_count(user_summary, "send")
         cells = [user_summary["name"], email_link, sent_count]
         row_class = ""
@@ -107,10 +107,11 @@ def realm_user_summary_table(
     return user_records, content
 
 
-def realm_client_table(user_summaries: Dict[str, Dict[str, Dict[str, Any]]]) -> str:
+def realm_client_table(user_summaries: Dict[str, Dict[str, Any]]) -> str:
     exclude_keys = [
         "internal",
         "name",
+        "user_profile_id",
         "use",
         "send",
         "pointer",
@@ -120,7 +121,7 @@ def realm_client_table(user_summaries: Dict[str, Dict[str, Dict[str, Any]]]) -> 
 
     rows = []
     for email, user_summary in user_summaries.items():
-        email_link = user_activity_link(email)
+        email_link = user_activity_link(email, user_summary["user_profile_id"])
         name = user_summary["name"]
         for k, v in user_summary.items():
             if k in exclude_keys:


### PR DESCRIPTION
Using user IDs instead of emails is more reliable since users can
have arbitrarily complex emails that are hard to encode in a URL.
This has led to NoReverseMatch exceptions in the past.

@timabbott FYI :)