### PR TITLE
compose: Improve compose preview UI.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -289,6 +289,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
         assert.equal(spinner.selector, "#compose-send-button .loader");
         show_button_spinner_called = true;
     });
+    $("#compose .preview_mode_hidden").css = () => {};
 
     page_params.user_id = new_user.user_id;
 
@@ -329,6 +330,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
 });
 
 test_ui("finish", ({override, override_rewire}) => {
+    $("#compose .preview_mode_hidden").css = () => {};
     override(notifications, "clear_compose_notifications", () => {});
     override(reminder, "is_deferred_delivery", () => false);
     override(document, "to_$", () => $("document-stub"));
@@ -548,8 +550,8 @@ test_ui("trigger_submit_compose_form", ({override, override_rewire}) => {
 
 test_ui("on_events", ({override, override_rewire}) => {
     initialize_handlers({override, override_rewire});
-
     override(rendered_markdown, "update_elements", () => {});
+    $("#compose .preview_mode_hidden").css = () => {};
 
     function setup_parents_and_mock_remove(container_sel, target_sel, parent) {
         const container = $.create("fake " + container_sel);

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -117,6 +117,7 @@ test("start", ({override, override_rewire}) => {
     override_rewire(compose_actions, "complete_starting_tasks", () => {});
     override_rewire(compose_actions, "blur_compose_inputs", () => {});
     override_rewire(compose_actions, "clear_textarea", () => {});
+    $("#compose .preview_mode_hidden").css = () => {};
 
     let compose_defaults;
     override(narrow_state, "set_compose_defaults", () => compose_defaults);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -87,6 +87,10 @@ export function clear_preview_area() {
     $("#compose .preview_content").empty();
     $("#compose .markdown_preview").show();
     autosize.update($("#compose-textarea"));
+
+    // While in preview mode we hide unneeded compose_control_buttons,
+    // so here we are re-showing them.
+    $("#compose .preview_mode_hidden").css({visibility: "visible"});
 }
 
 export function update_fade() {
@@ -664,6 +668,9 @@ export function initialize() {
     $("#compose").on("click", ".markdown_preview", (e) => {
         e.preventDefault();
         e.stopPropagation();
+
+        // Hide unneeded compose_control_buttons in preview mode.
+        $("#compose .preview_mode_hidden").css({visibility: "hidden"});
 
         const content = $("#compose-textarea").val();
         $("#compose-textarea").hide();

--- a/static/templates/compose_control_buttons.hbs
+++ b/static/templates/compose_control_buttons.hbs
@@ -1,23 +1,25 @@
 <div class="compose_control_buttons_container order-1">
     <a role="button" class="markdown_preview compose_control_button fa fa-eye" aria-label="{{t 'Preview' }}" tabindex=0 data-tippy-content="{{t 'Preview' }}"></a>
     <a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"></a>
-    <div class="divider">|</div>
-    <input type="file" class="file_input notvisible pull-left" multiple />
-    {{#if file_upload_enabled }}
-    <a role="button" class="compose_control_button compose_upload_file fa fa-paperclip notdisplayed" aria-label="{{t 'Upload files' }}" tabindex=0 data-tippy-content="{{t 'Upload files' }}"></a>
-    {{/if}}
-    <a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"></a>
-    <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 data-tippy-content="{{t 'Add emoji' }}"></a>
-    <a role="button" class="compose_control_button fa fa-clock-o time_pick" aria-label="{{t 'Add global time' }}" tabindex=0 data-tippy-content="{{t 'Add global time<br />Everyone sees global times in their own time zone.' }}" data-tippy-maxWidth="none" data-tippy-allowHtml="true"></a>
-    <a role="button" class="compose_control_button compose_gif_icon {{#unless giphy_enabled }} hide {{/unless}} zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0 data-tippy-content="{{t 'Add GIF' }}"></a>
-    <div class="divider hide-sm">|</div>
-    <div class="{{#if message_id}}hide-lg{{else}}hide-sm{{/if}}">
-        {{> compose_control_buttons_in_popover}}
-    </div>
-    <a role="button" class="compose_control_button compose_draft_button hide-sm" tabindex=0 href="#drafts" data-tippy-content="{{t 'Drafts' }}">
-        {{t 'Drafts' }}
-    </a>
-    <div class="compose_control_menu_wrapper">
-        <a class="compose_control_button zulip-icon zulip-icon-ellipsis-v-solid hide {{#if message_id}}show-lg{{else}}show-sm{{/if}} compose_control_menu" tabindex=0 data-tippy-content="Compose actions"></a>
+    <div class="compose_control_buttons_container order-1 preview_mode_hidden">
+        <div class="divider">|</div>
+        <input type="file" class="file_input notvisible pull-left" multiple />
+        {{#if file_upload_enabled }}
+        <a role="button" class="compose_control_button compose_upload_file fa fa-paperclip notdisplayed" aria-label="{{t 'Upload files' }}" tabindex=0 data-tippy-content="{{t 'Upload files' }}"></a>
+        {{/if}}
+        <a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"></a>
+        <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 data-tippy-content="{{t 'Add emoji' }}"></a>
+        <a role="button" class="compose_control_button fa fa-clock-o time_pick" aria-label="{{t 'Add global time' }}" tabindex=0 data-tippy-content="{{t 'Add global time<br />Everyone sees global times in their own time zone.' }}" data-tippy-maxWidth="none" data-tippy-allowHtml="true"></a>
+        <a role="button" class="compose_control_button compose_gif_icon {{#unless giphy_enabled }} hide {{/unless}} zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0 data-tippy-content="{{t 'Add GIF' }}"></a>
+        <div class="divider hide-sm">|</div>
+        <div class="{{#if message_id}}hide-lg{{else}}hide-sm{{/if}}">
+            {{> compose_control_buttons_in_popover}}
+        </div>
+        <a role="button" class="compose_control_button compose_draft_button hide-sm" tabindex=0 href="#drafts" data-tippy-content="{{t 'Drafts' }}">
+            {{t 'Drafts' }}
+        </a>
+        <div class="compose_control_menu_wrapper">
+            <a class="compose_control_button zulip-icon zulip-icon-ellipsis-v-solid hide {{#if message_id}}show-lg{{else}}show-sm{{/if}} compose_control_menu" tabindex=0 data-tippy-content="Compose actions"></a>
+        </div>
     </div>
 </div>

--- a/static/templates/compose_control_buttons.hbs
+++ b/static/templates/compose_control_buttons.hbs
@@ -1,10 +1,11 @@
 <div class="compose_control_buttons_container order-1">
+    <a role="button" class="markdown_preview compose_control_button fa fa-eye" aria-label="{{t 'Preview' }}" tabindex=0 data-tippy-content="{{t 'Preview' }}"></a>
+    <a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"></a>
+    <div class="divider">|</div>
     <input type="file" class="file_input notvisible pull-left" multiple />
     {{#if file_upload_enabled }}
     <a role="button" class="compose_control_button compose_upload_file fa fa-paperclip notdisplayed" aria-label="{{t 'Upload files' }}" tabindex=0 data-tippy-content="{{t 'Upload files' }}"></a>
     {{/if}}
-    <a role="button" class="markdown_preview compose_control_button fa fa-eye" aria-label="{{t 'Preview' }}" tabindex=0 data-tippy-content="{{t 'Preview' }}"></a>
-    <a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"></a>
     <a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"></a>
     <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 data-tippy-content="{{t 'Add emoji' }}"></a>
     <a role="button" class="compose_control_button fa fa-clock-o time_pick" aria-label="{{t 'Add global time' }}" tabindex=0 data-tippy-content="{{t 'Add global time<br />Everyone sees global times in their own time zone.' }}" data-tippy-maxWidth="none" data-tippy-allowHtml="true"></a>


### PR DESCRIPTION
* Moved preview icon to front.
* New div with class for hideable compose control buttons.
* Hides unneeded compose control buttons while message text is in preview mode.

[CZO Discussion](https://chat.zulip.org/#narrow/stream/49-development-help/topic/disabling.20format.20helper.20icons.20.28testing.29/near/1319227)

**Fixes:** #20962 
**Fixes part of:** #20972

**PR of disabling icons method**: #20993  

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Manually tested in both dark and light themes, also added tests in
node_tests/compose.js and compose_actions.js

**GIFs or screenshots:**
![compose_box_edit_mode](https://user-images.githubusercontent.com/41695888/151799143-d6d253dc-4a9c-44a7-b9f1-d28fd073105d.png)
![Hidding_everthing_except_edit_icon](https://user-images.githubusercontent.com/41695888/152652440-552c0260-b53c-41b6-895d-30ae8a23eb6d.gif)
![preview_state](https://user-images.githubusercontent.com/41695888/152652450-9e4c21e1-8c5f-411d-855c-a71ee8fb64d4.png)



