### PR TITLE
recent Topics: Reset text when navigating to recent topics

### DIFF
--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -127,6 +127,9 @@ function build_message_view_header(filter) {
         const message_view_header_data = make_message_view_header(filter);
         append_and_display_title_area(message_view_header_data);
         bind_title_area_handlers();
+        if (recent_topics_util.is_visible) {
+            $("#search_query").val("");
+        }
         if (page_params.search_pills_enabled && $("#search_query").is(":focus")) {
             open_search_bar_and_close_narrow_description();
         } else {


### PR DESCRIPTION
Added code to reset search bar text (opened on clicking recent topics) to  when navigating to recent topics. 

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes: #20956 


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

https://user-images.githubusercontent.com/78212650/151528597-0b404d8e-9af1-4e05-904e-9872db7d43a0.mp4



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
