### PR TITLE
preserve pm-with syntax in search bar for blank searcher

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -1582,6 +1582,10 @@ test("navbar_helpers", () => {
     assert.equal(filter.generate_redirect_url(), complex_operators_test_case.redirect_url);
     assert.equal(filter.is_common_narrow(), false);
 
+    const pm_with_no_operand = [{operator:"pm-with", operand:""},];
+    filter = new Filter(pm_with_no_operand);
+    assert.equal(filter.is_common_narrow(), false);
+
     const stream_topic_search_operator = [
         {operator: "stream", operand: "foo"},
         {operator: "topic", operand: "bar"},

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -496,13 +496,18 @@ export class Filter {
         // stream, stream + topic,
         // is: private, pm-with:,
         // is: mentioned, is: resolved
+        const term_types = this.sorted_term_types();
+        // check for pm-with:"" filter (because it would result in empty search results)
+        if (_.isEqual(term_types, ["pm-with"]) && (this.operands("pm-with").length === 1 && this.operands("pm-with")[0] === "")){
+            return false;
+        }
+
         if (this.can_mark_messages_read()) {
             return true;
         }
         // that leaves us with checking:
         // is: starred
         // (which can_mark_messages_read_does not check as starred messages are always read)
-        const term_types = this.sorted_term_types();
 
         if (_.isEqual(term_types, ["is-starred"])) {
             return true;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/20073
solves the issue with pm-with syntax when the operand is blank

**Testing plan:** <!-- How have you tested? -->
I tried different variations locally 



**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![temp](https://user-images.githubusercontent.com/50860115/142771508-fa0982dc-e04b-4285-992f-f58ea1fed226.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
