### PR TITLE
realm: Rename plan type constants to be more descriptive.

### DIFF
--- a/analytics/tests/test_support_views.py
+++ b/analytics/tests/test_support_views.py
@@ -466,7 +466,7 @@ class TestSupportEndpoint(ZulipTestCase):
         )
         self.assert_in_success_response(["Sponsorship approved for lear"], result)
         lear_realm.refresh_from_db()
-        self.assertEqual(lear_realm.plan_type, Realm.STANDARD_FREE)
+        self.assertEqual(lear_realm.plan_type, Realm.PLAN_TYPE_STANDARD_FREE)
         customer = get_customer_by_realm(lear_realm)
         assert customer is not None
         self.assertFalse(customer.sponsorship_pending)

--- a/analytics/views/installation_activity.py
+++ b/analytics/views/installation_activity.py
@@ -223,11 +223,14 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
             if string_id in estimated_arrs:
                 row["arr"] = estimated_arrs[string_id]
 
-            if row["plan_type"] in [Realm.STANDARD, Realm.PLUS]:
+            if row["plan_type"] in [Realm.PLAN_TYPE_STANDARD, Realm.PLAN_TYPE_PLUS]:
                 row["effective_rate"] = 100 - int(realms_to_default_discount.get(string_id, 0))
-            elif row["plan_type"] == Realm.STANDARD_FREE:
+            elif row["plan_type"] == Realm.PLAN_TYPE_STANDARD_FREE:
                 row["effective_rate"] = 0
-            elif row["plan_type"] == Realm.LIMITED and string_id in realms_to_default_discount:
+            elif (
+                row["plan_type"] == Realm.PLAN_TYPE_LIMITED
+                and string_id in realms_to_default_discount
+            ):
                 row["effective_rate"] = 100 - int(realms_to_default_discount[string_id])
             else:
                 row["effective_rate"] = ""

--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -59,11 +59,11 @@ if settings.BILLING_ENABLED:
 
 def get_plan_name(plan_type: int) -> str:
     return {
-        Realm.SELF_HOSTED: "self hosted",
-        Realm.LIMITED: "limited",
-        Realm.STANDARD: "standard",
-        Realm.STANDARD_FREE: "open source",
-        Realm.PLUS: "plus",
+        Realm.PLAN_TYPE_SELF_HOSTED: "self hosted",
+        Realm.PLAN_TYPE_LIMITED: "limited",
+        Realm.PLAN_TYPE_STANDARD: "standard",
+        Realm.PLAN_TYPE_STANDARD_FREE: "open source",
+        Realm.PLAN_TYPE_PLUS: "plus",
     }[plan_type]
 
 

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -728,7 +728,7 @@ def process_initial_upgrade(
 
     from zerver.lib.actions import do_change_plan_type
 
-    do_change_plan_type(realm, Realm.STANDARD, acting_user=user)
+    do_change_plan_type(realm, Realm.PLAN_TYPE_STANDARD, acting_user=user)
 
 
 def update_license_ledger_for_manual_plan(
@@ -948,7 +948,7 @@ def update_sponsorship_status(
 def approve_sponsorship(realm: Realm, *, acting_user: Optional[UserProfile]) -> None:
     from zerver.lib.actions import do_change_plan_type, internal_send_private_message
 
-    do_change_plan_type(realm, Realm.STANDARD_FREE, acting_user=acting_user)
+    do_change_plan_type(realm, Realm.PLAN_TYPE_STANDARD_FREE, acting_user=acting_user)
     customer = get_customer_by_realm(realm)
     if customer is not None and customer.sponsorship_pending:
         customer.sponsorship_pending = False
@@ -973,7 +973,7 @@ def approve_sponsorship(realm: Realm, *, acting_user: Optional[UserProfile]) -> 
 
 
 def is_sponsored_realm(realm: Realm) -> bool:
-    return realm.plan_type == Realm.STANDARD_FREE
+    return realm.plan_type == Realm.PLAN_TYPE_STANDARD_FREE
 
 
 def get_discount_for_realm(realm: Realm) -> Optional[Decimal]:
@@ -997,7 +997,7 @@ def do_change_plan_status(plan: CustomerPlan, status: int) -> None:
 def process_downgrade(plan: CustomerPlan) -> None:
     from zerver.lib.actions import do_change_plan_type
 
-    do_change_plan_type(plan.customer.realm, Realm.LIMITED, acting_user=None)
+    do_change_plan_type(plan.customer.realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)
     plan.status = CustomerPlan.ENDED
     plan.save(update_fields=["status"])
 

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -519,7 +519,7 @@ class StripeTest(StripeTestCase):
         self.login_user(user)
         response = self.client_get("/upgrade/")
         self.assert_in_success_response(["Pay annually"], response)
-        self.assertNotEqual(user.realm.plan_type, Realm.STANDARD)
+        self.assertNotEqual(user.realm.plan_type, Realm.PLAN_TYPE_STANDARD)
         self.assertFalse(Customer.objects.filter(realm=user.realm).exists())
 
         # Click "Make payment" in Stripe Checkout
@@ -648,7 +648,7 @@ class StripeTest(StripeTestCase):
         )
         # Check that we correctly updated Realm
         realm = get_realm("zulip")
-        self.assertEqual(realm.plan_type, Realm.STANDARD)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD)
         self.assertEqual(realm.max_invites, Realm.INVITES_STANDARD_REALM_DAILY_MAX)
         # Check that we can no longer access /upgrade
         response = self.client_get("/upgrade/")
@@ -789,7 +789,7 @@ class StripeTest(StripeTestCase):
         )
         # Check that we correctly updated Realm
         realm = get_realm("zulip")
-        self.assertEqual(realm.plan_type, Realm.STANDARD)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD)
         self.assertEqual(realm.max_invites, Realm.INVITES_STANDARD_REALM_DAILY_MAX)
         # Check that we can no longer access /upgrade
         response = self.client_get("/upgrade/")
@@ -827,7 +827,7 @@ class StripeTest(StripeTestCase):
             free_trial_end_date = self.now + timedelta(days=60)
 
             self.assert_in_success_response(["Pay annually", "Free Trial", "60 day"], response)
-            self.assertNotEqual(user.realm.plan_type, Realm.STANDARD)
+            self.assertNotEqual(user.realm.plan_type, Realm.PLAN_TYPE_STANDARD)
             self.assertFalse(Customer.objects.filter(realm=user.realm).exists())
 
             with patch("corporate.lib.stripe.timezone_now", return_value=self.now):
@@ -904,7 +904,7 @@ class StripeTest(StripeTestCase):
             )
 
             realm = get_realm("zulip")
-            self.assertEqual(realm.plan_type, Realm.STANDARD)
+            self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD)
             self.assertEqual(realm.max_invites, Realm.INVITES_STANDARD_REALM_DAILY_MAX)
 
             with patch("corporate.views.billing_page.timezone_now", return_value=self.now):
