### PR TITLE
compose:Fix alignment of close button in warning banner

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -248,13 +248,14 @@
 .compose_not_subscribed {
     padding: 4px 0 4px 0;
     display: flex;
-    align-items: center;
     justify-content: space-between;
+    position: relative;
 }
 
 #compose_not_subscribed_close {
-    top: 1px;
-    right: 10px;
+    top: 0;
+    right: 0;
+    position: absolute;
 }
 
 .compose_invite_close,
@@ -275,7 +276,7 @@
 
 .compose_invite_user p,
 .compose_not_subscribed p {
-    margin: 0;
+    margin: 0 20px;
     display: inline-block;
     max-width: calc(100% - 100px);
 }


### PR DESCRIPTION
Fixes: #19770

This PR fixes the alignment of the close button in the warning banner. I have tested it out in all the mentioned languages in the issue in all the viewports and works perfectly fine. 

**GIFs or screenshots:**
In the English Language:
![english](https://user-images.githubusercontent.com/73348574/137641252-949893bb-b48c-4e0c-bd65-a00757bda9d7.gif)

In the Russian Language:
![Russian](https://user-images.githubusercontent.com/73348574/137641262-ee6e9e67-b489-4944-bf8c-18d133af4dae.gif)
