### PR TITLE
message: Fix the long message UI in docs.

### DIFF
--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -115,8 +115,8 @@ the hotkeys too:
   - click on the star button in the right column
   - use 'Ctrl + S' to star a message
 - Message length
-  - send a long message and see if '[More]' appears
-  - click on the 'more' or 'collapse' link
+  - send a long message and see if 'Show more' button appears
+  - click on the 'Show more' or 'Show less' button
   - use i to collapse/expand a message irrespective of message length
 - use 'v' to show all images in the thread
 - use 'M' to mute the thread

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -124,6 +124,11 @@ export function initialize() {
             return true;
         }
 
+        // Button to expand or condense long messages.
+        if (target.is("button.message_expander") || target.is("button.message_condenser")) {
+            return true;
+        }
+
         // Inline image and twitter previews.
         if (target.is("img.message_inline_image") || target.is("img.twitter-avatar")) {
             return true;

--- a/static/js/condense.js
+++ b/static/js/condense.js
@@ -20,11 +20,13 @@ This library implements two related, similar concepts:
 const _message_content_height_cache = new Map();
 
 function show_more_link(row) {
+    row.find(".expand_condense_buttons_wrapper").show();
     row.find(".message_condenser").hide();
     row.find(".message_expander").show();
 }
 
 function show_condense_link(row) {
+    row.find(".expand_condense_buttons_wrapper").show();
     row.find(".message_expander").hide();
     row.find(".message_condenser").show();
 }
@@ -42,30 +44,32 @@ function uncondense_row(row) {
 }
 
 export function uncollapse(row) {
-    // Uncollapse a message, restoring the condensed message [More] or
-    // [Show less] link if necessary.
+    // Uncollapse a message, restoring the condensed message 'Show more' or
+    // 'Show less' button if necessary.
     const message = message_lists.current.get(rows.id(row));
     message.collapsed = false;
     message_flags.save_uncollapsed(message);
 
     const process_row = function process_row(row) {
         const content = row.find(".message_content");
+        const expand_condense_buttons_wrapper = row.find(".expand_condense_buttons_wrapper");
         content.removeClass("collapsed");
 
         if (message.condensed === true) {
             // This message was condensed by the user, so re-show the
-            // [More] link.
+            // 'Show more' button.
             condense_row(row);
         } else if (message.condensed === false) {
             // This message was un-condensed by the user, so re-show the
-            // [Show less] link.
+            // 'Show less' button.
             uncondense_row(row);
         } else if (content.hasClass("could-be-condensed")) {
             // By default, condense a long message.
             condense_row(row);
         } else {
-            // This was a short message, no more need for a [More] link.
+            // This was a short message, no more need for a 'Show more' button.
             row.find(".message_expander").hide();
+            expand_condense_buttons_wrapper.hide();
         }
     };
 
@@ -77,8 +81,8 @@ export function uncollapse(row) {
 }
 
 export function collapse(row) {
-    // Collapse a message, hiding the condensed message [More] or
-    // [Show less] link if necessary.
+    // Collapse a message, hiding the condensed message 'Show more' or
+    // 'Show less' button if necessary.
     const message = message_lists.current.get(rows.id(row));
     message.collapsed = true;
 
@@ -115,7 +119,7 @@ export function toggle_collapse(message) {
     // This function implements a multi-way toggle, to try to do what
     // the user wants for messages:
     //
-    // * If the message is currently showing any [More] link, either
+    // * // * If the message is currently showing 'Show more' button, either
     //   because it was previously condensed or collapsed, fully display it.
     // * If the message is fully visible, either because it's too short to
     //   condense or because it's already uncondensed, collapse it
@@ -196,6 +200,7 @@ export function condense_and_collapse(elems) {
 
     for (const elem of elems) {
         const content = $(elem).find(".message_content");
+        const expand_condense_buttons_wrapper = $(elem).find(".expand_condense_buttons_wrapper");
 
         if (content.length !== 1) {
             // We could have a "/me did this" message or something
@@ -219,8 +224,10 @@ export function condense_and_collapse(elems) {
         if (long_message) {
             // All long messages are flagged as such.
             content.addClass("could-be-condensed");
+            expand_condense_buttons_wrapper.show();
         } else {
             content.removeClass("could-be-condensed");
+            expand_condense_buttons_wrapper.hide();
         }
 
         // If message.condensed is defined, then the user has manually
@@ -243,10 +250,11 @@ export function condense_and_collapse(elems) {
             $(elem).find(".message_expander").hide();
         }
 
-        // Completely hide the message and replace it with a [More]
-        // link if the user has collapsed it.
+        // Completely hide the message and replace it with a 'Show More'
+        // button if the user has collapsed it.
         if (message.collapsed) {
             content.addClass("collapsed");
+            expand_condense_buttons_wrapper.show();
             $(elem).find(".message_expander").show();
         }
     }

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -267,7 +267,7 @@ export function handler() {
     }
     resize_page_components();
 
-    // Re-compute and display/remove [More] links to messages
+    // Re-compute and display/remove Show more'/'Show less' button to messages
     condense.condense_and_collapse($(".message_table .message_row"));
 
     // This function might run onReady (if we're in a narrow window),

--- a/static/styles/night_mode.css
+++ b/static/styles/night_mode.css
@@ -192,6 +192,13 @@ body.night-mode {
         background-color: hsl(208, 17%, 29%);
     }
 
+    .private-message .expand_condense_buttons_wrapper {
+        .message_expander,
+        .message_condenser {
+            background-color: hsl(208, 17%, 29%);
+        }
+    }
+
     /* do not turn the .message_header .stream_label text dark on hover because they're
        on a dark background, and don't change the dark labels dark either. */
     .message_header:not(.dark_background)
@@ -296,6 +303,13 @@ body.night-mode {
         .emoji-popover-category-tabs
         .emoji-popover-tab-item.active {
         background-color: hsla(0, 0%, 0%, 0.5);
+    }
+
+    .expand_condense_buttons_wrapper {
+        .message_expander,
+        .message_condenser {
+            background-color: hsl(212, 28%, 18%);
+        }
     }
 
     .new-style .tab-switcher .ind-tab.selected,

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1196,6 +1196,13 @@ td.pointer {
     /* Base color backgrounds for messageboxes,
        private messages, mentions, and unread messages */
 
+    .expand_condense_buttons_wrapper {
+        .message_expander,
+        .message_condenser {
+            background-color: hsl(192deg 20% 95%);
+        }
+    }
+
     .message-header-contents {
         background-color: hsla(192, 19%, 75%, 0.2);
         box-shadow: inset 1px 1px 0 hsl(0, 0%, 88%);
@@ -1437,6 +1444,12 @@ div.focused_table {
     display: block;
     position: relative;
     overflow: hidden;
+    /* We are using very high value here to imitate an infinite value so that
+    we can enable collapse/expand animation. */
+    max-height: 1000vh;
+    transition: max-height 0.5s ease-in-out, mask-size 0.3s ease-in-out;
+    mask-image: none;
+    mask-size: 200% 200%;
 
     &:empty {
         display: none;
@@ -1446,12 +1459,22 @@ div.focused_table {
         max-height: 8.5em;
         min-height: 0;
         overflow: hidden;
+        mask-image: linear-gradient(to bottom, hsl(0, 0%, 100%), transparent);
+        mask-size: 60% 101%;
+
+        ~ .expand_condense_buttons_wrapper {
+            margin: -20px 0 20px;
+        }
     }
 
     &.collapsed {
         max-height: 0;
         min-height: 0;
         overflow: hidden;
+
+        ~ .expand_condense_buttons_wrapper {
+            margin: 12px 0;
+        }
     }
 }
 
@@ -1606,19 +1629,30 @@ div.focused_table {
     }
 }
 
-.message_length_controller {
+.topic_move_breadcrumb_messages {
+    margin-top: 10px !important;
+}
+
+.expand_condense_buttons_wrapper {
     display: none;
-    text-align: center;
-    color: hsl(200, 100%, 40%);
+    height: 25px;
+    position: relative;
+    margin: 12px;
+    transition: margin-top 0.5s ease-in-out, margin-bottom 0.5s ease-in-out;
 
-    /* to match .message_content */
-    margin-left: 5px;
-    margin-right: 35px;
-    /* to make message-uncollapse easier */
-    margin-top: 10px;
-
-    &:hover {
-        text-decoration: underline;
+    .message_expander,
+    .message_condenser {
+        display: none;
+        position: absolute;
+        left: 50%;
+        text-align: center;
+        color: inherit;
+        background-color: hsl(0, 0%, 100%);
+        width: 100px;
+        border-radius: 10px;
+        border: solid 1px hsl(215deg 47% 50%);
+        font-size: 13px;
+        font-weight: 400;
     }
 }
 

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -49,8 +49,10 @@
 <div class="message_edit">
     <div class="message_edit_form"></div>
 </div>
-<div class="message_expander message_length_controller" title="{{t 'Expand message (-)' }}">{{t "[More…]" }}</div>
-<div class="message_condenser message_length_controller" title="{{t 'Show less' }} (-)">[{{t "Show less" }}]</div>
+<div class="expand_condense_buttons_wrapper message_length_controller">
+    <button type="button" class="message_expander" title="{{t 'Show more' }} (-)">{{t "Show more" }}</button>
+    <button type="button"class="message_condenser" title="{{t 'Show less' }} (-)">{{t "Show less" }}</button>
+</div>
 
 {{#unless is_hidden}}
 <div class="message_reactions">{{> message_reactions }}</div>


### PR DESCRIPTION
This PR aims to solve the issue https://github.com/zulip/zulip/issues/19055

This commit makes the following changes in the UI:

- Replace the [More...] link with a button that says "Show more".

