### PR TITLE
test_events: Rename functions to use dark_theme and light_theme.

### DIFF
--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1691,14 +1691,14 @@ class NormalActionsTest(BaseAction):
         events = self.verify_action(action, state_change_expected=True)
         check_realm_update_dict("events[0]", events[0])
 
-    def test_change_realm_day_mode_logo_source(self) -> None:
+    def test_change_realm_light_theme_logo_source(self) -> None:
         action = lambda: do_change_logo_source(
             self.user_profile.realm, Realm.LOGO_UPLOADED, False, acting_user=self.user_profile
         )
         events = self.verify_action(action, state_change_expected=True)
         check_realm_update_dict("events[0]", events[0])
 
-    def test_change_realm_night_mode_logo_source(self) -> None:
+    def test_change_realm_dark_theme_logo_source(self) -> None:
         action = lambda: do_change_logo_source(
             self.user_profile.realm, Realm.LOGO_UPLOADED, True, acting_user=self.user_profile
         )


### PR DESCRIPTION
This commit renames the tests for changing logo in test_events
to use dark_theme and light_theme instead of night_mode and
day_mode.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

 <!-- How have you tested? -->
<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
