### PR TITLE
stream_settings: Make disabled tab look disabled in dark mode.

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -357,6 +357,10 @@ body.dark-theme {
         border-color: hsla(0, 0%, 0%, 0.9);
     }
 
+    .ind-tab.disabled {
+        color: hsla(0, 0%, 42%, 0.9) !important;
+    }
+
     .message_reactions:hover .message_reaction + .reaction_button,
     .message_reactions .message_reaction {
         background-color: transparent;


### PR DESCRIPTION
Make diabled tab look disabled in dark mode by adding color to ".ind-tab.disabled" in "dark_theme.css".

Fixes #20917.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="344" alt="Screenshot 2022-01-26 at 12 56 33" src="https://user-images.githubusercontent.com/85362194/151120711-d5942cec-d7e4-490f-9b61-5f4cb8908417.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
