### PR TITLE
developer docs: Extend contributor guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,6 +224,26 @@ labels.
   have a new feature you'd like to add, you can start a conversation [in our
   development community](https://zulip.com/development-community/#where-do-i-send-my-message)
   explaining the feature idea and the problem that you're hoping to solve.
+- **I think my PR is done, but it hasn't been merged yet. What's going on?**
+  1. **Double-check that you have addressed all the feedback**, including any comments
+     on [Git commit
+     discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html#commit-discipline).
+  2. If all the feedback has been addressed, did you leave a comment explaining that
+     you have done so and **requesting a re-review**? If not, it may not be a
+     clear to project maintainers that your PR is ready for another look.
+  3. It is common for PRs to require **multiple rounds of review**. For example,
+     prior to getting code review from project maintainers, you may receive
+     feedback on the UI (without regard for the implementation), and your code
+     may be reviewed by other contributors. This helps us make good use of
+     project maintainers' time, and helps you make progress on the PR by
+     getting more frequent feedback.
+  4. If you think the PR is ready and haven't seen any updates for a couple
+     of weeks, it can be helpful to post a **comment summarizing your
+     understanding of the state of the review process**.
+  5. Finally, **Zulip project maintainers are people too**! They may be busy
+     with other work, and sometimes they might even take a vacation. ;) It can
+     occasionally take a few weeks for a PR in the final stages of the review
+     process to be merged.
 
 ## What makes a great Zulip contributor?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,17 +229,24 @@ labels.
      on [Git commit
      discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html#commit-discipline).
   2. If all the feedback has been addressed, did you leave a comment explaining that
-     you have done so and **requesting a re-review**? If not, it may not be a
+     you have done so and **requesting another review**? If not, it may not be a
      clear to project maintainers that your PR is ready for another look.
   3. It is common for PRs to require **multiple rounds of review**. For example,
      prior to getting code review from project maintainers, you may receive
      feedback on the UI (without regard for the implementation), and your code
-     may be reviewed by other contributors. This helps us make good use of
-     project maintainers' time, and helps you make progress on the PR by
-     getting more frequent feedback.
+     may be [reviewed by other
+     contributors](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html).
+     This helps us make good use of project maintainers' time, and helps you
+     make progress on the PR by getting more frequent feedback.
   4. If you think the PR is ready and haven't seen any updates for a couple
      of weeks, it can be helpful to post a **comment summarizing your
-     understanding of the state of the review process**.
+     understanding of the state of the review process**. Your comment should
+     make it easy to understand what has been done and what remains by:
+     - Summarizing the changes made since the last review you received.
+     - Highlighting remaining questions or decisions, with links to any
+       relevant chat.zulip.org threads.
+     - Providing updated screenshots and information on manual testing if
+       appropriate.
   5. Finally, **Zulip project maintainers are people too**! They may be busy
      with other work, and sometimes they might even take a vacation. ;) It can
      occasionally take a few weeks for a PR in the final stages of the review


### PR DESCRIPTION
Covers why someone's PR might not be merged right away, based on discussion on chat.zulip.org.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
manual

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screen Shot 2022-01-12 at 4 49 33 PM](https://user-images.githubusercontent.com/2090066/149246143-ecf3dcb2-8ee5-4ea3-9db3-b08a7d810877.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
