### PR TITLE
api: Add validation for special characters in topic.

### DIFF
--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -1,3 +1,4 @@
+import unicodedata
 from typing import Iterable, List, Optional, Sequence, Union, cast
 
 from django.utils.translation import gettext as _
@@ -40,6 +41,10 @@ def validate_topic(topic: str) -> str:
     if topic == "":
         raise JsonableError(_("Topic can't be empty"))
 
+    for character in topic:
+        unicodeCategory = unicodedata.category(character)
+        if unicodeCategory in ["Cc", "Cs", "Cn"]:
+            raise JsonableError(_("Invalid characters in topic!"))
     return topic
 
 

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -730,6 +730,37 @@ class MessagePOSTTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Missing topic")
 
+    def test_invalid_topic(self) -> None:
+        """
+        Sending a message with invalid 'Cc', 'Cs' and 'Cn' category of unicode characters
+        """
+        # For 'Cc' category
+        self.login("hamlet")
+        result = self.client_post(
+            "/json/messages",
+            {
+                "type": "stream",
+                "to": "Verona",
+                "client": "test suite",
+                "topic": "Test\n\rTopic",
+                "content": "Test message",
+            },
+        )
+        self.assert_json_error(result, "Invalid characters in topic!")
+
+        # For 'Cn' category
+        result = self.client_post(
+            "/json/messages",
+            {
+                "type": "stream",
+                "to": "Verona",
+                "client": "test suite",
+                "topic": "Test\uFFFETopic",
+                "content": "Test message",
+            },
+        )
+        self.assert_json_error(result, "Invalid characters in topic!")
+
     def test_invalid_message_type(self) -> None:
         """
         Messages other than the type of "private" or "stream" are considered as invalid


### PR DESCRIPTION
We add check for various categories of Unicode such as Cc, Cn, and Cf. Which affected various parts of UI.

For tests, I have sent API requests using `curl` and Included various `Cc`, `Cf` characters 
For `Cc` -> `$'ab\n\rcd'`
For `Cf` -> `'a<200d>b'` 

Fixes #20128