### PR TITLE
Terms of Service: fix the link to Rules of Use

### DIFF
--- a/templates/corporate/policies/terms.md
+++ b/templates/corporate/policies/terms.md
@@ -16,7 +16,7 @@ the Services in any way means that you agree to all of these Terms,
 and these Terms will remain in effect while you use the
 Services. These Terms include the provisions in this document as well
 as those in the [Privacy Policy](/policies/privacy), [Rules of
-Use](/policies/privacy), and, if applicable, [Data Processing
+Use](/policies/rules), and, if applicable, [Data Processing
 Addendum](/static/images/policies/Zulip-Data-Processing-Addendum.pdf). **Your
 use of or participation in certain Services may also be subject to
 additional policies, rules and/or conditions (“Additional Terms”),


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Wrong link to [Rules of Use](https://zulip.com/policies/rules#zulip-rules-of-use) from [Terms of Service](https://zulip.com/policies/terms#terms-of-service).

**Testing plan:** <!-- How have you tested? -->
1. Navigate to [Terms of Service](https://zulip.com/policies/terms#terms-of-service)\!
2. Follow the link to [Rules of Use](https://zulip.com/policies/rules#zulip-rules-of-use)\!
3. Verify that the document title contains the string **Rules of Use**\!

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

N/A

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