@@ -959,7 +959,7 @@ class StripeTest(StripeTestCase):
             realm.refresh_from_db()
             self.assertEqual(customer_plan.status, CustomerPlan.ACTIVE)
             self.assertEqual(customer_plan.next_invoice_date, add_months(free_trial_end_date, 1))
-            self.assertEqual(realm.plan_type, Realm.STANDARD)
+            self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD)
             [invoice] = stripe.Invoice.list(customer=stripe_customer.id)
             invoice_params = {
                 "amount_due": 15 * 80 * 100,
@@ -1035,7 +1035,7 @@ class StripeTest(StripeTestCase):
             response = self.client_get("/upgrade/")
 
             self.assert_in_success_response(["Pay annually", "Free Trial", "60 day"], response)
-            self.assertNotEqual(user.realm.plan_type, Realm.STANDARD)
+            self.assertNotEqual(user.realm.plan_type, Realm.PLAN_TYPE_STANDARD)
             self.assertFalse(Customer.objects.filter(realm=user.realm).exists())
 
             with patch("corporate.lib.stripe.timezone_now", return_value=self.now):
@@ -1105,7 +1105,7 @@ class StripeTest(StripeTestCase):
             )
 
             realm = get_realm("zulip")
-            self.assertEqual(realm.plan_type, Realm.STANDARD)
+            self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD)
             self.assertEqual(realm.max_invites, Realm.INVITES_STANDARD_REALM_DAILY_MAX)
 
             with patch("corporate.views.billing_page.timezone_now", return_value=self.now):
@@ -1138,7 +1138,7 @@ class StripeTest(StripeTestCase):
             realm.refresh_from_db()
             self.assertEqual(customer_plan.status, CustomerPlan.ACTIVE)
             self.assertEqual(customer_plan.next_invoice_date, add_months(free_trial_end_date, 12))
-            self.assertEqual(realm.plan_type, Realm.STANDARD)
+            self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD)
             [invoice] = stripe.Invoice.list(customer=stripe_customer.id)
             invoice_params = {
                 "amount_due": 123 * 80 * 100,
@@ -1273,7 +1273,7 @@ class StripeTest(StripeTestCase):
         )
         # Check that we did not update Realm
         realm = get_realm("zulip")
-        self.assertNotEqual(realm.plan_type, Realm.STANDARD)
+        self.assertNotEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD)
         # Check that we still get redirected to /upgrade
         response = self.client_get("/billing/")
         self.assertEqual(response.status_code, 302)
@@ -1315,7 +1315,7 @@ class StripeTest(StripeTestCase):
         )
         # Check that we correctly updated Realm
         realm = get_realm("zulip")
-        self.assertEqual(realm.plan_type, Realm.STANDARD)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD)
         # Check that we can no longer access /upgrade
         response = self.client_get("/upgrade/")
         self.assertEqual(response.status_code, 302)
@@ -1589,7 +1589,7 @@ class StripeTest(StripeTestCase):
             response,
         )
 
-        user.realm.plan_type = Realm.STANDARD_FREE
+        user.realm.plan_type = Realm.PLAN_TYPE_STANDARD_FREE
         user.realm.save()
         self.login_user(self.example_user("hamlet"))
         response = self.client_get("/billing/")
@@ -1604,12 +1604,12 @@ class StripeTest(StripeTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual("/upgrade/", response.url)
 
-        user.realm.plan_type = Realm.STANDARD_FREE
+        user.realm.plan_type = Realm.PLAN_TYPE_STANDARD_FREE
         user.realm.save()
         response = self.client_get("/billing/")
         self.assertEqual(response.status_code, 200)
 
-        user.realm.plan_type = Realm.LIMITED
+        user.realm.plan_type = Realm.PLAN_TYPE_LIMITED
         user.realm.save()
         Customer.objects.create(realm=user.realm, stripe_customer_id="cus_123")
         response = self.client_get("/billing/")
@@ -1623,13 +1623,13 @@ class StripeTest(StripeTestCase):
         response = self.client_get("/upgrade/")
         self.assertEqual(response.status_code, 200)
 
-        user.realm.plan_type = Realm.STANDARD_FREE
+        user.realm.plan_type = Realm.PLAN_TYPE_STANDARD_FREE
         user.realm.save()
         response = self.client_get("/upgrade/")
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "/billing/")
 
-        user.realm.plan_type = Realm.LIMITED
+        user.realm.plan_type = Realm.PLAN_TYPE_LIMITED
         user.realm.save()
         customer = Customer.objects.create(realm=user.realm, stripe_customer_id="cus_123")
         response = self.client_get("/upgrade/")
@@ -1809,7 +1809,7 @@ class StripeTest(StripeTestCase):
         user = self.example_user("hamlet")
         approve_sponsorship(user.realm, acting_user=user)
         realm = get_realm("zulip")
-        self.assertEqual(realm.plan_type, Realm.STANDARD_FREE)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD_FREE)
 
         expected_message = "Your organization's request for sponsored hosting has been approved! :tada:.\nYou have been upgraded to Zulip Cloud Standard, free of charge."
         sender = get_system_bot(settings.NOTIFICATION_BOT, user.realm_id)
@@ -1986,7 +1986,7 @@ class StripeTest(StripeTestCase):
             update_license_ledger_if_needed(user.realm, self.next_year)
         plan = CustomerPlan.objects.first()
         assert plan is not None
-        self.assertEqual(get_realm("zulip").plan_type, Realm.LIMITED)
+        self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_LIMITED)
         self.assertEqual(plan.status, CustomerPlan.ENDED)
         self.assertEqual(
             LicenseLedger.objects.order_by("-id")
@@ -2400,7 +2400,7 @@ class StripeTest(StripeTestCase):
 
             plan = CustomerPlan.objects.get()
             self.assertEqual(plan.next_invoice_date, free_trial_end_date)
-            self.assertEqual(get_realm("zulip").plan_type, Realm.STANDARD)
+            self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_STANDARD)
             self.assertEqual(plan.status, CustomerPlan.FREE_TRIAL)
 
             # Add some extra users before the realm is deactivated
@@ -2418,7 +2418,7 @@ class StripeTest(StripeTestCase):
                 self.client_patch("/json/billing/plan", {"status": CustomerPlan.ENDED})
 
             plan.refresh_from_db()
-            self.assertEqual(get_realm("zulip").plan_type, Realm.LIMITED)
+            self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_LIMITED)
             self.assertEqual(plan.status, CustomerPlan.ENDED)
             self.assertEqual(plan.invoiced_through, last_ledger_entry)
             self.assertIsNone(plan.next_invoice_date)
