### PR TITLE
docs: Consistently hyphenate “web-public”

### DIFF
--- a/frontend_tests/node_tests/browser_history.js
+++ b/frontend_tests/node_tests/browser_history.js
@@ -66,7 +66,7 @@ test("update internal hash if required", ({override_rewire}) => {
     assert.equal(stub.num_calls, 1);
 });
 
-test("web public view hash restore", () => {
+test("web-public view hash restore", () => {
     browser_history.update("#");
     assert.equal(window.location.hash, "");
     const new_hash = "#narrow/is/private";

--- a/static/js/browser_history.js
+++ b/static/js/browser_history.js
@@ -31,7 +31,7 @@ export function set_hash_before_overlay(hash) {
 }
 
 export function update_web_public_hash(hash) {
-    // Returns true if hash is web public compatible.
+    // Returns true if hash is web-public compatible.
     if (hash_util.is_spectator_compatible(hash)) {
         state.spectator_old_hash = hash;
         return true;

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -105,7 +105,7 @@ const default_stream_ids = new Set();
 export const stream_privacy_policy_values = {
     web_public: {
         code: "web-public",
-        name: $t({defaultMessage: "Web public"}),
+        name: $t({defaultMessage: "Web-public"}),
         description: $t({
             defaultMessage:
                 "Organization members can join (guests must be invited by a subscriber); anyone on the Internet can view complete message history without creating an account",

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -65,7 +65,7 @@
                                 <i class="fa fa-lock" title="{{t 'This is a private stream' }}" aria-hidden="true"></i>
                             </span>
                             <span id="compose-globe-icon">
-                                <i class="fa fa-globe" title="{{t 'This is a web public stream' }}" aria-hidden="true"></i>
+                                <i class="fa fa-globe" title="{{t 'This is a web-public stream' }}" aria-hidden="true"></i>
                             </span>
                             <input type="text" class="recipient_box" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="30" value="" placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Stream' }}" />
                             <i class="fa fa-angle-right" aria-hidden="true"></i>

--- a/static/templates/login_to_access.hbs
+++ b/static/templates/login_to_access.hbs
@@ -11,7 +11,7 @@
                 <p>
                     {{#tr}}
                         Since you are not logged in, you can only view messages in
-                        <z-link>web public streams</z-link>.
+                        <z-link>web-public streams</z-link>.
                         {{#*inline "z-link"}}<a target="_blank" href="https://zulipchat.com/help/stream-permissions">{{> @partial-block}}</a>{{/inline}}
                     {{/tr}}
                 </p>

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -13,7 +13,7 @@
                 {{/if}}
 
                 {{~#if is_web_public ~}}
-                    <i class="fa fa-globe recipient-row-stream-icon" title="{{t 'This is a web public stream' }}" aria-label="{{t 'This is a web public stream' }}"></i>
+                    <i class="fa fa-globe recipient-row-stream-icon" title="{{t 'This is a web-public stream' }}" aria-label="{{t 'This is a web-public stream' }}"></i>
                 {{/if}}
 
                 {{~! Recipient (e.g. stream/topic or topic) ~}}

--- a/static/templates/stream_settings/stream_permission_description.hbs
+++ b/static/templates/stream_settings/stream_permission_description.hbs
@@ -13,7 +13,7 @@
     {{else if is_web_public}}
     <li>
         {{#tr}}
-        This is a <b>web public stream</b>. Any member of the organization can join without an invitation and anyone on the internet can read the content published.
+        This is a <b>web-public stream</b>. Any member of the organization can join without an invitation and anyone on the internet can read the content published.
         {{/tr}}
     </li>
     {{else}}

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -99,7 +99,7 @@ format used by the Zulip server that they are interacting with.
 **Feature level 103**
 
 * [`POST /register`](/api/register-queue): Added `create_web_public_stream_policy`
-  policy for which users can create web public streams.
+  policy for which users can create web-public streams.
 * [`PATCH /realm`]: Added support for updating `create_web_public_stream_policy`.
 * [`POST /register`](/api/register-queue): Added `can_create_web_public_streams` boolean
   field to the response.

--- a/templates/zerver/help/web-public-streams.md
+++ b/templates/zerver/help/web-public-streams.md
@@ -1,15 +1,15 @@
-# Web public streams
+# Web-public streams
 
 !!! warn ""
 
     This feature is under development, and is not yet available on Zulip Cloud.
 
-Administrators may enable the option to create **web public streams**.
-Web public streams can be viewed by anyone on the Internet without
+Administrators may enable the option to create **web-public streams**.
+Web-public streams can be viewed by anyone on the Internet without
 creating an account in your organization.
 
 For example, you can [link to a Zulip
-topic](/help/link-to-a-message-or-conversation) in a web public stream
+topic](/help/link-to-a-message-or-conversation) in a web-public stream
 from a GitHub issue, a social media post, or a forum thread, and
 anyone will be able to click the link and view the discussion in the
 Zulip web application without needing to create an account.
@@ -17,24 +17,24 @@ Zulip web application without needing to create an account.
 Users who wish to post content will need to create an account in order
 to do so.
 
-Web public streams are indicated with a globe (<i class="fa
+Web-public streams are indicated with a globe (<i class="fa
 fa-globe"></i>) icon.
 
-## Enabling web public streams in your organization
+## Enabling web-public streams in your organization
 
-Enabling web public streams makes it possible to create web public
+Enabling web-public streams makes it possible to create web-public
 streams in your organization. It also makes certain information about
 your organization accessible to anyone on the Internet via the Zulip
 API (details below).
 
-To help protect closed organizations, creating web public streams is
+To help protect closed organizations, creating web-public streams is
 disabled by default for all organizations.
 
-### Information that can be accessed via API when web public streams are enabled
+### Information that can be accessed via API when web-public streams are enabled
 
 The following information about your organization can be accessed via the Zulip
-API if web public streams are enabled and there is currently at least one web
-public stream.
+API if web-public streams are enabled and there is currently at least one
+web-public stream.
 
 * The organization's settings (linkifiers, custom emoji, permissions
   settings, etc.)
@@ -42,13 +42,13 @@ public stream.
 * Names of user groups and their membership
 * Names and descriptions of streams
 
-Enabling web public streams is thus primarily recommended for open
+Enabling web-public streams is thus primarily recommended for open
 communities such as open-source projects and research communities.
 
-### Enable or disable web public streams
+### Enable or disable web-public streams
 
 !!! warn ""
-    Self-hosted Zulip servers must enable support for web public streams by setting
+    Self-hosted Zulip servers must enable support for web-public streams by setting
     `WEB_PUBLIC_STREAMS_ENABLED = True` in their [server
     settings](https://zulip.readthedocs.io/en/latest/production/settings.html)
     prior to proceeding.
@@ -58,50 +58,50 @@ communities such as open-source projects and research communities.
 {settings_tab|organization-permissions}
 
 2. Under **Stream permissions**, toggle the checkbox labeled "Allow
-   creating web public streams (visible to anyone on the Internet)".
+   creating web-public streams (visible to anyone on the Internet)".
 
 {end_tabs}
 
-### Manage who can create web public streams
+### Manage who can create web-public streams
 
 {start_tabs}
 
 {settings_tab|organization-permissions}
 
 2. Under **Stream permissions**, make sure the checkbox labeled "Allow
-   creating web public streams (visible to anyone on the Internet)" is
+   creating web-public streams (visible to anyone on the Internet)" is
    checked.
 
-3. Under **Who can create web public streams?**, select the option you prefer.
+3. Under **Who can create web-public streams?**, select the option you prefer.
 
 {end_tabs}
 
 !!! tip ""
     See [Managing abuse](#managing-abuse) to learn why only
-    trusted roles like Moderators and Administrators can create web public streams.
+    trusted roles like Moderators and Administrators can create web-public streams.
 
-## Creating a web public stream
+## Creating a web-public stream
 
-To create a new web public stream, follow the [instructions for
+To create a new web-public stream, follow the [instructions for
 creating stream](/help/create-a-stream#create-a-stream_1), selecting
-the **Web public** option for **Who can access the stream?**.
+the **Web-public** option for **Who can access the stream?**.
 
-To make an existing stream web public, follow the instructions to
+To make an existing stream web-public, follow the instructions to
 [change the privacy of a
-stream](/help/change-the-privacy-of-a-stream), selecting the **Web
-public** option for **Who can access the stream?**.
+stream](/help/change-the-privacy-of-a-stream), selecting the
+**Web-public** option for **Who can access the stream?**.
 
 ## What can logged out visitors do?
 
-Logged out visitors can browse all content in web public streams,
+Logged out visitors can browse all content in web-public streams,
 including using Zulip's [built-in search](/help/search-for-messages)
 to find conversations. Logged out visitors can only access
-the web public streams in your organization, and the topics, messages
+the web-public streams in your organization, and the topics, messages
 (including uploaded files) and emoji reactions in those streams.
 
 They **cannot**:
 
-* View streams that are not configured as web public streams (or see
+* View streams that are not configured as web-public streams (or see
   whether any such streams exist) without creating an account.
 * Send messages.
 * React with emoji.
@@ -124,8 +124,8 @@ detailed below.
 ### Information about users
 
 Logged out visitors can see the following information about users who
-participate in web public streams. They do not see this information
-about users who do not participate in web public streams in the Zulip
+participate in web-public streams. They do not see this information
+about users who do not participate in web-public streams in the Zulip
 UI, though they may access it via the Zulip API.
 
 * Name
@@ -147,7 +147,7 @@ but not to logged out visitors:
   and whether they have set themselves as unavailable.
 * Detailed profile information, such as [custom profile
   fields](/help/add-custom-profile-fields).
-* Which users are subscribed to which web public streams.
+* Which users are subscribed to which web-public streams.
 
 ## Managing abuse
 
@@ -156,12 +156,12 @@ that allows hosting files visible to the Internet is a potential target for bad
 actors looking for places to distribute illegal or malicious content.
 
 In order to protect Zulip organizations from
-bad actors, web public streams have a few limitations designed to make
+bad actors, web-public streams have a few limitations designed to make
 Zulip an inconvenient target:
 
 * Only users in trusted roles like Moderators can be given permission
-  to create web public streams. This is intended to make it hard for
-  an attacker to host malicious content in an unadvertised web public
+  to create web-public streams. This is intended to make it hard for
+  an attacker to host malicious content in an unadvertised web-public
   stream in a legitimate organization.
 * There are rate limits for unauthenticated access to uploaded
   files, including viewing avatars and custom emoji.
@@ -177,7 +177,7 @@ with Zulip's Rules of Use.
 
 ## Caveats
 
-The web public visitors feature is not yet integrated with Zulip's
+The web-public visitors feature is not yet integrated with Zulip's
 live-update system. As a result, a visitor will not see messages that are sent
 while Zulip is open until they reload the browser window.
 

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -197,7 +197,7 @@ def login_context(request: HttpRequest) -> Dict[str, Any]:
     else:
         realm_description = get_realm_rendered_description(realm)
         realm_invite_required = realm.invite_required
-        # We offer web public access only if the realm has actual web
+        # We offer web-public access only if the realm has actual web
         # public streams configured, in addition to having it enabled.
         realm_web_public_access_enabled = realm.allow_web_public_streams_access()
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3763,7 +3763,7 @@ def validate_user_access_to_subscribers_helper(
     if stream_dict["is_web_public"]:
         return
 
-    # With the exception of web public streams, a guest must
+    # With the exception of web-public streams, a guest must
     # be subscribed to a stream (even a public one) in order
     # to see subscribers.
     if user_profile.is_guest:

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -717,7 +717,7 @@ def access_web_public_message(
     message_id: int,
 ) -> Message:
     """Access control method for unauthenticated requests interacting
-    with a message in web public streams.
+    with a message in web-public streams.
     """
 
     # We throw a MissingAuthenticationError for all errors in this

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -45,7 +45,7 @@ def is_web_public_narrow(narrow: Optional[Iterable[Dict[str, Any]]]) -> bool:
         return False
 
     for term in narrow:
-        # Web public queries are only allowed for limited types of narrows.
+        # Web-public queries are only allowed for limited types of narrows.
         # term == {'operator': 'streams', 'operand': 'web-public', 'negated': False}
         if (
             term["operator"] == "streams"

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -600,7 +600,7 @@ def filter_stream_authorization(
         if stream.recipient_id in subscribed_recipient_ids:
             continue
 
-        # Web public streams are accessible even to guests
+        # Web-public streams are accessible even to guests
         if stream.is_web_public:
             continue
 
@@ -698,7 +698,7 @@ def list_to_streams(
 
         if web_public_stream_requested:
             if not user_profile.realm.web_public_streams_enabled():
-                raise JsonableError(_("Web public streams are not enabled."))
+                raise JsonableError(_("Web-public streams are not enabled."))
             if not user_profile.can_create_web_public_streams():
                 # We set create_web_public_stream_policy to allow only organization owners
                 # to create web-public streams, because of their sensitive nature.

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -250,8 +250,8 @@ class Realm(models.Model):
         default=2 ** 31 - 1,
     )
 
-    # Allow users to access web public streams without login. This
-    # setting also controls API access of web public streams.
+    # Allow users to access web-public streams without login. This
+    # setting also controls API access of web-public streams.
     enable_spectator_access: bool = models.BooleanField(default=False)
 
     # Whether the organization has enabled inline image and URL previews.
@@ -924,7 +924,7 @@ class Realm(models.Model):
         If any of the streams in the realm is web
         public and `enable_spectator_access` and
         settings.WEB_PUBLIC_STREAMS_ENABLED is True,
-        then the Realm is web public.
+        then the Realm is web-public.
         """
         return self.has_web_public_streams()
 
@@ -2245,7 +2245,7 @@ class Stream(models.Model):
             "invite_only": False,
             "history_public_to_subscribers": True,
             "is_web_public": True,
-            "policy_name": gettext_lazy("Web public"),
+            "policy_name": gettext_lazy("Web-public"),
         },
         "public": {
             "invite_only": False,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3605,7 +3605,7 @@ paths:
                                     enable_spectator_access:
                                       type: boolean
                                       description: |
-                                        Whether web public streams are enabled in this organization.
+                                        Whether web-public streams are enabled in this organization.
 
                                         Can only be enabled if the `WEB_PUBLIC_STREAMS_ENABLED`
                                         [server setting][server-settings] is enabled on the Zulip
@@ -6732,9 +6732,9 @@ paths:
           in: query
           description: |
             This parameter determines whether any newly created streams will be
-            web public streams.
+            web-public streams.
 
-            Note that creating web public streams requires the
+            Note that creating web-public streams requires the
             `WEB_PUBLIC_STREAMS_ENABLED` [server setting][server-settings]
             to be enabled on the Zulip server in question, the organization
             to have enabled the `enable_spectator_access` realm setting, and
@@ -10663,7 +10663,7 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          Whether web public streams and related anonymous access APIs/features
+                          Whether web-public streams and related anonymous access APIs/features
                           are enabled in this organization.
 
                           Can only be enabled if the `WEB_PUBLIC_STREAMS_ENABLED`
@@ -12663,7 +12663,7 @@ paths:
         - name: include_web_public
           in: query
           description: |
-            Include all web public streams.
+            Include all web-public streams.
           schema:
             type: boolean
             default: false
@@ -12914,7 +12914,7 @@ paths:
           description: |
             Change whether the stream is a web-public stream.
 
-            Note that creating web public streams requires the
+            Note that creating web-public streams requires the
             `WEB_PUBLIC_STREAMS_ENABLED` [server setting][server-settings]
             to be enabled on the Zulip server in question, the organization
             to have enabled the `enable_spectator_access` realm setting, and

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -425,7 +425,7 @@ class TestDigestEmailMessages(ZulipTestCase):
         self.assertEqual(stream_count, 0)
         self.assertEqual(stream_info["html"], [])
 
-        # but they do if we make it web public
+        # but they do if we make it web-public
         stream.is_web_public = True
         stream.save()
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2588,7 +2588,7 @@ class SubscribeActionTest(BaseAction):
         check_stream_update("events[0]", events[0])
         check_message("events[1]", events[1])
 
-        # Update stream privacy - make stream web public
+        # Update stream privacy - make stream web-public
         action = lambda: do_change_stream_permission(
             stream,
             invite_only=False,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -360,7 +360,7 @@ class HomeTest(ZulipTestCase):
         self.assertEqual(actual_keys, expected_keys)
         self.assertEqual(self.client.session.get("prefers_web_public_view"), True)
 
-        # Web public session key should clear once user is logged in
+        # Web-public session key should clear once user is logged in
         self.login("hamlet")
         self.client_get("/")
         self.assertEqual(self.client.session.get("prefers_web_public_view"), None)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -292,7 +292,7 @@ class TestCreateStreams(ZulipTestCase):
                 "name": "publicstream",
                 "description": "Public stream with public history",
             },
-            {"name": "webpublicstream", "description": "Web public stream", "is_web_public": True},
+            {"name": "webpublicstream", "description": "Web-public stream", "is_web_public": True},
             {
                 "name": "privatestream",
                 "description": "Private stream with non-public history",
@@ -724,7 +724,7 @@ class StreamAdminTest(ZulipTestCase):
         with self.settings(WEB_PUBLIC_STREAMS_ENABLED=False):
             self.assertFalse(user_profile.can_create_web_public_streams())
             self.assertFalse(owner.can_create_web_public_streams())
-            with self.assertRaisesRegex(JsonableError, "Web public streams are not enabled."):
+            with self.assertRaisesRegex(JsonableError, "Web-public streams are not enabled."):
                 list_to_streams(
                     streams_raw,
                     owner,
@@ -907,7 +907,7 @@ class StreamAdminTest(ZulipTestCase):
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_OWNER, acting_user=None)
         with self.settings(WEB_PUBLIC_STREAMS_ENABLED=False):
             result = self.client_patch(f"/json/streams/{stream_id}", params)
-        self.assert_json_error(result, "Web public streams are not enabled.")
+        self.assert_json_error(result, "Web-public streams are not enabled.")
 
         bad_params = {
             "stream_name": orjson.dumps("test_stream").decode(),
@@ -942,7 +942,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**King Hamlet|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
-            "for this stream from **Public** to **Web public**."
+            "for this stream from **Public** to **Web-public**."
         )
         self.assertEqual(messages[0].content, expected_notification)
 
@@ -2535,7 +2535,7 @@ class DefaultStreamTest(ZulipTestCase):
         self.login_user(user_profile)
         self.assertEqual(user_profile.role, UserProfile.ROLE_GUEST)
 
-        # Get all the streams that Polonius has access to (subscribed + web public streams)
+        # Get all the streams that Polonius has access to (subscribed + web-public streams)
         result = self.client_get("/json/streams", {"include_web_public": "true"})
         streams = result.json()["streams"]
         sub_info = gather_subscriptions_helper(user_profile)
@@ -4350,7 +4350,7 @@ class SubscriptionAPITest(ZulipTestCase):
         public_stream = self.make_stream("public_stream", invite_only=False)
         private_stream = self.make_stream("private_stream2", invite_only=True)
         # This test should be added as soon as the subscription endpoint allows
-        # guest users to subscribe to web public streams. Although they are already
+        # guest users to subscribe to web-public streams. Although they are already
         # authorized, the decorator in "add_subscriptions_backend" still needs to be
         # deleted.
         #
@@ -5760,7 +5760,7 @@ class GetSubscribersTest(ZulipTestCase):
         never_subscribed = gather_subscriptions_helper(guest_user, True).never_subscribed
 
         # A guest user can only see never subscribed streams that are web-public.
-        # For Polonius, the only web public stream that he is not subscribed at
+        # For Polonius, the only web-public stream that he is not subscribed at
         # this point is Rome.
         self.assert_length(never_subscribed, 1)
 
@@ -5894,7 +5894,7 @@ class AccessStreamTest(ZulipTestCase):
 
         stream_name = "web_public_stream"
         stream = self.make_stream(stream_name, guest_user_profile.realm, is_web_public=True)
-        # Guest users have access to web public streams even if they aren't subscribed.
+        # Guest users have access to web-public streams even if they aren't subscribed.
         (stream_ret, sub_ret) = access_stream_by_id(guest_user_profile, stream.id)
         self.assertTrue(can_access_stream_history(guest_user_profile, stream))
         assert sub_ret is None

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -316,7 +316,7 @@ def update_stream_backend(
     if is_web_public:
         # Enforce restrictions on creating web-public streams.
         if not user_profile.realm.web_public_streams_enabled():
-            raise JsonableError(_("Web public streams are not enabled."))
+            raise JsonableError(_("Web-public streams are not enabled."))
         if not user_profile.can_create_web_public_streams():
             raise JsonableError(_("Insufficient permission"))
         # Forbid parameter combinations that are inconsistent


### PR DESCRIPTION
In English, compound adjectives should essentially always be hyphenated. This makes them easier to parse, especially for users who might not recognize that the words “web public” go together as a phrase.