### PR TITLE
compose_actions: Add comment about spread syntax overwrite behavior.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -182,6 +182,8 @@ function fill_in_opts_from_current_narrowed_view(msg_type, opts) {
         // Set default parameters based on the current narrowed view.
         ...narrow_state.set_compose_defaults(),
 
+        // Set parameters based on provided opts, overwriting
+        // those set based on current narrowed view, if necessary.
         ...opts,
     };
 }


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Based on: https://chat.zulip.org/#narrow/stream/92-learning/topic/spread.20syntax.20will.20overwrite.20properties/near/1288718.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
function now reads as:
```js
function fill_in_opts_from_current_narrowed_view(msg_type, opts) {
    return {
        message_type: msg_type,
        stream: "",
        topic: "",
        private_message_recipient: "",
        trigger: "unknown",
        // Set default parameters based on the current narrowed view.
        ...narrow_state.set_compose_defaults(),

        // Set parameters based on provided opts, overwriting
        // those set based on current narrowed view, if necessary.
        ...opts,
    };
}
```
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