@@ -2485,7 +2485,7 @@ class StripeTest(StripeTestCase):
         assert current_plan is not None
         next_invoice_date = add_months(self.next_year, 1)
         self.assertEqual(current_plan.next_invoice_date, next_invoice_date)
-        self.assertEqual(get_realm("zulip").plan_type, Realm.STANDARD)
+        self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_STANDARD)
         self.assertEqual(current_plan.status, CustomerPlan.ACTIVE)
 
         old_plan = CustomerPlan.objects.all().order_by("id").first()
@@ -2703,7 +2703,7 @@ class StripeTest(StripeTestCase):
 
         plan = CustomerPlan.objects.get()
         self.assertEqual(plan.next_invoice_date, self.next_month)
-        self.assertEqual(get_realm("zulip").plan_type, Realm.STANDARD)
+        self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_STANDARD)
         self.assertEqual(plan.status, CustomerPlan.ACTIVE)
 
         # Add some extra users before the realm is deactivated
@@ -2719,7 +2719,7 @@ class StripeTest(StripeTestCase):
 
         plan.refresh_from_db()
         self.assertTrue(get_realm("zulip").deactivated)
-        self.assertEqual(get_realm("zulip").plan_type, Realm.LIMITED)
+        self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_LIMITED)
         self.assertEqual(plan.status, CustomerPlan.ENDED)
         self.assertEqual(plan.invoiced_through, last_ledger_entry)
         self.assertIsNone(plan.next_invoice_date)
@@ -2764,7 +2764,7 @@ class StripeTest(StripeTestCase):
         current_plan = CustomerPlan.objects.all().order_by("id").last()
         assert current_plan is not None
         self.assertEqual(current_plan.next_invoice_date, self.next_month)
-        self.assertEqual(get_realm("zulip").plan_type, Realm.STANDARD)
+        self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_STANDARD)
         self.assertEqual(current_plan.status, CustomerPlan.ACTIVE)
 
         old_plan = CustomerPlan.objects.all().order_by("id").first()
@@ -2907,44 +2907,44 @@ class StripeTest(StripeTestCase):
         )
         # To create local Customer object but no Stripe customer.
         attach_discount_to_realm(realm, Decimal(20), acting_user=None)
-        rows.append(Row(realm, Realm.SELF_HOSTED, None, None, False, False))
+        rows.append(Row(realm, Realm.PLAN_TYPE_SELF_HOSTED, None, None, False, False))
 
         realm, _, _, _ = create_realm(
             users_to_create=1, create_stripe_customer=True, create_plan=False
         )
-        rows.append(Row(realm, Realm.SELF_HOSTED, None, None, False, False))
+        rows.append(Row(realm, Realm.PLAN_TYPE_SELF_HOSTED, None, None, False, False))
 
         realm, customer, _, _ = create_realm(
             users_to_create=1, create_stripe_customer=True, create_plan=False, num_invoices=1
         )
-        rows.append(Row(realm, Realm.SELF_HOSTED, None, None, True, False))
+        rows.append(Row(realm, Realm.PLAN_TYPE_SELF_HOSTED, None, None, True, False))
 
         realm, _, plan, _ = create_realm(
             users_to_create=1, create_stripe_customer=True, create_plan=True
         )
-        rows.append(Row(realm, Realm.STANDARD, plan, CustomerPlan.ACTIVE, False, False))
+        rows.append(Row(realm, Realm.PLAN_TYPE_STANDARD, plan, CustomerPlan.ACTIVE, False, False))
 
         realm, customer, plan, _ = create_realm(
             users_to_create=1, create_stripe_customer=True, create_plan=True, num_invoices=1
         )
-        rows.append(Row(realm, Realm.STANDARD, plan, CustomerPlan.ACTIVE, False, False))
+        rows.append(Row(realm, Realm.PLAN_TYPE_STANDARD, plan, CustomerPlan.ACTIVE, False, False))
 
         realm, customer, plan, _ = create_realm(
             users_to_create=3, create_stripe_customer=True, create_plan=True, num_invoices=2
         )
-        rows.append(Row(realm, Realm.LIMITED, plan, CustomerPlan.ENDED, True, True))
+        rows.append(Row(realm, Realm.PLAN_TYPE_LIMITED, plan, CustomerPlan.ENDED, True, True))
 
         realm, customer, plan, invoices = create_realm(
             users_to_create=1, create_stripe_customer=True, create_plan=True, num_invoices=2
         )
         for invoice in invoices:
             stripe.Invoice.pay(invoice, paid_out_of_band=True)
-        rows.append(Row(realm, Realm.STANDARD, plan, CustomerPlan.ACTIVE, False, False))
+        rows.append(Row(realm, Realm.PLAN_TYPE_STANDARD, plan, CustomerPlan.ACTIVE, False, False))
 
         realm, customer, plan, _ = create_realm(
             users_to_create=20, create_stripe_customer=True, create_plan=True, num_invoices=2
         )
-        rows.append(Row(realm, Realm.STANDARD, plan, CustomerPlan.ACTIVE, False, False))
+        rows.append(Row(realm, Realm.PLAN_TYPE_STANDARD, plan, CustomerPlan.ACTIVE, False, False))
 
         with patch("corporate.lib.stripe.void_all_open_invoices") as void_all_open_invoices_mock:
             downgrade_small_realms_behind_on_payments_as_needed()
@@ -3429,7 +3429,7 @@ class BillingHelpersTest(ZulipTestCase):
         realm = get_realm("zulip")
         self.assertFalse(is_sponsored_realm(realm))
 
-        realm.plan_type = Realm.STANDARD_FREE
+        realm.plan_type = Realm.PLAN_TYPE_STANDARD_FREE
         realm.save()
         self.assertTrue(is_sponsored_realm(realm))
 
@@ -3787,7 +3787,7 @@ class TestTestClasses(ZulipTestCase):
         self.assertEqual(ledger.licenses_at_next_renewal, 60)
 
         realm.refresh_from_db()
-        self.assertEqual(realm.plan_type, Realm.STANDARD)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD)
 
     def test_subscribe_realm_to_monthly_plan_on_manual_license_management(self) -> None:
         realm = get_realm("zulip")
@@ -3808,4 +3808,4 @@ class TestTestClasses(ZulipTestCase):
         self.assertEqual(ledger.licenses_at_next_renewal, 30)
 
         realm.refresh_from_db()
-        self.assertEqual(realm.plan_type, Realm.STANDARD)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD)

--- a/corporate/views/billing_page.py
+++ b/corporate/views/billing_page.py
@@ -75,7 +75,7 @@ def billing_home(
         "has_active_plan": False,
     }
 
-    if user.realm.plan_type == user.realm.STANDARD_FREE:
+    if user.realm.plan_type == user.realm.PLAN_TYPE_STANDARD_FREE:
         context["is_sponsored"] = True
         return render(request, "corporate/billing.html", context=context)
 

