### PR TITLE
Fix #20828- Styles/Portico: Fixed Input form alignment

### DIFF
--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -1007,7 +1007,7 @@ button#register_auth_button_gitlab {
 
 .goto-account-page {
     #realm_redirect_subdomain {
-        text-align: right;
+        text-align: left;
         position: relative;
         padding-right: 10px;
     }


### PR DESCRIPTION
This PR solves the alignment of text in input form,it was set to right,which should be left.
Fixes:#20828


![Zulip - Google Chrome 19-01-2022 12 14 32 AM](https://user-images.githubusercontent.com/72331432/150003538-76e65b97-86aa-46db-83b9-5624e9a311fa.png)
