### PR TITLE
change_password: Set requires_system_checks to a list

### DIFF
--- a/zerver/management/commands/change_password.py
+++ b/zerver/management/commands/change_password.py
@@ -1,6 +1,6 @@
 import getpass
 from argparse import ArgumentParser
-from typing import Any
+from typing import Any, List
 
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
@@ -19,7 +19,7 @@ class Command(ZulipBaseCommand):
 
     help = "Change a user's password."
     requires_migrations_checks = True
-    requires_system_checks = False
+    requires_system_checks: List[str] = []
 
     def _get_pass(self, prompt: str = "Password: ") -> str:
         p = getpass.getpass(prompt=prompt)


### PR DESCRIPTION
Django 3.2 expects a list, and Django 4.1 will require one.  Fixes `RemovedInDjango41Warning: Using a boolean value for requires_system_checks is deprecated. Use '__all__' instead of True, and [] (an empty list) instead of False.`