### PR TITLE
puppet: Put comments on iptables lines.

### DIFF
--- a/puppet/zulip_ops/manifests/firewall_allow.pp
+++ b/puppet/zulip_ops/manifests/firewall_allow.pp
@@ -16,12 +16,12 @@ define zulip_ops::firewall_allow (
   concat::fragment { "iptables_v4_${portname}":
     target  => '/etc/iptables/rules.v4',
     order   => $order,
-    content => "-A INPUT -p ${proto} --dport ${portname} -j ACCEPT\n",
+    content => "-A INPUT -p ${proto} --dport ${portname} -j ACCEPT -m comment --comment \"${name}\"\n",
   }
 
   concat::fragment { "iptables_v6_${portname}":
     target  => '/etc/iptables/rules.v6',
     order   => $order,
-    content => "-A INPUT -p ${proto} --dport ${portname} -j ACCEPT\n",
+    content => "-A INPUT -p ${proto} --dport ${portname} -j ACCEPT -m comment --comment \"${name}\"\n",
   }
 }


### PR DESCRIPTION
In addition to documenting the rules.v4 and rules.v6 files slightly,
these comments show up in `iptables -L`:

```
root@hostname:~# iptables -L INPUT
Chain INPUT (policy ACCEPT)
target     prot opt source               destination
ACCEPT     all  --  anywhere             anywhere
LOGDROP    all  --  anywhere             localhost/8
ACCEPT     all  --  anywhere             anywhere             state RELATED,ESTABLISHED
ACCEPT     tcp  --  anywhere             anywhere             tcp dpt:ssh /* ssh */
ACCEPT     tcp  --  anywhere             anywhere             tcp dpt:3000 /* grafana */
ACCEPT     tcp  --  anywhere             anywhere             tcp dpt:9100 /* node_exporter */
LOGDROP    all  --  anywhere             anywhere
```

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Test applied.