### PR TITLE
home: Delete prefers_web_public_view key after user is logged in.

### DIFF
--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -330,6 +330,12 @@ class HomeTest(ZulipTestCase):
         ]
         expected_keys = [i for i in self.expected_page_params_keys if i not in removed_keys]
         self.assertEqual(actual_keys, expected_keys)
+        self.assertEqual(self.client.session.get("prefers_web_public_view"), True)
+
+        # Web public session key should clear once user is logged in
+        self.login("hamlet")
+        self.client_get("/")
+        self.assertEqual(self.client.session.get("prefers_web_public_view"), None)
 
     def test_home_under_2fa_without_otp_device(self) -> None:
         with self.settings(TWO_FACTOR_AUTHENTICATION_ENABLED=True):

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -148,6 +148,10 @@ def home_real(request: HttpRequest) -> HttpResponse:
     if request.user.is_authenticated:
         user_profile = request.user
         realm = user_profile.realm
+
+        # User is logged in and hence no longer `prefers_web_public_view`.
+        if "prefers_web_public_view" in request.session.keys():
+            del request.session["prefers_web_public_view"]
     else:
         realm = get_valid_realm_from_request(request)
 


### PR DESCRIPTION
Since `prefers_web_public_view` key in session is only
relevant to users without an account, this key should no longer
be present in the user's session object.

Fixes #19907
