### PR TITLE
popovers: Fix alignment of "edit" and "delete" buttons in Drafts

### DIFF
--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -109,7 +109,7 @@
             display: inline-block;
             position: absolute;
             top: 9px;
-            right: -80px;
+            right: -103px;
             font-size: 0.9em;
 
             @media (width < $sm_min) {


### PR DESCRIPTION
Fixes: #20529

Manually tested different right margins for the icons using Chrome Dev Tools

Screenshots after applying changes :
![103](https://user-images.githubusercontent.com/79650357/147438759-8387ce01-e0d5-4c89-a181-6d7bd8757393.png)

![Screenshot from 2021-12-27 09-25-16](https://user-images.githubusercontent.com/79650357/147438768-79ec1698-7133-4b8c-a7b5-73ed53b69d98.png)
![Screenshot from 2021-12-27 09-29-44](https://user-images.githubusercontent.com/79650357/147438779-c9d36c22-90d1-4fe6-a30c-1b305019026f.png)
