### PR TITLE
lint: Enforce consistent style of using transaction.atomic decorator.

### DIFF
--- a/confirmation/migrations/0009_confirmation_expiry_date_backfill.py
+++ b/confirmation/migrations/0009_confirmation_expiry_date_backfill.py
@@ -21,7 +21,7 @@ def set_expiry_date_for_existing_confirmations(
     UNSUBSCRIBE = 4
     MULTIUSE_INVITE = 6
 
-    @transaction.atomic()
+    @transaction.atomic
     def backfill_confirmations_between(lower_bound: int, upper_bound: int) -> None:
         confirmations = Confirmation.objects.filter(id__gte=lower_bound, id__lte=upper_bound)
         for confirmation in confirmations:

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -481,6 +481,10 @@ python_rules = RuleList(
             "pattern": "\\.(called(_once|_with|_once_with)?|not_called|has_calls|not_called)[(]",
             "description": 'A mock function is missing a leading "assert_"',
         },
+        {
+            "pattern": "@transaction.atomic\\(\\)",
+            "description": "Use @transaction.atomic as function decorator for consistency.",
+        },
         *whitespace_rules,
     ],
     max_length=110,


### PR DESCRIPTION
> When decorating a function, @transaction.atomic and
@transaction.atomic() are equivalent. We can add a linting rule to
enforce consistency.

I noticed that I used `@transaction.atomic()` in a migration from a bit ago, inconsistently with the usual `@transaction.atomic` we use elsewhere. Might be useful to have a linting rule to prevent this kind of mixing of styles.