### PR TITLE
setup-certbot: Reinstate nginx reload after installation.

### DIFF
--- a/scripts/setup/setup-certbot
+++ b/scripts/setup/setup-certbot
@@ -125,4 +125,12 @@ if [ -z "$skip_symlink" ]; then
     symlink_with_backup "$CERT_DIR"/fullchain.pem /etc/ssl/certs/zulip.combined-chain.crt
 fi
 
+# "certbot certonly" does not run deploy hooks, so reload nginx if
+# need be to pick up the new certificate.
+case "$method" in
+    webroot)
+        service nginx reload
+        ;;
+esac
+
 echo "Certbot SSL certificate configuration succeeded."


### PR DESCRIPTION
If nginx was already installed, and we're using the webroot method of
initializing certbot, nginx needs to be reloaded.  Hooks in
`/etc/letsencrypt/renewal-hooks/deploy/` do not run during initial
`certbot certonly`, so an explicit reload is required.

**Testing plan:** New install wit self-signed, transitioned to certbot.
