### PR TITLE
sentry: Increase shutdown_timeout from 2s to 10s.

### DIFF
--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -68,6 +68,10 @@ def setup_sentry(dsn: Optional[str], environment: str) -> None:
             SqlalchemyIntegration(),
         ],
         before_send=add_context,
+        # Increase possible max wait to send exceptions during
+        # shutdown, from 2 to 10; potentially-large exceptions are of
+        # value to catch during shutdown.
+        shutdown_timeout=10,
         # Because we strip the email/username from the Sentry data
         # above, the effect of this flag is that the requests/users
         # involved in exceptions will be identified in Sentry only by


### PR DESCRIPTION
This increases the possible maximum wait time to send exceptions
during shutdown.  The larger value makes it possible to send larger
exceptions, and weather larger network hiccups, during shutdown.  In
instances where a service is crash-looping, it is already not serving
requests reliably, and better ensuring those exceptions are captured
is of significant value.