### PR TITLE
events: Don't send data related to custom profile field to spectator.

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -143,7 +143,9 @@ def fetch_initial_state_data(
     if want("alert_words"):
         state["alert_words"] = [] if user_profile is None else user_alert_words(user_profile)
 
-    if want("custom_profile_fields"):
+    # Spectators can't access full user profiles or personal settings,
+    # so there's no need to send custom profile field data.
+    if want("custom_profile_fields") and user_profile is not None:
         fields = custom_profile_fields_for_realm(realm.id)
         state["custom_profile_fields"] = [f.as_dict() for f in fields]
         state["custom_profile_field_types"] = {
@@ -392,6 +394,8 @@ def fetch_initial_state_data(
             user_profile,
             client_gravatar=client_gravatar,
             user_avatar_url_field_optional=user_avatar_url_field_optional,
+            # Don't send custom profile field values to spectators.
+            include_custom_profile_fields=user_profile is not None,
         )
         state["cross_realm_bots"] = list(get_cross_realm_dicts())
 

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -349,6 +349,8 @@ class HomeTest(ZulipTestCase):
         page_params = self._get_page_params(result)
         actual_keys = sorted(str(k) for k in page_params.keys())
         removed_keys = [
+            "custom_profile_field_types",
+            "custom_profile_fields",
             "last_event_id",
             "narrow",
             "narrow_stream",


### PR DESCRIPTION
Since spectators can't access personal profile settings and
can't view profile for other users. Hence, we don't send realm
custom profile field data and user's profile data to spectators.

Fixes #20301
