### PR TITLE
edit_bot: Remove unnecessary CSS from bot owner button.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -908,11 +908,6 @@ input[type="checkbox"] {
     .buttons {
         margin: 10px 0 5px;
     }
-
-    button.dropdown-toggle {
-        font-weight: 600;
-        color: hsl(0, 0%, 67%);
-    }
 }
 
 .edit_bot_email {


### PR DESCRIPTION
This was introduced in 134a6f8bbae77ba85ae9dd19830eb1a1ceaa851e.

I removed the bold font since it looked out-of-place.

![image](https://user-images.githubusercontent.com/58626718/141069933-eb1b28a4-a400-4c6e-a6fa-ca9afa8e3ebc.png)