### PR TITLE
docs: Suggest updating settings.py in OIDC instructions.

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -827,6 +827,11 @@ enabling `zproject.backends.GenericOpenIdConnectBackend` in
 `AUTHENTICATION_BACKENDS` and following the steps outlined in the
 comment documentation in `/etc/zulip/settings.py`.
 
+If your server was originally installed from a release in the
+`4.x` series or earlier, you will need to update your `settings.py`
+file. You can find instructions on how to do that in a
+[separate doc][update-inline-comments].
+
 Note that `SOCIAL_AUTH_OIDC_ENABLED_IDPS` only supports a single IdP currently.
 
 The Return URL to authorize with the provider is


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/2-general/topic/OIDC/near/1286797

OIDC config features a get_secret call (so it requires adding an import)
as well as having a bunch of its instructions in the form of comments on
the various keys of the config dict - thus users should really update
settings.py to fetch all of that.

