### PR TITLE
Show user id in full user-profile modal and edit user UI.

### DIFF
--- a/static/templates/settings/admin_human_form.hbs
+++ b/static/templates/settings/admin_human_form.hbs
@@ -9,6 +9,10 @@
             <label for="email">{{t "Email" }}</label>
             <input type="text" autocomplete="off" name="email" value="{{ email }}" readonly/>
         </div>
+        <div class="input-group user_id_container">
+            <label for="user_id">{{t "User ID" }}</label>
+            <input type="text" autocomplete="off" name="user_id" value="{{ user_id }}" readonly/>
+        </div>
         <div class="input-group">
             <label class="input-label" for="user-role-select">{{t 'User role' }}
                 {{> ../help_link_widget link="/help/roles-and-permissions" }}

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -24,6 +24,10 @@
                         <span class="value">{{email}}</span>
                     </div>
                     {{/if}}
+                    <div id="user_id" class="default-field">
+                        <span class="name">{{#tr}}User ID{{/tr}}</span>
+                        <span class="value">{{user_id}}</span>
+                    </div>
                     <div id="date-joined" class="default-field">
                         <span class="name">{{#tr}}Joined{{/tr}}</span>
                         <span class="value">{{date_joined}}</span>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit adds user id in full user-profile modal.
- Second commit adds user id in edit user UI.
<!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2021-10-28 22-53-16](https://user-images.githubusercontent.com/35494118/139305235-abf63700-c8f7-45da-9847-dadde683ed24.png)
![Screenshot from 2021-10-28 22-53-05](https://user-images.githubusercontent.com/35494118/139305227-69f2b629-b4ca-42b4-b1c6-8c41ea194695.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
