### PR TITLE
Press Enter to Send color change.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -439,7 +439,7 @@ input.recipient_box {
     height: 2.2em;
 
     .compose_checkbox_label {
-        color: hsl(0, 0%, 67%);
+        color: hsl(0, 0%, 30%);
         margin: 4px;
     }
 }

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -1101,6 +1101,13 @@ body.night-mode {
             background-color: hsl(228, 96%, 71%);
         }
     }
+
+    /* Same as the one from compose.css, but used prevent day mode style override in night mode with the !important directive */
+    #send_controls {
+        .compose_checkbox_label {
+            color: hsl(0, 0%, 80%);
+        }
+    }
 }
 
 @supports (-moz-appearance: none) {


### PR DESCRIPTION
Fixes #19958 

**Testing plan:** <!-- How have you tested? -->
Set up development environment on my machine according to https://zulip.readthedocs.io/en/latest/development/index.html and edited the CSS files while tracking the changes in my browser (Firefox).

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Changed the current Press Enter to Send field:
![image](https://user-images.githubusercontent.com/26484801/137246878-c982bf11-9b9a-4f6a-8f26-db9cc6fc5541.png)
To one a with a bit less lightness:
![image](https://user-images.githubusercontent.com/26484801/137393705-bd8d87df-049d-443b-a136-0a4cd788093d.png)


Also added the compose_checkbox_label style to the night_mode.css, allowing day mode and night mode to have different colors on Press Enter to Send. I then raised the lightness a bit to make it clearer.
Current night mode style is the same as daymode:
![image](https://user-images.githubusercontent.com/26484801/137247332-9cdd34f7-f670-4331-aa6f-efad471231eb.png)
But was changed to the following:
(This one was very minor as it already seemed good before)
![image](https://user-images.githubusercontent.com/26484801/137247233-a6b0e4f6-0347-42b2-8971-0dbc1aeb309e.png)


Tried to make my commits follow the guidelines in https://zulip.readthedocs.io/en/latest/contributing/version-control.html#commit-discipline as close as possible.