### PR TITLE
streams: Add extra line break to description change notification.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5124,7 +5124,7 @@ def send_change_stream_description_notification(
 
     with override_language(stream.realm.default_language):
         notification_string = _(
-            "{user} changed the description for this stream.\n"
+            "{user} changed the description for this stream.\n\n"
             "Old description:\n"
             "``` quote\n"
             "{old_description}\n"

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1204,7 +1204,7 @@ class StreamAdminTest(ZulipTestCase):
 
         messages = get_topic_messages(user_profile, stream, "stream events")
         expected_notification = (
-            f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this stream.\n"
+            f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this stream.\n\n"
             "Old description:\n"
             "``` quote\n"
             "Test description\n"
@@ -1266,7 +1266,7 @@ class StreamAdminTest(ZulipTestCase):
 
         messages = get_topic_messages(user_profile, stream, "stream events")
         expected_notification = (
-            f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this stream.\n"
+            f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this stream.\n\n"
             "Old description:\n"
             "``` quote\n"
             "See https://zulip.com/team\n"


### PR DESCRIPTION
The extra line break above "Old description:" aids readability.

Before:
![stream_desc_notification](https://user-images.githubusercontent.com/7251823/148817658-b50a932d-8925-49e8-bd77-3c7e24b95869.png)

After:
![stream_desc_notification (1)](https://user-images.githubusercontent.com/7251823/148817682-adfd4bb5-535f-428b-98a4-14727a44597a.png)

@timabbott Should be a quick merge! Thanks! :)
