### PR TITLE
dark-theme: Fix organisation setting overlap bug.

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -645,7 +645,7 @@ body.dark-theme {
     .modal-footer,
     .modal-bg .modal-header {
         border-color: hsla(0, 0%, 0%, 0.2);
-        background-color: hsla(0, 0%, 0%, 0.2);
+        background-color: hsl(211, 28%, 14%);
     }
 
     .table-striped tbody tr:nth-child(odd) td {


### PR DESCRIPTION
Scrolling up in left sidebar of organisation settings causes overlap
with tab container. We remove the transparent color and add solid color
to solve this issue.

![image](https://user-images.githubusercontent.com/51414879/144808461-7d97940e-2a15-43cd-9e2d-c5eca27644f3.png)
