### PR TITLE
Fix for the issue 20753

### DIFF
--- a/static/styles/widgets.css
+++ b/static/styles/widgets.css
@@ -83,6 +83,18 @@
     }
 }
 
+.question-section {
+    position: relative;
+    page-break-inside: avoid;
+
+    &:after {
+        content: "";
+        display: block;
+        height: 200px;
+        margin-bottom: -200px;
+    }
+}
+
 button {
     &.task {
         height: 20px;
@@ -151,8 +163,8 @@ button {
 
 .poll-edit-question {
     opacity: 0.4;
-    display: inline-block;
-    margin-left: 5px;
+    display: inline;
+    margin: 0 0 8px 5px;
 
     &:hover {
         opacity: 1;
@@ -160,7 +172,7 @@ button {
 }
 
 .poll-question-header {
-    display: inline-block;
+    display: inline;
 }
 
 .current-user-vote {

--- a/static/styles/widgets.css
+++ b/static/styles/widgets.css
@@ -87,7 +87,7 @@
     position: relative;
     page-break-inside: avoid;
 
-    &:after {
+    &::after {
         content: "";
         display: block;
         height: 200px;

--- a/static/templates/widgets/poll_widget.hbs
+++ b/static/templates/widgets/poll_widget.hbs
@@ -1,9 +1,11 @@
 <div class="poll-widget">
-    <h4 class="poll-question-header"></h4>
-    <div class="poll-please-wait">
-        {{t 'We are about to have a poll.  Please wait for the question.'}}
+    <div class="question-section">
+        <h4 class="poll-question-header"></h4>
+        <div class="poll-please-wait">
+            {{t 'We are about to have a poll.  Please wait for the question.'}}
+        </div>
+        <i class="fa fa-pencil poll-edit-question"></i>
     </div>
-    <i class="fa fa-pencil poll-edit-question"></i>
     <div class="poll-question-bar">
         <input type="text" class="poll-question" placeholder="{{t 'Add question'}}" />
         <button class="poll-question-remove"><i class="fa fa-remove"></i></button>

--- a/static/templates/widgets/poll_widget.hbs
+++ b/static/templates/widgets/poll_widget.hbs
@@ -5,12 +5,13 @@
             {{t 'We are about to have a poll.  Please wait for the question.'}}
         </div>
         <i class="fa fa-pencil poll-edit-question"></i>
-    </div>
-    <div class="poll-question-bar">
+        <div class="poll-question-bar">
         <input type="text" class="poll-question" placeholder="{{t 'Add question'}}" />
         <button class="poll-question-remove"><i class="fa fa-remove"></i></button>
         <button class="poll-question-check"><i class="fa fa-check"></i></button>
+        </div>
     </div>
+    
     <div class="poll-author-help">
         {{t 'Tip: You can also send "/poll Some question"'}}
     </div>

--- a/static/templates/widgets/poll_widget.hbs
+++ b/static/templates/widgets/poll_widget.hbs
@@ -6,12 +6,11 @@
         </div>
         <i class="fa fa-pencil poll-edit-question"></i>
         <div class="poll-question-bar">
-        <input type="text" class="poll-question" placeholder="{{t 'Add question'}}" />
-        <button class="poll-question-remove"><i class="fa fa-remove"></i></button>
-        <button class="poll-question-check"><i class="fa fa-check"></i></button>
+            <input type="text" class="poll-question" placeholder="{{t 'Add question'}}" />
+            <button class="poll-question-remove"><i class="fa fa-remove"></i></button>
+            <button class="poll-question-check"><i class="fa fa-check"></i></button>
         </div>
     </div>
-    
     <div class="poll-author-help">
         {{t 'Tip: You can also send "/poll Some question"'}}
     </div>


### PR DESCRIPTION
Places Poll-question editing icon on the same line as the poll question from [issues #20753 and #20757](https://github.com/zulip/zulip/issues/20753)

**Testing plan:**
Made a poll in the #test stream where I added a multiline question so that I can observe the behaviour of the icon while I fixed the issue. 

**GIFs or screenshots:**
1. ![image](https://user-images.githubusercontent.com/22577790/150808386-6adb2194-8c61-42c6-b0d0-6d185aaabdcd.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

Fixes: #20753.