### PR TITLE
Resolved issue 19353 task 4

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -46,6 +46,7 @@ mock_esm("../../static/js/message_lists", {
 });
 mock_esm("../../static/js/resize", {
     reset_compose_textarea_max_height: noop,
+    reset_compose_preview_area_max_height: noop,
 });
 
 const people = zrequire("people");

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -667,6 +667,8 @@ export function initialize() {
         const content = $("#compose-textarea").val();
         $("#compose-textarea").hide();
         $("#compose .markdown_preview").hide();
+        const compose_non_preview_area_height = $("#compose").height();
+        resize.reset_compose_preview_area_max_height(undefined, compose_non_preview_area_height);
         $("#compose .undo_markdown_preview").show();
         $("#compose .preview_message_area").show();
 

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -183,6 +183,33 @@ export function reset_compose_textarea_max_height(bottom_whitespace_height) {
     );
 }
 
+export function reset_compose_preview_area_max_height(
+    bottom_whitespace_height,
+    compose_non_preview_area_height,
+) {
+    // Compute bottom_whitespace_height if not provided by caller.
+    if (bottom_whitespace_height === undefined) {
+        const h = narrow_window ? left_userlist_get_new_heights() : get_new_heights();
+        bottom_whitespace_height = h.bottom_whitespace_height;
+    }
+
+    // Compute compose_non_preview_area_height if not provided by caller.
+    if (compose_non_preview_area_height === undefined) {
+        const compose_height = Number.parseInt($("#compose").outerHeight(), 10);
+        const compose_preview_area_height = Number.parseInt(
+            $("#preview_message_area").outerHeight(),
+            10,
+        );
+        compose_non_preview_area_height = compose_height - compose_preview_area_height;
+    }
+
+    $("#preview_message_area").css(
+        "max-height",
+        // The 5 here leaves space for the selected message border.
+        bottom_whitespace_height - compose_non_preview_area_height - 5,
+    );
+}
+
 export function resize_bottom_whitespace(h) {
     $("#bottom_whitespace").height(h.bottom_whitespace_height);
 
@@ -194,6 +221,7 @@ export function resize_bottom_whitespace(h) {
     // we also resize compose every time it is opened.
     if ($(".message_comp").is(":visible")) {
         reset_compose_textarea_max_height(h.bottom_whitespace_height);
+        reset_compose_preview_area_max_height(h.bottom_whitespace_height);
     }
 }
 


### PR DESCRIPTION
Fixes part 4 of #19353

**Testing plan:** <!-- How have you tested? -->

- The compose box was covering last message of stream during preview mode in on, I have changed preview box max-height so that compose box's max-height can never be more than bottom white space height.
- Tested On Docker Dovelopment Environment, also checked by changing size of browser window while in preview mode for responsiveness.

**Screenshots:**

### Before

<img src="https://raw.githubusercontent.com/brijsiyag/RawContent/main/Zulip/Issue-19353/Before.png" />

### After

<img src="https://raw.githubusercontent.com/brijsiyag/RawContent/main/Zulip/Issue-19353/After.png" />
