### PR TITLE
tests: Use read_test_image_file

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -65,8 +65,8 @@ from zerver.lib.storage import static_path
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import (
     create_s3_buckets,
-    get_test_image_file,
     load_subdomain_token,
+    read_test_image_file,
     use_s3_backend,
 )
 from zerver.lib.types import Validator
@@ -6228,8 +6228,7 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
     @use_s3_backend
     def test_update_user_avatar_for_s3(self) -> None:
         bucket = create_s3_buckets(settings.S3_AVATAR_BUCKET)[0]
-        with get_test_image_file("img.png") as f:
-            test_image_data = f.read()
+        test_image_data = read_test_image_file("img.png")
         self.change_ldap_user_attr("hamlet", "jpegPhoto", test_image_data)
         with self.settings(AUTH_LDAP_USER_ATTR_MAP={"full_name": "cn", "avatar": "jpegPhoto"}):
             self.perform_ldap_sync(self.example_user("hamlet"))

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -43,7 +43,7 @@ from zerver.data_import.slack import (
 )
 from zerver.lib.import_realm import do_import_realm
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import get_test_image_file
+from zerver.lib.test_helpers import read_test_image_file
 from zerver.lib.topic import EXPORT_TOPIC_NAME
 from zerver.models import Realm, RealmAuditLog, Recipient, UserProfile, get_realm
 
@@ -1103,8 +1103,7 @@ class SlackImporter(ZulipTestCase):
             {},
             team_info_fixture["team"],
         ]
-        with get_test_image_file("img.png") as f:
-            mock_requests_get.return_value.raw = BytesIO(f.read())
+        mock_requests_get.return_value.raw = BytesIO(read_test_image_file("img.png"))
 
         with self.assertLogs(level="INFO"):
             do_convert_data(test_slack_zip_file, output_dir, token)

--- a/zerver/tests/test_transfer.py
+++ b/zerver/tests/test_transfer.py
@@ -7,7 +7,12 @@ from moto import mock_s3
 from zerver.lib.actions import check_add_realm_emoji
 from zerver.lib.avatar_hash import user_avatar_path
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import avatar_disk_path, create_s3_buckets, get_test_image_file
+from zerver.lib.test_helpers import (
+    avatar_disk_path,
+    create_s3_buckets,
+    get_test_image_file,
+    read_test_image_file,
+)
 from zerver.lib.transfer import (
     transfer_avatars_to_s3,
     transfer_emoji_to_s3,
@@ -98,8 +103,7 @@ class TransferUploadsToS3Test(ZulipTestCase):
         original_key = bucket.Object(emoji_path + ".original")
         resized_key = bucket.Object(emoji_path)
 
-        with get_test_image_file("img.png") as image_file:
-            image_data = image_file.read()
+        image_data = read_test_image_file("img.png")
         resized_image_data, is_animated, still_image_data = resize_emoji(image_data)
 
         self.assertEqual(is_animated, False)
@@ -133,8 +137,7 @@ class TransferUploadsToS3Test(ZulipTestCase):
             )
         )
 
-        with get_test_image_file("animated_img.gif") as image_file:
-            image_data = image_file.read()
+        image_data = read_test_image_file("animated_img.gif")
         resized_image_data, is_animated, still_image_data = resize_emoji(image_data)
 
         self.assertEqual(is_animated, True)


### PR DESCRIPTION
Fixes a `ResourceWarning` from the unclosed file at test_upload.py:1954.