### PR TITLE
api docs: Fix a few bugs where we describe status emoji.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1520,7 +1520,7 @@ paths:
                                     This will be "" for users who set a status without selecting
                                     an emoji.
 
-                                    **Changes**; New in Zulip 5.0 (feature level 86).
+                                    **Changes**: New in Zulip 5.0 (feature level 86).
                                 emoji_code:
                                   type: string
                                   description: |
@@ -1530,7 +1530,7 @@ paths:
                                     This will be "" for users who set a status without selecting
                                     an emoji.
 
-                                    **Changes**; New in Zulip 5.0 (feature level 86).
+                                    **Changes**: New in Zulip 5.0 (feature level 86).
                                 reaction_type:
                                   type: string
                                   description: |
@@ -1540,7 +1540,7 @@ paths:
                                     This will be "" for users who set a status without selecting
                                     an emoji.
 
-                                    **Changes**; New in Zulip 5.0 (feature level 86).
+                                    **Changes**: New in Zulip 5.0 (feature level 86).
                                 user_id:
                                   type: integer
                                   description: |
@@ -9470,7 +9470,7 @@ paths:
                             away:
                               type: boolean
                               description: |
-                                Whether the user has marked themself "away".
+                                Whether the user has marked themself "away" with this status.
                             status_text:
                               type: string
                               description: |
@@ -9478,19 +9478,31 @@ paths:
                             emoji_name:
                               type: string
                               description: |
