### PR TITLE
puppet: Use sysv status command, not supervisorctl status.

### DIFF
--- a/puppet/zulip/manifests/common.pp
+++ b/puppet/zulip/manifests/common.pp
@@ -12,6 +12,7 @@ class zulip::common {
       # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=877086
       # "restart" is actually "stop" under sysvinit
       $supervisor_reload = '/etc/init.d/supervisor restart && (/etc/init.d/supervisor start || /bin/true) && /etc/init.d/supervisor status'
+      $supervisor_status = '/etc/init.d/supervisor status'
     }
     'redhat': {
       $nagios_plugins = 'nagios-plugins'
@@ -22,6 +23,7 @@ class zulip::common {
       $supervisor_service = 'supervisord'
       $supervisor_start = 'systemctl start supervisord'
       $supervisor_reload = 'systemctl reload supervisord'
+      $supervisor_status = 'systemctl status supervisord'
     }
     default: {
       fail('osfamily not supported')

--- a/puppet/zulip/manifests/supervisor.pp
+++ b/puppet/zulip/manifests/supervisor.pp
@@ -98,9 +98,6 @@ class zulip::supervisor {
       #
       # Also, to handle the case that supervisord wasn't running at
       # all, we check if it is not running and if so, start it.
-      #
-      # We use supervisor[d] as the pattern so the bash/grep commands
-      # don't match.
       hasrestart => true,
       # lint:ignore:140chars
       restart    => "bash -c 'if pgrep -x supervisord >/dev/null; then supervisorctl reread && supervisorctl update; else ${zulip::common::supervisor_start}; fi'",

--- a/puppet/zulip/manifests/supervisor.pp
+++ b/puppet/zulip/manifests/supervisor.pp
@@ -81,7 +81,7 @@ class zulip::supervisor {
         Package['supervisor'],
       ],
       hasstatus  => true,
-      status     => 'supervisorctl status',
+      status     => $zulip::common::supervisor_status,
       # Restarting the whole supervisorctl on every update to its
       # configuration files has the unfortunate side-effect of
       # restarting all of the services it controls; this results in an


### PR DESCRIPTION
Since Supervisor 4, which is installed on Ubuntu 20.04 and Debian 11,
`supervisorctl status` returns exit code 3 if any of the
supervisor-controlled processes are not running.

Using `supervisorctl status` as the Puppet `status` command for
Supervisor leads to unnecessarily trying to "start" a Supervisor
process which is already started, but happens to have one or more of
its managed processes stopped.  This is an unnecessary no-op in
production environments, but in docker-init enviroments, such as in
CI, attempting to start the process a second time is an error.

Switch to checking if supervisor is running by way of sysv init.  This
fixes the potential error in CI, as well as eliminates unnecessary
"starts" of supervisor when it was already running -- a situation
which made zulip-puppet-apply not idempotent:

```
root@alexmv-prod:~# supervisorctl status
process-fts-updates                                             STOPPED   Nov 10 12:33 AM
smokescreen                                                     RUNNING   pid 1287280, uptime 0:35:32
zulip-django                                                    STOPPED   Nov 10 12:33 AM
zulip-tornado                                                   STOPPED   Nov 10 12:33 AM
[...]

root@alexmv-prod:~# ~zulip/deployments/current/scripts/zulip-puppet-apply --force
Notice: Compiled catalog for alexmv-prod.zulipdev.org in environment production in 2.32 seconds
Notice: /Stage[main]/Zulip::Supervisor/Service[supervisor]/ensure: ensure changed 'stopped' to 'running'
Notice: Applied catalog in 0.91 seconds

root@alexmv-prod:~# ~zulip/deployments/current/scripts/zulip-puppet-apply --force
Notice: Compiled catalog for alexmv-prod.zulipdev.org in environment production in 2.35 seconds
Notice: /Stage[main]/Zulip::Supervisor/Service[supervisor]/ensure: ensure changed 'stopped' to 'running'
Notice: Applied catalog in 0.92 seconds
```

**Testing plan:** Cherry-picked atop #20202.
