### PR TITLE
requirements: Upgrade Python requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -53,9 +53,9 @@ async-generator==1.10 \
     --hash=sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b \
     --hash=sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144
     # via pyre-check
-attrs==21.2.0 \
-    --hash=sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1 \
-    --hash=sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb
+attrs==21.4.0 \
+    --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
+    --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
     # via
     #   automat
     #   jsonschema
@@ -606,6 +606,7 @@ importlib-metadata==4.8.3 ; python_version < "3.10" \
     #   markdown
     #   moto
     #   pep517
+    #   redis
     #   sqlalchemy
     #   zulip-bots
 incremental==21.3.0 \
@@ -961,9 +962,9 @@ more-itertools==8.12.0 \
     --hash=sha256:43e6dd9942dffd72661a2c4ef383ad7da1e6a3e968a927ad7a6083ab410a688b \
     --hash=sha256:7dc6ad46f05f545f900dd59e8dfb4e84a4827b97b3cfecb175ea0c7d247f6064
     # via openapi-core
-moto[s3]==2.2.19 \
-    --hash=sha256:5dd76e2568b167a5310d113cd000748dc8504549fec1fab2b214b42de6612dbe \
-    --hash=sha256:c07dba1bf56c7f0b67899936f8c2bfcbd0b77cbaba97056c2871de806a06fe8f
+moto[s3]==2.3.0 \
+    --hash=sha256:0a1913f8cfe1ea8a14bf7807de1e34df9731818dca70c91f3f42015c2d7a102c \
+    --hash=sha256:0d6a179622bb9d0cd8141bb33d78882039ce7400aca3a8c07ad6d00076b60c62
     # via -r requirements/dev.in
 mypy==0.930 \
     --hash=sha256:0feb82e9fa849affca7edd24713dbe809dce780ced9f3feca5ed3d80e40b777f \
@@ -1021,10 +1022,10 @@ openapi-core==0.14.2 \
     --hash=sha256:3426b5ae551a04f7d7a3a625ca600bff157affb4eb691d36412997f6a9ac6898 \
     --hash=sha256:62ad93c8114ce6025f25b004ff0f3674eea8bc4ae920c726e98921fdbe41b4f3
     # via -r requirements/common.in
-openapi-schema-validator==0.1.5 \
-    --hash=sha256:215b516d0942f4e8e2446cf3f7d4ff2ed71d102ebddcc30526d8a3f706ab1df6 \
-    --hash=sha256:a4b2712020284cee880b4c55faa513fbc2f8f07f365deda6098f8ab943c9f0df \
-    --hash=sha256:b65d6c2242620bfe76d4c749b61cd9657e4528895a8f4fb6f916085b508ebd24
+openapi-schema-validator==0.1.6 \
+    --hash=sha256:230db361c71a5b08b25ec926797ac8b59a8f499bbd7316bd15b6cd0fc9aea5df \
+    --hash=sha256:8ef097b78c191c89d9a12cdf3d311b2ecf9d3b80bbe8610dbc67a812205a6a8d \
+    --hash=sha256:af023ae0d16372cf8dd0d128c9f3eaa080dc3cd5dfc69e6a247579f25bd10503
     # via
     #   openapi-core
     #   openapi-spec-validator
@@ -1066,6 +1067,7 @@ packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
     # via
+    #   redis
     #   semgrep
     #   sphinx
 parse==1.19.0 \
@@ -1096,9 +1098,9 @@ pexpect==4.8.0 \
     --hash=sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937 \
     --hash=sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c
     # via ipython
-phonenumberslite==8.12.39 \
-    --hash=sha256:1001fd304ccf5ec7f926fd039ef07eefffa9880573698baede00a3becb8de6ad \
-    --hash=sha256:5b77990b6832675fa3a2e60a05e738af0bf96908352a8ee90b4d4ec964a03977
+phonenumberslite==8.12.40 \
+    --hash=sha256:153885eefec397058c8ce91fb987f55545b2cfa945f22a904584ddf162aa82b1 \
+    --hash=sha256:e6fe6cad1091f8928e34a98570cade4758f4cf4e70e9e32ff7eca517ce98e273
     # via django-two-factor-auth
 pickleshare==0.7.5 \
     --hash=sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca \
@@ -1211,18 +1213,18 @@ psutil==5.8.0 \
     # via
     #   pyre-check
     #   testslide
-psycopg2==2.9.2 \
-    --hash=sha256:26322c3f114de1f60c1b0febf8fdd595c221b4f624524178f515d07350a71bd1 \
-    --hash=sha256:6796ac614412ce374587147150e56d03b7845c9e031b88aacdcadc880e81bb38 \
-    --hash=sha256:77b9105ef37bc005b8ffbcb1ed6d8685bb0e8ce84773738aa56421a007ec5a7a \
-    --hash=sha256:77d09a79f9739b97099d2952bbbf18eaa4eaf825362387acbb9552ec1b3fa228 \
-    --hash=sha256:91c7fd0fe9e6c118e8ff5b665bc3445781d3615fa78e131d0b4f8c85e8ca9ec8 \
-    --hash=sha256:a761b60da0ecaf6a9866985bcde26327883ac3cdb90535ab68b8d784f02b05ef \
-    --hash=sha256:a84da9fa891848e0270e8e04dcca073bc9046441eeb47069f5c0e36783debbea \
-    --hash=sha256:b8816c6410fa08d2a022e4e38d128bae97c1855e176a00493d6ec62ccd606d57 \
-    --hash=sha256:dfc32db6ce9ecc35a131320888b547199f79822b028934bb5b332f4169393e15 \
-    --hash=sha256:f65cba7924363e0d2f416041b48ff69d559548f2cb168ff972c54e09e1e64db8 \
-    --hash=sha256:fd7ddab7d6afee4e21c03c648c8b667b197104713e57ec404d5b74097af21e31
+psycopg2==2.9.3 \
+    --hash=sha256:06f32425949bd5fe8f625c49f17ebb9784e1e4fe928b7cce72edc36fb68e4c0c \
+    --hash=sha256:0762c27d018edbcb2d34d51596e4346c983bd27c330218c56c4dc25ef7e819bf \
+    --hash=sha256:083707a696e5e1c330af2508d8fab36f9700b26621ccbcb538abe22e15485362 \
+    --hash=sha256:34b33e0162cfcaad151f249c2649fd1030010c16f4bbc40a604c1cb77173dcf7 \
+    --hash=sha256:4295093a6ae3434d33ec6baab4ca5512a5082cc43c0505293087b8a46d108461 \
+    --hash=sha256:8cf3878353cc04b053822896bc4922b194792df9df2f1ad8da01fb3043602126 \
+    --hash=sha256:8e841d1bf3434da985cc5ef13e6f75c8981ced601fd70cc6bf33351b91562981 \
+    --hash=sha256:9572e08b50aed176ef6d66f15a21d823bb6f6d23152d35e8451d7d2d18fdac56 \
+    --hash=sha256:a81e3866f99382dfe8c15a151f1ca5fde5815fde879348fe5a9884a7c092a305 \
+    --hash=sha256:cb10d44e6694d763fa1078a26f7f6137d69f555a78ec85dc2ef716c37447e4b2 \
+    --hash=sha256:d3ca6421b942f60c008f81a3541e8faf6865a28d5a9b48544b0ee4f40cac7fca
     # via -r requirements/common.in
 ptyprocess==0.7.0 \
     --hash=sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35 \
