### PR TITLE
api_docs: Have user settings with enum integers use schema keyword.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7624,15 +7624,13 @@ paths:
 
             Automatic detection is implementing using the standard `prefers-color-scheme`
             media query.
-          content:
-            application/json:
-              schema:
-                type: integer
-                enum:
-                  - 1
-                  - 2
-                  - 3
-              example: 1
+          schema:
+            type: integer
+            enum:
+              - 1
+              - 2
+              - 3
+          example: 1
         - name: enable_drafts_synchronization
           in: query
           description: |
@@ -7704,15 +7702,13 @@ paths:
             - 1 - Automatic
             - 2 - Always
             - 3 - Never
-          content:
-            application/json:
-              schema:
-                type: integer
-                enum:
-                  - 1
-                  - 2
-                  - 3
-              example: 1
+          schema:
+            type: integer
+            enum:
+              - 1
+              - 2
+              - 3
+          example: 1
         - name: enable_stream_desktop_notifications
           in: query
           description: |
@@ -7832,15 +7828,13 @@ paths:
             - 1 - All unreads
             - 2 - Private messages and mentions
             - 3 - None
-          content:
-            application/json:
-              schema:
-                type: integer
-                enum:
-                  - 1
-                  - 2
-                  - 3
-              example: 1
+          schema:
+            type: integer
+            enum:
+              - 1
+              - 2
+              - 3
+          example: 1
         - name: realm_name_in_notifications
           in: query
           description: |
@@ -12171,16 +12165,13 @@ paths:
             media query.
 
             **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
-            the `PATCH /settings/display` endpoint.
-          content:
-            application/json:
-              schema:
-                type: integer
-                enum:
-                  - 1
-                  - 2
-                  - 3
-              example: 1
+          schema:
+            type: integer
+            enum:
+              - 1
+              - 2
+              - 3
+          example: 1
         - name: enable_drafts_synchronization
           in: query
           description: |
@@ -12290,15 +12281,13 @@ paths:
 
             **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
             the `PATCH /settings/display` endpoint.
-          content:
-            application/json:
-              schema:
-                type: integer
-                enum:
-                  - 1
-                  - 2
-                  - 3
-              example: 1
+          schema:
+            type: integer
+            enum:
+              - 1
+              - 2
+              - 3
+          example: 1
         - name: timezone
           in: query
           description: |
@@ -12502,15 +12491,13 @@ paths:
 
             **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
             the `PATCH /settings/notifications` endpoint.
-          content:
-            application/json:
-              schema:
-                type: integer
-                enum:
-                  - 1
-                  - 2
-                  - 3
-              example: 1
+          schema:
+            type: integer
+            enum:
+              - 1
+              - 2
+              - 3
+          example: 1
         - name: realm_name_in_notifications
           in: query
           description: |


### PR DESCRIPTION
There are three user settings that are integer enums: `color_scheme`, `demote_inactive_streams` and `desktop_icon_count_displays`.

Unlike the other user settings, these were using the `content` keyword instead of the `schema` keyword in their definitions, which caused them not to be rendered correctly in the api documentation.

Changes the keyword to `schema` and fixes the indentation for these three user settings in the two endpoints using them. See [this CZO chat](https://chat.zulip.org/#narrow/stream/378-api-design/topic/enums.20in.20user.20settings) for more context.

[HTML diff](https://pastebin.com/AmdHa4E9) shows addition of "Must be one of ..." for enum values.

**Screenshot comparing updates to current:**
![Screenshot from 2022-01-28 15-14-02](https://user-images.githubusercontent.com/63245456/151562899-a79771ed-c83b-4692-a4b2-b3b81cab8ae7.png)
