### PR TITLE
Add `Manage this user` option in user-info popover for admins.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -424,29 +424,13 @@ function get_human_profile_data(fields_user_pills) {
     return new_profile_data;
 }
 
-function confirm_deactivation(row, user_id, status_field) {
+function confirm_deactivation(user_id, handle_confirm) {
     const user = people.get_by_user_id(user_id);
     const opts = {
         username: user.full_name,
         email: settings_data.email_for_user_settings(user),
     };
     const html_body = render_settings_deactivation_user_modal(opts);
-
-    function handle_confirm() {
-        const row = get_user_info_row(user_id);
-        const row_deactivate_button = row.find("button.deactivate");
-        row_deactivate_button.prop("disabled", true).text($t({defaultMessage: "Working…"}));
-        const opts = {
-            success_continuation() {
-                update_view_on_deactivate(row);
-            },
-            error_continuation() {
-                row_deactivate_button.text($t({defaultMessage: "Deactivate"}));
-            },
-        };
-        const url = "/json/users/" + encodeURIComponent(user_id);
-        settings_ui.do_settings_change(channel.del, url, {}, status_field, opts);
-    }
 
     confirm_dialog.launch({
         html_heading: $t_html({defaultMessage: "Deactivate {name}"}, {name: user.full_name}),
@@ -464,7 +448,24 @@ function handle_deactivation(tbody, status_field) {
 
         const row = $(e.target).closest(".user_row");
         const user_id = row.data("user-id");
-        confirm_deactivation(row, user_id, status_field);
+
+        function handle_confirm() {
+            const row = get_user_info_row(user_id);
+            const row_deactivate_button = row.find("button.deactivate");
+            row_deactivate_button.prop("disabled", true).text($t({defaultMessage: "Working…"}));
+            const opts = {
+                success_continuation() {
+                    update_view_on_deactivate(row);
+                },
+                error_continuation() {
+                    row_deactivate_button.text($t({defaultMessage: "Deactivate"}));
+                },
+            };
+            const url = "/json/users/" + encodeURIComponent(user_id);
+            settings_ui.do_settings_change(channel.del, url, {}, status_field, opts);
+        }
+
+        confirm_deactivation(user_id, handle_confirm);
     });
 }
 

--- a/static/templates/settings/admin_human_form.hbs
+++ b/static/templates/settings/admin_human_form.hbs
@@ -22,5 +22,10 @@
             </select>
         </div>
         <div class="custom-profile-field-form"></div>
+        <div class="input-group new-style">
+            <button class="button rounded btn-danger deactivate_user_button">
+                {{t 'Deactivate user' }}
+            </button>
+        </div>
     </form>
 </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This commit adds "Mange this user" option in the user-info popover which opens
the user-info modal.
    
We show a spinner on submit button in this case as modal is not closed immediately
and thus we need some indicator to show that the task is in progress. There is no spinner
on submit button in the modal opened from "Users" section of organization settings.
    
Error handling for this case is different than when the modal is opened from "Users"
section of organization settings because there is no overlay in the background of
modal in this case.
    
In this case, we show error inside the modal and do not close it and in case the change
is completed successfully we just close the modal without showing any message.
    
Fixes part of #18944.
 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Modal when the change is failed and server returns error.
![change-user-info-failed](https://user-images.githubusercontent.com/35494118/143597953-a3b47339-a752-4df6-ab42-9704cce77b8d.gif)

User information updated successfully
![change-user-info](https://user-images.githubusercontent.com/35494118/143597963-bdb6c144-8505-4451-ab8e-0d0eae0c552e.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
