### PR TITLE
puppet: Allow routing camo requests through an outgoing proxy.

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -538,6 +538,20 @@ the system and deployment; `/etc/zulip/settings.py` is used to
 configure the application itself. The `zulip.conf` sections and
 settings are described below.
 
+When a setting refers to "set to true" or "set to false", the values
+`true` and `false` are canonical, but any of the following values will
+be considered "true", case-insensitively:
+
+- 1
+- y
+- t
+- yes
+- true
+- enable
+- enabled
+
+Any other value (including the empty string) is considered false.
+
 ### `[machine]`
 
 #### `puppet_classes`
@@ -560,8 +574,7 @@ you will need to add **`zulip::apache_sso`** to the list.
 
 #### `pgroonga`
 
-Set to the string `enabled` if enabling the [multi-language PGroonga
-search
+Set to true if enabling the [multi-language PGroonga search
 extension](../subsystems/full-text-search.html#multi-language-full-text-search).
 
 ### `[deployment]`
@@ -591,9 +604,9 @@ repository](../production/upgrade-or-modify.html#upgrading-from-a-git-repository
 
 #### `http_only`
 
-If set to non-empty, [configures Zulip to allow HTTP
-access][using-http]; use if Zulip is deployed behind a reverse proxy
-that is handling SSL/TLS termination.
+If set to true, [configures Zulip to allow HTTP access][using-http];
+use if Zulip is deployed behind a reverse proxy that is handling
+SSL/TLS termination.
 
 #### `nginx_listen_port`
 
@@ -603,7 +616,7 @@ Set to the port number if you [prefer to listen on a port other than
 #### `no_serve_uploads`
 
 To enable the [the S3 uploads backend][s3-uploads], one needs to both
-configure `settings.py` and set this to 'true' to configure
+configure `settings.py` and set this to true to configure
 `nginx`. Remove this field to return to the local uploads backend (any
 non-empty value is currently equivalent to true).
 
@@ -618,10 +631,11 @@ mode). The calculation is based on whether the system has enough
 memory (currently 3.5GiB) to run a single-server Zulip installation in
 the multiprocess mode.
 
-Set to `true` or `false` to override the automatic calculation. This
-override is useful both Docker systems (where the above algorithm
-might see the host's memory, not the container's) and/or when using
-remote servers for postgres, memcached, redis, and RabbitMQ.
+Set explicitly to true or false to override the automatic
+calculation. This override is useful both Docker systems (where the
+above algorithm might see the host's memory, not the container's)
+and/or when using remote servers for postgres, memcached, redis, and
+RabbitMQ.
 
 #### `rolling_restart`
 
@@ -670,10 +684,10 @@ setting](https://www.postgresql.org/docs/current/runtime-config-query.html#GUC-R
 
 #### `replication`
 
-Set to non-empty to enable replication to enable [log shipping
-replication between PostgreSQL servers](#postgresql-warm-standby).
-This should be enabled on the primary, as well as any replicas, and
-further requires configuration of
+Set to true to enable replication to enable [log shipping replication
+between PostgreSQL servers](#postgresql-warm-standby). This should be
+enabled on the primary, as well as any replicas, and further requires
+configuration of
 [wal-g](../production/export-and-import.html#backup-details).
 
 #### `replication_primary`

--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -759,3 +759,10 @@ Defaults to `4750` if unspecified.
 
 The IP address that Smokescreen should bind to and listen on.
 Defaults to `127.0.0.1`.
+
+#### `enable_for_camo`
+
+Because Camo includes logic to deny access to private subnets, routing
+its requests through Smokescreen is generally not necessary. Set to
+true or false to override the default, which uses the proxy only if
+it is not the default of Smokescreen on a local host.

--- a/puppet/zulip/files/postgresql/process_fts_updates
+++ b/puppet/zulip/files/postgresql/process_fts_updates
@@ -141,7 +141,15 @@ except ImportError:
     config_file = configparser.RawConfigParser()
     config_file.read("/etc/zulip/zulip.conf")
 
-    if config_file.has_option("machine", "pgroonga"):
+    if get_config(config_file, "machine", "pgroonga", "false").lower() in [
+        "1",
+        "y",
+        "t",
+        "yes",
+        "true",
+        "enable",
+        "enabled",
+    ]:
         USING_PGROONGA = True
 
     pg_args["user"] = get_config(config_file, "postgresql", "database_user", "zulip")

--- a/puppet/zulip/lib/puppet/parser/functions/zulipconf.rb
+++ b/puppet/zulip/lib/puppet/parser/functions/zulipconf.rb
@@ -5,7 +5,12 @@ module Puppet::Parser::Functions
     zulip_conf_path = lookupvar("zulip_conf_path")
     output = `/usr/bin/crudini --get #{zulip_conf_path} #{joined} 2>&1`; result = $?.success?
     if result
-      output.strip()
+      if [true, false].include? default
+        # If the default is a bool, coerce into a bool
+        ['1','y','t','true','yes','enable','enabled'].include? output.strip.downcase
+      else
+        output.strip
+      end
     else
       default
     end

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -73,7 +73,7 @@ class zulip::app_frontend_base {
   # multiprocess.  Multiprocess scales much better, but requires more
   # RAM; we just auto-detect based on available system RAM.
   $queues_multiprocess_default = $zulip::common::total_memory_mb > 3500
-  $queues_multiprocess = Boolean(zulipconf('application_server', 'queue_workers_multiprocess', $queues_multiprocess_default))
+  $queues_multiprocess = zulipconf('application_server', 'queue_workers_multiprocess', $queues_multiprocess_default)
   $queues = [
     'deferred_work',
     'digest_emails',

--- a/puppet/zulip/manifests/camo.pp
+++ b/puppet/zulip/manifests/camo.pp
@@ -16,6 +16,29 @@ class zulip::camo (String $listen_address = '0.0.0.0') {
     tarball_prefix => "go-camo-${version}",
   }
 
+  # We would like to not waste resources by going through Smokescreen,
+  # as go-camo already prohibits private-IP access; but a
+  # non-Smokescreen exit proxy may be required to access the public
+  # Internet.  The `enable_for_camo` flag, if it exists, can override
+  # our guess, in either direction.
+  $proxy_host = zulipconf('http_proxy', 'host', 'localhost')
+  $proxy_port = zulipconf('http_proxy', 'port', '4750')
+  $proxy_is_smokescreen = ($proxy_host in ['localhost', '127.0.0.1', '::1']) and ($proxy_port == '4750')
+  $camo_use_proxy = zulipconf('http_proxy', 'enable_for_camo', !$proxy_is_smokescreen)
+  if $camo_use_proxy {
+    if $proxy_is_smokescreen {
+      include zulip::smokescreen
+    }
+
+    if $proxy_host != '' and $proxy_port != '' {
+      $proxy = "http://${proxy_host}:${proxy_port}"
+    } else {
+      $proxy = ''
+    }
+  } else {
+    $proxy = ''
+  }
+
   file { "${zulip::common::supervisor_conf_dir}/go-camo.conf":
     ensure  => file,
     require => [

--- a/puppet/zulip/manifests/nginx.pp
+++ b/puppet/zulip/manifests/nginx.pp
@@ -39,8 +39,12 @@ class zulip::nginx {
   # For installations using S3 to serve uploaded files, we want Django
   # to handle the /serve_uploads and /user_avatars routes, so that it
   # can serve a redirect (after doing authentication, for uploads).
-  $no_serve_uploads = zulipconf('application_server', 'no_serve_uploads', '')
-  if $no_serve_uploads == '' {
+  $no_serve_uploads = zulipconf('application_server', 'no_serve_uploads', false)
+  if $no_serve_uploads {
+    file { '/etc/nginx/zulip-include/app.d/uploads-internal.conf':
+      ensure  => absent,
+    }
+  } else {
     file { '/etc/nginx/zulip-include/app.d/uploads-internal.conf':
       ensure  => file,
       require => Package[$zulip::common::nginx],
@@ -49,10 +53,6 @@ class zulip::nginx {
       mode    => '0644',
       notify  => Service['nginx'],
       source  => 'puppet:///modules/zulip/nginx/zulip-include-maybe/uploads-internal.conf',
-    }
-  } else {
-    file { '/etc/nginx/zulip-include/app.d/uploads-internal.conf':
-      ensure  => absent,
     }
   }
 

--- a/puppet/zulip/manifests/postgresql_base.pp
+++ b/puppet/zulip/manifests/postgresql_base.pp
@@ -72,8 +72,8 @@ class zulip::postgresql_base {
     source  => 'puppet:///modules/zulip/nagios_plugins/zulip_postgresql',
   }
 
-  $pgroonga = zulipconf('machine', 'pgroonga', '')
-  if $pgroonga == 'enabled' {
+  $pgroonga = zulipconf('machine', 'pgroonga', false)
+  if $pgroonga {
     # Needed for optional our full text search system
 
     # Removed 2020-12 in version 4.0; these lines can be removed when

--- a/puppet/zulip/manifests/profile/app_frontend.pp
+++ b/puppet/zulip/manifests/profile/app_frontend.pp
@@ -4,8 +4,8 @@ class zulip::profile::app_frontend {
   include zulip::app_frontend_base
   include zulip::app_frontend_once
 
-  $nginx_http_only = zulipconf('application_server', 'http_only', undef)
-  if $nginx_http_only != '' {
+  $nginx_http_only = zulipconf('application_server', 'http_only', false)
+  if $nginx_http_only {
     $nginx_listen_port = zulipconf('application_server', 'nginx_listen_port', 80)
   } else {
     $nginx_listen_port = zulipconf('application_server', 'nginx_listen_port', 443)

--- a/puppet/zulip/manifests/profile/app_frontend.pp
+++ b/puppet/zulip/manifests/profile/app_frontend.pp
@@ -10,7 +10,6 @@ class zulip::profile::app_frontend {
   } else {
     $nginx_listen_port = zulipconf('application_server', 'nginx_listen_port', 443)
   }
-  $no_serve_uploads = zulipconf('application_server', 'no_serve_uploads', undef)
   $ssl_dir = $::osfamily ? {
     'debian' => '/etc/ssl',
     'redhat' => '/etc/pki/tls',

--- a/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
+++ b/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
@@ -1,4 +1,4 @@
-<% if @nginx_http_only != '' -%>
+<% if @nginx_http_only -%>
 <% else -%>
 server {
     listen 80;
@@ -15,7 +15,7 @@ server {
 include /etc/nginx/zulip-include/upstreams;
 
 server {
-<% if @nginx_http_only != '' -%>
+<% if @nginx_http_only -%>
     listen <%= @nginx_listen_port %>;
     listen [::]:<%= @nginx_listen_port %>;
 <% else -%>

--- a/puppet/zulip/templates/supervisor/go-camo.conf.erb
+++ b/puppet/zulip/templates/supervisor/go-camo.conf.erb
@@ -1,5 +1,6 @@
 [program:go-camo]
 command=/usr/local/bin/secret-env-wrapper GOCAMO_HMAC=camo_key <%= @bin %> --listen=<%= @listen_address %>:9292 -H "Strict-Transport-Security: max-age=15768000" -H "X-Frame-Options: DENY" --verbose
+environment=HTTP_PROXY="<%= @proxy %>",HTTPS_PROXY="<%= @proxy %>"
 priority=15
 autostart=true
 autorestart=true


### PR DESCRIPTION
This also standardizes some bool truethiness properties in puppet.  The last commit is a candidate to backport.

Fixes: #20550.

**Testing plan:** Test install, set a non-standard proxy and saw camo get reconfigured to use it.
