### PR TITLE
documentation_api: Deduplicate ignored_parameters_unsupported.

### DIFF
--- a/templates/zerver/help/include/rest-endpoints.md
+++ b/templates/zerver/help/include/rest-endpoints.md
@@ -77,7 +77,7 @@
 * [Get all custom profile fields](/api/get-custom-profile-fields)
 * [Reorder custom profile fields](/api/reorder-custom-profile-fields)
 * [Create a custom profile field](/api/create-custom-profile-field)
-* [Change default values of user preferences](/api/update-realm-user-settings-defaults)
+* [Update realm-level defaults of user settings](/api/update-realm-user-settings-defaults)
 
 #### Real-time events
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7550,7 +7550,7 @@ paths:
   /realm/user_settings_defaults:
     patch:
       operationId: update-realm-user-settings-defaults
-      summary: Update realm-level defaults of user settings.
+      summary: Update realm-level defaults of user settings
       tags: ["server_and_organizations"]
       x-requires-administrator: true
       description: |
@@ -7908,16 +7908,7 @@ paths:
                       result: {}
                       msg: {}
                       ignored_parameters_unsupported:
-                        type: array
-                        items:
-                          type: string
-                        description: |
-                          This field lists any parameters sent in the request that are not
-                          supported by the endpoint. While this can be expected, e.g. when sending
-                          both current and legacy names for a parameter to a Zulip server of
-                          unknown version, this often indicates a bug in the client
-                          implementation or an attempt to configure a new feature, while
-                          connected to an older Zulip server that does not support the feature.
+                        $ref: "#/components/schemas/IgnoredParametersUnsupported"
                     example:
                       {
                         "ignored_parameters_unsupported":
@@ -12004,18 +11995,32 @@ paths:
         endpoint only supported the `full_name`, `email`,
         `old_password`, and `new_password` parameters. Notification
         settings were managed by `PATCH /settings/notifications`, and
-        all other settings by `PATCH /settings/display`. The feature level
-        80 migration to merge these endpoints did not change how request
-        parameters are encoded. Note, however, that it did change the
-        handling of any invalid parameters present in a request to change
-        notification or display settings, since the merged endpoint uses
-        the new response format that was introduced for `/settings` in
-        Zulip 5.0 (feature level 78).
+        all other settings by `PATCH /settings/display`.
+
+        The feature level 80 migration to merge these endpoints did not
+        change how request parameters are encoded. However, it did change
+        the handling of any invalid parameters present in a request
+        (see feature level 78 change below).
 
         The `/settings/display` and `/settings/notifications`
         endpoints are now deprecated aliases for this endpoint for
         backwards-compatibility, and will be removed once clients have
         migrated to use this endpoint.
+
+        **Changes**: New in Zulip 5.0 (feature level 78). Previously,
+        the `/settings` endpoint indicated which parameters it had
+        processed by including in the response object `"key": value`
+        entries for values successfully changed by the request. Now the
+        `/settings` endpoint indicates which parameters sent with the
+        request were not supported by this endpoint (see
+        `ignored_parameters_unsupported` below).
+
+        The `/settings/notifications` and `/settings/display` endpoints
+        also had this behavior before they became aliases of `/settings`
+        in Zulip 5.0 (see feature level 80 change above).
+
+        Before these changes, request parameters that were not supported
+        (or were unchanged) were silently ignored.
       x-curl-examples-parameters:
         oneOf:
           - type: include
@@ -12530,28 +12535,7 @@ paths:
                       result: {}
                       msg: {}
                       ignored_parameters_unsupported:
-                        type: array
-                        items:
-                          type: string
-                        description: |
-                          This field lists any parameters sent in the request that are not
-                          supported by the endpoint. While this can be expected, e.g. when sending
-                          both current and legacy names for a parameter to a Zulip server of
-                          unknown version, this often indicates a bug in the client
-                          implementation or an attempt to configure a new feature, while
-                          connected to an older Zulip server that does not support the feature.
-
-                          **Changes**: New in Zulip 5.0 (feature level 78). Previously,
-                          the `/settings` endpoint indicated which parameters it had
-                          processed by including in the response object `"key": value`
-                          entries for values successfully changed by the request.
-
-                          The `/settings/notifications` and `/settings/display` endpoints
-                          also had this behavior before they became aliases of `/settings`
-                          in Zulip 5.0 (feature level 80).
-
-                          Before those changes, request parameters that were not supported
-                          or were unchanged were silently ignored.
+                        $ref: "#/components/schemas/IgnoredParametersUnsupported"
                     example:
                       {
                         "ignored_parameters_unsupported": ["name", "password"],
@@ -13570,6 +13554,19 @@ components:
         `/fetch_api_key` or `/dev_fetch_api_key` endpoints.
 
   schemas:
+    IgnoredParametersUnsupported:
+      type: array
+      items:
+        type: string
+      description: |
+        An array of any parameters sent in the request that are not
+        supported by the endpoint. While this can be expected, e.g. when sending
+        both current and legacy names for a parameter to a Zulip server of
+        unknown version, this often indicates either a bug in the client
+        implementation or an attempt to configure a new feature while
+        connected to an older Zulip server that does not support said feature.
+
+        **Changes**: New in Zulip 5.0 (feature level 78)
     EventIdSchema:
       type: integer
       description: |


### PR DESCRIPTION
Created a schema for the `ignored_parameters_unsupported` array that is returned by the `/settings` and `/realm/user_settings_defaults` endpoints and removed the duplicated text in the api documentation.

I wasn't sure about style and order for the schema. Re:order, I put it at the top of the schema section in the zulip.yaml. And re:style, I went with the camelcase starting with a capital letter as that seemed to be the standard (the `profile_data` schema is the only one in the document that doesn't follow camelcase pattern).

The `/settings` endpoint had some change documentation (feature levels 78 and 80) that needed to be included in for that endpoint, but not in every endpoint usage of the new schema, so I put the change log in the main description of the endpoint definition, which required some light editing and cleaning of the text.

I also cleaned up some small errors in the `/realm/user_settings_defaults` definition (there was a period in the summary) and sidebar link /`api/update-realm-user-settings-defaults` (didn't match the summary).

In regards to testing beyond the zulip testing suites, I did some visual checks to make sure that the information shown currently for these endpoint documentation is included in the new versions (see images below).

![zulip_update_realm](https://user-images.githubusercontent.com/63245456/138106661-16ee3c53-4287-42d9-9d5e-95c7f88e7291.png)

![zulip_update_settings_change](https://user-images.githubusercontent.com/63245456/138106671-7fbc234d-f8ef-47f9-8159-586c136acf14.png)

![zulip_update_settings](https://user-images.githubusercontent.com/63245456/138106710-e7837e13-aa73-4705-b574-c3c921cf790c.png)

Fixes #19674
