### PR TITLE
webhooks: Add support for GitHub discussion messages.

### DIFF
--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -486,9 +486,9 @@ A temporary team so that I can get some webhook fixtures!
         self.assertTrue(stack_info)
 
     def test_discussion_msg(self) -> None:
-        expected_message = "Codertocat started a new discussion [Welcome to discussions!](https://github.com/baxterthehacker/public-repo/discussions/90) in General:\n```quote\nWe're glad to have you here!\n```"
+        expected_message = "Codertocat created [discussion #90](https://github.com/baxterthehacker/public-repo/discussions/90) in General:\n```quote\n### Welcome to discussions!\nWe're glad to have you here!\n```"
         self.check_webhook("discussion", TOPIC_DISCUSSION, expected_message)
 
     def test_discussion_comment_msg(self) -> None:
-        expected_message = "Codertocat [commented](https://github.com/baxterthehacker/public-repo/discussions/90#discussioncomment-544078) on [discussion](https://github.com/baxterthehacker/public-repo/discussions/90):\n```quote\nI have so many questions to ask you!\n```"
+        expected_message = "Codertocat [commented](https://github.com/baxterthehacker/public-repo/discussions/90#discussioncomment-544078) on [discussion #90](https://github.com/baxterthehacker/public-repo/discussions/90):\n```quote\nI have so many questions to ask you!\n```"
         self.check_webhook("discussion_comment", TOPIC_DISCUSSION, expected_message)

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -30,12 +30,8 @@ from zerver.models import UserProfile
 fixture_to_headers = get_http_headers_from_filename("HTTP_X_GITHUB_EVENT")
 
 TOPIC_FOR_DISCUSSION = "{repo} discussion #{number}: {title}"
-DISCUSSION_TEMPLATE = (
-    "{author} started a new discussion [{title}]({url}) in {category}:\n```quote\n{body}\n```"
-)
-DISCUSSION_COMMENT_TEMPLATE = (
-    "{author} [commented]({comment_url}) on [discussion]({discussion_url}):\n```quote\n{body}\n```"
-)
+DISCUSSION_TEMPLATE = "{author} created [discussion #{discussion_id}]({url}) in {category}:\n```quote\n### {title}\n{body}\n```"
+DISCUSSION_COMMENT_TEMPLATE = "{author} [commented]({comment_url}) on [discussion #{discussion_id}]({discussion_url}):\n```quote\n{body}\n```"
 
 
 class Helper:
@@ -266,10 +262,11 @@ def get_discussion_body(helper: Helper) -> str:
     payload = helper.payload
     return DISCUSSION_TEMPLATE.format(
         author=get_sender_name(payload),
-        title=payload["discussion"]["title"],
         url=payload["discussion"]["html_url"],
         body=payload["discussion"]["body"],
         category=payload["discussion"]["category"]["name"],
+        discussion_id=payload["discussion"]["number"],
+        title=payload["discussion"]["title"],
     )
 
 
@@ -280,6 +277,7 @@ def get_discussion_comment_body(helper: Helper) -> str:
         body=payload["comment"]["body"],
         discussion_url=payload["discussion"]["html_url"],
         comment_url=payload["comment"]["html_url"],
+        discussion_id=payload["discussion"]["number"],
     )
 
 


### PR DESCRIPTION
We aim to use Zulip topics thoughtfully in displaying messages from
discussions, as well as linking to the discussion in every message so
that it's easy to view them.

![image](https://user-images.githubusercontent.com/51414879/138516783-f4d704d0-4aaf-453d-8169-37209b873ac1.png)
[Link to discussion](https://github.com/madrix01/gotest1/discussions/49)

Fixes #19938.