### PR TITLE
settings: Fix css for custom profile fields in edit user form.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1478,40 +1478,6 @@ input[type="checkbox"] {
         }
     }
 
-    .custom_user_field {
-        padding-bottom: 20px;
-
-        textarea {
-            width: 320px;
-            height: 80px;
-        }
-
-        &:hover .remove_date {
-            display: inline-flex;
-        }
-
-        .remove_date {
-            opacity: 0.5;
-            display: none;
-            cursor: pointer;
-            position: relative;
-            top: 2px;
-            left: -20px;
-
-            &:hover {
-                opacity: 1;
-            }
-        }
-
-        .datepicker {
-            cursor: default;
-        }
-
-        .person_picker {
-            min-width: 206px;
-        }
-    }
-
     .content-wrapper {
         position: absolute;
         left: 251px;
@@ -1562,8 +1528,42 @@ input[type="checkbox"] {
         cursor: default;
     }
 
-    .custom_user_field .field_hint {
-        color: hsl(0, 0%, 67%);
+    .custom_user_field {
+        padding-bottom: 20px;
+
+        .field_hint {
+            color: hsl(0, 0%, 67%);
+        }
+
+        textarea {
+            width: 320px;
+            height: 80px;
+        }
+
+        &:hover .remove_date {
+            display: inline-flex;
+        }
+
+        .remove_date {
+            opacity: 0.5;
+            display: none;
+            cursor: pointer;
+            position: relative;
+            top: 2px;
+            left: -20px;
+
+            &:hover {
+                opacity: 1;
+            }
+        }
+
+        .datepicker {
+            cursor: default;
+        }
+
+        .person_picker {
+            min-width: 206px;
+        }
     }
 
     #show_my_user_profile_modal {
@@ -1942,8 +1942,11 @@ input[type="checkbox"] {
         margin-top: 5px;
     }
 
-    #settings_page .custom_user_field textarea {
-        width: calc(100% - 25px);
+    #settings_page,
+    #edit-user-form {
+        .custom_user_field textarea {
+            width: calc(100% - 25px);
+        }
     }
 }
 


### PR DESCRIPTION
Previously the edit user modal element was appended inside the
settings overlay itself, so the styles for .custom_user_field
elements nested inside #settings_page were sufficient both for
edit user UI and profile section in personal settings.

e6e60107 changed the code to append edit user modal to body
element and thus existing css was no longer applied to custom
profile fields with custom_user_field class in edit user modal.

This commit fixes to have same styles for .custom_user_field
elements in #edit_user_form.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before

![Screenshot from 2021-10-29 12-26-37](https://user-images.githubusercontent.com/35494118/139389917-e93ce3d3-e0ca-4564-8f4d-373bddecb6f1.png)

After

![Screenshot from 2021-10-29 12-31-17](https://user-images.githubusercontent.com/35494118/139390351-3e492677-8cc9-470b-a2b9-a46e2d9d0f2e.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

