### PR TITLE
Fix #20797: Added a message when no result is found.

### DIFF
--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -153,8 +153,12 @@ export function build_stream_list(force_rerender) {
     for (const stream_id of stream_groups.dormant_streams) {
         add_sidebar_li(stream_id);
     }
-
-    parent.append(elems);
+    
+    if (elems.length > 0) {
+        parent.append(elems);
+    } else {
+        parent.append('<div class="stream-not-found"> No search results </div>');
+    }
 }
 
 export function get_stream_li(stream_id) {

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -153,7 +153,7 @@ export function build_stream_list(force_rerender) {
     for (const stream_id of stream_groups.dormant_streams) {
         add_sidebar_li(stream_id);
     }
-    
+
     if (elems.length > 0) {
         parent.append(elems);
     } else {

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -84,6 +84,12 @@ li.show-more-topics {
     max-width: 18em;
 }
 
+.stream-not-found {
+    margin-left: 10px;
+    color: hsl(0, 0%, 67%);
+    font-style: italic;
+}
+
 #stream_filters {
     overflow: visible;
     margin-bottom: 5px;


### PR DESCRIPTION
Fixes-#20797.


This pr, adds a `no result found` tag when a search for an item is made is in the filter which is not in the list.  It's a similar approach when we try to find a user which is not on the list 