### PR TITLE
compose: Add stream privacy decorations in banner box.

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -166,17 +166,25 @@ export function is_window_focused() {
 export function notify_above_composebox(
     note,
     link_class,
+    is_private_stream,
+    is_global_stream,
+    is_stream_message,
     above_composebox_narrow_url,
     link_msg_id,
-    link_text,
+    default_message,
+    message_recipient,
 ) {
     const $notification = $(
         render_compose_notification({
             note,
             link_class,
+            is_private_stream,
+            is_global_stream,
+            is_stream_message,
             above_composebox_narrow_url,
             link_msg_id,
-            link_text,
+            default_message,
+            message_recipient,
         }),
     );
     clear_compose_notifications();
@@ -617,6 +625,9 @@ export function notify_local_mixes(messages, need_user_to_scroll) {
         let reason = get_local_notify_mix_reason(message);
 
         const above_composebox_narrow_url = get_above_composebox_narrow_url(message);
+        const is_global_stream = stream_data.is_web_public_by_stream_name(message.stream);
+        const is_private_stream = stream_data.is_invite_only_by_stream_name(message.stream);
+        const is_stream_message = message.type === "stream";
 
         if (!reason) {
             if (need_user_to_scroll) {
@@ -634,17 +645,22 @@ export function notify_local_mixes(messages, need_user_to_scroll) {
 
         const link_msg_id = message.id;
         const link_class = "compose_notification_narrow_by_topic";
-        const link_text = $t(
-            {defaultMessage: "Narrow to {message_recipient}"},
+        const default_message = $t({defaultMessage: "Narrow to "});
+        const message_recipient = $t(
+            {defaultMessage: "{message_recipient}"},
             {message_recipient: get_message_header(message)},
         );
 
         notify_above_composebox(
             reason,
             link_class,
+            is_private_stream,
+            is_global_stream,
+            is_stream_message,
             above_composebox_narrow_url,
             link_msg_id,
-            link_text,
+            default_message,
+            message_recipient,
         );
     }
 }
@@ -670,16 +686,24 @@ export function notify_messages_outside_current_search(messages) {
             continue;
         }
         const above_composebox_narrow_url = get_above_composebox_narrow_url(message);
-        const link_text = $t(
-            {defaultMessage: "Narrow to {message_recipient}"},
+        const is_stream_message = message.type === "stream";
+        const is_global_stream = stream_data.is_web_public_by_stream_name(message.stream);
+        const is_private_stream = stream_data.is_invite_only_by_stream_name(message.stream);
+        const default_message = $t({defaultMessage: "Narrow to "});
+        const message_recipient = $t(
+            {defaultMessage: "{message_recipient}"},
             {message_recipient: get_message_header(message)},
         );
         notify_above_composebox(
             $t({defaultMessage: "Sent! Your recent message is outside the current search."}),
             "compose_notification_narrow_by_topic",
+            is_global_stream,
+            is_private_stream,
+            is_stream_message,
             above_composebox_narrow_url,
             message.id,
-            link_text,
+            default_message,
+            message_recipient,
         );
     }
 }

--- a/static/js/stream_bar.js
+++ b/static/js/stream_bar.js
@@ -4,21 +4,20 @@ import * as color_class from "./color_class";
 import * as stream_data from "./stream_data";
 
 function update_compose_stream_icon(stream_name) {
-    const $streamfield = $("#stream_message_recipient_stream");
     const $globe_icon = $("#stream-message .compose-globe-icon");
     const $lock_icon = $("#stream-message .compose-lock-icon");
-
+    const $hashtag = $("#stream-message .hashtag");
     // Reset state
     $globe_icon.hide();
     $lock_icon.hide();
-    $streamfield.removeClass("lock-padding");
+    $hashtag.hide();
 
     if (stream_data.is_invite_only_by_stream_name(stream_name)) {
         $lock_icon.show();
-        $streamfield.addClass("lock-padding");
     } else if (stream_data.is_web_public_by_stream_name(stream_name)) {
         $globe_icon.show();
-        $streamfield.addClass("lock-padding");
+    } else {
+        $hashtag.show();
     }
 }
 

--- a/static/js/stream_bar.js
+++ b/static/js/stream_bar.js
@@ -5,8 +5,8 @@ import * as stream_data from "./stream_data";
 
 function update_compose_stream_icon(stream_name) {
     const $streamfield = $("#stream_message_recipient_stream");
-    const $globe_icon = $("#compose-globe-icon");
-    const $lock_icon = $("#compose-lock-icon");
+    const $globe_icon = $("#stream-message .compose-globe-icon");
+    const $lock_icon = $("#stream-message .compose-lock-icon");
 
     // Reset state
     $globe_icon.hide();

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -388,6 +388,24 @@ div[id^="message-edit-send-status"],
 .compose-notifications-content {
     padding: 4px 22px;
     text-align: center;
+
+    .compose_notification_narrow_by_topic {
+        &:hover {
+            text-decoration: none;
+        }
+    }
+
+    .compose-lock-icon,
+    .compose-globe-icon,
+    .hashtag {
+        vertical-align: baseline;
+        line-height: 17px;
+        margin-left: 2px;
+    }
+
+    .hashtag {
+        vertical-align: middle;
+    }
 }
 
 .composition-area {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -135,23 +135,24 @@
 
     #private-message .to_text {
         vertical-align: middle;
-
         font-weight: 600;
     }
 
-    #compose-lock-icon,
-    #compose-globe-icon {
-        position: relative;
-        left: 6px;
-        top: 0.5px;
-        width: 0;
-    }
+    #stream-message {
+        .compose-lock-icon,
+        .compose-globe-icon {
+            position: relative;
+            left: 6px;
+            top: 0.5px;
+            width: 0;
+        }
 
-    #compose-globe-icon {
-        left: 4.5px;
+        .compose-globe-icon {
+            left: 4.5px;
 
-        .zulip-icon-globe {
-            font-size: 12px;
+            .zulip-icon-globe {
+                font-size: 12px;
+            }
         }
     }
 

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -140,7 +140,8 @@
 
     #stream-message {
         .compose-lock-icon,
-        .compose-globe-icon {
+        .compose-globe-icon,
+        .hashtag {
             position: relative;
             left: 6px;
             top: 0.5px;
@@ -152,6 +153,14 @@
 
             .zulip-icon-globe {
                 font-size: 12px;
+            }
+        }
+
+        .hashtag {
+            &:empty {
+                &::after {
+                    font-size: 17px;
+                }
             }
         }
     }

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -71,10 +71,10 @@
                         <div id="stream-message" class="order-1">
                             <div class="stream-selection-header-colorblock message_header_stream left_part" tab-index="-1"></div>
                             <div class="right_part">
-                                <span id="compose-lock-icon">
+                                <span class="compose-lock-icon">
                                     <i class="fa fa-lock" title="{{t 'This is a private stream' }}" aria-hidden="true"></i>
                                 </span>
-                                <span id="compose-globe-icon">
+                                <span class="compose-globe-icon">
                                     <i class="zulip-icon zulip-icon-globe" title="{{t 'This is a web-public stream' }}" aria-hidden="true"></i>
                                 </span>
                                 <a role="button" class="narrow_to_compose_recipients zulip-icon zulip-icon-arrow-left-circle order-1" data-tooltip-template-id="narrow_to_compose_recipients_tooltip" tabindex="0">

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -74,12 +74,13 @@
                                 <span class="compose-lock-icon">
                                     <i class="fa fa-lock" title="{{t 'This is a private stream' }}" aria-hidden="true"></i>
                                 </span>
+                                <span class="hashtag"></span>
                                 <span class="compose-globe-icon">
                                     <i class="zulip-icon zulip-icon-globe" title="{{t 'This is a web-public stream' }}" aria-hidden="true"></i>
                                 </span>
                                 <a role="button" class="narrow_to_compose_recipients zulip-icon zulip-icon-arrow-left-circle order-1" data-tooltip-template-id="narrow_to_compose_recipients_tooltip" tabindex="0">
                                 </a>
-                                <input type="text" class="recipient_box" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="30" value="" placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Stream' }}" />
+                                <input type="text" class="recipient_box lock-padding" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="30" value="" placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Stream' }}" />
                                 <i class="fa fa-angle-right" aria-hidden="true"></i>
                                 <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="60" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
                             </div>

--- a/static/templates/compose_notification.hbs
+++ b/static/templates/compose_notification.hbs
@@ -1,5 +1,27 @@
 {{! Content of sent-message notifications }}
 <div class="compose-notifications-content">
-    {{note}} {{#if link_class}}<a href="{{above_composebox_narrow_url}}" class="{{link_class}}" data-message-id="{{link_msg_id}}">{{link_text}}</a>{{/if}}
-    <button type="button" class="out-of-view-notification-close close">&times;</button>
+    {{note}}
+    {{#if link_class}}
+        <a
+          href="{{above_composebox_narrow_url}}"
+          class="{{link_class}}"
+          data-message-id="{{link_msg_id}}"
+          >{{default_message}}
+            {{#if is_global_stream}}
+                <span class="compose-globe-icon">
+                    <i class="fa fa-globe"></i>
+                </span>
+            {{else if is_private_stream}}
+                <span class="compose-lock-icon">
+                    <i class="fa fa-lock"></i>
+                </span>
+            {{else if is_stream_message}}
+                <span class="hashtag"></span>
+            {{/if}}
+            {{message_recipient}}</a>
+    {{/if}}
+    <button
+      type="button"
+      class="out-of-view-notification-close close"
+      >&times;</button>
 </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is for issue #19878 
Fixes part (1/2) -
Add stream privacy decorations in banner box.

Part (2/2) in another PR as suggested by @alya in Zulip chat https://chat.zulip.org/#narrow/stream/9-issues/topic/missing.20hash.20before.20stream.20name/near/1261461 -
Add stream privacy decorations in compose box.

**Testing plan:** <!-- How have you tested? -->
Lint test.
Node test.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/53873549/145938338-0371369c-5c06-418a-ac88-b43c377f1df7.png)

**Changes explained:**

Earlier sent message notification - "Sent! Your message is outside current narrow. Narrow to test > blue"

Updated sent message notification - "Sent! Your message is outside current narrow. Narrow to #test > blue"


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
