### PR TITLE
python: Convert deprecated Django ugettext alias to gettext again

### DIFF
--- a/zerver/lib/drafts.py
+++ b/zerver/lib/drafts.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Set, cast
 
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from zerver.lib.actions import recipient_for_user_profiles
 from zerver.lib.addressee import get_user_profiles_by_ids

--- a/zerver/webhooks/freshstatus/view.py
+++ b/zerver/webhooks/freshstatus/view.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List
 
 import dateutil.parser
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from zerver.decorator import webhook_view
 from zerver.lib.actions import send_rate_limited_pm_notification_to_bot_owner

--- a/zerver/webhooks/uptimerobot/view.py
+++ b/zerver/webhooks/uptimerobot/view.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from zerver.decorator import webhook_view
 from zerver.lib.actions import send_rate_limited_pm_notification_to_bot_owner


### PR DESCRIPTION
`django.utils.translation.ugettext` is a deprecated alias of `django.utils.translation.gettext` as of Django 3.0, and will be removed in Django 4.0.

Commit e7ed907cf6663e2ab1db751fa8e6a6f7cea32e09 (#18174) fixed this before, but new instances have been added.