### PR TITLE
docs: Fix grammar problems found by LanguageTool.

### DIFF
--- a/docs/production/email-gateway.md
+++ b/docs/production/email-gateway.md
@@ -125,7 +125,7 @@ Congratulations! The integration should be fully operational.
    su zulip -c '/home/zulip/deployments/current/manage.py email_mirror'
    ```
 
-1. Once everything is working, Install the cron job which will poll
+1. Once everything is working, install the cron job which will poll
    the inbox every minute for new messages using the tool you tested
    in the last step:
    ```bash

--- a/docs/production/install-existing-server.md
+++ b/docs/production/install-existing-server.md
@@ -2,9 +2,9 @@
 :orphan:
 ```
 
-# Production installation on existing server
+# Production installation on an existing server
 
-Here are some tips for installing the latest release Zulip on a
+Here are some tips for installing the latest release of Zulip on a
 production server running Debian or Ubuntu. The Zulip installation
 scripts assume that it has carte blanche to overwrite your
 configuration files in /etc, so we recommend against installing it on

--- a/docs/production/security-model.md
+++ b/docs/production/security-model.md
@@ -35,11 +35,11 @@ announcement).
 - Zulip requires CSRF tokens in all interactions with the web API to
   prevent CSRF attacks.
 
-- The preferred way to log in to Zulip is using an SSO solution like
-  Google auth, LDAP, or similar, but Zulip also supports password
-  authentication. See
-  [the authentication methods documentation](../production/authentication-methods.md)
-  for details on Zulip's available authentication methods.
+- The preferred way to log in to Zulip is using a single sign-on (SSO)
+  solution like Google authentication, LDAP, or similar, but Zulip
+  also supports password authentication. See [the authentication
+  methods documentation](../production/authentication-methods.md) for
+  details on Zulip's available authentication methods.
 
 ### Passwords
 
@@ -168,11 +168,11 @@ strength allowed is controlled by two settings in
 
 - To properly remove a user's access to a Zulip team, it does not
   suffice to change their password or deactivate their account in a
-  SSO system, since neither of those prevents authenticating with the
-  user's API key or those of bots the user has created. Instead, you
-  should
-  [deactivate the user's account](https://zulip.com/help/deactivate-or-reactivate-a-user)
-  via Zulip's "Organization settings" interface.
+  single sign-on (SSO) system, since neither of those prevents
+  authenticating with the user's API key or those of bots the user has
+  created. Instead, you should [deactivate the user's
+  account](https://zulip.com/help/deactivate-or-reactivate-a-user) via
+  Zulip's "Organization settings" interface.
 
 - The Zulip mobile apps authenticate to the server by sending the
   user's password and retrieving the user's API key; the apps then use
@@ -260,7 +260,7 @@ strength allowed is controlled by two settings in
 
 - Notably, these first 3 features give end users (limited) control to cause
   the Zulip server to make HTTP requests on their behalf. Because of this,
-  Zulip routes all outgoing outgoing HTTP requests [through
+  Zulip routes all outgoing HTTP requests [through
   Smokescreen][smokescreen-setup] to ensure that Zulip cannot be
   used to execute [SSRF attacks][ssrf] against other systems on an
   internal corporate network. The default Smokescreen configuration

--- a/docs/production/settings.md
+++ b/docs/production/settings.md
@@ -23,7 +23,7 @@ su zulip -c '/home/zulip/deployments/current/scripts/restart-server'
 Zulip has dozens of settings documented in the comments in
 `/etc/zulip/settings.py`; you can review [the latest version of the
 settings.py template][settings-py-template], and if you've upgraded
-from an old versions of Zulip, we recommend [carefully updating your
+from an old version of Zulip, we recommend [carefully updating your
 `/etc/zulip/settings.py`][update-settings-docs] to fold in the inline
 comment documentation for new configuration settings after upgrading
 to each new major release.

--- a/docs/production/video-calls.md
+++ b/docs/production/video-calls.md
@@ -20,7 +20,7 @@ installation, you'll need to register a custom Zoom app as follows:
    - Disable the option to publish the app on the Marketplace.
    - Click **Create**.
 
-1. Inside of the Zoom app management page:
+1. Inside the Zoom app management page:
 
    - On the **App Credentials** tab, set both the **Redirect URL for
      OAuth** and the **Whitelist URL** to


### PR DESCRIPTION
The discussion thread can be found at https://chat.zulip.org/#narrow/stream/18-tools/topic/grammar.20checker.
I use this shell script:
```bash
# DOUBLE_PUNCTUATION: Use of two consecutive dots or commas
# EN_REPEATEDWORDS: Suggest synonyms for repeated words.
# COMMA_COMPOUND_SENTENCE: comma between independent clauses
# AI_HYDRA_LEO_MISSING_COMMA: This rule identifies whether commas are missing in a sentence.
# AI_HYDRA_LEO_MISSING_A: This rule identifies whether the article 'a' is missing in a sentence.
# UNLIKELY_OPENING_PUNCTUATION: Loose punctuation mark
disabled_rules="DOUBLE_PUNCTUATION,EN_REPEATEDWORDS,COMMA_COMPOUND_SENTENCE,AI_HYDRA_LEO_MISSING_COMMA,AI_HYDRA_LEO_MISSING_A,UNLIKELY_OPENING_PUNCTUATION"

pylanguagetool -l en-US \
    --rules --disabled-rules "$disabled_rules" \
    --disabled-categories "TYPOS,TYPOGRAPHY" \
    "$doc"
```