### PR TITLE
Install Smokescreen by default

### DIFF
--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -307,7 +307,7 @@ log][commit-log] for an up-to-date list of raw changes.
   major release.
 
 [docker-zulip-manual]: https://github.com/zulip/docker-zulip#manual-configuration
-[smokescreen]: ../production/deployment.html#using-an-outgoing-http-proxy
+[smokescreen]: ../production/deployment.html#customizing-the-outgoing-http-proxy
 [update-settings-docs]: ../production/upgrade-or-modify.html#updating-settings-py-inline-documentation
 
 #### Full feature changelog

--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -223,28 +223,14 @@ behind reverse proxies.
 
 [using-http]: ../production/deployment.html#configuring-zulip-to-allow-http
 
-## Using an outgoing HTTP proxy
+## Customizing the outgoing HTTP proxy
 
-Zulip supports routing all of its outgoing HTTP and HTTPS traffic
-through an HTTP `CONNECT` proxy, such as [Smokescreen][smokescreen];
-this includes outgoing webhooks, image and website previews, and
-mobile push notifications. You may wish to enable this feature to
-provide a consistent egress point, or enforce access control on URLs
-to prevent [SSRF][ssrf] against internal resources.
+To protect against [SSRF][ssrf], Zulip 4.8 and above default to
+routing all outgoing HTTP and HTTPS traffic through
+[Smokescreen][smokescreen], an HTTP `CONNECT` proxy; this includes
+outgoing webhooks, website previews, and mobile push notifications.
 
