### PR TITLE
api: Migrate `/update-subscription-settings` response value.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 5.0
 
+**Feature level 111**
+
+* [`POST /subscriptions/properties`](/api/update-subscription-settings):
+  Removed `subscription_data` from response object, replacing it with
+  `ignored_parameters_unsupported`.
+
 **Feature level 110**
 
 * [`POST /register`](/api/register-queue): Added

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 110
+API_FEATURE_LEVEL = 111
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7857,6 +7857,11 @@ paths:
         per-stream notification settings.
 
         `POST {{ api_url }}/v1/users/me/subscriptions/properties`
+
+        **Changes**: Prior to Zulip 5.0 (feature level 111), response
+        object included the `subscription_data` in the the
+        request. The endpoint now returns the more ergonimic
+        `ignored_parameters_unsupported` field instead.
       parameters:
         - name: subscription_data
           in: query
@@ -7910,71 +7915,11 @@ paths:
                     properties:
                       result: {}
                       msg: {}
-                      subscription_data:
-                        type: array
-                        items:
-                          type: object
-                          additionalProperties: false
-                          properties:
-                            stream_id:
-                              description: |
-                                The unique ID of the stream.
-                              type: integer
-                            property:
-                              type: string
-                              description: |
-                                The changed property. It is one of:
-
-                                - `color`: The hex value of the user's personal display color for the stream.
-                                - `is_muted`: Whether the stream is [muted](/help/mute-a-stream).<br>
-                                  **Changes**: Prior to Zulip 2.1, this feature was
-                                  represented by the more confusingly named `in_home_view` (with the
-                                  opposite value, `in_home_view=!is_muted`); for
-                                  backwards-compatibility, modern Zulip still accepts/returns that property.
-                                - `pin_to_top`: Whether to pin the stream at the top of the stream list.
-                                - `desktop_notifications`: Whether to show desktop notifications for all
-                                  messages sent to the stream.
-                                - `audible_notifications`: Whether to play a sound notification for all
-                                  messages sent to the stream.
-                                - `push_notifications`: Whether to trigger a mobile push notification for
-                                  all messages sent to the stream.
-                                - `email_notifications`: Whether to trigger an email notification for all
-                                  messages sent to the stream.
-                                - `wildcard_mentions_notify`: whether wildcard mentions trigger notifications
-                                  as though they were personal mentions in this stream.
-                              enum:
-                                - color
-                                - is_muted
-                                - pin_to_top
-                                - desktop_notifications
-                                - audible_notifications
-                                - push_notifications
-                                - email_notifications
-                                - wildcard_mentions_notify
-                                - in_home_view
-                            value:
-                              description: |
-                                The desired value of the property.
-                              oneOf:
-                                - type: boolean
-                                - type: string
-                        description: |
-                          The same `subscription_data` array sent by the client for the request.
+                      ignored_parameters_unsupported:
+                        $ref: "#/components/schemas/IgnoredParametersUnsupported"
                     example:
                       {
-                        "subscription_data":
-                          [
-                            {
-                              "stream_id": 1,
-                              "property": "pin_to_top",
-                              "value": true,
-                            },
-                            {
-                              "stream_id": 3,
-                              "property": "color",
-                              "value": "#f00f00",
-                            },
-                          ],
+                        "ignored_parameters_unsupported": ["invalid_parameter"],
                         "result": "success",
                         "msg": "",
                       }
@@ -11976,13 +11921,12 @@ paths:
         backwards-compatibility, and will be removed once clients have
         migrated to use this endpoint.
 
-        **Changes**: New in Zulip 5.0 (feature level 78). Previously,
+        **Changes**: Prior to Zulip 5.0 (feature level 78),
         the `/settings` endpoint indicated which parameters it had
         processed by including in the response object `"key": value`
-        entries for values successfully changed by the request. Now the
-        `/settings` endpoint indicates which parameters sent with the
-        request were not supported by this endpoint (see
-        `ignored_parameters_unsupported` below).
+        entries for values successfully changed by the request. That
+        was replaced by the more ergonomic
+        `ignored_parameters_unsupported` response parameter.
 
         The `/settings/notifications` and `/settings/display` endpoints
         also had this behavior before they became aliases of `/settings`
@@ -13548,7 +13492,12 @@ components:
         implementation or an attempt to configure a new feature while
         connected to an older Zulip server that does not support said feature.
 
-        **Changes**: New in Zulip 5.0 (feature level 78)
+        **Changes**: Added to `POST /users/me/subscriptions/properties` in
+        Zulip 5.0 (feature level 111).
+
+        Added to `PATCH /realm/user_settings_defaults` in Zulip 5.0 (feature level 96).
+
+        Introduced in `PATCH /settings` in Zulip 5.0 (feature level 78).
     EventIdSchema:
       type: integer
       description: |


### PR DESCRIPTION
Migrates the `/update-subscription-settings` api endpoint to the `ignored_parameters_unsupported` model, which is also currently used by `/update-settings` and `update-realm-user-settings-defaults`.

Previously the `/update-subscription-settings` endpoint returned a copy of the data object sent in the request. This change is a step towards preparing for an eventual migration to have all endpoints return an `ignored_parameters_unsupported` block.

Fixes #15307. Follow-up from #20332.

**Questions for reviewers**:
- There are now 3 views (`realm.py`, `user_settings.py` and `streams.py` with almost identical code for generating the ignored parameters. Keeping in mind that there's an eventual plan to have an ignored parameters block returned in all endpoints, does it make sense to write/have a function that these 3 views (and potentially more) can import / share? If so, where would that best be located?

- Unlike the other endpoints using the ignored parameters model, this endpoint takes an object array as it's sole parameter. Does it make sense to have this endpoint function more like other updates to settings? Having the `stream_id` and `property` as parameters?

**Testing plan:** Added a test to `test_subs.py` to confirm that the `ignored_parameters_unsupported` is returned if and when the supported parameter is also in the request. Manually tested in dev environment confirming the response as expected in the network tab of dev tools.