### PR TITLE
[ADDED] Fedora 35 support

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -15,7 +15,7 @@ that's running one of:
 - Ubuntu 20.04 Focal, 18.04 Bionic
 - Debian 10 Buster, 11 Bullseye (beta)
 - CentOS 7 (beta)
-- Fedora 33 and 34 (beta)
+- Fedora 33, 34 and 35 (beta)
 - RHEL 7 (beta)
 
 You can just run the Zulip provision script on your machine.

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -184,7 +184,7 @@ backoff
 pymongo
 
 # Non-backtracking regular expressions
-google-re2
+#google-re2==0.0.5 # https://github.com/google/re2/issues/271
 
 # For querying recursive group membership
 django-cte

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -465,7 +465,7 @@ gitlint-core==0.17.0 \
     --hash=sha256:772dfd33effaa8515ca73e901466aa938c19ced894bec6783d19691f57429691 \
     --hash=sha256:cb99ccd736a698b910385211203bda94bf4ce29086d0c08f8f58a18c40a98377
     # via -r requirements/dev.in
-google-re2==0.2.20211101 \
+google-re2==0.0.5 \
     --hash=sha256:07cc08c067156c8fc13d5cb074a4ad2496f3fc73d2b83b80cdfaa2c873edada6 \
     --hash=sha256:0be575a2204257eee3e2767415d4c2043ffc31b272a10ce64f1e013151f25927 \
     --hash=sha256:1f3b1a0664fcf934e23e449f700fc5fd83a1d93806bd8dc2c395506d05a138a7 \
@@ -482,7 +482,9 @@ google-re2==0.2.20211101 \
     --hash=sha256:9536f4d965eaa6754170b4ebdabd6a89b64fe4560cc207fec5272bfad345e8be \
     --hash=sha256:c1fb5dbc23fcc2d5a634e23a185ea08e552a83d76bf324ab52b15eb8c0f87795 \
     --hash=sha256:d3dc0f87924bf9be5cd14e69c3d90cd5c78cf455facaf0dbe859795e4c227ceb \
-    --hash=sha256:f3c6bac568fb4fedc8c3c8991ae3ac021fd52340f5a64444d100f0b76e6fba71
+    --hash=sha256:f3c6bac568fb4fedc8c3c8991ae3ac021fd52340f5a64444d100f0b76e6fba71 \
+    --hash=sha256:427e683ac116d161ac60b7d2c481def4f1b2c087309ae8e91da0d1a2725dd6c5
+
     # via -r requirements/common.in
 greenlet==1.1.2 \
     --hash=sha256:00e44c8afdbe5467e4f7b5851be223be68adb4272f44696ee71fe46b7036a711 \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -303,7 +303,7 @@ ecdsa==0.17.0 \
 future==0.18.2 \
     --hash=sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d
     # via python-twitter
-google-re2==0.2.20211101 \
+google-re2==0.0.5 \
     --hash=sha256:07cc08c067156c8fc13d5cb074a4ad2496f3fc73d2b83b80cdfaa2c873edada6 \
     --hash=sha256:0be575a2204257eee3e2767415d4c2043ffc31b272a10ce64f1e013151f25927 \
     --hash=sha256:1f3b1a0664fcf934e23e449f700fc5fd83a1d93806bd8dc2c395506d05a138a7 \
@@ -320,7 +320,8 @@ google-re2==0.2.20211101 \
     --hash=sha256:9536f4d965eaa6754170b4ebdabd6a89b64fe4560cc207fec5272bfad345e8be \
     --hash=sha256:c1fb5dbc23fcc2d5a634e23a185ea08e552a83d76bf324ab52b15eb8c0f87795 \
     --hash=sha256:d3dc0f87924bf9be5cd14e69c3d90cd5c78cf455facaf0dbe859795e4c227ceb \
-    --hash=sha256:f3c6bac568fb4fedc8c3c8991ae3ac021fd52340f5a64444d100f0b76e6fba71
+    --hash=sha256:f3c6bac568fb4fedc8c3c8991ae3ac021fd52340f5a64444d100f0b76e6fba71 \
+    --hash=sha256:427e683ac116d161ac60b7d2c481def4f1b2c087309ae8e91da0d1a2725dd6c5
     # via -r requirements/common.in
 greenlet==1.1.2 \
     --hash=sha256:00e44c8afdbe5467e4f7b5851be223be68adb4272f44696ee71fe46b7036a711 \

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -95,6 +95,8 @@ elif vendor == "fedora" and os_version == "33":
     POSTGRESQL_VERSION = "13"
 elif vendor == "fedora" and os_version == "34":
     POSTGRESQL_VERSION = "13"
+elif vendor == "fedora" and os_version == "35":
+    POSTGRESQL_VERSION = "13"    
 elif vendor == "rhel" and os_version.startswith("7."):
     POSTGRESQL_VERSION = "10"
 elif vendor == "centos" and os_version == "7":


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This PR is for Issue #20635 . I have added support for Fedora 34.

**Changes:**
I have had to downgrade `google-re2` version to 0.0.5 as it is the only latest version that works best with fedora. If you have any suggestions to make it Fedora specific, kindly comment on this PR.

**Testing plan:** <!-- How have you tested? -->
This was tested on my local system which is based on Fedora 35. It works perfectly as per my knowledge.

**Important Note:**
In python 3.10 collections.MutableMapping has been changed to collections.abc.MutableMapping. So I would advise not using Python 3.10. As I had to manually change this.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
