### PR TITLE
nagios: `pg_is_in_recovery()` is better to know replica/primary status.

### DIFF
--- a/puppet/zulip/files/nagios_plugins/zulip_postgresql/check_postgresql_replication_lag
+++ b/puppet/zulip/files/nagios_plugins/zulip_postgresql/check_postgresql_replication_lag
@@ -76,27 +76,30 @@ def loc_to_abs_offset(loc_str: str) -> int:
     return 0xFF000000 * int(xlog_file, 16) + int(file_offset, 16)
 
 
-replication_info = run_sql_query(
-    "sender_host, status, pg_last_wal_replay_lsn(), pg_last_wal_receive_lsn()"
-    " from pg_stat_wal_receiver"
-)
+is_in_recovery = run_sql_query("pg_is_in_recovery()")
 
-if replication_info:
-    (primary_server, state, replay_loc, recv_loc) = replication_info[0]
-
-    recv_offset = loc_to_abs_offset(recv_loc)
-    replay_lag = recv_offset - loc_to_abs_offset(replay_loc)
-
-    if state != "streaming":
-        report("CRITICAL", f"replica is in state {state}, not streaming")
-
-    msg = f"replica is {replay_lag} bytes behind in replay of WAL logs from {primary_server}"
-    if replay_lag > 5 * 16 * 1024 ** 2:
-        report("CRITICAL", msg)
-    elif replay_lag > 16 * 1024 ** 2:
-        report("WARNING", msg)
+if is_in_recovery[0][0] == "t":
+    replication_info = run_sql_query(
+        "sender_host, status, pg_last_wal_replay_lsn(), pg_last_wal_receive_lsn()"
+        " from pg_stat_wal_receiver"
+    )
+    if not replication_info:
+        report("CRITICAL", "Replaying WAL logs from backups")
     else:
-        report("OK", msg)
+        (primary_server, state, replay_loc, recv_loc) = replication_info[0]
+        recv_offset = loc_to_abs_offset(recv_loc)
+        replay_lag = recv_offset - loc_to_abs_offset(replay_loc)
+
+        if state != "streaming":
+            report("CRITICAL", f"replica is in state {state}, not streaming")
+
+        msg = f"replica is {replay_lag} bytes behind in replay of WAL logs from {primary_server}"
+        if replay_lag > 5 * 16 * 1024 ** 2:
+            report("CRITICAL", msg)
+        elif replay_lag > 16 * 1024 ** 2:
+            report("WARNING", msg)
+        else:
+            report("OK", msg)
 
 else:
     replication_info = run_sql_query(


### PR DESCRIPTION
It is possible to be in recovery, and downloading WAL logs from
archives, and not yet be replicating.  If one only checks the
streaming log status, it reports as "no replicas" which is technically
accurate but not a useful summation of the state of the replica.

**Testing plan:** Tested with such a replica.
