### PR TITLE
user_sidebar: Set personal presence dot based on the user's settings.

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -6,7 +6,7 @@ const {mock_esm, set_global, with_field, zrequire} = require("../zjsunit/namespa
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
 const $ = require("../zjsunit/zjquery");
-const {page_params} = require("../zjsunit/zpage_params");
+const {page_params, user_settings} = require("../zjsunit/zpage_params");
 
 const window_stub = $.create("window-stub");
 set_global("to_$", () => window_stub);
@@ -98,6 +98,7 @@ let presence_info;
 
 function test(label, f) {
     run_test(label, (helpers) => {
+        user_settings.presence_enabled = true;
         // Simulate a small window by having the
         // fill_screen_with_content render the entire
         // list in one pass.  We will do more refined
@@ -143,6 +144,11 @@ test("get_status", () => {
     assert.equal(presence.get_status(alice.user_id), "active");
     assert.equal(presence.get_status(mark.user_id), "idle");
     assert.equal(presence.get_status(fred.user_id), "active");
+
+    user_settings.presence_enabled = false;
+    assert.equal(presence.get_status(page_params.user_id), "offline");
+    user_settings.presence_enabled = true;
+    assert.equal(presence.get_status(page_params.user_id), "active");
 
     presence_info.delete(zoe.user_id);
     assert.equal(presence.get_status(zoe.user_id), "offline");

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -97,6 +97,7 @@ function add_canned_users() {
 
 function test(label, f) {
     run_test(label, ({override}) => {
+        user_settings.presence_enabled = true;
         compose_fade_helper.clear_focused_recipient();
         stream_data.clear_subscriptions();
         peer_data.clear_for_testing();

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -817,6 +817,7 @@ run_test("user_settings", ({override}) => {
 
     event = event_fixtures.user_settings__presence_enabled;
     user_settings.presence_enabled = true;
+    override(activity, "redraw_user", noop);
     dispatch(event);
     assert_same(user_settings.presence_enabled, false);
 

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const {mock_esm, with_field, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
+const {user_settings} = require("../zjsunit/zpage_params");
 
 const reload_state = mock_esm("../../static/js/reload_state", {
     is_in_progress: () => false,
@@ -77,6 +78,7 @@ people.initialize_current_user(me.user_id);
 
 function test(label, f) {
     run_test(label, ({override}) => {
+        user_settings.presence_enabled = true;
         presence.clear_internal_data();
         f({override});
     });

--- a/static/js/presence.js
+++ b/static/js/presence.js
@@ -1,6 +1,7 @@
 import * as blueslip from "./blueslip";
 import * as people from "./people";
 import * as reload_state from "./reload_state";
+import {user_settings} from "./user_settings";
 import * as watchdog from "./watchdog";
 
 // This module just manages data.  See activity.js for
@@ -40,7 +41,12 @@ export function is_active(user_id) {
 
 export function get_status(user_id) {
     if (people.is_my_user_id(user_id)) {
-        return "active";
+        if (user_settings.presence_enabled) {
+            // if the current user is sharing presence, they always see themselves as online.
+            return "active";
+        }
+        // if the current user is not sharing presence, they always see themselves as offline.
+        return "offline";
     }
     if (presence_info.has(user_id)) {
         return presence_info.get(user_id).status;

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -676,6 +676,7 @@ export function dispatch_normal_event(event) {
             if (event.property === "presence_enabled") {
                 user_settings.presence_enabled = event.value;
                 $("#user_presence_enabled").prop("checked", user_settings.presence_enabled);
+                activity.redraw_user(page_params.user_id);
                 break;
             }
             settings_display.update_page(event.property);


### PR DESCRIPTION
If a user chooses to not broadcast their presence status to others, we
still show the user as available in their own user sidebar. Instead, one's
own availability should appear the same as it does for other users.

With tweaks from YashRE42: rebasing to use user_settings instead of
page_params, as introduced in the series of commits ending with
8755a76cf63ad75eb1b4118ead17663af7aca9e9, adding code comments and
moving the redraw call to `server_events_dispatch.js`.

Fixes #18846.

Rebased and edited from #18877.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
Added test coverage via node tests.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![](https://user-images.githubusercontent.com/33805964/143673608-eb8d0b5d-43d6-41e0-ba5f-fd3a50972049.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
