### PR TITLE
data_exports: Fixes the heading cutoff in Settings.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1830,7 +1830,8 @@ input[type="checkbox"] {
 }
 
 .admin_exports_table {
-    margin: 20px;
+    margin-top: 20px;
+    margin-bottom: 20px;
 }
 
 @media (width < $lg_min) {


### PR DESCRIPTION
Fixes #20311

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
Manually
A minor tweak does the job.
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![Screenshot (67)](https://user-images.githubusercontent.com/76519771/142750605-ced5f1b6-c30b-4155-a4df-8db02b70e6c6.png)


![Screenshot (66)](https://user-images.githubusercontent.com/76519771/142750609-5621d393-0810-4836-8ed1-71046bf17998.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
