### PR TITLE
open-source: Stop quote used as image for feature from overflowing.

### DIFF
--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -4167,6 +4167,18 @@ nav {
         div.quote {
             width: 400px;
         }
+
+        @media (width < 1024px) {
+            div.quote {
+                width: 300px;
+            }
+        }
+
+        @media (width < 768px) {
+            div.quote {
+                width: auto;
+            }
+        }
     }
 
     .topics-image {


### PR DESCRIPTION
In small screens, the quote used as a standin for image used
to overflow from screen as it didn't had responsive size set.
This image has additional bound of `max-width: 100%` which
stops them from overflowing which the quote did not.

before:
<img width="858" alt="Screenshot 2021-11-06 at 9 07 01 AM" src="https://user-images.githubusercontent.com/25124304/140596712-057a78c4-42e1-4046-be4d-4a2674f6fef1.png">
<img width="858" alt="Screenshot 2021-11-06 at 9 06 28 AM" src="https://user-images.githubusercontent.com/25124304/140596718-2d6eeb6b-3036-49b1-a6de-8005bdfde5b0.png">
after:
<img width="858" alt="Screenshot 2021-11-06 at 9 06 46 AM" src="https://user-images.githubusercontent.com/25124304/140596715-e49310a8-f346-4d61-9a2d-9fef224f65b7.png">
<img width="858" alt="Screenshot 2021-11-06 at 9 06 36 AM" src="https://user-images.githubusercontent.com/25124304/140596717-8567a9f8-21af-4dfc-84c7-c73213834ed1.png">
