### PR TITLE
Fix edit and delete icon alignments in drafts menu.

### DIFF
--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -87,6 +87,8 @@
 
         &.active {
             outline: 2px solid hsl(215, 47%, 50%);
+            /* this offset ensures no gap between the blue box and the draft in active state */
+            outline-offset: -1px;
         }
 
         .message_row {
@@ -109,7 +111,7 @@
             display: inline-block;
             position: absolute;
             top: 9px;
-            right: -80px;
+            right: -103px;
             font-size: 0.9em;
 
             @media (width < $sm_min) {


### PR DESCRIPTION
Fixed the 'edit' and 'delete' buttons alignment in the draft menu. Also increased the draft's text width.
This PR is for the issue #20529 

Screenshots of the draft menu in various sizes:

![Screenshot from 2021-12-10 17-58-17](https://user-images.githubusercontent.com/52635773/145579310-cddb91ab-9a71-4eea-80bd-dd0bd31a7518.png)
![Screenshot from 2021-12-10 17-58-24](https://user-images.githubusercontent.com/52635773/145579314-21e382a8-bfd0-4f37-8c13-ec3205962b71.png)
![Screenshot from 2021-12-10 17-58-31](https://user-images.githubusercontent.com/52635773/145579321-f7ed32ef-d163-4dda-a65d-a34ababab0e1.png)
![Screenshot from 2021-12-10 17-59-08](https://user-images.githubusercontent.com/52635773/145579322-f1c827c0-7572-44e9-ad01-0243aa7a2cf6.png)
