### PR TITLE
python: Remove re.UNICODE flag (redundant in Python 3)

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -148,7 +148,7 @@ EMOJI_REGEX = r"(?P<syntax>:[\w\-\+]+:)"
 def verbose_compile(pattern: str) -> Pattern[str]:
     return re.compile(
         f"^(.*?){pattern}(.*?)$",
-        re.DOTALL | re.UNICODE | re.VERBOSE,
+        re.DOTALL | re.VERBOSE,
     )
 
 
@@ -169,7 +169,7 @@ def get_compiled_stream_link_regex() -> Pattern[str]:
     # are not required.
     return re.compile(
         STREAM_LINK_REGEX,
-        re.DOTALL | re.UNICODE | re.VERBOSE,
+        re.DOTALL | re.VERBOSE,
     )
 
 
@@ -192,7 +192,7 @@ def get_compiled_stream_topic_link_regex() -> Pattern[str]:
     # are not required.
     return re.compile(
         STREAM_TOPIC_LINK_REGEX,
-        re.DOTALL | re.UNICODE | re.VERBOSE,
+        re.DOTALL | re.VERBOSE,
     )
 
 
@@ -2404,7 +2404,7 @@ def maybe_update_markdown_engines(linkifiers_key: int, email_gateway: bool) -> N
 #
 # We also use repr() to improve reproducibility, and to escape terminal control
 # codes, which can do surprisingly nasty things.
-_privacy_re = re.compile("\\w", flags=re.UNICODE)
+_privacy_re = re.compile("\\w")
 
 
 def privacy_clean_markdown(content: str) -> str:

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -94,8 +94,8 @@ def sanitize_name(value: str) -> str:
     * not stripping trailing dashes and underscores.
     """
     value = unicodedata.normalize("NFKC", value)
-    value = re.sub(r"[^\w\s.-]", "", value, flags=re.U).strip()
-    value = re.sub(r"[-\s]+", "-", value, flags=re.U)
+    value = re.sub(r"[^\w\s.-]", "", value).strip()
+    value = re.sub(r"[-\s]+", "-", value)
     assert value not in {"", ".", ".."}
     return mark_safe(value)
 

--- a/zerver/management/commands/makemessages.py
+++ b/zerver/management/commands/makemessages.py
@@ -45,10 +45,10 @@ from django.template.base import BLOCK_TAG_END, BLOCK_TAG_START
 from django.utils.translation import template
 
 strip_whitespace_right = re.compile(
-    f"({BLOCK_TAG_START}-?\\s*(trans|pluralize).*?-{BLOCK_TAG_END})\\s+", re.U
+    f"({BLOCK_TAG_START}-?\\s*(trans|pluralize).*?-{BLOCK_TAG_END})\\s+"
 )
 strip_whitespace_left = re.compile(
-    f"\\s+({BLOCK_TAG_START}-\\s*(endtrans|pluralize).*?-?{BLOCK_TAG_END})", re.U
+    f"\\s+({BLOCK_TAG_START}-\\s*(endtrans|pluralize).*?-?{BLOCK_TAG_END})"
 )
 
 regexes = [


### PR DESCRIPTION
https://docs.python.org/3/library/re.html#re.A