### PR TITLE
Fix #19998: Put status emoji before status message

### DIFF
--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -83,7 +83,6 @@
         {{#unless is_me}}<hr />{{/unless}}
         <li class="user_info_status_text">
             <span id="status_message">
-                {{status_text}}
                 {{#if status_emoji_info}}
                     {{#if status_emoji_info.emoji_alt_code}}
                         <div class="emoji_alt_code">&nbsp:{{status_emoji_info.emoji_name}}:</div>
@@ -95,6 +94,7 @@
                         {{/if}}
                     {{/if}}
                 {{/if}}
+                {{status_text}}
                 {{#if is_me}}(<a tabindex="0" class="clear_status">{{#tr}}clear{{/tr}}</a>){{/if}}
             </span>
         </li>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#19998 

**Testing plan:** <!-- How have you tested? -->
Manually tested since there is very minimal change.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


![zulip](https://user-images.githubusercontent.com/70739349/137877474-8048ee82-7c48-45aa-8e3a-e57ea6d185da.jpg)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
