### PR TITLE
loading_page: Fix the color of the app-loading text when Display Settings set to Automatic.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -41,6 +41,9 @@
     top: unset;
     bottom: 20px;
     }
+    body.color-scheme-automatic #app-loading{
+    color: hsl(0, 0%, 20%);
+    }
     body.night-mode #app-loading {
     background-color: hsl(212, 28%, 18%);
     color: hsl(236, 33%, 90%);


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #20172
**Testing plan:** <!-- How have you tested? -->
Manually
These changes don't affect the Day & Night mode in any way.
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![lp-corrected](https://user-images.githubusercontent.com/76519771/140597320-4afa7f54-5bbe-4781-a3ae-6907b0b031b2.png)
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
