### PR TITLE
settings: Limit non-logged-in email-sending to 5/day, not per 30 min.

### DIFF
--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -394,7 +394,7 @@ RATE_LIMITING_RULES = {
         (86400, 5),  # 5 per day
     ],
     "sends_email_by_ip": [
-        (1800, 5),
+        (86400, 5),
     ],
 }
 


### PR DESCRIPTION
This more closely matches email_change_by_user and
password_reset_form_by_email limits; legitimate users are unlikely to
need to send more than 5 emails to themselves during a day.
