### PR TITLE
tippy: Fix persistent message action tooltips on icons after blur.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -151,6 +151,13 @@ export function initialize() {
         },
     });
 
+    $("body").on("blur", ".message_control_button", (e) => {
+        // Remove tooltip when user is trying to tab through all the icons.
+        // If user tabs slowly, tooltips are displayed otherwise they are
+        // distroyed before they can be displayed.
+        e.currentTarget._tippy.destroy();
+    });
+
     delegate("body", {
         target: ".message_table .message_time",
         appendTo: () => document.body,


### PR DESCRIPTION
When users tabs through the message action icons, they used to
persist even when the focus is not on them. We manually
destroy them on blur event since tippy has some issue with
handling elements with opacity hiding effect.
