### PR TITLE
invitations: Check invitation from a now-deactivated user.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -503,7 +503,12 @@ def process_new_human_user(
     add_new_user_history(user_profile, streams)
 
     # mit_beta_users don't have a referred_by field
-    if not mit_beta_user and prereg_user is not None and prereg_user.referred_by is not None:
+    if (
+        not mit_beta_user
+        and prereg_user is not None
+        and prereg_user.referred_by is not None
+        and prereg_user.referred_by.is_active
+    ):
         # This is a cross-realm private message.
         with override_language(prereg_user.referred_by.default_language):
             internal_send_private_message(

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1281,6 +1281,31 @@ class InviteUserTest(InviteUserBase):
             inviter.email,
         )
 
+    def test_invite_from_now_deactivated_user(self) -> None:
+        """
+        While accepting an invitation from a user,
+        processing for a new user account will only
+        be completed if the inviter is not deactivated
+        after sending the invite.
+        """
+        inviter = self.example_user("hamlet")
+        self.login_user(inviter)
+        invitee = self.nonreg_email("alice")
+
+        result = self.invite(invitee, ["Denmark"])
+        self.assert_json_success(result)
+
+        prereg_user = PreregistrationUser.objects.get(email=invitee)
+        change_user_is_active(inviter, False)
+        do_create_user(
+            invitee,
+            "password",
+            inviter.realm,
+            "full name",
+            prereg_user=prereg_user,
+            acting_user=None,
+        )
+
     def test_successful_invite_user_as_owner_from_owner_account(self) -> None:
         self.login("desdemona")
         invitee = self.nonreg_email("alice")


### PR DESCRIPTION
While accepting an invitation from a user, there was
no condition in place to check if the user sending the
invitation is now-deactivated. This commit adds a
condition for the same.
Fixes #18569

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
Added a test `test_invite_from_now_deactivated_user` under `InviteUserTest` in `test_signup.py`.
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Raises the following error without this patch.
![image](https://user-images.githubusercontent.com/76661350/143171529-f4d81463-9365-4b5a-9653-e37be40ab598.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
