### PR TITLE
stream_create: Always insert change-stream-privacy button.

### DIFF
--- a/static/templates/stream_settings/stream_settings.hbs
+++ b/static/templates/stream_settings/stream_settings.hbs
@@ -46,14 +46,12 @@
                 <h3 class="stream_setting_subsection_title">
                     {{t "Stream permissions" }}
                 </h3>
-                {{#if can_change_stream_permissions}}
                 <div class="stream_permission_change_info alert-notification"></div>
                 <div class="button-group">
-                    <a class="change-stream-privacy button rounded small btn-warning" role="button">
+                    <a class="change-stream-privacy button rounded small btn-warning" {{#unless can_change_stream_permissions}}style="display:none"{{/unless}} role="button">
                         <i class="fa fa-pencil" aria-hidden="true"></i>
                     </a>
                 </div>
-                {{/if}}
             </div>
             <div class="subscription-type">
                 <div class="subscription-type-text">


### PR DESCRIPTION
Previously, if an admin created a private stream with shared history
or a private stream with protected history, they would see the general
tab for that stream in the right side of the subscriptions_overlay as
expected, but, they would not see the pencil button to change stream
privacy unless they clicked a different stream and came back.

The reason for this has to do with how we receive events when we
create a sub. We first get an event with type "stream" and op
"create", we then get an event with type "subscription" and op "add"
ie we create the stream and then sub ourselves to it. Now, we render
`stream_settings.hbs` while handling the "stream create" event, at
this time we pass `can_change_stream_permissions` as false since
`(!sub.invite_only || sub.subscribed)` is false because we're not
subscribed yet. This causes us to skip the insertion of the
"change-stream-privacy" block which is a problem because when we're
handling the "subscription add" event, we run
`stream_ui_updates.update_change_stream_privacy_settings(sub)` which
tries to show the element via `.show()` but can't since the element
does not exist and as a result the admin user does not see the pencil
edit button.

This commit fixes the above bug by changing the template such that we
always insert the button, but conditionally apply
`style="display:none"`.

Fixes: #20345.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
This user flow doesn't have many existing tests... can we open a "goof first issue" labeled issue?

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![241121-stream_creation_pencil_edit_after-2](https://user-images.githubusercontent.com/33805964/143279419-90aad759-30ee-45f3-9ff0-5bf27551250b.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
