### PR TITLE
requirements: Ensure that importlib-metadata installs on > py3.8.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -16,7 +16,7 @@ Jinja2
 
 # Needed for Markdown processing
 Markdown
-importlib-metadata;python_version<"3.8"  # for Markdown
+importlib-metadata;python_version<"3.10"  # for Markdown
 Pygments
 jsx-lexer
 

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -61,7 +61,7 @@ https://github.com/zulip/zulint/archive/9908540b7734b51f86ccabab706befc2ff33212a
 # These modules are built into later versions of Python and will
 # generate different locked files if executed with Python ≥ 3.7, so
 # despite being dependent packages, they have to be added separately.
-importlib-metadata;python_version<"3.8"  # for jsonpickle, jsonschema
+importlib-metadata;python_version<"3.10"  # for jsonpickle, jsonschema
 
 # Needed for using integration logo svg files as bot avatars
 cairosvg

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -529,7 +529,7 @@ imagesize==1.2.0 \
     --hash=sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1 \
     --hash=sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1
     # via sphinx
-importlib-metadata==4.8.1 ; python_version < "3.8" \
+importlib-metadata==4.8.1 ; python_version < "3.10" \
     --hash=sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15 \
     --hash=sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1
     # via

--- a/requirements/mypy.in
+++ b/requirements/mypy.in
@@ -29,4 +29,4 @@ types-redis
 types-requests
 types-six
 
-importlib-metadata;python_version<"3.8"  # for sqlalchemy
+importlib-metadata;python_version<"3.10"  # for sqlalchemy

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -70,7 +70,7 @@ greenlet==1.1.2 \
     --hash=sha256:fa877ca7f6b48054f847b61d6fa7bed5cebb663ebc55e018fda12db09dcc664c \
     --hash=sha256:fdcec0b8399108577ec290f55551d926d9a1fa6cad45882093a7a07ac5ec147b
     # via sqlalchemy
-importlib-metadata==4.8.1 ; python_version < "3.8" \
+importlib-metadata==4.8.1 ; python_version < "3.10" \
     --hash=sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15 \
     --hash=sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1
     # via

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -380,7 +380,7 @@ idna==3.3 \
     --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff \
     --hash=sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d
     # via requests
-importlib-metadata==4.8.1 ; python_version < "3.8" \
+importlib-metadata==4.8.1 ; python_version < "3.10" \
     --hash=sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15 \
     --hash=sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1
     # via

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 107
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "164.4"
+PROVISION_VERSION = "164.5"


### PR DESCRIPTION
In #20012, it was discovered that since our `zulip_bots` package
requires `importlib-metadata >= 3.6; python_version < "3.10"`
whereas the server requires
`importlib-metadata==4.8.1 ; python_version < "3.8". This results
in `importlib-metadata` not being installed on Python 3.8 and
Python 3.9. This commit resolves that discrepancy.

Thanks to Anders Kaseorg (@andersk) for reporting this bug!

@timabbott FYI, this is the issue we talked about a few days ago.
