### PR TITLE
streams: Update formatting of retention change notification.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5429,25 +5429,29 @@ def send_change_stream_message_retention_days_notification(
 
     with override_language(stream.realm.default_language):
         if old_value == Stream.MESSAGE_RETENTION_SPECIAL_VALUES_MAP["unlimited"]:
-            notification_string = _(
-                "{user} has changed the [message retention period](/help/message-retention-policy) for this stream from "
-                "**Forever** to **{new_value} days**. Messages will be automatically deleted after {new_value} days."
-            )
-            notification_string = notification_string.format(user=user_mention, new_value=new_value)
+            old_retention_period = _("Forever")
+            new_retention_period = f"{new_value} days"
+            summary_line = f"Messages in this stream will now be automatically deleted {new_value} days after they are sent."
         elif new_value == Stream.MESSAGE_RETENTION_SPECIAL_VALUES_MAP["unlimited"]:
-            notification_string = _(
-                "{user} has changed the [message retention period](/help/message-retention-policy) for this stream from "
-                "**{old_value} days** to **Forever**."
-            )
-            notification_string = notification_string.format(user=user_mention, old_value=old_value)
+            old_retention_period = f"{old_value} days"
+            new_retention_period = _("Forever")
+            summary_line = _("Messages in this stream will now be retained forever.")
         else:
-            notification_string = _(
-                "{user} has changed the [message retention period](/help/message-retention-policy) for this stream from "
-                "**{old_value} days** to **{new_value} days**. Messages will be automatically deleted after {new_value} days."
-            )
-            notification_string = notification_string.format(
-                user=user_mention, old_value=old_value, new_value=new_value
-            )
+            old_retention_period = f"{old_value} days"
+            new_retention_period = f"{new_value} days"
+            summary_line = f"Messages in this stream will now be automatically deleted {new_value} days after they are sent."
+        notification_string = _(
+            "{user} has changed the [message retention period](/help/message-retention-policy) for this stream:\n"
+            "* **Old retention period**: {old_retention_period}\n"
+            "* **New retention period**: {new_retention_period}\n\n"
+            "{summary_line}"
+        )
+        notification_string = notification_string.format(
+            user=user_mention,
+            old_retention_period=old_retention_period,
+            new_retention_period=new_retention_period,
+            summary_line=summary_line,
+        )
         internal_send_stream_message(
             sender, stream, Realm.STREAM_EVENTS_NOTIFICATION_TOPIC, notification_string
         )

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1781,9 +1781,10 @@ class StreamAdminTest(ZulipTestCase):
         messages = get_topic_messages(user_profile, stream, "stream events")
         self.assert_length(messages, 1)
         expected_notification = (
-            f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) "
-            "for this stream from **Forever** to **2 days**. Messages will be automatically "
-            "deleted after 2 days."
+            f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) for this stream:\n"
+            "* **Old retention period**: Forever\n"
+            "* **New retention period**: 2 days\n\n"
+            "Messages in this stream will now be automatically deleted 2 days after they are sent."
         )
         self.assertEqual(messages[0].content, expected_notification)
         realm_audit_log = RealmAuditLog.objects.filter(
@@ -1803,9 +1804,10 @@ class StreamAdminTest(ZulipTestCase):
         messages = get_topic_messages(user_profile, stream, "stream events")
         self.assert_length(messages, 2)
         expected_notification = (
-            f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) "
-            "for this stream from **2 days** to **8 days**. Messages will be automatically "
-            "deleted after 8 days."
+            f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) for this stream:\n"
+            "* **Old retention period**: 2 days\n"
+            "* **New retention period**: 8 days\n\n"
+            "Messages in this stream will now be automatically deleted 8 days after they are sent."
         )
         self.assertEqual(messages[1].content, expected_notification)
         realm_audit_log = RealmAuditLog.objects.filter(
@@ -1826,8 +1828,10 @@ class StreamAdminTest(ZulipTestCase):
         messages = get_topic_messages(user_profile, stream, "stream events")
         self.assert_length(messages, 3)
         expected_notification = (
-            f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) "
-            "for this stream from **8 days** to **Forever**."
+            f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) for this stream:\n"
+            "* **Old retention period**: 8 days\n"
+            "* **New retention period**: Forever\n\n"
+            "Messages in this stream will now be retained forever."
         )
         self.assertEqual(messages[2].content, expected_notification)
         realm_audit_log = RealmAuditLog.objects.filter(


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is meant to close: #20969

**Testing plan:** <!-- How have you tested? -->

I updated the `notification_string` variable from `send_change_stream_message_retention_days_notification` method to the new format. With local development setup, as an owner of organization I made changes to retention policy of the stream. I tested following scenarios:
1. Change retention policy from forever to 4 days
2. Change retention policy from 4 days to 1 day
3. Change retention policy from 1 day to forever



**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

1. Notification when retention policy is changed from Forever to 4 days:
![Screenshot from 2022-01-30 00-34-17](https://user-images.githubusercontent.com/451188/151674208-08db7ed8-5179-4ce5-b314-ee64330767fa.png)

2. Notification when retention policy is changed from 4 days to 1 day:
![Screenshot from 2022-01-30 00-40-18](https://user-images.githubusercontent.com/451188/151674312-fbcc6a66-7cdf-44fd-b812-6700c8d0d567.png)


3. Notification when retention policy is changed from 4 day to Forever:

![Screenshot from 2022-01-30 00-41-42](https://user-images.githubusercontent.com/451188/151674340-6682c0d8-c6f8-4da0-ae77-b2fe42912f33.png)

** Need input**
`days` is plural in all the message strings and grammatically it doesn't work with single/1 day. @alya is it okay if we keep it this way, it was also the case with the notification prior to current formatting in this PR.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
