### PR TITLE
computed_settings: Remove deprecated Jinja2 autoescape extension

### DIFF
--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -627,7 +627,6 @@ base_template_engine_settings: Dict[str, Any] = {
         "environment": "zproject.jinja2.environment",
         "extensions": [
             "jinja2.ext.i18n",
-            "jinja2.ext.autoescape",
         ],
         "context_processors": [
             "zerver.context_processors.zulip_default_context",


### PR DESCRIPTION
It’s built in to Jinja2 as of 2.9.  Fixes `DeprecationWarning: The 'autoescape' extension is deprecated and will be removed in Jinja 3.1. This is built in now.`

**Testing plan:** Verified that backend templates still escape interpolated variables (e.g. the realm name on /devlogin).