### PR TITLE
doc links: Fix documentation links.

### DIFF
--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -332,7 +332,7 @@ type changes in the future.
   isort in check mode, or in write mode with
   `tools/lint --only=black,isort --fix`. You may find it helpful to
   [integrate
-  Black](https://black.readthedocs.io/en/stable/editor_integration.html)
+  Black](https://black.readthedocs.io/en/stable/integrations/editors.html)
   and
   [isort](https://pycqa.github.io/isort/#installing-isorts-for-your-preferred-text-editor)
   with your editor.

--- a/docs/git/setup.md
+++ b/docs/git/setup.md
@@ -65,4 +65,4 @@ And, if none of the above are to your liking, try [one of these][gitbook-guis].
 [gitgui-gitxdev]: https://rowanj.github.io/gitx/
 [gitgui-sourcetree]: https://www.sourcetreeapp.com/
 [github-help-add-ssh-key]: https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account
-[tig]: http://jonas.nitro.dk/tig/
+[tig]: https://jonas.github.io/tig/

--- a/docs/production/video-calls.md
+++ b/docs/production/video-calls.md
@@ -53,7 +53,7 @@ BigBlueButton server and configure it:
 
 1. Get the Shared Secret using the `bbb-conf --secret` command on your
    BigBlueButton Server. See also [the BigBlueButton
-   documentation](https://docs.bigbluebutton.org/2.2/customize.html#extract-the-shared-secret).
+   documentation](https://docs.bigbluebutton.org/admin/customize.html#extract-the-shared-secret).
 
 2. Get the URL to your BigBlueButton API. The URL has the form of
    `https://bigbluebutton.example.com/bigbluebutton/` and can also be

--- a/docs/subsystems/html-css.md
+++ b/docs/subsystems/html-css.md
@@ -132,7 +132,7 @@ whenever a template is changed.
 ### Translation
 
 All user-facing strings (excluding pages only visible to sysadmins or
-developers) should be tagged for [translation][].
+developers) should be tagged for [translation][trans].
 
 ### Tooltips
 
@@ -284,7 +284,7 @@ function in those scenarios, add it to `zulip_test`. This is also
 
 [jinja2]: http://jinja.pocoo.org/
 [handlebars]: https://handlebarsjs.com/
-[trans]: http://jinja.pocoo.org/docs/dev/templates/#i18n
+[trans]: https://jinja.palletsprojects.com/en/3.0.x/extensions/#i18n-extension
 [jconditionals]: http://jinja.pocoo.org/docs/2.9/templates/#list-of-control-structures
 [hconditionals]: https://handlebarsjs.com/guide/#block_helpers.html
 [translation]: ../translating/translating.md

--- a/docs/translating/internationalization.md
+++ b/docs/translating/internationalization.md
@@ -146,7 +146,7 @@ can use the `_()` function in the templates like this:
 If a piece of text contains both a literal string component and variables,
 you can use a block translation, which makes use of placeholders to
 help translators to translate an entire sentence. To translate a
-block, Jinja2 uses the [trans][] tag. So rather than writing
+block, Jinja2 uses the [trans][trans] tag. So rather than writing
 something ugly and confusing for translators like this:
 
 ```jinja
@@ -333,7 +333,7 @@ organizations from the command line.
 
 [jinja2]: http://jinja.pocoo.org/
 [handlebars]: https://handlebarsjs.com/
-[trans]: http://jinja.pocoo.org/docs/dev/templates/#i18n
+[trans]: https://jinja.palletsprojects.com/en/3.0.x/extensions/#i18n-extension
 [formatjs]: https://formatjs.io/
 [icu messageformat]: https://formatjs.io/docs/intl-messageformat
 [helpers]: https://handlebarsjs.com/guide/block-helpers.html

--- a/docs/translating/spanish.md
+++ b/docs/translating/spanish.md
@@ -24,7 +24,7 @@ Use informal Spanish for translation:
   to decide what wouldn't sound awkward / rude in Spanish.
 
 - Latest RAE rule ("solo" should
-  [**never**](https://www.rae.es/consultas/el-adverbio-solo-y-los-pronombres-demostrativos-sin-tilde)
+  [**never**](https://www.rae.es/espanol-al-dia/el-adverbio-solo-y-los-pronombres-demostrativos-sin-tilde)
   have accent, even when it can be replaced with "solamente").
 
 Some terms are very tricky to translate, so be sure to communicate

--- a/docs/tutorials/reading-list.md
+++ b/docs/tutorials/reading-list.md
@@ -77,7 +77,7 @@ _Tutorial_ - [clean-code-javascript Software engineering principles](https://git
 
 _Course_ - [React native and redux course](https://www.udemy.com/course/the-complete-react-native-and-redux-course/) (_Not free!_)
 
-_Slides_ - [TypeScript vs. CoffeeScript vs. ES6](https://www.slideshare.net/NeilGreen1/type-script-vs-coffeescript-vs-es6)
+_Video_ - [TypeScript vs. CoffeeScript vs. ES6](https://www.youtube.com/watch?v=Ae4h9GC9cCg)
 
 ## TypeScript
 

--- a/templates/zerver/integrations/big-blue-button.md
+++ b/templates/zerver/integrations/big-blue-button.md
@@ -10,7 +10,7 @@ configure your zulip server to use that BigBlueButton server.
 
 1. Get the Shared Secret using the `bbb-conf --secret` command on your
    BigBlueButton Server. See also
-   [BigBlueButton documentation](https://docs.bigbluebutton.org/2.2/customize.html#extract-the-shared-secret).
+   [BigBlueButton documentation](https://docs.bigbluebutton.org/admin/customize.html#extract-the-shared-secret).
 
 1. Get the URL to your BigBlueButton API. The URL has the form of
    `https://bigbluebutton.example.com/bigbluebutton/` and can also be


### PR DESCRIPTION
Fixes documentation links found by running ./tools/test-documentation.

- Big Blue Button link in docs/production/video-calls.md. 
- Big Blue Button link in templates/zerver/integrations/big-blue-button.md 
- Black IDE integration link in docs/contributing/code-style.md 
- Neil Green Presentation on TypeScript vs Coffee Script vs ES6 in docs/tutorials/reading-list.md  
- "solo" link in docs/translating/spanish.md
- TIg link in docs/git/setup.md
- Jinja translation tag link in docs/subsystems/html-css.md
- Jinja translation tag link in docs/translating/internationalization.md