### PR TITLE
Show "hidden" in users and subscriber list when email is not accessible. (Narrow screen commits remaining)

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -312,6 +312,11 @@ section.active.create_table = (active_users) => {
 
     loading.destroy_indicator($("#admin_page_users_loading_indicator"));
     $("#admin_users_table").show();
+    if (settings_data.show_email()) {
+        $("#admin-user-list").find(".user_id").addClass("hide-user-id-narrow-width");
+    } else {
+        $("#admin-user-list").find(".user_email").addClass("hide-user-email-narrow-width");
+    }
 };
 
 section.deactivated.create_table = (deactivated_users) => {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1979,3 +1979,12 @@ input[type="checkbox"] {
         margin-top: 10px;
     }
 }
+
+@media (width < 840px) {
+    #admin-user-list {
+        .hide-user-id-narrow-width,
+        .hide-user-email-narrow-width {
+            display: none;
+        }
+    }
+}

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -387,6 +387,14 @@ td .button {
     .table tr:first-of-type td {
         border-top: none;
     }
+
+    .name {
+        width: 190px;
+    }
+
+    .email {
+        width: 190px;
+    }
 }
 
 .dynamic-input {
@@ -1716,10 +1724,6 @@ input[type="checkbox"] {
     tbody {
         border-bottom: none;
     }
-}
-
-#admin-user-list .last_active {
-    width: 100px;
 }
 
 .required-text {

--- a/static/templates/settings/admin_user_list.hbs
+++ b/static/templates/settings/admin_user_list.hbs
@@ -8,11 +8,11 @@
         <span class="email">{{display_email}}</span>
     </td>
     {{else}}
-    <td>
+    <td class="user_email">
         <span class="hidden-email">{{t "(hidden)"}}</span>
     </td>
     {{/if}}
-    <td>
+    <td class="user_id">
         <span class="user_id">{{user_id}}</span>
     </td>
     {{#unless is_bot}}

--- a/static/templates/settings/admin_user_list.hbs
+++ b/static/templates/settings/admin_user_list.hbs
@@ -1,10 +1,10 @@
 <tr class="user_row{{#unless is_active}} deactivated_user{{/unless}}" data-user-id="{{user_id}}">
-    <td>
+    <td class="name">
         <span class="user_name" >{{full_name}} {{#if is_current_user}}<span class="my_user_status">{{t '(you)' }}</span>{{/if}}</span>
         <i class="fa fa-ban deactivated-user-icon" title="{{t 'User is deactivated' }}" {{#if is_active}}style="display: none;"{{/if}}></i>
     </td>
     {{#if display_email}}
-    <td>
+    <td class="email">
         <span class="email">{{display_email}}</span>
     </td>
     {{else}}

--- a/static/templates/settings/user_list_admin.hbs
+++ b/static/templates/settings/user_list_admin.hbs
@@ -9,7 +9,7 @@
         <table class="table table-condensed table-striped wrapped-table">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
-                <th data-sort="email">{{t "Email" }}</th>
+                <th data-sort="email" class="user_email">{{t "Email" }}</th>
                 <th class="user_id" data-sort="id">{{t "User ID" }}</th>
                 <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 <th class="last_active" data-sort="last_active">{{t "Last active" }}</th>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First two commits are for showing "hidden" instead of hiding the column when emails are not accessible according to organization setting.
- Last two commits are for improving the narrow width UI.

Discussion about the narrow width behavior - https://chat.zulip.org/#narrow/stream/101-design/topic/user-level.20email.20address.20visbility.20setting. 
 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2021-11-03 23-43-19](https://user-images.githubusercontent.com/35494118/140902867-43cd59f1-3568-4e0e-9415-0a9559e0ead0.png)


![Screenshot from 2021-11-09 15-28-07](https://user-images.githubusercontent.com/35494118/140903532-81740ff3-c251-490d-94e8-cbb04445223e.png)
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
