### PR TITLE
compose: Align blue selection properly in Drafts.

### DIFF
--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -87,6 +87,8 @@
 
         &.active {
             outline: 2px solid hsl(215, 47%, 50%);
+            /* this offset ensures no gap between the blue box and the draft in active state */
+            outline-offset: -1px;
         }
 
         .message_row {


### PR DESCRIPTION
Added a negative `outline-offset` of the same width as the grey border for the blue selection outline around the `draft-info-box`.

This removes the gap between the blue box in the active state, while the unselected `draft-info-box`es look the same as before, with a grey border.

Fixes: #20950.

**Testing plan:** 
Tested manually, both for light and dark modes, to check that the blue selection outline now fits snuggly around the draft info box, while the unselected look is untampered with.

**GIFs or screenshots:** 
![image](https://user-images.githubusercontent.com/68962290/151534625-5bc9b7e3-1f2b-41cb-a1cd-5427c9b6deef.png)
![image](https://user-images.githubusercontent.com/68962290/151534678-b8a9369d-1b31-46b5-b2b6-95e2e78c69da.png)

