### PR TITLE
Dark-theme stats page

### DIFF
--- a/static/js/dark_theme.ts
+++ b/static/js/dark_theme.ts
@@ -1,13 +1,28 @@
 import $ from "jquery";
 
 export function enable(): void {
+    if (typeof Storage !== "undefined") {
+        localStorage.setItem("theme-value", "dark-theme");
+    } else {
+        // Sorry! No Web Storage support..
+    }
     $("body").removeClass("color-scheme-automatic").addClass("dark-theme");
 }
 
 export function disable(): void {
+    if (typeof Storage !== "undefined") {
+        localStorage.setItem("theme-value", "light-theme");
+    } else {
+        // Sorry! No Web Storage support..
+    }
     $("body").removeClass("color-scheme-automatic").removeClass("dark-theme");
 }
 
 export function default_preference_checker(): void {
+    if (typeof Storage !== "undefined") {
+        localStorage.setItem("theme-value", "light-theme");
+    } else {
+        // Sorry! No Web Storage support..
+    }
     $("body").removeClass("dark-theme").addClass("color-scheme-automatic");
 }

--- a/static/js/page_params.ts
+++ b/static/js/page_params.ts
@@ -36,6 +36,7 @@ export const page_params: {
     server_web_public_streams_enabled: boolean;
     translation_data: Record<string, string>;
     zulip_plan_is_not_limited: boolean;
+    color_theme: string;
 } = $("#page-params").remove().data("params");
 const t2 = performance.now();
 export const page_params_parse_time = t2 - t1;

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -12,12 +12,12 @@ Plotly.register([PlotlyBar, PlotlyPie]);
 const font_14pt = {
     family: "Source Sans 3",
     size: 14,
-    color: "rgb(0,0,0)",
+    color: "hsl(0,0%,0%)",
 };
 
-let button_color = "rgb(235,235,235)";
+let button_color = "hsl(0,0%,92.2%)";
 
-let plot_color = "rgb(255,255,255)";
+let plot_color = "hsl(0,0%,100%)";
 
 //  function to set theme for stats page
 function setTheme(theme) {
@@ -25,14 +25,14 @@ function setTheme(theme) {
         document.querySelector("body").classList.remove("color-scheme-automatic");
         document.querySelector("body").classList.add("dark-theme");
         plot_color = "rgb(0,0,0)";
-        font_14pt.color = "rgb(221,222,238)";
-        button_color = "rgb(20,20,20)";
+        font_14pt.color = "hsl(236,33.3%,90%)";
+        button_color = "hsl(0,0%,7.8%)";
     } else {
         document.querySelector("body").classList.remove("dark-theme");
         document.querySelector("body").classList.add("color-scheme-automatic");
-        plot_color = "rgb(255,255,255)";
-        font_14pt.color = "rgb(0,0,0)";
-        button_color = "rgb(235,235,235)";
+        plot_color = "hsl(0,0%,100%)";
+        font_14pt.color = "hsl(0,0%,0%)";
+        button_color = "hsl(0,0%,92.2%)";
     }
 }
 

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -9,11 +9,36 @@ import {page_params} from "../page_params";
 
 Plotly.register([PlotlyBar, PlotlyPie]);
 
