### PR TITLE
Add frontend part for `create_web_public_stream_policy` setting.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -277,6 +277,7 @@ run_test("allow normal typing when processing text", ({override}) => {
 run_test("streams", ({override}) => {
     settings_data.user_can_create_private_streams = () => true;
     settings_data.user_can_create_public_streams = () => true;
+    settings_data.user_can_create_web_public_streams = () => true;
     override(overlays, "streams_open", () => true);
     override(overlays, "is_active", () => true);
     assert_mapping("S", stream_settings_ui, "keyboard_sub");
@@ -284,6 +285,7 @@ run_test("streams", ({override}) => {
     assert_mapping("n", stream_settings_ui, "open_create_stream");
     settings_data.user_can_create_private_streams = () => false;
     settings_data.user_can_create_public_streams = () => false;
+    settings_data.user_can_create_web_public_streams = () => false;
     assert_unmapped("n");
 });
 

--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -283,3 +283,49 @@ run_test("user_can_invite_others_to_realm_nobody_case", () => {
         settings_config.invite_to_realm_policy_values.nobody.code;
     assert.equal(settings_data.user_can_invite_others_to_realm(), false);
 });
+
+run_test("user_can_create_web_public_streams", () => {
+    page_params.is_owner = true;
+    page_params.server_web_public_streams_enabled = true;
+    page_params.realm_enable_spectator_access = true;
+    page_params.realm_create_web_public_stream_policy =
+        settings_config.create_web_public_stream_policy_values.nobody.code;
+    assert.equal(settings_data.user_can_create_web_public_streams(), false);
+
+    page_params.realm_create_web_public_stream_policy =
+        settings_config.create_web_public_stream_policy_values.by_owners_only.code;
+    assert.equal(settings_data.user_can_create_web_public_streams(), true);
+
+    page_params.realm_enable_spectator_access = false;
+    page_params.server_web_public_streams_enabled = true;
+    assert.equal(settings_data.user_can_create_web_public_streams(), false);
+
+    page_params.realm_enable_spectator_access = true;
+    page_params.server_web_public_streams_enabled = false;
+    assert.equal(settings_data.user_can_create_web_public_streams(), false);
+
+    page_params.realm_enable_spectator_access = false;
+    page_params.server_web_public_streams_enabled = false;
+    assert.equal(settings_data.user_can_create_web_public_streams(), false);
+
+    page_params.realm_enable_spectator_access = true;
+    page_params.server_web_public_streams_enabled = true;
+    page_params.is_owner = false;
+    page_params.is_admin = true;
+    assert.equal(settings_data.user_can_create_web_public_streams(), false);
+
+    page_params.realm_create_web_public_stream_policy =
+        settings_config.create_web_public_stream_policy_values.by_admins_only.code;
+    assert.equal(settings_data.user_can_create_web_public_streams(), true);
+
+    page_params.is_admin = false;
+    page_params.is_moderator = true;
+    assert.equal(settings_data.user_can_create_web_public_streams(), false);
+
+    page_params.realm_create_web_public_stream_policy =
+        settings_config.create_web_public_stream_policy_values.by_moderators_only.code;
+    assert.equal(settings_data.user_can_create_web_public_streams(), true);
+
+    page_params.is_moderator = false;
+    assert.equal(settings_data.user_can_create_web_public_streams(), false);
+});

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -685,6 +685,9 @@ test("set_up", ({override, mock_template}) => {
     $("#allowed_domains_label").set_parent($.create("<stub-allowed-domain-label-parent>"));
     const waiting_period_parent_elem = $.create("waiting-period-parent-stub");
     $("#id_realm_waiting_period_threshold").set_parent(waiting_period_parent_elem);
+    $("#id_realm_create_web_public_stream_policy").set_parent(
+        $.create("<stub-create-web-public-stream-policy-parent>"),
+    );
 
     // TEST set_up() here, but this mostly just allows us to
     // get access to the click handlers.

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -158,6 +158,8 @@ export function build_page() {
         email_notifications_batching_period_values:
             settings_config.email_notifications_batching_period_values,
         twenty_four_hour_time_values: settings_config.twenty_four_hour_time_values,
+        create_web_public_stream_policy_values:
+            settings_config.create_web_public_stream_policy_values,
     };
 
     if (options.realm_logo_source !== "D" && options.realm_night_logo_source === "D") {

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -746,7 +746,8 @@ export function process_hotkey(e, hotkey) {
             event_name === "n_key" &&
             overlays.streams_open() &&
             (settings_data.user_can_create_private_streams() ||
-                settings_data.user_can_create_public_streams())
+                settings_data.user_can_create_public_streams() ||
+                settings_data.user_can_create_web_public_streams())
         ) {
             stream_settings_ui.open_create_stream();
             return true;

--- a/static/js/page_params.ts
+++ b/static/js/page_params.ts
@@ -12,14 +12,17 @@ export const page_params: {
     is_admin: boolean;
     is_guest: boolean;
     is_moderator: boolean;
+    is_owner: boolean;
     is_spectator: boolean;
     realm_add_custom_emoji_policy: number;
     realm_avatar_changes_disabled: boolean;
     realm_create_private_stream_policy: number;
     realm_create_public_stream_policy: number;
+    realm_create_web_public_stream_policy: number;
     realm_delete_own_message_policy: number;
     realm_edit_topic_policy: number;
     realm_email_address_visibility: number;
+    realm_enable_spectator_access: boolean;
     realm_invite_to_realm_policy: number;
     realm_invite_to_stream_policy: number;
     realm_move_messages_between_streams_policy: number;
@@ -30,6 +33,7 @@ export const page_params: {
     request_language: string;
     server_avatar_changes_disabled: boolean;
     server_name_changes_disabled: boolean;
+    server_web_public_streams_enabled: boolean;
     translation_data: Record<string, string>;
     zulip_plan_is_not_limited: boolean;
 } = $("#page-params").remove().data("params");

--- a/static/js/popover_menus.js
+++ b/static/js/popover_menus.js
@@ -44,7 +44,8 @@ export function initialize() {
                 render_left_sidebar_stream_setting_popover({
                     can_create_streams:
                         settings_data.user_can_create_private_streams() ||
-                        settings_data.user_can_create_public_streams(),
+                        settings_data.user_can_create_public_streams() ||
+                        settings_data.user_can_create_web_public_streams(),
                 }),
             );
             left_sidebar_stream_setting_popover_displayed = true;

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -214,7 +214,7 @@ export function dispatch_normal_event(event) {
                 private_message_policy: noop,
                 send_welcome_emails: noop,
                 message_content_allowed_in_email_notifications: noop,
-                realm_enable_spectator_access: noop,
+                enable_spectator_access: noop,
                 signup_notifications_stream_id: noop,
                 emails_restricted_to_domains: noop,
                 video_chat_provider: compose.update_video_chat_button_display,

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -227,6 +227,29 @@ export const wildcard_mention_policy_values = {
     },
 };
 
+export const create_web_public_stream_policy_values = {
+    by_moderators_only: {
+        order: 1,
+        code: 4,
+        description: $t({defaultMessage: "Admins and moderators"}),
+    },
+    by_admins_only: {
+        order: 2,
+        code: 2,
+        description: $t({defaultMessage: "Admins only"}),
+    },
+    by_owners_only: {
+        order: 3,
+        code: 7,
+        description: $t({defaultMessage: "Owners only"}),
+    },
+    nobody: {
+        order: 4,
+        code: 6,
+        description: $t({defaultMessage: "Nobody"}),
+    },
+};
+
 export const common_message_policy_values = {
     by_everyone: {
         order: 1,

--- a/static/js/settings_data.ts
+++ b/static/js/settings_data.ts
@@ -181,6 +181,31 @@ export function user_can_create_public_streams(): boolean {
     return user_has_permission(page_params.realm_create_public_stream_policy);
 }
 
+export function user_can_create_web_public_streams(): boolean {
+    if (
+        !page_params.server_web_public_streams_enabled ||
+        !page_params.realm_enable_spectator_access
+    ) {
+        return false;
+    }
+
+    if (
+        page_params.realm_create_web_public_stream_policy ===
+        settings_config.create_web_public_stream_policy_values.nobody.code
+    ) {
+        return false;
+    }
+
+    if (
+        page_params.realm_create_web_public_stream_policy ===
+        settings_config.create_web_public_stream_policy_values.by_owners_only.code
+    ) {
+        return page_params.is_owner;
+    }
+
+    return user_has_permission(page_params.realm_create_web_public_stream_policy);
+}
+
 export function user_can_move_messages_between_streams(): boolean {
     return user_has_permission(page_params.realm_move_messages_between_streams_policy);
 }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -218,6 +218,7 @@ function get_subsection_property_elements(element) {
 const simple_dropdown_properties = [
     "realm_create_private_stream_policy",
     "realm_create_public_stream_policy",
+    "realm_create_web_public_stream_policy",
     "realm_invite_to_stream_policy",
     "realm_user_group_edit_policy",
     "realm_private_message_policy",
@@ -349,6 +350,13 @@ function set_digest_emails_weekday_visibility() {
     );
 }
 
+function set_create_web_public_stream_dropdown_visibility() {
+    change_element_block_display_property(
+        "id_realm_create_web_public_stream_policy",
+        page_params.server_web_public_streams_enabled && page_params.realm_enable_spectator_access,
+    );
+}
+
 export function populate_realm_domains(realm_domains) {
     if (!meta.loaded) {
         return;
@@ -444,6 +452,9 @@ function update_dependent_subsettings(property_name) {
                 settings_realm_user_settings_defaults.realm_default_settings_panel,
             );
             set_digest_emails_weekday_visibility();
+            break;
+        case "realm_enable_spectator_access":
+            set_create_web_public_stream_dropdown_visibility();
             break;
     }
 }
@@ -988,6 +999,7 @@ export function build_page() {
     set_org_join_restrictions_dropdown();
     set_message_content_in_email_notifications_visiblity();
     set_digest_emails_weekday_visibility();
+    set_create_web_public_stream_dropdown_visibility();
 
     register_save_discard_widget_handlers($(".admin-realm-form"), "/json/realm", false);
 

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -301,6 +301,7 @@ function clear_error_display() {
 export function show_new_stream_modal() {
     $("#stream-creation").removeClass("hide");
     $(".right .settings").hide();
+    stream_settings_ui.hide_or_disable_stream_privacy_options_if_required($("#stream-creation"));
 
     const add_people_container = $("#people_to_add");
     add_people_container.html(

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -794,6 +794,11 @@ export function initialize() {
                     change_stream_message_retention_days_block_display_property(dropdown_value);
                 });
             },
+            on_show: () => {
+                stream_settings_ui.hide_or_disable_stream_privacy_options_if_required(
+                    $("#stream_privacy_modal"),
+                );
+            },
         });
         e.preventDefault();
         e.stopPropagation();

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -607,7 +607,8 @@ export function setup_page(callback) {
         const template_data = {
             can_create_streams:
                 settings_data.user_can_create_private_streams() ||
-                settings_data.user_can_create_public_streams(),
+                settings_data.user_can_create_public_streams() ||
+                settings_data.user_can_create_web_public_streams(),
             hide_all_streams: !should_list_all_streams(),
             max_name_length: page_params.max_stream_name_length,
             max_description_length: page_params.max_stream_description_length,
@@ -651,6 +652,7 @@ export function setup_page(callback) {
             if (
                 settings_data.user_can_create_private_streams() ||
                 settings_data.user_can_create_public_streams() ||
+                settings_data.user_can_create_web_public_streams() ||
                 page_params.realm_is_zephyr_mirror_realm
             ) {
                 open_create_stream();
@@ -983,6 +985,29 @@ export function sub_or_unsub(sub, stream_row) {
         ajaxUnsubscribe(sub, stream_row);
     } else {
         ajaxSubscribe(sub.name, sub.color, stream_row);
+    }
+}
+
+export function hide_or_disable_stream_privacy_options_if_required(container) {
+    if (!settings_data.user_can_create_web_public_streams()) {
+        const web_public_stream_elem = container.find(
+            `input[value='${CSS.escape(
+                stream_data.stream_privacy_policy_values.web_public.code,
+            )}']`,
+        );
+        if (!web_public_stream_elem.is(":checked")) {
+            if (
+                !page_params.server_web_public_streams_enabled ||
+                !page_params.realm_enable_spectator_access
+            ) {
+                web_public_stream_elem.closest(".radio-input-parent").hide();
+                container
+                    .find(".stream-privacy-values .radio-input-parent:visible:last")
+                    .css("border-bottom", "none");
+            } else {
+                web_public_stream_elem.prop("disabled", true);
+            }
+        }
     }
 }
 

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -1009,6 +1009,28 @@ export function hide_or_disable_stream_privacy_options_if_required(container) {
             }
         }
     }
+
+    if (!settings_data.user_can_create_public_streams()) {
+        const public_stream_elem = container.find(
+            `input[value='${CSS.escape(stream_data.stream_privacy_policy_values.public.code)}']`,
+        );
+        public_stream_elem.prop("disabled", true);
+    }
+
+    if (!settings_data.user_can_create_private_streams()) {
+        // Disable both "Private, shared history" and "Private, protected history" options.
+        const private_stream_elem = container.find(
+            `input[value='${CSS.escape(stream_data.stream_privacy_policy_values.private.code)}']`,
+        );
+        const private_with_public_history_elem = container.find(
+            `input[value='${CSS.escape(
+                stream_data.stream_privacy_policy_values.private_with_public_history.code,
+            )}']`,
+        );
+
+        private_stream_elem.prop("disabled", true);
+        private_with_public_history_elem.prop("disabled", true);
+    }
 }
 
 export function initialize() {

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -107,7 +107,7 @@
                   setting_name="realm_enable_spectator_access"
                   prefix="id_"
                   is_checked=realm_enable_spectator_access
-                  render_only=page_params.development_environment
+                  render_only=page_params.server_web_public_streams_enabled
                   label=admin_settings_label.realm_enable_spectator_access}}
                 <div class="input-group">
                     <label for="realm_create_private_stream_policy" class="dropdown-title">{{t "Who can create private streams" }}</label>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -109,6 +109,12 @@
                   is_checked=realm_enable_spectator_access
                   render_only=page_params.server_web_public_streams_enabled
                   label=admin_settings_label.realm_enable_spectator_access}}
+                <div class="input-group realm_create_web_public_stream_policy">
+                    <label for="realm_create_web_public_stream_policy" class="dropdown-title">{{t "Who can create web-public streams" }}</label>
+                    <select name="realm_create_web_public_stream_policy" id="id_realm_create_web_public_stream_policy" class="prop-element" data-setting-widget-type="number">
+                        {{> dropdown_options_widget option_values=create_web_public_stream_policy_values}}
+                    </select>
+                </div>
                 <div class="input-group">
                     <label for="realm_create_private_stream_policy" class="dropdown-title">{{t "Who can create private streams" }}</label>
                     <select name="realm_create_private_stream_policy" id="id_realm_create_private_stream_policy" class="prop-element" data-setting-widget-type="number">

--- a/static/templates/stream_settings/stream_types.hbs
+++ b/static/templates/stream_settings/stream_types.hbs
@@ -1,5 +1,5 @@
 <div class="grey-box new-style">
-    <div class="input-group">
+    <div class="input-group stream-privacy-values">
         <div class="alert stream-privacy-status"></div>
         <h4>{{t 'Who can access the stream?'}}
             {{> ../help_link_widget link="/help/stream-permissions" }}

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 109
+API_FEATURE_LEVEL = 110
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -293,6 +293,7 @@ def fetch_initial_state_data(
         state["server_inline_url_embed_preview"] = settings.INLINE_URL_EMBED_PREVIEW
         state["server_avatar_changes_disabled"] = settings.AVATAR_CHANGES_DISABLED
         state["server_name_changes_disabled"] = settings.NAME_CHANGES_DISABLED
+        state["server_web_public_streams_enabled"] = settings.WEB_PUBLIC_STREAMS_ENABLED
         state["giphy_rating_options"] = realm.GIPHY_RATING_OPTIONS
 
         state["server_needs_upgrade"] = is_outdated_server(user_profile)

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -896,6 +896,9 @@ class Realm(models.Model):
             # target every open Internet service that can host files.
             return False
 
+        if not self.enable_spectator_access:
+            return False
+
         return True
 
     def has_web_public_streams(self) -> bool:
@@ -909,10 +912,11 @@ class Realm(models.Model):
     def allow_web_public_streams_access(self) -> bool:
         """
         If any of the streams in the realm is web
-        public and `enable_spectator_access` is True,
+        public and `enable_spectator_access` and
+        settings.WEB_PUBLIC_STREAMS_ENABLED is True,
         then the Realm is web public.
         """
-        return self.enable_spectator_access and self.has_web_public_streams()
+        return self.has_web_public_streams()
 
 
 post_save.connect(flush_realm, sender=Realm)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11100,6 +11100,16 @@ paths:
                           such that the web app will display to the current user a prominent warning.
 
                           **Changes**: New in Zulip 5.0 (feature level 74).
+                      server_web_public_streams_enabled:
+                        type: boolean
+                        description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
+                          Whether web public streams are enabled in the server. Similar topic_name
+                          `realm_enable_spectator_access` but based on the `WEB_PUBLIC_STREAMS_ENABLED`
+                          Zulip server level setting.
+
+                          **Changes**: New in Zulip 5.0 (feature level 110).
                       event_queue_longpoll_timeout_seconds:
                         type: integer
                         description: |

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -190,6 +190,7 @@ class HomeTest(ZulipTestCase):
         "server_name_changes_disabled",
         "server_needs_upgrade",
         "server_timestamp",
+        "server_web_public_streams_enabled",
         "settings_send_digest_emails",
         "show_billing",
         "show_plans",

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -847,6 +847,14 @@ class RealmTest(ZulipTestCase):
             self.assertEqual(realm.has_web_public_streams(), False)
             self.assertEqual(realm.web_public_streams_enabled(), False)
 
+        realm.enable_spectator_access = False
+        realm.save()
+        self.assertEqual(realm.has_web_public_streams(), False)
+        self.assertEqual(realm.web_public_streams_enabled(), False)
+
+        realm.enable_spectator_access = True
+        realm.save()
+
         # Convert Rome to a public stream
         rome.is_web_public = False
         rome.save()

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -314,8 +314,8 @@ def update_stream_backend(
         # Enforce restrictions on creating web-public streams.
         if not user_profile.realm.web_public_streams_enabled():
             raise JsonableError(_("Web public streams are not enabled."))
-        if not user_profile.is_realm_owner:
-            raise OrganizationOwnerRequired()
+        if not user_profile.can_create_web_public_streams():
+            raise JsonableError(_("Insufficient permission"))
         # Forbid parameter combinations that are inconsistent
         if is_private or history_public_to_subscribers is False:
             raise JsonableError(_("Invalid parameters"))


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit is a prep commit for a small fix.
- Second commit is to pass `settings.WEB_PUBLIC_STREAMS_ENABLED` to clients.
- Third commit is to show enable_spectator_access setting in UI only is server-level `settings.WEB_PUBLIC_STREAMS_ENABLED` is set to True.
- Fourth commit is to allow changing existing stream to web-public only is user is allowed to create web-public streams.
- Fifth commit is to check `enable_spectator_access` setting while creating streams in the API.
- Sixth commit adds `user_can_create_web_public_streams` function.
- Seventh commit adds dropdown for the setting and also controls the behavior of UI elements according to the setting.
- Eigth commit is to disable the stream-privacy choices according to realm settings.

Related issue - #20287, #20296.
 <!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
