### PR TITLE
Fix multiple message edit upload bug.

### DIFF
--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -105,7 +105,7 @@ test("get_item", () => {
     assert.equal(upload.get_item("source", {mode: "edit", row: 123}), "message-edit-file-input");
     assert.equal(
         upload.get_item("drag_drop_container", {mode: "edit", row: 1}),
-        $(".message_edit_form"),
+        $(`#zfilt${CSS.escape(1)} .message_edit_form`),
     );
     assert.equal(
         upload.get_item("markdown_preview_hide_button", {mode: "edit", row: 65}),

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -77,7 +77,7 @@ export function get_item(key, config) {
             case "source":
                 return "message-edit-file-input";
             case "drag_drop_container":
-                return $(".message_edit_form");
+                return $(`#zfilt${CSS.escape(config.row)} .message_edit_form`);
             case "markdown_preview_hide_button":
                 return $(`#edit_form_${CSS.escape(config.row)} .undo_markdown_preview`);
             default:


### PR DESCRIPTION
As reported at [#issues > bug in edit message](https://chat.zulip.org/#narrow/stream/9-issues/topic/bug.20in.20edit.20message):

Previously, opening multiple message_edits and then drag-dropping a
file into any one of them would cause all of them to upload ie you'd
get one uploaded file in each message_edit.

This bug was caused by returning multiple elements from
upload.get_item("drag_drop_container", config) when config.mode =
"edit".

This commit changes the selector to use the row provided (config.row),
and so ensures that the above bug doesn't happen.

<details>
<summary>
bug (before)
</summary>

![](https://user-images.githubusercontent.com/33805964/139434243-844c8580-9dcb-45ee-a524-69df2b313e88.gif)

</details>

**Testing plan:**
>
Edited relevant test line in `./frontend_tests/node_tests/upload.js`

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<details>
<summary>
after
</summary>

![](https://user-images.githubusercontent.com/33805964/139434250-6a7fe4f3-9a61-4548-bdbb-124b274d62d4.gif)

</details>

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
