### PR TITLE
compose: Focus cursor in textarea after banner is closed.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -401,6 +401,11 @@ export function render_compose_box() {
     common.adjust_mac_shortcuts(".enter_sends kbd");
 }
 
+function focus_on_textarea() {
+    const textarea = $("#compose-textarea");
+    textarea.focus();
+}
+
 export function initialize() {
     render_compose_box();
 
@@ -459,12 +464,16 @@ export function initialize() {
         const sub = stream_data.get_sub(stream_name);
         stream_settings_ui.sub_or_unsub(sub);
         $("#compose-send-status").hide();
+
+        focus_on_textarea();
     });
 
     $("#compose-send-status").on("click", "#compose_not_subscribed_close", (event) => {
         event.preventDefault();
 
         $("#compose-send-status").hide();
+
+        focus_on_textarea();
     });
 
     $("#compose_resolved_topic").on("click", ".compose_unresolve_topic", (event) => {
@@ -480,12 +489,16 @@ export function initialize() {
             message_edit.toggle_resolve_topic(message_id, topic_name);
             compose_validate.clear_topic_resolved_warning();
         });
+
+        focus_on_textarea();
     });
 
     $("#compose_resolved_topic").on("click", ".compose_resolved_topic_close", (event) => {
         event.preventDefault();
 
         compose_validate.clear_topic_resolved_warning();
+
+        focus_on_textarea();
     });
 
     $("#compose_invite_users").on("click", ".compose_invite_link", (event) => {
@@ -530,6 +543,8 @@ export function initialize() {
         if (all_invites.children().length === 0) {
             all_invites.hide();
         }
+
+        focus_on_textarea();
     });
 
     $("#compose_private_stream_alert").on(
@@ -544,6 +559,8 @@ export function initialize() {
             if (stream_alert.children().length === 0) {
                 stream_alert.hide();
             }
+
+            focus_on_textarea();
         },
     );
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -18,6 +18,7 @@ import * as giphy from "./giphy";
 import {$t, $t_html} from "./i18n";
 import * as loading from "./loading";
 import * as markdown from "./markdown";
+import * as message_edit from "./message_edit";
 import * as notifications from "./notifications";
 import {page_params} from "./page_params";
 import * as people from "./people";
@@ -96,6 +97,7 @@ export function update_fade() {
     }
 
     const msg_type = compose_state.get_message_type();
+    compose_validate.warn_if_topic_resolved();
     compose_fade.set_focused_recipient(msg_type);
     compose_fade.update_all();
 }
