### PR TITLE
semgrep: Enforce use of get_object_from_key for Confirmation fetching.

### DIFF
--- a/tools/semgrep.yml
+++ b/tools/semgrep.yml
@@ -166,3 +166,18 @@ rules:
             ...
     message: "Use change_user_is_active to mutate user_profile.is_active"
     severity: ERROR
+
+  - id: confirmation-object-get
+    languages: [python]
+    patterns:
+      - pattern-either:
+          - pattern: Confirmation.objects.get(...)
+          - pattern: Confirmation.objects.filter(..., confirmation_key=..., ...)
+      - pattern-not-inside: |
+          def get_object_from_key(...):
+            ...
+    paths:
+      exclude:
+        - zerver/tests/
+    message: "Do not fetch a Confirmation object directly, use get_object_from_key instead"
+    severity: ERROR


### PR DESCRIPTION
```
get_object_from_key should be used when trying to fetch a Confirmation
object. There are some places that need to make
Confirmation.objects.filter(...) queries, so we can't completely ban the
pattern, but we can ban .get(...) and
.filter(..., confirmation_key=..., ...).
```

These are the places that still rely on using .filter(), and it probably makes sense for them to keep doing so:
```
analytics/views/support.py:    confirmations = Confirmation.objects.filter(
analytics/views/support.py-        type__in=types, object_id__in=object_ids, date_sent__gte=lowest_datetime
--
confirmation/migrations/0009_confirmation_expiry_date_backfill.py:        confirmations = Confirmation.objects.filter(id__gte=lower_bound, id__lte=upper_bound)
confirmation/migrations/0009_confirmation_expiry_date_backfill.py-        for confirmation in confirmations:
--
tools/semgrep.yml:          - pattern: Confirmation.objects.filter(..., confirmation_key=..., ...)
tools/semgrep.yml-      - pattern-not-inside: |
--
zerver/lib/actions.py:    multiuse_confirmation_objs = Confirmation.objects.filter(
zerver/lib/actions.py-        realm=user_profile.realm, type=Confirmation.MULTIUSE_INVITE, expiry_date__gte=timezone_now()
--
zerver/lib/actions.py:    Confirmation.objects.filter(content_type=content_type, object_id=prereg_user.id).delete()
zerver/lib/actions.py-    prereg_user.delete()
--
zerver/lib/actions.py:    Confirmation.objects.filter(content_type=content_type, object_id=multiuse_invite.id).delete()
zerver/lib/actions.py-    multiuse_invite.delete()
--
zerver/views/development/email_log.py:    key = Confirmation.objects.filter(type=Confirmation.EMAIL_CHANGE).latest("id").confirmation_key
zerver/views/development/email_log.py-    url = confirmation_url(key, realm, Confirmation.EMAIL_CHANGE)
```