### PR TITLE
compose: Fixes #20639 by preventing upload files tooltip from hiding …

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -115,6 +115,9 @@ export function initialize() {
         // so that regular users don't have to see
         // them unless they want to.
         delay: [300, 20],
+        // This ensures that the upload files tooltip
+        // doesn't hide behind the left sidebar.
+        appendTo: () => document.body,
     });
 
     delegate("body", {


### PR DESCRIPTION
Prevent upload files tooltip from hiding behind the left sidebar.
https://github.com/zulip/zulip/issues/20639

All tests ran successfully.

![zulip](https://user-images.githubusercontent.com/69853994/147515549-ed66469b-e8b8-4777-b993-91d0076d0107.png)

