### PR TITLE
message_edit: Show private stream linked alert above message edit box.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -400,6 +400,11 @@ test("content_typeahead_selected", ({override}) => {
         caret_called2 = true;
         return this;
     };
+    fake_this.$element.attr = function (attr_name) {
+        assert.equal(attr_name, "id");
+        return "compose-textarea";
+    };
+
     autosize_called = false;
     set_timeout_called = false;
 

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -840,7 +840,7 @@ export function content_typeahead_selected(item, event) {
                 highlight.end = highlight.start + item.placeholder.length;
             }
             break;
-        case "stream":
+        case "stream": {
             beginning = beginning.slice(0, -this.token.length - 1);
             if (beginning.endsWith("#*")) {
                 beginning = beginning.slice(0, -2);
@@ -854,8 +854,15 @@ export function content_typeahead_selected(item, event) {
             } else {
                 beginning += "** ";
             }
-            compose_validate.warn_if_private_stream_is_linked(item);
+
+            let $message_row;
+            if ($textbox.attr("id") !== "compose-textarea") {
+                $message_row = $textbox.closest(".message_row");
+            }
+
+            compose_validate.warn_if_private_stream_is_linked(item, $message_row);
             break;
+        }
         case "syntax": {
             // Isolate the end index of the triple backticks/tildes, including
             // possibly a space afterward

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -667,6 +667,21 @@ function edit_message($row, raw_content) {
         });
     }
     composebox_typeahead.initialize_topic_edit_typeahead($message_edit_topic, message.stream, true);
+
+    $(".message_edit_private_stream_alert").on(
+        "click",
+        ".compose_private_stream_alert_close",
+        (e) => {
+            const $stream_alert_row = $(e.target).parents(".compose_private_stream_alert");
+            const $stream_alert = $(e.target).closest(".home-error-bar");
+
+            $stream_alert_row.remove();
+
+            if ($stream_alert.children().length === 0) {
+                $stream_alert.hide();
+            }
+        },
+    );
 }
 
 function start_edit_maintaining_scroll($row, content) {

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -5,6 +5,7 @@
         <span class="send-status-close">&times;</span>
         <span class="error-msg"></span>
     </div>
+    <div class="alert home-error-bar message_edit_private_stream_alert"></div>
     {{#if is_stream}}
     <div class="edit-controls">
         <div class="message_edit_header">


### PR DESCRIPTION
We now show the warning while linking private stream above the message
edit input instead of compose-box.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

<!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![private-warning](https://user-images.githubusercontent.com/35494118/147365304-05b577f9-afd8-48de-819a-21b2da8602cc.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
