### PR TITLE
compose: Use calendarContainer to check if flatpickr is open.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -628,7 +628,7 @@ export function initialize() {
         }
     });
 
-    let instance = null;
+    let instance = {};
     $("body").on("click", ".time_pick", (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -640,11 +640,10 @@ export function initialize() {
             target_textarea = $(`#edit_form_${CSS.escape(edit_message_id)} .message_edit_content`);
         }
 
-        if (instance === null) {
+        if (!instance.calendarContainer) {
             const on_timestamp_selection = (val) => {
                 const timestr = `<time:${val}> `;
                 compose_ui.insert_syntax_and_focus(timestr, target_textarea);
-                instance = null;
             };
 
             instance = composebox_typeahead.show_flatpickr(
@@ -656,16 +655,11 @@ export function initialize() {
                     position: "above center",
                 },
             );
-
-            $(document).one("compose_canceled.zulip compose_finished.zulip", () => {
-                instance = null;
-            });
             return;
         }
 
         instance.close();
         instance.destroy();
-        instance = null;
     });
 
     $("#compose").on("click", ".markdown_preview", (e) => {


### PR DESCRIPTION
`calendarContainer` is defined for flatpickr instance if it is
open.

This also fixes a bug where the flatpickr doesn't open when
user tries to toggle it using the global time icon in compose.