-const font_14pt = {
+let font_14pt = {
     family: "Source Sans 3",
     size: 14,
-    color: "#000000",
+    color: "rgb(0,0,0)",
 };
+
+let button_color = "rgb(235,235,235)";
+
+let plot_color = "rgb(255,255,255)";
+
+//  function to set theme for stats page
+function setTheme(theme) {
+    if (theme === "dark-theme") {
+        document.querySelector("body").classList.remove("color-scheme-automatic");
+        document.querySelector("body").classList.add("dark-theme");
+        plot_color = "rgb(0,0,0)";
+        font_14pt.color = "rgb(221,222,238)";
+        button_color = "rgb(20,20,20)";
+    } else {
+        document.querySelector("body").classList.remove("dark-theme");
+        document.querySelector("body").classList.add("color-scheme-automatic");
+        plot_color = "rgb(255,255,255)";
+        font_14pt.color = "rgb(0,0,0)";
+        button_color = "rgb(235,235,235)";
+    }
+}
+
+//  Reading value of theme
+const theme = localStorage.getItem("theme-value");
+setTheme(theme);
 
 let last_full_update = Number.POSITIVE_INFINITY;
 
@@ -73,7 +98,7 @@ function update_last_full_update(end_times) {
         return;
     }
 
-    last_full_update = Math.min(last_full_update, end_times.at(-1));
+    last_full_update = Math.min(last_full_update, end_times[end_times.length - 1]);
     const update_time = new Date(last_full_update * 1000);
     const locale_date = update_time.toLocaleDateString("en-US", {
         year: "numeric",
@@ -136,13 +161,16 @@ function populate_messages_sent_over_time(data) {
         barmode: "group",
         width: 750,
         height: 400,
+        plot_bgcolor: plot_color,
+        paper_bgcolor: plot_color,
         margin: {l: 40, r: 0, b: 40, t: 0},
         xaxis: {
             fixedrange: true,
-            rangeslider: {bordercolor: "#D8D8D8", borderwidth: 1},
+            rangeslider: {bordercolor: font_14pt.color /* "#D8D8D8"*/, borderwidth: 1},
             type: "date",
+            color: font_14pt.color,
         },
-        yaxis: {fixedrange: true, rangemode: "tozero"},
+        yaxis: {fixedrange: true, rangemode: "tozero", color: font_14pt.color},
         legend: {
             x: 0.62,
             y: 1.12,
@@ -161,6 +189,7 @@ function populate_messages_sent_over_time(data) {
                 {stepmode: "backward", ...button2},
                 {step: "all", label: $t({defaultMessage: "All time"})},
             ],
+            bgcolor: button_color,
         };
     }
 
@@ -253,7 +282,7 @@ function populate_messages_sent_over_time(data) {
             dates,
             values,
             last_value_is_partial: !is_boundary(
-                new Date(start_dates.at(-1).getTime() + 60 * 60 * 1000),
+                new Date(start_dates[start_dates.length - 1].getTime() + 60 * 60 * 1000),
             ),
         };
     }
@@ -386,7 +415,7 @@ function compute_summary_chart_data(time_series_data, num_steps, labels_) {
         }
         let sum = 0;
         for (let i = 1; i <= num_steps; i += 1) {
-            sum += array.at(-i);
+            sum += array[array.length - i];
         }
         data.set(key, sum);
     }
@@ -423,9 +452,11 @@ function populate_messages_sent_by_client(data) {
         width: 750,
         height: null, // set in draw_plot()
         margin: {l: 3, r: 40, b: 40, t: 0},
+        plot_bgcolor: plot_color,
+        paper_bgcolor: plot_color,
         font: font_14pt,
-        xaxis: {range: null}, // set in draw_plot()
-        yaxis: {showticklabels: false},
+        xaxis: {range: null, color: font_14pt.color}, // set in draw_plot()
+        yaxis: {showticklabels: false, color: font_14pt.color},
         showlegend: false,
     };
 
@@ -580,6 +611,8 @@ function populate_messages_sent_by_message_type(data) {
         margin: {l: 90, r: 0, b: 0, t: 0},
         width: 750,
         height: 300,
+        plot_bgcolor: plot_color,
+        paper_bgcolor: plot_color,
         font: font_14pt,
     };
 
@@ -695,9 +728,12 @@ function populate_number_of_users(data) {
         width: 750,
         height: 370,
         margin: {l: 40, r: 0, b: 65, t: 20},
+        plot_bgcolor: plot_color,
+        paper_bgcolor: plot_color,
         xaxis: {
             fixedrange: true,
-            rangeslider: {bordercolor: "#D8D8D8", borderwidth: 1},
+            rangeslider: {bordercolor: font_14pt.color, borderwidth: 1.2},
+            color: font_14pt.color,
             rangeselector: {
                 x: 0.64,
                 y: -0.79,
@@ -716,9 +752,10 @@ function populate_number_of_users(data) {
                     },
                     {step: "all", label: $t({defaultMessage: "All time"})},
                 ],
+                bgcolor: button_color,
             },
         },
-        yaxis: {fixedrange: true, rangemode: "tozero"},
+        yaxis: {fixedrange: true, rangemode: "tozero", color: font_14pt.color},
         font: font_14pt,
     };
 
