### PR TITLE
scim: Add a /help/ page for Okta SCIM.

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -6,7 +6,7 @@
     # version e.g. to say that something is likely to have changed.
     # For more info see: https://www.sphinx-doc.org/en/master/templating.html
     #}
-    {% if pagename in ["production/modify", "production/upgrade"] and release.endswith('+git') %}
+    {% if pagename in ["production/modify", "production/upgrade", "production/scim"] and release.endswith('+git') %}
     {#
     # This page doesn't exist in the stable documentation yet.
     # This temporary workaround prevents test failures and should be removed after the next release.

--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -584,6 +584,12 @@ to the root and `engineering` subdomains:
 </saml2:Attribute>
 ```
 
+### SCIM
+
+Many SAML IdPs also offer SCIM provisioning to manage automatically
+deactivating accounts; consider configuring the [Zulip SCIM
+integration](../production/scim.md).
+
 ### Using Keycloak as a SAML IdP
 
 1. Make sure you reviewed [this article][saml-help-center], which


### PR DESCRIPTION
We will also want some `ReadTheDocs` documentation for self-hosters, any idea where that should go? A new page under `https://zulip.readthedocs.io/en/latest/production/scim.html`? It doesn't really fit into any of the existing categories.