### PR TITLE
scripts: Only stop/start existing tornado processes.

### DIFF
--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -137,7 +137,7 @@ if has_application_server():
             )
     else:
         logging.info("%s Tornado process", verbing)
-        subprocess.check_call(["supervisorctl", action, "zulip-tornado", "zulip-tornado:*"])
+        subprocess.check_call(["supervisorctl", action, "zulip-tornado:*"])
 
     # Finally, restart the Django uWSGI processes.
     logging.info("%s django server", verbing)

--- a/scripts/stop-server
+++ b/scripts/stop-server
@@ -39,7 +39,7 @@ if has_application_server():
     # closer to "empty."  We stop Django before Tornado so it doesn't try
     # to make requests to make queues with a down'd Tornado.
     services.append("zulip-django")
-    services.extend(["zulip-tornado", "zulip-tornado:*"])
+    services.append("zulip-tornado:*")
     services.append("zulip-workers:*")
     if has_application_server(once=True):
         # These used to be included in "zulip-workers:*"; since we may


### PR DESCRIPTION
Stopping both `zulip-tornado` and `zulip-tornado:*` causes errors on
deploys with tornado sharding, as the plain `zulip-tornado` service
does not exist.

Pass `zulip-tornado:*`, which matches both plain `zulip-tornado`, as
well as the sharded `zulip-tornado:zulip-tornado-port-9800` cases.

**Testing plan:** Tested on an unsharded prod host.
