### PR TITLE
Placed "press enter to send" checkbox below send button

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -174,6 +174,7 @@
 
 #below-compose-content {
     display: flex;
+    flex-direction: column;
     width: 100%;
     margin-top: 6px;
     margin-bottom: -2px;
@@ -415,6 +416,7 @@ input.recipient_box {
 
 #compose-send-button {
     height: 25px;
+    float: right;
     padding-top: 3px;
     padding-bottom: 3px;
     margin-bottom: 0;
@@ -423,8 +425,10 @@ input.recipient_box {
 }
 
 #send_controls {
-    font-size: 0.8em;
+    font-size: 0.6rem;
     height: 2.2em;
+    display: inline;
+    float: right;
 
     .compose_checkbox_label {
         color: hsl(0, 0%, 67%);
@@ -471,10 +475,8 @@ input.recipient_box {
 }
 
 .compose_right_float_container {
-    display: flex;
     white-space: nowrap;
     gap: 4px;
-    margin-top: 10px;
 }
 
 a.compose_control_button {

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -3,30 +3,26 @@
         <div id="compose_buttons">
             <span class="new_message_button reply_button_container">
                 <button type="button" class="button small rounded compose_reply_button"
-                  id="left_bar_compose_reply_button_big"
-                  title="{{t 'Reply to selected message' }} (r)">
+                    id="left_bar_compose_reply_button_big" title="{{t 'Reply to selected message' }} (r)">
                     <span class="compose_reply_button_label">{{t 'Compose message' }}</span>
                 </button>
             </span>
             <span class="new_message_button mobile_button_container">
                 <button type="button" class="button small rounded compose_mobile_button"
-                  id="left_bar_compose_mobile_button_big"
-                  title="{{t 'New message' }} (c)">
+                    id="left_bar_compose_mobile_button_big" title="{{t 'New message' }} (c)">
                     <span>+</span>
                 </button>
             </span>
             <span class="new_message_button stream_button_container">
                 <button type="button" class="button small rounded compose_stream_button"
-                  id="left_bar_compose_stream_button_big"
-                  title="{{t 'New topic' }} (c)">
+                    id="left_bar_compose_stream_button_big" title="{{t 'New topic' }} (c)">
                     <span class="compose_stream_button_label">{{t 'New topic' }}</span>
                 </button>
             </span>
             {{#unless embedded }}
             <span class="new_message_button private_button_container">
                 <button type="button" class="button small rounded compose_private_button"
-                  id="left_bar_compose_private_button_big"
-                  title="{{t 'New private message' }} (x)">
+                    id="left_bar_compose_private_button_big" title="{{t 'New private message' }} (x)">
                     <span class="compose_private_button_label">{{t 'New private message' }}</span>
                 </button>
             </span>
@@ -51,9 +47,12 @@
         <div id="out-of-view-notification" class="notification-alert"></div>
         <div class="composition-area">
             <div id="compose_top_right">
-                <button type="button" class="expand_composebox_button fa fa-angle-up" aria-label="{{t 'Expand compose' }}" tabindex=0 title="{{t 'Expand compose' }}"></button>
-                <button type="button" class="collapse_composebox_button fa fa-angle-down" aria-label="{{t 'Collapse compose' }}" tabindex=0 title="{{t 'Collapse compose' }}"></button>
-                <button type="button" class="close" id='compose_close' title="{{t 'Cancel compose' }} (Esc)">&times;</button>
+                <button type="button" class="expand_composebox_button fa fa-angle-up"
+                    aria-label="{{t 'Expand compose' }}" tabindex=0 title="{{t 'Expand compose' }}"></button>
+                <button type="button" class="collapse_composebox_button fa fa-angle-down"
+                    aria-label="{{t 'Collapse compose' }}" tabindex=0 title="{{t 'Collapse compose' }}"></button>
+                <button type="button" class="close" id='compose_close'
+                    title="{{t 'Cancel compose' }} (Esc)">&times;</button>
             </div>
             <form id="send_message_form" action="/json/messages" method="post">
                 {{ csrf_input }}
@@ -64,9 +63,14 @@
                             <span id="compose-lock-icon">
                                 <i class="fa fa-lock" title="{{t 'This is a private stream' }}" aria-hidden="true"></i>
                             </span>
-                            <input type="text" class="recipient_box" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="30" value="" placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Stream' }}" />
+                            <input type="text" class="recipient_box" name="stream_message_recipient_stream"
+                                id="stream_message_recipient_stream" maxlength="30" value=""
+                                placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0"
+                                aria-label="{{t 'Stream' }}" />
                             <i class="fa fa-angle-right" aria-hidden="true"></i>
-                            <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="60" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
+                            <input type="text" class="recipient_box" name="stream_message_recipient_topic"
+                                id="stream_message_recipient_topic" maxlength="60" value="" placeholder="{{t 'Topic' }}"
+                                autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
                         </div>
                     </div>
                     <div id="private-message">
@@ -76,15 +80,20 @@
                         <div class="right_part">
                             <div class="pm_recipient">
                                 <div class="pill-container" data-before="{{t 'You and' }}">
-                                    <div class="input" contenteditable="true" id="private_message_recipient" data-no-recipients-text="{{t 'Add one or more users' }}" data-some-recipients-text="{{t 'Add another user...' }}"></div>
+                                    <div class="input" contenteditable="true" id="private_message_recipient"
+                                        data-no-recipients-text="{{t 'Add one or more users' }}"
+                                        data-some-recipients-text="{{t 'Add another user...' }}"></div>
                                 </div>
                             </div>
                         </div>
                     </div>
                     <div class="messagebox-wrapper">
                         <div class="messagebox">
-                            <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
-                            <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area" style="display:none;">
+                            <textarea class="new_message_textarea" name="content" id='compose-textarea'
+                                placeholder="{{t 'Compose your message here' }}" tabindex="0"
+                                aria-label="{{t 'Compose your message here...' }}"></textarea>
+                            <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area"
+                                style="display:none;">
                                 <div class="markdown_preview_spinner"></div>
                                 <div class="preview_content rendered_markdown"></div>
                             </div>
@@ -92,11 +101,13 @@
                             <div id="below-compose-content">
                                 <div>
                                     <div class="compose_right_float_container order-3">
-                                        <button type="submit" id="compose-send-button" class="button small send_message animated-purple-button" title="{{t 'Send' }} (Ctrl + Enter)">{{t 'Send' }}</button>
+                                        <button type="submit" id="compose-send-button"
+                                            class="button small send_message animated-purple-button"
+                                            title="{{t 'Send' }} (Ctrl + Enter)">{{t 'Send' }}</button>
                                         {{> compose_control_buttons }}
                                     </div>
                                 </div>
-                                
+
                                 <div class="compose_right_float_container order-2">
                                     <span id="compose_limit_indicator"></span>
                                     <div id="send_controls" class="new-style">

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -90,10 +90,13 @@
                             </div>
                             <div class="drag"></div>
                             <div id="below-compose-content">
-                                <div class="compose_right_float_container order-3">
-                                    <button type="submit" id="compose-send-button" class="button small send_message animated-purple-button" title="{{t 'Send' }} (Ctrl + Enter)">{{t 'Send' }}</button>
+                                <div>
+                                    <div class="compose_right_float_container order-3">
+                                        <button type="submit" id="compose-send-button" class="button small send_message animated-purple-button" title="{{t 'Send' }} (Ctrl + Enter)">{{t 'Send' }}</button>
+                                        {{> compose_control_buttons }}
+                                    </div>
                                 </div>
-                                {{> compose_control_buttons }}
+                                
                                 <div class="compose_right_float_container order-2">
                                     <span id="compose_limit_indicator"></span>
                                     <div id="send_controls" class="new-style">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#20303 

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="1199" alt="Screenshot 2021-11-23 at 01 06 52" src="https://user-images.githubusercontent.com/85362194/142924865-1aa941e3-6392-4921-93c3-d46e9c8e335b.png">
<img width="1222" alt="Screenshot 2021-11-23 at 01 07 07" src="https://user-images.githubusercontent.com/85362194/142924873-21c0a899-63e6-483d-860a-ca3054107926.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
