### PR TITLE
tests: Ensure stream senders get a UserMessage row.

### DIFF
--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -115,8 +115,10 @@ def fetch_api_key() -> Dict[str, object]:
     ]
 )
 def iago_message_id() -> Dict[str, object]:
+    iago = helpers.example_user("iago")
+    helpers.subscribe(iago, "Denmark")
     return {
-        "message_id": helpers.send_stream_message(helpers.example_user("iago"), "Denmark"),
+        "message_id": helpers.send_stream_message(iago, "Denmark"),
     }
 
 

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -452,6 +452,7 @@ class TestDigestEmailMessages(ZulipTestCase):
         message_ids = []  # List[int]
         for sender_name in senders:
             sender = self.example_user(sender_name)
+            self.subscribe(sender, stream)
             content = f"some content for {stream} from {sender_name}"
             message_id = self.send_stream_message(sender, stream, content)
             message_ids.append(message_id)

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -573,8 +573,11 @@ class TestMissedMessages(ZulipTestCase):
     def _extra_context_in_missed_stream_messages_mention_two_senders(
         self, send_as_user: bool
     ) -> None:
+        cordelia = self.example_user("cordelia")
+        self.subscribe(cordelia, "Denmark")
+
         for i in range(0, 3):
-            self.send_stream_message(self.example_user("cordelia"), "Denmark", str(i))
+            self.send_stream_message(cordelia, "Denmark", str(i))
         msg_id = self.send_stream_message(
             self.example_user("othello"), "Denmark", "@**King Hamlet**"
         )
@@ -1213,15 +1216,17 @@ class TestMissedMessages(ZulipTestCase):
     def test_stream_mentions_multiple_people(self) -> None:
         """Subject should be stream name and topic as usual."""
         hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+
+        self.subscribe(cordelia, "Denmark")
+
         msg_id_1 = self.send_stream_message(
             self.example_user("iago"), "Denmark", "@**King Hamlet**"
         )
         msg_id_2 = self.send_stream_message(
             self.example_user("othello"), "Denmark", "@**King Hamlet**"
         )
