### PR TITLE
hashchange: Update spectator hash when hash changed internally. 

### DIFF
--- a/static/js/browser_history.js
+++ b/static/js/browser_history.js
@@ -30,6 +30,15 @@ export function set_hash_before_overlay(hash) {
     state.hash_before_overlay = hash;
 }
 
+export function update_web_public_hash(hash) {
+    // Returns true if hash is web public compatible.
+    if (hash_util.is_spectator_compatible(hash)) {
+        state.spectator_old_hash = hash;
+        return true;
+    }
+    return false;
+}
+
 export function save_old_hash() {
     state.old_hash = window.location.hash;
 

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -315,14 +315,9 @@ function do_hashchange_overlay(old_hash) {
 function hashchanged(from_reload, e) {
     const current_hash = window.location.hash;
     const old_hash = e && (e.oldURL ? new URL(e.oldURL).hash : browser_history.old_hash());
+    const is_hash_web_public_compatible = browser_history.update_web_public_hash(current_hash);
 
     const was_internal_change = browser_history.save_old_hash();
-
-    const is_hash_web_public_compatible = hash_util.is_spectator_compatible(current_hash);
-    if (is_hash_web_public_compatible) {
-        browser_history.state.spectator_old_hash = current_hash;
-    }
-
     if (was_internal_change) {
         return undefined;
     }

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -54,6 +54,7 @@ function set_hash(hash) {
     if (history.pushState) {
         const url = get_full_url(hash);
         history.pushState(null, null, url);
+        browser_history.update_web_public_hash(hash);
     } else {
         blueslip.warn("browser does not support pushState");
         window.location.hash = hash;

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -349,17 +349,6 @@ function hashchanged(from_reload, e) {
     return ret;
 }
 
-export function replace_hash(hash) {
-    if (!window.history.replaceState) {
-        // We may have strange behavior with the back button.
-        blueslip.warn("browser does not support replaceState");
-        return;
-    }
-
-    const url = get_full_url(hash);
-    window.history.replaceState(null, null, url);
-}
-
 export function initialize() {
     $(window).on("hashchange", (e) => {
         hashchanged(false, e.originalEvent);


### PR DESCRIPTION
Since some narrow changes (using replaceState) don't call hashchanged, we have to
update spectator hash manually.