### PR TITLE
templates: fixed sender prefix in dialog.

### DIFF
--- a/static/templates/search_operators.hbs
+++ b/static/templates/search_operators.hbs
@@ -173,7 +173,7 @@
                 {{#*inline "z-operator"}}<p><span class="operator">{{> @partial-block}}</span></p>{{/inline}}
                 {{#*inline "z-stream-prefix"}}stream:{{/inline}}
                 {{#*inline "z-stream"}}<span class="operator_value">{{> @partial-block}}</span>{{/inline}}
-                {{#*inline "z-sender-prefix"}}email:{{/inline}}
+                {{#*inline "z-sender-prefix"}}sender:{{/inline}}
                 {{#*inline "z-email"}}<span class="operator_value">{{> @partial-block}}</span>{{/inline}}
                 {{#*inline "z-keyword"}}<span class="operator_value">keyword</span>{{/inline}}
             {{/tr}}


### PR DESCRIPTION
The prefix was incorrect in the help dialog, changed the prefix from `email` to `sender`