### PR TITLE
compose: Fix keyboard UI with new global time widget

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -615,10 +615,11 @@ export function initialize() {
         }
     });
 
-    let instance = {};
     $("body").on("click", ".time_pick", (e) => {
         e.preventDefault();
         e.stopPropagation();
+
+        $(e.target).toggleClass("has_popover");
 
         let target_textarea;
         let edit_message_id;
@@ -630,13 +631,13 @@ export function initialize() {
             target_textarea = $(compose_click_target).closest("form").find("textarea");
         }
 
-        if (!instance.calendarContainer) {
+        if ($(e.target).hasClass("has_popover")) {
             const on_timestamp_selection = (val) => {
                 const timestr = `<time:${val}> `;
                 compose_ui.insert_syntax_and_focus(timestr, target_textarea);
             };
 
-            instance = composebox_typeahead.show_flatpickr(
+            composebox_typeahead.show_flatpickr(
                 $(compose_click_target)[0],
                 on_timestamp_selection,
                 new Date(),
@@ -645,11 +646,7 @@ export function initialize() {
                     position: "above center",
                 },
             );
-            return;
         }
-
-        instance.close();
-        instance.destroy();
     });
 
     $("#compose").on("click", ".markdown_preview", (e) => {


### PR DESCRIPTION
#20130 

This should fix the keyboard issue for the ```enter``` and ```escape``` commands. This is a work in progress, and the remaining commands for ```tab```, arrow keys and numpad (?) are not implemented. But their default implementation is cancelled because I noticed they caused some other issues. The default implemention for ```tab``` when opening the time picker caused it to switch focus to the zulip logo in the top left corner, and using the ```left_arrow``` command seems to open the message editor. The issue seems to be depending on which DOM element the user is focusing on, and there might be some inconsistency there.

When opening the timer picker with keyboard navigation, I noticed the year changes to ```1910```. But using ```container.trigger("focus")``` instead of ```container.find(".flatpickr-monthDropdown-months").trigger("focus")``` seems to resolve this issue.

I did not see a8c488bc565b9d7626e99c968cce5b44e633985a before pushing my changes, so some changes in there are overridden. However, I believe it is better to toggle a class (like the emoji picker does) to indicate whether the popover is active.