### PR TITLE
Revert "settings: Silence CryptographyDeprecationWarning spam from a dependency."

### DIFF
--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -1,12 +1,10 @@
 import os
 import sys
 import time
-import warnings
 from copy import deepcopy
 from typing import Any, Dict, List, Tuple, Union
 from urllib.parse import urljoin
 
-from cryptography.utils import CryptographyDeprecationWarning
 from django.template.loaders import app_directories
 
 import zerver.lib.logging_util
@@ -1007,11 +1005,6 @@ LOGGING: Dict[str, Any] = {
         },
     },
 }
-
-# Silence CryptographyDeprecationWarning spam from a dependency:
-# /srv/zulip-py3-venv/lib/python3.6/site-packages/jose/backends/cryptography_backend.py:18: CryptographyDeprecationWarning: int_from_bytes is deprecated, use int.from_bytes instead
-# TODO: Clean this up when possible after future dependency upgrades.
-warnings.filterwarnings("ignore", category=CryptographyDeprecationWarning, module="jose.*")
 
 if DEVELOPMENT:
     CONTRIBUTOR_DATA_FILE_PATH = os.path.join(DEPLOY_ROOT, "var/github-contributors.json")


### PR DESCRIPTION
The warning was fixed in python-jose 3.3.0, which we pulled in with commit 61e1e38a00f4ef9fe4c1a302b93ce059646c62a6 (#18705).

This reverts commit 1df725e6f17bcc2a78837789c5632d1f5dc0f5cf (#18567).