### PR TITLE
compose: Improve icon for closing compose box (Fixes #20403)

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -239,14 +239,15 @@
 
     button {
         background: transparent;
-        font-size: 20px;
-        font-weight: bold;
+        font-size: 15px;
+        font-weight: normal;
         line-height: 20px;
         opacity: 0.6;
         border: 0;
         padding: 0;
         margin-left: 4px;
         vertical-align: unset;
+        text-shadow: none;
 
         &:hover {
             opacity: 1;

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -68,9 +68,9 @@
                 <div class="compose_table">
                     <div id="compose_top">
                         <div id="compose_top_right" class="order-2">
-                            <button type="button" class="expand_composebox_button fa fa-angle-up" aria-label="{{t 'Expand compose' }}" data-tippy-content="{{t 'Expand compose' }}"></button>
-                            <button type="button" class="collapse_composebox_button fa fa-angle-down" aria-label="{{t 'Collapse compose' }}" data-tippy-content="{{t 'Collapse compose' }}"></button>
-                            <button type="button" class="close" id="compose_close" data-tooltip-template-id="compose_close_tooltip">&times;</button>
+                            <button type="button" class="expand_composebox_button fa fa-chevron-up" aria-label="{{t 'Expand compose' }}" title="{{t 'Expand compose' }}"></button>
+                            <button type="button" class="collapse_composebox_button fa fa-chevron-down" aria-label="{{t 'Collapse compose' }}" data-tippy-content="{{t 'Collapse compose' }}"></button>
+                            <button type="button" class="close fa fa-times" id='compose_close' data-tooltip-template-id="compose_close_tooltip"></button>
                             <template id="compose_close_tooltip">{{t 'Cancel compose' }} <span class="hotkey-hint">(Esc)</span></template>
                         </div>
                         <div id="stream-message" class="order-1">


### PR DESCRIPTION
https://github.com/zulip/zulip/issues/20403

before:

![image](https://user-images.githubusercontent.com/140002/148443486-fa207d91-9fb4-4d81-b4cd-d860bf77ba90.png)


after:

![image](https://user-images.githubusercontent.com/140002/148443350-bb0fa366-d6d3-4ccc-a5da-6140abdb0f29.png)

cc @alya (posted #20403 )
