### PR TITLE
presence: Clean up CSS code related to idle circles

### DIFF
--- a/docs/subsystems/presence.md
+++ b/docs/subsystems/presence.md
@@ -23,11 +23,10 @@ requests contains a few parameters. The most important is "status",
 which had 2 valid values:
 
 - "active" -- this means the user has interacted with the client
-  recently. We use this for the "green" state in the web app.
+  recently.
 - "idle" -- the user has not interacted with the client recently.
   This is important for the case where a user left a Zulip tab open on
-  their desktop at work and went home for the weekend. We use this
-  for the "orange" state in the web app.
+  their desktop at work and went home for the weekend.
 
 The client receives in the response to that request a data set that,
 for each user, contains their status and timestamp that we last heard

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -180,7 +180,7 @@ test("user_circle, level, status_description", () => {
     assert.equal(buddy_data.get_user_circle_class(me.user_id), "user_circle_green");
 
     set_presence(fred.user_id, "idle");
-    assert.equal(buddy_data.get_user_circle_class(fred.user_id), "user_circle_orange");
+    assert.equal(buddy_data.get_user_circle_class(fred.user_id), "user_circle_idle");
     assert.equal(buddy_data.level(fred.user_id), 2);
     assert.equal(buddy_data.status_description(fred.user_id), "translated: Idle");
 

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -93,7 +93,7 @@ test("build_private_messages_list", ({override}) => {
             is_zero: false,
             is_active: false,
             url: "#narrow/pm-with/101,102-group",
-            user_circle_class: "user_circle_fraction",
+            user_circle_class: undefined,
             is_group: true,
         },
     ];
@@ -143,7 +143,7 @@ test("build_private_messages_list_bot", ({override}) => {
             is_zero: false,
             is_active: false,
             url: "#narrow/pm-with/101,102-group",
-            user_circle_class: "user_circle_fraction",
+            user_circle_class: undefined,
             is_group: true,
         },
     ];

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -41,7 +41,7 @@ export function get_user_circle_class(user_id) {
         case "active":
             return "user_circle_green";
         case "idle":
-            return "user_circle_orange";
+            return "user_circle_idle";
         case "away_them":
         case "away_me":
             return "user_circle_empty_line";

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -76,9 +76,7 @@ export function _get_convos() {
 
         let user_circle_class;
 
-        if (is_group) {
-            user_circle_class = "user_circle_fraction";
-        } else {
+        if (!is_group) {
             const user_id = Number.parseInt(user_ids_string, 10);
             user_circle_class = buddy_data.get_user_circle_class(user_id);
             const recipient_user_obj = people.get_by_user_id(user_id);

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -74,8 +74,7 @@
     }
 
     .user_circle {
-        width: 8px;
-        height: 8px;
+        /* see user_circles.css for more detail */
         margin: 0 5px;
         display: block;
     }

--- a/static/styles/user_circles.css
+++ b/static/styles/user_circles.css
@@ -1,3 +1,4 @@
+$active_color: hsl(106, 74%, 44%);
 $idle_color: hsl(29, 84%, 51%);
 
 .user_circle_green,
@@ -12,8 +13,8 @@ $idle_color: hsl(29, 84%, 51%);
 }
 
 .user_circle_green {
-    background-color: hsl(106, 74%, 44%);
-    border-color: hsl(106, 74%, 44%);
+    background-color: $active_color;
+    border-color: $active_color;
 }
 
 .user_circle_idle {

--- a/static/styles/user_circles.css
+++ b/static/styles/user_circles.css
@@ -1,8 +1,7 @@
 .user_circle_green,
 .user_circle_orange,
 .user_circle_empty,
-.user_circle_empty_line,
-.user_circle_fraction {
+.user_circle_empty_line {
     border-radius: 50%;
     border: 1px solid;
     float: left;
@@ -12,10 +11,6 @@
 
 .user_circle_green {
     background-color: hsl(106, 74%, 44%);
-}
-
-.user_circle_green,
-.user_circle_fraction {
     border-color: hsl(106, 74%, 44%);
 }
 

--- a/static/styles/user_circles.css
+++ b/static/styles/user_circles.css
@@ -1,5 +1,7 @@
+$idle_color: hsl(29, 84%, 51%);
+
 .user_circle_green,
-.user_circle_orange,
+.user_circle_idle,
 .user_circle_empty,
 .user_circle_empty_line {
     border-radius: 50%;
@@ -14,12 +16,12 @@
     border-color: hsl(106, 74%, 44%);
 }
 
-.user_circle_orange {
-    border-color: hsl(29, 84%, 51%);
+.user_circle_idle {
+    border-color: $idle_color;
     background: linear-gradient(
         to bottom,
         hsla(0, 0%, 100%, 0) 50%,
-        hsla(29, 84%, 51%, 1) 50%
+        $idle_color 50%
     );
 }
 

--- a/static/styles/user_circles.css
+++ b/static/styles/user_circles.css
@@ -1,5 +1,6 @@
-$active_color: hsl(106, 74%, 44%);
-$idle_color: hsl(29, 84%, 51%);
+$active_color: hsl(137, 37%, 60%);
+$idle_color: hsl(54, 31%, 75%);
+$empty_border_color: hsl(0, 0%, 66%);
 
 .user_circle_green,
 .user_circle_idle,
@@ -34,11 +35,11 @@ $idle_color: hsl(29, 84%, 51%);
 
 .user_circle_empty {
     background-color: none;
-    border-color: hsl(0, 0%, 50%);
+    border-color: $empty_border_color;
 }
 
 .user_circle_empty_line {
-    border-color: hsl(0, 0%, 50%);
+    border-color: $empty_border_color;
 
     &::after {
         content: "";

--- a/static/styles/user_circles.css
+++ b/static/styles/user_circles.css
@@ -9,21 +9,27 @@ $idle_color: hsl(29, 84%, 51%);
     border: 1px solid;
     float: left;
     position: relative;
-    top: 5px;
+}
+
+.user_circle {
+    top: 6px;
+    height: 6px;
+    width: 6px;
 }
 
 .user_circle_green {
     background-color: $active_color;
     border-color: $active_color;
+    top: 5px;
+    width: 8px;
+    height: 8px;
 }
 
 .user_circle_idle {
     border-color: $idle_color;
-    background: linear-gradient(
-        to bottom,
-        hsla(0, 0%, 100%, 0) 50%,
-        $idle_color 50%
-    );
+    background: $idle_color;
+    width: 7px;
+    height: 7px;
 }
 
 .user_circle_empty {


### PR DESCRIPTION
It seems like orange is the loudest possible color to
denote a quasi-neutral-idle state, so I hope this is
viewed as at least an incremental improvement.
