### PR TITLE
api: Fix feature level 107 in the API change log.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -44,6 +44,7 @@ format used by the Zulip server that they are interacting with.
   final `zulip://` redirect URL.
 
 **Feature level 107**
+
 * [`POST /register`](/api/register-queue), [`PATCH /settings`](/api/update-settings),
   [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults):
   Added user setting `escape_navigates_to_default_view` to allow users to


### PR DESCRIPTION
Adds a new line between feature level 107 and its content, so that said content renders correctly as an unordered list item.

**Screenshot of current API changelog**
![Screenshot from 2021-12-14 18-24-34](https://user-images.githubusercontent.com/63245456/146048570-5710e5ef-bec6-4da7-a047-05f9b4660d67.png)

**Screenshot of fixed API changelog**
![Screenshot from 2021-12-14 18-24-18](https://user-images.githubusercontent.com/63245456/146048579-3141a3bb-88dd-4e48-8517-0041fc50ab62.png)