### PR TITLE
settings_streams: Replace the input with dropdown.

### DIFF
--- a/static/templates/settings/default_streams_list_admin.hbs
+++ b/static/templates/settings/default_streams_list_admin.hbs
@@ -11,10 +11,12 @@
                 <div class="settings-section-title">{{t "Add new default stream" }}</div>
                 <div class="inline-block" id="default_stream_inputs">
                     <label for="default_stream_name">{{t "Stream name" }}</label>
-                    <input class="create_default_stream" type="text" placeholder="{{t 'Stream name' }}" name="stream_name" autocomplete="off" />
+                    {{> dropdown_list_widget
+                      widget_name="default_stream_id"
+                      list_placeholder=(t 'Filter streams')}}
                 </div>
                 <div class="inline-block">
-                    <button type="submit" id="do_submit_stream" class="button rounded sea-green">{{t "Add stream" }}</button>
+                    <button type="submit" id="do_submit_stream" class="button rounded sea-green" disabled="disabled">{{t "Add stream" }}</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) --> Fixes #20838

Stuck at, Currently the dropdown stream names does not updates as soon as the default stream list is updated. It gets updated only after a refresh, while the list should update whenever a new stream is added or removed from the default stream list.

TODO:
1. Replaced input box with dropdown list -> Done
2. No stream should be selected by default -> Done
**3. Streams that are already on the list should not appear in the selection drop-down -> Done (But it works only after a refresh)**
4. The "Add stream" button should be disabled if no stream has been selected. (Tooltip: No stream selected) -> Done

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![dropwdown](https://user-images.githubusercontent.com/59444243/151659794-7a094125-f480-4d40-a449-d9b32d8287ce.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
