### PR TITLE
hash_util: Encode url component derived from browser.

### DIFF
--- a/frontend_tests/node_tests/hash_util.js
+++ b/frontend_tests/node_tests/hash_util.js
@@ -208,5 +208,5 @@ run_test("test_search_public_streams_notice_url", () => {
 
 run_test("test_current_hash_as_next", () => {
     window.location.hash = "#foo";
-    assert.equal(hash_util.current_hash_as_next(), "next=/#foo");
+    assert.equal(hash_util.current_hash_as_next(), "next=/%23foo");
 });

--- a/static/js/hash_util.js
+++ b/static/js/hash_util.js
@@ -310,5 +310,5 @@ export function is_spectator_compatible(hash) {
 }
 
 export function current_hash_as_next() {
-    return `next=/${window.location.hash}`;
+    return `next=/${encodeURIComponent(window.location.hash)}`;
 }


### PR DESCRIPTION
This is for security reasons.

based on comment - https://github.com/zulip/zulip/pull/18863/files/34a37f55d6eec6f56505f20532cdb720d2de7d30#r755550046