### PR TITLE
stream_settings: Fix color of icon of the title in right column.

### DIFF
--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -40,7 +40,13 @@ import * as ui_report from "./ui_report";
 import * as util from "./util";
 
 export function set_right_panel_title(sub) {
-    $("#subscription_overlay .stream-info-title").html(render_selected_stream_title(sub));
+    let title_icon_color = "#333333";
+    if (settings_data.using_dark_theme()) {
+        title_icon_color = "#dddeee";
+    }
+    $("#subscription_overlay .stream-info-title").html(
+        render_selected_stream_title({sub, title_icon_color}),
+    );
 }
 
 export const show_subs_pane = {

--- a/static/templates/stream_settings/selected_stream_title.hbs
+++ b/static/templates/stream_settings/selected_stream_title.hbs
@@ -1,5 +1,5 @@
 {{> stream_privacy_icon
-  invite_only=invite_only
-  is_web_public=is_web_public
-  color="#000000" }}
-<span class="stream-name-title">{{name}}</span>
+  invite_only=sub.invite_only
+  is_web_public=sub.is_web_public
+  color=title_icon_color }}
+<span class="stream-name-title">{{sub.name}}</span>


### PR DESCRIPTION
This PR fixes two things -

- We use the exact same color that is used for stream name in
day mode.
- Previously, we were passing black color explicitly to the stream_privacy_icon
template. This commit changes it to pass different color in the night mode which
is the same used for stream name in night mode.

Reported here - https://chat.zulip.org/#narrow/stream/9-issues/topic/stream.20settings.20.23.20symbol
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![title-icon-night-mode](https://user-images.githubusercontent.com/35494118/152022512-8dba3f99-5d22-40ac-9610-5e1fc47bed8e.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
