### PR TITLE
bot docs: Migrate script name from zulip-terminal to zulip-bot-shell.

### DIFF
--- a/templates/zerver/api/writing-bots.md
+++ b/templates/zerver/api/writing-bots.md
@@ -109,22 +109,22 @@ above as an orientation.
 ## Testing a bot's output
 
 If you just want to see how a bot reacts to a message, but don't want to set it up on a server,
-we have a little tool to help you out: `zulip-terminal`
+we have a little tool to help you out: `zulip-bot-shell`
 
 * [Install all requirements](#installing-a-development-version-of-the-zulip-bots-package).
 
-* Run `zulip-terminal` to test one of the bots in
+* Run `zulip-bot-shell` to test one of the bots in
   [`zulip_bots/bots`](https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots).
 
 Example invocations are below:
 
 ```
-> zulip-terminal converter
+> zulip-bot-shell converter
 
 Enter your message: "12 meter yard"
 Response: 12.0 meter = 13.12336 yard
 
-> zulip-terminal -b ~/followup.conf followup
+> zulip-bot-shell -b ~/followup.conf followup
 
 Enter your message: "Task completed"
 Response: stream: followup topic: foo_sender@zulip.com


### PR DESCRIPTION
This change is intended to reduce confusion between zulip-bot-shell
(test bots interactively without a server) and the zulip/zulip-terminal
project and its associated command (zulip-term).

Latest reference at https://chat.zulip.org/#narrow/stream/127-integrations/topic/Migrating.20bot.20zulip-terminal.20script

Accompanying API/bots repo change zulip/python-zulip-api#736