### PR TITLE
puppet: Provide more attributes to teleport on ssh nodes.

### DIFF
--- a/puppet/zulip_ops/files/teleport_node.yaml
+++ b/puppet/zulip_ops/files/teleport_node.yaml
@@ -10,7 +10,21 @@ ssh_service:
   enabled: "yes"
   commands:
     - name: hostname
-      command: [/bin/hostname]
+      command: ["/bin/hostname"]
+      period: 1h0m0s
+    - name: uname
+      command: ["/usr/bin/uptrack-uname", "-r"]
+      period: 1h0m0s
+    - name: distro
+      command: ["/usr/bin/lsb_release", "-ds"]
+      period: 1h0m0s
+    - name: classes
+      command:
+        - /usr/bin/crudini
+        - --get
+        - /etc/zulip/zulip.conf
+        - machine
+        - puppet_classes
       period: 1h0m0s
 
 proxy_service:


### PR DESCRIPTION
This is helpful in case we need to know at a glance, e.g. which hosts are which distributions.