### PR TITLE
mailmap: Add mailmap entry for Yash RE.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -39,3 +39,5 @@ Vishnu KS <vishnu@zulip.com> <hackerkid@vishnuks.com>
 Vishnu KS <vishnu@zulip.com> <yo@vishnuks.com>
 Alya Abbott <alya@zulip.com> <alyaabbott@elance-odesk.com>
 Sahil Batra <sahil@zulip.com> <sahilbatra839@gmail.com>
+Yash RE <33805964+YashRE42@users.noreply.github.com> <YashRE42@github.com>
+Yash RE <33805964+YashRE42@users.noreply.github.com>


### PR DESCRIPTION
This corrects the shortlog for the dozen or so commits had been made
with the wrong email ID for Yash RE and also unifies on "Yash RE"
rather than "YashRE42" or "Yash Rathore".

before:
>   232  YashRE42 <33805964+YashRE42@users.noreply.github.com>

after:
>   248  Yash RE <33805964+YashRE42@users.noreply.github.com>
