### PR TITLE
compose_actions: Fix misplaced caret position when qouting.

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -338,7 +338,7 @@ test("quote_and_reply", ({override}) => {
     let expected_replacement;
     let replaced;
     override(compose_ui, "replace_syntax", (syntax, replacement) => {
-        assert.equal(syntax, "[Quoting…]");
+        assert.equal(syntax, "translated: [Quoting…]");
         assert.equal(replacement, expected_replacement);
         replaced = true;
     });
@@ -361,7 +361,7 @@ test("quote_and_reply", ({override}) => {
     override(message_lists.current, "selected_id", () => 100);
 
     override(compose_ui, "insert_syntax_and_focus", (syntax) => {
-        assert.equal(syntax, "[Quoting…]\n");
+        assert.equal(syntax, "translated: [Quoting…]\n");
     });
 
     const opts = {

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -162,9 +162,9 @@ run_test("smart_insert", () => {
     textbox = make_textbox("");
     textbox.caret(0);
     textbox.trigger("blur");
-    compose_ui.smart_insert(textbox, "[Quoting…]\n");
-    assert.equal(textbox.insert_text, "[Quoting…]\n");
-    assert.equal(textbox.val(), "[Quoting…]\n");
+    compose_ui.smart_insert(textbox, "translated: [Quoting…]\n");
+    assert.equal(textbox.insert_text, "translated: [Quoting…]\n");
+    assert.equal(textbox.val(), "translated: [Quoting…]\n");
     assert.ok(textbox.focused);
 
     textbox = make_textbox("abc");
@@ -342,7 +342,7 @@ run_test("quote_and_reply", ({override}) => {
 
     set_compose_content_with_caret("hello %there"); // "%" is used to encode/display position of focus before change
     compose_actions.quote_and_reply();
-    assert.equal(get_compose_content_with_caret(), "hello \n[Quoting…]\n%there");
+    assert.equal(get_compose_content_with_caret(), "hello \ntranslated: [Quoting…]\n%there");
 
     success_function({
         raw_content: "Testing caret position",
@@ -358,7 +358,7 @@ run_test("quote_and_reply", ({override}) => {
     // add a newline before the quoted message.
     set_compose_content_with_caret("%hello there");
     compose_actions.quote_and_reply();
-    assert.equal(get_compose_content_with_caret(), "[Quoting…]\n%hello there");
+    assert.equal(get_compose_content_with_caret(), "translated: [Quoting…]\n%hello there");
 
     success_function({
         raw_content: "Testing with caret initially positioned at 0.",
@@ -381,7 +381,7 @@ run_test("quote_and_reply", ({override}) => {
     // quoting a message, the quoted message should be placed
     // at the beginning of compose-box.
     compose_actions.quote_and_reply();
-    assert.equal(get_compose_content_with_caret(), "[Quoting…]\n%");
+    assert.equal(get_compose_content_with_caret(), "translated: [Quoting…]\n%");
 
     success_function({
         raw_content: "Testing with compose-box closed initially.",
@@ -399,7 +399,7 @@ run_test("quote_and_reply", ({override}) => {
     // message should start from the beginning of compose-box.
     set_compose_content_with_caret("  \n\n \n %");
     compose_actions.quote_and_reply();
-    assert.equal(get_compose_content_with_caret(), "[Quoting…]\n%");
+    assert.equal(get_compose_content_with_caret(), "translated: [Quoting…]\n%");
 
     success_function({
         raw_content: "Testing with compose-box containing whitespaces and newlines only.",

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -482,8 +482,6 @@ export function quote_and_reply(opts) {
         respond_to_message(opts);
     }
 
-    const prev_caret = textarea.caret();
-
     compose_ui.insert_syntax_and_focus("[Quoting…]\n", textarea);
 
     function replace_content(message) {
@@ -492,6 +490,7 @@ export function quote_and_reply(opts) {
         //     ```quote
         //     message content
         //     ```
+        const prev_caret = textarea.caret();
         let content = $t(
             {defaultMessage: "{username} [said]({link_to_message}):"},
             {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -463,7 +463,7 @@ export function quote_and_reply(opts) {
     const textarea = $("#compose-textarea");
     const message_id = message_lists.current.selected_id();
     const message = message_lists.current.selected_message();
-    const quoting_placeholder = "[Quoting…]";
+    const quoting_placeholder = $t({defaultMessage: "[Quoting…]"});
 
     if (compose_state.has_message_content()) {
         // The user already started typing a message,

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -463,6 +463,7 @@ export function quote_and_reply(opts) {
     const textarea = $("#compose-textarea");
     const message_id = message_lists.current.selected_id();
     const message = message_lists.current.selected_message();
+    const quoting_placeholder = "[Quoting…]";
 
     if (compose_state.has_message_content()) {
         // The user already started typing a message,
@@ -482,7 +483,7 @@ export function quote_and_reply(opts) {
         respond_to_message(opts);
     }
 
-    compose_ui.insert_syntax_and_focus("[Quoting…]\n", textarea);
+    compose_ui.insert_syntax_and_focus(quoting_placeholder + "\n", textarea);
 
     function replace_content(message) {
         // Final message looks like:
@@ -501,10 +502,26 @@ export function quote_and_reply(opts) {
         content += "\n";
         const fence = fenced_code.get_unused_fence(message.raw_content);
         content += `${fence}quote\n${message.raw_content}\n${fence}`;
-        compose_ui.replace_syntax("[Quoting…]", content, textarea);
+
+        const placeholder_offset = $(textarea).val().indexOf(quoting_placeholder);
+        compose_ui.replace_syntax(quoting_placeholder, content, textarea);
         compose_ui.autosize_textarea($("#compose-textarea"));
-        // Update textarea caret to point to the new line after quoted message.
-        textarea.caret(prev_caret + content.length + 1);
+
+        // When replacing content in a textarea, we need to move the
+        // cursor to preserve its logical position if and only if the
+        // content we just added was before the current cursor
+        // position.  If we do, we need to move it by the increase in
+        // the length of the content before the placeholder.
+        if (prev_caret >= placeholder_offset + quoting_placeholder.length) {
+            textarea.caret(prev_caret + content.length - quoting_placeholder.length);
+        } else if (prev_caret > placeholder_offset) {
+            /* In the rare case that our cursor was inside the
+             * placeholder, we treat that as though the cursor was
+             * just after the placeholder. */
+            textarea.caret(placeholder_offset + content.length + 1);
+        } else {
+            textarea.caret(prev_caret);
+        }
     }
 
     if (message && message.raw_content) {


### PR DESCRIPTION
When replying with a quote, the cursor moves back to the beginning
once the quote resolves and disrupts ongoing typing.

Fixes #20071.
