### PR TITLE
provision: Install non-PGDG PGroonga package in development environment

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -199,7 +199,7 @@ elif "debian" in os_families():
     SYSTEM_DEPENDENCIES = [
         *DEBIAN_DEPENDECIES,
         f"postgresql-{POSTGRESQL_VERSION}",
-        f"postgresql-{POSTGRESQL_VERSION}-pgdg-pgroonga",
+        f"postgresql-{POSTGRESQL_VERSION}-pgroonga",
         *VENV_DEPENDENCIES,
     ]
 elif "rhel" in os_families():


### PR DESCRIPTION
The development environment installs PostgreSQL from the OS, not PGDG, so we should install the non-PGDG PGroonga package to match. This is required on Debian 10 where `postgresql-12-pgdg-pgroonga` does not exist.

Part of #20200, but we should merge this now so that we can `provision` more historical versions when #20200 is merged.

**Testing plan:** Tested in both the current Ubuntu 18.04 Vagrant dev environment and the new Debian 10 one from #20200.