### PR TITLE
process_queue: Improve handling of exceptions in process_queue. 

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -459,6 +459,7 @@ python_rules = RuleList(
             "pattern": "exit[(]1[)]",
             "include_only": {"/management/commands/"},
             "description": "Raise CommandError to exit with failure in management commands",
+            "exclude": {"zerver/management/commands/process_queue.py"},
         },
         {
             "pattern": ".is_realm_admin =",

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -456,7 +456,7 @@ python_rules = RuleList(
             ],
         },
         {
-            "pattern": "exit[(]1[)]",
+            "pattern": r"exit[(][1-9]\d*[)]",
             "include_only": {"/management/commands/"},
             "description": "Raise CommandError to exit with failure in management commands",
             "exclude": {"zerver/management/commands/process_queue.py"},

--- a/zerver/management/commands/process_queue.py
+++ b/zerver/management/commands/process_queue.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
                 if not settings.DEVELOPMENT:
                     logger.info("launching queue worker thread " + queue_name)
                 cnt += 1
-                td = Threaded_worker(queue_name, logger)
+                td = ThreadedWorker(queue_name, logger)
                 td.start()
             assert len(queues) == cnt
             logger.info("%d queue worker threads were launched", cnt)
@@ -111,7 +111,7 @@ class Command(BaseCommand):
                     worker.start()
 
 
-class Threaded_worker(threading.Thread):
+class ThreadedWorker(threading.Thread):
     def __init__(self, queue_name: str, logger: logging.Logger) -> None:
         threading.Thread.__init__(self)
         self.logger = logger

--- a/zerver/management/commands/process_queue.py
+++ b/zerver/management/commands/process_queue.py
@@ -1,10 +1,12 @@
 import logging
+import os
 import signal
 import sys
 import threading
 from argparse import ArgumentParser
+from contextlib import contextmanager
 from types import FrameType
-from typing import Any, List
+from typing import Any, Iterator, List
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
@@ -12,6 +14,22 @@ from django.utils import autoreload
 from sentry_sdk import configure_scope
 
 from zerver.worker.queue_processors import get_active_worker_queues, get_worker
+
+
+@contextmanager
+def log_and_exit_if_exception(
+    logger: logging.Logger, queue_name: str, threaded: bool
+) -> Iterator[None]:
+    try:
+        yield
+    except Exception:
+        logger.exception("Unhandled exception from queue: %s", queue_name, stack_info=True)
+        if threaded:
+            # Sending SIGUSR1 is the right way to exit - triggering the
+            # exit_with_three signal handler, causing exit and reload.
+            os.kill(os.getpid(), signal.SIGUSR1)
+        else:
+            sys.exit(1)
 
 
 class Command(BaseCommand):
@@ -57,7 +75,7 @@ class Command(BaseCommand):
                 if not settings.DEVELOPMENT:
                     logger.info("launching queue worker thread " + queue_name)
                 cnt += 1
-                td = Threaded_worker(queue_name)
+                td = Threaded_worker(queue_name, logger)
                 td.start()
             assert len(queues) == cnt
             logger.info("%d queue worker threads were launched", cnt)
@@ -79,26 +97,33 @@ class Command(BaseCommand):
                 sys.exit(0)
 
             logger.info("Worker %d connecting to queue %s", worker_num, queue_name)
-            worker = get_worker(queue_name)
-            with configure_scope() as scope:
-                scope.set_tag("queue_worker", queue_name)
-                scope.set_tag("worker_num", worker_num)
+            with log_and_exit_if_exception(logger, queue_name, threaded=False):
+                worker = get_worker(queue_name)
+                with configure_scope() as scope:
+                    scope.set_tag("queue_worker", queue_name)
+                    scope.set_tag("worker_num", worker_num)
 
-                worker.setup()
-                signal.signal(signal.SIGTERM, signal_handler)
-                signal.signal(signal.SIGINT, signal_handler)
-                signal.signal(signal.SIGUSR1, signal_handler)
-                worker.ENABLE_TIMEOUTS = True
-                worker.start()
+                    worker.setup()
+                    signal.signal(signal.SIGTERM, signal_handler)
+                    signal.signal(signal.SIGINT, signal_handler)
+                    signal.signal(signal.SIGUSR1, signal_handler)
+                    worker.ENABLE_TIMEOUTS = True
+                    worker.start()
 
 
 class Threaded_worker(threading.Thread):
-    def __init__(self, queue_name: str) -> None:
+    def __init__(self, queue_name: str, logger: logging.Logger) -> None:
         threading.Thread.__init__(self)
-        self.worker = get_worker(queue_name)
+        self.logger = logger
+        self.queue_name = queue_name
+
+        with log_and_exit_if_exception(logger, queue_name, threaded=True):
+            self.worker = get_worker(queue_name)
 
     def run(self) -> None:
-        with configure_scope() as scope:
+        with configure_scope() as scope, log_and_exit_if_exception(
+            self.logger, self.queue_name, threaded=True
+        ):
             scope.set_tag("queue_worker", self.worker.queue_name)
             self.worker.setup()
             logging.debug("starting consuming " + self.worker.queue_name)


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/9-issues/topic/.E2.9C.94.20'Last.20active'.20not.20worked/near/1275878

Unhandled exceptions propagating to process_queue were not caught there,
causing improper logging - errors didn't land in errors.log as expected.
Exceptions should be caught and explicitly logged by the process_queue
logger.

Furthermore, in multi-threaded mode we want the autoreload mechanism to
be working - which it doesn't without catching the exceptions. The
correct approach is to - again - catch the exception, log it and then
send SIGUSR1 signal to trigger exit and autoreload.

Tested by modifying a worker to throw an exception at the start and then running `process_queue --queue_name X` (single-process mode) and `process_queue --multi_threaded X` (thread mode) in dev environment and verifying that the traceback gets logged by the `process_queue` logger and lands in `errors.log` as expected.