### PR TITLE
compose: Disable unneeded buttons while in preview.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -297,6 +297,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     $("#compose .undo_markdown_preview").show();
     $("#compose .preview_message_area").show();
     $("#compose .markdown_preview").hide();
+    $("#compose").addClass("preview_mode");
     user_settings.enter_sends = true;
     let send_message_called = false;
     override_rewire(compose, "send_message", () => {
@@ -307,6 +308,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     assert.ok(!$("#compose .undo_markdown_preview").visible());
     assert.ok(!$("#compose .preview_message_area").visible());
     assert.ok($("#compose .markdown_preview").visible());
+    assert.ok(!$("#compose").hasClass("preview_mode"));
     assert.ok(send_message_called);
     assert.ok(show_button_spinner_called);
 
@@ -357,6 +359,7 @@ test_ui("finish", ({override, override_rewire}) => {
         $("#compose .undo_markdown_preview").show();
         $("#compose .preview_message_area").show();
         $("#compose .markdown_preview").hide();
+        $("#compsoe").addClass("preview_mode");
         $("#compose-textarea").val("foobarfoobar");
         compose_state.set_message_type("private");
         override_rewire(compose_state, "private_message_recipient", () => "bob@example.com");
@@ -375,6 +378,7 @@ test_ui("finish", ({override, override_rewire}) => {
         assert.ok(!$("#compose .undo_markdown_preview").visible());
         assert.ok(!$("#compose .preview_message_area").visible());
         assert.ok($("#compose .markdown_preview").visible());
+        assert.ok(!$("#compose").hasClass("preview_mode"));
         assert.ok(send_message_called);
         assert.ok(compose_finished_event_checked);
 
@@ -382,6 +386,7 @@ test_ui("finish", ({override, override_rewire}) => {
         $("#compose .undo_markdown_preview").show();
         $("#compose .preview_message_area").show();
         $("#compose .markdown_preview").hide();
+        $("#compose").addClass("preview_mode");
         $("#compose-textarea").val("foobarfoobar");
         compose_state.set_message_type("stream");
         override_rewire(compose_state, "stream_name", () => "social");
@@ -397,6 +402,7 @@ test_ui("finish", ({override, override_rewire}) => {
         assert.ok(!$("#compose .undo_markdown_preview").visible());
         assert.ok(!$("#compose .preview_message_area").visible());
         assert.ok($("#compose .markdown_preview").visible());
+        assert.ok(!$("#compose").hasClass("preview_mode"));
         assert.ok(schedule_message);
         assert.ok(compose_finished_event_checked);
     })();
@@ -775,6 +781,7 @@ test_ui("on_events", ({override, override_rewire}) => {
             $("#compose .markdown_preview").show();
             $("#compose .undo_markdown_preview").hide();
             $("#compose .preview_message_area").hide();
+            $("#compose").removeClass("preview_mode");
         }
 
         function assert_visibilities() {
@@ -782,6 +789,7 @@ test_ui("on_events", ({override, override_rewire}) => {
             assert.ok(!$("#compose .markdown_preview").visible());
             assert.ok($("#compose .undo_markdown_preview").visible());
             assert.ok($("#compose .preview_message_area").visible());
+            assert.ok($("#compose").hasClass("preview_mode"));
         }
 
         function setup_mock_markdown_contains_backend_only_syntax(msg_content, return_val) {
@@ -902,6 +910,7 @@ test_ui("on_events", ({override, override_rewire}) => {
         $("#compose .undo_markdown_preview").show();
         $("#compose .preview_message_area").show();
         $("#compose .markdown_preview").hide();
+        $("#compose").removeClass("preview_mode");
 
         const event = {
             preventDefault: noop,
@@ -914,6 +923,7 @@ test_ui("on_events", ({override, override_rewire}) => {
         assert.ok(!$("#compose .undo_markdown_preview").visible());
         assert.ok(!$("#compose .preview_message_area").visible());
         assert.ok($("#compose .markdown_preview").visible());
+        assert.ok(!$("#compose").hasClass("preview_mode"));
     })();
 });
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -89,6 +89,11 @@ export function clear_preview_area() {
     $("#compose .preview_content").empty();
     $("#compose .markdown_preview").show();
     autosize.update($("#compose-textarea"));
+
+    // While in preview mode we disable unneeded compose_control_buttons,
+    // so here we are re-enabling that compose_control_buttons
+    $("#compose").removeClass("preview_mode");
+    $("#compose .preview_mode_disabled .compose_control_button").attr("tabindex", 0);
 }
 
 export function update_fade() {
@@ -677,6 +682,11 @@ export function initialize() {
     $("#compose").on("click", ".markdown_preview", (e) => {
         e.preventDefault();
         e.stopPropagation();
+
+        // Disable unneeded compose_control_buttons as we don't
+        // need them in preview mode.
+        $("#compose").addClass("preview_mode");
+        $("#compose .preview_mode_disabled .compose_control_button").attr("tabindex", -1);
 
         const content = $("#compose-textarea").val();
         $("#compose-textarea").hide();

--- a/static/js/popover_menus.js
+++ b/static/js/popover_menus.js
@@ -132,6 +132,7 @@ export function initialize() {
                 parse_html(
                     render_compose_control_buttons_popover({
                         giphy_enabled: giphy.is_giphy_enabled(),
+                        preview_mode_on: $("#compose").hasClass("preview_mode"),
                     }),
                 ),
             );

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -778,3 +778,14 @@ a.compose_control_button.hide {
         flex: 1;
     }
 }
+
+.preview_mode {
+    .preview_mode_disabled {
+        cursor: not-allowed;
+        opacity: 0.3;
+
+        .compose_control_button {
+            pointer-events: none;
+        }
+    }
+}

--- a/static/templates/compose_control_buttons.hbs
+++ b/static/templates/compose_control_buttons.hbs
@@ -1,15 +1,18 @@
 <div class="compose_control_buttons_container order-1">
-    <input type="file" class="file_input notvisible pull-left" multiple />
-    {{#if file_upload_enabled }}
-    <a role="button" class="compose_control_button compose_upload_file fa fa-paperclip notdisplayed" aria-label="{{t 'Upload files' }}" tabindex=0 data-tippy-content="{{t 'Upload files' }}"></a>
-    {{/if}}
     <a role="button" class="markdown_preview compose_control_button fa fa-eye" aria-label="{{t 'Preview' }}" tabindex=0 data-tippy-content="{{t 'Preview' }}"></a>
     <a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"></a>
-    <a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"></a>
-    <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 data-tippy-content="{{t 'Add emoji' }}"></a>
-    <a role="button" class="compose_control_button fa fa-clock-o time_pick" aria-label="{{t 'Add global time' }}" tabindex=0 data-tooltip-template-id="add-global-time-tooltip" data-tippy-maxWidth="none"></a>
-    <a role="button" class="compose_control_button compose_gif_icon {{#unless giphy_enabled }} hide {{/unless}} zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0 data-tippy-content="{{t 'Add GIF' }}"></a>
-    <div class="divider hide-sm">|</div>
+    <div class="compose_control_buttons_container preview_mode_disabled">
+        <div class="divider">|</div>
+        <input type="file" class="file_input notvisible pull-left" multiple />
+        {{#if file_upload_enabled }}
+        <a role="button" class="compose_control_button compose_upload_file fa fa-paperclip notdisplayed" aria-label="{{t 'Upload files' }}" tabindex=0 data-tippy-content="{{t 'Upload files' }}"></a>
+        {{/if}}
+        <a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"></a>
+        <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 data-tippy-content="{{t 'Add emoji' }}"></a>
+        <a role="button" class="compose_control_button fa fa-clock-o time_pick" aria-label="{{t 'Add global time' }}" tabindex=0 data-tooltip-template-id="add-global-time-tooltip" data-tippy-maxWidth="none"></a>
+        <a role="button" class="compose_control_button compose_gif_icon {{#unless giphy_enabled }} hide {{/unless}} zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0 data-tippy-content="{{t 'Add GIF' }}"></a>
+        <div class="divider hide-sm">|</div>
+    </div>
     <div class="{{#if message_id}}hide-lg{{else}}hide-sm{{/if}}">
         {{> compose_control_buttons_in_popover}}
     </div>

--- a/static/templates/compose_control_buttons_in_popover.hbs
+++ b/static/templates/compose_control_buttons_in_popover.hbs
@@ -1,5 +1,7 @@
-<a role="button" data-format-type="bold" class="compose_control_button fa fa-bold formatting_button" aria-label="{{t 'Bold' }}" tabindex=0 data-tippy-content="{{t 'Bold' }}"></a>
-<a role="button" data-format-type="italic" class="compose_control_button fa fa-italic formatting_button" aria-label="{{t 'Italic' }}" tabindex=0 data-tippy-content="{{t 'Italic' }}"></a>
-<a role="button" data-format-type="link" class="compose_control_button fa fa-link formatting_button" aria-label="{{t 'Link' }}" tabindex=0 data-tippy-content="{{t 'Link' }}"></a>
-<div class="divider hide-sm">|</div>
+<div class="compose_control_buttons_container preview_mode_disabled">
+    <a role="button" data-format-type="bold" class="compose_control_button fa fa-bold formatting_button" aria-label="{{t 'Bold' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} value="{{preview_mode_on}}" data-tippy-content="{{t 'Bold' }}"></a>
+    <a role="button" data-format-type="italic" class="compose_control_button fa fa-italic formatting_button" aria-label="{{t 'Italic' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Italic' }}"></a>
+    <a role="button" data-format-type="link" class="compose_control_button fa fa-link formatting_button" aria-label="{{t 'Link' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Link' }}"></a>
+    <div class="divider hide-sm">|</div>
+</div>
 <a role="button" class="compose_control_button compose_help_button fa fa-question" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>

--- a/static/templates/compose_control_buttons_popover.hbs
+++ b/static/templates/compose_control_buttons_popover.hbs
@@ -1,3 +1,3 @@
-<div class="compose_control_buttons_container order-1">
+<div class="compose_control_buttons_container order-1 {{#if preview_mode_on}} preview_mode {{/if}}">
     {{> compose_control_buttons_in_popover}}
 </div>


### PR DESCRIPTION
Moved the preview icon to the front.

It perform's `addClass("preview_mode")`  on
the `#compose` id whenever user clicks on preview
button to disable them, and `removeClass("preview_mode")`
when `clear_preview_area()` gets called to re-enable
them.

`clear_preview_area()` runs also on click of edit button.

To disable it sets `opacity: 0.3` to gray out buttons, and
now to set the cursor to disable mode I needed to wrap
the control buttons with `div`, as `pointer-events: none`
disables all mouse functions, `pointer-events: none` is
needed for disabling click event of buttons.

As `#compose` is not parent id of compose control buttons
in a popover, so I had to pass variable `preview_mode_on=bool`
in render file of popover.

Skipping disabled buttons while tabbing, by changing
`tabindex` value.

**Fixes:** https://github.com/zulip/zulip/issues/20962
**Fixes part of:** https://github.com/zulip/zulip/issues/20972

**Testing plan:** Manually tested in both dark
and light themes also added tests in node_tests/compose.js

**GIFs or screenshots:** 
![disable_except_help_draft_icon](https://user-images.githubusercontent.com/41695888/156828507-7cf99fde-0f46-4c23-bbf2-d51cd3e34c47.png)
![skip_disabled_icons_on_tab_press](https://user-images.githubusercontent.com/41695888/157086365-6dd9baa4-a41d-43bf-b9aa-b5a8b7205aab.gif)
<details>
<summary>
Mobile screen view:
</summary>

![skip_disabled_icons_on_tab_press_mobile_screen](https://user-images.githubusercontent.com/41695888/157085961-a1352d38-e131-489d-bd28-1561c6d07b97.gif)
</details>