### PR TITLE
audit_log: Reserve a number for STREAM_REACTIVATED.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3830,6 +3830,7 @@ class AbstractRealmAuditLog(models.Model):
     STREAM_CREATED = 601
     STREAM_DEACTIVATED = 602
     STREAM_NAME_CHANGED = 603
+    STREAM_REACTIVATED = 604
 
     event_type: int = models.PositiveSmallIntegerField()
 


### PR DESCRIPTION
We don't yet have a do_reactivate_stream function, but we reserve a
number since:
1. It'll likely be added in the future.
2. For now, we can restore archived stream with some manual intervention
in the Django shell, and for that we'll want to create an appropriate
RealmAuditLog entry.
