### PR TITLE
message_edit: Fix incorrect use of _.trimStart

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -642,7 +642,10 @@ export function start(row, edit_box_open_callback) {
 export function toggle_resolve_topic(message_id, old_topic_name) {
     let new_topic_name;
     if (old_topic_name.startsWith(RESOLVED_TOPIC_PREFIX)) {
-        new_topic_name = _.trimStart(old_topic_name, RESOLVED_TOPIC_PREFIX);
+        new_topic_name = old_topic_name.replace(
+            new RegExp(`^(${_.escapeRegExp(RESOLVED_TOPIC_PREFIX)}\s*)+`),
+            "",
+        );
     } else {
         new_topic_name = RESOLVED_TOPIC_PREFIX + old_topic_name;
     }


### PR DESCRIPTION
`_.trimStart` is not for removing a given string from the start. It’s for removing a given set of characters from the start, as many times as they appear and in any order: `_.trimStart("pepperment", "pe") == "rment"`, not `"pperment"`.

Introduced by 696236b6fcd88415962c5df9fe649d391ee1ad43 (#18808).