### PR TITLE
Fix alignment of edit and delete buttons in Drafts

### DIFF
--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -109,7 +109,7 @@
             display: inline-block;
             position: absolute;
             top: 9px;
-            right: -80px;
+            right: -103px;
             font-size: 0.9em;
 
             @media (width < $sm_min) {


### PR DESCRIPTION
PR for issue #20529 

Manually tested different right margins for the icons using Chrome Dev Tools

Screenshots after applying changes :
![103](https://user-images.githubusercontent.com/79650357/147433845-9b2ad179-acf7-438d-aff0-e46b0a3cc305.png)

![Screenshot from 2021-12-27 09-25-16](https://user-images.githubusercontent.com/79650357/147433877-4c7efdef-a75f-46a2-979a-2684f96db875.png)
![Screenshot from 2021-12-27 09-29-44](https://user-images.githubusercontent.com/79650357/147433886-07df8c2d-1af2-4afb-8cf6-355feac073f1.png)

