### PR TITLE
export: Fix deleting a not-yet-completed realm export 500s the server.

### DIFF
--- a/zerver/tests/test_realm_export.py
+++ b/zerver/tests/test_realm_export.py
@@ -97,6 +97,13 @@ class RealmExportTest(ZulipTestCase):
         with self.assertRaises(botocore.exceptions.ClientError):
             bucket.Object(path_id).load()
 
+        # try to delete a not-yet-completed realm export.
+        audit_log_entry.refresh_from_db()
+        extra_data = audit_log_entry.extra_data
+        assert extra_data is None:
+            result = self.client_delete(f"/json/export/realm/{audit_log_entry.id}")
+            self.assert_json_error(result, "Export cannot be deleted until complete")
+
         # Try to delete an export with a `deleted_timestamp` key.
         audit_log_entry.refresh_from_db()
         extra_data = audit_log_entry.extra_data
@@ -163,6 +170,13 @@ class RealmExportTest(ZulipTestCase):
         self.assert_json_success(result)
         response = self.client_get(export_path)
         self.assertEqual(response.status_code, 404)
+
+        # try to delete a not-yet-completed realm export.
+        audit_log_entry.refresh_from_db()
+        extra_data = audit_log_entry.extra_data
+        assert extra_data is None:
+            result = self.client_delete(f"/json/export/realm/{audit_log_entry.id}")
+            self.assert_json_error(result, "Export cannot be deleted until complete")
 
         # Try to delete an export with a `deleted_timestamp` key.
         audit_log_entry.refresh_from_db()

--- a/zerver/views/realm_export.py
+++ b/zerver/views/realm_export.py
@@ -13,7 +13,6 @@ from zerver.lib.exceptions import JsonableError
 from zerver.lib.export import get_realm_exports_serialized
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.response import json_success
-from zerver.lib.utils import assert_is_not_none
 from zerver.models import RealmAuditLog, UserProfile
 
 
@@ -91,7 +90,9 @@ def delete_realm_export(request: HttpRequest, user: UserProfile, export_id: int)
     except RealmAuditLog.DoesNotExist:
         raise JsonableError(_("Invalid data export ID"))
 
-    export_data = orjson.loads(assert_is_not_none(audit_log_entry.extra_data))
+    if audit_log_entry.extra_data is None:
+        raise JsonableError(_("Export cannot be deleted until complete"))
+    export_data = orjson.loads(audit_log_entry.extra_data)
     if "deleted_timestamp" in export_data:
         raise JsonableError(_("Export already deleted"))
     do_delete_realm_export(user, audit_log_entry)


### PR DESCRIPTION
In realm_export.py, trying to delete a not-yet-completed realm export 500s the server so instead, we return an error message. Fixes [#20197](https://github.com/zulip/zulip/issues/20197)

