### PR TITLE
user_sidebar: Set personal presence dot to be accurate to server info.

### DIFF
--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -361,7 +361,7 @@ test("title_data", () => {
     let expected_data = {
         first_line: "Human Myself",
         second_line: "out to lunch",
-        third_line: "translated: Active now",
+        third_line: "translated: Last active: translated: More than 2 weeks ago",
         show_you: true,
     };
     page_params.user_id = me.user_id;
@@ -570,8 +570,8 @@ test("get_items_for_users", ({override_rewire}) => {
             name: "Human Myself",
             num_unread: 0,
             status_emoji_info,
-            user_circle_class: "user_circle_green",
-            user_circle_status: "translated: Active",
+            user_circle_class: "user_circle_empty",
+            user_circle_status: "translated: Offline",
             user_id: 1001,
         },
         {

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -84,10 +84,6 @@ function test(label, f) {
     });
 }
 
-test("my user", () => {
-    assert.equal(presence.get_status(me.user_id), "active");
-});
-
 test("unknown user", ({override}) => {
     const unknown_user_id = 999;
     const now = 888888;

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -220,7 +220,7 @@ export function mark_client_active() {
     // exported for testing
     if (!client_is_active) {
         client_is_active = true;
-        send_presence_to_server(false);
+        send_presence_to_server(true);
     }
 }
 

--- a/static/js/presence.js
+++ b/static/js/presence.js
@@ -40,11 +40,7 @@ export function is_active(user_id) {
 }
 
 export function get_status(user_id) {
-    if (people.is_my_user_id(user_id)) {
-        if (user_settings.presence_enabled) {
-            // if the current user is sharing presence, they always see themselves as online.
-            return "active";
-        }
+    if (people.is_my_user_id(user_id) && !user_settings.presence_enabled) {
         // if the current user is not sharing presence, they always see themselves as offline.
         return "offline";
     }
@@ -224,7 +220,6 @@ export function update_info_for_small_realm() {
 
     for (const person of persons) {
         const user_id = person.user_id;
-        let status = "offline";
 
         if (presence_info.has(user_id)) {
             // this is normal, we have data for active
@@ -237,12 +232,8 @@ export function update_info_for_small_realm() {
             continue;
         }
 
-        if (people.is_my_user_id(user_id)) {
-            status = "active";
-        }
-
         presence_info.set(user_id, {
-            status,
+            status: "offline",
             last_active: undefined,
         });
     }


### PR DESCRIPTION
commit message:
```
Previously, we'd handle our own presence circle as a special case by
always marking ourselves as online. In commit
345616ad02636939e51bf4cffde65d0dca3499df we changed this to be more
accurate to what the current client sends to the server (and thus what
other clients see) in terms of whether the current client shares
presence info or not. However, that change still left us in a state
where we wouldn't be accurate with other users in terms of being
"unavailable".

Hence, this commit removes the code which treated the current user as
a special case in presence and makes it such that the current user
also sees themselves as unavailable if that's what the current user is
broadcasting to other users (an example of this is if you've left a
Zulip tab open on a different monitor but that window does not have
focus).

Fixes: #18846.
```
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Follow up which fixes: #18846 based on feedback at https://github.com/zulip/zulip/pull/20376#discussion_r758832653.

**Testing plan:** <!-- How have you tested? -->
Existing node tests pass.

Manual testing via adjusting 
```javascript
// ./static/js/activity.js

/* Broadcast "idle" to server after 5 minutes of local inactivity */
const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
/* Time between keep-alive pings */
const ACTIVE_PING_INTERVAL_MS = 50 * 1000;
```
It feels as though this is unlikely to trigger with the default values.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<details>
<summary>
screenshot
</summary>

![](https://user-images.githubusercontent.com/33805964/146016614-bf15c129-22ca-4c25-80db-9279ea5dff12.png)
</details>

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
