### PR TITLE
condense: Do not cache message_content height of 0 from recent_topics.

### DIFF
--- a/static/js/condense.js
+++ b/static/js/condense.js
@@ -3,6 +3,7 @@ import $ from "jquery";
 import * as message_flags from "./message_flags";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
+import * as recent_topics_util from "./recent_topics_util";
 import * as rows from "./rows";
 
 /*
@@ -163,7 +164,9 @@ function get_message_height(elem, message_id) {
 
     // shown to be ~2.5x faster than Node.getBoundingClientRect().
     const height = elem.offsetHeight;
-    _message_content_height_cache.set(message_id, height);
+    if (!recent_topics_util.is_visible()) {
+        _message_content_height_cache.set(message_id, height);
+    }
     return height;
 }
 


### PR DESCRIPTION
Previously, we suffered a bug where we would not properly condense
messages on first load of CZO (ie after login).

This bug was an unintended consequence of setting recent topics as the
default view, because since the page loads to recent_topics the
message_list is hidden but still gets rendered into the DOM and when
condense_and_collapse runs, it causes get_message_height to cache a
message height of 0, which results in the message not being collapsed.
There may be other ways to trigger the same broken mechanism.

This commit changes the function so we only return 0 but don't cache
the result.

Fixes: #20666.

**Testing plan:** <!-- How have you tested? -->
Manual testing only. No existing node tests.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
see issue for before gif.
<details>
<summary>
After gif
</summary>

![](https://user-images.githubusercontent.com/33805964/147861937-36e4f279-e687-486e-8126-a09544966d6a.gif)
</details>

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