--- a/templates/zerver/pricing_model.html
+++ b/templates/zerver/pricing_model.html
@@ -26,14 +26,14 @@
                     </div>
                     <div class="bottom">
                         <div class="text-content">
-                            {% if not realm or realm.plan_type == realm.SELF_HOSTED %}
+                            {% if not realm or realm.plan_type == realm.PLAN_TYPE_SELF_HOSTED %}
                             <div class="pricing-details">
                                 Free cloud service
                             </div>
                             <a href="/new/" class="button green">
                                 Create organization
                             </a>
-                            {% elif realm.plan_type == realm.LIMITED or sponsorship_pending %}
+                            {% elif realm.plan_type == realm.PLAN_TYPE_LIMITED or sponsorship_pending %}
                             <div class="pricing-details"></div>
                             <a href='/upgrade' class="button black-current-value" type="button">
                                 Current plan
@@ -79,7 +79,7 @@
                                 Upgrade to Standard
                                 {% endif %}
                             </a>
-                            {% elif realm.plan_type in [realm.STANDARD, realm.STANDARD_FREE] %}
+                            {% elif realm.plan_type in [realm.PLAN_TYPE_STANDARD, realm.PLAN_TYPE_STANDARD_FREE] %}
                             <a href='/billing' class="button black-current-value" type="button">
                                 {% if realm_on_free_trial %}
                                 Current plan (free trial)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4625,23 +4625,23 @@ def do_change_plan_type(
         extra_data={"old_value": old_value, "new_value": plan_type},
     )
 
-    if plan_type == Realm.PLUS:
+    if plan_type == Realm.PLAN_TYPE_PLUS:
         realm.max_invites = Realm.INVITES_STANDARD_REALM_DAILY_MAX
         realm.message_visibility_limit = None
         realm.upload_quota_gb = Realm.UPLOAD_QUOTA_STANDARD
-    elif plan_type == Realm.STANDARD:
+    elif plan_type == Realm.PLAN_TYPE_STANDARD:
         realm.max_invites = Realm.INVITES_STANDARD_REALM_DAILY_MAX
         realm.message_visibility_limit = None
         realm.upload_quota_gb = Realm.UPLOAD_QUOTA_STANDARD
-    elif plan_type == Realm.SELF_HOSTED:
+    elif plan_type == Realm.PLAN_TYPE_SELF_HOSTED:
         realm.max_invites = None  # type: ignore[assignment] # Apparent mypy bug with Optional[int] setter.
         realm.message_visibility_limit = None
         realm.upload_quota_gb = None
-    elif plan_type == Realm.STANDARD_FREE:
+    elif plan_type == Realm.PLAN_TYPE_STANDARD_FREE:
         realm.max_invites = Realm.INVITES_STANDARD_REALM_DAILY_MAX
         realm.message_visibility_limit = None
         realm.upload_quota_gb = Realm.UPLOAD_QUOTA_STANDARD
-    elif plan_type == Realm.LIMITED:
+    elif plan_type == Realm.PLAN_TYPE_LIMITED:
         realm.max_invites = settings.INVITES_DEFAULT_REALM_DAILY_MAX
         realm.message_visibility_limit = Realm.MESSAGE_VISIBILITY_LIMITED
         realm.upload_quota_gb = Realm.UPLOAD_QUOTA_LIMITED
