### PR TITLE
developer-docs: Rename "version-control" doc to "commit-discipline".

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,5 +7,5 @@
   -->
 
 <!-- Also be sure to make clear, coherent commits:
-  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
+  https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html
   -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,7 +238,7 @@ experience, these are the best predictors of success:
   guidelines](https://zulip.com/developer-community/#getting-help) and
   [this essay][good-questions-blog] for some good advice.
 - Learning and practicing
-  [Git commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html#commit-discipline).
+  [Git commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html).
 - Submitting carefully tested code. This generally means checking your work
   through a combination of automated tests and manually clicking around the
   UI trying to find bugs in your work. See

--- a/docs/contributing/code-reviewing.md
+++ b/docs/contributing/code-reviewing.md
@@ -237,7 +237,7 @@ We also strongly recommend reviewers to go through the following resources.
 - [Zulip code of conduct](../code-of-conduct.md)
 
 [code-style]: ../contributing/code-style.md
-[commit-messages]: ../contributing/version-control.html#commit-messages
+[commit-messages]: ../contributing/commit-discipline.html#commit-messages
 [test-writing]: ../testing/testing.md
 [mypy]: ../testing/mypy.md
 [git tool]: ../git/zulip-tools.html#fetch-a-pull-request-and-rebase

--- a/docs/contributing/commit-discipline.md
+++ b/docs/contributing/commit-discipline.md
@@ -1,6 +1,4 @@
-# Version control
-
-## Commit discipline
+# Commit discipline
 
 We follow the Git project's own commit discipline practice of "Each
 commit is a minimal coherent idea". This discipline takes a bit of work,

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -5,7 +5,7 @@
 maxdepth: 3
 ---
 
-version-control
+commit-discipline
 code-style
 code-reviewing
 zulipbot-usage

--- a/docs/git/overview.md
+++ b/docs/git/overview.md
@@ -61,8 +61,8 @@ Git workflow, or if you'd like a Git refresher.
 [continuous-integration]: ../testing/continuous-integration.md
 [zulip-git-guide-fork-ci]: ../git/cloning.html#step-3-configure-continuous-integration-for-your-fork
 [zulip-rtd-code-style]: ../contributing/code-style.md
-[zulip-rtd-commit-discipline]: ../contributing/version-control.html#commit-discipline
-[zulip-rtd-commit-messages]: ../contributing/version-control.html#commit-messages
+[zulip-rtd-commit-discipline]: ../contributing/commit-discipline.md
+[zulip-rtd-commit-messages]: ../contributing/commit-discipline.html#commit-messages
 [zulip-rtd-dev-overview]: ../development/overview.md
 [zulip-rtd-lint-tools]: ../contributing/code-style.html#lint-tools
 [zulip-rtd-mypy]: ../testing/mypy.md

--- a/docs/git/using.md
+++ b/docs/git/using.md
@@ -453,5 +453,5 @@ complicated rebase.
 [how-git-is-different]: ./the-git-difference.md
 [self-multiple-computers]: ../git/troubleshooting.html#working-from-multiple-computers
 [zulip-git-guide-up-to-date]: ../git/using.html#keep-your-fork-up-to-date
-[zulip-rtd-commit-discipline]: ../contributing/version-control.html#commit-discipline
-[zulip-rtd-commit-messages]: ../contributing/version-control.html#commit-messages
+[zulip-rtd-commit-discipline]: ../contributing/commit-discipline.md
+[zulip-rtd-commit-messages]: ../contributing/commit-discipline.html#commit-messages

--- a/templates/zerver/api/incoming-webhooks-walkthrough.md
+++ b/templates/zerver/api/incoming-webhooks-walkthrough.md
@@ -473,8 +473,8 @@ request:
    https://zulip.readthedocs.io/en/latest/contributing/code-style.html) and take a look
    through your code to double-check that you've followed Zulip's guidelines.
 3. Take a look at your Git history to ensure your commits have been clear and
-   logical (see [Version control](
-   https://zulip.readthedocs.io/en/latest/contributing/version-control.html) for tips). If not,
+   logical (see [Commit discipline](
+   https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html) for tips). If not,
    consider revising them with `git rebase --interactive`. For most incoming webhooks,
    you'll want to squash your changes into a single commit and include a good,
    clear commit message.


### PR DESCRIPTION
Coming from the discussion here: https://chat.zulip.org/#narrow/stream/2-general/topic/contributing.20guide.20updated/near/1287008.

This commit performs the rename mentioned in the summary and also
changes all links and references to use the new name. Additionally,
since we're removing the `## Commit discipline` heading, it changes
links of the type `/version-control.html#commit-discipline` to be just
`/commit-discipline.html`.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
