### PR TITLE
ci: Run production tests when files mentioning zilencer are changed.

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/production-suite.yml
       - "**/migrations/**"
       - babel.config.js
+      - manage.py
       - postcss.config.js
       - puppet/**
       - requirements/**
@@ -16,6 +17,9 @@ on:
       - tools/**
       - webpack.config.ts
       - yarn.lock
+      - zerver/worker/queue_processors.py
+      - zerver/lib/push_notifications.py
+      - zerver/decorator.py
       - zproject/**
 
 defaults:


### PR DESCRIPTION
Production installs do not use the zilencer application, but the tests
do include it; as such, changes to any files which reference zilencer
are more likely to pass tests but fail production installs.

Run production tests when those files are changed.
