### PR TITLE
Fix:Added argument for the method

### DIFF
--- a/zerver/management/commands/fetch_tor_exit_nodes.py
+++ b/zerver/management/commands/fetch_tor_exit_nodes.py
@@ -41,7 +41,7 @@ Does nothing unless RATE_LIMIT_TOR_TOGETHER is enabled.
             help="Number of times to retry fetching data from TOR",
         )
 
-    def handle(*args: Any, **options: Any) -> None:
+    def handle(self, *args: Any, **options: Any) -> None:
         if not settings.RATE_LIMIT_TOR_TOGETHER:
             return
 


### PR DESCRIPTION
A method which should have the bound instance as first argument has no argument defined. Python will throw an error when you'll try to call this method.