### PR TITLE
docs: Fix the path to the py3 venv.

### DIFF
--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -298,7 +298,7 @@ instructions for other supported platforms.
    collations. Regenerate the affected indexes by running:
 
    ```bash
-   /srv/zulip-py3-venv/bin/python /home/zulip/deployments/current/scripts/setup/reindex-textual-data --force
+   /home/zulip/deployments/current/zulip-py3-venv/bin/python /home/zulip/deployments/current/scripts/setup/reindex-textual-data --force
    ```
 
 6. Finally, we need to reinstall the current version of Zulip, which
@@ -461,7 +461,7 @@ instructions for other supported platforms.
    collations. Regenerate the affected indexes by running:
 
    ```bash
-   /srv/zulip-py3-venv/bin/python /home/zulip/deployments/current/scripts/setup/reindex-textual-data --force
+   /home/zulip/deployments/current/zulip-py3-venv/bin/python /home/zulip/deployments/current/scripts/setup/reindex-textual-data --force
    ```
 
 7. As root, finish by verifying the contents of the full-text indexes:
@@ -534,7 +534,7 @@ instructions for other supported platforms.
    collations. Regenerate the affected indexes by running:
 
    ```bash
-   /srv/zulip-py3-venv/bin/python /home/zulip/deployments/current/scripts/setup/reindex-textual-data --force
+   /home/zulip/deployments/current/zulip-py3-venv/bin/python /home/zulip/deployments/current/scripts/setup/reindex-textual-data --force
    ```
 
 8. As root, finish by verifying the contents of the full-text indexes:


### PR DESCRIPTION
`/srv/zulip-py3-venv` only exists on development hosts; use the path
to the current venv.

**Testing plan:** https://chat.zulip.org/#narrow/stream/31-production-help/topic/zulip-py3-venv.20missing/near/1318904

cc @andersk 