### PR TITLE
zilencer: Truncate APNS notifications correctly.

### DIFF
--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -302,7 +302,10 @@ class PushBouncerNotificationTest(BouncerTestCase):
         payload = {
             "user_id": hamlet.id,
             "gcm_payload": {"event": "remove", "zulip_message_ids": many_ids},
-            "apns_payload": {"event": "remove", "zulip_message_ids": many_ids},
+            "apns_payload": {
+                "badge": 0,
+                "custom": {"zulip": {"event": "remove", "zulip_message_ids": many_ids}},
+            },
             "gcm_options": {},
         }
         with mock.patch(
@@ -335,7 +338,15 @@ class PushBouncerNotificationTest(BouncerTestCase):
         apple_push.assert_called_once_with(
             hamlet.id,
             [apple_token],
-            {"event": "remove", "zulip_message_ids": ",".join(str(i) for i in range(50, 250))},
+            {
+                "badge": 0,
+                "custom": {
+                    "zulip": {
+                        "event": "remove",
+                        "zulip_message_ids": ",".join(str(i) for i in range(50, 250)),
+                    }
+                },
+            },
             remote=server,
         )
         android_push.assert_called_once_with(

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -250,7 +250,10 @@ def remote_server_notify_push(
         user_id, android_devices, gcm_payload, gcm_options, remote=server
     )
 
-    apns_payload = truncate_payload(apns_payload)
+    if isinstance(apns_payload.get("custom"), dict) and isinstance(
+        apns_payload["custom"].get("zulip"), dict
+    ):
+        apns_payload["custom"]["zulip"] = truncate_payload(apns_payload["custom"]["zulip"])
     send_apple_push_notification(user_id, apple_devices, apns_payload, remote=server)
 
     return json_success(


### PR DESCRIPTION
APNs payloads nest the zulip-custom data further than the top level,
as Android notifications do.  This led to APNs data silently never
being truncated; this case was not caught in tests because the mocks
provided the wrong data for the APNs structure.

Adjust to look in the appropriate place within the APNs data, and
truncate that.

**Testing plan:** Fixed the tests.