### PR TITLE
streams: Hide fake emails in stream creation form.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -151,18 +151,21 @@ const steven = {
 
 const alice1 = {
     email: "alice1@example.com",
+    delivery_email: "alice1-delivery@example.com",
     user_id: 202,
     full_name: "Alice",
 };
 
 const bob = {
     email: "bob@example.com",
+    delivery_email: "bob-delivery@example.com",
     user_id: 203,
     full_name: "Bob van Roberts",
 };
 
 const alice2 = {
     email: "alice2@example.com",
+    delivery_email: "alice2-delivery@example.com",
     user_id: 204,
     full_name: "Alice",
 };
@@ -556,15 +559,51 @@ test_people("get_people_for_stream_create", () => {
     people.add_active_user(bob);
     people.add_active_user(alice2);
     assert.equal(people.get_active_human_count(), 4);
+    page_params.is_admin = true;
+    page_params.realm_email_address_visibility = admins_only;
 
-    const others = people.get_people_for_stream_create();
-    const expected = [
+    let others = people.get_people_for_stream_create();
+    let expected = [
+        {
+            email: "alice1-delivery@example.com",
+            user_id: alice1.user_id,
+            full_name: "Alice",
+            checked: false,
+            disabled: false,
+            show_email: true,
+        },
+        {
+            email: "alice2-delivery@example.com",
+            user_id: alice2.user_id,
+            full_name: "Alice",
+            checked: false,
+            disabled: false,
+            show_email: true,
+        },
+        {
+            email: "bob-delivery@example.com",
+            user_id: bob.user_id,
+            full_name: "Bob van Roberts",
+            checked: false,
+            disabled: false,
+            show_email: true,
+        },
+    ];
+    assert.deepEqual(others, expected);
+
+    page_params.is_admin = false;
+    alice1.delivery_email = undefined;
+    alice2.delivery_email = undefined;
+    bob.delivery_email = undefined;
+    others = people.get_people_for_stream_create();
+    expected = [
         {
             email: "alice1@example.com",
             user_id: alice1.user_id,
             full_name: "Alice",
             checked: false,
             disabled: false,
+            show_email: false,
         },
         {
             email: "alice2@example.com",
@@ -572,6 +611,7 @@ test_people("get_people_for_stream_create", () => {
             full_name: "Alice",
             checked: false,
             disabled: false,
+            show_email: false,
         },
         {
             email: "bob@example.com",
@@ -579,6 +619,7 @@ test_people("get_people_for_stream_create", () => {
             full_name: "Bob van Roberts",
             checked: false,
             disabled: false,
+            show_email: false,
         },
     ];
     assert.deepEqual(others, expected);

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -1069,7 +1069,8 @@ export function get_people_for_stream_create() {
     for (const person of active_user_dict.values()) {
         if (!is_my_user_id(person.user_id)) {
             people_minus_you.push({
-                email: person.email,
+                email: get_visible_email(person),
+                show_email: settings_data.show_email(),
                 user_id: person.user_id,
                 full_name: person.full_name,
                 checked: false,

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -13,6 +13,7 @@ import * as loading from "./loading";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as people from "./people";
+import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
 import * as stream_settings_data from "./stream_settings_data";
 import * as stream_settings_ui from "./stream_settings_ui";
@@ -312,7 +313,8 @@ export function show_new_stream_modal() {
     // Add current user on top of list
     const current_user = people.get_by_user_id(page_params.user_id);
     all_users.unshift({
-        email: current_user.email,
+        show_email: settings_data.show_email(),
+        email: people.get_visible_email(current_user),
         user_id: current_user.user_id,
         full_name: current_user.full_name,
         checked: true,

--- a/static/templates/new_stream_user.hbs
+++ b/static/templates/new_stream_user.hbs
@@ -1,5 +1,5 @@
 <label class="checkbox add-user-label" id="user_checkbox_{{user_id}}">
     <input type="checkbox" name="user" {{#if checked}}checked="checked"{{#if disabled}} disabled="disabled"{{/if}}{{/if}} data-user-id="{{user_id}}"/>
     <span></span>
-    {{full_name}} ({{email}})
+    {{full_name}} {{#if show_email}}({{email}}){{else}}({{#tr}}User ID: {user_id}; <em>email hidden</em>{{/tr}}){{/if}}
 </label>

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -165,6 +165,8 @@ IGNORED_PHRASES = [
     # Used in our case studies
     r"Technical University of Munich",
     r"University of California San Diego",
+    # Used in stream creation form
+    r"email hidden",
 ]
 
 # Sort regexes in descending order of their lengths. As a result, the


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR hides fake emails in stream creation form and instead shows user-ids.
<!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2021-11-17 13-15-31](https://user-images.githubusercontent.com/35494118/142157583-00b777df-1a9b-4052-9258-3e7e5807b576.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
