### PR TITLE
overlay: Fix bug of information overlay not closing when text is selected.

### DIFF
--- a/static/styles/informational_overlays.css
+++ b/static/styles/informational_overlays.css
@@ -25,7 +25,8 @@
             font-size: 1.5rem;
             color: hsl(0, 0%, 67%);
             font-weight: 600;
-            margin: 1px 15px;
+            margin: 0 15px;
+            cursor: pointer;
         }
     }
 

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -192,7 +192,7 @@
     <div class="informational-overlays overlay new-style" data-overlay="informationalOverlays" aria-hidden="true">
         <div class="overlay-content modal-bg">
             <div class="overlay-tabs">
-                <button class="button no-style exit">&times;</button>
+                <span class="exit">&times;</span>
             </div>
             <div class="overlay-body">
             </div>


### PR DESCRIPTION
There was a bug where information overlay was not closing on clicking "x" when
some text was selected. This was due to `document.getSelection().type`
returning "Range" and we do not close the modal in that case as per the code
added in 081d74141b13.

As the "x" icon was button, the `document.getSelection().type` was still
returning "Range" for the text selected, but when the "x" icon is inside a
`span`, as in settings overlay, clicking on "x" deselects the already selected
text and selection type is not "Range" and thus modal is closed.

This PR also improves the vertical alignment of "x".

Fixes #20645.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![info-overlay-close](https://user-images.githubusercontent.com/35494118/148548634-908dfeaa-c501-42b0-ba1e-909a55081586.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
