### PR TITLE
api: Prevent special characters in streams name.

### DIFF
--- a/zerver/lib/string_validation.py
+++ b/zerver/lib/string_validation.py
@@ -34,11 +34,12 @@ def check_stream_name(stream_name: str) -> None:
         raise JsonableError(
             _("Stream name too long (limit: {} characters).").format(Stream.MAX_NAME_LENGTH)
         )
-    for i in stream_name:
-        if ord(i) == 0:
-            raise JsonableError(
-                _("Stream name '{}' contains NULL (0x00) characters.").format(stream_name)
-            )
+
+    invalid_character_pos = check_string_is_printable(stream_name)
+    if invalid_character_pos is not None:
+        raise JsonableError(
+            _("Invalid character in stream name, at position {}!").format(invalid_character_pos)
+        )
 
 
 def check_stream_topic(topic: str) -> None:


### PR DESCRIPTION
Special characters, including `\r`, `\n`, and more esoteric codepoints
like non-characters, can negatively affect rendering and UI behavior,
such as creating two streams with the same name, but with different URLs.

Check for, and prevent making new streams with, characters in the
Unicode categories of `Cc` (control characters), `Cs` (surrogates), and
`Cn` (unassigned, non-characters)

To learn more about Unicode characters 
- [Unicode Wikipedia](https://en.wikipedia.org/wiki/Unicode)
- https://www.unicode.org/reports/tr44/#General_Category_Values
- [Examples of Surrogate category](https://www.fileformat.info/info/unicode/category/Cs/list.htm) 
- [Examples of Non characters](https://www.unicode.org/faq/private_use.html#nonchar4)

For tests, I have created test for `Cc` and `Cn` characters, as python don't allow surrogate characters.

Fixes a part of #20128 