@@ -1419,8 +1421,9 @@ pyrsistent==0.18.0 \
     --hash=sha256:f3ef98d7b76da5eb19c37fda834d50262ff9167c65658d1d8f974d2e4d90676b \
     --hash=sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72
     # via jsonschema
-python-binary-memcached==0.30.1 \
-    --hash=sha256:f91c3d79d022121c22ef733e9beee86e0598e29ffec67401c68cece1ba7f036a
+python-binary-memcached==0.31.1 \
+    --hash=sha256:58c19c9a81e112633642bd5a26c1d8c6ac806bd055cf536b5b4bd2da701bc5b1 \
+    --hash=sha256:de4056f00a15d054dcf1af87d6cc9564876699e52da954c3ef44e8c5753d4050
     # via
     #   -r requirements/common.in
     #   django-bmemcached
@@ -1530,9 +1533,9 @@ queuelib==1.6.2 \
     --hash=sha256:4b207267f2642a8699a1f806045c56eb7ad1a85a10c0e249884580d139c2fcd2 \
     --hash=sha256:4b96d48f650a814c6fb2fd11b968f9c46178b683aad96d68f930fe13a8574d19
     # via scrapy
-redis==4.0.2 \
-    --hash=sha256:c8481cf414474e3497ec7971a1ba9b998c8efad0f0d289a009a5bbef040894f9 \
-    --hash=sha256:ccf692811f2c1fc7a92b466aa2599e4a6d2d73d5f736a2c70be600657c0da34a
+redis==4.1.0 \
+    --hash=sha256:21f0a23bce707909076e6ba2ce076cba59bff60d2ab22972e0647fdf620ffe47 \
+    --hash=sha256:e13fad67c098a33141bacde872786960e86a5c97a4255009bcd43c795fa1cc77
     # via -r requirements/common.in
 regex==2021.11.10 \
     --hash=sha256:0416f7399e918c4b0e074a0f66e5191077ee2ca32a0f99d4c187a62beb47aa05 \
@@ -1647,9 +1650,9 @@ rsa==4.8 \
     --hash=sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17 \
     --hash=sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb
     # via python-jose
-ruamel.yaml==0.17.17 \
-    --hash=sha256:9751de4cbb57d4bfbf8fc394e125ed4a2f170fbff3dc3d78abf50be85924f8be \
-    --hash=sha256:9af3ec5d7f8065582f3aa841305465025d0afd26c5fb54e15b964e11838fc74f
+ruamel.yaml==0.17.19 \
+    --hash=sha256:92ac00b312c9a83ff3253a8f7b86dfe6f9996b4082b103af84b8df99175945bc \
+    --hash=sha256:b9ce9a925d0f0c35a1dbba56b40f253c53cd526b0fa81cf7b1d24996f28fb1d7
     # via semgrep
 ruamel.yaml.clib==0.2.6 \
     --hash=sha256:0847201b767447fc33b9c235780d3aa90357d20dd6108b92be544427bea197dd \
@@ -1876,9 +1879,9 @@ tinycss2==1.1.1 \
     # via
     #   cairosvg
     #   cssselect2
-tlds==2021122100 \
-    --hash=sha256:11439f7ee29f44dd84d53d4e0f81b767d2f6579e32fece2f8f071a21d3af8cce \
-    --hash=sha256:4185f490c613d2cec597f41333e3d376d5b99cbd13c7b170a8295c076debfb22
+tlds==2021122800 \
+    --hash=sha256:594fbe1c59ecd52e5b785e72385bc82c84d7b4971035475298ccfc5a94751f38 \
+    --hash=sha256:f2d1970c333345595d97ddf0b3ac599823a4ff42da74831da19d94a6460ffc38
     # via -r requirements/common.in
 tomli==1.2.3 \
     --hash=sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f \
@@ -1941,65 +1944,65 @@ typeguard==2.13.3 \
     --hash=sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4 \
     --hash=sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1
     # via testslide
-types-boto==2.49.2 \
-    --hash=sha256:13c6a6a7aa83085ca6c1ab173199e4db31e38f488609fb96e64898ed5fd4dd84 \
-    --hash=sha256:b20ded0fc2da8d5c778bc1abb764a2fc86796765f0408be29d72c6a5d20ac171
+types-boto==2.49.3 \
+    --hash=sha256:27645e05058cad878839e5cb9edb48ef7215045481680db5d6ced374ce7a3a8d \
+    --hash=sha256:c7aadb5a613e022b96267d350193148c92a6ebe3f705f127e03654eda970c721
     # via -r requirements/mypy.in
 types-certifi==2021.10.8.0 \
     --hash=sha256:33308fb722d28cad8ae19834dcc4d2593509ac80bcbabe77c6d8e9a25001c2de \
     --hash=sha256:ca164939fe86b5f70988eed480b788162ee81f62e72f486a7b96cb53f4112355
     # via -r requirements/mypy.in
