### PR TITLE
queue_processors: Set a bounded prefetch size on rabbitmq queues.

### DIFF
--- a/tools/tests/test_check_rabbitmq_queue.py
+++ b/tools/tests/test_check_rabbitmq_queue.py
@@ -25,7 +25,6 @@ class AnalyzeQueueStatsTests(TestCase):
             "name",
             {
                 "update_time": time.time(),
-                "current_queue_size": 10000,
                 "recent_average_consume_time": None,
             },
             10000,
@@ -38,7 +37,6 @@ class AnalyzeQueueStatsTests(TestCase):
             "name",
             {
                 "update_time": time.time(),
-                "current_queue_size": 10000,
                 "queue_last_emptied_timestamp": time.time() - 10000,
                 "recent_average_consume_time": 1,
             },
@@ -52,7 +50,6 @@ class AnalyzeQueueStatsTests(TestCase):
             "name",
             {
                 "update_time": time.time(),
-                "current_queue_size": 10000,
                 "queue_last_emptied_timestamp": time.time() - 10000,
                 "recent_average_consume_time": 0.0001,
             },
@@ -66,7 +63,6 @@ class AnalyzeQueueStatsTests(TestCase):
                 "name",
                 {
                     "update_time": time.time(),
-                    "current_queue_size": 11,
                     "queue_last_emptied_timestamp": time.time() - 10000,
                     "recent_average_consume_time": 1,
                 },
@@ -79,7 +75,6 @@ class AnalyzeQueueStatsTests(TestCase):
                 "name",
                 {
                     "update_time": time.time(),
-                    "current_queue_size": 9,
                     "queue_last_emptied_timestamp": time.time() - 10000,
                     "recent_average_consume_time": 1,
                 },

--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -252,7 +252,10 @@ class TornadoQueueClient(QueueClient[Channel]):
     def __init__(self) -> None:
         super().__init__(
             # TornadoConnection can process heartbeats, so enable them.
-            rabbitmq_heartbeat=None
+            rabbitmq_heartbeat=None,
+            # Only ask for 100 un-acknowledged messages at once from
+            # the server, rather than an unbounded number.
+            prefetch=100,
         )
         self._on_open_cbs: List[Callable[[Channel], None]] = []
         self._connection_failure_count = 0

--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -32,10 +32,12 @@ class QueueClient(Generic[ChannelT], metaclass=ABCMeta):
         self,
         # Disable RabbitMQ heartbeats by default because BlockingConnection can't process them
         rabbitmq_heartbeat: Optional[int] = 0,
+        prefetch: int = 0,
     ) -> None:
         self.log = logging.getLogger("zulip.queue")
         self.queues: Set[str] = set()
         self.channel: Optional[ChannelT] = None
+        self.prefetch = prefetch
         self.consumers: Dict[str, Set[Consumer[ChannelT]]] = defaultdict(set)
         self.rabbitmq_heartbeat = rabbitmq_heartbeat
         self.is_consuming = False
@@ -158,9 +160,12 @@ class SimpleQueueClient(QueueClient[BlockingChannel]):
             self._connect()
 
         assert self.channel is not None
+        self.channel.basic_qos(prefetch_count=self.prefetch)
+
         if queue_name not in self.queues:
             self.channel.queue_declare(queue=queue_name, durable=True)
             self.queues.add(queue_name)
+
         callback(self.channel)
 
     def start_json_consumer(
@@ -329,9 +334,13 @@ class TornadoQueueClient(QueueClient[Channel]):
             self.connection.close()
 
     def ensure_queue(self, queue_name: str, callback: Callable[[Channel], object]) -> None:
-        def finish(frame: Any) -> None:
+        def set_qos(frame: Any) -> None:
             assert self.channel is not None
             self.queues.add(queue_name)
+            self.channel.basic_qos(prefetch_count=self.prefetch, callback=finish)
+
+        def finish(frame: Any) -> None:
+            assert self.channel is not None
             callback(self.channel)
 
         if queue_name not in self.queues:
@@ -342,7 +351,7 @@ class TornadoQueueClient(QueueClient[Channel]):
                 return
 
             assert self.channel is not None
-            self.channel.queue_declare(queue=queue_name, durable=True, callback=finish)
+            self.channel.queue_declare(queue=queue_name, durable=True, callback=set_qos)
         else:
             assert self.channel is not None
             callback(self.channel)

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -60,7 +60,6 @@ from zerver.models import (
     get_stream,
 )
 from zerver.tornado.handlers import AsyncDjangoHandler, allocate_handler_id
-from zerver.worker import queue_processors
 from zilencer.models import RemoteZulipServer
 from zproject.backends import ExternalAuthDataDict, ExternalAuthResult
 
@@ -90,12 +89,6 @@ def stub_event_queue_user_events(
     with mock.patch("zerver.lib.events.request_event_queue", return_value=event_queue_return):
         with mock.patch("zerver.lib.events.get_user_events", return_value=user_events_return):
             yield
-
-
-@contextmanager
-def simulated_queue_client(client: Callable[[], object]) -> Iterator[None]:
-    with mock.patch.object(queue_processors, "SimpleQueueClient", client):
-        yield
 
 
 @contextmanager

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -47,7 +47,7 @@ Event = Dict[str, Any]
 
 
 class FakeClient:
-    def __init__(self) -> None:
+    def __init__(self, prefetch: int = 0) -> None:
         self.queues: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
 
     def enqueue(self, queue_name: str, data: Dict[str, Any]) -> None:

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -1067,7 +1067,7 @@ class NoopWorker(QueueProcessingWorker):
 class BatchNoopWorker(LoopQueueProcessingWorker):
     """Used to profile the queue processing framework, in zilencer's queue_rate."""
 
-    batch_size = 500
+    batch_size = 100
 
     def __init__(self, max_consume: int = 1000, slow_queries: Sequence[int] = []) -> None:
         self.consumed = 0


### PR DESCRIPTION
RabbitMQ clients have a setting called prefetch[1], which controls how
many un-acknowledged events the server forwards to the local queue in
the client.  The default is 0; this means that when clients first
connect, the server must send them every message in the queue.

This itself may cause unbounded memory usage in the client, but also
has other detrimental effects.  While the client is attempting to
process the head of the queue, it may be unable to read from the TCP
socket at the rate that the server is sending to it -- filling the TCP
buffers, and causing the server's writes to block.  If the server
blocks for more than 30 seconds, it times out the send, and closes the
connection with:

```
closing AMQP connection <0.30902.126> (127.0.0.1:53870 -> 127.0.0.1:5672):
{writer,send_failed,{error,timeout}}
```

This is https://github.com/pika/pika/issues/753#issuecomment-318119222.

Set a prefetch limit of 100 messages, or the batch size, to better
handle queues which start with large numbers of outstanding events.

Setting prefetch=1 causes significant performance degradation in the
no-op queue worker, to 30% of the prefetch=0 performance.  Setting
prefetch=100 achieves 90% of the prefetch=0 performance, and higher
values offer only minor gains above that.  For batch workers, their
performance is not notably degraded by prefetch equal to their batch
size, and they cannot function on smaller prefetches than their batch
size.

[1] https://www.rabbitmq.com/confirms.html#channel-qos-prefetch

**GIFs or screenshots:** 

![Batch no-op queue processing rate by prefetch](https://user-images.githubusercontent.com/28347/141610472-180d734e-4f12-4e8e-9b5e-af9b16462947.png)
![No-op queue processing rate by prefetch value](https://user-images.githubusercontent.com/28347/141610474-08d853e0-8bdf-4903-ab50-c31534d68ba1.png)
