### PR TITLE
zjsunit: Split deprecated __Rewire__ functionality out of override, with_field

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -272,7 +272,7 @@ test("PM_update_dom_counts", () => {
     assert.equal(count.text(), "");
 });
 
-test("handlers", ({override, mock_template}) => {
+test("handlers", ({override, override_rewire, mock_template}) => {
     let filter_key_handlers;
 
     mock_template("user_presence_rows.hbs", false, () => {});
@@ -295,7 +295,7 @@ test("handlers", ({override, mock_template}) => {
 
     let narrowed;
 
-    override(narrow, "by", (method, email) => {
+    override_rewire(narrow, "by", (method, email) => {
         assert.equal(email, "alice@zulip.com");
         narrowed = true;
     });
@@ -564,7 +564,7 @@ test("redraw_muted_user", () => {
     assert.equal(appended_html, undefined);
 });
 
-test("update_presence_info", ({override}) => {
+test("update_presence_info", ({override, override_rewire}) => {
     override(pm_list, "update_private_messages", () => {});
 
     page_params.realm_presence_disabled = false;
@@ -577,7 +577,7 @@ test("update_presence_info", ({override}) => {
         },
     };
 
-    override(buddy_data, "matches_filter", () => true);
+    override_rewire(buddy_data, "matches_filter", () => true);
 
     const alice_li = $.create("alice stub");
     buddy_list_add(alice.user_id, alice_li);
@@ -677,8 +677,8 @@ test("away_status", ({override}) => {
     assert.ok(!user_status.is_away(alice.user_id));
 });
 
-test("electron_bridge", ({override}) => {
-    override(activity, "send_presence_to_server", () => {});
+test("electron_bridge", ({override_rewire}) => {
+    override_rewire(activity, "send_presence_to_server", () => {});
 
     function with_bridge_idle(bridge_idle, f) {
         with_field(

--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -39,8 +39,8 @@ run_test("render_alert_words_ui", ({mock_template}) => {
     assert.ok(new_alert_word.is_focused());
 });
 
-run_test("add_alert_word", ({override}) => {
-    override(alert_words_ui, "render_alert_words_ui", () => {}); // we've already tested this above
+run_test("add_alert_word", ({override_rewire}) => {
+    override_rewire(alert_words_ui, "render_alert_words_ui", () => {}); // we've already tested this above
 
     alert_words_ui.set_up_alert_words();
 
@@ -94,8 +94,8 @@ run_test("add_alert_word", ({override}) => {
     assert.ok(alert_word_status.visible());
 });
 
-run_test("add_alert_word_keypress", ({override}) => {
-    override(alert_words_ui, "render_alert_words_ui", () => {});
+run_test("add_alert_word_keypress", ({override_rewire}) => {
+    override_rewire(alert_words_ui, "render_alert_words_ui", () => {});
     alert_words_ui.set_up_alert_words();
 
     const create_form = $("#create_alert_word_form");
@@ -120,8 +120,8 @@ run_test("add_alert_word_keypress", ({override}) => {
     assert.ok(called);
 });
 
-run_test("remove_alert_word", ({override}) => {
-    override(alert_words_ui, "render_alert_words_ui", () => {});
+run_test("remove_alert_word", ({override_rewire}) => {
+    override_rewire(alert_words_ui, "render_alert_words_ui", () => {});
     alert_words_ui.set_up_alert_words();
 
     const word_list = $("#alert_words_list");
@@ -167,8 +167,8 @@ run_test("remove_alert_word", ({override}) => {
     assert.ok(alert_word_status.visible());
 });
 
-run_test("close_status_message", ({override}) => {
-    override(alert_words_ui, "render_alert_words_ui", () => {});
+run_test("close_status_message", ({override_rewire}) => {
+    override_rewire(alert_words_ui, "render_alert_words_ui", () => {});
     alert_words_ui.set_up_alert_words();
 
     const alert_word_settings = $("#alert-word-settings");

--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -78,7 +78,7 @@ run_test("planchange", ({override}) => {
     });
 });
 
-run_test("licensechange", ({override}) => {
+run_test("licensechange", ({override, override_rewire}) => {
     override(helpers, "set_tab", () => {});
     let create_ajax_request_called = false;
     create_ajax_request_called = false;
@@ -99,7 +99,7 @@ run_test("licensechange", ({override}) => {
     });
 
     let create_update_license_request_called = false;
-    override(billing, "create_update_license_request", () => {
+    override_rewire(billing, "create_update_license_request", () => {
         create_update_license_request_called = true;
     });
 

--- a/frontend_tests/node_tests/browser_history.js
+++ b/frontend_tests/node_tests/browser_history.js
@@ -12,10 +12,10 @@ window.location.hash = "#bogus";
 const browser_history = zrequire("browser_history");
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, (...args) => {
         window.location.hash = "#bogus";
         browser_history.clear_for_testing();
-        f({override});
+        f(...args);
     });
 }
 
@@ -49,10 +49,10 @@ test("error for bad hashes", () => {
     browser_history.update(hash);
 });
 
-test("update internal hash if required", ({override}) => {
+test("update internal hash if required", ({override_rewire}) => {
     const hash = "#test/hash";
     const stub = make_stub();
-    override(browser_history, "update", stub.f);
+    override_rewire(browser_history, "update", stub.f);
     browser_history.update_hash_internally_if_required(hash);
     assert.equal(stub.num_calls, 1);
 

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -96,7 +96,7 @@ function add_canned_users() {
 }
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         user_settings.presence_enabled = true;
         compose_fade_helper.clear_focused_recipient();
         stream_data.clear_subscriptions();
@@ -107,7 +107,7 @@ function test(label, f) {
         people.add_active_user(me);
         people.initialize_current_user(me.user_id);
         muted_users.set_muted_users([]);
-        f({override});
+        f({override, override_rewire});
     });
 }
 
@@ -462,9 +462,9 @@ test("bulk_data_hacks", () => {
     assert.equal(user_ids.length, 700);
 });
 
-test("always show me", ({override}) => {
+test("always show me", ({override_rewire}) => {
     const present_user_ids = [];
-    override(presence, "get_user_ids", () => present_user_ids);
+    override_rewire(presence, "get_user_ids", () => present_user_ids);
     assert.deepEqual(buddy_data.get_filtered_and_sorted_user_ids(""), [me.user_id]);
 
     // Make sure we didn't mutate the list passed to us.
@@ -512,7 +512,7 @@ test("level", () => {
     assert.equal(buddy_data.level(selma.user_id), 3);
 });
 
-test("user_last_seen_time_status", ({override}) => {
+test("user_last_seen_time_status", ({override, override_rewire}) => {
     set_presence(selma.user_id, "active");
     set_presence(me.user_id, "active");
 
@@ -529,7 +529,7 @@ test("user_last_seen_time_status", ({override}) => {
         "translated: Last active: translated: More than 2 weeks ago",
     );
 
-    override(presence, "last_active_date", (user_id) => {
+    override_rewire(presence, "last_active_date", (user_id) => {
         assert.equal(user_id, old_user.user_id);
         return new Date(1526137743000);
     });
@@ -548,7 +548,7 @@ test("user_last_seen_time_status", ({override}) => {
     assert.equal(buddy_data.user_last_seen_time_status(selma.user_id), "translated: Idle");
 });
 
-test("get_items_for_users", ({override}) => {
+test("get_items_for_users", ({override_rewire}) => {
     people.add_active_user(alice);
     people.add_active_user(fred);
     user_status.set_away(alice.user_id);
@@ -558,7 +558,7 @@ test("get_items_for_users", ({override}) => {
         emoji_code: "1f697",
         reaction_type: "unicode_emoji",
     };
-    override(user_status, "get_status_emoji", () => status_emoji_info);
+    override_rewire(user_status, "get_status_emoji", () => status_emoji_info);
 
     const user_ids = [me.user_id, alice.user_id, fred.user_id];
     assert.deepEqual(buddy_data.get_items_for_users(user_ids), [
@@ -601,8 +601,8 @@ test("get_items_for_users", ({override}) => {
     ]);
 });
 
-test("error handling", ({override}) => {
-    override(presence, "get_user_ids", () => [42]);
+test("error handling", ({override_rewire}) => {
+    override_rewire(presence, "get_user_ids", () => [42]);
     blueslip.expect("error", "Unknown user_id in get_by_user_id: 42");
     blueslip.expect("warn", "Got user_id in presence but not people: 42");
     buddy_data.get_filtered_and_sorted_user_ids();

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const _ = require("lodash");
 
-const {mock_esm, with_field, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, with_field_rewire, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
 const {page_params, user_settings} = require("../zjsunit/zpage_params");
@@ -456,7 +456,7 @@ test("bulk_data_hacks", () => {
 
     // Make our shrink limit higher, and go back to an empty search.
     // We won't get all 1000 users, just the present ones.
-    with_field(buddy_data, "max_size_before_shrinking", 50000, () => {
+    with_field_rewire(buddy_data, "max_size_before_shrinking", 50000, () => {
         user_ids = buddy_data.get_filtered_and_sorted_user_ids("");
     });
     assert.equal(user_ids.length, 700);

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -79,8 +79,8 @@ run_test("copy_data_attribute_value", ({override}) => {
     assert.ok(faded_out);
 });
 
-run_test("adjust_mac_shortcuts non-mac", ({override}) => {
-    override(common, "has_mac_keyboard", () => false);
+run_test("adjust_mac_shortcuts non-mac", ({override_rewire}) => {
+    override_rewire(common, "has_mac_keyboard", () => false);
 
     // The adjust_mac_shortcuts has a really simple guard
     // at the top, and we just test the early-return behavior
@@ -88,7 +88,7 @@ run_test("adjust_mac_shortcuts non-mac", ({override}) => {
     common.adjust_mac_shortcuts("selector-that-does-not-exist");
 });
 
-run_test("adjust_mac_shortcuts mac", ({override}) => {
+run_test("adjust_mac_shortcuts mac", ({override_rewire}) => {
     const keys_to_test_mac = new Map([
         ["Backspace", "Delete"],
         ["Enter", "Return"],
@@ -104,7 +104,7 @@ run_test("adjust_mac_shortcuts mac", ({override}) => {
         ["Ctrl + Backspace + End", "⌘ + Delete + Fn + →"],
     ]);
 
-    override(common, "has_mac_keyboard", () => true);
+    override_rewire(common, "has_mac_keyboard", () => true);
 
     const test_items = [];
     let key_no = 1;

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -93,22 +93,22 @@ function test_ui(label, f) {
     run_test(label, f);
 }
 
-function initialize_handlers({override}) {
-    override(compose, "compute_show_video_chat_button", () => false);
-    override(compose, "render_compose_box", () => {});
-    override(upload, "setup_upload", () => undefined);
+function initialize_handlers({override, override_rewire}) {
+    override_rewire(compose, "compute_show_video_chat_button", () => false);
+    override_rewire(compose, "render_compose_box", () => {});
+    override_rewire(upload, "setup_upload", () => undefined);
     override(resize, "watch_manual_resize", () => {});
     compose.initialize();
 }
 
-test_ui("send_message_success", ({override}) => {
+test_ui("send_message_success", ({override_rewire}) => {
     $("#compose-textarea").val("foobarfoobar");
     $("#compose-textarea").trigger("blur");
     $("#compose-send-status").show();
     $("#compose-send-button .loader").show();
 
     let reify_message_id_checked;
-    override(echo, "reify_message_id", (local_id, message_id) => {
+    override_rewire(echo, "reify_message_id", (local_id, message_id) => {
         assert.equal(local_id, "1001");
         assert.equal(message_id, 12);
         reify_message_id_checked = true;
@@ -124,7 +124,7 @@ test_ui("send_message_success", ({override}) => {
     assert.ok(reify_message_id_checked);
 });
 
-test_ui("send_message", ({override}) => {
+test_ui("send_message", ({override, override_rewire}) => {
     MockDate.set(new Date(fake_now * 1000));
 
     override(sent_messages, "start_tracking_message", () => {});
@@ -153,17 +153,17 @@ test_ui("send_message", ({override}) => {
         compose_state.topic("");
         compose_state.set_message_type("private");
         page_params.user_id = new_user.user_id;
-        override(compose_state, "private_message_recipient", () => "alice@example.com");
+        override_rewire(compose_state, "private_message_recipient", () => "alice@example.com");
 
         const server_message_id = 127;
-        override(echo, "insert_message", (message) => {
+        override_rewire(echo, "insert_message", (message) => {
             assert.equal(message.timestamp, fake_now);
         });
 
         override(markdown, "apply_markdown", () => {});
         override(markdown, "add_topic_links", () => {});
 
-        override(echo, "try_deliver_locally", (message_request) => {
+        override_rewire(echo, "try_deliver_locally", (message_request) => {
             const local_id_float = 123.04;
             return echo.insert_local_message(message_request, local_id_float);
         });
@@ -190,7 +190,7 @@ test_ui("send_message", ({override}) => {
             stub_state.send_msg_called += 1;
         });
 
-        override(echo, "reify_message_id", (local_id, message_id) => {
+        override_rewire(echo, "reify_message_id", (local_id, message_id) => {
             assert.equal(typeof local_id, "string");
             assert.equal(typeof message_id, "number");
             assert.equal(message_id, server_message_id);
@@ -224,7 +224,7 @@ test_ui("send_message", ({override}) => {
 
     let echo_error_msg_checked;
 
-    override(echo, "message_send_error", (local_id, error_response) => {
+    override_rewire(echo, "message_send_error", (local_id, error_response) => {
         assert.equal(local_id, 123.04);
         assert.equal(error_response, "Error sending message: Server says 408");
         echo_error_msg_checked = true;
@@ -253,7 +253,7 @@ test_ui("send_message", ({override}) => {
         $("#compose-send-button .loader").show();
         $("#compose-textarea").off("select");
         echo_error_msg_checked = false;
-        override(echo, "try_deliver_locally", () => {});
+        override_rewire(echo, "try_deliver_locally", () => {});
 
         override(sent_messages, "get_new_local_id", () => "loc-55");
 
@@ -274,7 +274,7 @@ test_ui("send_message", ({override}) => {
     })();
 });
 
-test_ui("enter_with_preview_open", ({override}) => {
+test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     override(notifications, "clear_compose_notifications", () => {});
     override(reminder, "is_deferred_delivery", () => false);
     override(document, "to_$", () => $("document-stub"));
@@ -297,7 +297,7 @@ test_ui("enter_with_preview_open", ({override}) => {
     $("#compose .markdown_preview").hide();
     user_settings.enter_sends = true;
     let send_message_called = false;
-    override(compose, "send_message", () => {
+    override_rewire(compose, "send_message", () => {
         send_message_called = true;
     });
     compose.enter_with_preview_open();
@@ -322,7 +322,7 @@ test_ui("enter_with_preview_open", ({override}) => {
     assert.equal($("#compose-error-msg").html(), "never-been-set");
 });
 
-test_ui("finish", ({override}) => {
+test_ui("finish", ({override, override_rewire}) => {
     override(notifications, "clear_compose_notifications", () => {});
     override(reminder, "is_deferred_delivery", () => false);
     override(document, "to_$", () => $("document-stub"));
@@ -357,15 +357,15 @@ test_ui("finish", ({override}) => {
         $("#compose .markdown_preview").hide();
         $("#compose-textarea").val("foobarfoobar");
         compose_state.set_message_type("private");
-        override(compose_state, "private_message_recipient", () => "bob@example.com");
-        override(compose_pm_pill, "get_user_ids", () => []);
+        override_rewire(compose_state, "private_message_recipient", () => "bob@example.com");
+        override_rewire(compose_pm_pill, "get_user_ids", () => []);
 
         let compose_finished_event_checked = false;
         $(document).on("compose_finished.zulip", () => {
             compose_finished_event_checked = true;
         });
         let send_message_called = false;
-        override(compose, "send_message", () => {
+        override_rewire(compose, "send_message", () => {
             send_message_called = true;
         });
         assert.ok(compose.finish());
@@ -382,8 +382,8 @@ test_ui("finish", ({override}) => {
         $("#compose .markdown_preview").hide();
         $("#compose-textarea").val("foobarfoobar");
         compose_state.set_message_type("stream");
-        override(compose_state, "stream_name", () => "social");
-        override(people, "get_by_user_id", () => []);
+        override_rewire(compose_state, "stream_name", () => "social");
+        override_rewire(people, "get_by_user_id", () => []);
         compose_finished_event_checked = false;
         let schedule_message = false;
         override(reminder, "schedule_message", () => {
@@ -400,7 +400,7 @@ test_ui("finish", ({override}) => {
     })();
 });
 
-test_ui("initialize", ({override, mock_template}) => {
+test_ui("initialize", ({override, override_rewire, mock_template}) => {
     override(giphy, "is_giphy_enabled", () => true);
 
     let compose_actions_expected_opts;
@@ -416,7 +416,7 @@ test_ui("initialize", ({override, mock_template}) => {
     // normal workflow of the function. All the tests for the on functions are
     // done in subsequent tests directly below this test.
 
-    override(compose, "compute_show_video_chat_button", () => false);
+    override_rewire(compose, "compute_show_video_chat_button", () => false);
 
     let resize_watch_manual_resize_checked = false;
     override(resize, "watch_manual_resize", (elem) => {
@@ -435,7 +435,7 @@ test_ui("initialize", ({override, mock_template}) => {
 
     let setup_upload_called = false;
     let uppy_cancel_all_called = false;
-    override(upload, "setup_upload", (config) => {
+    override_rewire(upload, "setup_upload", (config) => {
         assert.equal(config.mode, "compose");
         setup_upload_called = true;
         return {
@@ -497,8 +497,8 @@ test_ui("initialize", ({override, mock_template}) => {
     })();
 });
 
-test_ui("update_fade", ({override}) => {
-    initialize_handlers({override});
+test_ui("update_fade", ({override, override_rewire}) => {
+    initialize_handlers({override, override_rewire});
 
     const selector =
         "#stream_message_recipient_stream,#stream_message_recipient_topic,#private_message_recipient";
@@ -507,12 +507,12 @@ test_ui("update_fade", ({override}) => {
     let set_focused_recipient_checked = false;
     let update_all_called = false;
 
-    override(compose_fade, "set_focused_recipient", (msg_type) => {
+    override_rewire(compose_fade, "set_focused_recipient", (msg_type) => {
         assert.equal(msg_type, "private");
         set_focused_recipient_checked = true;
     });
 
-    override(compose_fade, "update_all", () => {
+    override_rewire(compose_fade, "update_all", () => {
         update_all_called = true;
     });
 
@@ -527,8 +527,8 @@ test_ui("update_fade", ({override}) => {
     assert.ok(update_all_called);
 });
 
-test_ui("trigger_submit_compose_form", ({override}) => {
-    initialize_handlers({override});
+test_ui("trigger_submit_compose_form", ({override, override_rewire}) => {
+    initialize_handlers({override, override_rewire});
 
     let prevent_default_checked = false;
     let compose_finish_checked = false;
@@ -537,7 +537,7 @@ test_ui("trigger_submit_compose_form", ({override}) => {
             prevent_default_checked = true;
         },
     };
-    override(compose, "finish", () => {
+    override_rewire(compose, "finish", () => {
         compose_finish_checked = true;
     });
 
@@ -549,8 +549,8 @@ test_ui("trigger_submit_compose_form", ({override}) => {
     assert.ok(compose_finish_checked);
 });
 
-test_ui("on_events", ({override}) => {
-    initialize_handlers({override});
+test_ui("on_events", ({override, override_rewire}) => {
+    initialize_handlers({override, override_rewire});
 
     override(rendered_markdown, "update_elements", () => {});
 
@@ -598,7 +598,7 @@ test_ui("on_events", ({override}) => {
         $("#compose-send-status").show();
 
         let compose_finish_checked = false;
-        override(compose, "finish", () => {
+        override_rewire(compose, "finish", () => {
             compose_finish_checked = true;
         });
 
@@ -907,12 +907,12 @@ test_ui("on_events", ({override}) => {
     })();
 });
 
-test_ui("create_message_object", ({override}) => {
+test_ui("create_message_object", ({override_rewire}) => {
     $("#stream_message_recipient_stream").val("social");
     $("#stream_message_recipient_topic").val("lunch");
     $("#compose-textarea").val("burrito");
 
-    override(compose_state, "get_message_type", () => "stream");
+    override_rewire(compose_state, "get_message_type", () => "stream");
 
     let message = compose.create_message_object();
     assert.equal(message.to, social.stream_id);
@@ -927,7 +927,7 @@ test_ui("create_message_object", ({override}) => {
     assert.equal(message.topic, "lunch");
     assert.equal(message.content, "burrito");
 
-    override(compose_state, "get_message_type", () => "private");
+    override_rewire(compose_state, "get_message_type", () => "private");
     compose_state.__Rewire__(
         "private_message_recipient",
         () => "alice@example.com, bob@example.com",
@@ -939,7 +939,7 @@ test_ui("create_message_object", ({override}) => {
     assert.equal(message.content, "burrito");
 
     const {email_list_to_user_ids_string} = people;
-    override(people, "email_list_to_user_ids_string", () => undefined);
+    override_rewire(people, "email_list_to_user_ids_string", () => undefined);
     message = compose.create_message_object();
     assert.deepEqual(message.to, [alice.email, bob.email]);
     people.email_list_to_user_ids_string = email_list_to_user_ids_string;

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -254,7 +254,7 @@ run_test("compute_placeholder_text", () => {
     );
 });
 
-run_test("quote_and_reply", ({override}) => {
+run_test("quote_and_reply", ({override, override_rewire}) => {
     const selected_message = {
         type: "stream",
         stream: "devel",
@@ -368,7 +368,7 @@ run_test("quote_and_reply", ({override}) => {
         "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n```quote\nTesting with caret initially positioned at 0.\n```\n%hello there",
     );
 
-    override(compose_actions, "respond_to_message", () => {
+    override_rewire(compose_actions, "respond_to_message", () => {
         // Reset compose state to replicate the re-opening of compose-box.
         textarea_val = "";
         textarea_caret_pos = 0;
@@ -437,14 +437,14 @@ run_test("set_compose_box_top", () => {
     assert.equal(compose_top, "");
 });
 
-run_test("test_compose_height_changes", ({override}) => {
+run_test("test_compose_height_changes", ({override, override_rewire}) => {
     let autosize_destroyed = false;
     override(autosize, "destroy", () => {
         autosize_destroyed = true;
     });
 
     let compose_box_top_set = false;
-    override(compose_ui, "set_compose_box_top", (set_top) => {
+    override_rewire(compose_ui, "set_compose_box_top", (set_top) => {
         compose_box_top_set = set_top;
     });
 
@@ -617,9 +617,9 @@ run_test("format_text", () => {
     assert.equal(wrap_selection_called, false);
 });
 
-run_test("markdown_shortcuts", ({override}) => {
+run_test("markdown_shortcuts", ({override_rewire}) => {
     let format_text_type;
-    override(compose_ui, "format_text", (textarea, type) => {
+    override_rewire(compose_ui, "format_text", (textarea, type) => {
         format_text_type = type;
     });
 

--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -59,9 +59,9 @@ people.add_cross_realm_user(welcome_bot);
 
 function test_ui(label, f) {
     // The sloppy_$ flag lets us re-use setup from prior tests.
-    run_test(label, ({override, mock_template}) => {
+    run_test(label, ({override, override_rewire, mock_template}) => {
         $("#compose-textarea").val("some message");
-        f({override, mock_template});
+        f({override, override_rewire, mock_template});
     });
 }
 
@@ -248,7 +248,7 @@ test_ui("validate", ({override, mock_template}) => {
     );
 });
 
-test_ui("get_invalid_recipient_emails", ({override}) => {
+test_ui("get_invalid_recipient_emails", ({override_rewire}) => {
     const welcome_bot = {
         email: "welcome-bot@example.com",
         user_id: 124,
@@ -264,7 +264,7 @@ test_ui("get_invalid_recipient_emails", ({override}) => {
 
     people.initialize(page_params.user_id, params);
 
-    override(compose_state, "private_message_recipient", () => "welcome-bot@example.com");
+    override_rewire(compose_state, "private_message_recipient", () => "welcome-bot@example.com");
     assert.deepEqual(compose_validate.get_invalid_recipient_emails(), []);
 });
 
@@ -320,7 +320,7 @@ test_ui("test_wildcard_mention_allowed", () => {
     assert.ok(!compose_validate.wildcard_mention_allowed());
 });
 
-test_ui("validate_stream_message", ({override, mock_template}) => {
+test_ui("validate_stream_message", ({override_rewire, mock_template}) => {
     // This test is in kind of continuation to test_validate but since it is
     // primarily used to get coverage over functions called from validate()
     // we are separating it up in different test. Though their relative position
@@ -351,7 +351,7 @@ test_ui("validate_stream_message", ({override, mock_template}) => {
         compose_content = data;
     };
 
-    override(compose_validate, "wildcard_mention_allowed", () => true);
+    override_rewire(compose_validate, "wildcard_mention_allowed", () => true);
     compose_state.message_content("Hey @**all**");
     assert.ok(!compose_validate.validate());
     assert.equal($("#compose-send-button").prop("disabled"), false);
@@ -359,7 +359,7 @@ test_ui("validate_stream_message", ({override, mock_template}) => {
     assert.equal(compose_content, "compose_all_everyone_stub");
     assert.ok($("#compose-all-everyone").visible());
 
-    override(compose_validate, "wildcard_mention_allowed", () => false);
+    override_rewire(compose_validate, "wildcard_mention_allowed", () => false);
     assert.ok(!compose_validate.validate());
     assert.equal(
         $("#compose-error-msg").html(),
@@ -630,7 +630,7 @@ test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
     }
 });
 
-test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
+test_ui("warn_if_mentioning_unsubscribed_user", ({override, override_rewire, mock_template}) => {
     override(settings_data, "user_can_subscribe_other_users", () => true);
 
     let mentioned = {
@@ -676,7 +676,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
     const checks = [
         (function () {
             let called;
-            override(compose_validate, "needs_subscribe_warning", (user_id, stream_id) => {
+            override_rewire(compose_validate, "needs_subscribe_warning", (user_id, stream_id) => {
                 called = true;
                 assert.equal(user_id, 34);
                 assert.equal(stream_id, 111);

--- a/frontend_tests/node_tests/compose_video.js
+++ b/frontend_tests/node_tests/compose_video.js
@@ -53,13 +53,13 @@ const realm_available_video_chat_providers = {
 };
 
 function test(label, f) {
-    run_test(label, ({override, mock_template}) => {
+    run_test(label, ({override, override_rewire, mock_template}) => {
         page_params.realm_available_video_chat_providers = realm_available_video_chat_providers;
-        f({override, mock_template});
+        f({override, override_rewire, mock_template});
     });
 }
 
-test("videos", ({override, mock_template}) => {
+test("videos", ({override, override_rewire, mock_template}) => {
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.disabled.id;
 
     override(upload, "setup_upload", () => {});
@@ -84,7 +84,7 @@ test("videos", ({override, mock_template}) => {
             },
         };
 
-        override(compose_ui, "insert_syntax_and_focus", () => {
+        override_rewire(compose_ui, "insert_syntax_and_focus", () => {
             called = true;
         });
 
@@ -110,7 +110,7 @@ test("videos", ({override, mock_template}) => {
             },
         };
 
-        override(compose_ui, "insert_syntax_and_focus", (syntax) => {
+        override_rewire(compose_ui, "insert_syntax_and_focus", (syntax) => {
             syntax_to_insert = syntax;
             called = true;
         });
@@ -148,7 +148,7 @@ test("videos", ({override, mock_template}) => {
             },
         };
 
-        override(compose_ui, "insert_syntax_and_focus", (syntax) => {
+        override_rewire(compose_ui, "insert_syntax_and_focus", (syntax) => {
             syntax_to_insert = syntax;
             called = true;
         });
@@ -194,7 +194,7 @@ test("videos", ({override, mock_template}) => {
             },
         };
 
-        override(compose_ui, "insert_syntax_and_focus", (syntax) => {
+        override_rewire(compose_ui, "insert_syntax_and_focus", (syntax) => {
             syntax_to_insert = syntax;
             called = true;
         });

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {mock_esm, set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, set_global, with_field_rewire, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 const {page_params, user_settings} = require("../zjsunit/zpage_params");
@@ -433,9 +433,14 @@ test("content_typeahead_selected", ({override_rewire}) => {
 
     fake_this.query = "@back";
     fake_this.token = "back";
-    with_field(compose_validate, "warn_if_mentioning_unsubscribed_user", unexpected_warn, () => {
-        actual_value = ct.content_typeahead_selected.call(fake_this, backend);
-    });
+    with_field_rewire(
+        compose_validate,
+        "warn_if_mentioning_unsubscribed_user",
+        unexpected_warn,
+        () => {
+            actual_value = ct.content_typeahead_selected.call(fake_this, backend);
+        },
+    );
     expected_value = "@*Backend* ";
     assert.equal(actual_value, expected_value);
 
@@ -453,9 +458,14 @@ test("content_typeahead_selected", ({override_rewire}) => {
 
     fake_this.query = "@_kin";
     fake_this.token = "kin";
-    with_field(compose_validate, "warn_if_mentioning_unsubscribed_user", unexpected_warn, () => {
-        actual_value = ct.content_typeahead_selected.call(fake_this, hamlet);
-    });
+    with_field_rewire(
+        compose_validate,
+        "warn_if_mentioning_unsubscribed_user",
+        unexpected_warn,
+        () => {
+            actual_value = ct.content_typeahead_selected.call(fake_this, hamlet);
+        },
+    );
 
     expected_value = "@_**King Hamlet** ";
     assert.equal(actual_value, expected_value);
@@ -480,9 +490,14 @@ test("content_typeahead_selected", ({override_rewire}) => {
 
     fake_this.query = "@_back";
     fake_this.token = "back";
-    with_field(compose_validate, "warn_if_mentioning_unsubscribed_user", unexpected_warn, () => {
-        actual_value = ct.content_typeahead_selected.call(fake_this, backend);
-    });
+    with_field_rewire(
+        compose_validate,
+        "warn_if_mentioning_unsubscribed_user",
+        unexpected_warn,
+        () => {
+            actual_value = ct.content_typeahead_selected.call(fake_this, backend);
+        },
+    );
     expected_value = "@_*Backend* ";
     assert.equal(actual_value, expected_value);
 
@@ -1578,7 +1593,7 @@ test("message people", ({override}) => {
     };
 
     function get_results(search_key) {
-        return with_field(ct, "max_num_items", 2, () =>
+        return with_field_rewire(ct, "max_num_items", 2, () =>
             ct.get_person_suggestions(search_key, opts),
         );
     }

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -295,7 +295,7 @@ const make_emoji = (emoji_dict) => ({
 });
 
 function test(label, f) {
-    run_test(label, ({override, mock_template}) => {
+    run_test(label, ({override, override_rewire, mock_template}) => {
         people.init();
         user_groups.init();
 
@@ -319,7 +319,7 @@ function test(label, f) {
 
         muted_users.set_muted_users([]);
 
-        f({override, mock_template});
+        f({override, override_rewire, mock_template});
     });
 }
 
@@ -343,7 +343,7 @@ test("topics_seen_for", ({override}) => {
     assert.deepEqual(ct.topics_seen_for("non-existing-stream"), []);
 });
 
-test("content_typeahead_selected", ({override}) => {
+test("content_typeahead_selected", ({override_rewire}) => {
     const fake_this = {
         query: "",
         $element: {},
@@ -392,7 +392,7 @@ test("content_typeahead_selected", ({override}) => {
     // mention
     fake_this.completing = "mention";
 
-    override(compose_validate, "warn_if_mentioning_unsubscribed_user", () => {});
+    override_rewire(compose_validate, "warn_if_mentioning_unsubscribed_user", () => {});
 
     fake_this.query = "@**Mark Tw";
     fake_this.token = "Mark Tw";
@@ -401,7 +401,7 @@ test("content_typeahead_selected", ({override}) => {
     assert.equal(actual_value, expected_value);
 
     let warned_for_mention = false;
-    override(compose_validate, "warn_if_mentioning_unsubscribed_user", (mentioned) => {
+    override_rewire(compose_validate, "warn_if_mentioning_unsubscribed_user", (mentioned) => {
         assert.equal(mentioned, othello);
         warned_for_mention = true;
     });
@@ -525,7 +525,7 @@ test("content_typeahead_selected", ({override}) => {
     // stream
     fake_this.completing = "stream";
     let warned_for_stream_link = false;
-    override(compose_validate, "warn_if_private_stream_is_linked", (linked_stream) => {
+    override_rewire(compose_validate, "warn_if_private_stream_is_linked", (linked_stream) => {
         assert.equal(linked_stream, sweden_stream);
         warned_for_stream_link = true;
     });
@@ -610,7 +610,7 @@ function sorted_names_from(subs) {
     return subs.map((sub) => sub.name).sort();
 }
 
-test("initialize", ({override, mock_template}) => {
+test("initialize", ({override, override_rewire, mock_template}) => {
     let expected_value;
 
     mock_template("typeahead_list_item.hbs", true, (data, html) => {
@@ -730,7 +730,7 @@ test("initialize", ({override, mock_template}) => {
     let pm_recipient_typeahead_called = false;
     $("#private_message_recipient").typeahead = (options) => {
         let inserted_users = [];
-        override(user_pill, "get_user_ids", () => inserted_users);
+        override_rewire(user_pill, "get_user_ids", () => inserted_users);
 
         // This should match the users added at the beginning of this test file.
         let actual_value = options.source("");
@@ -840,7 +840,7 @@ test("initialize", ({override, mock_template}) => {
         };
 
         let appended_name;
-        override(compose_pm_pill, "set_from_typeahead", (item) => {
+        override_rewire(compose_pm_pill, "set_from_typeahead", (item) => {
             appended_name = item.full_name;
         });
 
@@ -862,7 +862,7 @@ test("initialize", ({override, mock_template}) => {
 
         let appended_names = [];
 
-        override(compose_pm_pill, "set_from_typeahead", (item) => {
+        override_rewire(compose_pm_pill, "set_from_typeahead", (item) => {
             appended_names.push(item.full_name);
         });
 
@@ -1015,13 +1015,13 @@ test("initialize", ({override, mock_template}) => {
             subscribed: false,
         };
         // Subscribed stream is active
-        override(stream_data, "is_active", () => false);
+        override_rewire(stream_data, "is_active", () => false);
         fake_this = {completing: "stream", token: "s"};
         actual_value = sort_items(fake_this, [sweden_stream, serbia_stream]);
         expected_value = [sweden_stream, serbia_stream];
         assert.deepEqual(actual_value, expected_value);
         // Subscribed stream is inactive
-        override(stream_data, "is_active", () => true);
+        override_rewire(stream_data, "is_active", () => true);
         actual_value = sort_items(fake_this, [sweden_stream, serbia_stream]);
         expected_value = [sweden_stream, serbia_stream];
         assert.deepEqual(actual_value, expected_value);
@@ -1157,7 +1157,7 @@ test("initialize", ({override, mock_template}) => {
     assert.ok(compose_textarea_typeahead_called);
 });
 
-test("begins_typeahead", ({override}) => {
+test("begins_typeahead", ({override, override_rewire}) => {
     override(stream_topic_history_util, "get_server_history", () => {});
 
     const begin_typehead_this = {
@@ -1177,7 +1177,7 @@ test("begins_typeahead", ({override}) => {
 
     function get_values(input, rest) {
         // Stub out split_at_cursor that uses $(':focus')
-        override(ct, "split_at_cursor", () => [input, rest]);
+        override_rewire(ct, "split_at_cursor", () => [input, rest]);
         const values = ct.get_candidates.call(begin_typehead_this, input);
         return values;
     }
@@ -1395,11 +1395,11 @@ test("tokenizing", () => {
     assert.equal(ct.tokenize_compose_str("foo #streams@foo"), "#streams@foo");
 });
 
-test("content_highlighter", ({override}) => {
+test("content_highlighter", ({override_rewire}) => {
     let fake_this = {completing: "emoji"};
     const emoji = {emoji_name: "person shrugging", emoji_url: "¯\\_(ツ)_/¯"};
     let th_render_typeahead_item_called = false;
-    override(typeahead_helper, "render_emoji", (item) => {
+    override_rewire(typeahead_helper, "render_emoji", (item) => {
         assert.deepEqual(item, emoji);
         th_render_typeahead_item_called = true;
     });
@@ -1407,14 +1407,14 @@ test("content_highlighter", ({override}) => {
 
     fake_this = {completing: "mention"};
     let th_render_person_called = false;
-    override(typeahead_helper, "render_person", (person) => {
+    override_rewire(typeahead_helper, "render_person", (person) => {
         assert.deepEqual(person, othello);
         th_render_person_called = true;
     });
     ct.content_highlighter.call(fake_this, othello);
 
     let th_render_user_group_called = false;
-    override(typeahead_helper, "render_user_group", (user_group) => {
+    override_rewire(typeahead_helper, "render_user_group", (user_group) => {
         assert.deepEqual(user_group, backend);
         th_render_user_group_called = true;
     });
@@ -1426,7 +1426,7 @@ test("content_highlighter", ({override}) => {
     const me_slash = {
         text: "/me is excited (Display action text)",
     };
-    override(typeahead_helper, "render_typeahead_item", (item) => {
+    override_rewire(typeahead_helper, "render_typeahead_item", (item) => {
         assert.deepEqual(item, {
             primary: "/me is excited (Display action text)",
         });
@@ -1436,7 +1436,7 @@ test("content_highlighter", ({override}) => {
 
     fake_this = {completing: "stream"};
     let th_render_stream_called = false;
-    override(typeahead_helper, "render_stream", (stream) => {
+    override_rewire(typeahead_helper, "render_stream", (stream) => {
         assert.deepEqual(stream, denmark_stream);
         th_render_stream_called = true;
     });
@@ -1444,7 +1444,7 @@ test("content_highlighter", ({override}) => {
 
     fake_this = {completing: "syntax"};
     th_render_typeahead_item_called = false;
-    override(typeahead_helper, "render_typeahead_item", (item) => {
+    override_rewire(typeahead_helper, "render_typeahead_item", (item) => {
         assert.deepEqual(item, {primary: "py"});
         th_render_typeahead_item_called = true;
     });

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -684,7 +684,7 @@ run_test("typing", ({override}) => {
     dispatch(event);
 });
 
-run_test("user_settings", ({override}) => {
+run_test("user_settings", ({override, override_rewire}) => {
     settings_display.set_default_language_name = () => {};
     let event = event_fixtures.user_settings__default_language;
     user_settings.default_language = "en";
@@ -815,7 +815,7 @@ run_test("user_settings", ({override}) => {
         assert_same(user_settings.emojiset, "google");
     }
 
-    override(starred_messages, "rerender_ui", noop);
+    override_rewire(starred_messages, "rerender_ui", noop);
     event = event_fixtures.user_settings__starred_message_counts;
     user_settings.starred_message_counts = false;
     dispatch(event);
@@ -831,7 +831,7 @@ run_test("user_settings", ({override}) => {
         const stub = make_stub();
         event = event_fixtures.user_settings__demote_inactive_streams;
         override(stream_data, "set_filter_out_inactives", noop);
-        override(stream_list, "update_streams_sidebar", stub.f);
+        override_rewire(stream_list, "update_streams_sidebar", stub.f);
         user_settings.demote_inactive_streams = 1;
         dispatch(event);
         assert.equal(stub.num_calls, 1);
@@ -873,8 +873,8 @@ run_test("update_message (read)", ({override}) => {
     assert_same(args.message_ids, [999]);
 });
 
-run_test("update_message (add star)", ({override}) => {
-    override(starred_messages, "rerender_ui", noop);
+run_test("update_message (add star)", ({override, override_rewire}) => {
+    override_rewire(starred_messages, "rerender_ui", noop);
 
     const event = event_fixtures.update_message_flags__starred_add;
     const stub = make_stub();
@@ -888,8 +888,8 @@ run_test("update_message (add star)", ({override}) => {
     assert.equal(msg.starred, true);
 });
 
-run_test("update_message (remove star)", ({override}) => {
-    override(starred_messages, "rerender_ui", noop);
+run_test("update_message (remove star)", ({override, override_rewire}) => {
+    override_rewire(starred_messages, "rerender_ui", noop);
     const event = event_fixtures.update_message_flags__starred_remove;
     const stub = make_stub();
     override(ui, "update_starred_view", stub.f);
@@ -902,8 +902,8 @@ run_test("update_message (remove star)", ({override}) => {
     assert.equal(msg.starred, false);
 });
 
-run_test("update_message (wrong data)", ({override}) => {
-    override(starred_messages, "rerender_ui", noop);
+run_test("update_message (wrong data)", ({override_rewire}) => {
+    override_rewire(starred_messages, "rerender_ui", noop);
     const event = {
         ...event_fixtures.update_message_flags__starred_add,
         messages: [0], // message does not exist
@@ -912,10 +912,10 @@ run_test("update_message (wrong data)", ({override}) => {
     // update_starred_view never gets invoked, early return is successful
 });
 
-run_test("delete_message", ({override}) => {
+run_test("delete_message", ({override, override_rewire}) => {
     const event = event_fixtures.delete_message;
 
-    override(stream_list, "update_streams_sidebar", noop);
+    override_rewire(stream_list, "update_streams_sidebar", noop);
 
     const message_events_stub = make_stub();
     override(message_events, "remove_messages", message_events_stub.f);
@@ -924,7 +924,7 @@ run_test("delete_message", ({override}) => {
     override(unread_ops, "process_read_messages_event", unread_ops_stub.f);
 
     const stream_topic_history_stub = make_stub();
-    override(stream_topic_history, "remove_messages", stream_topic_history_stub.f);
+    override_rewire(stream_topic_history, "remove_messages", stream_topic_history_stub.f);
 
     dispatch(event);
 
@@ -943,7 +943,7 @@ run_test("delete_message", ({override}) => {
     assert_same(args.opts.max_removed_msg_id, 1337);
 });
 
-run_test("user_status", ({override}) => {
+run_test("user_status", ({override, override_rewire}) => {
     let event = event_fixtures.user_status__set_away;
     {
         const stub = make_stub();
@@ -986,7 +986,7 @@ run_test("user_status", ({override}) => {
     {
         const stub = make_stub();
         override(activity, "redraw_user", stub.f);
-        override(compose_pm_pill, "get_user_ids", () => [event.user_id]);
+        override_rewire(compose_pm_pill, "get_user_ids", () => [event.user_id]);
         dispatch(event);
         assert.equal(stub.num_calls, 1);
         const args = stub.get_args("user_id");

--- a/frontend_tests/node_tests/dispatch_subs.js
+++ b/frontend_tests/node_tests/dispatch_subs.js
@@ -44,9 +44,9 @@ people.initialize_current_user(me.user_id);
 const dispatch = server_events_dispatch.dispatch_normal_event;
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         stream_data.clear_subscriptions();
-        f({override});
+        f({override, override_rewire});
     });
 }
 
@@ -181,11 +181,11 @@ test("stream update", ({override}) => {
     assert.equal(args.value, event.value);
 });
 
-test("stream create", ({override}) => {
+test("stream create", ({override, override_rewire}) => {
     const event = event_fixtures.stream__create;
 
     const stub = make_stub();
-    override(stream_data, "create_streams", stub.f);
+    override_rewire(stream_data, "create_streams", stub.f);
     override(stream_settings_ui, "add_sub_to_table", noop);
     override(overlays, "streams_open", () => true);
     dispatch(event);
@@ -197,7 +197,7 @@ test("stream create", ({override}) => {
     );
 });
 
-test("stream delete (normal)", ({override}) => {
+test("stream delete (normal)", ({override, override_rewire}) => {
     const event = event_fixtures.stream__delete;
 
     for (const stream of event.streams) {
@@ -206,7 +206,7 @@ test("stream delete (normal)", ({override}) => {
 
     stream_data.subscribe_myself(event.streams[0]);
 
-    override(stream_data, "delete_sub", noop);
+    override_rewire(stream_data, "delete_sub", noop);
     override(settings_streams, "update_default_streams_table", noop);
 
     narrow_state.is_for_stream_id = () => true;

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -104,10 +104,10 @@ const short_msg = {
 };
 
 function test(label, f) {
-    run_test(label, ({override, mock_template}) => {
+    run_test(label, ({override, override_rewire, mock_template}) => {
         $("#draft_overlay").css = () => {};
         localStorage.clear();
-        f({override, mock_template});
+        f({override, override_rewire, mock_template});
     });
 }
 
@@ -201,11 +201,11 @@ test("snapshot_message", ({override}) => {
     assert.equal(drafts.snapshot_message(), undefined);
 });
 
-test("initialize", ({override}) => {
+test("initialize", ({override_rewire}) => {
     window.addEventListener = (event_name, f) => {
         assert.equal(event_name, "beforeunload");
         let called = false;
-        override(drafts, "update_draft", () => {
+        override_rewire(drafts, "update_draft", () => {
             called = true;
         });
         f();
@@ -320,7 +320,7 @@ test("delete_all_drafts", () => {
     assert.deepEqual(draft_model.get(), {});
 });
 
-test("format_drafts", ({override, mock_template}) => {
+test("format_drafts", ({override_rewire, mock_template}) => {
     function feb12() {
         return new Date(1549958107000); // 2/12/2019 07:55:07 AM (UTC+0)
     }
@@ -419,7 +419,9 @@ test("format_drafts", ({override, mock_template}) => {
     assert.deepEqual(draft_model.get(), data);
 
     const stub_render_now = timerender.render_now;
-    override(timerender, "render_now", (time) => stub_render_now(time, new Date(1549958107000)));
+    override_rewire(timerender, "render_now", (time) =>
+        stub_render_now(time, new Date(1549958107000)),
+    );
 
     sub_store.get = function (stream_id) {
         assert.equal(stream_id, 30);
@@ -432,8 +434,8 @@ test("format_drafts", ({override, mock_template}) => {
         return "<draft table stub>";
     });
 
-    override(drafts, "open_overlay", noop);
-    override(drafts, "set_initial_element", noop);
+    override_rewire(drafts, "open_overlay", noop);
+    override_rewire(drafts, "set_initial_element", noop);
 
     $.create("#drafts_table .draft-row", {children: []});
     drafts.launch();

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -139,7 +139,7 @@ test("draft_model edit", () => {
     const unread_count = $('<span class="unread_count"></span>');
     $(".top_left_drafts").set_find_results(".unread_count", unread_count);
 
-    with_overrides((override) => {
+    with_overrides(({override}) => {
         override(Date, "now", () => 1);
         const expected = {...draft_1};
         expected.updatedAt = 1;
@@ -147,7 +147,7 @@ test("draft_model edit", () => {
         assert.deepEqual(draft_model.getDraft(id), expected);
     });
 
-    with_overrides((override) => {
+    with_overrides(({override}) => {
         override(Date, "now", () => 2);
         const expected = {...draft_2};
         expected.updatedAt = 2;

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -192,7 +192,7 @@ run_test("update_message_lists", () => {
     assert.equal(view_args.new, 402);
 });
 
-run_test("insert_local_message streams", ({override}) => {
+run_test("insert_local_message streams", ({override, override_rewire}) => {
     const fake_now = 555;
     MockDate.set(new Date(fake_now * 1000));
 
@@ -210,7 +210,7 @@ run_test("insert_local_message streams", ({override}) => {
         add_topic_links_called = true;
     });
 
-    override(echo, "insert_message", (message) => {
+    override_rewire(echo, "insert_message", (message) => {
         assert.equal(message.display_recipient, "general");
         assert.equal(message.timestamp, fake_now);
         assert.equal(message.sender_email, "iago@zulip.com");
@@ -233,7 +233,7 @@ run_test("insert_local_message streams", ({override}) => {
     assert.ok(insert_message_called);
 });
 
-run_test("insert_local_message PM", ({override}) => {
+run_test("insert_local_message PM", ({override, override_rewire}) => {
     const local_id_float = 102.01;
 
     page_params.user_id = 123;
@@ -254,7 +254,7 @@ run_test("insert_local_message PM", ({override}) => {
     let apply_markdown_called = false;
     let insert_message_called = false;
 
-    override(echo, "insert_message", (message) => {
+    override_rewire(echo, "insert_message", (message) => {
         assert.equal(message.display_recipient.length, 3);
         insert_message_called = true;
     });
@@ -280,12 +280,12 @@ run_test("insert_local_message PM", ({override}) => {
     assert.ok(insert_message_called);
 });
 
-run_test("test reify_message_id", ({override}) => {
+run_test("test reify_message_id", ({override, override_rewire}) => {
     const local_id_float = 103.01;
 
     override(markdown, "apply_markdown", () => {});
     override(markdown, "add_topic_links", () => {});
-    override(echo, "insert_message", () => {});
+    override_rewire(echo, "insert_message", () => {});
 
     const message_request = {
         type: "stream",

--- a/frontend_tests/node_tests/example7.js
+++ b/frontend_tests/node_tests/example7.js
@@ -72,7 +72,7 @@ const denmark_stream = {
     subscribed: false,
 };
 
-run_test("unread_ops", ({override}) => {
+run_test("unread_ops", ({override, override_rewire}) => {
     stream_data.clear_subscriptions();
     stream_data.add_sub(denmark_stream);
     message_store.clear_for_testing();
@@ -90,7 +90,7 @@ run_test("unread_ops", ({override}) => {
     ];
 
     // We don't want recent topics to process message for this test.
-    override(recent_topics_util, "is_visible", () => false);
+    override_rewire(recent_topics_util, "is_visible", () => false);
     // Show message_viewport as not visible so that messages will be stored as unread.
     override(message_viewport, "is_visible_and_focused", () => false);
 

--- a/frontend_tests/node_tests/example8.js
+++ b/frontend_tests/node_tests/example8.js
@@ -65,7 +65,7 @@ people.add_active_user(kitty);
 
     It's usage below will make it more clear to you.
 */
-run_test("typing_events.render_notifications_for_narrow", ({override, mock_template}) => {
+run_test("typing_events.render_notifications_for_narrow", ({override_rewire, mock_template}) => {
     // All typists are rendered in `#typing_notifications`.
     const typing_notifications = $("#typing_notifications");
 
@@ -78,7 +78,7 @@ run_test("typing_events.render_notifications_for_narrow", ({override, mock_templ
 
     // As we are not testing any functionality of `get_users_typing_for_narrow`,
     // let's override it to return two typists.
-    override(typing_events, "get_users_typing_for_narrow", () => two_typing_users_ids);
+    override_rewire(typing_events, "get_users_typing_for_narrow", () => two_typing_users_ids);
 
     const two_typing_users_rendered_html = "Two typing users rendered html stub";
 
@@ -125,7 +125,7 @@ run_test("typing_events.render_notifications_for_narrow", ({override, mock_templ
     // Change to having four typists and verify the rendered html has
     // 'Several people are typing…' but not the list of users.
     const four_typing_users_ids = [anna.user_id, vronsky.user_id, levin.user_id, kitty.user_id];
-    override(typing_events, "get_users_typing_for_narrow", () => four_typing_users_ids);
+    override_rewire(typing_events, "get_users_typing_for_narrow", () => four_typing_users_ids);
 
     typing_events.render_notifications_for_narrow();
     assert.ok(typing_notifications.html().includes("Several people are typing…"));

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -61,9 +61,9 @@ function make_sub(name, stream_id) {
 }
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         stream_data.clear_subscriptions();
-        f({override});
+        f({override, override_rewire});
     });
 }
 
@@ -1610,10 +1610,10 @@ test("navbar_helpers", () => {
     assert.equal(filter.generate_redirect_url(), default_redirect.redirect_url);
 });
 
-test("error_cases", ({override}) => {
+test("error_cases", ({override_rewire}) => {
     // This test just gives us 100% line coverage on defensive code that
     // should not be reached unless we break other code.
-    override(people, "pm_with_user_ids", () => {});
+    override_rewire(people, "pm_with_user_ids", () => {});
 
     const predicate = get_predicate([["pm-with", "Joe@example.com"]]);
     assert.ok(!predicate({type: "private"}));

--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -116,7 +116,7 @@ run_test("people_slugs", () => {
     assert.equal(hash, "#narrow/pm-with/42-alice");
 });
 
-function test_helper({override, change_tab}) {
+function test_helper({override, override_rewire, change_tab}) {
     let events = [];
     let narrow_terms;
 
@@ -141,7 +141,7 @@ function test_helper({override, change_tab}) {
             events.push("change_tab_to " + hash);
         });
 
-        override(narrow, "activate", (terms) => {
+        override_rewire(narrow, "activate", (terms) => {
             narrow_terms = terms;
             events.push("narrow.activate");
         });
@@ -162,15 +162,15 @@ function test_helper({override, change_tab}) {
     };
 }
 
-run_test("hash_interactions", ({override}) => {
+run_test("hash_interactions", ({override, override_rewire}) => {
     window_stub = $.create("window-stub");
     user_settings.default_view = "recent_topics";
 
-    override(recent_topics_util, "is_visible", () => false);
-    const helper = test_helper({override, change_tab: true});
+    override_rewire(recent_topics_util, "is_visible", () => false);
+    const helper = test_helper({override, override_rewire, change_tab: true});
 
     let recent_topics_ui_shown = false;
-    override(recent_topics_ui, "show", () => {
+    override_rewire(recent_topics_ui, "show", () => {
         recent_topics_ui_shown = true;
     });
     window.location.hash = "#unknown_hash";
@@ -303,10 +303,10 @@ run_test("hash_interactions", ({override}) => {
     helper.assert_events([[ui_util, "blur_active_element"]]);
 });
 
-run_test("save_narrow", ({override}) => {
-    override(recent_topics_util, "is_visible", () => false);
+run_test("save_narrow", ({override, override_rewire}) => {
+    override_rewire(recent_topics_util, "is_visible", () => false);
 
-    const helper = test_helper({override});
+    const helper = test_helper({override, override_rewire});
 
     let operators = [{operator: "is", operand: "private"}];
 

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -121,7 +121,7 @@ emoji.initialize({
 });
 
 function stubbing(module, func_name_to_stub, test_function) {
-    with_overrides((override) => {
+    with_overrides(({override}) => {
         const stub = make_stub();
         override(module, func_name_to_stub, stub.f);
         test_function(stub);
@@ -331,13 +331,13 @@ run_test("misc", () => {
     const message_view_only_keys = "@+>RjJkKsSuvi:GM";
 
     // Check that they do nothing without a selected message
-    with_overrides((override) => {
+    with_overrides(({override}) => {
         override(message_lists.current, "empty", () => true);
         assert_unmapped(message_view_only_keys);
     });
 
     // Check that they do nothing while in the settings overlay
-    with_overrides((override) => {
+    with_overrides(({override}) => {
         override(overlays, "settings_open", () => true);
         assert_unmapped("@*+->rRjJkKsSuvi:GM");
     });

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -128,6 +128,14 @@ function stubbing(module, func_name_to_stub, test_function) {
     });
 }
 
+function stubbing_rewire(module, func_name_to_stub, test_function) {
+    with_overrides(({override_rewire}) => {
+        const stub = make_stub();
+        override_rewire(module, func_name_to_stub, stub.f);
+        test_function(stub);
+    });
+}
+
 // Set up defaults for most tests.
 hotkey.__Rewire__("in_content_editable_widget", () => false);
 hotkey.__Rewire__("processing_text", () => false);
@@ -236,6 +244,13 @@ function assert_mapping(c, module, func_name, shiftKey) {
     });
 }
 
+function assert_mapping_rewire(c, module, func_name, shiftKey) {
+    stubbing_rewire(module, func_name, (stub) => {
+        assert.ok(process(c, shiftKey));
+        assert.equal(stub.num_calls, 1);
+    });
+}
+
 function assert_unmapped(s) {
     for (const c of s) {
         assert.equal(process(c), false);
@@ -250,14 +265,14 @@ function test_normal_typing() {
     assert_unmapped('~!@#$%^*()_+{}:"<>');
 }
 
-run_test("allow normal typing when processing text", ({override}) => {
+run_test("allow normal typing when processing text", ({override_rewire}) => {
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
     assert_unmapped("bfmoyz");
     assert_unmapped("BEFHILNOQTUWXYZ");
 
     // All letters should return false if we are composing text.
-    override(hotkey, "processing_text", () => true);
+    override_rewire(hotkey, "processing_text", () => true);
 
     for (const settings_open of [() => true, () => false]) {
         for (const is_active of [() => true, () => false]) {
@@ -292,7 +307,7 @@ run_test("streams", ({override}) => {
 run_test("basic mappings", () => {
     assert_mapping("?", browser_history, "go_to_location");
     assert_mapping("/", search, "initiate_search");
-    assert_mapping("w", activity, "initiate_search");
+    assert_mapping_rewire("w", activity, "initiate_search");
     assert_mapping("q", stream_list, "initiate_search");
 
     assert_mapping("A", narrow, "stream_cycle_backward");

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -38,9 +38,9 @@ function pill_html(value, data_id, img_src) {
     return require("../../static/templates/input_pill.hbs")(opts);
 }
 
-function override_random_id({override}) {
+function override_random_id({override_rewire}) {
     let id_seq = 0;
-    override(input_pill, "random_id", () => {
+    override_rewire(input_pill, "random_id", () => {
         id_seq += 1;
         return "some_id" + id_seq;
     });
@@ -51,13 +51,13 @@ run_test("random_id", () => {
     input_pill.random_id();
 });
 
-run_test("basics", ({override, mock_template}) => {
+run_test("basics", ({override_rewire, mock_template}) => {
     mock_template("input_pill.hbs", true, (data, html) => {
         assert.equal(data.display_value, "JavaScript");
         return html;
     });
 
-    override_random_id({override});
+    override_random_id({override_rewire});
     const config = {};
 
     blueslip.expect("error", "Pill needs container.");
@@ -147,13 +147,13 @@ function set_up() {
     };
 }
 
-run_test("copy from pill", ({override, mock_template}) => {
+run_test("copy from pill", ({override_rewire, mock_template}) => {
     mock_template("input_pill.hbs", true, (data, html) => {
         assert.ok(["BLUE", "RED"].includes(data.display_value));
         return html;
     });
 
-    override_random_id({override});
+    override_random_id({override_rewire});
     const info = set_up();
     const config = info.config;
     const container = info.container;
@@ -393,14 +393,14 @@ run_test("Enter key with text", ({mock_template}) => {
     assert.deepEqual(widget.items(), [items.blue, items.red, items.yellow]);
 });
 
-run_test("insert_remove", ({override, mock_template}) => {
+run_test("insert_remove", ({override_rewire, mock_template}) => {
     mock_template("input_pill.hbs", true, (data, html) => {
         assert.equal(typeof data.display_value, "string");
         assert.ok(html.startsWith, "<div class='pill'");
         return html;
     });
 
-    override_random_id({override});
+    override_random_id({override_rewire});
     const info = set_up();
 
     const config = info.config;
@@ -503,14 +503,14 @@ run_test("insert_remove", ({override, mock_template}) => {
     assert.ok(next_pill_focused);
 });
 
-run_test("exit button on pill", ({override, mock_template}) => {
+run_test("exit button on pill", ({override_rewire, mock_template}) => {
     mock_template("input_pill.hbs", true, (data, html) => {
         assert.equal(typeof data.display_value, "string");
         assert.ok(html.startsWith, "<div class='pill'");
         return html;
     });
 
-    override_random_id({override});
+    override_random_id({override_rewire});
     const info = set_up();
 
     const config = info.config;

--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -23,13 +23,13 @@ const rows = zrequire("rows");
 const lightbox = zrequire("lightbox");
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         lightbox.clear_for_testing();
-        f({override});
+        f({override, override_rewire});
     });
 }
 
-test("pan_and_zoom", ({override}) => {
+test("pan_and_zoom", ({override_rewire}) => {
     const img = $.create("img-stub");
     const link = $.create("link-stub");
     const msg = $.create("msg-stub");
@@ -39,7 +39,7 @@ test("pan_and_zoom", ({override}) => {
     img.set_parent(link);
     link.closest = () => msg;
 
-    override(rows, "id", (row) => {
+    override_rewire(rows, "id", (row) => {
         assert.equal(row, msg);
         return 1234;
     });
@@ -53,20 +53,20 @@ test("pan_and_zoom", ({override}) => {
         return "message-stub";
     };
 
-    override(lightbox, "render_lightbox_list_images", () => {});
+    override_rewire(lightbox, "render_lightbox_list_images", () => {});
 
     lightbox.open(img);
 
     assert.equal(fetched_zid, 1234);
 });
 
-test("youtube", ({override}) => {
+test("youtube", ({override_rewire}) => {
     const href = "https://youtube.com/some-random-clip";
     const img = $.create("img-stub");
     const link = $.create("link-stub");
     const msg = $.create("msg-stub");
 
-    override(rows, "id", (row) => {
+    override_rewire(rows, "id", (row) => {
         assert.equal(row, msg);
         return 4321;
     });
@@ -86,7 +86,7 @@ test("youtube", ({override}) => {
     link.closest = () => msg;
     link.attr("href", href);
 
-    override(lightbox, "render_lightbox_list_images", () => {});
+    override_rewire(lightbox, "render_lightbox_list_images", () => {});
 
     lightbox.open(img);
     assert.equal($(".image-actions .open").attr("href"), href);

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -187,10 +187,10 @@ markdown.initialize(markdown_config.get_helpers());
 linkifiers.initialize(example_realm_linkifiers);
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         page_params.realm_users = [];
         linkifiers.update_linkifier_rules(example_realm_linkifiers);
-        f({override});
+        f({override, override_rewire});
     });
 }
 
@@ -812,7 +812,7 @@ test("translate_emoticons_to_names", () => {
     }
 });
 
-test("missing unicode emojis", ({override}) => {
+test("missing unicode emojis", ({override_rewire}) => {
     const message = {raw_content: "\u{1F6B2}"};
 
     markdown.apply_markdown(message);
@@ -821,7 +821,7 @@ test("missing unicode emojis", ({override}) => {
         '<p><span aria-label="bike" class="emoji emoji-1f6b2" role="img" title="bike">:bike:</span></p>',
     );
 
-    override(emoji, "get_emoji_name", (codepoint) => {
+    override_rewire(emoji, "get_emoji_name", (codepoint) => {
         // Now simulate that we don't know any emoji names.
         assert.equal(codepoint, "1f6b2");
         // return undefined

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const markdown_test_cases = require("../../zerver/tests/fixtures/markdown_test_cases");
 const markdown_assert = require("../zjsunit/markdown_assert");
-const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {set_global, with_field_rewire, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
 const {page_params, user_settings} = require("../zjsunit/zpage_params");
@@ -833,7 +833,7 @@ test("missing unicode emojis", ({override_rewire}) => {
 test("katex_throws_unexpected_exceptions", () => {
     blueslip.expect("error", "Error: some-exception");
     const message = {raw_content: "$$a$$"};
-    with_field(
+    with_field_rewire(
         markdown,
         "katex",
         {

--- a/frontend_tests/node_tests/message_flags.js
+++ b/frontend_tests/node_tests/message_flags.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {mock_esm, set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, set_global, with_field_rewire, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 const channel = mock_esm("../../static/js/channel");
@@ -151,7 +151,7 @@ run_test("read", ({override}) => {
 
     // For testing purpose limit the batch size value to 5 instead of 1000
     function send_read(messages) {
-        with_field(message_flags, "_unread_batch_size", 5, () => {
+        with_field_rewire(message_flags, "_unread_batch_size", 5, () => {
             message_flags.send_read(messages);
         });
     }
@@ -270,7 +270,7 @@ run_test("read_empty_data", ({override}) => {
 
     // For testing purpose limit the batch size value to 5 instead of 1000
     function send_read(messages) {
-        with_field(message_flags, "_unread_batch_size", 5, () => {
+        with_field_rewire(message_flags, "_unread_batch_size", 5, () => {
             message_flags.send_read(messages);
         });
     }

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {set_global, with_field_rewire, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
 
@@ -129,7 +129,7 @@ run_test("muting", () => {
 
     // `messages_filtered_for_topic_mutes` should skip filtering
     // messages if `excludes_muted_topics` is false.
-    with_field(
+    with_field_rewire(
         muted_topics,
         "is_topic_muted",
         () => {
@@ -145,7 +145,7 @@ run_test("muting", () => {
 
     // If we are in a 1:1 PM narrow, `messages_filtered_for_user_mutes` should skip
     // filtering messages.
-    with_field(
+    with_field_rewire(
         muted_topics,
         "is_user_muted",
         () => {

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {mock_esm, set_global, with_field, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, set_global, with_field_rewire, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
 const {page_params} = require("../zjsunit/zpage_params");
@@ -227,7 +227,7 @@ test("errors", () => {
     };
 
     // This should early return and not run pm_conversations.set_partner
-    with_field(
+    with_field_rewire(
         pm_conversations,
         "set_partner",
         () => assert.fail(),

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {with_field, zrequire} = require("../zjsunit/namespace");
+const {with_field_rewire, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 const {page_params} = require("../zjsunit/zpage_params");
@@ -550,7 +550,7 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
 
 run_test("narrow_to_compose_target errors", () => {
     function test() {
-        with_field(
+        with_field_rewire(
             narrow,
             "activate",
             () => {

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -572,9 +572,9 @@ run_test("narrow_to_compose_target errors", () => {
     test();
 });
 
-run_test("narrow_to_compose_target streams", ({override}) => {
+run_test("narrow_to_compose_target streams", ({override_rewire}) => {
     const args = {called: false};
-    override(narrow, "activate", (operators, opts) => {
+    override_rewire(narrow, "activate", (operators, opts) => {
         args.operators = operators;
         args.opts = opts;
         args.called = true;
@@ -620,16 +620,16 @@ run_test("narrow_to_compose_target streams", ({override}) => {
     assert.deepEqual(args.operators, [{operator: "stream", operand: "ROME"}]);
 });
 
-run_test("narrow_to_compose_target PMs", ({override}) => {
+run_test("narrow_to_compose_target PMs", ({override_rewire}) => {
     const args = {called: false};
-    override(narrow, "activate", (operators, opts) => {
+    override_rewire(narrow, "activate", (operators, opts) => {
         args.operators = operators;
         args.opts = opts;
         args.called = true;
     });
 
     let emails;
-    override(compose_state, "private_message_recipient", () => emails);
+    override_rewire(compose_state, "private_message_recipient", () => emails);
 
     compose_state.set_message_type("private");
     people.add_active_user(ray);

--- a/frontend_tests/node_tests/narrow_unread.js
+++ b/frontend_tests/node_tests/narrow_unread.js
@@ -196,12 +196,12 @@ run_test("get_unread_ids", () => {
     });
 });
 
-run_test("defensive code", ({override}) => {
+run_test("defensive code", ({override_rewire}) => {
     // Test defensive code.  We actually avoid calling
     // _possible_unread_message_ids for any case where we
     // couldn't compute the unread message ids, but that
     // invariant is hard to future-proof.
-    override(narrow_state, "_possible_unread_message_ids", () => undefined);
+    override_rewire(narrow_state, "_possible_unread_message_ids", () => undefined);
     const terms = [{operator: "some-unhandled-case", operand: "whatever"}];
     set_filter(terms);
     assert_unread_info({

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -50,14 +50,14 @@ stream_data.add_sub(muted);
 muted_topics.add_muted_topic(general.stream_id, "muted topic");
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         page_params.is_admin = false;
         page_params.realm_users = [];
         user_settings.enable_desktop_notifications = true;
         user_settings.enable_sounds = true;
         user_settings.wildcard_mentions_notify = true;
         user_settings.notification_sound = "ding";
-        f({override});
+        f({override, override_rewire});
     });
 }
 
@@ -280,8 +280,8 @@ test("message_is_notifiable", () => {
     assert.equal(notifications.message_is_notifiable(message), true);
 });
 
-test("basic_notifications", ({override}) => {
-    override(ui, "replace_emoji_with_text", () => {});
+test("basic_notifications", ({override_rewire}) => {
+    override_rewire(ui, "replace_emoji_with_text", () => {});
 
     let n; // Object for storing all notification data for assertions.
     let last_closed_message_id = null;

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -62,9 +62,9 @@ function initialize() {
 }
 
 function test_people(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         initialize();
-        f({override});
+        f({override, override_rewire});
     });
 }
 
@@ -889,7 +889,7 @@ test_people("message_methods", () => {
     assert.equal(people.sender_is_guest(message), false);
 });
 
-test_people("extract_people_from_message", ({override}) => {
+test_people("extract_people_from_message", ({override_rewire}) => {
     let message = {
         type: "stream",
         sender_full_name: maria.full_name,
@@ -899,7 +899,7 @@ test_people("extract_people_from_message", ({override}) => {
     assert.ok(!people.is_known_user_id(maria.user_id));
 
     let reported;
-    override(people, "report_late_add", (user_id, email) => {
+    override_rewire(people, "report_late_add", (user_id, email) => {
         assert.equal(user_id, maria.user_id);
         assert.equal(email, maria.email);
         reported = true;

--- a/frontend_tests/node_tests/people_errors.js
+++ b/frontend_tests/node_tests/people_errors.js
@@ -40,7 +40,7 @@ run_test("is_my_user_id", () => {
     assert.equal(people.is_my_user_id(me.user_id.toString()), true);
 });
 
-run_test("blueslip", ({override}) => {
+run_test("blueslip", ({override_rewire}) => {
     const unknown_email = "alicebobfred@example.com";
 
     blueslip.expect("debug", "User email operand unknown: " + unknown_email);
@@ -104,8 +104,8 @@ run_test("blueslip", ({override}) => {
     const reply_to = people.pm_reply_to(message);
     assert.ok(reply_to.includes("?"));
 
-    override(people, "pm_with_user_ids", () => [42]);
-    override(people, "get_by_user_id", () => {});
+    override_rewire(people, "pm_with_user_ids", () => [42]);
+    override_rewire(people, "get_by_user_id", () => {});
     blueslip.expect("error", "Unknown people in message");
     const uri = people.pm_with_url({});
     assert.equal(uri.indexOf("unk"), uri.length - 3);

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -53,10 +53,10 @@ people.add_active_user(bot_test);
 people.initialize_current_user(me.user_id);
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         pm_conversations.clear_for_testing();
         pm_list.clear_for_testing();
-        f({override});
+        f({override, override_rewire});
     });
 }
 
@@ -220,10 +220,10 @@ test("is_all_privates", ({override}) => {
     assert.equal(pm_list.is_all_privates(), true);
 });
 
-test("expand", ({override}) => {
+test("expand", ({override, override_rewire}) => {
     override(narrow_state, "filter", private_filter);
     override(narrow_state, "active", () => true);
-    override(pm_list, "_build_private_messages_list", () => "PM_LIST_CONTENTS");
+    override_rewire(pm_list, "_build_private_messages_list", () => "PM_LIST_CONTENTS");
     let html_updated;
     override(vdom, "update", () => {
         html_updated = true;
@@ -236,13 +236,13 @@ test("expand", ({override}) => {
     assert.ok($(".top_left_private_messages").hasClass("active-filter"));
 });
 
-test("update_private_messages", ({override}) => {
+test("update_private_messages", ({override, override_rewire}) => {
     let html_updated;
     let container_found;
 
     override(narrow_state, "filter", private_filter);
     override(narrow_state, "active", () => true);
-    override(pm_list, "_build_private_messages_list", () => "PM_LIST_CONTENTS");
+    override_rewire(pm_list, "_build_private_messages_list", () => "PM_LIST_CONTENTS");
 
     $("#private-container").find = (sel) => {
         assert.equal(sel, "ul");

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {mock_esm, with_field, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, with_field_rewire, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 
@@ -268,7 +268,7 @@ test("ensure coverage", ({override}) => {
     // where functions early exit.
     override(narrow_state, "active", () => false);
 
-    with_field(
+    with_field_rewire(
         pm_list,
         "rebuild_recent",
         () => {

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -98,16 +98,16 @@ function make_image_stubber() {
 }
 
 function test_ui(label, f) {
-    run_test(label, ({override, mock_template}) => {
+    run_test(label, ({override, override_rewire, mock_template}) => {
         page_params.is_admin = false;
         page_params.realm_email_address_visibility = 3;
         page_params.custom_profile_fields = [];
-        override(popovers, "clipboard_enable", () => ({
+        override_rewire(popovers, "clipboard_enable", () => ({
             on: noop,
         }));
         popovers.clear_for_testing();
         popovers.register_click_handlers();
-        f({override, mock_template});
+        f({override, override_rewire, mock_template});
     });
 }
 
@@ -214,7 +214,7 @@ test_ui("sender_hover", ({override, mock_template}) => {
     // todo: load image
 });
 
-test_ui("actions_popover", ({override, mock_template}) => {
+test_ui("actions_popover", ({override, override_rewire, mock_template}) => {
     override($.fn, "popover", noop);
 
     const target = $.create("click target");
@@ -240,7 +240,7 @@ test_ui("actions_popover", ({override, mock_template}) => {
         };
     };
 
-    override(message_edit, "get_editability", () => 4);
+    override_rewire(message_edit, "get_editability", () => 4);
 
     stream_data.id_to_slug = (stream_id) => {
         assert.equal(stream_id, 123);

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {mock_esm, with_field, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, with_field_rewire, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
 const {user_settings} = require("../zjsunit/zpage_params");
@@ -100,7 +100,7 @@ test("unknown user", ({override}) => {
     // If the server is suspected to be offline or reloading,
     // then we suppress errors.  The use case here is that we
     // haven't gotten info for a brand new user yet.
-    with_field(
+    with_field_rewire(
         watchdog,
         "suspects_user_is_offline",
         () => true,

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -113,9 +113,9 @@ people.add_active_user(cali);
 people.add_active_user(alexus);
 
 function test(label, f) {
-    run_test(label, ({override, mock_template}) => {
+    run_test(label, ({override, override_rewire, mock_template}) => {
         page_params.user_id = alice_user_id;
-        f({override, mock_template});
+        f({override, override_rewire, mock_template});
     });
 }
 
@@ -269,7 +269,7 @@ test("unknown realm emojis (insert)", () => {
     );
 });
 
-test("sending", ({override}) => {
+test("sending", ({override, override_rewire}) => {
     const message = {...sample_message};
     assert.equal(message.id, 1001);
     override(message_store, "get", (message_id) => {
@@ -279,8 +279,8 @@ test("sending", ({override}) => {
 
     let emoji_name = "smile"; // should be a current reaction
 
-    override(reactions, "add_reaction", () => {});
-    override(reactions, "remove_reaction", () => {});
+    override_rewire(reactions, "add_reaction", () => {});
+    override_rewire(reactions, "remove_reaction", () => {});
 
     {
         const stub = make_stub();
@@ -371,7 +371,7 @@ test("set_reaction_count", () => {
     assert.equal(count_element.text(), "5");
 });
 
-test("find_reaction", ({override}) => {
+test("find_reaction", ({override_rewire}) => {
     const message_id = 99;
     const local_id = "unicode_emoji,1f44b";
     const reaction_section = $.create("section-stub");
@@ -382,7 +382,7 @@ test("find_reaction", ({override}) => {
         reaction_stub,
     );
 
-    override(reactions, "get_reaction_section", (arg) => {
+    override_rewire(reactions, "get_reaction_section", (arg) => {
         assert.equal(arg, message_id);
         return reaction_section;
     });
@@ -590,7 +590,7 @@ test("add_reaction/remove_reaction", ({override}) => {
     });
 });
 
-test("view.insert_new_reaction (me w/unicode emoji)", ({override, mock_template}) => {
+test("view.insert_new_reaction (me w/unicode emoji)", ({override_rewire, mock_template}) => {
     const opts = {
         message_id: 501,
         reaction_type: "unicode_emoji",
@@ -601,7 +601,7 @@ test("view.insert_new_reaction (me w/unicode emoji)", ({override, mock_template}
 
     const message_reactions = $.create("our-reactions");
 
-    override(reactions, "get_reaction_section", (message_id) => {
+    override_rewire(reactions, "get_reaction_section", (message_id) => {
         assert.equal(message_id, opts.message_id);
         return message_reactions;
     });
@@ -637,7 +637,7 @@ test("view.insert_new_reaction (me w/unicode emoji)", ({override, mock_template}
     assert.ok(insert_called);
 });
 
-test("view.insert_new_reaction (them w/zulip emoji)", ({override, mock_template}) => {
+test("view.insert_new_reaction (them w/zulip emoji)", ({override_rewire, mock_template}) => {
     const opts = {
         message_id: 502,
         reaction_type: "realm_emoji",
@@ -648,7 +648,7 @@ test("view.insert_new_reaction (them w/zulip emoji)", ({override, mock_template}
 
     const message_reactions = $.create("our-reactions");
 
-    override(reactions, "get_reaction_section", (message_id) => {
+    override_rewire(reactions, "get_reaction_section", (message_id) => {
         assert.equal(message_id, opts.message_id);
         return message_reactions;
     });
@@ -686,7 +686,7 @@ test("view.insert_new_reaction (them w/zulip emoji)", ({override, mock_template}
     assert.ok(insert_called);
 });
 
-test("view.update_existing_reaction (me)", ({override}) => {
+test("view.update_existing_reaction (me)", ({override_rewire}) => {
     const opts = {
         message_id: 503,
         reaction_type: "unicode_emoji",
@@ -698,13 +698,13 @@ test("view.update_existing_reaction (me)", ({override}) => {
 
     const our_reaction = $.create("our-reaction-stub");
 
-    override(reactions, "find_reaction", (message_id, local_id) => {
+    override_rewire(reactions, "find_reaction", (message_id, local_id) => {
         assert.equal(message_id, opts.message_id);
         assert.equal(local_id, "unicode_emoji,1f3b1");
         return our_reaction;
     });
 
-    override(reactions, "set_reaction_count", (reaction, count) => {
+    override_rewire(reactions, "set_reaction_count", (reaction, count) => {
         assert.equal(reaction, our_reaction);
         assert.equal(count, 2);
     });
@@ -718,7 +718,7 @@ test("view.update_existing_reaction (me)", ({override}) => {
     );
 });
 
-test("view.update_existing_reaction (them)", ({override}) => {
+test("view.update_existing_reaction (them)", ({override_rewire}) => {
     const opts = {
         message_id: 504,
         reaction_type: "unicode_emoji",
@@ -730,13 +730,13 @@ test("view.update_existing_reaction (them)", ({override}) => {
 
     const our_reaction = $.create("our-reaction-stub");
 
-    override(reactions, "find_reaction", (message_id, local_id) => {
+    override_rewire(reactions, "find_reaction", (message_id, local_id) => {
         assert.equal(message_id, opts.message_id);
         assert.equal(local_id, "unicode_emoji,1f3b1");
         return our_reaction;
     });
 
-    override(reactions, "set_reaction_count", (reaction, count) => {
+    override_rewire(reactions, "set_reaction_count", (reaction, count) => {
         assert.equal(reaction, our_reaction);
         assert.equal(count, 4);
     });
@@ -750,7 +750,7 @@ test("view.update_existing_reaction (them)", ({override}) => {
     );
 });
 
-test("view.remove_reaction (me)", ({override}) => {
+test("view.remove_reaction (me)", ({override_rewire}) => {
     const opts = {
         message_id: 505,
         reaction_type: "unicode_emoji",
@@ -763,13 +763,13 @@ test("view.remove_reaction (me)", ({override}) => {
     const our_reaction = $.create("our-reaction-stub");
     our_reaction.addClass("reacted");
 
-    override(reactions, "find_reaction", (message_id, local_id) => {
+    override_rewire(reactions, "find_reaction", (message_id, local_id) => {
         assert.equal(message_id, opts.message_id);
         assert.equal(local_id, "unicode_emoji,1f3b1");
         return our_reaction;
     });
 
-    override(reactions, "set_reaction_count", (reaction, count) => {
+    override_rewire(reactions, "set_reaction_count", (reaction, count) => {
         assert.equal(reaction, our_reaction);
         assert.equal(count, 2);
     });
@@ -783,7 +783,7 @@ test("view.remove_reaction (me)", ({override}) => {
     );
 });
 
-test("view.remove_reaction (them)", ({override}) => {
+test("view.remove_reaction (them)", ({override_rewire}) => {
     const opts = {
         message_id: 506,
         reaction_type: "unicode_emoji",
@@ -796,13 +796,13 @@ test("view.remove_reaction (them)", ({override}) => {
     const our_reaction = $.create("our-reaction-stub");
     our_reaction.addClass("reacted");
 
-    override(reactions, "find_reaction", (message_id, local_id) => {
+    override_rewire(reactions, "find_reaction", (message_id, local_id) => {
         assert.equal(message_id, opts.message_id);
         assert.equal(local_id, "unicode_emoji,1f3b1");
         return our_reaction;
     });
 
-    override(reactions, "set_reaction_count", (reaction, count) => {
+    override_rewire(reactions, "set_reaction_count", (reaction, count) => {
         assert.equal(reaction, our_reaction);
         assert.equal(count, 1);
     });
@@ -817,7 +817,7 @@ test("view.remove_reaction (them)", ({override}) => {
     );
 });
 
-test("view.remove_reaction (last person)", ({override}) => {
+test("view.remove_reaction (last person)", ({override_rewire}) => {
     const opts = {
         message_id: 507,
         reaction_type: "unicode_emoji",
@@ -829,7 +829,7 @@ test("view.remove_reaction (last person)", ({override}) => {
 
     const our_reaction = $.create("our-reaction-stub");
 
-    override(reactions, "find_reaction", (message_id, local_id) => {
+    override_rewire(reactions, "find_reaction", (message_id, local_id) => {
         assert.equal(message_id, opts.message_id);
         assert.equal(local_id, "unicode_emoji,1f3b1");
         return our_reaction;
@@ -843,7 +843,7 @@ test("view.remove_reaction (last person)", ({override}) => {
     assert.ok(removed);
 });
 
-test("error_handling", ({override}) => {
+test("error_handling", ({override, override_rewire}) => {
     override(message_store, "get", () => {});
 
     blueslip.expect("error", "reactions: Bad message id: 55");
@@ -855,7 +855,7 @@ test("error_handling", ({override}) => {
         emoji_code: "991",
         user_id: 99,
     };
-    override(reactions, "current_user_has_reacted_to_emoji", () => true);
+    override_rewire(reactions, "current_user_has_reacted_to_emoji", () => true);
     reactions.toggle_emoji_reaction(55, bogus_event.emoji_name);
 
     reactions.add_reaction(bogus_event);

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -330,11 +330,11 @@ function stub_out_filter_buttons() {
 }
 
 function test(label, f) {
-    run_test(label, ({override, mock_template}) => {
+    run_test(label, ({override, override_rewire, mock_template}) => {
         $(".header").css = () => {};
 
         messages = sample_messages.map((message) => ({...message}));
-        f({override, mock_template});
+        f({override, override_rewire, mock_template});
     });
 }
 
@@ -367,7 +367,7 @@ test("test_recent_topics_show", ({mock_template}) => {
     assert.equal(rt.inplace_rerender("stream_unknown:topic_unknown"), false);
 });
 
-test("test_filter_all", ({override, mock_template}) => {
+test("test_filter_all", ({override_rewire, mock_template}) => {
     // Just tests inplace rerender of a message
     // in All topics filter.
     const expected = {
@@ -394,7 +394,7 @@ test("test_filter_all", ({override, mock_template}) => {
     i = row_data.length;
     rt.clear_for_tests();
     stub_out_filter_buttons();
-    override(rt, "is_visible", () => true);
+    override_rewire(rt, "is_visible", () => true);
     rt.set_filter("all");
     rt.process_messages([messages[0]]);
 
@@ -414,11 +414,11 @@ test("test_filter_all", ({override, mock_template}) => {
     row_data = generate_topic_data([[1, "topic-1", 0, false, true]]);
     i = row_data.length;
     rt.set_default_focus();
-    override(rt, "is_in_focus", () => false);
+    override_rewire(rt, "is_in_focus", () => false);
     assert.equal(rt.inplace_rerender("1:topic-1"), true);
 });
 
-test("test_filter_unread", ({override, mock_template}) => {
+test("test_filter_unread", ({override_rewire, mock_template}) => {
     let expected_filter_unread = false;
 
     mock_template("recent_topics_table.hbs", false, (data) => {
@@ -460,12 +460,12 @@ test("test_filter_unread", ({override, mock_template}) => {
     });
 
     rt.clear_for_tests();
-    override(rt, "is_visible", () => true);
+    override_rewire(rt, "is_visible", () => true);
     rt.set_default_focus();
 
     stub_out_filter_buttons();
     rt.process_messages(messages);
-    override(rt, "is_in_focus", () => false);
+    override_rewire(rt, "is_in_focus", () => false);
     assert.equal(rt.inplace_rerender("1:topic-1"), true);
 
     $("#recent_topics_filter_buttons").removeClass("btn-recent-selected");
@@ -526,7 +526,7 @@ test("test_filter_unread", ({override, mock_template}) => {
     rt.set_filter("all");
 });
 
-test("test_filter_participated", ({override, mock_template}) => {
+test("test_filter_participated", ({override_rewire, mock_template}) => {
     let expected_filter_participated;
 
     mock_template("recent_topics_table.hbs", false, (data) => {
@@ -567,13 +567,13 @@ test("test_filter_participated", ({override, mock_template}) => {
     });
 
     rt.clear_for_tests();
-    override(rt, "is_visible", () => true);
+    override_rewire(rt, "is_visible", () => true);
     rt.set_default_focus();
     stub_out_filter_buttons();
     expected_filter_participated = false;
     rt.process_messages(messages);
 
-    override(rt, "is_in_focus", () => false);
+    override_rewire(rt, "is_in_focus", () => false);
     assert.equal(rt.inplace_rerender("1:topic-4"), true);
 
     // Set muted filter
@@ -633,8 +633,8 @@ test("test_filter_participated", ({override, mock_template}) => {
     rt.set_filter("all");
 });
 
-test("test_update_unread_count", ({override}) => {
-    override(rt, "is_visible", () => false);
+test("test_update_unread_count", ({override_rewire}) => {
+    override_rewire(rt, "is_visible", () => false);
     rt.clear_for_tests();
     stub_out_filter_buttons();
     rt.set_filter("all");
@@ -645,7 +645,7 @@ test("test_update_unread_count", ({override}) => {
     rt.update_topic_unread_count(messages[9]);
 });
 
-test("basic assertions", ({override, mock_template}) => {
+test("basic assertions", ({override_rewire, mock_template}) => {
     rt.clear_for_tests();
 
     mock_template("recent_topics_table.hbs", false, () => {});
@@ -654,7 +654,7 @@ test("basic assertions", ({override, mock_template}) => {
     });
 
     stub_out_filter_buttons();
-    override(rt, "is_visible", () => true);
+    override_rewire(rt, "is_visible", () => true);
     rt.set_default_focus();
     rt.set_filter("all");
     rt.process_messages(messages);
@@ -762,19 +762,19 @@ test("basic assertions", ({override, mock_template}) => {
     // update_topic_is_muted now relies on external libraries completely
     // so we don't need to check anythere here.
     generate_topic_data([[1, topic1, 0, false, true]]);
-    override(rt, "is_in_focus", () => false);
+    override_rewire(rt, "is_in_focus", () => false);
     assert.equal(rt.update_topic_is_muted(stream1, topic1), true);
     // a topic gets muted which we are not tracking
     assert.equal(rt.update_topic_is_muted(stream1, "topic-10"), false);
 });
 
-test("test_reify_local_echo_message", ({override, mock_template}) => {
+test("test_reify_local_echo_message", ({override_rewire, mock_template}) => {
     mock_template("recent_topics_table.hbs", false, () => {});
     mock_template("recent_topic_row.hbs", false, () => {});
 
     rt.clear_for_tests();
     stub_out_filter_buttons();
-    override(rt, "is_visible", () => true);
+    override_rewire(rt, "is_visible", () => true);
     rt.set_filter("all");
     rt.process_messages(messages);
 
@@ -820,8 +820,8 @@ test("test_reify_local_echo_message", ({override, mock_template}) => {
     );
 });
 
-test("test_delete_messages", ({override}) => {
-    override(rt, "is_visible", () => false);
+test("test_delete_messages", ({override, override_rewire}) => {
+    override_rewire(rt, "is_visible", () => false);
     rt.clear_for_tests();
     stub_out_filter_buttons();
     rt.set_filter("all");
@@ -859,9 +859,9 @@ test("test_delete_messages", ({override}) => {
     rt.update_topics_of_deleted_message_ids([-1]);
 });
 
-test("test_topic_edit", ({override}) => {
+test("test_topic_edit", ({override, override_rewire}) => {
     override(all_messages_data, "all_messages", () => messages);
-    override(rt, "is_visible", () => false);
+    override_rewire(rt, "is_visible", () => false);
 
     // NOTE: This test should always run in the end as it modified the messages data.
     rt.clear_for_tests();

--- a/frontend_tests/node_tests/search_pill.js
+++ b/frontend_tests/node_tests/search_pill.js
@@ -70,10 +70,10 @@ run_test("get_items", () => {
     );
 });
 
-run_test("create_pills", ({override}) => {
+run_test("create_pills", ({override_rewire}) => {
     let input_pill_create_called = false;
 
-    override(input_pill, "create", () => {
+    override_rewire(input_pill, "create", () => {
         input_pill_create_called = true;
         return {dummy: "dummy"};
     });

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -76,18 +76,18 @@ function get_suggestions(base_query, query) {
 }
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         init();
-        f({override});
+        f({override, override_rewire});
     });
 }
 
-test("basic_get_suggestions", ({override}) => {
+test("basic_get_suggestions", ({override_rewire}) => {
     const query = "fred";
 
-    override(stream_data, "subscribed_streams", () => []);
+    override_rewire(stream_data, "subscribed_streams", () => []);
 
-    override(narrow_state, "stream", () => "office");
+    override_rewire(narrow_state, "stream", () => "office");
 
     const suggestions = get_suggestions("", query);
 
@@ -95,8 +95,8 @@ test("basic_get_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("basic_get_suggestions_for_spectator", ({override}) => {
-    override(stream_data, "subscribed_streams", () => []);
+test("basic_get_suggestions_for_spectator", ({override_rewire}) => {
+    override_rewire(stream_data, "subscribed_streams", () => []);
     page_params.is_spectator = true;
 
     const query = "";
@@ -375,10 +375,10 @@ test("group_suggestions", () => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("empty_query_suggestions", ({override}) => {
+test("empty_query_suggestions", ({override_rewire}) => {
     const query = "";
 
-    override(stream_data, "subscribed_streams", () => ["devel", "office"]);
+    override_rewire(stream_data, "subscribed_streams", () => ["devel", "office"]);
 
     const suggestions = get_suggestions("", query);
 
@@ -416,12 +416,12 @@ test("empty_query_suggestions", ({override}) => {
     assert.equal(describe("has:attachment"), "Messages with one or more attachment");
 });
 
-test("has_suggestions", ({override}) => {
+test("has_suggestions", ({override_rewire}) => {
     // Checks that category wise suggestions are displayed instead of a single
     // default suggestion when suggesting `has` operator.
     let query = "h";
-    override(stream_data, "subscribed_streams", () => ["devel", "office"]);
-    override(narrow_state, "stream", () => {});
+    override_rewire(stream_data, "subscribed_streams", () => ["devel", "office"]);
+    override_rewire(narrow_state, "stream", () => {});
 
     let suggestions = get_suggestions("", query);
     let expected = ["h", "has:link", "has:image", "has:attachment"];
@@ -472,10 +472,10 @@ test("has_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("check_is_suggestions", ({override}) => {
+test("check_is_suggestions", ({override_rewire}) => {
     let query = "i";
-    override(stream_data, "subscribed_streams", () => ["devel", "office"]);
-    override(narrow_state, "stream", () => {});
+    override_rewire(stream_data, "subscribed_streams", () => ["devel", "office"]);
+    override_rewire(narrow_state, "stream", () => {});
 
     let suggestions = get_suggestions("", query);
     let expected = [
@@ -596,10 +596,10 @@ test("check_is_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("sent_by_me_suggestions", ({override}) => {
-    override(stream_data, "subscribed_streams", () => []);
+test("sent_by_me_suggestions", ({override_rewire}) => {
+    override_rewire(stream_data, "subscribed_streams", () => []);
 
-    override(narrow_state, "stream", () => {});
+    override_rewire(narrow_state, "stream", () => {});
 
     let query = "";
     let suggestions = get_suggestions("", query);
@@ -672,18 +672,18 @@ test("sent_by_me_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("topic_suggestions", ({override}) => {
+test("topic_suggestions", ({override, override_rewire}) => {
     let suggestions;
     let expected;
 
     override(stream_topic_history_util, "get_server_history", () => {});
-    override(stream_data, "subscribed_streams", () => ["office"]);
-    override(narrow_state, "stream", () => "office");
+    override_rewire(stream_data, "subscribed_streams", () => ["office"]);
+    override_rewire(narrow_state, "stream", () => "office");
 
     const devel_id = 44;
     const office_id = 77;
 
-    override(stream_data, "get_stream_id", (stream_name) => {
+    override_rewire(stream_data, "get_stream_id", (stream_name) => {
         switch (stream_name) {
             case "office":
                 return office_id;
@@ -761,10 +761,10 @@ test("topic_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("whitespace_glitch", ({override}) => {
+test("whitespace_glitch", ({override_rewire}) => {
     const query = "stream:office "; // note trailing space
 
-    override(stream_data, "subscribed_streams", () => ["office"]);
+    override_rewire(stream_data, "subscribed_streams", () => ["office"]);
 
     const suggestions = get_suggestions("", query);
 
@@ -773,10 +773,10 @@ test("whitespace_glitch", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("stream_completion", ({override}) => {
-    override(stream_data, "subscribed_streams", () => ["office", "dev help"]);
+test("stream_completion", ({override_rewire}) => {
+    override_rewire(stream_data, "subscribed_streams", () => ["office", "dev help"]);
 
-    override(narrow_state, "stream", () => {});
+    override_rewire(narrow_state, "stream", () => {});
 
     let query = "stream:of";
     let suggestions = get_suggestions("", query);
@@ -817,8 +817,8 @@ function people_suggestion_setup() {
     people.add_active_user(alice);
 }
 
-test("people_suggestions", ({override}) => {
-    override(narrow_state, "stream", noop);
+test("people_suggestions", ({override_rewire}) => {
+    override_rewire(narrow_state, "stream", noop);
     people_suggestion_setup();
 
     let query = "te";
@@ -881,10 +881,10 @@ test("people_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("people_suggestion (Admin only email visibility)", ({override}) => {
+test("people_suggestion (Admin only email visibility)", ({override_rewire}) => {
     /* Suggestions when realm_email_address_visibility is set to admin
     only */
-    override(narrow_state, "stream", noop);
+    override_rewire(narrow_state, "stream", noop);
     people_suggestion_setup();
 
     const query = "te";
@@ -942,8 +942,8 @@ test("operator_suggestions", () => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("queries_with_spaces", ({override}) => {
-    override(stream_data, "subscribed_streams", () => ["office", "dev help"]);
+test("queries_with_spaces", ({override_rewire}) => {
+    override_rewire(stream_data, "subscribed_streams", () => ["office", "dev help"]);
 
     // test allowing spaces with quotes surrounding operand
     let query = 'stream:"dev he"';

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -74,18 +74,18 @@ function get_suggestions(base_query, query) {
 }
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         init();
-        f({override});
+        f({override, override_rewire});
     });
 }
 
-test("basic_get_suggestions", ({override}) => {
+test("basic_get_suggestions", ({override_rewire}) => {
     const query = "fred";
 
-    override(stream_data, "subscribed_streams", () => []);
+    override_rewire(stream_data, "subscribed_streams", () => []);
 
-    override(narrow_state, "stream", () => "office");
+    override_rewire(narrow_state, "stream", () => "office");
 
     const suggestions = get_suggestions("", query);
 
@@ -356,10 +356,10 @@ test("group_suggestions", () => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("empty_query_suggestions", ({override}) => {
+test("empty_query_suggestions", ({override_rewire}) => {
     const query = "";
 
-    override(stream_data, "subscribed_streams", () => ["devel", "office"]);
+    override_rewire(stream_data, "subscribed_streams", () => ["devel", "office"]);
 
     const suggestions = get_suggestions("", query);
 
@@ -397,12 +397,12 @@ test("empty_query_suggestions", ({override}) => {
     assert.equal(describe("has:attachment"), "Messages with one or more attachment");
 });
 
-test("has_suggestions", ({override}) => {
+test("has_suggestions", ({override_rewire}) => {
     // Checks that category wise suggestions are displayed instead of a single
     // default suggestion when suggesting `has` operator.
     let query = "h";
-    override(stream_data, "subscribed_streams", () => ["devel", "office"]);
-    override(narrow_state, "stream", () => {});
+    override_rewire(stream_data, "subscribed_streams", () => ["devel", "office"]);
+    override_rewire(narrow_state, "stream", () => {});
 
     let suggestions = get_suggestions("", query);
     let expected = ["h", "has:link", "has:image", "has:attachment"];
@@ -456,9 +456,9 @@ test("has_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("check_is_suggestions", ({override}) => {
-    override(stream_data, "subscribed_streams", () => ["devel", "office"]);
-    override(narrow_state, "stream", () => {});
+test("check_is_suggestions", ({override_rewire}) => {
+    override_rewire(stream_data, "subscribed_streams", () => ["devel", "office"]);
+    override_rewire(narrow_state, "stream", () => {});
 
     let query = "i";
     let suggestions = get_suggestions("", query);
@@ -543,10 +543,10 @@ test("check_is_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("sent_by_me_suggestions", ({override}) => {
-    override(stream_data, "subscribed_streams", () => []);
+test("sent_by_me_suggestions", ({override_rewire}) => {
+    override_rewire(stream_data, "subscribed_streams", () => []);
 
-    override(narrow_state, "stream", () => {});
+    override_rewire(narrow_state, "stream", () => {});
 
     let query = "";
     let suggestions = get_suggestions("", query);
@@ -614,18 +614,18 @@ test("sent_by_me_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("topic_suggestions", ({override}) => {
+test("topic_suggestions", ({override, override_rewire}) => {
     let suggestions;
     let expected;
 
     override(stream_topic_history_util, "get_server_history", () => {});
-    override(stream_data, "subscribed_streams", () => ["office"]);
-    override(narrow_state, "stream", () => "office");
+    override_rewire(stream_data, "subscribed_streams", () => ["office"]);
+    override_rewire(narrow_state, "stream", () => "office");
 
     const devel_id = 44;
     const office_id = 77;
 
-    override(stream_data, "get_stream_id", (stream_name) => {
+    override_rewire(stream_data, "get_stream_id", (stream_name) => {
         switch (stream_name) {
             case "office":
                 return office_id;
@@ -709,10 +709,10 @@ test("topic_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("whitespace_glitch", ({override}) => {
+test("whitespace_glitch", ({override_rewire}) => {
     const query = "stream:office "; // note trailing space
 
-    override(stream_data, "subscribed_streams", () => ["office"]);
+    override_rewire(stream_data, "subscribed_streams", () => ["office"]);
 
     const suggestions = get_suggestions("", query);
 
@@ -721,10 +721,10 @@ test("whitespace_glitch", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("stream_completion", ({override}) => {
-    override(stream_data, "subscribed_streams", () => ["office", "dev help"]);
+test("stream_completion", ({override_rewire}) => {
+    override_rewire(stream_data, "subscribed_streams", () => ["office", "dev help"]);
 
-    override(narrow_state, "stream", () => {});
+    override_rewire(narrow_state, "stream", () => {});
 
     let query = "stream:of";
     let suggestions = get_suggestions("", query);
@@ -742,12 +742,12 @@ test("stream_completion", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("people_suggestions", ({override}) => {
+test("people_suggestions", ({override_rewire}) => {
     let query = "te";
 
-    override(stream_data, "subscribed_streams", () => []);
+    override_rewire(stream_data, "subscribed_streams", () => []);
 
-    override(narrow_state, "stream", () => {});
+    override_rewire(narrow_state, "stream", () => {});
 
     const ted = {
         email: "ted@zulip.com",
@@ -856,8 +856,8 @@ test("operator_suggestions", () => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("queries_with_spaces", ({override}) => {
-    override(stream_data, "subscribed_streams", () => ["office", "dev help"]);
+test("queries_with_spaces", ({override_rewire}) => {
+    override_rewire(stream_data, "subscribed_streams", () => ["office", "dev help"]);
 
     // test allowing spaces with quotes surrounding operand
     let query = 'stream:"dev he"';

--- a/frontend_tests/node_tests/settings_muted_topics.js
+++ b/frontend_tests/node_tests/settings_muted_topics.js
@@ -20,10 +20,10 @@ const frontend = {
 };
 stream_data.add_sub(frontend);
 
-run_test("settings", ({override}) => {
+run_test("settings", ({override_rewire}) => {
     muted_topics.add_muted_topic(frontend.stream_id, "js", 1577836800);
     let populate_list_called = false;
-    override(settings_muted_topics, "populate_list", () => {
+    override_rewire(settings_muted_topics, "populate_list", () => {
         const opts = muted_topics.get_muted_topics();
         assert.deepEqual(opts, [
             {

--- a/frontend_tests/node_tests/settings_muted_users.js
+++ b/frontend_tests/node_tests/settings_muted_users.js
@@ -13,10 +13,10 @@ const muted_users = zrequire("muted_users");
 
 const noop = () => {};
 
-run_test("settings", ({override}) => {
+run_test("settings", ({override_rewire}) => {
     muted_users.add_muted_user(5, 1577836800);
     let populate_list_called = false;
-    override(settings_muted_users, "populate_list", () => {
+    override_rewire(settings_muted_users, "populate_list", () => {
         const opts = muted_users.get_muted_users();
         assert.deepEqual(opts, [
             {

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -51,7 +51,7 @@ const sub_store = zrequire("sub_store");
 const dropdown_list_widget = zrequire("dropdown_list_widget");
 
 function test(label, f) {
-    run_test(label, ({override, mock_template}) => {
+    run_test(label, ({override, override_rewire, mock_template}) => {
         $("#realm-icon-upload-widget .upload-spinner-background").css = () => {};
         page_params.is_admin = false;
         page_params.realm_domains = [
@@ -60,7 +60,7 @@ function test(label, f) {
         ];
         page_params.realm_authentication_methods = {};
         settings_org.reset();
-        f({override, mock_template});
+        f({override, override_rewire, mock_template});
     });
 }
 
@@ -642,7 +642,7 @@ function test_discard_changes_button(discard_changes) {
     settings_org.__Rewire__("change_save_button_state", stubbed_function);
 }
 
-test("set_up", ({override, mock_template}) => {
+test("set_up", ({override, override_rewire, mock_template}) => {
     mock_template("settings/admin_realm_domains_list.hbs", false, () => "stub-domains-list");
 
     const verify_realm_domains = simulate_realm_domains_table();
@@ -666,7 +666,7 @@ test("set_up", ({override, mock_template}) => {
         upload_realm_logo_or_icon = f;
     };
 
-    override(dropdown_list_widget, "DropdownListWidget", () => ({
+    override_rewire(dropdown_list_widget, "DropdownListWidget", () => ({
         render: noop,
         update: noop,
     }));
@@ -691,7 +691,7 @@ test("set_up", ({override, mock_template}) => {
 
     // TEST set_up() here, but this mostly just allows us to
     // get access to the click handlers.
-    override(settings_org, "maybe_disable_widgets", noop);
+    override_rewire(settings_org, "maybe_disable_widgets", noop);
     settings_org.set_up();
 
     verify_realm_domains();
@@ -826,7 +826,7 @@ test("test get_sorted_options_list", () => {
     assert.deepEqual(settings_org.get_sorted_options_list(option_values_2), expected_option_values);
 });
 
-test("misc", ({override}) => {
+test("misc", ({override_rewire}) => {
     page_params.is_admin = false;
 
     const stub_notification_disable_parent = $.create("<stub notification_disable parent");
@@ -893,7 +893,7 @@ test("misc", ({override}) => {
     settings_account.update_email_change_display();
     assert.ok(!$("#change_email").prop("disabled"));
 
-    override(stream_settings_data, "get_streams_for_settings_page", () => [
+    override_rewire(stream_settings_data, "get_streams_for_settings_page", () => [
         {name: "some_stream", stream_id: 75},
         {name: "some_stream", stream_id: 42},
     ]);

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -87,7 +87,7 @@ const name_selector = `#user-groups #${CSS.escape(1)} .name`;
 const description_selector = `#user-groups #${CSS.escape(1)} .description`;
 const instructions_selector = `#user-groups #${CSS.escape(1)} .save-instructions`;
 
-test_ui("populate_user_groups", ({override, mock_template}) => {
+test_ui("populate_user_groups", ({override_rewire, mock_template}) => {
     const realm_user_group = {
         id: 1,
         name: "Mobile",
@@ -156,7 +156,7 @@ test_ui("populate_user_groups", ({override, mock_template}) => {
         return people.get_by_user_id !== undefined && people.get_by_user_id !== noop;
     };
 
-    override(settings_user_groups, "can_edit", () => true);
+    override_rewire(settings_user_groups, "can_edit", () => true);
 
     const all_pills = new Map();
 
@@ -355,7 +355,7 @@ test_ui("populate_user_groups", ({override, mock_template}) => {
         "function",
     );
 });
-test_ui("with_external_user", ({override, mock_template}) => {
+test_ui("with_external_user", ({override_rewire, mock_template}) => {
     const realm_user_group = {
         id: 1,
         name: "Mobile",
@@ -376,10 +376,10 @@ test_ui("with_external_user", ({override, mock_template}) => {
 
     people.get_by_user_id = () => noop;
 
-    override(user_pill, "append_person", () => noop);
+    override_rewire(user_pill, "append_person", () => noop);
 
     let can_edit_called = 0;
-    override(settings_user_groups, "can_edit", () => {
+    override_rewire(settings_user_groups, "can_edit", () => {
         can_edit_called += 1;
         return false;
     });
@@ -493,10 +493,10 @@ test_ui("with_external_user", ({override, mock_template}) => {
     assert.equal(turned_off["click/whole"], true);
 });
 
-test_ui("reload", ({override}) => {
+test_ui("reload", ({override_rewire}) => {
     $("#user-groups").html("Some text");
     let populate_user_groups_called = false;
-    override(settings_user_groups, "populate_user_groups", () => {
+    override_rewire(settings_user_groups, "populate_user_groups", () => {
         populate_user_groups_called = true;
     });
     settings_user_groups.reload();
@@ -510,7 +510,7 @@ test_ui("reset", () => {
     assert.equal(result, undefined);
 });
 
-test_ui("on_events", ({override, mock_template}) => {
+test_ui("on_events", ({override_rewire, mock_template}) => {
     mock_template("confirm_dialog/confirm_delete_user.hbs", false, (data) => {
         assert.deepEqual(data, {
             group_name: "Mobile",
@@ -518,7 +518,7 @@ test_ui("on_events", ({override, mock_template}) => {
         return "stub";
     });
 
-    override(settings_user_groups, "can_edit", () => true);
+    override_rewire(settings_user_groups, "can_edit", () => true);
 
     (function test_admin_user_group_form_submit_triggered() {
         const handler = $(".organization form.admin-user-group-form").get_on_handler("submit");
@@ -664,7 +664,7 @@ test_ui("on_events", ({override, mock_template}) => {
 
             // Cancel button triggers blur event.
             let settings_user_groups_reload_called = false;
-            override(settings_user_groups, "reload", () => {
+            override_rewire(settings_user_groups, "reload", () => {
                 settings_user_groups_reload_called = true;
             });
             api_endpoint_called = false;

--- a/frontend_tests/node_tests/starred_messages.js
+++ b/frontend_tests/node_tests/starred_messages.js
@@ -96,7 +96,7 @@ run_test("rerender_ui", () => {
     }
 
     user_settings.starred_message_counts = true;
-    with_overrides((override) => {
+    with_overrides(({override}) => {
         const stub = make_stub();
         override(stream_popover, "hide_topic_popover", () => {});
         override(top_left_corner, "update_starred_count", stub.f);
@@ -107,7 +107,7 @@ run_test("rerender_ui", () => {
     });
 
     user_settings.starred_message_counts = false;
-    with_overrides((override) => {
+    with_overrides(({override}) => {
         const stub = make_stub();
         override(stream_popover, "hide_topic_popover", () => {});
         override(top_left_corner, "update_starred_count", stub.f);

--- a/frontend_tests/node_tests/starred_messages.js
+++ b/frontend_tests/node_tests/starred_messages.js
@@ -12,18 +12,18 @@ const starred_messages = zrequire("starred_messages");
 const stream_popover = zrequire("stream_popover");
 const top_left_corner = zrequire("top_left_corner");
 
-run_test("add starred", ({override}) => {
+run_test("add starred", ({override_rewire}) => {
     starred_messages.starred_ids.clear();
     assert.deepEqual(starred_messages.get_starred_msg_ids(), []);
     assert.equal(starred_messages.get_count(), 0);
 
-    override(starred_messages, "rerender_ui", () => {});
+    override_rewire(starred_messages, "rerender_ui", () => {});
     starred_messages.add([1, 2]);
     assert.deepEqual(starred_messages.get_starred_msg_ids(), [1, 2]);
     assert.equal(starred_messages.get_count(), 2);
 });
 
-run_test("remove starred", ({override}) => {
+run_test("remove starred", ({override_rewire}) => {
     starred_messages.starred_ids.clear();
     assert.deepEqual(starred_messages.get_starred_msg_ids(), []);
 
@@ -32,7 +32,7 @@ run_test("remove starred", ({override}) => {
     }
     assert.deepEqual(starred_messages.get_starred_msg_ids(), [1, 2, 3]);
 
-    override(starred_messages, "rerender_ui", () => {});
+    override_rewire(starred_messages, "rerender_ui", () => {});
     starred_messages.remove([2, 3]);
     assert.deepEqual(starred_messages.get_starred_msg_ids(), [1]);
     assert.equal(starred_messages.get_count(), 1);
@@ -77,14 +77,14 @@ run_test("get starred ids in topic", () => {
     assert.deepEqual(starred_messages.get_count_in_topic(20, "topic"), 1);
 });
 
-run_test("initialize", ({override}) => {
+run_test("initialize", ({override_rewire}) => {
     starred_messages.starred_ids.clear();
     for (const id of [1, 2, 3]) {
         starred_messages.starred_ids.add(id);
     }
 
     page_params.starred_messages = [4, 5, 6];
-    override(starred_messages, "rerender_ui", () => {});
+    override_rewire(starred_messages, "rerender_ui", () => {});
     starred_messages.initialize();
     assert.deepEqual(starred_messages.get_starred_msg_ids(), [4, 5, 6]);
 });
@@ -96,10 +96,10 @@ run_test("rerender_ui", () => {
     }
 
     user_settings.starred_message_counts = true;
-    with_overrides(({override}) => {
+    with_overrides(({override_rewire}) => {
         const stub = make_stub();
-        override(stream_popover, "hide_topic_popover", () => {});
-        override(top_left_corner, "update_starred_count", stub.f);
+        override_rewire(stream_popover, "hide_topic_popover", () => {});
+        override_rewire(top_left_corner, "update_starred_count", stub.f);
         starred_messages.rerender_ui();
         assert.equal(stub.num_calls, 1);
         const args = stub.get_args("count");
@@ -107,10 +107,10 @@ run_test("rerender_ui", () => {
     });
 
     user_settings.starred_message_counts = false;
-    with_overrides(({override}) => {
+    with_overrides(({override_rewire}) => {
         const stub = make_stub();
-        override(stream_popover, "hide_topic_popover", () => {});
-        override(top_left_corner, "update_starred_count", stub.f);
+        override_rewire(stream_popover, "hide_topic_popover", () => {});
+        override_rewire(top_left_corner, "update_starred_count", stub.f);
         starred_messages.rerender_ui();
         assert.equal(stub.num_calls, 1);
         const args = stub.get_args("count");

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -40,7 +40,7 @@ function contains_sub(subs, sub) {
 }
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         page_params.is_admin = false;
         page_params.realm_users = [];
         page_params.is_guest = false;
@@ -48,7 +48,7 @@ function test(label, f) {
         people.add_active_user(me);
         people.initialize_current_user(me.user_id);
         stream_data.clear_subscriptions();
-        f({override});
+        f({override, override_rewire});
     });
 }
 
@@ -718,7 +718,7 @@ test("canonicalized_name", () => {
     assert.deepStrictEqual(stream_data.canonicalized_name("Stream_Bar"), "stream_bar");
 });
 
-test("create_sub", ({override}) => {
+test("create_sub", ({override_rewire}) => {
     const india = {
         stream_id: 102,
         name: "India",
@@ -737,7 +737,7 @@ test("create_sub", ({override}) => {
         color: "#76ce90",
     };
 
-    override(color_data, "pick_color", () => "#bd86e5");
+    override_rewire(color_data, "pick_color", () => "#bd86e5");
 
     const india_sub = stream_data.create_sub_from_server_data(india);
     assert.ok(india_sub);

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -109,15 +109,15 @@ for (const sub of subs) {
 }
 
 function test_ui(label, f) {
-    run_test(label, ({override, mock_template}) => {
+    run_test(label, ({override, override_rewire, mock_template}) => {
         page_params.user_id = me.user_id;
         stream_subscribers_ui.initialize();
         stream_edit.initialize();
-        f({override, mock_template});
+        f({override, override_rewire, mock_template});
     });
 }
 
-test_ui("subscriber_pills", ({override, mock_template}) => {
+test_ui("subscriber_pills", ({override_rewire, mock_template}) => {
     mock_template("input_pill.hbs", true, (data, html) => {
         assert.equal(typeof data.display_value, "string");
         return html;
@@ -129,7 +129,7 @@ test_ui("subscriber_pills", ({override, mock_template}) => {
         () => "stream_subscription_request_result",
     );
 
-    override(people, "sort_but_pin_current_user_on_top", noop);
+    override_rewire(people, "sort_but_pin_current_user_on_top", noop);
 
     const subscriptions_table_selector = "#manage_streams_container";
     const input_field_stub = $.create(".input");
@@ -178,7 +178,7 @@ test_ui("subscriber_pills", ({override, mock_template}) => {
     let expected_user_ids = [];
     let input_typeahead_called = false;
     let add_subscribers_request = false;
-    override(stream_subscribers_ui, "invite_user_to_stream", (user_ids, sub) => {
+    override_rewire(stream_subscribers_ui, "invite_user_to_stream", (user_ids, sub) => {
         assert.equal(sub.stream_id, denmark.stream_id);
         assert.deepEqual(user_ids.sort(), expected_user_ids.sort());
         add_subscribers_request = true;
@@ -306,8 +306,8 @@ test_ui("subscriber_pills", ({override, mock_template}) => {
     let fake_this = $subscription_settings;
     let event = {target: fake_this};
 
-    override(stream_ui_updates, "update_toggler_for_sub", noop);
-    override(stream_ui_updates, "update_add_subscriptions_elements", noop);
+    override_rewire(stream_ui_updates, "update_toggler_for_sub", noop);
+    override_rewire(stream_ui_updates, "update_add_subscriptions_elements", noop);
 
     const {stream_notification_settings, pm_mention_notification_settings} = settings_config;
     for (const setting of [...stream_notification_settings, ...pm_mention_notification_settings]) {
@@ -350,8 +350,8 @@ test_ui("subscriber_pills", ({override, mock_template}) => {
 
     // Only Denmark stream pill is created and a
     // request is sent to add all it's subscribers.
-    override(user_pill, "get_user_ids", () => []);
-    override(user_group_pill, "get_user_ids", () => []);
+    override_rewire(user_pill, "get_user_ids", () => []);
+    override_rewire(user_group_pill, "get_user_ids", () => []);
     expected_user_ids = potential_denmark_stream_subscribers;
     add_subscribers_handler(event);
 
@@ -363,14 +363,14 @@ test_ui("subscriber_pills", ({override, mock_template}) => {
 
     // No request is sent if we try to subscribe ourselves
     // only and are already subscribed to the stream.
-    override(user_pill, "get_user_ids", () => [me.user_id]);
+    override_rewire(user_pill, "get_user_ids", () => [me.user_id]);
     add_subscribers_handler(event);
     assert.ok(!add_subscribers_request);
 
     // Denmark stream pill and fred and mark user pills are created.
     // But only one request for mark is sent even though a mark user
     // pill is created and mark is also a subscriber of Denmark stream.
-    override(user_pill, "get_user_ids", () => [mark.user_id, fred.user_id]);
+    override_rewire(user_pill, "get_user_ids", () => [mark.user_id, fred.user_id]);
     stream_pill.get_user_ids = () => peer_data.get_subscribers(denmark.stream_id);
     expected_user_ids = potential_denmark_stream_subscribers.concat(fred.user_id);
     add_subscribers_handler(event);
@@ -379,8 +379,8 @@ test_ui("subscriber_pills", ({override, mock_template}) => {
         return user_id === mark.user_id;
     }
     // Deactivated user_id is not included in request.
-    override(user_pill, "get_user_ids", () => [mark.user_id, fred.user_id]);
-    override(people, "is_person_active", is_person_active);
+    override_rewire(user_pill, "get_user_ids", () => [mark.user_id, fred.user_id]);
+    override_rewire(people, "is_person_active", is_person_active);
     expected_user_ids = [mark.user_id];
     add_subscribers_handler(event);
 });

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -84,9 +84,9 @@ function narrow_to_frontend() {
 }
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         stream_data.clear_subscriptions();
-        f({override});
+        f({override, override_rewire});
     });
 }
 
@@ -263,10 +263,10 @@ test("marked_subscribed (error)", () => {
     blueslip.reset();
 });
 
-test("marked_subscribed (normal)", ({override}) => {
+test("marked_subscribed (normal)", ({override, override_rewire}) => {
     const sub = {...frontend};
     stream_data.add_sub(sub);
-    override(stream_data, "subscribe_myself", noop);
+    override_rewire(stream_data, "subscribe_myself", noop);
     override(stream_color, "update_stream_color", noop);
 
     narrow_to_frontend();
@@ -280,7 +280,7 @@ test("marked_subscribed (normal)", ({override}) => {
 
     override(stream_list, "add_sidebar_row", stream_list_stub.f);
     override(message_util, "do_unread_count_updates", message_util_stub.f);
-    override(message_view_header, "render_title_area", message_view_header_stub.f);
+    override_rewire(message_view_header, "render_title_area", message_view_header_stub.f);
     override(message_lists.current, "update_trailing_bookend", () => {
         list_updated = true;
     });
@@ -300,8 +300,8 @@ test("marked_subscribed (normal)", ({override}) => {
     narrow_state.reset_current_filter();
 });
 
-test("marked_subscribed (color)", ({override}) => {
-    override(stream_data, "subscribe_myself", noop);
+test("marked_subscribed (color)", ({override, override_rewire}) => {
+    override_rewire(stream_data, "subscribe_myself", noop);
     override(message_util, "do_unread_count_updates", noop);
     override(stream_list, "add_sidebar_row", noop);
 
@@ -353,7 +353,7 @@ test("marked_subscribed (emails)", ({override}) => {
     assert.deepEqual(sub, args.sub);
 });
 
-test("mark_unsubscribed (update_settings_for_unsubscribed)", ({override}) => {
+test("mark_unsubscribed (update_settings_for_unsubscribed)", ({override, override_rewire}) => {
     // Test unsubscribe
     const sub = {...dev_help};
     assert.ok(sub.subscribed);
@@ -362,22 +362,22 @@ test("mark_unsubscribed (update_settings_for_unsubscribed)", ({override}) => {
 
     override(stream_settings_ui, "update_settings_for_unsubscribed", stub.f);
     override(stream_list, "remove_sidebar_row", noop);
-    override(stream_data, "unsubscribe_myself", noop);
+    override_rewire(stream_data, "unsubscribe_myself", noop);
 
     stream_events.mark_unsubscribed(sub);
     const args = stub.get_args("sub");
     assert.deepEqual(args.sub, sub);
 });
 
-test("mark_unsubscribed (render_title_area)", ({override}) => {
+test("mark_unsubscribed (render_title_area)", ({override, override_rewire}) => {
     const sub = {...frontend, subscribed: true};
     stream_data.add_sub(sub);
 
     // Test update bookend and remove done event
     narrow_to_frontend();
     const message_view_header_stub = make_stub();
-    override(message_view_header, "render_title_area", message_view_header_stub.f);
-    override(stream_data, "unsubscribe_myself", noop);
+    override_rewire(message_view_header, "render_title_area", message_view_header_stub.f);
+    override_rewire(stream_data, "unsubscribe_myself", noop);
     override(stream_settings_ui, "update_settings_for_unsubscribed", noop);
     override(message_lists.current, "update_trailing_bookend", noop);
     override(stream_list, "remove_sidebar_row", noop);

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -85,18 +85,18 @@ function create_social_sidebar_row({mock_template}) {
 }
 
 function test_ui(label, f) {
-    run_test(label, ({override, mock_template}) => {
+    run_test(label, ({override, override_rewire, mock_template}) => {
         stream_data.clear_subscriptions();
         stream_list.stream_sidebar.rows.clear();
-        f({override, mock_template});
+        f({override, override_rewire, mock_template});
     });
 }
 
-test_ui("create_sidebar_row", ({override, mock_template}) => {
+test_ui("create_sidebar_row", ({override_rewire, mock_template}) => {
     // Make a couple calls to create_sidebar_row() and make sure they
     // generate the right markup as well as play nice with get_stream_li().
     user_settings.demote_inactive_streams = 1;
-    override(unread, "num_unread_for_stream", () => num_unread_for_stream);
+    override_rewire(unread, "num_unread_for_stream", () => num_unread_for_stream);
 
     stream_data.add_sub(devel);
     stream_data.add_sub(social);
@@ -156,11 +156,11 @@ test_ui("create_sidebar_row", ({override, mock_template}) => {
     assert.ok(!social_li.hasClass("out_of_home_view"));
 
     const row = stream_list.stream_sidebar.get_row(stream_id);
-    override(stream_data, "is_active", () => true);
+    override_rewire(stream_data, "is_active", () => true);
     row.update_whether_active();
     assert.ok(!social_li.hasClass("inactive_stream"));
 
-    override(stream_data, "is_active", () => false);
+    override_rewire(stream_data, "is_active", () => false);
     row.update_whether_active();
     assert.ok(social_li.hasClass("inactive_stream"));
 
@@ -173,8 +173,8 @@ test_ui("create_sidebar_row", ({override, mock_template}) => {
     assert.ok(removed);
 });
 
-test_ui("pinned_streams_never_inactive", ({override, mock_template}) => {
-    override(unread, "num_unread_for_stream", () => num_unread_for_stream);
+test_ui("pinned_streams_never_inactive", ({override_rewire, mock_template}) => {
+    override_rewire(unread, "num_unread_for_stream", () => num_unread_for_stream);
 
     stream_data.add_sub(devel);
     stream_data.add_sub(social);
@@ -186,16 +186,16 @@ test_ui("pinned_streams_never_inactive", ({override, mock_template}) => {
     const social_sidebar = $("<social sidebar row>");
     let stream_id = social.stream_id;
     let row = stream_list.stream_sidebar.get_row(stream_id);
-    override(stream_data, "is_active", () => false);
+    override_rewire(stream_data, "is_active", () => false);
 
     stream_list.build_stream_list();
     assert.ok(social_sidebar.hasClass("inactive_stream"));
 
-    override(stream_data, "is_active", () => true);
+    override_rewire(stream_data, "is_active", () => true);
     row.update_whether_active();
     assert.ok(!social_sidebar.hasClass("inactive_stream"));
 
-    override(stream_data, "is_active", () => false);
+    override_rewire(stream_data, "is_active", () => false);
     row.update_whether_active();
     assert.ok(social_sidebar.hasClass("inactive_stream"));
 
@@ -203,7 +203,7 @@ test_ui("pinned_streams_never_inactive", ({override, mock_template}) => {
     const devel_sidebar = $("<devel sidebar row>");
     stream_id = devel.stream_id;
     row = stream_list.stream_sidebar.get_row(stream_id);
-    override(stream_data, "is_active", () => false);
+    override_rewire(stream_data, "is_active", () => false);
 
     stream_list.build_stream_list();
     assert.ok(!devel_sidebar.hasClass("inactive_stream"));
@@ -363,14 +363,14 @@ test_ui("zoom_in_and_zoom_out", () => {
     assert.ok($("#streams_list").hasClass("zoom-out"));
 });
 
-test_ui("narrowing", ({override}) => {
+test_ui("narrowing", ({override_rewire}) => {
     initialize_stream_data();
 
     topic_list.close = noop;
     topic_list.rebuild = noop;
     topic_list.active_stream_id = noop;
     topic_list.get_stream_li = noop;
-    override(scroll_util, "scroll_element_into_container", noop);
+    override_rewire(scroll_util, "scroll_element_into_container", noop);
 
     assert.ok(!$("<devel sidebar row html>").hasClass("active-filter"));
 
@@ -417,8 +417,8 @@ test_ui("focusout_user_filter", () => {
     click_handler(e);
 });
 
-test_ui("focus_user_filter", ({override}) => {
-    override(scroll_util, "scroll_element_into_container", noop);
+test_ui("focus_user_filter", ({override_rewire}) => {
+    override_rewire(scroll_util, "scroll_element_into_container", noop);
     stream_list.set_event_handlers();
 
     initialize_stream_data();
@@ -431,15 +431,15 @@ test_ui("focus_user_filter", ({override}) => {
     click_handler(e);
 });
 
-test_ui("sort_streams", ({override}) => {
-    override(scroll_util, "scroll_element_into_container", noop);
+test_ui("sort_streams", ({override_rewire}) => {
+    override_rewire(scroll_util, "scroll_element_into_container", noop);
 
     // Get coverage on early-exit.
     stream_list.build_stream_list();
 
     initialize_stream_data();
 
-    override(stream_data, "is_active", (sub) => sub.name !== "cars");
+    override_rewire(stream_data, "is_active", (sub) => sub.name !== "cars");
 
     let appended_elems;
     $("#stream_filters").append = (elems) => {
@@ -483,7 +483,7 @@ test_ui("sort_streams", ({override}) => {
     assert.ok(!stream_list.stream_sidebar.has_row_for(stream_id));
 });
 
-test_ui("separators_only_pinned_and_dormant", ({override}) => {
+test_ui("separators_only_pinned_and_dormant", ({override_rewire}) => {
     // Test only pinned and dormant streams
 
     // Get coverage on early-exit.
@@ -517,7 +517,7 @@ test_ui("separators_only_pinned_and_dormant", ({override}) => {
     };
     add_row(DenmarkSub);
 
-    override(stream_data, "is_active", (sub) => sub.name !== "Denmark");
+    override_rewire(stream_data, "is_active", (sub) => sub.name !== "Denmark");
 
     let appended_elems;
     $("#stream_filters").append = (elems) => {
@@ -583,7 +583,7 @@ test_ui("separators_only_pinned", () => {
 
 narrow_state.active = () => false;
 
-test_ui("rename_stream", ({override, mock_template}) => {
+test_ui("rename_stream", ({override_rewire, mock_template}) => {
     initialize_stream_data();
 
     const sub = stream_data.get_sub_by_name("devel");
@@ -610,7 +610,7 @@ test_ui("rename_stream", ({override, mock_template}) => {
     });
 
     let count_updated;
-    override(stream_list, "update_count_in_dom", (li) => {
+    override_rewire(stream_list, "update_count_in_dom", (li) => {
         assert.equal(li, li_stub);
         count_updated = true;
     });
@@ -619,10 +619,10 @@ test_ui("rename_stream", ({override, mock_template}) => {
     assert.ok(count_updated);
 });
 
-test_ui("refresh_pin", ({override, mock_template}) => {
+test_ui("refresh_pin", ({override_rewire, mock_template}) => {
     initialize_stream_data();
 
-    override(scroll_util, "scroll_element_into_container", noop);
+    override_rewire(scroll_util, "scroll_element_into_container", noop);
 
     const sub = {
         name: "maybe_pin",
@@ -643,11 +643,11 @@ test_ui("refresh_pin", ({override, mock_template}) => {
 
     mock_template("stream_sidebar_row.hbs", false, () => ({to_$: () => li_stub}));
 
-    override(stream_list, "update_count_in_dom", noop);
+    override_rewire(stream_list, "update_count_in_dom", noop);
     $("#stream_filters").append = noop;
 
     let scrolled;
-    override(stream_list, "scroll_stream_into_view", (li) => {
+    override_rewire(stream_list, "scroll_stream_into_view", (li) => {
         assert.equal(li, li_stub);
         scrolled = true;
     });
@@ -656,7 +656,7 @@ test_ui("refresh_pin", ({override, mock_template}) => {
     assert.ok(scrolled);
 });
 
-test_ui("create_initial_sidebar_rows", ({override, mock_template}) => {
+test_ui("create_initial_sidebar_rows", ({override, override_rewire, mock_template}) => {
     initialize_stream_data();
 
     const html_dict = new Map();
@@ -666,7 +666,7 @@ test_ui("create_initial_sidebar_rows", ({override, mock_template}) => {
         html_dict.set(stream_id, widget.get_li().html());
     });
 
-    override(stream_list, "update_count_in_dom", noop);
+    override_rewire(stream_list, "update_count_in_dom", noop);
 
     mock_template("stream_sidebar_row.hbs", false, (data) => "<div>stub-html-" + data.name);
 

--- a/frontend_tests/node_tests/stream_search.js
+++ b/frontend_tests/node_tests/stream_search.js
@@ -62,7 +62,7 @@ function clear_search_input() {
     stream_list.clear_search({stopPropagation: noop});
 }
 
-run_test("basics", ({override}) => {
+run_test("basics", ({override_rewire}) => {
     let cursor_helper;
     const input = $(".stream-list-filter");
     const section = $(".stream_search_section");
@@ -96,7 +96,7 @@ run_test("basics", ({override}) => {
 
     function verify_list_updated(f) {
         let updated;
-        override(stream_list, "update_streams_sidebar", () => {
+        override_rewire(stream_list, "update_streams_sidebar", () => {
             updated = true;
         });
 

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -45,9 +45,9 @@ function sort_groups(query) {
 }
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         stream_data.clear_subscriptions();
-        f({override});
+        f({override, override_rewire});
     });
 }
 
@@ -62,14 +62,14 @@ test("no_subscribed_streams", () => {
     assert.equal(stream_sort.first_stream_id(), undefined);
 });
 
-test("basics", ({override}) => {
+test("basics", ({override_rewire}) => {
     stream_data.add_sub(scalene);
     stream_data.add_sub(fast_tortoise);
     stream_data.add_sub(pneumonia);
     stream_data.add_sub(clarinet);
     stream_data.add_sub(weaving);
 
-    override(stream_data, "is_active", (sub) => sub.name !== "pneumonia");
+    override_rewire(stream_data, "is_active", (sub) => sub.name !== "pneumonia");
 
     // Test sorting into categories/alphabetized
     let sorted = sort_groups("");

--- a/frontend_tests/node_tests/stream_topic_history.js
+++ b/frontend_tests/node_tests/stream_topic_history.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {mock_esm, with_field, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, with_field_rewire, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 const channel = mock_esm("../../static/js/channel");
@@ -137,7 +137,7 @@ test("is_complete_for_stream_id", () => {
         first: () => ({id: 5}),
     };
 
-    with_field(all_messages_data, "all_messages_data", all_messages_data_stub, () => {
+    with_field_rewire(all_messages_data, "all_messages_data", all_messages_data_stub, () => {
         assert.equal(stream_topic_history.is_complete_for_stream_id(sub.stream_id), true);
 
         // Now simulate a more recent message id.

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -15,16 +15,16 @@ const people = zrequire("people");
 const pm_list = zrequire("pm_list");
 const top_left_corner = zrequire("top_left_corner");
 
-run_test("narrowing", ({override}) => {
+run_test("narrowing", ({override_rewire}) => {
     // activating narrow
 
     let pm_expanded;
     let pm_closed;
 
-    override(pm_list, "close", () => {
+    override_rewire(pm_list, "close", () => {
         pm_closed = true;
     });
-    override(pm_list, "expand", () => {
+    override_rewire(pm_list, "expand", () => {
         pm_expanded = true;
     });
 

--- a/frontend_tests/node_tests/topic_generator.js
+++ b/frontend_tests/node_tests/topic_generator.js
@@ -39,7 +39,7 @@ run_test("streams", () => {
     assert_prev_stream("announce", "test here");
 });
 
-run_test("topics", ({override}) => {
+run_test("topics", ({override_rewire}) => {
     const streams = [1, 2, 3, 4];
     const topics = new Map([
         [1, ["read", "read", "1a", "1b", "read", "1c"]],
@@ -85,7 +85,7 @@ run_test("topics", ({override}) => {
         devel: devel_stream_id,
     };
 
-    override(stream_topic_history, "get_recent_topic_names", (stream_id) => {
+    override_rewire(stream_topic_history, "get_recent_topic_names", (stream_id) => {
         switch (stream_id) {
             case muted_stream_id:
                 return ["ms-topic1", "ms-topic2"];
@@ -96,15 +96,19 @@ run_test("topics", ({override}) => {
         return [];
     });
 
-    override(stream_data, "get_stream_id", (stream_name) => stream_id_dct[stream_name]);
+    override_rewire(stream_data, "get_stream_id", (stream_name) => stream_id_dct[stream_name]);
 
-    override(stream_data, "is_stream_muted_by_name", (stream_name) => stream_name === "muted");
+    override_rewire(
+        stream_data,
+        "is_stream_muted_by_name",
+        (stream_name) => stream_name === "muted",
+    );
 
-    override(unread, "topic_has_any_unread", (stream_id) =>
+    override_rewire(unread, "topic_has_any_unread", (stream_id) =>
         [devel_stream_id, muted_stream_id].includes(stream_id),
     );
 
-    override(muted_topics, "is_topic_muted", (stream_name, topic) => topic === "muted");
+    override_rewire(muted_topics, "is_topic_muted", (stream_name, topic) => topic === "muted");
 
     let next_item = tg.get_next_topic("announce", "whatever");
     assert.deepEqual(next_item, {
@@ -119,10 +123,10 @@ run_test("topics", ({override}) => {
     });
 });
 
-run_test("get_next_unread_pm_string", ({override}) => {
+run_test("get_next_unread_pm_string", ({override_rewire}) => {
     pm_conversations.recent.get_strings = () => ["1", "read", "2,3", "4", "unk"];
 
-    override(unread, "num_unread_for_person", (user_ids_string) => {
+    override_rewire(unread, "num_unread_for_person", (user_ids_string) => {
         if (user_ids_string === "unk") {
             return undefined;
         }
@@ -142,7 +146,7 @@ run_test("get_next_unread_pm_string", ({override}) => {
     assert.equal(tg.get_next_unread_pm_string("read"), "2,3");
     assert.equal(tg.get_next_unread_pm_string("2,3"), "4");
 
-    override(unread, "num_unread_for_person", () => 0);
+    override_rewire(unread, "num_unread_for_person", () => 0);
 
     assert.equal(tg.get_next_unread_pm_string("2,3"), undefined);
 });

--- a/frontend_tests/node_tests/topic_list_data.js
+++ b/frontend_tests/node_tests/topic_list_data.js
@@ -38,9 +38,9 @@ function get_list_info(zoomed) {
 }
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         stream_topic_history.reset();
-        f({override});
+        f({override, override_rewire});
     });
 }
 
@@ -122,15 +122,15 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
     assert.equal(list_info.num_possible_topics, 2);
 });
 
-test("get_list_info unreads", ({override}) => {
+test("get_list_info unreads", ({override, override_rewire}) => {
     let list_info;
 
-    override(stream_topic_history, "get_recent_topic_names", () =>
+    override_rewire(stream_topic_history, "get_recent_topic_names", () =>
         _.range(15).map((i) => "topic " + i),
     );
 
     const unread_cnt = new Map();
-    override(unread, "num_unread_for_topic", (stream_id, topic_name) => {
+    override_rewire(unread, "num_unread_for_topic", (stream_id, topic_name) => {
         assert.equal(stream_id, general.stream_id);
         return unread_cnt.get(topic_name) || 0;
     });

--- a/frontend_tests/node_tests/transmit.js
+++ b/frontend_tests/node_tests/transmit.js
@@ -98,7 +98,7 @@ run_test("transmit_message_ajax_reload_pending", () => {
     assert.ok(reload_initiated);
 });
 
-run_test("reply_message_stream", ({override}) => {
+run_test("reply_message_stream", ({override_rewire}) => {
     const stream_message = {
         type: "stream",
         stream: "social",
@@ -111,7 +111,7 @@ run_test("reply_message_stream", ({override}) => {
 
     let send_message_args;
 
-    override(transmit, "send_message", (args) => {
+    override_rewire(transmit, "send_message", (args) => {
         send_message_args = args;
     });
 
@@ -135,7 +135,7 @@ run_test("reply_message_stream", ({override}) => {
     });
 });
 
-run_test("reply_message_private", ({override}) => {
+run_test("reply_message_private", ({override_rewire}) => {
     const fred = {
         user_id: 3,
         email: "fred@example.com",
@@ -154,7 +154,7 @@ run_test("reply_message_private", ({override}) => {
 
     let send_message_args;
 
-    override(transmit, "send_message", (args) => {
+    override_rewire(transmit, "send_message", (args) => {
         send_message_args = args;
     });
 

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -97,7 +97,7 @@ stream_data.create_streams([
 ]);
 
 function test(label, f) {
-    run_test(label, ({override, mock_template}) => {
+    run_test(label, ({override, override_rewire, mock_template}) => {
         pm_conversations.clear_for_testing();
         recent_senders.clear_for_testing();
         peer_data.clear_for_testing();
@@ -107,11 +107,11 @@ function test(label, f) {
         page_params.realm_email_address_visibility =
             settings_config.email_address_visibility_values.admins_only.code;
 
-        f({override, mock_template});
+        f({override, override_rewire, mock_template});
     });
 }
 
-test("sort_streams", ({override}) => {
+test("sort_streams", ({override_rewire}) => {
     let test_streams = [
         {
             stream_id: 101,
@@ -150,7 +150,7 @@ test("sort_streams", ({override}) => {
         },
     ];
 
-    override(stream_data, "is_active", (sub) => sub.name !== "dead");
+    override_rewire(stream_data, "is_active", (sub) => sub.name !== "dead");
 
     test_streams = th.sort_streams(test_streams, "d");
     assert.deepEqual(test_streams[0].name, "Denmark"); // Pinned streams first

--- a/frontend_tests/node_tests/typing_events.js
+++ b/frontend_tests/node_tests/typing_events.js
@@ -38,7 +38,7 @@ people.add_active_user(vronsky);
 people.add_active_user(levin);
 people.add_active_user(kitty);
 
-run_test("render_notifications_for_narrow", ({override, mock_template}) => {
+run_test("render_notifications_for_narrow", ({override_rewire, mock_template}) => {
     const typing_notifications = $("#typing_notifications");
 
     const two_typing_users_ids = [anna.user_id, vronsky.user_id];
@@ -49,7 +49,7 @@ run_test("render_notifications_for_narrow", ({override, mock_template}) => {
 
     // Having only two(<MAX_USERS_TO_DISPLAY_NAME) typists, both of them
     // should be rendered but not 'Several people are typing…'
-    override(typing_events, "get_users_typing_for_narrow", () => two_typing_users_ids);
+    override_rewire(typing_events, "get_users_typing_for_narrow", () => two_typing_users_ids);
     typing_events.render_notifications_for_narrow();
     assert.ok(typing_notifications.visible());
     assert.ok(typing_notifications.html().includes(`${anna.full_name} is typing…`));
@@ -57,7 +57,7 @@ run_test("render_notifications_for_narrow", ({override, mock_template}) => {
     assert.ok(!typing_notifications.html().includes("Several people are typing…"));
 
     // Having 3(=MAX_USERS_TO_DISPLAY_NAME) typists should also display only names
-    override(typing_events, "get_users_typing_for_narrow", () => three_typing_users_ids);
+    override_rewire(typing_events, "get_users_typing_for_narrow", () => three_typing_users_ids);
     typing_events.render_notifications_for_narrow();
     assert.ok(typing_notifications.visible());
     assert.ok(typing_notifications.html().includes(`${anna.full_name} is typing…`));
@@ -66,7 +66,7 @@ run_test("render_notifications_for_narrow", ({override, mock_template}) => {
     assert.ok(!typing_notifications.html().includes("Several people are typing…"));
 
     // Having 4(>MAX_USERS_TO_DISPLAY_NAME) typists should display "Several people are typing…"
-    override(typing_events, "get_users_typing_for_narrow", () => four_typing_users_ids);
+    override_rewire(typing_events, "get_users_typing_for_narrow", () => four_typing_users_ids);
     typing_events.render_notifications_for_narrow();
     assert.ok(typing_notifications.visible());
     assert.ok(typing_notifications.html().includes("Several people are typing…"));
@@ -76,7 +76,7 @@ run_test("render_notifications_for_narrow", ({override, mock_template}) => {
     assert.ok(!typing_notifications.html().includes(`${kitty.full_name} is typing…`));
 
     // #typing_notifications should be hidden when there are no typists.
-    override(typing_events, "get_users_typing_for_narrow", () => []);
+    override_rewire(typing_events, "get_users_typing_for_narrow", () => []);
     typing_events.render_notifications_for_narrow();
     assert.ok(!typing_notifications.visible());
 });

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -20,7 +20,7 @@ function returns_time(secs) {
     };
 }
 
-run_test("basics", ({override}) => {
+run_test("basics", ({override_rewire}) => {
     typing_status.initialize_state();
 
     // invalid conversation basically does nothing
@@ -263,7 +263,7 @@ run_test("basics", ({override}) => {
     // test that we correctly detect if worker.get_recipient
     // and typing_status.state.current_recipient are the same
 
-    override(compose_pm_pill, "get_user_ids_string", () => "1,2,3");
+    override_rewire(compose_pm_pill, "get_user_ids_string", () => "1,2,3");
     typing_status.state.current_recipient = typing.get_recipient();
 
     const call_count = {
@@ -275,7 +275,7 @@ run_test("basics", ({override}) => {
 
     // stub functions to see how may time they are called
     for (const method of Object.keys(call_count)) {
-        override(typing_status, method, () => {
+        override_rewire(typing_status, method, () => {
             call_count[method] += 1;
         });
     }
@@ -294,14 +294,14 @@ run_test("basics", ({override}) => {
 
     // change in recipient and new_recipient should make us
     // call typing_status.stop_last_notification
-    override(compose_pm_pill, "get_user_ids_string", () => "2,3,4");
+    override_rewire(compose_pm_pill, "get_user_ids_string", () => "2,3,4");
     typing_status.update(worker, typing.get_recipient());
     assert.deepEqual(call_count.maybe_ping_server, 2);
     assert.deepEqual(call_count.start_or_extend_idle_timer, 3);
     assert.deepEqual(call_count.stop_last_notification, 1);
 
     // Stream messages are represented as get_user_ids_string being empty
-    override(compose_pm_pill, "get_user_ids_string", () => "");
+    override_rewire(compose_pm_pill, "get_user_ids_string", () => "");
     typing_status.update(worker, typing.get_recipient());
     assert.deepEqual(call_count.maybe_ping_server, 2);
     assert.deepEqual(call_count.start_or_extend_idle_timer, 3);

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -55,10 +55,10 @@ function test_notifiable_count(home_unread_messages, expected_notifiable_count) 
 }
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         unread.declare_bankruptcy();
         muted_topics.set_muted_topics([]);
-        f({override});
+        f({override, override_rewire});
     });
 }
 
@@ -244,12 +244,12 @@ test("muting", () => {
     assert.equal(unread.num_unread_for_stream(unknown_stream_id), 0);
 });
 
-test("num_unread_for_topic", ({override}) => {
+test("num_unread_for_topic", ({override_rewire}) => {
     // Test the num_unread_for_topic() function using many
     // messages.
     const stream_id = 301;
 
-    override(sub_store, "get", (arg) => {
+    override_rewire(sub_store, "get", (arg) => {
         if (arg === stream_id) {
             return {name: "Some stream"};
         }
@@ -317,13 +317,13 @@ test("num_unread_for_topic", ({override}) => {
     assert.deepEqual(msg_ids, []);
 });
 
-test("home_messages", ({override}) => {
-    override(stream_data, "is_subscribed", () => true);
-    override(stream_data, "is_muted", () => false);
+test("home_messages", ({override_rewire}) => {
+    override_rewire(stream_data, "is_subscribed", () => true);
+    override_rewire(stream_data, "is_muted", () => false);
 
     const stream_id = 401;
 
-    override(sub_store, "get", () => ({
+    override_rewire(sub_store, "get", () => ({
         name: "whatever",
     }));
 
@@ -356,7 +356,7 @@ test("home_messages", ({override}) => {
     test_notifiable_count(counts.home_unread_messages, 0);
 
     // Now unsubscribe all our streams.
-    override(stream_data, "is_subscribed", () => false);
+    override_rewire(stream_data, "is_subscribed", () => false);
     counts = unread.get_counts();
     assert.equal(counts.home_unread_messages, 0);
     test_notifiable_count(counts.home_unread_messages, 0);

--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -19,13 +19,13 @@ const location = set_global("location", {});
 const helpers = zrequire("../js/billing/helpers");
 zrequire("../js/billing/upgrade");
 
-run_test("initialize", ({override}) => {
+run_test("initialize", ({override_rewire}) => {
     page_params.annual_price = 8000;
     page_params.monthly_price = 800;
     page_params.seat_count = 8;
     page_params.percent_off = 20;
 
-    override(helpers, "set_tab", (page_name) => {
+    override_rewire(helpers, "set_tab", (page_name) => {
         assert.equal(page_name, "upgrade");
     });
 
@@ -69,11 +69,11 @@ run_test("initialize", ({override}) => {
         },
     );
 
-    override(helpers, "show_license_section", (section) => {
+    override_rewire(helpers, "show_license_section", (section) => {
         assert.equal(section, "automatic");
     });
 
-    override(helpers, "update_charged_amount", (prices, schedule) => {
+    override_rewire(helpers, "update_charged_amount", (prices, schedule) => {
         assert.equal(prices.annual, 6400);
         assert.equal(prices.monthly, 640);
         assert.equal(schedule, "monthly");
@@ -99,7 +99,7 @@ run_test("initialize", ({override}) => {
     const invoice_click_handler = $("#invoice-button").get_on_handler("click");
     const request_sponsorship_click_handler = $("#sponsorship-button").get_on_handler("click");
 
-    override(helpers, "is_valid_input", () => true);
+    override_rewire(helpers, "is_valid_input", () => true);
     add_card_click_handler(e);
     assert.equal(create_ajax_request_form_call_count, 1);
     invoice_click_handler(e);
@@ -107,13 +107,13 @@ run_test("initialize", ({override}) => {
     request_sponsorship_click_handler(e);
     assert.equal(create_ajax_request_form_call_count, 3);
 
-    override(helpers, "is_valid_input", () => false);
+    override_rewire(helpers, "is_valid_input", () => false);
     add_card_click_handler(e);
     invoice_click_handler(e);
     request_sponsorship_click_handler(e);
     assert.equal(create_ajax_request_form_call_count, 3);
 
-    override(helpers, "show_license_section", (section) => {
+    override_rewire(helpers, "show_license_section", (section) => {
         assert.equal(section, "manual");
     });
     const license_change_handler = $("input[type=radio][name=license_management]").get_on_handler(
@@ -121,7 +121,7 @@ run_test("initialize", ({override}) => {
     );
     license_change_handler.call({value: "manual"});
 
-    override(helpers, "update_charged_amount", (prices, schedule) => {
+    override_rewire(helpers, "update_charged_amount", (prices, schedule) => {
         assert.equal(prices.annual, 6400);
         assert.equal(prices.monthly, 640);
         assert.equal(schedule, "monthly");

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -29,9 +29,9 @@ const compose_actions = zrequire("compose_actions");
 const upload = zrequire("upload");
 
 function test(label, f) {
-    run_test(label, ({override}) => {
+    run_test(label, ({override, override_rewire}) => {
         page_params.max_file_upload_size_mib = 25;
-        f({override});
+        f({override, override_rewire});
     });
 }
 
@@ -187,7 +187,7 @@ test("show_error_message", () => {
     assert.equal($("#compose-error-msg").text(), "translated: An unknown error occurred.");
 });
 
-test("upload_files", ({override}) => {
+test("upload_files", ({override_rewire}) => {
     let uppy_cancel_all_called = false;
     let files = [
         {
@@ -210,7 +210,7 @@ test("upload_files", ({override}) => {
         getFiles: () => [...files],
     };
     let hide_upload_status_called = false;
-    override(upload, "hide_upload_status", (config) => {
+    override_rewire(upload, "hide_upload_status", (config) => {
         hide_upload_status_called = true;
         assert.equal(config.mode, "compose");
     });
@@ -221,7 +221,7 @@ test("upload_files", ({override}) => {
 
     page_params.max_file_upload_size_mib = 0;
     let show_error_message_called = false;
-    override(upload, "show_error_message", (config, message) => {
+    override_rewire(upload, "show_error_message", (config, message) => {
         show_error_message_called = true;
         assert.equal(config.mode, "compose");
         assert.equal(
@@ -239,13 +239,13 @@ test("upload_files", ({override}) => {
         on_click_close_button_callback = callback;
     };
     let compose_ui_insert_syntax_and_focus_called = false;
-    override(compose_ui, "insert_syntax_and_focus", (syntax, textarea) => {
+    override_rewire(compose_ui, "insert_syntax_and_focus", (syntax, textarea) => {
         assert.equal(syntax, "[translated: Uploading budapest.png…]()");
         assert.equal(textarea, $("#compose-textarea"));
         compose_ui_insert_syntax_and_focus_called = true;
     });
     let compose_ui_autosize_textarea_called = false;
-    override(compose_ui, "autosize_textarea", () => {
+    override_rewire(compose_ui, "autosize_textarea", () => {
         compose_ui_autosize_textarea_called = true;
     });
     let markdown_preview_hide_button_clicked = false;
@@ -296,7 +296,7 @@ test("upload_files", ({override}) => {
             type: "image/png",
         },
     ];
-    override(compose_ui, "replace_syntax", (old_syntax, new_syntax, textarea) => {
+    override_rewire(compose_ui, "replace_syntax", (old_syntax, new_syntax, textarea) => {
         compose_ui_replace_syntax_called = true;
         assert.equal(old_syntax, "[translated: Uploading budapest.png…]()");
         assert.equal(new_syntax, "");
@@ -366,7 +366,7 @@ test("uppy_config", () => {
     assert.equal(uppy_used_progressbar, true);
 });
 
-test("file_input", ({override}) => {
+test("file_input", ({override_rewire}) => {
     upload.setup_upload({mode: "compose"});
 
     const change_handler = $("body").get_on_handler("change", "#compose .file_input");
@@ -378,7 +378,7 @@ test("file_input", ({override}) => {
         },
     };
     let upload_files_called = false;
-    override(upload, "upload_files", (uppy, config, files) => {
+    override_rewire(upload, "upload_files", (uppy, config, files) => {
         assert.equal(config.mode, "compose");
         assert.equal(files, files);
         upload_files_called = true;
@@ -387,7 +387,7 @@ test("file_input", ({override}) => {
     assert.ok(upload_files_called);
 });
 
-test("file_drop", ({override}) => {
+test("file_drop", ({override_rewire}) => {
     upload.setup_upload({mode: "compose"});
 
     let prevent_default_counter = 0;
@@ -417,7 +417,7 @@ test("file_drop", ({override}) => {
     };
     const drop_handler = $("#compose").get_on_handler("drop");
     let upload_files_called = false;
-    override(upload, "upload_files", () => {
+    override_rewire(upload, "upload_files", () => {
         upload_files_called = true;
     });
     drop_handler(drop_event);
@@ -425,7 +425,7 @@ test("file_drop", ({override}) => {
     assert.equal(upload_files_called, true);
 });
 
-test("copy_paste", ({override}) => {
+test("copy_paste", ({override_rewire}) => {
     upload.setup_upload({mode: "compose"});
 
     const paste_handler = $("#compose").get_on_handler("paste");
@@ -448,7 +448,7 @@ test("copy_paste", ({override}) => {
         },
     };
     let upload_files_called = false;
-    override(upload, "upload_files", () => {
+    override_rewire(upload, "upload_files", () => {
         upload_files_called = true;
     });
 
@@ -464,7 +464,7 @@ test("copy_paste", ({override}) => {
     assert.equal(upload_files_called, false);
 });
 
-test("uppy_events", ({override}) => {
+test("uppy_events", ({override_rewire}) => {
     const callbacks = {};
     let uppy_cancel_all_called = false;
     let state = {};
@@ -506,11 +506,11 @@ test("uppy_events", ({override}) => {
         },
     };
     let compose_actions_start_called = false;
-    override(compose_actions, "start", () => {
+    override_rewire(compose_actions, "start", () => {
         compose_actions_start_called = true;
     });
     let compose_ui_replace_syntax_called = false;
-    override(compose_ui, "replace_syntax", (old_syntax, new_syntax, textarea) => {
+    override_rewire(compose_ui, "replace_syntax", (old_syntax, new_syntax, textarea) => {
         compose_ui_replace_syntax_called = true;
         assert.equal(old_syntax, "[translated: Uploading copenhagen.png…]()");
         assert.equal(
@@ -520,7 +520,7 @@ test("uppy_events", ({override}) => {
         assert.equal(textarea, $("#compose-textarea"));
     });
     let compose_ui_autosize_textarea_called = false;
-    override(compose_ui, "autosize_textarea", () => {
+    override_rewire(compose_ui, "autosize_textarea", () => {
         compose_ui_autosize_textarea_called = true;
     });
     on_upload_success_callback(file, response);
@@ -546,7 +546,7 @@ test("uppy_events", ({override}) => {
         func();
     });
     let hide_upload_status_called = false;
-    override(upload, "hide_upload_status", () => {
+    override_rewire(upload, "hide_upload_status", () => {
         hide_upload_status_called = true;
     });
     $("#compose-send-status").removeClass("alert-error");
@@ -603,7 +603,7 @@ test("uppy_events", ({override}) => {
     uppy_cancel_all_called = false;
     compose_ui_replace_syntax_called = false;
     const on_restriction_failed_callback = callbacks["restriction-failed"];
-    override(upload, "show_error_message", (config, message) => {
+    override_rewire(upload, "show_error_message", (config, message) => {
         show_error_message_called = true;
         assert.equal(config.mode, "compose");
         assert.equal(message, "Some error message");
@@ -611,7 +611,7 @@ test("uppy_events", ({override}) => {
     on_info_visible_callback();
     assert.ok(uppy_cancel_all_called);
     assert.ok(show_error_message_called);
-    override(compose_ui, "replace_syntax", (old_syntax, new_syntax, textarea) => {
+    override_rewire(compose_ui, "replace_syntax", (old_syntax, new_syntax, textarea) => {
         compose_ui_replace_syntax_called = true;
         assert.equal(old_syntax, "[translated: Uploading copenhagen.png…]()");
         assert.equal(new_syntax, "");
@@ -642,7 +642,7 @@ test("uppy_events", ({override}) => {
     const on_upload_error_callback = callbacks["upload-error"];
     show_error_message_called = false;
     compose_ui_replace_syntax_called = false;
-    override(upload, "show_error_message", (config, message) => {
+    override_rewire(upload, "show_error_message", (config, message) => {
         show_error_message_called = true;
         assert.equal(config.mode, "compose");
         assert.equal(message, "Response message");
@@ -659,7 +659,7 @@ test("uppy_events", ({override}) => {
     assert.ok(compose_ui_replace_syntax_called);
 
     compose_ui_replace_syntax_called = false;
-    override(upload, "show_error_message", (config, message) => {
+    override_rewire(upload, "show_error_message", (config, message) => {
         show_error_message_called = true;
         assert.equal(config.mode, "compose");
         assert.equal(message, undefined);

--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -410,7 +410,7 @@ exports.with_overrides = function (test_function) {
     };
 
     try {
-        test_function(override);
+        test_function({override});
     } finally {
         restore_callbacks.reverse();
         for (const restore_callback of restore_callbacks) {

--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -322,26 +322,37 @@ exports.finish = function () {
 
 exports.with_field = function (obj, field, val, f) {
     if ("__esModule" in obj && "__Rewire__" in obj) {
-        const old_val = field in obj ? obj[field] : obj.__GetDependency__(field);
-        try {
-            obj.__Rewire__(field, val);
-            return f();
-        } finally {
-            obj.__Rewire__(field, old_val);
+        throw new TypeError(
+            "Cannot mutate an ES module from outside. Consider exporting a test helper function from it instead.",
+        );
+    }
+
+    const had_val = Object.prototype.hasOwnProperty.call(obj, field);
+    const old_val = obj[field];
+    try {
+        obj[field] = val;
+        return f();
+    } finally {
+        if (had_val) {
+            obj[field] = old_val;
+        } else {
+            delete obj[field];
         }
-    } else {
-        const had_val = Object.prototype.hasOwnProperty.call(obj, field);
-        const old_val = obj[field];
-        try {
-            obj[field] = val;
-            return f();
-        } finally {
-            if (had_val) {
-                obj[field] = old_val;
-            } else {
-                delete obj[field];
-            }
-        }
+    }
+};
+
+exports.with_field_rewire = function (obj, field, val, f) {
+    // This is deprecated because it relies on the slow
+    // babel-plugin-rewire-ts plugin.  Consider alternatives such
+    // as exporting a helper function for tests from the module
+    // containing the function you need to mock.
+
+    const old_val = field in obj ? obj[field] : obj.__GetDependency__(field);
+    try {
+        obj.__Rewire__(field, val);
+        return f();
+    } finally {
+        obj.__Rewire__(field, old_val);
     }
 };
 

--- a/frontend_tests/zjsunit/test.js
+++ b/frontend_tests/zjsunit/test.js
@@ -30,7 +30,7 @@ exports.run_test = (label, f, opts) => {
 
     try {
         namespace._start_template_mocking();
-        namespace.with_overrides((override) => {
+        namespace.with_overrides(({override}) => {
             f({override, mock_template: namespace._mock_template});
         });
         namespace._finish_template_mocking();

--- a/frontend_tests/zjsunit/test.js
+++ b/frontend_tests/zjsunit/test.js
@@ -30,8 +30,8 @@ exports.run_test = (label, f, opts) => {
 
     try {
         namespace._start_template_mocking();
-        namespace.with_overrides(({override}) => {
-            f({override, mock_template: namespace._mock_template});
+        namespace.with_overrides(({override, override_rewire}) => {
+            f({override, override_rewire, mock_template: namespace._mock_template});
         });
         namespace._finish_template_mocking();
     } catch (error) {


### PR DESCRIPTION
Annotate our indirect uses of `__Rewire__` in a greppable way (`override_rewire`, `with_field_rewire`), to make it easier to avoid introducing new uses and eventually remove the existing uses. After removing all of them, we’ll be able to remove the expensive, buggy, and unmaintained babel-plugin-rewire-ts plugin from the Node tests.

[Discussion](https://chat.zulip.org/#narrow/stream/18-tools/topic/__Rewire__/near/1306662)

Current statistics:

* `override` (ok): 421
* `override_rewire` (:-1: deprecated): 307
* `with_field` (ok): 21
* `with_field_rewire` (:-1: deprecated): 15
* `__Rewire__` (:-1: deprecated): 36

Cc @showell
