### PR TITLE
settings:Change dropdown option label & position,label of input field.

### DIFF
--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -345,7 +345,7 @@ const time_limit_dropdown_values = new Map([
     [
         "custom_limit",
         {
-            text: $t({defaultMessage: "Up to N minutes after posting"}),
+            text: $t({defaultMessage: "Custom"}),
         },
     ],
 ]);
@@ -411,7 +411,7 @@ export const msg_delete_limit_dropdown_values = new Map([
     [
         "custom_limit",
         {
-            text: $t({defaultMessage: "Up to N minutes after posting"}),
+            text: $t({defaultMessage: "Custom"}),
         },
     ],
 ]);
@@ -623,7 +623,7 @@ export const email_notifications_batching_period_values = [
     },
     {
         value: "custom_period",
-        description: $t({defaultMessage: "N minutes"}),
+        description: $t({defaultMessage: "Custom"}),
     },
 ];
 

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -129,17 +129,17 @@
                     <option value="{{ this.value }}">{{ this.description }}</option>
                 {{/each}}
             </select>
-            <div class="dependent-inline-block">
-                <label for="email_notification_batching_period_edit_minutes" class="inline-block">
-                    {{t 'N' }}:
-                </label>
-                <input type="text"
-                  name="email_notification_batching_period_edit_minutes"
-                  class="email_notification_batching_period_edit_minutes admin-realm-time-limit-input prop-element"
-                  data-setting-widget-type="number"
-                  autocomplete="off"
-                  id="{{prefix}}email_notification_batching_period_edit_minutes"/>
-            </div>
+        </div>
+        <div class="dependent-block">
+            <label for="email_notification_batching_period_edit_minutes" class="inline-block">
+                {{t 'Delay period (minutes)' }}:
+            </label>
+            <input type="text"
+              name="email_notification_batching_period_edit_minutes"
+              class="email_notification_batching_period_edit_minutes admin-realm-time-limit-input prop-element"
+              data-setting-widget-type="number"
+              autocomplete="off"
+              id="{{prefix}}email_notification_batching_period_edit_minutes"/>
         </div>
 
         {{#each notification_settings.email_message_notification_settings}}

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -154,16 +154,16 @@
                             <option value="{{0}}">{{1.text}}</option>
                         {{/each}}
                     </select>
-                    <div class="dependent-inline-block">
-                        <label for="id_realm_message_content_edit_limit_minutes" class="inline-block realm-time-limit-label">
-                            {{t 'N' }}:
-                        </label>
-                        <input type="text" id="id_realm_message_content_edit_limit_minutes"
-                          name="realm_message_content_edit_limit_minutes"
-                          class="admin-realm-time-limit-input prop-element"
-                          autocomplete="off"
-                          value="{{ realm_message_content_edit_limit_minutes }}"/>
-                    </div>
+                </div>
+                <div class="dependent-block">
+                    <label for="id_realm_message_content_edit_limit_minutes" class="inline-block realm-time-limit-label">
+                        {{t 'Duration editing is allowed after posting (minutes)'}}:&nbsp;
+                    </label>
+                    <input type="text" id="id_realm_message_content_edit_limit_minutes"
+                      name="realm_message_content_edit_limit_minutes"
+                      class="admin-realm-time-limit-input prop-element"
+                      autocomplete="off"
+                      value="{{ realm_message_content_edit_limit_minutes }}"/>
                 </div>
 
                 <div class="input-group">
@@ -200,16 +200,16 @@
                             <option value="{{0}}">{{1.text}}</option>
                         {{/each}}
                     </select>
-                    <div class="dependent-inline-block">
-                        <label for="id_realm_message_content_delete_limit_minutes" class="inline-block realm-time-limit-label">
-                            {{t 'N' }}:
-                        </label>
-                        <input type="text" id="id_realm_message_content_delete_limit_minutes"
-                          name="realm_message_content_delete_limit_minutes"
-                          class="admin-realm-time-limit-input prop-element"
-                          autocomplete="off"
-                          value="{{ realm_message_content_delete_limit_minutes }}"/>
-                    </div>
+                </div>
+                <div class="dependent-block">
+                    <label for="id_realm_message_content_delete_limit_minutes" class="inline-block realm-time-limit-label">
+                        {{t "Duration deletion is allowed after posting (minutes)" }}:
+                    </label>
+                    <input type="text" id="id_realm_message_content_delete_limit_minutes"
+                      name="realm_message_content_delete_limit_minutes"
+                      class="admin-realm-time-limit-input prop-element"
+                      autocomplete="off"
+                      value="{{ realm_message_content_delete_limit_minutes }}"/>
                 </div>
 
                 <div class="input-group">


### PR DESCRIPTION
**Changes made**
1. Changed label of **"Up to N minutes after posting"** option in "Allow message editing" dropdown menu to **"Custom"**. 
2. Upon selection of **"Custom"** option, now the input field opens below dropdown, with label **"Duration editing is allowed after posting (minutes)"**.

**GIF** 
![2](https://user-images.githubusercontent.com/45902236/140640634-66d586c0-d372-4636-8793-74047ff5816c.gif)

Fixes #20177
