### PR TITLE
move_topic_to_stream: Fix clipped stream select dropdown.

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -707,5 +707,11 @@ ul {
             margin: 0 5px 5px -10px;
             text-indent: 10px;
         }
+
+        .dropdown-menu {
+            position: fixed;
+            top: 125px;
+            left: 40px;
+        }
     }
 }


### PR DESCRIPTION
The stream select dropdown's height was clipped by the modal
container which resulted in the dropdown only being displayed
partially. We could either move the dropdown to under `body` or use
`position: fixed` for it be able to show outside parent container.
We go for the later option.
<img width="553" alt="Screenshot 2021-12-03 at 7 48 32 PM" src="https://user-images.githubusercontent.com/25124304/144617502-331d42a2-951d-4d73-8173-a48b00426549.png">


I don't think we need to do a JS computation of the position here since the position of the dropdown is ok for the most part. On width < 400px it looks like this:
<img width="301" alt="Screenshot 2021-12-03 at 7 48 22 PM" src="https://user-images.githubusercontent.com/25124304/144617479-4b3c8a6f-1bb3-4794-980b-863e9d3841b5.png">
Which looks good enough?