### PR TITLE
api_documentation: Display `null` data type if potential value.

### DIFF
--- a/zerver/lib/markdown/api_arguments_table_generator.py
+++ b/zerver/lib/markdown/api_arguments_table_generator.py
@@ -191,4 +191,6 @@ def generate_data_type(schema: Mapping[str, Any]) -> str:
         data_type = "(" + generate_data_type(schema["items"]) + ")[]"
     else:
         data_type = schema["type"]
+        if "nullable" in schema and schema["nullable"]:
+            data_type = data_type + " | null"
     return data_type


### PR DESCRIPTION
If null is a potential value of data type for a return value or parameter in the API endpoint, then it is rendered as an option as discussed [here in CZO](https://chat.zulip.org/#narrow/stream/378-api-design/topic/.22type.22.20annotations.20and.20.60null.60).

This currently relies on the 'nullable' setting in the OpenAPI spec that [was removed in the 3.1.0 release](https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0). If/when the OpenAPI version is updated for Zulip, then how the `data_type` for parameters and return values is rendered will need to be reworked.

**Testing plan:** Manually went through the API docs in the dev environment on the branch with the change and ran a command line diff against any html that had 'null' in the page = 11 comparisons (see link to diff on pastebin). 

Since the change added 'null' as new content, I didn't run a diff against pages where it did not appear. I also didn't run a diff against the `get-drafts` page because the null text appears in the description text and not in the return value type. I did do a visual check to make sure that there were no additions of 'null' text to that page.

[Diff of changes in html rendered pages](https://pastebin.com/BGEhrBbj)

I believe the diffs do show one endpoint that is inaccurate regarding the null value, `update-subscription-settings`. It is listed as an option for a return value in the description text, but then it is not recorded as `nullable: true` in the documentation. This is why the diff has no changes even though 'null' appears on the page.

**Screenshots**:
![Screenshot from 2021-11-17 15-26-44](https://user-images.githubusercontent.com/63245456/142219226-f6d85a12-df31-4b25-bba9-8c413d27d2ff.png)
![Screenshot from 2021-11-17 15-27-55](https://user-images.githubusercontent.com/63245456/142219233-f8cdcce7-8419-454e-8f87-18898e89f131.png)