-types-chardet==4.0.1 \
-    --hash=sha256:6d2a73711c98f875ab73b87956e8bc1e7ac74f4bd9464631a1ce68f21bc3c1d1 \
-    --hash=sha256:a503019a8c4b945adc2c460857a0cc6958101e410a7ed8aa1a669a88b6179be1
+types-chardet==4.0.2 \
+    --hash=sha256:133806b34cf17228ab230ff6cbdb22635c95840a733ad5cf2a352a633b176188 \
+    --hash=sha256:1e05ac2f3bc46c4f067d59211aa54b63755e6d05f6d51022438a269fce139a26
     # via -r requirements/mypy.in
 types-commonmark==0.9.1 \
     --hash=sha256:60b382ec663e3e6bf0e4937d5af761899f1720e3cf33e14498bdf8ce0af46526 \
     --hash=sha256:c23509ba155c6c087d308dd1f891d414667f847553a651d6b3882d786b2b6970
     # via -r requirements/mypy.in
-types-dataclasses==0.6.1 \
-    --hash=sha256:6568532fed11f854e4db2eb48063385b323b93ecadd09f10a215d56246c306d7 \
-    --hash=sha256:aa45bb0dacdba09e3195a36ff8337bba45eac03b6f31c4645e87b4a2a47830dd
+types-dataclasses==0.6.2 \
+    --hash=sha256:19ea746937b82bfa0d3bba1dd78858eca2ed81932eae888c3f2966aa3fd0aec6 \
+    --hash=sha256:d74876d7a5e39ae6285765dd871e3b85d8186251f7b48e18130a35024c78bf73
     # via -r requirements/mypy.in
-types-decorator==5.1.0 \
-    --hash=sha256:242dcba983c9dce067b7c2d635fa11479254536d3de6056c808539040168a380 \
-    --hash=sha256:99abd00c614e54e75ee08d88799886acc2918cc88905eca6474ba917b327729b
+types-decorator==5.1.1 \
+    --hash=sha256:5817108fdbfbd4ea69b1072b1b57c9a726a4178cfd08160cb5bd4f993769b6c1 \
+    --hash=sha256:e1d2cd93f5507bcfbc68b698cda0159ca6c4a0d351d34724e3765bb603b08b92
     # via -r requirements/mypy.in
-types-docutils==0.17.1 \
-    --hash=sha256:6a7473d845fb15266d0a1742a5dfa2cf5240ddd8a64e4de9646f88a72c424c00 \
-    --hash=sha256:e7dc9db04f6dcc78fd7d903b99d9b4dc3c8b296e3f151114207a8f102e84361e
+types-docutils==0.17.2 \
+    --hash=sha256:a36cd6f8088e742ef9254ffb41746d93b55a3f36cf23ee7fa4d99e74b9d95a07 \
+    --hash=sha256:f50f5f05b8007aedc82949b4e4147398898cec1d6b4eb22a612f9e9b947621e8
     # via types-pygments
 types-jsonschema==4.3.0 \
     --hash=sha256:3107fa29766689e183c09ae98cac1f72aa246837c9f3697e609dc606e67c3077 \
     --hash=sha256:3b40478baa7d5b37fd261672d2d4049c5d0c69cbd891a05436ebd8732beb2c25
     # via -r requirements/mypy.in
-types-markdown==3.3.9 \
-    --hash=sha256:0fd38830517560f88c2f460ce5dc7006d831f560ec2a73f50c4ac06efac06793 \
-    --hash=sha256:4ab46c58185796366fd0e0a83fa901fbe8107f141d1ac3f1bca6b31df0e8b86c
+types-markdown==3.3.10 \
+    --hash=sha256:0e3153dc4ad3454326465e4e4e21fd90e8fc74966225ec5aeef15895a2c5d94a \
+    --hash=sha256:d4004e36a33cd3417cd299324232fc28e9915171a7ce46b43bf5b0c579db459d
     # via -r requirements/mypy.in
-types-oauthlib==3.1.4 \
-    --hash=sha256:06021a3cd350a144eee28286c6c0ada76fdae6afa45cd85f26fe29ce1fb2131d \
-    --hash=sha256:3436dfd502cebc1287ce6e8c0b2ce3bbda7a14b78c3b85e11abf71afdec8d7e0
+types-oauthlib==3.1.5 \
+    --hash=sha256:a8736acf764140f66c6ddd17227039e68db97feb58ce38fcde0f8a5319166f3a \
+    --hash=sha256:b89499e8d93ad23abf6a34790332a9e72c2a6be241a17f3b3c2b4f69514a8a5c
     # via -r requirements/mypy.in
-types-pillow==8.3.10 \
-    --hash=sha256:87632a5f3475e3eb4d1a23ae19ad568270c5d46c8e2821034e7cdca13f4c68dc \
-    --hash=sha256:cc7ab69803533ccfed16fb9a452c7b3f72ad3f903cb161917ba5acbedc7babe8
+types-pillow==8.3.11 \
+    --hash=sha256:998189334e616b1dd42c9634669efbf726184039e96e9a23ec95246e0ecff3fc \
+    --hash=sha256:aa96a739184f48f69e6f30218400623fc5a95f5fec199c447663a32538440405
     # via -r requirements/mypy.in
-types-polib==1.1.5 \
-    --hash=sha256:b2edb66228e4085dd419aa224f75c2b27f54898b2d8b7a383c05d5a1d8e3f901 \
-    --hash=sha256:fdd8b083736506a3b68b5e89c6e923c2c1f2684e35c4ede5c495b833103b4376
+types-polib==1.1.6 \
+    --hash=sha256:6b3fc54440884617c3283031df1cc746ab8a93063cad527de14182c925cc9260 \
+    --hash=sha256:9897aadea2ef30b64f0765e1f3caecb326d464d6d340ad88c4e204a9249a7294
     # via -r requirements/mypy.in
