### PR TITLE
Modify user deactivation modal content.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -428,7 +428,7 @@ function confirm_deactivation(row, user_id, status_field) {
     const user = people.get_by_user_id(user_id);
     const opts = {
         username: user.full_name,
-        email: user.email,
+        email: settings_data.email_for_user_settings(user),
     };
     const html_body = render_settings_deactivation_user_modal(opts);
 

--- a/static/templates/confirm_dialog/confirm_deactivate_user.hbs
+++ b/static/templates/confirm_dialog/confirm_deactivate_user.hbs
@@ -1,6 +1,6 @@
 <p>
     {{#tr}}
-        By deactivating <z-user></z-user>, they will be logged out immediately.
+        When you deactivate <z-user></z-user>, they will be immediately logged out.
         {{#*inline "z-user"}}<strong>{{username}}</strong>{{#if email}} &lt;{{email}}&gt;{{/if}}{{/inline}}
     {{/tr}}
 </p>

--- a/static/templates/confirm_dialog/confirm_deactivate_user.hbs
+++ b/static/templates/confirm_dialog/confirm_deactivate_user.hbs
@@ -1,7 +1,7 @@
 <p>
     {{#tr}}
         By deactivating <z-user></z-user>, they will be logged out immediately.
-        {{#*inline "z-user"}}<strong>{{username}}</strong> &lt;{{email}}&gt;{{/inline}}
+        {{#*inline "z-user"}}<strong>{{username}}</strong>{{#if email}} &lt;{{email}}&gt;{{/if}}{{/inline}}
     {{/tr}}
 </p>
 <p>{{t "Their password will be cleared from our systems, and any bots they maintain will be disabled." }}</p>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit is to only show real email in the user deactivation modal.
- Second commit repharases the text as suggested [here](https://chat.zulip.org/#narrow/stream/101-design/topic/user-level.20email.20address.20visbility.20setting/near/1303461).

 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Real email avaiable
![Screenshot from 2022-01-04 15-50-05](https://user-images.githubusercontent.com/35494118/148044634-9fad0d95-fe3a-47b6-8be0-238686283e4f.png)
 
Email not available
![Screenshot from 2022-01-04 15-50-26](https://user-images.githubusercontent.com/35494118/148044665-5d848d1d-1273-4d43-bd06-8f1838c9a4e6.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
