### PR TITLE
Add user-id column in users and subscribers list.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -76,6 +76,10 @@ function sort_last_active(a, b) {
     );
 }
 
+function sort_user_id(a, b) {
+    return compare_a_b(a.user_id, b.user_id);
+}
+
 function get_user_info_row(user_id) {
     return $(`tr.user_row[data-user-id='${CSS.escape(user_id)}']`);
 }
@@ -300,6 +304,7 @@ section.active.create_table = (active_users) => {
             email: sort_email,
             last_active: sort_last_active,
             role: sort_role,
+            id: sort_user_id,
         },
         simplebar_container: $("#admin-user-list .progressive-table-wrapper"),
     });
@@ -327,6 +332,7 @@ section.deactivated.create_table = (deactivated_users) => {
         sort_fields: {
             email: sort_email,
             role: sort_role,
+            id: sort_user_id,
         },
         simplebar_container: $("#admin-deactivated-users-list .progressive-table-wrapper"),
     });

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -276,6 +276,7 @@ section.bots.create_table = () => {
         sort_fields: {
             email: sort_bot_email,
             bot_owner: sort_bot_owner,
+            id: sort_user_id,
         },
         simplebar_container: $("#admin-bot-list .progressive-table-wrapper"),
     });

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -210,7 +210,7 @@ function format_member_list_elem(person) {
 function get_subscriber_list(sub_row) {
     const stream_id_str = sub_row.data("stream-id");
     return $(
-        `.subscription_settings[data-stream-id="${CSS.escape(stream_id_str)}"] .subscriber-list`,
+        `.subscription_settings[data-stream-id="${CSS.escape(stream_id_str)}"] .subscriber_table`,
     );
 }
 
@@ -535,6 +535,7 @@ export function show_settings_for(node) {
         other_settings,
         stream_post_policy_values: stream_data.stream_post_policy_values,
         message_retention_text: get_retention_policy_text_for_subscription_type(sub),
+        show_email: settings_data.show_email(),
     });
     ui.get_content_element($("#stream_settings")).html(html);
 

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -242,15 +242,21 @@
             margin: auto;
             border-radius: 6px;
 
+            tbody {
+                border-bottom: none;
+
+                tr:last-of-type {
+                    border-bottom: none;
+                }
+            }
+
             tr {
                 border-bottom: 1px solid hsl(0, 0%, 93%);
 
-                &:last-of-type {
-                    border-bottom: none;
-                }
-
-                td {
+                td,
+                th {
                     padding: 4px 0;
+                    vertical-align: middle;
 
                     &:first-of-type {
                         padding-left: 10px;
@@ -258,10 +264,6 @@
 
                     &:last-of-type {
                         padding-right: 10px;
-                    }
-
-                    &.unsubscribe {
-                        text-align: right;
                     }
                 }
             }
@@ -275,13 +277,25 @@
                 content: "No subscribers to this stream.";
                 display: block;
 
-                text-align: center;
                 color: hsl(0, 0%, 67%);
+                padding: 5px 5px 5px 10px;
             }
 
-            &:empty {
-                display: block;
-                padding: 5px;
+            thead th {
+                color: inherit;
+                background-color: hsl(0, 0%, 100%);
+
+                &:first-of-type {
+                    border-top-left-radius: 4px;
+                }
+
+                &:last-of-type {
+                    border-top-right-radius: 4px;
+                }
+
+                position: sticky;
+                top: 0;
+                z-index: 1;
             }
         }
     }

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -263,7 +263,7 @@
                     }
 
                     &:last-of-type {
-                        padding-right: 10px;
+                        padding-left: 5px;
                     }
                 }
             }

--- a/static/templates/settings/admin_user_list.hbs
+++ b/static/templates/settings/admin_user_list.hbs
@@ -8,11 +8,9 @@
         <span class="email">{{display_email}}</span>
     </td>
     {{/if}}
