### PR TITLE
ci: Change github UID from 3434 to 1001

### DIFF
--- a/tools/ci/Dockerfile
+++ b/tools/ci/Dockerfile
@@ -59,8 +59,8 @@ RUN apt-get update \
     zlib1g-dev
 
 ARG USERNAME=github
-RUN groupadd --gid 3434 $USERNAME \
-  && useradd --uid 3434 --gid $USERNAME --shell /bin/bash --create-home $USERNAME \
+RUN groupadd --gid 1001 $USERNAME \
+  && useradd --uid 1001 --gid $USERNAME --shell /bin/bash --create-home $USERNAME \
   && echo "$USERNAME ALL = (ALL) NOPASSWD: ALL" >> /etc/sudoers.d/50-$USERNAME \
   && echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep
 


### PR DESCRIPTION
CircleCI expected 3434; GitHub Actions expects 1001. This is the reason zulip-ci.yml currently needs to mess with the permissions in `/__w`.