### PR TITLE
search: Keep search box open when selecting from auto-complete

### DIFF
--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -319,6 +319,24 @@ test("initialize", () => {
     search_button.prop("disabled", true);
     search_query_box.trigger("focus");
     assert.ok(!search_button.prop("disabled"));
+
+    _setup("ver");
+    ev.key = "ArrowDown";
+    search_query_box.is = () => false;
+    searchbox_form.trigger(ev);
+    searchbox_form.trigger(ev);
+    ev.key = "Enter";
+    searchbox_form.trigger(ev);
+    assert.ok(!is_blurred);
+    
+
+    _setup("ver");
+    ev.key = "ArrowDown";
+    search_query_box.is = () => true;
+    searchbox_form.trigger(ev);
+    ev.key = "Enter";
+    searchbox_form.trigger(ev);
+    assert.ok(is_blurred);
 });
 
 test("initiate_search", () => {

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -328,7 +328,6 @@ test("initialize", () => {
     ev.key = "Enter";
     searchbox_form.trigger(ev);
     assert.ok(!is_blurred);
-    
 
     _setup("ver");
     ev.key = "ArrowDown";

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -141,7 +141,7 @@ run_test("initialize", () => {
             ];
             _setup("ver");
             assert.equal(opts.updater("ver"), "ver");
-            assert.ok(is_blurred);
+            assert.ok(!is_blurred);
 
             operators = [
                 {
@@ -152,7 +152,7 @@ run_test("initialize", () => {
             ];
             _setup("stream:Verona");
             assert.equal(opts.updater("stream:Verona"), "stream:Verona");
-            assert.ok(is_blurred);
+            assert.ok(!is_blurred);
 
             search.__Rewire__("is_using_input_method", true);
             _setup("stream:Verona");
@@ -171,7 +171,6 @@ run_test("initialize", () => {
 
     search_query_box.val("test string");
     narrow_state.search_string = () => "ver";
-    search_query_box.trigger("blur");
     assert.equal(search_query_box.val(), "test string");
 
     search.__Rewire__("is_using_input_method", false);
@@ -251,7 +250,7 @@ run_test("initialize", () => {
     ev.key = "Enter";
     search_query_box.is = () => true;
     searchbox_form.trigger(ev);
-    assert.ok(is_blurred);
+    assert.ok(!is_blurred);
 
     _setup("ver");
     search.__Rewire__("is_using_input_method", true);
@@ -264,7 +263,7 @@ run_test("initialize", () => {
     ev.key = "Enter";
     search_query_box.is = () => true;
     searchbox_form.trigger(ev);
-    assert.ok(is_blurred);
+    assert.ok(!is_blurred);
     assert.ok(!search_button.prop("disabled"));
 });
 

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -12,7 +12,9 @@ page_params.search_pills_enabled = false;
 const noop = () => {};
 
 const narrow = mock_esm("../../static/js/narrow");
-const narrow_state = mock_esm("../../static/js/narrow_state");
+const narrow_state = mock_esm("../../static/js/narrow_state", {
+    filter: () => false,
+});
 const search_suggestion = mock_esm("../../static/js/search_suggestion");
 mock_esm("../../static/js/ui_util", {
     change_tab_to: noop,
@@ -171,6 +173,7 @@ run_test("initialize", () => {
 
     search_query_box.val("test string");
     narrow_state.search_string = () => "ver";
+    search_query_box.trigger("blur");
     assert.equal(search_query_box.val(), "test string");
 
     search.__Rewire__("is_using_input_method", false);
@@ -250,7 +253,7 @@ run_test("initialize", () => {
     ev.key = "Enter";
     search_query_box.is = () => true;
     searchbox_form.trigger(ev);
-    assert.ok(!is_blurred);
+    assert.ok(is_blurred);
 
     _setup("ver");
     search.__Rewire__("is_using_input_method", true);
@@ -263,7 +266,7 @@ run_test("initialize", () => {
     ev.key = "Enter";
     search_query_box.is = () => true;
     searchbox_form.trigger(ev);
-    assert.ok(!is_blurred);
+    assert.ok(is_blurred);
     assert.ok(!search_button.prop("disabled"));
 });
 

--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -129,7 +129,7 @@ function build_message_view_header(filter) {
         bind_title_area_handlers();
         if (page_params.search_pills_enabled && $("#search_query").is(":focus")) {
             open_search_bar_and_close_narrow_description();
-        } else {
+        } else if (!search.used_typeahead) {
             close_search_bar_and_open_narrow_description();
         }
     }

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -46,8 +46,7 @@ export function narrow_or_search_for_term(search_string) {
     // so leave the current text in.
     if (!page_params.search_pills_enabled && !used_typeahead) {
         search_query_box.trigger("blur");
-    }
-    if (used_typeahead) {
+    } else if (used_typeahead) {
         search_query_box.trigger("focus");
     }
     return search_string;
@@ -169,9 +168,7 @@ export function initialize() {
                 // Pill is already added during keydown event of input pills.
                 narrow_or_search_for_term(search_query_box.val());
 
-                if (used_typeahead) {
-                    search_query_box.trigger("focus");
-                } else {
+                if (!used_typeahead) {
                     search_query_box.trigger("blur");
                     update_buttons_with_focus(false);
                 }


### PR DESCRIPTION
This PR resolves [Issue 20394](https://github.com/zulip/zulip/issues/20394).

**Testing plan:**
This issue pertaining to the search bar was tested within the development environment and successfully keeps the search bar in focus when the user chooses a search suggestion. When the user chooses a search suggestion via **enter** or a **mouse click** the search bar remains in focus so that the user can continue their search query if needed. When they blur the search bar manually, the message_view_header then repopulates the search bar.

I added 2 additional tests within the search.js frontend/nodejs test file. One test where the user does not use a search suggestion and one where the user does use a search suggestion.

**GIFs or screenshots:**
Here is an example of the search bar remaining in focus when the user chooses a search suggestion via arrows and enter key:
![search bar using enter](https://user-images.githubusercontent.com/44930242/144672860-09e88704-98de-47dd-aee0-284eb869299e.gif)

Here is an example of the search bar remaining in focus when the user chooses a search suggestion via a mouse click:
![search suggestion with click](https://user-images.githubusercontent.com/44930242/144672890-169ff9ef-67a7-4e66-89c2-71dfd6cfab9c.gif)



Thank you!