### PR TITLE
Duplicate drafts bug

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -24,6 +24,11 @@ const localStorage = set_global("localStorage", {
         ls_container.clear();
     },
 });
+const setTimeout_delay = 3000;
+set_global("setTimeout", (f, delay) => {
+    assert.equal(delay, setTimeout_delay);
+    f();
+});
 const compose_state = mock_esm("../../static/js/compose_state");
 mock_esm("../../static/js/markdown", {
     apply_markdown: noop,
@@ -35,6 +40,26 @@ mock_esm("../../static/js/stream_data", {
     get_sub(stream_name) {
         assert.equal(stream_name, "stream");
         return {stream_id: 30};
+    },
+});
+const tippy_sel = ".top_left_drafts .unread_count";
+let tippy_args;
+let tippy_show_called;
+let tippy_destroy_called;
+mock_esm("tippy.js", {
+    default: (sel, opts) => {
+        assert.equal(sel, tippy_sel);
+        assert.deepEqual(opts, tippy_args);
+        return [
+            {
+                show: () => {
+                    tippy_show_called = true;
+                },
+                destroy: () => {
+                    tippy_destroy_called = true;
+                },
+            },
+        ];
     },
 });
 const sub_store = mock_esm("../../static/js/sub_store");
@@ -219,6 +244,54 @@ test("remove_old_drafts", () => {
 
     drafts.remove_old_drafts();
     assert.deepEqual(draft_model.get(), {id3: draft_3});
+});
+
+test("update_draft", ({override}) => {
+    override(compose_state, "composing", () => false);
+    let draft_id = drafts.update_draft();
+    assert.equal(draft_id, undefined);
+
+    override(compose_state, "composing", () => true);
+    override(compose_state, "message_content", () => "dummy content");
+    override(compose_state, "get_message_type", () => "private");
+    override(compose_state, "private_message_recipient", () => "aaron@zulip.com");
+
+    const container = $(".top_left_drafts");
+    const child = $(".unread_count");
+    container.set_find_results(".unread_count", child);
+
+    tippy_args = {
+        content: "translated: Saved as draft",
+        arrow: true,
+        placement: "right",
+    };
+    tippy_show_called = false;
+    tippy_destroy_called = false;
+
+    override(Date, "now", () => 5);
+    override(Math, "random", () => 2);
+    draft_id = drafts.update_draft();
+    assert.ok(tippy_show_called);
+    assert.ok(tippy_destroy_called);
+    assert.equal(draft_id, "5-2");
+
+    override(Date, "now", () => 6);
+
+    tippy_show_called = false;
+    tippy_destroy_called = false;
+    draft_id = drafts.update_draft();
+    assert.ok(tippy_show_called);
+    assert.ok(tippy_destroy_called);
+    assert.equal(draft_id, "5-2");
+
+    override(Date, "now", () => 7);
+
+    tippy_show_called = false;
+    tippy_destroy_called = false;
+    draft_id = drafts.update_draft({no_notify: true});
+    assert.ok(!tippy_show_called);
+    assert.ok(!tippy_destroy_called);
+    assert.equal(draft_id, "5-2");
 });
 
 test("delete_all_drafts", () => {

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -271,27 +271,39 @@ test("update_draft", ({override}) => {
     override(Date, "now", () => 5);
     override(Math, "random", () => 2);
     draft_id = drafts.update_draft();
+    assert.equal(draft_id, "5-2");
     assert.ok(tippy_show_called);
     assert.ok(tippy_destroy_called);
-    assert.equal(draft_id, "5-2");
 
     override(Date, "now", () => 6);
 
+    override(compose_state, "message_content", () => "dummy content edited once");
     tippy_show_called = false;
     tippy_destroy_called = false;
     draft_id = drafts.update_draft();
+    assert.equal(draft_id, "5-2");
     assert.ok(tippy_show_called);
     assert.ok(tippy_destroy_called);
-    assert.equal(draft_id, "5-2");
 
     override(Date, "now", () => 7);
 
+    // message contents not edited
+    tippy_show_called = false;
+    tippy_destroy_called = false;
+    draft_id = drafts.update_draft();
+    assert.equal(draft_id, "5-2");
+    assert.ok(!tippy_show_called);
+    assert.ok(!tippy_destroy_called);
+
+    override(Date, "now", () => 8);
+
+    override(compose_state, "message_content", () => "dummy content edited a second time");
     tippy_show_called = false;
     tippy_destroy_called = false;
     draft_id = drafts.update_draft({no_notify: true});
+    assert.equal(draft_id, "5-2");
     assert.ok(!tippy_show_called);
     assert.ok(!tippy_destroy_called);
-    assert.equal(draft_id, "5-2");
 });
 
 test("delete_all_drafts", () => {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -276,6 +276,10 @@ export function start(msg_type, opts) {
         compose_state.message_content(opts.content);
     }
 
+    if (opts.draft_id) {
+        $("#compose-textarea").data("draft-id", opts.draft_id);
+    }
+
     compose_state.set_message_type(msg_type);
 
     // Show either stream/topic fields or "You and" field.

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -175,6 +175,12 @@ function draft_notify() {
     setTimeout(remove_instance, 3000);
 }
 
+function maybe_notify(no_notify) {
+    if (!no_notify) {
+        draft_notify();
+    }
+}
+
 export function update_draft(opts = {}) {
     const no_notify = opts.no_notify || false;
     const draft = snapshot_message();
@@ -194,9 +200,7 @@ export function update_draft(opts = {}) {
         // We don't save multiple drafts of the same message;
         // just update the existing draft.
         draft_model.editDraft(draft_id, draft);
-        if (!no_notify) {
-            draft_notify();
-        }
+        maybe_notify(no_notify);
         return draft_id;
     }
 
@@ -204,9 +208,7 @@ export function update_draft(opts = {}) {
     // one.
     const new_draft_id = draft_model.addDraft(draft);
     $("#compose-textarea").data("draft-id", new_draft_id);
-    if (!no_notify) {
-        draft_notify();
-    }
+    maybe_notify(no_notify);
 
     return new_draft_id;
 }

--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -6,6 +6,7 @@ import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
 import * as compose_state from "./compose_state";
 import {csrf_token} from "./csrf";
+import * as drafts from "./drafts";
 import * as hash_util from "./hash_util";
 import * as hashchange from "./hashchange";
 import {localstorage} from "./localstorage";
@@ -49,6 +50,10 @@ function preserve_state(send_after_reload, save_pointer, save_narrow, save_compo
 
         if (msg_type) {
             url += "+msg=" + encodeURIComponent(compose_state.message_content());
+            const draft_id = drafts.update_draft();
+            if (draft_id) {
+                url += "+draft_id=" + encodeURIComponent(draft_id);
+            }
         }
     }
 
@@ -147,6 +152,7 @@ export function initialize() {
                 topic: topic || "",
                 private_message_recipient: vars.recipient || "",
                 content: vars.msg || "",
+                draft_id: vars.draft_id || "",
             });
             if (send_now) {
                 compose.finish();


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
copy-pasting the last commit message:
```
We received a complaint about the generation of multiple duplicate
drafts for a single message. It was discovered that the likely cause
of this was how we were handling clients that were frequently
suspending/unsuspending, we would initiate a reload when we discovered
this, and expect the `beforeunload` handler to save the draft. This
behaved correctly, however, we would also save the compose state and
fill it in via `preserve_state` in reload.js. The important detail
here is that `preserve_state` would not encode and preserve the
`draft_id` for the current message, partly because it had no way of
knowing the `draft_id` of the draft... since we have not saved it yet,
the `beforeunload` event happens after `preserve_state`. As such,
performing any action that would trigger a draft to be saved, eg
pressing Esc to close the compose box, would save a duplicate draft of
the same message.

To resolve the above bug, we (1) ensure that we call
`drafts.update_draft()` in `preserve_state`, this returns a draft_id
to us, which we (2) ensure that we encode as part of the url and (3)
set on the `#composebox-textarea` as a `draft-id` data attribute,
which we check the next time we try to save the draft, post reload.

Note that this causes us to save the draft twice, once from
preserve_state and then again from the `beforeunload` handler, but we
do not add two drafts since the second update_draft call just edits
the timestamp because it finds the `draft-id` data attribute on the
`#composebox-textarea` set by the first call.
```

**Testing plan:** <!-- How have you tested? -->
This PR adds node tests to `drafts.js`.
`reload.js` currently has no node test coverage.

**GIFs:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<details>
<summary>
before
</summary>

![301121-duplicate_drafts_bug_before](https://user-images.githubusercontent.com/33805964/144111898-8dfa9cee-101e-4ef3-9c83-98ed19618a88.gif)
</details>

<details>
<summary>
after
</summary>

![301121-duplicate_drafts_bug_after](https://user-images.githubusercontent.com/33805964/144111870-0c4a3878-8a89-4fc6-b994-f67cccbf6d31.gif)
</details>

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
