### PR TITLE
Fix poll title editing button to place it in the  same line

### DIFF
--- a/static/styles/widgets.css
+++ b/static/styles/widgets.css
@@ -160,7 +160,7 @@ button {
 }
 
 .poll-question-header {
-    display: inline-block;
+    display: inline;
 }
 
 .current-user-vote {


### PR DESCRIPTION
The change is made to place the 'poll title editing' button in the same line as of poll title.
See the linked image for reference:
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  --> 
<img width="784" alt="Screenshot 2022-01-12 at 08 47 41" src="https://user-images.githubusercontent.com/85362194/149057883-7fde0360-2b1a-4356-8d0a-3dea51b70a32.png">

Fixes: #20753 