### PR TITLE
Fix flatpickr not being displayed on touch based devices.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -778,6 +778,7 @@ export function show_flatpickr(element, callback, default_timestamp, options = {
         positionElement: element,
         dateFormat: "Z",
         formatDate: (date) => formatISO(date),
+        disableMobile: true,
         ...options,
     });
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2687,9 +2687,34 @@ select.inline_select_topic_edit {
     margin: 0;
 }
 
-/* Hide the up and down arrows in the Flatpickr datepicker year */
-.flatpickr-months .numInputWrapper span {
-    display: none;
+.flatpickr-calendar {
+    /* Hide the up and down arrows in the Flatpickr datepicker year */
+    .flatpickr-months .numInputWrapper span {
+        display: none;
+    }
+
+    .flatpickr-time-separator {
+        position: relative;
+        left: 5px;
+    }
+
+    .flatpickr-time input {
+        margin: 0 5px;
+    }
+
+    @media (width < $md_min) {
+        /* Center align flatpickr on mobile
+         * devices so that it doesn't go out of
+         * the viewport. */
+        left: 0 !important;
+        right: 0 !important;
+        margin: auto;
+
+        &::after,
+        &::before {
+            border-top-width: 0;
+        }
+    }
 }
 
 #about-zulip {


### PR DESCRIPTION
before:
<img width="513" alt="Screenshot 2021-11-09 at 9 59 55 PM" src="https://user-images.githubusercontent.com/25124304/140964701-bd0be46f-aee5-4e73-b675-b8485987ce8a.png">

after:
<img width="513" alt="Screenshot 2021-11-09 at 9 58 45 PM" src="https://user-images.githubusercontent.com/25124304/140964741-17486de9-56a4-4a22-b239-a029a7f844e5.png">


discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/global.20time.20flatpickr.20mobile