### PR TITLE
api: Add `subscription_data` details to `/update-subscription-settings`.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7911,32 +7911,74 @@ paths:
             each subscription. Each object represents a subscription, and must have
             a `stream_id` key that identifies the stream, as well as the `property`
             being modified and its new `value`.
-
-            The possible values for each `property` and `value` pairs are:
-
-            - `color` (string): The hex value of the user's display color for the stream.
-            - `is_muted` (boolean): Whether the stream is [muted](/help/mute-a-stream).<br>
-              **Changes**: Prior to Zulip 2.1, this feature was
-              represented by the more confusingly named `in_home_view` (with the
-              opposite value, `in_home_view=!is_muted`); for
-              backwards-compatibility, modern Zulip still accepts that property.
-            - `pin_to_top` (boolean): Whether to pin the stream at the top of the stream list.
-            - `desktop_notifications` (boolean): Whether to show desktop notifications
-              for all messages sent to the stream.
-            - `audible_notifications` (boolean): Whether to play a sound
-              notification for all messages sent to the stream.
-            - `push_notifications` (boolean): Whether to trigger a mobile push
-              notification for all messages sent to the stream.
-            - `email_notifications` (boolean): Whether to trigger an email
-              notification for all messages sent to the stream.
-            - `wildcard_mentions_notify` (boolean): Whether wildcard mentions trigger
-              notifications as though they were personal mentions in this stream.
           content:
             application/json:
               schema:
                 type: array
                 items:
                   type: object
+                  additionalProperties: false
+                  properties:
+                    stream_id:
+                      type: integer
+                      description: |
+                        The unique ID of a stream.
+                    property:
+                      type: string
+                      enum:
+                        - "color"
+                        - "is_muted"
+                        - "in_home_view"
+                        - "pin_to_top"
+                        - "desktop_notifications"
+                        - "audible_notifications"
+                        - "push_notifications"
+                        - "email_notifications"
+                        - "wildcard_mentions_notify"
+                      description: |
+                        One of the stream properties described below:
+
+                        - `"color"`: The hex value of the user's display color for the stream.
+
+                        - `"is_muted"`: Whether the stream is [muted](/help/mute-a-stream).<br>
+                          **Changes**: Prior to Zulip 2.1, this feature was represented
+                          by the more confusingly named `in_home_view` (with the
+                          opposite value: `in_home_view=!is_muted`); for
+                          backwards-compatibility, modern Zulip still accepts that property.
+
+                        - `"pin_to_top"`: Whether to pin the stream at the top of the stream list.
+
+                        - `"desktop_notifications"`: Whether to show desktop notifications
+                          for all messages sent to the stream.
+
+                        - `"audible_notifications"`: Whether to play a sound
+                          notification for all messages sent to the stream.
+
+                        - `"push_notifications"`: Whether to trigger a mobile push
+                          notification for all messages sent to the stream.
+
+                        - `"email_notifications"`: Whether to trigger an email
+                          notification for all messages sent to the stream.
+
+                        - `"wildcard_mentions_notify"`: Whether wildcard mentions trigger
+                          notifications as though they were personal mentions in this stream.
+                    value:
+                      oneOf:
+                        - type: boolean
+                        - type: string
+                      description: |
+                        The new value of the property being modified.
+
+                        If the property is `"color"`, then `value` is a string
+                        representing the hex value of the user's display
+                        color for the stream. For all other above properties,
+                        `value` is a boolean.
+                  required:
+                    - stream_id
+                    - property
+                    - value
+                  example:
+                    {"stream_id": 2, "property": "is_muted", "value": true}
               example:
                 [
                   {"stream_id": 1, "property": "pin_to_top", "value": true},


### PR DESCRIPTION
Adds detailed definition of objects in the `subscription_data` parameter array for the `/update-subscription-settings` endpoint.

[HTML diff](https://pastebin.com/A5MwmWKb) matches the changes in the api documentation.

Fixes #20825. Follow-up to #20409.

**GIFs or screenshots:**
![Screenshot from 2022-01-25 12-51-25](https://user-images.githubusercontent.com/63245456/150992978-f03a7ea1-526c-4335-b383-50c5599d793c.png)

