### PR TITLE
frontend performance: stream to recent topics renarrows

### DIFF
--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -414,6 +414,7 @@ test("test_filter_all", ({override, mock_template}) => {
     row_data = generate_topic_data([[1, "topic-1", 0, false, true]]);
     i = row_data.length;
     rt.set_default_focus();
+    override(rt, "is_in_focus", () => false);
     assert.equal(rt.inplace_rerender("1:topic-1"), true);
 });
 
@@ -464,6 +465,7 @@ test("test_filter_unread", ({override, mock_template}) => {
 
     stub_out_filter_buttons();
     rt.process_messages(messages);
+    override(rt, "is_in_focus", () => false);
     assert.equal(rt.inplace_rerender("1:topic-1"), true);
 
     $("#recent_topics_filter_buttons").removeClass("btn-recent-selected");
@@ -571,6 +573,7 @@ test("test_filter_participated", ({override, mock_template}) => {
     expected_filter_participated = false;
     rt.process_messages(messages);
 
+    override(rt, "is_in_focus", () => false);
     assert.equal(rt.inplace_rerender("1:topic-4"), true);
 
     // Set muted filter
@@ -630,7 +633,8 @@ test("test_filter_participated", ({override, mock_template}) => {
     rt.set_filter("all");
 });
 
-test("test_update_unread_count", () => {
+test("test_update_unread_count", ({override}) => {
+    override(rt, "is_visible", () => false);
     rt.clear_for_tests();
     stub_out_filter_buttons();
     rt.set_filter("all");
@@ -758,6 +762,7 @@ test("basic assertions", ({override, mock_template}) => {
     // update_topic_is_muted now relies on external libraries completely
     // so we don't need to check anythere here.
     generate_topic_data([[1, topic1, 0, false, true]]);
+    override(rt, "is_in_focus", () => false);
     assert.equal(rt.update_topic_is_muted(stream1, topic1), true);
     // a topic gets muted which we are not tracking
     assert.equal(rt.update_topic_is_muted(stream1, "topic-10"), false);
@@ -816,6 +821,7 @@ test("test_reify_local_echo_message", ({override, mock_template}) => {
 });
 
 test("test_delete_messages", ({override}) => {
+    override(rt, "is_visible", () => false);
     rt.clear_for_tests();
     stub_out_filter_buttons();
     rt.set_filter("all");
@@ -855,6 +861,7 @@ test("test_delete_messages", ({override}) => {
 
 test("test_topic_edit", ({override}) => {
     override(all_messages_data, "all_messages", () => messages);
+    override(rt, "is_visible", () => false);
 
     // NOTE: This test should always run in the end as it modified the messages data.
     rt.clear_for_tests();

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -20,7 +20,7 @@ import * as navigate from "./navigate";
 import * as people from "./people";
 import * as recent_senders from "./recent_senders";
 import {get, process_message, topics} from "./recent_topics_data";
-import {get_topic_key, is_in_focus, is_visible} from "./recent_topics_util";
+import {get_topic_key, is_in_focus, is_visible, set_visible} from "./recent_topics_util";
 import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
 import * as sub_store from "./sub_store";
@@ -600,6 +600,7 @@ export function show() {
     // a messages narrow. We hide it and show recent topics.
     $("#message_feed_container").hide();
     $("#recent_topics_view").show();
+    set_visible(true);
     $("#message_view_header_underpadding").hide();
     $(".header").css("padding-bottom", "0px");
 
@@ -622,6 +623,7 @@ function filter_buttons() {
 export function hide() {
     $("#message_feed_container").show();
     $("#recent_topics_view").hide();
+    set_visible(false);
     // On firefox (and flaky on other browsers), focus
     // remains on search box even after it is hidden. We
     // forcefully blur it so that focus returns to the visible

--- a/static/js/recent_topics_util.js
+++ b/static/js/recent_topics_util.js
@@ -4,8 +4,14 @@ import * as compose_state from "./compose_state";
 import * as overlays from "./overlays";
 import * as popovers from "./popovers";
 
+let is_rt_visible = false;
+
+export function set_visible(value) {
+    is_rt_visible = value;
+}
+
 export function is_visible() {
-    return $("#recent_topics_view").is(":visible");
+    return is_rt_visible;
 }
 
 export function is_in_focus() {


### PR DESCRIPTION
## What's this PR for?
This is mainly proof of concept for frontend performance improvements.

Copying the commit messages-
First commit:
recent_topics: Don't rely on ":visible" to avoid forced reflow. 

Previously, navigating from any stream to the recent topics view would
cause a forced reflow every time we checked `is_visible()` because it
would call `$("#recent_topics_view").is(":visible")`.

The reason for this is related to how browsers ship frames, the
process follows these steps:
JavaScript > style calculations > layout > paint > composite.
(The layout step is called Reflow in firefox.)

Typically, the browser will handle these steps in the most optimal
manner possible, delaying expensive operations until they're needed.

However, it is possible to cause the browser to perform a layout
earlier than necessary. An example of this is what we previously did:

When we call `top_left_corner.narrow_to_recent_topics()`, we ask to
add a class via `.addClass()`, this schedules a Style Recalculation,
then, when we call `message_view_header.make_message_view_header()` it
calls `recent_topics_util.is_visible()` which calls
`$("#recent_topics_view").is(":visible")`.

Before the browser can get this value, it realizes that our dom was
invalidated by `.addClass()` and so it must execute the scheduled
Style Recalculation and cause a layout.

This is called a forced synchronous layout.

This commit adds a JavaScript variable representing the visible state,
in order to prevent the above behavior. It does not matter whether
this value is tracked in `recent_topics_ui`, `recent_topics_util` or
`recent_topics_data`, this commit places it in `recent_topics_ui` but
we may move it if we need to.

This commit reduces the main thread run time of
build_message_view_header from 131.81 ms to 5.20 ms.

Unfortunately we still have the case where
`recent_topics_ui.revive_current_focus()` calls
`recent_topics_ui.set_table_focus()` which causes a reflow.

However, by eliminating this reflow we save ~120ms. (We only save this
sometimes, as other things can still cost us a reflow.)

Further reading: https://developers.google.com/web/fundamentals/performance/rendering/avoid-large-complex-layouts-and-layout-thrashing

Second commit:
frontend: Batch dom writes together during stream to recent topics. 

In this commit we try to further reduce layout trashing during stream
to recent topics renarrows by attempting to batch dom writes together.

This manages to push back our layout trashing all the way to simple
bar upstream.

https://togithub.com/Grsmto/simplebar/issues/162
https://togithub.com/Grsmto/simplebar/issues/371
https://togithub.com/Grsmto/simplebar/issues/372

This attempt is not pretty, it breaks tests for obvious reasons and
should be considered more akin to a proof of concept. It could be said
that this just an imitation of the right way to do this, which would
be to use FASTdom (https://togithub.com/wilsonpage/fastdom).

We gain about ~60 to 73 ms by doing this.


## Profiling data:
### Generation process:
1) Checkout to desired commit.
2) Start server, open chrome page to zulip dev, let page load completely.
3) Open the chrome profiler.
4) Seperate the dock to its own window. (This is important to ensure that all profiles are run on the same viewport dimensions.)
5) Start recording the profile.
6) Click Venice in stream list.
7) Click Recent Topics in top left corner.
8) Repeat (6) and (7) two more times, to have 3 samples.

### main:
1) 450.4 ms
2) 487.1 ms
3) 477.4 ms (screenshot)

### first commit:
1) 336.9 ms
2) 358.1 ms
3) 346.0 ms (screenshot)

### second commit:
1) 276.7 ms
2) 275.4 ms
3) 273.3 ms (screenshot)

**Profile screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
 main
![](https://user-images.githubusercontent.com/33805964/140400789-f3748be9-2591-46dd-be28-502e1d5f160c.JPG)
first commit
![](https://user-images.githubusercontent.com/33805964/140400761-1103a8b7-dce4-4e01-a4ab-326a11a5ae60.JPG)
second commit
![](https://user-images.githubusercontent.com/33805964/140400755-fd069ef2-bdb6-48d3-a778-9b1a209f6dcb.JPG)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
