### PR TITLE
install-yarn: Verify that the install location is /srv/zulip-yarn

### DIFF
--- a/scripts/lib/install-yarn
+++ b/scripts/lib/install-yarn
@@ -10,7 +10,8 @@ check_version() {
     # than running yarn --version.
     link="$(command -v yarn)" \
         && bin="$(readlink -f "$link")" \
-        && current_version="$(jq -r '.version' "${bin%/*/*}/package.json")" \
+        && [ "$bin" = /srv/zulip-yarn/bin/yarn ] \
+        && current_version="$(jq -r '.version' /srv/zulip-yarn/package.json)" \
         && [ "$current_version" = "$version" ]
 }
 


### PR DESCRIPTION
`scripts.lib.node_cache` expects Yarn to be in `/srv/zulip-yarn`, so if it’s installed somewhere else, even if it’s the right version, we need to reinstall it.