### PR TITLE
puppet: Manage current smokescreen binary so it is not tidied.

### DIFF
--- a/puppet/zulip/manifests/smokescreen.pp
+++ b/puppet/zulip/manifests/smokescreen.pp
@@ -23,6 +23,12 @@ class zulip::smokescreen {
       Zulip::External_Dep['smokescreen-src'],
     ],
   }
+  # This resource exists purely so it doesn't get tidied; it is
+  # created by the 'compile smokescreen' step.
+  file { $bin:
+    ensure  => file,
+    require => Exec['compile smokescreen'],
+  }
   unless $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '18.04' {
     # Puppet 5.5.0 and below make this always-noisy, as they spout out
     # a notify line about tidying the managed file above.  Skip


### PR DESCRIPTION
Fix another tidy error caused by 1e4e6a09af23; as also noted in
f9a39b6703b9, these resources are necessary such that tidy does not
cleanup of smokescreen, and then force a recompilation of it again.

**Testing plan:** Test-applied, verified that zulip-puppet-apply is now stable.
