### PR TITLE
message feed: Show names of users who reacted.

### DIFF
--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -425,14 +425,32 @@ test("add_reaction/remove_reaction", ({override}) => {
 
     let view_calls = [];
 
-    override(reactions.view, "insert_new_reaction", (opts) => {
-        view_calls.push({name: "insert_new_reaction", opts});
-    });
-    override(reactions.view, "update_existing_reaction", (opts) => {
-        view_calls.push({name: "update_existing_reaction", opts});
-    });
-    override(reactions.view, "remove_reaction", (opts) => {
-        view_calls.push({name: "remove_reaction", opts});
+    override(
+        reactions.view,
+        "insert_new_reaction",
+        (clean_reaction_object, message_id, user_id) => {
+            view_calls.push({
+                name: "insert_new_reaction",
+                clean_reaction_object,
+                message_id,
+                user_id,
+            });
+        },
+    );
+    override(
+        reactions.view,
+        "update_existing_reaction",
+        (clean_reaction_object, message_id, user_id) => {
+            view_calls.push({
+                name: "update_existing_reaction",
+                clean_reaction_object,
+                message_id,
+                user_id,
+            });
+        },
+    );
+    override(reactions.view, "remove_reaction", (clean_reaction_object, message_id, user_id) => {
+        view_calls.push({name: "remove_reaction", clean_reaction_object, message_id, user_id});
     });
 
     function test_view_calls(test_params) {
@@ -478,13 +496,20 @@ test("add_reaction/remove_reaction", ({override}) => {
         expected_view_calls: [
             {
                 name: "insert_new_reaction",
-                opts: {
-                    message_id: 2001,
-                    reaction_type: "unicode_emoji",
-                    emoji_name: "8ball",
-                    emoji_code: "1f3b1",
-                    user_id: alice.user_id,
+                clean_reaction_object: {
+                    class: "message_reaction reacted",
+                    count: 1,
+                    emoji_alt_code: false,
+                    emoji_code: alice_8ball_event.emoji_code,
+                    emoji_name: alice_8ball_event.emoji_name,
+                    is_realm_emoji: false,
+                    label: "translated: You (click to remove) reacted with :8ball:",
+                    local_id: "unicode_emoji,1f3b1",
+                    reaction_type: alice_8ball_event.reaction_type,
+                    user_ids: [alice.user_id],
                 },
+                message_id: alice_8ball_event.message_id,
+                user_id: alice_8ball_event.user_id,
             },
         ],
         alice_emojis: ["8ball"],
@@ -506,14 +531,20 @@ test("add_reaction/remove_reaction", ({override}) => {
         expected_view_calls: [
             {
                 name: "update_existing_reaction",
-                opts: {
-                    message_id: 2001,
-                    reaction_type: "unicode_emoji",
-                    emoji_name: "8ball",
-                    emoji_code: "1f3b1",
-                    user_id: bob.user_id,
-                    user_list: [alice.user_id, bob.user_id],
+                clean_reaction_object: {
+                    class: "message_reaction reacted",
+                    count: 2,
+                    emoji_alt_code: false,
+                    emoji_code: bob_8ball_event.emoji_code,
+                    emoji_name: bob_8ball_event.emoji_name,
+                    is_realm_emoji: false,
+                    label: "translated: You (click to remove) and Bob van Roberts reacted with :8ball:",
+                    local_id: "unicode_emoji,1f3b1",
+                    reaction_type: bob_8ball_event.reaction_type,
+                    user_ids: [alice.user_id, bob.user_id],
                 },
+                message_id: bob_8ball_event.message_id,
+                user_id: bob_8ball_event.user_id,
             },
         ],
         alice_emojis: ["8ball"],
@@ -526,13 +557,20 @@ test("add_reaction/remove_reaction", ({override}) => {
         expected_view_calls: [
             {
                 name: "insert_new_reaction",
-                opts: {
-                    message_id: 2001,
-                    reaction_type: "unicode_emoji",
-                    emoji_name: "airplane",
-                    emoji_code: "2708",
-                    user_id: cali.user_id,
+                clean_reaction_object: {
+                    class: "message_reaction",
+                    count: 1,
+                    emoji_alt_code: false,
+                    emoji_code: cali_airplane_event.emoji_code,
+                    emoji_name: cali_airplane_event.emoji_name,
+                    is_realm_emoji: false,
+                    label: "translated: Cali reacted with :airplane:",
+                    local_id: "unicode_emoji,2708",
+                    reaction_type: cali_airplane_event.reaction_type,
+                    user_ids: [cali.user_id],
                 },
+                message_id: cali_airplane_event.message_id,
+                user_id: cali_airplane_event.user_id,
             },
         ],
         alice_emojis: ["8ball"],
@@ -545,14 +583,20 @@ test("add_reaction/remove_reaction", ({override}) => {
         expected_view_calls: [
             {
                 name: "remove_reaction",
-                opts: {
-                    message_id: 2001,
-                    reaction_type: "unicode_emoji",
-                    emoji_name: "8ball",
-                    emoji_code: "1f3b1",
-                    user_id: bob.user_id,
-                    user_list: [alice.user_id],
+                clean_reaction_object: {
+                    class: "message_reaction reacted",
+                    count: 1,
+                    emoji_alt_code: false,
+                    emoji_code: bob_8ball_event.emoji_code,
+                    emoji_name: bob_8ball_event.emoji_name,
+                    is_realm_emoji: false,
+                    label: "translated: You (click to remove) reacted with :8ball:",
+                    local_id: "unicode_emoji,1f3b1",
+                    reaction_type: bob_8ball_event.reaction_type,
+                    user_ids: [alice.user_id],
                 },
+                message_id: bob_8ball_event.message_id,
+                user_id: bob_8ball_event.user_id,
             },
         ],
         alice_emojis: ["8ball"],
@@ -565,14 +609,20 @@ test("add_reaction/remove_reaction", ({override}) => {
         expected_view_calls: [
             {
                 name: "remove_reaction",
-                opts: {
-                    message_id: 2001,
-                    reaction_type: "unicode_emoji",
-                    emoji_name: "8ball",
-                    emoji_code: "1f3b1",
-                    user_id: alice.user_id,
-                    user_list: [],
+                clean_reaction_object: {
+                    class: "message_reaction reacted",
+                    count: 1,
+                    emoji_alt_code: false,
+                    emoji_code: alice_8ball_event.emoji_code,
+                    emoji_name: alice_8ball_event.emoji_name,
+                    is_realm_emoji: false,
+                    label: "translated: You (click to remove) reacted with :8ball:",
+                    local_id: "unicode_emoji,1f3b1",
+                    reaction_type: alice_8ball_event.reaction_type,
+                    user_ids: [],
                 },
+                message_id: alice_8ball_event.message_id,
+                user_id: alice_8ball_event.user_id,
             },
         ],
         alice_emojis: [],
@@ -589,15 +639,21 @@ test("add_reaction/remove_reaction", ({override}) => {
 });
 
 test("view.insert_new_reaction (me w/unicode emoji)", ({mock_template}) => {
-    const opts = {
-        message_id: 501,
-        reaction_type: "unicode_emoji",
-        emoji_name: "8ball",
+    const clean_reaction_object = {
+        class: "message_reaction",
+        count: 1,
+        emoji_alt_code: false,
         emoji_code: "1f3b1",
-        user_id: alice.user_id,
+        emoji_name: "8ball",
+        is_realm_emoji: false,
+        label: "translated: You (click to remove) reacted with :8ball:",
+        local_id: "unicode_emoji,1f3b1",
+        reaction_type: "unicode_emoji",
+        user_ids: [alice.user_id],
     };
+    const message_id = 501;
 
-    const $message_reactions = stub_reactions(opts.message_id);
+    const $message_reactions = stub_reactions(message_id);
     $message_reactions.find = (selector) => {
         assert.equal(selector, ".reaction_button");
         return "reaction-button-stub";
@@ -611,9 +667,9 @@ test("view.insert_new_reaction (me w/unicode emoji)", ({mock_template}) => {
             emoji_code: "1f3b1",
             local_id: "unicode_emoji,1f3b1",
             class: "message_reaction reacted",
-            message_id: opts.message_id,
+            message_id,
             label: "translated: You (click to remove) reacted with :8ball:",
-            reaction_type: opts.reaction_type,
+            reaction_type: clean_reaction_object.reaction_type,
             is_realm_emoji: false,
         });
         return "<new-reaction-stub>";
@@ -625,20 +681,26 @@ test("view.insert_new_reaction (me w/unicode emoji)", ({mock_template}) => {
         insert_called = true;
     };
 
-    reactions.view.insert_new_reaction(opts);
+    reactions.view.insert_new_reaction(clean_reaction_object, message_id, alice.user_id);
     assert.ok(insert_called);
 });
 
 test("view.insert_new_reaction (them w/zulip emoji)", ({mock_template}) => {
-    const opts = {
-        message_id: 502,
-        reaction_type: "realm_emoji",
-        emoji_name: "zulip",
+    const clean_reaction_object = {
+        class: "message_reaction",
+        count: 1,
+        emoji_alt_code: false,
         emoji_code: "zulip",
-        user_id: bob.user_id,
+        emoji_name: "zulip",
+        is_realm_emoji: false,
+        label: "translated: You (click to remove) reacted with :zulip:",
+        local_id: "realm_emoji,zulip",
+        reaction_type: "realm_emoji",
+        user_ids: [bob.user_id],
     };
+    const message_id = 501;
 
-    const $message_reactions = stub_reactions(opts.message_id);
+    const $message_reactions = stub_reactions(message_id);
     $message_reactions.find = (selector) => {
         assert.equal(selector, ".reaction_button");
         return "reaction-button-stub";
@@ -654,10 +716,10 @@ test("view.insert_new_reaction (them w/zulip emoji)", ({mock_template}) => {
             emoji_code: "zulip",
             local_id: "realm_emoji,zulip",
             class: "message_reaction",
-            message_id: opts.message_id,
+            message_id,
             label: "translated: Bob van Roberts reacted with :zulip:",
             still_url: undefined,
-            reaction_type: opts.reaction_type,
+            reaction_type: clean_reaction_object.reaction_type,
         });
         return "<new-reaction-stub>";
     });
@@ -668,25 +730,29 @@ test("view.insert_new_reaction (them w/zulip emoji)", ({mock_template}) => {
         insert_called = true;
     };
 
-    reactions.view.insert_new_reaction(opts);
+    reactions.view.insert_new_reaction(clean_reaction_object, message_id, bob.user_id);
     assert.ok(insert_called);
 });
 
 test("view.update_existing_reaction (me)", () => {
-    const opts = {
-        message_id: 503,
-        reaction_type: "unicode_emoji",
-        emoji_name: "8ball",
+    const clean_reaction_object = {
+        class: "message_reaction",
+        count: 1,
+        emoji_alt_code: false,
         emoji_code: "1f3b1",
-        user_id: alice.user_id,
-        user_list: [alice.user_id, bob.user_id],
+        emoji_name: "8ball",
+        is_realm_emoji: false,
+        local_id: "unicode_emoji,1f3b1",
+        reaction_type: "unicode_emoji",
+        user_ids: [alice.user_id, bob.user_id],
     };
+    const message_id = 503;
 
-    const $our_reaction = stub_reaction(opts.message_id, "unicode_emoji,1f3b1");
+    const $our_reaction = stub_reaction(message_id, "unicode_emoji,1f3b1");
     const $reaction_count = $.create("reaction-count-stub");
     $our_reaction.set_find_results(".message_reaction_count", $reaction_count);
 
-    reactions.view.update_existing_reaction(opts);
+    reactions.view.update_existing_reaction(clean_reaction_object, message_id, alice.user_id);
 
     assert.equal($reaction_count.text(), "2");
     assert.ok($our_reaction.hasClass("reacted"));
@@ -697,20 +763,24 @@ test("view.update_existing_reaction (me)", () => {
 });
 
 test("view.update_existing_reaction (them)", () => {
-    const opts = {
-        message_id: 504,
-        reaction_type: "unicode_emoji",
-        emoji_name: "8ball",
+    const clean_reaction_object = {
+        class: "message_reaction",
+        count: 1,
+        emoji_alt_code: false,
         emoji_code: "1f3b1",
-        user_id: bob.user_id,
-        user_list: [alice.user_id, bob.user_id, cali.user_id, alexus.user_id],
+        emoji_name: "8ball",
+        is_realm_emoji: false,
+        local_id: "unicode_emoji,1f3b1",
+        reaction_type: "unicode_emoji",
+        user_ids: [alice.user_id, bob.user_id, cali.user_id, alexus.user_id],
     };
+    const message_id = 504;
 
-    const $our_reaction = stub_reaction(opts.message_id, "unicode_emoji,1f3b1");
+    const $our_reaction = stub_reaction(message_id, "unicode_emoji,1f3b1");
     const $reaction_count = $.create("reaction-count-stub");
     $our_reaction.set_find_results(".message_reaction_count", $reaction_count);
 
-    reactions.view.update_existing_reaction(opts);
+    reactions.view.update_existing_reaction(clean_reaction_object, message_id, alexus.user_id);
 
     assert.equal($reaction_count.text(), "4");
     assert.ok(!$our_reaction.hasClass("reacted"));
@@ -721,21 +791,25 @@ test("view.update_existing_reaction (them)", () => {
 });
 
 test("view.remove_reaction (me)", () => {
-    const opts = {
-        message_id: 505,
-        reaction_type: "unicode_emoji",
-        emoji_name: "8ball",
+    const clean_reaction_object = {
+        class: "message_reaction",
+        count: 1,
+        emoji_alt_code: false,
         emoji_code: "1f3b1",
-        user_id: alice.user_id,
-        user_list: [bob.user_id, cali.user_id],
+        emoji_name: "8ball",
+        is_realm_emoji: false,
+        local_id: "unicode_emoji,1f3b1",
+        reaction_type: "unicode_emoji",
+        user_ids: [bob.user_id, cali.user_id],
     };
+    const message_id = 505;
 
-    const $our_reaction = stub_reaction(opts.message_id, "unicode_emoji,1f3b1");
+    const $our_reaction = stub_reaction(message_id, "unicode_emoji,1f3b1");
     const $reaction_count = $.create("reaction-count-stub");
     $our_reaction.addClass("reacted");
     $our_reaction.set_find_results(".message_reaction_count", $reaction_count);
 
-    reactions.view.remove_reaction(opts);
+    reactions.view.remove_reaction(clean_reaction_object, message_id, alice.user_id);
 
     assert.equal($reaction_count.text(), "2");
     assert.ok(!$our_reaction.hasClass("reacted"));
@@ -746,22 +820,26 @@ test("view.remove_reaction (me)", () => {
 });
 
 test("view.remove_reaction (them)", () => {
-    const opts = {
-        message_id: 506,
-        reaction_type: "unicode_emoji",
-        emoji_name: "8ball",
+    const clean_reaction_object = {
+        class: "message_reaction",
+        count: 1,
+        emoji_alt_code: false,
         emoji_code: "1f3b1",
-        user_id: bob.user_id,
-        user_list: [alice.user_id],
+        emoji_name: "8ball",
+        is_realm_emoji: false,
+        local_id: "unicode_emoji,1f3b1",
+        reaction_type: "unicode_emoji",
+        user_ids: [alice.user_id],
     };
+    const message_id = 506;
 
-    const $our_reaction = stub_reaction(opts.message_id, "unicode_emoji,1f3b1");
+    const $our_reaction = stub_reaction(message_id, "unicode_emoji,1f3b1");
     const $reaction_count = $.create("reaction-count-stub");
     $our_reaction.addClass("reacted");
     $our_reaction.set_find_results(".message_reaction_count", $reaction_count);
 
     $our_reaction.addClass("reacted");
-    reactions.view.remove_reaction(opts);
+    reactions.view.remove_reaction(clean_reaction_object, message_id, bob.user_id);
 
     assert.equal($reaction_count.text(), "1");
     assert.ok($our_reaction.hasClass("reacted"));
@@ -772,22 +850,26 @@ test("view.remove_reaction (them)", () => {
 });
 
 test("view.remove_reaction (last person)", () => {
-    const opts = {
-        message_id: 507,
-        reaction_type: "unicode_emoji",
-        emoji_name: "8ball",
+    const clean_reaction_object = {
+        class: "message_reaction",
+        count: 1,
+        emoji_alt_code: false,
         emoji_code: "1f3b1",
-        user_id: bob.user_id,
-        user_list: [],
+        emoji_name: "8ball",
+        is_realm_emoji: false,
+        local_id: "unicode_emoji,1f3b1",
+        reaction_type: "unicode_emoji",
+        user_ids: [],
     };
+    const message_id = 507;
 
-    const $our_reaction = stub_reaction(opts.message_id, "unicode_emoji,1f3b1");
+    const $our_reaction = stub_reaction(message_id, "unicode_emoji,1f3b1");
 
     let removed;
     $our_reaction.remove = () => {
         removed = true;
     };
-    reactions.view.remove_reaction(opts);
+    reactions.view.remove_reaction(clean_reaction_object, message_id, bob.user_id);
     assert.ok(removed);
 });
 

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -511,14 +511,14 @@ function make_clean_reaction({local_id, user_ids, emoji_name, emoji_code, reacti
         user_ids,
         ...emoji.get_emoji_details_for_rendering({emoji_name, emoji_code, reaction_type}),
     };
-
-    update_user_fields(clean_reaction_object);
-
     clean_reaction_object.emoji_alt_code = user_settings.emojiset === "text";
     clean_reaction_object.is_realm_emoji =
         clean_reaction_object.reaction_type === "realm_emoji" ||
         clean_reaction_object.reaction_type === "zulip_extra_emoji";
 
+    // Call update_user_fields last, so it can rely on
+    // clean_reaction_object being otherwise fully populated.
+    update_user_fields(clean_reaction_object);
     return clean_reaction_object;
 }
 

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -249,7 +249,7 @@ export function add_reaction(event) {
     if (clean_reaction_object) {
         clean_reaction_object.user_ids.push(user_id);
         update_user_fields(clean_reaction_object);
-        view.update_existing_reaction(clean_reaction_object, message_id, user_id);
+        view.update_existing_reaction(clean_reaction_object, message, user_id);
     } else {
         clean_reaction_object = make_clean_reaction({
             local_id,
@@ -260,16 +260,16 @@ export function add_reaction(event) {
         });
 
         message.clean_reactions.set(local_id, clean_reaction_object);
-        view.insert_new_reaction(clean_reaction_object, message_id, user_id);
+        view.insert_new_reaction(clean_reaction_object, message, user_id);
     }
 }
 
-view.update_existing_reaction = function (clean_reaction_object, message_id, acting_user_id) {
+view.update_existing_reaction = function (clean_reaction_object, message, acting_user_id) {
     // Our caller ensures that this message already has a reaction
     // for this emoji and sets up our user_list.  This function
     // simply updates the DOM.
     const local_id = get_local_reaction_id(clean_reaction_object);
-    const $reaction = find_reaction(message_id, local_id);
+    const $reaction = find_reaction(message.id, local_id);
 
     set_reaction_count($reaction, clean_reaction_object.user_ids.length);
 
@@ -284,13 +284,13 @@ view.update_existing_reaction = function (clean_reaction_object, message_id, act
     }
 };
 
-view.insert_new_reaction = function (clean_reaction_object, message_id, user_id) {
+view.insert_new_reaction = function (clean_reaction_object, message, user_id) {
     // Our caller ensures we are the first user to react to this
     // message with this emoji. We then render the emoji/title/count
     // and insert it before the add button.
 
     const context = {
-        message_id,
+        message_id: message.id,
         ...emoji.get_emoji_details_for_rendering(clean_reaction_object),
     };
 
@@ -315,7 +315,7 @@ view.insert_new_reaction = function (clean_reaction_object, message_id, user_id)
     const $new_reaction = $(render_message_reaction(context));
 
     // Now insert it before the add button.
-    const $reaction_button_element = get_add_reaction_button(message_id);
+    const $reaction_button_element = get_add_reaction_button(message.id);
     $new_reaction.insertBefore($reaction_button_element);
 };
 
@@ -351,12 +351,12 @@ export function remove_reaction(event) {
         message.clean_reactions.delete(local_id);
     }
 
-    view.remove_reaction(clean_reaction_object, message_id, user_id);
+    view.remove_reaction(clean_reaction_object, message, user_id);
 }
 
-view.remove_reaction = function (clean_reaction_object, message_id, user_id) {
+view.remove_reaction = function (clean_reaction_object, message, user_id) {
     const local_id = get_local_reaction_id(clean_reaction_object);
-    const $reaction = find_reaction(message_id, local_id);
+    const $reaction = find_reaction(message.id, local_id);
     const reaction_count = clean_reaction_object.user_ids.length;
 
     if (reaction_count === 0) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -211,6 +211,9 @@ function get_subsection_property_elements(element) {
         // Because the emojiset widget has a unique radio button
         // structure, it needs custom code.
         const $color_scheme_elem = $subsection.find(".setting_color_scheme");
+        const $display_emoji_reaction_users_elem = $subsection.find(
+            ".display_emoji_reaction_users",
+        );
         const $emojiset_elem = $subsection.find("input[name='emojiset']:checked");
         const $user_list_style_elem = $subsection.find("input[name='user_list_style']:checked");
         const $translate_emoticons_elem = $subsection.find(".translate_emoticons");
@@ -219,6 +222,7 @@ function get_subsection_property_elements(element) {
             $emojiset_elem,
             $user_list_style_elem,
             $translate_emoticons_elem,
+            $display_emoji_reaction_users_elem,
         ];
     }
     return Array.from($subsection.find(".prop-element"));

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -53,10 +53,13 @@
         top: 1px;
         font-size: 90%;
         display: flex;
-        color: hsl(200, 100%, 40%);
         margin: 0 3px;
         padding: 2px 0;
         line-height: 1em;
+    }
+
+    .message_reaction:hover .message_reaction_count {
+        color: hsl(200, 100%, 40%);
     }
 
     i {

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -5,14 +5,15 @@
     user-select: none;
 
     .message_reaction {
+        display: flex;
         float: left;
         margin: 0.15em;
         padding: 0 2px 0 0;
-        height: 19px;
         cursor: pointer;
         background-color: hsl(0, 0%, 100%);
         border: 1px solid hsl(194, 37%, 84%);
         border-radius: 4px;
+        align-items: center;
 
         &.reacted {
             background-color: hsl(195, 50%, 95%);
@@ -27,7 +28,7 @@
             pointer-events: none;
             margin: 2px 0.1em 3px;
             padding: 3px;
-            height: 14px;
+            height: 13px;
             border-radius: 4px;
             padding-left: 0.3em;
             border: 1px solid hsl(0, 0%, 73%);
@@ -37,10 +38,10 @@
 
         .emoji {
             display: inline-block;
+            flex-shrink: 0;
             vertical-align: top;
             top: 0;
             margin: 1px 3px;
-
             height: 17px;
             width: 17px;
             position: relative;
@@ -49,12 +50,12 @@
 
     .message_reaction_count {
         position: relative;
-        top: 4px;
+        top: 1px;
         font-size: 90%;
-        display: inline-block;
-        vertical-align: top;
+        display: flex;
         color: hsl(200, 100%, 40%);
-        margin: 0 1px 0 0;
+        margin: 0 3px;
+        padding: 2px 0;
         line-height: 1em;
     }
 
@@ -71,9 +72,11 @@
     }
 
     .reaction_button {
+        display: flex;
+        align-items: center;
+
         i {
             font-size: 1em;
-            margin-right: 3px;
         }
 
         &:hover i {
@@ -100,8 +103,7 @@
         .message_reaction_count {
             font-size: 1.1em;
             color: hsl(0, 0%, 33%);
-            margin-left: 3px;
-            top: 0.5px;
+            margin-right: 0;
         }
 
         &:hover .message_reaction_count {

--- a/static/templates/message_reaction.hbs
+++ b/static/templates/message_reaction.hbs
@@ -6,5 +6,5 @@
     {{else}}
         <div class="emoji emoji-{{this.emoji_code}}"></div>
     {{/if}}
-    <div class="message_reaction_count">{{this.count}}</div>
+    <div class="message_reaction_count">{{this.vote_text}}</div>
 </div>

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -74,13 +74,11 @@
           label=settings_label.translate_emoticons
           prefix=prefix}}
 
-        {{#if page_params.development_environment }}
         {{> settings_checkbox
           setting_name="display_emoji_reaction_users"
           is_checked=settings_object.display_emoji_reaction_users
           label=settings_label.display_emoji_reaction_users
           prefix=prefix}}
-        {{/if}}
 
         <div class="input-group">
             <label class="title">{{t "User list style" }}</label>


### PR DESCRIPTION
Fixes: #20980.

Adds a setting to the bottom of Settings > Display Setting > Theme section to show names of reacting users on a message when the number of reactions are small.
When checked, the names of reacting users appear beside their reaction(s) if the total votes on the message are 3 or less. When total votes exceed 3, it shows the count instead.

**GIFs or screenshots (Live Update):** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


https://user-images.githubusercontent.com/59819879/163678894-e97128c3-4c28-42da-ae5b-9827bb506996.mp4


**Changes are reflected immediately on checking/unchecking the setting box:**

https://user-images.githubusercontent.com/59819879/163678920-d2e6d5e2-6970-4294-8d88-e779f9e01c0e.mp4



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
