### PR TITLE
settings: Fix behavior of realm-level notfication batching settings UI.

### DIFF
--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -65,7 +65,7 @@ function update_desktop_icon_count_display(settings_panel) {
     }
 }
 
-function set_notification_batching_ui(container, setting_seconds, force_custom) {
+export function set_notification_batching_ui(container, setting_seconds, force_custom) {
     const edit_elem = container.find(".email_notification_batching_period_edit_minutes");
     const valid_period_values = settings_config.email_notifications_batching_period_values.map(
         (x) => x.value,

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -66,7 +66,6 @@ function update_desktop_icon_count_display(settings_panel) {
 }
 
 function set_notification_batching_ui(container, setting_seconds, force_custom) {
-    const select_elem = container.find(".setting_email_notifications_batching_period_seconds");
     const edit_elem = container.find(".email_notification_batching_period_edit_minutes");
     const valid_period_values = settings_config.email_notifications_batching_period_values.map(
         (x) => x.value,
@@ -75,15 +74,12 @@ function set_notification_batching_ui(container, setting_seconds, force_custom) 
     // We display the custom widget if either the user just selected
     // custom_period, or the current value cannot be represented with
     // the existing set of values.
-    if (force_custom || !valid_period_values.includes(setting_seconds)) {
-        const setting_minutes = setting_seconds / 60;
-        select_elem.val("custom_period");
-        edit_elem.val(setting_minutes);
-        edit_elem.parent().show();
-    } else {
-        select_elem.val(setting_seconds);
-        edit_elem.parent().hide();
-    }
+    const show_edit_elem = force_custom || !valid_period_values.includes(setting_seconds);
+    const select_elem_val = show_edit_elem ? "custom_period" : setting_seconds;
+
+    container.find(".setting_email_notifications_batching_period_seconds").val(select_elem_val);
+    edit_elem.val(setting_seconds / 60);
+    settings_org.change_element_block_display_property(edit_elem.attr("id"), show_edit_elem);
 }
 
 export function set_enable_digest_emails_visibility(settings_panel) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -126,6 +126,12 @@ function get_property_value(property_name, for_realm_default_settings) {
         if (property_name === "twenty_four_hour_time") {
             return JSON.stringify(realm_user_settings_defaults.twenty_four_hour_time);
         }
+        if (
+            property_name === "email_notifications_batching_period_seconds" ||
+            property_name === "email_notification_batching_period_edit_minutes"
+        ) {
+            return realm_user_settings_defaults.email_notifications_batching_period_seconds;
+        }
         return realm_user_settings_defaults[property_name];
     }
 
@@ -488,6 +494,13 @@ function discard_property_element_changes(elem, for_realm_default_settings) {
                 .find(`.setting_emojiset_choice[value='${CSS.escape(property_value)}'`)
                 .prop("checked", true);
             break;
+        case "email_notifications_batching_period_seconds":
+        case "email_notification_batching_period_edit_minutes":
+            settings_notifications.set_notification_batching_ui(
+                $("#realm-user-default-settings"),
+                realm_user_settings_defaults.email_notifications_batching_period_seconds,
+            );
+            break;
         default:
             if (property_value !== undefined) {
                 set_input_element_value(elem, property_value);
@@ -680,6 +693,18 @@ function get_auth_method_table_data() {
     return new_auth_methods;
 }
 
+function get_email_notification_batching_setting_element_value() {
+    const select_elem_val = $("#realm-user-default-settings")
+        .find(".setting_email_notifications_batching_period_seconds")
+        .val();
+    if (select_elem_val !== "custom_period") {
+        return Number.parseInt(select_elem_val, 10);
+    }
+    const edit_elem_val = $("#realm_email_notification_batching_period_edit_minutes").val();
+    const setting_value_in_minutes = Number.parseInt(edit_elem_val, 10);
+    return setting_value_in_minutes * 60;
+}
+
 function check_property_changed(elem, for_realm_default_settings) {
     elem = $(elem);
     const property_name = extract_property_name(elem, for_realm_default_settings);
@@ -702,6 +727,11 @@ function check_property_changed(elem, for_realm_default_settings) {
         case "realm_default_code_block_language":
             changed_val = default_code_language_widget.value();
             break;
+        case "email_notifications_batching_period_seconds":
+        case "email_notification_batching_period_edit_minutes": {
+            changed_val = get_email_notification_batching_setting_element_value();
+            break;
+        }
         default:
             if (current_val !== undefined) {
                 changed_val = get_input_element_value(elem, typeof current_val);
@@ -784,6 +814,14 @@ export function register_save_discard_widget_handlers(
             // within a subsection whose changes should not affect the
             // visibility of the discard button
             return false;
+        }
+
+        if ($(e.target).hasClass("setting_email_notifications_batching_period_seconds")) {
+            const show_elem = $(e.target).val() === "custom_period";
+            change_element_block_display_property(
+                "realm_email_notification_batching_period_edit_minutes",
+                show_elem,
+            );
         }
 
         const subsection = $(e.target).closest(".org-subsection-parent");
@@ -927,6 +965,14 @@ export function register_save_discard_widget_handlers(
         for (let input_elem of properties_elements) {
             input_elem = $(input_elem);
             if (check_property_changed(input_elem, for_realm_default_settings)) {
+                if (
+                    input_elem.hasClass("email_notification_batching_period_edit_minutes") ||
+                    input_elem.hasClass("setting_email_notifications_batching_period_seconds")
+                ) {
+                    const setting_value = get_email_notification_batching_setting_element_value();
+                    data.email_notifications_batching_period_seconds = setting_value;
+                    continue;
+                }
                 const input_value = get_input_element_value(input_elem);
                 if (input_value !== undefined) {
                     let property_name;

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -233,7 +233,7 @@ function set_property_dropdown_value(property_name) {
     $(`#id_${CSS.escape(property_name)}`).val(get_property_value(property_name));
 }
 
-function change_element_block_display_property(elem_id, show_element) {
+export function change_element_block_display_property(elem_id, show_element) {
     const elem = $(`#${CSS.escape(elem_id)}`);
     if (show_element) {
         elem.parent().show();

--- a/static/js/settings_realm_user_settings_defaults.js
+++ b/static/js/settings_realm_user_settings_defaults.js
@@ -35,6 +35,11 @@ export function update_page(property) {
         return;
     }
 
+    if (property === "email_notifications_batching_period_seconds") {
+        settings_notifications.set_notification_batching_ui(container, value);
+        return;
+    }
+
     // The twenty_four_hour_time setting is represented as a boolean
     // in the API, but a dropdown with "true"/"false" as strings in
     // the UI, so we need to convert its format here.

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -138,7 +138,7 @@
                   class="email_notification_batching_period_edit_minutes admin-realm-time-limit-input prop-element"
                   data-setting-widget-type="number"
                   autocomplete="off"
-                  value="{{ email_notifications_batching_period_seconds }}"/>
+                  id="{{prefix}}email_notification_batching_period_edit_minutes"/>
             </div>
         </div>
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit is a prep commit to use `settings_org.change_element_block_display_property` in `set_notification_batching_ui`.
- Second commit is the main commit to fix the behavior of changing realm-level notification batching period setting from UI which was broken after 4f63378e7f9e.
 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![batching-period-setting](https://user-images.githubusercontent.com/35494118/144447700-e0939230-9a50-4caa-b29a-2b551c19824c.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
