### PR TITLE
Fix accidentally deleted zulip-rtd-git-cloning links and update all django doc version numbers.

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -303,3 +303,6 @@ submit a pull request, or you can ask for help in
 [#development help](https://chat.zulip.org/#narrow/stream/49-development-help)
 on chat.zulip.org, and a core team member can help guide you through
 adding support for the platform.
+
+[zulip-rtd-git-cloning]: ../git/cloning.html#step-1b-clone-to-your-machine
+[zulip-rtd-git-connect]: ../git/cloning.html#step-1c-connect-your-fork-to-zulip-upstream

--- a/docs/development/using.md
+++ b/docs/development/using.md
@@ -94,7 +94,7 @@ for mobile development][mobile-dev-server].
 
 [rest-api]: https://zulip.com/api/rest
 [authentication-dev-server]: ./authentication.md
-[django-runserver]: https://docs.djangoproject.com/en/1.8/ref/django-admin/#runserver-port-or-address-port
+[django-runserver]: https://docs.djangoproject.com/en/3.2/ref/django-admin/#runserver
 [new-feature-tutorial]: ../tutorials/new-feature-tutorial.md
 [testing-docs]: ../testing/testing.md
 [mobile-dev-server]: https://github.com/zulip/zulip-mobile/blob/main/docs/howto/dev-server.md#using-a-dev-version-of-the-server

