### PR TITLE
scim: Order Users by id when queried using filter syntax.

### DIFF
--- a/zerver/lib/scim_filter.py
+++ b/zerver/lib/scim_filter.py
@@ -59,4 +59,7 @@ class ZulipUserFilterQuery(UserFilterQuery):
         realm = RequestNotes.get_notes(request).realm
         assert realm is not None
 
-        return "AND zerver_realm.id = %s AND zerver_userprofile.is_bot = False", [realm.id]
+        return (
+            "AND zerver_realm.id = %s AND zerver_userprofile.is_bot = False ORDER BY zerver_userprofile.id",
+            [realm.id],
+        )

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -246,7 +246,6 @@ class TestSCIMUser(SCIMTestCase):
         )
         self.assertEqual(result.status_code, 200)
         output_data = orjson.loads(result.content)
-        output_data["Resources"].sort(key=lambda d: d["id"])
 
         user_query = UserProfile.objects.filter(
             realm=realm, is_bot=False, delivery_email__endswith="@zulip.com"


### PR DESCRIPTION
django-scim2 doesn't order the rows when fetching them in reponse to a
query using the filter syntax. We ensure that ORDER BY id is always
appended to the SQL queries.

This commit also reverts the test change added in https://github.com/zulip/zulip/pull/20369 - because we actually want that test to fail if the results are returned unordered.