### PR TITLE
Issue20213 todo list

### DIFF
--- a/static/js/todo_widget.js
+++ b/static/js/todo_widget.js
@@ -5,7 +5,6 @@ import render_widgets_todo_widget_tasks from "../templates/widgets/todo_widget_t
 
 import * as blueslip from "./blueslip";
 import {$t} from "./i18n";
-import * as util from "./util";
 
 // Any single user should send add a finite number of tasks
 // to a todo list. We arbitrarily pick this value.
@@ -17,7 +16,6 @@ export class TaskData {
 
     get_widget_data() {
         const all_tasks = Array.from(this.task_map.values());
-        all_tasks.sort((a, b) => util.strcmp(a.task, b.task));
 
         const pending_tasks = [];
         const completed_tasks = [];

--- a/static/styles/widgets.css
+++ b/static/styles/widgets.css
@@ -26,6 +26,33 @@
     }
 }
 
+.todo-name-header {
+    display: inline-block;
+}
+
+.todo-edit-name {
+    opacity: 0.4;
+    display: inline-block;
+    margin-left: 5px;
+
+    &:hover {
+        opacity: 1;
+    }
+}
+
+.todo-name-check,
+.todo-name-remove {
+    width: 28px !important;
+    height: 28px;
+    border-radius: 3px;
+    border: 1px solid hsl(0, 0%, 80%);
+    background-color: hsl(0, 0%, 100%);
+
+    &:hover {
+        border-color: hsl(0, 0%, 60%);
+    }
+}
+
 .todo-widget,
 .poll-widget {
     h4 {
@@ -61,7 +88,8 @@
         border-style: solid;
         border-radius: 3px;
         margin-right: 4px;
-        padding-left: 2px; /* padding for Chromium browsers */
+        padding-left: 2px;
+        /* padding for Chromium browsers */
         padding-right: 2px;
         min-width: 28px;
         background-color: hsl(0, 0%, 100%);
@@ -125,6 +153,7 @@ input,
 button {
     &.add-task,
     &.add-desc,
+    &.todo-name,
     &.poll-option,
     &.poll-question {
         padding: 4px 6px;

--- a/static/templates/widgets/todo_widget.hbs
+++ b/static/templates/widgets/todo_widget.hbs
@@ -1,5 +1,11 @@
 <div class="todo-widget">
-    <h4>Task list</h4>
+    <h4 class="todo-name-header"></h4>
+    <i class="fa fa-pencil todo-edit-name"></i>
+    <div class="todo-name-bar">
+        <input type="text" class="todo-name" placeholder="{{t 'Task list'}}" />
+        <button class="todo-name-remove"><i class="fa fa-remove"></i></button>
+        <button class="todo-name-check"><i class="fa fa-check"></i></button>
+    </div>
     <div class="add-task-bar">
         <input type="text" class="add-task" placeholder="{{t 'New task'}}" />
         <input type="text" class="add-desc" placeholder="{{t 'Description'}}" />

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -525,6 +525,16 @@ def validate_todo_data(todo_data: object) -> None:
         checker("todo data", todo_data)
         return
 
+    if todo_data["type"] == "task_list_name":
+        checker = check_dict_only(
+            [
+                ("type", check_string),
+                ("task_list_name", check_string),
+            ]
+        )
+        checker("todo data", todo_data)
+        return
+
     raise ValidationError(f"Unknown type for todo data: {todo_data['type']}")
 
 

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -41,7 +41,17 @@ def get_extra_data_from_widget_type(content: str, widget_type: Optional[str]) ->
             "options": options,
         }
         return extra_data
-    return None
+    if widget_type == "todo":
+        # This is used to extract the name from the todo command.
+        # The command '/todo name' will pre-set the name in the todo
+        lines = content.splitlines()
+        name = ""
+        if lines and lines[0]:
+            name = lines.pop(0).strip()
+        extra_data = {
+            "name": name,
+        }
+        return extra_data
 
 
 def do_widget_post_save_actions(send_request: SendMessageRequest) -> None:

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -97,7 +97,7 @@ class WidgetContentTestCase(ZulipTestCase):
             self.assertEqual(get_widget_data(content=message), (None, None))
 
         # Add a positive check for context
-        self.assertEqual(get_widget_data(content="/todo"), ("todo", None))
+        self.assertEqual(get_widget_data(content="/todo"), ("todo", {"name": ""}))
 
     def test_explicit_widget_content(self) -> None:
         # Users can send widget_content directly on messages
@@ -165,7 +165,31 @@ class WidgetContentTestCase(ZulipTestCase):
 
         expected_submessage_content = dict(
             widget_type="todo",
-            extra_data=None,
+            extra_data={"name": ""},
+        )
+
+        submessage = SubMessage.objects.get(message_id=message.id)
+        self.assertEqual(submessage.msg_type, "widget")
+        self.assertEqual(orjson.loads(submessage.content), expected_submessage_content)
+
+        content = "/todo Task List Name"
+
+        payload = dict(
+            type="stream",
+            to=stream_name,
+            client="test suite",
+            topic="whatever",
+            content=content,
+        )
+        result = self.api_post(sender, "/api/v1/messages", payload)
+        self.assert_json_success(result)
+
+        message = self.get_last_message()
+        self.assertEqual(message.content, content)
+
+        expected_submessage_content = dict(
+            widget_type="todo",
+            extra_data={"name": "Task List Name"},
         )
 
         submessage = SubMessage.objects.get(message_id=message.id)
@@ -362,6 +386,12 @@ class WidgetContentTestCase(ZulipTestCase):
         assert_error('{"type": "strike"}', "key is missing")
         assert_error('{"type": "strike", "key": 999}', 'data["key"] is not a string')
 
+        assert_error('{"type": "task_list_name"}', "task_list_name key is missing")
+        assert_error(
+            '{"type": "task_list_name", "task_list_name": 999}',
+            'data["task_list_name"] is not a string',
+        )
+
         def assert_success(data: Dict[str, object]) -> None:
             content = orjson.dumps(data).decode()
             result = post_submessage(content)
@@ -369,6 +399,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         assert_success(dict(type="new_task", key=7, task="eat", desc="", completed=False))
         assert_success(dict(type="strike", key="5,9"))
+        assert_success(dict(type="task_list_name", task_list_name="name"))
 
     def test_get_widget_type(self) -> None:
         sender = self.example_user("cordelia")


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Solve some of the suggestions in issue #20213 :
- Tasks are now arranged in the order they are created, and they are still separated bewteen completed and uncompleted ones.
- The widget has now a name and it can be edited.

**Testing plan:** <!-- How have you tested? -->
Tests and manual checking.
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Create widget with name (if left empty, name will be "Task list" as it is right now):
![todo name](https://user-images.githubusercontent.com/43895065/145867949-9c92050b-a058-4741-a98f-03fb24d773c4.gif)
Ability to rename the widget:
![todo renaming](https://user-images.githubusercontent.com/43895065/145867957-b4263c88-5c26-4433-bd6d-3d855240f9e3.gif)
Tasks are now added chronologically:
![todo order adding](https://user-images.githubusercontent.com/43895065/145867955-3ec98213-56b5-403e-8832-33d26dc7cf91.gif)
We keep separating done tasks from undone ones:
![todo completed tasks](https://user-images.githubusercontent.com/43895065/145867960-99f004e9-c6b6-47ed-b6c6-4c95f0366604.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
