### PR TITLE
Add live-update code for updating the stream-privacy choices due to change in stream creation settings.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -66,6 +66,7 @@ const settings_user_groups = mock_esm("../../static/js/settings_user_groups");
 const settings_users = mock_esm("../../static/js/settings_users");
 const stream_data = mock_esm("../../static/js/stream_data");
 const stream_events = mock_esm("../../static/js/stream_events");
+const stream_settings_ui = mock_esm("../../static/js/stream_settings_ui");
 const submessage = mock_esm("../../static/js/submessage");
 const typing_events = mock_esm("../../static/js/typing_events");
 const ui = mock_esm("../../static/js/ui");
@@ -347,11 +348,31 @@ run_test("realm settings", ({override}) => {
         assert.equal(page_params[parameter_name], 1);
     }
 
+    let update_called = false;
     let event = event_fixtures.realm__update__create_private_stream_policy;
+    stream_settings_ui.update_stream_privacy_choices = (property) => {
+        assert_same(property, "create_private_stream_policy");
+        update_called = true;
+    };
     test_realm_integer(event, "realm_create_private_stream_policy");
 
+    update_called = false;
     event = event_fixtures.realm__update__create_public_stream_policy;
+    stream_settings_ui.update_stream_privacy_choices = (property) => {
+        assert_same(property, "create_public_stream_policy");
+        update_called = true;
+    };
     test_realm_integer(event, "realm_create_public_stream_policy");
+
+    update_called = false;
+    event = event_fixtures.realm__update__create_web_public_stream_policy;
+    stream_settings_ui.update_stream_privacy_choices = (property) => {
+        assert_same(property, "create_web_public_stream_policy");
+        update_called = true;
+    };
+    dispatch(event);
+    assert_same(page_params.realm_create_web_public_stream_policy, 2);
+    assert_same(update_called, true);
 
     event = event_fixtures.realm__update__invite_to_stream_policy;
     test_realm_integer(event, "realm_invite_to_stream_policy");

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -418,6 +418,16 @@ run_test("realm settings", ({override}) => {
     dispatch(event);
     assert_same(page_params.realm_default_code_block_language, "javascript");
 
+    update_called = false;
+    stream_settings_ui.update_stream_privacy_choices = (property) => {
+        assert_same(property, "create_web_public_stream_policy");
+        update_called = true;
+    };
+    event = event_fixtures.realm__update__enable_spectator_access;
+    dispatch(event);
+    assert_same(page_params.realm_enable_spectator_access, true);
+    assert_same(update_called, true);
+
     event = event_fixtures.realm__update_dict__default;
     page_params.realm_allow_message_editing = false;
     page_params.realm_message_content_edit_limit_seconds = 0;

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -254,6 +254,13 @@ exports.fixtures = {
         value: 2,
     },
 
+    realm__update__create_web_public_stream_policy: {
+        type: "realm",
+        op: "update",
+        property: "create_web_public_stream_policy",
+        value: 2,
+    },
+
     realm__update__default_code_block_language: {
         type: "realm",
         op: "update",

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -289,6 +289,13 @@ exports.fixtures = {
         value: false,
     },
 
+    realm__update__enable_spectator_access: {
+        type: "realm",
+        op: "update",
+        property: "enable_spectator_access",
+        value: true,
+    },
+
     realm__update__invite_required: {
         type: "realm",
         op: "update",

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -190,6 +190,7 @@ export function dispatch_normal_event(event) {
                 bot_creation_policy: settings_bots.update_bot_permissions_ui,
                 create_public_stream_policy: noop,
                 create_private_stream_policy: noop,
+                create_web_public_stream_policy: noop,
                 invite_to_stream_policy: noop,
                 default_code_block_language: noop,
                 default_language: noop,

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -233,6 +233,15 @@ export function dispatch_normal_event(event) {
                         if (event.property === "name" && window.electron_bridge !== undefined) {
                             window.electron_bridge.send_event("realm_name", event.value);
                         }
+
+                        const stream_creation_settings = [
+                            "create_private_stream_policy",
+                            "create_public_stream_policy",
+                            "create_web_public_stream_policy",
+                        ];
+                        if (stream_creation_settings.includes(event.property)) {
+                            stream_settings_ui.update_stream_privacy_choices(event.property);
+                        }
                     }
                     break;
                 case "update_dict":

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -242,6 +242,12 @@ export function dispatch_normal_event(event) {
                         if (stream_creation_settings.includes(event.property)) {
                             stream_settings_ui.update_stream_privacy_choices(event.property);
                         }
+
+                        if (event.property === "enable_spectator_access") {
+                            stream_settings_ui.update_stream_privacy_choices(
+                                "create_web_public_stream_policy",
+                            );
+                        }
                     }
                     break;
                 case "update_dict":

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -338,9 +338,10 @@ export function show_new_stream_modal() {
         html_selector: (user) => $(`#${CSS.escape("user_checkbox_" + user.user_id)}`),
     });
 
+    // Select the first enabled choice for stream privacy.
+    $("#make-invite-only input:not([disabled]):first").prop("checked", true);
     // Make the options default to the same each time:
-    // public, "announce stream" on.
-    $("#make-invite-only input:radio[value=public]").prop("checked", true);
+    // "announce stream" on.
     $("#stream_creation_form .stream-message-retention-days-input").hide();
     $("#stream_creation_form select[name=stream_message_retention_setting]").val("realm_default");
 

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -988,22 +988,29 @@ export function sub_or_unsub(sub, stream_row) {
     }
 }
 
-export function hide_or_disable_web_public_stream_privacy_option(container) {
+export function update_web_public_stream_privacy_option_state(container) {
     const web_public_stream_elem = container.find(
         `input[value='${CSS.escape(stream_data.stream_privacy_policy_values.web_public.code)}']`,
     );
-    if (!web_public_stream_elem.is(":checked")) {
-        if (
-            !page_params.server_web_public_streams_enabled ||
-            !page_params.realm_enable_spectator_access
-        ) {
-            web_public_stream_elem.closest(".radio-input-parent").hide();
+    if (
+        !page_params.server_web_public_streams_enabled ||
+        (!page_params.realm_enable_spectator_access && !web_public_stream_elem.is(":checked"))
+    ) {
+        web_public_stream_elem.closest(".radio-input-parent").hide();
+        container
+            .find(".stream-privacy-values .radio-input-parent:visible:last")
+            .css("border-bottom", "none");
+    } else {
+        if (!web_public_stream_elem.is(":visible")) {
             container
                 .find(".stream-privacy-values .radio-input-parent:visible:last")
-                .css("border-bottom", "none");
-        } else {
-            web_public_stream_elem.prop("disabled", true);
+                .css("border-bottom", "");
+            web_public_stream_elem.closest(".radio-input-parent").show();
         }
+        web_public_stream_elem.prop(
+            "disabled",
+            !settings_data.user_can_create_web_public_streams(),
+        );
     }
 }
 
@@ -1030,9 +1037,7 @@ export function disable_private_stream_privacy_option(container) {
 }
 
 export function hide_or_disable_stream_privacy_options_if_required(container) {
-    if (!settings_data.user_can_create_web_public_streams()) {
-        hide_or_disable_web_public_stream_privacy_option(container);
-    }
+    update_web_public_stream_privacy_option_state(container);
 
     if (!settings_data.user_can_create_public_streams()) {
         disable_public_stream_privacy_option(container);

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -988,48 +988,58 @@ export function sub_or_unsub(sub, stream_row) {
     }
 }
 
+export function hide_or_disable_web_public_stream_privacy_option(container) {
+    const web_public_stream_elem = container.find(
+        `input[value='${CSS.escape(stream_data.stream_privacy_policy_values.web_public.code)}']`,
+    );
+    if (!web_public_stream_elem.is(":checked")) {
+        if (
+            !page_params.server_web_public_streams_enabled ||
+            !page_params.realm_enable_spectator_access
+        ) {
+            web_public_stream_elem.closest(".radio-input-parent").hide();
+            container
+                .find(".stream-privacy-values .radio-input-parent:visible:last")
+                .css("border-bottom", "none");
+        } else {
+            web_public_stream_elem.prop("disabled", true);
+        }
+    }
+}
+
+export function disable_public_stream_privacy_option(container) {
+    const public_stream_elem = container.find(
+        `input[value='${CSS.escape(stream_data.stream_privacy_policy_values.public.code)}']`,
+    );
+    public_stream_elem.prop("disabled", true);
+}
+
+export function disable_private_stream_privacy_option(container) {
+    // Disable both "Private, shared history" and "Private, protected history" options.
+    const private_stream_elem = container.find(
+        `input[value='${CSS.escape(stream_data.stream_privacy_policy_values.private.code)}']`,
+    );
+    const private_with_public_history_elem = container.find(
+        `input[value='${CSS.escape(
+            stream_data.stream_privacy_policy_values.private_with_public_history.code,
+        )}']`,
+    );
+
+    private_stream_elem.prop("disabled", true);
+    private_with_public_history_elem.prop("disabled", true);
+}
+
 export function hide_or_disable_stream_privacy_options_if_required(container) {
     if (!settings_data.user_can_create_web_public_streams()) {
-        const web_public_stream_elem = container.find(
-            `input[value='${CSS.escape(
-                stream_data.stream_privacy_policy_values.web_public.code,
-            )}']`,
-        );
-        if (!web_public_stream_elem.is(":checked")) {
-            if (
-                !page_params.server_web_public_streams_enabled ||
-                !page_params.realm_enable_spectator_access
-            ) {
-                web_public_stream_elem.closest(".radio-input-parent").hide();
-                container
-                    .find(".stream-privacy-values .radio-input-parent:visible:last")
-                    .css("border-bottom", "none");
-            } else {
-                web_public_stream_elem.prop("disabled", true);
-            }
-        }
+        hide_or_disable_web_public_stream_privacy_option(container);
     }
 
     if (!settings_data.user_can_create_public_streams()) {
-        const public_stream_elem = container.find(
-            `input[value='${CSS.escape(stream_data.stream_privacy_policy_values.public.code)}']`,
-        );
-        public_stream_elem.prop("disabled", true);
+        disable_public_stream_privacy_option(container);
     }
 
     if (!settings_data.user_can_create_private_streams()) {
-        // Disable both "Private, shared history" and "Private, protected history" options.
-        const private_stream_elem = container.find(
-            `input[value='${CSS.escape(stream_data.stream_privacy_policy_values.private.code)}']`,
-        );
-        const private_with_public_history_elem = container.find(
-            `input[value='${CSS.escape(
-                stream_data.stream_privacy_policy_values.private_with_public_history.code,
-            )}']`,
-        );
-
-        private_stream_elem.prop("disabled", true);
-        private_with_public_history_elem.prop("disabled", true);
+        disable_private_stream_privacy_option(container);
     }
 }
 

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -1021,7 +1021,7 @@ export function update_public_stream_privacy_option_state(container) {
     public_stream_elem.prop("disabled", !settings_data.user_can_create_public_streams());
 }
 
-export function disable_private_stream_privacy_option(container) {
+export function update_private_stream_privacy_option_state(container) {
     // Disable both "Private, shared history" and "Private, protected history" options.
     const private_stream_elem = container.find(
         `input[value='${CSS.escape(stream_data.stream_privacy_policy_values.private.code)}']`,
@@ -1032,8 +1032,11 @@ export function disable_private_stream_privacy_option(container) {
         )}']`,
     );
 
-    private_stream_elem.prop("disabled", true);
-    private_with_public_history_elem.prop("disabled", true);
+    private_stream_elem.prop("disabled", !settings_data.user_can_create_private_streams());
+    private_with_public_history_elem.prop(
+        "disabled",
+        !settings_data.user_can_create_private_streams(),
+    );
 }
 
 export function hide_or_disable_stream_privacy_options_if_required(container) {
@@ -1041,9 +1044,7 @@ export function hide_or_disable_stream_privacy_options_if_required(container) {
 
     update_public_stream_privacy_option_state(container);
 
-    if (!settings_data.user_can_create_private_streams()) {
-        disable_private_stream_privacy_option(container);
-    }
+    update_private_stream_privacy_option_state(container);
 }
 
 export function initialize() {

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -1014,11 +1014,11 @@ export function update_web_public_stream_privacy_option_state(container) {
     }
 }
 
-export function disable_public_stream_privacy_option(container) {
+export function update_public_stream_privacy_option_state(container) {
     const public_stream_elem = container.find(
         `input[value='${CSS.escape(stream_data.stream_privacy_policy_values.public.code)}']`,
     );
-    public_stream_elem.prop("disabled", true);
+    public_stream_elem.prop("disabled", !settings_data.user_can_create_public_streams());
 }
 
 export function disable_private_stream_privacy_option(container) {
@@ -1039,9 +1039,7 @@ export function disable_private_stream_privacy_option(container) {
 export function hide_or_disable_stream_privacy_options_if_required(container) {
     update_web_public_stream_privacy_option_state(container);
 
-    if (!settings_data.user_can_create_public_streams()) {
-        disable_public_stream_privacy_option(container);
-    }
+    update_public_stream_privacy_option_state(container);
 
     if (!settings_data.user_can_create_private_streams()) {
         disable_private_stream_privacy_option(container);

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -1047,6 +1047,32 @@ export function hide_or_disable_stream_privacy_options_if_required(container) {
     update_private_stream_privacy_option_state(container);
 }
 
+export function update_stream_privacy_choices(policy) {
+    if (!overlays.streams_open()) {
+        return;
+    }
+    const change_privacy_modal_opened = $("#stream_privacy_modal").is(":visible");
+    const stream_creation_form_opened = $("#stream-creation").is(":visible");
+
+    if (!change_privacy_modal_opened && !stream_creation_form_opened) {
+        return;
+    }
+    let container = $("#stream-creation");
+    if (change_privacy_modal_opened) {
+        container = $("#stream_privacy_modal");
+    }
+
+    if (policy === "create_private_stream_policy") {
+        update_private_stream_privacy_option_state(container);
+    }
+    if (policy === "create_public_stream_policy") {
+        update_public_stream_privacy_option_state(container);
+    }
+    if (policy === "create_web_public_stream_policy") {
+        update_web_public_stream_privacy_option_state(container);
+    }
+}
+
 export function initialize() {
     $("#subscriptions_table").on("click", ".create_stream_button", (e) => {
         e.preventDefault();


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First four commits are for refactoring such that the existing function can be split into three separate functions for public, private and web-public streams and changing the logic such that same functions can be used for both enabling and disabling the choices.
- Fifth commit is a minor fix which was missed in the commit adding web-public stream setting to frontend.
- Sixth commit is the main commit to live-update the choices based on the stream-creation policies.
- Seventh commit is to live-update the web-public stream choice based on `enable_spectator_access` setting.
- Last commit is to select the first enabled choice by default in stream creation form.

Follow up of #20340.
 <!-- How have you tested? -->

<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
