### PR TITLE
Repace `Light mode` and `Day mode` with `Light theme` and also replace `night theme` with `dark theme`.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -173,7 +173,7 @@ const dark_slash = {
 const light_slash = {
     name: "light",
     aliases: "day",
-    text: "translated: /light (Toggle light mode)",
+    text: "translated: /light (Toggle light theme)",
 };
 
 const sweden_stream = {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -408,7 +408,7 @@ export const slash_commands = [
         aliases: "",
     },
     {
-        text: $t({defaultMessage: "/light (Toggle light mode)"}),
+        text: $t({defaultMessage: "/light (Toggle light theme)"}),
         name: "light",
         aliases: "day",
     },

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -56,7 +56,7 @@ export const color_scheme_values = {
     },
     day: {
         code: 3,
-        description: $t({defaultMessage: "Day mode"}),
+        description: $t({defaultMessage: "Light theme"}),
     },
 };
 

--- a/static/js/zcommand.js
+++ b/static/js/zcommand.js
@@ -74,7 +74,7 @@ export function enter_day_mode() {
                         command: "/night",
                     });
                 },
-                title_text: $t({defaultMessage: "Light mode"}),
+                title_text: $t({defaultMessage: "Light theme"}),
                 undo_button_text: $t({defaultMessage: "Dark theme"}),
             });
         },
@@ -97,7 +97,7 @@ export function enter_night_mode() {
                     });
                 },
                 title_text: $t({defaultMessage: "Dark theme"}),
-                undo_button_text: $t({defaultMessage: "Light mode"}),
+                undo_button_text: $t({defaultMessage: "Light theme"}),
             });
         },
     });

--- a/templates/zerver/help/configure-default-new-user-settings.md
+++ b/templates/zerver/help/configure-default-new-user-settings.md
@@ -14,7 +14,7 @@ preference settings, including the following:
 
 * Display settings, including:
     * Default view ([Recent topics](/help/recent-topics) vs. [All messages](/help/reading-strategies#all-messages))
-    * [Light mode vs. dark theme](/help/dark-theme)
+    * [Light theme vs. dark theme](/help/dark-theme)
     * [Emoji theme](/help/emoji-and-emoticons#change-your-emoji-set)
 * Notification settings, including:
     * [What types of messages trigger notifications][default-notifications]

--- a/templates/zerver/help/dark-theme.md
+++ b/templates/zerver/help/dark-theme.md
@@ -16,6 +16,6 @@ for working in a dark space.
 The default is **Sync with computer**, which detects which theme to use based
 on the color scheme used by your operating system.
 
-You can also specify **Dark theme** or **Day mode** if you'd like
+You can also specify **Dark theme** or **Light theme** if you'd like
 Zulip to use the same color scheme regardless of your operating system
 configuration.

--- a/templates/zerver/help/dark-theme.md
+++ b/templates/zerver/help/dark-theme.md
@@ -1,6 +1,6 @@
 # Dark theme
 
-Zulip provides both a light theme and a night theme, which is great
+Zulip provides both a light theme and a dark theme, which is great
 for working in a dark space.
 
 ## Manage color theme

--- a/templates/zerver/help/include/add-a-wide-logo.md
+++ b/templates/zerver/help/include/add-a-wide-logo.md
@@ -12,4 +12,4 @@ transparent background, and trim any bordering whitespace. To upload a logo:
 
 {end_tabs}
 
-Make sure to test the logo in both light mode and [dark theme](/help/dark-theme).
+Make sure to test the logo in both light theme and [dark theme](/help/dark-theme).

--- a/zerver/lib/zcommand.py
+++ b/zerver/lib/zcommand.py
@@ -45,7 +45,7 @@ def process_zcommands(content: str, user_profile: UserProfile) -> Dict[str, Any]
         )
     elif command == "day":
         if user_profile.color_scheme == UserProfile.COLOR_SCHEME_LIGHT:
-            return dict(msg="You are still in light mode.")
+            return dict(msg="You are still in light theme.")
         return dict(
             msg=change_mode_setting(
                 command="light",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7539,7 +7539,7 @@ paths:
 
             - 1 - Automatic
             - 2 - Dark theme
-            - 3 - Day mode
+            - 3 - Light theme
 
             Automatic detection is implementing using the standard `prefers-color-scheme`
             media query.
@@ -9478,7 +9478,7 @@ paths:
 
                               - 1 - Automatic
                               - 2 - Dark theme
-                              - 3 - Day mode
+                              - 3 - Light theme
 
                               Automatic detection is implementing using the standard `prefers-color-scheme`
                               media query.
@@ -11186,7 +11186,7 @@ paths:
 
                               - 1 - Automatic
                               - 2 - Dark theme
-                              - 3 - Day mode
+                              - 3 - Light theme
 
                               Automatic detection is implementing using the standard `prefers-color-scheme`
                               media query.
@@ -12083,7 +12083,7 @@ paths:
 
             - 1 - Automatic
             - 2 - Dark theme
-            - 3 - Day mode
+            - 3 - Light theme
 
             Automatic detection is implementing using the standard `prefers-color-scheme`
             media query.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3659,7 +3659,7 @@ paths:
                                     night_logo_source:
                                       type: string
                                       description: |
-                                        String indicating whether the organization's night theme
+                                        String indicating whether the organization's dark theme
                                         [profile wide logo](/help/create-your-organization-profile) was uploaded
                                         by a user or is the default. Useful for UI allowing editing the
                                         organization's wide logo.
@@ -3669,7 +3669,7 @@ paths:
                                     night_logo_url:
                                       type: string
                                       description: |
-                                        The URL of the organization's night theme wide-format logo configured in the
+                                        The URL of the organization's dark theme wide-format logo configured in the
                                         [organization profile](/help/create-your-organization-profile).
                                     notifications_stream_id:
                                       type: integer
@@ -10792,14 +10792,14 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          The URL of the organization's night theme wide-format logo configured in the
+                          The URL of the organization's dark theme wide-format logo configured in the
                           [organization profile](/help/create-your-organization-profile).
                       realm_night_logo_source:
                         type: string
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          String indicating whether the organization's night theme
+                          String indicating whether the organization's dark theme
                           [profile wide logo](/help/create-your-organization-profile) was uploaded
                           by a user or is the default. Useful for UI allowing editing the
                           organization's wide logo.

--- a/zerver/tests/test_zcommand.py
+++ b/zerver/tests/test_zcommand.py
@@ -49,7 +49,7 @@ class ZcommandTest(ZulipTestCase):
 
         result = self.client_post("/json/zcommand", payload)
         self.assert_json_success(result)
-        self.assertIn("still in light mode", result.json()["msg"])
+        self.assertIn("still in light theme", result.json()["msg"])
 
     def test_fluid_zcommand(self) -> None:
         self.login("hamlet")


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Follow-up of #20294.
Not replaced `night theme` in `templates/zerver/api/changelog.md` for now.

Have not done slash command changes mentioned in #20294 yet. Will do in a separate PR.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
