### PR TITLE
documentation: Add help article for supported browsers.

### DIFF
--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -62,8 +62,9 @@
             </a>
         </div>
         <div id="third-party-apps">
-            Zulip also works great in pinned browser tabs and
-            multi-protocol desktop chat apps
+            Zulip also works great in pinned
+            <a href="/help/supported-browsers">browser tabs</a>
+            and multi-protocol desktop chat apps
             like <a href="https://rambox.pro">Rambox</a>
             and <a href="https://getferdi.com">Ferdi</a>.
         </div>

--- a/templates/zerver/help/include/set-up-your-account.md
+++ b/templates/zerver/help/include/set-up-your-account.md
@@ -2,7 +2,7 @@
     If this is your first time using Zulip, we recommend starting with the web
     or desktop experience to set up your account and get oriented.
 
-- Get the [mobile and desktop apps](/apps). Zulip also works great in a browser.
+- Get the [mobile and desktop apps](/apps). Zulip also works great in a [browser](/help/supported-browsers).
 - [Add a profile picture](/help/change-your-profile-picture) and
   [edit your profile information](https://zulip.com/help/edit-your-profile) to tell others
   about yourself.

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -119,6 +119,7 @@
 * [Zulip in a Terminal](/help/zulip-in-a-terminal)
 * [Connect through a proxy](/help/connect-through-a-proxy)
 * [Use a custom certificate](/help/custom-certificates)
+* [Supported browsers](/help/supported-browsers)
 
 # Zulip administration
 

--- a/templates/zerver/help/supported-browsers.md
+++ b/templates/zerver/help/supported-browsers.md
@@ -1,0 +1,11 @@
+# Supported browsers
+
+In addition to the [mobile and desktop apps](/apps), many people use
+Zulip in their preferred modern web browser. For the best user
+experience, the latest stable version of the browsers below are
+recommended.
+
+* [Chrome](https://www.google.com/chrome/)
+* [Firefox](https://mozilla.org/en-US/firefox/browsers/)
+* [Edge](https://microsoft.com/en-us/edge/)
+* [Safari](https://apple.com/safari/)

--- a/templates/zerver/unsupported_browser.html
+++ b/templates/zerver/unsupported_browser.html
@@ -15,9 +15,9 @@
                         {% endtrans %}
                     </p>
                     <p>
-                        {% trans %}
-                        Zulip supports modern browsers like Firefox,
-                        Chrome, and Edge.
+                        {% trans supported_browsers_page_link="https://zulip.com/help/supported-browsers %}
+                        Zulip supports <a href="{{ supported_browsers_page_link }}"> modern browsers</a>
+                        like Firefox, Chrome, and Edge.
                         {% endtrans %}
                     </p>
                     <p>


### PR DESCRIPTION
Created new /help article for supported web browsers and updated
links in the /apps page as well as the unsupported-browser template
and the help/set-up-your-account article.

Decided on a simple straight-forward text that will not need to be
updated regularly. Similar information pages on Slack and Discord
(see links) are geared toward both OS as well as browser support,
which could be another way to address this issue, but could possibly
require more content maintenance.

* [Slack](https://slack.com/intl/en-es/help/articles/115002037526-System-requirements-for-using-Slack)
* [Discord](https://support.discord.com/hc/en-us/articles/213491697-What-are-the-OS-system-requirements-for-Discord-)

In addition to lint and test suites, did a visual check of links
in the development environment (see below). I do not have Windows
or Internet Explorer, so I was unable to visually check the updates
to the unsupported-browsers template.

![Zulip_browser_support](https://user-images.githubusercontent.com/63245456/137477851-99ee2a50-cde6-407f-90c2-56775387f7a0.gif)

Fixes #14732