### PR TITLE
recent_topics: Check if topic exists before reviving focus to it.

### DIFF
--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -181,6 +181,14 @@ export function revive_current_focus() {
 
     if (is_table_focused()) {
         if (last_visited_topic) {
+            const topic_data = topics.get(last_visited_topic);
+            if (!topic_data) {
+                // `last_visited_topic` was renamed. We fallback to focus on
+                // the first visible topic since if the topic was recently edited,
+                // it most likely has a latest edit confirmation message.
+                set_table_focus(0, col_focus);
+                return true;
+            }
             const topic_last_msg_id = topics.get(last_visited_topic).last_msg_id;
             const current_list = topics_widget.get_current_list();
             const last_visited_topic_index = current_list.findIndex(


### PR DESCRIPTION
Check if `last_visited_topic` exits before reviving focus to it,
since it maybe have been renamed. We fallback to focus on the first
topic in that case.

Found this while working on #15290