### PR TITLE
data_import: Fix a few KeyError bugs in Rocket.Chat import tool.

### DIFF
--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -137,6 +137,10 @@ def process_users(
 def get_stream_name(rc_channel: Dict[str, Any]) -> str:
     if rc_channel.get("teamMain"):
         return f'[TEAM] {rc_channel["name"]}'
+    elif rc_channel.get("t") == "l":
+        # Rocket.Chat livechat channels uses the `fname` field
+        # to specify the channel name.
+        return rc_channel["fname"]
     else:
         return rc_channel["name"]
 
@@ -389,7 +393,7 @@ def process_message_attachment(
         upload_file.write(b"".join(upload_file_data["chunk"]))
 
     attachment_content = (
-        f'{upload_file_data["description"]}\n\n[{file_name}](/user_uploads/{s3_path})'
+        f'{upload_file_data.get("description", "")}\n\n[{file_name}](/user_uploads/{s3_path})'
     )
 
     fileinfo = {

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -246,6 +246,14 @@ class RocketChatImporter(ZulipTestCase):
             huddle_id_to_huddle_map=huddle_id_to_huddle_map,
         )
 
+        # Add a dummy livechat channel
+        room_id_to_room_map["2t6Lyzd2KAD3nS8Ch"] = {
+            "_id": "2t6Lyzd2KAD3nS8Ch",
+            "fname": "guest",
+            "t": "l",
+            "ts": datetime.datetime(2019, 11, 6, 0, 38, 42, 796000),
+        }
+
         zerver_stream = convert_channel_data(
             room_id_to_room_map=room_id_to_room_map,
             team_id_to_team_map=team_id_to_team_map,
@@ -254,8 +262,8 @@ class RocketChatImporter(ZulipTestCase):
         )
 
         # Only rooms are converted to streams.
-        self.assert_length(room_id_to_room_map, 6)
-        self.assert_length(zerver_stream, 6)
+        self.assert_length(room_id_to_room_map, 7)
+        self.assert_length(zerver_stream, 7)
 
         # Normal public stream
         self.assertEqual(zerver_stream[0]["name"], "general")
@@ -290,6 +298,14 @@ class RocketChatImporter(ZulipTestCase):
         self.assertEqual(zerver_stream[5]["rendered_description"], "")
         self.assertEqual(zerver_stream[5]["stream_post_policy"], 1)
         self.assertEqual(zerver_stream[5]["realm"], realm_id)
+
+        # Livechat channel
+        self.assertEqual(zerver_stream[6]["name"], "guest")
+        self.assertEqual(zerver_stream[6]["invite_only"], False)
+        self.assertEqual(zerver_stream[6]["description"], "")
+        self.assertEqual(zerver_stream[6]["rendered_description"], "")
+        self.assertEqual(zerver_stream[6]["stream_post_policy"], 1)
+        self.assertEqual(zerver_stream[6]["realm"], realm_id)
 
     def test_convert_stream_subscription_data(self) -> None:
         fixture_dir_name = self.fixture_file_name("", "rocketchat_fixtures")


### PR DESCRIPTION
This commit fixes a few bugs in Rocket.Chat import tool as reported on CZO.

CZO Link: https://chat.zulip.org/#narrow/stream/9-issues/topic/Rocketchat.20Import