-types-psycopg2==2.9.4 \
-    --hash=sha256:3b1230df902610bf16f9272e0654652fd7a17504f3131ed4f2a552a5643e762c \
-    --hash=sha256:8c25c1c2860d9a51bb165f7b953872d7842e1770e75483597ee919cd834bf456
+types-psycopg2==2.9.5 \
+    --hash=sha256:a412838a5f68ef382db0ea6105d45de05d082dbad3ad467a824eadd5d3f32a78 \
+    --hash=sha256:b409d70bdd324325c8f3aa86bd5aba95a4a3f9d1039bd25e14b449aedb137a55
     # via -r requirements/mypy.in
-types-pygments==2.9.6 \
-    --hash=sha256:9b036b328ee9dbbfeec9f4f87940479bd71d4dc81f0c2d868a5452455c774a61 \
-    --hash=sha256:dfa0471bba797c237e9a40a4a323ff5ca7d21c9a37998f573f352d8c8b59fb1f
+types-pygments==2.9.10 \
+    --hash=sha256:2f0582b95dc0ff200f15a952e9e3213621d78959991f1c9dd5b1cbbdbd42de13 \
+    --hash=sha256:89473da21e983e881feb12cb45f2296355f859f50a710414ffe8afde92861742
     # via -r requirements/mypy.in
-types-python-dateutil==2.8.3 \
-    --hash=sha256:42262d0b8f8ecb06cdc5c458956685eb3b27c74f170adf541d1cc5ee4ff68bdc \
-    --hash=sha256:d94e7c7ecd9f0e23b3a78087eae12c0d7aa4af9e067a8ea963ad03ed0abd1cb7
+types-python-dateutil==2.8.4 \
+    --hash=sha256:29b85e25b832170f8d5ed383bf68cf5d9ee9066e2354221c6e9dd381dab71c5c \
+    --hash=sha256:82a6160961d7b24418eeb383a5356f262229bd1450e0ccd82ad40f8a67baaafd
     # via -r requirements/mypy.in
 types-pytz==2021.3.3 \
     --hash=sha256:75859c64c9a97d68259af6da208e8f5aaf4be4536e4d431a82a6e8b848fc183d \
@@ -2009,17 +2012,21 @@ types-pyyaml==6.0.1 \
     --hash=sha256:2e27b0118ca4248a646101c5c318dc02e4ca2866d6bc42e84045dbb851555a76 \
     --hash=sha256:d5b318269652e809b5c30a5fe666c50159ab80bfd41cd6bafe655bf20b29fcba
     # via -r requirements/mypy.in
-types-redis==4.0.5 \
-    --hash=sha256:1d7b720ba06596ea580a8cc947d7b34d99edc6065e9be5ccc2a6bc8295f6da46 \
-    --hash=sha256:5395e345bbf6f7eff7acd654a9434a62fbaf3d7f9c153afbfd0286fcd8f154cf
+types-redis==4.1.1 \
+    --hash=sha256:b6684f05e25ed8ff3badef34493224e86db38465d37d942b9772f8d3fd856c2e \
+    --hash=sha256:d867400f7ad81474cdd727cf0f4bf66f95b77ecdcf9987afc117c0b44864bb79
     # via -r requirements/mypy.in
-types-requests==2.26.2 \
-    --hash=sha256:0e22d9cdeff4c3eb068eb883d59b127c98d80525f3d0412a1c4499c6ae1f711e \
-    --hash=sha256:fabe1acc784708ac798ced6373568465b93642c8aa1ebd33e2921b60d4e7aa29
+types-requests==2.26.3 \
+    --hash=sha256:ad18284931c5ddbf050ccdd138f200d18fd56f88aa3567019d8da9b2d4fe0344 \
+    --hash=sha256:d63fa617846dcefff5aa2d59e47ab4ffd806e4bb0567115f7adbb5e438302fe4
     # via -r requirements/mypy.in
-types-six==1.16.3 \
-    --hash=sha256:8dda49da00f9610f2442b6bd0566088a83127f8fc8093c52e1d175eb2111fec4 \
-    --hash=sha256:b1e21becdaee01e11cdb788f820ac030b9f22d14b91f88184a31cc2424064163
+types-setuptools==57.4.5 \
+    --hash=sha256:920a7c1ee120025e939a1707f8fd09a1266edbf7848eae7b8de7c5909a824cc8 \
+    --hash=sha256:a4600efdca68a33204ad9c083fd9966d63aee61a7d007e912b6afc6ff57d6e02
+    # via types-pygments
+types-six==1.16.6 \
+    --hash=sha256:cd1de6caa1a434c8cbbebf7957fc2bdc8da34e4952f7bfbd0b03957200d6330b \
+    --hash=sha256:eee1683402add1c42a9913451ba0dd5872cad3ab8fce58944e5db5d6eca1006c
     # via
     #   -r requirements/mypy.in
     #   types-boto

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,9 +11,9 @@ alabaster==0.7.12 \
     --hash=sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359 \
     --hash=sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02
     # via sphinx
-attrs==21.2.0 \
-    --hash=sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1 \
-    --hash=sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb
+attrs==21.4.0 \
+    --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
+    --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
     # via markdown-it-py
 babel==2.9.1 \
     --hash=sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9 \

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -187,65 +187,65 @@ typed-ast==1.5.1 \
     --hash=sha256:ca9e8300d8ba0b66d140820cf463438c8e7b4cdc6fd710c059bfcfb1531d03fb \
     --hash=sha256:de4ecae89c7d8b56169473e08f6bfd2df7f95015591f43126e4ea7865928677e
     # via mypy
