### PR TITLE
api_docs: Fix small typos in organizational role description.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6131,8 +6131,8 @@ paths:
                           - 400
                           - 600
                         description: |
-                          [Organization-level role](/help/roles-and-permissions)) of the user.
-                          Poosible values are:
+                          [Organization-level role](/help/roles-and-permissions) of the user.
+                          Possible values are:
 
                           - Organization owner => 100
                           - Organization administrator => 200


### PR DESCRIPTION
Fixes two small typos in the description of the `role` value returned from the `/get-own-user` endpoint.

Double-checked for other "))" instances in the OpenAPI documentation since I fixed this same typo in another part of the documentation last week. All other cases are correct in that the second closing parenthesis has a corresponding opening parenthesis in the text, and the first closing parenthesis is part of a link.
