### PR TITLE
Remove Ubuntu 18.04 support

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -197,19 +197,19 @@ jobs:
         run: sudo /tmp/production-verify ${{ matrix.extra-args }}
 
       - name: Install pgroonga
-        if: ${{ matrix.is_bionic }}
+        if: ${{ matrix.os == 'focal' }}
         run: sudo /tmp/production-pgroonga
 
       - name: Verify install after installing pgroonga
-        if: ${{ matrix.is_bionic }}
+        if: ${{ matrix.os == 'focal' }}
         run: sudo /tmp/production-verify ${{ matrix.extra-args }}
 
       - name: Upgrade postgresql
-        if: ${{ matrix.is_bionic }}
+        if: ${{ matrix.os == 'focal' }}
         run: sudo /tmp/production-upgrade-pg
 
       - name: Verify install after upgrading postgresql
-        if: ${{ matrix.is_bionic }}
+        if: ${{ matrix.os == 'focal' }}
         run: sudo /tmp/production-verify ${{ matrix.extra-args }}
 
       - name: Report status

--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -30,13 +30,13 @@ jobs:
   production_build:
     # This job builds a release tarball from the current commit, which
     # will be used for all of the following install/upgrade tests.
-    name: Bionic production build
+    name: Debian 10 production build
     runs-on: ubuntu-latest
 
     # Docker images are built from 'tools/ci/Dockerfile'; the comments at
     # the top explain how to build and upload these images.
-    # Bionic ships with Python 3.6.
-    container: zulip/ci:bionic
+    # Debian 10 ships with Python 3.7.3.
+    container: zulip/ci:buster
     steps:
       - name: Add required permissions
         run: |
@@ -83,12 +83,6 @@ jobs:
           key: v1-emoji-${{ github.job }}-${{ hashFiles('tools/setup/emoji/emoji_map.json') }}-${{ hashFiles('tools/setup/emoji/build_emoji') }}-${{ hashFiles('tools/setup/emoji/emoji_setup_utils.py') }}-${{ hashFiles('tools/setup/emoji/emoji_names.py') }}-${{ hashFiles('package.json') }}
           restore-keys: v1-emoji-${{ github.job }}
 
-      - name: Do Bionic hack
-        run: |
-          # Temporary hack till `sudo service redis-server start` gets fixes in Bionic. See
-          # https://chat.zulip.org/#narrow/stream/3-backend/topic/Ubuntu.20bionic.20CircleCI
-          sudo sed -i '/^bind/s/bind.*/bind 0.0.0.0/' /etc/redis/redis.conf
-
       - name: Build production tarball
         run: ./tools/ci/production-build
 
@@ -115,27 +109,18 @@ jobs:
         include:
           # Docker images are built from 'tools/ci/Dockerfile'; the comments at
           # the top explain how to build and upload these images.
-          - docker_image: zulip/ci:bionic
-            name: Bionic production install with custom db name and user
-            is_bionic: true
-            os: bionic
-            extra_args: --test-custom-db
-
           - docker_image: zulip/ci:focal
             name: Focal production install
-            is_focal: true
             os: focal
             extra_args: ""
 
           - docker_image: zulip/ci:buster
-            name: Buster production install
-            is_buster: true
+            name: Buster production install with custom db name and user
             os: buster
-            extra_args: ""
+            extra_args: --test-custom-db
 
           - docker_image: zulip/ci:bullseye
             name: Bullseye production install
-            is_bullseye: true
             os: bullseye
             extra_args: ""
 
@@ -180,13 +165,6 @@ jobs:
           path: /srv/zulip-npm-cache
           key: v1-yarn-deps-${{ matrix.os }}-${{ hashFiles('/tmp/package.json') }}-${{ hashFiles('/tmp/yarn.lock') }}
           restore-keys: v1-yarn-deps-${{ matrix.os }}
-
-      - name: Do Bionic hack
-        if: ${{ matrix.is_bionic }}
-        run: |
-          # Temporary hack till `sudo service redis-server start` gets fixes in Bionic. See
-          # https://chat.zulip.org/#narrow/stream/3-backend/topic/Ubuntu.20bionic.20CircleCI
-          sudo sed -i '/^bind/s/bind.*/bind 0.0.0.0/' /etc/redis/redis.conf
 
       - name: Install production
         run: |

--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -18,11 +18,10 @@ jobs:
         include:
           # Base images are built using `tools/ci/Dockerfile.prod.template`.
           # The comments at the top explain how to build and upload these images.
-          # Bionic ships with Python 3.6.
-          - docker_image: zulip/ci:bionic
-            name: Ubuntu 18.04 Bionic (Python 3.6, backend + frontend)
-            os: bionic
-            is_bionic: true
+          # Debian 10 ships with Python 3.7.3.
+          - docker_image: zulip/ci:buster
+            name: Debian 10 Buster (Python 3.7, backend + frontend)
+            os: buster
             include_frontend_tests: true
           # Focal ships with Python 3.8.2.
           - docker_image: zulip/ci:focal
@@ -79,13 +78,6 @@ jobs:
           key: v1-emoji-${{ matrix.os }}-${{ hashFiles('tools/setup/emoji/emoji_map.json') }}-${{ hashFiles('tools/setup/emoji/build_emoji') }}-${{ hashFiles('tools/setup/emoji/emoji_setup_utils.py') }}-${{ hashFiles('tools/setup/emoji/emoji_names.py') }}-${{ hashFiles('package.json') }}
           restore-keys: v1-emoji-${{ matrix.os }}
 
