### PR TITLE
streams: Add notifications for description changes.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3915,6 +3915,7 @@ class AbstractRealmAuditLog(models.Model):
     STREAM_NAME_CHANGED = 603
     STREAM_REACTIVATED = 604
     STREAM_MESSAGE_RETENTION_DAYS_CHANGED = 605
+    STREAM_PROPERTY_CHANGED = 607
 
     # The following values are only for RemoteZulipServerAuditLog
     # Values should be exactly 10000 greater than the corresponding

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2532,9 +2532,12 @@ class SubscribeActionTest(BaseAction):
         )
         check_subscription_add("events[0]", events[0])
 
-        action = lambda: do_change_stream_description(stream, "new description")
-        events = self.verify_action(action, include_subscribers=include_subscribers)
+        action = lambda: do_change_stream_description(
+            stream, "new description", acting_user=self.example_user("hamlet")
+        )
+        events = self.verify_action(action, include_subscribers=include_subscribers, num_events=2)
         check_stream_update("events[0]", events[0])
+        check_message("events[1]", events[1])
 
         # Update stream privacy - make stream web public
         action = lambda: do_change_stream_permission(

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1216,6 +1216,20 @@ class StreamAdminTest(ZulipTestCase):
         )
         self.assertEqual(messages[-1].content, expected_notification)
 
+        realm_audit_log = RealmAuditLog.objects.filter(
+            event_type=RealmAuditLog.STREAM_PROPERTY_CHANGED,
+            modified_stream=stream,
+        ).last()
+        assert realm_audit_log is not None
+        expected_extra_data = orjson.dumps(
+            {
+                RealmAuditLog.OLD_VALUE: "Test description",
+                RealmAuditLog.NEW_VALUE: "a multi line description",
+                "property": "description",
+            }
+        ).decode()
+        self.assertEqual(realm_audit_log.extra_data, expected_extra_data)
+
         # Verify that we don't render inline URL previews in this code path.
         with self.settings(INLINE_URL_EMBED_PREVIEW=True):
             result = self.client_patch(
@@ -1263,6 +1277,20 @@ class StreamAdminTest(ZulipTestCase):
             "```"
         )
         self.assertEqual(messages[-1].content, expected_notification)
+
+        realm_audit_log = RealmAuditLog.objects.filter(
+            event_type=RealmAuditLog.STREAM_PROPERTY_CHANGED,
+            modified_stream=stream,
+        ).last()
+        assert realm_audit_log is not None
+        expected_extra_data = orjson.dumps(
+            {
+                RealmAuditLog.OLD_VALUE: "See https://zulip.com/team",
+                RealmAuditLog.NEW_VALUE: "Test description",
+                "property": "description",
+            }
+        ).decode()
+        self.assertEqual(realm_audit_log.extra_data, expected_extra_data)
 
     def test_change_stream_description_requires_admin(self) -> None:
         user_profile = self.example_user("hamlet")

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -284,7 +284,7 @@ def update_stream_backend(
         if "\n" in description:
             # We don't allow newline characters in stream descriptions.
             description = description.replace("\n", " ")
-        do_change_stream_description(stream, description)
+        do_change_stream_description(stream, description, acting_user=user_profile)
     if new_name is not None:
         new_name = new_name.strip()
         if stream.name == new_name:


### PR DESCRIPTION
Here is a screenshot of a sample notification message:
![stream_desc_notification](https://user-images.githubusercontent.com/7251823/148453564-6f3296f7-f316-4f62-a2fe-7328a2c6ec52.png)

@timabbott As you requested in your review of #20540, I split out the stream description changes into a smaller PR, with the following new changes:
* We now use `STREAM_PROPERTY_CHANGED` with the property name encoded in the `extra_data` dictionary in our `RealmAuditLog` entries.
* Made `acting_user` a required keyword argument in `do_change_stream_description`.
* Changed the `user_profile` argument to `acting_user` in `send_change_stream_description_notification`, for consistency with the calling code.
