### PR TITLE
documentation: Replace deprecated request.is_ajax() method

### DIFF
--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -286,8 +286,10 @@ class IntegrationView(ApiURLView):
 
 @has_request_variables
 def integration_doc(request: HttpRequest, integration_name: str = REQ()) -> HttpResponse:
-    if not request.is_ajax():
+    # FIXME: This check is jQuery-specific.
+    if request.headers.get("x-requested-with") != "XMLHttpRequest":
         return HttpResponseNotFound()
+
     try:
         integration = INTEGRATIONS[integration_name]
     except KeyError:


### PR DESCRIPTION
This was deprecated in Django 3.1 for being jQuery-specific, and removed in Django 4.0. Replicate the jQuery-specific check.

**Testing plan**: Tested that the /integrations pages still work in the dev server.