-        msg_id_3 = self.send_stream_message(
-            self.example_user("cordelia"), "Denmark", "Regular message"
-        )
+        msg_id_3 = self.send_stream_message(cordelia, "Denmark", "Regular message")
 
         handle_missedmessage_emails(
             hamlet.id,

--- a/zerver/tests/test_embedded_bot_system.py
+++ b/zerver/tests/test_embedded_bot_system.py
@@ -59,6 +59,7 @@ class TestEmbeddedBotMessaging(ZulipTestCase):
 
     def test_message_to_embedded_bot_with_initialize(self) -> None:
         assert self.bot_profile is not None
+        self.subscribe(self.user_profile, "Denmark")
         with patch(
             "zulip_bots.bots.helloworld.helloworld.HelloWorldHandler.initialize", create=True
         ) as mock_initialize:

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -96,6 +96,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         realm = hamlet.realm
         stream_name = "Denmark"
 
+        self.subscribe(cordelia, stream_name)
         self.unsubscribe(hamlet, stream_name)
 
         queue_data = dict(

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -365,9 +365,7 @@ class PreviewTestCase(ZulipTestCase):
     def test_edit_message_history(self) -> None:
         user = self.example_user("hamlet")
         self.login_user(user)
-        msg_id = self.send_stream_message(
-            user, "Scotland", topic_name="editing", content="original"
-        )
+        msg_id = self.send_stream_message(user, "Denmark", topic_name="editing", content="original")
 
         url = "http://test.org/"
         self.create_mock_response(url)
@@ -448,7 +446,7 @@ class PreviewTestCase(ZulipTestCase):
         edited_url = "http://edited.org/"
         with mock_queue_publish("zerver.lib.actions.queue_json_publish") as patched:
             msg_id = self.send_stream_message(
-                user, "Scotland", topic_name="foo", content=original_url
+                user, "Denmark", topic_name="foo", content=original_url
             )
             patched.assert_called_once()
             queue = patched.call_args[0][0]
@@ -559,7 +557,7 @@ class PreviewTestCase(ZulipTestCase):
         self.login_user(user)
         url = "http://test.org/"
         with mock_queue_publish("zerver.lib.actions.queue_json_publish") as patched:
-            msg_id = self.send_stream_message(user, "Scotland", topic_name="foo", content=url)
+            msg_id = self.send_stream_message(user, "Denmark", topic_name="foo", content=url)
             patched.assert_called_once()
             queue = patched.call_args[0][0]
             self.assertEqual(queue, "embed_links")
@@ -663,7 +661,7 @@ class PreviewTestCase(ZulipTestCase):
         self.login_user(user)
         url = "http://test.org/audio.mp3"
         with mock_queue_publish("zerver.lib.actions.queue_json_publish") as patched:
-            msg_id = self.send_stream_message(user, "Scotland", topic_name="foo", content=url)
+            msg_id = self.send_stream_message(user, "Denmark", topic_name="foo", content=url)
             patched.assert_called_once()
             queue = patched.call_args[0][0]
             self.assertEqual(queue, "embed_links")
@@ -695,7 +693,7 @@ class PreviewTestCase(ZulipTestCase):
         self.login_user(user)
         url = "http://test.org/foo.html"
         with mock_queue_publish("zerver.lib.actions.queue_json_publish") as patched:
-            msg_id = self.send_stream_message(user, "Scotland", topic_name="foo", content=url)
+            msg_id = self.send_stream_message(user, "Denmark", topic_name="foo", content=url)
             patched.assert_called_once()
             queue = patched.call_args[0][0]
             self.assertEqual(queue, "embed_links")
@@ -730,7 +728,7 @@ class PreviewTestCase(ZulipTestCase):
         self.login_user(user)
         url = "http://test.org/foo.html"
         with mock_queue_publish("zerver.lib.actions.queue_json_publish") as patched:
-            msg_id = self.send_stream_message(user, "Scotland", topic_name="foo", content=url)
+            msg_id = self.send_stream_message(user, "Denmark", topic_name="foo", content=url)
             patched.assert_called_once()
             queue = patched.call_args[0][0]
             self.assertEqual(queue, "embed_links")
@@ -767,7 +765,7 @@ class PreviewTestCase(ZulipTestCase):
         self.login_user(user)
         url = "http://test.org/"
         with mock_queue_publish("zerver.lib.actions.queue_json_publish") as patched:
-            msg_id = self.send_stream_message(user, "Scotland", topic_name="foo", content=url)
+            msg_id = self.send_stream_message(user, "Denmark", topic_name="foo", content=url)
             patched.assert_called_once()
             queue = patched.call_args[0][0]
             self.assertEqual(queue, "embed_links")

--- a/zerver/tests/test_message_dict.py
+++ b/zerver/tests/test_message_dict.py
@@ -110,7 +110,7 @@ class MessageDictTest(ZulipTestCase):
             self.login_user(hamlet)
             msg_id = self.send_stream_message(
                 hamlet,
-                "Scotland",
+                "Denmark",
                 topic_name="editing",
                 content="before edit",
             )
@@ -262,6 +262,7 @@ class MessageDictTest(ZulipTestCase):
             stream_name = "Denmark"
             if not Stream.objects.filter(realm=realm, name=stream_name).exists():
                 self.make_stream(stream_name, realm)
+            self.subscribe(sender, stream_name)
             msg_id = self.send_stream_message(sender, "Denmark", "hello world", topic_name, realm)
             return Message.objects.get(id=msg_id)
 
@@ -522,6 +523,8 @@ class TestMessageForIdsDisplayRecipientFetching(ZulipTestCase):
 
     def test_display_recipient_stream(self) -> None:
         cordelia = self.example_user("cordelia")
+        self.subscribe(cordelia, "Denmark")
+
         message_ids = [
             self.send_stream_message(cordelia, "Verona", content="test"),
             self.send_stream_message(cordelia, "Denmark", content="test"),
@@ -574,6 +577,10 @@ class TestMessageForIdsDisplayRecipientFetching(ZulipTestCase):
         cordelia = self.example_user("cordelia")
         othello = self.example_user("othello")
         iago = self.example_user("iago")
+
+        self.subscribe(cordelia, "Denmark")
+        self.subscribe(hamlet, "Scotland")
+
         message_ids = [
             self.send_huddle_message(hamlet, [cordelia, othello], "test"),
             self.send_stream_message(cordelia, "Verona", content="test"),

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -112,7 +112,7 @@ class EditMessagePayloadTest(EditMessageTestCase):
     def test_edit_message_no_changes(self) -> None:
         self.login("hamlet")
         msg_id = self.send_stream_message(
-            self.example_user("hamlet"), "Scotland", topic_name="editing", content="before edit"
+            self.example_user("hamlet"), "Denmark", topic_name="editing", content="before edit"
         )
         result = self.client_patch(
             "/json/messages/" + str(msg_id),
@@ -158,7 +158,7 @@ class EditMessagePayloadTest(EditMessageTestCase):
 
     def test_propagate_invalid(self) -> None:
         self.login("hamlet")
-        id1 = self.send_stream_message(self.example_user("hamlet"), "Scotland", topic_name="topic1")
+        id1 = self.send_stream_message(self.example_user("hamlet"), "Denmark", topic_name="topic1")
 
         result = self.client_patch(
             "/json/messages/" + str(id1),
@@ -183,7 +183,7 @@ class EditMessagePayloadTest(EditMessageTestCase):
     def test_edit_message_no_topic(self) -> None:
         self.login("hamlet")
         msg_id = self.send_stream_message(
-            self.example_user("hamlet"), "Scotland", topic_name="editing", content="before edit"
+            self.example_user("hamlet"), "Denmark", topic_name="editing", content="before edit"
         )
         result = self.client_patch(
             "/json/messages/" + str(msg_id),
@@ -221,7 +221,7 @@ class EditMessagePayloadTest(EditMessageTestCase):
         self.login("hamlet")
         msg_id = self.send_stream_message(
             self.example_user("hamlet"),
-            "Scotland",
+            "Denmark",
             topic_name="editing",
             content="/poll Games?\nYES\nNO",
         )
@@ -277,7 +277,7 @@ class EditMessageTest(EditMessageTestCase):
         the cache against the database"""
         self.login("hamlet")
         msg_id = self.send_stream_message(
-            self.example_user("hamlet"), "Scotland", topic_name="editing", content="before edit"
+            self.example_user("hamlet"), "Denmark", topic_name="editing", content="before edit"
         )
         result = self.client_patch(
             "/json/messages/" + str(msg_id),
@@ -333,6 +333,7 @@ class EditMessageTest(EditMessageTestCase):
         )
 
         non_web_public_stream = self.make_stream("non-web-public-stream")
+        self.subscribe(user_profile, non_web_public_stream.name)
         non_web_public_stream_msg_id = self.send_stream_message(
             user_profile, non_web_public_stream.name, content="non web-public message"
         )
@@ -438,7 +439,7 @@ class EditMessageTest(EditMessageTestCase):
     def test_edit_message_no_permission(self) -> None:
         self.login("hamlet")
         msg_id = self.send_stream_message(
-            self.example_user("iago"), "Scotland", topic_name="editing", content="before edit"
+            self.example_user("iago"), "Denmark", topic_name="editing", content="before edit"
         )
         result = self.client_patch(
             "/json/messages/" + str(msg_id),
@@ -452,7 +453,7 @@ class EditMessageTest(EditMessageTestCase):
     def test_edit_message_no_content(self) -> None:
         self.login("hamlet")
         msg_id = self.send_stream_message(
-            self.example_user("hamlet"), "Scotland", topic_name="editing", content="before edit"
+            self.example_user("hamlet"), "Denmark", topic_name="editing", content="before edit"
         )
         result = self.client_patch(
             "/json/messages/" + str(msg_id),
@@ -507,7 +508,7 @@ class EditMessageTest(EditMessageTestCase):
         # Single-line edit
         msg_id_1 = self.send_stream_message(
             self.example_user("hamlet"),
-            "Scotland",
+            "Denmark",
             topic_name="editing",
             content="content before edit",
         )
@@ -545,7 +546,7 @@ class EditMessageTest(EditMessageTestCase):
         # Edits on new lines
         msg_id_2 = self.send_stream_message(
             self.example_user("hamlet"),
-            "Scotland",
+            "Denmark",
             topic_name="editing",
             content="content before edit, line 1\n\ncontent before edit, line 3",
         )
@@ -596,7 +597,7 @@ class EditMessageTest(EditMessageTestCase):
         self.login("hamlet")
         msg_id = self.send_stream_message(
             self.example_user("hamlet"),
-            "Scotland",
+            "Denmark",
             topic_name="editing",
             content="We will edit this to render as empty.",
         )
@@ -630,7 +631,7 @@ class EditMessageTest(EditMessageTestCase):
         self.login("hamlet")
         msg_id_1 = self.send_stream_message(
             self.example_user("hamlet"),
-            "Scotland",
+            "Denmark",
             topic_name="editing",
             content="Here is a link to [zulip](www.zulip.org).",
         )
@@ -673,7 +674,7 @@ class EditMessageTest(EditMessageTestCase):
 
         msg_id = self.send_stream_message(
             self.example_user("hamlet"),
-            "Scotland",
+            "Denmark",
             topic_name="editing",
             content="This message has not been edited.",
         )
@@ -690,11 +691,11 @@ class EditMessageTest(EditMessageTestCase):
         cordelia = self.example_user("cordelia")
 
         self.login_user(hamlet)
-        self.subscribe(hamlet, "Scotland")
-        self.subscribe(cordelia, "Scotland")
+        self.subscribe(hamlet, "Denmark")
+        self.subscribe(cordelia, "Denmark")
 
         msg_id = self.send_stream_message(
-            hamlet, "Scotland", content="@**Cordelia, Lear's daughter**"
+            hamlet, "Denmark", content="@**Cordelia, Lear's daughter**"
         )
 
         user_info = get_user_info_for_message_updates(msg_id)
@@ -711,7 +712,7 @@ class EditMessageTest(EditMessageTestCase):
         self.login("hamlet")
         hamlet = self.example_user("hamlet")
         msg_id = self.send_stream_message(
-            self.example_user("hamlet"), "Scotland", topic_name="topic 1", content="content 1"
+            self.example_user("hamlet"), "Denmark", topic_name="topic 1", content="content 1"
         )
         result = self.client_patch(
             "/json/messages/" + str(msg_id),
@@ -900,7 +901,7 @@ class EditMessageTest(EditMessageTestCase):
         self.login("iago")
         # send a message in the past
         id_ = self.send_stream_message(
-            self.example_user("iago"), "Scotland", content="content", topic_name="topic"
+            self.example_user("iago"), "Denmark", content="content", topic_name="topic"
         )
         message = Message.objects.get(id=id_)
         message.date_sent = message.date_sent - datetime.timedelta(seconds=180)
@@ -977,7 +978,7 @@ class EditMessageTest(EditMessageTestCase):
 
         # send a message in the past
         id_ = self.send_stream_message(
-            self.example_user("hamlet"), "Scotland", content="content", topic_name="topic"
+            self.example_user("hamlet"), "Denmark", content="content", topic_name="topic"
         )
         message = Message.objects.get(id=id_)
         message.date_sent = message.date_sent - datetime.timedelta(seconds=180)
@@ -985,7 +986,7 @@ class EditMessageTest(EditMessageTestCase):
 
         # Guest user must be subscribed to the stream to access the message.
         polonius = self.example_user("polonius")
-        self.subscribe(polonius, "Scotland")
+        self.subscribe(polonius, "Denmark")
 
         # any user can edit the topic of a message
         set_message_editing_params(True, 0, Realm.POLICY_EVERYONE)
@@ -1179,6 +1180,7 @@ class EditMessageTest(EditMessageTestCase):
         stream_name = "Macbeth"
         self.make_stream(stream_name, history_public_to_subscribers=True)
         self.subscribe(cordelia, stream_name)
+        self.subscribe(shiva, stream_name)
         message_id = self.send_stream_message(cordelia, stream_name, "Hello everyone")
 
         realm = cordelia.realm
@@ -1225,11 +1227,11 @@ class EditMessageTest(EditMessageTestCase):
 
     def test_topic_edit_history_saved_in_all_message(self) -> None:
         self.login("hamlet")
-        id1 = self.send_stream_message(self.example_user("hamlet"), "Scotland", topic_name="topic1")
-        id2 = self.send_stream_message(self.example_user("iago"), "Scotland", topic_name="topic1")
-        id3 = self.send_stream_message(self.example_user("iago"), "Rome", topic_name="topic1")
-        id4 = self.send_stream_message(self.example_user("hamlet"), "Scotland", topic_name="topic2")
-        id5 = self.send_stream_message(self.example_user("iago"), "Scotland", topic_name="topic1")
+        id1 = self.send_stream_message(self.example_user("hamlet"), "Denmark", topic_name="topic1")
+        id2 = self.send_stream_message(self.example_user("iago"), "Denmark", topic_name="topic1")
+        id3 = self.send_stream_message(self.example_user("iago"), "Verona", topic_name="topic1")
+        id4 = self.send_stream_message(self.example_user("hamlet"), "Denmark", topic_name="topic2")
+        id5 = self.send_stream_message(self.example_user("iago"), "Denmark", topic_name="topic1")
 
         def verify_edit_history(new_topic: str, len_edit_history: int) -> None:
             for msg_id in [id1, id2, id5]:
@@ -1276,13 +1278,9 @@ class EditMessageTest(EditMessageTestCase):
 
     def test_topic_and_content_edit(self) -> None:
         self.login("hamlet")
-        id1 = self.send_stream_message(
-            self.example_user("hamlet"), "Scotland", "message 1", "topic"
-        )
-        id2 = self.send_stream_message(self.example_user("iago"), "Scotland", "message 2", "topic")
-        id3 = self.send_stream_message(
-            self.example_user("hamlet"), "Scotland", "message 3", "topic"
-        )
+        id1 = self.send_stream_message(self.example_user("hamlet"), "Denmark", "message 1", "topic")
+        id2 = self.send_stream_message(self.example_user("iago"), "Denmark", "message 2", "topic")
+        id3 = self.send_stream_message(self.example_user("hamlet"), "Denmark", "message 3", "topic")
 
         new_topic = "edited"
         result = self.client_patch(
@@ -1318,11 +1316,11 @@ class EditMessageTest(EditMessageTestCase):
 
     def test_propagate_topic_forward(self) -> None:
         self.login("hamlet")
-        id1 = self.send_stream_message(self.example_user("hamlet"), "Scotland", topic_name="topic1")
-        id2 = self.send_stream_message(self.example_user("iago"), "Scotland", topic_name="topic1")
-        id3 = self.send_stream_message(self.example_user("iago"), "Rome", topic_name="topic1")
-        id4 = self.send_stream_message(self.example_user("hamlet"), "Scotland", topic_name="topic2")
-        id5 = self.send_stream_message(self.example_user("iago"), "Scotland", topic_name="topic1")
+        id1 = self.send_stream_message(self.example_user("hamlet"), "Denmark", topic_name="topic1")
+        id2 = self.send_stream_message(self.example_user("iago"), "Denmark", topic_name="topic1")
+        id3 = self.send_stream_message(self.example_user("iago"), "Verona", topic_name="topic1")
+        id4 = self.send_stream_message(self.example_user("hamlet"), "Denmark", topic_name="topic2")
+        id5 = self.send_stream_message(self.example_user("iago"), "Denmark", topic_name="topic1")
 
         result = self.client_patch(
             "/json/messages/" + str(id1),
@@ -1342,12 +1340,12 @@ class EditMessageTest(EditMessageTestCase):
 
     def test_propagate_all_topics(self) -> None:
         self.login("hamlet")
-        id1 = self.send_stream_message(self.example_user("hamlet"), "Scotland", topic_name="topic1")
-        id2 = self.send_stream_message(self.example_user("hamlet"), "Scotland", topic_name="topic1")
-        id3 = self.send_stream_message(self.example_user("iago"), "Rome", topic_name="topic1")
-        id4 = self.send_stream_message(self.example_user("hamlet"), "Scotland", topic_name="topic2")
-        id5 = self.send_stream_message(self.example_user("iago"), "Scotland", topic_name="topic1")
-        id6 = self.send_stream_message(self.example_user("iago"), "Scotland", topic_name="topic3")
+        id1 = self.send_stream_message(self.example_user("hamlet"), "Denmark", topic_name="topic1")
+        id2 = self.send_stream_message(self.example_user("hamlet"), "Denmark", topic_name="topic1")
+        id3 = self.send_stream_message(self.example_user("iago"), "Verona", topic_name="topic1")
+        id4 = self.send_stream_message(self.example_user("hamlet"), "Denmark", topic_name="topic2")
+        id5 = self.send_stream_message(self.example_user("iago"), "Denmark", topic_name="topic1")
+        id6 = self.send_stream_message(self.example_user("iago"), "Denmark", topic_name="topic3")
 
         result = self.client_patch(
             "/json/messages/" + str(id2),
@@ -1368,10 +1366,10 @@ class EditMessageTest(EditMessageTestCase):
 
     def test_propagate_all_topics_with_different_uppercase_letters(self) -> None:
         self.login("hamlet")
-        id1 = self.send_stream_message(self.example_user("hamlet"), "Scotland", topic_name="topic1")
-        id2 = self.send_stream_message(self.example_user("hamlet"), "Scotland", topic_name="Topic1")
-        id3 = self.send_stream_message(self.example_user("iago"), "Rome", topic_name="topiC1")
-        id4 = self.send_stream_message(self.example_user("iago"), "Scotland", topic_name="toPic1")
+        id1 = self.send_stream_message(self.example_user("hamlet"), "Denmark", topic_name="topic1")
+        id2 = self.send_stream_message(self.example_user("hamlet"), "Denmark", topic_name="Topic1")
+        id3 = self.send_stream_message(self.example_user("iago"), "Verona", topic_name="topiC1")
+        id4 = self.send_stream_message(self.example_user("iago"), "Denmark", topic_name="toPic1")
 
         result = self.client_patch(
             "/json/messages/" + str(id2),
@@ -2144,16 +2142,18 @@ class EditMessageTest(EditMessageTestCase):
     def test_mark_topic_as_resolved(self) -> None:
         self.login("iago")
         admin_user = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+
         # Set the user's translation language to German to test that
         # it is overridden by the realm's default language.
         admin_user.default_language = "de"
         admin_user.save()
         stream = self.make_stream("new")
         self.subscribe(admin_user, stream.name)
+        self.subscribe(hamlet, stream.name)
+
         original_topic = "topic 1"
-        id1 = self.send_stream_message(
-            self.example_user("hamlet"), "new", topic_name=original_topic
-        )
+        id1 = self.send_stream_message(hamlet, "new", topic_name=original_topic)
         id2 = self.send_stream_message(admin_user, "new", topic_name=original_topic)
 
         # Check that we don't incorrectly send "unresolve topic"
@@ -2250,7 +2250,7 @@ class DeleteMessageTest(ZulipTestCase):
     def test_delete_message_invalid_request_format(self) -> None:
         self.login("iago")
         hamlet = self.example_user("hamlet")
-        msg_id = self.send_stream_message(hamlet, "Scotland")
+        msg_id = self.send_stream_message(hamlet, "Denmark")
         result = self.client_delete(f"/json/messages/{msg_id + 1}", {"message_id": msg_id})
         self.assert_json_error(result, "Invalid message(s)")
         result = self.client_delete(f"/json/messages/{msg_id}")
@@ -2291,7 +2291,7 @@ class DeleteMessageTest(ZulipTestCase):
         set_message_deleting_params(Realm.POLICY_ADMINS_ONLY, "unlimited")
         hamlet = self.example_user("hamlet")
         self.login_user(hamlet)
-        msg_id = self.send_stream_message(hamlet, "Scotland")
+        msg_id = self.send_stream_message(hamlet, "Denmark")
 
         result = test_delete_message_by_owner(msg_id=msg_id)
         self.assert_json_error(result, "You don't have permission to delete this message")
@@ -2305,7 +2305,7 @@ class DeleteMessageTest(ZulipTestCase):
         # Test if message deleting is allowed.
         # Test if time limit is None(no limit).
         set_message_deleting_params(Realm.POLICY_EVERYONE, "unlimited")
-        msg_id = self.send_stream_message(hamlet, "Scotland")
+        msg_id = self.send_stream_message(hamlet, "Denmark")
         message = Message.objects.get(id=msg_id)
         message.date_sent = message.date_sent - datetime.timedelta(seconds=600)
         message.save()
@@ -2318,12 +2318,12 @@ class DeleteMessageTest(ZulipTestCase):
 
         # Test if time limit is non-zero.
         set_message_deleting_params(Realm.POLICY_EVERYONE, 240)
-        msg_id_1 = self.send_stream_message(hamlet, "Scotland")
+        msg_id_1 = self.send_stream_message(hamlet, "Denmark")
         message = Message.objects.get(id=msg_id_1)
         message.date_sent = message.date_sent - datetime.timedelta(seconds=120)
         message.save()
 
-        msg_id_2 = self.send_stream_message(hamlet, "Scotland")
+        msg_id_2 = self.send_stream_message(hamlet, "Denmark")
         message = Message.objects.get(id=msg_id_2)
         message.date_sent = message.date_sent - datetime.timedelta(seconds=360)
         message.save()
@@ -2341,7 +2341,7 @@ class DeleteMessageTest(ZulipTestCase):
         self.assert_json_success(result)
 
         # Test multiple delete requests with no latency issues
-        msg_id = self.send_stream_message(hamlet, "Scotland")
+        msg_id = self.send_stream_message(hamlet, "Denmark")
         result = test_delete_message_by_owner(msg_id=msg_id)
         self.assert_json_success(result)
         result = test_delete_message_by_owner(msg_id=msg_id)
@@ -2423,7 +2423,7 @@ class DeleteMessageTest(ZulipTestCase):
         into a problem.
         """
         hamlet = self.example_user("hamlet")
-        self.send_stream_message(hamlet, "Scotland")
+        self.send_stream_message(hamlet, "Denmark")
         message = self.get_last_message()
 
         with self.tornado_redirected_to_list([], expected_num_events=1):

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -2054,10 +2054,10 @@ class GetOldMessagesTest(ZulipTestCase):
 
         # We need to send a message here to ensure that we actually
         # have a stream message in this narrow view.
-        self.send_stream_message(hamlet, "Scotland")
-        self.send_stream_message(othello, "Scotland")
+        self.send_stream_message(hamlet, "Denmark")
+        self.send_stream_message(othello, "Denmark")
         self.send_personal_message(othello, hamlet)
-        self.send_stream_message(iago, "Scotland")
+        self.send_stream_message(iago, "Denmark")
 
         test_operands = [othello.email, othello.id]
         for operand in test_operands:
@@ -3012,6 +3012,7 @@ class GetOldMessagesTest(ZulipTestCase):
         othello = self.example_user("othello")
 
         self.make_stream("England")
+        self.subscribe(cordelia, "England")
 
         # Send a few messages that Hamlet won't have UserMessage rows for.
         unsub_message_id = self.send_stream_message(cordelia, "England")

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -344,12 +344,12 @@ class UnreadCountTests(ZulipTestCase):
 class FixUnreadTests(ZulipTestCase):
     def test_fix_unreads(self) -> None:
         user = self.example_user("hamlet")
+        othello = self.example_user("othello")
         realm = get_realm("zulip")
 
         def send_message(stream_name: str, topic_name: str) -> int:
-            msg_id = self.send_stream_message(
-                self.example_user("othello"), stream_name, topic_name=topic_name
-            )
+            self.subscribe(othello, stream_name)
+            msg_id = self.send_stream_message(othello, stream_name, topic_name=topic_name)
             um = UserMessage.objects.get(user_profile=user, message_id=msg_id)
             return um.id
 
@@ -484,8 +484,11 @@ class PushNotificationMarkReadFlowsTest(ZulipTestCase):
         mock_push_notifications.return_value = True
         self.login("hamlet")
         user_profile = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
         stream = self.subscribe(user_profile, "test_stream")
+        self.subscribe(cordelia, "test_stream")
         second_stream = self.subscribe(user_profile, "second_stream")
+        self.subscribe(cordelia, "second_stream")
 
         property_name = "push_notifications"
         result = self.api_post(
@@ -509,14 +512,12 @@ class PushNotificationMarkReadFlowsTest(ZulipTestCase):
         self.assert_json_success(result)
         self.assertEqual(self.get_mobile_push_notification_ids(user_profile), [])
 
-        message_id = self.send_stream_message(
-            self.example_user("cordelia"), "test_stream", "hello", "test_topic"
-        )
+        message_id = self.send_stream_message(cordelia, "test_stream", "hello", "test_topic")
         second_message_id = self.send_stream_message(
-            self.example_user("cordelia"), "test_stream", "hello", "other_topic"
+            cordelia, "test_stream", "hello", "other_topic"
         )
         third_message_id = self.send_stream_message(
-            self.example_user("cordelia"), "second_stream", "hello", "test_topic"
+            cordelia, "second_stream", "hello", "test_topic"
         )
 
         self.assertEqual(
@@ -826,10 +827,13 @@ class GetUnreadMsgsTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         othello = self.example_user("othello")
 
+        self.subscribe(sender, "Denmark")
+
         pm1_message_id = self.send_personal_message(sender, user_profile, "hello1")
         pm2_message_id = self.send_personal_message(sender, user_profile, "hello2")
 
         muted_stream = self.subscribe(user_profile, "Muted stream")
+        self.subscribe(sender, muted_stream.name)
         self.mute_stream(user_profile, muted_stream)
         self.mute_topic(user_profile, "Denmark", "muted-topic")
 

--- a/zerver/tests/test_message_topics.py
+++ b/zerver/tests/test_message_topics.py
@@ -173,11 +173,12 @@ class TopicHistoryTest(ZulipTestCase):
         self.assert_json_error(result, "Invalid stream id")
 
     def test_get_topics_web_public_stream_web_public_request(self) -> None:
+        iago = self.example_user("iago")
         stream = self.make_stream("web-public-steram", is_web_public=True)
+        self.subscribe(iago, stream.name)
+
         for i in range(3):
-            self.send_stream_message(
-                self.example_user("iago"), stream.name, topic_name="topic" + str(i)
-            )
+            self.send_stream_message(iago, stream.name, topic_name="topic" + str(i))
 
         endpoint = f"/json/users/me/{stream.id}/topics"
         result = self.client_get(endpoint)

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1307,6 +1307,7 @@ class HandlePushNotificationTest(PushNotificationTest):
         not have received the message in the first place"""
         self.make_stream("public_stream")
         sender = self.example_user("iago")
+        self.subscribe(sender, "public_stream")
         message_id = self.send_stream_message(sender, "public_stream", "test")
         missed_message = {"message_id": message_id}
         with self.assertLogs("zerver.lib.push_notifications", level="ERROR") as logger, mock.patch(
@@ -1328,7 +1329,9 @@ class HandlePushNotificationTest(PushNotificationTest):
         self.setup_apns_tokens()
         self.setup_gcm_tokens()
         self.make_stream("public_stream")
+        sender = self.example_user("iago")
         self.subscribe(self.user_profile, "public_stream")
+        self.subscribe(sender, "public_stream")
         logger_string = "zulip.soft_deactivation"
         with self.assertLogs(logger_string, level="INFO") as info_logs:
             do_soft_deactivate_users([self.user_profile])
@@ -1339,7 +1342,6 @@ class HandlePushNotificationTest(PushNotificationTest):
                 f"INFO:{logger_string}:Soft-deactivated batch of 1 users; 0 remain to process",
             ],
         )
-        sender = self.example_user("iago")
         message_id = self.send_stream_message(sender, "public_stream", "test")
         missed_message = {
             "message_id": message_id,

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -1109,7 +1109,7 @@ class ReactionAPIEventTest(EmojiReactionBase):
         into a problem.
         """
         hamlet = self.example_user("hamlet")
-        self.send_stream_message(hamlet, "Scotland")
+        self.send_stream_message(hamlet, "Denmark")
         message = self.get_last_message()
         reaction = Reaction(
             user_profile=hamlet,

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -1004,7 +1004,7 @@ class TestRestoreStreamMessages(ArchiveMessagesTestingBase):
         hamlet = self.example_user("hamlet")
 
         realm = get_realm("zulip")
-        stream_name = "Denmark"
+        stream_name = "Verona"
         stream = get_stream(stream_name, realm)
 
         message_ids_to_archive_manually = [
@@ -1052,7 +1052,7 @@ class TestDoDeleteMessages(ZulipTestCase):
     def test_do_delete_messages_multiple(self) -> None:
         realm = get_realm("zulip")
         cordelia = self.example_user("cordelia")
-        message_ids = [self.send_stream_message(cordelia, "Denmark", str(i)) for i in range(0, 10)]
+        message_ids = [self.send_stream_message(cordelia, "Verona", str(i)) for i in range(0, 10)]
         messages = Message.objects.filter(id__in=message_ids)
 
         with queries_captured() as queries:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -843,6 +843,7 @@ class LoginTest(ZulipTestCase):
         reset_emails_in_zulip_realm()
 
         realm = get_realm("zulip")
+        hamlet = self.example_user("hamlet")
         stream_names = [f"stream_{i}" for i in range(40)]
         for stream_name in stream_names:
             stream = self.make_stream(stream_name, realm=realm)
@@ -852,9 +853,10 @@ class LoginTest(ZulipTestCase):
         # unread.  This prevents a bug where this test would start
         # failing the test database was generated more than
         # ONBOARDING_RECENT_TIMEDELTA ago.
+        self.subscribe(hamlet, "stream_0")
         self.send_stream_message(
-            self.example_user("hamlet"),
-            stream_names[0],
+            hamlet,
+            "stream_0",
             topic_name="test topic",
             content="test message",
         )

--- a/zerver/tests/test_submessage.py
+++ b/zerver/tests/test_submessage.py
@@ -193,7 +193,7 @@ class TestBasics(ZulipTestCase):
         into a problem.
         """
         hamlet = self.example_user("hamlet")
-        message_id = self.send_stream_message(hamlet, "Scotland")
+        message_id = self.send_stream_message(hamlet, "Denmark")
 
         with self.tornado_redirected_to_list([], expected_num_events=1):
             with mock.patch("zerver.lib.actions.send_event") as m:

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -91,6 +91,12 @@ from zerver.views.streams import compose_views
 
 
 class TestMiscStuff(ZulipTestCase):
+    def test_test_helper(self) -> None:
+        cordelia = self.example_user("cordelia")
+        s = self.subscribed_stream_name_list(cordelia)
+        self.assertIn("* Verona", s)
+        self.assertNotIn("* Denmark", s)
+
     def test_empty_results(self) -> None:
         # These are essentially just tests to ensure line
         # coverage for codepaths that won't ever really be

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -410,7 +410,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         body = f"Illegal message ...[zulip.txt](http://{host}/user_uploads/" + d1_path_id + ")"
         cordelia = self.example_user("cordelia")
         with self.assertLogs(level="WARNING") as warn_log:
-            self.send_stream_message(cordelia, "Denmark", body, "test")
+            self.send_stream_message(cordelia, "Verona", body, "test")
         self.assertTrue(
             f"WARNING:root:User {cordelia.id} tried to share upload" in warn_log.output[0]
             and "but lacks permission" in warn_log.output[0]
@@ -428,13 +428,14 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         # Then, have that new recipient user publish it.
         body = f"Third message ...[zulip.txt](http://{host}/user_uploads/" + d1_path_id + ")"
-        self.send_stream_message(self.example_user("othello"), "Denmark", body, "test")
+        self.send_stream_message(self.example_user("othello"), "Verona", body, "test")
         self.assertEqual(Attachment.objects.get(path_id=d1_path_id).messages.count(), 3)
         self.assertTrue(Attachment.objects.get(path_id=d1_path_id).is_realm_public)
         self.assertFalse(Attachment.objects.get(path_id=d1_path_id).is_web_public)
 
         # Finally send to Rome, the web-public stream, and confirm it's now web-public
         body = f"Fourth message ...[zulip.txt](http://{host}/user_uploads/" + d1_path_id + ")"
+        self.subscribe(self.example_user("othello"), "Rome")
         self.send_stream_message(self.example_user("othello"), "Rome", body, "test")
         self.assertEqual(Attachment.objects.get(path_id=d1_path_id).messages.count(), 4)
         self.assertTrue(Attachment.objects.get(path_id=d1_path_id).is_realm_public)


### PR DESCRIPTION
We now complain if a test author sends a stream message
that does not result in the sender getting a
UserMessage row for the message.

This is basically 100% equivalent to complaining that
the author failed to subscribe the sender to the stream
as part of the test setup, as far as I can tell, so the
AssertionError instructs the author to subscribe the
sender to the stream.

We exempt bots from this check, although it is
plausible we should only exempt the system bots like
the notification bot.

I considered auto-subscribing the sender to the stream,
but that can be a little more expensive than the
current check, and we generally want test setup to be
explicit.

If there is some legitimate way than a subscribed human
sender can't get a UserMessage, then we probably want
an explicit test for that, or we may want to change the
backend to just write a UserMessage row in that
hypothetical situation.

For most tests, including almost all the ones fixed
here, the author just wants their test setup to
realistically reflect normal operation, and often devs
may not realize that Cordelia is not subscribed to
Denmark or not realize that Hamlet is not subscribed to
Scotland.

Some of us don't remember our Shakespeare from high
school, and our stream subscriptions don't even
necessarily reflect which countries the Bard placed his
characters in.

There may also be some legitimate use case where an
author wants to simulate sending a message to an
unsubscribed stream, but for those edge cases, they can
always set allow_unsubscribed_sender to True.

