### PR TITLE
topic_list: Fix search box not focused in expanded state.

### DIFF
--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -214,6 +214,9 @@ export class TopicListWidget {
         const input = this.parent_elem.find("#filter-topic-input");
         if (input.length) {
             this.update_topic_search_text(input.val());
+            // Only set focus on search input if it was focused before the update.
+            this.topic_search_focused_before_build =
+                document.activeElement.id === "filter-topic-input";
         } else {
             // Clear the topic search input when zooming out.
             this.update_topic_search_text("");
@@ -233,7 +236,6 @@ export class TopicListWidget {
 
         const find = () => this.parent_elem.find(".topic-list");
 
-        this.topic_search_focused_before_build = document.activeElement.id === "filter-topic-input";
         vdom.update(replace_content, find, new_dom, this.prior_dom);
 
         this.prior_dom = new_dom;


### PR DESCRIPTION
We only check `topic_search_focused_before_build` if the
search box is visible.


I checked:
* Search focused on clicking `more topics`
* Search remains focused when new topic is created and search is focused while topic list is expanded.
* Compose remains focused when new topic is created and compose is focused while topic list is expanded.