### PR TITLE
Add quoted content into currently focused editing window if in message edit

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -712,6 +712,10 @@ export function initialize() {
         e.stopPropagation();
     });
 
+    $("body").on("mousedown", "div.message_controls, a.respond_button", (e) => {
+        e.preventDefault();
+    });
+
     if (page_params.narrow !== undefined) {
         if (page_params.narrow_topic !== undefined) {
             compose_actions.start("stream", {topic: page_params.narrow_topic});

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -466,13 +466,13 @@ export function on_topic_narrow() {
 }
 
 export function quote_and_reply(opts) {
-    const is_message_edit_open = $(".message_edit_content").length > 0
-    const textarea = is_message_edit_open == true ? $(".message_edit_content").eq(0) : $("#compose-textarea"); 
+    const active_ele = document.activeElement;
+    const is_message_edit_open = active_ele && active_ele.className === "message_edit_content";
+    const textarea = is_message_edit_open ? $(active_ele) : $("#compose-textarea");
     const message_id = message_lists.current.selected_id();
     const message = message_lists.current.selected_message();
     const quoting_placeholder = $t({defaultMessage: "[Quoting…]"});
-
-    if (is_message_edit_open == true || compose_state.has_message_content()) {
+    if (is_message_edit_open || compose_state.has_message_content()) {
         // The user already started typing a message,
         // so we won't re-open the compose box.
         // (If you did re-open the compose box, you
@@ -513,7 +513,7 @@ export function quote_and_reply(opts) {
         const placeholder_offset = $(textarea).val().indexOf(quoting_placeholder);
         compose_ui.replace_syntax(quoting_placeholder, content, textarea);
         compose_ui.autosize_textarea(textarea);
-        
+
         // When replacing content in a textarea, we need to move the
         // cursor to preserve its logical position if and only if the
         // content we just added was before the current cursor

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -466,12 +466,13 @@ export function on_topic_narrow() {
 }
 
 export function quote_and_reply(opts) {
-    const textarea = $("#compose-textarea");
+    const is_message_edit_open = $(".message_edit_content").length > 0
+    const textarea = is_message_edit_open == true ? $(".message_edit_content").eq(0) : $("#compose-textarea"); 
     const message_id = message_lists.current.selected_id();
     const message = message_lists.current.selected_message();
     const quoting_placeholder = $t({defaultMessage: "[Quoting…]"});
 
-    if (compose_state.has_message_content()) {
+    if (is_message_edit_open == true || compose_state.has_message_content()) {
         // The user already started typing a message,
         // so we won't re-open the compose box.
         // (If you did re-open the compose box, you
@@ -511,8 +512,8 @@ export function quote_and_reply(opts) {
 
         const placeholder_offset = $(textarea).val().indexOf(quoting_placeholder);
         compose_ui.replace_syntax(quoting_placeholder, content, textarea);
-        compose_ui.autosize_textarea($("#compose-textarea"));
-
+        compose_ui.autosize_textarea(textarea);
+        
         // When replacing content in a textarea, we need to move the
         // cursor to preserve its logical position if and only if the
         // content we just added was before the current cursor

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -339,6 +339,9 @@ function create_copy_to_clipboard_handler(row, source, message_id) {
 }
 
 function edit_message(row, raw_content) {
+    console.log("edit_message() called");
+    console.log(row);
+    console.log(raw_content);
     let stream_widget;
     row.find(".message_reactions").hide();
     condense.hide_message_expander(row);

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -339,9 +339,6 @@ function create_copy_to_clipboard_handler(row, source, message_id) {
 }
 
 function edit_message(row, raw_content) {
-    console.log("edit_message() called");
-    console.log(row);
-    console.log(raw_content);
     let stream_widget;
     row.find(".message_reactions").hide();
     condense.hide_message_expander(row);


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is made for #20380 

**Testing plan:** <!-- How have you tested? -->
UI manual test
Frontend lint test
Backend lint test

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
  
![tempsnip](https://user-images.githubusercontent.com/87924063/145886274-1335b524-e533-423b-a8cd-df53babfc963.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
