### PR TITLE
compose: Fix alignment of close buttons in stream invite banners.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -276,12 +276,13 @@
     position: absolute;
 }
 
-.compose_resolved_topic_close,
-.compose_invite_close,
-.compose_private_stream_alert_close {
+.compose_resolved_topic_user_controls .compose_resolved_topic_close,
+.compose_invite_user_controls .compose_invite_close,
+.compose_private_stream_alert_controls .compose_private_stream_alert_close {
     display: inline-block;
-    margin-top: 4px;
-
+    position: absolute;
+    margin-top: -2px;
+    margin-right: -2px;
     width: 10px;
 }
 


### PR DESCRIPTION
Fixes #20839. Also I made the space between the close button the subscribe button consistent (in case of one line). 

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  --> 
![other-1line](https://user-images.githubusercontent.com/69853994/150368530-0f577e4e-9327-42a5-beaa-95a34f03c75b.png)
![other-2line](https://user-images.githubusercontent.com/69853994/150368544-86d14c12-403c-4e14-893a-077ef8458624.png)
![you-1line](https://user-images.githubusercontent.com/69853994/150368553-2ed5e82b-c91b-4dea-b7ee-2212567164e1.png)
![you-2lines](https://user-images.githubusercontent.com/69853994/150368560-cd468cb1-b313-45d5-a960-8f18d5af30e9.png)


