### PR TITLE
templates: Indent each blocks.

### DIFF
--- a/static/templates/blueslip_stacktrace.hbs
+++ b/static/templates/blueslip_stacktrace.hbs
@@ -7,22 +7,22 @@
 </div>
 <div class="stacktrace-content">
     {{#each stackframes}}
-    <div data-full-path="{{ full_path }}" data-line-no="{{ line_number }}">
-        <div class="stackframe">
-            <i class="fa fa-caret-right expand"></i>
-            <span class="subtle">at</span>
-            {{#if function_name}}
-            {{ function_name.scope }}<b>{{ function_name.name }}</b>
-            {{/if}}
-            <span class="subtle">{{ show_path }}:{{ line_number }}</span>
-        </div>
-        <div class="code-context" style="display: none">
-            <div class="code-context-content">
-                {{~#each context~}}
-                <div {{#if focus}}class="focus-line"{{/if}}><span class="line-number">{{ line_number }}</span> {{ line }}</div>
-                {{~/each~}}
+        <div data-full-path="{{ full_path }}" data-line-no="{{ line_number }}">
+            <div class="stackframe">
+                <i class="fa fa-caret-right expand"></i>
+                <span class="subtle">at</span>
+                {{#if function_name}}
+                {{ function_name.scope }}<b>{{ function_name.name }}</b>
+                {{/if}}
+                <span class="subtle">{{ show_path }}:{{ line_number }}</span>
+            </div>
+            <div class="code-context" style="display: none">
+                <div class="code-context-content">
+                    {{~#each context~}}
+                        <div {{#if focus}}class="focus-line"{{/if}}><span class="line-number">{{ line_number }}</span> {{ line }}</div>
+                    {{~/each~}}
+                </div>
             </div>
         </div>
-    </div>
     {{/each}}
 </div>

--- a/static/templates/default_language_modal.hbs
+++ b/static/templates/default_language_modal.hbs
@@ -14,25 +14,25 @@
 </p>
 <table>
     {{#each language_list}}
-    <tr>
-        <td>
-            <a class="language" data-code="{{this.first.code}}" data-name="{{this.first.name}}">
-                {{#if this.first.selected}}
-                <b>{{this.first.name_with_percent}}</b>
-                {{else}}
-                {{this.first.name_with_percent}}
-                {{/if}}
-            </a>
-        </td>
-        <td>
-            <a class="language" data-code="{{this.second.code}}" data-name="{{this.second.name}}">
-                {{#if this.second.selected}}
-                <b>{{this.second.name_with_percent}}</b>
-                {{else}}
-                {{this.second.name_with_percent}}
-                {{/if}}
-            </a>
-        </td>
-    </tr>
+        <tr>
+            <td>
+                <a class="language" data-code="{{this.first.code}}" data-name="{{this.first.name}}">
+                    {{#if this.first.selected}}
+                    <b>{{this.first.name_with_percent}}</b>
+                    {{else}}
+                    {{this.first.name_with_percent}}
+                    {{/if}}
+                </a>
+            </td>
+            <td>
+                <a class="language" data-code="{{this.second.code}}" data-name="{{this.second.name}}">
+                    {{#if this.second.selected}}
+                    <b>{{this.second.name_with_percent}}</b>
+                    {{else}}
+                    {{this.second.name_with_percent}}
+                    {{/if}}
+                </a>
+            </td>
+        </tr>
     {{/each}}
 </table>

--- a/static/templates/draft_table_body.hbs
+++ b/static/templates/draft_table_body.hbs
@@ -20,7 +20,7 @@
                 </div>
 
                 {{#each drafts}}
-                {{> draft}}
+                    {{> draft}}
                 {{/each}}
             </div>
         </div>

--- a/static/templates/emoji_popover_content.hbs
+++ b/static/templates/emoji_popover_content.hbs
@@ -5,17 +5,17 @@
     </div>
     <div class="emoji-popover-category-tabs">
         {{#each emoji_categories}}
-        <span class="emoji-popover-tab-item {{#if @first}} active {{/if}}" data-tab-name='{{name}}' title='{{name}}'><i class="fa {{icon}}"></i></span>
+            <span class="emoji-popover-tab-item {{#if @first}} active {{/if}}" data-tab-name='{{name}}' title='{{name}}'><i class="fa {{icon}}"></i></span>
         {{/each}}
     </div>
     <div class="emoji-popover-emoji-map" data-simplebar data-simplebar-auto-hide="false" data-message-id="{{message_id}}">
         {{#each emoji_categories }}
-        <div class="emoji-popover-subheading" data-section="{{name}}">{{name}}</div>
-        <div class="emoji-collection" data-section="{{name}}">
-            {{#each this.emojis }}
-            {{> emoji_popover_emoji type="emoji_picker_emoji" section=@../index index=@index message_id=../../message_id is_status_emoji_popover=../../is_status_emoji_popover emoji_dict=this}}
-            {{/each}}
-        </div>
+            <div class="emoji-popover-subheading" data-section="{{name}}">{{name}}</div>
+            <div class="emoji-collection" data-section="{{name}}">
+                {{#each this.emojis }}
+                    {{> emoji_popover_emoji type="emoji_picker_emoji" section=@../index index=@index message_id=../../message_id is_status_emoji_popover=../../is_status_emoji_popover emoji_dict=this}}
+                {{/each}}
+            </div>
         {{/each}}
     </div>
     <div class="emoji-search-results-container" data-simplebar data-simplebar-auto-hide="false" data-message-id="{{message_id}}">

--- a/static/templates/emoji_popover_search_results.hbs
+++ b/static/templates/emoji_popover_search_results.hbs
@@ -1,3 +1,3 @@
 {{#each search_results}}
-{{> emoji_popover_emoji type="emoji_search_result" section="0" index=@index message_id=../message_id is_status_emoji_popover=../is_status_emoji_popover emoji_dict=this }}
+    {{> emoji_popover_emoji type="emoji_search_result" section="0" index=@index message_id=../message_id is_status_emoji_popover=../is_status_emoji_popover emoji_dict=this }}
 {{/each}}

--- a/static/templates/invitation_failed_error.hbs
+++ b/static/templates/invitation_failed_error.hbs
@@ -8,7 +8,7 @@
 {{/if}}
 <ul>
     {{#each error_list}}
-    <li>{{this}}</li>
+        <li>{{this}}</li>
     {{/each}}
 </ul>
 {{#if is_invitee_deactivated}}

--- a/static/templates/invite_subscription.hbs
+++ b/static/templates/invite_subscription.hbs
@@ -6,16 +6,16 @@
 <div id="invite-stream-checkboxes" class="new-style">
     {{#each streams}}
 
-    <label class="checkbox display-block">
-        <input type="checkbox" name="stream" value="{{stream_id}}"
-          {{#if default_stream}}checked="checked"{{/if}} />
-        <span></span>
-        {{#if invite_only}}<i class="fa fa-lock" aria-hidden="true"></i>{{/if}}
-        {{#if (eq name ../notifications_stream)}}
-        #{{name}} <i>({{t 'Receives new stream notifications' }})</i>
-        {{else}}
-        #{{name}}
-        {{/if}}
-    </label>
+        <label class="checkbox display-block">
+            <input type="checkbox" name="stream" value="{{stream_id}}"
+              {{#if default_stream}}checked="checked"{{/if}} />
+            <span></span>
+            {{#if invite_only}}<i class="fa fa-lock" aria-hidden="true"></i>{{/if}}
+            {{#if (eq name ../notifications_stream)}}
+            #{{name}} <i>({{t 'Receives new stream notifications' }})</i>
+            {{else}}
+            #{{name}}
+            {{/if}}
+        </label>
     {{/each}}
 </div>

--- a/static/templates/invite_user.hbs
+++ b/static/templates/invite_user.hbs
@@ -34,7 +34,7 @@
                     <div>
                         <select id="expires_in">
                             {{#each expires_in_options}}
-                            <option {{#if this.default }}selected{{/if}} name="expires_in" value="{{this.value}}">{{this.description}}</option>
+                                <option {{#if this.default }}selected{{/if}} name="expires_in" value="{{this.value}}">{{this.description}}</option>
                             {{/each}}
                         </select>
                     </div>

--- a/static/templates/markdown_help.hbs
+++ b/static/templates/markdown_help.hbs
@@ -12,14 +12,14 @@
 
                 <tbody>
                     {{#each markdown_help_rows}}
-                    <tr>
-                        {{#if note_html}}
-                        <td colspan="2">{{{note_html}}}</td>
-                        {{else}}
-                        <td><div class="preserve_spaces">{{markdown}}</div> {{{usage_html}}}</td>
-                        <td class="rendered_markdown">{{{output_html}}} {{{effect_html}}}</td>
-                        {{/if}}
-                    </tr>
+                        <tr>
+                            {{#if note_html}}
+                            <td colspan="2">{{{note_html}}}</td>
+                            {{else}}
+                            <td><div class="preserve_spaces">{{markdown}}</div> {{{usage_html}}}</td>
+                            <td class="rendered_markdown">{{{output_html}}} {{{effect_html}}}</td>
+                            {{/if}}
+                        </tr>
                     {{/each}}
                 </tbody>
             </table>

--- a/static/templates/message_reactions.hbs
+++ b/static/templates/message_reactions.hbs
@@ -1,5 +1,5 @@
 {{#each this/msg/message_reactions}}
-{{> message_reaction}}
+    {{> message_reaction}}
 {{/each}}
 <div class="reaction_button hidden-for-spectators" data-tippy-content="{{t 'Add emoji reaction' }}" aria-label="{{t 'Add emoji reaction' }} (:)">
     <i class="fa fa-smile-o" role="button" aria-haspopup="true" tabindex="0" aria-label="{{t 'Add emoji reaction' }} (:)"></i>

--- a/static/templates/new_stream_users.hbs
+++ b/static/templates/new_stream_users.hbs
@@ -9,11 +9,11 @@
 
 <div id="stream-checkboxes">
     {{#each streams}}
-    <label class="checkbox add-user-label" data-stream-id="{{this.stream_id}}">
-        <input type="checkbox" name="stream" />
-        <span></span>
-        {{this.name}} ( <i class="fa fa-user" aria-hidden="true"></i> {{this.subscriber_count}})
-    </label>
+        <label class="checkbox add-user-label" data-stream-id="{{this.stream_id}}">
+            <input type="checkbox" name="stream" />
+            <span></span>
+            {{this.name}} ( <i class="fa fa-user" aria-hidden="true"></i> {{this.subscriber_count}})
+        </label>
     {{/each}}
 </div>
 

--- a/static/templates/playground_links_popover_content.hbs
+++ b/static/templates/playground_links_popover_content.hbs
@@ -1,13 +1,13 @@
 {{! Contents of "view code in playground" popover for code blocks}}
 <ul class="nav nav-list">
     {{#each playground_info}}
-    <li>
-        <a href="{{this/playground_url}}" target="_blank" rel="noopener noreferrer" class="popover_playground_link">
-            {{#tr}}
-            View in {name}
-            {{/tr}}
-        </a>
-    </li>
+        <li>
+            <a href="{{this/playground_url}}" target="_blank" rel="noopener noreferrer" class="popover_playground_link">
+                {{#tr}}
+                View in {name}
+                {{/tr}}
+            </a>
+        </li>
     {{/each}}
 </ul>
 

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -43,9 +43,9 @@
 
                 {{! exterior links (e.g. to a trac ticket) }}
                 {{#each topic_links}}
-                <a href="{{this.url}}" target="_blank" rel="noopener noreferrer" class="no-underline">
-                    <i class="fa fa-external-link-square recipient_bar_icon" data-tippy-content="Open {{this.text}}" aria-label="{{t 'External link' }}"></i>
-                </a>
+                    <a href="{{this.url}}" target="_blank" rel="noopener noreferrer" class="no-underline">
+                        <i class="fa fa-external-link-square recipient_bar_icon" data-tippy-content="Open {{this.text}}" aria-label="{{t 'External link' }}"></i>
+                    </a>
                 {{/each}}
 
                 {{! edit topic pencil icon }}

--- a/static/templates/set_status_overlay.hbs
+++ b/static/templates/set_status_overlay.hbs
@@ -15,18 +15,18 @@
         </div>
         <div class="user-status-options">
             {{#each default_status_messages_and_emoji_info}}
-            <button type="button" class="button no-style user-status-value">
-                {{#if emoji.emoji_alt_code}}
-                    <div class="emoji_alt_code">&nbsp:{{emoji.emoji_name}}:</div>
-                {{else}}
-                    {{#if emoji.url}}
-                    <img src="{{emoji.url}}" class="emoji status_emoji" />
+                <button type="button" class="button no-style user-status-value">
+                    {{#if emoji.emoji_alt_code}}
+                        <div class="emoji_alt_code">&nbsp:{{emoji.emoji_name}}:</div>
                     {{else}}
-                    <div class="emoji status_emoji emoji-{{emoji.emoji_code}}"></div>
+                        {{#if emoji.url}}
+                        <img src="{{emoji.url}}" class="emoji status_emoji" />
+                        {{else}}
+                        <div class="emoji status_emoji emoji-{{emoji.emoji_code}}"></div>
+                        {{/if}}
                     {{/if}}
-                {{/if}}
-                {{status_text}}
-            </button>
+                    {{status_text}}
+                </button>
             {{/each}}
         </div>
     </div>

--- a/static/templates/settings/admin_profile_field_list.hbs
+++ b/static/templates/settings/admin_profile_field_list.hbs
@@ -42,7 +42,7 @@
                     <hr />
                     <div class="edit_profile_field_choices_container">
                         {{#each choices}}
-                        {{> profile_field_choice }}
+                            {{> profile_field_choice }}
                         {{/each}}
                     </div>
                 </div>
@@ -53,7 +53,7 @@
                 <label for="external_acc_field_type">{{t "External account type" }}</label>
                 <select name="external_acc_field_type">
                     {{#each ../realm_default_external_accounts}}
-                    <option value='{{@key}}'>{{this.text}}</option>
+                        <option value='{{@key}}'>{{this.text}}</option>
                     {{/each}}
                     <option value="custom">{{t 'Custom' }}</option>
                 </select>

--- a/static/templates/settings/bot_settings.hbs
+++ b/static/templates/settings/bot_settings.hbs
@@ -53,7 +53,7 @@
                         <label for="select_service_name">{{t "Bot"}}</label>
                         <select name="service_name" id="select_service_name">
                             {{#each page_params.realm_embedded_bots}}
-                            <option value="{{this.name}}">{{this.name}}</option>
+                                <option value="{{this.name}}">{{this.name}}</option>
                             {{/each}}
                         </select>
                     </div>
@@ -91,7 +91,7 @@
                     <div id="config_inputbox">
                         {{#each page_params.realm_embedded_bots as |bot index|}}
                             {{#each bot.config as |config_value config_key|}}
-                            {{> ../embedded_bot_config_item botname=bot.name key=config_key value=config_value}}
+                                {{> ../embedded_bot_config_item botname=bot.name key=config_key value=config_value}}
                             {{/each}}
                         {{/each}}
                     </div>

--- a/static/templates/settings/custom_user_profile_field.hbs
+++ b/static/templates/settings/custom_user_profile_field.hbs
@@ -9,7 +9,7 @@
         <select class="custom_user_field_value">
             <option value=""></option>
             {{#each field_choices}}
-            <option value="{{ this.value }}" {{#if this.selected}}selected{{/if}}>{{ this.text }}</option>
+                <option value="{{ this.value }}" {{#if this.selected}}selected{{/if}}>{{ this.text }}</option>
             {{/each}}
         </select>
         {{else if is_user_field }}

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -24,7 +24,7 @@
             <label for="twenty_four_hour_time" class="dropdown-title">{{ settings_label.twenty_four_hour_time }}</label>
             <select name="twenty_four_hour_time" class="setting_twenty_four_hour_time prop-element" data-setting-widget-type="string">
                 {{#each twenty_four_hour_time_values}}
-                <option value='{{ this.value }}'>{{ this.description }}</option>
+                    <option value='{{ this.value }}'>{{ this.description }}</option>
                 {{/each}}
             </select>
         </div>
@@ -49,20 +49,20 @@
             <label class="emoji-theme title">{{t "Emoji theme" }}</label>
             <div class="emojiset_choices grey-box">
                 {{#each settings_object.emojiset_choices}}
-                <label>
-                    <input type="radio" class="setting_emojiset_choice prop-element" name="emojiset" value="{{this.key}}" data-setting-widget-type="radio-group"/>
-                    <span>{{this.text}}</span>
-                    <span class="right">
-                        {{#if (eq this.key "text") }}
-                        <div class="emoji_alt_code">&nbsp;:relaxed:</div>
-                        {{else}}
-                        <img class="emoji" src="/static/generated/emoji/images-{{this.key}}-64/1f642.png" />
-                        <img class="emoji" src="/static/generated/emoji/images-{{this.key}}-64/1f44d.png" />
-                        <img class="emoji" src="/static/generated/emoji/images-{{this.key}}-64/1f680.png" />
-                        <img class="emoji" src="/static/generated/emoji/images-{{this.key}}-64/1f389.png" />
-                        {{/if}}
-                    </span>
-                </label>
+                    <label>
+                        <input type="radio" class="setting_emojiset_choice prop-element" name="emojiset" value="{{this.key}}" data-setting-widget-type="radio-group"/>
+                        <span>{{this.text}}</span>
+                        <span class="right">
+                            {{#if (eq this.key "text") }}
+                            <div class="emoji_alt_code">&nbsp;:relaxed:</div>
+                            {{else}}
+                            <img class="emoji" src="/static/generated/emoji/images-{{this.key}}-64/1f642.png" />
+                            <img class="emoji" src="/static/generated/emoji/images-{{this.key}}-64/1f44d.png" />
+                            <img class="emoji" src="/static/generated/emoji/images-{{this.key}}-64/1f680.png" />
+                            <img class="emoji" src="/static/generated/emoji/images-{{this.key}}-64/1f389.png" />
+                            {{/if}}
+                        </span>
+                    </label>
                 {{/each}}
             </div>
         </div>
@@ -106,12 +106,12 @@
         </div>
 
         {{#each display_settings.settings.user_display_settings}}
-        {{> settings_checkbox
-          setting_name=this
-          is_checked=(lookup ../settings_object this)
-          label=(lookup ../settings_label this)
-          render_only=(lookup ../display_settings.render_only this)
-          prefix=../prefix}}
+            {{> settings_checkbox
+              setting_name=this
+              is_checked=(lookup ../settings_object this)
+              label=(lookup ../settings_label this)
+              render_only=(lookup ../display_settings.render_only this)
+              prefix=../prefix}}
         {{/each}}
 
     </div>

--- a/static/templates/settings/dropdown_options_widget.hbs
+++ b/static/templates/settings/dropdown_options_widget.hbs
@@ -1,3 +1,3 @@
 {{#each option_values}}
-<option value='{{this.code}}'>{{this.description}}</option>
+    <option value='{{this.code}}'>{{this.description}}</option>
 {{/each}}

--- a/static/templates/settings/edit_embedded_bot_service.hbs
+++ b/static/templates/settings/edit_embedded_bot_service.hbs
@@ -1,9 +1,9 @@
 <div id="config_edit_inputbox">
     {{#each service.config_data}}
-    <div class="input-group">
-        <label for="embedded_bot_{{@key}}_edit">{{@key}}</label>
-        <input type="text" name="{{@key}}" id="embedded_bot_{{@key}}_edit"
-          maxlength=1000 value="{{this}}" />
-    </div>
+        <div class="input-group">
+            <label for="embedded_bot_{{@key}}_edit">{{@key}}</label>
+            <input type="text" name="{{@key}}" id="embedded_bot_{{@key}}_edit"
+              maxlength=1000 value="{{this}}" />
+        </div>
     {{/each}}
 </div>

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -28,16 +28,16 @@
             </thead>
             <tbody>
                 {{#each general_settings}}
-                <tr>
-                    <td>{{ this.label }}</td>
-                    {{#each this.notification_settings}}
-                    {{> notification_settings_checkboxes
-                      setting_name=this.setting_name
-                      is_checked=this.is_checked
-                      is_disabled=this.is_disabled
-                      prefix=../../prefix }}
-                    {{/each}}
-                </tr>
+                    <tr>
+                        <td>{{ this.label }}</td>
+                        {{#each this.notification_settings}}
+                            {{> notification_settings_checkboxes
+                              setting_name=this.setting_name
+                              is_checked=this.is_checked
+                              is_disabled=this.is_disabled
+                              prefix=../../prefix }}
+                        {{/each}}
+                    </tr>
                 {{/each}}
             </tbody>
             {{#unless for_realm_settings}}
@@ -60,11 +60,11 @@
         {{/unless}}
 
         {{#each notification_settings.desktop_notification_settings}}
-        {{> settings_checkbox
-          setting_name=this
-          is_checked=(lookup ../settings_object this)
-          label=(lookup ../settings_label this)
-          prefix=../prefix}}
+            {{> settings_checkbox
+              setting_name=this
+              is_checked=(lookup ../settings_object this)
+              label=(lookup ../settings_label this)
+              prefix=../prefix}}
         {{/each}}
 
         <label for="notification_sound">
@@ -78,7 +78,7 @@
               {{/unless}}>
                 <option value="none">{{t "None" }}</option>
                 {{#each settings_object.available_notification_sounds}}
-                <option value="{{ this }}">{{ this }}</option>
+                    <option value="{{ this }}">{{ this }}</option>
                 {{/each}}
             </select>
             <span class="play_notification_sound">
@@ -103,12 +103,12 @@
         </div>
 
         {{#each notification_settings.mobile_notification_settings}}
-        {{> settings_checkbox
-          setting_name=this
-          is_checked=(lookup ../settings_object this)
-          label=(lookup ../settings_label this)
-          show_push_notifications_tooltip=(lookup ../show_push_notifications_tooltip this)
-          prefix=../prefix}}
+            {{> settings_checkbox
+              setting_name=this
+              is_checked=(lookup ../settings_object this)
+              label=(lookup ../settings_label this)
+              show_push_notifications_tooltip=(lookup ../show_push_notifications_tooltip this)
+              prefix=../prefix}}
         {{/each}}
     </div>
 
@@ -126,7 +126,7 @@
             </label>
             <select name="email_notifications_batching_period_seconds" class="setting_email_notifications_batching_period_seconds prop-element" data-setting-widget-type="number">
                 {{#each email_notifications_batching_period_values}}
-                <option value="{{ this.value }}">{{ this.description }}</option>
+                    <option value="{{ this.value }}">{{ this.description }}</option>
                 {{/each}}
             </select>
             <div class="dependent-inline-block">
@@ -143,11 +143,11 @@
         </div>
 
         {{#each notification_settings.email_message_notification_settings}}
-        {{> settings_checkbox
-          setting_name=this
-          is_checked=(lookup ../settings_object this)
-          label=(lookup ../settings_label this)
-          prefix=../prefix}}
+            {{> settings_checkbox
+              setting_name=this
+              is_checked=(lookup ../settings_object this)
+              label=(lookup ../settings_label this)
+              prefix=../prefix}}
         {{/each}}
     </div>
 
@@ -158,11 +158,11 @@
             {{> settings_save_discard_widget section_name="other-emails-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
         {{#each notification_settings.other_email_settings}}
-        {{> settings_checkbox
-          setting_name=this
-          is_checked=(lookup ../settings_object this)
-          label=(lookup ../settings_label this)
-          prefix=../prefix}}
+            {{> settings_checkbox
+              setting_name=this
+              is_checked=(lookup ../settings_object this)
+              label=(lookup ../settings_label this)
+              prefix=../prefix}}
         {{/each}}
     </div>
 </form>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -151,7 +151,7 @@
                     <label for="realm_msg_edit_limit_setting" class="dropdown-title">{{t "Allow message editing" }}</label>
                     <select name="realm_msg_edit_limit_setting" id="id_realm_msg_edit_limit_setting" class="prop-element">
                         {{#each msg_edit_limit_dropdown_values}}
-                        <option value="{{0}}">{{1.text}}</option>
+                            <option value="{{0}}">{{1.text}}</option>
                         {{/each}}
                     </select>
                     <div class="dependent-inline-block">
@@ -197,7 +197,7 @@
                     </label>
                     <select name="realm_msg_delete_limit_setting" id="id_realm_msg_delete_limit_setting" class="prop-element">
                         {{#each msg_delete_limit_dropdown_values}}
-                        <option value="{{0}}">{{1.text}}</option>
+                            <option value="{{0}}">{{1.text}}</option>
                         {{/each}}
                     </select>
                     <div class="dependent-inline-block">

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -61,7 +61,7 @@
                     <label for="realm_default_language" class="dropdown-title">{{t "Default language" }}</label>
                     <select name="realm_default_language" class ="setting-widget prop-element" id="id_realm_default_language" data-setting-widget-type="string">
                         {{#each language_list}}
-                        <option value='{{this.code}}'>{{this.name}}</option>
+                            <option value='{{this.code}}'>{{this.name}}</option>
                         {{/each}}
                     </select>
                 </div>
@@ -118,7 +118,7 @@
                     </label>
                     <select name="realm_video_chat_provider" class ="setting-widget prop-element" id="id_realm_video_chat_provider" data-setting-widget-type="number">
                         {{#each realm_available_video_chat_providers}}
-                        <option value='{{this.id}}'>{{this.name}}</option>
+                            <option value='{{this.id}}'>{{this.name}}</option>
                         {{/each}}
                     </select>
                 </div>
@@ -129,7 +129,7 @@
                     </label>
                     <select name="realm_giphy_rating" class ="setting-widget prop-element" id="id_realm_giphy_rating" data-setting-widget-type="number" {{#if giphy_api_key_empty}}disabled{{/if}}>
                         {{#each giphy_rating_options}}
-                        <option value='{{this.id}}'>{{this.name}}</option>
+                            <option value='{{this.id}}'>{{this.name}}</option>
                         {{/each}}
                     </select>
                 </div>

--- a/static/templates/settings/profile_field_settings_admin.hbs
+++ b/static/templates/settings/profile_field_settings_admin.hbs
@@ -23,7 +23,7 @@
                     <label for="profile_field_type" class="control-label">{{t "Type" }}</label>
                     <select id="profile_field_type" name="field_type">
                         {{#each custom_profile_field_types}}
-                        <option value='{{this.id}}'>{{this.name}}</option>
+                            <option value='{{this.id}}'>{{this.name}}</option>
                         {{/each}}
                     </select>
                 </div>
@@ -31,7 +31,7 @@
                     <label for="profile_field_external_accounts_type" class="control-label">{{t "External account type" }}</label>
                     <select id="profile_field_external_accounts_type" name="external_acc_field_type">
                         {{#each realm_default_external_accounts}}
-                        <option value='{{@key}}'>{{this.text}}</option>
+                            <option value='{{@key}}'>{{this.text}}</option>
                         {{/each}}
                         <option value="custom">{{t 'Custom' }}</option>
                     </select>

--- a/static/templates/settings/profile_settings.hbs
+++ b/static/templates/settings/profile_settings.hbs
@@ -38,7 +38,7 @@
                                 {{/unless}}
 
                                 {{#each timezones}}
-                                <option value="{{ this }}">{{ this }}</option>
+                                    <option value="{{ this }}">{{ this }}</option>
                                 {{/each}}
                             </select>
                         </div>

--- a/static/templates/settings/stream_specific_notification_row.hbs
+++ b/static/templates/settings/stream_specific_notification_row.hbs
@@ -8,10 +8,10 @@
         {{stream.stream_name}}
     </td>
     {{#each stream_specific_notification_settings}}
-    {{> notification_settings_checkboxes
-      setting_name=this
-      prefix=(lookup ../stream "stream_id")
-      is_checked=(lookup ../stream this)
-      is_disabled=(lookup ../is_disabled this) }}
+        {{> notification_settings_checkboxes
+          setting_name=this
+          prefix=(lookup ../stream "stream_id")
+          is_checked=(lookup ../stream this)
+          is_disabled=(lookup ../is_disabled this) }}
     {{/each}}
 </tr>

--- a/static/templates/settings/uploaded_files_list.hbs
+++ b/static/templates/settings/uploaded_files_list.hbs
@@ -10,9 +10,9 @@
         {{#if messages }}
         <div class="attachment-messages">
             {{#each messages}}
-            <a class="ind-message" href="/#narrow/id/{{ this.id }}">
-                #{{ this.id }}
-            </a>
+                <a class="ind-message" href="/#narrow/id/{{ this.id }}">
+                    #{{ this.id }}
+                </a>
             {{/each}}
         </div>
         {{/if}}

--- a/static/templates/stream_settings/browse_streams_list.hbs
+++ b/static/templates/stream_settings/browse_streams_list.hbs
@@ -1,3 +1,3 @@
 {{#each subscriptions}}
-{{> browse_streams_list_item }}
+    {{> browse_streams_list_item }}
 {{/each}}

--- a/static/templates/stream_settings/stream_settings.hbs
+++ b/static/templates/stream_settings/stream_settings.hbs
@@ -80,17 +80,17 @@
             <div class="subscription-config">
                 <div class="subsection-parent">
                     {{#each other_settings}}
-                    <div class="input-group">
-                        {{> stream_settings_checkbox
-                          setting_name=name
-                          is_checked=is_checked
-                          is_muted=(lookup ../sub "is_muted")
-                          stream_id=(lookup ../sub "stream_id")
-                          notification_setting=false
-                          disabled_realm_setting=disabled_realm_setting
-                          is_disabled=is_disabled
-                          label=label}}
-                    </div>
+                        <div class="input-group">
+                            {{> stream_settings_checkbox
+                              setting_name=name
+                              is_checked=is_checked
+                              is_muted=(lookup ../sub "is_muted")
+                              stream_id=(lookup ../sub "stream_id")
+                              notification_setting=false
+                              disabled_realm_setting=disabled_realm_setting
+                              is_disabled=is_disabled
+                              label=label}}
+                        </div>
                     {{/each}}
 
                     <div class="input-group">
@@ -103,17 +103,17 @@
                 <h4 class="stream_setting_subsection_title">{{t "Notification settings" }}</h4>
                 <div class="subsection-parent">
                     {{#each notification_settings}}
-                    <div class="input-group">
-                        {{> stream_settings_checkbox
-                          setting_name=name
-                          is_checked=is_checked
-                          is_muted=(lookup ../sub "is_muted")
-                          stream_id=(lookup ../sub "stream_id")
-                          notification_setting=true
-                          disabled_realm_setting=disabled_realm_setting
-                          is_disabled=is_disabled
-                          label=label}}
-                    </div>
+                        <div class="input-group">
+                            {{> stream_settings_checkbox
+                              setting_name=name
+                              is_checked=is_checked
+                              is_muted=(lookup ../sub "is_muted")
+                              stream_id=(lookup ../sub "stream_id")
+                              notification_setting=true
+                              disabled_realm_setting=disabled_realm_setting
+                              is_disabled=is_disabled
+                              label=label}}
+                        </div>
                     {{/each}}
                 </div>
             </div>

--- a/static/templates/stream_settings/stream_types.hbs
+++ b/static/templates/stream_settings/stream_types.hbs
@@ -4,12 +4,12 @@
         {{> ../help_link_widget link="/help/stream-permissions" }}
     </h4>
     {{#each stream_privacy_policy_values}}
-    <div class="radio-input-parent">
-        <label class="radio">
-            <input type="radio" name="privacy" value="{{ this.code }}" {{#if (eq this.code ../stream_privacy_policy) }}checked{{/if}} />
-            <b>{{ this.name }}:</b> {{ this.description }}
-        </label>
-    </div>
+        <div class="radio-input-parent">
+            <label class="radio">
+                <input type="radio" name="privacy" value="{{ this.code }}" {{#if (eq this.code ../stream_privacy_policy) }}checked{{/if}} />
+                <b>{{ this.name }}:</b> {{ this.description }}
+            </label>
+        </div>
     {{/each}}
 </div>
 
@@ -18,12 +18,12 @@
         {{> ../help_link_widget link="/help/stream-sending-policy" }}
     </h4>
     {{#each stream_post_policy_values}}
-    <div class="radio-input-parent">
-        <label class="radio">
-            <input type="radio" name="stream-post-policy" value="{{ this.code }}" {{#if (eq this.code ../stream_post_policy) }}checked{{/if}} />
-            {{ this.description }}
-        </label>
-    </div>
+        <div class="radio-input-parent">
+            <label class="radio">
+                <input type="radio" name="stream-post-policy" value="{{ this.code }}" {{#if (eq this.code ../stream_post_policy) }}checked{{/if}} />
+                {{ this.description }}
+            </label>
+        </div>
     {{/each}}
 </div>
 

--- a/static/templates/typing_notifications.hbs
+++ b/static/templates/typing_notifications.hbs
@@ -4,7 +4,7 @@
         <li class="typing_notification">{{t "Several people are typing…" }}</li>
     {{else}}
         {{#each users}}
-        {{> typing_notification}}
+            {{> typing_notification}}
         {{/each}}
     {{/if}}
 </ul>

--- a/static/templates/user_group_info_popover_content.hbs
+++ b/static/templates/user_group_info_popover_content.hbs
@@ -8,16 +8,16 @@
 <hr />
 <ul class="nav nav-list member-list" data-simplebar data-simplebar-auto-hide="false">
     {{#each members}}
-    <li>
-        {{#if is_active }}
-            {{#if is_bot}}
-            <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
-            {{else}}
-            <span class="user_circle {{user_circle_class}}  popover_user_presence" title="{{user_last_seen_time_status}}"></span>
+        <li>
+            {{#if is_active }}
+                {{#if is_bot}}
+                <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
+                {{else}}
+                <span class="user_circle {{user_circle_class}}  popover_user_presence" title="{{user_last_seen_time_status}}"></span>
+                {{/if}}
             {{/if}}
-        {{/if}}
-        <span>{{full_name}}</span>
-    </li>
+            <span>{{full_name}}</span>
+        </li>
     {{/each}}
 </ul>
 <hr />

--- a/static/templates/user_presence_rows.hbs
+++ b/static/templates/user_presence_rows.hbs
@@ -1,4 +1,4 @@
 {{! User presence rows }}
 {{#each users}}
-{{> user_presence_row}}
+    {{> user_presence_row}}
 {{/each}}

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -42,24 +42,24 @@
                         </div>
                         <div id="content">
                             {{#each profile_data}}
-                            <div data-type="{{this.type}}" class="field-section custom_user_field" data-field-id="{{this.id}}">
-                                <div class="name">{{this.name}}</div>
-                                {{#if this.is_user_field}}
-                                    <div class="pill-container not-editable" data-field-id="{{this.id}}">
-                                        <div class="input" contenteditable="false" style="display: none;"></div>
-                                    </div>
-                                {{else if this.is_link}}
-                                    <a href="{{this.value}}" target="_blank" rel="noopener noreferrer" class="value">{{this.value}}</a>
-                                {{else if this.is_external_account}}
-                                    <a href="{{this.link}}" target="_blank" rel="noopener noreferrer" class="value">{{this.value}}</a>
-                                {{else}}
-                                    {{#if this.rendered_value}}
-                                    <div class="value rendered_markdown">{{rendered_markdown this.rendered_value}}</div>
+                                <div data-type="{{this.type}}" class="field-section custom_user_field" data-field-id="{{this.id}}">
+                                    <div class="name">{{this.name}}</div>
+                                    {{#if this.is_user_field}}
+                                        <div class="pill-container not-editable" data-field-id="{{this.id}}">
+                                            <div class="input" contenteditable="false" style="display: none;"></div>
+                                        </div>
+                                    {{else if this.is_link}}
+                                        <a href="{{this.value}}" target="_blank" rel="noopener noreferrer" class="value">{{this.value}}</a>
+                                    {{else if this.is_external_account}}
+                                        <a href="{{this.link}}" target="_blank" rel="noopener noreferrer" class="value">{{this.value}}</a>
                                     {{else}}
-                                    <div class="value">{{this.value}}</div>
+                                        {{#if this.rendered_value}}
+                                        <div class="value rendered_markdown">{{rendered_markdown this.rendered_value}}</div>
+                                        {{else}}
+                                        <div class="value">{{this.value}}</div>
+                                        {{/if}}
                                     {{/if}}
-                                {{/if}}
-                            </div>
+                                </div>
                             {{/each}}
                         </div>
                     </div>

--- a/static/templates/widgets/poll_widget_results.hbs
+++ b/static/templates/widgets/poll_widget_results.hbs
@@ -1,11 +1,11 @@
 {{#each options}}
-<li>
-    <button class="poll-vote {{#if current_user_vote}}current-user-vote{{/if}}" data-key="{{ key }}">
-        {{ count }}
-    </button>
-    <span class="poll-option">{{ option }}</span>
-    {{#if names}}
-    <span class="poll-names">({{ names }})</span>
-    {{/if}}
-</li>
+    <li>
+        <button class="poll-vote {{#if current_user_vote}}current-user-vote{{/if}}" data-key="{{ key }}">
+            {{ count }}
+        </button>
+        <span class="poll-option">{{ option }}</span>
+        {{#if names}}
+        <span class="poll-names">({{ names }})</span>
+        {{/if}}
+    </li>
 {{/each}}

--- a/static/templates/widgets/todo_widget_tasks.hbs
+++ b/static/templates/widgets/todo_widget_tasks.hbs
@@ -1,20 +1,20 @@
 <br />
 {{#each pending_tasks}}
-<li>
-    <label class="checkbox">
-        <input type="checkbox" class="task" data-key="{{ key }}" />
-        <span></span>
-        <strong>{{ task }}</strong>{{#if desc }} - {{ desc }}{{/if}}
-    </label>
+    <li>
+        <label class="checkbox">
+            <input type="checkbox" class="task" data-key="{{ key }}" />
+            <span></span>
+            <strong>{{ task }}</strong>{{#if desc }} - {{ desc }}{{/if}}
+        </label>
 
-</li>
+    </li>
 {{/each}}
 {{#each completed_tasks}}
-<li>
-    <label class="checkbox">
-        <input type="checkbox" class="task" data-key="{{ key }}" checked="checked"/>
-        <span></span>
-        <strike><em><strong>{{ task }}</strong>{{#if desc }} - {{ desc }}{{/if}}</em></strike>
-    </label>
-</li>
+    <li>
+        <label class="checkbox">
+            <input type="checkbox" class="task" data-key="{{ key }}" checked="checked"/>
+            <span></span>
+            <strike><em><strong>{{ task }}</strong>{{#if desc }} - {{ desc }}{{/if}}</em></strike>
+        </label>
+    </li>
 {{/each}}

--- a/static/templates/widgets/zform_choices.hbs
+++ b/static/templates/widgets/zform_choices.hbs
@@ -2,11 +2,11 @@
     <div class="widget-choices-heading">{{ heading }}</div>
     <ul>
         {{#each choices}}
-        <li>
-            <button data-idx="{{ this.idx }}">{{ this.short_name }}</button>
-            &nbsp;
-            {{ this.long_name }}
-        </li>
+            <li>
+                <button data-idx="{{ this.idx }}">{{ this.short_name }}</button>
+                &nbsp;
+                {{ this.long_name }}
+            </li>
         {{/each}}
     </ul>
 </div>

--- a/tools/lib/pretty_print.py
+++ b/tools/lib/pretty_print.py
@@ -27,7 +27,12 @@ def shift_indents_to_the_next_tokens(tokens: List[Token]) -> None:
 
 
 def token_allows_children_to_skip_indents(token: Token) -> bool:
-    # For legacy reasons we don't always indent blocks.
+    # To avoid excessive indentation in templates with other
+    # conditionals, we don't require extra indentation for template
+    # logic blocks don't contain further logic as direct children.
+
+    # Each blocks are excluded from this rule, since we want loops to
+    # stand out.
     if token.tag == "each":
         return False
 

--- a/tools/lib/pretty_print.py
+++ b/tools/lib/pretty_print.py
@@ -28,6 +28,9 @@ def shift_indents_to_the_next_tokens(tokens: List[Token]) -> None:
 
 def token_allows_children_to_skip_indents(token: Token) -> bool:
     # For legacy reasons we don't always indent blocks.
+    if token.tag == "each":
+        return False
+
     return token.kind in ("django_start", "handlebars_start") or token.tag == "a"
 
 


### PR DESCRIPTION
This is stacked on #20462.

We probably want to merge this **after** our next Zulip Cloud push.

We can probably extend this concept to other tags after we add some kind of check in check-templates that complains if your tags are too heavily indented, and that may require us to extract a few partial templates or something.  This will be a similar drill to code sweeps like introducing prettier/black.