### PR TITLE
Avoid MOVED label when topic is marked resolved

### DIFF
--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -66,6 +66,27 @@ function message_was_resolved(message) {
     if (message.topic.startsWith(message_edit.RESOLVED_TOPIC_PREFIX)) {
         return true;
     }
+
+    // To find unresolved situation we will have to dig information
+    // from edit_history. We use prev_topic and consider message resolved/unresolved when:
+    // 1. are either same as current topic
+    // 2. or they start with ✔
+    if (message.edit_history !== undefined) {
+        const last_edit = message.edit_history.at(-1);
+        let prev_topic;
+        if (util.get_edit_event_prev_topic(last_edit) !== undefined) {
+            prev_topic = util.get_edit_event_prev_topic(last_edit);
+        } else {
+            prev_topic = last_edit.prev_topic;
+        }
+        if (
+            prev_topic !== undefined &&
+            (prev_topic === message.topic ||
+                prev_topic.startsWith(message_edit.RESOLVED_TOPIC_PREFIX))
+        ) {
+            return true;
+        }
+    }
     return false;
 }
 

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -56,6 +56,19 @@ function same_recipient(a, b) {
     return util.same_recipient(a.msg, b.msg);
 }
 
+function message_was_resolved(message) {
+    if (message.topic === undefined) {
+        return false;
+    }
+
+    // if the message topic starts with the resolved topic prefix, the
+    // topic is just resolved, nothing more.
+    if (message.topic.startsWith(message_edit.RESOLVED_TOPIC_PREFIX)) {
+        return true;
+    }
+    return false;
+}
+
 function message_was_only_moved(message) {
     // Returns true if the message has had its stream/topic edited
     // (i.e. the message was moved), but its content has not been
@@ -254,6 +267,7 @@ export class MessageListView {
             message_container.edited_alongside_sender = include_sender && !status_message;
             message_container.edited_status_msg = include_sender && status_message;
             message_container.moved = message_was_only_moved(message_container.msg);
+            message_container.resolved = message_was_resolved(message_container.msg);
         } else {
             delete message_container.last_edit_timestr;
             message_container.edited_in_left_col = false;

--- a/static/templates/edited_notice.hbs
+++ b/static/templates/edited_notice.hbs
@@ -4,12 +4,14 @@
 </div>
 {{else}}
 {{#if moved}}
+{{#unless resolved}}
     <div class="message_edit_notice auto-select" title="{{#tr}}Moved ({last_edit_timestr}){{/tr}}">
         ({{t "MOVED" }})
     </div>
+{{/unless}}
 {{else}}
-    <div class="message_edit_notice auto-select" title="{{#tr}}Edited ({last_edit_timestr}){{/tr}}">
-        ({{t "EDITED" }})
-    </div>
+<div class="message_edit_notice auto-select" title="{{#tr}}Edited ({last_edit_timestr}){{/tr}}">
+    ({{t "EDITED" }})
+</div>
 {{/if}}
 {{/if}}


### PR DESCRIPTION
Fixes #19919

Derivative work of another PR: https://github.com/zulip/zulip/pull/20596

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** 

This is how topic looks before we mark it as resolved:

![Screenshot from 2022-01-31 11-07-15](https://user-images.githubusercontent.com/451188/151744268-24250cca-ba92-4932-abd5-95d9cd648c67.png)

As the [resolving the topic](https://zephyr.zulip.com/help/resolve-a-topic) mentions, messages are moved under new topic that has a ✔ in the name. But, **we don't want to show the label MOVED**. And we also want to maintain `EDITED` label of any message that was edited in the topic:

![Screenshot from 2022-01-31 11-07-30](https://user-images.githubusercontent.com/451188/151744555-f9aeee73-2c6e-4b75-917d-2540689c4932.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
