### PR TITLE
flatpickr: Improve look of `Confirm` button.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -774,7 +774,13 @@ export function show_flatpickr(element, callback, default_timestamp, options = {
         enableTime: true,
         clickOpens: false,
         defaultDate: default_timestamp,
-        plugins: [new ConfirmDatePlugin({showAlways: true})],
+        plugins: [
+            new ConfirmDatePlugin({
+                showAlways: true,
+                confirmText: $t({defaultMessage: "Confirm"}),
+                confirmIcon: "",
+            }),
+        ],
         positionElement: element,
         dateFormat: "Z",
         formatDate: (date) => formatISO(date),

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2702,6 +2702,13 @@ select.inline_select_topic_edit {
         margin: 0 5px;
     }
 
+    .flatpickr-confirm {
+        color: hsl(0, 0%, 100%);
+        background-color: hsl(213, 90%, 65%);
+        font-size: 18px;
+        font-weight: 600;
+    }
+
     @media (width < $md_min) {
         /* Center align flatpickr on mobile
          * devices so that it doesn't go out of


### PR DESCRIPTION
Instead of using JS to modify the content of the flatpickr after
it is rendered, we use css ::after pseudo class to do so.
<img width="473" alt="Screenshot 2021-11-10 at 11 10 36 AM" src="https://user-images.githubusercontent.com/25124304/141056425-d0f18108-6024-4c22-815d-e9258fa2b643.png">

