### PR TITLE
Fix black gradients on safari mobile.

### DIFF
--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -3984,7 +3984,7 @@ nav {
     .gradients .gradient.green {
         background: linear-gradient(
             -25deg,
-            transparent 10%,
+            hsla(156, 47%, 47%, 0) 10%,
             hsl(156, 47%, 47%) 80%
         );
     }
@@ -3992,7 +3992,7 @@ nav {
     .gradients .gradient.blue {
         background: linear-gradient(
             25deg,
-            transparent 10%,
+            hsla(196, 38%, 51%, 0) 10%,
             hsl(196, 38%, 51%) 80%
         );
     }
@@ -4000,7 +4000,7 @@ nav {
     .gradients .gradient.sunburst {
         background: linear-gradient(
             5deg,
-            transparent 20%,
+            hsla(49, 71%, 68%, 0) 20%,
             hsl(49, 71%, 68%) 80%
         );
     }

--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -410,6 +410,10 @@ nav {
 
     z-index: 2;
 
+    .gradients {
+        z-index: -1;
+    }
+
     section {
         max-width: 1440px;
         display: flex;
@@ -2636,10 +2640,6 @@ nav {
     left: 0;
     width: 100%;
     height: 1100px;
-
-    @media (width < 768px) {
-        height: 700px;
-    }
 }
 
 .gradients .gradient.dark-blue {
@@ -4003,6 +4003,10 @@ nav {
             transparent 20%,
             hsl(49, 71%, 68%) 80%
         );
+    }
+
+    .features-app .gradients .gradient {
+        height: 700px;
     }
 }
 

--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -7,9 +7,9 @@
 {% block portico_content %}
 
 {% include 'zerver/landing_nav.html' %}
-{% include 'zerver/gradients.html' %}
 
 <div class="portico-landing features-app">
+    {% include 'zerver/gradients.html' %}
     <section class="hero">
         <div class="copy">
             <h1>Powerful group chat.</h1>


### PR DESCRIPTION
before: 
<img width="564" alt="Screenshot 2021-11-17 at 11 17 16 PM" src="https://user-images.githubusercontent.com/25124304/142254368-c3c158ca-8dd3-489f-9dd3-9cc663d94ff4.png">
<img width="564" alt="Screenshot 2021-11-17 at 11 17 24 PM" src="https://user-images.githubusercontent.com/25124304/142254460-71efae8f-1a23-4e50-a820-066591cf8a69.png">
after:

<img width="564" alt="Screenshot 2021-11-17 at 11 17 42 PM" src="https://user-images.githubusercontent.com/25124304/142254541-2818cf00-0c13-4845-bfe2-eb061a3a32fd.png">
<img width="564" alt="Screenshot 2021-11-17 at 11 17 48 PM" src="https://user-images.githubusercontent.com/25124304/142254579-568c9cec-7ffe-4511-9d8a-23ebafaabac0.png">

