### PR TITLE
Add copy buttons to bot settings

### DIFF
--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -21,9 +21,7 @@ const bot_data_params = {
 
 const avatar = mock_esm("../../static/js/avatar");
 
-function ClipboardJS(sel) {
-    assert.equal(sel, "#copy_zuliprc");
-}
+function ClipboardJS() {}
 mock_cjs("clipboard", ClipboardJS);
 
 const bot_data = zrequire("bot_data");

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -551,6 +551,26 @@ export function set_up() {
         },
     });
 
+    new ClipboardJS("#copy_email", {
+        text(trigger) {
+            const bot_info = $(trigger).closest(".bot-information-box").find(".bot_info");
+            const bot_id = Number.parseInt(bot_info.attr("data-user-id"), 10);
+            const bot = bot_data.get(bot_id);
+            const email = bot.email;
+            return email;
+        },
+    });
+
+    new ClipboardJS("#copy_api_key", {
+        text(trigger) {
+            const bot_info = $(trigger).closest(".bot-information-box").find(".bot_info");
+            const bot_id = Number.parseInt(bot_info.attr("data-user-id"), 10);
+            const bot = bot_data.get(bot_id);
+            const api_key = bot.api_key;
+            return api_key;
+        },
+    });
+
     $("#bots_lists_navbar .add-a-new-bot-tab").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -767,6 +767,19 @@ input[type="checkbox"] {
         white-space: pre;
     }
 
+    .copy_email {
+        font-size: 0.85em;
+        position: relative;
+        margin-left: 5px;
+        color: hsl(0, 0%, 67%);
+        transition: all 0.3s ease;
+
+        &:hover {
+            color: hsl(0, 0%, 27%);
+        }
+    }
+
+    .copy_api_key,
     .regenerate_bot_api_key {
         position: relative;
         margin-left: 5px;
@@ -850,6 +863,10 @@ input[type="checkbox"] {
     .api_key .api-key-value-and-button {
         font-family: "Source Code Pro", monospace;
         font-size: 0.85em;
+        display: flex;
+    }
+
+    .email .email-value-and-button {
         display: flex;
     }
 

--- a/static/templates/settings/bot_avatar_row.hbs
+++ b/static/templates/settings/bot_avatar_row.hbs
@@ -28,7 +28,12 @@
         </div>
         <div class="email">
             <div class="field">{{t "Bot email" }}</div>
-            <div class="value">{{email}}</div>
+            <div class="email-value-and-button">
+                <div class="value">{{email}}</div>
+                <button type="submit" id="copy_email" class="button no-style btn-secondary copy_email" title="{{t 'Copy zuliprc' }}">
+                    <i class="fa fa-clipboard gray" aria-hidden="true"></i>
+                </button>
+            </div>
         </div>
         {{#if is_active}}
         <div class="api_key">
@@ -36,6 +41,9 @@
             <div class="api-key-value-and-button no-select">
                 <!-- have the `.text-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
                 <span class="value text-select">{{api_key}}</span>
+                <button type="submit" id="copy_api_key" class="button no-style btn-secondary copy_api_key" title="{{t 'Copy zuliprc' }}">
+                    <i class="fa fa-clipboard gray" aria-hidden="true"></i>
+                </button>
                 <button type="submit" class="button no-style btn-secondary regenerate_bot_api_key" title="{{t 'Generate new API key' }}" data-user-id="{{user_id}}">
                     <i class="fa fa-refresh" aria-hidden="true"></i>
                 </button>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Issue #19884

**Testing plan:** <!-- How have you tested? -->
As can be seen below, tested visually to confirm copy button is appearing as well as checking if it copies the correct email or api key. Additionally, tried regenerating API keys and copying them as well.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Light Mode
<img width="1027" alt="Screen Shot 2021-12-02 at 9 55 38 PM" src="https://user-images.githubusercontent.com/56496048/144538671-cb551277-4cf3-4589-ac47-5730d865e344.png">

Dark Mode
<img width="1030" alt="Screen Shot 2021-12-02 at 9 55 07 PM" src="https://user-images.githubusercontent.com/56496048/144538683-2055b3ec-67fd-446b-889f-f6b42943dfd2.png">


Recording

https://user-images.githubusercontent.com/56496048/144538693-5f41aa4e-1dca-4082-a01a-11d49a79b58c.mov



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