-                                The [emoji name](/api/add-reaction#parameters) for the emoji associated with the new status.
+                                The [emoji name](/api/add-reaction#parameters) for the emoji
+                                the user selected for their new status.
+
+                                This will be "" for users who set a status without selecting
+                                an emoji.
 
                                 **Changes**: New in Zulip 5.0 (feature level 86).
                             emoji_code:
                               type: string
                               description: |
-                                The [emoji code](/api/add-reaction#parameters) for the emoji associated with the new status.
+                                The [emoji code](/api/add-reaction#parameters) for the emoji
+                                the user selected for their new status.
+
+                                This will be "" for users who set a status without selecting
+                                an emoji.
 
                                 **Changes**: New in Zulip 5.0 (feature level 86).
                             reaction_type:
                               type: string
                               description: |
-                                The [emoji type](/api/add-reaction#parameters) for the emoji associated with the new status.
+                                The [emoji type](/api/add-reaction#parameters) for the emoji
+                                the user selected for their new status.
+
+                                This will be "" for users who set a status without selecting
+                                an emoji.
 
                                 **Changes**: New in Zulip 5.0 (feature level 86).
                       user_settings:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9416,8 +9416,7 @@ paths:
                           error messages when a search returns limited results because
                           a stop word in the query was ignored.
                       user_status:
-                        allOf:
-                          - $ref: "#/components/schemas/EmojiBase"
+                        type: object
                         description: |
                           Present if `user_status` is present in `fetch_event_types`.
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14485,8 +14485,7 @@ components:
         emoji_name:
           type: string
           description: |
-            The [emoji name](/api/add-reaction#parameters) for the emoji
-            the user selected for their new status.
+            The status emoji's human-readable name.
 
             This will be "" for users who set a status without selecting
             an emoji.
@@ -14495,8 +14494,8 @@ components:
         emoji_code:
           type: string
           description: |
-            The [emoji code](/api/add-reaction#parameters) for the emoji
-            the user selected for their new status.
+            A unique identifier for the status emoji, within the namespace
+            specified by `reaction_type`.
 
             This will be "" for users who set a status without selecting
             an emoji.
@@ -14505,8 +14504,15 @@ components:
         reaction_type:
           type: string
           description: |
-            The [emoji type](/api/add-reaction#parameters) for the emoji
-            the user selected for their new status.
+            One of the following values, specifying the namespace used for
+            `emoji_code`:
+
+            - `unicode_emoji`: Unicode emoji. (`emoji_code` will be the
+              status emoji's Unicode codepoint.)
+            - `realm_emoji`: Custom emoji. (`emoji_code` will be the status
+              emoji's ID.)
+            - `zulip_extra_emoji`: Special emoji included with Zulip. Exists to
+              namespace the `zulip` emoji.
 
             This will be "" for users who set a status without selecting
             an emoji.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14414,6 +14414,10 @@ components:
             Name of the emoji.
         reaction_type:
           type: string
+          enum:
+            - unicode_emoji
+            - realm_emoji
+            - zulip_extra_emoji
           description: |
             One of the following values:
 
@@ -14503,6 +14507,10 @@ components:
             **Changes**: New in Zulip 5.0 (feature level 86).
         reaction_type:
           type: string
+          enum:
+            - unicode_emoji
+            - realm_emoji
+            - zulip_extra_emoji
           description: |
             One of the following values, specifying the namespace used for
             `emoji_code`:
@@ -15563,6 +15571,10 @@ components:
         parameter was not specified.
       schema:
         type: string
+        enum:
+          - unicode_emoji
+          - realm_emoji
+          - zulip_extra_emoji
       example: "unicode_emoji"
       required: false
     EmojiCode:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1491,60 +1491,29 @@ paths:
                                   "id": 28,
                                 }
                             - type: object
-                              additionalProperties: false
                               description: |
                                 Event sent to all users in a Zulip organization when the
                                 status of a user changes.
-                              properties:
-                                id:
-                                  $ref: "#/components/schemas/EventIdSchema"
-                                type:
-                                  allOf:
-                                    - $ref: "#/components/schemas/EventTypeSchema"
-                                    - enum:
-                                        - user_status
-                                away:
-                                  type: boolean
-                                  description: |
-                                    Whether the user has marked themself "away" with this status.
-                                status_text:
-                                  type: string
-                                  description: |
-                                    The text content of the status message.
-                                emoji_name:
-                                  type: string
-                                  description: |
-                                    The [emoji name](/api/add-reaction#parameters) for the emoji
-                                    the user selected for their new status.
-
-                                    This will be "" for users who set a status without selecting
-                                    an emoji.
-
-                                    **Changes**: New in Zulip 5.0 (feature level 86).
-                                emoji_code:
-                                  type: string
-                                  description: |
-                                    The [emoji code](/api/add-reaction#parameters) for the emoji
-                                    the user selected for their new status.
-
-                                    This will be "" for users who set a status without selecting
-                                    an emoji.
-
-                                    **Changes**: New in Zulip 5.0 (feature level 86).
-                                reaction_type:
-                                  type: string
-                                  description: |
-                                    The [emoji type](/api/add-reaction#parameters) for the emoji
-                                    the user selected for their new status.
-
-                                    This will be "" for users who set a status without selecting
-                                    an emoji.
-
-                                    **Changes**: New in Zulip 5.0 (feature level 86).
-                                user_id:
-                                  type: integer
-                                  description: |
-                                    The ID of the user whose status changed.
+                              allOf:
+                                - $ref: "#/components/schemas/UserStatusBase"
+                                - additionalProperties: false
+                                  properties:
+                                    id:
+                                      $ref: "#/components/schemas/EventIdSchema"
+                                    type:
+                                      allOf:
+                                        - $ref: "#/components/schemas/EventTypeSchema"
+                                        - enum:
+                                            - user_status
+                                    user_id:
+                                      type: integer
+                                      description: |
+                                        The ID of the user whose status changed.
+                                    away: {}
+                                    status_text: {}
+                                    emoji_name: {}
+                                    emoji_code: {}
+                                    reaction_type: {}
                               example:
                                 {
                                   "type": "user_status",
@@ -9465,46 +9434,10 @@ paths:
                             `{user_id}`: Object containing the status details of a user
                             with the key of the object being the id of the user.
                           type: object
-                          additionalProperties: false
-                          properties:
-                            away:
-                              type: boolean
-                              description: |
-                                Whether the user has marked themself "away" with this status.
-                            status_text:
-                              type: string
-                              description: |
-                                The text content of the status message.
-                            emoji_name:
-                              type: string
-                              description: |
-                                The [emoji name](/api/add-reaction#parameters) for the emoji
-                                the user selected for their new status.
-
-                                This will be "" for users who set a status without selecting
-                                an emoji.
-
-                                **Changes**: New in Zulip 5.0 (feature level 86).
-                            emoji_code:
-                              type: string
-                              description: |
-                                The [emoji code](/api/add-reaction#parameters) for the emoji
-                                the user selected for their new status.
-
-                                This will be "" for users who set a status without selecting
-                                an emoji.
-
-                                **Changes**: New in Zulip 5.0 (feature level 86).
-                            reaction_type:
-                              type: string
-                              description: |
-                                The [emoji type](/api/add-reaction#parameters) for the emoji
-                                the user selected for their new status.
-
-                                This will be "" for users who set a status without selecting
-                                an emoji.
-
-                                **Changes**: New in Zulip 5.0 (feature level 86).
+                          additionalProperties:
+                            allOf:
+                              - $ref: "#/components/schemas/UserStatusBase"
+                              - additionalProperties: false
                       user_settings:
                         type: object
                         description: |
@@ -14537,6 +14470,49 @@ components:
                   type: boolean
                   description: |
                     Whether the user is a mirror dummy.
+    UserStatusBase:
+      type: object
+      description: |
+        Object containing details of a user's status.
+      properties:
+        away:
+          type: boolean
+          description: |
+            Whether the user has marked themself "away" with this status.
+        status_text:
+          type: string
+          description: |
+            The text content of the status message.
+        emoji_name:
+          type: string
+          description: |
+            The [emoji name](/api/add-reaction#parameters) for the emoji
+            the user selected for their new status.
+
+            This will be "" for users who set a status without selecting
+            an emoji.
+
+            **Changes**: New in Zulip 5.0 (feature level 86).
+        emoji_code:
+          type: string
+          description: |
+            The [emoji code](/api/add-reaction#parameters) for the emoji
+            the user selected for their new status.
+
+            This will be "" for users who set a status without selecting
+            an emoji.
+
+            **Changes**: New in Zulip 5.0 (feature level 86).
+        reaction_type:
+          type: string
+          description: |
+            The [emoji type](/api/add-reaction#parameters) for the emoji
+            the user selected for their new status.
+
+            This will be "" for users who set a status without selecting
+            an emoji.
+
+            **Changes**: New in Zulip 5.0 (feature level 86).
     Messages:
       allOf:
         - $ref: "#/components/schemas/MessagesBase"


### PR DESCRIPTION
See discussion at https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/Emoji.20statuses.20in.20zulip.2Eyaml/near/1317152 and following.

This is my first time looking into how this `zulip.yaml` file works. If there's anything I've misunderstood, or if there's some discussion I should reread (e.g., something in [`#api design > Shared OpenAPI descriptions`](https://chat.zulip.org/#narrow/stream/378-api-design/topic/Shared.20OpenAPI.20descriptions), please let me know. 🙂

### Screenshots after these changes:

`/register`
![image](https://user-images.githubusercontent.com/22248748/152043967-e8cfebfa-1f32-4169-80e8-0e589107c04b.png)

`GET /events`
![image](https://user-images.githubusercontent.com/22248748/152044060-e3798d83-9445-43d2-b73b-d0b3d5beca13.png)
