### PR TITLE
New landing page about self-hosting Zulip

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ world, with 74+ people who have each contributed 100+ commits. With
 over 1000 contributors merging over 500 commits a month, Zulip is the
 largest and fastest growing open source team chat project.
 
+Come find us on the [development community chat](https://zulip.com/development-community/)!
+
 [![GitHub Actions build status](https://github.com/zulip/zulip/actions/workflows/zulip-ci.yml/badge.svg)](https://github.com/zulip/zulip/actions/workflows/zulip-ci.yml?query=branch%3Amain)
 [![coverage status](https://img.shields.io/codecov/c/github/zulip/zulip/main.svg)](https://codecov.io/gh/zulip/zulip)
 [![Mypy coverage](https://img.shields.io/badge/mypy-100%25-green.svg)][mypy-coverage]
@@ -30,58 +32,50 @@ largest and fastest growing open source team chat project.
 
 ## Getting started
 
-Click on the appropriate link below. If nothing seems to apply,
-join us on the
-[Zulip community server](https://zulip.com/development-community/)
-and tell us what's up!
+- **Contributing code**. Check out our [guide for new
+  contributors](https://zulip.readthedocs.io/en/latest/overview/contributing.html)
+  to get started. We have invested into making Zulip’s code uniquely readable,
+  well tested, and easy to modify. Beyond that, we have written an extraordinary
+  150K words of documentation on how to contribute to Zulip.
 
-You might be interested in:
+- **Contributing non-code**. [Report an
+  issue](https://zulip.readthedocs.io/en/latest/overview/contributing.html#reporting-issues),
+  [translate](https://zulip.readthedocs.io/en/latest/translating/translating.html)
+  Zulip into your language, or [give us
+  feedback](https://zulip.readthedocs.io/en/latest/overview/contributing.html#user-feedback).
+  We'd love to hear from you, whether you've been using Zulip for years, or are just
+  trying it out for the first time.
 
-- **Contributing code**. Check out our
-  [guide for new contributors](https://zulip.readthedocs.io/en/latest/overview/contributing.html)
-  to get started. Zulip prides itself on maintaining a clean and
-  well-tested codebase, and a stock of hundreds of
-  [beginner-friendly issues][beginner-friendly].
+- **Checking Zulip out**. The best way to see Zulip in action is to drop by the
+  [Zulip community server](https://zulip.com/development-community/). We also
+  recommend reading about Zulip's [unique
+  approach](https://zulip.com/why-zulip/) to organizing conversations.
 
-- **Contributing non-code**.
-  [Report an issue](https://zulip.readthedocs.io/en/latest/overview/contributing.html#reporting-issues),
-  [translate](https://zulip.readthedocs.io/en/latest/translating/translating.html) Zulip
-  into your language,
-  [write](https://zulip.readthedocs.io/en/latest/overview/contributing.html#zulip-outreach)
-  for the Zulip blog, or
-  [give us feedback](https://zulip.readthedocs.io/en/latest/overview/contributing.html#user-feedback). We
-  would love to hear from you, even if you're just trying the product out.
+- **Running a Zulip server**. Self host Zulip directly on Ubuntu or Debian
+  Linux, in [Docker](https://github.com/zulip/docker-zulip), or with prebuilt
+  images for [Digital Ocean](https://marketplace.digitalocean.com/apps/zulip) and
+  [Render](https://render.com/docs/deploy-zulip).
+  Learn more about [self-hosting Zulip](https://zulip.com/self-hosting/).
 
-- **Supporting Zulip**. Advocate for your organization to use Zulip, become a [sponsor](https://github.com/sponsors/zulip), write a
-  review in the mobile app stores, or
-  [upvote Zulip](https://zulip.readthedocs.io/en/latest/overview/contributing.html#zulip-outreach) on
-  product comparison sites.
-
-- **Checking Zulip out**. The best way to see Zulip in action is to drop by
-  the
-  [Zulip community server](https://zulip.com/development-community/). We
-  also recommend reading Zulip for
-  [open source](https://zulip.com/for/open-source/), Zulip for
-  [companies](https://zulip.com/for/companies/), or Zulip for
-  [communities](https://zulip.com/for/working-groups-and-communities/).
-
-- **Running a Zulip server**. Use a preconfigured [DigitalOcean droplet](https://marketplace.digitalocean.com/apps/zulip),
-  [install Zulip](https://zulip.readthedocs.io/en/stable/production/install.html)
-  directly, or use Zulip's
-  experimental [Docker image](https://zulip.readthedocs.io/en/latest/production/deployment.html#zulip-in-docker).
-  Commercial support is available; see <https://zulip.com/plans> for details.
-
-- **Using Zulip without setting up a server**. <https://zulip.com>
-  offers free and commercial hosting, including providing our paid
-  plan for free to fellow open source projects.
+- **Using Zulip without setting up a server**. Learn about [Zulip
+  Cloud](https://zulip.com/plans/) hosting options. Zulip sponsors free [Zulip
+  Cloud Standard](https://zulip.com/plans/) for hundreds of worthy
+  organizations, including [fellow open-source
+  projects](https://zulip.com/for/open-source/).
 
 - **Participating in [outreach
   programs](https://zulip.readthedocs.io/en/latest/overview/contributing.html#outreach-programs)**
-  like Google Summer of Code.
+  like [Google Summer of Code](https://developers.google.com/open-source/gsoc/)
+  and [Outreachy](https://www.outreachy.org/).
 
-You may also be interested in reading our [blog](https://blog.zulip.org/) or
-following us on [Twitter](https://twitter.com/zulip).
+- **Supporting Zulip**. Advocate for your organization to use Zulip, become a
+  [sponsor](https://github.com/sponsors/zulip), write a review in the mobile app
+  stores, or [help others find
+  Zulip](https://zulip.readthedocs.io/en/latest/overview/contributing.html#help-others-find-zulip).
+
+You may also be interested in reading our [blog](https://blog.zulip.org/), and
+following us on [Twitter](https://twitter.com/zulip) and
+[LinkedIn](https://www.linkedin.com/company/zulip-project/).
+
 Zulip is distributed under the
 [Apache 2.0](https://github.com/zulip/zulip/blob/main/LICENSE) license.
-
-[beginner-friendly]: https://github.com/zulip/zulip/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22

--- a/docs/production/index.md
+++ b/docs/production/index.md
@@ -6,7 +6,7 @@ maxdepth: 3
 ---
 
 requirements
-Installing a production server <install>
+install
 troubleshooting
 management-commands
 settings

--- a/docs/production/install.md
+++ b/docs/production/install.md
@@ -1,16 +1,27 @@
-# Production installation
+# Install a Zulip server
 
-You'll need an Ubuntu or Debian system that satisfies
+## Before you begin
+
+To install a Zulip server, you'll need an Ubuntu or Debian system that satisfies
 [the installation requirements](requirements.md). Alternatively,
 you can use a preconfigured
 [DigitalOcean droplet](https://marketplace.digitalocean.com/apps/zulip?refcode=3ee45da8ee26), or
 Zulip's
 [experimental Docker image](deployment.md#zulip-in-docker).
 
-Note that if you're developing for Zulip, you should install Zulip's
-[development environment](../development/overview.md) instead. If
-you're just looking to play around with Zulip and see what it looks like,
-you can create a test organization at <https://zulip.com/new>.
+### Should I follow this installation guide?
+
+- If you are just looking to play around with Zulip and see what it looks like,
+  you can create a test Zulip Cloud organization at <https://zulip.com/new>.
+
+- If you are deciding between self-hosting Zulip and signing up for [Zulip Cloud](https://zulip.com/plans/),
+  our [self-hosing overview](https://zulip.com/self-hosting/) and [guide to
+  choosing between Zulip Cloud and
+  self-hosting](https://zulip.com/help/getting-your-organization-started-with-zulip#choosing-between-zulip-cloud-and-self-hosting)
+  are great places to start.
+
+- If you're developing for Zulip, you should follow the instructions
+  to install Zulip's [development environment](../development/overview.md).
 
 ## Step 1: Download the latest release
 


### PR DESCRIPTION
Here's how I'm imagining this could look:

1) Hero: add space above the buttons.
2) The first 4 sections ("100% free and open-source software" through "Easy to set up and maintain"): Add alternating background colors.
3) Not sure about what to do with the quote. Currently using it instead of an icon.
4) For the next 4 sections, I was thinking we could have them in a 2x2 grid of rectangles with text and an icon in each rectangle. (The icon could be above or, potentially, below.) I want to de-emphasize these compared to the first 4 sections; I think they are more for Igor and less for Linda/Franz.
5) Because I copied the plans boxes from /for/education, they are too big on the bottom.
6) We should make the font bigger.

I have icon options picked out for each section in a Paper doc. We will need to double-check the licenses, but I think first we need to decide whether we are going in this direction.

I would guess that we'll be able to re-use components from this page for our upcoming Zulip vs. X pages, so it's worth spending some time figuring out what we like.

@amanagr @timabbott what do you guys think?

@amanagr would you be up for playing with the CSS for this? Obviously, the text has not been finalized, but it will be roughly the amount of content you see (i.e. just a couple of lines per heading).

