### PR TITLE
micromodal cancel buttons #20209

### DIFF
--- a/static/styles/modal.css
+++ b/static/styles/modal.css
@@ -141,6 +141,8 @@
 .dialog_submit_button {
     margin-left: 12px;
     background-color: hsl(214, 100%, 31%);
+    outline: 1px solid transparent;
+    padding: 9px 20px;
     color: hsl(0, 0%, 100%) !important;
 }
 


### PR DESCRIPTION
https://github.com/zulip/zulip/issues/20209

I added padding and an outline to make the two buttons similar in size. 
![cropped-screenshot-modal](https://user-images.githubusercontent.com/79210550/142009823-65d29c27-99ee-42fa-bca0-79bb104c1b1a.png)






