### PR TITLE
header: Fix unresponsive dropdown pill on /help pages.

### DIFF
--- a/static/js/portico/header.js
+++ b/static/js/portico/header.js
@@ -8,12 +8,12 @@ $(() => {
 
     $(".dropdown").on("click", (e) => {
         const $this = $(e.target);
-        const dropdown_is_shown = $this.closest("ul .dropdown").hasClass("show");
+        const dropdown_is_shown = $this.closest(".dropdown").hasClass("show");
 
         if (!dropdown_is_shown) {
-            $this.closest("ul .dropdown").addClass("show");
+            $this.closest(".dropdown").addClass("show");
         } else if (dropdown_is_shown) {
-            $this.closest("ul .dropdown").removeClass("show");
+            $this.closest(".dropdown").removeClass("show");
         }
     });
 


### PR DESCRIPTION
My PR #18974 introduced a bug where the logged-in dropdown pill on
the /help pages stopped working and has been unresponsive ever
since. This was caused by the incorrect assumption that each
`.dropdown` would be inside an unordered list `ul`. However, that
isn't the case for the dropdown pill on the /help pages. This commit
simply removes said assumption, by widening the scope of the relevant
CSS selectors.

@timabbott :)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
