### PR TITLE
url_preview: Interpret og:image relative to full page URL

### DIFF
--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -1,5 +1,6 @@
 import re
 from typing import Any, Callable, Dict, Match, Optional
+from urllib.parse import urljoin
 
 import magic
 import requests
@@ -116,6 +117,8 @@ def get_link_embed_data(
         for key in ["title", "description", "image"]:
             if not data.get(key) and generic_data.get(key):
                 data[key] = generic_data[key]
+    if "image" in data:
+        data["image"] = urljoin(response.url, data["image"])
     return data
 
 


### PR DESCRIPTION
`og:image` is supposed to be an absolute URL, but some sites incorrectly provide a relative URL. In this case, it makes more sense to interpret it relative to the full page URL after redirects, rather than relative to just the domain part of the page URL before redirects.

See #4608, #4679 for the original context. (Although YouTube is no longer one of the sites with a relative `og:image`. A current example is https://meet.jit.si/.)