### PR TITLE
api_docs: Update regex for generating code example fixture.

### DIFF
--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -31,7 +31,7 @@ from zerver.openapi.openapi import (
     openapi_spec,
 )
 
-API_ENDPOINT_NAME = r"/[a-z_/-{}]+:[a-z]+"
+API_ENDPOINT_NAME = r"/[a-z_\-/-{}]+:[a-z]+"
 API_LANGUAGE = r"\w+"
 API_KEY_TYPE = r"fixture|example"
 MACRO_REGEXP = re.compile(


### PR DESCRIPTION
Updates regex in `openapi/markdown_extension.py` to match API endpoint names that contain dashes, which is the case for `zulip-outgoing-webhook` and `rest-error-handling`.

**Testing plan:** [API docs diff](https://pastebin.com/K2R0gV0C)

**GIFs or screenshots:**
![Screenshot from 2022-01-13 17-39-07](https://user-images.githubusercontent.com/63245456/149375228-1e07c2cf-ca3c-4fa0-bc31-ad68999cfd2e.png)

![Screenshot from 2022-01-13 17-39-37](https://user-images.githubusercontent.com/63245456/149375219-ccf8a9d3-d206-4287-906d-33c3f3d78973.png)
