### PR TITLE
Apply dark theme to upgrade tips

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -875,6 +875,7 @@ body.dark-theme {
         box-shadow: 0 0 0 1px hsla(0, 0%, 0%, 0.4);
     }
 
+    .upgrade-tip,
     .tip {
         color: inherit;
         background-color: hsla(46, 28%, 38%, 0.27);


### PR DESCRIPTION
Change dark theme colors of upgrade tips to match colors of other dark theme tips

<!-- What's this PR for?  (Just a link to an issue is fine.) --> https://github.com/zulip/zulip/issues/20431

**Testing plan:** <!-- How have you tested? --> Yes, I have run the front-end tests 

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  --> 
![zulip1](https://user-images.githubusercontent.com/69853994/144525343-44e79e51-8762-4918-a5ad-d8d804b3fe54.png)
![zulip2](https://user-images.githubusercontent.com/69853994/144525363-beaa089a-8350-4ceb-9551-d3d42957e6e2.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