@@ -5137,7 +5137,7 @@ def do_create_realm(
     realm.save(update_fields=["notifications_stream", "signup_notifications_stream"])
 
     if plan_type is None and settings.BILLING_ENABLED:
-        do_change_plan_type(realm, Realm.LIMITED, acting_user=None)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)
 
     admin_realm = get_realm(settings.SYSTEM_BOT_REALM)
     sender = get_system_bot(settings.NOTIFICATION_BOT, admin_realm.id)

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -282,7 +282,7 @@ def fetch_initial_state_data(
         state["realm_is_zephyr_mirror_realm"] = realm.is_zephyr_mirror_realm
         state["development_environment"] = settings.DEVELOPMENT
         state["realm_plan_type"] = realm.plan_type
-        state["zulip_plan_is_not_limited"] = realm.plan_type != Realm.LIMITED
+        state["zulip_plan_is_not_limited"] = realm.plan_type != Realm.PLAN_TYPE_LIMITED
         state["upgrade_text_for_wide_organization_logo"] = str(Realm.UPGRADE_TEXT_STANDARD)
 
         state["password_min_length"] = settings.PASSWORD_MIN_LENGTH
@@ -944,7 +944,7 @@ def apply_event(
 
             if event["property"] == "plan_type":
                 # Then there are some extra fields that also need to be set.
-                state["zulip_plan_is_not_limited"] = event["value"] != Realm.LIMITED
+                state["zulip_plan_is_not_limited"] = event["value"] != Realm.PLAN_TYPE_LIMITED
                 state["realm_upload_quota_mib"] = event["extra_data"]["upload_quota"]
 
             policy_permission_dict = {

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -68,7 +68,7 @@ def promote_sponsoring_zulip_in_realm(realm: Realm) -> bool:
 
     # If PROMOTE_SPONSORING_ZULIP is enabled, advertise sponsoring
     # Zulip in the gear menu of non-paying organizations.
-    return realm.plan_type in [Realm.STANDARD_FREE, Realm.SELF_HOSTED]
+    return realm.plan_type in [Realm.PLAN_TYPE_STANDARD_FREE, Realm.PLAN_TYPE_SELF_HOSTED]
 
 
 def get_billing_info(user_profile: Optional[UserProfile]) -> BillingInfo:
@@ -85,7 +85,7 @@ def get_billing_info(user_profile: Optional[UserProfile]) -> BillingInfo:
                 elif CustomerPlan.objects.filter(customer=customer).exists():
                     show_billing = True
 
-        if not user_profile.is_guest and user_profile.realm.plan_type == Realm.LIMITED:
+        if not user_profile.is_guest and user_profile.realm.plan_type == Realm.PLAN_TYPE_LIMITED:
             show_plans = True
 
     return BillingInfo(

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -1265,9 +1265,9 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
     import_analytics_data(realm=realm, import_dir=import_dir)
 
     if settings.BILLING_ENABLED:
-        do_change_plan_type(realm, Realm.LIMITED, acting_user=None)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)
     else:
-        do_change_plan_type(realm, Realm.SELF_HOSTED, acting_user=None)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_SELF_HOSTED, acting_user=None)
     return realm
 
 

--- a/zerver/lib/realm_logo.py
+++ b/zerver/lib/realm_logo.py
@@ -7,7 +7,7 @@ from zerver.models import Realm
 
 
 def get_realm_logo_source(realm: Realm, night: bool) -> str:
-    if realm.plan_type == Realm.LIMITED:
+    if realm.plan_type == Realm.PLAN_TYPE_LIMITED:
         return Realm.LOGO_DEFAULT
     if night:
         return realm.night_logo_source

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1338,7 +1338,7 @@ Output:
             licenses=licenses,
             licenses_at_next_renewal=licenses_at_next_renewal,
         )
-        realm.plan_type = Realm.STANDARD
+        realm.plan_type = Realm.PLAN_TYPE_STANDARD
         realm.save(update_fields=["plan_type"])
         return plan, ledger
 

--- a/zerver/management/commands/send_custom_email.py
+++ b/zerver/management/commands/send_custom_email.py
@@ -83,7 +83,7 @@ class Command(ZulipBaseCommand):
             # Sends at most one copy to each email address, even if it
             # is an administrator in several organizations.
             sponsored_realms = Realm.objects.filter(
-                plan_type=Realm.STANDARD_FREE, deactivated=False
+                plan_type=Realm.PLAN_TYPE_STANDARD_FREE, deactivated=False
             )
             admin_roles = [UserProfile.ROLE_REALM_ADMINISTRATOR, UserProfile.ROLE_REALM_OWNER]
             users = UserProfile.objects.filter(

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -536,12 +536,12 @@ class Realm(models.Model):
     # plan_type controls various features around resource/feature
     # limitations for a Zulip organization on multi-tenant installations
     # like Zulip Cloud.
-    SELF_HOSTED = 1
-    LIMITED = 2
-    STANDARD = 3
-    STANDARD_FREE = 4
-    PLUS = 10
-    plan_type: int = models.PositiveSmallIntegerField(default=SELF_HOSTED)
+    PLAN_TYPE_SELF_HOSTED = 1
+    PLAN_TYPE_LIMITED = 2
+    PLAN_TYPE_STANDARD = 3
+    PLAN_TYPE_STANDARD_FREE = 4
+    PLAN_TYPE_PLUS = 10
+    plan_type: int = models.PositiveSmallIntegerField(default=PLAN_TYPE_SELF_HOSTED)
 
     # This value is also being used in static/js/settings_bots.bot_creation_policy_values.
     # On updating it here, update it there as well.
@@ -834,7 +834,7 @@ class Realm(models.Model):
         return used_space
 
     def ensure_not_on_limited_plan(self) -> None:
-        if self.plan_type == Realm.LIMITED:
+        if self.plan_type == Realm.PLAN_TYPE_LIMITED:
             raise JsonableError(self.UPGRADE_TEXT_STANDARD)
 
     @property
@@ -885,7 +885,7 @@ class Realm(models.Model):
             # the server level before it is available to users.
             return False
 
-        if self.plan_type == Realm.LIMITED:
+        if self.plan_type == Realm.PLAN_TYPE_LIMITED:
             # In Zulip Cloud, we also require a paid or sponsored
             # plan, to protect against the spam/abuse attacks that
             # target every open Internet service that can host files.

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -395,7 +395,7 @@ class PlansPageTest(ZulipTestCase):
         self.assert_in_response("does not exist", result)
 
         realm = get_realm("zulip")
-        realm.plan_type = Realm.STANDARD_FREE
+        realm.plan_type = Realm.PLAN_TYPE_STANDARD_FREE
         realm.save(update_fields=["plan_type"])
         result = self.client_get("/plans/", subdomain="zulip")
         self.assertEqual(result.status_code, 302)
@@ -431,7 +431,7 @@ class PlansPageTest(ZulipTestCase):
         self.assert_not_in_success_response([current_plan, sponsorship_pending], result)
 
         realm = get_realm("zulip")
-        realm.plan_type = Realm.SELF_HOSTED
+        realm.plan_type = Realm.PLAN_TYPE_SELF_HOSTED
         realm.save(update_fields=["plan_type"])
 
         with self.settings(PRODUCTION=True):
@@ -451,7 +451,7 @@ class PlansPageTest(ZulipTestCase):
         self.assert_in_success_response([sign_up_now, upgrade_to_standard], result)
         self.assert_not_in_success_response([current_plan, sponsorship_pending], result)
 
-        realm.plan_type = Realm.LIMITED
+        realm.plan_type = Realm.PLAN_TYPE_LIMITED
         realm.save(update_fields=["plan_type"])
         result = self.client_get("/plans/", subdomain="zulip")
         self.assert_in_success_response([current_plan, upgrade_to_standard], result)
@@ -464,7 +464,7 @@ class PlansPageTest(ZulipTestCase):
                 [sign_up_now, sponsorship_pending, upgrade_to_standard], result
             )
 
-        realm.plan_type = Realm.STANDARD_FREE
+        realm.plan_type = Realm.PLAN_TYPE_STANDARD_FREE
         realm.save(update_fields=["plan_type"])
         result = self.client_get("/plans/", subdomain="zulip")
         self.assert_in_success_response([current_plan], result)
@@ -472,7 +472,7 @@ class PlansPageTest(ZulipTestCase):
             [sign_up_now, upgrade_to_standard, sponsorship_pending], result
         )
 
-        realm.plan_type = Realm.STANDARD
+        realm.plan_type = Realm.PLAN_TYPE_STANDARD
         realm.save(update_fields=["plan_type"])
         result = self.client_get("/plans/", subdomain="zulip")
         self.assert_in_success_response([current_plan], result)
@@ -494,7 +494,7 @@ class PlansPageTest(ZulipTestCase):
             [sign_up_now, upgrade_to_standard, sponsorship_pending], result
         )
 
-        realm.plan_type = Realm.LIMITED
+        realm.plan_type = Realm.PLAN_TYPE_LIMITED
         realm.save()
         customer.sponsorship_pending = True
         customer.save()

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1542,16 +1542,18 @@ class NormalActionsTest(BaseAction):
         realm = self.user_profile.realm
 
         state_data = fetch_initial_state_data(self.user_profile)
-        self.assertEqual(state_data["realm_plan_type"], Realm.SELF_HOSTED)
+        self.assertEqual(state_data["realm_plan_type"], Realm.PLAN_TYPE_SELF_HOSTED)
         self.assertEqual(state_data["zulip_plan_is_not_limited"], True)
 
         events = self.verify_action(
-            lambda: do_change_plan_type(realm, Realm.LIMITED, acting_user=self.user_profile)
+            lambda: do_change_plan_type(
+                realm, Realm.PLAN_TYPE_LIMITED, acting_user=self.user_profile
+            )
         )
         check_realm_update("events[0]", events[0], "plan_type")
 
         state_data = fetch_initial_state_data(self.user_profile)
