### PR TITLE
Display todo checkboxes properly.

### DIFF
--- a/static/js/todo_widget.js
+++ b/static/js/todo_widget.js
@@ -5,6 +5,7 @@ import render_widgets_todo_widget_tasks from "../templates/widgets/todo_widget_t
 
 import * as blueslip from "./blueslip";
 import {$t} from "./i18n";
+import {page_params} from "./page_params";
 import * as util from "./util";
 
 // Any single user should send add a finite number of tasks
@@ -193,6 +194,17 @@ export function activate(opts) {
 
         elem.find("input.task").on("click", (e) => {
             e.stopPropagation();
+
+            if (page_params.is_spectator) {
+                // Logically, spectators should not be able totoggle
+                // TODO checkboxes. However, the browser changes the
+                // checkbox's state before calling handlers like this,
+                // so we need to just toggle the checkbox back to its
+                // previous state.
+                $(e.target).prop("checked", !$(e.target).is(":checked"));
+                $(e.target).blur();
+                return;
+            }
             const key = $(e.target).attr("data-key");
 
             const data = task_data.handle.strike.outbound(key);


### PR DESCRIPTION
Checkboxes now don't change if a user who is not logged in clicks on them.

resolves https://github.com/zulip/zulip/issues/20300
![todo-checkboxes](https://user-images.githubusercontent.com/74348920/147112087-d05c4a3e-40ea-4083-b6d1-c0251cc87f18.gif)

