### PR TITLE
Zerver: removed multiple imports

### DIFF
--- a/zerver/lib/logging_util.py
+++ b/zerver/lib/logging_util.py
@@ -117,8 +117,6 @@ class ReturnEnabled(logging.Filter):
 
 class RequireReallyDeployed(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
-        from django.conf import settings
-
         return settings.PRODUCTION
 
 

--- a/zerver/management/commands/runtornado.py
+++ b/zerver/management/commands/runtornado.py
@@ -72,7 +72,6 @@ class Command(BaseCommand):
             )
 
         def inner_run() -> None:
-            from django.conf import settings
             from django.utils import translation
 
             translation.activate(settings.LANGUAGE_CODE)


### PR DESCRIPTION
A module or an import name is reimported multiple times. This can be confusing and should be fixed.

