### PR TITLE
puppet: Add a uwsgi exporter for monitoring.

### DIFF
--- a/puppet/zulip/manifests/common.pp
+++ b/puppet/zulip/manifests/common.pp
@@ -97,5 +97,14 @@ class zulip::common {
         'aarch64' => '2d185a8ed46161babeaaac8ce00ef1efdeccf3ef4ed234cd181eac6cad1ae4b2',
       },
     },
+
+    # https://github.com/timonwong/uwsgi_exporter/releases
+    'uwsgi_exporter' => {
+      'version' => '1.0.0',
+      'sha256' => {
+        'amd64'   => '7e924dec77bca1052b4782dcf31f0c6b2ebe71d6bf4a72412b97fec45962cef0',
+        'aarch64' => 'b36e26c8e94f1954c76aa9e9920be2f84ecc12b34f14a81086fedade8c48cb74',
+      },
+    },
   }
 }

--- a/puppet/zulip/templates/uwsgi.ini.template.erb
+++ b/puppet/zulip/templates/uwsgi.ini.template.erb
@@ -14,6 +14,8 @@ env= LANG=C.UTF-8
 uid=zulip
 gid=zulip
 
+stats=/home/zulip/deployments/uwsgi-stats
+
 ignore-sigpipe = true
 ignore-write-errors = true
 disable-write-exception = true

--- a/puppet/zulip_ops/manifests/app_frontend_monitoring.pp
+++ b/puppet/zulip_ops/manifests/app_frontend_monitoring.pp
@@ -1,6 +1,7 @@
 # @summary Munin monitoring of a Django frontend and RabbitMQ server.
 #
 class zulip_ops::app_frontend_monitoring {
+  include zulip_ops::prometheus::uwsgi
   include zulip_ops::munin_node
   $munin_plugins = [
     'rabbitmq_connections',

--- a/puppet/zulip_ops/manifests/prometheus/uwsgi.pp
+++ b/puppet/zulip_ops/manifests/prometheus/uwsgi.pp
@@ -1,0 +1,31 @@
+# @summary Prometheus monitoring of uwsgi servers
+#
+class zulip_ops::prometheus::uwsgi {
+  $version = $zulip::common::versions['uwsgi_exporter']['version']
+  $dir = "/srv/zulip-uwsgi_exporter-${version}"
+  $bin = "${dir}/uwsgi_exporter"
+  $arch = $::architecture ? {
+    'amd64'   => 'amd64',
+    'aarch64' => 'arm64',
+  }
+  zulip::external_dep { 'uwsgi_exporter':
+    version        => $version,
+    url            => "https://github.com/timonwong/uwsgi_exporter/releases/download/v${version}/uwsgi_exporter-${version}.linux-${arch}.tar.gz",
+    tarball_prefix => "uwsgi_exporter-${version}.linux-${arch}",
+  }
+
+  zulip_ops::firewall_allow { 'uwsgi_exporter': port => '9238' }
+  file { "${zulip::common::supervisor_conf_dir}/prometheus_uwsgi_exporter.conf":
+    ensure  => file,
+    require => [
+      User[zulip],
+      Package[supervisor],
+      Zulip::External_Dep['node_exporter'],
+    ],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('zulip_ops/supervisor/conf.d/prometheus_uwsgi_exporter.conf.template.erb'),
+    notify  => Service[supervisor],
+  }
+}

--- a/puppet/zulip_ops/templates/supervisor/conf.d/prometheus_uwsgi_exporter.conf.template.erb
+++ b/puppet/zulip_ops/templates/supervisor/conf.d/prometheus_uwsgi_exporter.conf.template.erb
@@ -1,0 +1,8 @@
+[program:prometheus_uwsgi_exporter]
+command=<%= @bin %> --stats.uri=unix:///home/zulip/deployments/uwsgi-stats --web.listen-address=:9238
+priority=10
+autostart=true
+autorestart=true
+user=zulip
+redirect_stderr=true
+stdout_logfile=/var/log/zulip/uwsgi_exporter.log


### PR DESCRIPTION
This allows investigation of how many workers are busy, and to track
"harikari" terminations.

----

The graphs below show the listen queue length, which is very helpful.  However, uwsgi only reports queue length for TCP sockets, not unix sockets; I adjusted the deployment to use them for the purposes of this graph.  There's a small overhead to using TCP sockets over UNIX domain sockets, but that matters primarily only at much higher bandwidths than I expect we hit with HTTP requests -- it may be worth the tiny overhead to gain the better insight here around causes of 502's.

Alternately, we may be able to fix uwsgi to understand queue lengths for unix sockets -- `ss -l | grep uwsgi-socket` can certainly find them, so I don't understand why [uwsgi tried to get a kernel patch](https://lists.openwall.net/netdev/2012/03/16/11) to [do so](https://github.com/unbit/uwsgi/commit/bb453da5b5b57e184e8e62ba51340c3a4d85e25e).

(edit) https://marc.info/?l=uwsgi&m=139659385014673&w=2 does work, but I'm not sure what the performance implications are over switching to TCP sockets.

**Testing plan:** Test-deployed:
<img width="1594" alt="Screen Shot 2022-01-03 at 12 47 08 PM" src="https://user-images.githubusercontent.com/28347/147978732-05028660-e620-4879-89cb-026dc7c3696c.png">

