### PR TITLE
muting: Fix a race in topic unmuting.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -230,6 +230,7 @@ from zerver.models import (
     UserPresence,
     UserProfile,
     UserStatus,
+    UserTopic,
     active_non_guest_user_ids,
     active_user_ids,
     custom_profile_fields_for_realm,
@@ -7740,7 +7741,10 @@ def do_mute_topic(
 
 
 def do_unmute_topic(user_profile: UserProfile, stream: Stream, topic: str) -> None:
-    remove_topic_mute(user_profile, stream.id, topic)
+    try:
+        remove_topic_mute(user_profile, stream.id, topic)
+    except UserTopic.DoesNotExist:
+        raise JsonableError(_("Topic is not muted"))
     event = dict(type="muted_topics", muted_topics=get_topic_mutes(user_profile))
     send_event(user_profile.realm, event, [user_profile.id])
 

--- a/zerver/views/muting.py
+++ b/zerver/views/muting.py
@@ -54,9 +54,6 @@ def unmute_topic(
         assert stream_id is not None
         stream = access_stream_for_unmute_topic_by_id(user_profile, stream_id, error)
 
-    if not topic_is_muted(user_profile, stream.id, topic_name):
-        raise JsonableError(error)
-
     do_unmute_topic(user_profile, stream, topic_name)
     return json_success()
 


### PR DESCRIPTION
Rather than check if the topic exists and then try to delete it, just
try to delete it, and catch the lack of matching rows.

**Testing plan:** Existing tests verify unmuting an not-muted topic errors with a 400.