--- a/docs/overview/directory-structure.md
+++ b/docs/overview/directory-structure.md
@@ -10,15 +10,15 @@ flow through these files.
 ### Core Python files
 
 Zulip uses the [Django web
-framework](https://docs.djangoproject.com/en/1.8/), so a lot of these
+framework](https://docs.djangoproject.com/en/3.2/), so a lot of these
 paths will be familiar to Django developers.
 
 - `zproject/urls.py` Main
-  [Django routes file](https://docs.djangoproject.com/en/1.8/topics/http/urls/).
+  [Django routes file](https://docs.djangoproject.com/en/3.2/topics/http/urls/).
   Defines which URLs are handled by which view functions or templates.
 
 - `zerver/models.py` Main
-  [Django models](https://docs.djangoproject.com/en/1.8/topics/db/models/)
+  [Django models](https://docs.djangoproject.com/en/3.2/topics/db/models/)
   file. Defines Zulip's database tables.
 
 - `zerver/lib/*.py` Most library code.
@@ -28,7 +28,7 @@ paths will be familiar to Django developers.
   all code calling `send_event` to trigger [pushing data to
   clients](../subsystems/events-system.md) must live here.
 
-- `zerver/views/*.py` Most [Django views](https://docs.djangoproject.com/en/1.8/topics/http/views/).
+- `zerver/views/*.py` Most [Django views](https://docs.djangoproject.com/en/3.2/topics/http/views/).
 
 - `zerver/webhooks/` Webhook views and tests for [Zulip's incoming webhook integrations](https://zulip.com/api/incoming-webhooks-overview).
 
@@ -38,7 +38,7 @@ paths will be familiar to Django developers.
 
 - `zerver/lib/markdown/` [Backend Markdown processor](../subsystems/markdown.md).
 
-- `zproject/backends.py` [Authentication backends](https://docs.djangoproject.com/en/1.8/topics/auth/customizing/).
+- `zproject/backends.py` [Authentication backends](https://docs.djangoproject.com/en/3.2/topics/auth/customizing/).
 
 ---
 

--- a/docs/production/email.md
+++ b/docs/production/email.md
@@ -205,7 +205,7 @@ aren't receiving emails from Zulip:
   will try to use the TLS protocol on port 465, which won't work.
 
 - Zulip's email sending configuration is based on the standard Django
-  [SMTP backend](https://docs.djangoproject.com/en/2.0/topics/email/#smtp-backend)
+  [SMTP backend](https://docs.djangoproject.com/en/3.2/topics/email/#smtp-backend)
   configuration. So if you're having trouble getting your email
   provider working, you may want to search for documentation related
   to using your email provider with Django.

--- a/docs/production/management-commands.md
+++ b/docs/production/management-commands.md
@@ -182,4 +182,4 @@ upgrade.
 [zulip-api]: https://zulip.com/api/rest
 [webhook-integrations]: https://zulip.com/api/incoming-webhooks-overview
 [management-commands-dev]: ../subsystems/management-commands.md
-[django-management]: https://docs.djangoproject.com/en/2.2/ref/django-admin/#django-admin-and-manage-py
+[django-management]: https://docs.djangoproject.com/en/3.2/ref/django-admin/#django-admin-and-manage-py

--- a/docs/subsystems/caching.md
+++ b/docs/subsystems/caching.md
@@ -262,4 +262,4 @@ cached by clients is changed. Clients are responsible for handling
 the events, updating their state, and rerendering any UI components
 that might display the modified state.
 
-[post-save-signals]: https://docs.djangoproject.com/en/2.0/ref/signals/#post-save
+[post-save-signals]: https://docs.djangoproject.com/en/3.2/ref/signals/#post-save

--- a/docs/subsystems/client.md
+++ b/docs/subsystems/client.md
@@ -29,7 +29,7 @@ The `webhook_view` auth decorator, used for most incoming
 webhooks, accepts the name of the integration as an argument and uses
 it to generate a client name that it adds to the `request_notes`
 object that can be accessed with the `request` (Django
-[HttpRequest](https://docs.djangoproject.com/en/1.8/ref/request-response/#django.http.HttpRequest))
+[HttpRequest](https://docs.djangoproject.com/en/3.2/ref/request-response/#django.http.HttpRequest))
 object via `zerver.lib.request.get_request_notes(request)`.
 
 In most integrations, `request_notes.client` is then passed to

--- a/docs/subsystems/logging.md
+++ b/docs/subsystems/logging.md
@@ -179,7 +179,7 @@ a new view:
 - The time when the browser was idle again after switching views
   (intended to catch issues where we generate a lot of deferred work).
 
-[django-errors]: https://docs.djangoproject.com/en/2.2/howto/error-reporting/
+[django-errors]: https://docs.djangoproject.com/en/3.2/howto/error-reporting/
 [python-logging]: https://docs.python.org/3/library/logging.html
-[django-logging]: https://docs.djangoproject.com/en/2.2/topics/logging/
+[django-logging]: https://docs.djangoproject.com/en/3.2/topics/logging/
 [sentry]: https://sentry.io

--- a/docs/subsystems/management-commands.md
+++ b/docs/subsystems/management-commands.md
@@ -62,4 +62,4 @@ to do anything special like restart the server when iteratively
 testing one, even if testing in a Zulip production environment where
 the server doesn't normally restart whenever a file is edited.
 
-[django-docs]: https://docs.djangoproject.com/en/2.2/howto/custom-management-commands/
+[django-docs]: https://docs.djangoproject.com/en/3.2/howto/custom-management-commands/

--- a/docs/subsystems/schema-migrations.md
+++ b/docs/subsystems/schema-migrations.md
@@ -1,7 +1,7 @@
 # Schema migrations
 
 Zulip uses the [standard Django system for doing schema
-migrations](https://docs.djangoproject.com/en/1.10/topics/migrations/).
+migrations](https://docs.djangoproject.com/en/3.2/topics/migrations/).
 There is some example usage in the [new feature
 tutorial](../tutorials/new-feature-tutorial.md).
 
@@ -164,7 +164,7 @@ an incorrect migration messes up a database in a way that's impossible
 to undo without going to backups.
 
 [django-migration-test-blog-post]: https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/
-[migrations-non-atomic]: https://docs.djangoproject.com/en/1.10/howto/writing-migrations/#non-atomic-migrations
+[migrations-non-atomic]: https://docs.djangoproject.com/en/3.2/howto/writing-migrations/#non-atomic-migrations
 
 ## Schema and initial data changes
 

--- a/docs/subsystems/settings.md
+++ b/docs/subsystems/settings.md
@@ -26,7 +26,7 @@ convenient for:
 ## Server settings
 
 Zulip uses the [Django settings
-system](https://docs.djangoproject.com/en/2.2/topics/settings/), which
+system](https://docs.djangoproject.com/en/3.2/topics/settings/), which
 means that the settings files are Python programs that set a lot of
 variables with all-capital names like `EMAIL_GATEWAY_PATTERN`. You can
 access these anywhere in the Zulip Django code using e.g.:
@@ -146,7 +146,7 @@ accessed in initialization of Django (or Zulip) internals
 (e.g. `DATABASES`). See the [Django docs on overriding settings in
 tests][django-test-settings] for more details.
 
-[django-test-settings]: https://docs.djangoproject.com/en/2.2/topics/testing/tools/#overriding-settings
+[django-test-settings]: https://docs.djangoproject.com/en/3.2/topics/testing/tools/#overriding-settings
 
 ## Realm settings
 

--- a/docs/testing/linters.md
+++ b/docs/testing/linters.md
@@ -212,7 +212,7 @@ option of Puppet.
 
 Zulip uses two HTML templating systems:
 
-- [Django templates](https://docs.djangoproject.com/en/1.10/topics/templates/)
+- [Django templates](https://docs.djangoproject.com/en/3.2/topics/templates/)
 - [handlebars](https://handlebarsjs.com/)
 
 Zulip has an internal tool that validates both types of templates for

--- a/docs/testing/testing-with-django.md
+++ b/docs/testing/testing-with-django.md
@@ -4,7 +4,7 @@
 
 Zulip uses the Django framework for its Python backend. We
 use the testing framework from
-[django.test](https://docs.djangoproject.com/en/1.10/topics/testing/)
+[django.test](https://docs.djangoproject.com/en/3.2/topics/testing/)
 to test our code. We have over a thousand automated tests that verify that
 our backend works as expected.
 

--- a/docs/tutorials/life-of-a-request.md
+++ b/docs/tutorials/life-of-a-request.md
@@ -55,7 +55,7 @@ application.
 ## Django routes the request to a view in urls.py files
 
 There are various
-[urls.py](https://docs.djangoproject.com/en/1.8/topics/http/urls/)
+[urls.py](https://docs.djangoproject.com/en/3.2/topics/http/urls/)
 files throughout the server codebase, which are covered in more detail
 in
 [the directory structure doc](../overview/directory-structure.md).
@@ -180,7 +180,7 @@ PUT=create_user_backend
 ```
 
 are supplied as arguments to `rest_path`, along with the
-[HTTPRequest](https://docs.djangoproject.com/en/1.8/ref/request-response/).
+[HTTPRequest](https://docs.djangoproject.com/en/3.2/ref/request-response/).
 The request has the HTTP verb `PUT`, which `rest_dispatch` can use to
 find the correct view to show:
 `zerver.views.users.create_user_backend`.
@@ -199,7 +199,7 @@ Our API works on JSON requests and responses. Every API endpoint should
 ```
 
 in a
-[HTTP response](https://docs.djangoproject.com/en/1.8/ref/request-response/)
+[HTTP response](https://docs.djangoproject.com/en/3.2/ref/request-response/)
 with a content type of 'application/json'.
 
 To pass back data from the server to the calling client, in the event of

--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -20,7 +20,7 @@ tests, use Django's tooling.
 Zulip's [directory structure](../overview/directory-structure.md)
 will also be helpful to review when creating a new feature. Many
 aspects of the structure will be familiar to Django developers. Visit
-[Django's documentation](https://docs.djangoproject.com/en/2.2/#index-first-steps)
+[Django's documentation](https://docs.djangoproject.com/en/3.2/#index-first-steps)
 for more information about how Django projects are typically
 organized. And finally, the
 [message sending](../subsystems/sending-messages.md) documentation on
@@ -240,7 +240,7 @@ Create the migration file using the Django `makemigrations` command:
 (NNNN is a number that is equal to the number of migrations.)
 
 If you run into problems, the
-[Django migration documentation](https://docs.djangoproject.com/en/1.8/topics/migrations/)
+[Django migration documentation](https://docs.djangoproject.com/en/3.2/topics/migrations/)
 is helpful.
 
 ### Test your migration changes

--- a/docs/tutorials/writing-views.md
+++ b/docs/tutorials/writing-views.md
@@ -35,7 +35,7 @@ or JSON (data for Zulip clients on all platforms, custom bots, and
 integrations).
 
 The format of the URL patterns in Django is [documented
-here](https://docs.djangoproject.com/en/1.8/topics/http/urls/), and
+here](https://docs.djangoproject.com/en/3.2/topics/http/urls/), and
 the Zulip specific details for these are discussed in detail in the
 [life of a request doc](life-of-a-request.html#options).
 
@@ -93,7 +93,7 @@ specific to Zulip.
 def home(request: HttpRequest) -> HttpResponse:
 ```
 
-[login-required-link]: https://docs.djangoproject.com/en/1.8/topics/auth/default/#django.contrib.auth.decorators.login_required
+[login-required-link]: https://docs.djangoproject.com/en/3.2/topics/auth/default/#django.contrib.auth.decorators.login_required
 
 ### Writing a template
 

--- a/templates/zerver/api/incoming-webhooks-walkthrough.md
+++ b/templates/zerver/api/incoming-webhooks-walkthrough.md
@@ -143,7 +143,7 @@ You should name your webhook function as such
 integration and is always lower-case.
 
 At minimum, the webhook function must accept `request` (Django
-[HttpRequest](https://docs.djangoproject.com/en/1.8/ref/request-response/#django.http.HttpRequest)
+[HttpRequest](https://docs.djangoproject.com/en/3.2/ref/request-response/#django.http.HttpRequest)
 object), and `user_profile` (Zulip's user object). You may also want to
 define additional parameters using the `REQ` object.
 

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -141,7 +141,7 @@ def check_send_webhook_message(
 def standardize_headers(input_headers: Union[None, Dict[str, Any]]) -> Dict[str, str]:
     """This method can be used to standardize a dictionary of headers with
     the standard format that Django expects. For reference, refer to:
-    https://docs.djangoproject.com/en/2.2/ref/request-response/#django.http.HttpRequest.headers
+    https://docs.djangoproject.com/en/3.2/ref/request-response/#django.http.HttpRequest.headers
 
     NOTE: Historically, Django's headers were not case-insensitive. We're still
     capitalizing our headers to make it easier to compare/search later if required.

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1705,7 +1705,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
     #
     # In Django, the convention is to use an empty string instead of NULL/None
     # for text-based fields. For more information, see
-    # https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.Field.null.
+    # https://docs.djangoproject.com/en/3.2/ref/models/fields/#django.db.models.Field.null.
     timezone: str = models.CharField(max_length=40, default="")
 
     AVATAR_FROM_GRAVATAR = "G"

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -233,8 +233,8 @@ def json_change_settings(
             raise JsonableError(_("New password is too weak!"))
 
         do_change_password(user_profile, new_password)
-        # In Django 1.10, password changes invalidates sessions, see
-        # https://docs.djangoproject.com/en/1.10/topics/auth/default/#session-invalidation-on-password-change
+        # Password changes invalidates sessions, see
+        # https://docs.djangoproject.com/en/3.2/topics/auth/default/#session-invalidation-on-password-change
         # for details. To avoid this logging the user out of their own
         # session (which would provide a confusing UX at best), we
         # update the session hash here.

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -240,7 +240,7 @@ SILENCED_SYSTEM_CHECKS = [
     # `unique=True`.  For us this is `email`, and it's unique only per-realm.
     # Per Django docs, this is perfectly fine so long as our authentication
     # backends support the username not being unique; and they do.
-    # See: https://docs.djangoproject.com/en/2.2/topics/auth/customizing/#django.contrib.auth.models.CustomUser.USERNAME_FIELD
+    # See: https://docs.djangoproject.com/en/3.2/topics/auth/customizing/#django.contrib.auth.models.CustomUser.USERNAME_FIELD
     "auth.W004",
     # models.E034 limits index names to 30 characters for Oracle compatibility.
     # We aren't using Oracle.

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -376,7 +376,7 @@ if TYPE_CHECKING:
 
 JWT_AUTH_KEYS: Dict[str, "JwtAuthKey"] = {}
 
-# https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-SERVER_EMAIL
+# https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-SERVER_EMAIL
 # Django setting for what from address to use in error emails.
 SERVER_EMAIL = ZULIP_ADMINISTRATOR
 # Django setting for who receives error emails.

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -44,7 +44,7 @@ EXTERNAL_HOST = "zulip.example.com"
 ## representing the host/domain names that your users can enter in
 ## their browsers to access Zulip.  This is a security measure; for
 ## details, see the Django documentation:
-## https://docs.djangoproject.com/en/2.2/ref/settings/#allowed-hosts
+## https://docs.djangoproject.com/en/3.2/ref/settings/#allowed-hosts
 ##
 ## Zulip automatically adds to this list 'localhost', '127.0.0.1', and
 ## patterns representing EXTERNAL_HOST and subdomains of it.  If you are

--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -79,7 +79,7 @@ def setup_sentry(dsn: Optional[str], environment: str) -> None:
     )
 
     # Ignore all of the loggers from django.security that are for user
-    # errors; see https://docs.djangoproject.com/en/3.0/ref/exceptions/#suspiciousoperation
+    # errors; see https://docs.djangoproject.com/en/3.2/ref/exceptions/#suspiciousoperation
     ignore_logger("django.security.SuspiciousOperation")
     ignore_logger("django.security.DisallowedHost")
     ignore_logger("django.security.DisallowedModelAdminLookup")


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
First commit: bug as described at https://github.com/zulip/zulip/pull/19993#discussion_r741441554 and 
[#documentation>links to other documentation](https://chat.zulip.org/#narrow/stream/19-documentation/topic/links.20to.20other.20documentation).

Second commit: (identical to commit message)
Previously, our docs had links to various versions of the Django docs,
eg https://docs.djangoproject.com/en/1.10/topics/migrations/ and
https://docs.djangoproject.com/en/2.0/ref/signals/#post-save, opening
a link to a doc with an outdated Django version would show a warning
"This document is for an insecure version of Django that is no longer
supported. Please upgrade to a newer release!".

This commit uses a search with the regex
"docs.djangoproject.com/en/([0-9].[0-9]*)/" and replaces all matches
with "docs.djangoproject.com/en/3.2/".

All the new links in this commit have been generated by the above
replace and it has NOT been verified that the contents are the same
(or if the linked pages even exist), however, this shouldn't be an
issue given that we use Django > 3.2.

**Testing plan:** <!-- How have you tested? --> 
First commit: Manually checked that the links work on the [preview doc](https://zulip--20144.org.readthedocs.build/en/20144/development/setup-advanced.html#using-the-vagrant-hyper-v-provider-on-windows-beta).
Second commit: Automated tests only.
Third commit: Automated tests only.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
