### PR TITLE
Change compose close icon to font awesome (v4.7) icon 

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -228,24 +228,31 @@
 
     button {
         background: transparent;
-        font-size: 20px;
-        font-weight: bold;
-        line-height: 20px;
         opacity: 0.6;
-        border: 0;
-        padding: 0;
         margin-left: 4px;
-        vertical-align: unset;
+        border: 0;
 
         &:hover {
             opacity: 1;
         }
     }
+
+    #compose_close {
+        font-weight: lighter !important;
+        text-shadow: none;
+        font-size: 15px;
+    }
 }
 
-.collapse_composebox_button,
-#compose_close {
+.collapse_composebox_button {
     display: none;
+}
+
+.expand_composebox_button,
+.collapse_composebox_button {
+    font-size: 20px;
+    margin-top: -1px;
+    font-weight: bold;
 }
 
 .compose_invite_user,

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -53,7 +53,7 @@
             <div id="compose_top_right">
                 <button type="button" class="expand_composebox_button fa fa-angle-up" aria-label="{{t 'Expand compose' }}" tabindex=0 title="{{t 'Expand compose' }}"></button>
                 <button type="button" class="collapse_composebox_button fa fa-angle-down" aria-label="{{t 'Collapse compose' }}" tabindex=0 title="{{t 'Collapse compose' }}"></button>
-                <button type="button" class="close" id='compose_close' title="{{t 'Cancel compose' }} (Esc)">&times;</button>
+                <button type="button" class="close fa fa-remove" id='compose_close' title="{{t 'Cancel compose' }} (Esc)"></button>
             </div>
             <form id="send_message_form" action="/json/messages" method="post">
                 {{ csrf_input }}


### PR DESCRIPTION
Replaced the Compose close icon with font awesome icon as it is in other places.

This PR is for issue #20403 

Screenshots:

![Screenshot from 2021-12-10 16-12-27](https://user-images.githubusercontent.com/52635773/145561772-95937162-cc32-4158-ad19-aae16f11b009.png)

![Screenshot from 2021-12-10 16-12-41](https://user-images.githubusercontent.com/52635773/145561787-fe95f55b-b01f-44ce-8b73-8ce985c65be8.png)
