### PR TITLE
4.x camo proxy

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -633,3 +633,10 @@ Defaults to `4750` if unspecified.
 
 The IP address that Smokescreen should bind to and listen on.
 Defaults to `127.0.0.1`.
+
+#### `enable_for_camo`
+
+Because Camo includes logic to deny access to private subnets, routing
+its requests through Smokescreen is generally not necessary. Set to
+'true' or 'false' to override the default, which uses the proxy only if
+it is not the default of Smokescreen on a local host.

--- a/puppet/zulip/lib/puppet/parser/functions/zulipconf.rb
+++ b/puppet/zulip/lib/puppet/parser/functions/zulipconf.rb
@@ -5,7 +5,12 @@ module Puppet::Parser::Functions
     zulip_conf_path = lookupvar("zulip_conf_path")
     output = `/usr/bin/crudini --get #{zulip_conf_path} #{joined} 2>&1`; result = $?.success?
     if result
-      output.strip()
+      if [true, false].include? default
+        # If the default is a bool, coerce into a bool
+        ['1','y','t','true','yes','enable','enabled'].include? output.strip.downcase
+      else
+        output.strip
+      end
     else
       default
     end

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -73,7 +73,7 @@ class zulip::app_frontend_base {
   # multiprocess.  Multiprocess scales much better, but requires more
   # RAM; we just auto-detect based on available system RAM.
   $queues_multiprocess_default = $zulip::common::total_memory_mb > 3500
-  $queues_multiprocess = Boolean(zulipconf('application_server', 'queue_workers_multiprocess', $queues_multiprocess_default))
+  $queues_multiprocess = zulipconf('application_server', 'queue_workers_multiprocess', $queues_multiprocess_default)
   $queues = [
     'deferred_work',
     'digest_emails',

--- a/puppet/zulip/manifests/camo.pp
+++ b/puppet/zulip/manifests/camo.pp
@@ -18,6 +18,29 @@ class zulip::camo (String $listen_address = '0.0.0.0') {
     bin            => 'bin/go-camo',
   }
 
+  # We would like to not waste resources by going through Smokescreen,
+  # as go-camo already prohibits private-IP access; but a
+  # non-Smokescreen exit proxy may be required to access the public
+  # Internet.  The `enable_for_camo` flag, if it exists, can override
+  # our guess, in either direction.
+  $proxy_host = zulipconf('http_proxy', 'host', 'localhost')
+  $proxy_port = zulipconf('http_proxy', 'port', '4750')
+  $proxy_is_smokescreen = ($proxy_host in ['localhost', '127.0.0.1', '::1']) and ($proxy_port == '4750')
+  $camo_use_proxy = zulipconf('http_proxy', 'enable_for_camo', !$proxy_is_smokescreen)
+  if $camo_use_proxy {
+    if $proxy_is_smokescreen {
+      include zulip::smokescreen
+    }
+
+    if $proxy_host != '' and $proxy_port != '' {
+      $proxy = "http://${proxy_host}:${proxy_port}"
+    } else {
+      $proxy = ''
+    }
+  } else {
+    $proxy = ''
+  }
+
   file { "${zulip::common::supervisor_conf_dir}/go-camo.conf":
     ensure  => file,
     require => [

--- a/puppet/zulip/templates/supervisor/go-camo.conf.erb
+++ b/puppet/zulip/templates/supervisor/go-camo.conf.erb
@@ -1,5 +1,6 @@
 [program:go-camo]
 command=/usr/local/bin/secret-env-wrapper GOCAMO_HMAC=camo_key <%= @bin %> --listen=<%= @listen_address %>:9292 -H "Strict-Transport-Security: max-age=15768000" -H "X-Frame-Options: DENY" --verbose
+environment=HTTP_PROXY="<%= @proxy %>",HTTPS_PROXY="<%= @proxy %>"
 priority=15
 autostart=true
 autorestart=true


### PR DESCRIPTION
(now with the right base commit)

This is a backport of #20696.  I'm opening a separate PR and not just cherry-picking because it's a little unusual, in that I'm picking half of one commit, and a slightly tweaked second one.

Specifically, the first commit is _only_ the behaviour difference of `zulipconf` (with a new commit message), which affects `queue_workers_multiprocess` but in a fully backwards-compatible way (anything other than `true` or `false` would have errored out).

The second commit differs only that the documentation says:
> Set to 'true' or 'false' to override the default
..rather than:
> Set to true or false to override the default
