### PR TITLE
frontend performance: Recent topics to stream renarrows.

### DIFF
--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -17,7 +17,6 @@ import * as message_view_header from "./message_view_header";
 import * as muted_topics from "./muted_topics";
 import * as narrow from "./narrow";
 import * as narrow_state from "./narrow_state";
-import * as navbar_alerts from "./navbar_alerts";
 import * as navigate from "./navigate";
 import * as people from "./people";
 import * as recent_senders from "./recent_senders";
@@ -684,9 +683,8 @@ export function hide() {
     // before it completely re-rerenders.
     message_view_header.render_title_area();
 
-    // Fixes misaligned message_view and hidden
-    // floating_recipient_bar.
-    navbar_alerts.resize_app();
+    // Fire our custom event
+    $("#message_feed_container").trigger("message_feed_shown");
 
     // This makes sure user lands on the selected message
     // and not always at the top of the narrow.

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -8,6 +8,7 @@ import * as message_viewport from "./message_viewport";
 import * as navbar_alerts from "./navbar_alerts";
 import * as navigate from "./navigate";
 import * as popovers from "./popovers";
+import * as recent_topics_util from "./recent_topics_util";
 import * as ui from "./ui";
 import {user_settings} from "./user_settings";
 import * as util from "./util";
@@ -282,5 +283,30 @@ export function handler() {
         }
 
         navigate.scroll_to_selected();
+    }
+}
+
+export function initialize() {
+    // Hack: If the app is loaded directly to recent topics, then we
+    // need to arrange to call navbar_alerts.resize_app when we first
+    // visit a message list. This is a workaround for bugs where the
+    // floating recipient bar will be invisible (as well as other
+    // alignment issues) when they are initially rendered in the
+    // background because recent topics is displayed.
+
+    if (recent_topics_util.is_visible()) {
+        // We bind the handler for the message_feed_container shown event, such
+        // that it will only get executed once.
+        //
+        // The selector here is based on #gear-menu, to take advantage
+        // of the Bootstrap the 'show' event handler on that legacy
+        // data-toggle element.
+        $('#gear-menu a[data-toggle="tab"][href="#message_feed_container"]').one("show", () => {
+            // We use a requestAnimationFrame here to prevent this call from
+            // causing a forced reflow.
+            window.requestAnimationFrame(() => {
+                navbar_alerts.resize_app();
+            });
+        });
     }
 }

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -658,6 +658,8 @@ export function initialize_everything() {
 
     // All overlays must be initialized before hashchange.js
     hashchange.initialize();
+    resize.initialize();
+
     unread_ui.initialize();
     activity.initialize();
     emoji_picker.initialize();


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
We had received a complaint on chat.zulip.org [#feedback > pressing n is slow](https://chat.zulip.org/#narrow/stream/137-feedback/topic/pressing.20n.20is.20slow) about navigation with
the keyboard `n` key being significantly slow (~5 seconds), the first
time `n` was pressed when starting from the recent topics view.

It was difficult to reproduce the amount of lag that was reported, but
running chrome with the profile tab set to 4x slowdown helped get
close to it.

Based on profiling from the original report, as well as locally with
chrome set to 4x slowdown, led to the realization that recent topics
to stream navigation involved a lot of dom thrashing, and so this
series of commits aims to prevent this path from causing forced
reflows.
<details>
<summary>
Profiling data
</summary>

## Profiling data:
### Generation process:
#### one time unreads setup
1) Start server, open chrome page to zulip dev, login as Iago.
2) Send 1 message in # ビデオゲーム.
3) Send 1 message in # 조리법 😎.
4) Logout, login as Cordelia, do not read the unread messages.

#### taking samples
1) Checkout to desired commit.
2) Start server, open chrome new tab, open profiler.
3) Separate the profiler dock to its own window. (This is important to ensure that all profiles are run on the same viewport dimensions.)
4) navigate page to zulip dev, this should log you in as Cordelia and open the recent topics view.
5) Set profiler to 4x slow down. (This is only really necessary if your machine is fast enough that we need to exaggerate the values.)
6) Start recording the profile.
7) Click Support in stream list.
8) Click Recent Topics in top left corner.
9) Repeat (7) and (8) two more times, to have one initial sample and two subsequent samples.

### main:
1) 2.39 s (screenshot)
2) 832.80 ms
3) 815.04 ms

### first commit:
1) 2.57 s (screenshot)
2) 879.65 ms
3) 764.52 ms

### second commit:
1) 2.57 s (screenshot)
2) 787.05 ms
3) 771.08 ms

### third commit:
1) 2.69 s (screenshot)
2) 814.88 ms
3) 746.61 ms

### fourth commit:
1) 970.82 ms (screenshot)
2) 648.25 ms
3) 676.63 ms

Here's a Zip with all of the profiles, which can be loaded into the chrome profiler for inspection:
[Profiling data.zip](https://github.com/zulip/zulip/files/7538738/Profiling.data.zip)

**Profile screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

### main:
![profile-on-main](https://user-images.githubusercontent.com/33805964/141783752-2be8b593-cbfc-4b1b-983a-fa5c7edafb0b.JPG)

### first commit:
![profile-after-first-commit](https://user-images.githubusercontent.com/33805964/141783756-d81a48ec-2740-4571-a075-54631ad0ff36.JPG)

### second commit:
![profile-after-second-commit](https://user-images.githubusercontent.com/33805964/141783759-2c72c9d4-6c8f-4261-8cbb-9a58a5331abb.JPG)

### third commit:
![profile-after-third-commit](https://user-images.githubusercontent.com/33805964/141783747-86557c4a-dd71-4771-9aba-01aaf4ba51cf.JPG)

### fourth commit:
![profile-after-forth-commit](https://user-images.githubusercontent.com/33805964/141783757-96dccc91-cbac-42db-9b79-f502e550a923.JPG)


Finally, testing the "n" hotkey at **6x slowdown**:
before (ie main):
![image](https://user-images.githubusercontent.com/33805964/141784562-6d19e0d0-51f7-4b17-b478-80f7f133ed11.png)
after (ie fourth commit)
![image](https://user-images.githubusercontent.com/33805964/141785188-d833d8a0-08f5-4cc5-a4ef-65d5e034ab79.png)
ie
before: 4.44 s
after: 1.04 s
[profiles at 6x slowdown.zip](https://github.com/zulip/zulip/files/7538752/profiles.at.6x.slowdown.zip)
</details>