### PR TITLE
Do not close compose when clicking a message edit.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -858,6 +858,13 @@ export function initialize() {
                 return;
             } else if (
                 !window.getSelection().toString() &&
+                // Clicking any input or text area should not close
+                // the compose box; this means using the sidebar
+                // filters or search widgets won't unnecessarily close
+                // compose.
+                !$(e.target).closest("input").length &&
+                !$(e.target).closest("textarea").length &&
+                !$(e.target).closest("select").length &&
                 // Clicks inside an overlay, popover, custom
                 // modal, or backdrop of one of the above
                 // should not have any effect on the compose


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fix for bug as described at [#frontend > Bug misinterpreting text as keyboard shortcuts](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Bug.20misinterpreting.20text.20as.20keyboard.20shortcuts)
<details>
  <summary>bug</summary>
  
![](https://user-images.githubusercontent.com/33805964/138529973-723af82d-eafd-449e-baa5-a657dd101da3.gif)
</details>


**Testing plan:** <!-- How have you tested? -->
Manual testing.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<details>
  <summary>after</summary>
  
![](https://user-images.githubusercontent.com/33805964/138529966-31cc73f0-d68b-46ed-b5ec-66057101faf2.gif)
</details>


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
