### PR TITLE
Minor puppet supervisor cleanups

### DIFF
--- a/puppet/zulip/manifests/supervisor.pp
+++ b/puppet/zulip/manifests/supervisor.pp
@@ -39,20 +39,6 @@ class zulip::supervisor {
     ensure => absent,
   }
 
-  # These were similarly moved, but were only referenced in zulip_ops,
-  # and thus can be removed as soon as all relevant hosts have been
-  # updated:
-  file { [
-    "${zulip::common::supervisor_system_conf_dir}/grafana.conf",
-    "${zulip::common::supervisor_system_conf_dir}/munin_tunnels.conf",
-    "${zulip::common::supervisor_system_conf_dir}/prometheus.conf",
-    "${zulip::common::supervisor_system_conf_dir}/prometheus_node_exporter.conf",
-    "${zulip::common::supervisor_system_conf_dir}/redis_tunnel.conf",
-    "${zulip::common::supervisor_system_conf_dir}/zmirror.conf",
-    ]:
-    ensure => absent,
-  }
-
   # In the docker environment, we don't want/need supervisor to be
   # started/stopped /bin/true is used as a decoy command, to maintain
   # compatibility with other code using the supervisor service.

--- a/puppet/zulip/manifests/supervisor.pp
+++ b/puppet/zulip/manifests/supervisor.pp
@@ -29,12 +29,12 @@ class zulip::supervisor {
   # subdirectory in 2020-10 in version 4.0; these lines can be removed
   # in Zulip version 5.0 and later.
   file { [
-    "${zulip::common::supervisor_system_conf_dir}/cron.conf",
-    "${zulip::common::supervisor_system_conf_dir}/nginx.conf",
-    "${zulip::common::supervisor_system_conf_dir}/smokescreen.conf",
-    "${zulip::common::supervisor_system_conf_dir}/thumbor.conf",
-    "${zulip::common::supervisor_system_conf_dir}/zulip.conf",
-    "${zulip::common::supervisor_system_conf_dir}/zulip_db.conf",
+    "${system_conf_dir}/cron.conf",
+    "${system_conf_dir}/nginx.conf",
+    "${system_conf_dir}/smokescreen.conf",
+    "${system_conf_dir}/thumbor.conf",
+    "${system_conf_dir}/zulip.conf",
+    "${system_conf_dir}/zulip_db.conf",
     ]:
     ensure => absent,
   }


### PR DESCRIPTION
**Testing plan:** Untested.  Verified that all zulip-ops files have been moved via:
```
tsh ls --format names | xargs -I{} tsh ssh root@{} 'hostname && ls /etc/supervisor/conf.d/*.conf'
```