### PR TITLE
onclick add stream: redirect users that can't create streams directly to browse stream

### DIFF
--- a/static/js/popover_menus.js
+++ b/static/js/popover_menus.js
@@ -59,7 +59,7 @@ function on_show_prep(instance) {
 export function initialize() {
     delegate("body", {
         ...default_popover_props,
-        target: "#streams_inline_cog",
+        target: "#streams_inline_icon",
         onShow(instance) {
             on_show_prep(instance);
             instance.setContent(

--- a/static/js/popover_menus.js
+++ b/static/js/popover_menus.js
@@ -61,16 +61,23 @@ export function initialize() {
         ...default_popover_props,
         target: "#streams_inline_icon",
         onShow(instance) {
+            const can_create_streams =
+                settings_data.user_can_create_private_streams() ||
+                settings_data.user_can_create_public_streams() ||
+                settings_data.user_can_create_web_public_streams();
             on_show_prep(instance);
-            instance.setContent(
-                render_left_sidebar_stream_setting_popover({
-                    can_create_streams:
-                        settings_data.user_can_create_private_streams() ||
-                        settings_data.user_can_create_public_streams() ||
-                        settings_data.user_can_create_web_public_streams(),
-                }),
-            );
+
+            if (!can_create_streams) {
+                // If the user can't create streams, we directly
+                // navigate them to the Manage streams subscribe UI.
+                window.location.assign("#streams/all");
+                // Returning false from an onShow handler cancels the show.
+                return false;
+            }
+
+            instance.setContent(render_left_sidebar_stream_setting_popover());
             left_sidebar_stream_setting_popover_displayed = true;
+            return true;
         },
         onHidden() {
             left_sidebar_stream_setting_popover_displayed = false;

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -523,7 +523,7 @@ export function set_event_handlers() {
         .expectOne()
         .on("click", (e) => {
             e.preventDefault();
-            if (e.target.id === "streams_inline_cog") {
+            if (e.target.id === "streams_inline_icon") {
                 return;
             }
             toggle_filter_displayed(e);

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -55,7 +55,7 @@ li.show-more-topics {
     }
 }
 
-#streams_inline_cog,
+#streams_inline_icon,
 .streams_filter_icon {
     float: right;
     opacity: 0.5;
@@ -68,7 +68,7 @@ li.show-more-topics {
     }
 }
 
-.streams_inline_cog_wrapper {
+.streams_inline_icon_wrapper {
     float: right;
 }
 
@@ -76,7 +76,7 @@ li.show-more-topics {
     margin-right: 10px;
 }
 
-#streams_inline_cog {
+#streams_inline_icon {
     margin-right: 10px;
 }
 

--- a/static/templates/left_sidebar.hbs
+++ b/static/templates/left_sidebar.hbs
@@ -71,8 +71,8 @@
         </ul>
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-tippy-content="{{t 'Filter streams' }} (q)">{{t 'STREAMS' }}</h4>
-                <span class="tippy-zulip-tooltip streams_inline_cog_wrapper hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}">
-                    <i id="streams_inline_cog" class='fa fa-plus' aria-hidden="true" ></i>
+                <span class="tippy-zulip-tooltip streams_inline_icon_wrapper hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}">
+                    <i id="streams_inline_icon" class='fa fa-plus' aria-hidden="true" ></i>
                 </span>
                 <i class="streams_filter_icon fa fa-filter tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Filter streams' }} (q)"></i>
                 <div class="input-append notdisplayed stream_search_section">

--- a/static/templates/left_sidebar_stream_setting_popover.hbs
+++ b/static/templates/left_sidebar_stream_setting_popover.hbs
@@ -4,11 +4,9 @@
             {{t "Browse streams" }}
         </a>
     </li>
-    {{#if can_create_streams }}
     <li>
         <a href="#streams/new">
             {{t "Create a stream" }}
         </a>
     </li>
-    {{/if}}
 </ul>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR tries to implement [issue-20676](https://github.com/zulip/zulip/issues/20676)

Here is the working proof:

**(For users that can create streams)**
![github1](https://user-images.githubusercontent.com/65943606/148208201-53cdcba9-c3d2-4a53-b534-31e8dfc69935.gif)

**(For users that can't)**
![gihub](https://user-images.githubusercontent.com/65943606/148208194-e333edc2-247d-4d78-8a68-31c672fe6a64.gif)


