### PR TITLE
push_notifications: Provide a hint when the server is not registered.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -211,7 +211,7 @@ class InvalidZulipServerError(JsonableError):
 
     @staticmethod
     def msg_format() -> str:
-        return "Zulip server auth failure: {role} is not registered"
+        return "Zulip server auth failure: {role} is not registered -- did you run `manage.py register_server`?"
 
 
 class InvalidZulipServerKeyError(InvalidZulipServerError):

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -247,7 +247,9 @@ class PushBouncerNotificationTest(BouncerTestCase):
             HTTP_AUTHORIZATION=api_auth,
         )
         self.assert_json_error(
-            result, "Zulip server auth failure: 5678-efgh is not registered", status_code=401
+            result,
+            "Zulip server auth failure: 5678-efgh is not registered -- did you run `manage.py register_server`?",
+            status_code=401,
         )
 
     def test_remote_push_user_endpoints(self) -> None:
@@ -1981,7 +1983,7 @@ class TestSendToPushBouncer(ZulipTestCase):
         self.assertEqual(
             str(exc.exception),
             "Push notifications bouncer error: "
-            "Zulip server auth failure: testRole is not registered",
+            "Zulip server auth failure: testRole is not registered -- did you run `manage.py register_server`?",
         )
 
     @responses.activate


### PR DESCRIPTION
An attempt to make, e.g. https://chat.zulip.org/#narrow/stream/9-issues/topic/.E2.9C.94.20push.20notifications.20auth.20failure, more self-serve.

**Testing plan:** Adjusted tests.