### PR TITLE
Add stream left-side-bar: 'Add stream' redirects to settings when user can't create stream

### DIFF
--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -14,6 +14,7 @@ import * as narrow_state from "./narrow_state";
 import * as popovers from "./popovers";
 import * as resize from "./resize";
 import * as scroll_util from "./scroll_util";
+import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
 import * as stream_popover from "./stream_popover";
 import * as stream_sort from "./stream_sort";
@@ -524,6 +525,10 @@ export function set_event_handlers() {
         .on("click", (e) => {
             e.preventDefault();
             if (e.target.id === "streams_inline_cog") {
+                if(!(settings_data.user_can_create_private_streams() || settings_data.user_can_create_public_streams() || settings_data.user_can_create_web_public_streams())){
+                    e.stopPropagation();
+                    location.assign("#streams/all");
+                }
                 return;
             }
             toggle_filter_displayed(e);


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #20676 

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
User that can't create stream:


https://user-images.githubusercontent.com/78212650/151428603-40b03966-031c-433d-93e0-de135a159fca.mp4

User that can create stream:


https://user-images.githubusercontent.com/78212650/151428690-57e51344-0acf-46a6-9b95-318aca8058ce.mp4



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
