### PR TITLE
settings_display: Make setting type selector row sticky.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1407,6 +1407,12 @@ input[type="checkbox"] {
         .org-settings-list {
             position: relative;
         }
+        .settings-sticky-bar {
+            position: sticky;
+            z-index: 1;
+            background-color: hsl(0, 0%, 100%);
+            top: 0;
+        }
     }
 
     .settings-header {

--- a/static/templates/settings_overlay.hbs
+++ b/static/templates/settings_overlay.hbs
@@ -9,7 +9,7 @@
     </div>
     <div class="sidebar left" data-simplebar>
         <div class="sidebar-list dark-grey small-text">
-            <div class="center tab-container"></div>
+            <div class="center tab-container settings-sticky-bar"></div>
             <ul class="normal-settings-list">
                 <li tabindex="0" data-section="profile">
                     <i class="icon fa fa-user" aria-hidden="true"></i>


### PR DESCRIPTION
This PR is for the issue on https://github.com/zulip/zulip/pull/19965

I tested by running the zulip interface in chrome browser, clicking on settings and making sure the Personal/Organizational tab remained at the top when scrolling through the contents of the sidebar.


https://user-images.githubusercontent.com/52905547/137501902-da821476-fb4d-47d7-93a9-ac44b61fed56.mov

