### PR TITLE
setup-advanced: Remove misleading python3 symlink suggestion

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -41,9 +41,7 @@ git remote add -f upstream https://github.com/zulip/zulip.git
 ```
 
 ```bash
-# On CentOS/RHEL, you must first install epel-release, and then python36,
-# and finally you must run `sudo ln -nsf /usr/bin/python36 /usr/bin/python3`
-# On Fedora, you must first install python3
+# On CentOS/RHEL/Fedora, you must first install python3
 # From a clone of zulip.git
 ./tools/provision
 source /srv/zulip-py3-venv/bin/activate


### PR DESCRIPTION
One should never have to manually symlink things in `/usr/bin`, especially with `-f`. That should be managed by the system package manager. Indeed, on CentOS 7 and 8, one can simply install the `python3` package and get a working `/usr/bin/python3`.