### PR TITLE
move_topic_to_stream: Fix position of error message and change its color scheme in night theme 

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -442,6 +442,7 @@ body.night-mode {
     .clear_search_button:disabled:hover,
     #user-groups .save-instructions,
     .close,
+    .send-status-close,
     #user_presences li:hover .user-list-sidebar-menu-icon,
     li.top_left_all_messages:hover .all-messages-sidebar-menu-icon,
     li.top_left_starred_messages:hover .starred-messages-sidebar-menu-icon,

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -692,8 +692,10 @@ ul {
     }
 
     #topic_stream_edit_form_error {
-        background-color: hsla(0, 70%, 87%, 0.7);
-        color: hsl(0, 100%, 50%);
+        background-color: transparent;
+        color: hsl(2, 46%, 68%);
+        border-color: hsl(2, 46%, 68%);
+        margin-bottom: 10px;
     }
 
     .topic_stream_edit_header {

--- a/static/templates/move_topic_to_stream.hbs
+++ b/static/templates/move_topic_to_stream.hbs
@@ -1,9 +1,9 @@
+<div id="topic_stream_edit_form_error" class="alert">
+    <span class="send-status-close">&times;</span>
+    <span class="error-msg"></span>
+</div>
 <p>{{#tr}}Move all messages in <strong>{topic_name}</strong>{{/tr}} to:</p>
 <form class="new-style" id="move_topic_form">
-    <div id="topic_stream_edit_form_error" class="alert">
-        <span class="send-status-close">&times;</span>
-        <span class="error-msg"></span>
-    </div>
     <p>{{t "Select a stream below or change topic name." }}</p>
     <div class="topic_stream_edit_header">
         <div class="stream_header_colorblock"></div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Fixes #20210

**Testing plan:** <!-- How have you tested? -->Manual

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Earlier :
![image](https://user-images.githubusercontent.com/77742477/141673955-e3e4725d-c7cf-45ee-a6db-eafdbe1ff0d1.png)

Now:
![image](https://user-images.githubusercontent.com/77742477/141674017-49f7a598-a26c-420a-a281-1fc9c53f2db6.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