@@ -463,6 +465,27 @@ export function initialize() {
         event.preventDefault();
 
         $("#compose-send-status").hide();
+    });
+
+    $("#compose_resolved_topic").on("click", ".compose_unresolve_topic", (event) => {
+        event.preventDefault();
+
+        const target = $(event.target).parents(".compose_resolved_topic");
+        const stream_name = target.attr("data-stream-name");
+        const topic_name = target.attr("data-topic-name");
+
+        const stream_id = stream_data.get_sub(stream_name).stream_id;
+
+        message_edit.with_first_message_id(stream_id, topic_name, (message_id) => {
+            message_edit.toggle_resolve_topic(message_id, topic_name);
+            compose_validate.clear_topic_resolved_warning();
+        });
+    });
+
+    $("#compose_resolved_topic").on("click", ".compose_resolved_topic_close", (event) => {
+        event.preventDefault();
+
+        compose_validate.clear_topic_resolved_warning();
     });
 
     $("#compose_invite_users").on("click", ".compose_invite_link", (event) => {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -106,6 +106,7 @@ function clear_box() {
     compose.clear_invites();
 
     // TODO: Better encapsulate at-mention warnings.
+    compose_validate.clear_topic_resolved_warning();
     compose_validate.clear_all_everyone_warnings();
     compose_validate.clear_announce_warnings();
     compose.clear_private_stream_alert();
@@ -285,6 +286,9 @@ export function start(msg_type, opts) {
     // Show either stream/topic fields or "You and" field.
     show_box(msg_type, opts);
 
+    // Show a warning if topic is resolved
+    compose_validate.warn_if_topic_resolved();
+
     // Reset the `max-height` property of `compose-textarea` so that the
     // compose-box do not cover the last messages of the current stream
     // while writing a long message.
@@ -460,6 +464,7 @@ export function on_topic_narrow() {
     // See #3300 for context--a couple users specifically asked for
     // this convenience.
     compose_state.topic(narrow_state.topic());
+    compose_validate.warn_if_topic_resolved();
     compose_fade.set_focused_recipient("stream");
     compose_fade.update_message_list();
     $("#compose-textarea").trigger("focus").trigger("select");

--- a/static/js/compose_validate.js
+++ b/static/js/compose_validate.js
@@ -5,6 +5,7 @@ import render_compose_announce from "../templates/compose_announce.hbs";
 import render_compose_invite_users from "../templates/compose_invite_users.hbs";
 import render_compose_not_subscribed from "../templates/compose_not_subscribed.hbs";
 import render_compose_private_stream_alert from "../templates/compose_private_stream_alert.hbs";
+import render_compose_resolved_topic from "../templates/compose_resolved_topic.hbs";
 
 import * as channel from "./channel";
 import * as compose_error from "./compose_error";
@@ -12,6 +13,7 @@ import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
 import {$t_html} from "./i18n";
+import * as message_edit from "./message_edit";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as people from "./people";
@@ -161,6 +163,40 @@ export function warn_if_mentioning_unsubscribed_user(mentioned) {
         }
 
         error_area.show();
+    }
+}
+
+export function clear_topic_resolved_warning() {
+    $("#compose_resolved_topic").hide();
+    $("#compose_resolved_topic").empty();
+    $("#compose-send-status").hide();
+}
+
+export function warn_if_topic_resolved() {
+    const stream_name = compose_state.stream_name();
+    const topic_name = compose_state.topic();
+
+    const sub = stream_data.get_sub(stream_name);
+
+    if (sub && topic_name.startsWith(message_edit.RESOLVED_TOPIC_PREFIX)) {
+        const error_area = $("#compose_resolved_topic");
+
+        if (error_area.html()) {
+            clear_topic_resolved_warning(); // This warning already exists
+        }
+
+        const context = {
+            stream_name,
+            topic_name,
+            can_move_topic: settings_data.user_can_move_messages_between_streams(),
+        };
+
+        const new_row = render_compose_resolved_topic(context);
+        error_area.append(new_row);
+
+        error_area.show();
+    } else {
+        clear_topic_resolved_warning();
     }
 }
 

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -5,6 +5,7 @@ import {all_messages_data} from "./all_messages_data";
 import * as channel from "./channel";
 import * as compose_fade from "./compose_fade";
 import * as compose_state from "./compose_state";
+import * as compose_validate from "./compose_validate";
 import * as condense from "./condense";
 import * as huddle_data from "./huddle_data";
 import * as message_edit from "./message_edit";
@@ -218,6 +219,7 @@ export function update_messages(events) {
             ) {
                 changed_compose = true;
                 compose_state.topic(new_topic);
+                compose_validate.warn_if_topic_resolved();
                 compose_fade.set_focused_recipient("stream");
             }
 

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -255,6 +255,7 @@
     display: none;
 }
 
+.compose_resolved_topic,
 .compose_invite_user,
 .compose_private_stream_alert,
 .compose-all-everyone,
@@ -272,6 +273,7 @@
     position: absolute;
 }
 
+.compose_resolved_topic_close,
 .compose_invite_close,
 .compose_private_stream_alert_close {
     display: inline-block;
@@ -280,6 +282,7 @@
     width: 10px;
 }
 
+.compose_resolved_topic_user_controls,
 .compose-all-everyone-controls,
 .compose-announce-controls,
 .compose_invite_user_controls,
@@ -289,8 +292,9 @@
 }
 
 .compose_invite_user p,
+.compose_resolved_topic p,
 .compose_not_subscribed p {
-    margin: 0 20px;
+    margin: 5px 20px;
     display: inline-block;
     max-width: calc(100% - 100px);
 }

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -43,6 +43,7 @@
             <span class="compose-send-status-close">&times;</span>
             <span id="compose-error-msg"></span>
         </div>
+        <div id="compose_resolved_topic" class="alert home-error-bar"></div>
         <div id="compose_invite_users" class="alert home-error-bar"></div>
         <div id="compose-all-everyone" class="alert home-error-bar"></div>
         <div id="compose-announce" class="alert home-error-bar"></div>

--- a/static/templates/compose_resolved_topic.hbs
+++ b/static/templates/compose_resolved_topic.hbs
@@ -1,0 +1,9 @@
+<div class="compose_resolved_topic" data-stream-name="{{stream_name}}" data-topic-name="{{topic_name}}">
+    <p>{{#tr}} You are sending a message to a resolved topic. You can send as-is or unresolve the topic first. {{/tr}}</p>
+    <div class="compose_resolved_topic_user_controls">
+        {{#if can_move_topic}}
+        <button class="btn btn-warning compose_unresolve_topic" >{{t "Unresolve topic" }}</button>
+        {{/if}}
+        <button type="button" class="compose_resolved_topic_close close">&times;</button>
+    </div>
+</div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) --> 
**Issue:** https://github.com/zulip/zulip/pull/19163#issuecomment-1006131367 Old behaviour does not put the cursor back in the textarea after the user clicks the button on the banner or dismisses the banner. This PR solves this issue by creating a seperate function `focus_on_textarea` and call them whenever we close the alert banners.


**Testing plan:** <!-- How have you tested? --> Currently it works with `compose_resolved_topic`, `compose_invite_users`, `compose_not_subscribed`, `compose_private_stream_alert` banners, whenever banner is closed via close button or any other button.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
