### PR TITLE
settings: Fix bug in "Default user settings" section.

### DIFF
--- a/frontend_tests/puppeteer_tests/settings.ts
+++ b/frontend_tests/puppeteer_tests/settings.ts
@@ -307,7 +307,7 @@ async function change_language(page: Page, language_data_code: string): Promise<
 }
 
 async function check_language_setting_status(page: Page): Promise<void> {
-    await page.waitForSelector("#user-display-settings .language-settings-status .reload_link", {
+    await page.waitForSelector("#user-display-settings .lang-time-settings-status .reload_link", {
         visible: true,
     });
 }
@@ -356,7 +356,9 @@ async function test_default_language_setting(page: Page): Promise<void> {
     await page.goto("http://zulip.zulipdev.com:9981/#settings"); // get back to normal language.
     await page.waitForSelector(display_settings_section, {visible: true});
     await page.click(display_settings_section);
-    await page.waitForSelector("#user-display-settings .language-settings-status", {visible: true});
+    await page.waitForSelector("#user-display-settings .lang-time-settings-status", {
+        visible: true,
+    });
     await page.waitForSelector("#user-display-settings .setting_default_language", {visible: true});
 }
 

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -112,7 +112,7 @@ export function set_up(settings_panel) {
 
             change_display_setting(
                 data,
-                container.find(".language-settings-status"),
+                container.find(".lang-time-settings-status"),
                 $t_html(
                     {
                         defaultMessage:

--- a/static/js/settings_realm_user_settings_defaults.js
+++ b/static/js/settings_realm_user_settings_defaults.js
@@ -28,10 +28,16 @@ export function update_page(property) {
     const container = $(realm_default_settings_panel.container);
     let value = realm_user_settings_defaults[property];
 
+    // settings_org.set_input_element_value doesn't support radio
+    // button widgets like this one.
     if (property === "emojiset") {
         container.find(`input[value=${CSS.escape(value)}]`).prop("checked", true);
         return;
     }
+
+    // The twenty_four_hour_time setting is represented as a boolean
+    // in the API, but a dropdown with "true"/"false" as strings in
+    // the UI, so we need to convert its format here.
     if (property === "twenty_four_hour_time") {
         value = value.toString();
     }

--- a/static/js/settings_realm_user_settings_defaults.js
+++ b/static/js/settings_realm_user_settings_defaults.js
@@ -26,12 +26,16 @@ export function update_page(property) {
         return;
     }
     const container = $(realm_default_settings_panel.container);
-    const value = realm_user_settings_defaults[property];
+    let value = realm_user_settings_defaults[property];
 
     if (property === "emojiset") {
         container.find(`input[value=${CSS.escape(value)}]`).prop("checked", true);
         return;
     }
+    if (property === "twenty_four_hour_time") {
+        value = value.toString();
+    }
+
     const input_elem = container.find(`[name=${CSS.escape(property)}]`);
     settings_org.set_input_element_value(input_elem, value);
 }

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -1,13 +1,16 @@
 <form class="display-settings-form">
     <div class="lang-time-settings {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
-        {{#unless for_realm_settings}}
         <!-- this is inline block so that the alert notification can sit beside
         it. If there's not an alert, don't make it inline-block.-->
         <div class="subsection-header inline-block">
+            {{#if for_realm_settings}}
+            <h3>{{t "Time" }}</h3>
+            {{else}}
             <h3>{{t "Language and time" }}</h3>
-            {{> settings_save_discard_widget section_name="language-settings" show_only_indicator=true }}
+            {{/if}}
+            {{> settings_save_discard_widget section_name="lang-time-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
-
+        {{#unless for_realm_settings}}
         <div class="input-group">
             <label class="inline-block title">{{t "Language" }}</label>
             <button type="button" class="setting_default_language button btn-link rounded small inline-block">


### PR DESCRIPTION
There was no heading for "Time format" setting in the
"Default user settings" section and thus no save-discard
widget to update the setting. This commit fixes the bug
and changes the heading to be only "Time" since there is
no realm-level default of language setting.

This bug was introduced in adb612a0b48.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? --> Tested manually in dev server.

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
