### PR TITLE
start-server: Start auxiliary services, if they exist.

### DIFF
--- a/scripts/lib/supervisor.py
+++ b/scripts/lib/supervisor.py
@@ -1,0 +1,27 @@
+import socket
+from http.client import HTTPConnection
+from typing import Dict, List, Optional, Tuple, Union
+from xmlrpc import client
+
+
+class UnixStreamHTTPConnection(HTTPConnection):
+    def connect(self) -> None:
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(self.host)
+
+
+class UnixStreamTransport(client.Transport, object):
+    def __init__(self, socket_path: str) -> None:
+        self.socket_path = socket_path
+        super(UnixStreamTransport, self).__init__()
+
+    def make_connection(
+        self, host: Union[Tuple[str, Dict[str, str]], str]
+    ) -> UnixStreamHTTPConnection:
+        return UnixStreamHTTPConnection(self.socket_path)
+
+
+def rpc() -> client.ServerProxy:
+    return client.ServerProxy(
+        "http://localhost", transport=UnixStreamTransport("/var/run/supervisor.sock")
+    )

--- a/scripts/lib/supervisor.py
+++ b/scripts/lib/supervisor.py
@@ -27,7 +27,9 @@ def rpc() -> client.ServerProxy:
     )
 
 
-def list_supervisor_processes(*filter_names: str) -> List[str]:
+def list_supervisor_processes(
+    filter_names: Optional[List[str]] = None, *, only_running: Optional[bool] = None
+) -> List[str]:
     results = []
     processes = rpc().supervisor.getAllProcessInfo()
     assert isinstance(processes, list)
@@ -49,5 +51,8 @@ def list_supervisor_processes(*filter_names: str) -> List[str]:
             if not match:
                 continue
 
-        results.append(name)
+        if only_running is None:
+            results.append(name)
+        elif only_running == (process["statename"] == "RUNNING"):
+            results.append(name)
     return results

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -617,25 +617,6 @@ def has_application_server(once: bool = False) -> bool:
     )
 
 
-def list_supervisor_processes(*args: str) -> List[str]:
-    worker_status = subprocess.run(
-        ["supervisorctl", "status", *args],
-        text=True,
-        stdout=subprocess.PIPE,
-    )
-    # `supervisorctl status` returns 3 if any are stopped, which is
-    # fine here; and exit code 4 is for no such process, which is
-    # handled below.
-    if worker_status.returncode not in (0, 3, 4):
-        worker_status.check_returncode()
-
-    processes = []
-    for status_line in worker_status.stdout.splitlines():
-        if not re.search(r"ERROR \(no such (process|group)\)", status_line):
-            processes.append(status_line.split()[0])
-    return processes
-
-
 def has_process_fts_updates() -> bool:
     return (
         # Current path

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -8,6 +8,7 @@ import sys
 import time
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from scripts.lib.supervisor import list_supervisor_processes
 from scripts.lib.zulip_tools import (
     DEPLOYMENTS_DIR,
     ENDC,
@@ -18,7 +19,6 @@ from scripts.lib.zulip_tools import (
     get_tornado_ports,
     has_application_server,
     has_process_fts_updates,
-    list_supervisor_processes,
     overwrite_symlink,
     start_arg_parser,
 )

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -91,6 +91,13 @@ if has_application_server():
 if has_process_fts_updates():
     workers.append("process-fts-updates")
 
+# Before we start (re)starting main services, make sure to start any
+# optional auxiliary services that we don't stop, but do expect to be
+# running, and aren't currently.
+aux_services = list_supervisor_processes(["go-camo", "smokescreen"], only_running=False)
+if aux_services:
+    subprocess.check_call(["supervisorctl", "start", *aux_services])
+
 if action == "restart" and len(workers) > 0:
     if args.less_graceful:
         # The less graceful form stops every worker now; we start them

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -71,7 +71,7 @@ if has_application_server():
     if action == "start" or args.less_graceful:
         workers.append("zulip-workers:*")
     else:
-        workers.extend(list_supervisor_processes("zulip-workers:*"))
+        workers.extend(list_supervisor_processes(["zulip-workers:*"]))
 
     if has_application_server(once=True):
         # These used to be included in "zulip-workers:*"; since we may
@@ -81,8 +81,10 @@ if has_application_server():
         # `supervisorctl`.
         workers.extend(
             list_supervisor_processes(
-                "zulip_deliver_scheduled_emails",
-                "zulip_deliver_scheduled_messages",
+                [
+                    "zulip_deliver_scheduled_emails",
+                    "zulip_deliver_scheduled_messages",
+                ]
             )
         )
 

--- a/scripts/stop-server
+++ b/scripts/stop-server
@@ -48,8 +48,10 @@ if has_application_server():
         # if they currently exist according to `supervisorctl`.
         services.extend(
             list_supervisor_processes(
-                "zulip_deliver_scheduled_emails",
-                "zulip_deliver_scheduled_messages",
+                [
+                    "zulip_deliver_scheduled_emails",
+                    "zulip_deliver_scheduled_messages",
+                ]
             ),
         )
 

--- a/scripts/stop-server
+++ b/scripts/stop-server
@@ -7,13 +7,13 @@ import sys
 import time
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from scripts.lib.supervisor import list_supervisor_processes
 from scripts.lib.zulip_tools import (
     ENDC,
     OKGREEN,
     WARNING,
     has_application_server,
     has_process_fts_updates,
-    list_supervisor_processes,
 )
 
 deploy_path = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))


### PR DESCRIPTION
Services like go-camo and smokescreen are not stopped in stop-server,
since they are upgraded and restarted by puppet application.  As such,
they also do not appear in start-server, despite the server relying on
them to be running to function properly.

Ensure those services are started, by starting them in start-server,
if they are configured in supervisor on the host.

**Testing plan:** Applied, run on a server.
