### PR TITLE
Fixes #20799 - portico/integration: fixed responsive of integration section.

### DIFF
--- a/static/styles/portico/integrations.css
+++ b/static/styles/portico/integrations.css
@@ -443,8 +443,16 @@ $category-text: hsl(219, 23%, 33%);
 
         .button {
             padding: 11px 25px;
-            margin: 5px;
+            margin: 0 auto;
             font-size: 0.9em;
+        }
+    }
+    @media (max-width: 550px) {
+        .button {
+            display: flex;
+            flex-wrap: wrap;
+            width: 170px;
+            justify-content: center;
         }
     }
 


### PR DESCRIPTION
fix- #20799

this makes the page responsive for all mobile screens


https://user-images.githubusercontent.com/72331432/149543200-644a9a03-9db1-4cea-80d3-e43803b9d7bd.mp4

