### PR TITLE
drafts: Fix time tooltip in drafts.

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -412,6 +412,10 @@ test("format_drafts", ({override_rewire, mock_template}) => {
 
     $("#drafts_table").append = noop;
 
+    override_rewire(drafts, "update_rendered_elements", (obj) => {
+        assert.equal(obj, $("#drafts_table"));
+    });
+
     const draft_model = drafts.draft_model;
     const ls = localstorage();
     const data = {id1: draft_1, id2: draft_2, id3: draft_3, id4: draft_4, id5: draft_5};

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -22,11 +22,18 @@ import * as markdown from "./markdown";
 import * as narrow from "./narrow";
 import * as overlays from "./overlays";
 import * as people from "./people";
+import * as rendered_markdown from "./rendered_markdown";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 import * as ui_util from "./ui_util";
 import * as util from "./util";
+
+function update_rendered_elements(parent) {
+    parent.find(".rendered_markdown").each(function () {
+        rendered_markdown.update_elements($(this));
+    });
+}
 
 function set_count(count) {
     const drafts_li = $(".top_left_drafts");
@@ -410,6 +417,7 @@ export function launch() {
         if ($("#drafts_table .draft-row").length > 0) {
             $("#drafts_table .no-drafts").hide();
         }
+        update_rendered_elements($("#drafts_table"));
     }
 
     function setup_event_handlers() {


### PR DESCRIPTION
Imported the `rendered_markdown` module into `drafts.js` and called the `update_elements` function inside the `render_widgets` function.

This ensures any dynamic markdown behaviour, like this time tooltip, is displayed in the drafts too, like it is the messages list view.

Fixes: #20948.

**Testing plan:** 
Tested manually, by hovering over the `time` element and verifying that the tooltip shows up as expected, identical to how it would appear in a sent message.

**GIFs or screenshots:** 
![image](https://user-images.githubusercontent.com/68962290/151466406-650266a4-b121-4316-96fb-26d106760504.png)

