### PR TITLE
search_suggestion: Show profile pictures in search auto-complete suggestions

### DIFF
--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -32,9 +32,9 @@ const search_pill = zrequire("search_pill");
 const {Filter} = zrequire("../js/filter");
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, mock_template}) => {
         page_params.search_pills_enabled = true;
-        f({override});
+        f({override, mock_template});
     });
 }
 
@@ -83,7 +83,7 @@ test("update_button_visibility", () => {
     assert.ok(!search_button.prop("disabled"));
 });
 
-test("initialize", () => {
+test("initialize", ({mock_template}) => {
     const search_query_box = $("#search_query");
     const searchbox_form = $("#searchbox_form");
     const search_button = $(".search_button");
@@ -141,10 +141,10 @@ test("initialize", () => {
             assert.equal(source, expected_source_value);
 
             /* Test highlighter */
-            let expected_value = "Search for ver";
+            let expected_value = `<div class="search_list_item">\n    Search for ver\n</div>\n`;
             assert.equal(opts.highlighter(source[0]), expected_value);
 
-            expected_value = "Stream <strong>Ver</strong>ona";
+            expected_value = `<div class="search_list_item">\n    Stream&nbsp;<strong>Ver</strong>ona\n</div>\n`;
             assert.equal(opts.highlighter(source[1]), expected_value);
 
             /* Test sorter */

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -89,6 +89,17 @@ test("initialize", () => {
     const search_button = $(".search_button");
     const searchbox = $("#searchbox");
 
+    mock_template("search_list_item.hbs", true, (data, html) => {
+        assert.equal(typeof data.description_html, "string");
+        if (data.is_person) {
+            assert.equal(typeof data.user_pill_context.id, "string");
+            assert.equal(typeof data.user_pill_context.display_value, "string");
+            assert.equal(typeof data.user_pill_context.has_image, "boolean");
+            assert.equal(typeof data.user_pill_context.img_src, "string");
+        }
+        return html;
+    });
+
     search_query_box[0] = "stub";
 
     search_pill.get_search_string_for_current_filter = () => "is:starred";
@@ -108,14 +119,14 @@ test("initialize", () => {
                     [
                         "stream:Verona",
                         {
-                            description: "Stream <strong>Ver</strong>ona",
+                            description_html: "Stream&nbsp;<strong>Ver</strong>ona",
                             search_string: "stream:Verona",
                         },
                     ],
                     [
                         "ver",
                         {
-                            description: "Search for ver",
+                            description_html: "Search for ver",
                             search_string: "ver",
                         },
                     ],

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -66,6 +66,17 @@ run_test("initialize", () => {
     const searchbox_form = $("#searchbox_form");
     const search_button = $(".search_button");
 
+    mock_template("search_list_item.hbs", true, (data, html) => {
+        assert.equal(typeof data.description_html, "string");
+        if (data.is_person) {
+            assert.equal(typeof data.user_pill_context.id, "string");
+            assert.equal(typeof data.user_pill_context.display_value, "string");
+            assert.equal(typeof data.user_pill_context.has_image, "boolean");
+            assert.equal(typeof data.user_pill_context.img_src, "string");
+        }
+        return html;
+    });
+
     search_suggestion.max_num_of_search_results = 999;
     search_query_box.typeahead = (opts) => {
         assert.equal(opts.fixed, true);
@@ -80,14 +91,14 @@ run_test("initialize", () => {
                     [
                         "stream:Verona",
                         {
-                            description: "Stream <strong>Ver</strong>ona",
+                            description_html: "Stream&nbsp;<strong>Ver</strong>ona",
                             search_string: "stream:Verona",
                         },
                     ],
                     [
                         "ver",
                         {
-                            description: "Search for ver",
+                            description_html: "Search for ver",
                             search_string: "ver",
                         },
                     ],

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -61,7 +61,7 @@ run_test("update_button_visibility", () => {
     assert.ok(!search_button.prop("disabled"));
 });
 
-run_test("initialize", () => {
+run_test("initialize", ({mock_template}) => {
     const search_query_box = $("#search_query");
     const searchbox_form = $("#searchbox_form");
     const search_button = $(".search_button");
@@ -113,10 +113,10 @@ run_test("initialize", () => {
             assert.equal(source, expected_source_value);
 
             /* Test highlighter */
-            let expected_value = "Search for ver";
+            let expected_value = `<div class="search_list_item">\n    Search for ver\n</div>\n`;
             assert.equal(opts.highlighter(source[0]), expected_value);
 
-            expected_value = "Stream <strong>Ver</strong>ona";
+            expected_value = `<div class="search_list_item">\n    Stream&nbsp;<strong>Ver</strong>ona\n</div>\n`;
             assert.equal(opts.highlighter(source[1]), expected_value);
 
             /* Test sorter */

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -402,7 +402,7 @@ test("empty_query_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
     assert.equal(describe("is:private"), "Private messages");
     assert.equal(describe("is:starred"), "Starred messages");
@@ -428,7 +428,7 @@ test("has_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
 
     assert.equal(describe("has:link"), "Messages with one or more link");
@@ -494,7 +494,7 @@ test("check_is_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
 
     assert.equal(describe("is:private"), "Private messages");
@@ -604,7 +604,10 @@ test("sent_by_me_suggestions", ({override}) => {
     let query = "";
     let suggestions = get_suggestions("", query);
     assert.ok(suggestions.strings.includes("sender:myself@zulip.com"));
-    assert.equal(suggestions.lookup_table.get("sender:myself@zulip.com").description, "Sent by me");
+    assert.equal(
+        suggestions.lookup_table.get("sender:myself@zulip.com").description_html,
+        "Sent by me",
+    );
 
     query = "sender";
     suggestions = get_suggestions("", query);
@@ -727,7 +730,7 @@ test("topic_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
     assert.equal(describe("te"), "Search for te");
     assert.equal(describe("stream:office topic:team"), "Stream office &gt; team");
@@ -835,7 +838,28 @@ test("people_suggestions", ({override}) => {
 
     assert.deepEqual(suggestions.strings, expected);
 
-    const describe = (q) => suggestions.lookup_table.get(q).description;
+    const is_person = (q) => suggestions.lookup_table.get(q).is_person;
+    assert.equal(is_person("pm-with:ted@zulip.com"), true);
+    assert.equal(is_person("sender:ted@zulip.com"), true);
+    assert.equal(is_person("group-pm-with:ted@zulip.com"), true);
+
+    const has_image = (q) => suggestions.lookup_table.get(q).user_pill_context.has_image;
+    assert.equal(has_image("pm-with:bob@zulip.com"), true);
+    assert.equal(has_image("sender:bob@zulip.com"), true);
+    assert.equal(has_image("group-pm-with:bob@zulip.com"), true);
+
+    const describe = (q) => suggestions.lookup_table.get(q).description_html;
+    assert.equal(describe("pm-with:ted@zulip.com"), "Private messages with");
+    assert.equal(describe("sender:ted@zulip.com"), "Sent by");
+    assert.equal(describe("group-pm-with:ted@zulip.com"), "Group private messages including");
+
+    let expectedString = "<strong>Te</strong>d Smith";
+
+    const get_full_name = (q) =>
+        suggestions.lookup_table.get(q).user_pill_context.display_value.string;
+    assert.equal(get_full_name("sender:ted@zulip.com"), expectedString);
+    assert.equal(get_full_name("pm-with:ted@zulip.com"), expectedString);
+    assert.equal(get_full_name("group-pm-with:ted@zulip.com"), expectedString);
 
     assert.equal(
         describe("pm-with:ted@zulip.com"),

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {mock_esm, with_field, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {page_params} = require("../zjsunit/zpage_params");
 
@@ -51,6 +51,7 @@ const jeff = {
 };
 
 const noop = () => {};
+const example_avatar_url = "http://example.com/example.png";
 
 function init() {
     page_params.is_admin = true;
@@ -809,6 +810,7 @@ function people_suggestion_setup() {
         email: "bob@zulip.com",
         user_id: 202,
         full_name: "Bob Térry",
+        avatar_url: example_avatar_url,
     };
 
     people.add_active_user(bob);
@@ -861,14 +863,12 @@ test("people_suggestions", ({override}) => {
     assert.equal(get_full_name("pm-with:ted@zulip.com"), expectedString);
     assert.equal(get_full_name("group-pm-with:ted@zulip.com"), expectedString);
 
-    assert.equal(
-        describe("pm-with:ted@zulip.com"),
-        "Private messages with <strong>Te</strong>d Smith &lt;<strong>te</strong>d@zulip.com&gt;",
-    );
-    assert.equal(
-        describe("sender:ted@zulip.com"),
-        "Sent by <strong>Te</strong>d Smith &lt;<strong>te</strong>d@zulip.com&gt;",
-    );
+    expectedString = `${example_avatar_url}?s=50`;
+
+    const get_avatar_url = (q) => suggestions.lookup_table.get(q).user_pill_context.img_src;
+    assert.equal(get_avatar_url("pm-with:bob@zulip.com"), expectedString);
+    assert.equal(get_avatar_url("sender:bob@zulip.com"), expectedString);
+    assert.equal(get_avatar_url("group-pm-with:bob@zulip.com"), expectedString);
 
     suggestions = get_suggestions("", "Ted "); // note space
     expected = [
@@ -903,38 +903,6 @@ test("people_suggestions", ({override}) => {
     expected = ["new"];
     suggestions = get_suggestions(base_query, query);
     assert.deepEqual(suggestions.strings, expected);
-});
-
-test("people_suggestion (Admin only email visibility)", ({override}) => {
-    /* Suggestions when realm_email_address_visibility is set to admin
-    only */
-    override(narrow_state, "stream", noop);
-    people_suggestion_setup();
-
-    const query = "te";
-    const suggestions = with_field(page_params, "is_admin", false, () =>
-        get_suggestions("", query),
-    );
-
-    const expected = [
-        "te",
-        "sender:bob@zulip.com",
-        "sender:ted@zulip.com",
-        "pm-with:bob@zulip.com", // bob térry
-        "pm-with:ted@zulip.com",
-        "group-pm-with:bob@zulip.com",
-        "group-pm-with:ted@zulip.com",
-    ];
-
-    assert.deepEqual(suggestions.strings, expected);
-
-    const describe = (q) => suggestions.lookup_table.get(q).description;
-
-    assert.equal(
-        describe("pm-with:ted@zulip.com"),
-        "Private messages with <strong>Te</strong>d Smith",
-    );
-    assert.equal(describe("sender:ted@zulip.com"), "Sent by <strong>Te</strong>d Smith");
 });
 
 test("operator_suggestions", () => {

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -383,7 +383,7 @@ test("empty_query_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
     assert.equal(describe("is:private"), "Private messages");
     assert.equal(describe("is:starred"), "Starred messages");
@@ -409,7 +409,7 @@ test("has_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
 
     assert.equal(describe("has:link"), "Messages with one or more link");
@@ -478,7 +478,7 @@ test("check_is_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
 
     assert.equal(describe("is:private"), "Private messages");
@@ -551,7 +551,10 @@ test("sent_by_me_suggestions", ({override}) => {
     let query = "";
     let suggestions = get_suggestions("", query);
     assert.ok(suggestions.strings.includes("sender:myself@zulip.com"));
-    assert.equal(suggestions.lookup_table.get("sender:myself@zulip.com").description, "Sent by me");
+    assert.equal(
+        suggestions.lookup_table.get("sender:myself@zulip.com").description_html,
+        "Sent by me",
+    );
 
     query = "sender";
     suggestions = get_suggestions("", query);
@@ -669,7 +672,7 @@ test("topic_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
     assert.equal(describe("te"), "Search for te");
     assert.equal(describe("stream:office topic:team"), "Stream office &gt; team");
@@ -784,7 +787,7 @@ test("people_suggestions", ({override}) => {
 
     assert.deepEqual(suggestions.strings, expected);
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
     assert.equal(
         describe("pm-with:ted@zulip.com"),

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,5 +1,7 @@
 import $ from "jquery";
 
+import render_search_list_item from "../templates/search_list_item.hbs";
+
 import {Filter} from "./filter";
 import * as message_view_header from "./message_view_header";
 import * as narrow from "./narrow";
@@ -94,7 +96,7 @@ export function initialize() {
         naturalSearch: true,
         highlighter(item) {
             const obj = search_map.get(item);
-            return obj.description;
+            return render_search_list_item(obj);
         },
         matcher() {
             return true;

--- a/static/styles/input_pill.css
+++ b/static/styles/input_pill.css
@@ -73,6 +73,17 @@
         }
     }
 
+    &.pill-container-btn {
+        cursor: pointer;
+        padding: 0;
+
+        .pill {
+            .exit {
+                display: none;
+            }
+        }
+    }
+
     .input {
         display: inline-block;
         padding: 2px 4px;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -660,6 +660,16 @@ strong {
                 background-repeat: repeat-x;
                 filter: progid:dximagetransform.microsoft.gradient(startcolorstr='hsla(328, 100%, 50%, 0.8)', endcolorstr='hsla(332, 100%, 50%, 0.7)', gradienttype=0);
             }
+
+            .search_list_item {
+                display: flex;
+                align-items: center;
+            }
+
+            .search_list_item .pill-container {
+                margin-left: 5px;
+            }
+
             /* styles defined for user_circle here only deal with positioning of user_presence_circle
             in typeahead list in order to ensure they are renderred correctly in in all screen sizes.
             Most of the style rules related to color, gradient etc. which are generally common throughout

--- a/static/templates/search_list_item.hbs
+++ b/static/templates/search_list_item.hbs
@@ -1,0 +1,8 @@
+<div class="search_list_item">
+    {{{ description_html }}}
+    {{#if is_person}}
+    <span class="pill-container pill-container-btn">
+        {{> input_pill user_pill_context}}
+    </span>
+    {{/if}}
+</div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fix #20267

What I've basically changed is how [`bootstrap-typeahead`](https://bootstrapdocs.com/v2.0.1/docs/javascript.html#typeahead) should render the auto-complete suggestions for **users only**. I've attempted to reuse the existing UI components (e.g. `input_pill`) and styling, but it seems hard to make them work together as expected without adding a container and some CSS. If you find a better approach, I'm open to all recommendations.

During the process of encapsulating the `typeahead` list items inside flexboxes, I noticed the whitespace right after `prefix` is not escaped in HTML. This can cause, for example, `"StreamDenmark"` because the whitespace before `"Denmark"` is ignored in HTML.

**Testing plan:** <!-- How have you tested? -->
- Manual Testing

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
On large screens:
![image](https://user-images.githubusercontent.com/55090719/145057916-64ea109b-3230-42a0-b7f8-f22019b480f4.png)
![image](https://user-images.githubusercontent.com/55090719/145057941-19147939-75f0-4c72-9024-8fcf2cc10b87.png)

On smaller screens:
![image](https://user-images.githubusercontent.com/55090719/145058064-e150d0f5-a077-4b20-849c-c5c18a9f5a55.png)
![image](https://user-images.githubusercontent.com/55090719/145058080-c1e3197b-35dc-4756-be7e-3c20cbfd8901.png)

When PM group:
![Screen Shot 2021-12-08 at 10 09 00 PM](https://user-images.githubusercontent.com/55090719/145330113-a809755b-a800-4706-922f-fb96f1a87ad0.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
