### PR TITLE
portico: Set background color to white.

### DIFF
--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -5,7 +5,7 @@ html {
 
 body {
     margin: 0;
-    background-color: hsl(0, 0%, 100%);
+    background-color: hsl(0, 0%, 100%) !important;
     color: hsl(0, 0%, 27%);
     line-height: normal;
 


### PR DESCRIPTION
There is no reason to have background color gray. Also, a page
can have either `white` (from `landing_page.css`) or `gray`
(from `portico.css`) background color depending on
webpack chunking order.  So, this fixes that bug.

Discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/.2Ffor.2FX.20background.20in.20Firefox