### PR TITLE
todo_widget: Disable /todo add task button if duplicate task name or no task name.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -185,4 +185,18 @@ export function initialize() {
             instance.destroy();
         },
     });
+
+    delegate("body", {
+        target: ".add-task-wrapper",
+        onShow(instance) {
+            // Handle dynamic text for todo widget add task button.
+            const elem = $(instance.reference);
+            const content = elem.attr("data-tippy-content");
+            if (content === undefined) {
+                return false;
+            }
+            instance.setContent(content);
+            return true;
+        },
+    });
 }

--- a/static/styles/widgets.css
+++ b/static/styles/widgets.css
@@ -114,6 +114,14 @@ button {
         &:hover {
             border-color: hsl(0, 0%, 60%);
         }
+
+        &:disabled {
+            position: relative;
+            z-index: -1;
+            filter: saturate(0);
+            background-color: hsl(0, 0%, 93%);
+            color: hsl(0, 3%, 52%);
+        }
     }
 }
 
@@ -166,4 +174,21 @@ button {
 
 .current-user-vote {
     background-color: hsla(156, 10%, 90%, 0.9);
+}
+
+.add-task-wrapper {
+    display: inline;
+    position: relative;
+    z-index: 1;
+
+    &:hover {
+        cursor: not-allowed;
+
+        .add-task:disabled {
+            cursor: not-allowed;
+            background-color: hsl(0, 0%, 93%);
+            color: hsl(156, 39%, 54%);
+            border-color: hsl(156, 39%, 77%);
+        }
+    }
 }

--- a/static/templates/widgets/todo_widget.hbs
+++ b/static/templates/widgets/todo_widget.hbs
@@ -3,7 +3,9 @@
     <div class="add-task-bar">
         <input type="text" class="add-task" placeholder="{{t 'New task'}}" />
         <input type="text" class="add-desc" placeholder="{{t 'Description'}}" />
-        <button class="add-task">{{t "Add task" }}</button>
+        <div class="add-task-wrapper">
+            <button class="add-task">{{t "Add task" }}</button>
+        </div>
         <div class="widget-error"></div>
     </div>
     <ul class="todo-widget">


### PR DESCRIPTION
This PR fixes https://github.com/zulip/zulip/issues/20211.

**Testing plan:**
Visual testing by trying to interact with add task button with no task name present and checking that it does get disabled with tooltip. Visual testing with duplicate task name and interacting with button to see that it is disabled with tooltip.

**GIFs or screenshots:** 
GIF of no task name present.
https://user-images.githubusercontent.com/36671046/143097792-34c83b54-6f1b-4858-a63b-16a05644a3cd.mp4

GIF of duplicate task name.
https://user-images.githubusercontent.com/36671046/143097808-ad01c77a-5017-4ed2-82e9-5016eb821d8c.mp4
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->