-types-boto==2.49.2 \
-    --hash=sha256:13c6a6a7aa83085ca6c1ab173199e4db31e38f488609fb96e64898ed5fd4dd84 \
-    --hash=sha256:b20ded0fc2da8d5c778bc1abb764a2fc86796765f0408be29d72c6a5d20ac171
+types-boto==2.49.3 \
+    --hash=sha256:27645e05058cad878839e5cb9edb48ef7215045481680db5d6ced374ce7a3a8d \
+    --hash=sha256:c7aadb5a613e022b96267d350193148c92a6ebe3f705f127e03654eda970c721
     # via -r requirements/mypy.in
 types-certifi==2021.10.8.0 \
     --hash=sha256:33308fb722d28cad8ae19834dcc4d2593509ac80bcbabe77c6d8e9a25001c2de \
     --hash=sha256:ca164939fe86b5f70988eed480b788162ee81f62e72f486a7b96cb53f4112355
     # via -r requirements/mypy.in
-types-chardet==4.0.1 \
-    --hash=sha256:6d2a73711c98f875ab73b87956e8bc1e7ac74f4bd9464631a1ce68f21bc3c1d1 \
-    --hash=sha256:a503019a8c4b945adc2c460857a0cc6958101e410a7ed8aa1a669a88b6179be1
+types-chardet==4.0.2 \
+    --hash=sha256:133806b34cf17228ab230ff6cbdb22635c95840a733ad5cf2a352a633b176188 \
+    --hash=sha256:1e05ac2f3bc46c4f067d59211aa54b63755e6d05f6d51022438a269fce139a26
     # via -r requirements/mypy.in
 types-commonmark==0.9.1 \
     --hash=sha256:60b382ec663e3e6bf0e4937d5af761899f1720e3cf33e14498bdf8ce0af46526 \
     --hash=sha256:c23509ba155c6c087d308dd1f891d414667f847553a651d6b3882d786b2b6970
     # via -r requirements/mypy.in
-types-dataclasses==0.6.1 \
-    --hash=sha256:6568532fed11f854e4db2eb48063385b323b93ecadd09f10a215d56246c306d7 \
-    --hash=sha256:aa45bb0dacdba09e3195a36ff8337bba45eac03b6f31c4645e87b4a2a47830dd
+types-dataclasses==0.6.2 \
+    --hash=sha256:19ea746937b82bfa0d3bba1dd78858eca2ed81932eae888c3f2966aa3fd0aec6 \
+    --hash=sha256:d74876d7a5e39ae6285765dd871e3b85d8186251f7b48e18130a35024c78bf73
     # via -r requirements/mypy.in
-types-decorator==5.1.0 \
-    --hash=sha256:242dcba983c9dce067b7c2d635fa11479254536d3de6056c808539040168a380 \
-    --hash=sha256:99abd00c614e54e75ee08d88799886acc2918cc88905eca6474ba917b327729b
+types-decorator==5.1.1 \
+    --hash=sha256:5817108fdbfbd4ea69b1072b1b57c9a726a4178cfd08160cb5bd4f993769b6c1 \
+    --hash=sha256:e1d2cd93f5507bcfbc68b698cda0159ca6c4a0d351d34724e3765bb603b08b92
     # via -r requirements/mypy.in
-types-docutils==0.17.1 \
-    --hash=sha256:6a7473d845fb15266d0a1742a5dfa2cf5240ddd8a64e4de9646f88a72c424c00 \
-    --hash=sha256:e7dc9db04f6dcc78fd7d903b99d9b4dc3c8b296e3f151114207a8f102e84361e
+types-docutils==0.17.2 \
+    --hash=sha256:a36cd6f8088e742ef9254ffb41746d93b55a3f36cf23ee7fa4d99e74b9d95a07 \
+    --hash=sha256:f50f5f05b8007aedc82949b4e4147398898cec1d6b4eb22a612f9e9b947621e8
     # via types-pygments
 types-jsonschema==4.3.0 \
     --hash=sha256:3107fa29766689e183c09ae98cac1f72aa246837c9f3697e609dc606e67c3077 \
     --hash=sha256:3b40478baa7d5b37fd261672d2d4049c5d0c69cbd891a05436ebd8732beb2c25
     # via -r requirements/mypy.in
-types-markdown==3.3.9 \
-    --hash=sha256:0fd38830517560f88c2f460ce5dc7006d831f560ec2a73f50c4ac06efac06793 \
-    --hash=sha256:4ab46c58185796366fd0e0a83fa901fbe8107f141d1ac3f1bca6b31df0e8b86c
+types-markdown==3.3.10 \
+    --hash=sha256:0e3153dc4ad3454326465e4e4e21fd90e8fc74966225ec5aeef15895a2c5d94a \
+    --hash=sha256:d4004e36a33cd3417cd299324232fc28e9915171a7ce46b43bf5b0c579db459d
     # via -r requirements/mypy.in
-types-oauthlib==3.1.4 \
-    --hash=sha256:06021a3cd350a144eee28286c6c0ada76fdae6afa45cd85f26fe29ce1fb2131d \
-    --hash=sha256:3436dfd502cebc1287ce6e8c0b2ce3bbda7a14b78c3b85e11abf71afdec8d7e0
+types-oauthlib==3.1.5 \
+    --hash=sha256:a8736acf764140f66c6ddd17227039e68db97feb58ce38fcde0f8a5319166f3a \
+    --hash=sha256:b89499e8d93ad23abf6a34790332a9e72c2a6be241a17f3b3c2b4f69514a8a5c
     # via -r requirements/mypy.in
-types-pillow==8.3.10 \
-    --hash=sha256:87632a5f3475e3eb4d1a23ae19ad568270c5d46c8e2821034e7cdca13f4c68dc \
-    --hash=sha256:cc7ab69803533ccfed16fb9a452c7b3f72ad3f903cb161917ba5acbedc7babe8
+types-pillow==8.3.11 \
+    --hash=sha256:998189334e616b1dd42c9634669efbf726184039e96e9a23ec95246e0ecff3fc \
+    --hash=sha256:aa96a739184f48f69e6f30218400623fc5a95f5fec199c447663a32538440405
     # via -r requirements/mypy.in
