### PR TITLE
openapi: Say message_content_delete_limit_seconds won't be 0 anymore.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -60,7 +60,8 @@ below features are supported.
 
 * [`POST /register`](/api/register-queue), [`GET
   /events`](/api/get-events): `message_content_delete_limit_seconds`
-  now represents no limit using `null`, instead of the integer 0.
+  now represents no limit using `null`, instead of the integer 0, and 0 is
+  no longer a possible value with any meaning.
 * `PATCH /realm`: One now sets `message_content_delete_limit_seconds`
   to no limit by passing the string `unlimited`, rather than the
   integer 0.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3580,7 +3580,7 @@ paths:
                                         with this organization's
                                         [message deletion policy](/help/configure-message-editing-and-deletion).
 
-                                        A 'null' value means no limit: messages can be deleted
+                                        Will not be 0. A 'null' value means no limit: messages can be deleted
                                         regardless of how long ago they were sent.
 
                                         **Changes**: No limit was represented using the
@@ -10731,7 +10731,7 @@ paths:
                           with this organization's
                           [message deletion policy](/help/configure-message-editing-and-deletion).
 
-                          A 'null' value means no limit: messages can be deleted
+                          Will not be 0. A 'null' value means no limit: messages can be deleted
                           regardless of how long ago they were sent.
 
                           **Changes**: No limit was represented using the


### PR DESCRIPTION
I think this is ensured by an assertion in
parse_message_content_delete_limit in zerver/lib/message.py:
  https://github.com/zulip/zulip/blob/b13bfa09c/zerver/lib/message.py#L1482