### PR TITLE
Improve how Zulip displays wordle 

### DIFF
--- a/frontend_tests/node_tests/emoji_picker.js
+++ b/frontend_tests/node_tests/emoji_picker.js
@@ -21,7 +21,7 @@ run_test("initialize", () => {
 
     const complete_emoji_catalog = _.sortBy(emoji_picker.complete_emoji_catalog, "name");
     assert.equal(complete_emoji_catalog.length, 11);
-    assert.equal(emoji.emojis_by_name.size, 1050);
+    assert.equal(emoji.emojis_by_name.size, 1052);
 
     let total_emoji_in_categories = 0;
 
@@ -43,7 +43,7 @@ run_test("initialize", () => {
     const popular_emoji_count = 6;
     const zulip_emoji_count = 1;
     assert_emoji_category(complete_emoji_catalog.pop(), "fa-car", 170);
-    assert_emoji_category(complete_emoji_catalog.pop(), "fa-hashtag", 195);
+    assert_emoji_category(complete_emoji_catalog.pop(), "fa-hashtag", 197);
     assert_emoji_category(complete_emoji_catalog.pop(), "fa-smile-o", 129);
     assert_emoji_category(complete_emoji_catalog.pop(), "fa-star-o", popular_emoji_count);
     assert_emoji_category(complete_emoji_catalog.pop(), "fa-thumbs-o-up", 102);

--- a/tools/setup/emoji/emoji_names.py
+++ b/tools/setup/emoji/emoji_names.py
@@ -1518,6 +1518,8 @@ EMOJI_NAME_MAPS: Dict[str, Dict[str, Any]] = {
     "25fb": {"canonical_name": "white_medium_square", "aliases": []},
     "2b1b": {"canonical_name": "black_large_square", "aliases": []},
     "2b1c": {"canonical_name": "white_large_square", "aliases": []},
+    "1f7e8": {"canonical_name": "large_yellow_square", "aliases": []},
+    "1f7e9": {"canonical_name": "large_green_square", "aliases": []},
     "1f508": {"canonical_name": "speaker", "aliases": []},
     "1f507": {"canonical_name": "mute", "aliases": ["no_sound"]},
     "1f509": {"canonical_name": "softer", "aliases": []},

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1475,11 +1475,8 @@ def make_realm_emoji(src: str, display_string: str) -> Element:
 
 def unicode_emoji_to_codepoint(unicode_emoji: str) -> str:
     codepoint = hex(ord(unicode_emoji))[2:]
-    # Unicode codepoints are minimum of length 4, padded
-    # with zeroes if the length is less than four.
-    while len(codepoint) < 4:
-        codepoint = "0" + codepoint
-    return codepoint
+    # Unicode codepoints are minimum of length 4, padded with zeroes
+    return codepoint.rjust(4, "0")
 
 
 class EmoticonTranslation(markdown.inlinepatterns.Pattern):

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1476,7 +1476,7 @@ def make_realm_emoji(src: str, display_string: str) -> Element:
 def unicode_emoji_to_codepoint(unicode_emoji: str) -> str:
     codepoint = hex(ord(unicode_emoji))[2:]
     # Unicode codepoints are minimum of length 4, padded
-    # with zeroes if the length is less than zero.
+    # with zeroes if the length is less than four.
     while len(codepoint) < 4:
         codepoint = "0" + codepoint
     return codepoint

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1410,6 +1410,7 @@ class Timestamp(markdown.inlinepatterns.Pattern):
 # \U0001f300-\U0001f5ff - Miscellaneous Symbols and Pictographs
 # \U0001f600-\U0001f64f - Emoticons (Emoji)
 # \U0001f680-\U0001f6ff - Transport and Map Symbols
+# \U0001f7e0-\U0001f7eb - Coloured Geometric Shapes (NOTE: Not Unicode standard category name)
 # \U0001f900-\U0001f9ff - Supplemental Symbols and Pictographs
 # \u2000-\u206f         - General Punctuation
 # \u2300-\u23ff         - Miscellaneous Technical
@@ -1429,6 +1430,7 @@ UNICODE_EMOJI_RE = (
     "(?P<syntax>["
     "\U0001F100-\U0001F64F"
     "\U0001F680-\U0001F6FF"
+    "\U0001F7E0-\U0001F7EB"
     "\U0001F900-\U0001F9FF"
     "\u2000-\u206F"
     "\u2300-\u27BF"


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

The PR aims to improve how Wordle gameplay gets displayed in Zulip. 
See https://chat.zulip.org/#narrow/stream/97-off-topic/topic/Wordle for some samples.

The PR also has a couple of other minor commits - a typo fix, and a better way of 0-padding codepoint strings.

**Testing plan:** <!-- How have you tested? -->
Tested locally with sample test messages

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

**Before**
![image](https://user-images.githubusercontent.com/315678/152217478-2b6675c7-5a74-401a-9aef-a8949c2e93ae.png)

**After**
![image](https://user-images.githubusercontent.com/315678/152217228-56f2fc58-7bf3-43d6-a0ad-32b5b5dabe06.png)
