### PR TITLE
puppeteer: Fix edit bot form test flake.

### DIFF
--- a/frontend_tests/puppeteer_tests/settings.ts
+++ b/frontend_tests/puppeteer_tests/settings.ts
@@ -208,7 +208,13 @@ async function test_invalid_edit_bot_form(page: Page): Promise<void> {
         await common.get_text_from_selector(page, "div.bot_edit_errors"),
         "Name is already in use!",
     );
-    await page.click("#edit_bot_modal .dialog_cancel_button");
+
+    const cancel_button_selector = "#edit_bot_modal .dialog_cancel_button";
+    await page.waitForFunction(
+        (cancel_button_selector: string) =>
+            !document.querySelector(cancel_button_selector)?.hasAttribute("disabled"),
+    );
+    await page.click(cancel_button_selector);
     await page.waitForXPath(
         `//*[@class="btn open_edit_bot_form" and @data-email="${bot1_email}"]/ancestor::*[@class="details"]/*[@class="name" and text()="Bot one"]`,
     );


### PR DESCRIPTION
This test was verifying if an error was displayed on trying
to rename a bot with an existing name and then close the edit
modal with 'cancel' button.

I think the cause for flake is that the 'cancel' was clicked when
it is disabled while the request was being made. The existing waits
should've also worked for this but I presume there's some race.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
ran the test once. Couldn't run it 100 times to see if the flake persist. 
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
