### PR TITLE
Fix handling of deactivated custom emoji in user status.

### DIFF
--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -39,7 +39,6 @@ mock_esm("../../static/js/stream_popover", {
 const people = zrequire("people");
 const user_status = zrequire("user_status");
 const message_edit = zrequire("message_edit");
-const emoji = zrequire("../shared/js/emoji");
 
 // Bypass some scary code that runs when we import the module.
 const popovers = with_field($.fn, "popover", noop, () => zrequire("popovers"));
@@ -114,7 +113,6 @@ function test_ui(label, f) {
 test_ui("sender_hover", ({override, mock_template}) => {
     page_params.is_spectator = false;
     override($.fn, "popover", noop);
-    override(emoji, "get_emoji_details_by_name", noop);
 
     const selection = ".sender_name, .sender_name-in-status, .inline_profile_picture";
     const handler = $("#main_div").get_on_handler("click", selection);

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -80,12 +80,6 @@ const emoji_params = {
             source_url: "/url/for/992",
             deactivated: true,
         },
-        zulip: {
-            id: "zulip",
-            name: "zulip",
-            source_url: "/url/for/zulip",
-            deactivated: false,
-        },
     },
     emoji_codes,
 };
@@ -621,14 +615,12 @@ test("view.insert_new_reaction (me w/unicode emoji)", ({override, mock_template}
 });
 
 test("view.insert_new_reaction (them w/zulip emoji)", ({override, mock_template}) => {
-    const zulip_emoji = emoji_params.realm_emoji.zulip;
     const opts = {
         message_id: 502,
         reaction_type: "realm_emoji",
         emoji_name: "zulip",
-        emoji_code: zulip_emoji.id,
+        emoji_code: "zulip",
         user_id: bob.user_id,
-        source_url: zulip_emoji.source_url,
     };
 
     const message_reactions = $.create("our-reactions");

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -78,6 +78,7 @@ const emoji_params = {
             id: "992",
             name: "inactive_realm_emoji",
             source_url: "/url/for/992",
+            still_url: "/still/url/for/992",
             deactivated: true,
         },
     },
@@ -168,6 +169,7 @@ test("basics", () => {
             label: "translated: Cali reacted with :frown:",
             emoji_alt_code: false,
             class: "message_reaction",
+            is_realm_emoji: false,
         },
         {
             emoji_name: "inactive_realm_emoji",
@@ -180,6 +182,7 @@ test("basics", () => {
             emoji_alt_code: false,
             is_realm_emoji: true,
             url: "/url/for/992",
+            still_url: "/still/url/for/992",
             class: "message_reaction reacted",
         },
         {
@@ -192,6 +195,7 @@ test("basics", () => {
             label: "translated: You (click to remove) and Bob van Roberts reacted with :smile:",
             emoji_alt_code: false,
             class: "message_reaction reacted",
+            is_realm_emoji: false,
         },
         {
             emoji_name: "tada",
@@ -203,6 +207,7 @@ test("basics", () => {
             label: "translated: Cali and Alexus reacted with :tada:",
             emoji_alt_code: false,
             class: "message_reaction",
+            is_realm_emoji: false,
         },
         {
             emoji_name: "rocket",
@@ -214,6 +219,7 @@ test("basics", () => {
             label: "translated: You (click to remove), Bob van Roberts and Cali reacted with :rocket:",
             emoji_alt_code: false,
             class: "message_reaction reacted",
+            is_realm_emoji: false,
         },
         {
             emoji_name: "wave",
@@ -225,18 +231,26 @@ test("basics", () => {
             label: "translated: Bob van Roberts, Cali and Alexus reacted with :wave:",
             emoji_alt_code: false,
             class: "message_reaction",
+            is_realm_emoji: false,
         },
     ];
     assert.deepEqual(result, expected_result);
 });
 
 test("unknown realm emojis (add)", () => {
-    blueslip.expect("error", "Cannot find/add realm emoji for code 'broken'.");
-    reactions.add_clean_reaction({
-        reaction_type: "realm_emoji",
-        emoji_code: "broken",
-        user_ids: [alice.user_id],
-    });
+    assert.throws(
+        () =>
+            reactions.view.insert_new_reaction({
+                reaction_type: "realm_emoji",
+                emoji_name: "false_emoji",
+                emoji_code: "broken",
+                user_ids: [alice.user_id],
+            }),
+        {
+            name: "Error",
+            message: "Cannot find realm emoji for code 'broken'.",
+        },
+    );
 });
 
 test("unknown realm emojis (insert)", () => {

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -240,12 +240,19 @@ test("unknown realm emojis (add)", () => {
 });
 
 test("unknown realm emojis (insert)", () => {
-    blueslip.expect("error", "Cannot find/insert realm emoji for code 'bogus'.");
-    reactions.view.insert_new_reaction({
-        reaction_type: "realm_emoji",
-        emoji_code: "bogus",
-        user_id: bob.user_id,
-    });
+    assert.throws(
+        () =>
+            reactions.view.insert_new_reaction({
+                reaction_type: "realm_emoji",
+                emoji_name: "fake_emoji",
+                emoji_code: "bogus",
+                user_id: bob.user_id,
+            }),
+        {
+            name: "Error",
+            message: "Cannot find realm emoji for code 'bogus'.",
+        },
+    );
 });
 
 test("sending", ({override}) => {
@@ -600,6 +607,8 @@ test("view.insert_new_reaction (me w/unicode emoji)", ({override, mock_template}
             class: "message_reaction reacted",
             message_id: opts.message_id,
             label: "translated: You (click to remove) reacted with :8ball:",
+            reaction_type: opts.reaction_type,
+            is_realm_emoji: false,
         });
         return "<new reaction html>";
     });
@@ -647,6 +656,8 @@ test("view.insert_new_reaction (them w/zulip emoji)", ({override, mock_template}
             class: "message_reaction",
             message_id: opts.message_id,
             label: "translated: Bob van Roberts reacted with :zulip:",
+            still_url: undefined,
+            reaction_type: opts.reaction_type,
         });
         return "<new reaction html>";
     });

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -308,33 +308,22 @@ view.insert_new_reaction = function (opts) {
     // before the add button.
 
     const message_id = opts.message_id;
-    const emoji_name = opts.emoji_name;
-    const emoji_code = opts.emoji_code;
     const user_id = opts.user_id;
     const user_list = [user_id];
 
     const context = {
         message_id,
-        emoji_name,
-        emoji_code,
+        ...emoji.get_emoji_details_for_rendering(opts),
     };
 
-    const new_label = generate_title(emoji_name, user_list);
-
-    if (opts.reaction_type !== "unicode_emoji") {
-        context.is_realm_emoji = true;
-        const emoji_info = emoji.all_realm_emojis.get(emoji_code);
-        if (!emoji_info) {
-            blueslip.error(`Cannot find/insert realm emoji for code '${emoji_code}'.`);
-            return;
-        }
-        context.url = emoji_info.emoji_url;
-    }
+    const new_label = generate_title(opts.emoji_name, user_list);
 
     context.count = 1;
     context.label = new_label;
     context.local_id = get_local_reaction_id(opts);
     context.emoji_alt_code = user_settings.emojiset === "text";
+    context.is_realm_emoji =
+        context.reaction_type === "realm_emoji" || context.reaction_type === "zulip_extra_emoji";
 
     if (opts.user_id === page_params.user_id) {
         context.class = "message_reaction reacted";

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -507,27 +507,15 @@ export function set_clean_reactions(message) {
 }
 
 export function add_clean_reaction(opts) {
-    const r = {};
+    const r = emoji.get_emoji_details_for_rendering(opts);
 
-    r.reaction_type = opts.reaction_type;
-    r.emoji_name = opts.emoji_name;
-    r.emoji_code = opts.emoji_code;
     r.local_id = opts.local_id;
 
     r.user_ids = opts.user_ids;
     update_user_fields(r);
 
     r.emoji_alt_code = user_settings.emojiset === "text";
-
-    if (r.reaction_type !== "unicode_emoji") {
-        r.is_realm_emoji = true;
-        const emoji_info = emoji.all_realm_emojis.get(r.emoji_code);
-        if (!emoji_info) {
-            blueslip.error(`Cannot find/add realm emoji for code '${r.emoji_code}'.`);
-            return;
-        }
-        r.url = emoji_info.emoji_url;
-    }
+    r.is_realm_emoji = r.reaction_type === "realm_emoji" || r.reaction_type === "zulip_extra_emoji";
 
     opts.message.clean_reactions.set(opts.local_id, r);
 }

--- a/static/js/user_status.js
+++ b/static/js/user_status.js
@@ -77,11 +77,12 @@ export function set_status_emoji(opts) {
     }
 
     user_status_emoji_info.set(opts.user_id, {
-        emoji_name: opts.emoji_name,
-        emoji_code: opts.emoji_code,
-        reaction_type: opts.reaction_type,
         emoji_alt_code: user_settings.emojiset === "text",
-        ...emoji.get_emoji_details_by_name(opts.emoji_name),
+        ...emoji.get_emoji_details_for_rendering({
+            emoji_name: opts.emoji_name,
+            emoji_code: opts.emoji_code,
+            reaction_type: opts.reaction_type,
+        }),
     });
 }
 
@@ -104,10 +105,7 @@ export function initialize(params) {
 
         if (dct.emoji_name) {
             user_status_emoji_info.set(user_id, {
-                emoji_name: dct.emoji_name,
-                emoji_code: dct.emoji_code,
-                reaction_type: dct.reaction_type,
-                ...emoji.get_emoji_details_by_name(dct.emoji_name),
+                ...emoji.get_emoji_details_for_rendering(dct),
             });
         }
     }

--- a/static/shared/js/emoji.js
+++ b/static/shared/js/emoji.js
@@ -10,6 +10,7 @@ export const emojis_by_name = new Map();
 
 export const all_realm_emojis = new Map();
 export const active_realm_emojis = new Map();
+export const deactivated_emoji_name_to_code = new Map();
 
 const default_emoji_aliases = new Map();
 
@@ -169,8 +170,16 @@ export function update_emojis(realm_emojis) {
             });
         }
     }
-    // Add the Zulip emoji to the realm emojis list
+
+    // Add the special Zulip emoji as though it were a realm emoji.
+
+    // The Zulip emoji is the only emoji that uses a string ("zulip")
+    // as its ID. All other emoji use numeric IDs. This special case
+    // is confusing; ideally we'd convert the Zulip emoji to be
+    // implemented using the RealmEmoji infrastructure.
     all_realm_emojis.set("zulip", zulip_emoji);
+
+    // here "zulip" is an emoji name, which is fine.
     active_realm_emojis.set("zulip", zulip_emoji);
 
     build_emoji_data(active_realm_emojis);

--- a/static/shared/js/emoji.js
+++ b/static/shared/js/emoji.js
@@ -218,6 +218,32 @@ export function get_emoji_details_by_name(emoji_name) {
     return emoji_info;
 }
 
+export function get_emoji_details_for_rendering(opts) {
+    if (!opts.emoji_name || !opts.emoji_code || !opts.reaction_type) {
+        throw new Error("Invalid params.");
+    }
+
+    if (opts.reaction_type !== "unicode_emoji") {
+        const realm_emoji = all_realm_emojis.get(opts.emoji_code);
+        if (!realm_emoji) {
+            throw new Error(`Cannot find realm emoji for code '${opts.emoji_code}'.`);
+        }
+        return {
+            url: realm_emoji.emoji_url,
+            still_url: realm_emoji.still_url,
+            emoji_name: opts.emoji_name,
+            emoji_code: opts.emoji_code,
+            reaction_type: opts.reaction_type,
+        };
+    }
+    // else
+    return {
+        emoji_name: opts.emoji_name,
+        emoji_code: opts.emoji_code,
+        reaction_type: opts.reaction_type,
+    };
+}
+
 export function initialize(params) {
     emoji_codes = params.emoji_codes;
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
I've opened this wip PR to get feedback on some changes:
I would be glad to simply implement the change suggested in the comment added by the first commit, rather than leaving the comment.
The third commit needs work, but I'm not certain about which direction we want the codebase to move towards.

Pasting the contents of the last commit message:

Previously, if a user had set a realm emoji as their status emoji and
someone would then delete the realm emoji, the app would fail to
initialize, because of the error we throw from `emoji.js`.

The current commit fixes this by just displaying the deactivated
emoji, similar to how we do when realm_emoji used as reactions are
deleted.

However, this commit has to resort to somewhat hacky additions to
solve the bug, which may also just be a symptom of other refactors
that are needed.

In addition, this also suffers from the flaw that if a new emoji is
added with the same name as the previously deleted emoji, then the
user status will show the new emoji. This could lead to shenanigans
and is why this is labeled as do_not_merge.

Fixes: #20274.


**Testing plan:** <!-- How have you tested? -->
added a case to user_status node test.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![191121deactivated-status-emoji](https://user-images.githubusercontent.com/33805964/142645151-dbd63ce5-af65-4c33-bf5a-6990db663cbe.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
