### PR TITLE
Replace compose close icon with font awesome icon.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -243,9 +243,13 @@
     }
 }
 
-.collapse_composebox_button,
-#compose_close {
+.collapse_composebox_button{
     display: none;
+}
+
+#compose_close {
+    font-size: 14px !important;
+    margin-top: -1px;
 }
 
 .compose_invite_user,

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -53,7 +53,7 @@
             <div id="compose_top_right">
                 <button type="button" class="expand_composebox_button fa fa-angle-up" aria-label="{{t 'Expand compose' }}" tabindex=0 title="{{t 'Expand compose' }}"></button>
                 <button type="button" class="collapse_composebox_button fa fa-angle-down" aria-label="{{t 'Collapse compose' }}" tabindex=0 title="{{t 'Collapse compose' }}"></button>
-                <button type="button" class="close" id='compose_close' title="{{t 'Cancel compose' }} (Esc)">&times;</button>
+                <button type="button" class="close fa fa-remove" id='compose_close' title="{{t 'Cancel compose' }} (Esc)"></button>
             </div>
             <form id="send_message_form" action="/json/messages" method="post">
                 {{ csrf_input }}


### PR DESCRIPTION
Replaced the Compose close icon with font awesome icon as it is in other places.

This PR is for issue #20403 