### PR TITLE
typeahead: Fix typeahead for custom selection triggers.

### DIFF
--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -376,6 +376,11 @@
     }
 
   , keydown: function (e) {
+    if (this.trigger_selection(e)) {
+      if (!this.shown) return;
+      e.preventDefault();
+      this.select(e);
+    }
       this.suppressKeyPressRepeat = !~$.inArray(e.keyCode, [40,38,9,13,27])
       this.move(e)
     }
@@ -406,10 +411,6 @@
           break
 
         default:
-          if (this.trigger_selection(e)) {
-            if (!this.shown) return;
-            this.select(e);
-          }
           var hideOnEmpty = false
           if (e.keyCode === 8 && this.options.helpOnEmptyStrings) { // backspace
             hideOnEmpty = true


### PR DESCRIPTION
Simulated "backspace-ing" the printable custom trigger key before actually selecting the chosen option from the menu.

This fixes the case when jumping to topic, would eat up any space or new line after the cursor, due to wrong splitting around the cursor, which was a result of using the printable custom trigger key, the ">", in contrast to a non printable one like Enter.

Here's the [CZO issue discussion thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/topic.20completion.20before.20text)

**Testing plan:** 
Tested manually, by using the custom selection trigger key ">" to jump to topics, with and without new line / space immediately after the cursor, and also for other typeaheads to ensure no functionality was broken.

**GIFs or screenshots:** 
https://www.loom.com/share/efa42561a2af4edb95f0d8a14c59fcfa
