### PR TITLE
message_controls: Inherit visibility from `.message_failed`.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -944,6 +944,10 @@ td.pointer {
             color: hsl(0, 100%, 50%);
             font-weight: bold;
         }
+
+        .message_control_button {
+            visibility: inherit;
+        }
     }
 
     .star_container {


### PR DESCRIPTION
copying commit message:
```
Previously, there was a bug where a failed message would only show the
`.message_failed` icons on hover, the intent was for them to always be
visible if a message failed to send.

The cause of the above bug was that in
e7b1de8ace45c91034b535df8d8ab7f96c885a04 we modified the html
structure of the icons such that each icon was inside its own div,
which possessed the `message_control_button` class, and both such divs
were inside a `.message_failed` div. The unintended consequence of this
change was that the rule `.message_controls .message_control_button`
would apply `visibility: hidden` to the icons.

Hence, this commit explicitly sets the visibility of
`.message_failed .message_control_button` to `inherit`.
```
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
[CZO link](https://chat.zulip.org/#narrow/stream/31-production-help/topic/Timeout.20errors/near/1289432)

**Testing plan:** <!-- How have you tested? -->
Visual testing for CSS change.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
  <details>
<summary>
gif with backend error
</summary>

![](https://user-images.githubusercontent.com/33805964/145716073-258538c5-c9b9-42ae-90cf-734f9fba4f67.gif)
</details>

  <details>
<summary>
gif with browser offline
</summary>

![](https://user-images.githubusercontent.com/33805964/145716075-ad7bcb24-5dd3-4bff-8a39-27eca0f32291.gif)
</details>


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
