### PR TITLE
stream_settings: Remove pencil icon from 'General' tab in stream settings.

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -864,6 +864,7 @@ h4.stream_setting_subsection_title {
 
     .stream-header {
         white-space: nowrap;
+        padding-top: 10px;
 
         .stream-name {
             display: inline-block;

--- a/static/templates/stream_settings/stream_settings.hbs
+++ b/static/templates/stream_settings/stream_settings.hbs
@@ -23,6 +23,13 @@
 
         <div class="general_settings stream_section">
             {{#with sub}}
+            <div class="tip" {{#if can_change_stream_permissions}}style="display:none"{{/if}}>
+                {{#if can_change_name_description}}
+                    {{t "Only subscribers to this stream can edit stream permissions."}}
+                {{else}}
+                    {{t "Only organization administrators can edit these settings."}}
+                {{/if}}
+            </div>
             <div class="stream-header">
                 {{> stream_privacy_icon
                   invite_only=invite_only
@@ -31,7 +38,7 @@
                     <span class="sub-stream-name" title="{{name}}">{{name}}</span>
                 </div>
                 <div class="stream_change_property_info alert-notification"></div>
-                <div class="button-group">
+                <div class="button-group" {{#unless can_change_name_description}}style="display:none"{{/unless}}>
                     <button id="open_stream_info_modal" class="button rounded small btn-warning" title="{{t 'Change stream info' }}">
                         <i class="fa fa-pencil" aria-hidden="true"></i>
                     </button>


### PR DESCRIPTION
For user who is not an administrator.
Also implemented a banner that tells user that they can't edit these
fields (but admins can).

Fixes #20001. 

**Testing plan:** <!-- How have you tested? -->
This is a UI change, I have tested it  manually.

This is how general tab in 'stream settings' look like:

On logging in as a **general user** or a **moderator**:
![Screenshot 2021-12-02 202050](https://user-images.githubusercontent.com/49791933/144551080-dd2fe5e0-1230-4a09-94e1-9b14778ec986.jpg)

On logging in as an **owner** or an **administrator**:
![image](https://user-images.githubusercontent.com/49791933/144551274-f577ac2f-95f0-4376-b15f-6ebedfe89206.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
