### PR TITLE
user_groups: Don't use access_user_group_by_id for notifications.

### DIFF
--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -31,11 +31,12 @@ from zerver.lib.url_encoding import (
     stream_narrow_url,
     topic_narrow_url,
 )
-from zerver.lib.user_groups import access_user_group_by_id, get_user_group_direct_members
+from zerver.lib.user_groups import get_user_group_direct_members
 from zerver.models import (
     Message,
     Recipient,
     Stream,
+    UserGroup,
     UserMessage,
     UserProfile,
     get_context_for_message,
@@ -367,7 +368,7 @@ def get_mentioned_user_group_name(
     smallest_user_group_size = math.inf
     smallest_user_group_name = None
     for user_group_id in mentioned_user_group_ids:
-        current_user_group = access_user_group_by_id(user_group_id, user_profile, for_mention=True)
+        current_user_group = UserGroup.objects.get(id=user_group_id, realm=user_profile.realm)
         current_user_group_size = len(get_user_group_direct_members(current_user_group))
 
         if current_user_group_size < smallest_user_group_size:

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -24,7 +24,6 @@ from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import access_message, bulk_access_messages_expect_usermessage, huddle_users
 from zerver.lib.remote_server import send_json_to_push_bouncer, send_to_push_bouncer
 from zerver.lib.timestamp import datetime_to_timestamp
-from zerver.lib.user_groups import access_user_group_by_id
 from zerver.models import (
     AbstractPushDeviceToken,
     ArchivedMessage,
@@ -32,6 +31,7 @@ from zerver.models import (
     NotificationTriggers,
     PushDeviceToken,
     Recipient,
+    UserGroup,
     UserMessage,
     UserProfile,
     get_display_recipient,
@@ -1001,9 +1001,7 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
     mentioned_user_group_id = missed_message.get("mentioned_user_group_id")
 
     if mentioned_user_group_id is not None:
-        user_group = access_user_group_by_id(
-            mentioned_user_group_id, user_profile, for_mention=True
-        )
+        user_group = UserGroup.objects.get(id=mentioned_user_group_id, realm=user_profile.realm)
         mentioned_user_group_name = user_group.name
 
     apns_payload = get_message_payload_apns(

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -9,12 +9,10 @@ from zerver.lib.exceptions import JsonableError
 from zerver.models import Realm, UserGroup, UserGroupMembership, UserProfile
 
 
-def access_user_group_by_id(
-    user_group_id: int, user_profile: UserProfile, for_mention: bool = False
-) -> UserGroup:
+def access_user_group_by_id(user_group_id: int, user_profile: UserProfile) -> UserGroup:
     try:
         user_group = UserGroup.objects.get(id=user_group_id, realm=user_profile.realm)
-        if not for_mention and user_group.is_system_group:
+        if user_group.is_system_group:
             raise JsonableError(_("Insufficient permission"))
         group_member_ids = get_user_group_direct_members(user_group)
         if (


### PR DESCRIPTION
Stop using `access_user_group_by_id` in notifications codepaths, as it
is meant to be used to check for _write_ access, not read
access (which is not limited).  In the notification codepaths, there
are no ACLs to apply, and the ID is known-good; just load it
directly. The `for_mention` flag is removed, as it was not used in the
mention codepaths at all, only the notification ones.