### PR TITLE
external links: Migrate the rest of /developer-community links.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,11 @@ Welcome to the Zulip community!
 ## Community
 
 The
-[Zulip community server](https://zulip.com/developer-community/)
+[Zulip community server](https://zulip.com/development-community/)
 is the primary communication forum for the Zulip community. It is a good
 place to start whether you have a question, are a new contributor, are a new
 user, or anything else. Please review our
-[community norms](https://zulip.com/developer-community/#community-norms)
+[community norms](https://zulip.com/development-community/#community-norms)
 before posting. The Zulip community is also governed by a
 [code of conduct](https://zulip.readthedocs.io/en/latest/code-of-conduct.html).
 
@@ -53,7 +53,7 @@ no one gets it right the first time, and there are a lot of people available
 to help.
 
 - First, make an account on the
-  [Zulip community server](https://zulip.com/developer-community/),
+  [Zulip community server](https://zulip.com/development-community/),
   paying special attention to the community norms. If you'd like, introduce
   yourself in
   [#new members](https://chat.zulip.org/#narrow/stream/95-new-members), using
@@ -178,7 +178,7 @@ start with.
 - You're encouraged to ask questions on how to best implement or debug your
   changes -- the Zulip maintainers are excited to answer questions to help
   you stay unblocked and working efficiently. You can ask questions in the
-  [Zulip development community](https://zulip.com/developer-community/),
+  [Zulip development community](https://zulip.com/development-community/),
   or on the GitHub issue or pull request.
 - We encourage early pull requests for work in progress. Prefix the title of
   work in progress pull requests with `[WIP]`, and remove the prefix when
@@ -222,7 +222,7 @@ labels.
 - **Can I come up with my own feature idea and work on it?** We welcome
   suggestions of features or other improvements that you feel would be valuable. If you
   have a new feature you'd like to add, you can start a conversation [in our
-  development community](https://zulip.com/developer-community/#where-do-i-send-my-message)
+  development community](https://zulip.com/development-community/#where-do-i-send-my-message)
   explaining the feature idea and the problem that you're hoping to solve.
 
 ## What makes a great Zulip contributor?
@@ -235,7 +235,7 @@ experience, these are the best predictors of success:
   your current understanding, including what you've done or tried so far and where
   you got stuck. Post tracebacks or other error messages if appropriate. For
   more information, check out the ["Getting help" section of our community
-  guidelines](https://zulip.com/developer-community/#getting-help) and
+  guidelines](https://zulip.com/development-community/#getting-help) and
   [this essay][good-questions-blog] for some good advice.
 - Learning and practicing
   [Git commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html#commit-discipline).
@@ -271,7 +271,7 @@ is, the best place to post issues is
 [#issues](https://chat.zulip.org/#narrow/stream/9-issues) (or
 [#mobile](https://chat.zulip.org/#narrow/stream/48-mobile) or
 [#desktop](https://chat.zulip.org/#narrow/stream/16-desktop)) on the
-[Zulip community server](https://zulip.com/developer-community/).
+[Zulip community server](https://zulip.com/development-community/).
 This allows us to interactively figure out what is going on, let you know if
 a similar issue has already been opened, and collect any other information
 we need. Choose a 2-4 word topic that describes the issue, explain the issue

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ largest and fastest growing open source group chat project.
 
 Click on the appropriate link below. If nothing seems to apply,
 join us on the
-[Zulip community server](https://zulip.com/developer-community/)
+[Zulip community server](https://zulip.com/development-community/)
 and tell us what's up!
 
 You might be interested in:
@@ -52,7 +52,7 @@ You might be interested in:
 
 - **Checking Zulip out**. The best way to see Zulip in action is to drop by
   the
-  [Zulip community server](https://zulip.com/developer-community/). We
+  [Zulip community server](https://zulip.com/development-community/). We
   also recommend reading Zulip for
   [open source](https://zulip.com/for/open-source/), Zulip for
   [companies](https://zulip.com/for/companies/), or Zulip for

--- a/docs/contributing/code-reviewing.md
+++ b/docs/contributing/code-reviewing.md
@@ -16,7 +16,7 @@ this?". Good choices include
 
 Alternatively, posting a message in
 [#code-review](https://chat.zulip.org/#narrow/stream/91-code-review) on [the Zulip
-development community server](https://zulip.com/developer-community/), would
+development community server](https://zulip.com/development-community/), would
 help in reaching out to a wider group of reviewers. Either way, please be
 patient and mindful of the fact that it isn't possible to provide a
 quick reply always, but that the reviewer would get to it sooner or later.

--- a/docs/contributing/gsoc-ideas.md
+++ b/docs/contributing/gsoc-ideas.md
@@ -81,7 +81,7 @@ tasks that are great for first-time contributors. Use
 to get your Zulip development environment set up and to find your first issue. If you have any
 trouble, please speak up in
 [#GSoC](https://chat.zulip.org/#narrow/stream/14-GSoC) on
-[the Zulip development community server](https://zulip.com/developer-community/)
+[the Zulip development community server](https://zulip.com/development-community/)
 (use your name as the topic).
 
 ## Application tips, and how to be a strong candidate
@@ -126,7 +126,7 @@ application deadline.
 
 We are more interested in candidates if we see them submitting good
 contributions to Zulip projects, helping other applicants on [GitHub](https://github.com/zulip/zulip)
-and on [chat.zulip.org](https://zulip.com/developer-community),
+and on [chat.zulip.org](https://zulip.com/development-community),
 learning from our suggestions, [trying to solve their own obstacles and
 then asking well-formed questions](https://www.mattringel.com/2013/09/30/you-must-try-and-then-you-must-ask/),
 and developing and sharing project ideas and project proposals which
@@ -147,14 +147,14 @@ providing everyone the personal help they need, and maintains balance
 between stream discussion and documentation. Becoming familiar and
 comfortable with this rhythm will be helpful to you as you interact
 with other developers on
-[chat.zulip.org](https://zulip.com/developer-community). It is always
+[chat.zulip.org](https://zulip.com/development-community). It is always
 better (and Zulip’s strong preference) to ask questions and have
 conversation through a public stream rather than a private message or
 an email. This benefits you by giving you faster response times and
 the benefit of many minds, as well as benefiting the community as
 other contributors learn from reading the conversation.
 
-- Stick to the [community norms](https://zulip.com/developer-community/).
+- Stick to the [community norms](https://zulip.com/development-community/).
 - Read these three blog posts
   - [Try, Then Ask](https://www.mattringel.com/2013/09/30/you-must-try-and-then-you-must-ask/)
   - [We Aren’t Just Making Code, We’re Making History](https://www.harihareswara.net/sumana/2016/10/12/0)
@@ -193,7 +193,7 @@ part on who is a good fit for the needs of each student as well as
 technical expertise as well as who has available time during the
 summer. You can reach us via
 [#GSoC](https://chat.zulip.org/#narrow/stream/14-GSoC) on [the Zulip
-development community server](https://zulip.com/developer-community/),
+development community server](https://zulip.com/development-community/),
 (compose a new stream message with your name as the topic).
 
 Zulip operates under group mentorship. That means you should generally

--- a/docs/contributing/summer-with-zulip.md
+++ b/docs/contributing/summer-with-zulip.md
@@ -35,7 +35,7 @@ materials](https://developers.google.com/open-source/gsoc/resources/manual).
   the rest of the Zulip community. We recommend the following:
 
   - Daily checkins on #checkins in
-    [the Zulip development community](https://zulip.com/developer-community/); ideally
+    [the Zulip development community](https://zulip.com/development-community/); ideally
     at some time of day you can both be online, but when not
     possible, async is better than nothing!
 
@@ -57,7 +57,7 @@ materials](https://developers.google.com/open-source/gsoc/resources/manual).
 
   - If you need feedback from the community / decisions made, ask in the
     appropriate public stream in
-    [the Zulip development community](https://zulip.com/developer-community/). Often
+    [the Zulip development community](https://zulip.com/development-community/). Often
     someone can provide important context that you need to succeed in your project.
 
   - Communicate clearly, especially in public places! You'll get much more

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -283,7 +283,7 @@ expected.
 
 As with other installation methods, please visit [#provision
 help][provision-help] in the [Zulip development community
-server](https://zulip.com/developer-community/) if you need help.
+server](https://zulip.com/development-community/) if you need help.
 
 [provision-help]: https://chat.zulip.org/#narrow/stream/21-provision-help
 
@@ -301,7 +301,7 @@ likely only a few lines of changes to `tools/lib/provision.py` and
 `scripts/lib/setup-apt-repo` if you'd like to do it yourself and
 submit a pull request, or you can ask for help in
 [#development help](https://chat.zulip.org/#narrow/stream/49-development-help)
-in [the Zulip development community](https://zulip.com/developer-community/),
+in [the Zulip development community](https://zulip.com/development-community/),
 and a core team member can help guide you through adding support for the platform.
 
 [zulip-rtd-git-cloning]: ../git/cloning.html#step-1b-clone-to-your-machine

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -28,7 +28,7 @@ errors](#troubleshooting-and-common-errors). If that doesn't help,
 please visit [#provision
 help](https://chat.zulip.org/#narrow/stream/21-provision-help) in the
 [Zulip development community
-server](https://zulip.com/developer-community/) for real-time help or
+server](https://zulip.com/development-community/) for real-time help or
 [file an issue](https://github.com/zulip/zulip/issues).
 
 When reporting your issue, please include the following information:
@@ -306,7 +306,7 @@ documented in the
 [Troubleshooting and common errors](#troubleshooting-and-common-errors)
 section. If that doesn't help, please visit
 [#provision help](https://chat.zulip.org/#narrow/stream/21-provision-help)
-in the [Zulip development community server](https://zulip.com/developer-community/) for
+in the [Zulip development community server](https://zulip.com/development-community/) for
 real-time help.
 
 On Windows, you will see the message
@@ -449,7 +449,7 @@ After provisioning, you'll want to
 If you run into any trouble, [#provision
 help](https://chat.zulip.org/#narrow/stream/21-provision-help) in the
 [Zulip development community
-server](https://zulip.com/developer-community/) is a great place to ask for
+server](https://zulip.com/development-community/) is a great place to ask for
 help.
 
 #### Rebuilding the development environment
@@ -548,7 +548,7 @@ If these solutions aren't working for you or you encounter an issue not
 documented below, there are a few ways to get further help:
 
 - Ask in [#provision help](https://chat.zulip.org/#narrow/stream/21-provision-help)
-  in the [Zulip development community server](https://zulip.com/developer-community/).
+  in the [Zulip development community server](https://zulip.com/development-community/).
 - [File an issue](https://github.com/zulip/zulip/issues).
 
 When reporting your issue, please include the following information:

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Welcome! Zulip's documentation is split into four parts:
 
 Zulip has well over 150,000 words of documentation. If you can't find
 what you're looking for, please [let us
-know](https://zulip.com/developer-community/)! Further information on
+know](https://zulip.com/development-community/)! Further information on
 the Zulip project and its features can be found at
 <https://zulip.com>.
 

--- a/docs/overview/release-lifecycle.md
+++ b/docs/overview/release-lifecycle.md
@@ -179,7 +179,7 @@ do not have any of these priority labels.
 We welcome participation from our user community in influencing the
 Zulip roadmap. If a bug or missing feature is causing significant
 pain for you, we'd love to hear from you, either in
-[chat.zulip.org](https://zulip.com/developer-community/) or on the relevant
+[chat.zulip.org](https://zulip.com/development-community/) or on the relevant
 GitHub issue. Please an include an explanation of your use case: such
 details can be extremely helpful in designing appropriately general
 solutions, and also helps us identify cases where an existing solution
@@ -229,7 +229,7 @@ independently as needed.
 [electron]: https://www.electronjs.org/
 [upgrading-to-main]: ../production/upgrade-or-modify.html#upgrading-to-main
 [os-upgrade]: ../production/upgrade-or-modify.html#upgrading-the-operating-system
-[chat-zulip-org]: https://zulip.com/developer-community/
+[chat-zulip-org]: https://zulip.com/development-community/
 [fork-zulip]: ../production/upgrade-or-modify.html#modifying-zulip
 [zulip-server]: https://github.com/zulip/zulip
 [mobile-beta]: https://github.com/zulip/zulip-mobile#using-the-beta

--- a/docs/production/install-existing-server.md
+++ b/docs/production/install-existing-server.md
@@ -102,5 +102,5 @@ We don't provide a convenient way to uninstall a Zulip server.
 
 Most of the limitations are things we'd accept a pull request to fix;
 we welcome contributions to shrink this list of gotchas. Chat with us
-in the [chat.zulip.org community](https://zulip.com/developer-community/) if you're
+in the [chat.zulip.org community](https://zulip.com/development-community/) if you're
 interested in helping!

--- a/docs/production/install.md
+++ b/docs/production/install.md
@@ -178,6 +178,6 @@ out! Please provide details like the full traceback from the bottom
 of `/var/log/zulip/errors.log` in your report (ideally in a [code
 block][code-block]).
 
-[chat-zulip-org]: https://zulip.com/developer-community/
+[chat-zulip-org]: https://zulip.com/development-community/
 [production-help]: https://chat.zulip.org/#narrow/stream/31-production-help
 [code-block]: https://zulip.com/help/code-blocks

--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -199,7 +199,7 @@ installing Zulip with a dedicated database server.
   accounts) per (1M messages to public streams).
 
 - **Example:** When
-  [the Zulip development community](https://zulip.com/developer-community/) server
+  [the Zulip development community](https://zulip.com/development-community/) server
   had 12K user accounts (~300 daily actives) and 800K messages of
   history (400K to public streams), it was a default configuration
   single-server installation with 16GB of RAM, 4 cores (essentially

--- a/docs/production/security-model.md
+++ b/docs/production/security-model.md
@@ -4,7 +4,7 @@ This section attempts to document the Zulip security model. It likely
 does not cover every issue; if there are details you're curious about,
 please feel free to ask questions in [#production
 help](https://chat.zulip.org/#narrow/stream/31-production-help) on the
-[Zulip community server](https://zulip.com/developer-community/) (or if you
+[Zulip community server](https://zulip.com/development-community/) (or if you
 think you've found a security bug, please report it to
 security@zulip.com so we can do a responsible security
 announcement).

--- a/docs/production/settings.md
+++ b/docs/production/settings.md
@@ -33,7 +33,7 @@ to each new major release.
 
 Since Zulip's settings file is a Python script, there are a number of
 other things that one can configure that are not documented; ask in
-[the Zulip development community](https://zulip.com/developer-community/)
+[the Zulip development community](https://zulip.com/development-community/)
 if there's something you'd like to do but can't figure out how to.
 
 ## Specific settings

--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -188,7 +188,7 @@ If you need help and don't have a support contract, you can visit
 [#production
 help](https://chat.zulip.org/#narrow/stream/31-production-help) in the
 [Zulip development community
-server](https://zulip.com/developer-community/) for best-effort help.
+server](https://zulip.com/development-community/) for best-effort help.
 Please include the relevant error output from the above logs in a
 [Markdown code
 block](https://zulip.com/help/code-blocks)
@@ -590,7 +590,7 @@ modified version of Zulip, please be responsible about communicating
 that fact:
 
 - Ideally, you'd reproduce the issue in an unmodified version (e.g. in
-  [the Zulip development community](https://zulip.com/developer-community/) or on
+  [the Zulip development community](https://zulip.com/development-community/) or on
   [zulip.com](https://zulip.com)).
 - Where that is difficult or you think it's very unlikely your changes
   are related to the issue, just mention your changes in the issue report.

--- a/docs/subsystems/performance.md
+++ b/docs/subsystems/performance.md
@@ -34,7 +34,7 @@ of load profiles:
   etc. have large numbers of users, many of whom are idle. (Many of
   the others likely stopped by to ask a question, got it answered, and
   then didn't need the community again for the next year). Our own
-  [Zulip development community](https://zulip.com/developer-community/) is a good
+  [Zulip development community](https://zulip.com/development-community/) is a good
   example for this, with more than 15K total user accounts, of which
   only several hundred have logged in during the last few weeks.
   Zulip has many important optimizations, including [soft

--- a/docs/testing/linters.md
+++ b/docs/testing/linters.md
@@ -93,7 +93,7 @@ extreme cases, but often it can be a simple matter of writing your code
 in a slightly different style to appease the linter. If you have
 problems getting something to lint, you can submit an unfinished PR
 and ask the reviewer to help you work through the lint problem, or you
-can find other people in the [Zulip Community](https://zulip.com/developer-community/)
+can find other people in the [Zulip Community](https://zulip.com/development-community/)
 to help you.
 
 Also, bear in mind that 100% of the lint code is open source, so if you

--- a/docs/translating/translating.md
+++ b/docs/translating/translating.md
@@ -21,7 +21,7 @@ These are the steps you should follow if you want to help translate
 Zulip:
 
 1. Join [#translation][translation-stream] in the [Zulip development
-   community server](https://zulip.com/developer-community/), and say hello.
+   community server](https://zulip.com/development-community/), and say hello.
    That stream is also the right place for any questions, updates on your
    progress, reporting problematic strings, etc.
 
@@ -87,7 +87,7 @@ Some useful tips for your translating journey:
 
 - When in doubt, ask for context in
   [#translation](https://chat.zulip.org/#narrow/stream/58-translation) in
-  the [Zulip development community server](https://zulip.com/developer-community/).
+  the [Zulip development community server](https://zulip.com/development-community/).
 
 - If there are multiple possible translations for a term, search for it in
   the _Concordance_ tool (the button with a magnet in the top right corner).

--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -575,7 +575,7 @@ in. For example in this case of `mandatory_topics` it will lie in
 
 _If you're not sure in which section your feature belongs, it's
 better to discuss it in
-[the Zulip development community](https://zulip.com/developer-community/)
+[the Zulip development community](https://zulip.com/development-community/)
 before implementing it._
 
 Note that some settings, like `realm_msg_edit_limit_setting`,

--- a/templates/zerver/api/client-libraries.md
+++ b/templates/zerver/api/client-libraries.md
@@ -33,7 +33,7 @@ writing new ones.  If you actively maintain a Zulip language binding
 and would like it to be listed here (or would like to collaborate with
 us in making it an official library), post in [this
 topic][integrations-thread] in
-[the Zulip development community](https://zulip.com/developer-community/)
+[the Zulip development community](https://zulip.com/development-community/)
 or submit a pull request [updating this
 page](https://zulip.readthedocs.io/en/latest/documentation/api.html).
 

--- a/templates/zerver/api/running-bots.md
+++ b/templates/zerver/api/running-bots.md
@@ -12,7 +12,7 @@ https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots).
 You'll need:
 
 * An account in a Zulip organization
-  (e.g. [the Zulip development community](https://zulip.com/developer-community/),
+  (e.g. [the Zulip development community](https://zulip.com/development-community/),
   `<yourSubdomain>.zulipchat.com`, or a Zulip organization on your own
   [development](https://zulip.readthedocs.io/en/latest/development/overview.html) or
   [production](https://zulip.readthedocs.io/en/latest/production/install.html) server).

--- a/templates/zerver/emails/followup_day1.source.html
+++ b/templates/zerver/emails/followup_day1.source.html
@@ -50,6 +50,6 @@
 </p>
 
 <p>
-    {% trans %}PS: Follow us on <a href="https://twitter.com/zulip">Twitter</a>, star us on <a href="https://github.com/zulip/zulip">GitHub</a>, or chat with us live on the <a href="https://zulip.com/developer-community/">Zulip community server</a>!{% endtrans %}
+    {% trans %}PS: Follow us on <a href="https://twitter.com/zulip">Twitter</a>, star us on <a href="https://github.com/zulip/zulip">GitHub</a>, or chat with us live on the <a href="https://zulip.com/development-community/">Zulip community server</a>!{% endtrans %}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/followup_day1.txt
+++ b/templates/zerver/emails/followup_day1.txt
@@ -36,4 +36,4 @@
 {{ _("Cheers,") }}
 {{ _("Team Zulip") }}
 
-{% trans %}PS: Check us out on Twitter (@zulip), star us on GitHub (https://github.com/zulip/zulip), or chat with us live on the Zulip community server (https://zulip.com/developer-community/)!{% endtrans %}
+{% trans %}PS: Check us out on Twitter (@zulip), star us on GitHub (https://github.com/zulip/zulip), or chat with us live on the Zulip community server (https://zulip.com/development-community/)!{% endtrans %}

--- a/templates/zerver/for/communities.md
+++ b/templates/zerver/for/communities.md
@@ -117,7 +117,7 @@ Zulip’s topic-based threading model solves the problems described above:
 ## Try Zulip today!
 
 You can see Zulip in action in our own
-[Zulip development community](https://zulip.com/developer-community/), which sends
+[Zulip development community](https://zulip.com/development-community/), which sends
 thousands of messages a week. We often get feedback from contributors
 around the world that they love how responsive Zulip’s project leaders
 are in public Zulip conversations. We are able to achieve this despite

--- a/templates/zerver/help/contact-support.md
+++ b/templates/zerver/help/contact-support.md
@@ -26,7 +26,7 @@ We love hearing feedback! Please reach out if you have feedback,
 questions, or just want to brainstorm how to make Zulip work for your
 organization.
 
-[development-community]: https://zulip.com/developer-community/
+[development-community]: https://zulip.com/development-community/
 
 ## Billing and commercial questions
 


### PR DESCRIPTION
We recently changed /developer-community to /development-community.
Now that this change is in production, we can also migrate the
external links in our ReadTheDocs documentation.