### PR TITLE
run-codespell: Fix invocation with multiple arguments

### DIFF
--- a/tools/run-codespell
+++ b/tools/run-codespell
@@ -7,16 +7,16 @@
 # We plan to replace this script with the `tools/lint` system as soon as we can.
 
 IGNORE_WORDS_FILE=.codespellignore
-FILES_TO_BE_CHECKED=$*
-if [ -z "$FILES_TO_BE_CHECKED" ]; then
+if [ "$#" -eq 0 ]; then
     echo "No argument specified. Checking on the entire repo..."
     FILES_TO_BE_CHECKED="$(git ls-files -- ':(exclude)locale' ':(exclude)*fixtures*' ':(exclude)*.svg' ':(exclude)docs/translating' ':(exclude)yarn.lock' ':(exclude)docs/THIRDPARTY' ':(exclude)*postgresql.conf.template.erb' ':(exclude)tools/setup/emoji/emoji_names.py' ':(exclude)tools/setup/emoji/emoji_map.json' ':(exclude)zerver/management/data/unified_reactions.json')"
+    mapfile -t FILES_TO_BE_CHECKED <<<"$FILES_TO_BE_CHECKED"
 else
-    echo "Checking $FILES_TO_BE_CHECKED"
+    FILES_TO_BE_CHECKED=("$@")
+    echo "Checking ${FILES_TO_BE_CHECKED[*]@Q}"
 fi
-mapfile -t FILES_TO_BE_CHECKED <<<"$FILES_TO_BE_CHECKED"
 
-if ! codespell --ignore-words=$IGNORE_WORDS_FILE "${FILES_TO_BE_CHECKED[@]}"; then
+if ! codespell --ignore-words="$IGNORE_WORDS_FILE" -- "${FILES_TO_BE_CHECKED[@]}"; then
     echo "You may check the files for typo again using ./tools/run-codespell <file 1> <file 2> ... <file n>"
     exit 1
 fi


### PR DESCRIPTION
Previously, `run-codespell file1 file2` would incorrectly invoke `codespell 'file1 file2'` with a single argument, which would be silently ignored.

@rht FYI.