### PR TITLE
Fix: Hide 'Remove owner' button when there is no owner assigned to the bot.

### DIFF
--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -27,7 +27,7 @@ const {DropdownListWidget, MultiSelectDropdownListWidget} = zrequire("dropdown_l
 const setup_dropdown_zjquery_data = (name) => {
     const input_group = $(".input_group");
     const reset_button = $(".dropdown_list_reset_button");
-    input_group.set_find_results(".dropdown_list_reset_button:enabled", reset_button);
+    input_group.set_find_results(".dropdown_list_reset_button", reset_button);
     $(`#${CSS.escape(name)}_widget #${CSS.escape(name)}_name`).closest = () => input_group;
     const $widget = $(`#${CSS.escape(name)}_widget #${CSS.escape(name)}_name`);
     return {reset_button, $widget};

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -831,7 +831,7 @@ test("misc", ({override_rewire}) => {
 
     const stub_notification_disable_parent = $.create("<stub notification_disable parent");
     stub_notification_disable_parent.set_find_results(
-        ".dropdown_list_reset_button:enabled",
+        ".dropdown_list_reset_button",
         $.create("<disable link>"),
     );
 
@@ -906,7 +906,7 @@ test("misc", ({override_rewire}) => {
     ];
     const dropdown_list_parent = $.create("<list parent>");
     dropdown_list_parent.set_find_results(
-        ".dropdown_list_reset_button:enabled",
+        ".dropdown_list_reset_button",
         $.create("<disable button>"),
     );
     for (const name of widget_settings) {

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -43,7 +43,7 @@ export function DropdownListWidget({
 DropdownListWidget.prototype.render_default_text = function (elem) {
     elem.text(this.default_text);
     elem.addClass("text-warning");
-    elem.closest(".input-group").find(".dropdown_list_reset_button:enabled").hide();
+    elem.closest(".input-group").find(".dropdown_list_reset_button").hide();
 };
 
 DropdownListWidget.prototype.render = function (value) {
@@ -67,7 +67,7 @@ DropdownListWidget.prototype.render = function (value) {
     const text = this.render_text(item.name);
     elem.text(text);
     elem.removeClass("text-warning");
-    elem.closest(".input-group").find(".dropdown_list_reset_button:enabled").show();
+    elem.closest(".input-group").find(".dropdown_list_reset_button").show();
 };
 
 DropdownListWidget.prototype.update = function (value) {
@@ -320,7 +320,7 @@ MultiSelectDropdownListWidget.prototype.render_button_text = function (elem, lim
 
     elem.text(text);
     elem.removeClass("text-warning");
-    elem.closest(".input-group").find(".dropdown_list_reset_button:enabled").show();
+    elem.closest(".input-group").find(".dropdown_list_reset_button").show();
 };
 
 // Override the DrodownListWidget `render` function.


### PR DESCRIPTION
Hides 'Remove owner' button when there is no owner assigned
to the bot by removing ':enabled' selector from the button.

Fixes part of #20831.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  --> 

https://user-images.githubusercontent.com/85362194/150151084-bec817db-65b5-488a-9f34-c458c416716a.mov



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
