### PR TITLE
integrations: Switch BigBlueButton over to SHA256.

### DIFF
--- a/zerver/tests/test_create_video_call.py
+++ b/zerver/tests/test_create_video_call.py
@@ -175,7 +175,7 @@ class TestVideoCall(ZulipTestCase):
             self.assertEqual(
                 response.json()["url"],
                 "/calls/bigbluebutton/join?meeting_id=zulip-1&password=AAAAAAAAAA"
-                "&checksum=697939301a52d3a2f0b3c3338895c1a5ab528933",
+                "&checksum=d5eb2098bcd0e69a33caf2b18490991b843c8fa6be779316b4303c7990aca687",
             )
 
     @responses.activate
@@ -194,7 +194,7 @@ class TestVideoCall(ZulipTestCase):
         self.assertEqual(
             response.url,
             "https://bbb.example.com/bigbluebutton/api/join?meetingID=zulip-1&password=a"
-            "&fullName=King%20Hamlet&checksum=7ddbb4e7e5aa57cb8c58db12003f3b5b040ff530",
+            "&fullName=King%20Hamlet&checksum=ca78d6d3c3e04918bfab9d7d6cbc6e50602ab2bdfe1365314570943346a71a00",
         )
 
     @responses.activate

--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -178,7 +178,7 @@ def get_bigbluebutton_url(request: HttpRequest, user_profile: UserProfile) -> Ht
     # https://docs.bigbluebutton.org/dev/api.html#usage for reference for checksum
     id = "zulip-" + str(random.randint(100000000000, 999999999999))
     password = b32encode(secrets.token_bytes(7))[:10].decode()
-    checksum = hashlib.sha1(
+    checksum = hashlib.sha256(
         (
             "create"
             + "meetingID="
@@ -257,7 +257,7 @@ def join_bigbluebutton(
             quote_via=quote,
         )
 
-        checksum = hashlib.sha1(
+        checksum = hashlib.sha256(
             ("join" + join_params + settings.BIG_BLUE_BUTTON_SECRET).encode()
         ).hexdigest()
         redirect_url_base = append_url_query_string(


### PR DESCRIPTION
This commit switches the BigBlueButton integration
to use SHA256 instead of SHA1 as BigBlueButton supports
it and scalelite does now, too.

This is regarding to #19966 

**Testing plan:** <!-- How have you tested? -->
Tested this with a BigBlueButton server: worked
Tested with Scalelite: did not work

Scalelite has just recently merged this into master.
