### PR TITLE
management: Add retry option to send_password_reset_email.

### DIFF
--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -261,6 +261,7 @@ def send_email(
 
     try:
         # This will call .open() for us, which is a no-op if it's already open;
+        raise smtplib.SMTPResponseException("test", "ll")
         # it will only call .close() if it was not open to begin with
         if connection.send_messages([mail]) == 0:
             logger.error("Unknown error sending %s email to %s", template, mail.to)


### PR DESCRIPTION
Inspired by the thread https://chat.zulip.org/#narrow/stream/31-production-help/topic/Mass.20password.20reset.20fails

This can be particularly useful when using this command to send emails
to all users, since the probability of a failure happening is much
higher than with a single user - and it's also more annoying if it
happens because there is no comfortable way to run the command again for
all users that didn't get their emails. Allowing retries should mitigate
these issues to an extent.
