### PR TITLE
git: Suppress diffs by default on giant Stripe API fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,19 @@
+# DIFFS: Noise suppression.
+#
+# Suppress noisy generated files in diffs.
+# (When you actually want to see these diffs, use `git diff -a`.)
+
+# Large test fixtures:
+corporate/tests/stripe_fixtures/*.json -diff
+
+
+# FORMATTING
+
+# Maintain LF (Unix-style) newlines in text files.
 *   text=auto eol=lf
+
+# Make sure various media files never get somehow auto-detected as text
+# and then newline-converted.
 *.gif binary
 *.jpg binary
 *.jpeg binary


### PR DESCRIPTION
Before:

$ git log -p -1 88fd399bec5a321e4688834784eaecb18a929235 | wc
  50015  134879 2016086

After:

$ git log -p -1 88fd399bec5a321e4688834784eaecb18a929235 | wc
   1554    6624  229028
$ git log -a -p -1 88fd399bec5a321e4688834784eaecb18a929235 | wc
  50015  134879 2016086

Also add some organization and explanatory comments to this file,
following what we have in zulip-mobile:.gitattributes .

