### PR TITLE
landing_page: Avoid gradient overflowing under content.

### DIFF
--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -2636,6 +2636,10 @@ nav {
     left: 0;
     width: 100%;
     height: 1100px;
+
+    @media (width < 768px) {
+        height: 700px;
+    }
 }
 
 .gradients .gradient.dark-blue {


### PR DESCRIPTION
Gradient under content makes links which are of similar color
hard to see.

before:

<img width="577" alt="Screenshot 2021-11-13 at 10 36 57 PM" src="https://user-images.githubusercontent.com/25124304/141652603-ac524f82-9756-447d-91cd-140ae146f3af.png">

after:
<img width="577" alt="Screenshot 2021-11-13 at 10 36 49 PM" src="https://user-images.githubusercontent.com/25124304/141652630-9a9e99de-329c-4d6f-94b1-ffef8314f981.png">

discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/.2Ffeatures.20page.20weird.20view