### PR TITLE
api_docs: Fix enum strings in parameters to have quotes.

### DIFF
--- a/zerver/lib/markdown/api_arguments_table_generator.py
+++ b/zerver/lib/markdown/api_arguments_table_generator.py
@@ -140,9 +140,12 @@ class APIArgumentsTablePreprocessor(Preprocessor):
         for argument in arguments:
             name = argument.get("argument") or argument.get("name")
             description = argument["description"]
-            oneof = ["`" + str(item) + "`" for item in argument.get("schema", {}).get("enum", [])]
-            if oneof:
-                description += "\nMust be one of: {}.".format(", ".join(oneof))
+            enums = argument.get("schema", {}).get("enum")
+            if enums is not None:
+                formatted_enums = [
+                    OBJECT_CODE_TEMPLATE.format(value=json.dumps(enum)) for enum in enums
+                ]
+                description += "\nMust be one of: {}. ".format(", ".join(formatted_enums))
 
             default = argument.get("schema", {}).get("default")
             if default is not None:


### PR DESCRIPTION
Fixes the rendering of parameters that are enums to show enum strings with quotation marks, while integers will continue to be rendered without quotation marks.

This allows for an empty string to be passed as an enum value and be rendered as such in the documentation. Null will be rendered without quotation marks, like integer values. See example screenshot below.

This reuses some of the code added in #20409 to render the details of object parameters. At some point it would be good to look at refactoring for duplicated code. Perhaps as a step towards adding some of these details (enum, default, required/optional) to the return values and events.

[HTML diff](https://pastebin.com/CaH7z8iB).

**Screenshot of example string and integer enum, both with null as an option:** 
![Screenshot from 2022-01-27 20-34-32](https://user-images.githubusercontent.com/63245456/151433171-55343068-cc1e-4526-b245-8fc223f4a0cf.png)
