### PR TITLE
message_feed_ui: Make unread marker line continuous.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1285,6 +1285,7 @@ td.pointer {
 .unread_marker {
     display: block;
     position: absolute;
+    height: 100%;
     left: 2px;
     top: 0;
     opacity: 0;


### PR DESCRIPTION
Make unread marker line continuous by adding "height: 100%" to  ".unread-marker"

Fixes #20981

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="958" alt="Screenshot 2022-01-29 at 11 49 57" src="https://user-images.githubusercontent.com/85362194/151650274-a998d6fa-4fc0-4202-ac26-61c867504a25.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
