### PR TITLE
[WIP] sidebar: Add "Rename topic" option to three-dot topic menu.

### DIFF
--- a/static/templates/rename_topic_modal.hbs
+++ b/static/templates/rename_topic_modal.hbs
@@ -1,0 +1,10 @@
+<p>{{#tr}}Rename <strong>{topic_name}</strong>{{/tr}} to:</p>
+<form class="new-style" id="rename_topic_form">
+    <div id="topic_stream_edit_form_error" class="alert">
+        <span class="send-status-close">&times;</span>
+        <span class="error-msg"></span>
+    </div>
+    <div class="topic_stream_edit_header">
+        <input name="new_topic_name" type="text" class="inline_topic_edit" id="new_topic_name" value="{{topic_name}}" />
+    </div>
+</form>

--- a/static/templates/topic_sidebar_actions.hbs
+++ b/static/templates/topic_sidebar_actions.hbs
@@ -67,7 +67,15 @@
         </a>
     </li>
     {{/if}}
-
+    {{#if can_only_rename_topic}}
+    <hr />
+    <li>
+        <a tabindex="0" class="sidebar-popover-rename-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+            <i class="fa fa-pencil" aria-hidden="true"></i>
+            {{t "Rename topic"}}
+        </a>
+    </li>
+    {{/if}}
     {{#if is_realm_admin}}
     <li>
         <a tabindex="0" class="sidebar-popover-delete-topic-messages" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">


### PR DESCRIPTION
We add option to "Rename topic" to three-dot topic menu for users
without move topic permissions.

I have solved this issue by:
- Adding `rename_topic_modal.hbs`
- Adding `build_rename_topic_popover` function.

this is what `rename_topic_modal` looks like
![image](https://user-images.githubusercontent.com/51414879/142380847-2fd58c57-9b67-42ec-9fa3-f36a63862c89.png)


Fixes #19886
