### PR TITLE
Doc: Fix typo in documentation

### DIFF
--- a/docs/subsystems/client.md
+++ b/docs/subsystems/client.md
@@ -20,7 +20,7 @@ A `Client` is used to sort messages into client categories such as
 Generally, integrations in Zulip should declare a unique User-Agent,
 so that it's easy to figure out which integration is involved when
 debugging an issue. For incoming webhook integrations, we do that
-convenentialy via the auth decorators (as we will describe shortly);
+conveniently via the auth decorators (as we will describe shortly);
 other integrations generally should set the first User-Agent element
 on their HTTP requests to something of the form
 ZulipIntegrationName/1.2 so that they are categorized properly.

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -586,7 +586,7 @@ strong {
     To resolve this, we just hide the tooltip for touch-events on
     touch-enabled devices resolving the above problem.  This means
     that tooltips will never appear on touchscreen devices, but that's
-    probably a reasoanble tradeoff here.
+    probably a reasonable tradeoff here.
 
     Source: https://drafts.csswg.org/mediaqueries-4/#mf-interaction
     */
@@ -661,7 +661,7 @@ strong {
                 filter: progid:dximagetransform.microsoft.gradient(startcolorstr='hsla(328, 100%, 50%, 0.8)', endcolorstr='hsla(332, 100%, 50%, 0.7)', gradienttype=0);
             }
             /* styles defined for user_circle here only deal with positioning of user_presence_circle
-            in typeahead list in order to ensure they are renderred correctly in in all screen sizes.
+            in typeahead list in order to ensure they are rendered correctly in in all screen sizes.
             Most of the style rules related to color, gradient etc. which are generally common throughout
             the app are defined in user_circles.css and are not overridden here. */
             .user_circle {


### PR DESCRIPTION
`convenentialy` ---> `conveniently`