### PR TITLE
Reorder stream-privacy choices in stream creation form and fix couple of bugs.

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -338,8 +338,8 @@ export function show_new_stream_modal() {
         html_selector: (user) => $(`#${CSS.escape("user_checkbox_" + user.user_id)}`),
     });
 
-    // Select the first enabled choice for stream privacy.
-    $("#make-invite-only input:not([disabled]):first").prop("checked", true);
+    // Select the first visible and enabled choice for stream privacy.
+    $("#make-invite-only input:visible:not([disabled]):first").prop("checked", true);
     // Make the options default to the same each time:
     // "announce stream" on.
     $("#stream_creation_form .stream-message-retention-days-input").hide();

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -103,6 +103,14 @@ const stream_ids_by_name = new FoldDict();
 const default_stream_ids = new Set();
 
 export const stream_privacy_policy_values = {
+    web_public: {
+        code: "web-public",
+        name: $t({defaultMessage: "Web public"}),
+        description: $t({
+            defaultMessage:
+                "Organization members can join (guests must be invited by a subscriber); anyone on the Internet can view complete message history without creating an account",
+        }),
+    },
     public: {
         code: "public",
         name: $t({defaultMessage: "Public"}),
@@ -125,14 +133,6 @@ export const stream_privacy_policy_values = {
         description: $t({
             defaultMessage:
                 "Must be invited by a subscriber; new subscribers can only see messages sent after they join; hidden from non-administrator users",
-        }),
-    },
-    web_public: {
-        code: "web-public",
-        name: $t({defaultMessage: "Web public"}),
-        description: $t({
-            defaultMessage:
-                "Organization members can join (guests must be invited by a subscriber); anyone on the Internet can view complete message history without creating an account",
         }),
     },
 };

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -994,8 +994,15 @@ export function update_web_public_stream_privacy_option_state(container) {
     );
     if (
         !page_params.server_web_public_streams_enabled ||
-        (!page_params.realm_enable_spectator_access && !web_public_stream_elem.is(":checked"))
+        !page_params.realm_enable_spectator_access
     ) {
+        const for_change_privacy_modal = container.attr("id") === "stream_privacy_modal";
+        if (for_change_privacy_modal && web_public_stream_elem.is(":checked")) {
+            // We do not hide web-public option in the "Change privacy" modal if
+            // stream is web-public already. The option is disabled in this case.
+            web_public_stream_elem.prop("disabled", true);
+            return;
+        }
         web_public_stream_elem.closest(".radio-input-parent").hide();
         container
             .find(".stream-privacy-values .radio-input-parent:visible:last")


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit reorders the stream-privacy options to keep web-public at top.
- Second commit changes the code to consider only visible options when selecting default stream privacy choice in stream creation form.
- Third commit fixes a live update bug to correctly hide the web-public option on disabling realm-level setting.
 <!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
