### PR TITLE
login_to_access: Remove icons for login buttons.

### DIFF
--- a/static/templates/login_to_access.hbs
+++ b/static/templates/login_to_access.hbs
@@ -18,11 +18,9 @@
             </main>
             <footer class="modal__footer">
                 <a class="modal__btn dialog_submit_button" href="{{signup_link}}">
-                    <i class="fa fa-pencil-square-o"></i>
                     <span>{{t "Sign up" }}</span>
                 </a>
                 <a class="modal__btn dialog_submit_button" href="{{login_link}}">
-                    <i class="fa fa-sign-in"></i>
                     <span>{{t "Log in" }}</span>
                 </a>
             </footer>


### PR DESCRIPTION
They don't serve the purpose of adding clarity to button.
![image](https://user-images.githubusercontent.com/25124304/151484867-67abbaba-e23c-42f4-af4f-afac6e0a4291.png)
