### PR TITLE
settings: Fix live `update_page` behavior for user settings.

### DIFF
--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -663,6 +663,9 @@ export function dispatch_normal_event(event) {
                 // Rerender buddy list status emoji
                 activity.build_user_sidebar();
             }
+            if (event.property === "escape_navigates_to_default_view") {
+                $("#go-to-default-view-hotkey-help").toggleClass("notdisplayed", !event.value);
+            }
             if (event.property === "enter_sends") {
                 user_settings.enter_sends = event.value;
                 $("#enter_sends").prop("checked", user_settings.enter_sends);
@@ -674,11 +677,7 @@ export function dispatch_normal_event(event) {
                 $("#user_presence_enabled").prop("checked", user_settings.presence_enabled);
                 break;
             }
-            if (event.property === "escape_navigates_to_default_view") {
-                $("#go-to-default-view-hotkey-help").toggleClass("notdisplayed", !event.value);
-                break;
-            }
-            settings_display.update_page(settings_display.user_settings_panel);
+            settings_display.update_page(event.property);
             break;
         }
 

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -179,28 +179,36 @@ export async function report_emojiset_change(settings_panel) {
     }
 }
 
-export function update_page(settings_panel) {
-    const default_language_name = user_default_language_name;
-    const container = $(settings_panel.container);
-    const settings_object = settings_panel.settings_object;
+export function update_page(property) {
+    if (!overlays.settings_open()) {
+        return;
+    }
+    const container = $(user_settings_panel.container);
+    let value = user_settings[property];
 
-    // Boolean fields
-    container.find(".left_side_userlist").prop("checked", settings_object.left_side_userlist);
-    container.find(".translate_emoticons").prop("checked", settings_object.translate_emoticons);
-    container
-        .find(".escape_navigates_to_default_view")
-        .prop("checked", settings_object.escape_navigates_to_default_view);
+    // The default_language button text updates to the language
+    // name and not the value of the user_settings property.
+    if (property === "default_language") {
+        container.find(".default_language_name").text(user_default_language_name);
+        return;
+    }
 
-    // Enum/select fields
-    container.find(".default_language_name").text(default_language_name);
-    container
-        .find(".setting_twenty_four_hour_time")
-        .val(JSON.stringify(settings_object.twenty_four_hour_time));
-    container.find(".setting_color_scheme").val(JSON.stringify(settings_object.color_scheme));
-    container.find(".setting_default_view").val(settings_object.default_view);
+    // settings_org.set_input_element_value doesn't support radio
+    // button widgets like this one.
+    if (property === "emojiset") {
+        container.find(`input[value=${CSS.escape(value)}]`).prop("checked", true);
+        return;
+    }
 
-    // TODO: Set emoji set selector here.
-    // Longer term, we'll want to automate this function
+    // The twenty_four_hour_time setting is represented as a boolean
+    // in the API, but a dropdown with "true"/"false" as strings in
+    // the UI, so we need to convert its format here.
+    if (property === "twenty_four_hour_time") {
+        value = value.toString();
+    }
+
+    const input_elem = container.find(`[name=${CSS.escape(property)}]`);
+    settings_org.set_input_element_value(input_elem, value);
 }
 
 export function initialize() {


### PR DESCRIPTION
Changes `user_settings.update_page` to only update the modified user setting instead of updating all of the user settings on the page. This is modeled on the behavior for updates to the realm user default settings.

@sahil839 - Would you mind looking over this commit for me? This is a follow up on [your feedback on PR 20070 here](https://github.com/zulip/zulip/pull/20070#discussion_r737166032). The change basically makes the `update_page` function work the same way as [the one you updated here](https://github.com/zulip/zulip/pull/19871/commits/852891413141423f4faaa8711c7be63c79f20981) for `realm_user_settings_defaults`, which is what I think you meant from your feedback.

If this is the change you had in mind, would it make sense to have both `user_settings` and `realm_default_user_settings` import and use the same function for the page update? And does it make sense to do this change without making the settings that require a reload of the page to be live updates as well?

**Testing plan:** I've done some manual testing, but would love feedback on whether writing a test to confirm the behavior makes sense. One thing that seems broken (when I test with or without these changes) is the emojiset update (see GIF below) as it doesn't update until the page does a hard refresh, but (unlike the user sidebar update and language update) no note is given to the user about that.

**GIFs or screenshots:**
### Updates to color scheme, user sidebar location and emojiset
![Zulip_fix_update_user_settings](https://user-images.githubusercontent.com/63245456/140799944-8e498acd-9289-416b-9bed-b3993285e821.gif)

### Update language (log out / log in)
![Zulip_language_update_user_settings](https://user-images.githubusercontent.com/63245456/140800811-19791cb5-8343-43e1-8b33-1dd699914f4a.gif)
