### PR TITLE
compose: Warn if private message @mentions recipient user

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -431,6 +431,7 @@ test("content_typeahead_selected", ({override}) => {
     fake_this.completing = "mention";
 
     override(compose_validate, "warn_if_mentioning_unsubscribed_user", () => {});
+    override(compose_validate, "warn_if_pm_mentions_user", (mention_text) => mention_text);
 
     fake_this.query = "@**Mark Tw";
     fake_this.token = "Mark Tw";

--- a/frontend_tests/puppeteer_tests/mention.ts
+++ b/frontend_tests/puppeteer_tests/mention.ts
@@ -39,4 +39,22 @@ async function test_mention(page: Page): Promise<void> {
     await common.check_messages_sent(page, "zhome", [["Verona > Test mention all", ["@all"]]]);
 }
 
+async function test_private_mention(page: Page): Promise<void> {
+    await common.log_in(page);
+    await page.click(".top_left_all_messages");
+    await page.waitForSelector("#zhome .message_row", {visible: true});
+
+    console.log("Creating private message draft");
+    await page.keyboard.press("KeyX");
+    await page.waitForSelector("#private_message_recipient", {visible: true});
+    await common.fill_form(page, "form#send_message_form", {content: "Test private message."});
+    await common.pm_recipient.set(page, "cordelia@zulip.com");
+    await common.select_item_via_typeahead(page, "#compose-textarea", "@**Cord", "Cordelia");
+    await common.ensure_enter_does_not_send(page);
+    await page.waitForSelector("#compose_pm_mentions_user_alert", {hidden: false});
+    await common.assert_compose_box_content(page, "@_**Cordelia, Lear's daughter** ");
+    await page.click("#compose_close");
+}
+
 common.run_test(test_mention);
+common.run_test(test_private_mention);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -82,6 +82,11 @@ export function clear_private_stream_alert() {
     $("#compose_private_stream_alert").empty();
 }
 
+export function clear_pm_mentions_user_alert() {
+    $("#compose_pm_mentions_user_alert").hide();
+    $("#compose_pm_mentions_user_alert").empty();
+}
+
 export function clear_preview_area() {
     $("#compose-textarea").show();
     $("#compose .undo_markdown_preview").hide();
@@ -281,6 +286,7 @@ export function finish() {
     clear_preview_area();
     clear_invites();
     clear_private_stream_alert();
+    clear_pm_mentions_user_alert();
     notifications.clear_compose_notifications();
 
     const message_content = compose_state.message_content();
@@ -542,6 +548,34 @@ export function initialize() {
             if ($stream_alert.children().length === 0) {
                 $stream_alert.hide();
             }
+        },
+    );
+
+    $("#compose_pm_mentions_user_alert").on(
+        "click",
+        ".compose_pm_mentions_user_alert_close",
+        (event) => {
+            const $mention_alert_row = $(event.target).parents(".compose_pm_mentions_user_alert");
+            const $mention_alert = $("#compose_pm_mentions_user_alert");
+
+            $mention_alert_row.remove();
+
+            if ($mention_alert.children().length === 0) {
+                $mention_alert.hide();
+            }
+        },
+    );
+    $("#compose_pm_mentions_user_alert").on(
+        "click",
+        "#compose_pm_mentions_user_alert_undo",
+        (event) => {
+            const $warning_area = $(event.target).closest(".compose_pm_mentions_user_alert");
+            const full_name = $warning_area.data("full-name");
+            const user_id = $warning_area.data("user-id");
+            compose_validate.undo_warn_if_pm_mentions_user(full_name, user_id);
+            event.preventDefault();
+            event.stopPropagation();
+            $("button.compose_pm_mentions_user_alert_close").trigger("click");
         },
     );
 

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -111,6 +111,7 @@ function clear_box() {
     compose_validate.clear_all_everyone_warnings();
     compose_validate.clear_announce_warnings();
     compose.clear_private_stream_alert();
+    compose.clear_pm_mentions_user_alert();
     compose_validate.set_user_acknowledged_all_everyone_flag(undefined);
     compose_validate.set_user_acknowledged_announce_flag(undefined);
 

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -814,15 +814,20 @@ export function content_typeahead_selected(item, event) {
                 // that functionality yet, and we haven't gotten much
                 // feedback on this being an actual pitfall.
             } else {
-                const mention_text = people.get_mention_syntax(
+                let mention_text = people.get_mention_syntax(
                     item.full_name,
                     item.user_id,
                     is_silent,
                 );
-                beginning += mention_text + " ";
                 if (!is_silent) {
                     compose_validate.warn_if_mentioning_unsubscribed_user(item);
+                    mention_text = compose_validate.warn_if_pm_mentions_user(
+                        mention_text,
+                        item.full_name,
+                        item.user_id,
+                    );
                 }
+                beginning += mention_text + " ";
             }
             break;
         }

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -293,6 +293,7 @@
     position: absolute;
 }
 
+.compose_pm_mentions_user_alert_close,
 .compose_resolved_topic_user_controls .compose_resolved_topic_close,
 .compose_invite_user_controls .compose_invite_close,
 .compose_private_stream_alert_controls .compose_private_stream_alert_close {
@@ -307,6 +308,7 @@
 .compose-all-everyone-controls,
 .compose-announce-controls,
 .compose_invite_user_controls,
+.compose_pm_mentions_user_alert_controls,
 .compose_private_stream_alert_controls {
     float: right;
     position: relative;
@@ -318,6 +320,12 @@
     margin: 5px 20px;
     display: inline-block;
     max-width: calc(100% - 100px);
+}
+
+.compose_pm_mentions_user_alert p {
+    margin: 5px 20px;
+    display: inline-block;
+    max-width: calc(100% - 120px);
 }
 
 #error-message-sub-button {

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -56,6 +56,7 @@
         <div id="compose-announce" class="alert home-error-bar"></div>
         <div id="compose_not_subscribed" class="alert home-error-bar"></div>
         <div id="compose_private_stream_alert" class="alert home-error-bar"></div>
+        <div id="compose_pm_mentions_user_alert" class="alert home-error-bar"></div>
         <div id="out-of-view-notification" class="notification-alert"></div>
         <div class="composition-area">
             <form id="send_message_form" action="/json/messages" method="post">

--- a/static/templates/compose_pm_mentions_user_alert.hbs
+++ b/static/templates/compose_pm_mentions_user_alert.hbs
@@ -1,0 +1,7 @@
+<div class="compose_pm_mentions_user_alert" data-user-id="{{user_id}}" data-full-name="{{full_name}}">
+    <p>{{#tr}}To avoid highlighting this message for <b>{full_name}</b>, we have updated it to use a silent mention (@_).{{/tr}}</p>
+    <div class="compose_pm_mentions_user_alert_controls">
+        <button id="compose_pm_mentions_user_alert_undo" class="btn btn-warning compose_undo" >{{t "Undo" }}</button>
+        <button type="button" class="compose_pm_mentions_user_alert_close close">&times;</button>
+    </div>
+</div>


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip/issues/17998

**Testing plan:**
This code copies from compose_private_stream_alert - I tested a set of cases: @user @otheruser @group box dismissal multiple mentions, etc. Message text came verbatim from @alya recommendation in the original issue.

**GIFs or screenshots:** 
![image](https://user-images.githubusercontent.com/140002/147013645-c2f78c01-fad2-43d1-b939-af1f38f03114.png)
