### PR TITLE
docs: Update links to zulip-announce mailing list.

### DIFF
--- a/docs/overview/release-lifecycle.md
+++ b/docs/overview/release-lifecycle.md
@@ -14,7 +14,7 @@ security support policies. In short:
   if you don't do so.
 - New server releases are announced via the low-traffic
   [zulip-announce email
-  list](https://groups.google.com/forum/#!forum/zulip-announce). We
+  list](https://groups.google.com/g/zulip-announce). We
   highly recommend subscribing so that you are notified about new
   security releases.
 - Zulip Cloud runs the branch that will become the next major

--- a/docs/production/install.md
+++ b/docs/production/install.md
@@ -109,12 +109,10 @@ together with using it with you.
 Learning more:
 
 - Subscribe to the [Zulip announcements email
-  list](https://groups.google.com/forum/#!forum/zulip-announce) for
+  list](https://groups.google.com/g/zulip-announce) for
   server administrators. This extremely low-traffic list is for
   important announcements, including [new
-  releases](../overview/release-lifecycle.md) and security issues. You
-  can also use the [RSS
-  feed](https://groups.google.com/forum/#!aboutgroup/zulip-announce).
+  releases](../overview/release-lifecycle.md) and security issues.
 - Follow [Zulip on Twitter](https://twitter.com/zulip).
 - Learn how to [configure your Zulip server settings](settings.md).
 - Learn about [Backups, export and import](../production/export-and-import.md)

--- a/docs/production/settings.md
+++ b/docs/production/settings.md
@@ -106,7 +106,7 @@ Some popular settings in `/etc/zulip/settings.py` include:
 ## Zulip announcement list
 
 If you haven't already, subscribe to the
-[zulip-announce](https://groups.google.com/forum/#!forum/zulip-announce)
+[zulip-announce](https://groups.google.com/g/zulip-announce)
 list so that you can receive important announces like new Zulip
 releases or major changes to the app ecosystem.
 


### PR DESCRIPTION
The links we have now redirect to "My groups" and not to our
Google group. Also, the RSS feed is no longer supported by Google,
so we should no longer link to it.

Fixes #19560.

@timabbott FYI :)
