### PR TITLE
puppet: Enable camo prometheus metrics.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-app.d/camo.conf
+++ b/puppet/zulip/files/nginx/zulip-include-app.d/camo.conf
@@ -1,5 +1,9 @@
 # Proxies /external_content to a local installation of the camo image
-# proxy software
+# proxy software.  Because camo serves its metrics at /metrics,
+# explicitly 404 that to external requests.
+location /external_content/metrics {
+    return 404;
+}
 location /external_content {
     rewrite /external_content/(.*) /$1 break;
     proxy_pass http://camo;

--- a/puppet/zulip/templates/supervisor/go-camo.conf.erb
+++ b/puppet/zulip/templates/supervisor/go-camo.conf.erb
@@ -1,5 +1,5 @@
 [program:go-camo]
-command=/usr/local/bin/secret-env-wrapper GOCAMO_HMAC=camo_key <%= @bin %> --listen=<%= @listen_address %>:9292 -H "Strict-Transport-Security: max-age=15768000" -H "X-Frame-Options: DENY" --verbose
+command=/usr/local/bin/secret-env-wrapper GOCAMO_HMAC=camo_key <%= @bin %> --listen=<%= @listen_address %>:9292 -H "Strict-Transport-Security: max-age=15768000" -H "X-Frame-Options: DENY" --metrics --verbose
 environment=HTTP_PROXY="<%= @proxy %>",HTTPS_PROXY="<%= @proxy %>"
 priority=15
 autostart=true


### PR DESCRIPTION
Doing so requires protecting /metrics from direct access when proxied
through nginx.  If camo is placed on a separate host, the equivalent
/metrics URL may need to be protected.

See https://github.com/cactus/go-camo#metrics for details on the
statistics so reported.  Note that 5xx responses are _expected_ from
go-camo's statistics, as it returns 502 status code when the remote
server responds with 500/502/503/504, or 504 when the remote host
times out.

**Testing plan:** Test deployed.  Verified that images still worked, and that metrics weren't available from `/external_content/metrics`, but were from http://localhost:9292/metrics
