### PR TITLE
users: Allow spectators to view user avatars.

### DIFF
--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -162,7 +162,7 @@ test_ui("sender_hover", ({override, mock_template}) => {
 
     mock_template("user_info_popover_title.hbs", false, (opts) => {
         assert.deepEqual(opts, {
-            user_avatar: "avatar/alice@example.com",
+            user_avatar: "http://zulip.zulipdev.com/avatar/42?s=50",
             user_is_guest: false,
         });
         return "title-html";

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -52,6 +52,7 @@ const alice = {
     is_guest: false,
     is_admin: false,
     role: 400,
+    date_joined: "2021-11-01T16:32:16.458735+00:00",
 };
 
 const me = {
@@ -111,6 +112,7 @@ function test_ui(label, f) {
 }
 
 test_ui("sender_hover", ({override, mock_template}) => {
+    page_params.is_spectator = false;
     override($.fn, "popover", noop);
     override(emoji, "get_emoji_details_by_name", noop);
 
@@ -196,6 +198,8 @@ test_ui("sender_hover", ({override, mock_template}) => {
             status_text: "on the beach",
             status_emoji_info,
             user_mention_syntax: "@**Alice Smith**",
+            date_joined: undefined,
+            spectator_view: false,
         });
         return "content-html";
     });

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -256,7 +256,8 @@ function render_user_info_popover(
         placement: popover_placement,
         template: render_no_arrow_popover({class: template_class}),
         title: render_user_info_popover_title({
-            user_avatar: "avatar/" + user.email,
+            // See the load_medium_avatar comment for important background.
+            user_avatar: people.small_avatar_url_for_person(user),
             user_is_guest: user.is_guest,
         }),
         html: true,
@@ -269,6 +270,13 @@ function render_user_info_popover(
     init_email_clipboard();
     init_email_tooltip(user);
 
+    // Note: We pass the normal-size avatar in initial rendering, and
+    // then query the server to replace it with the medium-size
+    // avatar.  The purpose of this double-fetch approach is to take
+    // advantage of the fact that the browser should already have the
+    // low-resolution image cached and thus display a low-resolution
+    // avatar rather than a blank area during the network delay for
+    // fetching the medium-size one.
     load_medium_avatar(user, $(".popover-avatar"));
 }
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1,5 +1,5 @@
 import ClipboardJS from "clipboard";
-import {add, formatISO, set} from "date-fns";
+import {add, formatISO, parseISO, set} from "date-fns";
 import ConfirmDatePlugin from "flatpickr/dist/plugins/confirmDate/confirmDate";
 import $ from "jquery";
 import tippy, {hideAll} from "tippy.js";
@@ -208,6 +208,13 @@ function render_user_info_popover(
     const status_text = user_status.get_status_text(user.user_id);
     const status_emoji_info = user_status.get_status_emoji(user.user_id);
 
+    const spectator_view = page_params.is_spectator;
+    let date_joined;
+    if (spectator_view) {
+        const dateFormat = new Intl.DateTimeFormat("default", {dateStyle: "long"});
+        date_joined = dateFormat.format(parseISO(user.date_joined));
+    }
+
     const args = {
         can_revoke_away,
         can_set_away,
@@ -234,6 +241,8 @@ function render_user_info_popover(
         status_text,
         status_emoji_info,
         user_mention_syntax: people.get_mention_syntax(user.full_name, user.user_id),
+        date_joined,
+        spectator_view,
     };
 
     if (user.is_bot) {

--- a/static/js/user_profile.js
+++ b/static/js/user_profile.js
@@ -152,7 +152,7 @@ export function show_user_profile(user) {
         full_name: user.full_name,
         email: people.get_visible_email(user),
         profile_data,
-        user_avatar: "avatar/" + user.email + "/medium",
+        user_avatar: "avatar/" + user.user_id + "/medium",
         is_me: people.is_current_user(user.email),
         date_joined: dateFormat.format(parseISO(user.date_joined)),
         last_seen: buddy_data.user_last_seen_time_status(user.user_id),

--- a/static/templates/left_sidebar.hbs
+++ b/static/templates/left_sidebar.hbs
@@ -11,7 +11,7 @@
                     <span>{{t 'All messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
-                <span class="arrow all-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
+                <span class="arrow all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_private_messages hidden-for-spectators">
                 <div class="private_messages_header top_left_row" title="{{t 'Private messages' }} (P)">

--- a/static/templates/stream_sidebar_row.hbs
+++ b/static/templates/stream_sidebar_row.hbs
@@ -12,6 +12,6 @@
 
             <span class="unread_count"></span>
         </div>
-        <span class="stream-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
+        <span class="stream-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
     </div>
 </li>

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -7,7 +7,7 @@
                 {{#if is_bot}}
                 <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
                 {{else}}
-                <span class="{{user_circle_class}} user_circle popover_user_presence tippy-zulip-tooltip" data-tippy-content="{{user_last_seen_time_status}}"></span>
+                <span class="{{user_circle_class}} user_circle popover_user_presence tippy-zulip-tooltip hidden-for-spectators" data-tippy-content="{{user_last_seen_time_status}}"></span>
                 {{/if}}
             {{/if}}
         </li>
@@ -49,6 +49,7 @@
         {{else}}
             <li>{{ user_type }}</li>
         {{/if}}
+        <li class="only-visible-for-spectators">Joined {{date_joined}}</li>
     </div>
 
     {{#if is_me}}
@@ -100,82 +101,86 @@
         </li>
     {{/if}}
 
-    <hr />
-    {{#if show_user_profile}}
-    <li>
-        <a tabindex="0" class="view_full_user_profile">
-            {{#if is_me}}
-                <i class="fa fa-user" aria-hidden="true"></i> {{#tr}}View your profile{{/tr}}
-            {{else}}
-                <i class="fa fa-user" aria-hidden="true"></i> {{#tr}}View full profile{{/tr}}
-            {{/if}}
-        </a>
-    </li>
-    {{/if}}
-    {{#if is_active}}
-        {{#unless is_me}}
+    {{#if spectator_view}}
+    {{else}}
+
+        <hr />
+        {{#if show_user_profile}}
         <li>
-            <a tabindex="0" class="{{ private_message_class }}">
-                <i class="fa fa-envelope" aria-hidden="true"></i> {{#tr}}Send private message{{/tr}} {{#if is_sender_popover}}<span class="hotkey-hint">(R)</span>{{/if}}
+            <a tabindex="0" class="view_full_user_profile">
+                {{#if is_me}}
+                    <i class="fa fa-user" aria-hidden="true"></i> {{#tr}}View your profile{{/tr}}
+                {{else}}
+                    <i class="fa fa-user" aria-hidden="true"></i> {{#tr}}View full profile{{/tr}}
+                {{/if}}
             </a>
         </li>
-        {{/unless}}
-    {{/if}}
-    {{#unless is_me}}
-    <li>
-        {{#if has_message_context}}
-        <a tabindex="0" class="mention_user">
-            <i class="fa fa-at" aria-hidden="true"></i>
-            {{#tr}}Reply mentioning user{{/tr}}
-            {{#if is_sender_popover}}<span class="hotkey-hint">(@)</span>{{/if}}
-        </a>
-        {{else}}
-        <a tabindex="0" class="copy_mention_syntax" data-clipboard-text="{{ user_mention_syntax }}">
-            <i class="fa fa-at" aria-hidden="true"></i>
-            {{#tr}}Copy mention syntax{{/tr}}
-            {{#if is_sender_popover}}<span class="hotkey-hint">(@)</span>{{/if}}
-        </a>
         {{/if}}
-    </li>
-    {{/unless}}
-    {{#if is_me}}
-    <li>
-        <a href="/#settings/profile">
-            <i class="fa fa-edit" aria-hidden="true"></i> {{#tr}}Edit your profile{{/tr}}
-        </a>
-    </li>
-    {{/if}}
-    <hr />
-    <li>
-        <a href="{{ pm_with_uri }}" class="narrow_to_private_messages">
-            <i class="fa fa-lock" aria-hidden="true"></i>
-            {{#if is_me}}
-                {{#tr}}View private messages to myself{{/tr}}
+        {{#if is_active}}
+            {{#unless is_me}}
+            <li>
+                <a tabindex="0" class="{{ private_message_class }}">
+                    <i class="fa fa-envelope" aria-hidden="true"></i> {{#tr}}Send private message{{/tr}} {{#if is_sender_popover}}<span class="hotkey-hint">(R)</span>{{/if}}
+                </a>
+            </li>
+            {{/unless}}
+        {{/if}}
+        {{#unless is_me}}
+        <li>
+            {{#if has_message_context}}
+            <a tabindex="0" class="mention_user">
+                <i class="fa fa-at" aria-hidden="true"></i>
+                {{#tr}}Reply mentioning user{{/tr}}
+                {{#if is_sender_popover}}<span class="hotkey-hint">(@)</span>{{/if}}
+            </a>
             {{else}}
-                {{#tr}}View private messages{{/tr}}
+            <a tabindex="0" class="copy_mention_syntax" data-clipboard-text="{{ user_mention_syntax }}">
+                <i class="fa fa-at" aria-hidden="true"></i>
+                {{#tr}}Copy mention syntax{{/tr}}
+                {{#if is_sender_popover}}<span class="hotkey-hint">(@)</span>{{/if}}
+            </a>
             {{/if}}
-        </a>
-    </li>
-    <li>
-        <a href="{{ sent_by_uri }}" class="narrow_to_messages_sent">
-            <i class="fa fa-paper-plane" aria-hidden="true"></i> {{#tr}}View messages sent{{/tr}}
-        </a>
-    </li>
+        </li>
+        {{/unless}}
+        {{#if is_me}}
+        <li>
+            <a href="/#settings/profile">
+                <i class="fa fa-edit" aria-hidden="true"></i> {{#tr}}Edit your profile{{/tr}}
+            </a>
+        </li>
+        {{/if}}
+        <hr />
+        <li>
+            <a href="{{ pm_with_uri }}" class="narrow_to_private_messages">
+                <i class="fa fa-lock" aria-hidden="true"></i>
+                {{#if is_me}}
+                    {{#tr}}View private messages to myself{{/tr}}
+                {{else}}
+                    {{#tr}}View private messages{{/tr}}
+                {{/if}}
+            </a>
+        </li>
+        <li>
+            <a href="{{ sent_by_uri }}" class="narrow_to_messages_sent">
+                <i class="fa fa-paper-plane" aria-hidden="true"></i> {{#tr}}View messages sent{{/tr}}
+            </a>
+        </li>
 
-    {{#if can_mute }}
-    <hr />
-    <li>
-        <a tabindex="0" class="sidebar-popover-mute-user">
-            <i class="fa fa-eye-slash" aria-hidden="true"></i> {{#tr}}Mute this user{{/tr}}
-        </a>
-    </li>
-    {{/if}}
-    {{#if can_unmute}}
-    <hr />
-    <li>
-        <a tabindex="0" class="sidebar-popover-unmute-user">
-            <i class="fa fa-eye" aria-hidden="true"></i> {{#tr}}Unmute this user{{/tr}}
-        </a>
-    </li>
+        {{#if can_mute }}
+        <hr />
+        <li>
+            <a tabindex="0" class="sidebar-popover-mute-user">
+                <i class="fa fa-eye-slash" aria-hidden="true"></i> {{#tr}}Mute this user{{/tr}}
+            </a>
+        </li>
+        {{/if}}
+        {{#if can_unmute}}
+        <hr />
+        <li>
+            <a tabindex="0" class="sidebar-popover-unmute-user">
+                <i class="fa fa-eye" aria-hidden="true"></i> {{#tr}}Unmute this user{{/tr}}
+            </a>
+        </li>
+        {{/if}}
     {{/if}}
 </ul>

--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -147,7 +147,10 @@ def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
             target_function = authenticated_rest_api_view(
                 allow_webhook_access="allow_incoming_webhooks" in view_flags,
             )(target_function)
-        elif request.path.startswith("/json") and "allow_anonymous_user_web" in view_flags:
+        elif (
+            request.path.startswith(("/json", "/avatar"))
+            and "allow_anonymous_user_web" in view_flags
+        ):
             # For endpoints that support anonymous web access, we do that.
             # TODO: Allow /api calls when this is stable enough.
             auth_kwargs = dict(allow_unauthenticated=True)

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1047,28 +1047,44 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
 
         self.logout()
 
-        # Test /avatar/<email_or_id> endpoint with HTTP basic auth.
-        response = self.api_get(hamlet, "/avatar/cordelia@zulip.com", {"foo": "bar"})
-        redirect_url = response["Location"]
-        self.assertTrue(redirect_url.endswith(str(avatar_url(cordelia)) + "&foo=bar"))
+        with self.settings(WEB_PUBLIC_STREAMS_ENABLED=False):
+            # Test /avatar/<email_or_id> endpoint with HTTP basic auth.
+            response = self.api_get(hamlet, "/avatar/cordelia@zulip.com", {"foo": "bar"})
+            redirect_url = response["Location"]
+            self.assertTrue(redirect_url.endswith(str(avatar_url(cordelia)) + "&foo=bar"))
 
-        response = self.api_get(hamlet, f"/avatar/{cordelia.id}", {"foo": "bar"})
-        redirect_url = response["Location"]
-        self.assertTrue(redirect_url.endswith(str(avatar_url(cordelia)) + "&foo=bar"))
+            response = self.api_get(hamlet, f"/avatar/{cordelia.id}", {"foo": "bar"})
+            redirect_url = response["Location"]
+            self.assertTrue(redirect_url.endswith(str(avatar_url(cordelia)) + "&foo=bar"))
 
-        # Test cross_realm_bot avatar access using email.
-        response = self.api_get(hamlet, "/avatar/welcome-bot@zulip.com", {"foo": "bar"})
-        redirect_url = response["Location"]
-        self.assertTrue(redirect_url.endswith(str(avatar_url(cross_realm_bot)) + "&foo=bar"))
+            # Test cross_realm_bot avatar access using email.
+            response = self.api_get(hamlet, "/avatar/welcome-bot@zulip.com", {"foo": "bar"})
+            redirect_url = response["Location"]
+            self.assertTrue(redirect_url.endswith(str(avatar_url(cross_realm_bot)) + "&foo=bar"))
 
-        # Test cross_realm_bot avatar access using id.
-        response = self.api_get(hamlet, f"/avatar/{cross_realm_bot.id}", {"foo": "bar"})
-        redirect_url = response["Location"]
-        self.assertTrue(redirect_url.endswith(str(avatar_url(cross_realm_bot)) + "&foo=bar"))
+            # Test cross_realm_bot avatar access using id.
+            response = self.api_get(hamlet, f"/avatar/{cross_realm_bot.id}", {"foo": "bar"})
+            redirect_url = response["Location"]
+            self.assertTrue(redirect_url.endswith(str(avatar_url(cross_realm_bot)) + "&foo=bar"))
 
+            # Without spectators enabled, no unauthenticated access.
+            response = self.client_get("/avatar/cordelia@zulip.com", {"foo": "bar"})
+            self.assert_json_error(
+                response,
+                "Not logged in: API authentication or user session required",
+                status_code=401,
+            )
+
+        # Allow unauthenticated/spectator requests by ID.
+        response = self.client_get(f"/avatar/{cordelia.id}", {"foo": "bar"})
+        self.assertEqual(302, response.status_code)
+
+        # Disallow unauthenticated/spectator requests by email.
         response = self.client_get("/avatar/cordelia@zulip.com", {"foo": "bar"})
         self.assert_json_error(
-            response, "Not logged in: API authentication or user session required", status_code=401
+            response,
+            "Not logged in: API authentication or user session required",
+            status_code=401,
         )
 
     def test_get_user_avatar_medium(self) -> None:
@@ -1090,18 +1106,34 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
 
         self.logout()
 
-        # Test /avatar/<email_or_id>/medium endpoint with HTTP basic auth.
-        response = self.api_get(hamlet, "/avatar/cordelia@zulip.com/medium", {"foo": "bar"})
-        redirect_url = response["Location"]
-        self.assertTrue(redirect_url.endswith(str(avatar_url(cordelia, True)) + "&foo=bar"))
+        with self.settings(WEB_PUBLIC_STREAMS_ENABLED=False):
+            # Test /avatar/<email_or_id>/medium endpoint with HTTP basic auth.
+            response = self.api_get(hamlet, "/avatar/cordelia@zulip.com/medium", {"foo": "bar"})
+            redirect_url = response["Location"]
+            self.assertTrue(redirect_url.endswith(str(avatar_url(cordelia, True)) + "&foo=bar"))
 
-        response = self.api_get(hamlet, f"/avatar/{cordelia.id}/medium", {"foo": "bar"})
-        redirect_url = response["Location"]
-        self.assertTrue(redirect_url.endswith(str(avatar_url(cordelia, True)) + "&foo=bar"))
+            response = self.api_get(hamlet, f"/avatar/{cordelia.id}/medium", {"foo": "bar"})
+            redirect_url = response["Location"]
+            self.assertTrue(redirect_url.endswith(str(avatar_url(cordelia, True)) + "&foo=bar"))
 
+            # Without spectators enabled, no unauthenticated access.
+            response = self.client_get("/avatar/cordelia@zulip.com/medium", {"foo": "bar"})
+            self.assert_json_error(
+                response,
+                "Not logged in: API authentication or user session required",
+                status_code=401,
+            )
+
+        # Allow unauthenticated/spectator requests by ID.
+        response = self.client_get(f"/avatar/{cordelia.id}/medium", {"foo": "bar"})
+        self.assertEqual(302, response.status_code)
+
+        # Disallow unauthenticated/spectator requests by email.
         response = self.client_get("/avatar/cordelia@zulip.com/medium", {"foo": "bar"})
         self.assert_json_error(
-            response, "Not logged in: API authentication or user session required", status_code=401
+            response,
+            "Not logged in: API authentication or user session required",
+            status_code=401,
         )
 
     def test_non_valid_user_avatar(self) -> None:

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -669,9 +669,14 @@ urls += [
     rest_path("thumbnail", GET=(backend_serve_thumbnail, {"override_api_url_scheme"})),
     # Avatars have the same constraint because their URLs are included
     # in API data structures used by both the mobile and web clients.
-    rest_path("avatar/<email_or_id>", GET=(avatar, {"override_api_url_scheme"})),
     rest_path(
-        "avatar/<email_or_id>/medium", {"medium": True}, GET=(avatar, {"override_api_url_scheme"})
+        "avatar/<email_or_id>",
+        GET=(avatar, {"override_api_url_scheme", "allow_anonymous_user_web"}),
+    ),
+    rest_path(
+        "avatar/<email_or_id>/medium",
+        {"medium": True},
+        GET=(avatar, {"override_api_url_scheme", "allow_anonymous_user_web"}),
     ),
 ]
 


### PR DESCRIPTION
users: Allow spectators to view user avatars.

If realm is web_public, spectators can now view avatar of other
users.

There is a special exception we had to introduce in rest model
to allow `/avatar` type of urls for `anonymous` access.

Fixes #19838

(First commit is there so that you test it locally without running into errors, it is a part of #18532)