-      - name: Do Bionic hack
-        if: ${{ matrix.is_bionic }}
-        run: |
-          # Temporary hack till `sudo service redis-server start` gets fixes in Bionic. See
-          # https://chat.zulip.org/#narrow/stream/3-backend/topic/Ubuntu.20bionic.20CircleCI
-          sudo sed -i '/^bind/s/bind.*/bind 0.0.0.0/' /etc/redis/redis.conf
-
       - name: Install dependencies
         run: |
           # This is the main setup job for the test suite
@@ -135,7 +127,7 @@ jobs:
           source tools/ci/activate-venv
 
           # Currently our compiled requirements files will differ for different python versions
-          # so we will run test-locked-requirements only for Bionic.
+          # so we will run test-locked-requirements only for Debian 10.
           # ./tools/test-locked-requirements
           # ./tools/test-run-dev  # https://github.com/zulip/zulip/pull/14233
           #
@@ -195,7 +187,7 @@ jobs:
           fi
 
       - name: Test locked requirements
-        if: ${{ matrix.is_bionic }}
+        if: ${{ matrix.os == 'buster' }}
         run: |
           . /srv/zulip-py3-venv/bin/activate && \
           ./tools/test-locked-requirements

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
   vm_num_cpus = "2"
   vm_memory = "2048"
 
-  ubuntu_mirror = ""
+  debian_mirror = ""
   vboxadd_version = nil
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
       when "HOST_IP_ADDR"; host_ip_addr = value
       when "GUEST_CPUS"; vm_num_cpus = value
       when "GUEST_MEMORY_MB"; vm_memory = value
-      when "UBUNTU_MIRROR"; ubuntu_mirror = value
+      when "DEBIAN_MIRROR"; debian_mirror = value
       when "VBOXADD_VERSION"; vboxadd_version = value
       end
     end
@@ -63,21 +63,21 @@ Vagrant.configure("2") do |config|
   config.vm.provider "docker" do |d, override|
     d.build_dir = File.join(__dir__, "tools", "setup", "dev-vagrant-docker")
     d.build_args = ["--build-arg", "VAGRANT_UID=#{Process.uid}"]
-    if !ubuntu_mirror.empty?
-      d.build_args += ["--build-arg", "UBUNTU_MIRROR=#{ubuntu_mirror}"]
+    if !debian_mirror.empty?
+      d.build_args += ["--build-arg", "DEBIAN_MIRROR=#{debian_mirror}"]
     end
     d.has_ssh = true
     d.create_args = ["--ulimit", "nofile=1024:65536"]
   end
 
   config.vm.provider "virtualbox" do |vb, override|
-    override.vm.box = "hashicorp/bionic64"
+    override.vm.box = "bento/debian-10"
     # It's possible we can get away with just 1.5GB; more testing needed
     vb.memory = vm_memory
     vb.cpus = vm_num_cpus
 
     if !vboxadd_version.nil?
-      override.vbguest.installer = Class.new(VagrantVbguest::Installers::Ubuntu) do
+      override.vbguest.installer = Class.new(VagrantVbguest::Installers::Debian) do
         define_method(:host_version) do |reload = false|
           VagrantVbguest::Version(vboxadd_version)
         end
@@ -88,15 +88,14 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provider "hyperv" do |h, override|
-    override.vm.box = "bento/ubuntu-18.04"
+    override.vm.box = "bento/debian-10"
     h.memory = vm_memory
     h.maxmemory = vm_memory
     h.cpus = vm_num_cpus
   end
 
   config.vm.provider "parallels" do |prl, override|
-    override.vm.box = "bento/ubuntu-18.04"
-    override.vm.box_version = "202005.21.0"
+    override.vm.box = "bento/debian-10"
     prl.memory = vm_memory
     prl.cpus = vm_num_cpus
   end
@@ -105,5 +104,5 @@ Vagrant.configure("2") do |config|
     # We want provision to be run with the permissions of the vagrant user.
     privileged: false,
     path: "tools/setup/vagrant-provision",
-    env: { "UBUNTU_MIRROR" => ubuntu_mirror }
+    env: { "DEBIAN_MIRROR" => debian_mirror }
 end

