### PR TITLE
compose: Add stream privacy decorations compose box.

### DIFF
--- a/static/js/stream_bar.js
+++ b/static/js/stream_bar.js
@@ -4,21 +4,20 @@ import * as color_class from "./color_class";
 import * as stream_data from "./stream_data";
 
 function update_compose_stream_icon(stream_name) {
-    const $streamfield = $("#stream_message_recipient_stream");
     const $globe_icon = $("#compose-globe-icon");
     const $lock_icon = $("#compose-lock-icon");
-
+    const $hashtag = $("#compose .hashtag");
     // Reset state
     $globe_icon.hide();
     $lock_icon.hide();
-    $streamfield.removeClass("lock-padding");
+    $hashtag.hide();
 
     if (stream_data.is_invite_only_by_stream_name(stream_name)) {
         $lock_icon.show();
-        $streamfield.addClass("lock-padding");
     } else if (stream_data.is_web_public_by_stream_name(stream_name)) {
         $globe_icon.show();
-        $streamfield.addClass("lock-padding");
+    } else {
+        $hashtag.show();
     }
 }
 

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -140,7 +140,8 @@
     }
 
     #compose-lock-icon,
-    #compose-globe-icon {
+    #compose-globe-icon,
+    .hashtag {
         position: relative;
         left: 6px;
         top: 0.5px;
@@ -152,6 +153,14 @@
 
         .zulip-icon-globe {
             font-size: 12px;
+        }
+    }
+
+    #stream-message .hashtag {
+        &:empty {
+            &::after {
+                font-size: 17px;
+            }
         }
     }
 

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -74,12 +74,13 @@
                                 <span id="compose-lock-icon">
                                     <i class="fa fa-lock" title="{{t 'This is a private stream' }}" aria-hidden="true"></i>
                                 </span>
+                                <span class="hashtag"></span>
                                 <span id="compose-globe-icon">
                                     <i class="zulip-icon zulip-icon-globe" title="{{t 'This is a web-public stream' }}" aria-hidden="true"></i>
                                 </span>
                                 <a role="button" class="narrow_to_compose_recipients zulip-icon zulip-icon-arrow-left-circle order-1" data-tooltip-template-id="narrow_to_compose_recipients_tooltip" tabindex="0">
                                 </a>
-                                <input type="text" class="recipient_box" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="30" value="" placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Stream' }}" />
+                                <input type="text" class="recipient_box lock-padding" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="30" value="" placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Stream' }}" />
                                 <i class="fa fa-angle-right" aria-hidden="true"></i>
                                 <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="60" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
                             </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is for issue #19878
Fixes part (2/2) -
Add stream privacy decorations in compose box.

**Testing plan:** <!-- How have you tested? -->
Lint test.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Public Stream -
![image](https://user-images.githubusercontent.com/53873549/146384638-684c1440-9078-464d-8b2c-89c8ee41f6d1.png)

Web Public Stream -
![image](https://user-images.githubusercontent.com/53873549/146384762-7c7c0f9c-91ed-40b6-a79c-5468e8ce55d9.png)

Private Stream -
![image](https://user-images.githubusercontent.com/53873549/146384913-a3ada7d3-3934-4fa9-9291-c5dbdf3dd343.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