-        self.assertEqual(state_data["realm_plan_type"], Realm.LIMITED)
+        self.assertEqual(state_data["realm_plan_type"], Realm.PLAN_TYPE_LIMITED)
         self.assertEqual(state_data["zulip_plan_is_not_limited"], False)
 
     def test_realm_emoji_events(self) -> None:

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -718,7 +718,7 @@ class HomeTest(ZulipTestCase):
         self.assertFalse(billing_info.show_plans)
 
         # realm owner, with inactive CustomerPlan and realm plan_type LIMITED -> show billing link and plans
-        do_change_plan_type(user.realm, Realm.LIMITED, acting_user=None)
+        do_change_plan_type(user.realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)
         with self.settings(CORPORATE_ENABLED=True):
             billing_info = get_billing_info(user)
         self.assertTrue(billing_info.show_billing)
@@ -747,7 +747,7 @@ class HomeTest(ZulipTestCase):
         # billing admin, with CustomerPlan and realm plan_type STANDARD -> show only billing link
         user.role = UserProfile.ROLE_MEMBER
         user.is_billing_admin = True
-        do_change_plan_type(user.realm, Realm.STANDARD, acting_user=None)
+        do_change_plan_type(user.realm, Realm.PLAN_TYPE_STANDARD, acting_user=None)
         user.save(update_fields=["role", "is_billing_admin"])
         with self.settings(CORPORATE_ENABLED=True):
             billing_info = get_billing_info(user)
@@ -755,7 +755,7 @@ class HomeTest(ZulipTestCase):
         self.assertFalse(billing_info.show_plans)
 
         # billing admin, with CustomerPlan and realm plan_type PLUS -> show only billing link
-        do_change_plan_type(user.realm, Realm.PLUS, acting_user=None)
+        do_change_plan_type(user.realm, Realm.PLAN_TYPE_PLUS, acting_user=None)
         user.save(update_fields=["role", "is_billing_admin"])
         with self.settings(CORPORATE_ENABLED=True):
             billing_info = get_billing_info(user)
@@ -763,7 +763,7 @@ class HomeTest(ZulipTestCase):
         self.assertFalse(billing_info.show_plans)
 
         # member, with CustomerPlan and realm plan_type STANDARD -> neither billing link or plans
-        do_change_plan_type(user.realm, Realm.STANDARD, acting_user=None)
+        do_change_plan_type(user.realm, Realm.PLAN_TYPE_STANDARD, acting_user=None)
         user.is_billing_admin = False
         user.save(update_fields=["is_billing_admin"])
         with self.settings(CORPORATE_ENABLED=True):
@@ -774,7 +774,7 @@ class HomeTest(ZulipTestCase):
         # guest, with CustomerPlan and realm plan_type SELF_HOSTED -> neither billing link or plans
         user.role = UserProfile.ROLE_GUEST
         user.save(update_fields=["role"])
-        do_change_plan_type(user.realm, Realm.SELF_HOSTED, acting_user=None)
+        do_change_plan_type(user.realm, Realm.PLAN_TYPE_SELF_HOSTED, acting_user=None)
         with self.settings(CORPORATE_ENABLED=True):
             billing_info = get_billing_info(user)
         self.assertFalse(billing_info.show_billing)
@@ -808,7 +808,7 @@ class HomeTest(ZulipTestCase):
     def test_promote_sponsoring_zulip_in_realm(self) -> None:
         realm = get_realm("zulip")
 
-        do_change_plan_type(realm, Realm.STANDARD_FREE, acting_user=None)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_STANDARD_FREE, acting_user=None)
         promote_zulip = promote_sponsoring_zulip_in_realm(realm)
         self.assertTrue(promote_zulip)
 
@@ -816,15 +816,15 @@ class HomeTest(ZulipTestCase):
             promote_zulip = promote_sponsoring_zulip_in_realm(realm)
         self.assertFalse(promote_zulip)
 
-        do_change_plan_type(realm, Realm.STANDARD_FREE, acting_user=None)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_STANDARD_FREE, acting_user=None)
         promote_zulip = promote_sponsoring_zulip_in_realm(realm)
         self.assertTrue(promote_zulip)
 
-        do_change_plan_type(realm, Realm.LIMITED, acting_user=None)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)
         promote_zulip = promote_sponsoring_zulip_in_realm(realm)
         self.assertFalse(promote_zulip)
 
-        do_change_plan_type(realm, Realm.STANDARD, acting_user=None)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_STANDARD, acting_user=None)
         promote_zulip = promote_sponsoring_zulip_in_realm(realm)
         self.assertFalse(promote_zulip)
 

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -1231,7 +1231,7 @@ class ImportExportTest(ZulipTestCase):
 
     def test_plan_type(self) -> None:
         realm = get_realm("zulip")
-        do_change_plan_type(realm, Realm.LIMITED, acting_user=None)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)
 
         self._setup_export_files(realm)
         self._export_realm(realm)
@@ -1240,7 +1240,7 @@ class ImportExportTest(ZulipTestCase):
             realm = do_import_realm(
                 os.path.join(settings.TEST_WORKER_DIR, "test-export"), "test-zulip-1"
             )
-            self.assertEqual(realm.plan_type, Realm.LIMITED)
+            self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_LIMITED)
             self.assertEqual(realm.max_invites, 100)
             self.assertEqual(realm.upload_quota_gb, 5)
             self.assertEqual(realm.message_visibility_limit, 10000)
@@ -1253,7 +1253,7 @@ class ImportExportTest(ZulipTestCase):
             realm = do_import_realm(
                 os.path.join(settings.TEST_WORKER_DIR, "test-export"), "test-zulip-2"
             )
-            self.assertEqual(realm.plan_type, Realm.SELF_HOSTED)
+            self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_SELF_HOSTED)
             self.assertEqual(realm.max_invites, 100)
             self.assertEqual(realm.upload_quota_gb, None)
             self.assertEqual(realm.message_visibility_limit, None)

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -357,14 +357,14 @@ class EditMessageTest(EditMessageTestCase):
         self.assertEqual(result.json()["raw_content"], "web-public message")
 
         # Verify LIMITED plan type does not allow web-public access.
-        do_change_plan_type(user_profile.realm, Realm.LIMITED, acting_user=None)
+        do_change_plan_type(user_profile.realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)
         result = self.client_get("/json/messages/" + str(web_public_stream_msg_id))
         self.assert_json_error(
             result, "Not logged in: API authentication or user session required", 401
         )
 
         # Verify works with STANDARD_FREE plan type too.
-        do_change_plan_type(user_profile.realm, Realm.STANDARD_FREE, acting_user=None)
+        do_change_plan_type(user_profile.realm, Realm.PLAN_TYPE_STANDARD_FREE, acting_user=None)
         result = self.client_get("/json/messages/" + str(web_public_stream_msg_id))
         self.assert_json_success(result)
         self.assertEqual(result.json()["raw_content"], "web-public message")

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -626,7 +626,7 @@ class RealmTest(ZulipTestCase):
 
     def test_initial_plan_type(self) -> None:
         with self.settings(BILLING_ENABLED=True):
