### PR TITLE
export: Remove `--delete-after-upload` flag in realm export.

### DIFF
--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -1947,7 +1947,6 @@ def export_realm_wrapper(
     threads: int,
     upload: bool,
     public_only: bool,
-    delete_after_upload: bool,
     percent_callback: Optional[Callable[[Any], None]] = None,
     consent_message_id: Optional[int] = None,
 ) -> Optional[str]:
@@ -1958,9 +1957,8 @@ def export_realm_wrapper(
         public_only=public_only,
         consent_message_id=consent_message_id,
     )
-    print(f"Finished exporting to {output_dir}")
+    shutil.rmtree(output_dir)
     print(f"Tarball written to {tarball_path}")
-
     if not upload:
         return None
 
@@ -1971,12 +1969,10 @@ def export_realm_wrapper(
     public_url = zerver.lib.upload.upload_backend.upload_export_tarball(
         realm, tarball_path, percent_callback=percent_callback
     )
-    print()
-    print(f"Uploaded to {public_url}")
+    print(f"\nUploaded to {public_url}")
 
-    if delete_after_upload:
-        os.remove(tarball_path)
-        print(f"Successfully deleted the tarball at {tarball_path}")
+    os.remove(tarball_path)
+    print(f"Successfully deleted the tarball at {tarball_path}")
     return public_url
 
 

--- a/zerver/management/commands/export.py
+++ b/zerver/management/commands/export.py
@@ -104,11 +104,6 @@ class Command(ZulipBaseCommand):
             action="store_true",
             help="Whether to upload resulting tarball to s3 or LOCAL_UPLOADS_DIR",
         )
-        parser.add_argument(
-            "--delete-after-upload",
-            action="store_true",
-            help="Automatically delete the local tarball after a successful export",
-        )
         self.add_realm_args(parser, required=True)
 
     def handle(self, *args: Any, **options: Any) -> None:
@@ -215,7 +210,6 @@ class Command(ZulipBaseCommand):
             threads=num_threads,
             upload=options["upload"],
             public_only=public_only,
-            delete_after_upload=options["delete_after_upload"],
             percent_callback=percent_callback,
             consent_message_id=consent_message_id,
         )

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -525,7 +525,6 @@ class TestExport(ZulipTestCase):
                 realm=realm,
                 public_only=False,
                 consent_message_id=message.id,
-                delete_after_upload=False,
                 threads=mock.ANY,
                 output_dir=mock.ANY,
                 percent_callback=mock.ANY,

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -979,7 +979,6 @@ class DeferredWorker(QueueProcessingWorker):
                     threads=6,
                     upload=True,
                     public_only=True,
-                    delete_after_upload=True,
                 )
             except Exception:
                 export_event.extra_data = orjson.dumps(


### PR DESCRIPTION
Issue #20081 

For the export realm following changes have been made:
- `./manage.py export --upload` would delete `.tar.gz` and unpacked dir
- `./manage.py export` would only delete `unpacked dir`

Besides, we have removed `--delete-after-upload` as we have set it as
the default.
The changes have been manually tested.