### PR TITLE
integration: Fix overflowing display name on open collective page.

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -423,9 +423,7 @@ WEBHOOK_INTEGRATIONS: List[WebhookIntegration] = [
         stream_name="opbeat",
         function="zerver.webhooks.opbeat.view.api_opbeat_webhook",
     ),
-    WebhookIntegration(
-        "opencollective", ["communication"], display_name="Open Collective Incoming Webhook"
-    ),
+    WebhookIntegration("opencollective", ["communication"], display_name="Open Collective"),
     WebhookIntegration("opsgenie", ["meta-integration", "monitoring"]),
     WebhookIntegration("pagerduty", ["monitoring"], display_name="PagerDuty"),
     WebhookIntegration("papertrail", ["monitoring"]),


### PR DESCRIPTION
Removed extra text to stop display name from flowing out of logo
container.
<img width="1296" alt="Screenshot 2021-11-22 at 10 02 14 AM" src="https://user-images.githubusercontent.com/25124304/142801562-0611ecab-a744-43b9-a82a-9e6e594c40c7.png">
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/integration.20name.20doesn't.20fit