### PR TITLE
Fix title at the top in right column of stream settings overlay.

### DIFF
--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -128,6 +128,11 @@ test_ui("subscriber_pills", ({override_rewire, mock_template}) => {
         false,
         () => "stream_subscription_request_result",
     );
+    mock_template(
+        "stream_settings/selected_stream_title.hbs",
+        false,
+        () => "selected_stream_title",
+    );
 
     override_rewire(people, "sort_but_pin_current_user_on_top", noop);
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -138,7 +138,7 @@ export function open_edit_panel_for_row(stream_row) {
     const sub = get_sub_for_target(stream_row);
 
     $(".stream-row.active").removeClass("active");
-    stream_settings_ui.show_subs_pane.settings(sub.name);
+    stream_settings_ui.show_subs_pane.settings(sub.name, sub.invite_only, sub.is_web_public);
     $(stream_row).addClass("active");
     setup_subscriptions_stream_hash(sub);
     setup_stream_settings(stream_row);

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -5,6 +5,7 @@ import tippy from "tippy.js";
 import render_unsubscribe_private_stream_modal from "../templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs";
 import render_browse_streams_list from "../templates/stream_settings/browse_streams_list.hbs";
 import render_browse_streams_list_item from "../templates/stream_settings/browse_streams_list_item.hbs";
+import render_selected_stream_title from "../templates/stream_settings/selected_stream_title.hbs";
 import render_stream_settings from "../templates/stream_settings/stream_settings.hbs";
 import render_stream_settings_overlay from "../templates/stream_settings/stream_settings_overlay.hbs";
 
@@ -44,10 +45,16 @@ export const show_subs_pane = {
         $(".nothing-selected").show();
         $("#subscription_overlay .stream-info-title").text($t({defaultMessage: "Stream settings"}));
     },
-    settings(stream_name) {
+    settings(stream_name, invite_only, is_web_public) {
         $(".settings, #stream-creation").hide();
         $(".settings").show();
-        $("#subscription_overlay .stream-info-title").text("# " + stream_name);
+        $("#subscription_overlay .stream-info-title").html(
+            render_selected_stream_title({
+                stream_name,
+                invite_only,
+                is_web_public,
+            }),
+        );
     },
     create_stream() {
         $(".nothing-selected, .settings, #stream-creation").hide();

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -47,7 +47,7 @@ export const show_subs_pane = {
     settings(stream_name) {
         $(".settings, #stream-creation").hide();
         $(".settings").show();
-        $("#subscription_overlay .stream-info-title").text("#" + stream_name);
+        $("#subscription_overlay .stream-info-title").text("# " + stream_name);
     },
     create_stream() {
         $(".nothing-selected, .settings, #stream-creation").hide();

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -522,6 +522,10 @@ h4.stream_setting_subsection_title {
                 line-height: 1;
                 margin: 9px 0;
                 font-weight: 600;
+
+                .large-icon {
+                    display: inline-block;
+                }
             }
         }
 
@@ -907,6 +911,8 @@ h4.stream_setting_subsection_title {
 
             &.hash::after {
                 top: 1px;
+                font-size: 1.09em;
+                font-weight: 800;
             }
         }
 
@@ -967,8 +973,6 @@ h4.stream_setting_subsection_title {
     .hash::after {
         position: relative;
         content: "#";
-        font-size: 1.09em;
-        font-weight: 800;
     }
 
     .settings {

--- a/static/templates/stream_settings/selected_stream_title.hbs
+++ b/static/templates/stream_settings/selected_stream_title.hbs
@@ -1,0 +1,4 @@
+{{> stream_privacy_icon
+  invite_only=invite_only
+  is_web_public=is_web_public }}
+<span class="stream-name-title">{{stream_name}}</span>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit adds space between # and stream name. (kept this commit separate in case we want to do minor CSS changes in the second commit).
- Second commit fixes the icon to be according to type of stream.
<!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2022-01-26 22-22-03](https://user-images.githubusercontent.com/35494118/151211936-883d1d13-1890-4b49-bd97-1a6787385212.png)
![Screenshot from 2022-01-26 22-22-07](https://user-images.githubusercontent.com/35494118/151211969-3532167c-c051-42b0-ad57-2086bf23c350.png)
![Screenshot from 2022-01-26 22-22-20](https://user-images.githubusercontent.com/35494118/151211977-cbc5b531-827b-4758-bea0-3af3ad8d2933.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
