### PR TITLE
Make certbot no longer set itself up as standalone

### DIFF
--- a/puppet/zulip/manifests/profile/app_frontend.pp
+++ b/puppet/zulip/manifests/profile/app_frontend.pp
@@ -60,6 +60,10 @@ class zulip::profile::app_frontend {
     source  => 'puppet:///modules/zulip/letsencrypt/nginx-deploy-hook.sh',
     require => Package[certbot],
   }
+  exec { 'fix-standalone-certbot':
+    onlyif  => 'test -d /etc/letsencrypt/renewal && grep -qx "authenticator = standalone" /etc/letsencrypt/renewal/*.conf',
+    command => "${::zulip_scripts_path}/lib/fix-standalone-certbot",
+  }
 
   # Restart the server regularly to avoid potential memory leak problems.
   file { '/etc/cron.d/restart-zulip':

--- a/scripts/lib/fix-standalone-certbot
+++ b/scripts/lib/fix-standalone-certbot
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+hostnames=$(grep -l 'authenticator = standalone' /etc/letsencrypt/renewal/*.conf | sed 's/.*\///; s/\.conf$//')
+
+for hostname in $hostnames; do
+    # Force a cert renewal to force the config file to update
+    /usr/bin/certbot certonly --webroot --webroot-path=/var/lib/zulip/certbot-webroot/ --force-renewal -d "$hostname"
+done
+
+# Pick up any updated certs
+service nginx reload

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -369,14 +369,10 @@ elif [ "$package_system" = yum ]; then
     fi
 fi
 
-if [ -n "$USE_CERTBOT" ]; then
-    # Puppet, which is run below, installs the post-deploy hook to
-    # reload nginx -- but it also installs nginx itself, so we're fine
-    # to run this now.
-    "$ZULIP_PATH"/scripts/setup/setup-certbot \
-        --method=standalone \
-        "$EXTERNAL_HOST" --email "$ZULIP_ADMINISTRATOR"
-elif [ -n "$SELF_SIGNED_CERT" ]; then
+# We generate a self-signed cert even with certbot, so we can use the
+# webroot authenticator, which requires nginx be set up with a
+# certificate.
+if [ -n "$SELF_SIGNED_CERT" ] || [ -n "$USE_CERTBOT" ]; then
     "$ZULIP_PATH"/scripts/setup/generate-self-signed-cert \
         --exists-ok "${EXTERNAL_HOST:-$(hostname)}"
 fi
@@ -483,6 +479,11 @@ if [ "$package_system" = apt ]; then
 elif [ "$package_system" = yum ]; then
     # No action is required because `yum update` already does upgrade.
     :
+fi
+
+if [ -n "$USE_CERTBOT" ]; then
+    "$ZULIP_PATH"/scripts/setup/setup-certbot \
+        "$EXTERNAL_HOST" --email "$ZULIP_ADMINISTRATOR"
 fi
 
 if has_class "zulip::nginx" && ! has_class "zulip::profile::docker"; then


### PR DESCRIPTION
Fixes #20593.

**Testing plan:** Tested upgrading a server, as well as installing a new one.  Both resulted in a `authenticator = webroot` certificate.