### PR TITLE
Improve help icons in settings

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -70,10 +70,10 @@ export function update_avatar_change_display() {
     if (!settings_data.user_can_change_avatar()) {
         // We disable this widget by simply hiding its edit UI.
         $("#user-avatar-upload-widget .image_upload_button").hide();
-        $(".user-avatar-section .settings-info-icon").show();
+        $(".user-avatar-section .settings-question-icon").show();
     } else {
         $("#user-avatar-upload-widget .image_upload_button").show();
-        $(".user-avatar-section .settings-info-icon").hide();
+        $(".user-avatar-section .settings-question-icon").hide();
     }
 }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -15,7 +15,7 @@ h3 {
 
     .fa-question-circle-o {
         top: 1px;
-        opacity: 0.4;
+        opacity: 0.6;
         position: relative;
 
         &:hover {
@@ -212,14 +212,14 @@ td .button {
     box-shadow: none;
 }
 
-.settings-info-icon {
+.settings-question-icon {
     padding-left: 3px;
     opacity: 0.9;
 }
 
 .email-change-form,
 .user-name-section {
-    .settings-info-icon {
+    .settings-question-icon {
         position: relative;
         top: 2px;
         left: 1px;
@@ -2004,5 +2004,17 @@ input[type="checkbox"] {
     #edit-linkifier-pattern-status,
     #edit-linkifier-format-status {
         margin-top: 10px;
+    }
+}
+
+div.settings-section-title a {
+    color: inherit;
+
+    i {
+        opacity: 0.6;
+
+        &:hover {
+            opacity: 1;
+        }
     }
 }

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -13,7 +13,7 @@
                             {{page_params.delivery_email}}
                             <i class="fa fa-pencil"></i>
                         </button>
-                        <i class="tippy-zulip-tooltip fa fa-question-circle change_email_tooltip settings-info-icon" {{#if (or (not page_params.realm_email_changes_disabled) page_params.is_admin)}}style="display: none;"{{/if}} data-tippy-content="{{t 'Email address changes are disabled in this organization.' }}"></i>
+                        <i class="tippy-zulip-tooltip fa fa-question-circle change_email_tooltip settings-question-icon" {{#if (or (not page_params.realm_email_changes_disabled) page_params.is_admin)}}style="display: none;"{{/if}} data-tippy-content="{{t 'Email address changes are disabled in this organization.' }}"></i>
                     </div>
 
                     <div id="change_email_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"

--- a/static/templates/settings/bot_settings.hbs
+++ b/static/templates/settings/bot_settings.hbs
@@ -39,7 +39,7 @@
                     <div class="input-group">
                         <label for="bot_type">
                             {{t "Bot type" }}
-                            <i class="fa fa-question-circle settings-info-icon bot_type_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content='{{t "Incoming webhooks can only send messages." }}'></i>
+                            <i class="fa fa-question-circle settings-question-icon bot_type_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content='{{t "Incoming webhooks can only send messages." }}'></i>
                         </label>
                         <select name="bot_type" id="create_bot_type">
                             {{#each page_params.bot_types}}

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -13,12 +13,12 @@
                     <th rowspan="2" width="14%" class="{{#if show_push_notifications_tooltip.push_notifications}}control-label-disabled{{/if}}">
                         {{t "Mobile"}}
                         {{#if (not page_params.realm_push_notifications_enabled) }}
-                        <i class="fa fa-question-circle settings-info-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Mobile push notifications are not configured on this server.' }}"></i>
+                        <i class="fa fa-question-circle settings-question-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Mobile push notifications are not configured on this server.' }}"></i>
                         {{/if}}
                     </th>
                     <th rowspan="2" width="14%">{{t "Email"}}</th>
                     <th rowspan="2" width="14%">@all
-                        <i class="fa fa-question-circle settings-info-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Whether wildcard mentions like @all are treated as mentions for the purpose of notifications.' }}"></i>
+                        <i class="fa fa-question-circle settings-question-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Whether wildcard mentions like @all are treated as mentions for the purpose of notifications.' }}"></i>
                     </th>
                 </tr>
                 <tr>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -9,7 +9,7 @@
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
                     <label for="realm_invite_to_realm_policy" class="dropdown-title">{{t "Who can invite users to this organization" }}
-                        <i class="fa fa-info-circle settings-info-icon realm_message_retention_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can change this setting.' }}"></i>
+                        <i class="fa fa-question-circle settings-question-icon realm_message_retention_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can change this setting.' }}"></i>
                     </label>
                     <select name="realm_invite_to_realm_policy" id="id_realm_invite_to_realm_policy" class="prop-element" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=invite_to_realm_policy_values}}
@@ -181,7 +181,7 @@
 
                 <div class="input-group">
                     <label for="realm_delete_own_message_policy" class="dropdown-title">{{t "Who can delete their own messages" }}
-                        <i class="fa fa-info-circle settings-info-icon tippy-zulip-tooltip"
+                        <i class="fa fa-question-circle settings-question-icon tippy-zulip-tooltip"
                           aria-hidden="true" data-tippy-content="{{t 'Administrators can delete any message.' }}"></i>
                     </label>
                     <select name="realm_delete_own_message_policy" id="id_realm_delete_own_message_policy" class="prop-element" data-setting-widget-type="number">
@@ -192,7 +192,7 @@
                 <div class="input-group">
                     <label for="realm_msg_delete_limit_setting" class="dropdown-title">
                         {{t "Time limit for deleting messages" }}
-                        <i class="fa fa-info-circle settings-info-icon tippy-zulip-tooltip"
+                        <i class="fa fa-question-circle settings-question-icon tippy-zulip-tooltip"
                           aria-hidden="true" data-tippy-content="{{t 'Administrators can delete any message.' }}"></i>
                     </label>
                     <select name="realm_msg_delete_limit_setting" id="id_realm_msg_delete_limit_setting" class="prop-element">

--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -67,7 +67,7 @@
         </div>
         <h3 class="light">
             {{t "Deactivate organization" }}
-            <i class="fa fa-info-circle settings-info-icon realm_deactivation_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can deactivate the organization.' }}"></i>
+            <i class="fa fa-question-circle settings-question-icon realm_deactivation_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can deactivate the organization.' }}"></i>
         </h3>
         <div class="deactivate-realm-section">
             <div class="input-group">

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -81,7 +81,7 @@
             <div class="inline-block organization-settings-parent">
                 <div class="input-group">
                     <label for="id_realm_message_retention_setting" class="dropdown-title">{{t "Message retention period" }}
-                        <i class="fa fa-info-circle settings-info-icon realm_message_retention_tooltip tippy-zulip-tooltip"
+                        <i class="fa fa-question-circle settings-question-icon realm_message_retention_tooltip tippy-zulip-tooltip"
                           aria-hidden="true" data-tippy-content="{{t 'Only owners can change message retention policy.' }}"></i>
                     </label>
                     <select name="realm_message_retention_setting"

--- a/static/templates/settings/profile_settings.hbs
+++ b/static/templates/settings/profile_settings.hbs
@@ -7,7 +7,7 @@
                     <div class="input-group inline-block grid user-name-parent">
                         <div class="user-name-section inline-block">
                             <label for="full_name" class="title inline-block">{{t "Full name" }}</label>
-                            <i class="fa fa-question-circle change_name_tooltip tippy-zulip-tooltip settings-info-icon"
+                            <i class="fa fa-question-circle change_name_tooltip tippy-zulip-tooltip settings-question-icon"
                               {{#if user_can_change_name}}style="display:none"{{/if}}
                               data-tippy-content="{{t 'Name changes are disabled in this organization. Contact an administrator to change your name.' }}">
                             </i>
@@ -55,7 +55,7 @@
         <div class="inline-block user-avatar-section">
             <h3>
                 {{t "Profile picture" }}
-                <i class="fa fa-question-circle change_name_tooltip tippy-zulip-tooltip settings-info-icon"
+                <i class="fa fa-question-circle change_name_tooltip tippy-zulip-tooltip settings-question-icon"
                   {{#if user_can_change_avatar}}style="display:none"{{/if}}
                   data-tippy-content="{{t 'Avatar changes are disabled in this organization.' }}">
                 </i>

--- a/static/templates/stream_settings/stream_creation_form.hbs
+++ b/static/templates/stream_settings/stream_creation_form.hbs
@@ -42,7 +42,7 @@
                         <span></span>
                         {{t "Announce stream" }}
                     </label>
-                    <span class="fa fa-question-circle settings-info-icon" aria-hidden="true" id="announce-stream-docs"></span>
+                    <span class="fa fa-question-circle settings-question-icon" aria-hidden="true" id="announce-stream-docs"></span>
                 </div>
             </section>
             <section class="block">

--- a/static/templates/stream_settings/stream_settings_checkbox.hbs
+++ b/static/templates/stream_settings/stream_settings_checkbox.hbs
@@ -21,7 +21,7 @@
     </p>
     {{/if}}
     {{#if (eq setting_name "push_notifications")}}
-    <i class="fa fa-question-circle settings-info-icon {{#unless disabled_realm_setting}}hide{{/unless}} tippy-zulip-tooltip"
+    <i class="fa fa-question-circle settings-question-icon {{#unless disabled_realm_setting}}hide{{/unless}} tippy-zulip-tooltip"
       data-tippy-content="{{t 'Mobile push notifications are not configured on this server.' }}">
     </i>
     {{/if}}

--- a/static/templates/stream_settings/stream_types.hbs
+++ b/static/templates/stream_settings/stream_types.hbs
@@ -37,7 +37,7 @@
 
     <div class="input-group inline-block message-retention-setting-group">
         <div class="dropdown-title">{{t "Message retention period" }}
-            <i class="fa fa-info-circle settings-info-icon stream_message_retention_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can change stream message retention policy.' }}"></i>
+            <i class="fa fa-question-circle settings-question-icon stream_message_retention_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can change stream message retention policy.' }}"></i>
         </div>
         <select name="stream_message_retention_setting"
           class="stream_message_retention_setting" class="prop-element"

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -123,7 +123,7 @@
         <div class="last-update">
             {{ _("Last update") }}: <span id="id_last_full_update"></span>
             <span class="last_update_tooltip" data-tippy-content="{% trans %}A full update of all the graphs happens once a day. The “messages sent over time” graph is updated once an hour.{% endtrans %}">
-                <span class="fa fa-info-circle" id="id_last_update_question_sign"></span>
+                <span class="fa fa-question-circle" id="id_last_update_question_sign"></span>
             </span>
             <br />
             <span class="docs_link"><a href="/help/analytics">{{ _("Analytics documentation") }}</a></span>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is made for the issue: https://github.com/zulip/zulip/issues/20484. We modified the help icons in the settings from ! to ? for consistency, increased opacity to 0.6 for better visibility in both light and dark modes.

**Testing plan:** <!-- How have you tested? -->
UI manual test
Frontend lint test
Backend lint test

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
In light theme:
![light_theme](https://user-images.githubusercontent.com/87924063/146649223-a63e5790-b3e6-4209-95f5-461bd70b98ba.png)

In dark theme: 
![dark_theme](https://user-images.githubusercontent.com/87924063/146649278-99635fd2-efa1-4274-8c71-10e52a600486.png)

"Add a new code playground":
![image](https://user-images.githubusercontent.com/87924063/145132504-c2b7991f-b219-4f87-970d-338e881ca11c.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->