### PR TITLE
stream_settings_overlay: Fix padding for right section headings.

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -510,7 +510,7 @@
         }
 
         .display-type {
-            padding: 6px;
+            padding: 2px;
             text-align: center;
             font-weight: 600;
             border-bottom: 1px solid hsl(0, 0%, 87%);


### PR DESCRIPTION
While working on #20222 I noticed that the section headings here don't look right:
![](https://user-images.githubusercontent.com/33805964/141335103-f7ebb983-210a-4e24-928d-81c63d16a046.png)


![](https://user-images.githubusercontent.com/33805964/141335221-ae9d6acb-8e03-4c67-a195-a55096d6721c.JPG)

ie, like the commit message says:

At some point we must have made a change that caused the "create
stream" and "#stream name" headings to take up more vertical space,
resulting in the dividing line for the headings of the right side of
the subscription overlay to be miss-aligned with the same for the left
side. For the "create stream" panel, it also caused the scroll bar and
some content to be visible through the partially transparent bottom
section in night mode.

In this commit we reduce the padding for those headings so that things
don't look broken anymore.

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![](https://user-images.githubusercontent.com/33805964/141335620-88818f35-388e-4a1f-a464-69a5e7099f90.JPG)

![](https://user-images.githubusercontent.com/33805964/141335712-e6085d8e-ac76-4d41-b1ca-a86b50f84e4f.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
