### PR TITLE
fix: throw proper error message through backend in generate_api_key

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -4345,7 +4345,7 @@ class JSONFetchAPIKeyTest(ZulipTestCase):
         user = self.example_user("hamlet")
         self.login_user(user)
         result = self.client_post("/json/fetch_api_key", dict(password="wrong"))
-        self.assert_json_error(result, "Your username or password is incorrect.", 400)
+        self.assert_json_error(result, "Password is incorrect.", 400)
 
     def test_invalid_subdomain(self) -> None:
         username = "hamlet"

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1143,7 +1143,7 @@ class FetchAPIKeyTest(ZulipTestCase):
     def test_fetch_api_key_wrong_password(self) -> None:
         self.login("cordelia")
         result = self.client_post("/json/fetch_api_key", dict(password="wrong_password"))
-        self.assert_json_error_contains(result, "password is incorrect")
+        self.assert_json_error_contains(result, "Password is incorrect")
 
 
 class InactiveUserTest(ZulipTestCase):

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -977,7 +977,7 @@ def json_fetch_api_key(
         if not authenticate(
             request=request, username=user_profile.delivery_email, password=password, realm=realm
         ):
-            raise JsonableError(_("Your username or password is incorrect."))
+            raise JsonableError(_("Password is incorrect."))
 
     api_key = get_api_key(user_profile)
     return json_success({"api_key": api_key, "email": user_profile.delivery_email})


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/20924


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


**BEFORE**
![Screenshot from 2022-01-26 19-16-20](https://user-images.githubusercontent.com/76561593/151281427-e713a769-6554-429f-9315-048b8d085e6b.png)


**AFTER**
![Screenshot from 2022-01-26 22-55-01](https://user-images.githubusercontent.com/76561593/151281386-5b8f6b5a-9d25-49cc-a040-5191b9e2df13.png)

