### PR TITLE
i18n: Fix 'add choice'/'add task' button's size.

### DIFF
--- a/static/styles/widgets.css
+++ b/static/styles/widgets.css
@@ -109,7 +109,6 @@ button {
         border-radius: 3px;
         border: 1px solid hsl(0, 0%, 80%);
         background-color: hsl(0, 0%, 100%);
-        width: 100px;
 
         &:hover {
             border-color: hsl(0, 0%, 60%);


### PR DESCRIPTION
Removed the CSS rule setting the button's width to 100px.
This lets the button take as much space as the language needs.

Fixes: #20077

**Testing plan:** I changed the url to test a few different languages like Russian and German, and saw that the Add Task and Add Choice buttons sized themselves according to the language and did not cause the text inside them to wrap unnecessarily.

**GIFs or screenshots:** These are for German (`/de`):

Before:

![image](https://user-images.githubusercontent.com/68962290/148688719-6415f78a-7981-4d24-8344-e206f47a230c.png)

After:

![image](https://user-images.githubusercontent.com/68962290/148688702-72c311e3-f19f-42a1-82ff-0536e96cf5ca.png)

