### PR TITLE
message: Check mandatory_topics setting in backend as well.

### DIFF
--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -245,7 +245,7 @@ test_ui("validate", ({override, mock_template}) => {
     assert.ok(!compose_validate.validate());
     assert.equal(
         $("#compose-error-msg").html(),
-        $t_html({defaultMessage: "Please specify a topic"}),
+        $t_html({defaultMessage: "Topics are required in this organization"}),
     );
 });
 

--- a/static/js/compose_validate.js
+++ b/static/js/compose_validate.js
@@ -526,7 +526,7 @@ function validate_stream_message() {
         const topic = compose_state.topic();
         if (topic === "") {
             compose_error.show(
-                $t_html({defaultMessage: "Please specify a topic"}),
+                $t_html({defaultMessage: "Topics are required in this organization"}),
                 $("#stream_message_recipient_topic"),
             );
             return false;

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3424,6 +3424,9 @@ def check_message(
             # else can sneak past the access check.
             assert sender.bot_type == sender.OUTGOING_WEBHOOK_BOT
 
+        if realm.mandatory_topics and topic_name == "(no topic)":
+            raise JsonableError(_("Topics are required in this organization"))
+
     elif addressee.is_private():
         user_profiles = addressee.user_profiles()
         mirror_message = client and client.name in [


### PR DESCRIPTION
Previously, we only checked mandatory_topics setting before
sending message in frontend and there was no restriction in
backend. This PR adds the check in backend also making
sure messages without topic cannot be sent through API as
well if mandatory_topics setting is set to True.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? --> Added test.

<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
