### PR TITLE
user-documentation: Add documentation to resize the compose box

### DIFF
--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -56,6 +56,7 @@
 
 ## Sending messages
 * [Open the compose box](/help/open-the-compose-box)
+* [Resize the compose box](/help/resize-the-compose-box)
 * [Format messages using Markdown](/help/format-your-message-using-markdown)
 * [Mention a user or group](/help/mention-a-user-or-group)
 * [Preview messages before sending](/help/preview-your-message-before-sending)

--- a/templates/zerver/help/open-the-compose-box.md
+++ b/templates/zerver/help/open-the-compose-box.md
@@ -37,3 +37,4 @@ can close the compose box using `Esc`, or up/down arrow if the box is empty.
 * [Replying to messages](/help/replying-to-messages)
 * [Messaging tips & tricks](/help/messaging-tips)
 * [Keyboard shortcuts](/help/keyboard-shortcuts)
+* [Resize the compose box](/help/resize-the-compose-box)

--- a/templates/zerver/help/resize-the-compose-box.md
+++ b/templates/zerver/help/resize-the-compose-box.md
@@ -1,0 +1,39 @@
+# Resize the compose box
+
+When composing a long message, it can be helpful to expand the compose
+box to display more text and avoid distractions. Note that the compose
+box also stretches automatically when you type a long message.
+
+## Expand the compose box
+
+{start_tabs}
+
+{!start-composing.md!}
+
+1. Click on the **<i class="fa fa-chevron-up"></i> icon** in the top
+   right corner of the compose box.
+
+{end_tabs}
+
+## Collapse the compose box
+
+{start_tabs}
+
+1. With the compose box in the expanded state, click on the **<i class="fa
+   fa-chevron-down"></i> icon** in the top right corner of the compose box.
+
+{end_tabs}
+
+## Stretch the compose box
+
+{start_tabs}
+
+{!start-composing.md!}
+
+1. Click and drag the bottom right corner of the compose box.
+
+{end_tabs}
+
+## Related articles
+
+* [Open the compose box](/help/open-the-compose-box)


### PR DESCRIPTION
This provides instructions to adjust the size of the compose box
detailing how to:

      1. Expand the compose box.
      2. Collapse the compose box.
      3. Stretch the compose box.

In addition to the above it also updates the sidebar help index to
include the newly created resize the compose box page.

Fixes #20017

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
