### PR TITLE
provision: Silently unset `PIP_USER` if set

### DIFF
--- a/tools/setup/setup_venvs.py
+++ b/tools/setup/setup_venvs.py
@@ -7,6 +7,9 @@ ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__f
 if ZULIP_PATH not in sys.path:
     sys.path.append(ZULIP_PATH)
 
+# unset PIP_USER if set, since it is not compatible with virtualenvs.
+os.environ.pop("PIP_USER", None)
+
 from scripts.lib.setup_venv import setup_virtualenv
 from scripts.lib.zulip_tools import overwrite_symlink
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

The `./tools/provision` script fails with the following error if `PIP_USER` is set:
```console
$ PIP_USER=1 ./tools/provision
created virtual environment CPython3.8.10.final.0-64 in 178ms
  creator CPython3Posix(dest=/srv/zulip-venv-cache/0a22135fa26b60fd916f864e4b659aeb7b0116a9/zulip-py3-venv, clear=False, global=False)
  seeder FromAppData(download=False, pip=latest, setuptools=latest, wheel=latest, pkg_resources=latest, via=copy, app_data_dir=/root/.local/share/virtualenv/seed-app-data/v1.0.1.debian.1)
  activators BashActivator,CShellActivator,FishActivator,PowerShellActivator,PythonActivator,XonshActivator
+ sudo -- chown -R 33333:33333 /srv/zulip-venv-cache/0a22135fa26b60fd916f864e4b659aeb7b0116a9/zulip-py3-venv
+ /srv/zulip-venv-cache/0a22135fa26b60fd916f864e4b659aeb7b0116a9/zulip-py3-venv/bin/pip install --force-reinstall --require-hashes -r /workspace/zulip/requirements/pip.txt
ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv.
```
Additionally, some environments (like GitPod) have the variable set by default.

**Testing plan:** <!-- How have you tested? -->
Ran `PIP_USER=1 ./tools/provision` and `unset PIP_USER; ./tools/provision`