### PR TITLE
api_docs: Add check for extra `additionalProperties` in return vals.

### DIFF
--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -157,6 +157,15 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
                         return_values[return_value]["additionalProperties"]["properties"],
                         spacing + 8,
                     )
+                elif return_values[return_value]["additionalProperties"].get(
+                    "additionalProperties", False
+                ):
+                    ans += self.render_table(
+                        return_values[return_value]["additionalProperties"]["additionalProperties"][
+                            "properties"
+                        ],
+                        spacing + 8,
+                    )
             if (
                 "items" in return_values[return_value]
                 and "properties" in return_values[return_value]["items"]


### PR DESCRIPTION
Adds a check in the return values Markdown preprossesor for `additionalProperties: true` when there are no properties listed in the schema.

This currently only happens in one place (the `presences` return value for the `/register-queue` endpoint), but will be helpful for de-duplicating text between the `register-queue` and `get-events` endpoints in general.

[HTML api documentation diff](https://pastebin.com/Z1K1XHLW) confirms that currently only impacts this one object description.

**Current documentation for `presences` return value in `register-queue` endpoint**:
![Screenshot from 2022-02-02 17-57-26](https://user-images.githubusercontent.com/63245456/152216715-febaaa45-ef4f-4ecd-8c0a-999150491314.png)

**Updated documentation for `presences` return value in `register-queue` endpoint**:
![Screenshot from 2022-02-02 17-56-57](https://user-images.githubusercontent.com/63245456/152216714-b6915335-f455-48b7-b95b-afcd69067669.png)




