### PR TITLE
compose: Fix numeric typing regression related to global time widget.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -768,6 +768,10 @@ export function content_highlighter(item) {
     }
 }
 
+function is_numeric_key(key) {
+    return ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"].includes(key);
+}
+
 export function show_flatpickr(element, callback, default_timestamp, options = {}) {
     const flatpickr_input = $("<input id='#timestamp_flatpickr'>");
 
@@ -788,7 +792,17 @@ export function show_flatpickr(element, callback, default_timestamp, options = {
         formatDate: (date) => formatISO(date),
         disableMobile: true,
         onKeyDown: (selectedDates, dateStr, instance, event) => {
+            if (is_numeric_key(event.key)) {
+                // Don't stopPropagation for numeric inputs, let them be handled normally
+                return;
+            }
+
             const hotkey = get_keydown_hotkey(event);
+
+            if (hotkey === "backspace" || hotkey === "delete") {
+                // Don't stopPropagation for backspace or delete, let them be handled normally
+                return;
+            }
 
             if (["tab", "shift_tab"].includes(hotkey.name)) {
                 const elems = [
@@ -815,10 +829,18 @@ export function show_flatpickr(element, callback, default_timestamp, options = {
     const container = $($(instance.innerContainer).parent());
 
     container.on("keydown", (e) => {
+        if (is_numeric_key(e.key)) {
+            return true; // Let users type numeric values
+        }
+
         const hotkey = get_keydown_hotkey(e);
 
         if (!hotkey) {
             return false;
+        }
+
+        if (hotkey.name === "backspace" || hotkey.name === "delete") {
+            return true; // Let backspace or delete be handled normally
         }
 
         if (hotkey.name === "enter") {


### PR DESCRIPTION
commit message:
```
In commit 1d54b383bd471af0a45a96b2dcf8d62aec60f516 we introduced some
changes to add better support for keyboard navigation with the global
time widget. Unfortunately, as a result of the fact that
get_keydown_hotkey returns undefined for numeric keys, we caused a
regression that prevented users from typing into the time picker.

Hence, this commit fixes the above bug by checking if the key pressed
is a numeric key.
```
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://chat.zulip.org/#narrow/stream/9-issues/topic/typing.20into.20time.20picker

**Testing plan:** <!-- How have you tested? -->
Only manual testing...

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<details>
<summary>
gif
</summary>

![](https://user-images.githubusercontent.com/33805964/146146310-76a5c5bc-dcb6-4afe-9a58-d5695101e1a0.gif)
</details>

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
