### PR TITLE
docs: requirements.md: Fix grammar problems found by LanguageTool.

### DIFF
--- a/docs/production/management-commands.md
+++ b/docs/production/management-commands.md
@@ -16,7 +16,7 @@ cd /home/zulip/deployments/current
 # Start by reading the help
 ./manage.py <command_name> --help
 
-# Once you've determine this is the command for you, run it!
+# Once you've determined this is the command for you, run it!
 ./manage.py <command_name> <args>
 ```
 

--- a/docs/production/mobile-push-notifications.md
+++ b/docs/production/mobile-push-notifications.md
@@ -115,7 +115,7 @@ to these terms.
 We've designed this push notification bouncer service with security
 and privacy in mind:
 
-- A central design goal of the the Push Notification Service is to
+- A central design goal of the Push Notification Service is to
   avoid any message content being stored or logged by the service,
   even in error cases.
 - The Push Notification Service only stores the necessary metadata for
@@ -237,7 +237,7 @@ the app stores yourself.
 If you've done that work, the Zulip server configuration for sending
 push notifications through the new app is quite straightforward:
 
-- Create a
+- Create an
   [FCM push notifications](https://firebase.google.com/docs/cloud-messaging)
   key in the Google Developer console and set `android_gcm_api_key` in
   `/etc/zulip/zulip-secrets.conf` to that key.

--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -7,9 +7,9 @@ To run a Zulip server, you will need:
   - Ubuntu 20.04 Focal
   - Debian 11 Bullseye
   - Debian 10 Buster
-- At least 2GB RAM, and 10GB disk space
-  - If you expect 100+ users: 4GB RAM, and 2 CPUs
-  - If you intend to [upgrade from Git][upgrade-from-git]: 3GB RAM, or
+- At least 2 GB RAM, and 10 GB disk space
+  - If you expect 100+ users: 4 GB RAM, and 2 CPUs
+  - If you intend to [upgrade from Git][upgrade-from-git]: 3 GB RAM, or
     2G and at least 1G of swap configured.
 - A hostname in DNS
 - Credentials for sending email
@@ -59,14 +59,14 @@ sudo apt update
 #### Hardware specifications
 
 - CPU and memory: For installations with 100+ users you'll need a
-  minimum of **2 CPUs** and **4GB RAM**. For installations with fewer
-  users, 1 CPU and 2GB RAM is sufficient. We strongly recommend against
-  installing with less than 2GB of RAM, as you will likely experience
+  minimum of **2 CPUs** and **4 GB RAM**. For installations with fewer
+  users, 1 CPU and 2 GB RAM is sufficient. We strongly recommend against
+  installing with less than 2 GB of RAM, as you will likely experience
   out of memory issues installing dependencies. We recommend against
   using highly CPU-limited servers like the AWS `t2` style instances
   for organizations with hundreds of users (active or no).
 
-- Disk space: You'll need at least 10GB of free disk space for a
+- Disk space: You'll need at least 10 GB of free disk space for a
   server with dozens of users. We recommend using an SSD and avoiding
   cloud storage backends that limit the IOPS per second, since the
   disk is primarily used for the Zulip database.
@@ -104,7 +104,7 @@ on hardware requirements for larger organizations.
   address as its external hostname (though we don't recommend that
   configuration).
 - Zulip supports [running behind a reverse proxy][reverse-proxy].
-- Zulip configures [Smokescreen, and outgoing HTTP
+- Zulip configures [Smokescreen, an outgoing HTTP
   proxy][smokescreen-proxy], to protect against [SSRF attacks][ssrf],
   which prevents user from making the Zulip server make requests to
   private resources. If your network has its own outgoing HTTP proxy,
@@ -176,11 +176,11 @@ installing Zulip with a dedicated database server.
 
 - **RAM:** We recommended more RAM for larger installations:
 
-  - With 25+ daily active users, 4GB of RAM.
-  - With 100+ daily active users, 8GB of RAM.
-  - With 400+ daily active users, 16GB of RAM for the Zulip
-    application server, plus 16GB for the database.
-  - With 2000+ daily active users 32GB of RAM, plus 32GB for the
+  - With 25+ daily active users, 4 GB of RAM.
+  - With 100+ daily active users, 8 GB of RAM.
+  - With 400+ daily active users, 16 GB of RAM for the Zulip
+    application server, plus 16 GB for the database.
+  - With 2000+ daily active users 32 GB of RAM, plus 32 GB for the
     database.
   - Roughly linear scaling beyond that.
 
@@ -195,23 +195,23 @@ installing Zulip with a dedicated database server.
 
 - **Disk for application server:** We recommend using [the S3 file
   uploads backend][s3-uploads] to store uploaded files at scale. With
-  the S3 backend configuration, we recommend 50GB of disk for the OS,
+  the S3 backend configuration, we recommend 50 GB of disk for the OS,
   Zulip software, logs and scratch/free space. Disk needs when
   storing uploads locally
 
 - **Disk for database:** SSD disk is highly recommended. For
-  installations where most messages have <100 recipients, 10GB per 1M
-  messages of history is sufficient plus 1GB per 1000 users is
+  installations where most messages have <100 recipients, 10 GB per 1M
+  messages of history is sufficient plus 1 GB per 1000 users is
   sufficient. If most messages are to public streams with 10K+ users
-  subscribed (like on chat.zulip.org), add 20GB per (1000 user
+  subscribed (like on chat.zulip.org), add 20 GB per (1000 user
   accounts) per (1M messages to public streams).
 
 - **Example:** When
   [the Zulip development community](https://zulip.com/development-community/) server
   had 12K user accounts (~300 daily actives) and 800K messages of
   history (400K to public streams), it was a default configuration
-  single-server installation with 16GB of RAM, 4 cores (essentially
-  always idle), and its database was using about 100GB of disk.
+  single-server installation with 16 GB of RAM, 4 cores (essentially
+  always idle), and its database was using about 100 GB of disk.
 
 - **Disaster recovery:** One can easily run a warm spare application
   server and a warm spare database (using [PostgreSQL warm standby


### PR DESCRIPTION
For detail about the unit space, see the discussion in https://chat.zulip.org/#narrow/stream/18-tools/topic/grammar.20checker/near/1312614.

```
https://community.languagetool.org/rule/show/UNIT_SPACE?lang=en
```
LT cites  Bureau international des poids et mesures for the rule. The bipm.org url linked is dead, but you can see the statement in the answer of https://english.stackexchange.com/questions/2794/punctuation-with-units:
> The numerical value always precedes the unit, and a space is always used to separate the unit from the number. (…) The only exceptions to this rule are for the unit symbols for degree, minute, and second for plane angle, °, ′, and ″, respectively, for which no space is left between the numerical value and the unit symbol.