### PR TITLE
message_edit: Swap propagate_mode with checkboxes in message edit form.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -550,7 +550,7 @@ function edit_message($row, raw_content) {
         editability !== editability_types.NO &&
         page_params.realm_message_content_edit_limit_seconds > 0
     ) {
-        $row.find(".message-edit-timer-control-group").show();
+        $row.find(".message-edit-timer").show();
     }
 
     // add timer

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1516,7 +1516,7 @@ div.focused_table {
 }
 
 #message_edit_topic {
-    margin: 0 5px 5px 0;
+    margin: 0 5px 10px 0;
 }
 
 .message_edit_header {
@@ -1533,7 +1533,7 @@ div.focused_table {
 .message_edit_topic_propagate {
     display: inline-block;
     width: 320px;
-    margin-bottom: 15px !important;
+    margin-bottom: 10px;
     max-width: 100%;
 }
 
@@ -1565,7 +1565,7 @@ div.focused_table {
 }
 
 .message_edit_breadcrumb_messages {
-    margin-bottom: 15px;
+    margin-bottom: 10px;
 }
 
 .message_length_controller {
@@ -2552,10 +2552,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
     .control-group.no-margin {
         margin-bottom: 0;
-    }
-
-    .action-buttons {
-        margin: 10px 0;
     }
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1458,7 +1458,7 @@ div.focused_table {
     color: hsl(0, 0%, 63%);
 }
 
-.message-edit-timer-control-group {
+.message-edit-timer {
     float: right;
     display: none;
     margin-top: 5px;
@@ -2548,10 +2548,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
         /* Setting resize as none hides the bottom right diagonal box
            (which even has a background color of its own!). */
         resize: none !important;
-    }
-
-    .control-group.no-margin {
-        margin-bottom: 0;
     }
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1517,7 +1517,6 @@ div.focused_table {
 
 #message_edit_topic {
     margin: 0 5px 5px 0;
-    width: auto;
 }
 
 .message_edit_header {
@@ -1540,7 +1539,7 @@ div.focused_table {
 
 .topic_move_breadcrumb_messages,
 .message_edit_breadcrumb_messages {
-    margin: 0 5px 5px 0 !important;
+    margin: 0 5px 5px 0;
     align-self: center;
     width: 100%;
     white-space: nowrap;
@@ -1563,6 +1562,10 @@ div.focused_table {
         display: inline-block;
         margin-right: 10px;
     }
+}
+
+.message_edit_breadcrumb_messages {
+    margin-bottom: 15px;
 }
 
 .message_length_controller {

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -1,6 +1,6 @@
 {{! Client-side Mustache template for rendering the message edit form. }}
 
-<form id="edit_form_{{message_id}}" class="form-horizontal new-style">
+<form id="edit_form_{{message_id}}" class="new-style">
     <div class="alert" id="message-edit-send-status-{{message_id}}">
         <span class="send-status-close">&times;</span>
         <span class="error-msg"></span>

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -6,49 +6,45 @@
         <span class="error-msg"></span>
     </div>
     {{#if is_stream}}
-    <div class="control-group no-margin">
-        <div class="controls edit-controls">
-            <div class="message_edit_header">
-                <div class="stream_header_colorblock" {{#unless is_stream_editable}}style="display:none"{{/unless}}></div>
-                <div class="select_stream_setting" {{#unless is_stream_editable}}style="display:none"{{/unless}}>
-                    {{> settings/dropdown_list_widget
-                      widget_name=select_move_stream_widget_name
-                      list_placeholder=(t 'Filter streams')}}
-                </div>
-                <i class="fa fa-angle-right" aria-hidden="true" {{#unless is_stream_editable}}style="display:none"{{/unless}}></i>
-                <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" autocomplete="off" />
+    <div class="edit-controls">
+        <div class="message_edit_header">
+            <div class="stream_header_colorblock" {{#unless is_stream_editable}}style="display:none"{{/unless}}></div>
+            <div class="select_stream_setting" {{#unless is_stream_editable}}style="display:none"{{/unless}}>
+                {{> settings/dropdown_list_widget
+                  widget_name=select_move_stream_widget_name
+                  list_placeholder=(t 'Filter streams')}}
             </div>
-            <select class='message_edit_topic_propagate' style='display:none;'>
-                <option value="change_one"> {{t "Move only this message" }}</option>
-                <option selected="selected" value="change_later"> {{t "Move this and all following messages in this topic" }}</option>
-                <option value="change_all"> {{t "Move all messages in this topic" }}</option>
-            </select>
-            <div class="message_edit_breadcrumb_messages"  style='display:none;'>
-                <label class="checkbox">
-                    <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />
-                    <span></span>
-                    {{t "Send notification to new topic" }}
-                </label>
-                <label class="checkbox">
-                    <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
-                    <span></span>
-                    {{t "Send notification to old topic" }}
-                </label>
-            </div>
+            <i class="fa fa-angle-right" aria-hidden="true" {{#unless is_stream_editable}}style="display:none"{{/unless}}></i>
+            <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" autocomplete="off" />
+        </div>
+        <select class='message_edit_topic_propagate' style='display:none;'>
+            <option value="change_one"> {{t "Move only this message" }}</option>
+            <option selected="selected" value="change_later"> {{t "Move this and all following messages in this topic" }}</option>
+            <option value="change_all"> {{t "Move all messages in this topic" }}</option>
+        </select>
+        <div class="message_edit_breadcrumb_messages"  style='display:none;'>
+            <label class="checkbox">
+                <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />
+                <span></span>
+                {{t "Send notification to new topic" }}
+            </label>
+            <label class="checkbox">
+                <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
+                <span></span>
+                {{t "Send notification to old topic" }}
+            </label>
         </div>
     </div>
     {{/if}}
-    <div class="control-group no-margin">
-        <div class="controls edit-controls">
-            {{> copy_message_button message_id=this.message_id}}
-            <textarea class="message_edit_content" maxlength="{{ max_message_length }}">{{content}}</textarea>
-            <div class="scrolling_list preview_message_area" id="preview_message_area_{{message_id}}" style="display:none;">
-                <div class="markdown_preview_spinner"></div>
-                <div class="preview_content rendered_markdown"></div>
-            </div>
+    <div class="edit-controls">
+        {{> copy_message_button message_id=this.message_id}}
+        <textarea class="message_edit_content" maxlength="{{ max_message_length }}">{{content}}</textarea>
+        <div class="scrolling_list preview_message_area" id="preview_message_area_{{message_id}}" style="display:none;">
+            <div class="markdown_preview_spinner"></div>
+            <div class="preview_content rendered_markdown"></div>
         </div>
     </div>
-    <div class="control-group action-buttons">
+    <div class="action-buttons">
         <div class="message_edit_spinner"></div>
         <div class="controls edit-controls">
             {{#if is_editable}}
@@ -70,7 +66,7 @@
                 <button type="button" class="button small rounded message_edit_close">{{t "Close" }}</button>
             {{/if}}
             {{#if has_been_editable}}
-            <div class="message-edit-timer-control-group">
+            <div class="message-edit-timer">
                 <span class="message_edit_countdown_timer"></span>
                 <span>
                     <i id="message_edit_tooltip" class="tippy-zulip-tooltip message_edit_tooltip fa fa-question-circle" aria-hidden="true"

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -17,24 +17,24 @@
                 </div>
                 <i class="fa fa-angle-right" aria-hidden="true" {{#unless is_stream_editable}}style="display:none"{{/unless}}></i>
                 <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" autocomplete="off" />
-                <div class="message_edit_breadcrumb_messages"  style='display:none;'>
-                    <label class="checkbox">
-                        <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />
-                        <span></span>
-                        {{t "Send notification to new topic" }}
-                    </label>
-                    <label class="checkbox">
-                        <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
-                        <span></span>
-                        {{t "Send notification to old topic" }}
-                    </label>
-                </div>
             </div>
             <select class='message_edit_topic_propagate' style='display:none;'>
                 <option value="change_one"> {{t "Move only this message" }}</option>
                 <option selected="selected" value="change_later"> {{t "Move this and all following messages in this topic" }}</option>
                 <option value="change_all"> {{t "Move all messages in this topic" }}</option>
             </select>
+            <div class="message_edit_breadcrumb_messages"  style='display:none;'>
+                <label class="checkbox">
+                    <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />
+                    <span></span>
+                    {{t "Send notification to new topic" }}
+                </label>
+                <label class="checkbox">
+                    <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
+                    <span></span>
+                    {{t "Send notification to old topic" }}
+                </label>
+            </div>
         </div>
     </div>
     {{/if}}


### PR DESCRIPTION
Issue #19973

![image](https://user-images.githubusercontent.com/75037620/137502688-8fd9c831-4695-459a-806b-5cd5f38ae6f8.png)

Made following change in `static/templates/message_edit_form.hbs`:

Swapped position of checkboxes with class `message_edit_breadcrumb_messages` and dropdown with class `message_edit_topic_propagate`