### PR TITLE
composebox_typeahead: Fix bug in global time backspace & delete cases.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -793,16 +793,12 @@ export function show_flatpickr(element, callback, default_timestamp, options = {
         disableMobile: true,
         onKeyDown: (selectedDates, dateStr, instance, event) => {
             if (is_numeric_key(event.key)) {
-                // Don't stopPropagation for numeric inputs, let them be handled normally
+                // Don't attempt to get_keydown_hotkey for numeric inputs
+                // as it would return undefined.
                 return;
             }
 
             const hotkey = get_keydown_hotkey(event);
-
-            if (hotkey === "backspace" || hotkey === "delete") {
-                // Don't stopPropagation for backspace or delete, let them be handled normally
-                return;
-            }
 
             if (["tab", "shift_tab"].includes(hotkey.name)) {
                 const elems = [
@@ -830,7 +826,8 @@ export function show_flatpickr(element, callback, default_timestamp, options = {
 
     container.on("keydown", (e) => {
         if (is_numeric_key(e.key)) {
-            return true; // Let users type numeric values
+            // Let users type numeric values
+            return true;
         }
 
         const hotkey = get_keydown_hotkey(e);
@@ -840,7 +837,8 @@ export function show_flatpickr(element, callback, default_timestamp, options = {
         }
 
         if (hotkey.name === "backspace" || hotkey.name === "delete") {
-            return true; // Let backspace or delete be handled normally
+            // Let backspace or delete be handled normally
+            return true;
         }
 
         if (hotkey.name === "enter") {


### PR DESCRIPTION
In the previous commit (bea41e975dbd8771698b32809692c95e820479bb) we
introduced a bug by using `hotkey` instead of `hotkey.name`, further
debugging revealed that the conditional was unnecessary and as such
has been removed in this commit, the comment for the is_numeric
conditional has also been changed to explain its actual purpose.

Some other inline comments have also been moved to be on their own
lines.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<details>
<summary>
gif
</summary>

![](https://user-images.githubusercontent.com/33805964/148147306-90b0b65b-2186-4574-b451-ae6eefe936c7.gif)
</details>


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
