### PR TITLE
openapi: Fix principals array type

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15431,11 +15431,13 @@ components:
       content:
         application/json:
           schema:
-            type: array
-            items:
-              oneOf:
-                - type: string
-                - type: integer
+            oneOf:
+              - type: array
+                items:
+                  type: string
+              - type: array
+                items:
+                  type: integer
           example: ["ZOE@zulip.com"]
     ReactionType:
       name: reaction_type


### PR DESCRIPTION
We do not accept heterogeneous arrays containing both user ids and email addresses.

This also happens to disallow an empty array, which is fine since the `principals` parameter should be omitted if the default to the calling user is desired.