### PR TITLE
puppet: Manage extracted resources again.

### DIFF
--- a/puppet/zulip/manifests/external_dep.pp
+++ b/puppet/zulip/manifests/external_dep.pp
@@ -29,6 +29,11 @@ define zulip::external_dep(
     },
   }
 
+  file { $dir:
+    ensure  => present,
+    require => Zulip::Sha256_Tarball_To[$title],
+  }
+
   unless $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '18.04' {
     # Puppet 5.5.0 and below make this always-noisy, as they spout out
     # a notify line about tidying the managed directory above.  Skip
@@ -39,7 +44,7 @@ define zulip::external_dep(
       recurse => 1,
       rmdirs  => true,
       matches => "zulip-${title}-*",
-      require => Zulip::Sha256_Tarball_To[$title],
+      require => File[$dir],
     }
   }
 }


### PR DESCRIPTION
1e4e6a09af23 removed the resources for the unpacked directory, on the
argument that they were unnecessary.  However, the directory (or file,
see below) that is unpacked must be managed, or it will be tidied on
the next puppet apply.

Add back the resource for `$dir`, but mark it `ensure => present`, to
support tarballs which only unpack to a single file (e.g. wal-g).

**Testing plan:** Test applied.