### PR TITLE
resolve topic: Limit unread flag on automated notifications.

### DIFF
--- a/templates/zerver/help/resolve-a-topic.md
+++ b/templates/zerver/help/resolve-a-topic.md
@@ -10,7 +10,8 @@ investigation, or notification. Marking a topic as resolved:
 * Puts a ✔ at the beginning of the topic name, e.g. `example topic`
   becomes `✔ example topic`.
 * Triggers an automated message from Notification Bot indicating that
-  you resolved the topic.
+  you resolved the topic. This message will be marked as unread
+  only for users who had participated in the topic.
 * Changes whether the topic appears when using the `is:resolved` and
   `-is:resolved` [search operators](/help/search-for-messages).
 

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -126,6 +126,7 @@ class SendMessageRequest:
     submessages: List[Dict[str, Any]] = field(default_factory=list)
     deliver_at: Optional[datetime.datetime] = None
     delivery_type: Optional[str] = None
+    limit_unread_user_ids: Optional[Set[int]] = None
 
 
 # We won't try to fetch more unread message IDs from the database than


### PR DESCRIPTION
Previously, users found it annoying that the automated "Resolve topic"
notifications triggered an unread for everyone in the stream; this
discouraged some users from using the feature on older threads for
fear of being annoying. We change this to a better default, of only
users who participated in the topic (via either messages or reactions)
being eligible for the new message being unread.

We will likely want to create global and stream-level notifications
settings to control this behavior as a follow-up -- some users, like
me, might prefer the simpler "Always unread" behavior in some streams.

Note that the automated notifications that a topic was resolved will
still result in the topic being moved to the top of the left sidebar.
This would be somewhat difficult to change, since the left sidebar
algorithm just looks at the highest message ID in the topic.

Fixes #19709.

Only tested manually.  @amanagr do you have time to add tests for this?  It'd be a huge help.