### PR TITLE
deletion: Preserve deleted objects for 30 days rather than 7.

### DIFF
--- a/templates/zerver/help/edit-or-delete-a-message.md
+++ b/templates/zerver/help/edit-or-delete-a-message.md
@@ -87,7 +87,7 @@ permissions to delete that message.
   you also delete the message.
 * For protection against accidental or immediately regretted
   deletions, messages deleted directly or via a [message retention
-  policy](/help/message-retention-policy) are archived for 7 days in a
+  policy](/help/message-retention-policy) are archived for 30 days in a
   format that can be restored by a server administrator.  After that
   time, they are permanently and irrecoverably deleted from the Zulip
   server.  Server administrators can adjust the archival time using

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -421,7 +421,7 @@ USER_LIMIT_FOR_SENDING_PRESENCE_UPDATE_EVENTS = 100
 
 # How many days deleted messages data should be kept before being
 # permanently deleted.
-ARCHIVED_DATA_VACUUMING_DELAY_DAYS = 7
+ARCHIVED_DATA_VACUUMING_DELAY_DAYS = 30
 
 # Enables billing pages and plan-based feature gates. If False, all features
 # are available to all realms.


### PR DESCRIPTION
We had an incident where someone didn't notice for a week that they'd
accidentally enabled a 30-day message retention policy, and thus we
were unable to restore the deleted the content.

After some review of what other products do (E.g. Dropbox preserves
things in a restoreable state for 30 days) we're adjusting this
setting's default value to be substantially longer, to give more time
for users to notice their mistake and correct it before data is
irrevocably deleted.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
