### PR TITLE
help: Add article for supported browsers

### DIFF
--- a/help/include/set-up-your-account.md
+++ b/help/include/set-up-your-account.md
@@ -3,7 +3,8 @@
     If this is your first time using Zulip, we recommend starting with the web
     or desktop experience to set up your account and get oriented.
 
-- Get the [mobile and desktop apps](/apps). Zulip also works great in a browser.
+- Get the [mobile and desktop apps](/apps). Zulip also works great in a
+  [browser](/help/supported-browsers).
 
 - [Add a profile picture](/help/change-your-profile-picture) and
   [edit your profile information](/help/edit-your-profile) to tell others

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -131,6 +131,7 @@
 ## Apps
 * [Desktop installation guides](/help/desktop-app-install-guide)
 * [Zulip in a Terminal](/help/zulip-in-a-terminal)
+* [Supported browsers](/help/supported-browsers)
 * [Connect through a proxy](/help/connect-through-a-proxy)
 * [Use a custom certificate](/help/custom-certificates)
 

--- a/help/supported-browsers.md
+++ b/help/supported-browsers.md
@@ -1,0 +1,25 @@
+# Supported browsers
+
+In addition to the [mobile and desktop apps](https://zulip.com/apps/),
+Zulip works great in all major modern web browsers. We recommend
+pinning the Zulip tab in your favorite browser, so that it's always
+easy to find.
+
+For the best user experience, the latest stable versions of the
+browsers below are recommended.
+
+* [Chrome](https://www.google.com/chrome/)
+* [Firefox](https://mozilla.org/en-US/firefox/browsers/)
+* [Edge](https://microsoft.com/en-us/edge/)
+* [Safari](https://apple.com/safari/)
+
+## Cross-protocol apps
+
+Zulip is supported by most multi-protocol desktop chat apps like
+[Rambox](https://rambox.pro) and [Ferdium](https://ferdium.org/).
+
+We recommend choosing a product in this space that regularly releases
+security updates; several popular cross-protocol Electron apps have
+gone defunct over the years. Using a poorly maintained Electron app is
+a major security risk similar to using an old version of Chrome with
+dozens of published security vulnerabilities.

--- a/templates/corporate/apps.html
+++ b/templates/corporate/apps.html
@@ -67,8 +67,9 @@
             </a>
         </div>
         <div id="third-party-apps">
-            Zulip also works great in pinned browser tabs and
-            multi-protocol desktop chat apps
+            Zulip also works great in pinned
+            <a href="/help/supported-browsers">browser tabs</a>
+            and multi-protocol desktop chat apps
             like <a href="https://rambox.pro">Rambox</a>
             and <a href="https://ferdium.org/">Ferdium</a>.
         </div>

--- a/templates/zerver/unsupported_browser.html
+++ b/templates/zerver/unsupported_browser.html
@@ -19,9 +19,9 @@
                         {% endtrans %}
                     </p>
                     <p>
-                        {% trans %}
-                        Zulip supports modern browsers like Firefox,
-                        Chrome, and Edge.
+                        {% trans supported_browsers_page_link="/help/supported-browsers" %}
+                        Zulip supports <a href="{{ supported_browsers_page_link }}">modern browsers</a>
+                        like Firefox, Chrome, and Edge.
                         {% endtrans %}
                     </p>
                     <p>


### PR DESCRIPTION
Created new /help article for supported web browsers and updated
links in the /apps page as well as the unsupported-browser template
and the help/set-up-your-account article.

Decided on a simple straight-forward text that will not need to be
updated regularly. Similar information pages on Slack and Discord
(see links) are geared toward both OS as well as browser support,
which could be another way to address this issue, but could possibly
require more content maintenance.

* [Slack](https://slack.com/intl/en-es/help/articles/115002037526-System-requirements-for-using-Slack)
* [Discord](https://support.discord.com/hc/en-us/articles/213491697-What-are-the-OS-system-requirements-for-Discord-)

In addition to lint and test suites, did a visual check of links
in the development environment (see below). I do not have Windows
or Internet Explorer, so I was unable to visually check the updates
to the unsupported-browsers template.

![Zulip_browser_support](https://user-images.githubusercontent.com/63245456/137477851-99ee2a50-cde6-407f-90c2-56775387f7a0.gif)

Fixes #14732