### PR TITLE
Muted streams settings

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -693,6 +693,52 @@ test("is_notifications_stream_muted", () => {
     assert.ok(stream_data.is_notifications_stream_muted());
 });
 
+test("muted_stream_ids", () => {
+    const denmark = {
+        subscribed: true,
+        color: "blue",
+        name: "Denmark",
+        stream_id: 1,
+        is_muted: true,
+        invite_only: true,
+        history_public_to_subscribers: true,
+    };
+    const social = {
+        subscribed: true,
+        color: "red",
+        name: "social",
+        stream_id: 2,
+        is_muted: false,
+        invite_only: true,
+        history_public_to_subscribers: false,
+        stream_post_policy: stream_data.stream_post_policy_values.admins.code,
+    };
+    const test = {
+        subscribed: true,
+        color: "yellow",
+        name: "test",
+        stream_id: 3,
+        is_muted: true,
+        invite_only: false,
+    };
+    const web_public_stream = {
+        subscribed: true,
+        color: "yellow",
+        name: "web_public_stream",
+        stream_id: 4,
+        is_muted: false,
+        invite_only: false,
+        history_public_to_subscribers: true,
+        is_web_public: true,
+    };
+    stream_data.add_sub(denmark);
+    stream_data.add_sub(social);
+    stream_data.add_sub(test);
+    stream_data.add_sub(web_public_stream);
+
+    assert.deepEqual(stream_data.muted_stream_ids(), [1, 3]);
+});
+
 test("realm_has_notifications_stream", () => {
     page_params.realm_notifications_stream_id = 10;
     assert.ok(stream_data.realm_has_notifications_stream());

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -380,6 +380,12 @@ export function subscribed_stream_ids() {
     return subscribed_subs().map((sub) => sub.stream_id);
 }
 
+export function muted_stream_ids() {
+    return subscribed_subs()
+        .filter((sub) => sub.is_muted)
+        .map((sub) => sub.stream_id);
+}
+
 export function get_subscribed_streams_for_user(user_id) {
     // Note that we only have access to subscribers of some streams
     // depending on our role.

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -289,6 +289,15 @@ export function setup_stream_settings(node) {
     show_settings_for(node);
 }
 
+export function update_muting_rendering(sub) {
+    const edit_container = stream_settings_containers.get_edit_container(sub);
+    const notification_checkboxes = edit_container.find(".sub_notification_setting");
+
+    edit_container.find(".mute-note").toggleClass("hide-mute-note", !sub.is_muted);
+    notification_checkboxes.toggleClass("muted-sub", sub.is_muted);
+    notification_checkboxes.find("input[type='checkbox']").prop("disabled", sub.is_muted);
+}
+
 function stream_is_muted_changed(e) {
     const sub = get_sub_for_target(e.target);
     if (!sub) {
@@ -296,17 +305,14 @@ function stream_is_muted_changed(e) {
         return;
     }
 
-    const edit_container = stream_settings_containers.get_edit_container(sub);
-    const notification_checkboxes = edit_container.find(".sub_notification_setting");
-
     stream_settings_ui.set_muted(
         sub,
         e.target.checked,
         `#stream_change_property_status${CSS.escape(sub.stream_id)}`,
     );
-    edit_container.find(".mute-note").toggleClass("hide-mute-note", !sub.is_muted);
-    notification_checkboxes.toggleClass("muted-sub", sub.is_muted);
-    notification_checkboxes.find("input[type='checkbox']").prop("disabled", sub.is_muted);
+
+    // TODO: This should be done via server_events.
+    update_muting_rendering(sub);
 }
 
 export function stream_setting_changed(e, from_notification_settings) {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -292,7 +292,9 @@ export function setup_stream_settings(node) {
 export function update_muting_rendering(sub) {
     const edit_container = stream_settings_containers.get_edit_container(sub);
     const notification_checkboxes = edit_container.find(".sub_notification_setting");
+    const is_muted_checkbox = edit_container.find("#sub_is_muted_setting .sub_setting_control");
 
+    is_muted_checkbox.prop("checked", sub.is_muted);
     edit_container.find(".mute-note").toggleClass("hide-mute-note", !sub.is_muted);
     notification_checkboxes.toggleClass("muted-sub", sub.is_muted);
     notification_checkboxes.find("input[type='checkbox']").prop("disabled", sub.is_muted);
@@ -310,9 +312,6 @@ function stream_is_muted_changed(e) {
         e.target.checked,
         `#stream_change_property_status${CSS.escape(sub.stream_id)}`,
     );
-
-    // TODO: This should be done via server_events.
-    update_muting_rendering(sub);
 }
 
 export function stream_setting_changed(e, from_notification_settings) {

--- a/static/js/stream_muting.js
+++ b/static/js/stream_muting.js
@@ -1,5 +1,3 @@
-import $ from "jquery";
-
 import {all_messages_data} from "./all_messages_data";
 import * as message_lists from "./message_lists";
 import * as message_scroll from "./message_scroll";
@@ -7,6 +5,7 @@ import * as message_util from "./message_util";
 import * as message_viewport from "./message_viewport";
 import * as navigate from "./navigate";
 import * as overlays from "./overlays";
+import * as stream_edit from "./stream_edit";
 import * as stream_list from "./stream_list";
 
 export function update_is_muted(sub, value) {
@@ -59,12 +58,6 @@ export function update_is_muted(sub, value) {
         }
     }, 0);
 
+    stream_edit.update_muting_rendering(sub);
     stream_list.set_in_home_view(sub.stream_id, !sub.is_muted);
-
-    const is_muted_checkbox = $(
-        `.subscription_settings[data-stream-id='${CSS.escape(
-            sub.stream_id,
-        )}'] #sub_is_muted_setting .sub_setting_control`,
-    );
-    is_muted_checkbox.prop("checked", value);
 }

--- a/static/js/stream_muting.js
+++ b/static/js/stream_muting.js
@@ -5,6 +5,7 @@ import * as message_util from "./message_util";
 import * as message_viewport from "./message_viewport";
 import * as navigate from "./navigate";
 import * as overlays from "./overlays";
+import * as settings_notifications from "./settings_notifications";
 import * as stream_edit from "./stream_edit";
 import * as stream_list from "./stream_list";
 
@@ -58,6 +59,7 @@ export function update_is_muted(sub, value) {
         }
     }, 0);
 
+    settings_notifications.update_muted_stream_state(sub);
     stream_edit.update_muting_rendering(sub);
     stream_list.set_in_home_view(sub.stream_id, !sub.is_muted);
 }

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -217,6 +217,11 @@ export function initialize() {
     });
 
     delegate("body", {
+        target: "#stream-specific-notify-table .unmute_stream",
+        appendTo: () => document.body,
+    });
+
+    delegate("body", {
         target: [
             ".rendered_markdown .copy_codeblock",
             "#compose_top_right [data-tippy-content]",

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -1205,6 +1205,12 @@ body.dark-theme {
     #id_realm_enable_spectator_access_label a {
         color: hsl(236, 33%, 90%);
     }
+
+    #stream-specific-notify-table .unmute_stream {
+        &:hover {
+            color: hsl(0, 0%, 100%);
+        }
+    }
 }
 
 @supports (-moz-appearance: none) {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -522,6 +522,16 @@ input[type="checkbox"] {
     }
 }
 
+#stream-specific-notify-table .unmute_stream {
+    position: relative;
+    left: 3px;
+
+    &:hover {
+        color: hsl(0, 0%, 20%);
+        cursor: pointer;
+    }
+}
+
 .organization-settings-parent > div:first-of-type {
     margin-top: 10px;
 }
@@ -630,6 +640,10 @@ input[type="checkbox"] {
             .stream-privacy span.hashtag,
             .filter-icon i {
                 padding-right: 0;
+            }
+
+            label {
+                cursor: default;
             }
         }
 

--- a/static/templates/settings/notification_settings_checkboxes.hbs
+++ b/static/templates/settings/notification_settings_checkboxes.hbs
@@ -1,7 +1,7 @@
 <td>
     <label class="checkbox">
         <input type="checkbox" name="{{setting_name}}" id="{{prefix}}{{setting_name}}"
-          {{#if is_disabled}}disabled="disabled"{{/if}}
+          {{#if (or is_muted is_disabled)}} disabled {{/if}}
           {{#if is_checked}}checked="checked"{{/if}} data-setting-widget-type="boolean"
           class="{{setting_name}}{{#unless is_disabled}} prop-element{{/unless}}"/>
         <span></span>

--- a/static/templates/settings/stream_specific_notification_row.hbs
+++ b/static/templates/settings/stream_specific_notification_row.hbs
@@ -1,4 +1,4 @@
-<tr class="stream-row" data-stream-id="{{stream.stream_id}}">
+<tr class="stream-row {{#if muted}}control-label-disabled{{/if}}" data-stream-id="{{stream.stream_id}}">
     <td>
         <span id="stream_privacy_swatch_{{stream.stream_id}}" class="stream-privacy filter-icon">
             {{> ../stream_privacy
@@ -6,12 +6,16 @@
               is_web_public=stream.is_web_public }}
         </span>
         {{stream.stream_name}}
+        <div class="fa fa-bell-slash-o unmute_stream" data-tippy-content="{{t 'Unmute' }}"
+          {{#unless muted}}style="display: none;"{{/unless}}></div>
     </td>
     {{#each stream_specific_notification_settings}}
         {{> notification_settings_checkboxes
           setting_name=this
           prefix=(lookup ../stream "stream_id")
           is_checked=(lookup ../stream this)
-          is_disabled=(lookup ../is_disabled this) }}
+          is_disabled=(lookup ../is_disabled this)
+          is_muted=../muted
+          }}
     {{/each}}
 </tr>


### PR DESCRIPTION
This pull request resolves https://github.com/zulip/zulip/issues/19780.
It fixes the inconsistencies in how muted streams are displayed in the settings. Additionally, the user is now able to unmute muted streams in their personal settings too.

![muted-streams-settings (1)](https://user-images.githubusercontent.com/74348920/143493751-269cd72c-544a-435e-84e0-0f719c221a3a.gif)

