### PR TITLE
hash_util: Remove dependency on narrow_state module.

### DIFF
--- a/frontend_tests/node_tests/hash_util.js
+++ b/frontend_tests/node_tests/hash_util.js
@@ -16,8 +16,6 @@ const ui_report = mock_esm("../../static/js/ui_report", {
 const hash_util = zrequire("hash_util");
 const stream_data = zrequire("stream_data");
 const people = zrequire("people");
-const {Filter} = zrequire("../js/filter");
-const narrow_state = zrequire("narrow_state");
 
 const hamlet = {
     user_id: 15,
@@ -185,23 +183,24 @@ run_test("test_by_conversation_and_time_uri", () => {
 });
 
 run_test("test_search_public_streams_notice_url", () => {
-    function set_uri(uri) {
-        const operators = hash_util.parse_narrow(uri.split("/"));
-        narrow_state.set_current_filter(new Filter(operators));
+    function get_operators(uri) {
+        return hash_util.parse_narrow(uri.split("/"));
     }
 
-    set_uri("#narrow/search/abc");
-    assert.equal(hash_util.search_public_streams_notice_url(), "#narrow/streams/public/search/abc");
-
-    set_uri("#narrow/has/link/has/image/has/attachment");
     assert.equal(
-        hash_util.search_public_streams_notice_url(),
+        hash_util.search_public_streams_notice_url(get_operators("#narrow/search/abc")),
+        "#narrow/streams/public/search/abc",
+    );
+
+    assert.equal(
+        hash_util.search_public_streams_notice_url(
+            get_operators("#narrow/has/link/has/image/has/attachment"),
+        ),
         "#narrow/streams/public/has/link/has/image/has/attachment",
     );
 
-    set_uri("#narrow/sender/15");
     assert.equal(
-        hash_util.search_public_streams_notice_url(),
+        hash_util.search_public_streams_notice_url(get_operators("#narrow/sender/15")),
         "#narrow/streams/public/sender/15-hamlet",
     );
 });

--- a/static/js/hash_util.js
+++ b/static/js/hash_util.js
@@ -1,7 +1,6 @@
 import $ from "jquery";
 
 import {$t_html} from "./i18n";
-import * as narrow_state from "./narrow_state";
 import * as people from "./people";
 import * as stream_data from "./stream_data";
 import * as ui_report from "./ui_report";
@@ -195,9 +194,7 @@ export function stream_edit_uri(sub) {
     return hash;
 }
 
-export function search_public_streams_notice_url() {
-    // Computes the URL of the current narrow if streams:public were added.
-    const operators = narrow_state.filter().operators();
+export function search_public_streams_notice_url(operators) {
     const public_operator = {operator: "streams", operand: "public"};
     return operators_to_hash([public_operator].concat(operators));
 }

--- a/static/js/message_scroll.js
+++ b/static/js/message_scroll.js
@@ -84,7 +84,9 @@ export function show_end_of_results_notice() {
     // It's a bit hacky to use the href, but
     // !filter.includes_full_stream_history() implies streams:public
     // wasn't already present.
-    const update_hash = hash_util.search_public_streams_notice_url();
+    // Computes the URL of the current narrow if streams:public were added.
+    const operators = narrow_state.filter().operators();
+    const update_hash = hash_util.search_public_streams_notice_url(operators);
     $(".all-messages-search-caution a.search-shared-history").attr("href", update_hash);
 }
 


### PR DESCRIPTION
We directly pass operators to remove dependency on narrow_state
module. This avoids a circular dependency of `filter` module
which is evident on the `/devtools/integrations/` page.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/error.20in.20http.3A.2F.2Flocalhost.3A9991.2Fdevtools.2Fintegrations.2F