### PR TITLE
search: Fix x icon overlap in search and filter inputs

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -462,6 +462,16 @@ div.overlay {
     }
 }
 
+.topic-list-filter {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+
+    input {
+        padding-right: 20px;
+    }
+}
+
 .stream-selection-header-colorblock {
     /* box-shadow: 0px 2px 3px hsl(0, 0%, 80%); */
     box-shadow: inset 0 2px 1px -2px hsl(0, 0%, 20%),

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -121,6 +121,11 @@ li.show-more-topics {
                 .input-append.topic_search_section {
                     margin-bottom: 3px;
                     margin-left: 3px;
+
+                    input {
+                        padding-right: 20px;
+                        width: calc(100% - 50px);
+                    }
                 }
             }
         }
@@ -550,10 +555,18 @@ li.expanded_private_message {
     margin-right: 12px;
     padding-left: $far_left_gutter_size;
     cursor: pointer;
+    margin-top: 3px;
+
+    input {
+        padding-right: 20px;
+    }
 }
 
 .stream-list-filter {
-    width: 236px;
+    width: 216px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 .topic-list-filter {

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -407,6 +407,10 @@ ul {
         .stream-search {
             margin-left: auto;
             align-self: center;
+            padding-right: 20px;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            overflow: hidden;
         }
 
         #clear_stream_search {

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -101,6 +101,10 @@
 
         #recent_topics_search {
             flex-grow: 1;
+            padding-right: 20px;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            overflow: hidden;
         }
 
         .clear_search_button {

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -230,6 +230,16 @@
     }
 }
 
+#user_search_section {
+    input {
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        padding-right: 20px;
+        width: calc(100% - 40px - 3px);
+    }
+}
+
 @media (width < $sm_min) {
     #userlist-toggle {
         height: 30px;

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -565,6 +565,10 @@ h4.stream_setting_subsection_title {
     display: inline-block;
     border-radius: 5px;
     box-shadow: none;
+    padding-right: 20px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 .stream_name_search_section {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1599,8 +1599,9 @@ div.focused_table {
 }
 
 .message_edit_topic_propagate {
-    width: auto;
-    margin-bottom: 5px !important;
+    display: inline-block;
+    width: 300px;
+    margin-bottom: 15px !important;
     max-width: 100%;
 }
 
@@ -1941,12 +1942,15 @@ div.focused_table {
         height: $header_height;
         padding: 0;
         padding-left: 5px;
-        padding-right: 20px;
+        padding-right: 40px;
         border: none;
         border-radius: 0;
         font-family: "Source Sans 3", sans-serif;
         font-weight: 300;
         line-height: $header_height;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
     }
 
     #search_arrows:focus {


### PR DESCRIPTION
Issue #19765 

To fix overlapping of x and input in search and filter inputs:

- Changed `padding-right` from `20px` to `40px`  in `#search_query`.

![image](https://user-images.githubusercontent.com/75037620/138769953-9a1d5941-f100-4fc7-a674-b6c0c1b059f0.png)

- Add `padding-right`  of `20px` in `#recent_topic_search`.

![image](https://user-images.githubusercontent.com/75037620/138770032-13305e0f-c235-40c0-9f60-e37ceda5da5f.png)

- Add `padding-right` of `20px` to input in `#streams_header` and decreased width from `236px` to `216px` in  `.stream-list-filter`.

![image](https://user-images.githubusercontent.com/75037620/138770410-e55ee083-0548-4186-9afb-3fea5d3f783a.png)

- Add `padding-right` of `20px` in `.topic-list-filter` and `20px` to input in `#topic_search_section`.

![image](https://user-images.githubusercontent.com/75037620/138770514-f1c546f5-7195-415a-ad09-4324ae824a78.png)

- Add `padding-right` of `20px` in `.stream-search`.

![image](https://user-images.githubusercontent.com/75037620/138770593-1b67fcd8-715c-493d-bf51-148ebff66230.png)

- Add `padding-right` of `20px` in `#search_stream_name`.

![image](https://user-images.githubusercontent.com/75037620/138770650-bfc646a6-0778-4ecf-bc2d-ea5ea88ba030.png)

- Declare `#user_search_section` and add `padding-right` of `20px` to input and decreased width.

![image](https://user-images.githubusercontent.com/75037620/138772160-48a50a2a-0576-4503-a95b-97c0b56516dc.png)

Fixes #19765