### PR TITLE
api: Add name check name for user group name.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -2022,9 +2022,11 @@ class PasswordTooWeakError(Exception):
 
 
 class UserGroup(models.Model):
+    MAX_NAME_LENGTH = 100
+
     objects = CTEManager()
     id: int = models.AutoField(auto_created=True, primary_key=True, verbose_name="ID")
-    name: str = models.CharField(max_length=100)
+    name: str = models.CharField(max_length=MAX_NAME_LENGTH)
     direct_members: Manager = models.ManyToManyField(
         UserProfile, through="UserGroupMembership", related_name="direct_groups"
     )

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -52,6 +52,11 @@ class UserGroupTestCase(ZulipTestCase):
         self.assertEqual(user_groups[1]["name"], "newgroup")
         self.assertEqual(user_groups[1]["description"], "")
         self.assertEqual(user_groups[1]["members"], [])
+    
+    def test_invalid_user_group_name(self) -> None:
+        realm = get_realm("zulip")
+        result = self.create_user_group_for_test("")
+        self.assert_json_error(result, "Group name can't be empty!")
 
     def test_get_direct_user_groups(self) -> None:
         othello = self.example_user("othello")


### PR DESCRIPTION
We add check for user group name and prevent making new user groups with, characters in the
Unicode categories of `Cc` (control characters), `Cs` (surrogates), and
`Cn` (unassigned, non-characters) or empty string when creating a group using API

Fixes a part of #20128 