### PR TITLE
Allow admins to get subscription status in private stream.

### DIFF
--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -639,7 +639,7 @@ def get_subscription_backend(
     stream_id: int = REQ(json_validator=check_int, path_only=True),
 ) -> HttpResponse:
     target_user = access_user_by_id(user_profile, user_id, for_admin=False)
-    (stream, sub) = access_stream_by_id(user_profile, stream_id)
+    (stream, sub) = access_stream_by_id(user_profile, stream_id, allow_realm_admin=True)
 
     subscription_status = {"is_subscribed": subscribed_to_stream(target_user, stream_id)}
 


### PR DESCRIPTION
We pass allow_realm_admin as True to access_stream_by_id for
`GET users/{user_id}/subscriptions{stream_id}` endpoint
because we want to allow non-subscribed admins to get
subscription status in private streams.

Fixes #19077.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? --> Added tests.

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
