### PR TITLE
Fix #20700: same background color for popover and selected item in the stats page

### DIFF
--- a/static/styles/portico/stats.css
+++ b/static/styles/portico/stats.css
@@ -11,6 +11,10 @@ p {
     margin-bottom: 0;
 }
 
+label{
+    font-weight: bold;
+}
+
 .app-main {
     padding: 0;
     width: auto;
@@ -101,7 +105,7 @@ p {
 }
 
 .buttons button {
-    background-color: hsl(0, 0%, 94%);
+    background-color: hsl(0, 0%, 100%);
 
     &.selected {
         background-color: hsl(0, 0%, 85%);
@@ -119,7 +123,7 @@ p {
     outline: none;
 
     &:hover {
-        background-color: hsl(0, 0%, 84%) !important;
+        background-color: hsl(0, 0%, 94%) !important;
     }
 
     &[data-user="everyone"] {

--- a/static/styles/portico/stats.css
+++ b/static/styles/portico/stats.css
@@ -11,7 +11,7 @@ p {
     margin-bottom: 0;
 }
 
-label{
+label {
     font-weight: bold;
 }
 


### PR DESCRIPTION
PR for issue [#20700 ]

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

https://user-images.githubusercontent.com/72064462/149455981-8bbff9db-3f1e-4841-a481-2e47eed8981f.mp4


