### PR TITLE
scroll_bar: Simplify module.

### DIFF
--- a/static/js/scroll_bar.js
+++ b/static/js/scroll_bar.js
@@ -48,7 +48,6 @@ export function initialize() {
 
         // Align floating recipient bar with the middle column.
         $(".fixed-app").css("left", "-" + sbWidth / 2 + "px");
-        $("#keyboard-icon").css({"margin-right": sbWidth + "px"});
     }
     set_layout_width();
 }

--- a/static/js/scroll_bar.js
+++ b/static/js/scroll_bar.js
@@ -1,6 +1,5 @@
 import $ from "jquery";
 
-import {media_breakpoints} from "./css_variables";
 import {user_settings} from "./user_settings";
 
 // A few of our width properties in Zulip depend on the width of the
@@ -40,59 +39,30 @@ let sbWidth;
 export function initialize() {
     // Workaround for browsers with fixed scrollbars
     sbWidth = getScrollbarWidth();
-    // These need to agree with zulip.css
-    const left_sidebar_width = 270;
-    const right_sidebar_width = 250;
-
     if (sbWidth > 0) {
-        $(".header").css("left", "-" + sbWidth + "px");
-        $(".header-main").css("left", sbWidth + "px");
-        $(".header-main .column-middle").css("margin-right", 7 + sbWidth + "px");
-
-        $(".fixed-app").css("left", "-" + sbWidth + "px");
-        $(".fixed-app .column-middle").css("margin-left", 7 + sbWidth + "px");
-
-        $(".column-right").css("right", sbWidth + "px");
-        $(".app-main .right-sidebar").css({
-            "margin-left": sbWidth + "px",
-            width: right_sidebar_width - sbWidth + "px",
-        });
-
-        $("#compose").css("left", "-" + sbWidth + "px");
-        $("#compose-content").css({left: sbWidth + "px", "margin-right": 7 + sbWidth + "px"});
-        $("#keyboard-icon").css({"margin-right": sbWidth + "px"});
-
-        $("head").append(
-            "<style> @media (min-width: " +
-                media_breakpoints.xl_min +
-                ") { #compose-content, .header-main .column-middle { margin-right: " +
-                (right_sidebar_width + sbWidth) +
-                "px !important; } } " +
-                "@media (min-width: " +
-                media_breakpoints.md_min +
-                ") { .fixed-app .column-middle { margin-left: " +
-                (left_sidebar_width + sbWidth) +
-                "px !important; } } " +
-                "</style>",
+        // Reduce width of screen-wide parent containers, whose width doesn't vary with scrollbar width, by scrollbar width.
+        $("#navbar-container .header, .fixed-app .app-main, #compose").css(
+            "width",
+            `calc(100% - ${sbWidth}px)`,
         );
+
+        // Align floating recipient bar with the middle column.
+        $(".fixed-app").css("left", "-" + sbWidth / 2 + "px");
+        $("#keyboard-icon").css({"margin-right": sbWidth + "px"});
     }
     set_layout_width();
 }
 
 export function set_layout_width() {
-    // This logic unfortunately leads to a flash of mispositioned
-    // content when reloading a Zulip browser window.  More details
-    // are available in the comments on the max-width of 1400px in
-    // the .app-main CSS rules.
     if (user_settings.fluid_layout_width) {
-        $(".header-main").css("max-width", "inherit");
-        $(".app .app-main").css("max-width", "inherit");
-        $(".fixed-app .app-main").css("max-width", "inherit");
-        $("#compose-container").css("max-width", "inherit");
+        $(".header-main, .app .app-main, .fixed-app .app-main, #compose-container").css(
+            "max-width",
+            "inherit",
+        );
     } else {
-        $(".header-main").css("max-width", 1400 + sbWidth + "px");
-        $(".app .app-main").css("max-width", 1400 + "px");
-        $(".fixed-app .app-main").css("max-width", 1400 + sbWidth + "px");
-        $("#compose-container").css("max-width", 1400 + sbWidth + "px");
+        $(".header-main, .app .app-main, .fixed-app .app-main, #compose-container").css(
+            "max-width",
+            "1400px",
+        );
     }
 }

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -208,6 +208,7 @@
     position: relative;
     cursor: pointer;
     font-size: 20px;
+    margin-right: 15px;
 }
 
 #sidebar-keyboard-shortcuts {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -339,16 +339,9 @@ p.n-margin {
 .app-main,
 .header-main {
     width: 100%;
-    /* TODO: This 1400px is wrong, but it's hard to do better.  On
-       browsers with a nonzero default scrollbar width (i.e. not
-       macOS), we actually want a max-width of 1400px+the width of the
-       scrollbar, which is done as an override in
-       static/js/scroll_bar.js.
-
-       And with the fluid_layout_width setting, we don't want a
-       max-width at all.  The consequence is that if you reload a
-       Zulip window, there's a brief flash where the content is
-       misplaced before the JS code can fix it. */
+    /* `max-width` is changed based on `fluid_layout_width` setting in
+       `scroll_bar.js`. User may or may not see a flash of mispositioned content
+       based on how quickly the JS code is executed. */
     max-width: 1400px;
     min-width: 950px;
     margin: 0 auto;


### PR DESCRIPTION
The content which is scrollable is moved left by the width of the
scrollbar when scrollbar is visible. The navbar, floating recipient bar
and composebox doesn't move. We reduce their width by scrollbar width
to adjust for the reduced width of the scrollable content.

Since floating recipient bar is center aligned (with margin: 0 auto)
we also have to move left by half the scrollbar width.

Group css classes having the same value being assigned together. This
makes the code easier to understand.