@@ -830,12 +867,15 @@ function populate_messages_read_over_time(data) {
         width: 750,
         height: 400,
         margin: {l: 40, r: 0, b: 40, t: 0},
+        plot_bgcolor: plot_color,
+        paper_bgcolor: plot_color,
         xaxis: {
+            color: font_14pt.color,
             fixedrange: true,
-            rangeslider: {bordercolor: "#D8D8D8", borderwidth: 1},
+            rangeslider: {bordercolor: font_14pt.color, borderwidth: 1},
             type: "date",
         },
-        yaxis: {fixedrange: true, rangemode: "tozero"},
+        yaxis: {fixedrange: true, rangemode: "tozero", color: font_14pt.color},
         legend: {
             x: 0.62,
             y: 1.12,
@@ -854,6 +894,7 @@ function populate_messages_read_over_time(data) {
                 {stepmode: "backward", ...button2},
                 {step: "all", label: $t({defaultMessage: "All time"})},
             ],
+            bgcolor: button_color,
         };
     }
 
@@ -939,7 +980,7 @@ function populate_messages_read_over_time(data) {
             dates,
             values,
             last_value_is_partial: !is_boundary(
-                new Date(start_dates.at(-1).getTime() + 60 * 60 * 1000),
+                new Date(start_dates[start_dates.length - 1].getTime() + 60 * 60 * 1000),
             ),
         };
     }

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -9,7 +9,7 @@ import {page_params} from "../page_params";
 
 Plotly.register([PlotlyBar, PlotlyPie]);
 
-let font_14pt = {
+const font_14pt = {
     family: "Source Sans 3",
     size: 14,
     color: "rgb(0,0,0)",

--- a/static/styles/portico/stats.css
+++ b/static/styles/portico/stats.css
@@ -268,7 +268,7 @@ body.dark-theme .chart-container {
 body.dark-theme .buttons button {
     background-color: hsl(0, 0%, 7.8%);
     color: hsl(236, 33.3%, 90%);
-    
+
     &.selected {
         background-color: hsl(0, 0%, 29.4%);
         color: hsl(236, 33.3%, 90%);

--- a/static/styles/portico/stats.css
+++ b/static/styles/portico/stats.css
@@ -240,3 +240,44 @@ p {
         }
     }
 }
+
+/*  css for dark dark-theme  */
+
+body.dark-theme {
+    background-color: hsl(212, 28%, 18%);
+}
+
+body.dark-theme .analytics-page-header {
+    color: hsl(236, 33.3%, 90%);
+}
+
+body.dark-theme .alert {
+    background-color: hsl(170, 46%, 54%);
+    color: hsl(0, 0%, 100%);
+}
+
+body.dark-theme .chart-container {
+    background-color: hsl(212, 28%, 8%);
+    color: hsl(236, 33.3%, 90%);
+
+    h1 {
+        color: hsl(236, 33.3%, 90%);
+    }
+}
+
+body.dark-theme .buttons button {
+    background-color: hsl(0, 0%, 7.8%);
+    color: hsl(236, 33.3%, 90%);
+    
+    &.selected {
+        background-color: hsl(0, 0%, 29.4%);
+        color: hsl(236, 33.3%, 90%);
+    }
+}
+
+body.dark-theme .button {
+    &:hover {
+        background-color: hsl(0, 0%, 29.4%) !important;
+        color: hsl(236, 33.3%, 90%);
+    }
+}


### PR DESCRIPTION
I made changes to 3 files:-
1) dark_theme.ts -> In this file, I create a variable in local storage that contains the value of the currently selected theme in the main app.

2) stats.js -> Created a function setTheme, where I first read the value of the selected theme( from local storage ) then change the font color, plot color, and button color according to the selected theme.  Also in all the layout objects created for each plot, I added attributes for background color and axis color.

3) stats.css-> In the setTheme function if the theme is dark then I added the dark-theme class to the body tag. then I added new styling for body.dark-theme objects in stats.css file. 

The font color for the dark theme is set the same as the text color of the dark theme in the main app.  SS of dark theme page :

![Screenshot from 2022-01-27 16-57-39](https://user-images.githubusercontent.com/55832722/151350208-eaf4e1ab-b991-450d-a456-67476209586b.png)

