### PR TITLE
feature: private group messages cannot be sent to more than 50 people

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2857,6 +2857,8 @@ def check_send_message(
 
     addressee = Addressee.legacy_build(sender, message_type_name, message_to, topic_name)
     try:
+        if len(message_to) > 50:
+            raise AssertionError("Private Message Groups must contain 50 participants or less.")
         message = check_message(
             sender,
             client,


### PR DESCRIPTION
If the limit of 50 people has been reached, the backend will throw an AssertionError saying that the message is being sent to more than 50 people.
TODO: This is only enforced in the backend and should be enforced in the front end as well.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/18171

**Testing plan:** <!-- How have you tested? -->
Creating more than 50 users and sending a message. In the second image below, the message has not been sent.

**GIFs or screenshots:** <!-- If a UI changes.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/44913669/146290300-bf10ec83-4c96-4580-b602-adbf1fe68dba.png)
![image](https://user-images.githubusercontent.com/44913669/146290325-0565335e-76f6-463a-bcaf-71e22f3eac85.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
