### PR TITLE
Add more format buttons

### DIFF
--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -1024,6 +1024,136 @@ run_test("format_text - quote", ({override}) => {
     assert.equal(wrap_selection_called, false);
 });
 
+run_test("format_text - spoiler", ({override}) => {
+    override(text_field_edit, "set", (field, text) => {
+        set_text = text;
+    });
+    override(text_field_edit, "wrapSelection", (field, syntax_start, syntax_end) => {
+        wrap_selection_called = true;
+        wrap_syntax_start = syntax_start;
+        wrap_syntax_end = syntax_end;
+    });
+
+    const spoiler_syntax_start = "```spoiler \n";
+    const spoiler_syntax_end = "\n```";
+
+    // Spoiler selected text
+    reset_state();
+    init_textarea("abc", {
+        start: 0,
+        end: 3,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "spoiler");
+    assert.equal(set_text, "");
+    assert.equal(wrap_selection_called, true);
+    assert.equal(wrap_syntax_start, spoiler_syntax_start);
+    assert.equal(wrap_syntax_end, spoiler_syntax_end);
+
+    // Undo spoiler, cursor at header position
+    reset_state();
+    init_textarea("```spoiler \nabc\n```", {
+        start: 11,
+        end: 11,
+        text: "",
+        length: 0,
+    });
+    compose_ui.format_text($textarea, "spoiler");
+    assert.equal(set_text, "abc");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("abc\n```spoiler \ndef\n```\nghi", {
+        start: 15,
+        end: 15,
+        text: "",
+        length: 0,
+    });
+    compose_ui.format_text($textarea, "spoiler");
+    assert.equal(set_text, "abc\ndef\nghi");
+    assert.equal(wrap_selection_called, false);
+
+    // Undo spoiler selected text, only content selected
+    reset_state();
+    init_textarea("```spoiler \nabc\n```", {
+        start: 12,
+        end: 15,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "spoiler");
+    assert.equal(set_text, "abc");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("```spoiler abc\ndef\n```", {
+        start: 15,
+        end: 18,
+        text: "def",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "spoiler");
+    assert.equal(set_text, "def");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("abc\n```spoiler d\nef\n```\nghi", {
+        start: 17,
+        end: 19,
+        text: "ef",
+        length: 2,
+    });
+    compose_ui.format_text($textarea, "spoiler");
+    assert.equal(set_text, "abc\nef\nghi");
+    assert.equal(wrap_selection_called, false);
+
+    // Undo spoiler selected text, content and title selected
+    reset_state();
+    init_textarea("```spoiler abc\ndef\n```", {
+        start: 11,
+        end: 18,
+        text: "abc\ndef",
+        length: 7,
+    });
+    compose_ui.format_text($textarea, "spoiler");
+    assert.equal(set_text, "abc\ndef");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("abc\n```spoiler d\nef\n```\nghi", {
+        start: 15,
+        end: 19,
+        text: "d\nef",
+        length: 4,
+    });
+    compose_ui.format_text($textarea, "spoiler");
+    assert.equal(set_text, "abc\nd\nef\nghi");
+    assert.equal(wrap_selection_called, false);
+
+    // Undo spoiler selected text, syntax selected
+    reset_state();
+    init_textarea("```spoiler abc\ndef\n```", {
+        start: 0,
+        end: 22,
+        text: "```spoiler abc\ndef\n```",
+        length: 22,
+    });
+    compose_ui.format_text($textarea, "spoiler");
+    assert.equal(set_text, "abc\ndef");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("abc\n```spoiler d\nef\n```\nghi", {
+        start: 4,
+        end: 23,
+        text: "```spoiler d\nef\n```",
+        length: 19,
+    });
+    compose_ui.format_text($textarea, "spoiler");
+    assert.equal(set_text, "abc\nd\nef\nghi");
+    assert.equal(wrap_selection_called, false);
+});
 run_test("markdown_shortcuts", ({override_rewire}) => {
     let format_text_type;
     override_rewire(compose_ui, "format_text", ($textarea, type) => {

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -672,6 +672,50 @@ run_test("format_text - link", ({override}) => {
     assert.equal(wrap_selection_called, false);
 });
 
+run_test("format_text - strikethrough", ({override}) => {
+    override(text_field_edit, "set", (field, text) => {
+        set_text = text;
+    });
+    override(text_field_edit, "wrapSelection", (field, syntax_start, syntax_end) => {
+        wrap_selection_called = true;
+        wrap_syntax_start = syntax_start;
+        wrap_syntax_end = syntax_end;
+    });
+
+    const strikethrough_syntax = "~~";
+
+    // Strikethrough selected text
+    reset_state();
+    compose_ui.format_text($textarea, "strikethrough");
+    assert.equal(set_text, "");
+    assert.equal(wrap_selection_called, true);
+    assert.equal(wrap_syntax_start, strikethrough_syntax);
+    assert.equal(wrap_syntax_end, strikethrough_syntax);
+
+    // Undo strikethrough selected text, syntax not selected
+    reset_state();
+    init_textarea("~~abc~~", {
+        start: 2,
+        end: 5,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "strikethrough");
+    assert.equal(set_text, "abc");
+    assert.equal(wrap_selection_called, false);
+
+    // Undo strikethrough selected text, syntax selected
+    reset_state();
+    init_textarea("~~abc~~", {
+        start: 0,
+        end: 7,
+        text: "~~abc~~",
+        length: 7,
+    });
+    compose_ui.format_text($textarea, "strikethrough");
+    assert.equal(set_text, "abc");
+});
+
 run_test("markdown_shortcuts", ({override_rewire}) => {
     let format_text_type;
     override_rewire(compose_ui, "format_text", ($textarea, type) => {

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -826,6 +826,116 @@ run_test("format_text - latex", ({override}) => {
     assert.equal(wrap_selection_called, false);
 });
 
+run_test("format_text - code", ({override}) => {
+    override(text_field_edit, "set", (field, text) => {
+        set_text = text;
+    });
+    override(text_field_edit, "wrapSelection", (field, syntax_start, syntax_end) => {
+        wrap_selection_called = true;
+        wrap_syntax_start = syntax_start;
+        wrap_syntax_end = syntax_end;
+    });
+
+    const code_syntax = "`";
+    const code_block_syntax_start = "```\n";
+    const code_block_syntax_end = "\n```";
+
+    // Code selected text
+    reset_state();
+    init_textarea("abc def", {
+        start: 0,
+        end: 3,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "code");
+    assert.equal(set_text, "");
+    assert.equal(wrap_selection_called, true);
+    assert.equal(wrap_syntax_start, code_syntax);
+    assert.equal(wrap_syntax_end, code_syntax);
+
+    reset_state();
+    init_textarea("abc", {
+        start: 0,
+        end: 3,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "code");
+    assert.equal(set_text, "");
+    assert.equal(wrap_selection_called, true);
+    assert.equal(wrap_syntax_start, code_block_syntax_start);
+    assert.equal(wrap_syntax_end, code_block_syntax_end);
+
+    // Undo code selected text, syntax not selected
+    reset_state();
+    init_textarea("`abc`", {
+        start: 1,
+        end: 4,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "code");
+    assert.equal(set_text, "abc");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("```\nabc\n```", {
+        start: 4,
+        end: 7,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "code");
+    assert.equal(set_text, "abc");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("abc\n```\ndef\n```\nghi", {
+        start: 8,
+        end: 11,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "code");
+    assert.equal(set_text, "abc\ndef\nghi");
+    assert.equal(wrap_selection_called, false);
+
+    // Undo code selected text, syntax selected
+    reset_state();
+    init_textarea("`abc` def", {
+        start: 0,
+        end: 5,
+        text: "`abc`",
+        length: 5,
+    });
+    compose_ui.format_text($textarea, "code");
+    assert.equal(set_text, "abc def");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("```\nabc\ndef\n```", {
+        start: 0,
+        end: 15,
+        text: "```\nabc\ndef\n```",
+        length: 15,
+    });
+    compose_ui.format_text($textarea, "code");
+    assert.equal(set_text, "abc\ndef");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("abc\n```\ndef\n```\nghi", {
+        start: 3,
+        end: 15,
+        text: "\n```\ndef\n```\n",
+        length: 12,
+    });
+    compose_ui.format_text($textarea, "code");
+    assert.equal(set_text, "abc\ndef\nghi");
+    assert.equal(wrap_selection_called, false);
+});
+
 // TODO: test for text before/after
 run_test("format_text - quote", ({override}) => {
     override(text_field_edit, "set", (field, text) => {

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -597,6 +597,81 @@ run_test("format_text - bold and italic", ({override}) => {
     assert.equal(wrap_selection_called, false);
 });
 
+run_test("format_text - link", ({override}) => {
+    override(text_field_edit, "set", (field, text) => {
+        set_text = text;
+    });
+    override(text_field_edit, "wrapSelection", (field, syntax_start, syntax_end) => {
+        wrap_selection_called = true;
+        wrap_syntax_start = syntax_start;
+        wrap_syntax_end = syntax_end;
+    });
+
+    const link_syntax_start = "[";
+    const link_syntax_end = "](url)";
+
+    // Link selected text
+    reset_state();
+    init_textarea("abc", {
+        start: 0,
+        end: 3,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "link");
+    assert.equal(set_text, "");
+    assert.equal(wrap_selection_called, true);
+    assert.equal(wrap_syntax_start, link_syntax_start);
+    assert.equal(wrap_syntax_end, link_syntax_end);
+
+    // Undo link selected text, url selected
+    reset_state();
+    init_textarea("[abc](def)", {
+        start: 6,
+        end: 9,
+        text: "def",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "link");
+    assert.equal(set_text, "abc def");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("[abc](url)", {
+        start: 6,
+        end: 9,
+        text: "url",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "link");
+    assert.equal(set_text, "abc");
+    assert.equal(wrap_selection_called, false);
+
+    // Undo link selected text, description selected
+    reset_state();
+    init_textarea("[abc](def)", {
+        start: 1,
+        end: 4,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "link");
+    assert.equal(set_text, "abc def");
+    assert.equal(wrap_selection_called, false);
+
+    // Undo link selected text, syntax selected
+    reset_state();
+    init_textarea("[abc](def)", {
+        start: 0,
+        end: 10,
+        text: "[abc](def)",
+        length: 10,
+    });
+    compose_ui.format_text($textarea, "link");
+    assert.equal(set_text, "abc def");
+    assert.equal(wrap_selection_called, false);
+});
+
 run_test("markdown_shortcuts", ({override_rewire}) => {
     let format_text_type;
     override_rewire(compose_ui, "format_text", ($textarea, type) => {

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -437,34 +437,37 @@ run_test("test_compose_height_changes", ({override, override_rewire}) => {
     assert.ok(!compose_box_top_set);
 });
 
-run_test("format_text", ({override}) => {
-    let set_text = "";
-    let wrap_selection_called = false;
-    let wrap_syntax = "";
+let set_text = "";
+let wrap_selection_called = false;
+let wrap_syntax_start = "";
+let wrap_syntax_end = "";
 
+function reset_state() {
+    set_text = "";
+    wrap_selection_called = false;
+    wrap_syntax_start = "";
+    wrap_syntax_end = "";
+}
+
+const $textarea = $("#compose-textarea");
+$textarea.get = () => ({
+    setSelectionRange() {},
+});
+
+function init_textarea(val, range) {
+    $textarea.val = () => val;
+    $textarea.range = () => range;
+}
+
+run_test("format_text - bold and italic", ({override}) => {
     override(text_field_edit, "set", (field, text) => {
         set_text = text;
     });
-    override(text_field_edit, "wrapSelection", (field, syntax) => {
+    override(text_field_edit, "wrapSelection", (field, syntax_start, syntax_end) => {
         wrap_selection_called = true;
-        wrap_syntax = syntax;
+        wrap_syntax_start = syntax_start;
+        wrap_syntax_end = syntax_end;
     });
-
-    function reset_state() {
-        set_text = "";
-        wrap_selection_called = false;
-        wrap_syntax = "";
-    }
-
-    const $textarea = $("#compose-textarea");
-    $textarea.get = () => ({
-        setSelectionRange() {},
-    });
-
-    function init_textarea(val, range) {
-        $textarea.val = () => val;
-        $textarea.range = () => range;
-    }
 
     const italic_syntax = "*";
     const bold_syntax = "**";
@@ -480,7 +483,8 @@ run_test("format_text", ({override}) => {
     compose_ui.format_text($textarea, "bold");
     assert.equal(set_text, "");
     assert.equal(wrap_selection_called, true);
-    assert.equal(wrap_syntax, bold_syntax);
+    assert.equal(wrap_syntax_start, bold_syntax);
+    assert.equal(wrap_syntax_end, bold_syntax);
 
     // Undo bold selected text, syntax not selected
     reset_state();
@@ -517,7 +521,8 @@ run_test("format_text", ({override}) => {
     compose_ui.format_text($textarea, "italic");
     assert.equal(set_text, "");
     assert.equal(wrap_selection_called, true);
-    assert.equal(wrap_syntax, italic_syntax);
+    assert.equal(wrap_syntax_start, italic_syntax);
+    assert.equal(wrap_syntax_end, italic_syntax);
 
     // Undo italic selected text, syntax not selected
     reset_state();

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -716,6 +716,116 @@ run_test("format_text - strikethrough", ({override}) => {
     assert.equal(set_text, "abc");
 });
 
+run_test("format_text - latex", ({override}) => {
+    override(text_field_edit, "set", (field, text) => {
+        set_text = text;
+    });
+    override(text_field_edit, "wrapSelection", (field, syntax_start, syntax_end) => {
+        wrap_selection_called = true;
+        wrap_syntax_start = syntax_start;
+        wrap_syntax_end = syntax_end;
+    });
+
+    const latex_syntax = "$$";
+    const block_latex_syntax_start = "```math\n";
+    const block_latex_syntax_end = "\n```";
+
+    // Latex selected text
+    reset_state();
+    init_textarea("abc", {
+        start: 0,
+        end: 3,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "latex");
+    assert.equal(set_text, "");
+    assert.equal(wrap_selection_called, true);
+    assert.equal(wrap_syntax_start, latex_syntax);
+    assert.equal(wrap_syntax_end, latex_syntax);
+
+    reset_state();
+    init_textarea("abc\ndef", {
+        start: 0,
+        end: 7,
+        text: "abc\ndef",
+        length: 7,
+    });
+    compose_ui.format_text($textarea, "latex");
+    assert.equal(set_text, "");
+    assert.equal(wrap_selection_called, true);
+    assert.equal(wrap_syntax_start, block_latex_syntax_start);
+    assert.equal(wrap_syntax_end, block_latex_syntax_end);
+
+    // Undo latex selected text, syntax not selected
+    reset_state();
+    init_textarea("$$abc$$", {
+        start: 2,
+        end: 5,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "latex");
+    assert.equal(set_text, "abc");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("```math\nabc\ndef\n```", {
+        start: 8,
+        end: 15,
+        text: "abc\ndef",
+        length: 7,
+    });
+    compose_ui.format_text($textarea, "latex");
+    assert.equal(set_text, "abc\ndef");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("abc\n```math\nde\nf\n```\nghi", {
+        start: 12,
+        end: 16,
+        text: "de\nf",
+        length: 4,
+    });
+    compose_ui.format_text($textarea, "latex");
+    assert.equal(set_text, "abc\nde\nf\nghi");
+    assert.equal(wrap_selection_called, false);
+
+    // Undo latex selected text, syntax selected
+    reset_state();
+    init_textarea("$$abc$$", {
+        start: 0,
+        end: 7,
+        text: "$$abc$$",
+        length: 7,
+    });
+    compose_ui.format_text($textarea, "latex");
+    assert.equal(set_text, "abc");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("```math\nabc\ndef\n```", {
+        start: 0,
+        end: 19,
+        text: "```math\nabc\ndef\n```",
+        length: 19,
+    });
+    compose_ui.format_text($textarea, "latex");
+    assert.equal(set_text, "abc\ndef");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("abc\n```math\nde\nf\n```\nghi", {
+        start: 4,
+        end: 19,
+        text: "```math\nde\nf\n```",
+        length: 16,
+    });
+    compose_ui.format_text($textarea, "latex");
+    assert.equal(set_text, "abc\nde\nf\nghi");
+    assert.equal(wrap_selection_called, false);
+});
+
 run_test("markdown_shortcuts", ({override_rewire}) => {
     let format_text_type;
     override_rewire(compose_ui, "format_text", ($textarea, type) => {

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -826,6 +826,94 @@ run_test("format_text - latex", ({override}) => {
     assert.equal(wrap_selection_called, false);
 });
 
+// TODO: test for text before/after
+run_test("format_text - quote", ({override}) => {
+    override(text_field_edit, "set", (field, text) => {
+        set_text = text;
+    });
+    override(text_field_edit, "wrapSelection", (field, syntax_start, syntax_end) => {
+        wrap_selection_called = true;
+        wrap_syntax_start = syntax_start;
+        wrap_syntax_end = syntax_end;
+    });
+
+    const quote_syntax_start = "```quote\n";
+    const quote_syntax_end = "\n```";
+
+    // Quote selected text
+    reset_state();
+    init_textarea("abc", {
+        start: 0,
+        end: 3,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "quote");
+    assert.equal(set_text, "");
+    assert.equal(wrap_selection_called, true);
+    assert.equal(wrap_syntax_start, quote_syntax_start);
+    assert.equal(wrap_syntax_end, quote_syntax_end);
+
+    reset_state();
+    init_textarea("abc\ndef\nghi", {
+        start: 4,
+        end: 7,
+        text: "def",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "quote");
+    assert.equal(set_text, "");
+    assert.equal(wrap_selection_called, true);
+    assert.equal(wrap_syntax_start, quote_syntax_start);
+    assert.equal(wrap_syntax_end, quote_syntax_end);
+
+    // Undo quote selected text, syntax not selected
+    reset_state();
+    init_textarea("```quote\nabc\n```", {
+        start: 9,
+        end: 12,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "quote");
+    assert.equal(set_text, "abc");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("abc\n```quote\ndef\n```\nghi", {
+        start: 13,
+        end: 16,
+        text: "abc",
+        length: 3,
+    });
+    compose_ui.format_text($textarea, "quote");
+    assert.equal(set_text, "abc\ndef\nghi");
+    assert.equal(wrap_selection_called, false);
+
+    // Undo quote selected text, syntax selected
+    reset_state();
+    init_textarea("```quote\nabc\n```", {
+        start: 0,
+        end: 16,
+        text: "```quote\nabc\n```",
+        length: 16,
+    });
+    compose_ui.format_text($textarea, "quote");
+    assert.equal(set_text, "abc");
+    assert.equal(wrap_selection_called, false);
+
+    reset_state();
+    init_textarea("abc\n```quote\ndef\n```\nghi", {
+        start: 4,
+        end: 19,
+        text: "```quote\ndef\n```",
+        length: 16,
+    });
+    compose_ui.format_text($textarea, "quote");
+    assert.equal(set_text, "abc\ndef\nghi");
+    assert.equal(wrap_selection_called, false);
+});
+
 run_test("markdown_shortcuts", ({override_rewire}) => {
     let format_text_type;
     override_rewire(compose_ui, "format_text", ($textarea, type) => {

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -242,6 +242,8 @@ export function format_text($textarea, type) {
     const bold_syntax = "**";
     const bold_and_italic_syntax = "***";
     const strikethrough_syntax = "~~";
+    let quote_syntax_start = "```quote\n";
+    let quote_syntax_end = "\n```";
     let latex_syntax_start = "$$";
     let latex_syntax_end = "$$";
     let is_selected_text_italic = false;
@@ -267,6 +269,15 @@ export function format_text($textarea, type) {
         case "bold":
             // Ctrl + B: Toggle bold syntax on selection.
             add_formatting(bold_syntax, bold_syntax, field, range, text, selected_text);
+            break;
+        case "quote":
+            if (range.start !== 0 && !text.includes("\n" + selected_text)) {
+                quote_syntax_start = "\n```quote\n";
+            }
+            if (range.end !== text.length && !text.includes(selected_text + "\n")) {
+                quote_syntax_end = "\n```\n";
+            }
+            add_formatting(quote_syntax_start, quote_syntax_end, field, range, text, selected_text);
             break;
         case "strikethrough":
             add_formatting(

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -241,6 +241,7 @@ export function format_text($textarea, type) {
     const italic_syntax = "*";
     const bold_syntax = "**";
     const bold_and_italic_syntax = "***";
+    const strikethrough_syntax = "~~";
     let is_selected_text_italic = false;
     let is_inner_text_italic = false;
     const field = $textarea.get(0);
@@ -259,6 +260,16 @@ export function format_text($textarea, type) {
         case "bold":
             // Ctrl + B: Toggle bold syntax on selection.
             add_formatting(bold_syntax, bold_syntax, field, range, text, selected_text);
+            break;
+        case "strikethrough":
+            add_formatting(
+                strikethrough_syntax,
+                strikethrough_syntax,
+                field,
+                range,
+                text,
+                selected_text,
+            );
             break;
         case "italic":
             // Ctrl + I: Toggle italic syntax on selection. This is

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -241,6 +241,8 @@ export function format_text($textarea, type) {
     const italic_syntax = "*";
     const bold_syntax = "**";
     const bold_and_italic_syntax = "***";
+    let code_syntax_start = "```\n";
+    let code_syntax_end = "\n```";
     const strikethrough_syntax = "~~";
     let quote_syntax_start = "```quote\n";
     let quote_syntax_end = "\n```";
@@ -257,6 +259,16 @@ export function format_text($textarea, type) {
         latex_syntax_start = "```math\n";
         latex_syntax_end = "\n```";
     }
+    if (
+        !selected_text.slice(1, -1).includes("\n") &&
+        selected_text.length > 0 &&
+        selected_text.length < text.length &&
+        ((range.start !== 0 && text[range.start - 1] !== "\n") ||
+            (range.end !== text.length && text[range.end] !== "\n"))
+    ) {
+        code_syntax_start = "`";
+        code_syntax_end = "`";
+    }
 
     // Remove new line and space around selected text.
     const left_trim_length = range.text.length - range.text.trimStart().length;
@@ -269,6 +281,17 @@ export function format_text($textarea, type) {
         case "bold":
             // Ctrl + B: Toggle bold syntax on selection.
             add_formatting(bold_syntax, bold_syntax, field, range, text, selected_text);
+            break;
+        case "code":
+            if (code_syntax_start !== "`") {
+                if (range.start !== 0 && !text.includes("\n" + selected_text)) {
+                    code_syntax_start = "\n```\n";
+                }
+                if (range.end !== text.length && !text.includes(selected_text + "\n")) {
+                    code_syntax_end = "\n```\n";
+                }
+            }
+            add_formatting(code_syntax_start, code_syntax_end, field, range, text, selected_text);
             break;
         case "quote":
             if (range.start !== 0 && !text.includes("\n" + selected_text)) {

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -242,12 +242,19 @@ export function format_text($textarea, type) {
     const bold_syntax = "**";
     const bold_and_italic_syntax = "***";
     const strikethrough_syntax = "~~";
+    let latex_syntax_start = "$$";
+    let latex_syntax_end = "$$";
     let is_selected_text_italic = false;
     let is_inner_text_italic = false;
     const field = $textarea.get(0);
     let range = $textarea.range();
     let text = $textarea.val();
     const selected_text = range.text;
+
+    if (selected_text.includes("\n")) {
+        latex_syntax_start = "```math\n";
+        latex_syntax_end = "\n```";
+    }
 
     // Remove new line and space around selected text.
     const left_trim_length = range.text.length - range.text.trimStart().length;
@@ -270,6 +277,9 @@ export function format_text($textarea, type) {
                 text,
                 selected_text,
             );
+            break;
+        case "latex":
+            add_formatting(latex_syntax_start, latex_syntax_end, field, range, text, selected_text);
             break;
         case "italic":
             // Ctrl + I: Toggle italic syntax on selection. This is

--- a/static/templates/compose_control_buttons_in_popover.hbs
+++ b/static/templates/compose_control_buttons_in_popover.hbs
@@ -5,6 +5,7 @@
 <a role="button" data-format-type="link" class="compose_control_button fa fa-link formatting_button" aria-label="{{t 'Link' }}" tabindex=0 data-tippy-content="{{t 'Link' }}"></a>
 <div class="divider">|</div>
 <a role="button" data-format-type="quote" class="compose_control_button fa fa-quote-left formatting_button" aria-label="{{t 'Quote' }}" tabindex=0 data-tippy-content="{{t 'Quote' }}"></a>
+<a role="button" data-format-type="spoiler" class="compose_control_button fa fa-minus formatting_button" aria-label="{{t 'Spoiler' }}" tabindex=0 data-tippy-content="{{t 'Spoiler' }}"></a>
 <a role="button" data-format-type="latex" class="compose_control_button fa fa-superscript formatting_button" aria-label="{{t 'LaTeX' }}" tabindex=0 data-tippy-content="{{t 'LaTeX' }}"></a>
 <div class="divider">|</div>
 <a role="button" class="compose_control_button compose_help_button fa fa-question" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>

--- a/static/templates/compose_control_buttons_in_popover.hbs
+++ b/static/templates/compose_control_buttons_in_popover.hbs
@@ -3,4 +3,6 @@
 <a role="button" data-format-type="strikethrough" class="compose_control_button fa fa-strikethrough formatting_button" aria-label="{{t 'Strikethrough' }}" tabindex=0 data-tippy-content="{{t 'Strikethrough' }}"></a>
 <a role="button" data-format-type="link" class="compose_control_button fa fa-link formatting_button" aria-label="{{t 'Link' }}" tabindex=0 data-tippy-content="{{t 'Link' }}"></a>
 <div class="divider">|</div>
+<a role="button" data-format-type="latex" class="compose_control_button fa fa-superscript formatting_button" aria-label="{{t 'LaTeX' }}" tabindex=0 data-tippy-content="{{t 'LaTeX' }}"></a>
+<div class="divider">|</div>
 <a role="button" class="compose_control_button compose_help_button fa fa-question" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>

--- a/static/templates/compose_control_buttons_in_popover.hbs
+++ b/static/templates/compose_control_buttons_in_popover.hbs
@@ -3,6 +3,7 @@
 <a role="button" data-format-type="strikethrough" class="compose_control_button fa fa-strikethrough formatting_button" aria-label="{{t 'Strikethrough' }}" tabindex=0 data-tippy-content="{{t 'Strikethrough' }}"></a>
 <a role="button" data-format-type="link" class="compose_control_button fa fa-link formatting_button" aria-label="{{t 'Link' }}" tabindex=0 data-tippy-content="{{t 'Link' }}"></a>
 <div class="divider">|</div>
+<a role="button" data-format-type="quote" class="compose_control_button fa fa-quote-left formatting_button" aria-label="{{t 'Quote' }}" tabindex=0 data-tippy-content="{{t 'Quote' }}"></a>
 <a role="button" data-format-type="latex" class="compose_control_button fa fa-superscript formatting_button" aria-label="{{t 'LaTeX' }}" tabindex=0 data-tippy-content="{{t 'LaTeX' }}"></a>
 <div class="divider">|</div>
 <a role="button" class="compose_control_button compose_help_button fa fa-question" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>

--- a/static/templates/compose_control_buttons_in_popover.hbs
+++ b/static/templates/compose_control_buttons_in_popover.hbs
@@ -1,6 +1,7 @@
 <a role="button" data-format-type="bold" class="compose_control_button fa fa-bold formatting_button" aria-label="{{t 'Bold' }}" tabindex=0 data-tippy-content="{{t 'Bold' }}"></a>
 <a role="button" data-format-type="italic" class="compose_control_button fa fa-italic formatting_button" aria-label="{{t 'Italic' }}" tabindex=0 data-tippy-content="{{t 'Italic' }}"></a>
 <a role="button" data-format-type="strikethrough" class="compose_control_button fa fa-strikethrough formatting_button" aria-label="{{t 'Strikethrough' }}" tabindex=0 data-tippy-content="{{t 'Strikethrough' }}"></a>
+<a role="button" data-format-type="code" class="compose_control_button fa fa-code formatting_button" aria-label="{{t 'Code' }}" tabindex=0 data-tippy-content="{{t 'Code' }}"></a>
 <a role="button" data-format-type="link" class="compose_control_button fa fa-link formatting_button" aria-label="{{t 'Link' }}" tabindex=0 data-tippy-content="{{t 'Link' }}"></a>
 <div class="divider">|</div>
 <a role="button" data-format-type="quote" class="compose_control_button fa fa-quote-left formatting_button" aria-label="{{t 'Quote' }}" tabindex=0 data-tippy-content="{{t 'Quote' }}"></a>

--- a/static/templates/compose_control_buttons_in_popover.hbs
+++ b/static/templates/compose_control_buttons_in_popover.hbs
@@ -1,5 +1,6 @@
 <a role="button" data-format-type="bold" class="compose_control_button fa fa-bold formatting_button" aria-label="{{t 'Bold' }}" tabindex=0 data-tippy-content="{{t 'Bold' }}"></a>
 <a role="button" data-format-type="italic" class="compose_control_button fa fa-italic formatting_button" aria-label="{{t 'Italic' }}" tabindex=0 data-tippy-content="{{t 'Italic' }}"></a>
+<a role="button" data-format-type="strikethrough" class="compose_control_button fa fa-strikethrough formatting_button" aria-label="{{t 'Strikethrough' }}" tabindex=0 data-tippy-content="{{t 'Strikethrough' }}"></a>
 <a role="button" data-format-type="link" class="compose_control_button fa fa-link formatting_button" aria-label="{{t 'Link' }}" tabindex=0 data-tippy-content="{{t 'Link' }}"></a>
 <div class="divider">|</div>
 <a role="button" class="compose_control_button compose_help_button fa fa-question" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>

--- a/static/templates/compose_control_buttons_in_popover.hbs
+++ b/static/templates/compose_control_buttons_in_popover.hbs
@@ -1,5 +1,5 @@
 <a role="button" data-format-type="bold" class="compose_control_button fa fa-bold formatting_button" aria-label="{{t 'Bold' }}" tabindex=0 data-tippy-content="{{t 'Bold' }}"></a>
 <a role="button" data-format-type="italic" class="compose_control_button fa fa-italic formatting_button" aria-label="{{t 'Italic' }}" tabindex=0 data-tippy-content="{{t 'Italic' }}"></a>
 <a role="button" data-format-type="link" class="compose_control_button fa fa-link formatting_button" aria-label="{{t 'Link' }}" tabindex=0 data-tippy-content="{{t 'Link' }}"></a>
-<div class="divider hide-sm">|</div>
+<div class="divider">|</div>
 <a role="button" class="compose_control_button compose_help_button fa fa-question" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>


### PR DESCRIPTION
Resolves https://github.com/zulip/zulip/issues/20302

Added the following format buttons:

- Inline code
- Quote
- Spoiler
- Code block
- Strikethrough
- Latex
![format-buttons](https://user-images.githubusercontent.com/74348920/147888401-1f2fdcff-9cc9-48fa-bd83-140eb12ccf14.png)