-    {{#unless is_bot}}
     <td>
         <span class="user_id">{{user_id}}</span>
     </td>
-    {{/unless}}
     {{#unless is_bot}}
     <td>
         <span class="user_role">{{user_role_text}}</span>

--- a/static/templates/settings/admin_user_list.hbs
+++ b/static/templates/settings/admin_user_list.hbs
@@ -10,6 +10,11 @@
     {{/if}}
     {{#unless is_bot}}
     <td>
+        <span class="user_id">{{user_id}}</span>
+    </td>
+    {{/unless}}
+    {{#unless is_bot}}
+    <td>
         <span class="user_role">{{user_role_text}}</span>
     </td>
     {{/unless}}

--- a/static/templates/settings/bot_list_admin.hbs
+++ b/static/templates/settings/bot_list_admin.hbs
@@ -9,6 +9,7 @@
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 <th data-sort="email">{{t "Email" }}</th>
+                <th data-sort="id">{{t "User ID"}}</th>
                 <th data-sort="bot_owner">{{t "Owner" }}</th>
                 <th data-sort="alphabetic" data-sort-prop="bot_type">{{t "Bot type" }}</th>
                 {{#if is_admin}}

--- a/static/templates/settings/deactivated_users_admin.hbs
+++ b/static/templates/settings/deactivated_users_admin.hbs
@@ -13,6 +13,7 @@
                 {{#if show_email}}
                 <th data-sort="email">{{t "Email" }}</th>
                 {{/if}}
+                <th class="user_id" data-sort="id">{{t "User ID" }}</th>
                 <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 {{#if is_admin}}
                 <th class="actions">{{t "Actions" }}</th>

--- a/static/templates/settings/user_list_admin.hbs
+++ b/static/templates/settings/user_list_admin.hbs
@@ -12,6 +12,7 @@
                 {{#if show_email}}
                 <th data-sort="email">{{t "Email" }}</th>
                 {{/if}}
+                <th class="user_id" data-sort="id">{{t "User ID" }}</th>
                 <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 <th class="last_active" data-sort="last_active">{{t "Last active" }}</th>
                 {{#if is_admin}}

--- a/static/templates/stream_settings/stream_member_list_entry.hbs
+++ b/static/templates/stream_settings/stream_member_list_entry.hbs
@@ -3,6 +3,7 @@
     {{#if show_email}}
     <td class="subscriber-email">{{email}}</td>
     {{/if}}
+    <td class="subscriber-user-id">{{user_id}}</td>
     {{#if displaying_for_admin}}
     <td class="unsubscribe">
         <div class="subscriber_list_remove">

--- a/static/templates/stream_settings/stream_members.hbs
+++ b/static/templates/stream_settings/stream_members.hbs
@@ -34,6 +34,7 @@
                     {{#if show_email}}
                     <th>{{t "Email" }}</th>
                     {{/if}}
+                    <th>{{t "User ID" }}</th>
                     {{#if is_realm_admin}}
                     <th class="actions">{{t "Actions" }}</th>
                     {{/if}}

--- a/static/templates/stream_settings/stream_members.hbs
+++ b/static/templates/stream_settings/stream_members.hbs
@@ -28,7 +28,18 @@
     <div class="subscriber-list-box">
         <div class="subscriber_list_container" data-simplebar>
             <div class="subscriber_list_loading_indicator"></div>
-            <table class="subscriber-list"></table>
+            <table class="subscriber-list table table-striped">
+                <thead class="table-sticky-headers">
+                    <th>{{t "Name" }}</th>
+                    {{#if show_email}}
+                    <th>{{t "Email" }}</th>
+                    {{/if}}
+                    {{#if is_realm_admin}}
+                    <th class="actions">{{t "Actions" }}</th>
+                    {{/if}}
+                </thead>
+                <tbody class="subscriber_table"></tbody>
+            </table>
         </div>
     </div>
 </div>

--- a/static/templates/stream_settings/stream_settings.hbs
+++ b/static/templates/stream_settings/stream_settings.hbs
@@ -118,7 +118,7 @@
         <div class="subscriber_settings stream_section">
             {{#with sub}}
             <div class="subscription-members-setting">
-                {{> stream_members}}
+                {{> stream_members show_email=../show_email}}
             </div>
             {{/with}}
         </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit adds user-id column in active and deactivated users list.
- Second commit adds user-id column in bots list.
- Third commit adds heading row in subscriber-list.
- Fourth commit adds user-id column in subscriber-list.
 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2021-11-03 11-06-59](https://user-images.githubusercontent.com/35494118/140014314-2089b505-0c47-41ee-b02b-2677cc33d111.png)
![Screenshot from 2021-11-03 11-07-03](https://user-images.githubusercontent.com/35494118/140014319-51f2a81f-6667-46a6-a29f-082a7066e224.png)

![Screenshot from 2021-11-02 22-27-23](https://user-images.githubusercontent.com/35494118/140014324-36d01dba-73ce-4e65-bfb7-828e1d88c231.png)
![Screenshot from 2021-11-02 23-27-27](https://user-images.githubusercontent.com/35494118/140014323-568dcfef-f8f9-4fb3-81ba-9d0db200e120.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
