### PR TITLE
docs: Add disabling of Force POST Binding to Keyclock SLO instructions.

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -611,6 +611,7 @@ another IdP.
    the user's email address in the NameID to know which user's
    sessions to terminate.
 1. Make sure `Front Channel Logout` is enabled, which it should be by default.
+   Disable `Force POST Binding`, as Zulip only supports the Redirect binding.
 1. In `Fine Grain SAML Endpoint Configuration`, set `Logout Service Redirect Binding URL`
    to the same value you provided for `SSO URL` above.
 1. Add the IdP's `Redirect Binding URL`for `SingleLogoutService` to


### PR DESCRIPTION
This needs to be disabled, because python3-saml only supports the
Redirect binding. This step was forgotten in the original writing of
this doc.
