### PR TITLE
puppet: Swap the one use of the `cron` resource for an /etc/cron.d file.

### DIFF
--- a/puppet/zulip/files/cron.d/pg-backup-and-purge
+++ b/puppet/zulip/files/cron.d/pg-backup-and-purge
@@ -1,0 +1,3 @@
+PATH=/bin:/usr/bin:/usr/local/bin
+
+0 2 * * * postgres /usr/local/bin/pg_backup_and_purge

--- a/puppet/zulip/manifests/postgresql_backups.pp
+++ b/puppet/zulip/manifests/postgresql_backups.pp
@@ -12,8 +12,9 @@ class zulip::postgresql_backups {
     },
   }
   file { '/usr/local/bin/wal-g':
-    ensure => 'link',
-    target => "/usr/local/bin/wal-g-${wal_g_version}",
+    ensure  => 'link',
+    target  => "/usr/local/bin/wal-g-${wal_g_version}",
+    require => Zulip::Sha256_tarball_to['wal-g'],
   }
   file { '/usr/local/bin/env-wal-g':
     ensure  => file,
@@ -21,7 +22,10 @@ class zulip::postgresql_backups {
     group   => 'postgres',
     mode    => '0750',
     source  => 'puppet:///modules/zulip/postgresql/env-wal-g',
-    require => Package[$zulip::postgresql_common::postgresql],
+    require => [
+      Package[$zulip::postgresql_common::postgresql],
+      File['/usr/local/bin/wal-g'],
+    ],
   }
 
   file { '/usr/local/bin/pg_backup_and_purge':


### PR DESCRIPTION
The `cron` resource places its contents in the user's crontab, which
makes it unlike every other cron job that Zulip installs.

Switch to using `/etc/cron.d` files, like all other cron jobs.

**Testing plan:** Test-applied on a host.
