### PR TITLE
Fix bug in drafts sidebar menu

### DIFF
--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -33,6 +33,7 @@ mock_esm("../../static/js/stream_popover", {
     hide_topic_popover: noop,
     hide_all_messages_popover: noop,
     hide_starred_messages_popover: noop,
+    hide_drafts_popover: noop,
     hide_streamlist_sidebar: noop,
 });
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1313,6 +1313,7 @@ export function hide_all_except_sidebars(opts) {
     stream_popover.hide_topic_popover();
     stream_popover.hide_all_messages_popover();
     stream_popover.hide_starred_messages_popover();
+    stream_popover.hide_drafts_popover();
     hide_user_sidebar_popover();
     hide_user_info_popover();
     hide_playground_links_popover();


### PR DESCRIPTION
This is a follow up to pull request https://github.com/zulip/zulip/pull/20239
I noticed a bug that i overlooked in the original pull request, where the drafts sidebar menu is not closed if you click on somewhere else on the page.