### PR TITLE
compose: Fix bug where stream color didn't update on mouse selection.

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -324,7 +324,7 @@ export function initialize_kitchen_sink_stuff() {
         $(this).removeClass("active");
     });
 
-    $("#stream_message_recipient_stream").on("blur", function () {
+    $("#stream_message_recipient_stream").on("change", function () {
         stream_bar.decorate(this.value, $("#stream-message .message_header_stream"), true);
     });
 


### PR DESCRIPTION
Called the `decorate` function to update stream color in the compose box on `change` instead of `blur`.

On clicking on a stream option, the input box for the stream name remained in focus, hence decorate wasn't triggered on blur. Using the change event instead, ensures that decorate will be called anytime the stream is changed.

Fixes: #20871

**Testing plan:** 
Tested manually that the stream color changed on clicking. I also made sure that color changing worked as before on using enter/tab, and that it reset to grey anytime it was changed to a blank string.

**GIFs or screenshots:** 
https://www.loom.com/share/344d1508736d4eed8d3da8f45855a586
