### PR TITLE
upgrade: Catch "upgrade" attempts which would downgrade the database.

### DIFF
--- a/scripts/lib/check-database-compatibility.py
+++ b/scripts/lib/check-database-compatibility.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import logging
+import os
+import sys
+
+ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, ZULIP_PATH)
+from scripts.lib.setup_path import setup_path
+from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, assert_not_running_as_root, parse_version_from
+from version import ZULIP_VERSION as new_version
+
+assert_not_running_as_root()
+setup_path()
+os.environ["DJANGO_SETTINGS_MODULE"] = "zproject.settings"
+
+import django
+from django.db import connection
+from django.db.migrations.loader import MigrationLoader
+
+django.setup()
+loader = MigrationLoader(connection)
+missing = set(loader.applied_migrations)
+for key, migration in loader.disk_migrations.items():
+    missing.discard(key)
+    missing.difference_update(migration.replaces)
+if not missing:
+    sys.exit(0)
+
+current_version = parse_version_from(os.path.join(DEPLOYMENTS_DIR, "current"))
+logging.error(
+    "This is not an upgrade -- the current deployment (version %s) "
+    "contains database migrations which %s (version %s) does not.",
+    current_version,
+    len(missing),
+    ZULIP_PATH,
+    new_version,
+)
+sys.exit(1)

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -82,6 +82,11 @@ parser.add_argument("deploy_path", metavar="deploy_path", help="Path to deployme
 parser.add_argument("--skip-puppet", action="store_true", help="Skip doing puppet/apt upgrades.")
 parser.add_argument("--skip-migrations", action="store_true", help="Skip doing migrations.")
 parser.add_argument(
+    "--skip-downgrade-check",
+    action="store_true",
+    help="Skip the safety check to prevent database downgrades.",
+)
+parser.add_argument(
     "--from-git", action="store_true", help="Upgrading from git, so run update-prod-static."
 )
 parser.add_argument(
@@ -208,6 +213,14 @@ if not os.path.exists(os.path.join(deploy_path, "zproject/prod_settings.py")):
 subprocess.check_call(
     [os.path.join(deploy_path, "scripts", "lib", "create-production-venv"), deploy_path]
 )
+
+# Check to make sure that this upgrade is not actually a database
+# downgrade.
+if not args.skip_downgrade_check:
+    subprocess.check_call(
+        [os.path.join(deploy_path, "scripts", "lib", "check-database-compatibility.py")],
+        preexec_fn=su_to_zulip,
+    )
 
 # Make sure the right version of node is installed
 subprocess.check_call([os.path.join(deploy_path, "scripts", "lib", "install-node")])

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -105,15 +105,20 @@ def get_deploy_root() -> str:
     )
 
 
+def parse_version_from(deploy_path: str) -> str:
+    with open(os.path.join(deploy_path, "version.py")) as f:
+        result = re.search('ZULIP_VERSION = "(.*)"', f.read())
+        if result:
+            return result.groups()[0]
+    return "0.0.0"
+
+
 def get_deployment_version(extract_path: str) -> str:
     version = "0.0.0"
     for item in os.listdir(extract_path):
         item_path = os.path.join(extract_path, item)
         if item.startswith("zulip-server") and os.path.isdir(item_path):
-            with open(os.path.join(item_path, "version.py")) as f:
-                result = re.search('ZULIP_VERSION = "(.*)"', f.read())
-                if result:
-                    version = result.groups()[0]
+            version = parse_version_from(item_path)
             break
     return version
 


### PR DESCRIPTION
Attempting to "upgrade" from `main` to 4.x should abort; Django does
not prevent running old code against the new database (though it
likely errors at runtime), and `./manage.py migrate` from the old
version during the "upgrade" does not downgrade the database, since
the migrations are entirely missing in that directory, so don't get
reversed.

Compare the list of applied migrations to the list of on-disk
migrations, and abort if there are applied migrations which are not
found on disk.

Fixes: #19284.

**Testing plan:** Cherry-picked to 4.x, tried to "upgrade" from main to 4.x:
```
root@alexmv-prod:/home/zulip/deployments/next# ~zulip/deployments/current/scripts/upgrade-zulip-from-git --remote-url https://github.com/alexmv/zulip.git 4.x
2022-02-03 23:16:00,394 upgrade-zulip-from-git: Fetching the latest commits
[...]
Using cached Python venv from /srv/zulip-venv-cache/a7fb0fe17c8b91b591927bfa8f133a90b20f3d18/zulip-py3-venv
+ ln -nsf /srv/zulip-venv-cache/a7fb0fe17c8b91b591927bfa8f133a90b20f3d18/zulip-py3-venv /home/zulip/deployments/2022-02-03-23-16-00/zulip-py3-venv
2022-02-03 23:17:30.125 ERR  [] This is not an upgrade -- the current deployment (version 5.0-dev+git) contains 52 database migrations which /home/zulip/deployments/2022-02-03-23-16-00 (version 4.9+git) does not.
Traceback (most recent call last):
  File "/home/zulip/deployments/2022-02-03-23-16-00/scripts/lib/upgrade-zulip-stage-2", line 206, in <module>
    subprocess.check_call(
  File "/usr/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/home/zulip/deployments/2022-02-03-23-16-00/scripts/lib/check-database-compatibility.py']' returned non-zero exit status 1.

Zulip upgrade failed (exit code 1)!

The upgrade process is designed to be idempotent, so you can retry after resolving whatever issue caused the failure (there should be a traceback above). A log of this installation is available in /var/log/zulip/upgrade.log
```