### PR TITLE
added 'copy' buttons to bot settings

### DIFF
--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -19,9 +19,7 @@ const bot_data_params = {
     ],
 };
 
-function ClipboardJS(sel) {
-    assert.equal(sel, "#copy_zuliprc");
-}
+function ClipboardJS() {}
 mock_cjs("clipboard", ClipboardJS);
 
 const bot_data = zrequire("bot_data");

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -497,6 +497,12 @@ export function show_edit_bot_info_modal(user_id, from_user_info_popover) {
     });
 }
 
+function show_alert_on_copy_handler(box) {
+    box.find("span.bot-info-copy-alert").text($t({defaultMessage: "Copied!"}));
+    box.find("span.bot-info-copy-alert").css("display", "block");
+    box.find("span.bot-info-copy-alert").delay(1000).fadeOut(300);
+}
+
 export function set_up() {
     $("#download_botserverrc").on("click", function () {
         const OUTGOING_WEBHOOK_BOT_TYPE_INT = 3;
@@ -599,38 +605,38 @@ export function set_up() {
 
     new ClipboardJS("#copy_zuliprc", {
         text(trigger) {
-            const $bot_info = $(trigger).closest(".bot-information-box").find(".bot_info");
+            const $bot_info_box = $(trigger).closest(".bot-information-box");
+            const $bot_info = $bot_info_box.find(".bot_info");
             const bot_id = Number.parseInt($bot_info.attr("data-user-id"), 10);
             const bot = bot_data.get(bot_id);
             const data = generate_zuliprc_content(bot);
+            show_alert_on_copy_handler($bot_info_box);
             return data;
         },
     });
 
     new ClipboardJS("#copy_bot_email", {
         text(trigger) {
-            const bot_info = $(trigger).closest(".bot-information-box").find(".bot_info");
-            const bot_id = Number.parseInt(bot_info.attr("data-user-id"), 10);
+            const $bot_info_box = $(trigger).closest(".bot-information-box");
+            const $bot_info = $bot_info_box.find(".bot_info");
+            const bot_id = Number.parseInt($bot_info.attr("data-user-id"), 10);
             const bot = bot_data.get(bot_id);
             const email = bot.email;
+            show_alert_on_copy_handler($bot_info_box);
             return email;
         },
     });
 
     new ClipboardJS("#copy_api_key", {
         text(trigger) {
-            const bot_info = $(trigger).closest(".bot-information-box").find(".bot_info");
-            const bot_id = Number.parseInt(bot_info.attr("data-user-id"), 10);
+            const $bot_info_box = $(trigger).closest(".bot-information-box");
+            const $bot_info = $bot_info_box.find(".bot_info");
+            const bot_id = Number.parseInt($bot_info.attr("data-user-id"), 10);
             const bot = bot_data.get(bot_id);
             const api_key = bot.api_key;
+            show_alert_on_copy_handler($bot_info_box);
             return api_key;
         },
-    });
-
-    $("#bots_lists_navbar .add-a-new-bot-tab").on("click", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        focus_tab.add_a_new_bot_tab();
     });
 
     $("#bots_lists_navbar .active-bots-tab").on("click", (e) => {

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -607,6 +607,32 @@ export function set_up() {
         },
     });
 
+    new ClipboardJS("#copy_bot_email", {
+        text(trigger) {
+            const bot_info = $(trigger).closest(".bot-information-box").find(".bot_info");
+            const bot_id = Number.parseInt(bot_info.attr("data-user-id"), 10);
+            const bot = bot_data.get(bot_id);
+            const email = bot.email;
+            return email;
+        },
+    });
+
+    new ClipboardJS("#copy_api_key", {
+        text(trigger) {
+            const bot_info = $(trigger).closest(".bot-information-box").find(".bot_info");
+            const bot_id = Number.parseInt(bot_info.attr("data-user-id"), 10);
+            const bot = bot_data.get(bot_id);
+            const api_key = bot.api_key;
+            return api_key;
+        },
+    });
+
+    $("#bots_lists_navbar .add-a-new-bot-tab").on("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        focus_tab.add_a_new_bot_tab();
+    });
+
     $("#bots_lists_navbar .active-bots-tab").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -235,6 +235,10 @@ body.dark-theme {
         }
     }
 
+    .bot-info-copy-alert {
+        background: hsl(211, 28%, 14%);
+    }
+
     /* do not turn the .message_header .stream_label text dark on hover because they're
        on a dark background, and don't change the dark labels dark either. */
     .message_header:not(.dark_background)

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -700,6 +700,15 @@ input[type="checkbox"] {
     margin-bottom: 2px;
 }
 
+.bot-info-copy-alert {
+    position: absolute;
+    top: 2px;
+    right: 8px;
+    color: hsl(170, 48%, 54%);
+    background-color: hsl(0, 0%, 100%);
+    font-weight: 400;
+}
+
 .bots_list {
     display: none;
     list-style-type: none;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -720,7 +720,9 @@ input[type="checkbox"] {
         white-space: pre;
     }
 
-    .regenerate_bot_api_key {
+    .regenerate_bot_api_key,
+    .copy_api_key,
+    .copy_bot_email {
         position: relative;
         margin-left: 5px;
         color: hsl(0, 0%, 67%);
@@ -729,6 +731,10 @@ input[type="checkbox"] {
         &:hover {
             color: hsl(0, 0%, 27%);
         }
+    }
+
+    .copy_bot_email {
+        font-size: 12px;
     }
 
     .edit-bot-buttons {

--- a/static/templates/settings/bot_avatar_row.hbs
+++ b/static/templates/settings/bot_avatar_row.hbs
@@ -1,4 +1,5 @@
 <li class="bot-information-box white-box">
+    <span class="bot-info-copy-alert"></span>
     <div class="image overflow-hidden">
         <img src="{{avatar_url}}" class="avatar" />
         <div class="details">

--- a/static/templates/settings/bot_avatar_row.hbs
+++ b/static/templates/settings/bot_avatar_row.hbs
@@ -31,7 +31,12 @@
         </div>
         <div class="email">
             <div class="field">{{t "Bot email" }}</div>
-            <div class="value">{{email}}</div>
+            <div class="value">
+                {{email}}
+                <button type="submit" id="copy_bot_email" class="button no-style btn-secondary copy_bot_email" title="{{t 'Copy email' }}">
+                    <i class="fa fa-clipboard"></i>
+                </button>
+            </div>
         </div>
         {{#if is_active}}
         <div class="api_key">
@@ -39,6 +44,10 @@
             <div class="api-key-value-and-button no-select">
                 <!-- have the `.text-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
                 <span class="value text-select">{{api_key}}</span>
+                <button type="submit" id="copy_api_key" class="button no-style btn-secondary copy_api_key" title="{{t 'Copy API key' }}">
+                    <i class="fa fa-clipboard"></i>
+                </button>
+
                 <button type="submit" class="button no-style btn-secondary regenerate_bot_api_key" title="{{t 'Generate new API key' }}" data-user-id="{{user_id}}">
                     <i class="fa fa-refresh" aria-hidden="true"></i>
                 </button>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #19884 

**Testing plan:** <!-- How have you tested? -->
I tested the 'copy' buttons added for for copying the bot email and API key on the bot settings page.  The email or API key gets copied to the clipboard whenever the respective button is pressed.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/59819879/148661746-f7cbb881-952a-4e6a-b4c6-fd90a15d75e2.png)

![chrome-capture](https://user-images.githubusercontent.com/59819879/148661754-d9ff83e8-3331-4ace-a07a-7819b4773662.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
