### PR TITLE
remote_server: Add management command for deactivation.

### DIFF
--- a/docs/production/mobile-push-notifications.md
+++ b/docs/production/mobile-push-notifications.md
@@ -36,12 +36,12 @@ You can enable this for your Zulip server as follows:
 
    ```bash
    # As root:
-   su zulip -c '/home/zulip/deployments/current/manage.py register_server'
+   su zulip -c '/home/zulip/deployments/current/manage.py mobile_push_service --register'
    # Or as the zulip user, you can skip the `su zulip -c`:
-   /home/zulip/deployments/current/manage.py register_server
+   /home/zulip/deployments/current/manage.py mobile_push_service --register
 
    # docker-zulip users can run this inside the container with `docker exec`:
-   docker exec -it -u zulip <container_name> /home/zulip/deployments/current/manage.py register_server
+   docker exec -it -u zulip <container_name> /home/zulip/deployments/current/manage.py mobile_push_service --register
    ```
 
    This command will print the registration data it would send to the
@@ -80,11 +80,11 @@ Your server's registration includes the server's hostname and contact
 email address (from `EXTERNAL_HOST` and `ZULIP_ADMINISTRATOR` in
 `/etc/zulip/settings.py`, aka the `--hostname` and `--email` options
 in the installer). You can update your server's registration data by
-running `manage.py register_server` again.
+running `manage.py mobile_push_service --register` again.
 
 If you'd like to rotate your server's API key for this service
 (`zulip_org_key`), you need to use
-`manage.py register_server --rotate-key` option; it will automatically
+`manage.py mobile_push_service --rotate-key` option; it will automatically
 generate a new `zulip_org_key` and store that new key in
 `/etc/zulip/zulip-secrets.conf`.
 

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -218,7 +218,7 @@ class InvalidZulipServerError(JsonableError):
 
     @staticmethod
     def msg_format() -> str:
-        return "Zulip server auth failure: {role} is not registered -- did you run `manage.py register_server`?"
+        return "Zulip server auth failure: {role} is not registered -- did you run `manage.py mobile_push_service --register`?"
 
 
 class InvalidZulipServerKeyError(InvalidZulipServerError):

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -261,7 +261,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
         )
         self.assert_json_error(
             result,
-            "Zulip server auth failure: invalid_uuid is not registered -- did you run `manage.py register_server`?",
+            "Zulip server auth failure: invalid_uuid is not registered -- did you run `manage.py mobile_push_service --register`?",
             status_code=401,
         )
         del self.API_KEYS["invalid_uuid"]
@@ -276,7 +276,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
         )
         self.assert_json_error(
             result,
-            f"Zulip server auth failure: {credentials_uuid} is not registered -- did you run `manage.py register_server`?",
+            f"Zulip server auth failure: {credentials_uuid} is not registered -- did you run `manage.py mobile_push_service --register`?",
             status_code=401,
         )
 
@@ -2101,7 +2101,7 @@ class TestSendToPushBouncer(ZulipTestCase):
         self.assertEqual(
             str(exc.exception),
             "Push notifications bouncer error: "
-            "Zulip server auth failure: testRole is not registered -- did you run `manage.py register_server`?",
+            "Zulip server auth failure: testRole is not registered -- did you run `manage.py mobile_push_service --register`?",
         )
 
     @responses.activate

--- a/zilencer/models.py
+++ b/zilencer/models.py
@@ -22,7 +22,7 @@ def get_remote_server_by_uuid(uuid: str) -> "RemoteZulipServer":
 class RemoteZulipServer(models.Model):
     """Each object corresponds to a single remote Zulip server that is
     registered for the Mobile Push Notifications Service via
-    `manage.py register_server`.
+    `manage.py mobile_push_service --register`.
     """
 
     UUID_LENGTH = 36


### PR DESCRIPTION
Testing plan:
* The `mobile_push_service` management command was tested manually and then the outcome was verified by manually checking the database via `python3 manage.py shell`.
* The rest of the changes have accompanying unit tests.