### PR TITLE
migrations: Fix RealmAuditLog creation in migration 0374.

### DIFF
--- a/zerver/migrations/0374_backfill_user_delete_realmauditlog.py
+++ b/zerver/migrations/0374_backfill_user_delete_realmauditlog.py
@@ -14,6 +14,7 @@ def backfill_user_deleted_logs(apps: StateApps, schema_editor: DatabaseSchemaEdi
         is_mirror_dummy=True, is_active=False, delivery_email__regex=r"^deleteduser\d+@.+"
     ):
         entry = RealmAuditLog(
+            realm_id=user_profile.realm_id,
             modified_user=user_profile,
             acting_user=user_profile,
             event_type=RealmAuditLog.USER_DELETED,


### PR DESCRIPTION
This was failing to set `realm_id`

https://chat.zulip.org/#narrow/stream/31-production-help/topic/upgrade.20from.20git.20main/near/1313493