### PR TITLE
message_feed_display: Show multiple attached images horizontally.

### DIFF
--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -309,7 +309,7 @@
         margin-bottom: 5px;
         margin-left: 5px;
         height: 100px;
-        display: block !important;
+        display: inline-block !important;
         border: none !important;
     }
 


### PR DESCRIPTION
Show multiple attached images horizontally by changing "display: block" to "display: inline-block" of ".message_inline_image".

Fixes #20975

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

https://user-images.githubusercontent.com/85362194/151646766-bdfef46c-307c-47fc-bca3-331554bd6da8.mov



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
