### PR TITLE
webhooks/slack: Stop wrapping message content in backticks.

### DIFF
--- a/zerver/webhooks/slack/tests.py
+++ b/zerver/webhooks/slack/tests.py
@@ -9,7 +9,7 @@ class SlackWebhookTests(WebhookTestCase):
     def test_slack_channel_to_topic(self) -> None:
 
         expected_topic = "channel: general"
-        expected_message = "**slack_user**: `test\n`"
+        expected_message = "**slack_user**: test"
         self.check_webhook(
             "message_info",
             expected_topic,
@@ -22,7 +22,7 @@ class SlackWebhookTests(WebhookTestCase):
         self.STREAM_NAME = "general"
         self.url = "{}{}".format(self.url, "&channels_map_to_topics=0")
         expected_topic = "Message from Slack"
-        expected_message = "**slack_user**: `test\n`"
+        expected_message = "**slack_user**: test"
         self.check_webhook(
             "message_info",
             expected_topic,

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -9,7 +9,7 @@ from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.models import UserProfile
 
-ZULIP_MESSAGE_TEMPLATE = "**{message_sender}**: `{text}`"
+ZULIP_MESSAGE_TEMPLATE = "**{message_sender}**: {text}"
 VALID_OPTIONS = {"SHOULD_NOT_BE_MAPPED": "0", "SHOULD_BE_MAPPED": "1"}
 
 


### PR DESCRIPTION
Prior to this commit, we wrapped all incoming messages from Slack
in backticks. This led to weird formatting errors when an incom-
ing message from Slack contains backticks, to refer to a function
name, for instance.

@timabbott FYI :)