### PR TITLE
Fix: Added literal syntax instead of literal data

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -34,7 +34,7 @@ def get_filtered_commands() -> Dict[str, str]:
     development-focused management commands in production.
     """
     all_commands = get_commands()
-    documented_commands = dict()
+    documented_commands = {}
     documented_apps = [
         # "auth" removed because its commands are not applicable to Zulip.
         # "contenttypes" removed because we don't use that subsystem, and

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -163,8 +163,7 @@ def get_user_group_mentions_data(
     mentioned_user_ids: Set[int], mentioned_user_group_ids: List[int], mention_data: MentionData
 ) -> Dict[int, int]:
     # Maps user_id -> mentioned user_group_id
-    mentioned_user_groups_map: Dict[int, int] = dict()
-
+    mentioned_user_groups_map: Dict[int, int] = {}
     # Add members of the mentioned user groups into `mentions_user_ids`.
     for group_id in mentioned_user_group_ids:
         member_ids = mention_data.get_group_members(group_id)

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -423,7 +423,7 @@ def validate_against_openapi_schema(
         # (E.g. the several dozen format variants for individual
         # events returned by GET /events) and instead just display the
         # specific variant we expect to match the response.
-        brief_error_display_schema = {"nullable": False, "oneOf": list()}
+        brief_error_display_schema = {"nullable": False, "oneOf": []}
         brief_error_display_schema_oneOf = []
         brief_error_validator_value = []
 


### PR DESCRIPTION
Using the literal syntax can give minor performance bumps compared to using function calls to create dict, list and tuple.

This is because here, the name dict must be looked up in the global scope in case it has been rebound. Same goes for the other two types list() and tuple().