### PR TITLE
compose: Fix compose box initialization order.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -20,7 +20,6 @@ const fake_now = 555;
 
 const channel = mock_esm("../../static/js/channel");
 const compose_actions = mock_esm("../../static/js/compose_actions");
-const giphy = mock_esm("../../static/js/giphy");
 const loading = mock_esm("../../static/js/loading");
 const markdown = mock_esm("../../static/js/markdown");
 const notifications = mock_esm("../../static/js/notifications");
@@ -95,7 +94,6 @@ function test_ui(label, f) {
 
 function initialize_handlers({override, override_rewire}) {
     override_rewire(compose, "compute_show_video_chat_button", () => false);
-    override_rewire(compose, "render_compose_box", () => {});
     override_rewire(upload, "setup_upload", () => undefined);
     override(resize, "watch_manual_resize", () => {});
     compose.initialize();
@@ -400,9 +398,7 @@ test_ui("finish", ({override, override_rewire}) => {
     })();
 });
 
-test_ui("initialize", ({override, override_rewire, mock_template}) => {
-    override(giphy, "is_giphy_enabled", () => true);
-
+test_ui("initialize", ({override, override_rewire}) => {
     let compose_actions_expected_opts;
     let compose_actions_start_checked;
 
@@ -443,13 +439,6 @@ test_ui("initialize", ({override, override_rewire, mock_template}) => {
                 uppy_cancel_all_called = true;
             },
         };
-    });
-
-    mock_template("compose.hbs", false, (context) => {
-        assert.equal(context.embedded, false);
-        assert.equal(context.file_upload_enabled, true);
-        assert.equal(context.giphy_enabled, true);
-        return "fake-compose-template";
     });
 
     compose.initialize();

--- a/frontend_tests/node_tests/compose_video.js
+++ b/frontend_tests/node_tests/compose_video.js
@@ -53,13 +53,13 @@ const realm_available_video_chat_providers = {
 };
 
 function test(label, f) {
-    run_test(label, ({override, override_rewire, mock_template}) => {
+    run_test(label, ({override, override_rewire}) => {
         page_params.realm_available_video_chat_providers = realm_available_video_chat_providers;
-        f({override, override_rewire, mock_template});
+        f({override, override_rewire});
     });
 }
 
-test("videos", ({override, override_rewire, mock_template}) => {
+test("videos", ({override, override_rewire}) => {
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.disabled.id;
 
     override(upload, "setup_upload", () => {});
@@ -67,7 +67,6 @@ test("videos", ({override, override_rewire, mock_template}) => {
 
     stub_out_video_calls();
 
-    mock_template("compose.hbs", false, () => "fake-compose-template");
     compose.initialize();
 
     (function test_no_provider_video_link_compose_clicked() {
@@ -220,20 +219,18 @@ test("videos", ({override, override_rewire, mock_template}) => {
     })();
 });
 
-test("test_video_chat_button_toggle disabled", ({override, mock_template}) => {
+test("test_video_chat_button_toggle disabled", ({override}) => {
     override(upload, "setup_upload", () => {});
     override(upload, "feature_check", () => {});
-    mock_template("compose.hbs", false, () => "fake-compose-template");
 
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.disabled.id;
     compose.initialize();
     assert.equal($("#below-compose-content .video_link").visible(), false);
 });
 
-test("test_video_chat_button_toggle no url", ({override, mock_template}) => {
+test("test_video_chat_button_toggle no url", ({override}) => {
     override(upload, "setup_upload", () => {});
     override(upload, "feature_check", () => {});
-    mock_template("compose.hbs", false, () => "fake-compose-template");
 
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
     page_params.jitsi_server_url = null;
@@ -241,10 +238,9 @@ test("test_video_chat_button_toggle no url", ({override, mock_template}) => {
     assert.equal($("#below-compose-content .video_link").visible(), false);
 });
 
-test("test_video_chat_button_toggle enabled", ({override, mock_template}) => {
+test("test_video_chat_button_toggle enabled", ({override}) => {
     override(upload, "setup_upload", () => {});
     override(upload, "feature_check", () => {});
-    mock_template("compose.hbs", false, () => "fake-compose-template");
 
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
     page_params.jitsi_server_url = "https://meet.jit.si";

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -1,11 +1,8 @@
 import $ from "jquery";
 import _ from "lodash";
 
-import render_compose from "../templates/compose.hbs";
-
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
-import * as common from "./common";
 import * as compose_actions from "./compose_actions";
 import * as compose_error from "./compose_error";
 import * as compose_fade from "./compose_fade";
@@ -14,7 +11,6 @@ import * as compose_ui from "./compose_ui";
 import * as compose_validate from "./compose_validate";
 import * as echo from "./echo";
 import * as flatpickr from "./flatpickr";
-import * as giphy from "./giphy";
 import {$t, $t_html} from "./i18n";
 import * as loading from "./loading";
 import * as markdown from "./markdown";
@@ -387,21 +383,7 @@ export function render_and_show_preview(preview_spinner, preview_content_box, co
     }
 }
 
-export function render_compose_box() {
-    $("#compose-container").append(
-        render_compose({
-            embedded: $("#compose").attr("data-embedded") === "",
-            file_upload_enabled: page_params.max_file_upload_size_mib > 0,
-            giphy_enabled: giphy.is_giphy_enabled(),
-        }),
-    );
-    $(`.enter_sends_${user_settings.enter_sends}`).show();
-    common.adjust_mac_shortcuts(".enter_sends kbd");
-}
-
 export function initialize() {
-    render_compose_box();
-
     $("#below-compose-content .video_link").toggle(compute_show_video_chat_button());
     $(
         "#stream_message_recipient_stream,#stream_message_recipient_topic,#private_message_recipient",

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -5,6 +5,7 @@ import generated_emoji_codes from "../generated/emoji/emoji_codes.json";
 import generated_pygments_data from "../generated/pygments_data.json";
 import * as emoji from "../shared/js/emoji";
 import * as fenced_code from "../shared/js/fenced_code";
+import render_compose from "../templates/compose.hbs";
 import render_edit_content_button from "../templates/edit_content_button.hbs";
 import render_left_sidebar from "../templates/left_sidebar.hbs";
 import render_navbar from "../templates/navbar.hbs";
@@ -16,6 +17,7 @@ import * as alert_words from "./alert_words";
 import * as blueslip from "./blueslip";
 import * as bot_data from "./bot_data";
 import * as click_handlers from "./click_handlers";
+import * as common from "./common";
 import * as compose from "./compose";
 import * as compose_closed_ui from "./compose_closed_ui";
 import * as compose_pm_pill from "./compose_pm_pill";
@@ -183,6 +185,18 @@ function initialize_navbar() {
     });
 
     $("#navbar-container").html(rendered_navbar);
+}
+
+function initialize_compose_box() {
+    $("#compose-container").append(
+        render_compose({
+            embedded: $("#compose").attr("data-embedded") === "",
+            file_upload_enabled: page_params.max_file_upload_size_mib > 0,
+            giphy_enabled: giphy.is_giphy_enabled(),
+        }),
+    );
+    $(`.enter_sends_${user_settings.enter_sends}`).show();
+    common.adjust_mac_shortcuts(".enter_sends kbd");
 }
 
 export function initialize_kitchen_sink_stuff() {
@@ -554,8 +568,8 @@ export function initialize_everything() {
     // modules were migrated from Django templates to handlebars).
     initialize_left_sidebar();
     initialize_right_sidebar();
+    initialize_compose_box();
     settings.initialize();
-    compose.initialize();
     initialize_navbar();
     realm_logo.render();
 
@@ -598,6 +612,7 @@ export function initialize_everything() {
     markdown.initialize(markdown_config.get_helpers());
     linkifiers.initialize(page_params.realm_linkifiers);
     realm_playground.initialize(page_params.realm_playgrounds, generated_pygments_data);
+    compose.initialize();
     composebox_typeahead.initialize(); // Must happen after compose.initialize()
     search.initialize();
     tutorial.initialize();


### PR DESCRIPTION
This effectively reverts part of
70d444a8eb93cda92fcca7362c6917f2f7ef6ddd.  While it's correct that we
want to render this bit of Handlebars template early, it was not
correct to move all compose box initialization earlier.

Do the same thing we do with the left/right sidebar container
templates, which is to render them directly in `ui_init.js`.

Fixes #20778.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Tested the `?stream=` feature manually.  The node tests fail; @amanagr can you help?  I think we're basically undoing bits of your commit that went with this initialization order change.

@rwbarton FYI as well.