### PR TITLE
Fix some events logic around do_deactivate_user

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -7589,6 +7589,8 @@ def revoke_invites_generated_by_user(user_profile: UserProfile) -> None:
         confirmation.expiry_date = now
 
     Confirmation.objects.bulk_update(confirmations_to_revoke, ["expiry_date"])
+    if len(confirmations_to_revoke):
+        notify_invites_changed(realm=user_profile.realm)
 
 
 def do_create_multiuse_invite_link(

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -746,6 +746,11 @@ def apply_event(
             state["raw_users"][person_user_id] = person
         elif event["op"] == "remove":
             state["raw_users"][person_user_id]["is_active"] = False
+            if include_subscribers:
+                for sub in state["subscriptions"]:
+                    sub["subscribers"] = [
+                        user_id for user_id in sub["subscribers"] if user_id != person_user_id
+                    ]
         elif event["op"] == "update":
             is_me = person_user_id == user_profile.id
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -744,7 +744,25 @@ class NormalActionsTest(BaseAction):
         )
         check_invites_changed("events[0]", events[0])
 
+    def test_deactivate_user_invites_changed_event(self) -> None:
+        self.user_profile = self.example_user("iago")
+        user_profile = self.example_user("cordelia")
+        invite_expires_in_days = 2
+        do_invite_users(
+            user_profile,
+            ["foo@zulip.com"],
+            [],
+            invite_expires_in_days=invite_expires_in_days,
+        )
+
+        events = self.verify_action(
+            lambda: do_deactivate_user(user_profile, acting_user=None), num_events=2
+        )
+        check_invites_changed("events[0]", events[0])
+
     def test_revoke_user_invite_event(self) -> None:
+        # We need set self.user_profile to be an admin, so that
+        # we receive the invites_changed event.
         self.user_profile = self.example_user("iago")
         streams = []
         for stream_name in ["Denmark", "Verona"]:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1839,12 +1839,18 @@ class NormalActionsTest(BaseAction):
         events = self.verify_action(action)
         check_realm_bot_update("events[0]", events[0], "services")
 
-    def test_do_deactivate_user(self) -> None:
+    def test_do_deactivate_bot(self) -> None:
         bot = self.create_bot("test")
         action = lambda: do_deactivate_user(bot, acting_user=None)
         events = self.verify_action(action, num_events=2)
         check_realm_user_remove("events[0]", events[0])
         check_realm_bot_remove("events[1]", events[1])
+
+    def test_do_deactivate_user(self) -> None:
+        user_profile = self.example_user("cordelia")
+        action = lambda: do_deactivate_user(user_profile, acting_user=None)
+        events = self.verify_action(action, num_events=1)
+        check_realm_user_remove("events[0]", events[0])
 
     def test_do_reactivate_user(self) -> None:
         bot = self.create_bot("test")


### PR DESCRIPTION
https://github.com/zulip/zulip/pull/20768 didn't add sending of `invites_changed` event when revoking invitations. Also spotted a bug in `apply_event` logic for user deactivation event.