### PR TITLE
tools: Run node_tests with coverage in parallel through node.js.

### DIFF
--- a/frontend_tests/node_tests/example2.js
+++ b/frontend_tests/node_tests/example2.js
@@ -67,6 +67,9 @@ run_test("message_store", () => {
     message_store.set_message_booleans(in_message);
     assert.equal(in_message.alerted, true);
 
+    const failure = false;
+    assert.ok(failure);
+
     // Let's add a message into our message_store via
     // message_helper.process_new_message.
     assert.equal(message_store.get(in_message.id), undefined);

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -37,11 +37,8 @@ function immediate(f) {
     return () => f();
 }
 
-// Find the files we need to run.
+// Find the files we need to run (argv[0] is node command, argv[1] is this file).
 const files = process.argv.slice(2);
-if (files.length === 0) {
-    throw new Error("No tests found");
-}
 
 // Set up our namespace helpers.
 const window = new Proxy(global, {

--- a/frontend_tests/zjsunit/parallel_runner.js
+++ b/frontend_tests/zjsunit/parallel_runner.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const child_process = require("child_process");
+
+const parallel = process.argv[2];
+
+// Find the files we need to run.
+const files = process.argv.slice(3);
+if (files.length === 0) {
+    throw new Error("No tests found");
+}
+
+const index = require.resolve("./index");
+
+function create_file_groups(files, parallel) {
+    const group_size = Math.ceil(files.length / parallel);
+    const file_groups = [];
+    for (let i = 0; i < parallel; i += 1) {
+        const file_group = files.slice(i * group_size, (i + 1) * group_size);
+        // never generate an empty group or send it to a forked process.
+        if (file_group.length > 0) {
+            file_groups.push(file_group);
+        }
+    }
+    return file_groups;
+}
+
+const file_groups = create_file_groups(files, parallel);
+
+for (const file_group of file_groups) {
+    const worker_process = child_process.fork(index, file_group, {stdio: "inherit"});
+    worker_process.on("error", (error) => {
+        console.error(error);
+        // if we fail to create a child processes, send a non zero
+        // return code, so that we don't check coverage
+        process.exitCode = 2;
+    });
+    worker_process.on("exit", (code) => {
+        if (code === undefined || code !== 0) {
+            // if any worker_process ends without running all its test
+            // files eg due to an error, send a non zero return code,
+            // so that we don't check coverage
+            process.exitCode = 1;
+        }
+    });
+}

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -20,7 +20,7 @@ sanity_check.check_venv(__file__)
 import orjson
 from zulint.printer import BOLDRED, CYAN, ENDC, GREEN
 
-INDEX_JS = os.path.join(ROOT_DIR, "frontend_tests/zjsunit/index.js")
+PARALLEL_RUNNER_JS = os.path.join(ROOT_DIR, "frontend_tests/zjsunit/parallel_runner.js")
 NODE_COVERAGE_PATH = os.path.join(ROOT_DIR, "var/node-coverage/coverage-final.json")
 
 # Ideally, we wouldn't need this line, but it seems to be required to
@@ -223,12 +223,6 @@ options = parser.parse_args()
 individual_files = options.args
 parallel = options.parallel
 
-if options.coverage and parallel > 1:
-    parallel = 1
-    print(
-        BOLDRED + "You cannot use --coverage with parallel tests. Running in serial mode.\n" + ENDC
-    )
-
 assert_provisioning_status_ok(options.skip_provision_check)
 
 
@@ -281,11 +275,11 @@ def run_tests_via_node_js() -> int:
     os.environ["TZ"] = "UTC"
 
     # The index.js test runner is the real "driver" here, and we launch
-    # with either nyc or node, depending on whether we want coverage
-    # reports.  Running under nyc is slower and creates funny
-    # tracebacks, so you generally want to get coverage reports only
-    # after making sure tests will pass.
-    node_tests_cmd = ["node", "--stack-trace-limit=100", INDEX_JS]
+    # with either nyc or node, via parallel_runner.js, depending on
+    # whether we want coverage reports.  Running under nyc is slower and
+    # creates funny tracebacks, so you generally want to get coverage
+    # reports only after making sure tests will pass.
+    node_tests_cmd = ["node", "--stack-trace-limit=100", PARALLEL_RUNNER_JS]
     if individual_files:
         # If we passed a specific set of tests, run in serial mode.
         global parallel
@@ -300,17 +294,9 @@ def run_tests_via_node_js() -> int:
 
     # If we got this far, we can run the tests!
     ret = 0
-    if parallel > 1:
-        sub_tests = [test_files[i::parallel] for i in range(parallel)]
-        parallel_processes = [subprocess.Popen(node_tests_cmd + sub_test) for sub_test in sub_tests]
-
-        for process in parallel_processes:
-            status_code = process.wait()
-            if status_code != 0:
-                ret = status_code
-        return ret
-
+    node_tests_cmd += str(parallel)
     node_tests_cmd += test_files
+
     if options.coverage:
         coverage_dir = os.path.join(ROOT_DIR, "var/node-coverage")
 
@@ -322,7 +308,8 @@ def run_tests_via_node_js() -> int:
         command += node_tests_cmd
     else:
         # Normal testing, no coverage analysis.
-        # Run the index.js test runner, which runs all the other tests.
+        # Run the index.js test runner, via parallel_runner.js,
+        # which runs all the other tests.
         command = node_tests_cmd
 
     try:


### PR DESCRIPTION
This PR is intended to supersede #20150.

Previously, we'd force node tests to run in serial mode. One might
think this is because it's not possible to consolidate coverage from
multiple runs, but nyc actually does this by default!

The default behaviour to merge multiple runs depended on using the
`--no-clean` argument, but given that there is no explicit guarantee
given in nyc documentation that `--no-clean` is safe to run in
parallel (ie would not suffer from eg concurrent write errors), and
realizing that the alternative (generating coverage from all parallel
runs in a separate folder and use `nyc merge` to combine them into a
single `coverage-final.json`) would be expensive to maintain, and also
be unable to leverage any of nyc's builtin optimizations for
instrumentation with parallel test runners (if any).
(The fact that nyc can handle child_processes is one of its main
differences from istanbul.js.)

Hence, in this commit, we reimplement parallelization for node tests
through node (this was previously through python) and make changes
that enable us to run node tests with coverage, in parallel.

An unintended benefit of this change is that stopping node tests via
keyboard interrupt (ctrl-C) now properly exits and ends all parallel
runners, where as previously they would continue to run (and print to
the terminal). This was only a minor nuisance as the tests would run
fast and end quickly anyway.

The net difference from this commit as measured by bash `time` when
node tests are run with coverage is:
real: ~ -14.486s
user: ~ +55.337s
sys: ~ +1.917s
(Lower values are better).

The net difference from this commit as measured by bash `time` when
node tests are run without coverage is:
real: ~ -0.7s
user: ~ -1.239s
sys: ~ +0.096s
(Lower values are better).

**Testing plan:** <!-- How have you tested? -->
I have verified that if say I change:
```diff
diff --git a/frontend_tests/node_tests/activity.js b/frontend_tests/node_tests/activity.js
index 6c2b5b04de..9cdcf26884 100644
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -208,7 +208,7 @@ test("presence_list_full_update", ({override, mock_template}) => {
     override(padded_widget, "update_padding", () => {});
 
     mock_template("user_presence_rows.hbs", false, (data) => {
-        assert.equal(data.users.length, 7);
+        assert.equal(data.users.length, 200);
         assert.equal(data.users[0].user_id, me.user_id);
     });
```

Tests fail with the following output:
```bash
(zulip-py3-venv) re@DESKTOP-4C9KNPD:~/zulip$ ./tools/test-js-with-node --coverage
Starting node tests...
running test example2
running test stream_data
running test activity
running test navbar_alerts
running test notifications
running test stream_edit
running test example3
running test password
running test peer_data
running test example4
--------------------------------------------------
test failed: /home/re/zulip/frontend_tests/node_tests/activity.js > presence_list_full_update

AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

7 !== 200

    at /home/re/zulip/frontend_tests/node_tests/activity.js:10:910
    at render (/home/re/zulip/frontend_tests/zjsunit/namespace.js:42:237)
    at BuddyList.items_to_html (/home/re/zulip/static/js/buddy_list.js:2:12205)
    at BuddyList.render_more (/home/re/zulip/static/js/buddy_list.js:9:696)
    at BuddyList.<anonymous> (/home/re/zulip/frontend_tests/node_tests/activity.js:6:119)
    at BuddyList.new_f [as fill_screen_with_content] (/home/re/zulip/frontend_tests/zjsunit/namespace.js:95:773)
    at BuddyList.populate (/home/re/zulip/static/js/buddy_list.js:9:76)
    at /home/re/zulip/static/js/activity.js:19:1461
    at Object.lib.measure_time (/home/re/zulip/frontend_tests/zjsunit/zblueslip.js:12:1088)
    at Object.build_user_sidebar (/home/re/zulip/static/js/activity.js:19:1343)
running test people

=============================== Coverage summary ===============================
Statements   : 25.98% ( 908/3494 )
Branches     : 15.62% ( 198/1267 )
Functions    : 22.82% ( 202/885 )
Lines        : 26.93% ( 888/3297 )
================================================================================

** Tests failed, PLEASE FIX! **
```

additionally, the coverage as reported by CI on this commit is:
https://github.com/zulip/zulip/runs/4241458795?check_suite_focus=true
![](https://user-images.githubusercontent.com/33805964/142288788-a9b6d002-e46d-4671-8566-c7a1af2f16d0.png)
which **is not the same** as the the coverage on main:
https://github.com/zulip/zulip/runs/4232577468?check_suite_focus=true
![](https://user-images.githubusercontent.com/33805964/142249415-669e6d23-1c3a-4869-9e12-4037abd11752.png)

But the difference is small and may just be due to adding `parallel_runner.js`?

**Profiling data** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Values of `real` time as received from time(./tools/test-js-with-node --coverage)
| Run | first | second | third |
| ---- | ---- | ---- | ---- |
| main | 0m40.388s | 0m39.819s | 0m39.565s |
| python | 0m29.334s | 0m27.078s | 0m26.452s |
| node | 0m25.381s | 0m26.159s | 0m24.773s |

Values of `real` time as received from time(./tools/test-js-with-node)
run | first | second | third
-- | -- | -- | --
python (main) | 6.297s | 6.571s | 6.623s
node | 5.916s | 5.83s | 5.644s

Here's an .md with the data collected: [data.md](https://github.com/zulip/zulip/files/7556624/data.md)