### PR TITLE
Add WildValue class for enforcing JSON type checking in webhooks

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -278,6 +278,10 @@ python_rules = RuleList(
             "description": "Use the assert_length helper instead of assertEqual(len(..), ..).",
             "good_lines": ["assert_length(data, 2)"],
             "bad_lines": ["assertEqual(len(data), 2)"],
+            "exclude_line": {
+                ("zerver/tests/test_decorators.py", "self.assertEqual(len(x), 2)"),
+                ("zerver/tests/test_decorators.py", 'self.assertEqual(len(x["b"]), 3)'),
+            },
         },
         {
             "pattern": "assertTrue[(]len[(][^ ]*[)]",

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -857,7 +857,7 @@ def internal_notify_view(
     return _wrapped_view_func
 
 
-def to_utc_datetime(timestamp: str) -> datetime.datetime:
+def to_utc_datetime(var_name: str, timestamp: str) -> datetime.datetime:
     return timestamp_to_datetime(float(timestamp))
 
 

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -130,7 +130,7 @@ class _REQ(Generic[ResultT]):
         self,
         whence: Optional[str] = None,
         *,
-        converter: Optional[Callable[[str], ResultT]] = None,
+        converter: Optional[Callable[[str, str], ResultT]] = None,
         default: Union[_NotSpecified, ResultT, None] = NotSpecified,
         json_validator: Optional[Validator[ResultT]] = None,
         str_validator: Optional[Validator[ResultT]] = None,
@@ -204,7 +204,7 @@ class _REQ(Generic[ResultT]):
 def REQ(
     whence: Optional[str] = ...,
     *,
-    converter: Callable[[str], ResultT],
+    converter: Callable[[str, str], ResultT],
     default: ResultT = ...,
     intentionally_undocumented: bool = ...,
     documentation_pending: bool = ...,
@@ -278,7 +278,7 @@ def REQ(
 def REQ(
     whence: Optional[str] = None,
     *,
-    converter: Optional[Callable[[str], ResultT]] = None,
+    converter: Optional[Callable[[str, str], ResultT]] = None,
     default: Union[_REQ._NotSpecified, ResultT] = _REQ.NotSpecified,
     json_validator: Optional[Validator[ResultT]] = None,
     str_validator: Optional[Validator[ResultT]] = None,
@@ -413,7 +413,7 @@ def has_request_variables(view_func: ViewFuncT) -> ViewFuncT:
 
             if param.converter is not None and not default_assigned:
                 try:
-                    val = param.converter(val)
+                    val = param.converter(post_var_name, val)
                 except JsonableError:
                     raise
                 except Exception:

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -31,6 +31,7 @@ import zerver.tornado.handlers as handlers
 from zerver.lib.exceptions import ErrorCode, InvalidJSONError, JsonableError
 from zerver.lib.notes import BaseNotes
 from zerver.lib.types import Validator, ViewFuncT
+from zerver.lib.validator import check_anything
 from zerver.models import Client, Realm
 
 
@@ -168,6 +169,10 @@ class _REQ(Generic[ResultT]):
 
         """
 
+        if argument_type == "body" and converter is None and json_validator is None:
+            # legacy behavior
+            json_validator = cast(Callable[[str, object], ResultT], check_anything)
+
         self.post_var_name = whence
         self.func_var_name: Optional[str] = None
         self.converter = converter
@@ -206,6 +211,7 @@ def REQ(
     *,
     converter: Callable[[str, str], ResultT],
     default: ResultT = ...,
+    argument_type: Optional[Literal["body"]] = ...,
     intentionally_undocumented: bool = ...,
     documentation_pending: bool = ...,
     aliases: Sequence[str] = ...,
@@ -221,6 +227,7 @@ def REQ(
     *,
     default: ResultT = ...,
     json_validator: Validator[ResultT],
+    argument_type: Optional[Literal["body"]] = ...,
     intentionally_undocumented: bool = ...,
     documentation_pending: bool = ...,
     aliases: Sequence[str] = ...,
@@ -368,46 +375,45 @@ def has_request_variables(view_func: ViewFuncT) -> ViewFuncT:
                 continue
             assert func_var_name is not None
 
+            post_var_name: Optional[str]
+
             if param.argument_type == "body":
+                post_var_name = "request"
                 try:
-                    val = orjson.loads(request.body)
-                except orjson.JSONDecodeError:
-                    raise InvalidJSONError(_("Malformed JSON"))
-                kwargs[func_var_name] = val
-                continue
+                    val = request.body.decode(request.encoding or "utf-8")
+                except UnicodeDecodeError:
+                    raise JsonableError(_("Malformed payload"))
             else:
                 # This is a view bug, not a user error, and thus should throw a 500.
                 assert param.argument_type is None, "Invalid argument type"
 
-            post_var_names = [param.post_var_name]
-            post_var_names += param.aliases
+                post_var_names = [param.post_var_name]
+                post_var_names += param.aliases
+                post_var_name = None
 
-            post_var_name: Optional[str] = None
-
-            for req_var in post_var_names:
-                assert req_var is not None
-                if req_var in request.POST:
-                    val = request.POST[req_var]
-                    request_notes.processed_parameters.add(req_var)
-                elif req_var in request.GET:
-                    val = request.GET[req_var]
-                    request_notes.processed_parameters.add(req_var)
-                else:
-                    # This is covered by test_REQ_aliases, but coverage.py
-                    # fails to recognize this for some reason.
-                    continue  # nocoverage
-                if post_var_name is not None:
+                for req_var in post_var_names:
                     assert req_var is not None
-                    raise RequestConfusingParmsError(post_var_name, req_var)
-                post_var_name = req_var
+                    if req_var in request.POST:
+                        val = request.POST[req_var]
+                        request_notes.processed_parameters.add(req_var)
+                    elif req_var in request.GET:
+                        val = request.GET[req_var]
+                        request_notes.processed_parameters.add(req_var)
+                    else:
+                        # This is covered by test_REQ_aliases, but coverage.py
+                        # fails to recognize this for some reason.
+                        continue  # nocoverage
+                    if post_var_name is not None:
+                        raise RequestConfusingParmsError(post_var_name, req_var)
+                    post_var_name = req_var
 
-            if post_var_name is None:
-                post_var_name = param.post_var_name
-                assert post_var_name is not None
-                if param.default is _REQ.NotSpecified:
-                    raise RequestVariableMissingError(post_var_name)
-                kwargs[func_var_name] = param.default
-                continue
+                if post_var_name is None:
+                    post_var_name = param.post_var_name
+                    assert post_var_name is not None
+                    if param.default is _REQ.NotSpecified:
+                        raise RequestVariableMissingError(post_var_name)
+                    kwargs[func_var_name] = param.default
+                    continue
 
             if param.converter is not None:
                 try:
@@ -422,6 +428,8 @@ def has_request_variables(view_func: ViewFuncT) -> ViewFuncT:
                 try:
                     val = orjson.loads(val)
                 except orjson.JSONDecodeError:
+                    if param.argument_type == "body":
+                        raise InvalidJSONError(_("Malformed JSON"))
                     raise JsonableError(_('Argument "{}" is not valid JSON.').format(post_var_name))
 
                 try:

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -56,7 +56,7 @@ def REQ_topic() -> Optional[str]:
     return REQ(
         whence="topic",
         aliases=["subject"],
-        converter=lambda x: x.strip(),
+        converter=lambda var_name, x: x.strip(),
         default=None,
     )
 

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -28,6 +28,7 @@ for any particular type of object.
 
 """
 import re
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from typing import (
@@ -35,7 +36,9 @@ from typing import (
     Callable,
     Collection,
     Dict,
+    Iterator,
     List,
+    NoReturn,
     Optional,
     Set,
     Tuple,
@@ -51,7 +54,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator, validate_email
 from django.utils.translation import gettext as _
 
-from zerver.lib.exceptions import JsonableError
+from zerver.lib.exceptions import InvalidJSONError, JsonableError
 from zerver.lib.timezone import canonicalize_timezone
 from zerver.lib.types import ProfileFieldData, Validator
 
@@ -587,3 +590,133 @@ def check_string_or_int(var_name: str, val: object) -> Union[str, int]:
         return val
 
     raise ValidationError(_("{var_name} is not a string or integer").format(var_name=var_name))
+
+
+@dataclass
+class WildValue:
+    var_name: str
+    value: object
+
+    def __bool__(self) -> bool:
+        return bool(self.value)
+
+    def __eq__(self, other: object) -> bool:
+        return self.value == other
+
+    def __len__(self) -> int:
+        if not isinstance(self.value, (dict, list, str)):
+            raise ValidationError(
+                _("{var_name} does not have a length").format(var_name=self.var_name)
+            )
+        return len(self.value)
+
+    def __str__(self) -> NoReturn:
+        raise TypeError("cannot convert WildValue to string; try .tame(check_string)")
+
+    def _need_list(self) -> NoReturn:
+        raise ValidationError(_("{var_name} is not a list").format(var_name=self.var_name))
+
+    def _need_dict(self) -> NoReturn:
+        raise ValidationError(_("{var_name} is not a dict").format(var_name=self.var_name))
+
+    def __iter__(self) -> Iterator["WildValue"]:
+        self._need_list()
+
+    def __contains__(self, key: str) -> bool:
+        self._need_dict()
+
+    def __getitem__(self, key: Union[int, str]) -> "WildValue":
+        if isinstance(key, int):
+            self._need_list()
+        else:
+            self._need_dict()
+
+    def get(self, key: str, default: object = None) -> "WildValue":
+        self._need_dict()
+
+    def keys(self) -> Iterator[str]:
+        self._need_dict()
+
+    def values(self) -> Iterator["WildValue"]:
+        self._need_dict()
+
+    def items(self) -> Iterator[Tuple[str, "WildValue"]]:
+        self._need_dict()
+
+    def tame(self, validator: Validator[ResultT]) -> ResultT:
+        return validator(self.var_name, self.value)
+
+
+class WildValueList(WildValue):
+    value: List[object]
+
+    def __iter__(self) -> Iterator[WildValue]:
+        for i, item in enumerate(self.value):
+            yield wrap_wild_value(f"{self.var_name}[{i}]", item)
+
+    def __getitem__(self, key: Union[int, str]) -> WildValue:
+        if not isinstance(key, int):
+            return super().__getitem__(key)
+
+        var_name = f"{self.var_name}[{key!r}]"
+
+        try:
+            item = self.value[key]
+        except IndexError:
+            raise ValidationError(_("{var_name} is missing").format(var_name=var_name)) from None
+
+        return wrap_wild_value(var_name, item)
+
+
+class WildValueDict(WildValue):
+    value: Dict[str, object]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.value
+
+    def __getitem__(self, key: Union[int, str]) -> WildValue:
+        if not isinstance(key, str):
+            return super().__getitem__(key)
+
+        var_name = f"{self.var_name}[{key!r}]"
+
+        try:
+            item = self.value[key]
+        except KeyError:
+            raise ValidationError(_("{var_name} is missing").format(var_name=var_name)) from None
+
+        return wrap_wild_value(var_name, item)
+
+    def get(self, key: str, default: object = None) -> "WildValue":
+        item = self.value.get(key, default)
+        if isinstance(item, WildValue):
+            return item
+        return wrap_wild_value(f"{self.var_name}[{key!r}]", item)
+
+    def keys(self) -> Iterator[str]:
+        yield from self.value.keys()
+
+    def values(self) -> Iterator["WildValue"]:
+        for key, value in self.value.items():
+            yield wrap_wild_value(f"{self.var_name}[{key!r}]", value)
+
+    def items(self) -> Iterator[Tuple[str, "WildValue"]]:
+        for key, value in self.value.items():
+            yield key, wrap_wild_value(f"{self.var_name}[{key!r}]", value)
+
+
+def wrap_wild_value(var_name: str, value: object) -> WildValue:
+    if isinstance(value, list):
+        return WildValueList(var_name, value)
+    if isinstance(value, dict):
+        return WildValueDict(var_name, value)
+    return WildValue(var_name, value)
+
+
+def to_wild_value(var_name: str, input: str) -> WildValue:
+    try:
+        value = orjson.loads(input)
+    except orjson.JSONDecodeError:
+        raise InvalidJSONError(_("Malformed JSON"))
+
+    return wrap_wild_value(var_name, value)

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -530,7 +530,7 @@ def validate_todo_data(todo_data: object) -> None:
 
 
 # Converter functions for use with has_request_variables
-def to_non_negative_int(s: str, max_int_size: int = 2**32 - 1) -> int:
+def to_non_negative_int(var_name: str, s: str, max_int_size: int = 2**32 - 1) -> int:
     x = int(s)
     if x < 0:
         raise ValueError("argument is negative")
@@ -539,15 +539,15 @@ def to_non_negative_int(s: str, max_int_size: int = 2**32 - 1) -> int:
     return x
 
 
-def to_float(s: str) -> float:
+def to_float(var_name: str, s: str) -> float:
     return float(s)
 
 
-def to_decimal(s: str) -> Decimal:
+def to_decimal(var_name: str, s: str) -> Decimal:
     return Decimal(s)
 
 
-def to_timezone_or_empty(s: str) -> str:
+def to_timezone_or_empty(var_name: str, s: str) -> str:
     if s in pytz.all_timezones_set:
         return canonicalize_timezone(s)
     else:
@@ -555,11 +555,11 @@ def to_timezone_or_empty(s: str) -> str:
 
 
 def to_converted_or_fallback(
-    sub_converter: Callable[[str], ResultT], default: ResultT
-) -> Callable[[str], ResultT]:
-    def converter(s: str) -> ResultT:
+    sub_converter: Callable[[str, str], ResultT], default: ResultT
+) -> Callable[[str, str], ResultT]:
+    def converter(var_name: str, s: str) -> ResultT:
         try:
-            return sub_converter(s)
+            return sub_converter(var_name, s)
         except ValueError:
             return default
 

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -58,6 +58,10 @@ from zerver.lib.types import ProfileFieldData, Validator
 ResultT = TypeVar("ResultT")
 
 
+def check_anything(var_name: str, val: object) -> object:
+    return val
+
+
 def check_string(var_name: str, val: object) -> str:
     if not isinstance(val, str):
         raise ValidationError(_("{var_name} is not a string").format(var_name=var_name))

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -91,7 +91,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
         data["field_data"] = "invalid"
         result = self.client_post("/json/realm/profile_fields", info=data)
-        error_msg = "Bad value for 'field_data': invalid"
+        error_msg = 'Argument "field_data" is not valid JSON.'
         self.assert_json_error(result, error_msg)
 
         data["field_data"] = orjson.dumps(
@@ -101,7 +101,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
             }
         ).decode()
         result = self.client_post("/json/realm/profile_fields", info=data)
-        self.assert_json_error(result, "field_data is not a dict")
+        self.assert_json_error(result, "field_data contains a value that is not an allowed_type")
 
         data["field_data"] = orjson.dumps(
             {
@@ -137,7 +137,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
             }
         ).decode()
         result = self.client_post("/json/realm/profile_fields", info=data)
-        self.assert_json_error(result, 'field_data["order"] is not a string')
+        self.assert_json_error(result, "field_data contains a value that is not an allowed_type")
 
         data["field_data"] = orjson.dumps({}).decode()
         result = self.client_post("/json/realm/profile_fields", info=data)
@@ -212,7 +212,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
         data["field_data"] = "invalid"
         result = self.client_post("/json/realm/profile_fields", info=data)
-        self.assert_json_error(result, "Bad value for 'field_data': invalid")
+        self.assert_json_error(result, 'Argument "field_data" is not valid JSON.')
 
         data["field_data"] = orjson.dumps({}).decode()
         result = self.client_post("/json/realm/profile_fields", info=data)
@@ -272,7 +272,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
             }
         ).decode()
         result = self.client_post("/json/realm/profile_fields", info=data)
-        self.assert_json_error(result, 'field_data["url_pattern"] is not a string')
+        self.assert_json_error(result, "field_data contains a value that is not an allowed_type")
 
         data["field_data"] = orjson.dumps(
             {
@@ -485,7 +485,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
             f"/json/realm/profile_fields/{field.id}",
             info={"name": "Favorite editor", "field_data": "invalid"},
         )
-        self.assert_json_error(result, "Bad value for 'field_data': invalid")
+        self.assert_json_error(result, 'Argument "field_data" is not valid JSON.')
 
         field_data = orjson.dumps(
             {

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -154,7 +154,7 @@ class DecoratorTestCase(ZulipTestCase):
         self.assertEqual(str(cm.exception), "Can't decide between 'number' and 'x' arguments")
 
     def test_REQ_converter(self) -> None:
-        def my_converter(data: str) -> List[int]:
+        def my_converter(var_name: str, data: str) -> List[int]:
             lst = orjson.loads(data)
             if not isinstance(lst, list):
                 raise ValueError("not a list")
@@ -766,13 +766,13 @@ class ValidatorTestCase(ZulipTestCase):
             check_int("x", x)
 
     def test_to_non_negative_int(self) -> None:
-        self.assertEqual(to_non_negative_int("5"), 5)
+        self.assertEqual(to_non_negative_int("x", "5"), 5)
         with self.assertRaisesRegex(ValueError, "argument is negative"):
-            to_non_negative_int("-1")
+            to_non_negative_int("x", "-1")
         with self.assertRaisesRegex(ValueError, re.escape("5 is too large (max 4)")):
-            to_non_negative_int("5", max_int_size=4)
+            to_non_negative_int("x", "5", max_int_size=4)
         with self.assertRaisesRegex(ValueError, re.escape(f"{2**32} is too large (max {2**32-1})")):
-            to_non_negative_int(str(2**32))
+            to_non_negative_int("x", str(2**32))
 
     def test_check_float(self) -> None:
         x: Any = 5.5

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -130,7 +130,8 @@ class DecoratorTestCase(ZulipTestCase):
     def test_REQ_aliases(self) -> None:
         @has_request_variables
         def double(
-            request: HttpRequest, x: int = REQ(whence="number", aliases=["x", "n"], converter=int)
+            request: HttpRequest,
+            x: int = REQ(whence="number", aliases=["x", "n"], json_validator=check_int),
         ) -> HttpResponse:
             return json_response(data={"number": x + x})
 

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -249,6 +249,12 @@ class DecoratorTestCase(ZulipTestCase):
             return json_response(data={"payload": payload})
 
         request = HostRequestMock()
+        request.body = b"\xde\xad\xbe\xef"
+        with self.assertRaises(JsonableError) as cm:
+            get_payload(request)
+        self.assertEqual(str(cm.exception), "Malformed payload")
+
+        request = HostRequestMock()
         request.body = b"notjson"
         with self.assertRaises(JsonableError) as cm:
             get_payload(request)

--- a/zerver/tests/test_integrations_dev_panel.py
+++ b/zerver/tests/test_integrations_dev_panel.py
@@ -14,7 +14,7 @@ class TestIntegrationsDevPanel(ZulipTestCase):
         bot = get_user("webhook-bot@zulip.com", self.zulip_realm)
         url = f"/api/v1/external/airbrake?api_key={bot.api_key}"
         target_url = "/devtools/integrations/check_send_webhook_fixture_message"
-        body = "{}"  # This empty body should generate a KeyError on the webhook code side.
+        body = "{}"  # This empty body should generate a ValidationError on the webhook code side.
 
         data = {
             "url": url,
@@ -29,9 +29,9 @@ class TestIntegrationsDevPanel(ZulipTestCase):
             expected_response = {"result": "error", "msg": "Internal server error"}
             self.assertEqual(orjson.loads(response.content), expected_response)
 
-        # Intention of this test looks like to trigger keyError
-        # so just testing KeyError is printed along with Traceback in logs
-        self.assertTrue("KeyError" in logs.output[0])
+        # Intention of this test looks like to trigger ValidationError
+        # so just testing ValidationError is printed along with Traceback in logs
+        self.assertTrue("ValidationError" in logs.output[0])
         self.assertTrue("Traceback (most recent call last)" in logs.output[0])
         self.assertEqual(
             logs.output[1], "ERROR:django.request:Internal Server Error: /api/v1/external/airbrake"

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -67,7 +67,7 @@ def get_events_backend(
     user_client: Optional[Client] = REQ(
         converter=get_client, default=None, intentionally_undocumented=True
     ),
-    last_event_id: Optional[int] = REQ(converter=int, default=None),
+    last_event_id: Optional[int] = REQ(json_validator=check_int, default=None),
     queue_id: Optional[str] = REQ(default=None),
     # apply_markdown, client_gravatar, all_public_streams, and various
     # other parameters are only used when registering a new queue via this

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -65,7 +65,7 @@ def get_events_backend(
     # user_client is intended only for internal Django=>Tornado requests
     # and thus shouldn't be documented for external use.
     user_client: Optional[Client] = REQ(
-        converter=get_client, default=None, intentionally_undocumented=True
+        converter=lambda var_name, s: get_client(s), default=None, intentionally_undocumented=True
     ),
     last_event_id: Optional[int] = REQ(json_validator=check_int, default=None),
     queue_id: Optional[str] = REQ(default=None),

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -20,10 +20,11 @@ from zerver.lib.exceptions import JsonableError
 from zerver.lib.external_accounts import validate_external_account_field_data
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
-from zerver.lib.types import ProfileDataElementValue, ProfileFieldData
+from zerver.lib.types import ProfileDataElementValue, ProfileFieldData, Validator
 from zerver.lib.users import validate_user_custom_profile_data
 from zerver.lib.validator import (
     check_capped_string,
+    check_dict,
     check_dict_only,
     check_int,
     check_list,
@@ -94,6 +95,11 @@ def validate_custom_profile_field(
         raise JsonableError(_("Invalid field type."))
 
 
+check_profile_field_data: Validator[ProfileFieldData] = check_dict(
+    value_validator=check_union([check_dict(value_validator=check_string), check_string])
+)
+
+
 @require_realm_admin
 @has_request_variables
 def create_realm_custom_profile_field(
@@ -101,7 +107,7 @@ def create_realm_custom_profile_field(
     user_profile: UserProfile,
     name: str = REQ(default="", converter=lambda x: x.strip()),
     hint: str = REQ(default=""),
-    field_data: ProfileFieldData = REQ(default={}, converter=orjson.loads),
+    field_data: ProfileFieldData = REQ(default={}, json_validator=check_profile_field_data),
     field_type: int = REQ(json_validator=check_int),
 ) -> HttpResponse:
     validate_custom_profile_field(name, hint, field_type, field_data)
@@ -148,7 +154,7 @@ def update_realm_custom_profile_field(
     field_id: int,
     name: str = REQ(default="", converter=lambda x: x.strip()),
     hint: str = REQ(default=""),
-    field_data: ProfileFieldData = REQ(default={}, converter=orjson.loads),
+    field_data: ProfileFieldData = REQ(default={}, json_validator=check_profile_field_data),
 ) -> HttpResponse:
     realm = user_profile.realm
     try:

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -105,7 +105,7 @@ check_profile_field_data: Validator[ProfileFieldData] = check_dict(
 def create_realm_custom_profile_field(
     request: HttpRequest,
     user_profile: UserProfile,
-    name: str = REQ(default="", converter=lambda x: x.strip()),
+    name: str = REQ(default="", converter=lambda var_name, x: x.strip()),
     hint: str = REQ(default=""),
     field_data: ProfileFieldData = REQ(default={}, json_validator=check_profile_field_data),
     field_type: int = REQ(json_validator=check_int),
@@ -152,7 +152,7 @@ def update_realm_custom_profile_field(
     request: HttpRequest,
     user_profile: UserProfile,
     field_id: int,
-    name: str = REQ(default="", converter=lambda x: x.strip()),
+    name: str = REQ(default="", converter=lambda var_name, x: x.strip()),
     hint: str = REQ(default=""),
     field_data: ProfileFieldData = REQ(default={}, json_validator=check_profile_field_data),
 ) -> HttpResponse:

--- a/zerver/views/events_register.py
+++ b/zerver/views/events_register.py
@@ -7,7 +7,7 @@ from zerver.lib.events import do_events_register
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
-from zerver.lib.validator import check_bool, check_dict, check_list, check_string
+from zerver.lib.validator import check_bool, check_dict, check_int, check_list, check_string
 from zerver.models import Stream, UserProfile
 
 
@@ -69,7 +69,7 @@ def events_register_backend(
     narrow: NarrowT = REQ(
         json_validator=check_list(check_list(check_string, length=2)), default=[]
     ),
-    queue_lifespan_secs: int = REQ(converter=int, default=0, documentation_pending=True),
+    queue_lifespan_secs: int = REQ(json_validator=check_int, default=0, documentation_pending=True),
 ) -> HttpResponse:
     if all_public_streams and not user_profile.can_access_public_streams():
         raise JsonableError(_("User not authorized for this query"))

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -600,7 +600,7 @@ def get_search_fields(
     }
 
 
-def narrow_parameter(json: str) -> OptionalNarrowListT:
+def narrow_parameter(var_name: str, json: str) -> OptionalNarrowListT:
 
     data = orjson.loads(json)
     if not isinstance(data, list):

--- a/zerver/webhooks/airbrake/view.py
+++ b/zerver/webhooks/airbrake/view.py
@@ -1,11 +1,10 @@
 # Webhooks for external integrations.
-from typing import Any, Dict
-
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import WildValue, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -18,7 +17,7 @@ AIRBRAKE_MESSAGE_TEMPLATE = '[{error_class}]({error_url}): "{error_message}" occ
 def api_airbrake_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Any] = REQ(argument_type="body"),
+    payload: WildValue = REQ(argument_type="body", converter=to_wild_value),
 ) -> HttpResponse:
     subject = get_subject(payload)
     body = get_body(payload)
@@ -26,14 +25,16 @@ def api_airbrake_webhook(
     return json_success(request)
 
 
-def get_subject(payload: Dict[str, Any]) -> str:
-    return AIRBRAKE_TOPIC_TEMPLATE.format(project_name=payload["error"]["project"]["name"])
+def get_subject(payload: WildValue) -> str:
+    return AIRBRAKE_TOPIC_TEMPLATE.format(
+        project_name=payload["error"]["project"]["name"].tame(check_string)
+    )
 
 
-def get_body(payload: Dict[str, Any]) -> str:
+def get_body(payload: WildValue) -> str:
     data = {
-        "error_url": payload["airbrake_error_url"],
-        "error_class": payload["error"]["error_class"],
-        "error_message": payload["error"]["error_message"],
+        "error_url": payload["airbrake_error_url"].tame(check_string),
+        "error_class": payload["error"]["error_class"].tame(check_string),
+        "error_message": payload["error"]["error_message"].tame(check_string),
     }
     return AIRBRAKE_MESSAGE_TEMPLATE.format(**data)

--- a/zerver/webhooks/alertmanager/view.py
+++ b/zerver/webhooks/alertmanager/view.py
@@ -1,11 +1,12 @@
 # Webhooks for external integrations.
-from typing import Any, Dict, List
+from typing import Dict, List
 
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import WildValue, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -15,7 +16,7 @@ from zerver.models import UserProfile
 def api_alertmanager_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Any] = REQ(argument_type="body"),
+    payload: WildValue = REQ(argument_type="body", converter=to_wild_value),
     name_field: str = REQ("name", default="instance"),
     desc_field: str = REQ("desc", default="alertname"),
 ) -> HttpResponse:
@@ -25,15 +26,17 @@ def api_alertmanager_webhook(
         labels = alert.get("labels", {})
         annotations = alert.get("annotations", {})
 
-        name = labels.get(name_field, annotations.get(name_field, "(unknown)"))
-        desc = labels.get(desc_field, annotations.get(desc_field, f"<missing field: {desc_field}>"))
+        name = labels.get(name_field, annotations.get(name_field, "(unknown)")).tame(check_string)
+        desc = labels.get(
+            desc_field, annotations.get(desc_field, f"<missing field: {desc_field}>")
+        ).tame(check_string)
 
-        url = alert.get("generatorURL").replace("tab=1", "tab=0")
+        url = alert["generatorURL"].tame(check_string).replace("tab=1", "tab=0")
 
         body = f"{desc} ([graph]({url}))"
         if name not in topics:
             topics[name] = {"firing": [], "resolved": []}
-        topics[name][alert["status"]].append(body)
+        topics[name][alert["status"].tame(check_string)].append(body)
 
     for topic, statuses in topics.items():
         for status, messages in statuses.items():

--- a/zerver/webhooks/appfollow/view.py
+++ b/zerver/webhooks/appfollow/view.py
@@ -1,12 +1,12 @@
 # Webhooks for external integrations.
 import re
-from typing import Any, Dict
 
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import WildValue, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -16,9 +16,9 @@ from zerver.models import UserProfile
 def api_appfollow_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Any] = REQ(argument_type="body"),
+    payload: WildValue = REQ(argument_type="body", converter=to_wild_value),
 ) -> HttpResponse:
-    message = payload["text"]
+    message = payload["text"].tame(check_string)
     app_name_search = re.search(r"\A(.+)", message)
     assert app_name_search is not None
     app_name = app_name_search.group(0)

--- a/zerver/webhooks/appveyor/view.py
+++ b/zerver/webhooks/appveyor/view.py
@@ -1,10 +1,9 @@
-from typing import Any, Dict
-
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import WildValue, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -22,7 +21,7 @@ APPVEYOR_MESSAGE_TEMPLATE = """
 def api_appveyor_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Any] = REQ(argument_type="body"),
+    payload: WildValue = REQ(argument_type="body", converter=to_wild_value),
 ) -> HttpResponse:
 
     body = get_body_for_http_request(payload)
@@ -32,25 +31,25 @@ def api_appveyor_webhook(
     return json_success(request)
 
 
-def get_subject_for_http_request(payload: Dict[str, Any]) -> str:
+def get_subject_for_http_request(payload: WildValue) -> str:
     event_data = payload["eventData"]
-    return APPVEYOR_TOPIC_TEMPLATE.format(project_name=event_data["projectName"])
+    return APPVEYOR_TOPIC_TEMPLATE.format(project_name=event_data["projectName"].tame(check_string))
 
 
-def get_body_for_http_request(payload: Dict[str, Any]) -> str:
+def get_body_for_http_request(payload: WildValue) -> str:
     event_data = payload["eventData"]
 
     data = {
-        "project_name": event_data["projectName"],
-        "build_version": event_data["buildVersion"],
-        "status": event_data["status"],
-        "build_url": event_data["buildUrl"],
-        "commit_url": event_data["commitUrl"],
-        "committer_name": event_data["committerName"],
-        "commit_date": event_data["commitDate"],
-        "commit_message": event_data["commitMessage"],
-        "commit_id": event_data["commitId"],
-        "started": event_data["started"],
-        "finished": event_data["finished"],
+        "project_name": event_data["projectName"].tame(check_string),
+        "build_version": event_data["buildVersion"].tame(check_string),
+        "status": event_data["status"].tame(check_string),
+        "build_url": event_data["buildUrl"].tame(check_string),
+        "commit_url": event_data["commitUrl"].tame(check_string),
+        "committer_name": event_data["committerName"].tame(check_string),
+        "commit_date": event_data["commitDate"].tame(check_string),
+        "commit_message": event_data["commitMessage"].tame(check_string),
+        "commit_id": event_data["commitId"].tame(check_string),
+        "started": event_data["started"].tame(check_string),
+        "finished": event_data["finished"].tame(check_string),
     }
     return APPVEYOR_MESSAGE_TEMPLATE.format(**data)

--- a/zerver/webhooks/basecamp/view.py
+++ b/zerver/webhooks/basecamp/view.py
@@ -1,6 +1,5 @@
 import re
 import string
-from typing import Any, Dict
 
 from django.http import HttpRequest, HttpResponse
 
@@ -8,6 +7,7 @@ from zerver.decorator import webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventType
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import WildValue, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -42,7 +42,7 @@ ALL_EVENT_TYPES = [
 def api_basecamp_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Any] = REQ(argument_type="body"),
+    payload: WildValue = REQ(argument_type="body", converter=to_wild_value),
 ) -> HttpResponse:
     event = get_event_type(payload)
 
@@ -78,24 +78,24 @@ def api_basecamp_webhook(
     return json_success(request)
 
 
-def get_project_name(payload: Dict[str, Any]) -> str:
-    return payload["recording"]["bucket"]["name"]
+def get_project_name(payload: WildValue) -> str:
+    return payload["recording"]["bucket"]["name"].tame(check_string)
 
 
-def get_event_type(payload: Dict[str, Any]) -> str:
-    return payload["kind"]
+def get_event_type(payload: WildValue) -> str:
+    return payload["kind"].tame(check_string)
 
 
-def get_event_creator(payload: Dict[str, Any]) -> str:
-    return payload["creator"]["name"]
+def get_event_creator(payload: WildValue) -> str:
+    return payload["creator"]["name"].tame(check_string)
 
 
-def get_subject_url(payload: Dict[str, Any]) -> str:
-    return payload["recording"]["app_url"]
+def get_subject_url(payload: WildValue) -> str:
+    return payload["recording"]["app_url"].tame(check_string)
 
 
-def get_subject_title(payload: Dict[str, Any]) -> str:
-    return payload["recording"]["title"]
+def get_subject_title(payload: WildValue) -> str:
+    return payload["recording"]["title"].tame(check_string)
 
 
 def get_verb(event: str, prefix: str) -> str:
@@ -115,14 +115,14 @@ def add_punctuation_if_necessary(body: str, title: str) -> str:
     return body
 
 
-def get_document_body(event: str, payload: Dict[str, Any]) -> str:
+def get_document_body(event: str, payload: WildValue) -> str:
     return get_generic_body(event, payload, "document_", DOCUMENT_TEMPLATE)
 
 
-def get_questions_answer_body(event: str, payload: Dict[str, Any]) -> str:
+def get_questions_answer_body(event: str, payload: WildValue) -> str:
     verb = get_verb(event, "question_answer_")
     question = payload["recording"]["parent"]
-    title = question["title"]
+    title = question["title"].tame(check_string)
     template = add_punctuation_if_necessary(QUESTIONS_ANSWER_TEMPLATE, title)
 
     return template.format(
@@ -130,41 +130,41 @@ def get_questions_answer_body(event: str, payload: Dict[str, Any]) -> str:
         verb=verb,
         answer_url=get_subject_url(payload),
         question_title=title,
-        question_url=question["app_url"],
+        question_url=question["app_url"].tame(check_string),
     )
 
 
-def get_comment_body(event: str, payload: Dict[str, Any]) -> str:
+def get_comment_body(event: str, payload: WildValue) -> str:
     verb = get_verb(event, "comment_")
     task = payload["recording"]["parent"]
-    template = add_punctuation_if_necessary(COMMENT_TEMPLATE, task["title"])
+    template = add_punctuation_if_necessary(COMMENT_TEMPLATE, task["title"].tame(check_string))
 
     return template.format(
         user_name=get_event_creator(payload),
         verb=verb,
         answer_url=get_subject_url(payload),
-        task_title=task["title"],
-        task_url=task["app_url"],
+        task_title=task["title"].tame(check_string),
+        task_url=task["app_url"].tame(check_string),
     )
 
 
-def get_questions_body(event: str, payload: Dict[str, Any]) -> str:
+def get_questions_body(event: str, payload: WildValue) -> str:
     return get_generic_body(event, payload, "question_", QUESTION_TEMPLATE)
 
 
-def get_message_body(event: str, payload: Dict[str, Any]) -> str:
+def get_message_body(event: str, payload: WildValue) -> str:
     return get_generic_body(event, payload, "message_", MESSAGE_TEMPLATE)
 
 
-def get_todo_list_body(event: str, payload: Dict[str, Any]) -> str:
+def get_todo_list_body(event: str, payload: WildValue) -> str:
     return get_generic_body(event, payload, "todolist_", TODO_LIST_TEMPLATE)
 
 
-def get_todo_body(event: str, payload: Dict[str, Any]) -> str:
+def get_todo_body(event: str, payload: WildValue) -> str:
     return get_generic_body(event, payload, "todo_", TODO_TEMPLATE)
 
 
-def get_generic_body(event: str, payload: Dict[str, Any], prefix: str, template: str) -> str:
+def get_generic_body(event: str, payload: WildValue, prefix: str, template: str) -> str:
     verb = get_verb(event, prefix)
     title = get_subject_title(payload)
     template = add_punctuation_if_necessary(template, title)

--- a/zerver/webhooks/beanstalk/view.py
+++ b/zerver/webhooks/beanstalk/view.py
@@ -2,7 +2,7 @@
 import base64
 import re
 from functools import wraps
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Dict, List, Optional, Tuple, cast
 
 from django.http import HttpRequest, HttpResponse
 
@@ -10,7 +10,7 @@ from zerver.decorator import authenticated_rest_api_view
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.types import ViewFuncT
-from zerver.lib.validator import check_dict
+from zerver.lib.validator import WildValue, check_int, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.lib.webhooks.git import TOPIC_WITH_BRANCH_TEMPLATE, get_push_commits_event_message
 from zerver.models import UserProfile
@@ -20,7 +20,7 @@ def build_message_from_gitlog(
     user_profile: UserProfile,
     name: str,
     ref: str,
-    commits: List[Dict[str, str]],
+    commits: WildValue,
     before: str,
     after: str,
     url: str,
@@ -32,21 +32,21 @@ def build_message_from_gitlog(
     short_ref = re.sub(r"^refs/heads/", "", ref)
     subject = TOPIC_WITH_BRANCH_TEMPLATE.format(repo=name, branch=short_ref)
 
-    commits = _transform_commits_list_to_common_format(commits)
-    content = get_push_commits_event_message(pusher, url, short_ref, commits, deleted=deleted)
+    commits_data = _transform_commits_list_to_common_format(commits)
+    content = get_push_commits_event_message(pusher, url, short_ref, commits_data, deleted=deleted)
 
     return subject, content
 
 
-def _transform_commits_list_to_common_format(commits: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+def _transform_commits_list_to_common_format(commits: WildValue) -> List[Dict[str, str]]:
     new_commits_list = []
     for commit in commits:
         new_commits_list.append(
             {
-                "name": commit["author"]["name"],
-                "sha": commit.get("id"),
-                "url": commit.get("url"),
-                "message": commit.get("message"),
+                "name": commit["author"]["name"].tame(check_string),
+                "sha": commit["id"].tame(check_string),
+                "url": commit["url"].tame(check_string),
+                "message": commit["message"].tame(check_string),
             }
         )
     return new_commits_list
@@ -79,7 +79,7 @@ def beanstalk_decoder(view_func: ViewFuncT) -> ViewFuncT:
 def api_beanstalk_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Any] = REQ(json_validator=check_dict([])),
+    payload: WildValue = REQ(converter=to_wild_value),
     branches: Optional[str] = REQ(default=None),
 ) -> HttpResponse:
     # Beanstalk supports both SVN and Git repositories
@@ -87,24 +87,24 @@ def api_beanstalk_webhook(
     # 'uri' key that is only present for Git repos
     git_repo = "uri" in payload
     if git_repo:
-        if branches is not None and branches.find(payload["branch"]) == -1:
+        if branches is not None and branches.find(payload["branch"].tame(check_string)) == -1:
             return json_success(request)
 
         subject, content = build_message_from_gitlog(
             user_profile,
-            payload["repository"]["name"],
-            payload["ref"],
+            payload["repository"]["name"].tame(check_string),
+            payload["ref"].tame(check_string),
             payload["commits"],
-            payload["before"],
-            payload["after"],
-            payload["repository"]["url"],
-            payload["pusher_name"],
+            payload["before"].tame(check_string),
+            payload["after"].tame(check_string),
+            payload["repository"]["url"].tame(check_string),
+            payload["pusher_name"].tame(check_string),
         )
     else:
-        author = payload.get("author_full_name")
-        url = payload.get("changeset_url")
-        revision = payload.get("revision")
-        (short_commit_msg, _, _) = payload["message"].partition("\n")
+        author = payload["author_full_name"].tame(check_string)
+        url = payload["changeset_url"].tame(check_string)
+        revision = payload["revision"].tame(check_int)
+        (short_commit_msg, _, _) = payload["message"].tame(check_string).partition("\n")
 
         subject = f"svn r{revision}"
         content = f"{author} pushed [revision {revision}]({url}):\n\n> {short_commit_msg}"

--- a/zerver/webhooks/beanstalk/view.py
+++ b/zerver/webhooks/beanstalk/view.py
@@ -43,7 +43,7 @@ def _transform_commits_list_to_common_format(commits: List[Dict[str, Any]]) -> L
     for commit in commits:
         new_commits_list.append(
             {
-                "name": commit["author"].get("username"),
+                "name": commit["author"]["name"],
                 "sha": commit.get("id"),
                 "url": commit.get("url"),
                 "message": commit.get("message"),
@@ -89,9 +89,6 @@ def api_beanstalk_webhook(
     if git_repo:
         if branches is not None and branches.find(payload["branch"]) == -1:
             return json_success(request)
-        # To get a linkable url,
-        for commit in payload["commits"]:
-            commit["author"] = {"username": commit["author"]["name"]}
 
         subject, content = build_message_from_gitlog(
             user_profile,

--- a/zerver/webhooks/beeminder/tests.py
+++ b/zerver/webhooks/beeminder/tests.py
@@ -1,5 +1,4 @@
-from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 
@@ -10,7 +9,7 @@ class BeeminderHookTests(WebhookTestCase):
     WEBHOOK_DIR_NAME = "beeminder"
 
     @patch("zerver.webhooks.beeminder.view.time.time")
-    def test_beeminder_derail(self, time: Any) -> None:
+    def test_beeminder_derail(self, time: MagicMock) -> None:
         time.return_value = 1517739100  # 5.6 hours from fixture value
         expected_topic = "beekeeper"
         expected_message = """
@@ -26,7 +25,7 @@ You are going to derail from goal **gainweight** in **5.6 hours**. You need **+2
         )
 
     @patch("zerver.webhooks.beeminder.view.time.time")
-    def test_beeminder_derail_worried(self, time: Any) -> None:
+    def test_beeminder_derail_worried(self, time: MagicMock) -> None:
         time.return_value = 1517739100  # 5.6 hours from fixture value
         expected_topic = "beekeeper"
         expected_message = """

--- a/zerver/webhooks/beeminder/view.py
+++ b/zerver/webhooks/beeminder/view.py
@@ -1,12 +1,12 @@
 # Webhooks for external integrations.
 import time
-from typing import Any, Dict
 
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import WildValue, check_int, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -17,8 +17,8 @@ MESSAGE_TEMPLATE = (
 )
 
 
-def get_time(payload: Dict[str, Any]) -> Any:
-    losedate = payload["goal"]["losedate"]
+def get_time(payload: WildValue) -> float:
+    losedate = payload["goal"]["losedate"].tame(check_int)
     time_remaining = (losedate - time.time()) / 3600
     return time_remaining
 
@@ -28,12 +28,12 @@ def get_time(payload: Dict[str, Any]) -> Any:
 def api_beeminder_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Any] = REQ(argument_type="body"),
+    payload: WildValue = REQ(argument_type="body", converter=to_wild_value),
 ) -> HttpResponse:
 
-    goal_name = payload["goal"]["slug"]
-    limsum = payload["goal"]["limsum"]
-    pledge = payload["goal"]["pledge"]
+    goal_name = payload["goal"]["slug"].tame(check_string)
+    limsum = payload["goal"]["limsum"].tame(check_string)
+    pledge = payload["goal"]["pledge"].tame(check_int)
     time_remain = get_time(payload)  # time in hours
     # To show user's probable reaction by looking at pledge amount
     if pledge > 0:

--- a/zerver/webhooks/bitbucket/view.py
+++ b/zerver/webhooks/bitbucket/view.py
@@ -1,11 +1,11 @@
-from typing import Any, Mapping, Optional
+from typing import Optional
 
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import authenticated_rest_api_view
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
-from zerver.lib.validator import check_dict
+from zerver.lib.validator import WildValue, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.lib.webhooks.git import TOPIC_WITH_BRANCH_TEMPLATE, get_push_commits_event_message
 from zerver.models import UserProfile
@@ -16,18 +16,22 @@ from zerver.models import UserProfile
 def api_bitbucket_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Mapping[str, Any] = REQ(json_validator=check_dict([])),
+    payload: WildValue = REQ(converter=to_wild_value),
     branches: Optional[str] = REQ(default=None),
 ) -> HttpResponse:
     repository = payload["repository"]
 
     commits = [
         {
-            "name": commit.get("author") or payload.get("user"),
-            "sha": commit.get("raw_node"),
-            "message": commit.get("message"),
+            "name": commit["author"].tame(check_string)
+            if "author" in commit
+            else payload.get("user", "Someone").tame(check_string),
+            "sha": commit["raw_node"].tame(check_string),
+            "message": commit["message"].tame(check_string),
             "url": "{}{}commits/{}".format(
-                payload.get("canon_url"), repository.get("absolute_url"), commit.get("raw_node")
+                payload["canon_url"].tame(check_string),
+                repository["absolute_url"].tame(check_string),
+                commit["raw_node"].tame(check_string),
             ),
         }
         for commit in payload["commits"]
@@ -36,21 +40,21 @@ def api_bitbucket_webhook(
     if len(commits) == 0:
         # Bitbucket doesn't give us enough information to really give
         # a useful message :/
-        subject = repository["name"]
+        subject = repository["name"].tame(check_string)
         content = "{} [force pushed]({}).".format(
-            payload.get("user", "Someone"),
-            payload["canon_url"] + repository["absolute_url"],
+            payload.get("user", "Someone").tame(check_string),
+            payload["canon_url"].tame(check_string) + repository["absolute_url"].tame(check_string),
         )
     else:
-        branch = payload["commits"][-1]["branch"]
+        branch = payload["commits"][-1]["branch"].tame(check_string)
         if branches is not None and branches.find(branch) == -1:
             return json_success(request)
 
-        committer = payload.get("user")
-        content = get_push_commits_event_message(
-            committer if committer is not None else "Someone", None, branch, commits
+        committer = payload.get("user", "Someone").tame(check_string)
+        content = get_push_commits_event_message(committer, None, branch, commits)
+        subject = TOPIC_WITH_BRANCH_TEMPLATE.format(
+            repo=repository["name"].tame(check_string), branch=branch
         )
-        subject = TOPIC_WITH_BRANCH_TEMPLATE.format(repo=repository["name"], branch=branch)
 
     check_send_webhook_message(request, user_profile, subject, content, unquote_url_parameters=True)
     return json_success(request)

--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
+from zerver.lib.validator import wrap_wild_value
 from zerver.webhooks.bitbucket2.view import get_user_info
 
 TOPIC = "Repository name"
@@ -430,7 +431,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         self.assert_json_success(result)
 
     def test_get_user_info(self) -> None:
-        self.assertEqual(get_user_info({}), "Unknown user")
+        self.assertEqual(get_user_info(wrap_wild_value("request", {})), "Unknown user")
 
         dct = dict(
             nickname="alice",
@@ -438,10 +439,10 @@ class Bitbucket2HookTests(WebhookTestCase):
             display_name="Alice Smith",
         )
 
-        self.assertEqual(get_user_info(dct), "Alice Smith")
+        self.assertEqual(get_user_info(wrap_wild_value("request", dct)), "Alice Smith")
         del dct["display_name"]
 
-        self.assertEqual(get_user_info(dct), "alice")
+        self.assertEqual(get_user_info(wrap_wild_value("request", dct)), "alice")
         del dct["nickname"]
 
-        self.assertEqual(get_user_info(dct), "Unknown user")
+        self.assertEqual(get_user_info(wrap_wild_value("request", dct)), "Unknown user")

--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -2,7 +2,7 @@
 import re
 import string
 from functools import partial
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from django.http import HttpRequest, HttpResponse
 from typing_extensions import Protocol
@@ -11,6 +11,7 @@ from zerver.decorator import log_unsupported_webhook_event, webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventType
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import WildValue, check_bool, check_int, check_string, to_wild_value
 from zerver.lib.webhooks.common import (
     check_send_webhook_message,
     validate_extract_webhook_http_header,
@@ -79,7 +80,7 @@ ALL_EVENT_TYPES = [
 def api_bitbucket2_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Any] = REQ(argument_type="body"),
+    payload: WildValue = REQ(argument_type="body", converter=to_wild_value),
     branches: Optional[str] = REQ(default=None),
     user_specified_topic: Optional[str] = REQ("topic", default=None),
 ) -> HttpResponse:
@@ -116,7 +117,7 @@ def api_bitbucket2_webhook(
 
 
 def get_subject_for_branch_specified_events(
-    payload: Dict[str, Any], branch_name: Optional[str] = None
+    payload: WildValue, branch_name: Optional[str] = None
 ) -> str:
     return TOPIC_WITH_BRANCH_TEMPLATE.format(
         repo=get_repository_name(payload["repository"]),
@@ -124,63 +125,62 @@ def get_subject_for_branch_specified_events(
     )
 
 
-def get_push_subjects(payload: Dict[str, Any]) -> List[str]:
+def get_push_subjects(payload: WildValue) -> List[str]:
     subjects_list = []
     for change in payload["push"]["changes"]:
-        potential_tag = (change["new"] or change["old"] or {}).get("type")
+        potential_tag = (change["new"] or change["old"])["type"].tame(check_string)
         if potential_tag == "tag":
-            subjects_list.append(str(get_subject(payload)))
+            subjects_list.append(get_subject(payload))
         else:
             if change.get("new"):
-                branch_name = change["new"]["name"]
+                branch_name = change["new"]["name"].tame(check_string)
             else:
-                branch_name = change["old"]["name"]
-            subjects_list.append(str(get_subject_for_branch_specified_events(payload, branch_name)))
+                branch_name = change["old"]["name"].tame(check_string)
+            subjects_list.append(get_subject_for_branch_specified_events(payload, branch_name))
     return subjects_list
 
 
-def get_subject(payload: Dict[str, Any]) -> str:
-    assert payload["repository"] is not None
+def get_subject(payload: WildValue) -> str:
     return BITBUCKET_TOPIC_TEMPLATE.format(
         repository_name=get_repository_name(payload["repository"])
     )
 
 
-def get_subject_based_on_type(payload: Dict[str, Any], type: str) -> str:
+def get_subject_based_on_type(payload: WildValue, type: str) -> str:
     if type.startswith("pull_request"):
         return TOPIC_WITH_PR_OR_ISSUE_INFO_TEMPLATE.format(
             repo=get_repository_name(payload["repository"]),
             type="PR",
-            id=payload["pullrequest"]["id"],
-            title=payload["pullrequest"]["title"],
+            id=payload["pullrequest"]["id"].tame(check_int),
+            title=payload["pullrequest"]["title"].tame(check_string),
         )
     if type.startswith("issue"):
         return TOPIC_WITH_PR_OR_ISSUE_INFO_TEMPLATE.format(
             repo=get_repository_name(payload["repository"]),
             type="issue",
-            id=payload["issue"]["id"],
-            title=payload["issue"]["title"],
+            id=payload["issue"]["id"].tame(check_int),
+            title=payload["issue"]["title"].tame(check_string),
         )
     assert type != "push"
     return get_subject(payload)
 
 
-def get_type(request: HttpRequest, payload: Dict[str, Any]) -> str:
-    if payload.get("push"):
+def get_type(request: HttpRequest, payload: WildValue) -> str:
+    if "push" in payload:
         return "push"
-    elif payload.get("fork"):
+    elif "fork" in payload:
         return "fork"
-    elif payload.get("comment") and payload.get("commit"):
+    elif "comment" in payload and "commit" in payload:
         return "commit_comment"
-    elif payload.get("commit_status"):
+    elif "commit_status" in payload:
         return "change_commit_status"
-    elif payload.get("issue"):
-        if payload.get("changes"):
+    elif "issue" in payload:
+        if "changes" in payload:
             return "issue_updated"
-        if payload.get("comment"):
+        if "comment" in payload:
             return "issue_commented"
         return "issue_created"
-    elif payload.get("pullrequest"):
+    elif "pullrequest" in payload:
         pull_request_template = "pull_request_{}"
         # Note that we only need the HTTP header to determine pullrequest events.
         # We rely on the payload itself to determine the other ones.
@@ -200,7 +200,7 @@ def get_type(request: HttpRequest, payload: Dict[str, Any]) -> str:
 
 
 class BodyGetter(Protocol):
-    def __call__(self, payload: Dict[str, Any], include_title: bool) -> str:
+    def __call__(self, payload: WildValue, include_title: bool) -> str:
         ...
 
 
@@ -210,65 +210,65 @@ def get_body_based_on_type(
     return GET_SINGLE_MESSAGE_BODY_DEPENDING_ON_TYPE_MAPPER[type]
 
 
-def get_push_bodies(payload: Dict[str, Any]) -> List[str]:
+def get_push_bodies(payload: WildValue) -> List[str]:
     messages_list = []
     for change in payload["push"]["changes"]:
-        potential_tag = (change["new"] or change["old"] or {}).get("type")
+        potential_tag = (change["new"] or change["old"])["type"].tame(check_string)
         if potential_tag == "tag":
             messages_list.append(get_push_tag_body(payload, change))
         # if change['new'] is None, that means a branch was deleted
-        elif change.get("new") is None:
+        elif change["new"].value is None:
             messages_list.append(get_remove_branch_push_body(payload, change))
-        elif change.get("forced"):
+        elif change["forced"].tame(check_bool):
             messages_list.append(get_force_push_body(payload, change))
         else:
             messages_list.append(get_normal_push_body(payload, change))
     return messages_list
 
 
-def get_remove_branch_push_body(payload: Dict[str, Any], change: Dict[str, Any]) -> str:
+def get_remove_branch_push_body(payload: WildValue, change: WildValue) -> str:
     return get_remove_branch_event_message(
         get_actor_info(payload),
-        change["old"]["name"],
+        change["old"]["name"].tame(check_string),
     )
 
 
-def get_force_push_body(payload: Dict[str, Any], change: Dict[str, Any]) -> str:
+def get_force_push_body(payload: WildValue, change: WildValue) -> str:
     return get_force_push_commits_event_message(
         get_actor_info(payload),
-        change["links"]["html"]["href"],
-        change["new"]["name"],
-        change["new"]["target"]["hash"],
+        change["links"]["html"]["href"].tame(check_string),
+        change["new"]["name"].tame(check_string),
+        change["new"]["target"]["hash"].tame(check_string),
     )
 
 
-def get_commit_author_name(commit: Dict[str, Any]) -> str:
-    if commit["author"].get("user"):
+def get_commit_author_name(commit: WildValue) -> str:
+    if "user" in commit["author"]:
         return get_user_info(commit["author"]["user"])
-    return commit["author"]["raw"].split()[0]
+    return commit["author"]["raw"].tame(check_string).split()[0]
 
 
-def get_normal_push_body(payload: Dict[str, Any], change: Dict[str, Any]) -> str:
+def get_normal_push_body(payload: WildValue, change: WildValue) -> str:
     commits_data = [
         {
             "name": get_commit_author_name(commit),
-            "sha": commit.get("hash"),
-            "url": commit.get("links").get("html").get("href"),
-            "message": commit.get("message"),
+            "sha": commit["hash"].tame(check_string),
+            "url": commit["links"]["html"]["href"].tame(check_string),
+            "message": commit["message"].tame(check_string),
         }
         for commit in change["commits"]
     ]
 
     return get_push_commits_event_message(
         get_actor_info(payload),
-        change["links"]["html"]["href"],
-        change["new"]["name"],
+        change["links"]["html"]["href"].tame(check_string),
+        change["new"]["name"].tame(check_string),
         commits_data,
-        is_truncated=change["truncated"],
+        is_truncated=change["truncated"].tame(check_bool),
     )
 
 
-def get_fork_body(payload: Dict[str, Any], include_title: bool) -> str:
+def get_fork_body(payload: WildValue, include_title: bool) -> str:
     return BITBUCKET_FORK_BODY.format(
         actor=get_user_info(payload["actor"]),
         fork_name=get_repository_full_name(payload["fork"]),
@@ -276,20 +276,20 @@ def get_fork_body(payload: Dict[str, Any], include_title: bool) -> str:
     )
 
 
-def get_commit_comment_body(payload: Dict[str, Any], include_title: bool) -> str:
+def get_commit_comment_body(payload: WildValue, include_title: bool) -> str:
     comment = payload["comment"]
-    action = "[commented]({})".format(comment["links"]["html"]["href"])
+    action = "[commented]({})".format(comment["links"]["html"]["href"].tame(check_string))
     return get_commits_comment_action_message(
         get_actor_info(payload),
         action,
-        comment["commit"]["links"]["html"]["href"],
-        comment["commit"]["hash"],
-        comment["content"]["raw"],
+        comment["commit"]["links"]["html"]["href"].tame(check_string),
+        comment["commit"]["hash"].tame(check_string),
+        comment["content"]["raw"].tame(check_string),
     )
 
 
-def get_commit_status_changed_body(payload: Dict[str, Any], include_title: bool) -> str:
-    commit_api_url = payload["commit_status"]["links"]["commit"]["href"]
+def get_commit_status_changed_body(payload: WildValue, include_title: bool) -> str:
+    commit_api_url = payload["commit_status"]["links"]["commit"]["href"].tame(check_string)
     commit_id = commit_api_url.split("/")[-1]
 
     commit_info = "[{short_commit_id}]({repo_url}/commits/{commit_id})".format(
@@ -299,89 +299,95 @@ def get_commit_status_changed_body(payload: Dict[str, Any], include_title: bool)
     )
 
     return BITBUCKET_COMMIT_STATUS_CHANGED_BODY.format(
-        key=payload["commit_status"]["key"],
-        system_url=payload["commit_status"]["url"],
+        key=payload["commit_status"]["key"].tame(check_string),
+        system_url=payload["commit_status"]["url"].tame(check_string),
         commit_info=commit_info,
-        status=payload["commit_status"]["state"],
+        status=payload["commit_status"]["state"].tame(check_string),
     )
 
 
-def get_issue_commented_body(payload: Dict[str, Any], include_title: bool) -> str:
-    action = "[commented]({}) on".format(payload["comment"]["links"]["html"]["href"])
+def get_issue_commented_body(payload: WildValue, include_title: bool) -> str:
+    action = "[commented]({}) on".format(
+        payload["comment"]["links"]["html"]["href"].tame(check_string)
+    )
     return get_issue_action_body(payload, action, include_title)
 
 
-def get_issue_action_body(payload: Dict[str, Any], action: str, include_title: bool) -> str:
+def get_issue_action_body(payload: WildValue, action: str, include_title: bool) -> str:
     issue = payload["issue"]
     assignee = None
     message = None
     if action == "created":
         if issue["assignee"]:
             assignee = get_user_info(issue["assignee"])
-        message = issue["content"]["raw"]
+        message = issue["content"]["raw"].tame(check_string)
 
     return get_issue_event_message(
         get_actor_info(payload),
         action,
-        issue["links"]["html"]["href"],
-        issue["id"],
+        issue["links"]["html"]["href"].tame(check_string),
+        issue["id"].tame(check_int),
         message,
         assignee,
-        title=issue["title"] if include_title else None,
+        title=issue["title"].tame(check_string) if include_title else None,
     )
 
 
-def get_pull_request_action_body(payload: Dict[str, Any], action: str, include_title: bool) -> str:
+def get_pull_request_action_body(payload: WildValue, action: str, include_title: bool) -> str:
     pull_request = payload["pullrequest"]
     return get_pull_request_event_message(
         get_actor_info(payload),
         action,
         get_pull_request_url(pull_request),
-        pull_request.get("id"),
-        title=pull_request["title"] if include_title else None,
+        pull_request["id"].tame(check_int),
+        title=pull_request["title"].tame(check_string) if include_title else None,
     )
 
 
 def get_pull_request_created_or_updated_body(
-    payload: Dict[str, Any], action: str, include_title: bool
+    payload: WildValue, action: str, include_title: bool
 ) -> str:
     pull_request = payload["pullrequest"]
     assignee = None
-    if pull_request.get("reviewers"):
-        assignee = get_user_info(pull_request.get("reviewers")[0])
+    if pull_request["reviewers"]:
+        assignee = get_user_info(pull_request["reviewers"][0])
 
     return get_pull_request_event_message(
         get_actor_info(payload),
         action,
         get_pull_request_url(pull_request),
-        pull_request.get("id"),
-        target_branch=pull_request["source"]["branch"]["name"],
-        base_branch=pull_request["destination"]["branch"]["name"],
-        message=pull_request["description"],
+        pull_request["id"].tame(check_int),
+        target_branch=pull_request["source"]["branch"]["name"].tame(check_string),
+        base_branch=pull_request["destination"]["branch"]["name"].tame(check_string),
+        message=pull_request["description"].tame(check_string),
         assignee=assignee,
-        title=pull_request["title"] if include_title else None,
+        title=pull_request["title"].tame(check_string) if include_title else None,
     )
 
 
 def get_pull_request_comment_created_action_body(
-    payload: Dict[str, Any],
+    payload: WildValue,
     include_title: bool,
 ) -> str:
-    action = "[commented]({})".format(payload["comment"]["links"]["html"]["href"])
+    action = "[commented]({})".format(
+        payload["comment"]["links"]["html"]["href"].tame(check_string)
+    )
     return get_pull_request_comment_action_body(payload, action, include_title)
 
 
 def get_pull_request_deleted_or_updated_comment_action_body(
-    payload: Dict[str, Any],
+    payload: WildValue,
     action: str,
     include_title: bool,
 ) -> str:
-    action = "{} a [comment]({})".format(action, payload["comment"]["links"]["html"]["href"])
+    action = "{} a [comment]({})".format(
+        action, payload["comment"]["links"]["html"]["href"].tame(check_string)
+    )
     return get_pull_request_comment_action_body(payload, action, include_title)
 
 
 def get_pull_request_comment_action_body(
-    payload: Dict[str, Any],
+    payload: WildValue,
     action: str,
     include_title: bool,
 ) -> str:
@@ -389,14 +395,14 @@ def get_pull_request_comment_action_body(
     return get_pull_request_event_message(
         get_actor_info(payload),
         action,
-        payload["pullrequest"]["links"]["html"]["href"],
-        payload["pullrequest"]["id"],
-        message=payload["comment"]["content"]["raw"],
-        title=payload["pullrequest"]["title"] if include_title else None,
+        payload["pullrequest"]["links"]["html"]["href"].tame(check_string),
+        payload["pullrequest"]["id"].tame(check_int),
+        message=payload["comment"]["content"]["raw"].tame(check_string),
+        title=payload["pullrequest"]["title"].tame(check_string) if include_title else None,
     )
 
 
-def get_push_tag_body(payload: Dict[str, Any], change: Dict[str, Any]) -> str:
+def get_push_tag_body(payload: WildValue, change: WildValue) -> str:
     if change.get("new"):
         tag = change["new"]
         action = "pushed"
@@ -406,8 +412,8 @@ def get_push_tag_body(payload: Dict[str, Any], change: Dict[str, Any]) -> str:
 
     return get_push_tag_event_message(
         get_actor_info(payload),
-        tag.get("name"),
-        tag_url=tag["links"]["html"].get("href"),
+        tag["name"].tame(check_string),
+        tag_url=tag["links"]["html"]["href"].tame(check_string),
         action=action,
     )
 
@@ -419,10 +425,10 @@ def append_punctuation(title: str, message: str) -> str:
     return message
 
 
-def get_repo_updated_body(payload: Dict[str, Any], include_title: bool) -> str:
+def get_repo_updated_body(payload: WildValue, include_title: bool) -> str:
     changes = ["website", "name", "links", "language", "full_name", "description"]
     body = ""
-    repo_name = payload["repository"]["name"]
+    repo_name = payload["repository"]["name"].tame(check_string)
     actor = get_actor_info(payload)
 
     for change in changes:
@@ -435,49 +441,49 @@ def get_repo_updated_body(payload: Dict[str, Any], include_title: bool) -> str:
                 actor=actor,
                 change=change,
                 repo_name=repo_name,
-                old=old,
-                new=new,
+                old=str(old.value),
+                new=str(new.value),
             )
-            message = append_punctuation(str(new), message) + "\n"
+            message = append_punctuation(str(new.value), message) + "\n"
             body += message
         elif new and not old:
             message = BITBUCKET_REPO_UPDATED_ADDED.format(
                 actor=actor,
                 change=change,
                 repo_name=repo_name,
-                new=new,
+                new=str(new.value),
             )
-            message = append_punctuation(str(new), message) + "\n"
+            message = append_punctuation(str(new.value), message) + "\n"
             body += message
 
     return body
 
 
-def get_pull_request_url(pullrequest_payload: Dict[str, Any]) -> str:
-    return pullrequest_payload["links"]["html"]["href"]
+def get_pull_request_url(pullrequest_payload: WildValue) -> str:
+    return pullrequest_payload["links"]["html"]["href"].tame(check_string)
 
 
-def get_repository_url(repository_payload: Dict[str, Any]) -> str:
-    return repository_payload["links"]["html"]["href"]
+def get_repository_url(repository_payload: WildValue) -> str:
+    return repository_payload["links"]["html"]["href"].tame(check_string)
 
 
-def get_repository_name(repository_payload: Dict[str, Any]) -> str:
-    return repository_payload["name"]
+def get_repository_name(repository_payload: WildValue) -> str:
+    return repository_payload["name"].tame(check_string)
 
 
-def get_repository_full_name(repository_payload: Dict[str, Any]) -> str:
-    return repository_payload["full_name"]
+def get_repository_full_name(repository_payload: WildValue) -> str:
+    return repository_payload["full_name"].tame(check_string)
 
 
-def get_user_info(dct: Dict[str, Any]) -> str:
+def get_user_info(dct: WildValue) -> str:
     # See https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/
     # Since GDPR, we don't get username; instead, we either get display_name
     # or nickname.
     if "display_name" in dct:
-        return dct["display_name"]
+        return dct["display_name"].tame(check_string)
 
     if "nickname" in dct:
-        return dct["nickname"]
+        return dct["nickname"].tame(check_string)
 
     # We call this an unsupported_event, even though we
     # are technically still sending a message.
@@ -488,18 +494,18 @@ def get_user_info(dct: Dict[str, Any]) -> str:
     return "Unknown user"
 
 
-def get_actor_info(payload: Dict[str, Any]) -> str:
+def get_actor_info(payload: WildValue) -> str:
     actor = payload["actor"]
     return get_user_info(actor)
 
 
-def get_branch_name_for_push_event(payload: Dict[str, Any]) -> Optional[str]:
+def get_branch_name_for_push_event(payload: WildValue) -> Optional[str]:
     change = payload["push"]["changes"][-1]
-    potential_tag = (change["new"] or change["old"] or {}).get("type")
+    potential_tag = (change["new"] or change["old"])["type"].tame(check_string)
     if potential_tag == "tag":
         return None
     else:
-        return (change["new"] or change["old"]).get("name")
+        return (change["new"] or change["old"])["name"].tame(check_string)
 
 
 GET_SINGLE_MESSAGE_BODY_DEPENDING_ON_TYPE_MAPPER: Dict[str, BodyGetter] = {

--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -438,7 +438,7 @@ def get_repo_updated_body(payload: Dict[str, Any], include_title: bool) -> str:
                 old=old,
                 new=new,
             )
-            message = append_punctuation(new, message) + "\n"
+            message = append_punctuation(str(new), message) + "\n"
             body += message
         elif new and not old:
             message = BITBUCKET_REPO_UPDATED_ADDED.format(
@@ -447,7 +447,7 @@ def get_repo_updated_body(payload: Dict[str, Any], include_title: bool) -> str:
                 repo_name=repo_name,
                 new=new,
             )
-            message = append_punctuation(new, message) + "\n"
+            message = append_punctuation(str(new), message) + "\n"
             body += message
 
     return body

--- a/zerver/webhooks/bitbucket3/view.py
+++ b/zerver/webhooks/bitbucket3/view.py
@@ -1,6 +1,6 @@
 import string
 from functools import partial
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from django.http import HttpRequest, HttpResponse
 from typing_extensions import Protocol
@@ -9,6 +9,7 @@ from zerver.decorator import webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventType
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import WildValue, check_int, check_none_or, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.lib.webhooks.git import (
     CONTENT_MESSAGE_TEMPLATE,
@@ -59,15 +60,16 @@ def fixture_to_headers(fixture_name: str) -> Dict[str, str]:
     return {}
 
 
-def get_user_name(payload: Dict[str, Any]) -> str:
+def get_user_name(payload: WildValue) -> str:
     user_name = "[{name}]({url})".format(
-        name=payload["actor"]["name"], url=payload["actor"]["links"]["self"][0]["href"]
+        name=payload["actor"]["name"].tame(check_string),
+        url=payload["actor"]["links"]["self"][0]["href"].tame(check_string),
     )
     return user_name
 
 
 def ping_handler(
-    payload: Dict[str, Any],
+    payload: WildValue,
     branches: Optional[str],
     include_title: Optional[str],
 ) -> List[Dict[str, str]]:
@@ -80,17 +82,19 @@ def ping_handler(
 
 
 def repo_comment_handler(
-    payload: Dict[str, Any],
+    payload: WildValue,
     action: str,
     branches: Optional[str],
     include_title: Optional[str],
 ) -> List[Dict[str, str]]:
-    repo_name = payload["repository"]["name"]
+    repo_name = payload["repository"]["name"].tame(check_string)
     subject = BITBUCKET_TOPIC_TEMPLATE.format(repository_name=repo_name)
-    sha = payload["commit"]
-    commit_url = payload["repository"]["links"]["self"][0]["href"][: -len("browse")]
+    sha = payload["commit"].tame(check_string)
+    commit_url = payload["repository"]["links"]["self"][0]["href"].tame(check_string)[
+        : -len("browse")
+    ]
     commit_url += f"commits/{sha}"
-    message = payload["comment"]["text"]
+    message = payload["comment"]["text"].tame(check_string)
     if action == "deleted their comment":
         message = f"~~{message}~~"
     body = get_commits_comment_action_message(
@@ -104,33 +108,35 @@ def repo_comment_handler(
 
 
 def repo_forked_handler(
-    payload: Dict[str, Any],
+    payload: WildValue,
     branches: Optional[str],
     include_title: Optional[str],
 ) -> List[Dict[str, str]]:
-    repo_name = payload["repository"]["origin"]["name"]
+    repo_name = payload["repository"]["origin"]["name"].tame(check_string)
     subject = BITBUCKET_TOPIC_TEMPLATE.format(repository_name=repo_name)
     body = BITBUCKET_FORK_BODY.format(
-        display_name=payload["actor"]["displayName"],
+        display_name=payload["actor"]["displayName"].tame(check_string),
         username=get_user_name(payload),
-        fork_name=payload["repository"]["name"],
-        fork_url=payload["repository"]["links"]["self"][0]["href"],
+        fork_name=payload["repository"]["name"].tame(check_string),
+        fork_url=payload["repository"]["links"]["self"][0]["href"].tame(check_string),
     )
     return [{"subject": subject, "body": body}]
 
 
 def repo_modified_handler(
-    payload: Dict[str, Any],
+    payload: WildValue,
     branches: Optional[str],
     include_title: Optional[str],
 ) -> List[Dict[str, str]]:
-    subject_new = BITBUCKET_TOPIC_TEMPLATE.format(repository_name=payload["new"]["name"])
-    new_name = payload["new"]["name"]
+    subject_new = BITBUCKET_TOPIC_TEMPLATE.format(
+        repository_name=payload["new"]["name"].tame(check_string)
+    )
+    new_name = payload["new"]["name"].tame(check_string)
     body = BITBUCKET_REPO_UPDATED_CHANGED.format(
         actor=get_user_name(payload),
         change="name",
-        repo_name=payload["old"]["name"],
-        old=payload["old"]["name"],
+        repo_name=payload["old"]["name"].tame(check_string),
+        old=payload["old"]["name"].tame(check_string),
         new=new_name,
     )  # As of writing this, the only change we'd be notified about is a name change.
     punctuation = "." if new_name[-1] not in string.punctuation else ""
@@ -138,12 +144,12 @@ def repo_modified_handler(
     return [{"subject": subject_new, "body": body}]
 
 
-def repo_push_branch_data(payload: Dict[str, Any], change: Dict[str, Any]) -> Dict[str, str]:
-    event_type = change["type"]
-    repo_name = payload["repository"]["name"]
+def repo_push_branch_data(payload: WildValue, change: WildValue) -> Dict[str, str]:
+    event_type = change["type"].tame(check_string)
+    repo_name = payload["repository"]["name"].tame(check_string)
     user_name = get_user_name(payload)
-    branch_name = change["ref"]["displayId"]
-    branch_head = change["toHash"]
+    branch_name = change["ref"]["displayId"].tame(check_string)
+    branch_head = change["toHash"].tame(check_string)
 
     if event_type == "ADD":
         body = get_create_branch_event_message(
@@ -160,24 +166,24 @@ def repo_push_branch_data(payload: Dict[str, Any], change: Dict[str, Any]) -> Di
     elif event_type == "DELETE":
         body = get_remove_branch_event_message(user_name, branch_name)
     else:
-        message = "{}.{}".format(payload["eventKey"], event_type)  # nocoverage
+        message = "{}.{}".format(payload["eventKey"].tame(check_string), event_type)  # nocoverage
         raise UnsupportedWebhookEventType(message)
 
     subject = TOPIC_WITH_BRANCH_TEMPLATE.format(repo=repo_name, branch=branch_name)
     return {"subject": subject, "body": body}
 
 
-def repo_push_tag_data(payload: Dict[str, Any], change: Dict[str, Any]) -> Dict[str, str]:
-    event_type = change["type"]
-    repo_name = payload["repository"]["name"]
-    tag_name = change["ref"]["displayId"]
+def repo_push_tag_data(payload: WildValue, change: WildValue) -> Dict[str, str]:
+    event_type = change["type"].tame(check_string)
+    repo_name = payload["repository"]["name"].tame(check_string)
+    tag_name = change["ref"]["displayId"].tame(check_string)
 
     if event_type == "ADD":
         action = "pushed"
     elif event_type == "DELETE":
         action = "removed"
     else:
-        message = "{}.{}".format(payload["eventKey"], event_type)  # nocoverage
+        message = "{}.{}".format(payload["eventKey"].tame(check_string), event_type)  # nocoverage
         raise UnsupportedWebhookEventType(message)
 
     subject = BITBUCKET_TOPIC_TEMPLATE.format(repository_name=repo_name)
@@ -186,15 +192,15 @@ def repo_push_tag_data(payload: Dict[str, Any], change: Dict[str, Any]) -> Dict[
 
 
 def repo_push_handler(
-    payload: Dict[str, Any],
+    payload: WildValue,
     branches: Optional[str],
     include_title: Optional[str],
 ) -> List[Dict[str, str]]:
     data = []
     for change in payload["changes"]:
-        event_target_type = change["ref"]["type"]
+        event_target_type = change["ref"]["type"].tame(check_string)
         if event_target_type == "BRANCH":
-            branch = change["ref"]["displayId"]
+            branch = change["ref"]["displayId"].tame(check_string)
             if branches:
                 if branch not in branches:
                     continue
@@ -202,16 +208,18 @@ def repo_push_handler(
         elif event_target_type == "TAG":
             data.append(repo_push_tag_data(payload, change))
         else:
-            message = "{}.{}".format(payload["eventKey"], event_target_type)  # nocoverage
+            message = "{}.{}".format(
+                payload["eventKey"].tame(check_string), event_target_type
+            )  # nocoverage
             raise UnsupportedWebhookEventType(message)
     return data
 
 
-def get_assignees_string(pr: Dict[str, Any]) -> Optional[str]:
+def get_assignees_string(pr: WildValue) -> Optional[str]:
     reviewers = []
     for reviewer in pr["reviewers"]:
-        name = reviewer["user"]["name"]
-        link = reviewer["user"]["links"]["self"][0]["href"]
+        name = reviewer["user"]["name"].tame(check_string)
+        link = reviewer["user"]["links"]["self"][0]["href"].tame(check_string)
         reviewers.append(f"[{name}]({link})")
     if len(reviewers) == 0:
         assignees = None
@@ -222,26 +230,26 @@ def get_assignees_string(pr: Dict[str, Any]) -> Optional[str]:
     return assignees
 
 
-def get_pr_subject(repo: str, type: str, id: str, title: str) -> str:
+def get_pr_subject(repo: str, type: str, id: int, title: str) -> str:
     return TOPIC_WITH_PR_OR_ISSUE_INFO_TEMPLATE.format(repo=repo, type=type, id=id, title=title)
 
 
-def get_simple_pr_body(payload: Dict[str, Any], action: str, include_title: Optional[str]) -> str:
+def get_simple_pr_body(payload: WildValue, action: str, include_title: Optional[str]) -> str:
     pr = payload["pullRequest"]
     return get_pull_request_event_message(
         user_name=get_user_name(payload),
         action=action,
-        url=pr["links"]["self"][0]["href"],
-        number=pr["id"],
-        title=pr["title"] if include_title else None,
+        url=pr["links"]["self"][0]["href"].tame(check_string),
+        number=pr["id"].tame(check_int),
+        title=pr["title"].tame(check_string) if include_title else None,
     )
 
 
 def get_pr_opened_or_modified_body(
-    payload: Dict[str, Any], action: str, include_title: Optional[str]
+    payload: WildValue, action: str, include_title: Optional[str]
 ) -> str:
     pr = payload["pullRequest"]
-    description = pr.get("description")
+    description = pr.get("description").tame(check_none_or(check_string))
     assignees_string = get_assignees_string(pr)
     if assignees_string:
         # Then use the custom message template for this particular integration so that we can
@@ -249,13 +257,13 @@ def get_pr_opened_or_modified_body(
         parameters = {
             "user_name": get_user_name(payload),
             "action": action,
-            "url": pr["links"]["self"][0]["href"],
-            "number": pr["id"],
-            "source": pr["fromRef"]["displayId"],
-            "destination": pr["toRef"]["displayId"],
+            "url": pr["links"]["self"][0]["href"].tame(check_string),
+            "number": pr["id"].tame(check_int),
+            "source": pr["fromRef"]["displayId"].tame(check_string),
+            "destination": pr["toRef"]["displayId"].tame(check_string),
             "message": description,
             "assignees": assignees_string,
-            "title": pr["title"] if include_title else None,
+            "title": pr["title"].tame(check_string) if include_title else None,
         }
         if include_title:
             body = PULL_REQUEST_OPENED_OR_MODIFIED_TEMPLATE_WITH_REVIEWERS_WITH_TITLE.format(
@@ -271,76 +279,79 @@ def get_pr_opened_or_modified_body(
     return get_pull_request_event_message(
         user_name=get_user_name(payload),
         action=action,
-        url=pr["links"]["self"][0]["href"],
-        number=pr["id"],
-        target_branch=pr["fromRef"]["displayId"],
-        base_branch=pr["toRef"]["displayId"],
-        message=pr.get("description"),
+        url=pr["links"]["self"][0]["href"].tame(check_string),
+        number=pr["id"].tame(check_int),
+        target_branch=pr["fromRef"]["displayId"].tame(check_string),
+        base_branch=pr["toRef"]["displayId"].tame(check_string),
+        message=description,
         assignee=assignees_string if assignees_string else None,
-        title=pr["title"] if include_title else None,
+        title=pr["title"].tame(check_string) if include_title else None,
     )
 
 
-def get_pr_needs_work_body(payload: Dict[str, Any], include_title: Optional[str]) -> str:
+def get_pr_needs_work_body(payload: WildValue, include_title: Optional[str]) -> str:
     pr = payload["pullRequest"]
     if not include_title:
         return PULL_REQUEST_MARKED_AS_NEEDS_WORK_TEMPLATE.format(
             user_name=get_user_name(payload),
-            number=pr["id"],
-            url=pr["links"]["self"][0]["href"],
+            number=pr["id"].tame(check_int),
+            url=pr["links"]["self"][0]["href"].tame(check_string),
         )
     return PULL_REQUEST_MARKED_AS_NEEDS_WORK_TEMPLATE_WITH_TITLE.format(
         user_name=get_user_name(payload),
-        number=pr["id"],
-        url=pr["links"]["self"][0]["href"],
-        title=pr["title"],
+        number=pr["id"].tame(check_int),
+        url=pr["links"]["self"][0]["href"].tame(check_string),
+        title=pr["title"].tame(check_string),
     )
 
 
-def get_pr_reassigned_body(payload: Dict[str, Any], include_title: Optional[str]) -> str:
+def get_pr_reassigned_body(payload: WildValue, include_title: Optional[str]) -> str:
     pr = payload["pullRequest"]
     assignees_string = get_assignees_string(pr)
     if not assignees_string:
         if not include_title:
             return PULL_REQUEST_REASSIGNED_TO_NONE_TEMPLATE.format(
                 user_name=get_user_name(payload),
-                number=pr["id"],
-                url=pr["links"]["self"][0]["href"],
+                number=pr["id"].tame(check_int),
+                url=pr["links"]["self"][0]["href"].tame(check_string),
             )
-        punctuation = "." if pr["title"][-1] not in string.punctuation else ""
+        punctuation = "." if pr["title"].tame(check_string)[-1] not in string.punctuation else ""
         message = PULL_REQUEST_REASSIGNED_TO_NONE_TEMPLATE_WITH_TITLE.format(
             user_name=get_user_name(payload),
-            number=pr["id"],
-            url=pr["links"]["self"][0]["href"],
-            title=pr["title"],
+            number=pr["id"].tame(check_int),
+            url=pr["links"]["self"][0]["href"].tame(check_string),
+            title=pr["title"].tame(check_string),
         )
         message = f"{message}{punctuation}"
         return message
     if not include_title:
         return PULL_REQUEST_REASSIGNED_TEMPLATE.format(
             user_name=get_user_name(payload),
-            number=pr["id"],
-            url=pr["links"]["self"][0]["href"],
+            number=pr["id"].tame(check_int),
+            url=pr["links"]["self"][0]["href"].tame(check_string),
             assignees=assignees_string,
         )
     return PULL_REQUEST_REASSIGNED_TEMPLATE_WITH_TITLE.format(
         user_name=get_user_name(payload),
-        number=pr["id"],
-        url=pr["links"]["self"][0]["href"],
+        number=pr["id"].tame(check_int),
+        url=pr["links"]["self"][0]["href"].tame(check_string),
         assignees=assignees_string,
-        title=pr["title"],
+        title=pr["title"].tame(check_string),
     )
 
 
 def pr_handler(
-    payload: Dict[str, Any],
+    payload: WildValue,
     action: str,
     branches: Optional[str],
     include_title: Optional[str],
 ) -> List[Dict[str, str]]:
     pr = payload["pullRequest"]
     subject = get_pr_subject(
-        pr["toRef"]["repository"]["name"], type="PR", id=pr["id"], title=pr["title"]
+        pr["toRef"]["repository"]["name"].tame(check_string),
+        type="PR",
+        id=pr["id"].tame(check_int),
+        title=pr["title"].tame(check_string),
     )
     if action in ["opened", "modified"]:
         body = get_pr_opened_or_modified_body(payload, action, include_title)
@@ -355,25 +366,28 @@ def pr_handler(
 
 
 def pr_comment_handler(
-    payload: Dict[str, Any],
+    payload: WildValue,
     action: str,
     branches: Optional[str],
     include_title: Optional[str],
 ) -> List[Dict[str, str]]:
     pr = payload["pullRequest"]
     subject = get_pr_subject(
-        pr["toRef"]["repository"]["name"], type="PR", id=pr["id"], title=pr["title"]
+        pr["toRef"]["repository"]["name"].tame(check_string),
+        type="PR",
+        id=pr["id"].tame(check_int),
+        title=pr["title"].tame(check_string),
     )
-    message = payload["comment"]["text"]
+    message = payload["comment"]["text"].tame(check_string)
     if action == "deleted their comment on":
         message = f"~~{message}~~"
     body = get_pull_request_event_message(
         user_name=get_user_name(payload),
         action=action,
-        url=pr["links"]["self"][0]["href"],
-        number=pr["id"],
+        url=pr["links"]["self"][0]["href"].tame(check_string),
+        number=pr["id"].tame(check_int),
         message=message,
-        title=pr["title"] if include_title else None,
+        title=pr["title"].tame(check_string) if include_title else None,
     )
 
     return [{"subject": subject, "body": body}]
@@ -381,7 +395,7 @@ def pr_comment_handler(
 
 class EventHandler(Protocol):
     def __call__(
-        self, payload: Dict[str, Any], branches: Optional[str], include_title: Optional[str]
+        self, payload: WildValue, branches: Optional[str], include_title: Optional[str]
     ) -> List[Dict[str, str]]:
         ...
 
@@ -416,13 +430,13 @@ ALL_EVENT_TYPES = list(EVENT_HANDLER_MAP.keys())
 def api_bitbucket3_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Any] = REQ(argument_type="body"),
+    payload: WildValue = REQ(argument_type="body", converter=to_wild_value),
     branches: Optional[str] = REQ(default=None),
     user_specified_topic: Optional[str] = REQ("topic", default=None),
 ) -> HttpResponse:
-    try:
-        eventkey = payload["eventKey"]
-    except KeyError:
+    if "eventKey" in payload:
+        eventkey = payload["eventKey"].tame(check_string)
+    else:
         eventkey = request.META["HTTP_X_EVENT_KEY"]
     handler = EVENT_HANDLER_MAP.get(eventkey)
     if handler is None:

--- a/zerver/webhooks/canarytoken/view.py
+++ b/zerver/webhooks/canarytoken/view.py
@@ -1,11 +1,12 @@
 # Webhooks for external integrations.
-from typing import Any, Dict, Optional
+from typing import Optional
 
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import WildValue, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -15,7 +16,7 @@ from zerver.models import UserProfile
 def api_canarytoken_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    message: Dict[str, Any] = REQ(argument_type="body"),
+    message: WildValue = REQ(argument_type="body", converter=to_wild_value),
     user_specified_topic: Optional[str] = REQ("topic", default=None),
 ) -> HttpResponse:
     """
@@ -28,9 +29,9 @@ def api_canarytoken_webhook(
     """
     topic = "canarytoken alert"
     body = (
-        f"**:alert: Canarytoken has been triggered on {message['time']}!**\n\n"
-        f"{message['memo']} \n\n"
-        f"[Manage this canarytoken]({message['manage_url']})"
+        f"**:alert: Canarytoken has been triggered on {message['time'].tame(check_string)}!**\n\n"
+        f"{message['memo'].tame(check_string)} \n\n"
+        f"[Manage this canarytoken]({message['manage_url'].tame(check_string)})"
     )
 
     if user_specified_topic:

--- a/zerver/webhooks/circleci/view.py
+++ b/zerver/webhooks/circleci/view.py
@@ -1,10 +1,9 @@
-from typing import Any, Dict
-
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import WildValue, check_int, check_none_or, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -22,7 +21,7 @@ ALL_EVENT_TYPES = list(outcome_to_formatted_status_map.keys())
 def api_circleci_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Any] = REQ(argument_type="body"),
+    payload: WildValue = REQ(argument_type="body", converter=to_wild_value),
 ) -> HttpResponse:
     payload = payload["payload"]
     subject = get_subject(payload)
@@ -33,64 +32,65 @@ def api_circleci_webhook(
         user_profile,
         subject,
         body,
-        payload.get("status") if not payload.get("build_num") else payload.get("outcome"),
+        payload["status"].tame(check_string)
+        if "build_num" not in payload
+        else payload["outcome"].tame(check_string),
     )
     return json_success(request)
 
 
-def get_subject(payload: Dict[str, Any]) -> str:
-    repository_name = payload["reponame"]
-    return f"{repository_name}"
+def get_subject(payload: WildValue) -> str:
+    return payload["reponame"].tame(check_string)
 
 
-def get_commit_range_info(payload: Dict[str, Any]) -> str:
+def get_commit_range_info(payload: WildValue) -> str:
     commits = payload["all_commit_details"]
     num_commits = len(commits)
 
     if num_commits == 1:
-        commit_id = commits[0]["commit"][:10]
-        commit_url = commits[0]["commit_url"]
+        commit_id = commits[0]["commit"].tame(check_string)[:10]
+        commit_url = commits[0]["commit_url"].tame(check_string)
         return f"- **Commit:** [{commit_id}]({commit_url})"
 
-    vcs_provider = payload["user"]["vcs_type"]  # Same as payload["why"]?
-    first_commit_id = commits[0]["commit"]
+    vcs_provider = payload["user"]["vcs_type"].tame(check_string)  # Same as payload["why"]?
+    first_commit_id = commits[0]["commit"].tame(check_string)
     shortened_first_commit_id = first_commit_id[:10]
-    last_commit_id = commits[-1]["commit"]
+    last_commit_id = commits[-1]["commit"].tame(check_string)
     shortened_last_commit_id = last_commit_id[:10]
     if vcs_provider == "github":
         # Then use GitHub's commit range feature to form the appropriate url.
-        vcs_url = payload["vcs_url"]
+        vcs_url = payload["vcs_url"].tame(check_string)
         commit_range_url = f"{vcs_url}/compare/{first_commit_id}...{last_commit_id}"
         return f"- **Commits ({num_commits}):** [{shortened_first_commit_id} ... {shortened_last_commit_id}]({commit_range_url})"
     else:
         # Bitbucket doesn't have a good commit range URL feature like GitHub does.
         # So let's just show the two separately.
         # https://community.atlassian.com/t5/Bitbucket-questions/BitBucket-4-14-diff-between-any-two-commits/qaq-p/632974
-        first_commit_url = commits[0]["commit_url"]
-        last_commit_url = commits[-1]["commit_url"]
+        first_commit_url = commits[0]["commit_url"].tame(check_string)
+        last_commit_url = commits[-1]["commit_url"].tame(check_string)
         return f"- **Commits ({num_commits}):** [{shortened_first_commit_id}]({first_commit_url}) ... [{shortened_last_commit_id}]({last_commit_url})"
 
 
-def get_authors_and_committer_info(payload: Dict[str, Any]) -> str:
+def get_authors_and_committer_info(payload: WildValue) -> str:
     body = ""
 
     author_names = set()
     committer_names = set()
     for commit in payload["all_commit_details"]:
-        author_name = commit["author_name"]
-        author_username = commit["author_login"]
-        if author_username:
+        author_name = commit["author_name"].tame(check_string)
+        author_username = commit["author_login"].tame(check_none_or(check_string))
+        if author_username is not None:
             author_names.add(f"{author_name} ({author_username})")
         else:
-            author_names.add(commit["author_name"])
+            author_names.add(author_name)
 
-        if commit.get("committer_email", None):
-            committer_name = commit["committer_name"]
-            committer_username = commit["committer_login"]
-            if committer_username:
+        if commit["committer_email"].tame(check_none_or(check_string)) is not None:
+            committer_name = commit["committer_name"].tame(check_string)
+            committer_username = commit["committer_login"].tame(check_none_or(check_string))
+            if committer_username is not None:
                 committer_names.add(f"{committer_name} ({committer_username})")
             else:
-                committer_names.add(commit["committer_name"])
+                committer_names.add(committer_name)
 
     author_names_list = list(author_names)
     author_names_list.sort()
@@ -115,33 +115,33 @@ def get_authors_and_committer_info(payload: Dict[str, Any]) -> str:
     return body
 
 
-def super_minimal_body(payload: Dict[str, Any]) -> str:
-    branch_name = payload["branch"]
-    status = payload["status"]
+def super_minimal_body(payload: WildValue) -> str:
+    branch_name = payload["branch"].tame(check_string)
+    status = payload["status"].tame(check_string)
     formatted_status = outcome_to_formatted_status_map.get(status, status)
-    build_url = payload["build_url"]
-    username = payload["username"]
+    build_url = payload["build_url"].tame(check_string)
+    username = payload["username"].tame(check_string)
     return f"[Build]({build_url}) triggered by {username} on branch `{branch_name}` {formatted_status}."
 
 
-def get_body(payload: Dict[str, Any]) -> str:
-    build_num = payload.get("build_num", None)
-    if not build_num:
+def get_body(payload: WildValue) -> str:
+    if "build_num" not in payload:
         return super_minimal_body(payload)
 
-    build_url = payload["build_url"]
+    build_num = payload["build_num"].tame(check_int)
+    build_url = payload["build_url"].tame(check_string)
 
-    outcome = payload["outcome"]
+    outcome = payload["outcome"].tame(check_string)
     formatted_status = outcome_to_formatted_status_map.get(outcome, outcome)
 
-    branch_name = payload["branch"]
-    workflow_name = payload["workflows"]["workflow_name"]
-    job_name = payload["workflows"]["job_name"]
+    branch_name = payload["branch"].tame(check_string)
+    workflow_name = payload["workflows"]["workflow_name"].tame(check_string)
+    job_name = payload["workflows"]["job_name"].tame(check_string)
 
     commit_range_info = get_commit_range_info(payload)
     pull_request_info = ""
     if len(payload["pull_requests"]) > 0:
-        pull_request_url = payload["pull_requests"][0]["url"]
+        pull_request_url = payload["pull_requests"][0]["url"].tame(check_string)
         pull_request_info = f"- **Pull request:** {pull_request_url}"
     authors_and_committers_info = get_authors_and_committer_info(payload)
 

--- a/zerver/webhooks/codeship/view.py
+++ b/zerver/webhooks/codeship/view.py
@@ -1,11 +1,10 @@
 # Webhooks for external integrations.
-from typing import Any, Dict
-
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import WildValue, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -27,7 +26,7 @@ CODESHIP_STATUS_MAPPER = {
 def api_codeship_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Any] = REQ(argument_type="body"),
+    payload: WildValue = REQ(argument_type="body", converter=to_wild_value),
 ) -> HttpResponse:
     payload = payload["build"]
     subject = get_subject_for_http_request(payload)
@@ -37,21 +36,23 @@ def api_codeship_webhook(
     return json_success(request)
 
 
-def get_subject_for_http_request(payload: Dict[str, Any]) -> str:
-    return CODESHIP_TOPIC_TEMPLATE.format(project_name=payload["project_name"])
+def get_subject_for_http_request(payload: WildValue) -> str:
+    return CODESHIP_TOPIC_TEMPLATE.format(
+        project_name=payload["project_name"].tame(check_string),
+    )
 
 
-def get_body_for_http_request(payload: Dict[str, Any]) -> str:
+def get_body_for_http_request(payload: WildValue) -> str:
     return CODESHIP_MESSAGE_TEMPLATE.format(
-        build_url=payload["build_url"],
-        committer=payload["committer"],
-        branch=payload["branch"],
+        build_url=payload["build_url"].tame(check_string),
+        committer=payload["committer"].tame(check_string),
+        branch=payload["branch"].tame(check_string),
         status=get_status_message(payload),
     )
 
 
-def get_status_message(payload: Dict[str, Any]) -> str:
-    build_status = payload["status"]
+def get_status_message(payload: WildValue) -> str:
+    build_status = payload["status"].tame(check_string)
     return CODESHIP_STATUS_MAPPER.get(
         build_status, CODESHIP_DEFAULT_STATUS.format(status=build_status)
     )

--- a/zerver/webhooks/crashlytics/view.py
+++ b/zerver/webhooks/crashlytics/view.py
@@ -1,11 +1,10 @@
 # Webhooks for external integrations.
-from typing import Any, Dict
-
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import WildValue, check_int, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -23,7 +22,7 @@ VERIFICATION_EVENT = "verification"
 def api_crashlytics_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Any] = REQ(argument_type="body"),
+    payload: WildValue = REQ(argument_type="body", converter=to_wild_value),
 ) -> HttpResponse:
     event = payload["event"]
     if event == VERIFICATION_EVENT:
@@ -32,12 +31,12 @@ def api_crashlytics_webhook(
     else:
         issue_body = payload["payload"]
         subject = CRASHLYTICS_TOPIC_TEMPLATE.format(
-            display_id=issue_body["display_id"],
-            title=issue_body["title"],
+            display_id=issue_body["display_id"].tame(check_int),
+            title=issue_body["title"].tame(check_string),
         )
         body = CRASHLYTICS_MESSAGE_TEMPLATE.format(
-            impacted_devices_count=issue_body["impacted_devices_count"],
-            url=issue_body["url"],
+            impacted_devices_count=issue_body["impacted_devices_count"].tame(check_int),
+            url=issue_body["url"].tame(check_string),
         )
 
     check_send_webhook_message(request, user_profile, subject, body)

--- a/zerver/webhooks/hellosign/view.py
+++ b/zerver/webhooks/hellosign/view.py
@@ -1,11 +1,11 @@
 from typing import Any, Dict, List
 
-import orjson
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import check_dict
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -14,7 +14,7 @@ WAS_JUST_SIGNED_BY = "was just signed by {signed_recipients}"
 BODY = "The `{contract_title}` document {actions}."
 
 
-def get_message_body(payload: Dict[str, Dict[str, Any]]) -> str:
+def get_message_body(payload: Dict[str, Any]) -> str:
     contract_title = payload["signature_request"]["title"]
     recipients: Dict[str, List[str]] = {}
     signatures = payload["signature_request"]["signatures"]
@@ -59,7 +59,7 @@ def get_recipients_text(recipients: List[str]) -> str:
 def api_hellosign_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Dict[str, Any]] = REQ(whence="json", converter=orjson.loads),
+    payload: Dict[str, Any] = REQ(whence="json", json_validator=check_dict()),
 ) -> HttpResponse:
     if "signature_request" in payload:
         body = get_message_body(payload)

--- a/zerver/webhooks/librato/view.py
+++ b/zerver/webhooks/librato/view.py
@@ -9,6 +9,7 @@ from zerver.decorator import webhook_view
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import check_dict
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -162,7 +163,7 @@ class LibratoWebhookHandler(LibratoWebhookParser):
 def api_librato_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
-    payload: Dict[str, Any] = REQ(converter=orjson.loads, default={}),
+    payload: Dict[str, Any] = REQ(json_validator=check_dict(), default={}),
 ) -> HttpResponse:
     try:
         attachments = orjson.loads(request.body).get("attachments", [])

--- a/zerver/webhooks/slack_incoming/view.py
+++ b/zerver/webhooks/slack_incoming/view.py
@@ -10,6 +10,7 @@ from zerver.decorator import webhook_view
 from zerver.lib.exceptions import InvalidJSONError
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.validator import check_dict
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -20,7 +21,7 @@ def api_slack_incoming_webhook(
     request: HttpRequest,
     user_profile: UserProfile,
     user_specified_topic: Optional[str] = REQ("topic", default=None),
-    payload: Optional[Dict[str, Any]] = REQ("payload", converter=orjson.loads, default=None),
+    payload: Optional[Dict[str, Any]] = REQ("payload", json_validator=check_dict(), default=None),
 ) -> HttpResponse:
 
     # Slack accepts webhook payloads as payload="encoded json" as


### PR DESCRIPTION
This is a proposed strategy for eradicating the unchecked `Any` annotations from webhooks, and making them more robust against unexpected input. The idea is to wrap unverified JSON in a `WildValue` wrapper class whose type annotations force the caller to validate all retrieved from it and its recursive children using the existing `zerver.lib.validator` functions.

This strategy is not as controlled as it would be to declare and validate all the types up front, because it might lead to `django.core.exceptions.ValidationError` being raised at random times as parts of input data are retrieved. But I figure that for webhooks, this is mostly okay. There’s an open question as to where exactly we should handle these `ValidationError`s and whether we should convert them to a different error type.

I demonstrate this strategy by applying it to all webhooks named A through C.