### PR TITLE
install: Try apt-get update if the Ubuntu universe check fails

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -232,8 +232,12 @@ EOF
         ;;
 esac
 
-if [ "$os_id" = ubuntu ] && ! apt-cache policy \
-    | grep -q "^     release v=$os_version_id,o=Ubuntu,a=$os_version_codename,n=$os_version_codename,l=Ubuntu,c=universe"; then
+has_universe() {
+    apt-cache policy \
+        | grep -q "^     release v=$os_version_id,o=Ubuntu,a=$os_version_codename,n=$os_version_codename,l=Ubuntu,c=universe"
+}
+
+if [ "$os_id" = ubuntu ] && ! has_universe && ! { apt-get update && has_universe; }; then
     set +x
     cat <<'EOF'
 


### PR DESCRIPTION
On a system where `apt-get update` has never been run, `apt-cache policy` may show no repositories at all. Try to correct this with `apt-get update` before giving up.