### PR TITLE
settings: Show user name in heading of deactivation modal.

### DIFF
--- a/frontend_tests/puppeteer_tests/user-deactivation.ts
+++ b/frontend_tests/puppeteer_tests/user-deactivation.ts
@@ -27,7 +27,7 @@ async function test_deactivate_user(page: Page): Promise<void> {
 
     assert.strictEqual(
         await common.get_text_from_selector(page, ".dialog_heading"),
-        "Deactivate " + (await common.get_internal_email_from_name(page, "cordelia")),
+        "Deactivate " + common.fullname.cordelia,
         "Deactivate modal has wrong user.",
     );
     assert.strictEqual(

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -449,7 +449,7 @@ function confirm_deactivation(row, user_id, status_field) {
     }
 
     confirm_dialog.launch({
-        html_heading: $t_html({defaultMessage: "Deactivate {email}"}, {email: user.email}),
+        html_heading: $t_html({defaultMessage: "Deactivate {name}"}, {name: user.full_name}),
         html_body,
         on_click: handle_confirm,
     });


### PR DESCRIPTION
We show user name in heading of the deactivation confirmation
modal instead of email, since there can be a case when admin
does not have access to real email and we already show email,
if accessible, in the content of the modal.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

 <!-- How have you tested? -->
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2022-01-06 13-50-21](https://user-images.githubusercontent.com/35494118/148351830-962a6a8a-4f67-4281-999d-f766412fc14b.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
