### PR TITLE
onboarding: Manage occurrence of 'help' command.

### DIFF
--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -93,7 +93,7 @@ def send_initial_pms(user: UserProfile) -> None:
             )
             + "\n\n",
             _("Here are a few messages I understand:") + " ",
-            bot_commands(is_initial_pm=True),
+            bot_commands(),
         ]
     )
 
@@ -109,7 +109,7 @@ def send_initial_pms(user: UserProfile) -> None:
     )
 
 
-def bot_commands(is_initial_pm: bool = False) -> str:
+def bot_commands(no_help_command: bool = False) -> str:
     commands = [
         "apps",
         "profile",
@@ -119,7 +119,7 @@ def bot_commands(is_initial_pm: bool = False) -> str:
         "message formatting",
         "keyboard shortcuts",
     ]
-    if is_initial_pm:
+    if not no_help_command:
         commands.append("help")
     return ", ".join(["`" + command + "`" for command in commands]) + "."
 
@@ -201,7 +201,7 @@ def select_welcome_bot_response(human_response_lower: str) -> str:
         return "".join(
             [
                 _("Here are a few messages I understand:") + " ",
-                bot_commands() + "\n\n",
+                bot_commands(no_help_command=True) + "\n\n",
                 _(
                     "Check out our [Getting started guide](/help/getting-started-with-zulip), "
                     "or browse the [Help center](/help/) to learn more!"

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -159,7 +159,7 @@ class TutorialTests(ZulipTestCase):
             expected_response = (
                 "I’m sorry, I did not understand your message. Please try one of the following commands: "
                 "`apps`, `profile`, `theme`, `streams`, "
-                "`topics`, `message formatting`, `keyboard shortcuts`."
+                "`topics`, `message formatting`, `keyboard shortcuts`, `help`."
             )
             self.assertEqual(most_recent_message(user).content, expected_response)
 


### PR DESCRIPTION
"help" command occurs in the command list in
initial pms or when bot doesn't understand the message. It doesn't
occur when the bot is respoding to the "help" command itself.

![image](https://user-images.githubusercontent.com/49791933/144905968-98f10f43-94d7-4379-9160-a49c8646d49d.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
