### PR TITLE
compose: Add drafts link to the bottom of compose box.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -594,6 +594,13 @@ input.recipient_box {
         font-size: 20px;
         margin: 0 3px;
     }
+
+    .compose_draft_button {
+        font-size: 15px;
+        font-weight: 600;
+        font-family: "Source Sans 3", sans-serif;
+        padding-left: 5px;
+    }
 }
 
 .compose_right_float_container {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -189,13 +189,6 @@
     .compose_bottom_bottom_container {
         display: flex;
         justify-content: space-between;
-
-        .message-control-link {
-            .fa-question-circle {
-                margin-right: 4px;
-            }
-            padding-left: 5px;
-        }
     }
 }
 
@@ -540,18 +533,6 @@ input.recipient_box {
 }
 
 .tippy-content .compose_control_buttons_container {
-    .message-control-link {
-        /* Override tippy theme. */
-        padding: 4px 4px 0;
-        color: hsl(200, 100%, 40%);
-        font-size: 14px;
-
-        &:hover,
-        &:focus {
-            color: hsl(200, 100%, 25%);
-        }
-    }
-
     .compose_gif_icon {
         bottom: 5px;
     }
@@ -571,7 +552,7 @@ input.recipient_box {
     }
 
     .compose_control_menu {
-        padding: 3px 7px 0;
+        padding: 0 7px;
         font-size: 15px;
     }
 
@@ -600,6 +581,14 @@ input.recipient_box {
         font-weight: 600;
         font-family: "Source Sans 3", sans-serif;
         padding-left: 5px;
+    }
+
+    .compose_help_button {
+        font-size: 21px;
+        line-height: 27px;
+        font-weight: 550;
+        padding: 0 5px;
+        margin: 0;
     }
 }
 

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -99,14 +99,6 @@ body.dark-theme {
             &.compose_control_button:hover {
                 color: hsl(200, 79%, 66%);
             }
-
-            &.message-control-link {
-                color: hsl(200, 100%, 40%);
-
-                &:hover {
-                    color: hsl(200, 79%, 66%);
-                }
-            }
         }
 
         &[data-placement^="top"] {

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -106,9 +106,6 @@
                                     {{> compose_control_buttons }}
                                 </div>
                                 <div class="compose_bottom_bottom_container">
-                                    <a role="button" class="message-control-link" tabindex=0 data-overlay-trigger="message-formatting">
-                                        <i class="fa fa-question-circle"></i>{{t 'Help' }}
-                                    </a>
                                     <span id="compose_limit_indicator"></span>
                                     <div class="enter_sends">
                                         <span class="enter_sends_true">

--- a/static/templates/compose_control_buttons.hbs
+++ b/static/templates/compose_control_buttons.hbs
@@ -10,6 +10,10 @@
     <div class="{{#if message_id}}hide-lg{{else}}hide-sm{{/if}}">
         {{> compose_control_buttons_in_popover}}
     </div>
+    <div class="divider hide-sm">|</div>
+    <a role="button" class="compose_control_button compose_draft_button hide-sm" tabindex=0 href="#drafts" data-tippy-content="{{t 'Drafts' }}">
+        {{t 'Drafts' }}
+    </a>
     <div class="compose_control_menu_wrapper">
         <a class="compose_control_button zulip-icon zulip-icon-ellipsis-v-solid hide {{#if message_id}}show-lg{{else}}show-sm{{/if}} compose_control_menu" tabindex=0 data-tippy-content="Compose actions"></a>
     </div>

--- a/static/templates/compose_control_buttons.hbs
+++ b/static/templates/compose_control_buttons.hbs
@@ -7,6 +7,7 @@
     <a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"></a>
     <a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"></a>
     <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 data-tippy-content="{{t 'Add emoji' }}"></a>
+    <a role="button" class="compose_control_button fa fa-clock-o time_pick" aria-label="{{t 'Add global time' }}" tabindex=0 data-tippy-content="{{t 'Add global time<br />Everyone sees global times in their own time zone.' }}" data-tippy-maxWidth="none" data-tippy-allowHtml="true"></a>
     <div class="{{#if message_id}}hide-lg{{else}}hide-sm{{/if}}">
         {{> compose_control_buttons_in_popover}}
     </div>

--- a/static/templates/compose_control_buttons_in_popover.hbs
+++ b/static/templates/compose_control_buttons_in_popover.hbs
@@ -1,5 +1,4 @@
 <a role="button" class="compose_control_button compose_gif_icon {{#unless giphy_enabled }} hide {{/unless}} zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0 data-tippy-content="{{t 'Add GIF' }}"></a>
-<a role="button" class="compose_control_button fa fa-clock-o time_pick" aria-label="{{t 'Add global time' }}" tabindex=0 data-tippy-content="{{t 'Add global time<br />Everyone sees global times in their own time zone.' }}" data-tippy-maxWidth="none" data-tippy-allowHtml="true"></a>
 <div class="divider">|</div>
 <a role="button" data-format-type="bold" class="compose_control_button fa fa-bold formatting_button" aria-label="{{t 'Bold' }}" tabindex=0 data-tippy-content="{{t 'Bold' }}"></a>
 <a role="button" data-format-type="italic" class="compose_control_button fa fa-italic formatting_button" aria-label="{{t 'Italic' }}" tabindex=0 data-tippy-content="{{t 'Italic' }}"></a>

--- a/static/templates/compose_control_buttons_in_popover.hbs
+++ b/static/templates/compose_control_buttons_in_popover.hbs
@@ -4,3 +4,4 @@
 <a role="button" data-format-type="bold" class="compose_control_button fa fa-bold formatting_button" aria-label="{{t 'Bold' }}" tabindex=0 data-tippy-content="{{t 'Bold' }}"></a>
 <a role="button" data-format-type="italic" class="compose_control_button fa fa-italic formatting_button" aria-label="{{t 'Italic' }}" tabindex=0 data-tippy-content="{{t 'Italic' }}"></a>
 <a role="button" data-format-type="link" class="compose_control_button fa fa-link formatting_button" aria-label="{{t 'Link' }}" tabindex=0 data-tippy-content="{{t 'Link' }}"></a>
+<a role="button" class="compose_control_button compose_help_button" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting">Aa</a>


### PR DESCRIPTION
Add drafts link since we now have the space to do so
due to the new 2nd line at the bottom of compose box.
<img width="1086" alt="Screenshot 2022-01-07 at 12 16 58 PM" src="https://user-images.githubusercontent.com/25124304/148503564-d0a23376-66a6-4f79-bf2d-1e4ae16eb13f.png">

czo- https://chat.zulip.org/#narrow/stream/101-design/topic/drafts.20.2320707