### PR TITLE
settings_display: Add spacing to the `Save` and `Add Emoji` button

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1843,6 +1843,12 @@ input[type="checkbox"] {
         display: block;
     }
 
+    .new-user-group-form div.user_name,
+    .new-user-group-form div.user_description,
+    .new-emoji-form div.emoji_name {
+        margin-bottom: 5px;
+    }
+
     .user-avatar-section .avatar-controls {
         display: inline-block;
         margin-top: 10px;
@@ -1907,6 +1913,20 @@ input[type="checkbox"] {
 @media (width < $sm_min) {
     #pw_strength {
         margin: auto;
+    }
+
+    .new-user-group-form #admin_user_submit,
+    .new-emoji-form #admin_emoji_submit {
+        margin: 5px 0;
+    }
+
+    .new-emoji-form div.emoji_name {
+        margin: 0 0 15px;
+    }
+
+    .new-emoji-form #emoji_upload_button,
+    .new-emoji-form #emoji_image_clear_button {
+        margin-left: -3px;
     }
 
     #linkifier-settings .new-linkifier-form,

--- a/static/templates/settings/emoji_settings_admin.hbs
+++ b/static/templates/settings/emoji_settings_admin.hbs
@@ -10,7 +10,7 @@
             <div class="new-emoji-form">
                 <div class="settings-section-title new-emoji-section-title no-padding">{{t "Add a new emoji" }}</div>
                 <div class="alert" id="admin-emoji-status"></div>
-                <div class="inline-block">
+                <div class="inline-block emoji_name">
                     <label for="emoji_name">{{t "Emoji name" }}</label>
                     <input type="text" name="name" id="emoji_name" placeholder="{{t 'leafy green vegetable' }}" />
                 </div>

--- a/static/templates/settings/user_groups_admin.hbs
+++ b/static/templates/settings/user_groups_admin.hbs
@@ -22,15 +22,15 @@
                 <div class="new-user-group-form">
                     <div class="settings-section-title new-user-group-section-title no-padding">{{t "Add a new user group" }}</div>
                     <div class="alert" id="admin-user-group-status"></div>
-                    <div class="inline-block">
+                    <div class="inline-block user_name">
                         <label for="user_group_name">{{t "Name" }}</label>
                         <input type="text" name="name" id="user_group_name" maxlength="100" placeholder="{{t 'marketing' }}" />
                     </div>
-                    <div class="inline-block">
+                    <div class="inline-block user_decription">
                         <label for="user_group_description">{{t "Description" }}</label>
                         <input type="text" name="description" id="user_group_description" maxlength="300" placeholder="{{t 'Marketing team' }}" />
                     </div>
-                    <button type="submit" class="button rounded sea-green">
+                    <button type="submit" id="admin_user_submit" class="button rounded sea-green">
                         {{t 'Save' }}
                     </button>
                 </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes: #20118 

**Testing plan:** <!-- How have you tested? -->
Manually

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
#### For Save button-
Before:
![Screenshot-20211103123908-597x179](https://user-images.githubusercontent.com/76884959/140024932-7f89d75e-a510-4d96-86ff-37dfe4bb26a6.png)

After:
![Screenshot-20211103123838-595x193](https://user-images.githubusercontent.com/76884959/140024951-e07ee777-fdb9-4a9b-9ba8-1122691c80e4.png)

#### For Add Emoji button-
Before:
![Screenshot-20211103162949-599x189](https://user-images.githubusercontent.com/76884959/140050633-42203b14-a52b-444f-94a9-6e7af79f8bc2.png)
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

After:
![Screenshot-20211103163016-595x192](https://user-images.githubusercontent.com/76884959/140050707-087f12ff-b1d6-4f7e-8080-49b9730c726a.png)

