### PR TITLE
settings: Fix code for special case of theme settings subsection.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -215,12 +215,13 @@ export function extract_property_name(elem, for_realm_default_settings) {
 
 function get_subsection_property_elements(element) {
     const subsection = $(element).closest(".org-subsection-parent");
-    if (subsection.hasClass("emoji-settings")) {
+    if (subsection.hasClass("theme-settings")) {
         // Because the emojiset widget has a unique radio button
         // structure, it needs custom code.
+        const color_scheme_elem = subsection.find(".setting_color_scheme");
         const emojiset_elem = subsection.find("input[name='emojiset']:checked");
         const translate_emoticons_elem = subsection.find(".translate_emoticons");
-        return [emojiset_elem, translate_emoticons_elem];
+        return [color_scheme_elem, emojiset_elem, translate_emoticons_elem];
     }
     return Array.from(subsection.find(".prop-element"));
 }


### PR DESCRIPTION
We handle "Theme settings" subsection separately in
get_subsection_property_elements as it contains unique
radio-button structure for emojiset setting.

This should have been fixed while reorganizing the section
to have color scheme and emoji related settings under same
subsection in adb612a0b484.

Fixes #20644.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![save-discard](https://user-images.githubusercontent.com/35494118/147590064-c1c3320c-e20e-4c8e-b1ac-c1de6aa94d7a.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
