### PR TITLE
Change stream settings ui

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -60,7 +60,7 @@ export function get_retention_policy_text_for_subscription_type(sub) {
         (sub.message_retention_days === null ||
             sub.message_retention_days === settings_config.retain_message_forever)
     ) {
-        return undefined;
+        return $t({defaultMessage: "Messages in this stream will be retained forever."});
     }
 
     // Forever for this stream, overriding the organization default

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -30,6 +30,7 @@ import * as ui from "./ui";
 import * as ui_report from "./ui_report";
 import {user_settings} from "./user_settings";
 import * as util from "./util";
+import * as settings_org from "./settings_org";
 
 export let toggler;
 export let select_tab = "personal_settings";
@@ -519,6 +520,8 @@ export function initialize() {
         stream_settings_ui.hide_or_disable_stream_privacy_options_if_required(
             $(".changeable-settings"),
         );
+
+        $("#manage_streams_container").find(".discard-button").show();
     });
 
     $("#manage_streams_container").on("click", "#save-settings", (e) => {
@@ -538,6 +541,25 @@ export function initialize() {
         });
 
         $(".changeable-settings").replaceWith(general_settings);
+    });
+
+    $("#manage_streams_container").on("change input", "input, select, textarea", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        // const $subsection = $(e.target).closest(".org-subsection-parent");
+        
+        // $subsection.find(".save-button").show();
+        // const properties_elements = get_subsection_property_elements($subsection);
+        // const show_change_process_button = properties_elements.some((elem) =>
+        //     check_property_changed(elem, for_realm_default_settings),
+        // );
+    
+        const $save_btn_controls = $("#manage_streams_container").find(".save-button-controls");
+        // const button_state = show_change_process_button ? "unsaved" : "discarded";
+        settings_org.change_save_button_state($save_btn_controls, "unsaved");
+
+        return undefined;
     });
 
     $("#manage_streams_container").on("click", "#cancel-settings-change", (e) => {

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -1078,16 +1078,12 @@ export function update_stream_privacy_choices(policy) {
     if (!overlays.streams_open()) {
         return;
     }
-    const change_privacy_modal_opened = $("#stream_privacy_modal").is(":visible");
     const stream_creation_form_opened = $("#stream-creation").is(":visible");
 
-    if (!change_privacy_modal_opened && !stream_creation_form_opened) {
+    if (!stream_creation_form_opened) {
         return;
     }
-    let $container = $("#stream-creation");
-    if (change_privacy_modal_opened) {
-        $container = $("#stream_privacy_modal");
-    }
+    const $container = $("#stream-creation");
 
     if (policy === "create_private_stream_policy") {
         update_private_stream_privacy_option_state($container);

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -897,6 +897,7 @@ h4.user_group_setting_subsection_title {
     }
 
     .subscription-type {
+        margin-top: -10px;
         margin-bottom: 10px;
 
         .subscription-type-text {
@@ -905,6 +906,10 @@ h4.user_group_setting_subsection_title {
 
         b {
             font-weight: 600;
+        }
+
+        h4 {
+            font-weight: normal;
         }
     }
 
@@ -934,6 +939,10 @@ h4.user_group_setting_subsection_title {
 
         &.show {
             display: block;
+        }
+
+        h3 {
+            font-weight: 600;
         }
     }
 

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -913,6 +913,67 @@ h4.user_group_setting_subsection_title {
         }
     }
 
+    .save-button-controls {
+        float: right
+    }
+
+    .save-discard-widget-button {
+        border-radius: 5px;
+        border: 1px solid hsl(0, 0%, 80%);
+        padding: 3px 14px 4px 11px;
+        text-decoration: none;
+        color: hsl(0, 0%, 47%);
+        min-width: 80px;
+        /* Limit the height of the button */
+        line-height: 1.2;
+        vertical-align: text-bottom;
+
+        &:hover,
+        &:focus {
+            background-color: hsl(0, 0%, 100%);
+            border: 1px solid hsl(0, 0%, 61%);
+            color: hsl(0, 0%, 18%);
+
+            .save-discard-widget-button-icon {
+                color: hsl(0, 0%, 47%);
+            }
+        }
+
+        &.primary {
+            background-color: hsl(156, 30%, 50%);
+            color: hsl(0, 0%, 100%);
+            border: 1px solid hsl(155, 30%, 50%);
+
+            &:hover,
+            &:focus {
+                background-color: hsl(166, 35%, 57%);
+                border: 1px solid hsl(166, 35%, 57%);
+            }
+
+            .save-discard-widget-button-icon {
+                font-weight: lighter;
+                color: hsl(0, 0%, 100%);
+            }
+
+            &.saving {
+                background-color: hsl(156, 14%, 40%);
+                border-color: hsl(156, 14%, 40%);
+            }
+        }
+
+        .save-discard-widget-button-icon {
+            vertical-align: middle;
+            margin-right: 3px;
+            font-size: 15px;
+            font-weight: 500;
+        }
+
+        .save-discard-widget-button-text {
+            vertical-align: middle;
+            line-height: 1;
+        }
+    }
+
     .hash::after {
         position: relative;
         content: "#";

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -839,6 +839,24 @@ h4.user_group_setting_subsection_title {
             vertical-align: top;
             margin: -5px 0 0;
         }
+
+        .change_name_and_description {
+            margin-top: -35px;
+
+            label {
+                font-size: 15px;
+                font-weight: 600;
+            }
+        }
+
+        #change_stream_name {
+            margin-bottom: 10px;
+            width: 70%;
+        }
+
+        #change_stream_description {
+            resize: vertical;
+        }
     }
 
     .group-description-wrapper,
@@ -928,6 +946,11 @@ h4.user_group_setting_subsection_title {
     .loading_indicator_text {
         font-weight: 400;
         line-height: 20px;
+    }
+
+    #save-settings {
+        color: hsl(156, 39%, 54%);
+        border: 1px solid hsl(156, 39%, 54%);
     }
 
     .subsection-parent .input-group {

--- a/static/templates/stream_settings/change_general_stream_settings.hbs
+++ b/static/templates/stream_settings/change_general_stream_settings.hbs
@@ -5,14 +5,7 @@
     </div>
     <div class="stream-header">
         <div class="stream_change_property_info alert-notification"></div>
-        <div class="button-group">
-            <button id="cancel-settings-change" class="button rounded small btn-warning tippy-zulip-tooltip" data-tippy-content="{{t 'Discard changes' }}">
-                <i class="fa fa-times" aria-hidden="true"></i>
-            </button>
-            <button id="save-settings" class="button rounded small btn-warning tippy-zulip-tooltip" data-tippy-content="{{t 'Save changes' }}">
-                <i class="fa fa-check" aria-hidden="true"></i>
-            </button>
-        </div>
+        {{> ../settings/settings_save_discard_widget section_name="stream_settings" }}
         <div class="change_name_and_description">
             <div class="stream_setting_subsection_header">
                 <h3 class="stream_setting_subsection_title">

--- a/static/templates/stream_settings/change_general_stream_settings.hbs
+++ b/static/templates/stream_settings/change_general_stream_settings.hbs
@@ -33,18 +33,79 @@
             {{t "Stream permissions" }}
         </h3>
         <div class="stream_permission_change_info alert-notification"></div>
-        <div class="button-group">
-            <button class="change-stream-privacy button rounded small btn-warning" title="{{t 'Change stream permissions' }}" {{#unless can_change_stream_permissions}}style="display:none"{{/unless}}>
-                <i class="fa fa-pencil" aria-hidden="true"></i>
-            </button>
-        </div>
     </div>
     <div class="subscription-type">
-        <div class="subscription-type-text">
-            {{> stream_permission_description
-              stream_post_policy_values=../stream_post_policy_values
-              message_retention_text=../message_retention_text}}
+        <div class="input-group stream-privacy-values">
+            <div class="alert stream-privacy-status"></div>
+            <h4>{{t 'Who can access the stream?'}}
+                {{> ../help_link_widget link="/help/stream-permissions" }}
+            </h4>
+            {{#each ../stream_privacy_policy_values}}
+                <div class="radio-input-parent">
+                    <label class="radio">
+                        <input type="radio" name="privacy" value="{{ this.code }}" {{#if (eq this.code ../../stream_privacy_policy) }}checked{{/if}} />
+                        <b>{{ this.name }}:</b> {{ this.description }}
+                    </label>
+                </div>
+            {{/each}}
         </div>
+
+        <div class="input-group">
+            <h4>{{t 'Who can post to the stream?'}}
+                {{> ../help_link_widget link="/help/stream-sending-policy" }}
+            </h4>
+            {{#each ../stream_post_policy_values}}
+                <div class="radio-input-parent">
+                    <label class="radio">
+                        <input type="radio" name="stream-post-policy" value="{{ this.code }}" {{#if (eq this.code ../stream_post_policy) }}checked{{/if}} />
+                        {{ this.description }}
+                    </label>
+                </div>
+            {{/each}}
+        </div>
+
+        <div>
+            <h4>{{t "Message retention period" }}
+                {{> ../help_link_widget link="/help/message-retention-policy" }}
+            </h4>
+
+            {{> ../settings/upgrade_tip_widget
+              zulip_plan_is_not_limited=../zulip_plan_is_not_limited}}
+
+            <div class="radio-input-parent">
+                <label class="radio">
+                    <input type="radio" name="message_retention" class="retention_period" value="realm_default" {{#if (eq "realm_default" ../stream_message_retention_days) }}checked{{/if}}
+                      {{#unless ../is_owner}}disabled{{/unless}}/>
+                    Use organization level settings {{../org_level_message_retention_setting}}
+                </label>
+            </div>
+            <div class="radio-input-parent">
+                <label class="radio">
+                    <input type="radio" name="message_retention" class="retention_period" value="unlimited" {{#if (eq "unlimited" ../stream_message_retention_days) }}checked{{/if}}
+                      {{#unless ../is_owner}}disabled{{/unless}}/>
+                    Retain forever
+                </label>
+            </div>
+            <div class="radio-input-parent">
+                <label class="radio">
+                    <input type="radio" name="message_retention" class="retention_period" value="retain_for_period" {{#if (eq "retain_for_period" ../stream_message_retention_days) }}checked{{/if}}
+                      {{#unless ../is_owner}}disabled{{/unless}}/>
+                    Retain for N days after posting
+                </label>
+            </div>
+
+            <div class="dependent-inline-block stream-message-retention-days-input">
+                <label class="inline-block">
+                    {{t 'N' }}:
+                </label>
+                <input type="text" autocomplete="off"
+                  name="stream-message-retention-days"
+                  class="stream-message-retention-days"
+                  value="{{#if (eq "retain_for_period" ../stream_message_retention_days)}}{{../retention_days}}{{/if}}"
+                  {{#if ../disable_message_retention_setting}}disabled{{/if}}/>
+            </div>
+        </div>
+
     </div>
 </div>
 {{/with}}

--- a/static/templates/stream_settings/change_general_stream_settings.hbs
+++ b/static/templates/stream_settings/change_general_stream_settings.hbs
@@ -4,23 +4,29 @@
         {{> stream_settings_tip}}
     </div>
     <div class="stream-header">
-        {{> stream_privacy_icon
-          invite_only=invite_only
-          is_web_public=is_web_public }}
-        <div class="stream-name">
-            <span class="sub-stream-name" title="{{name}}">{{name}}</span>
-        </div>
         <div class="stream_change_property_info alert-notification"></div>
         <div class="button-group">
-            <button id="change_settings" class="button rounded small btn-warning tippy-zulip-tooltip" {{#unless can_change_stream_permissions}}style="display:none"{{/unless}} data-tippy-content="{{t 'Change stream settings' }}">
-                <i class="fa fa-pencil" aria-hidden="true"></i>
+            <button id="cancel-settings-change" class="button rounded small btn-warning tippy-zulip-tooltip" data-tippy-content="{{t 'Discard changes' }}">
+                <i class="fa fa-times" aria-hidden="true"></i>
+            </button>
+            <button id="save-settings" class="button rounded small btn-warning tippy-zulip-tooltip" data-tippy-content="{{t 'Save changes' }}">
+                <i class="fa fa-check" aria-hidden="true"></i>
             </button>
         </div>
-    </div>
-    <div class="stream-description">
-        {{> stream_description
-          rendered_description=rendered_description
-          }}
+        <div class="change_name_and_description">
+            <div class="stream_setting_subsection_header">
+                <h3 class="stream_setting_subsection_title">
+                    {{t "Stream name" }}
+                </h3>
+            </div>
+            <input type="text" id="change_stream_name" value="{{ name }}" />
+            <div class="stream_setting_subsection_header">
+                <h3 class="stream_setting_subsection_title">
+                    {{t "Stream description" }}
+                </h3>
+            </div>
+            <textarea id="change_stream_description" maxlength="1000">{{ rendered_description }}</textarea>
+        </div>
     </div>
     <div class="stream_setting_subsection_header">
         <h3 class="stream_setting_subsection_title">

--- a/static/templates/stream_settings/general_stream_settings.hbs
+++ b/static/templates/stream_settings/general_stream_settings.hbs
@@ -27,11 +27,6 @@
             {{t "Stream permissions" }}
         </h3>
         <div class="stream_permission_change_info alert-notification"></div>
-        <div class="button-group">
-            <button class="change-stream-privacy button rounded small btn-warning" title="{{t 'Change stream permissions' }}" {{#unless can_change_stream_permissions}}style="display:none"{{/unless}}>
-                <i class="fa fa-pencil" aria-hidden="true"></i>
-            </button>
-        </div>
     </div>
     <div class="subscription-type">
         <div class="subscription-type-text">

--- a/static/templates/stream_settings/general_stream_settings.hbs
+++ b/static/templates/stream_settings/general_stream_settings.hbs
@@ -1,0 +1,44 @@
+{{#with sub}}
+<div class="changeable-settings">
+    <div class="stream-settings-tip-container">
+        {{> stream_settings_tip}}
+    </div>
+    <div class="stream-header">
+        {{> stream_privacy_icon
+          invite_only=invite_only
+          is_web_public=is_web_public }}
+        <div class="stream-name">
+            <span class="sub-stream-name" title="{{name}}">{{name}}</span>
+        </div>
+        <div class="stream_change_property_info alert-notification"></div>
+        <div class="button-group" {{#unless can_change_name_description}}style="display:none"{{/unless}}>
+            <button id="open_stream_info_modal" class="button rounded small btn-warning" title="{{t 'Change stream info' }}">
+                <i class="fa fa-pencil" aria-hidden="true"></i>
+            </button>
+        </div>
+    </div>
+    <div class="stream-description">
+        {{> stream_description
+          rendered_description=rendered_description
+          }}
+    </div>
+    <div class="stream_setting_subsection_header">
+        <h3 class="stream_setting_subsection_title">
+            {{t "Stream permissions" }}
+        </h3>
+        <div class="stream_permission_change_info alert-notification"></div>
+        <div class="button-group">
+            <button class="change-stream-privacy button rounded small btn-warning" title="{{t 'Change stream permissions' }}" {{#unless can_change_stream_permissions}}style="display:none"{{/unless}}>
+                <i class="fa fa-pencil" aria-hidden="true"></i>
+            </button>
+        </div>
+    </div>
+    <div class="subscription-type">
+        <div class="subscription-type-text">
+            {{> stream_permission_description
+              stream_post_policy_values=../stream_post_policy_values
+              message_retention_text=../message_retention_text}}
+        </div>
+    </div>
+</div>
+{{/with}}

--- a/static/templates/stream_settings/stream_permission_description.hbs
+++ b/static/templates/stream_settings/stream_permission_description.hbs
@@ -1,3 +1,7 @@
+
+<h4>{{t 'Who can access the stream?'}}
+    {{> ../help_link_widget link="/help/stream-permissions" }}
+</h4>
 <ul>
     {{#if invite_only}}
     <li>
@@ -24,6 +28,11 @@
         {{/tr}}
     </li>
     {{/if}}
+</ul>
+<h4>{{t 'Who can post to the stream?'}}
+    {{> ../help_link_widget link="/help/stream-sending-policy" }}
+</h4>
+<ul>
     <li>
         {{#if (eq stream_post_policy stream_post_policy_values.admins.code)}}
         {{t 'Only organization administrators can post.'}}
@@ -35,9 +44,14 @@
         {{t 'All stream subscribers can post.'}}
         {{/if}}
     </li>
-    {{#if message_retention_text}}
+</ul>
+{{#if message_retention_text}}
+<h4>{{t "Message retention for stream" }}
+    {{> ../help_link_widget link="/help/message-retention-policy" }}
+</h4>
+<ul>
     <li>
         {{message_retention_text}}
     </li>
-    {{/if}}
 </ul>
+{{/if}}

--- a/static/templates/stream_settings/stream_settings.hbs
+++ b/static/templates/stream_settings/stream_settings.hbs
@@ -22,48 +22,7 @@
     <div class="inner-box">
 
         <div class="general_settings stream_section">
-            {{#with sub}}
-            <div class="stream-settings-tip-container">
-                {{> stream_settings_tip}}
-            </div>
-            <div class="stream-header">
-                {{> stream_privacy_icon
-                  invite_only=invite_only
-                  is_web_public=is_web_public }}
-                <div class="stream-name">
-                    <span class="sub-stream-name" title="{{name}}">{{name}}</span>
-                </div>
-                <div class="stream_change_property_info alert-notification"></div>
-                <div class="button-group" {{#unless can_change_name_description}}style="display:none"{{/unless}}>
-                    <button id="open_stream_info_modal" class="button rounded small btn-warning tippy-zulip-tooltip" data-tippy-content="{{t 'Change stream info' }}">
-                        <i class="fa fa-pencil" aria-hidden="true"></i>
-                    </button>
-                </div>
-            </div>
-            <div class="stream-description">
-                {{> stream_description
-                  rendered_description=rendered_description
-                  }}
-            </div>
-            <div class="stream_setting_subsection_header">
-                <h3 class="stream_setting_subsection_title">
-                    {{t "Stream permissions" }}
-                </h3>
-                <div class="stream_permission_change_info alert-notification"></div>
-                <div class="button-group">
-                    <button class="change-stream-privacy button rounded small btn-warning tippy-zulip-tooltip" data-tippy-content="{{t 'Change stream permissions' }}" {{#unless can_change_stream_permissions}}style="display:none"{{/unless}}>
-                        <i class="fa fa-pencil" aria-hidden="true"></i>
-                    </button>
-                </div>
-            </div>
-            <div class="subscription-type">
-                <div class="subscription-type-text">
-                    {{> stream_permission_description
-                      stream_post_policy_values=../stream_post_policy_values
-                      message_retention_text=../message_retention_text}}
-                </div>
-            </div>
-            {{/with}}
+            {{> general_stream_settings}}
             <div class="stream-email-box" {{#unless sub.email_address}}style="display: none;"{{/unless}}>
                 <h3 class="stream_setting_subsection_title">
                     {{t "Email address" }}


### PR DESCRIPTION
Resolves https://github.com/zulip/zulip/issues/19519

This redesigns the stream settings UI and allows the user to edit the stream name, stream description and privacy settings in-place.

How it looks while viewing the stream settings:

![tmp](https://user-images.githubusercontent.com/74348920/189642368-18022682-fc2d-43b6-af14-12543a064ad3.png)

How it looks while editing the settings:

![tmp2](https://user-images.githubusercontent.com/74348920/189642417-9a325746-15fc-48e0-a497-81faf97b5fb4.png)


