### PR TITLE
documentation: Fix ordered list text wrapping in some /help articles.

### DIFF
--- a/templates/zerver/help/animated-gifs-from-giphy.md
+++ b/templates/zerver/help/animated-gifs-from-giphy.md
@@ -13,13 +13,19 @@ messages.
 Be thoughtful when using this feature! Animated GIFs can be fun, but
 they can also distract from the content of a conversation.
 
+{start_tabs}
 1. First, [open the compose box](/help/open-the-compose-box).
+
 1. **Click the GIPHY logo** at the bottom of the compose box. This
    opens the GIPHY search tool.
+
 1. Use the search tool to find a GIF you'd like to use.
+
 1. **Click on an image** to insert a link to the GIF in the compose box.
+
 1. Send the message.  Zulip will display the GIF like any other linked
    image.
+{end_tabs}
 
 You can [preview the
 message](/help/preview-your-message-before-sending) before sending to

--- a/templates/zerver/help/desktop-app-install-guide.md
+++ b/templates/zerver/help/desktop-app-install-guide.md
@@ -17,6 +17,7 @@ look at the newest features, consider the [beta releases](#install-a-beta-releas
 <!-- TODO why zip? -->
 
 1. Download [Zulip for macOS](https://zulip.com/apps/mac).
+
 1. Open the file, and drag the app into the `Applications` folder.
 
 The app will update automatically to future versions.
@@ -24,6 +25,7 @@ The app will update automatically to future versions.
 #### Homebrew
 
 1. Run `brew cask install zulip` in Terminal.
+
 1. Run Zulip from `Applications`. <!-- TODO fact check -->
 
 The app will update automatically to future versions. `brew upgrade` will
@@ -34,6 +36,7 @@ also work, if you prefer.
 #### Web installer (recommended)
 
 1. Download and run [Zulip for Windows](https://zulip.com/apps/windows).
+
 1. Run Zulip from the Start menu.
 
 The app will update automatically to future versions.
@@ -42,8 +45,10 @@ The app will update automatically to future versions.
 
 1. Download [zulip-x.x.x-x64.nsis.7z][latest] for 64-bit desktops
    (common), or [zulip-x.x.x-ia32.nsis.7z][latest] for 32-bit (rare).
+
 2. Copy the installer file to the machine you want to install the app
    on, and run it there.
+
 3. Run Zulip from the Start menu.
 
 The app will NOT update automatically. You can repeat these steps to upgrade
@@ -74,9 +79,11 @@ regular software update on your system, e.g. with
 #### AppImage (recommended for all other distros)
 
 1. Download [Zulip for Linux](https://zulip.com/apps/linux).
+
 2. Make the file executable, with
    `chmod a+x Zulip-x.x.x-x86_64.AppImage` from a terminal (replace
    `x.x.x` with the actual name of the downloaded file).
+
 3. Run the file from your app launcher, or from a terminal.
 
 No installer is necessary; this file is the Zulip app. The app will update

--- a/templates/zerver/help/include/how-to-start-a-new-topic.md
+++ b/templates/zerver/help/include/how-to-start-a-new-topic.md
@@ -1,15 +1,18 @@
 {start_tabs}
 {tab|stream}
 1. Click the **New topic** button at the bottom of the Zulip window, or type `c`.
+
 2. Enter a topic name. Auto-complete will provide suggestions for previously
    used topics.
 
 {!compose-and-send-message.md!}
 
 {tab|not-stream}
-1. Click the “New topic” button at the bottom of the Zulip window, or type `c`.
+1. Click the **New topic** button at the bottom of the Zulip window, or type `c`.
+
 2. Enter a stream name. Auto-complete will provide suggestions for streams you
    can send to.
+
 2. Enter a topic name. Auto-complete will provide suggestions for previously
    used topics.
 

--- a/templates/zerver/help/include/left-sidebar-topics.md
+++ b/templates/zerver/help/include/left-sidebar-topics.md
@@ -4,6 +4,7 @@ unread message counts for each stream.
 {start_tabs}
 1. Click on the name of a stream in the left sidebar. You will see a list of the
    most recent unread topics in that stream.
+
 2. The initially shown list of topics usually has what you need, but you can
    click on "more topics" underneath to see additional topics.
 {end_tabs}

--- a/templates/zerver/help/include/reading-pms.md
+++ b/templates/zerver/help/include/reading-pms.md
@@ -1,12 +1,17 @@
 {start_tabs}
 1. Click on **Private messages** in the left sidebar.
+
 2. Click on a conversation in the left sidebar under **Private messages**.
+
 3. Read the conversation, scrolling down with the mouse or by pressing `Fn` + `↓`.
+
 4. If the conversation is not of interest, you can
    [mark all messages as read](/help/marking-messages-as-read) or do so by jumping
    to the end using the `End` key.
+
 5. Click on the next conversation in the left sidebar, or use the `p` key to go to the
    next unread conversation.
+
 6. To go to older unread conversations, use the `p` key or scroll down in the
    **Private messages** section of the left sidebar to view.
 {end_tabs}

--- a/templates/zerver/help/include/reading-topics.md
+++ b/templates/zerver/help/include/reading-topics.md
@@ -1,22 +1,32 @@
 {start_tabs}
 {tab|via-recent-topics}
 1. Open **Recent topics** from the left sidebar or by pressing the `Esc` key.
+
 2. Click on the name of a topic in the **Topic** column.
+
 3. Read the topic, scrolling down with the mouse or by pressing `Fn` + `↓`.
+
 4. If the topic is not of interest, you can
    [mark all messages as read](/help/marking-messages-as-read) or do so by jumping
    to the end using the `End` key.
+
 5. You can then click on another topic in the left sidebar, use the `n` key to go to the
    next unread topic, or go back to the **Recent topics** view.
+
 {tab|via-left-sidebar}
 1. Click on the name of a stream in the left sidebar. You will see a list of the
    most recent unread topics in that stream.
+
 2. Click on a topic in the left sidebar.
+
 3. Read the topic, scrolling down with the mouse or by pressing `Fn` + `↓`.
+
 4. If the topic is not of interest, you can
    [mark all messages as read](/help/marking-messages-as-read) or do so by jumping
    to the end using the `End` key.
+
 5. Click on the next topic in the left sidebar, or use the `n` key to go to the
    next unread topic.
+
 6. To go to older unread topics, use the `n` key or click "more topics" to view.
 {end_tabs}

--- a/templates/zerver/help/include/starting-a-new-private-thread.md
+++ b/templates/zerver/help/include/starting-a-new-private-thread.md
@@ -1,6 +1,7 @@
 {start_tabs}
 1. Click the **New private message** button at the bottom of the Zulip window,
    or type `x`.
+
 2. Type the names of one or more recipients. Auto-complete will provide
    suggestions for users you can message.
 

--- a/templates/zerver/help/saml-authentication.md
+++ b/templates/zerver/help/saml-authentication.md
@@ -118,16 +118,20 @@ how to configure these SAML providers to work with Zulip.
 ## Configure SAML with Keycloak
 
 1. Make sure you have created your organization.
+
 1. Make sure your Keycloak server is up and running. We assume the URL
    is `https://keycloak.example.com` and your Keycloak realm is `yourrealm`.
+
 1. In Keycloak, register a new Client for your Zulip organization:
     * Client-ID: `https://zulipchat.com`
     * Client Protocol: `saml`
     * Client SAML Endpoint: leave this field empty
+
 1. In the `Settings` tab for your new Keycloak client, set the following properties:
     - Valid Redirect URIs: `https://auth.zulipchat.com/*`
     - Base URL: `https://auth.zulipchat.com/complete/saml/`
     - Client Signature Required: `Disable`
+
 1. In the `Mappers` tab for your new Keycloak client:
     * Create a Mapper for first name:
         * Property: `firstName`

--- a/templates/zerver/help/scim.md
+++ b/templates/zerver/help/scim.md
@@ -19,25 +19,35 @@ side of SCIM for their deployment.
 
 1. Before you begin, contact [email support](mailto:support@zulip.com) to receive
    the bearer token that Okta will use to authenticate to make its SCIM requests.
+
 1. In your Okta Dashboard, go to `Applications` and choose `Browse App Catalog`.
+
 1. Search for `SCIM` and select `SCIM 2.0 Test App (Header Auth)`.
+
 1. Click `Add` and choose your `Application label`. For example, you can name it `Zulip SCIM`.
+
 1. Continue to `Sign-On Options`. Leave the `SAML` options, as this type of Okta application
    doesn't actually support `SAML` authentication, and you'll need to set up a separate Okta app
    to activate `SAML` for your Zulip organization.
+
 1. In `Credentials Details`, set `Application username format` to `Email` and
     `Update application username on` to `Create and update`.
+
 1. The Okta app has been added. Navigate to the `Provisioning` tab.
+
 1. Click `Configure API Integration` and check the `Enable API integration` box.
    Okta will ask you for the `Base URL` and `API token`. The `Base URL` should be
    `yourorganization.zulipchat.com/scim/v2` and for `API token` you'll set the value
    given to you by support. When you proceed to the next step, Okta will verify that
    these details are correct by making a SCIM request to the Zulip server.
+
 1. In the `To App` section of the `Provisioning` tab (which should be opened by default
    when you continue from the previous step), edit the `Provisioning to App` settings
    to enable `Create Users`, `Update User Attributes` and `Deactivate Users`.
+
 1. In `Attribute Mappings`, remove all attributes except `userName`, `givenName`
    and `familyName`.
+
 1. Now the integration should be ready and you can `Assign` users to
    the app to configure their Zulip accounts to be managed by
    SCIM. When you assign a user, Okta will check if the account exists


### PR DESCRIPTION
@alya This is a minor change to some of the `/help` markdown directories to correct the text wrapping of ordered lists in the content of the article. It looks like there needs to be a line break in the markdown file when there is an ordered list so that the text wrapping is indented properly. The line break wraps the list item in a `<p>` tag.

I also noticed in `/help/starting-a-new-topic` the `not-stream` tab had text in quotation marks that was intended to be bold.

And in `help/animated-gifs-from-giphy` there was an instruction block without a the tab widget, so I added that in as well.

To keep the purpose of the changes clear, I didn't change any of the numbering inconsistencies in the markdown files. I'm not sure if there is a preferred format (all ordered list items are `1. ` for example) as it doesn't impact how the page is rendered. 

**GIFs or screenshots:** left = updates on local host, right = current docs, narrowed view to cause text wrapping
![Screenshot from 2021-11-23 16-55-57](https://user-images.githubusercontent.com/63245456/143062442-237e2b47-883e-4641-a3bf-84031fd540b9.png)

![Screenshot from 2021-11-23 16-55-12](https://user-images.githubusercontent.com/63245456/143062448-bddd3ee2-4f3d-486b-bad1-33594852a04f.png)

![Screenshot from 2021-11-23 16-53-26](https://user-images.githubusercontent.com/63245456/143062451-21e7c31b-b6c3-499d-b4e7-8ff7aae5611e.png)

![Screenshot from 2021-11-23 16-52-23](https://user-images.githubusercontent.com/63245456/143062456-426513bd-18f5-4a89-b670-e54cfe36d41b.png)

![Screenshot from 2021-11-23 16-50-44](https://user-images.githubusercontent.com/63245456/143062459-56e4cf85-167f-4ee8-aac6-470e39290dbd.png)

