### PR TITLE
upload-release, test_console_output: Avoid appending to bytes in a loop

### DIFF
--- a/tools/upload-release
+++ b/tools/upload-release
@@ -96,14 +96,14 @@ if ordered_filenames[1] == new_basename:
     file_hashes["zulip-server-latest.tar.gz"] = file_hashes[new_basename]
 
 print("Updating SHA256SUMS.txt..")
-contents = b""
+contents = ""
 for ordered_filename in ordered_filenames:
     # natsorted type annotation is insufficiently generic
     assert isinstance(ordered_filename, str)
-    contents += f"{file_hashes[ordered_filename]}  {ordered_filename}\n".encode()
+    contents += f"{file_hashes[ordered_filename]}  {ordered_filename}\n"
 bucket.put_object(
     ACL="public-read",
-    Body=contents,
+    Body=contents.encode(),
     ContentType="text/plain",
     Key="server/SHA256SUMS.txt",
 )

--- a/zerver/lib/test_console_output.py
+++ b/zerver/lib/test_console_output.py
@@ -35,7 +35,7 @@ class ExtraConsoleOutputFinder:
         ]
         self.compiled_line_pattern = re.compile(b"|".join(valid_line_patterns))
         self.partial_line = b""
-        self.full_extra_output = b""
+        self.full_extra_output = bytearray()
 
     def find_extra_output(self, data: bytes) -> None:
         *lines, self.partial_line = (self.partial_line + data).split(b"\n")


### PR DESCRIPTION
Appending to `bytes` in a loop leads to a quadratic slowdown since Python doesn’t optimize this for `bytes` like it does for `str`.