### PR TITLE
documentation: Fix text wrapping and alignment of ordered lists.

### DIFF
--- a/static/styles/portico/markdown.css
+++ b/static/styles/portico/markdown.css
@@ -112,10 +112,17 @@
         list-style: none;
 
         & > li {
+            position: relative;
+            vertical-align: top;
+            /* This needs to be wide enough for 2-digit numbers. */
+            padding-left: 33px;
+            top: -2px;
             counter-increment: item;
-            margin-bottom: 5px;
 
             &::before {
+                position: absolute;
+                top: 0;
+                left: 0;
                 content: counter(item);
                 display: inline-block;
                 vertical-align: top;
@@ -129,15 +136,6 @@
                 text-align: center;
             }
 
-            & > p {
-                display: inline-block;
-                vertical-align: top;
-                /* This needs to be wide enough for 2-digit numbers. */
-                max-width: calc(100% - 40px);
-                position: relative;
-                top: -2px;
-            }
-
             & > .codehilite,
             & > p:not(:first-child) {
                 padding-left: 24px;
@@ -149,7 +147,7 @@
             }
 
             & > ul {
-                padding-left: 20px;
+                margin-bottom: 5px;
             }
 
             .warn,
@@ -157,10 +155,6 @@
             .keyboard_tip {
                 margin: 5px 25px;
             }
-        }
-
-        p {
-            margin: 0 0 2px;
         }
 
         @media (width <= 500px) {
@@ -189,7 +183,7 @@
             margin: 15px 10px;
 
             & > li {
-                margin: 5px 0;
+                margin: 2.5px 0;
             }
         }
 


### PR DESCRIPTION
Moves CSS rules that rely on list items in an ordered list being wrapped in a `<p>` tag so that they apply to the list item itself.

Uses `position: absolute` to set the `::before` pseudo-element in place and `position: relative` to adjust the list items so that they do not overlap.

Ideally, when [all modern browsers support](https://bugs.webkit.org/show_bug.cgi?id=204163) the `content` property for `::marker` pseudo-elements, this design can be revisited. 

Fixes #20440.

**Testing plan:** Manual tested by reviewing help center docs with normal and narrow screen width. See screenshots below.

### Same help center doc where the issue was noticed
![Screenshot from 2021-12-07 19-50-13](https://user-images.githubusercontent.com/63245456/145089055-4bedec1c-793b-480e-9254-415a475a76a8.png)

### Zoomed in to see spacing between counter and list text, also narrowed screen width to check text wrapping
![Screenshot from 2021-12-07 19-50-46](https://user-images.githubusercontent.com/63245456/145089042-62983fd8-73fa-4780-99f1-37687a9da7c4.png)

### Comparison of changes to current documentation page as there are some slight spacing changes
![Screenshot from 2021-12-07 19-53-04](https://user-images.githubusercontent.com/63245456/145089036-74b7bd7d-6b5c-427e-a447-2592332c8a03.png)

### Example of counters with two digits, which is why there is so much space between the counter and list text
![Screenshot from 2021-12-07 19-34-57](https://user-images.githubusercontent.com/63245456/145087792-a75330b9-6132-4d78-b63f-9056c4d61edf.png)

### Zoom in on the counters with two digits
![Screenshot from 2021-12-07 19-54-55](https://user-images.githubusercontent.com/63245456/145089242-6353d84e-b64c-4bfd-a097-0bf2dd7776ea.png)