### PR TITLE
settings: Fix text alignment in save and discard buttons.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1076,6 +1076,7 @@ input[type="checkbox"] {
         text-decoration: none;
         color: hsl(0, 0%, 47%);
         min-width: 80px;
+        /* Limit the height of the button */
         line-height: 1.2;
         vertical-align: text-bottom;
 
@@ -1117,6 +1118,11 @@ input[type="checkbox"] {
             margin-right: 3px;
             font-size: 15px;
             font-weight: 500;
+        }
+
+        .save-discard-widget-button-text {
+            vertical-align: middle;
+            line-height: 1;
         }
     }
 


### PR DESCRIPTION
Fix for #20583.

This is to solve the text alignment in the save and discard buttons wrt. the icons.

**Testing plan:** <!-- How have you tested? -->
Manual

**Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2022-01-30 19-28-03](https://user-images.githubusercontent.com/79650357/151708138-b2c223b5-36d6-4e27-a126-072fe7794d8b.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
