### PR TITLE
message_view_header: Hide subscriber count for spectators.

### DIFF
--- a/static/templates/message_view_header.hbs
+++ b/static/templates/message_view_header.hbs
@@ -2,7 +2,7 @@
 <a class="stream" href="{{stream_settings_link}}">
     {{> navbar_icon_and_title }}
 </a>
-<a class="sub_count no-style tippy-zulip-tooltip" data-tippy-content="{{sub_count_tooltip_text}}" data-tippy-placement="bottom" href="{{stream_settings_link}}">
+<a class="sub_count no-style tippy-zulip-tooltip hidden-for-spectators" data-tippy-content="{{sub_count_tooltip_text}}" data-tippy-placement="bottom" href="{{stream_settings_link}}">
     <i class="fa fa-user-o"></i>{{formatted_sub_count}}
 </a>
 <span class="narrow_description navbar-click-opens-search rendered_markdown">


### PR DESCRIPTION
While we figure out a plan in #19842 to display
subscriber count for spectators without doing a heavy query
to the database, we hide this section in navbar.
<img width="798" alt="Screenshot 2021-11-03 at 6 33 38 PM" src="https://user-images.githubusercontent.com/25124304/140064940-0364435e-a34e-4929-be8b-049871f28af5.png">
