### PR TITLE
api_documentation: Update subscriptions parameter in OpenAPI doc.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6630,6 +6630,21 @@ paths:
                 type: array
                 items:
                   type: object
+                  additionalProperties: false
+                  properties:
+                    name:
+                      type: string
+                      description: The name of a stream.
+                    description:
+                      type: string
+                      description: A short description of the stream.
+                  required:
+                    - name
+                  example:
+                    no-description:
+                      value: {"name": "Verona"}
+                    with-description:
+                      value: {"name": "Verona", "description": "Italian city"}
               example: [{"name": "Verona", "description": "Italian city"}]
           required: true
         - $ref: "#/components/parameters/Principals"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6634,10 +6634,13 @@ paths:
                   properties:
                     name:
                       type: string
-                      description: The name of a stream.
+                      description: |
+                        The name of the stream.
                     description:
                       type: string
-                      description: A short description of the stream.
+                      description: |
+                        The [description](/help/change-the-stream-description)
+                        to use for a new stream being created, in text/markdown format.
                   required:
                     - name
                   example:
@@ -14140,13 +14143,15 @@ components:
         description:
           type: string
           description: |
-            The short description of a stream in text/markdown format,
+            The [description](/help/change-the-stream-description) of the stream in text/markdown format,
             intended to be used to prepopulate UI for editing a stream's
             description.
+
+            See also `rendered_description`.
         rendered_description:
           type: string
           description: |
-            A short description of a stream rendered as HTML, intended to
+            The [description](/help/change-the-stream-description) of the stream rendered as HTML, intended to
             be used when displaying the stream description in a UI.
 
             One should use the standard Zulip rendered_markdown CSS when
@@ -14154,6 +14159,8 @@ components:
             work correctly. And any client-side security logic for
             user-generated message content should be applied when displaying
             this HTML as though it were the body of a Zulip message.
+
+            See also `description`.
         date_created:
           type: integer
           description: |


### PR DESCRIPTION
regarding -
POST https://yourZulipDomain.zulipchat.com/api/v1/users/me/subscriptions

![image](https://user-images.githubusercontent.com/49791933/150355045-c05c72ce-19eb-4de5-9eb7-a45b1e340c5b.png)

The definition of the "subscription" parameter didn't include full
information about the parameter. It only said that an array of objects
is passed as a parameter, and relied on description of the parameter
to explain what the object contained. I edited the definition to contain
the full information about the object.

Fixes #20824.