-            self.assertEqual(do_create_realm("hosted", "hosted").plan_type, Realm.LIMITED)
+            self.assertEqual(do_create_realm("hosted", "hosted").plan_type, Realm.PLAN_TYPE_LIMITED)
             self.assertEqual(
                 get_realm("hosted").max_invites, settings.INVITES_DEFAULT_REALM_DAILY_MAX
             )
@@ -636,7 +636,9 @@ class RealmTest(ZulipTestCase):
             self.assertEqual(get_realm("hosted").upload_quota_gb, Realm.UPLOAD_QUOTA_LIMITED)
 
         with self.settings(BILLING_ENABLED=False):
-            self.assertEqual(do_create_realm("onpremise", "onpremise").plan_type, Realm.SELF_HOSTED)
+            self.assertEqual(
+                do_create_realm("onpremise", "onpremise").plan_type, Realm.PLAN_TYPE_SELF_HOSTED
+            )
             self.assertEqual(
                 get_realm("onpremise").max_invites, settings.INVITES_DEFAULT_REALM_DAILY_MAX
             )
@@ -665,49 +667,52 @@ class RealmTest(ZulipTestCase):
     def test_change_plan_type(self) -> None:
         realm = get_realm("zulip")
         iago = self.example_user("iago")
-        self.assertEqual(realm.plan_type, Realm.SELF_HOSTED)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_SELF_HOSTED)
         self.assertEqual(realm.max_invites, settings.INVITES_DEFAULT_REALM_DAILY_MAX)
         self.assertEqual(realm.message_visibility_limit, None)
         self.assertEqual(realm.upload_quota_gb, None)
 
-        do_change_plan_type(realm, Realm.STANDARD, acting_user=iago)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_STANDARD, acting_user=iago)
         realm = get_realm("zulip")
         realm_audit_log = RealmAuditLog.objects.filter(
             event_type=RealmAuditLog.REALM_PLAN_TYPE_CHANGED
         ).last()
         assert realm_audit_log is not None
-        expected_extra_data = {"old_value": Realm.SELF_HOSTED, "new_value": Realm.STANDARD}
+        expected_extra_data = {
+            "old_value": Realm.PLAN_TYPE_SELF_HOSTED,
+            "new_value": Realm.PLAN_TYPE_STANDARD,
+        }
         self.assertEqual(realm_audit_log.extra_data, str(expected_extra_data))
         self.assertEqual(realm_audit_log.acting_user, iago)
-        self.assertEqual(realm.plan_type, Realm.STANDARD)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD)
         self.assertEqual(realm.max_invites, Realm.INVITES_STANDARD_REALM_DAILY_MAX)
         self.assertEqual(realm.message_visibility_limit, None)
         self.assertEqual(realm.upload_quota_gb, Realm.UPLOAD_QUOTA_STANDARD)
 
-        do_change_plan_type(realm, Realm.LIMITED, acting_user=iago)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_LIMITED, acting_user=iago)
         realm = get_realm("zulip")
-        self.assertEqual(realm.plan_type, Realm.LIMITED)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_LIMITED)
         self.assertEqual(realm.max_invites, settings.INVITES_DEFAULT_REALM_DAILY_MAX)
         self.assertEqual(realm.message_visibility_limit, Realm.MESSAGE_VISIBILITY_LIMITED)
         self.assertEqual(realm.upload_quota_gb, Realm.UPLOAD_QUOTA_LIMITED)
 
-        do_change_plan_type(realm, Realm.STANDARD_FREE, acting_user=iago)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_STANDARD_FREE, acting_user=iago)
         realm = get_realm("zulip")
-        self.assertEqual(realm.plan_type, Realm.STANDARD_FREE)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD_FREE)
         self.assertEqual(realm.max_invites, Realm.INVITES_STANDARD_REALM_DAILY_MAX)
         self.assertEqual(realm.message_visibility_limit, None)
         self.assertEqual(realm.upload_quota_gb, Realm.UPLOAD_QUOTA_STANDARD)
 
-        do_change_plan_type(realm, Realm.LIMITED, acting_user=iago)
-        do_change_plan_type(realm, Realm.PLUS, acting_user=iago)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_LIMITED, acting_user=iago)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_PLUS, acting_user=iago)
         realm = get_realm("zulip")
-        self.assertEqual(realm.plan_type, Realm.PLUS)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_PLUS)
         self.assertEqual(realm.max_invites, Realm.INVITES_STANDARD_REALM_DAILY_MAX)
         self.assertEqual(realm.message_visibility_limit, None)
         self.assertEqual(realm.upload_quota_gb, Realm.UPLOAD_QUOTA_STANDARD)
 
-        do_change_plan_type(realm, Realm.SELF_HOSTED, acting_user=iago)
-        self.assertEqual(realm.plan_type, Realm.SELF_HOSTED)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_SELF_HOSTED, acting_user=iago)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_SELF_HOSTED)
         self.assertEqual(realm.max_invites, settings.INVITES_DEFAULT_REALM_DAILY_MAX)
         self.assertEqual(realm.message_visibility_limit, None)
         self.assertEqual(realm.upload_quota_gb, None)
@@ -715,7 +720,7 @@ class RealmTest(ZulipTestCase):
     def test_message_retention_days(self) -> None:
         self.login("iago")
         realm = get_realm("zulip")
-        self.assertEqual(realm.plan_type, Realm.SELF_HOSTED)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_SELF_HOSTED)
 
         req = dict(message_retention_days=orjson.dumps(10).decode())
         result = self.client_patch("/json/realm", req)
@@ -747,12 +752,12 @@ class RealmTest(ZulipTestCase):
         result = self.client_patch("/json/realm", req)
         self.assert_json_success(result)
 
-        do_change_plan_type(realm, Realm.LIMITED, acting_user=None)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)
         req = dict(message_retention_days=orjson.dumps(10).decode())
         result = self.client_patch("/json/realm", req)
         self.assert_json_error(result, "Available on Zulip Standard. Upgrade to access.")
 
-        do_change_plan_type(realm, Realm.STANDARD, acting_user=None)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_STANDARD, acting_user=None)
         req = dict(message_retention_days=orjson.dumps(10).decode())
         result = self.client_patch("/json/realm", req)
         self.assert_json_success(result)
@@ -766,7 +771,7 @@ class RealmTest(ZulipTestCase):
         self.assertEqual(realm.email_address_visibility, Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE)
         self.assertEqual(realm.description, "")
         self.assertTrue(realm.invite_required)
-        self.assertEqual(realm.plan_type, Realm.LIMITED)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_LIMITED)
         self.assertEqual(realm.org_type, Realm.ORG_TYPES["unspecified"]["id"])
         self.assertEqual(type(realm.date_created), datetime.datetime)
 
