### PR TITLE
settings: Remove extraneous banner from settings tabs

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -64,6 +64,8 @@ function insert_tip_box() {
         .not("#emoji-settings")
         .not("#user-groups-admin")
         .not("#organization-auth-settings")
+        .not("#admin-bot-list")
+        .not("#admin-invites-list")
         .prepend(tip_box);
 }
 


### PR DESCRIPTION
This fix excludes the bots and invitation settings tabs from having the organization_settings_tip.hbs template being inserted in them.

Fixes: zulip#19967.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
Manual Testing

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![banner1](https://user-images.githubusercontent.com/50860115/143736092-fdbbbab4-f704-4513-8353-1460a1ff4bea.png)

![banner2](https://user-images.githubusercontent.com/50860115/143736096-83d7a6d2-b125-40fa-9cd2-10cadd2aaaae.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
