### PR TITLE
message: Check wildcard mention restrictions while editing message.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3068,6 +3068,13 @@ def check_update_message(
         )
         links_for_embed |= rendering_result.links_for_preview
 
+        if message.is_stream_message() and rendering_result.mentions_wildcard:
+            stream = access_stream_by_id(user_profile, message.recipient.type_id)[0]
+            if not wildcard_mention_allowed(message.sender, stream):
+                raise JsonableError(
+                    _("You do not have permission to use wildcard mentions in this stream.")
+                )
+
     new_stream = None
     number_changed = 0
 

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -1170,6 +1170,57 @@ class EditMessageTest(EditMessageTestCase):
                 called = True
         self.assertTrue(called)
 
+    def test_wildcard_mention_restrictions_when_editing(self) -> None:
+        cordelia = self.example_user("cordelia")
+        shiva = self.example_user("shiva")
+        self.login("cordelia")
+        stream_name = "Macbeth"
+        self.make_stream(stream_name, history_public_to_subscribers=True)
+        self.subscribe(cordelia, stream_name)
+        message_id = self.send_stream_message(cordelia, stream_name, "Hello everyone")
+
+        realm = cordelia.realm
+        do_set_realm_property(
+            realm,
+            "wildcard_mention_policy",
+            Realm.WILDCARD_MENTION_POLICY_MODERATORS,
+            acting_user=None,
+        )
+
+        with mock.patch("zerver.lib.message.num_subscribers_for_stream_id", return_value=17):
+            result = self.client_patch(
+                "/json/messages/" + str(message_id),
+                {
+                    "message_id": message_id,
+                    "content": "Hello @**everyone**",
+                },
+            )
+        self.assert_json_error(
+            result, "You do not have permission to use wildcard mentions in this stream."
+        )
+
+        with mock.patch("zerver.lib.message.num_subscribers_for_stream_id", return_value=14):
+            result = self.client_patch(
+                "/json/messages/" + str(message_id),
+                {
+                    "message_id": message_id,
+                    "content": "Hello @**everyone**",
+                },
+            )
+        self.assert_json_success(result)
+
+        self.login("shiva")
+        message_id = self.send_stream_message(shiva, stream_name, "Hi everyone")
+        with mock.patch("zerver.lib.message.num_subscribers_for_stream_id", return_value=17):
+            result = self.client_patch(
+                "/json/messages/" + str(message_id),
+                {
+                    "message_id": message_id,
+                    "content": "Hello @**everyone**",
+                },
+            )
+        self.assert_json_success(result)
+
     def test_topic_edit_history_saved_in_all_message(self) -> None:
         self.login("hamlet")
         id1 = self.send_stream_message(self.example_user("hamlet"), "Scotland", topic_name="topic1")


### PR DESCRIPTION
This PR adds code to check whether a user is allowed to use
wildcard mention in a large stream or not while editing a message
based on the realm settings.

Previously this was only checked while sending message, thus user
was easily able to use wildcard mention by first sending a normal
message and then using a wildcard mention by editing it.

Observed the bug on CZO today and discussed in https://chat.zulip.org/#narrow/stream/9-issues/topic/wildcard.20mentions
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

 <!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