@@ -784,7 +789,7 @@ class RealmTest(ZulipTestCase):
         self.assertEqual(realm.signup_notifications_stream.name, "core team")
         self.assertEqual(realm.signup_notifications_stream.realm, realm)
 
-        self.assertEqual(realm.plan_type, Realm.LIMITED)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_LIMITED)
 
     def test_do_create_realm_with_keyword_arguments(self) -> None:
         date_created = timezone_now() - datetime.timedelta(days=100)
@@ -796,7 +801,7 @@ class RealmTest(ZulipTestCase):
             email_address_visibility=Realm.EMAIL_ADDRESS_VISIBILITY_MEMBERS,
             description="realm description",
             invite_required=False,
-            plan_type=Realm.STANDARD_FREE,
+            plan_type=Realm.PLAN_TYPE_STANDARD_FREE,
             org_type=Realm.ORG_TYPES["community"]["id"],
         )
         self.assertEqual(realm.string_id, "realm_string_id")
@@ -805,7 +810,7 @@ class RealmTest(ZulipTestCase):
         self.assertEqual(realm.email_address_visibility, Realm.EMAIL_ADDRESS_VISIBILITY_MEMBERS)
         self.assertEqual(realm.description, "realm description")
         self.assertFalse(realm.invite_required)
-        self.assertEqual(realm.plan_type, Realm.STANDARD_FREE)
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD_FREE)
         self.assertEqual(realm.org_type, Realm.ORG_TYPES["community"]["id"])
         self.assertEqual(realm.date_created, date_created)
 
@@ -855,7 +860,7 @@ class RealmTest(ZulipTestCase):
             self.assertEqual(realm.web_public_streams_enabled(), False)
             self.assertEqual(realm.has_web_public_streams(), False)
 
-        realm.plan_type = Realm.LIMITED
+        realm.plan_type = Realm.PLAN_TYPE_LIMITED
         realm.save()
         self.assertEqual(Stream.objects.filter(realm=realm, is_web_public=True).count(), 1)
         self.assertEqual(realm.web_public_streams_enabled(), False)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1263,7 +1263,7 @@ class StreamAdminTest(ZulipTestCase):
         user_profile = self.example_user("desdemona")
         self.login_user(user_profile)
         realm = user_profile.realm
-        do_change_plan_type(realm, Realm.LIMITED, acting_user=None)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)
         stream = self.subscribe(user_profile, "stream_name1")
 
         result = self.client_patch(
@@ -1271,7 +1271,7 @@ class StreamAdminTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Available on Zulip Standard. Upgrade to access.")
 
-        do_change_plan_type(realm, Realm.SELF_HOSTED, acting_user=None)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_SELF_HOSTED, acting_user=None)
         events: List[Mapping[str, Any]] = []
         with self.tornado_redirected_to_list(events, expected_num_events=1):
             result = self.client_patch(
@@ -1437,13 +1437,13 @@ class StreamAdminTest(ZulipTestCase):
             },
         ]
 
-        do_change_plan_type(realm, Realm.LIMITED, acting_user=admin)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_LIMITED, acting_user=admin)
         with self.assertRaisesRegex(
             JsonableError, "Available on Zulip Standard. Upgrade to access."
         ):
             list_to_streams(streams_raw, owner, autocreate=True)
 
-        do_change_plan_type(realm, Realm.SELF_HOSTED, acting_user=admin)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_SELF_HOSTED, acting_user=admin)
         result = list_to_streams(streams_raw, owner, autocreate=True)
         self.assert_length(result[0], 0)
         self.assert_length(result[1], 3)

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1512,7 +1512,7 @@ class RealmLogoTest(UploadSerializeMixin, ZulipTestCase):
 
     def test_upload_limited_plan_type(self) -> None:
         user_profile = self.example_user("iago")
-        do_change_plan_type(user_profile.realm, Realm.LIMITED, acting_user=None)
+        do_change_plan_type(user_profile.realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)
         self.login_user(user_profile)
         with get_test_image_file(self.correct_files[0][0]) as fp:
             result = self.client_post(
@@ -1556,7 +1556,7 @@ class RealmLogoTest(UploadSerializeMixin, ZulipTestCase):
             f"/user_avatars/{realm.id}/realm/{file_name}?version=2&night={is_night_str}",
         )
 
-        do_change_plan_type(realm, Realm.LIMITED, acting_user=user_profile)
+        do_change_plan_type(realm, Realm.PLAN_TYPE_LIMITED, acting_user=user_profile)
         if self.night:
             self.assertEqual(realm.night_logo_source, Realm.LOGO_UPLOADED)
         else:

--- a/zerver/views/portico.py
+++ b/zerver/views/portico.py
@@ -44,7 +44,7 @@ def plans_view(request: HttpRequest) -> HttpResponse:
     realm_on_free_trial = False
 
     if realm is not None:
-        if realm.plan_type == Realm.SELF_HOSTED and settings.PRODUCTION:
+        if realm.plan_type == Realm.PLAN_TYPE_SELF_HOSTED and settings.PRODUCTION:
             return HttpResponseRedirect("https://zulip.com/plans")
         if not request.user.is_authenticated:
             return redirect_to_login(next="/plans")

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -312,7 +312,7 @@ class Command(BaseCommand):
                 description="The Zulip development environment default organization."
                 "  It's great for testing!",
                 invite_required=False,
-                plan_type=Realm.SELF_HOSTED,
+                plan_type=Realm.PLAN_TYPE_SELF_HOSTED,
                 org_type=Realm.ORG_TYPES["business"]["id"],
             )
             RealmDomain.objects.create(realm=zulip_realm, domain="zulip.com")
@@ -327,7 +327,7 @@ class Command(BaseCommand):
                     name="MIT",
                     emails_restricted_to_domains=True,
                     invite_required=False,
-                    plan_type=Realm.SELF_HOSTED,
+                    plan_type=Realm.PLAN_TYPE_SELF_HOSTED,
                     org_type=Realm.ORG_TYPES["business"]["id"],
                 )
                 RealmDomain.objects.create(realm=mit_realm, domain="mit.edu")
@@ -337,7 +337,7 @@ class Command(BaseCommand):
                     name="Lear & Co.",
                     emails_restricted_to_domains=False,
                     invite_required=False,
-                    plan_type=Realm.SELF_HOSTED,
+                    plan_type=Realm.PLAN_TYPE_SELF_HOSTED,
                     org_type=Realm.ORG_TYPES["business"]["id"],
                 )
 


### PR DESCRIPTION
It is confusing to have the plan type constants not be namespaced
by the thing they represent. We already have a namespacing
convention in place for constants, so we should use it for
Realm.plan_type as well.

@timabbott FYI
