### PR TITLE
python: Replace deprecated jinja2.utils.Markup with markupsafe.Markup

### DIFF
--- a/analytics/views/activity_common.py
+++ b/analytics/views/activity_common.py
@@ -9,7 +9,7 @@ from django.db.backends.utils import CursorWrapper
 from django.db.models.query import QuerySet
 from django.template import loader
 from django.urls import reverse
-from jinja2.utils import Markup as mark_safe
+from markupsafe import Markup as mark_safe
 
 eastern_tz = pytz.timezone("US/Eastern")
 

--- a/analytics/views/installation_activity.py
+++ b/analytics/views/installation_activity.py
@@ -10,7 +10,7 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.template import loader
 from django.utils.timezone import now as timezone_now
-from jinja2.utils import Markup as mark_safe
+from markupsafe import Markup as mark_safe
 from psycopg2.sql import SQL, Composable, Literal
 
 from analytics.lib.counts import COUNT_STATS

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -14,7 +14,7 @@ from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.http import urlsafe_base64_encode
 from django.utils.translation import gettext as _
-from jinja2.utils import Markup as mark_safe
+from markupsafe import Markup as mark_safe
 from two_factor.forms import AuthenticationTokenForm as TwoFactorAuthenticationTokenForm
 from two_factor.utils import totp_digits
 

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -23,7 +23,7 @@ from django.core.signing import BadSignature, TimestampSigner
 from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.translation import gettext as _
-from jinja2.utils import Markup as mark_safe
+from markupsafe import Markup as mark_safe
 from mypy_boto3_s3.client import S3Client
 from mypy_boto3_s3.service_resource import Bucket, Object
 from PIL import Image, ImageOps

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -24,7 +24,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_safe
-from jinja2.utils import Markup as mark_safe
+from markupsafe import Markup as mark_safe
 from social_django.utils import load_backend, load_strategy
 from two_factor.forms import BackupTokenForm
 from two_factor.views import LoginView as BaseTwoFactorLoginView


### PR DESCRIPTION
Fixes `DeprecationWarning: 'jinja2.Markup' is deprecated and will be removed in Jinja 3.1. Import 'markupsafe.Markup' instead.`