-To use Smokescreen:
-
-1. Add `, zulip::profile::smokescreen` to the list of `puppet_classes`
-   in `/etc/zulip/zulip.conf`. A typical value after this change is:
-
-   ```ini
-   puppet_classes = zulip::profile::standalone, zulip::profile::smokescreen
-   ```
-
-1. Optionally, configure the [smokescreen ACLs][smokescreen-acls]. By
-   default, Smokescreen denies access to all [non-public IP
-   addresses](https://en.wikipedia.org/wiki/Private_network), including
-   127.0.0.1.
+To use a custom outgoing proxy:
 
 1. Add the following block to `/etc/zulip/zulip.conf`, substituting in
    your proxy's hostname/IP and port:
@@ -255,19 +241,28 @@ To use Smokescreen:
    port = 4750
    ```
 
-1. If you intend to also make the Smokescreen install available to
-   other hosts, set `listen_address` in the same block. Note that you
-   must control access to the Smokescreen port if you do this, as
-   failing to do so opens a public HTTP proxy!
-
 1. As root, run
    `/home/zulip/deployments/current/scripts/zulip-puppet-apply`. This
-   will compile and install Smokescreen, reconfigure services to use
-   it, and restart Zulip.
+   will reconfigure and restart Zulip.
 
-If you would like to use an already-installed HTTP proxy, omit the
-first step, and adjust the IP address and port in the second step
-accordingly.
+If you have a deployment with multiple frontend servers, or wish to
+install Smokescreen on a separate host, you can apply the
+`zulip::profile::smokescreen` Puppet class on that host, and follow
+the above steps, setting the `[http_proxy]` block to point to that
+host.
+
+If you wish to disable the outgoing proxy entirely, follow the above
+steps, configuring an empty `host` value.
+
+Optionally, you can also configure the [Smokescreen ACL
+list][smokescreen-acls]. By default, Smokescreen denies access to all
+[non-public IP
+addresses](https://en.wikipedia.org/wiki/Private_network), including
+127.0.0.1, but allows traffic to all public Internet hosts.
+
+In Zulip 4.7 and older, to enable SSRF protection via Smokescreen, you
+will need to explicitly add the `zulip::profile::smokescreen` Puppet
+class, and configure the `[http_proxy]` block as above.
 
 [smokescreen]: https://github.com/stripe/smokescreen
 [smokescreen-acls]: https://github.com/stripe/smokescreen#acls
@@ -651,11 +646,13 @@ load balancers whose `X-Forwarded-For` should be respected.
 #### `host`
 
 The hostname or IP address of an [outgoing HTTP `CONNECT`
-proxy](#using-an-outgoing-http-proxy).
+proxy](#customizing-the-outgoing-http-proxy). Defaults to `localhost`
+if unspecified.
 
 #### `port`
 
 The TCP port of the HTTP `CONNECT` proxy on the host specified above.
+Defaults to `4750` if unspecified.
 
 #### `listen_address`
 

--- a/docs/production/mobile-push-notifications.md
+++ b/docs/production/mobile-push-notifications.md
@@ -18,7 +18,7 @@ support forwarding push notifications to a central push notification
 forwarding service. Accessing this service requires outgoing HTTPS
 access to the public Internet; if that is restricted by a proxy, you
 will need to [configure Zulip to use your outgoing HTTP
-proxy](../production/deployment.html#using-an-outgoing-http-proxy)
+proxy](../production/deployment.html#customizing-the-outgoing-http-proxy)
 first.
 
 You can enable this for your Zulip server as follows:

--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -96,13 +96,14 @@ on hardware requirements for larger organizations.
   address as its external hostname (though we don't recommend that
   configuration).
 - Zulip supports [running behind a reverse proxy][reverse-proxy].
-- Zulip servers running inside a private network should configure the
-  [Smokescreen integration][smokescreen-proxy] to protect against
-  [SSRF attacks][ssrf], where users could make the Zulip server make
-  requests to private resources.
+- Zulip configures [Smokescreen, and outgoing HTTP
+  proxy][smokescreen-proxy], to protect against [SSRF attacks][ssrf],
+  which prevents user from making the Zulip server make requests to
+  private resources. If your network has its own outgoing HTTP proxy,
+  Zulip supports using that instead.
 
 [ssrf]: https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
-[smokescreen-proxy]: ../production/deployment.html#using-an-outgoing-http-proxy
+[smokescreen-proxy]: ../production/deployment.html#customizing-the-outgoing-http-proxy
 [reverse-proxy]: ../production/deployment.html#putting-the-zulip-application-behind-a-reverse-proxy
 [email-mirror-code]: https://github.com/zulip/zulip/blob/main/zerver/management/commands/email_mirror.py
 

--- a/docs/production/security-model.md
+++ b/docs/production/security-model.md
@@ -259,15 +259,15 @@ strength allowed is controlled by two settings in
   - Mobile push notifications (must be configured to be enabled)
 
 - Notably, these first 3 features give end users (limited) control to cause
-  the Zulip server to make HTTP requests on their behalf. As a result,
-  Zulip supports routing all outgoing outgoing HTTP requests [through
+  the Zulip server to make HTTP requests on their behalf. Because of this,
+  Zulip routes all outgoing outgoing HTTP requests [through
   Smokescreen][smokescreen-setup] to ensure that Zulip cannot be
   used to execute [SSRF attacks][ssrf] against other systems on an
   internal corporate network. The default Smokescreen configuration
   denies access to all non-public IP addresses, including 127.0.0.1.
 
 [ssrf]: https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
-[smokescreen-setup]: ../production/deployment.html#using-an-outgoing-http-proxy
+[smokescreen-setup]: ../production/deployment.html#customizing-the-outgoing-http-proxy
 
 ## Final notes and security response
 

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -96,8 +96,14 @@ class zulip::app_frontend_base {
     $uwsgi_default_processes = 4
   }
   $tornado_ports = $zulip::tornado_sharding::tornado_ports
-  $proxy_host = zulipconf('http_proxy', 'host', '')
-  $proxy_port = zulipconf('http_proxy', 'port', '')
+
+  $proxy_host = zulipconf('http_proxy', 'host', 'localhost')
+  $proxy_port = zulipconf('http_proxy', 'port', '4750')
+
+  if ($proxy_host in ['localhost', '127.0.0.1', '::1']) and ($proxy_port == '4750') {
+    include zulip::smokescreen
+  }
+
   if $proxy_host != '' and $proxy_port != '' {
     $proxy = "http://${proxy_host}:${proxy_port}"
   } else {

--- a/puppet/zulip/manifests/app_frontend_once.pp
+++ b/puppet/zulip/manifests/app_frontend_once.pp
@@ -2,8 +2,8 @@
 # in a cluster.
 
 class zulip::app_frontend_once {
-  $proxy_host = zulipconf('http_proxy', 'host', '')
-  $proxy_port = zulipconf('http_proxy', 'port', '')
+  $proxy_host = zulipconf('http_proxy', 'host', 'localhost')
+  $proxy_port = zulipconf('http_proxy', 'port', '4750')
   if $proxy_host != '' and $proxy_port != '' {
     $proxy = "http://${proxy_host}:${proxy_port}"
   } else {

--- a/puppet/zulip/manifests/external_dep.pp
+++ b/puppet/zulip/manifests/external_dep.pp
@@ -1,0 +1,44 @@
+define zulip::external_dep(
+  String $version,
+  String $sha256,
+  String $url,
+  String $tarball_prefix,
+  String $bin = '',
+) {
+
+  $dir = "/srv/zulip-${title}-${version}/"
+
+  zulip::sha256_tarball_to { $title:
+    url     => $url,
+    sha256  => $sha256,
+    install => {
+      $tarball_prefix => $dir,
+    },
+  }
+
+  file { $dir:
+    ensure  => directory,
+    require => Zulip::Sha256_tarball_to[$title],
+  }
+
+  if $bin != '' {
+    file { "${dir}${bin}":
+      ensure  => file,
+      require => File[$dir],
+    }
+  }
+
+  unless $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '18.04' {
+    # Puppet 5.5.0 and below make this always-noisy, as they spout out
+    # a notify line about tidying the managed directory above.  Skip
+    # on Bionic, which has that old version; they'll get tidied upon
+    # upgrade to 20.04.
+    tidy { "/srv/zulip-${title}-*":
+      path    => '/srv/',
+      recurse => 1,
+      rmdirs  => true,
+      matches => "zulip-${title}-*",
+      require => File[$dir],
+    }
+  }
+}

--- a/puppet/zulip/manifests/golang.pp
+++ b/puppet/zulip/manifests/golang.pp
@@ -18,4 +18,23 @@ class zulip::golang {
     ensure  => file,
     require => Zulip::Sha256_tarball_to['golang'],
   }
+
+  file { $dir:
+    ensure  => directory,
+    require => Zulip::Sha256_tarball_to['golang'],
+  }
+
+  unless $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '18.04' {
+    # Puppet 5.5.0 and below make this always-noisy, as they spout out
+    # a notify line about tidying the managed directory above.  Skip
+    # on Bionic, which has that old version; they'll get tidied upon
+    # upgrade to 20.04.
+    tidy { '/srv/zulip-golang-*':
+      path    => '/srv/',
+      recurse => 1,
+      rmdirs  => true,
+      matches => 'zulip-golang-*',
+      require => File[$dir],
+    }
+  }
 }

--- a/puppet/zulip/manifests/golang.pp
+++ b/puppet/zulip/manifests/golang.pp
@@ -1,18 +1,18 @@
 # @summary go compiler and tools
 #
 class zulip::golang {
-  $golang_version = '1.17.3'
+  $version = '1.17.3'
   zulip::sha256_tarball_to { 'golang':
-    url     => "https://golang.org/dl/go${golang_version}.linux-amd64.tar.gz",
+    url     => "https://golang.org/dl/go${version}.linux-amd64.tar.gz",
     sha256  => '550f9845451c0c94be679faf116291e7807a8d78b43149f9506c1b15eb89008c',
     install => {
-      'go/' => "/srv/golang-${golang_version}/",
+      'go/' => "/srv/golang-${version}/",
     },
   }
 
   file { '/srv/golang':
     ensure  => 'link',
-    target  => "/srv/golang-${golang_version}/",
+    target  => "/srv/golang-${version}/",
     require => Zulip::Sha256_tarball_to['golang'],
   }
 }

--- a/puppet/zulip/manifests/golang.pp
+++ b/puppet/zulip/manifests/golang.pp
@@ -6,35 +6,11 @@ class zulip::golang {
   $dir = "/srv/zulip-golang-${version}/"
   $bin = "${dir}bin/go"
 
-  zulip::sha256_tarball_to { 'golang':
-    url     => "https://golang.org/dl/go${version}.linux-amd64.tar.gz",
-    sha256  => '550f9845451c0c94be679faf116291e7807a8d78b43149f9506c1b15eb89008c',
-    install => {
-      'go/' => $dir,
-    },
-  }
-
-  file { $bin:
-    ensure  => file,
-    require => Zulip::Sha256_tarball_to['golang'],
-  }
-
-  file { $dir:
-    ensure  => directory,
-    require => Zulip::Sha256_tarball_to['golang'],
-  }
-
-  unless $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '18.04' {
-    # Puppet 5.5.0 and below make this always-noisy, as they spout out
-    # a notify line about tidying the managed directory above.  Skip
-    # on Bionic, which has that old version; they'll get tidied upon
-    # upgrade to 20.04.
-    tidy { '/srv/zulip-golang-*':
-      path    => '/srv/',
-      recurse => 1,
-      rmdirs  => true,
-      matches => 'zulip-golang-*',
-      require => File[$dir],
-    }
+  zulip::external_dep { 'golang':
+    version        => $version,
+    url            => "https://golang.org/dl/go${version}.linux-amd64.tar.gz",
+    sha256         => '550f9845451c0c94be679faf116291e7807a8d78b43149f9506c1b15eb89008c',
+    tarball_prefix => 'go/',
+    bin            => 'bin/go',
   }
 }

--- a/puppet/zulip/manifests/golang.pp
+++ b/puppet/zulip/manifests/golang.pp
@@ -1,10 +1,10 @@
 # @summary go compiler and tools
 #
 class zulip::golang {
-  $golang_version = '1.16.4'
+  $golang_version = '1.17.3'
   zulip::sha256_tarball_to { 'golang':
     url     => "https://golang.org/dl/go${golang_version}.linux-amd64.tar.gz",
-    sha256  => '7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59',
+    sha256  => '550f9845451c0c94be679faf116291e7807a8d78b43149f9506c1b15eb89008c',
     install => {
       'go/' => "/srv/golang-${golang_version}/",
     },

--- a/puppet/zulip/manifests/golang.pp
+++ b/puppet/zulip/manifests/golang.pp
@@ -1,0 +1,18 @@
+# @summary go compiler and tools
+#
+class zulip::golang {
+  $golang_version = '1.16.4'
+  zulip::sha256_tarball_to { 'golang':
+    url     => "https://golang.org/dl/go${golang_version}.linux-amd64.tar.gz",
+    sha256  => '7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59',
+    install => {
+      'go/' => "/srv/golang-${golang_version}/",
+    },
+  }
+
+  file { '/srv/golang':
+    ensure  => 'link',
+    target  => "/srv/golang-${golang_version}/",
+    require => Zulip::Sha256_tarball_to['golang'],
+  }
+}

--- a/puppet/zulip/manifests/golang.pp
+++ b/puppet/zulip/manifests/golang.pp
@@ -3,7 +3,7 @@
 class zulip::golang {
   $version = '1.17.3'
 
-  $dir = "/srv/golang-${version}/"
+  $dir = "/srv/zulip-golang-${version}/"
   $bin = "${dir}bin/go"
 
   zulip::sha256_tarball_to { 'golang':

--- a/puppet/zulip/manifests/golang.pp
+++ b/puppet/zulip/manifests/golang.pp
@@ -2,17 +2,21 @@
 #
 class zulip::golang {
   $version = '1.17.3'
+
+  $dir = "/srv/golang-${version}/"
+  $bin = '/srv/golang/bin/go'
+
   zulip::sha256_tarball_to { 'golang':
     url     => "https://golang.org/dl/go${version}.linux-amd64.tar.gz",
     sha256  => '550f9845451c0c94be679faf116291e7807a8d78b43149f9506c1b15eb89008c',
     install => {
-      'go/' => "/srv/golang-${version}/",
+      'go/' => $dir,
     },
   }
 
   file { '/srv/golang':
     ensure  => 'link',
-    target  => "/srv/golang-${version}/",
+    target  => $dir,
     require => Zulip::Sha256_tarball_to['golang'],
   }
 }

--- a/puppet/zulip/manifests/golang.pp
+++ b/puppet/zulip/manifests/golang.pp
@@ -4,7 +4,7 @@ class zulip::golang {
   $version = '1.17.3'
 
   $dir = "/srv/golang-${version}/"
-  $bin = '/srv/golang/bin/go'
+  $bin = "${dir}bin/go"
 
   zulip::sha256_tarball_to { 'golang':
     url     => "https://golang.org/dl/go${version}.linux-amd64.tar.gz",
@@ -14,9 +14,8 @@ class zulip::golang {
     },
   }
 
-  file { '/srv/golang':
-    ensure  => 'link',
-    target  => $dir,
+  file { $bin:
+    ensure  => file,
     require => Zulip::Sha256_tarball_to['golang'],
   }
 }

--- a/puppet/zulip/manifests/profile/smokescreen.pp
+++ b/puppet/zulip/manifests/profile/smokescreen.pp
@@ -2,56 +2,5 @@
 #
 class zulip::profile::smokescreen {
   include zulip::profile::base
-  include zulip::supervisor
-  include zulip::golang
-
-  $version = 'dc403015f563eadc556a61870c6ad327688abe88'
-  $dir = "/srv/zulip-smokescreen-src-${version}/"
-  $bin = "/usr/local/bin/smokescreen-${version}-go-${zulip::golang::version}"
-
-  zulip::external_dep { 'smokescreen-src':
-    version        => $version,
-    url            => "https://github.com/stripe/smokescreen/archive/${version}.tar.gz",
-    sha256         => 'ad4b181d14adcd9425045152b903a343dbbcfcad3c1e7625d2c65d1d50e1959d',
-    tarball_prefix => "smokescreen-${version}/",
-  }
-
-  exec { 'compile smokescreen':
-    command     => "${zulip::golang::bin} build -o ${bin}",
-    cwd         => $dir,
-    # GOCACHE is required; nothing is written to GOPATH, but it is required to be set
-    environment => ['GOCACHE=/tmp/gocache', 'GOPATH=/root/go'],
-    creates     => $bin,
-    require     => [File[$zulip::golang::bin], File[$dir]],
-  }
-  file { $bin:
-    ensure  => file,
-    require => Exec['compile smokescreen'],
-  }
-  unless $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '18.04' {
-    # Puppet 5.5.0 and below make this always-noisy, as they spout out
-    # a notify line about tidying the managed file above.  Skip
-    # on Bionic, which has that old version; they'll get tidied upon
-    # upgrade to 20.04.
-    tidy { '/usr/local/bin/smokescreen-*':
-      path    => '/usr/local/bin',
-      recurse => 1,
-      matches => 'smokescreen-*',
-      require => File[$bin],
-    }
-  }
-
-  $listen_address = zulipconf('http_proxy', 'listen_address', '127.0.0.1')
-  file { "${zulip::common::supervisor_conf_dir}/smokescreen.conf":
-    ensure  => file,
-    require => [
-      Package[supervisor],
-      File[$bin],
-    ],
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    content => template('zulip/supervisor/smokescreen.conf.erb'),
-    notify  => Service[supervisor],
-  }
+  include zulip::smokescreen
 }

--- a/puppet/zulip/manifests/profile/smokescreen.pp
+++ b/puppet/zulip/manifests/profile/smokescreen.pp
@@ -28,12 +28,6 @@ class zulip::profile::smokescreen {
     ensure  => file,
     require => Exec['compile smokescreen'],
   }
-  file { '/usr/local/bin/smokescreen':
-    ensure  => 'link',
-    target  => $bin,
-    require => File[$bin],
-    notify  => Service[supervisor],
-  }
   unless $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '18.04' {
     # Puppet 5.5.0 and below make this always-noisy, as they spout out
     # a notify line about tidying the managed file above.  Skip
@@ -43,7 +37,7 @@ class zulip::profile::smokescreen {
       path    => '/usr/local/bin',
       recurse => 1,
       matches => 'smokescreen-*',
-      require => [File[$bin], File['/usr/local/bin/smokescreen']],
+      require => File[$bin],
     }
   }
 

--- a/puppet/zulip/manifests/profile/smokescreen.pp
+++ b/puppet/zulip/manifests/profile/smokescreen.pp
@@ -7,7 +7,7 @@ class zulip::profile::smokescreen {
 
   $version = 'dc403015f563eadc556a61870c6ad327688abe88'
   $dir = "/srv/zulip-smokescreen-src-${version}/"
-  $bin = "/usr/local/bin/smokescreen-${version}"
+  $bin = "/usr/local/bin/smokescreen-${version}-go-${zulip::golang::version}"
 
   zulip::external_dep { 'smokescreen-src':
     version        => $version,

--- a/puppet/zulip/manifests/profile/smokescreen.pp
+++ b/puppet/zulip/manifests/profile/smokescreen.pp
@@ -6,20 +6,22 @@ class zulip::profile::smokescreen {
   include zulip::golang
 
   $version = 'dc403015f563eadc556a61870c6ad327688abe88'
-  zulip::sha256_tarball_to { 'smokescreen':
-    url     => "https://github.com/stripe/smokescreen/archive/${version}.tar.gz",
-    sha256  => 'ad4b181d14adcd9425045152b903a343dbbcfcad3c1e7625d2c65d1d50e1959d',
-    install => {
-      "smokescreen-${version}/" => "/srv/zulip-smokescreen-src-${version}/",
-    },
+  $dir = "/srv/zulip-smokescreen-src-${version}/"
+
+  zulip::external_dep { 'smokescreen-src':
+    version        => $version,
+    url            => "https://github.com/stripe/smokescreen/archive/${version}.tar.gz",
+    sha256         => 'ad4b181d14adcd9425045152b903a343dbbcfcad3c1e7625d2c65d1d50e1959d',
+    tarball_prefix => "smokescreen-${version}/",
   }
+
   exec { 'compile smokescreen':
     command     => "${zulip::golang::bin} build -o /usr/local/bin/smokescreen-${version}",
-    cwd         => "/srv/zulip-smokescreen-src-${version}/",
+    cwd         => $dir,
     # GOCACHE is required; nothing is written to GOPATH, but it is required to be set
     environment => ['GOCACHE=/tmp/gocache', 'GOPATH=/root/go'],
     creates     => "/usr/local/bin/smokescreen-${version}",
-    require     => [File[$zulip::golang::bin], Zulip::Sha256_tarball_to['smokescreen']],
+    require     => [File[$zulip::golang::bin], File[$dir]],
   }
 
   file { '/usr/local/bin/smokescreen':

--- a/puppet/zulip/manifests/profile/smokescreen.pp
+++ b/puppet/zulip/manifests/profile/smokescreen.pp
@@ -19,7 +19,7 @@ class zulip::profile::smokescreen {
     # GOCACHE is required; nothing is written to GOPATH, but it is required to be set
     environment => ['GOCACHE=/tmp/gocache', 'GOPATH=/root/go'],
     creates     => "/usr/local/bin/smokescreen-${version}",
-    require     => [Zulip::Sha256_tarball_to['golang'], Zulip::Sha256_tarball_to['smokescreen']],
+    require     => [File[$zulip::golang::bin], Zulip::Sha256_tarball_to['smokescreen']],
   }
 
   file { '/usr/local/bin/smokescreen':

--- a/puppet/zulip/manifests/profile/smokescreen.pp
+++ b/puppet/zulip/manifests/profile/smokescreen.pp
@@ -3,20 +3,7 @@
 class zulip::profile::smokescreen {
   include zulip::profile::base
   include zulip::supervisor
-
-  $golang_version = '1.16.4'
-  zulip::sha256_tarball_to { 'golang':
-    url     => "https://golang.org/dl/go${golang_version}.linux-amd64.tar.gz",
-    sha256  => '7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59',
-    install => {
-      'go/' => "/srv/golang-${golang_version}/",
-    },
-  }
-  file { '/srv/golang':
-    ensure  => 'link',
-    target  => "/srv/golang-${golang_version}/",
-    require => Zulip::Sha256_tarball_to['golang'],
-  }
+  include zulip::golang
 
   $version = 'bfca45c5e61f3587eaaf1dcc89a0c4116501cba3'
   zulip::sha256_tarball_to { 'smokescreen':

--- a/puppet/zulip/manifests/profile/smokescreen.pp
+++ b/puppet/zulip/manifests/profile/smokescreen.pp
@@ -14,7 +14,7 @@ class zulip::profile::smokescreen {
     },
   }
   exec { 'compile smokescreen':
-    command     => "/srv/golang/bin/go build -o /usr/local/bin/smokescreen-${version}",
+    command     => "${zulip::golang::bin} build -o /usr/local/bin/smokescreen-${version}",
     cwd         => "/srv/smokescreen-src-${version}/",
     # GOCACHE is required; nothing is written to GOPATH, but it is required to be set
     environment => ['GOCACHE=/tmp/gocache', 'GOPATH=/root/go'],

--- a/puppet/zulip/manifests/profile/smokescreen.pp
+++ b/puppet/zulip/manifests/profile/smokescreen.pp
@@ -7,6 +7,7 @@ class zulip::profile::smokescreen {
 
   $version = 'dc403015f563eadc556a61870c6ad327688abe88'
   $dir = "/srv/zulip-smokescreen-src-${version}/"
+  $bin = "/usr/local/bin/smokescreen-${version}"
 
   zulip::external_dep { 'smokescreen-src':
     version        => $version,
@@ -16,17 +17,17 @@ class zulip::profile::smokescreen {
   }
 
   exec { 'compile smokescreen':
-    command     => "${zulip::golang::bin} build -o /usr/local/bin/smokescreen-${version}",
+    command     => "${zulip::golang::bin} build -o ${bin}",
     cwd         => $dir,
     # GOCACHE is required; nothing is written to GOPATH, but it is required to be set
     environment => ['GOCACHE=/tmp/gocache', 'GOPATH=/root/go'],
-    creates     => "/usr/local/bin/smokescreen-${version}",
+    creates     => $bin,
     require     => [File[$zulip::golang::bin], File[$dir]],
   }
 
   file { '/usr/local/bin/smokescreen':
     ensure  => 'link',
-    target  => "/usr/local/bin/smokescreen-${version}",
+    target  => $bin,
     require => Exec['compile smokescreen'],
     notify  => Service[supervisor],
   }
@@ -36,7 +37,7 @@ class zulip::profile::smokescreen {
     ensure  => file,
     require => [
       Package[supervisor],
-      File['/usr/local/bin/smokescreen'],
+      File[$bin],
     ],
     owner   => 'root',
     group   => 'root',

--- a/puppet/zulip/manifests/profile/smokescreen.pp
+++ b/puppet/zulip/manifests/profile/smokescreen.pp
@@ -10,12 +10,12 @@ class zulip::profile::smokescreen {
     url     => "https://github.com/stripe/smokescreen/archive/${version}.tar.gz",
     sha256  => 'ad4b181d14adcd9425045152b903a343dbbcfcad3c1e7625d2c65d1d50e1959d',
     install => {
-      "smokescreen-${version}/" => "/srv/smokescreen-src-${version}/",
+      "smokescreen-${version}/" => "/srv/zulip-smokescreen-src-${version}/",
     },
   }
   exec { 'compile smokescreen':
     command     => "${zulip::golang::bin} build -o /usr/local/bin/smokescreen-${version}",
-    cwd         => "/srv/smokescreen-src-${version}/",
+    cwd         => "/srv/zulip-smokescreen-src-${version}/",
     # GOCACHE is required; nothing is written to GOPATH, but it is required to be set
     environment => ['GOCACHE=/tmp/gocache', 'GOPATH=/root/go'],
     creates     => "/usr/local/bin/smokescreen-${version}",

--- a/puppet/zulip/manifests/profile/smokescreen.pp
+++ b/puppet/zulip/manifests/profile/smokescreen.pp
@@ -5,10 +5,10 @@ class zulip::profile::smokescreen {
   include zulip::supervisor
   include zulip::golang
 
-  $version = 'bfca45c5e61f3587eaaf1dcc89a0c4116501cba3'
+  $version = 'dc403015f563eadc556a61870c6ad327688abe88'
   zulip::sha256_tarball_to { 'smokescreen':
     url     => "https://github.com/stripe/smokescreen/archive/${version}.tar.gz",
-    sha256  => '7aa2719abd282930b01394e5e748885a8e8cb8121fe97a15446f93623ec13f59',
+    sha256  => 'ad4b181d14adcd9425045152b903a343dbbcfcad3c1e7625d2c65d1d50e1959d',
     install => {
       "smokescreen-${version}/" => "/srv/smokescreen-src-${version}/",
     },

--- a/puppet/zulip/manifests/smokescreen.pp
+++ b/puppet/zulip/manifests/smokescreen.pp
@@ -1,0 +1,54 @@
+class zulip::smokescreen {
+  include zulip::supervisor
+  include zulip::golang
+
+  $version = 'dc403015f563eadc556a61870c6ad327688abe88'
+  $dir = "/srv/zulip-smokescreen-src-${version}/"
+  $bin = "/usr/local/bin/smokescreen-${version}-go-${zulip::golang::version}"
+
+  zulip::external_dep { 'smokescreen-src':
+    version        => $version,
+    url            => "https://github.com/stripe/smokescreen/archive/${version}.tar.gz",
+    sha256         => 'ad4b181d14adcd9425045152b903a343dbbcfcad3c1e7625d2c65d1d50e1959d',
+    tarball_prefix => "smokescreen-${version}/",
+  }
+
+  exec { 'compile smokescreen':
+    command     => "${zulip::golang::bin} build -o ${bin}",
+    cwd         => $dir,
+    # GOCACHE is required; nothing is written to GOPATH, but it is required to be set
+    environment => ['GOCACHE=/tmp/gocache', 'GOPATH=/root/go'],
+    creates     => $bin,
+    require     => [File[$zulip::golang::bin], File[$dir]],
+  }
+  file { $bin:
+    ensure  => file,
+    require => Exec['compile smokescreen'],
+  }
+  unless $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '18.04' {
+    # Puppet 5.5.0 and below make this always-noisy, as they spout out
+    # a notify line about tidying the managed file above.  Skip
+    # on Bionic, which has that old version; they'll get tidied upon
+    # upgrade to 20.04.
+    tidy { '/usr/local/bin/smokescreen-*':
+      path    => '/usr/local/bin',
+      recurse => 1,
+      matches => 'smokescreen-*',
+      require => File[$bin],
+    }
+  }
+
+  $listen_address = zulipconf('http_proxy', 'listen_address', '127.0.0.1')
+  file { "${zulip::common::supervisor_conf_dir}/smokescreen.conf":
+    ensure  => file,
+    require => [
+      Package[supervisor],
+      File[$bin],
+    ],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('zulip/supervisor/smokescreen.conf.erb'),
+    notify  => Service[supervisor],
+  }
+}

--- a/puppet/zulip/templates/supervisor/smokescreen.conf.erb
+++ b/puppet/zulip/templates/supervisor/smokescreen.conf.erb
@@ -1,5 +1,5 @@
 [program:smokescreen]
-command=/usr/local/bin/smokescreen-<%= @version %> --listen-ip <%= @listen_address %>
+command=<%= @bin %> --listen-ip <%= @listen_address %>
 priority=15
 autostart=true
 autorestart=true


### PR DESCRIPTION
Clean up Smokescreen installation, and enable it by default for all application frontends.

**Testing plan:** Installed on a test production host, verified it installed smokescreen; verified it uninstalled when unsetting the config, or setting to some other host.
