### PR TITLE
Disable `enable_spectator_access` setting in UI when server-level setting is set to False.

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -160,6 +160,7 @@ export function build_page() {
         twenty_four_hour_time_values: settings_config.twenty_four_hour_time_values,
         create_web_public_stream_policy_values:
             settings_config.create_web_public_stream_policy_values,
+        disable_enable_spectator_access_setting: !page_params.server_web_public_streams_enabled,
     };
 
     if (options.realm_logo_source !== "D" && options.realm_night_logo_source === "D") {

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -1140,6 +1140,14 @@ body.dark-theme {
             color: hsl(236, 15%, 70%);
         }
     }
+
+    /* Originally the icon inherits the color of label, but when the setting
+    is disabled, the color of the label is changed and thus the icon becomes
+    too light. So, we set the color explicitly to original color of label to
+    keep the color of the icon same even when the setting is disabled. */
+    #id_realm_enable_spectator_access_label a {
+        color: hsl(236, 33%, 90%);
+    }
 }
 
 @supports (-moz-appearance: none) {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -641,11 +641,6 @@ input[type="checkbox"] {
     }
 }
 
-.disableable {
-    margin-left: 22px;
-    margin-top: -10px;
-}
-
 .admin-realm-message-content-delete-limit-minutes {
     width: 5ch;
     text-align: right;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -380,6 +380,14 @@ td .button {
     .hidden-email {
         font-style: italic;
     }
+
+    /* Originally the icon inherits the color of label, but when the setting
+    is disabled, the color of the label is changed and thus the icon becomes
+    too light. So, we set the color explicitly to original color of label to
+    keep the color of the icon same even when the setting is disabled. */
+    #id_realm_enable_spectator_access_label a {
+        color: hsl(0, 0%, 20%);
+    }
 }
 
 #admin-user-list,

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -107,7 +107,9 @@
                   setting_name="realm_enable_spectator_access"
                   prefix="id_"
                   is_checked=realm_enable_spectator_access
-                  label=admin_settings_label.realm_enable_spectator_access}}
+                  label=admin_settings_label.realm_enable_spectator_access
+                  is_disabled=disable_enable_spectator_access_setting
+                  help_link="help/web-public-streams"}}
                 <div class="input-group realm_create_web_public_stream_policy">
                     <label for="realm_create_web_public_stream_policy" class="dropdown-title">{{t "Who can create web-public streams" }}</label>
                     <select name="realm_create_web_public_stream_policy" id="id_realm_create_web_public_stream_policy" class="prop-element" data-setting-widget-type="number">

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -107,7 +107,6 @@
                   setting_name="realm_enable_spectator_access"
                   prefix="id_"
                   is_checked=realm_enable_spectator_access
-                  render_only=page_params.server_web_public_streams_enabled
                   label=admin_settings_label.realm_enable_spectator_access}}
                 <div class="input-group realm_create_web_public_stream_policy">
                     <label for="realm_create_web_public_stream_policy" class="dropdown-title">{{t "Who can create web-public streams" }}</label>

--- a/static/templates/settings/settings_checkbox.hbs
+++ b/static/templates/settings/settings_checkbox.hbs
@@ -1,8 +1,8 @@
 {{#unless (eq render_only false)}}
-<div class="input-group">
+<div class="input-group {{#if is_disabled}}control-label-disabled{{/if}}">
     <label class="checkbox">
         <input type="checkbox" class="{{setting_name}} inline-block setting-widget prop-element" name="{{setting_name}}" data-setting-widget-type="boolean"
-          id="{{prefix}}{{setting_name}}" {{#if is_checked}}checked="checked"{{/if}} />
+          id="{{prefix}}{{setting_name}}" {{#if is_checked}}checked="checked"{{/if}} {{#if is_disabled}}disabled{{/if}} />
         <span></span>
     </label>
     <label for="{{prefix}}{{setting_name}}" class="inline {{setting_name}}_label" id="{{prefix}}{{setting_name}}_label">

--- a/static/templates/settings/settings_checkbox.hbs
+++ b/static/templates/settings/settings_checkbox.hbs
@@ -1,5 +1,5 @@
 {{#unless (eq render_only false)}}
-<div class="input-group {{#if is_nested}}disableable{{/if}}">
+<div class="input-group">
     <label class="checkbox">
         <input type="checkbox" class="{{setting_name}} inline-block setting-widget prop-element" name="{{setting_name}}" data-setting-widget-type="boolean"
           id="{{prefix}}{{setting_name}}" {{#if is_checked}}checked="checked"{{/if}} />


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit just removes unused variable and a class.
- Second commit removes the render_only argument which was originally added to hide the setting according to server-level setting but was incorrect.
- Third commit is for disabling the setting in Ui according to sever-level setting. <!-- How have you tested? -->

Fixes #20417.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Enabled
![Screenshot from 2021-12-02 23-47-17](https://user-images.githubusercontent.com/35494118/144481922-f3308fa4-1021-425e-87ce-7825415d9fef.png)

Disabled
![Screenshot from 2021-12-03 00-00-42](https://user-images.githubusercontent.com/35494118/144481912-4341d1ce-bf31-44d9-a422-59b22416fb26.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
