### PR TITLE
mypy: Remove unused overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,6 @@ module = [
     "social_core.*",
     "social_django.*",
     "sourcemap.*",
-    "soupsieve.*",
-    "sphinx_rtd_theme.*",
     "talon_core.*",
     "tlds.*",
     "tornado.*",


### PR DESCRIPTION
`soupsieve` has types; `sphinx_rtd_theme` is no longer directly imported.