### PR TITLE
Use functional parameter destructuring for `opts` in reactions.js

### DIFF
--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -383,12 +383,15 @@ export function remove_reaction(event) {
     });
 }
 
-view.remove_reaction = function (opts) {
-    const message_id = opts.message_id;
-    const emoji_name = opts.emoji_name;
-    const user_list = opts.user_list;
-    const user_id = opts.user_id;
-    const local_id = get_local_reaction_id(opts);
+view.remove_reaction = function ({
+    message_id,
+    emoji_name,
+    user_list,
+    user_id,
+    reaction_type,
+    emoji_code,
+}) {
+    const local_id = get_local_reaction_id({reaction_type, emoji_code});
     const reaction = find_reaction(message_id, local_id);
 
     if (user_list.length === 0) {

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -253,14 +253,16 @@ export function add_reaction(event) {
         r.user_ids.push(user_id);
         update_user_fields(r);
     } else {
-        add_clean_reaction({
-            message,
+        message.clean_reactions.set(
             local_id,
-            user_ids: [user_id],
-            reaction_type: event.reaction_type,
-            emoji_name: event.emoji_name,
-            emoji_code: event.emoji_code,
-        });
+            make_clean_reaction({
+                local_id,
+                user_ids: [user_id],
+                reaction_type: event.reaction_type,
+                emoji_name: event.emoji_name,
+                emoji_code: event.emoji_code,
+            }),
+        );
     }
 
     const opts = {
@@ -498,18 +500,20 @@ export function set_clean_reactions(message) {
         const reaction = distinct_reactions.get(local_id);
         const user_ids = user_map.get(local_id);
 
-        add_clean_reaction({
-            message,
+        message.clean_reactions.set(
             local_id,
-            user_ids,
-            reaction_type: reaction.reaction_type,
-            emoji_name: reaction.emoji_name,
-            emoji_code: reaction.emoji_code,
-        });
+            make_clean_reaction({
+                local_id,
+                user_ids,
+                reaction_type: reaction.reaction_type,
+                emoji_name: reaction.emoji_name,
+                emoji_code: reaction.emoji_code,
+            }),
+        );
     }
 }
 
-function add_clean_reaction(opts) {
+function make_clean_reaction(opts) {
     const r = emoji.get_emoji_details_for_rendering(opts);
 
     r.local_id = opts.local_id;
@@ -520,7 +524,7 @@ function add_clean_reaction(opts) {
     r.emoji_alt_code = user_settings.emojiset === "text";
     r.is_realm_emoji = r.reaction_type === "realm_emoji" || r.reaction_type === "zulip_extra_emoji";
 
-    opts.message.clean_reactions.set(opts.local_id, r);
+    return r;
 }
 
 export function update_user_fields(r) {

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -303,31 +303,29 @@ view.update_existing_reaction = function ({
     }
 };
 
-view.insert_new_reaction = function (opts) {
+view.insert_new_reaction = function ({message_id, user_id, emoji_name, emoji_code, reaction_type}) {
     // Our caller ensures we are the first user to react to this
     // message with this emoji, and it populates user_list for
     // us.  We then render the emoji/title/count and insert it
     // before the add button.
 
-    const message_id = opts.message_id;
-    const user_id = opts.user_id;
     const user_list = [user_id];
 
     const context = {
         message_id,
-        ...emoji.get_emoji_details_for_rendering(opts),
+        ...emoji.get_emoji_details_for_rendering({emoji_name, emoji_code, reaction_type}),
     };
 
-    const new_label = generate_title(opts.emoji_name, user_list);
+    const new_label = generate_title(emoji_name, user_list);
 
     context.count = 1;
     context.label = new_label;
-    context.local_id = get_local_reaction_id(opts);
+    context.local_id = get_local_reaction_id({reaction_type, emoji_code});
     context.emoji_alt_code = user_settings.emojiset === "text";
     context.is_realm_emoji =
         context.reaction_type === "realm_emoji" || context.reaction_type === "zulip_extra_emoji";
 
-    if (opts.user_id === page_params.user_id) {
+    if (user_id === page_params.user_id) {
         context.class = "message_reaction reacted";
     } else {
         context.class = "message_reaction";

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -509,7 +509,7 @@ export function set_clean_reactions(message) {
     }
 }
 
-export function add_clean_reaction(opts) {
+function add_clean_reaction(opts) {
     const r = emoji.get_emoji_details_for_rendering(opts);
 
     r.local_id = opts.local_id;

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -502,13 +502,7 @@ export function set_clean_reactions(message) {
 
         message.clean_reactions.set(
             local_id,
-            make_clean_reaction({
-                local_id,
-                user_ids,
-                reaction_type: reaction.reaction_type,
-                emoji_name: reaction.emoji_name,
-                emoji_code: reaction.emoji_code,
-            }),
+            make_clean_reaction({local_id, user_ids, ...reaction}),
         );
     }
 }

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -513,12 +513,13 @@ export function set_clean_reactions(message) {
     }
 }
 
-function make_clean_reaction(opts) {
-    const r = emoji.get_emoji_details_for_rendering(opts);
+function make_clean_reaction({local_id, user_ids, emoji_name, emoji_code, reaction_type}) {
+    const r = {
+        local_id,
+        user_ids,
+        ...emoji.get_emoji_details_for_rendering({emoji_name, emoji_code, reaction_type}),
+    };
 
-    r.local_id = opts.local_id;
-
-    r.user_ids = opts.user_ids;
     update_user_fields(r);
 
     r.emoji_alt_code = user_settings.emojiset === "text";

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -279,16 +279,18 @@ export function add_reaction(event) {
     }
 }
 
-view.update_existing_reaction = function (opts) {
+view.update_existing_reaction = function ({
+    message_id,
+    emoji_name,
+    user_list,
+    user_id,
+    reaction_type,
+    emoji_code,
+}) {
     // Our caller ensures that this message already has a reaction
     // for this emoji and sets up our user_list.  This function
     // simply updates the DOM.
-
-    const message_id = opts.message_id;
-    const emoji_name = opts.emoji_name;
-    const user_list = opts.user_list;
-    const user_id = opts.user_id;
-    const local_id = get_local_reaction_id(opts);
+    const local_id = get_local_reaction_id({reaction_type, emoji_code});
     const reaction = find_reaction(message_id, local_id);
 
     set_reaction_count(reaction, user_list.length);


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Based on the conversation:
https://chat.zulip.org/#narrow/stream/6-frontend/topic/function.20parameter.20destructuring.20for.20.28opts.29

**Testing plan:** <!-- How have you tested? -->
Automated tests pass.

**notes:** <!-- How have you tested? -->
This makes it really clear to me that we should define `{emoji_name, emoji_code, reaction_type}` as `emoji_params`. (and possibly also rename `reaction_type` to `emoji_type`.)