### PR TITLE
cache: Log timing for cache misses.

### DIFF
--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -201,7 +201,11 @@ def cache_with_key(
             if val is not None:
                 return val[0]
 
+            t = time.time()
             val = func(*args, **kwargs)
+            elapsed = time.time() - t
+            elapsed_ms = elapsed * 1000
+            logging.info(f"CACHE: took {elapsed_ms:.2f}ms to compute value for {key}")
 
             cache_set(key, val, cache_name=cache_name, timeout=timeout)
 


### PR DESCRIPTION
We log every time we have to compute a value
to put in memcached.

If these log messages are more expensive than
the actual computation, then the computation
is probably quick enough that we shouldn't
be caching it.
