### PR TITLE
stream_settings: Fix live update of title in right column on changing name and privacy of stream.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -138,7 +138,7 @@ export function open_edit_panel_for_row(stream_row) {
     const sub = get_sub_for_target(stream_row);
 
     $(".stream-row.active").removeClass("active");
-    stream_settings_ui.show_subs_pane.settings(sub.name, sub.invite_only, sub.is_web_public);
+    stream_settings_ui.show_subs_pane.settings(sub);
     $(stream_row).addClass("active");
     setup_subscriptions_stream_hash(sub);
     setup_stream_settings(stream_row);

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -155,6 +155,11 @@ export function update_stream_name(sub, new_name) {
     const edit_container = stream_settings_containers.get_edit_container(sub);
     edit_container.find(".email-address").text(sub.email_address);
     edit_container.find(".sub-stream-name").text(new_name);
+
+    const active_data = stream_settings_ui.get_active_data();
+    if (active_data.id === sub.stream_id) {
+        stream_settings_ui.set_right_panel_title(sub);
+    }
 }
 
 export function update_stream_description(sub) {

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -45,16 +45,10 @@ export const show_subs_pane = {
         $(".nothing-selected").show();
         $("#subscription_overlay .stream-info-title").text($t({defaultMessage: "Stream settings"}));
     },
-    settings(stream_name, invite_only, is_web_public) {
+    settings(sub) {
         $(".settings, #stream-creation").hide();
         $(".settings").show();
-        $("#subscription_overlay .stream-info-title").html(
-            render_selected_stream_title({
-                stream_name,
-                invite_only,
-                is_web_public,
-            }),
-        );
+        $("#subscription_overlay .stream-info-title").html(render_selected_stream_title(sub));
     },
     create_stream() {
         $(".nothing-selected, .settings, #stream-creation").hide();

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -212,6 +212,11 @@ export function update_stream_privacy(slim_sub, values) {
     stream_ui_updates.update_add_subscriptions_elements(sub);
     stream_list.redraw_stream_privacy(sub);
 
+    const active_data = get_active_data();
+    if (active_data.id === sub.stream_id) {
+        set_right_panel_title(sub);
+    }
+
     // Update navbar if needed
     message_view_header.maybe_rerender_title_area_for_stream(sub);
 }

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -39,6 +39,10 @@ import * as ui from "./ui";
 import * as ui_report from "./ui_report";
 import * as util from "./util";
 
+export function set_right_panel_title(sub) {
+    $("#subscription_overlay .stream-info-title").html(render_selected_stream_title(sub));
+}
+
 export const show_subs_pane = {
     nothing_selected() {
         $(".settings, #stream-creation").hide();
@@ -48,7 +52,7 @@ export const show_subs_pane = {
     settings(sub) {
         $(".settings, #stream-creation").hide();
         $(".settings").show();
-        $("#subscription_overlay .stream-info-title").html(render_selected_stream_title(sub));
+        set_right_panel_title(sub);
     },
     create_stream() {
         $(".nothing-selected, .settings, #stream-creation").hide();

--- a/static/templates/stream_settings/selected_stream_title.hbs
+++ b/static/templates/stream_settings/selected_stream_title.hbs
@@ -1,4 +1,5 @@
 {{> stream_privacy_icon
   invite_only=invite_only
-  is_web_public=is_web_public }}
-<span class="stream-name-title">{{stream_name}}</span>
+  is_web_public=is_web_public
+  color="#000000" }}
+<span class="stream-name-title">{{name}}</span>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit is a prep commit for extracting the code into a new function.
- Last two commits is to update the title on changing name and privacy of stream.

<!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