-types-polib==1.1.5 \
-    --hash=sha256:b2edb66228e4085dd419aa224f75c2b27f54898b2d8b7a383c05d5a1d8e3f901 \
-    --hash=sha256:fdd8b083736506a3b68b5e89c6e923c2c1f2684e35c4ede5c495b833103b4376
+types-polib==1.1.6 \
+    --hash=sha256:6b3fc54440884617c3283031df1cc746ab8a93063cad527de14182c925cc9260 \
+    --hash=sha256:9897aadea2ef30b64f0765e1f3caecb326d464d6d340ad88c4e204a9249a7294
     # via -r requirements/mypy.in
-types-psycopg2==2.9.4 \
-    --hash=sha256:3b1230df902610bf16f9272e0654652fd7a17504f3131ed4f2a552a5643e762c \
-    --hash=sha256:8c25c1c2860d9a51bb165f7b953872d7842e1770e75483597ee919cd834bf456
+types-psycopg2==2.9.5 \
+    --hash=sha256:a412838a5f68ef382db0ea6105d45de05d082dbad3ad467a824eadd5d3f32a78 \
+    --hash=sha256:b409d70bdd324325c8f3aa86bd5aba95a4a3f9d1039bd25e14b449aedb137a55
     # via -r requirements/mypy.in
-types-pygments==2.9.6 \
-    --hash=sha256:9b036b328ee9dbbfeec9f4f87940479bd71d4dc81f0c2d868a5452455c774a61 \
-    --hash=sha256:dfa0471bba797c237e9a40a4a323ff5ca7d21c9a37998f573f352d8c8b59fb1f
+types-pygments==2.9.10 \
+    --hash=sha256:2f0582b95dc0ff200f15a952e9e3213621d78959991f1c9dd5b1cbbdbd42de13 \
+    --hash=sha256:89473da21e983e881feb12cb45f2296355f859f50a710414ffe8afde92861742
     # via -r requirements/mypy.in
-types-python-dateutil==2.8.3 \
-    --hash=sha256:42262d0b8f8ecb06cdc5c458956685eb3b27c74f170adf541d1cc5ee4ff68bdc \
-    --hash=sha256:d94e7c7ecd9f0e23b3a78087eae12c0d7aa4af9e067a8ea963ad03ed0abd1cb7
+types-python-dateutil==2.8.4 \
+    --hash=sha256:29b85e25b832170f8d5ed383bf68cf5d9ee9066e2354221c6e9dd381dab71c5c \
+    --hash=sha256:82a6160961d7b24418eeb383a5356f262229bd1450e0ccd82ad40f8a67baaafd
     # via -r requirements/mypy.in
 types-pytz==2021.3.3 \
     --hash=sha256:75859c64c9a97d68259af6da208e8f5aaf4be4536e4d431a82a6e8b848fc183d \
@@ -255,17 +255,21 @@ types-pyyaml==6.0.1 \
     --hash=sha256:2e27b0118ca4248a646101c5c318dc02e4ca2866d6bc42e84045dbb851555a76 \
     --hash=sha256:d5b318269652e809b5c30a5fe666c50159ab80bfd41cd6bafe655bf20b29fcba
     # via -r requirements/mypy.in
-types-redis==4.0.5 \
-    --hash=sha256:1d7b720ba06596ea580a8cc947d7b34d99edc6065e9be5ccc2a6bc8295f6da46 \
-    --hash=sha256:5395e345bbf6f7eff7acd654a9434a62fbaf3d7f9c153afbfd0286fcd8f154cf
+types-redis==4.1.1 \
+    --hash=sha256:b6684f05e25ed8ff3badef34493224e86db38465d37d942b9772f8d3fd856c2e \
+    --hash=sha256:d867400f7ad81474cdd727cf0f4bf66f95b77ecdcf9987afc117c0b44864bb79
     # via -r requirements/mypy.in
-types-requests==2.26.2 \
-    --hash=sha256:0e22d9cdeff4c3eb068eb883d59b127c98d80525f3d0412a1c4499c6ae1f711e \
-    --hash=sha256:fabe1acc784708ac798ced6373568465b93642c8aa1ebd33e2921b60d4e7aa29
+types-requests==2.26.3 \
+    --hash=sha256:ad18284931c5ddbf050ccdd138f200d18fd56f88aa3567019d8da9b2d4fe0344 \
+    --hash=sha256:d63fa617846dcefff5aa2d59e47ab4ffd806e4bb0567115f7adbb5e438302fe4
     # via -r requirements/mypy.in
-types-six==1.16.3 \
-    --hash=sha256:8dda49da00f9610f2442b6bd0566088a83127f8fc8093c52e1d175eb2111fec4 \
-    --hash=sha256:b1e21becdaee01e11cdb788f820ac030b9f22d14b91f88184a31cc2424064163
+types-setuptools==57.4.5 \
+    --hash=sha256:920a7c1ee120025e939a1707f8fd09a1266edbf7848eae7b8de7c5909a824cc8 \
+    --hash=sha256:a4600efdca68a33204ad9c083fd9966d63aee61a7d007e912b6afc6ff57d6e02
+    # via types-pygments
+types-six==1.16.6 \
+    --hash=sha256:cd1de6caa1a434c8cbbebf7957fc2bdc8da34e4952f7bfbd0b03957200d6330b \
+    --hash=sha256:eee1683402add1c42a9913451ba0dd5872cad3ab8fce58944e5db5d6eca1006c
     # via
     #   -r requirements/mypy.in
     #   types-boto

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -41,9 +41,9 @@ asgiref==3.4.1 \
     --hash=sha256:4ef1ab46b484e3c706329cedeff284a5d40824200638503f5768edb6de7d58e9 \
     --hash=sha256:ffc141aa908e6f175673e7b1b3b7af4fdb0ecb738fc5c8b88f69f055c2415214
     # via django
-attrs==21.2.0 \
-    --hash=sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1 \
-    --hash=sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb
+attrs==21.4.0 \
+    --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
+    --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
     # via
     #   jsonschema
     #   openapi-core
@@ -428,6 +428,7 @@ importlib-metadata==4.8.3 ; python_version < "3.10" \
     #   cssutils
     #   jsonschema
     #   markdown
