### PR TITLE
docs: Fix some typing error in docs

### DIFF
--- a/docs/contributing/accessibility.md
+++ b/docs/contributing/accessibility.md
@@ -33,11 +33,11 @@ There are tools available to automatically audit a web page for compliance
 with many of the WCAG guidelines. Here are some of the more useful ones:
 
 - [Accessibility Developer Tools][chrome-webstore]
-  This open source Chrome extension from Google adds an accessibility audit to
+  This open-source Chrome extension from Google adds an accessibility audit to
   the "Audits" tab of the Chrome Developer Tools. The audit is performed
   against the page's DOM via JavaScript, allowing it to identify some issues
   that a static HTML inspector would miss.
-- [aXe](https://www.deque.com/products/axe/) An open source Chrome and Firefox
+- [axe](https://www.deque.com/products/axe/) An open-source Chrome and Firefox
   extension which runs a somewhat different set of checks than Google's Chrome
   extension.
 - [Wave](https://wave.webaim.org/) This web application takes a URL and loads

--- a/docs/contributing/code-reviewing.md
+++ b/docs/contributing/code-reviewing.md
@@ -11,7 +11,7 @@ outside of the handful of people who do a ton of reviews -- and
 `@`-mention them with something like "`@person`, would you review
 this?". Good choices include
 
-- someone based in your timezone or a nearby timezone
+- someone based in your time zone or a nearby time zone
 - people working on similar things, or in a loosely related area
 
 Alternatively, posting a message in
@@ -20,7 +20,7 @@ development community server](https://zulip.com/development-community/), would
 help in reaching out to a wider group of reviewers. Either way, please be
 patient and mindful of the fact that it isn't possible to provide a
 quick reply always, but that the reviewer would get to it sooner or later.
-Lastly, ensuring the your PR passes CI and is organized into coherent
+Lastly, ensuring that your PR passes CI and is organized into coherent
 commits would help save reviewers time, which could otherwise be used
 to dive right into reviewing the PR's core functionality.
 
@@ -98,7 +98,7 @@ just saying you're busy and when you'll have time to look harder -- is
 still really valuable for the author and for anyone else who might
 review the PR.
 
-People in the Zulip project live and work in many timezones, and code
+People in the Zulip project live and work in many time zones, and code
 reviewers also need focused chunks of time to write code and do other
 things, so an immediate reply isn't always possible. But a good
 benchmark is to try to always reply **within one workday**, at least
@@ -170,8 +170,8 @@ sooner is better.
   conflicts) if there are still user experience issues under
   discussion for the feature itself.
 
-- _Completeness._ For refactorings, verify that the changes are
-  complete. Usually one can check that efficiently using `git grep`,
+- _Completeness._ When reviewing a refactor, verify that the changes are
+  complete. Usually, one can check that efficiently using `git grep`,
   and it's worth it, as we very frequently find issues by doing so.
 
 - _Documentation updates._ If this changes how something works, does it

--- a/docs/contributing/zulipbot-usage.md
+++ b/docs/contributing/zulipbot-usage.md
@@ -6,7 +6,7 @@ repositories in order to create a better workflow for Zulip contributors.
 
 Its purpose is to work around various limitations in GitHub's
 permissions and notifications systems to make it possible to have a
-much more democractic workflow for our contributors. It allows anyone
+much more democratic workflow for our contributors. It allows anyone
 to self-assign or label an issue, not just the core contributors
 trusted with full write access to the repository (which is the only
 model GitHub supports).


### PR DESCRIPTION
Made changes to correct some typing and grammatical errors in accessibility.md, code-reviewing.md and zulipbot-usage.md in the docs/contributing directory. 