### PR TITLE
compose_ui: Use white spinner on both dark and light theme.

### DIFF
--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -8,7 +8,6 @@ import * as loading from "./loading";
 import * as people from "./people";
 import * as popover_menus from "./popover_menus";
 import * as rtl from "./rtl";
-import * as settings_data from "./settings_data";
 import * as user_status from "./user_status";
 
 let full_size_status = false; // true or false
@@ -397,8 +396,8 @@ export function hide_compose_spinner() {
 }
 
 export function show_compose_spinner() {
-    const using_dark_theme = settings_data.using_dark_theme();
-    loading.show_button_spinner($("#compose-send-button .loader"), using_dark_theme);
+    // Always use white spinner.
+    loading.show_button_spinner($("#compose-send-button .loader"), true);
     $("#compose-send-button span").hide();
     $("#compose-send-button").addClass("disable-btn");
 }

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -404,7 +404,10 @@ export function show_compose_spinner() {
 
 export function get_compose_click_target(e) {
     const compose_control_buttons_popover = popover_menus.get_compose_control_buttons_popover();
-    if (compose_control_buttons_popover) {
+    if (
+        compose_control_buttons_popover &&
+        $(compose_control_buttons_popover.popper).has(e.target).length
+    ) {
         return compose_control_buttons_popover.reference;
     }
     return e.target;

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -437,7 +437,7 @@ input.recipient_box {
     .loader {
         display: none;
         position: relative;
-        top: -4px;
+        top: -6px;
     }
 }
 


### PR DESCRIPTION
Fixed alignment slightly.

<img width="760" alt="Screenshot 2021-12-04 at 10 29 25 AM" src="https://user-images.githubusercontent.com/25124304/144697851-37e65117-558b-493f-8456-95850ddd3a0e.png">
<img width="760" alt="Screenshot 2021-12-04 at 10 32 36 AM" src="https://user-images.githubusercontent.com/25124304/144697865-c11a4d5d-14d6-4bc5-b5c2-589baa9c8954.png">
