### PR TITLE
Add: Status emoji in message feed and PMs

### DIFF
--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -148,6 +148,7 @@ run_test("update_messages", () => {
             sender_id: 32,
             sent_by_me: false,
             starred: false,
+            status_emoji_info: undefined,
             stream: denmark.name,
             stream_id: denmark.stream_id,
             topic: "lunch",

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -72,7 +72,7 @@ test("close", () => {
 test("build_private_messages_list", ({override}) => {
     const timestamp = 0;
     pm_conversations.recent.insert([101, 102], timestamp);
-
+    pm_conversations.recent.insert([103], timestamp);
     let num_unread_for_person = 1;
     override(unread, "num_unread_for_person", () => num_unread_for_person);
 
@@ -87,12 +87,24 @@ test("build_private_messages_list", ({override}) => {
 
     const expected_data = [
         {
+            is_active: false,
+            is_group: false,
+            is_zero: false,
+            recipients: "Me Myself",
+            status_emoji_info: undefined,
+            unread: 1,
+            url: "#narrow/pm-with/103-me",
+            user_circle_class: "user_circle_empty",
+            user_ids_string: "103",
+        },
+        {
             recipients: "Alice, Bob",
             user_ids_string: "101,102",
             unread: 1,
             is_zero: false,
             is_active: false,
             url: "#narrow/pm-with/101,102-group",
+            status_emoji_info: undefined,
             user_circle_class: "user_circle_fraction",
             is_group: true,
         },
@@ -104,6 +116,8 @@ test("build_private_messages_list", ({override}) => {
     pm_list._build_private_messages_list();
     expected_data[0].unread = 0;
     expected_data[0].is_zero = true;
+    expected_data[1].unread = 0;
+    expected_data[1].is_zero = true;
     assert.deepEqual(pm_data, expected_data);
 
     pm_list._build_private_messages_list();
@@ -133,6 +147,7 @@ test("build_private_messages_list_bot", ({override}) => {
             is_zero: false,
             is_active: false,
             url: "#narrow/pm-with/314-outgoingwebhook",
+            status_emoji_info: undefined,
             user_circle_class: "user_circle_green",
             is_group: false,
         },
@@ -143,6 +158,7 @@ test("build_private_messages_list_bot", ({override}) => {
             is_zero: false,
             is_active: false,
             url: "#narrow/pm-with/101,102-group",
+            status_emoji_info: undefined,
             user_circle_class: "user_circle_fraction",
             is_group: true,
         },

--- a/static/js/message_helper.js
+++ b/static/js/message_helper.js
@@ -5,6 +5,7 @@ import * as people from "./people";
 import * as pm_conversations from "./pm_conversations";
 import * as recent_senders from "./recent_senders";
 import * as stream_topic_history from "./stream_topic_history";
+import * as user_status from "./user_status";
 import * as util from "./util";
 
 export function process_new_message(message) {
@@ -31,6 +32,7 @@ export function process_new_message(message) {
     if (sender) {
         message.sender_full_name = sender.full_name;
         message.sender_email = sender.email;
+        message.status_emoji_info = user_status.get_status_emoji(message.sender_id);
     }
 
     // Convert topic even for PMs, as legacy code

--- a/static/js/message_live_update.js
+++ b/static/js/message_live_update.js
@@ -28,5 +28,11 @@ export function update_avatar(user_id, avatar_url) {
     let url = avatar_url;
     url = people.format_small_avatar_url(url);
     message_store.update_property("small_avatar_url", url, {user_id});
+
+    rerender_messages_view();
+}
+
+export function update_user_status_emoji(user_id, status_emoji_info) {
+    message_store.update_property("status_emoji_info", status_emoji_info, {user_id});
     rerender_messages_view();
 }

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -124,6 +124,13 @@ export function update_property(property, value, info) {
                 }
             }
             break;
+        case "status_emoji_info":
+            for (const msg of stored_messages.values()) {
+                if (msg.sender_id && msg.sender_id === info.user_id) {
+                    msg[property] = value;
+                }
+            }
+            break;
     }
 }
 

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -10,6 +10,7 @@ import * as stream_popover from "./stream_popover";
 import * as ui from "./ui";
 import * as ui_util from "./ui_util";
 import * as unread from "./unread";
+import * as user_status from "./user_status";
 import * as vdom from "./vdom";
 
 let prior_dom;
@@ -75,6 +76,7 @@ export function _get_convos() {
         const is_active = user_ids_string === active_user_ids_string;
 
         let user_circle_class;
+        let status_emoji_info;
 
         if (is_group) {
             user_circle_class = "user_circle_fraction";
@@ -85,6 +87,8 @@ export function _get_convos() {
 
             if (recipient_user_obj.is_bot) {
                 user_circle_class = "user_circle_green";
+            } else {
+                status_emoji_info = user_status.get_status_emoji(user_id);
             }
         }
 
@@ -95,6 +99,7 @@ export function _get_convos() {
             is_zero: num_unread === 0,
             is_active,
             url: hash_util.pm_with_uri(reply_to),
+            status_emoji_info,
             user_circle_class,
             is_group,
         };

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -23,6 +23,7 @@ import * as message_events from "./message_events";
 import * as message_flags from "./message_flags";
 import * as message_list from "./message_list";
 import * as message_lists from "./message_lists";
+import * as message_live_update from "./message_live_update";
 import * as muted_topics_ui from "./muted_topics_ui";
 import * as muted_users_ui from "./muted_users_ui";
 import * as narrow_state from "./narrow_state";
@@ -32,6 +33,7 @@ import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as people from "./people";
+import * as pm_list from "./pm_list";
 import * as reactions from "./reactions";
 import * as realm_icon from "./realm_icon";
 import * as realm_logo from "./realm_logo";
@@ -769,6 +771,11 @@ export function dispatch_normal_event(event) {
             if (event.emoji_name !== undefined) {
                 user_status.set_status_emoji(event);
                 activity.redraw_user(event.user_id);
+                pm_list.update_private_messages();
+                message_live_update.update_user_status_emoji(
+                    event.user_id,
+                    user_status.get_status_emoji(event.user_id),
+                );
             }
             break;
         case "realm_export":

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2460,6 +2460,22 @@ div.topic_edit_spinner .loading_indicator_spinner {
     top: 3px;
 }
 
+.emoji_message_feed {
+    height: 16px;
+    width: 16px;
+    top: 0;
+}
+
+.status_emoji {
+    height: 16px;
+    width: 16px;
+    /* We are setting minimum width here because when the user's name is very long,
+    emoji's width decreases and causes it to break. */
+    min-width: 16px;
+    margin-left: 4px;
+    margin-right: 4px;
+}
+
 /* FIXME: Combine this rule with the one in portico.css somehow? */
 #pw_strength {
     width: 100%;

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -4,7 +4,7 @@
         {{#if include_sender}}
         <span title="{{t 'View user profile' }} (u)">
             {{> message_avatar ~}}
-            <span class="sender_name auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
+            <span class="sender_name auto-select" role="button" tabindex="0">{{msg/sender_full_name}}{{>status_emoji status_emoji_info=msg/status_emoji_info}}</span>
             {{#if sender_is_bot}}
             <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
             {{/if}}

--- a/static/templates/pm_list_item.hbs
+++ b/static/templates/pm_list_item.hbs
@@ -11,6 +11,7 @@
 
         <a href='{{url}}' class="conversation-partners">
             {{recipients}}
+            {{> status_emoji}}
         </a>
         <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
             {{unread}}

--- a/static/templates/status_emoji.hbs
+++ b/static/templates/status_emoji.hbs
@@ -1,0 +1,13 @@
+{{#if status_emoji_info}}
+    {{#if status_emoji_info.emoji_alt_code}}
+        <div class="emoji_alt_code">&nbsp:{{status_emoji_info.emoji_name}}:</div>
+    {{else}}
+        {{#if status_emoji_info.still_url}}
+        <img src="{{status_emoji_info.still_url}}" class="emoji status_emoji" data-animated-url="{{status_emoji_info.url}}" data-still-url="{{status_emoji_info.still_url}}" />
+        {{else if status_emoji_info.url}}
+        <img src="{{status_emoji_info.url}}" class="emoji status_emoji" data-animated-url="{{status_emoji_info.url}}" data-still-url="{{status_emoji_info.still_url}}" />
+        {{else}}
+        <div class="emoji status_emoji emoji-{{status_emoji_info.emoji_code}}"></div>
+        {{/if}}
+    {{/if}}
+{{/if}}

--- a/static/templates/user_presence_row.hbs
+++ b/static/templates/user_presence_row.hbs
@@ -6,19 +6,7 @@
           data-user-id="{{user_id}}"
           data-name="{{name}}">
             <span class="user-name">{{name}}</span>
-            {{#if status_emoji_info}}
-                {{#if status_emoji_info.emoji_alt_code}}
-                    <div class="emoji_alt_code">&nbsp:{{status_emoji_info.emoji_name}}:</div>
-                {{else}}
-                    {{#if status_emoji_info.still_url}}
-                    <img src="{{status_emoji_info.still_url}}" class="emoji status_emoji" data-animated-url="{{status_emoji_info.url}}" data-still-url="{{status_emoji_info.still_url}}" />
-                    {{else if status_emoji_info.url}}
-                    <img src="{{status_emoji_info.url}}" class="emoji status_emoji" data-animated-url="{{status_emoji_info.url}}" data-still-url="{{status_emoji_info.still_url}}" />
-                    {{else}}
-                    <div class="emoji status_emoji emoji-{{status_emoji_info.emoji_code}}"></div>
-                    {{/if}}
-                {{/if}}
-            {{/if}}
+            {{>status_emoji}}
         </a>
         <span class="unread_count">{{#if num_unread}}{{num_unread}}{{/if}}</span>
     </div>


### PR DESCRIPTION
**PR for issue #19865:** Show status emoji in message feed and PMs #19865

1. Shows the current status emoji of users in the PM list (area: left-sidebar)
2. Shows the current status emoji of users in the message feed (area: message feed UI)
3. The status emoji also resets and updates at all the above-mentioned locations whenever the user changes their current status.


**GIFs or screenshots:**

* **Overall UI change:**
<img width="1276" alt="Screenshot 2021-10-20 at 12 09 27 PM" src="https://user-images.githubusercontent.com/71231079/138053843-70df7bc6-eeb0-41c5-b8c5-c1ba082fd3da.png">

* **The current status emoji of users in the PM list (area: left-sidebar)**
<img width="261" alt="Screenshot 2021-10-20 at 12 10 06 PM" src="https://user-images.githubusercontent.com/71231079/138053954-8c3c6744-23e8-473e-8872-74104b8247fd.png">

* **The current status emoji of users in the message feed (area: message feed UI)**
<img width="771" alt="Screenshot 2021-10-20 at 12 11 42 PM" src="https://user-images.githubusercontent.com/71231079/138054176-ba4af0d8-d6aa-49e7-a1fa-236c5fa271de.png">

* **The status emoji updation whenever the user changes their current status.**
<img width="1280" alt="Screenshot 2021-10-20 at 12 12 44 PM" src="https://user-images.githubusercontent.com/71231079/138054342-dd967fac-4ed5-4ed3-b1a2-dbeec77d497c.png">