+    #   redis
     #   sqlalchemy
     #   zulip-bots
 ipython==7.16.2 \
@@ -686,10 +687,10 @@ openapi-core==0.14.2 \
     --hash=sha256:3426b5ae551a04f7d7a3a625ca600bff157affb4eb691d36412997f6a9ac6898 \
     --hash=sha256:62ad93c8114ce6025f25b004ff0f3674eea8bc4ae920c726e98921fdbe41b4f3
     # via -r requirements/common.in
-openapi-schema-validator==0.1.5 \
-    --hash=sha256:215b516d0942f4e8e2446cf3f7d4ff2ed71d102ebddcc30526d8a3f706ab1df6 \
-    --hash=sha256:a4b2712020284cee880b4c55faa513fbc2f8f07f365deda6098f8ab943c9f0df \
-    --hash=sha256:b65d6c2242620bfe76d4c749b61cd9657e4528895a8f4fb6f916085b508ebd24
+openapi-schema-validator==0.1.6 \
+    --hash=sha256:230db361c71a5b08b25ec926797ac8b59a8f499bbd7316bd15b6cd0fc9aea5df \
+    --hash=sha256:8ef097b78c191c89d9a12cdf3d311b2ecf9d3b80bbe8610dbc67a812205a6a8d \
+    --hash=sha256:af023ae0d16372cf8dd0d128c9f3eaa080dc3cd5dfc69e6a247579f25bd10503
     # via
     #   openapi-core
     #   openapi-spec-validator
@@ -727,6 +728,10 @@ orjson==3.6.1 \
     --hash=sha256:f15267d2e7195331b9823e278f953058721f0feaa5e6f2a7f62a8768858eed3b \
     --hash=sha256:fa7f9c3e8db204ff9e9a3a0ff4558c41f03f12515dd543720c6b0cebebcd8cbc
     # via -r requirements/common.in
+packaging==21.3 \
+    --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
+    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
+    # via redis
 parse==1.19.0 \
     --hash=sha256:9ff82852bcb65d139813e2a5197627a94966245c897796760a3a2a8eb66f020b
     # via openapi-core
@@ -738,9 +743,9 @@ pexpect==4.8.0 \
     --hash=sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937 \
     --hash=sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c
     # via ipython
-phonenumberslite==8.12.39 \
-    --hash=sha256:1001fd304ccf5ec7f926fd039ef07eefffa9880573698baede00a3becb8de6ad \
-    --hash=sha256:5b77990b6832675fa3a2e60a05e738af0bf96908352a8ee90b4d4ec964a03977
+phonenumberslite==8.12.40 \
+    --hash=sha256:153885eefec397058c8ce91fb987f55545b2cfa945f22a904584ddf162aa82b1 \
+    --hash=sha256:e6fe6cad1091f8928e34a98570cade4758f4cf4e70e9e32ff7eca517ce98e273
     # via django-two-factor-auth
 pickleshare==0.7.5 \
     --hash=sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca \
@@ -805,18 +810,18 @@ prompt-toolkit==3.0.24 \
     --hash=sha256:1bb05628c7d87b645974a1bad3f17612be0c29fa39af9f7688030163f680bad6 \
     --hash=sha256:e56f2ff799bacecd3e88165b1e2f5ebf9bcd59e80e06d395fa0cc4b8bd7bb506
     # via ipython
-psycopg2==2.9.2 \
-    --hash=sha256:26322c3f114de1f60c1b0febf8fdd595c221b4f624524178f515d07350a71bd1 \
-    --hash=sha256:6796ac614412ce374587147150e56d03b7845c9e031b88aacdcadc880e81bb38 \
-    --hash=sha256:77b9105ef37bc005b8ffbcb1ed6d8685bb0e8ce84773738aa56421a007ec5a7a \
-    --hash=sha256:77d09a79f9739b97099d2952bbbf18eaa4eaf825362387acbb9552ec1b3fa228 \
-    --hash=sha256:91c7fd0fe9e6c118e8ff5b665bc3445781d3615fa78e131d0b4f8c85e8ca9ec8 \
-    --hash=sha256:a761b60da0ecaf6a9866985bcde26327883ac3cdb90535ab68b8d784f02b05ef \
-    --hash=sha256:a84da9fa891848e0270e8e04dcca073bc9046441eeb47069f5c0e36783debbea \
-    --hash=sha256:b8816c6410fa08d2a022e4e38d128bae97c1855e176a00493d6ec62ccd606d57 \
-    --hash=sha256:dfc32db6ce9ecc35a131320888b547199f79822b028934bb5b332f4169393e15 \
-    --hash=sha256:f65cba7924363e0d2f416041b48ff69d559548f2cb168ff972c54e09e1e64db8 \
-    --hash=sha256:fd7ddab7d6afee4e21c03c648c8b667b197104713e57ec404d5b74097af21e31
+psycopg2==2.9.3 \
+    --hash=sha256:06f32425949bd5fe8f625c49f17ebb9784e1e4fe928b7cce72edc36fb68e4c0c \
+    --hash=sha256:0762c27d018edbcb2d34d51596e4346c983bd27c330218c56c4dc25ef7e819bf \
+    --hash=sha256:083707a696e5e1c330af2508d8fab36f9700b26621ccbcb538abe22e15485362 \
+    --hash=sha256:34b33e0162cfcaad151f249c2649fd1030010c16f4bbc40a604c1cb77173dcf7 \
+    --hash=sha256:4295093a6ae3434d33ec6baab4ca5512a5082cc43c0505293087b8a46d108461 \
+    --hash=sha256:8cf3878353cc04b053822896bc4922b194792df9df2f1ad8da01fb3043602126 \
+    --hash=sha256:8e841d1bf3434da985cc5ef13e6f75c8981ced601fd70cc6bf33351b91562981 \
+    --hash=sha256:9572e08b50aed176ef6d66f15a21d823bb6f6d23152d35e8451d7d2d18fdac56 \
+    --hash=sha256:a81e3866f99382dfe8c15a151f1ca5fde5815fde879348fe5a9884a7c092a305 \
+    --hash=sha256:cb10d44e6694d763fa1078a26f7f6137d69f555a78ec85dc2ef716c37447e4b2 \
+    --hash=sha256:d3ca6421b942f60c008f81a3541e8faf6865a28d5a9b48544b0ee4f40cac7fca
     # via -r requirements/common.in
 ptyprocess==0.7.0 \
     --hash=sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35 \
