### PR TITLE
rate_limit: Fix logging string when rate limiting email gateway.

### DIFF
--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -565,7 +565,7 @@ class WorkerTest(ZulipTestCase):
         self.assertEqual(
             warn_logs.output,
             [
-                "WARNING:zerver.worker.queue_processors:MirrorWorker: Rejecting an email from: None to realm: Zulip Dev - rate limited."
+                "WARNING:zerver.worker.queue_processors:MirrorWorker: Rejecting an email from: None to realm: zulip - rate limited."
             ]
             * 5,
         )

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -808,7 +808,7 @@ class MirrorWorker(QueueProcessingWorker):
                 logger.warning(
                     "MirrorWorker: Rejecting an email from: %s to realm: %s - rate limited.",
                     msg["From"],
-                    recipient_realm.name,
+                    recipient_realm.subdomain,
                 )
                 return
 


### PR DESCRIPTION
realm.name is not the right "name" to log, we should use realm.subdomain
like everywhere else.
