### PR TITLE
left_sidebar: Swap "Recent topics" with "Private messages".

### DIFF
--- a/static/templates/left_sidebar.hbs
+++ b/static/templates/left_sidebar.hbs
@@ -13,6 +13,15 @@
                 </a>
                 <span class="arrow all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
+            <li class="top_left_recent_topics top_left_row" title="{{t 'Recent topics' }} (t)">
+                <a href="#recent_topics">
+                    <span class="filter-icon">
+                        <i class="fa fa-clock-o" aria-hidden="true"></i>
+                    </span>
+                    {{~!-- squash whitespace --~}}
+                    <span>{{t 'Recent topics' }}</span>
+                </a>
+            </li>
             <li class="top_left_private_messages hidden-for-spectators">
                 <div class="private_messages_header top_left_row" title="{{t 'Private messages' }} (P)">
                     <a href="#narrow/is/private">
@@ -58,15 +67,6 @@
                     <span class="unread_count"></span>
                 </a>
                 <span class="arrow drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
-            </li>
-            <li class="top_left_recent_topics top_left_row" title="{{t 'Recent topics' }} (t)">
-                <a href="#recent_topics">
-                    <span class="filter-icon">
-                        <i class="fa fa-clock-o" aria-hidden="true"></i>
-                    </span>
-                    {{~!-- squash whitespace --~}}
-                    <span>{{t 'Recent topics' }}</span>
-                </a>
             </li>
         </ul>
         <div id="streams_list" class="zoom-out">


### PR DESCRIPTION
Fixes #20869.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
<!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2022-01-22 10-56-08](https://user-images.githubusercontent.com/35494118/150626111-36945154-159f-49b1-a41a-9809c5e53845.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
