### PR TITLE
test_script: Reword provision warning not to assume running tests.

### DIFF
--- a/tools/lib/test_script.py
+++ b/tools/lib/test_script.py
@@ -22,10 +22,11 @@ def get_version_file() -> str:
 
 
 PREAMBLE = """
-Before we run tests, we make sure your provisioning version
-is correct by looking at var/provision_version, which is at
-version {}, and we compare it to the version in source
-control (version.py), which is {}.
+Provisioning state check failed! This check compares
+`var/provision_version` (currently {}) to the version in
+source control (`version.py`), which is {}, to see if you
+likely need to provision before this command can run
+properly.
 """
 
 
@@ -36,18 +37,18 @@ def preamble(version: str) -> str:
 
 
 NEED_TO_DOWNGRADE = """
-It looks like you checked out a branch that expects an older
-version of dependencies than the version you provisioned last.
-This may be ok, but it's likely that you either want to rebase
-your branch on top of upstream/main or re-provision your VM.
+The branch you are currently on expects an older version of
+dependencies than the version you provisioned last. This may
+be ok, but it's likely that you either want to rebase your
+branch on top of upstream/main or re-provision your machine.
 
 Do this: `./tools/provision`
 """
 
 NEED_TO_UPGRADE = """
-It looks like you checked out a branch that has added
-dependencies beyond what you last provisioned. Your command
-is likely to fail until you add dependencies by provisioning.
+The branch you are currently on has added dependencies beyond
+what you last provisioned. Your command is likely to fail
+until you add dependencies by provisioning.
 
 Do this: `./tools/provision`
 """


### PR DESCRIPTION
Previously, running `./tools/run-dev.py` when provision was required
would lead to a warning along the lines of:

```
Before we run tests, we make sure your provisioning version
is correct by looking at var/provision_version, which is at
version 165.1, and we compare it to the version in source
control (version.py), which is 165.2.

It looks like you checked out a branch that has added
dependencies beyond what you last provisioned. Your command
is likely to fail until you add dependencies by provisioning.

Do this: `./tools/provision`

If you really know what you are doing, use --skip-provision-check to
run anyway.
```

The assumption that we're trying to run tests might cause some
confusion, especially if its the first time you're seeing the
provision warning.

Removing the second paragraph implies losing the info about whether
we're ahead or behind, but that could come through from the provision
version. It's also possible that we didn't checkout a different
branch, but eg just rebased with upstream. We might also not be on a
VM.

The warning you'd get after this commit would be along the lines of:
```
Provisioning state check failed! This check compares
`var/provision_version` (currently 165.2) to the version in
source control (`version.py`), which is 164.6, to see if you
likely need to provision before this command can run
properly. This command is likely to keep failing until you
provision.

Do this: `./tools/provision`

If you really know what you are doing, use --skip-provision-check to
run anyway.
```
