### PR TITLE
tests: Improve testing helper event schema for `update_message`.

### DIFF
--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1530,19 +1530,6 @@ update_message_required_fields = [
 update_message_stream_fields: List[Tuple[str, object]] = [
     ("stream_id", int),
     ("stream_name", str),
-    ("new_stream_id", int),
-    (
-        "propagate_mode",
-        EnumType(
-            [
-                # The order here needs to match the OpenAPI definitions
-                "change_one",
-                "change_later",
-                "change_all",
-            ]
-        ),
-    ),
-    (ORIG_TOPIC, str),
 ]
 
 update_message_content_fields: List[Tuple[str, object]] = [
@@ -1559,8 +1546,31 @@ update_message_topic_fields = [
     (TOPIC_NAME, str),
 ]
 
+update_message_change_stream_fields: List[Tuple[str, object]] = [
+    ("new_stream_id", int),
+]
+
+update_message_change_stream_or_topic_fields: List[Tuple[str, object]] = [
+    (
+        "propagate_mode",
+        EnumType(
+            [
+                # The order here needs to match the OpenAPI definitions
+                "change_one",
+                "change_later",
+                "change_all",
+            ]
+        ),
+    ),
+    (ORIG_TOPIC, str),
+]
+
 update_message_optional_fields = (
-    update_message_stream_fields + update_message_content_fields + update_message_topic_fields
+    update_message_stream_fields
+    + update_message_content_fields
+    + update_message_topic_fields
+    + update_message_change_stream_fields
+    + update_message_change_stream_or_topic_fields
 )
 
 # The schema here does not include the "embedded"
@@ -1596,13 +1606,11 @@ def check_update_message(
 
     if has_topic:
         expected_keys.update(tup[0] for tup in update_message_topic_fields)
+        expected_keys.update(tup[0] for tup in update_message_change_stream_or_topic_fields)
 
-    if not has_new_stream_id:
-        expected_keys.discard("new_stream_id")
-
-    if not has_new_stream_id and not has_topic:
-        expected_keys.discard("propagate_mode")
-        expected_keys.discard(ORIG_TOPIC)
+    if has_new_stream_id:
+        expected_keys.update(tup[0] for tup in update_message_change_stream_fields)
+        expected_keys.update(tup[0] for tup in update_message_change_stream_or_topic_fields)
 
     assert expected_keys == actual_keys
 


### PR DESCRIPTION
Further clarifies the fields returned by `update_message` event for the type of change (content, topic and/or stream) in the testing helper `zerver/lib/event_schema.py`. Follow-up task from #20587.

Creates a separate list for the two fields (`propagate_mode` and `org_subject`) that are returned for topic and/or stream changes, as well as a separate list for the one field (`new_stream_id`) that is only returned for stream changes.

These two separate lists allow for the basic schema to be built / checked easily. And, as the expected keys are built from the unions of the boolean parameters (`is_stream_message`, `has_content`, `has_topic`, `has_new_stream_id`), there's no duplication of fields when both the stream and topic of a message are changed.