### PR TITLE
minor: Fix typo in zjquery_element.js - "zjquery" was "zjuery".

### DIFF
--- a/frontend_tests/zjsunit/zjquery_element.js
+++ b/frontend_tests/zjsunit/zjquery_element.js
@@ -183,7 +183,7 @@ function FakeElement(selector, opts) {
         },
         remove() {
             throw new Error(`
-                We don't support remove in zjuery.
+                We don't support remove in zjquery.
 
                 You can do $(...).remove = ... if necessary.
 


### PR DESCRIPTION
What's this PR for?
Typo fix.