### PR TITLE
tools: Run node_tests with coverage in parallel.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -3,8 +3,10 @@ import argparse
 import glob
 import os
 import pwd
+import shutil
 import subprocess
 import sys
+import tempfile
 from typing import Any, Dict, List
 
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -212,12 +214,6 @@ options = parser.parse_args()
 individual_files = options.args
 parallel = options.parallel
 
-if options.coverage and parallel > 1:
-    parallel = 1
-    print(
-        BOLDRED + "You cannot use --coverage with parallel tests. Running in serial mode.\n" + ENDC
-    )
-
 assert_provisioning_status_ok(options.skip_provision_check)
 
 
@@ -291,12 +287,49 @@ def run_tests_via_node_js() -> int:
     ret = 0
     if parallel > 1:
         sub_tests = [test_files[i::parallel] for i in range(parallel)]
-        parallel_processes = [subprocess.Popen(node_tests_cmd + sub_test) for sub_test in sub_tests]
+        if options.coverage:
+            # ensure a clean start.
+            coverage_dir = os.path.join(ROOT_DIR, "var/node-coverage")
+            if os.path.exists(coverage_dir) and os.path.isdir(coverage_dir):
+                shutil.rmtree(coverage_dir)
+            os.mkdir(coverage_dir)
 
-        for process in parallel_processes:
-            status_code = process.wait()
-            if status_code != 0:
-                ret = status_code
+            # ensure that we work with a unique output folder just in case.
+            with tempfile.TemporaryDirectory(prefix="nyc_outputs_", dir=coverage_dir) as temp_dir:
+                nyc = os.path.join(ROOT_DIR, "node_modules/.bin/nyc")
+                command = [nyc, "--extension", ".hbs", "--extension", ".ts"]
+                command += ["--silent"]
+                command += ["--temp-directory", temp_dir]
+                command += node_tests_cmd
+                parallel_processes = [
+                    subprocess.Popen(command + sub_test) for sub_test in sub_tests
+                ]
+
+                for process in parallel_processes:
+                    status_code = process.wait()
+                    if status_code != 0:
+                        ret = status_code
+                        return ret
+
+                command = [nyc, "merge", temp_dir, NODE_COVERAGE_PATH]
+                ret = subprocess.check_call(command)
+                if ret != 0:
+                    return ret
+
+                # using a context manager ensures that we automatically clean up temp_dir
+            command = [nyc, "report"]
+            command += ["--temp-directory", coverage_dir]
+            command += ["--report-dir", coverage_dir]
+            command += ["-r=lcov", "-r=json", "-r=text-summary"]
+            ret = subprocess.check_call(command)
+        else:
+            parallel_processes = [
+                subprocess.Popen(node_tests_cmd + sub_test) for sub_test in sub_tests
+            ]
+            for process in parallel_processes:
+                status_code = process.wait()
+                if status_code != 0:
+                    ret = status_code
         return ret
 
     node_tests_cmd += test_files


### PR DESCRIPTION
Previously, we'd force node tests to run in serial mode. One might
think this is because it's not possible to consolidate coverage from
multiple runs, but nyc actually does this by default!

The important detail is that we need to run nyc with `--no-clear` to
make sure that we do not remove coverage from parallel runs. However,
since we're running with `--no-clear` it's important to ensure that we
start from an empty directory (ie we don't use coverage from previous
runs).

The work in progress bit here is to generate nice human readable
text-summaries which would be pretty helpful in eg CI output...

... Although, maybe it's unnecessary since we print human legible
messages when we've lost coverage that also explain what to do and the
summary table doesn't really provide much utility.

In the case that we decide that the summary isn't useful, we could
just remove the commented out bits.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** 
Automated CI tests and I've manually reviewed the changes before making this PR.

**Basic profiling results:** 
There is an ~11s decrease in real time, but a ~1m12s increase in user time and ~1.8s increase in sys time.

Without this commit we get:
```bash
(zulip-py3-venv) re@DESKTOP:~/zulip$ time (./tools/test-js-with-node --coverage)
You cannot use --coverage with parallel tests. Running in serial mode.

Starting node tests...
...
View coverage reports at http://zulipdev.com:9991/node-coverage/index.html

Test(s) passed. SUCCESS!

real    0m36.073s
user    0m43.504s
sys     0m1.532s
```

With this commit we get:
```bash
(zulip-py3-venv) re@DESKTOP:~/zulip$ time (./tools/test-js-with-node --coverage)
You should not be able to use --coverage with parallel tests. But trying anyways.

Starting node tests...
...
View coverage reports at http://zulipdev.com:9991/node-coverage/index.html

Test(s) passed. SUCCESS!

real    0m25.455s
user    1m55.173s
sys     0m3.318s
```
