### PR TITLE
notifications: Don't enqueue notifications for bots.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -119,6 +119,7 @@ class SendMessageRequest:
     long_term_idle_user_ids: Set[int]
     default_bot_user_ids: Set[int]
     service_bot_tuples: List[Tuple[int, int]]
+    all_bot_user_ids: Set[int]
     wildcard_mention_user_ids: Set[int]
     links_for_embed: Set[str]
     widget_content: Optional[Dict[str, Any]]

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -41,7 +41,24 @@ class UserMessageNotificationsData:
         stream_email_user_ids: Set[int],
         wildcard_mention_user_ids: Set[int],
         muted_sender_user_ids: Set[int],
+        all_bot_user_ids: Set[int],
     ) -> "UserMessageNotificationsData":
+
+        if user_id in all_bot_user_ids:
+            # Don't send any notifications to bots
+            return cls(
+                user_id=user_id,
+                pm_email_notify=False,
+                mention_email_notify=False,
+                wildcard_mention_email_notify=False,
+                pm_push_notify=False,
+                mention_push_notify=False,
+                wildcard_mention_push_notify=False,
+                online_push_enabled=False,
+                stream_push_notify=False,
+                stream_email_notify=False,
+                sender_is_muted=False,
+            )
 
         # `wildcard_mention_user_ids` are those user IDs for whom wildcard mentions should
         # obey notification settings of personal mentions. Hence, it isn't an independent

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -948,9 +948,16 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
         return
     user_profile = get_user_profile_by_id(user_profile_id)
 
-    if user_profile.is_bot:
-        # BUG: Investigate why it's possible to get here.
-        return  # nocoverage
+    if user_profile.is_bot:  # nocoverage
+        # We don't expect to reach here for bot users. However, this code exists
+        # to find and throw away any pre-existing events in the queue while
+        # upgrading from versions before our notifiability logic was implemented.
+        # TODO/compatibility: This block can be removed when one can no longer
+        # upgrade from versions <= 4.0 to versions >= 5.0
+        logger.warning(
+            "Send-push-notification event found for bot user %s. Skipping.", user_profile_id
+        )
+        return
 
     if not (
         user_profile.enable_offline_push_notifications

--- a/zerver/tests/test_notification_data.py
+++ b/zerver/tests/test_notification_data.py
@@ -1,10 +1,15 @@
 from zerver.lib.mention import MentionBackend, MentionData
-from zerver.lib.notification_data import get_user_group_mentions_data
+from zerver.lib.notification_data import UserMessageNotificationsData, get_user_group_mentions_data
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.user_groups import create_user_group
 
 
 class TestNotificationData(ZulipTestCase):
+    """
+    Because the `UserMessageNotificationsData` does not do any database queries, all user IDs
+    used in the following tests are arbitrary, and do not represent real users.
+    """
+
     def test_is_push_notifiable(self) -> None:
         user_id = self.example_user("hamlet").id
         acting_user_id = self.example_user("cordelia").id
@@ -211,6 +216,24 @@ class TestNotificationData(ZulipTestCase):
         acting_user_id = self.example_user("cordelia").id
         user_data = self.create_user_notifications_data_object(user_id=user_id, pm_push_notify=True)
         self.assertTrue(user_data.is_notifiable(acting_user_id=acting_user_id, idle=True))
+
+    def test_bot_user_notifiability(self) -> None:
+        # Non-bot user (`user_id=9`) should get notified, while bot user (`user_id=10`) shouldn't
+        for user_id, notifiable in [(9, True), (10, False)]:
+            user_data = UserMessageNotificationsData.from_user_id_sets(
+                user_id=user_id,
+                flags=["mentioned"],
+                private_message=True,
+                online_push_user_ids=set(),
+                pm_mention_email_disabled_user_ids=set(),
+                pm_mention_push_disabled_user_ids=set(),
+                all_bot_user_ids={10, 11, 12},
+                muted_sender_user_ids=set(),
+                stream_email_user_ids=set(),
+                stream_push_user_ids=set(),
+                wildcard_mention_user_ids=set(),
+            )
+            self.assertEqual(user_data.is_notifiable(acting_user_id=1000, idle=True), notifiable)
 
     def test_user_group_mentions_map(self) -> None:
         hamlet = self.example_user("hamlet")

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1586,6 +1586,7 @@ class RecipientInfoTest(ZulipTestCase):
             long_term_idle_user_ids=set(),
             default_bot_user_ids=set(),
             service_bot_tuples=[],
+            all_bot_user_ids=set(),
         )
 
         self.assertEqual(info, expected_info)
@@ -1767,6 +1768,7 @@ class RecipientInfoTest(ZulipTestCase):
             possibly_mentioned_user_ids={service_bot.id, normal_bot.id},
         )
         self.assertEqual(info["default_bot_user_ids"], {normal_bot.id})
+        self.assertEqual(info["all_bot_user_ids"], {normal_bot.id, service_bot.id})
 
     def test_get_recipient_info_invalid_recipient_type(self) -> None:
         hamlet = self.example_user("hamlet")

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -920,6 +920,7 @@ def process_message_event(
     stream_email_user_ids = set(event_template.get("stream_email_user_ids", []))
     wildcard_mention_user_ids = set(event_template.get("wildcard_mention_user_ids", []))
     muted_sender_user_ids = set(event_template.get("muted_sender_user_ids", []))
+    all_bot_user_ids = set(event_template.get("all_bot_user_ids", []))
 
     wide_dict: Dict[str, Any] = event_template["message_dict"]
 
@@ -967,6 +968,7 @@ def process_message_event(
             stream_email_user_ids=stream_email_user_ids,
             wildcard_mention_user_ids=wildcard_mention_user_ids,
             muted_sender_user_ids=muted_sender_user_ids,
+            all_bot_user_ids=all_bot_user_ids,
         )
 
         internal_data = asdict(user_notifications_data)
@@ -1113,6 +1115,7 @@ def process_message_update_event(
     stream_email_user_ids = set(event_template.pop("stream_email_user_ids", []))
     wildcard_mention_user_ids = set(event_template.pop("wildcard_mention_user_ids", []))
     muted_sender_user_ids = set(event_template.pop("muted_sender_user_ids", []))
+    all_bot_user_ids = set(event_template.pop("all_bot_user_ids", []))
 
     # TODO/compatibility: Translation code for the rename of
     # `push_notify_user_ids` to `online_push_user_ids`.  Remove this
@@ -1159,6 +1162,7 @@ def process_message_update_event(
             stream_email_user_ids=stream_email_user_ids,
             wildcard_mention_user_ids=wildcard_mention_user_ids,
             muted_sender_user_ids=muted_sender_user_ids,
+            all_bot_user_ids=all_bot_user_ids,
         )
 
         maybe_enqueue_notifications_for_message_update(


### PR DESCRIPTION
This replaces the temporary (and testless) fix in
24b1439 with a more permanent
fix.

Instead of checking if the user is a bot just before
sending the notifications, we now just don't enqueue
notifications for bots. This is done by sending a list
of bot IDs to the event_queue code, just like other
lists which are used for creating NotificationData objects.