@@ -951,6 +956,10 @@ pyopenssl==21.0.0 \
     --hash=sha256:5e2d8c5e46d0d865ae933bef5230090bdaf5506281e9eec60fa250ee80600cb3 \
     --hash=sha256:8935bd4920ab9abfebb07c41a4f58296407ed77f04bd1a92914044b848ba1ed6
     # via aioapns
+pyparsing==3.0.6 \
+    --hash=sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4 \
+    --hash=sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81
+    # via packaging
 pyrsistent==0.18.0 \
     --hash=sha256:097b96f129dd36a8c9e33594e7ebb151b1515eb52cceb08474c10a5479e799f2 \
     --hash=sha256:2aaf19dc8ce517a8653746d98e962ef480ff34b6bc563fc067be6401ffb457c7 \
@@ -974,8 +983,9 @@ pyrsistent==0.18.0 \
     --hash=sha256:f3ef98d7b76da5eb19c37fda834d50262ff9167c65658d1d8f974d2e4d90676b \
     --hash=sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72
     # via jsonschema
-python-binary-memcached==0.30.1 \
-    --hash=sha256:f91c3d79d022121c22ef733e9beee86e0598e29ffec67401c68cece1ba7f036a
+python-binary-memcached==0.31.1 \
+    --hash=sha256:58c19c9a81e112633642bd5a26c1d8c6ac806bd055cf536b5b4bd2da701bc5b1 \
+    --hash=sha256:de4056f00a15d054dcf1af87d6cc9564876699e52da954c3ef44e8c5753d4050
     # via
     #   -r requirements/common.in
     #   django-bmemcached
@@ -1063,9 +1073,9 @@ qrcode==6.1 \
     --hash=sha256:3996ee560fc39532910603704c82980ff6d4d5d629f9c3f25f34174ce8606cf5 \
     --hash=sha256:505253854f607f2abf4d16092c61d4e9d511a3b4392e60bff957a68592b04369
     # via django-two-factor-auth
-redis==4.0.2 \
-    --hash=sha256:c8481cf414474e3497ec7971a1ba9b998c8efad0f0d289a009a5bbef040894f9 \
-    --hash=sha256:ccf692811f2c1fc7a92b466aa2599e4a6d2d73d5f736a2c70be600657c0da34a
+redis==4.1.0 \
+    --hash=sha256:21f0a23bce707909076e6ba2ce076cba59bff60d2ab22972e0647fdf620ffe47 \
+    --hash=sha256:e13fad67c098a33141bacde872786960e86a5c97a4255009bcd43c795fa1cc77
     # via -r requirements/common.in
 regex==2021.11.10 \
     --hash=sha256:0416f7399e918c4b0e074a0f66e5191077ee2ca32a0f99d4c187a62beb47aa05 \
@@ -1274,9 +1284,9 @@ stripe==2.64.0 \
 https://github.com/zulip/talon/archive/1711705c952806d4a704c7dbf58f21db8e11756a.zip#egg=talon-core==1.4.8.zulip1&subdirectory=talon-core \
     --hash=sha256:e562269ba5f5d71f35f3dd7ee4c0c62a6c95dfb41984766eff645425c4dec71e
     # via -r requirements/common.in
-tlds==2021122100 \
-    --hash=sha256:11439f7ee29f44dd84d53d4e0f81b767d2f6579e32fece2f8f071a21d3af8cce \
-    --hash=sha256:4185f490c613d2cec597f41333e3d376d5b99cbd13c7b170a8295c076debfb22
+tlds==2021122800 \
+    --hash=sha256:594fbe1c59ecd52e5b785e72385bc82c84d7b4971035475298ccfc5a94751f38 \
+    --hash=sha256:f2d1970c333345595d97ddf0b3ac599823a4ff42da74831da19d94a6460ffc38
     # via -r requirements/common.in
 tornado==4.5.3 \
     --hash=sha256:5ef073ac6180038ccf99411fe05ae9aafb675952a2c8db60592d5daf8401f803 \

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 112
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "169.0"
+PROVISION_VERSION = "169.1"


### PR DESCRIPTION
* attrs: 21.2.0 → 21.4.0
  (python-attrs/attrs#895)
* moto[s3]: 2.2.19 → 2.3.0
* openapi-schema-validator: 0.1.5 → 0.1.6
* phonenumberslite: 8.12.39 → 8.12.40
* psycopg2: 2.9.2 → 2.9.3
* python-binary-memcached: 0.30.1 → 0.31.1
  (jaysonsantos/python-binary-memcached#245)
* redis: 4.0.2 → 4.1.0
* ruamel.yaml: 0.17.17 → 0.17.19
* tlds: 2021122100 → 2021122800
* types-boto: 2.49.2 → 2.49.3
* types-chardet: 4.0.1 → 4.0.2
* types-dataclasses: 0.6.1 → 0.6.2
* types-decorator: 5.1.0 → 5.1.1
* types-docutils: 0.17.1 → 0.17.2
* types-markdown: 3.3.9 → 3.3.10
* types-oauthlib: 3.1.4 → 3.1.5
* types-pillow: 8.3.10 → 8.3.11
* types-polib: 1.1.5 → 1.1.6
* types-psycopg2: 2.9.4 → 2.9.5
* types-pygments: 2.9.6 → 2.9.10
* types-python-dateutil: 2.8.3 → 2.8.4
* types-redis: 4.0.5 → 4.1.1
* types-requests: 2.26.2 → 2.26.3
* types-setuptools: (new) → 57.4.5
* types-six: 1.16.3 → 1.16.6