--- a/docs/contributing/code-reviewing.md
+++ b/docs/contributing/code-reviewing.md
@@ -117,7 +117,7 @@ sooner is better.
   the job to fail by clicking on the failed job. This will open
   up a page in the CI that has more details on why the job failed.
   For example [this](https://github.com/zulip/zulip/runs/2092955762)
-  is the page of the `Ubuntu 18.04 Bionic (Python 3.6, backend + frontend)` job.
+  is the page of the "Debian 10 Buster (Python 3.7, backend + frontend)" job.
   See our docs on [continuous integration](../testing/continuous-integration.md)
   to learn more.
 

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -12,7 +12,7 @@ Contents:
 If you'd like to install a Zulip development environment on a computer
 that's running one of:
 
-- Ubuntu 20.04 Focal, 18.04 Bionic
+- Ubuntu 20.04 Focal
 - Debian 10 Buster, 11 Bullseye (beta)
 - CentOS 7 (beta)
 - Fedora 33 and 34 (beta)

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -1,12 +1,12 @@
 ## Vagrant environment setup tutorial
 
 This section guides first-time contributors through installing the
-Zulip development environment on Windows, macOS, Ubuntu and Debian.
+Zulip development environment on Windows, macOS, and Linux.
 
 The recommended method for installing the Zulip development environment is to use
 Vagrant with VirtualBox on Windows, and Vagrant with Docker on
-macOS and Ubuntu. This method creates a virtual machine (for Windows)
-or a Linux container (for macOS and Ubuntu) inside which the Zulip server and
+macOS and Linux. This method creates a virtual machine (for Windows)
+or a Linux container (for macOS and Linux) inside which the Zulip server and
 all related services will run.
 
 Contents:
@@ -18,7 +18,7 @@ Contents:
 - [Step 3: Start the development environment](#step-3-start-the-development-environment)
 - [Step 4: Developing](#step-4-developing)
 - [Troubleshooting and common errors](#troubleshooting-and-common-errors)
-- [Specifying an Ubuntu mirror](#specifying-an-ubuntu-mirror)
+- [Specifying a Debian mirror](#specifying-a-debian-mirror)
 - [Specifying a proxy](#specifying-a-proxy)
 - [Customizing CPU and RAM allocation](#customizing-cpu-and-ram-allocation)
 
@@ -49,7 +49,7 @@ a proxy to access the internet.)
 
 - **All**: 2GB available RAM, Active broadband internet connection, [GitHub account][set-up-git].
 - **macOS**: macOS (10.11 El Capitan or newer recommended)
-- **Ubuntu LTS**: 20.04 or 18.04
+- **Ubuntu LTS**: 20.04
   - or **Debian**: 10 "buster" or 11 "bullseye"
 - **Windows**: Windows 64-bit (Win 10 recommended), hardware
   virtualization enabled (VT-x or AMD-V), administrator access.
@@ -233,7 +233,7 @@ projects and to instead follow these instructions exactly.)
 1. In your browser, visit <https://github.com/zulip/zulip>
    and click the `fork` button. You will need to be logged in to GitHub to
    do this.
-2. Open Terminal (macOS/Ubuntu) or Git BASH (Windows; must
+2. Open Terminal (macOS/Linux) or Git BASH (Windows; must
    **run as an Administrator**).
 3. In Terminal/Git BASH,
    [clone your fork of the Zulip repository](../git/cloning.html#step-1b-clone-to-your-machine) and
@@ -285,8 +285,8 @@ vagrant up --provider=docker
 The first time you run this command it will take some time because vagrant
 does the following:
 
-- downloads the base Ubuntu 18.04 virtual machine image (for macOS and Windows)
-  or container (for Ubuntu)
+- downloads the base Debian 10 virtual machine image (for macOS and Windows)
+  or container (for Linux)
 - configures this virtual machine/container for use with Zulip,
 - creates a shared directory mapping your clone of the Zulip code inside the
   virtual machine/container at `~/zulip`
@@ -324,7 +324,7 @@ $ vagrant ssh
 You should see output that starts like this:
 
 ```console
-Welcome to Ubuntu 18.04.2 LTS (GNU/Linux 4.15.0-54-generic x86_64)
+Linux debian-10 4.19.0-18-amd64 #1 SMP Debian 4.19.208-1 (2021-09-29) x86_64
 ```
 
 Congrats, you're now inside the Zulip development environment!
@@ -337,7 +337,7 @@ provisioning failed and you should look at the
 Next, start the Zulip server:
 
 ```console
-(zulip-py3-venv) vagrant@ubuntu-bionic:/srv/zulip
+(zulip-py3-venv) vagrant@debian-10:/srv/zulip
 $ ./tools/run-dev.py
 ```
 
@@ -425,7 +425,7 @@ output.
 #### Committing and pushing changes with Git
 
 When you're ready to commit or push changes via Git, you will do this by
-running Git commands in Terminal (macOS/Ubuntu) or Git BASH (Windows) in the
+running Git commands in Terminal (macOS/Linux) or Git BASH (Windows) in the
 directory where you cloned Zulip on your main machine.
 
 If you're new to working with Git/GitHub, check out our [Git & GitHub
@@ -485,7 +485,7 @@ From the window where run-dev.py is running:
 2016-05-04 18:33:13,330 INFO     127.0.0.1       GET     200  92ms /register/ (unauth@zulip via ?)
 ^C
 KeyboardInterrupt
-(zulip-py3-venv) vagrant@ubuntu-bionic:/srv/zulip$ exit
+(zulip-py3-venv) vagrant@debian-10:/srv/zulip$ exit
 logout
 Connection to 127.0.0.1 closed.
 christie@win10 ~/zulip
@@ -523,7 +523,7 @@ christie@win10 ~/zulip
 $ vagrant up
 $ vagrant ssh
 
-(zulip-py3-venv) vagrant@ubuntu-bionic:/srv/zulip
+(zulip-py3-venv) vagrant@debian-10:/srv/zulip
 $ ./tools/run-dev.py
 ```
 
@@ -788,8 +788,8 @@ by rebooting the guest via `vagrant halt; vagrant up`.
 
 The `vagrant up` command basically does the following:
 
-- Downloads an Ubuntu image and starts it using a Vagrant provider.
-- Uses `vagrant ssh` to connect to that Ubuntu guest, and then runs
+- Downloads a Debian image and starts it using a Vagrant provider.
+- Uses `vagrant ssh` to connect to that Debian guest, and then runs
   `tools/provision`, which has a lot of subcommands that are
   executed via Python's `subprocess` module. These errors mean that
   one of those subcommands failed.
@@ -823,7 +823,7 @@ Finally, if you encounter any issues that weren't caused by your
 Internet connection, please report them! We try hard to keep Zulip
 development environment provisioning free of bugs.
 
-##### `pip install` fails during `vagrant up` on Ubuntu
+##### `pip install` fails during `vagrant up` on Linux
 
 Likely causes are:
 
@@ -918,18 +918,18 @@ vagrant reload
 vagrant reload --provision
 ```
 
-### Specifying an Ubuntu mirror
+### Specifying a Debian mirror
 
 Bringing up a development environment for the first time involves
-downloading many packages from the Ubuntu archive. The Ubuntu cloud
-images use the global mirror `http://archive.ubuntu.com/ubuntu/` by
+downloading many packages from the Debian archive. The Debian cloud
+images use the global mirror `http://deb.debian.org/debian` by
 default, but you may find that you can speed up the download by using
 a local mirror closer to your location. To do this, create
 `~/.zulip-vagrant-config` and add a line like this, replacing the URL
 as appropriate:
 
 ```text
-UBUNTU_MIRROR http://us.archive.ubuntu.com/ubuntu/
+DEBIAN_MIRROR http://ftp.us.debian.org/debian
 ```
 
 ### Specifying a proxy

--- a/docs/development/test-install.md
+++ b/docs/development/test-install.md
@@ -62,7 +62,7 @@ branch, or a significant time has passed since you last used it.
 ### Test an install
 
 The `test-install` tooling takes a distribution release name
-(e.g. "focal" or "bionic"), the path to an unpacked release directory
+(e.g. "focal"), the path to an unpacked release directory
 or tarball, and then any of the normal options you want to pass down
 into the installer.
 

--- a/docs/production/postgresql.md
+++ b/docs/production/postgresql.md
@@ -6,10 +6,9 @@ PostgreSQL 10, 11, 12, and 13 are all supported.
 
 Previous versions of Zulip used whatever version of PostgreSQL was
 included with the base operating system (E.g. PostgreSQL 12 on Ubuntu
-Focal, 10 on Ubuntu Bionic, and 9.6 on Ubuntu Xenial). We recommend
-that installations currently using older PostgreSQL releases [upgrade
-to PostgreSQL 14][upgrade-postgresql], as we may drop support for
-older PostgreSQL in a future release.
+20.04). We recommend that installations currently using older
+PostgreSQL releases [upgrade to PostgreSQL 14][upgrade-postgresql], as
+we may drop support for older PostgreSQL in a future release.
 
 [upgrade-postgresql]: ../production/upgrade-or-modify.html#upgrading-postgresql
 

--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -5,7 +5,6 @@ To run a Zulip server, you will need:
 - A dedicated machine or VM
 - A supported OS:
   - Ubuntu 20.04 Focal
-  - Ubuntu 18.04 Bionic
   - Debian 11 Bullseye
   - Debian 10 Buster
 - At least 2GB RAM, and 10GB disk space
@@ -30,7 +29,7 @@ on issues you'll encounter](install-existing-server.md).
 
 #### Operating system
 
-Ubuntu 20.04 Focal, 18.04 Bionic, Debian 11 Bullseye, and Debian 10
+Ubuntu 20.04 Focal, Debian 11 Bullseye, and Debian 10
 Buster are supported for running Zulip in production. You can also
 run Zulip on other platforms that support Docker using
 [docker-zulip][docker-zulip-homepage].

--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -257,8 +257,10 @@ instructions for other supported platforms.
 
 ### Upgrading from Ubuntu 18.04 Bionic to 20.04 Focal
 
-1. Upgrade your server to the latest Zulip release (at least 3.0,
-   which adds support for Ubuntu Focal).
+1. Upgrade your server to the latest Zulip `3.x` or `4.x` release (at
+   least 3.0, which adds support for Ubuntu 20.04). You can only
+   upgrade to Zulip 5.0 and newer after completing this process, since
+   newer releases don't support Ubuntu 18.04.
 
 2. As the Zulip user, stop the Zulip server and run the following
    to back up the system:
@@ -354,14 +356,17 @@ instructions for other supported platforms.
    be able to navigate to its URL and confirm everything is working
    correctly.
 
-6. [Upgrade to the latest Zulip release](#upgrading-to-a-release), now
-   that your server is running a supported operating system.
+6. [Upgrade to the latest `4.x` release](#upgrading-to-a-release).
 
-7. As root, finish by verifying the contents of the full-text indexes:
+7. As root, verify the contents of the full-text indexes:
 
    ```bash
    /home/zulip/deployments/current/manage.py audit_fts_indexes
    ```
+
+8. [Upgrade from Bionic to
+   Focal](#upgrading-from-ubuntu-18-04-bionic-to-20-04-focal), so that
+   you are running a supported operating system.
 
 ### Upgrading from Ubuntu 14.04 Trusty to 16.04 Xenial
 
@@ -544,7 +549,7 @@ Starting with Zulip 3.0, we use the latest available version of
 PostgreSQL at installation time (currently version 14). Upgrades to
 the version of PostgreSQL are no longer linked to upgrades of the
 distribution; that is, you may opt to upgrade to PostgreSQL 14 while
-running Ubuntu 18.04 Bionic.
+running Ubuntu 20.04.
 
 To upgrade the version of PostgreSQL on the Zulip server:
 

--- a/docs/subsystems/dependencies.md
+++ b/docs/subsystems/dependencies.md
@@ -120,8 +120,8 @@ extension, used by our [full-text search](full-text-search.md).
 ## Python packages
 
 Zulip uses the version of Python itself provided by the host OS for
-the Zulip server. We currently support Python 3.6 and newer, with
-Ubuntu Bionic being the platform requiring 3.6 support. The comments
+the Zulip server. We currently support Python 3.7 and newer, with
+Debian 10 being the platform requiring 3.7 support. The comments
 in `.github/workflows/zulip-ci.yml` document the Python versions used
 by each supported platform.
 

--- a/docs/subsystems/release-checklist.md
+++ b/docs/subsystems/release-checklist.md
@@ -33,7 +33,7 @@ preparing a new release.
   Transifex and commit them.
 - Use `build-release-tarball` to generate a release tarball.
 - Test the new tarball extensively, both new install and upgrade from last
-  release, on both Bionic and Focal.
+  release, on Ubuntu 20.04.
 - Repeat until release is ready.
 - Send around the Paper blog post draft for review.
 - Move the blog post draft to Ghost. (For a draft in Dropbox Paper,

--- a/puppet/zulip/manifests/external_dep.pp
+++ b/puppet/zulip/manifests/external_dep.pp
@@ -34,17 +34,11 @@ define zulip::external_dep(
     require => Zulip::Sha256_Tarball_To[$title],
   }
 
-  unless $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '18.04' {
-    # Puppet 5.5.0 and below make this always-noisy, as they spout out
-    # a notify line about tidying the managed directory above.  Skip
-    # on Bionic, which has that old version; they'll get tidied upon
-    # upgrade to 20.04.
-    tidy { "/srv/zulip-${title}-*":
-      path    => '/srv/',
-      recurse => 1,
-      rmdirs  => true,
-      matches => "zulip-${title}-*",
-      require => File[$dir],
-    }
+  tidy { "/srv/zulip-${title}-*":
+    path    => '/srv/',
+    recurse => 1,
+    rmdirs  => true,
+    matches => "zulip-${title}-*",
+    require => File[$dir],
   }
 }

--- a/puppet/zulip/manifests/smokescreen.pp
+++ b/puppet/zulip/manifests/smokescreen.pp
@@ -29,17 +29,11 @@ class zulip::smokescreen {
     ensure  => file,
     require => Exec['compile smokescreen'],
   }
-  unless $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '18.04' {
-    # Puppet 5.5.0 and below make this always-noisy, as they spout out
-    # a notify line about tidying the managed file above.  Skip
-    # on Bionic, which has that old version; they'll get tidied upon
-    # upgrade to 20.04.
-    tidy { '/usr/local/bin/smokescreen-*':
-      path    => '/usr/local/bin',
-      recurse => 1,
-      matches => 'smokescreen-*',
-      require => Exec['compile smokescreen'],
-    }
+  tidy { '/usr/local/bin/smokescreen-*':
+    path    => '/usr/local/bin',
+    recurse => 1,
+    matches => 'smokescreen-*',
+    require => Exec['compile smokescreen'],
   }
 
   $listen_address = zulipconf('http_proxy', 'listen_address', '127.0.0.1')

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -8,9 +8,6 @@ Django[argon2]==3.2.*
 # needed for Literal, TypedDict
 typing-extensions
 
-# Backport of @dataclass
-dataclasses;python_version<"3.7"
-
 # Needed for rendering backend templates
 Jinja2
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -355,18 +355,6 @@ cssutils==2.3.0 \
     --hash=sha256:0cf1f6086b020dee18048ff3999339499f725934017ef9ae2cd5bb77f9ab5f46 \
     --hash=sha256:b2d3b16047caae82e5c590036935bafa1b621cf45c2f38885af4be4838f0fd00
     # via premailer
-dataclasses==0.8 ; python_version < "3.7" \
-    --hash=sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf \
-    --hash=sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97
-    # via
-    #   -r requirements/common.in
-    #   argon2-cffi
-    #   black
-    #   dataclasses-json
-    #   libcst
-    #   pyre-check
-    #   testslide
-    #   werkzeug
 dataclasses-json==0.5.6 \
     --hash=sha256:1d7f3a284a49d350ddbabde0e7d0c5ffa34a144aaf1bcb5b9f2c87673ff0c76e \
     --hash=sha256:1f60be3405dee30b86ffbf6a436db8ba5efaeeb676bfda358e516a97aa7dfce4

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -217,13 +217,6 @@ cssutils==2.3.0 \
     --hash=sha256:0cf1f6086b020dee18048ff3999339499f725934017ef9ae2cd5bb77f9ab5f46 \
     --hash=sha256:b2d3b16047caae82e5c590036935bafa1b621cf45c2f38885af4be4838f0fd00
     # via premailer
-dataclasses==0.8 ; python_version < "3.7" \
-    --hash=sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf \
-    --hash=sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97
-    # via
-    #   -r requirements/common.in
-    #   argon2-cffi
-    #   werkzeug
 decorator==5.1.0 \
     --hash=sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374 \
     --hash=sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -212,7 +212,7 @@ if [ -f /etc/os-release ]; then
 fi
 
 case "$os_id$os_version_id" in
-    debian10 | debian11 | ubuntu18.04 | ubuntu20.04) ;;
+    debian10 | debian11 | ubuntu20.04) ;;
     *)
         set +x
         cat <<EOF
@@ -222,7 +222,6 @@ Unsupported OS release: $os_id $os_version_id
 Zulip in production is supported only on:
  - Debian 10 "buster"
  - Debian 11 "bullseye"
- - Ubuntu 18.04 LTS "bionic"
  - Ubuntu 20.04 LTS "focal"
 
 For more information, see:

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -61,6 +61,7 @@ def error_desupported_os(vendor: str, os_version: str) -> "NoReturn":
 UNSUPPORTED_DISTROS = [
     ("ubuntu", "14.04"),
     ("ubuntu", "16.04"),
+    ("ubuntu", "18.04"),
     ("debian", "9"),
 ]
 distro_info = parse_os_release()
@@ -127,7 +128,6 @@ if os.path.exists("/etc/init.d/postgresql"):
     if not postgresql_version:
         default_postgresql_version = {
             ("debian", "10"): "11",
-            ("ubuntu", "18.04"): "10",
             ("ubuntu", "20.04"): "12",
             ("centos", "7"): "11",
         }

--- a/scripts/setup/apt-repos/ksplice/bionic.list
+++ b/scripts/setup/apt-repos/ksplice/bionic.list
@@ -1,2 +1,0 @@
-deb http://www.ksplice.com/apt bionic ksplice
-deb-src http://www.ksplice.com/apt bionic ksplice

--- a/scripts/setup/apt-repos/teleport/bionic.list
+++ b/scripts/setup/apt-repos/teleport/bionic.list
@@ -1,1 +1,0 @@
-deb https://deb.releases.teleport.dev/ stable main

--- a/scripts/setup/apt-repos/zulip/bionic.list
+++ b/scripts/setup/apt-repos/zulip/bionic.list
@@ -1,5 +1,0 @@
-deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
-deb-src http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
-
-deb http://ppa.launchpad.net/groonga/ppa/ubuntu bionic main
-deb-src http://ppa.launchpad.net/groonga/ppa/ubuntu bionic main

--- a/scripts/setup/apt-repos/zulip/cosmic.list
+++ b/scripts/setup/apt-repos/zulip/cosmic.list
@@ -1,5 +1,0 @@
-deb http://apt.postgresql.org/pub/repos/apt/ cosmic-pgdg main
-deb-src http://apt.postgresql.org/pub/repos/apt/ cosmic-pgdg main
-
-deb http://ppa.launchpad.net/groonga/ppa/ubuntu cosmic main
-deb-src http://ppa.launchpad.net/groonga/ppa/ubuntu cosmic main

--- a/scripts/setup/apt-repos/zulip/disco.list
+++ b/scripts/setup/apt-repos/zulip/disco.list
@@ -1,5 +1,0 @@
-deb http://apt.postgresql.org/pub/repos/apt/ disco-pgdg main
-deb-src http://apt.postgresql.org/pub/repos/apt/ disco-pgdg main
-
-deb http://ppa.launchpad.net/groonga/ppa/ubuntu disco main
-deb-src http://ppa.launchpad.net/groonga/ppa/ubuntu disco main

--- a/scripts/setup/apt-repos/zulip/eoan.list
+++ b/scripts/setup/apt-repos/zulip/eoan.list
@@ -1,5 +1,0 @@
-deb http://apt.postgresql.org/pub/repos/apt/ eoan-pgdg main
-deb-src http://apt.postgresql.org/pub/repos/apt/ eoan-pgdg main
-
-deb http://ppa.launchpad.net/groonga/ppa/ubuntu eoan main
-deb-src http://ppa.launchpad.net/groonga/ppa/ubuntu eoan main

--- a/scripts/setup/apt-repos/zulip_debathena/bionic.list
+++ b/scripts/setup/apt-repos/zulip_debathena/bionic.list
@@ -1,2 +1,0 @@
-deb http://debathena.mit.edu/apt bionic debathena debathena-config
-deb-src http://debathena.mit.edu/apt bionic debathena debathena-config

--- a/templates/zerver/api/incoming-webhooks-walkthrough.md
+++ b/templates/zerver/api/incoming-webhooks-walkthrough.md
@@ -258,7 +258,7 @@ After running the above command, you should see something similar to:
 Using `manage.py` from within the Zulip development environment:
 
 ```console
-(zulip-py3-venv) vagrant@ubuntu-bionic:/srv/zulip$
+(zulip-py3-venv) vagrant@debian-10:/srv/zulip$
 ./manage.py send_webhook_fixture_message \
     --fixture=zerver/webhooks/helloworld/fixtures/hello.json \
     '--url=http://localhost:9991/api/v1/external/helloworld?api_key=<api_key>'
@@ -384,7 +384,7 @@ Once you have written some tests, you can run just these new tests from within
 the Zulip development environment with this command:
 
 ```console
-(zulip-py3-venv) vagrant@ubuntu-bionic:/srv/zulip$
+(zulip-py3-venv) vagrant@debian-10:/srv/zulip$
 ./tools/test-backend zerver/webhooks/helloworld
 ```
 
@@ -433,7 +433,7 @@ stream name:
 To trigger a notification using this webhook, use
 `send_webhook_fixture_message` from the Zulip command line:
 
-    (zulip-py3-venv) vagrant@ubuntu-bionic:/srv/zulip$
+    (zulip-py3-venv) vagrant@debian-10:/srv/zulip$
     ./manage.py send_webhook_fixture_message \
         --fixture=zerver/tests/fixtures/helloworld/hello.json \
         '--url=http://localhost:9991/api/v1/external/helloworld?api_key=&lt;api_key&gt;'

--- a/tools/ci/Dockerfile
+++ b/tools/ci/Dockerfile
@@ -1,12 +1,12 @@
-# Dockerfile for a generic Ubuntu image with just the basics we need
-# to make it suitable for CI.  In particular:
+# Dockerfile for a generic Debian/Ubuntu image with just the basics we
+# need to make it suitable for CI.  In particular:
 #  * a non-root user to run as (a pain to try to do in setup,
 #    because by then we've already cloned the repo);
 #  * Git and other basic utilities.
 
-# To rebuild from this file for a given release, say Ubuntu 18.04 bionic:
-#   docker build . --build-arg=BASE_IMAGE=ubuntu:18.04 --pull --tag=zulip/ci:bionic
-#   docker push zulip/ci:bionic
+# To rebuild from this file for a given release, say Ubuntu 20.04 focal:
+#   docker build . --build-arg=BASE_IMAGE=ubuntu:20.04 --pull --tag=zulip/ci:focal
+#   docker push zulip/ci:focal
 #
 # tools/ci/build-docker-images will rebuild all images, but not push them.
 
@@ -17,16 +17,6 @@ RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 
 # Set the locale.
 ENV LC_ALL C.UTF-8
-
-# Upgrade git if it is less than v2.18 because GitHub Actions'
-# checkout installs source code using Rest API as an optimization
-# if the version is less than v2.18, which causes failure in provision
-# and tests because of the lack of git being initialized.
-RUN if (. /etc/os-release && [ "$ID $VERSION_ID" = 'ubuntu 18.04' ]); then \
-      apt-get update && \
-      apt-get -y install software-properties-common && \
-      add-apt-repository -y ppa:git-core/ppa; \
-    fi
 
 # Extra packages used by Zulip.
 RUN apt-get update \

--- a/tools/ci/Dockerfile.prod
+++ b/tools/ci/Dockerfile.prod
@@ -9,11 +9,6 @@ FROM $BASE_IMAGE
 # Remove already existing rabbitmq mnesia directory files
 RUN sudo rm -rf /var/lib/rabbitmq/mnesia/*
 
-# The bionic hack used in production suite
-RUN if (. /etc/os-release && [ "$ID $VERSION_ID" = 'ubuntu 18.04' ]); then \
-      sudo sed -i '/^bind/s/bind.*/bind 0.0.0.0/' /etc/redis/redis.conf; \
-    fi
-
 # Download the release tarball, start rabbitmq server and install the server
 ARG VERSION
 RUN cd $(mktemp -d) \

--- a/tools/ci/build-docker-images
+++ b/tools/ci/build-docker-images
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -eux
 cd "$(dirname "${BASH_SOURCE[0]}")"
-docker build . --build-arg=BASE_IMAGE=ubuntu:18.04 --pull --tag=zulip/ci:bionic
 docker build . --build-arg=BASE_IMAGE=ubuntu:20.04 --pull --tag=zulip/ci:focal
 docker build . --build-arg=BASE_IMAGE=debian:10 --pull --tag=zulip/ci:buster
-docker build . --build-arg=BASE_IMAGE=debian:bullseye --pull --tag=zulip/ci:bullseye
+docker build . --build-arg=BASE_IMAGE=debian:11 --pull --tag=zulip/ci:bullseye
 docker build . -f Dockerfile.prod --build-arg=BASE_IMAGE=zulip/ci:buster --build-arg=VERSION=3.4 --tag=zulip/ci:buster-3.4
 docker build . -f Dockerfile.prod --build-arg=BASE_IMAGE=zulip/ci:bullseye --build-arg=VERSION=4.7 --tag=zulip/ci:bullseye-4.7

--- a/tools/ci/production-install
+++ b/tools/ci/production-install
@@ -61,8 +61,8 @@ os_info="$(
     read -r os_version_id
 } <<<"$os_info"
 
-# Pin to PostgreSQL 10 on Bionic, so we can test upgrading it
-if [ "$os_id $os_version_id" = 'ubuntu 18.04' ]; then
+# Pin to PostgreSQL 10 on Ubuntu 20.04, so we can test upgrading it
+if [ "$os_id $os_version_id" = 'ubuntu 20.04' ]; then
     export POSTGRESQL_VERSION=10
 fi
 
@@ -75,7 +75,7 @@ else
     "$ZULIP_PATH"/scripts/setup/install --self-signed-cert --hostname 127.0.0.1 --email circleci@example.com --postgresql-database-user zulipcustomuser --postgresql-database-name zulipcustomdb
 fi
 
-if [ "$os_id $os_version_id" = 'ubuntu 18.04' ]; then
+if [ "$os_id $os_version_id" = 'ubuntu 20.04' ]; then
     if [ "$(crudini --get /etc/zulip/zulip.conf postgresql version)" != "10" ]; then
         echo "Installer did not install the PostgreSQL 10 that we asked for!"
         exit 1

--- a/tools/documentation.vnufilter
+++ b/tools/documentation.vnufilter
@@ -3,3 +3,4 @@
 Consider using the “h1” element as a top-level heading only \(all “h1” elements are treated as top-level headings by many screen readers and other tools\)\.
 Document uses the Unicode Private Use Area\(s\), which should not be used in publicly exchanged documents\. \(Charmod C073\)
 Section lacks heading\. Consider using “h2”-“h6” elements to add identifying headings to all sections\.
+Document uses the Unicode Private Use Area\(s\), which should not be used in publicly exchanged documents\. \(Charmod C073\)

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -83,8 +83,6 @@ if vendor == "debian" and os_version == "10":  # buster
     POSTGRESQL_VERSION = "11"
 elif vendor == "debian" and os_version == "11":  # bullseye
     POSTGRESQL_VERSION = "13"
-elif vendor == "ubuntu" and os_version == "18.04":  # bionic
-    POSTGRESQL_VERSION = "10"
 elif vendor == "ubuntu" and os_version == "20.04":  # focal
     POSTGRESQL_VERSION = "12"
 elif vendor == "ubuntu" and os_version == "21.10":  # impish

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -199,7 +199,7 @@ elif "debian" in os_families():
     SYSTEM_DEPENDENCIES = [
         *DEBIAN_DEPENDECIES,
         f"postgresql-{POSTGRESQL_VERSION}",
-        f"postgresql-{POSTGRESQL_VERSION}-pgdg-pgroonga",
+        f"postgresql-{POSTGRESQL_VERSION}-pgroonga",
         *VENV_DEPENDENCIES,
     ]
 elif "rhel" in os_families():

--- a/tools/provision
+++ b/tools/provision
@@ -19,7 +19,7 @@ fi
 
 os="$(. /etc/os-release && echo "$ID $VERSION_ID")"
 case "$os" in
-    'ubuntu 14.04' | 'ubuntu 16.04')
+    'ubuntu 14.04' | 'ubuntu 16.04' | 'ubuntu 18.04')
         echo "Error: $os is no longer a supported platform for Zulip." >&2
         if [ -e /home/vagrant ]; then
             # shellcheck disable=SC2016
@@ -32,8 +32,8 @@ esac
 
 python_version="$(python3 --version)"
 case "$python_version" in
-    Python\ 3.[0-5].*)
-        echo 'Error: Zulip requires an OS with Python 3.6 or later.' >&2
+    Python\ 3.[0-6].*)
+        echo 'Error: Zulip requires an OS with Python 3.7 or later.' >&2
         exit 1
         ;;
 esac

--- a/tools/setup/dev-vagrant-docker/Dockerfile
+++ b/tools/setup/dev-vagrant-docker/Dockerfile
@@ -1,18 +1,12 @@
-FROM ubuntu:18.04
+FROM debian:10
 
-ARG UBUNTU_MIRROR
+ARG DEBIAN_MIRROR
 
 # Basic packages and dependencies of docker-systemctl-replacement
 RUN echo locales locales/default_environment_locale select C.UTF-8 | debconf-set-selections \
     && echo locales locales/locales_to_be_generated select "C.UTF-8 UTF-8" | debconf-set-selections \
-    && { [ ! "$UBUNTU_MIRROR" ] || sed -i "s|http://\(\w*\.\)*archive\.ubuntu\.com/ubuntu/\? |$UBUNTU_MIRROR |" /etc/apt/sources.list; } \
-    # This restores man pages and other documentation that have been
-    # stripped from the default Ubuntu cloud image and installs
-    # ubuntu-minimal and ubuntu-standard.
-    #
-    # This makes sense to do because we're using this image as a
-    # development environment, not a minimal production system.
-    && printf 'y\n\n' | unminimize \
+    && { [ ! "$DEBIAN_MIRROR" ] || sed -i "s|http://\(\w*\.\)*\.debian\.org/debian |$DEBIAN_MIRROR |" /etc/apt/sources.list; } \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
            ca-certificates \
            curl \
@@ -39,7 +33,7 @@ RUN \
     && mkdir -p /run/sshd \
     # docker-systemctl-replacement doesn’t work with template units yet:
     # https://github.com/gdraheim/docker-systemctl-replacement/issues/62
-    && ln -ns /lib/systemd/system/postgresql@.service /etc/systemd/system/multi-user.target.wants/postgresql@10-main.service \
+    && ln -ns /lib/systemd/system/postgresql@.service /etc/systemd/system/multi-user.target.wants/postgresql@11-main.service \
     # redis fails to start with the default configuration if IPv6 is disabled:
     # https://github.com/antirez/redis/pull/5598
     && dpkg-divert --add --rename /etc/default/redis-server \

--- a/tools/test-install/prepare-base
+++ b/tools/test-install/prepare-base
@@ -10,9 +10,6 @@ RELEASE="$1"
 ARCH=amd64 # TODO: maybe i686 too
 
 case "$RELEASE" in
-    bionic)
-        extra_packages=(python-pip)
-        ;;
     focal)
         extra_packages=(python3-pip)
         ;;

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 113
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "169.2"
+PROVISION_VERSION = "169.3"

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -1,8 +1,7 @@
 import inspect
 import os
-import sys
 from collections import abc
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
 from unittest.mock import MagicMock, patch
 
 import yaml
@@ -328,15 +327,6 @@ so maybe we shouldn't mark it as intentionally undocumented in the URLs.
         needs to be mapped to list."""
 
         origin = getattr(t, "__origin__", None)
-        if sys.version_info < (3, 7):  # nocoverage
-            if origin == List:
-                origin = list
-            elif origin == Dict:
-                origin = dict
-            elif origin == Mapping:
-                origin = abc.Mapping
-            elif origin == Sequence:
-                origin = abc.Sequence
 
         if not origin:
             # Then it's most likely one of the fundamental data types

--- a/zerver/webhooks/helloworld/doc.md
+++ b/zerver/webhooks/helloworld/doc.md
@@ -17,7 +17,7 @@ integration](/api/incoming-webhooks-walkthrough).
     `send_webhook_fixture_message` from a [Zulip development
     environment](https://zulip.readthedocs.io/en/latest/development/overview.html):
 
-        (zulip-py3-venv) vagrant@ubuntu-bionic:/srv/zulip$
+        (zulip-py3-venv) vagrant@debian-10:/srv/zulip$
         ./manage.py send_webhook_fixture_message \
         > --fixture=zerver/tests/fixtures/helloworld/hello.json \
         > '--url=http://localhost:9991/api/v1/external/helloworld?api_key=&lt;api_key&gt;'


### PR DESCRIPTION
As a consequence:

* Bump minimum supported Python version to 3.7.
* Move Vagrant environment to Debian 10, which has Python 3.7.
* Move CI frontend tests to Debian 10.
* Move production build test to Debian 10.
* Move production PostgreSQL upgrade test to Ubuntu 20.04.

~~Gitlint is temporarily removed because it’s missing in Debian 10.~~ Fixed in #20384, included here.