### PR TITLE
streams: Add notifications for permission policy changes.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -150,6 +150,7 @@ from zerver.lib.streams import (
     check_stream_access_based_on_stream_post_policy,
     create_stream_if_needed,
     get_default_value_for_history_public_to_subscribers,
+    get_stream_permission_policy_name,
     get_web_public_streams_queryset,
     render_stream_description,
     send_stream_creation_event,
@@ -5007,13 +5008,45 @@ def do_change_can_create_users(user_profile: UserProfile, value: bool) -> None:
     user_profile.save(update_fields=["can_create_users"])
 
 
+def send_change_stream_permission_notification(
+    stream: Stream,
+    *,
+    old_policy_name: str,
+    new_policy_name: str,
+    acting_user: UserProfile,
+) -> None:
+    sender = get_system_bot(settings.NOTIFICATION_BOT, acting_user.realm_id)
+    user_mention = silent_mention_syntax_for_user(acting_user)
+
+    with override_language(stream.realm.default_language):
+        notification_string = _(
+            "{user} changed the [access permissions](/help/stream-permissions) "
+            "for this stream from **{old_policy}** to **{new_policy}**."
+        )
+        notification_string = notification_string.format(
+            user=user_mention,
+            old_policy=old_policy_name,
+            new_policy=new_policy_name,
+        )
+        internal_send_stream_message(
+            sender, stream, Realm.STREAM_EVENTS_NOTIFICATION_TOPIC, notification_string
+        )
+
+
 def do_change_stream_permission(
     stream: Stream,
     *,
     invite_only: Optional[bool] = None,
     history_public_to_subscribers: Optional[bool] = None,
     is_web_public: Optional[bool] = None,
+    acting_user: UserProfile,
 ) -> None:
+    old_policy_name = get_stream_permission_policy_name(
+        invite_only=stream.invite_only,
+        history_public_to_subscribers=stream.history_public_to_subscribers,
+        is_web_public=stream.is_web_public,
+    )
+
     # A note on these assertions: It's possible we'd be better off
     # making all callers of this function pass the full set of
     # parameters, rather than having default values.  Doing so would
@@ -5042,6 +5075,12 @@ def do_change_stream_permission(
 
     stream.save(update_fields=["invite_only", "history_public_to_subscribers", "is_web_public"])
 
+    new_policy_name = get_stream_permission_policy_name(
+        invite_only=stream.invite_only,
+        history_public_to_subscribers=stream.history_public_to_subscribers,
+        is_web_public=stream.is_web_public,
+    )
+
     event = dict(
         op="update",
         type="stream",
@@ -5053,6 +5092,12 @@ def do_change_stream_permission(
         name=stream.name,
     )
     send_event(stream.realm, event, can_access_stream_user_ids(stream))
+    send_change_stream_permission_notification(
+        stream,
+        old_policy_name=old_policy_name,
+        new_policy_name=new_policy_name,
+        acting_user=acting_user,
+    )
 
 
 def send_change_stream_post_policy_notification(

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5230,11 +5230,11 @@ def send_change_stream_description_notification(
     with override_language(stream.realm.default_language):
         notification_string = _(
             "{user} changed the description for this stream.\n\n"
-            "Old description:\n"
+            "* **Old description:**\n"
             "``` quote\n"
             "{old_description}\n"
             "```\n"
-            "New description:\n"
+            "* **New description:**\n"
             "``` quote\n"
             "{new_description}\n"
             "```"

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -57,6 +57,26 @@ class StreamDict(TypedDict, total=False):
     message_retention_days: Optional[int]
 
 
+def get_stream_permission_policy_name(
+    *,
+    invite_only: Optional[bool] = None,
+    history_public_to_subscribers: Optional[bool] = None,
+    is_web_public: Optional[bool] = None,
+) -> str:
+    policy_name = None
+    for permission, permission_dict in Stream.PERMISSION_POLICIES.items():
+        if (
+            permission_dict["invite_only"] == invite_only
+            and permission_dict["history_public_to_subscribers"] == history_public_to_subscribers
+            and permission_dict["is_web_public"] == is_web_public
+        ):
+            policy_name = permission_dict["policy_name"]
+            break
+
+    assert policy_name is not None
+    return policy_name
+
+
 def get_default_value_for_history_public_to_subscribers(
     realm: Realm,
     invite_only: bool,

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -2239,6 +2239,41 @@ class Stream(models.Model):
     # Foreign key to the Recipient object for STREAM type messages to this stream.
     recipient = models.ForeignKey(Recipient, null=True, on_delete=models.SET_NULL)
 
+    # Various permission policy configurations
+    PERMISSION_POLICIES: Dict[str, Dict[str, Any]] = {
+        "web_public": {
+            "invite_only": False,
+            "history_public_to_subscribers": True,
+            "is_web_public": True,
+            "policy_name": gettext_lazy("Web public"),
+        },
+        "public": {
+            "invite_only": False,
+            "history_public_to_subscribers": True,
+            "is_web_public": False,
+            "policy_name": gettext_lazy("Public"),
+        },
+        "private_shared_history": {
+            "invite_only": True,
+            "history_public_to_subscribers": True,
+            "is_web_public": False,
+            "policy_name": gettext_lazy("Private, shared history"),
+        },
+        "private_protected_history": {
+            "invite_only": True,
+            "history_public_to_subscribers": False,
+            "is_web_public": False,
+            "policy_name": gettext_lazy("Private, protected history"),
+        },
+        # Public streams with protected history are currently only
+        # available in Zephyr realms
+        "public_protected_history": {
+            "invite_only": False,
+            "history_public_to_subscribers": False,
+            "is_web_public": False,
+            "policy_name": gettext_lazy("Public, protected history"),
+        },
+    }
     invite_only: Optional[bool] = models.BooleanField(null=True, default=False)
     history_public_to_subscribers: bool = models.BooleanField(default=False)
 

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -128,7 +128,7 @@ def add_emoji_to_message() -> Dict[str, object]:
 
     # The message ID here is hardcoded based on the corresponding value
     # for the example message IDs we use in zulip.yaml.
-    message_id = 44
+    message_id = 46
     emoji_name = "octopus"
     emoji_code = "1f419"
     reaction_type = "unicode_emoji"

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -9,7 +9,7 @@ from django.test import override_settings
 from zulip_bots.custom_exceptions import ConfigValidationError
 
 from zerver.lib.actions import (
-    do_change_stream_invite_only,
+    do_change_stream_permission,
     do_deactivate_user,
     do_set_realm_property,
 )
@@ -420,7 +420,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         user_profile = self.example_user("hamlet")
         stream = get_stream("Denmark", user_profile.realm)
         self.subscribe(user_profile, stream.name)
-        do_change_stream_invite_only(stream, True)
+        do_change_stream_permission(stream, invite_only=True)
 
         self.assert_num_bots_equal(0)
         events: List[Mapping[str, Any]] = []
@@ -464,7 +464,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         realm = self.example_user("hamlet").realm
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user("hamlet"), "Denmark")
-        do_change_stream_invite_only(stream, True)
+        do_change_stream_permission(stream, invite_only=True)
 
         bot_info = {
             "full_name": "The Bot of Hamlet",
@@ -492,7 +492,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.login("hamlet")
         user_profile = self.example_user("hamlet")
         stream = self.subscribe(user_profile, "Denmark")
-        do_change_stream_invite_only(stream, True)
+        do_change_stream_permission(stream, invite_only=True)
 
         self.assert_num_bots_equal(0)
         events: List[Mapping[str, Any]] = []
@@ -536,7 +536,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         realm = self.example_user("hamlet").realm
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user("hamlet"), "Denmark")
-        do_change_stream_invite_only(stream, True)
+        do_change_stream_permission(stream, invite_only=True)
 
         self.assert_num_bots_equal(0)
         bot_info = {
@@ -1132,7 +1132,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.login("hamlet")
         user_profile = self.example_user("hamlet")
         stream = self.subscribe(user_profile, "Denmark")
-        do_change_stream_invite_only(stream, True)
+        do_change_stream_permission(stream, invite_only=True)
 
         bot_info = {
             "full_name": "The Bot of Hamlet",
@@ -1158,7 +1158,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         realm = self.example_user("hamlet").realm
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user("hamlet"), "Denmark")
-        do_change_stream_invite_only(stream, True)
+        do_change_stream_permission(stream, invite_only=True)
 
         bot_info = {
             "full_name": "The Bot of Hamlet",
@@ -1239,7 +1239,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.login("hamlet")
         user_profile = self.example_user("hamlet")
         stream = self.subscribe(user_profile, "Denmark")
-        do_change_stream_invite_only(stream, True)
+        do_change_stream_permission(stream, invite_only=True)
 
         bot_info = {
             "full_name": "The Bot of Hamlet",
@@ -1264,7 +1264,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         realm = self.example_user("hamlet").realm
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user("hamlet"), "Denmark")
-        do_change_stream_invite_only(stream, True)
+        do_change_stream_permission(stream, invite_only=True)
 
         bot_info = {
             "full_name": "The Bot of Hamlet",

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -420,7 +420,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         user_profile = self.example_user("hamlet")
         stream = get_stream("Denmark", user_profile.realm)
         self.subscribe(user_profile, stream.name)
-        do_change_stream_permission(stream, invite_only=True)
+        do_change_stream_permission(stream, invite_only=True, acting_user=user_profile)
 
         self.assert_num_bots_equal(0)
         events: List[Mapping[str, Any]] = []
@@ -464,7 +464,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         realm = self.example_user("hamlet").realm
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user("hamlet"), "Denmark")
-        do_change_stream_permission(stream, invite_only=True)
+        do_change_stream_permission(
+            stream, invite_only=True, acting_user=self.example_user("hamlet")
+        )
 
         bot_info = {
             "full_name": "The Bot of Hamlet",
@@ -492,7 +494,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.login("hamlet")
         user_profile = self.example_user("hamlet")
         stream = self.subscribe(user_profile, "Denmark")
-        do_change_stream_permission(stream, invite_only=True)
+        do_change_stream_permission(stream, invite_only=True, acting_user=user_profile)
 
         self.assert_num_bots_equal(0)
         events: List[Mapping[str, Any]] = []
@@ -536,7 +538,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         realm = self.example_user("hamlet").realm
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user("hamlet"), "Denmark")
-        do_change_stream_permission(stream, invite_only=True)
+        do_change_stream_permission(
+            stream, invite_only=True, acting_user=self.example_user("hamlet")
+        )
 
         self.assert_num_bots_equal(0)
         bot_info = {
@@ -1132,7 +1136,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.login("hamlet")
         user_profile = self.example_user("hamlet")
         stream = self.subscribe(user_profile, "Denmark")
-        do_change_stream_permission(stream, invite_only=True)
+        do_change_stream_permission(stream, invite_only=True, acting_user=user_profile)
 
         bot_info = {
             "full_name": "The Bot of Hamlet",
@@ -1158,7 +1162,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         realm = self.example_user("hamlet").realm
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user("hamlet"), "Denmark")
-        do_change_stream_permission(stream, invite_only=True)
+        do_change_stream_permission(
+            stream, invite_only=True, acting_user=self.example_user("hamlet")
+        )
 
         bot_info = {
             "full_name": "The Bot of Hamlet",
@@ -1239,7 +1245,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.login("hamlet")
         user_profile = self.example_user("hamlet")
         stream = self.subscribe(user_profile, "Denmark")
-        do_change_stream_permission(stream, invite_only=True)
+        do_change_stream_permission(stream, invite_only=True, acting_user=user_profile)
 
         bot_info = {
             "full_name": "The Bot of Hamlet",
@@ -1264,7 +1270,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         realm = self.example_user("hamlet").realm
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user("hamlet"), "Denmark")
-        do_change_stream_permission(stream, invite_only=True)
+        do_change_stream_permission(
+            stream, invite_only=True, acting_user=self.example_user("hamlet")
+        )
 
         bot_info = {
             "full_name": "The Bot of Hamlet",

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2578,17 +2578,27 @@ class SubscribeActionTest(BaseAction):
 
         # Update stream privacy - make stream web public
         action = lambda: do_change_stream_permission(
-            stream, invite_only=False, history_public_to_subscribers=True, is_web_public=True
+            stream,
+            invite_only=False,
+            history_public_to_subscribers=True,
+            is_web_public=True,
+            acting_user=self.example_user("hamlet"),
         )
-        events = self.verify_action(action, include_subscribers=include_subscribers)
+        events = self.verify_action(action, include_subscribers=include_subscribers, num_events=2)
         check_stream_update("events[0]", events[0])
+        check_message("events[1]", events[1])
 
         # Update stream privacy - make stream private
         action = lambda: do_change_stream_permission(
-            stream, invite_only=True, history_public_to_subscribers=True, is_web_public=False
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=True,
+            is_web_public=False,
+            acting_user=self.example_user("hamlet"),
         )
-        events = self.verify_action(action, include_subscribers=include_subscribers)
+        events = self.verify_action(action, include_subscribers=include_subscribers, num_events=2)
         check_stream_update("events[0]", events[0])
+        check_message("events[1]", events[1])
 
         # Update stream stream_post_policy property
         action = lambda: do_change_stream_post_policy(

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -5,7 +5,7 @@ import orjson
 from django.db import connection
 from django.http import HttpResponse
 
-from zerver.lib.actions import do_change_stream_invite_only
+from zerver.lib.actions import do_change_stream_permission
 from zerver.lib.fix_unreads import fix, fix_unsubscribed
 from zerver.lib.message import (
     MessageDict,
@@ -1264,12 +1264,12 @@ class MessageAccessTests(ZulipTestCase):
 
         # Guest user can access messages of subscribed private streams if
         # history is public to subscribers
-        do_change_stream_invite_only(stream, True, history_public_to_subscribers=True)
+        do_change_stream_permission(stream, invite_only=True, history_public_to_subscribers=True)
         result = self.change_star(message_id)
         self.assert_json_success(result)
 
         # With history not public to subscribers, they can still see new messages
-        do_change_stream_invite_only(stream, True, history_public_to_subscribers=False)
+        do_change_stream_permission(stream, invite_only=True, history_public_to_subscribers=False)
         self.login_user(normal_user)
         message_id = [
             self.send_stream_message(normal_user, stream_name, "test 2"),
@@ -1312,7 +1312,7 @@ class MessageAccessTests(ZulipTestCase):
         self.assert_length(filtered_messages, 1)
         self.assertEqual(filtered_messages[0].id, message_two_id)
 
-        do_change_stream_invite_only(stream, True, history_public_to_subscribers=True)
+        do_change_stream_permission(stream, invite_only=True, history_public_to_subscribers=True)
 
         with queries_captured() as queries:
             filtered_messages = bulk_access_messages(later_subscribed_user, messages, stream=stream)

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -1264,12 +1264,16 @@ class MessageAccessTests(ZulipTestCase):
 
         # Guest user can access messages of subscribed private streams if
         # history is public to subscribers
-        do_change_stream_permission(stream, invite_only=True, history_public_to_subscribers=True)
+        do_change_stream_permission(
+            stream, invite_only=True, history_public_to_subscribers=True, acting_user=guest_user
+        )
         result = self.change_star(message_id)
         self.assert_json_success(result)
 
         # With history not public to subscribers, they can still see new messages
-        do_change_stream_permission(stream, invite_only=True, history_public_to_subscribers=False)
+        do_change_stream_permission(
+            stream, invite_only=True, history_public_to_subscribers=False, acting_user=guest_user
+        )
         self.login_user(normal_user)
         message_id = [
             self.send_stream_message(normal_user, stream_name, "test 2"),
@@ -1312,7 +1316,12 @@ class MessageAccessTests(ZulipTestCase):
         self.assert_length(filtered_messages, 1)
         self.assertEqual(filtered_messages[0].id, message_two_id)
 
-        do_change_stream_permission(stream, invite_only=True, history_public_to_subscribers=True)
+        do_change_stream_permission(
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=True,
+            acting_user=self.example_user("cordelia"),
+        )
 
         with queries_captured() as queries:
             filtered_messages = bulk_access_messages(later_subscribed_user, messages, stream=stream)

--- a/zerver/tests/test_message_topics.py
+++ b/zerver/tests/test_message_topics.py
@@ -1,6 +1,6 @@
 from django.utils.timezone import now as timezone_now
 
-from zerver.lib.actions import do_change_stream_invite_only
+from zerver.lib.actions import do_change_stream_permission
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import Message, UserMessage, get_client, get_realm, get_stream
 
@@ -132,7 +132,7 @@ class TopicHistoryTest(ZulipTestCase):
         )
 
         # Now make stream private, but subscribe cordelia
-        do_change_stream_invite_only(stream, True)
+        do_change_stream_permission(stream, invite_only=True)
         self.subscribe(self.example_user("cordelia"), stream.name)
 
         result = self.client_get(endpoint, {})
@@ -234,7 +234,7 @@ class TopicDeleteTest(ZulipTestCase):
         self.assertEqual(self.get_last_message().id, last_msg_id)
 
         # Make stream private with limited history
-        do_change_stream_invite_only(stream, invite_only=True, history_public_to_subscribers=False)
+        do_change_stream_permission(stream, invite_only=True, history_public_to_subscribers=False)
 
         # ADMIN USER subscribed now
         user_profile = self.example_user("iago")
@@ -266,7 +266,7 @@ class TopicDeleteTest(ZulipTestCase):
         self.assertEqual(self.get_last_message().id, last_msg_id)
 
         # Make the stream's history public to subscribers
-        do_change_stream_invite_only(stream, invite_only=True, history_public_to_subscribers=True)
+        do_change_stream_permission(stream, invite_only=True, history_public_to_subscribers=True)
         # Delete the topic should now remove all messages
         result = self.client_post(
             endpoint,

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -543,7 +543,9 @@ class ReactionEventTest(ZulipTestCase):
         self.assert_json_success(remove)
 
         # Make stream history public to subscribers
-        do_change_stream_permission(stream, invite_only=False, history_public_to_subscribers=True)
+        do_change_stream_permission(
+            stream, invite_only=False, history_public_to_subscribers=True, acting_user=iago
+        )
         # Since stream history is public to subscribers, reacting to
         # message_before_id should notify all subscribers:
         # Iago and Hamlet.
@@ -562,7 +564,7 @@ class ReactionEventTest(ZulipTestCase):
         self.assert_json_success(remove)
 
         # Make stream web_public as well.
-        do_change_stream_permission(stream, is_web_public=True)
+        do_change_stream_permission(stream, is_web_public=True, acting_user=iago)
         # For is_web_public streams, events even on old messages
         # should go to all subscribers, including guests like polonius.
         with self.tornado_redirected_to_list(events, expected_num_events=1):

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -4,11 +4,7 @@ from unittest import mock
 import orjson
 from django.http import HttpResponse
 
-from zerver.lib.actions import (
-    do_change_stream_invite_only,
-    do_make_stream_web_public,
-    notify_reaction_update,
-)
+from zerver.lib.actions import do_change_stream_permission, notify_reaction_update
 from zerver.lib.cache import cache_get, to_dict_cache_key_id
 from zerver.lib.emoji import emoji_name_to_emoji_code
 from zerver.lib.exceptions import JsonableError
@@ -547,7 +543,7 @@ class ReactionEventTest(ZulipTestCase):
         self.assert_json_success(remove)
 
         # Make stream history public to subscribers
-        do_change_stream_invite_only(stream, False, history_public_to_subscribers=True)
+        do_change_stream_permission(stream, invite_only=False, history_public_to_subscribers=True)
         # Since stream history is public to subscribers, reacting to
         # message_before_id should notify all subscribers:
         # Iago and Hamlet.
@@ -566,7 +562,7 @@ class ReactionEventTest(ZulipTestCase):
         self.assert_json_success(remove)
 
         # Make stream web_public as well.
-        do_make_stream_web_public(stream)
+        do_change_stream_permission(stream, is_web_public=True)
         # For is_web_public streams, events even on old messages
         # should go to all subscribers, including guests like polonius.
         with self.tornado_redirected_to_list(events, expected_num_events=1):

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1228,11 +1228,11 @@ class StreamAdminTest(ZulipTestCase):
         messages = get_topic_messages(user_profile, stream, "stream events")
         expected_notification = (
             f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this stream.\n\n"
-            "Old description:\n"
+            "* **Old description:**\n"
             "``` quote\n"
             "Test description\n"
             "```\n"
-            "New description:\n"
+            "* **New description:**\n"
             "``` quote\n"
             "a multi line description\n"
             "```"
@@ -1290,11 +1290,11 @@ class StreamAdminTest(ZulipTestCase):
         messages = get_topic_messages(user_profile, stream, "stream events")
         expected_notification = (
             f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this stream.\n\n"
-            "Old description:\n"
+            "* **Old description:**\n"
             "``` quote\n"
             "See https://zulip.com/team\n"
             "```\n"
-            "New description:\n"
+            "* **New description:**\n"
             "``` quote\n"
             "Test description\n"
             "```"

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -475,6 +475,36 @@ class StreamAdminTest(ZulipTestCase):
         )
         self.assertEqual(messages[0].content, expected_notification)
 
+        history_public_to_subscribers_log = RealmAuditLog.objects.filter(
+            event_type=RealmAuditLog.STREAM_PROPERTY_CHANGED,
+            modified_stream=stream,
+        ).last()
+        assert history_public_to_subscribers_log is not None
+
+        expected_extra_data = orjson.dumps(
+            {
+                RealmAuditLog.OLD_VALUE: False,
+                RealmAuditLog.NEW_VALUE: True,
+                "property": "history_public_to_subscribers",
+            }
+        ).decode()
+        self.assertEqual(history_public_to_subscribers_log.extra_data, expected_extra_data)
+
+        invite_only_log = RealmAuditLog.objects.filter(
+            event_type=RealmAuditLog.STREAM_PROPERTY_CHANGED,
+            modified_stream=stream,
+        ).order_by("-id")[1]
+        assert invite_only_log is not None
+
+        expected_extra_data = orjson.dumps(
+            {
+                RealmAuditLog.OLD_VALUE: True,
+                RealmAuditLog.NEW_VALUE: False,
+                "property": "invite_only",
+            }
+        ).decode()
+        self.assertEqual(invite_only_log.extra_data, expected_extra_data)
+
         do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         params = {
             "stream_name": orjson.dumps("private_stream_2").decode(),
@@ -509,6 +539,36 @@ class StreamAdminTest(ZulipTestCase):
         )
         self.assertEqual(messages[0].content, expected_notification)
 
+        history_public_to_subscribers_log = RealmAuditLog.objects.filter(
+            event_type=RealmAuditLog.STREAM_PROPERTY_CHANGED,
+            modified_stream=stream,
+        ).last()
+        assert history_public_to_subscribers_log is not None
+
+        expected_extra_data = orjson.dumps(
+            {
+                RealmAuditLog.OLD_VALUE: False,
+                RealmAuditLog.NEW_VALUE: True,
+                "property": "history_public_to_subscribers",
+            }
+        ).decode()
+        self.assertEqual(history_public_to_subscribers_log.extra_data, expected_extra_data)
+
+        invite_only_log = RealmAuditLog.objects.filter(
+            event_type=RealmAuditLog.STREAM_PROPERTY_CHANGED,
+            modified_stream=stream,
+        ).order_by("-id")[1]
+        assert invite_only_log is not None
+
+        expected_extra_data = orjson.dumps(
+            {
+                RealmAuditLog.OLD_VALUE: True,
+                RealmAuditLog.NEW_VALUE: False,
+                "property": "invite_only",
+            }
+        ).decode()
+        self.assertEqual(invite_only_log.extra_data, expected_extra_data)
+
     def test_make_stream_private(self) -> None:
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
@@ -535,6 +595,36 @@ class StreamAdminTest(ZulipTestCase):
             "for this stream from **Public** to **Private, protected history**."
         )
         self.assertEqual(messages[0].content, expected_notification)
+
+        history_public_to_subscribers_log = RealmAuditLog.objects.filter(
+            event_type=RealmAuditLog.STREAM_PROPERTY_CHANGED,
+            modified_stream=stream,
+        ).last()
+        assert history_public_to_subscribers_log is not None
+
+        expected_extra_data = orjson.dumps(
+            {
+                RealmAuditLog.OLD_VALUE: True,
+                RealmAuditLog.NEW_VALUE: False,
+                "property": "history_public_to_subscribers",
+            }
+        ).decode()
+        self.assertEqual(history_public_to_subscribers_log.extra_data, expected_extra_data)
+
+        invite_only_log = RealmAuditLog.objects.filter(
+            event_type=RealmAuditLog.STREAM_PROPERTY_CHANGED,
+            modified_stream=stream,
+        ).order_by("-id")[1]
+        assert invite_only_log is not None
+
+        expected_extra_data = orjson.dumps(
+            {
+                RealmAuditLog.OLD_VALUE: False,
+                RealmAuditLog.NEW_VALUE: True,
+                "property": "invite_only",
+            }
+        ).decode()
+        self.assertEqual(invite_only_log.extra_data, expected_extra_data)
 
         default_stream = self.make_stream("default_stream", realm=realm)
         do_add_default_stream(default_stream)
@@ -579,6 +669,36 @@ class StreamAdminTest(ZulipTestCase):
             "for this stream from **Public** to **Private, protected history**."
         )
         self.assertEqual(messages[0].content, expected_notification)
+
+        history_public_to_subscribers_log = RealmAuditLog.objects.filter(
+            event_type=RealmAuditLog.STREAM_PROPERTY_CHANGED,
+            modified_stream=stream,
+        ).last()
+        assert history_public_to_subscribers_log is not None
+
+        expected_extra_data = orjson.dumps(
+            {
+                RealmAuditLog.OLD_VALUE: True,
+                RealmAuditLog.NEW_VALUE: False,
+                "property": "history_public_to_subscribers",
+            }
+        ).decode()
+        self.assertEqual(history_public_to_subscribers_log.extra_data, expected_extra_data)
+
+        invite_only_log = RealmAuditLog.objects.filter(
+            event_type=RealmAuditLog.STREAM_PROPERTY_CHANGED,
+            modified_stream=stream,
+        ).order_by("-id")[1]
+        assert invite_only_log is not None
+
+        expected_extra_data = orjson.dumps(
+            {
+                RealmAuditLog.OLD_VALUE: False,
+                RealmAuditLog.NEW_VALUE: True,
+                "property": "invite_only",
+            }
+        ).decode()
+        self.assertEqual(invite_only_log.extra_data, expected_extra_data)
 
     def test_create_web_public_stream(self) -> None:
         user_profile = self.example_user("hamlet")
@@ -654,7 +774,22 @@ class StreamAdminTest(ZulipTestCase):
         )
         self.assertEqual(messages[0].content, expected_notification)
 
+        realm_audit_log = RealmAuditLog.objects.filter(
+            event_type=RealmAuditLog.STREAM_PROPERTY_CHANGED,
+            modified_stream=stream,
+        ).last()
+        assert realm_audit_log is not None
+        expected_extra_data = orjson.dumps(
+            {
+                RealmAuditLog.OLD_VALUE: True,
+                RealmAuditLog.NEW_VALUE: False,
+                "property": "invite_only",
+            }
+        ).decode()
+        self.assertEqual(realm_audit_log.extra_data, expected_extra_data)
+
     def test_make_stream_private_with_public_history(self) -> None:
+        # Convert a public stream to a private stream with shared history
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
         realm = user_profile.realm
@@ -680,6 +815,62 @@ class StreamAdminTest(ZulipTestCase):
             "for this stream from **Public** to **Private, shared history**."
         )
         self.assertEqual(messages[0].content, expected_notification)
+
+        realm_audit_log = RealmAuditLog.objects.filter(
+            event_type=RealmAuditLog.STREAM_PROPERTY_CHANGED,
+            modified_stream=stream,
+        ).last()
+        assert realm_audit_log is not None
+        expected_extra_data = orjson.dumps(
+            {
+                RealmAuditLog.OLD_VALUE: False,
+                RealmAuditLog.NEW_VALUE: True,
+                "property": "invite_only",
+            }
+        ).decode()
+        self.assertEqual(realm_audit_log.extra_data, expected_extra_data)
+
+        # Convert a private stream with protected history to a private stream
+        # with shared history.
+        self.make_stream(
+            "private_protected_stream",
+            realm=realm,
+            invite_only=True,
+            history_public_to_subscribers=False,
+        )
+        params = {
+            "stream_name": orjson.dumps("public_protected_stream").decode(),
+            "is_private": orjson.dumps(True).decode(),
+            "history_public_to_subscribers": orjson.dumps(True).decode(),
+        }
+        stream_id = self.subscribe(user_profile, "private_protected_stream").id
+        result = self.client_patch(f"/json/streams/{stream_id}", params)
+        self.assert_json_success(result)
+        stream = get_stream("private_protected_stream", realm)
+        self.assertTrue(stream.invite_only)
+        self.assertTrue(stream.history_public_to_subscribers)
+
+        messages = get_topic_messages(user_profile, stream, "stream events")
+        self.assert_length(messages, 1)
+        expected_notification = (
+            f"@_**King Hamlet|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
+            "for this stream from **Private, protected history** to **Private, shared history**."
+        )
+        self.assertEqual(messages[0].content, expected_notification)
+
+        realm_audit_log = RealmAuditLog.objects.filter(
+            event_type=RealmAuditLog.STREAM_PROPERTY_CHANGED,
+            modified_stream=stream,
+        ).last()
+        assert realm_audit_log is not None
+        expected_extra_data = orjson.dumps(
+            {
+                RealmAuditLog.OLD_VALUE: False,
+                RealmAuditLog.NEW_VALUE: True,
+                "property": "history_public_to_subscribers",
+            }
+        ).decode()
+        self.assertEqual(realm_audit_log.extra_data, expected_extra_data)
 
     def test_make_stream_web_public(self) -> None:
         user_profile = self.example_user("hamlet")
@@ -754,6 +945,20 @@ class StreamAdminTest(ZulipTestCase):
             "for this stream from **Public** to **Web public**."
         )
         self.assertEqual(messages[0].content, expected_notification)
+
+        realm_audit_log = RealmAuditLog.objects.filter(
+            event_type=RealmAuditLog.STREAM_PROPERTY_CHANGED,
+            modified_stream=stream,
+        ).last()
+        assert realm_audit_log is not None
+        expected_extra_data = orjson.dumps(
+            {
+                RealmAuditLog.OLD_VALUE: False,
+                RealmAuditLog.NEW_VALUE: True,
+                "property": "is_web_public",
+            }
+        ).decode()
+        self.assertEqual(realm_audit_log.extra_data, expected_extra_data)
 
     def test_try_make_stream_public_with_private_history(self) -> None:
         user_profile = self.example_user("hamlet")

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -325,7 +325,10 @@ def update_stream_backend(
 
     if is_private is not None or is_web_public is not None:
         do_change_stream_permission(
-            stream, is_private, history_public_to_subscribers, is_web_public
+            stream,
+            invite_only=is_private,
+            history_public_to_subscribers=history_public_to_subscribers,
+            is_web_public=is_web_public,
         )
     return json_success()
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -329,6 +329,7 @@ def update_stream_backend(
             invite_only=is_private,
             history_public_to_subscribers=history_public_to_subscribers,
             is_web_public=is_web_public,
+            acting_user=user_profile,
         )
     return json_success()
 


### PR DESCRIPTION
@timabbott FYI! :) I didn't add the `RealmAuditLog` entries for permission changes just yet. I'll make that a separate commit. So we could potentially merge these two commits. A couple of details that might benefit from your feedback:

* Do we want to send a notification for permission changes to a Zephyr mirroring realm? I added the configuration to `Stream.PERMISSION_POLICIES` just for the sake of completeness but we might not need it there and just send notifications for the official permission policies we show in the stream settings UI.
* In my changes to `test_message_topics.py`, I needed to exclude `stream events` notifications to get the tests to pass. For this, I added a function to `zerver/lib/topic.py`. I am not sure if there is perhaps a better or faster way to exclude messages by topic for testing?

Thanks!