### PR TITLE
Use `transaction.atomic` for various functions in actions.py.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4786,6 +4786,7 @@ def do_change_realm_org_type(
     )
 
 
+@transaction.atomic(savepoint=False)
 def do_change_realm_plan_type(
     realm: Realm, plan_type: int, *, acting_user: Optional[UserProfile]
 ) -> None:
@@ -4834,7 +4835,7 @@ def do_change_realm_plan_type(
         "value": plan_type,
         "extra_data": {"upload_quota": realm.upload_quota_bytes()},
     }
-    send_event(realm, event, active_user_ids(realm.id))
+    transaction.on_commit(lambda: send_event(realm, event, active_user_ids(realm.id)))
 
 
 @transaction.atomic(durable=True)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1434,13 +1434,17 @@ def do_deactivate_stream(
 
 def send_user_email_update_event(user_profile: UserProfile) -> None:
     payload = dict(user_id=user_profile.id, new_email=user_profile.email)
-    send_event(
-        user_profile.realm,
-        dict(type="realm_user", op="update", person=payload),
-        active_user_ids(user_profile.realm_id),
+    event = dict(type="realm_user", op="update", person=payload)
+    transaction.on_commit(
+        lambda: send_event(
+            user_profile.realm,
+            event,
+            active_user_ids(user_profile.realm_id),
+        )
     )
 
 
+@transaction.atomic(savepoint=False)
 def do_change_user_delivery_email(user_profile: UserProfile, new_email: str) -> None:
     delete_user_profile_caches([user_profile])
 
@@ -1456,7 +1460,7 @@ def do_change_user_delivery_email(user_profile: UserProfile, new_email: str) -> 
     # about their new delivery email, since that field is private.
     payload = dict(user_id=user_profile.id, delivery_email=new_email)
     event = dict(type="realm_user", op="update", person=payload)
-    send_event(user_profile.realm, event, [user_profile.id])
+    transaction.on_commit(lambda: send_event(user_profile.realm, event, [user_profile.id]))
 
     if user_profile.avatar_source == UserProfile.AVATAR_FROM_GRAVATAR:
         # If the user is using Gravatar to manage their email address,
@@ -4636,17 +4640,20 @@ def do_regenerate_api_key(user_profile: UserProfile, acting_user: UserProfile) -
 
 def notify_avatar_url_change(user_profile: UserProfile) -> None:
     if user_profile.is_bot:
-        send_event(
-            user_profile.realm,
-            dict(
-                type="realm_bot",
-                op="update",
-                bot=dict(
-                    user_id=user_profile.id,
-                    avatar_url=avatar_url(user_profile),
-                ),
+        bot_event = dict(
+            type="realm_bot",
+            op="update",
+            bot=dict(
+                user_id=user_profile.id,
+                avatar_url=avatar_url(user_profile),
             ),
-            bot_owner_user_ids(user_profile),
+        )
+        transaction.on_commit(
+            lambda: send_event(
+                user_profile.realm,
+                bot_event,
+                bot_owner_user_ids(user_profile),
+            )
         )
 
     payload = dict(
@@ -4659,10 +4666,13 @@ def notify_avatar_url_change(user_profile: UserProfile) -> None:
         user_id=user_profile.id,
     )
 
-    send_event(
-        user_profile.realm,
-        dict(type="realm_user", op="update", person=payload),
-        active_user_ids(user_profile.realm_id),
+    event = dict(type="realm_user", op="update", person=payload)
+    transaction.on_commit(
+        lambda: send_event(
+            user_profile.realm,
+            event,
+            active_user_ids(user_profile.realm_id),
+        )
     )
 
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4676,6 +4676,7 @@ def notify_avatar_url_change(user_profile: UserProfile) -> None:
     )
 
 
+@transaction.atomic(savepoint=False)
 def do_change_avatar_fields(
     user_profile: UserProfile,
     avatar_source: str,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Added commits to use `transaction.atomic` for some of the `do_...` functions in `actions.py`.
 <!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
