### PR TITLE
[4.x] reindex-textual-data: Find psycopg2 in the virtualenv

### DIFF
--- a/scripts/setup/reindex-textual-data
+++ b/scripts/setup/reindex-textual-data
@@ -6,14 +6,14 @@ import os
 import sys
 import time
 
-import psycopg2
-import psycopg2.extensions
-from psycopg2.sql import SQL, Identifier
-
 sys.path.append(os.path.join(os.path.dirname(__file__), "../.."))
 from scripts.lib.setup_path import setup_path
 
 setup_path()
+
+import psycopg2
+import psycopg2.extensions
+from psycopg2.sql import SQL, Identifier
 
 from scripts.lib.zulip_tools import su_to_zulip
 


### PR DESCRIPTION
Backport the first commit of

* #20933

We can revert the second on `main` when this makes it into a release.