### PR TITLE
WIP drafts: frontend implementation of drafts synchronization

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -31,6 +31,7 @@ const bot_data = mock_esm("../../static/js/bot_data");
 const compose_pm_pill = mock_esm("../../static/js/compose_pm_pill");
 const composebox_typeahead = mock_esm("../../static/js/composebox_typeahead");
 const dark_theme = mock_esm("../../static/js/dark_theme");
+const drafts = mock_esm("../../static/js/drafts");
 const emoji_picker = mock_esm("../../static/js/emoji_picker");
 const hotspots = mock_esm("../../static/js/hotspots");
 const linkifiers = mock_esm("../../static/js/linkifiers");
@@ -254,6 +255,38 @@ run_test("default_streams", ({override}) => {
     assert.equal(stub.num_calls, 1);
     const args = stub.get_args("realm_default_streams");
     assert_same(args.realm_default_streams, event.default_streams);
+});
+
+run_test("drafts", ({override}) => {
+    let event = event_fixtures.drafts__add;
+    {
+        const stub = make_stub();
+        override(drafts, "compare_drafts", stub.f);
+        dispatch(event);
+        assert.equal(stub.num_calls, 1);
+        const args = stub.get_args("draft");
+        assert_same(args.draft, event.drafts[0]);
+    }
+
+    event = event_fixtures.drafts__update;
+    {
+        const stub = make_stub();
+        override(drafts, "compare_drafts", stub.f);
+        dispatch(event);
+        assert.equal(stub.num_calls, 1);
+        const args = stub.get_args("draft");
+        assert_same(args.draft, event.draft);
+    }
+
+    event = event_fixtures.drafts__remove;
+    {
+        const stub = make_stub();
+        override(drafts, "remove_draft", stub.f);
+        dispatch(event);
+        assert.equal(stub.num_calls, 1);
+        const args = stub.get_args("draft_id");
+        assert_same(args.draft_id, event.draft_id);
+    }
 });
 
 run_test("hotspots", ({override}) => {
@@ -1087,6 +1120,8 @@ run_test("server_event_dispatch_op_errors", ({override}) => {
     override(settings_user_groups_legacy, "reload", noop);
     blueslip.expect("error", "Unexpected event type user_group/other");
     server_events_dispatch.dispatch_normal_event({type: "user_group", op: "other"});
+    blueslip.expect("error", "Unexpected event type drafts/other");
+    server_events_dispatch.dispatch_normal_event({type: "drafts", op: "other"});
 });
 
 run_test("realm_user_settings_defaults", ({override}) => {

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -40,6 +40,9 @@ mock_esm("../../static/js/stream_data", {
         return {stream_id: 30};
     },
 });
+const compose_pm_pill = mock_esm("../../static/js/compose_pm_pill", {
+    get_user_ids: noop,
+});
 const tippy_sel = ".top_left_drafts .unread_count";
 let tippy_args;
 let tippy_show_called;
@@ -75,6 +78,7 @@ const draft_1 = {
     content: "Test stream message",
 };
 const draft_2 = {
+    pm_recipient_ids: [1],
     private_message_recipient: "aaron@zulip.com",
     reply_to: "aaron@zulip.com",
     type: "private",
@@ -167,6 +171,8 @@ test("snapshot_message", ({override_rewire}) => {
         compose_state.topic(curr_draft.topic);
         compose_state.private_message_recipient(curr_draft.private_message_recipient);
     }
+
+    compose_pm_pill.get_user_ids = () => [1];
 
     curr_draft = draft_1;
     set_compose_state();

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -162,6 +162,40 @@ exports.fixtures = {
         topic: "topic1",
     },
 
+    drafts__add: {
+        type: "drafts",
+        op: "add",
+        drafts: [
+            {
+                id: 12,
+                type: "stream",
+                to: [streams.devel.stream_id],
+                topic: "draft sync",
+                content: "new draft text",
+                timestamp: fake_then,
+            },
+        ],
+    },
+
+    drafts__remove: {
+        type: "drafts",
+        op: "remove",
+        draft_id: 12,
+    },
+
+    drafts__update: {
+        type: "drafts",
+        op: "update",
+        draft: {
+            id: 12,
+            type: "stream",
+            to: [streams.devel.stream_id],
+            topic: "draft sync",
+            content: "edited draft text",
+            timestamp: fake_now,
+        },
+    },
+
     has_zoom_token: {
         type: "has_zoom_token",
         value: true,

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -22,12 +22,14 @@ import * as markdown from "./markdown";
 import * as narrow from "./narrow";
 import * as narrow_state from "./narrow_state";
 import * as overlays from "./overlays";
+import {page_params} from "./page_params";
 import * as people from "./people";
 import * as rendered_markdown from "./rendered_markdown";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 import * as ui_util from "./ui_util";
+import {user_settings} from "./user_settings";
 import * as util from "./util";
 
 function set_count(count) {
@@ -757,6 +759,11 @@ export function set_initial_element(drafts) {
 
 export function initialize() {
     remove_old_drafts();
+
+    // enable drafts synchronization in dev env
+    if (page_params.development_environment) {
+        user_settings.enable_drafts_synchronization = true;
+    }
 
     window.addEventListener("beforeunload", () => {
         update_draft();

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -349,7 +349,7 @@ export function reify_message_id(local_id, server_id) {
 
     if (message.draft_id) {
         // Delete the draft if message was locally echoed
-        drafts.draft_model.deleteDraft(message.draft_id);
+        drafts.delete_draft(message.draft_id);
     }
 
     const opts = {old_id: Number.parseFloat(local_id), new_id: server_id};

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -14,6 +14,7 @@ import * as compose_pm_pill from "./compose_pm_pill";
 import * as composebox_typeahead from "./composebox_typeahead";
 import * as dark_theme from "./dark_theme";
 import * as emoji from "./emoji";
+import * as drafts from "./drafts";
 import * as emoji_picker from "./emoji_picker";
 import * as giphy from "./giphy";
 import * as hotspots from "./hotspots";
@@ -117,6 +118,28 @@ export function dispatch_normal_event(event) {
 
             break;
         }
+
+        case "drafts":
+            switch (event.op) {
+                case "add":
+                    for (const draft of event.drafts) {
+                        drafts.compare_drafts(draft);
+                    }
+                    // TODO: live update of drafts overlay if open
+                    break;
+                case "update":
+                    drafts.compare_drafts(event.draft);
+                    // TODO: live update of drafts overlay if open
+                    break;
+                case "remove":
+                    drafts.remove_draft(event.draft_id);
+                    // TODO: live update of drafts overlay if open
+                    break;
+                default:
+                    blueslip.error("Unexpected event type drafts/" + event.op);
+                    break;
+            }
+            break;
 
         case "has_zoom_token":
             page_params.has_zoom_token = event.value;


### PR DESCRIPTION
This builds on #18074, which implemented a user setting on the back end for drafts synchronization between clients. I attempted to keep the changes to local draft structure to a minimum, but it might be worth looking at aligning the local model and server model so that there isn't as much renaming of fields between the objects.

Current changes:
- Toggle drafts synchronization in the development environment
- Implement adding, updating and deleting local drafts on the server
- Implement fetching drafts from server
  - `drafts` events when client has event queue
  - `get` request on page load

To do:
- Add testing and review current changes for bugs / issues
  - Puppeteer test `drafts.ts` fails nondeterministically in my local dev environment; intuition is that occasionally the `drafts` event is arriving before the success when adding a new draft to the server. So adding a check for that race condition is a to-do.
  - Local echo of messages is now sending to the server and then being deleted on the server. Need to decide how to flag or adjust so that doesn't happen.
- Live update for overlays and other ui

**Testing plan:** Currently most of my testing has been manual testing (see video example below), as well as updating current tests that were effected by the changes (snapshot test in `node_tests/drafts.js` and `node_tests/dispatch.js` for the additions of the `drafts` events). I've noticed some local nondeterministic failures of `puppeteer_tests/drafts.ts`, which merits further investigation.

https://user-images.githubusercontent.com/63245456/148837109-9a9ea50e-eda8-478f-9bb7-0b9fa5d0116f.mp4

