### PR TITLE
api: Include `stream_id` for all updates to stream messages

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 5.0
 
+**Feature level 112**
+
+* [`GET /events`](/api/get-events): Updated `update_message` event type
+  to include `stream_id` field for all edits to stream messages.
+
 **Feature level 111**
 
 * [`POST /subscriptions/properties`](/api/update-subscription-settings):

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 111
+API_FEATURE_LEVEL = 112
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -6287,6 +6287,7 @@ def do_update_message(
         stream_id = target_message.recipient.type_id
         stream_being_edited = get_stream_by_id_in_realm(stream_id, realm)
         event["stream_name"] = stream_being_edited.name
+        event["stream_id"] = stream_being_edited.id
 
     ums = UserMessage.objects.filter(message=target_message.id)
 
@@ -6380,7 +6381,6 @@ def do_update_message(
     if topic_name is not None or new_stream is not None:
         orig_topic_name = target_message.topic_name()
         event["propagate_mode"] = propagate_mode
-        event["stream_id"] = target_message.recipient.type_id
 
     if new_stream is not None:
         assert content is None

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2030,6 +2030,11 @@ paths:
 
                                     The pre-edit stream for all of the messages with IDs in
                                     `message_ids`.
+
+                                    **Changes**: As of Zulip 5.0 (feature level 112), this field
+                                    is present for all edits to a stream message. Previously, it
+                                    was not present when only the content of the stream message was
+                                    edited.
                                 new_stream_id:
                                   type: integer
                                   description: |


### PR DESCRIPTION
Updates the `update_message` event type to always include a `stream_id` field when the message being edited is a stream message.

This change aligns with the current definition in the [`\get-events` endpoint](https://zulip.com/api/get-events#update_message) in the OpenAPI documentation. Also, see [this CZO chat](https://chat.zulip.org/#narrow/stream/378-api-design/topic/.60update_message.60.20event).

**Testing**: Updated the testing schema for `do_update_message` in `zerver/lib/event_schema.py` so that the stream message fields (name, id, new) are separate from the content and topic fields in the `update_message` event. The updated testing schema also moves the `flags` and `message_ids` lists to the required fields because they are currently being returned for any edit / update to any type of message. Previously, those fields were listed as topic related fields.

Also added verification in `zerver/tests/event_tests.py` for the event returned for changes to: private message content, stream message content-only, stream message topic-only, stream message new-stream-only.