### PR TITLE
puppet: Upgrade to Grafana 8.3.2, for CVE-2021-43813.

### DIFF
--- a/puppet/zulip_ops/manifests/profile/grafana.pp
+++ b/puppet/zulip_ops/manifests/profile/grafana.pp
@@ -4,14 +4,14 @@ class zulip_ops::profile::grafana {
   include zulip_ops::profile::base
   include zulip::supervisor
 
-  $version = '8.3.1'
+  $version = '8.3.2'
   $dir = "/srv/zulip-grafana-${version}/"
   $bin = "${dir}bin/grafana-server"
 
   zulip::external_dep { 'grafana':
     version        => $version,
     url            => "https://dl.grafana.com/oss/release/grafana-${version}.linux-${::architecture}.tar.gz",
-    sha256         => '097d85eb2ca6982becea8eccb72855ac11abf43e894af6a46d64bbc77922339b',
+    sha256         => '100f92c50aa612f213052c55594e58b68b7da641b751c5f144003d704730d189',
     tarball_prefix => "grafana-${version}/",
     bin            => 'bin/grafana-server',
   }


### PR DESCRIPTION
**Testing plan:** Deployed.