### PR TITLE
Fix password change modal to show errors when input is empty.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -459,11 +459,28 @@ export function set_up() {
         e.preventDefault();
         e.stopPropagation();
         const change_password_error = $("#change_password_modal").find("#dialog_error");
+        change_password_error.hide();
 
         const data = {
             old_password: $("#old_password").val(),
             new_password: $("#new_password").val(),
         };
+
+        function show_error_message(rendered_error_msg) {
+            change_password_error.html(rendered_error_msg);
+            change_password_error.addClass("alert-error").show();
+            dialog_widget.hide_dialog_spinner();
+        }
+
+        if (data.old_password === "") {
+            show_error_message($t_html({defaultMessage: "Please enter your password"}));
+            return;
+        }
+
+        if (data.new_password === "") {
+            show_error_message($t_html({defaultMessage: "Please choose a new password"}));
+            return;
+        }
 
         const new_pw_field = $("#new_password");
         const new_pw = data.new_password;

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -463,7 +463,6 @@ export function set_up() {
         const data = {
             old_password: $("#old_password").val(),
             new_password: $("#new_password").val(),
-            confirm_password: $("#confirm_password").val(),
         };
 
         const new_pw_field = $("#new_password");


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#19901 

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![password-change](https://user-images.githubusercontent.com/35494118/143489088-8ead8bf9-c107-43eb-8122-f8ecebc4376a.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
