### PR TITLE
ci: Remove /__w permission twiddling.

### DIFF
--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -50,22 +50,6 @@ jobs:
       HOME: /home/github/
 
     steps:
-      - name: Add required permissions
-        run: |
-          # The checkout actions doesn't clone to ~/zulip or allow
-          # us to use the path option to clone outside the current
-          # /__w/zulip/zulip directory. Since this directory is owned
-          # by root we need to change it's ownership to allow the
-          # github user to clone the code here.
-          # Note: /__w/ is a docker volume mounted to $GITHUB_WORKSPACE
-          # which is /home/runner/work/.
-          sudo chown -R github .
-
-          # This is the GitHub Actions specific cache directory the
-          # the current github user must be able to access for the
-          # cache action to work. It is owned by root currently.
-          sudo chmod -R 0777 /__w/_temp/
-
       - uses: actions/checkout@v2
 
       - name: Create cache directories


### PR DESCRIPTION
Commit 9f2ac49fb316e46b0740569ddac402e0a570d2bf (#19963) should make this unnecessary.

(@priyank-p FYI)