### PR TITLE
Live update the stream privacy icon.

### DIFF
--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -211,6 +211,7 @@ export function update_stream_privacy(slim_sub, values) {
 
     // Update UI elements
     update_left_panel_row(sub);
+    stream_ui_updates.update_stream_privacy_icon_in_settings(sub);
     stream_ui_updates.update_stream_subscription_type_text(sub);
     stream_ui_updates.update_change_stream_privacy_settings(sub);
     stream_ui_updates.update_settings_button_for_sub(sub);

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import render_stream_permission_description from "../templates/stream_settings/stream_permission_description.hbs";
+import render_stream_privacy_icon from "../templates/stream_settings/stream_privacy_icon.hbs";
 import render_stream_settings_tip from "../templates/stream_settings/stream_settings_tip.hbs";
 
 import * as hash_util from "./hash_util";
@@ -138,6 +139,22 @@ export function update_change_stream_privacy_settings(sub) {
     } else {
         $stream_privacy_btn.hide();
     }
+}
+
+export function update_stream_privacy_icon_in_settings(sub) {
+    if (!hash_util.is_editing_stream(sub.stream_id)) {
+        return;
+    }
+
+    const $stream_settings = stream_settings_containers.get_edit_container(sub);
+
+    $stream_settings.find(".general_settings .large-icon").replaceWith(
+        render_stream_privacy_icon({
+            invite_only: sub.invite_only,
+            color: sub.color,
+            is_web_public: sub.is_web_public,
+        }),
+    );
 }
 
 export function update_permissions_banner(sub) {


### PR DESCRIPTION
This live updates the stream privacy icon in the general stream
settings after changing the privacy setting of the stream.

![chrome-capture (1)](https://user-images.githubusercontent.com/74348920/151655715-ebc46f62-68b7-4a21-b90f-a8530eff8a1a.gif)

