### PR TITLE
settings: Make banner asking to confirm new email sticky.

### DIFF
--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -223,8 +223,14 @@ run_test("updates", () => {
         updated = true;
     };
 
+    let confirm_banner_hidden = false;
+    settings_account.hide_confirm_email_banner = () => {
+        confirm_banner_hidden = true;
+    };
+
     user_events.update_person({user_id: me.user_id, delivery_email: "you@example.org"});
     assert.ok(updated);
+    assert.ok(confirm_banner_hidden);
 
     const test_bot = {
         email: "test-bot@example.com",

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -283,6 +283,13 @@ export function add_custom_profile_fields_to_settings() {
     initialize_custom_date_type_fields(element_id);
 }
 
+export function hide_confirm_email_banner() {
+    if (!overlays.settings_open()) {
+        return;
+    }
+    $("#account-settings-status").hide();
+}
+
 export function set_up() {
     // Add custom profile fields elements to user account settings.
     add_custom_profile_fields_to_settings();
@@ -577,6 +584,7 @@ export function set_up() {
                 {defaultMessage: "Check your email ({email}) to confirm the new address."},
                 {email: data.email},
             ),
+            sticky: true,
         };
         settings_ui.do_settings_change(
             channel.patch,

--- a/static/js/user_events.js
+++ b/static/js/user_events.js
@@ -50,6 +50,7 @@ export const update_person = function update(person) {
         if (people.is_my_user_id(person.user_id)) {
             settings_account.update_email(delivery_email);
             page_params.delivery_email = delivery_email;
+            settings_account.hide_confirm_email_banner();
         }
     }
 


### PR DESCRIPTION
We make the banner, mentioning the user to confirm new email
after changing the email through settings, sticky and it
disappears either on reload or after confirming the new email.

Fixes #20686.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![email-change-banner](https://user-images.githubusercontent.com/35494118/148260790-4ffa0ad6-3412-43df-afce-94a76068de4f.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
