### PR TITLE
buddy_data: Remove unused huddle_fraction_present function.

### DIFF
--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -111,44 +111,6 @@ function test(label, f) {
     });
 }
 
-test("huddle_fraction_present", () => {
-    people.add_active_user(alice);
-    people.add_active_user(fred);
-    people.add_active_user(jill);
-    people.add_active_user(mark);
-
-    let huddle = "alice@zulip.com,fred@zulip.com,jill@zulip.com,mark@zulip.com";
-    huddle = people.emails_strings_to_user_ids_string(huddle);
-
-    let presence_info = new Map();
-    presence_info.set(alice.user_id, {status: "active"}); // counts as present
-    presence_info.set(fred.user_id, {status: "idle"}); // does not count as present
-    // jill not in list
-    presence_info.set(mark.user_id, {status: "offline"}); // does not count
-    presence.__Rewire__("presence_info", presence_info);
-
-    assert.equal(buddy_data.huddle_fraction_present(huddle), 0.5);
-
-    presence_info = new Map();
-    for (const user of [alice, fred, jill, mark]) {
-        presence_info.set(user.user_id, {status: "active"}); // counts as present
-    }
-    presence.__Rewire__("presence_info", presence_info);
-
-    assert.equal(buddy_data.huddle_fraction_present(huddle), 1);
-
-    huddle = "alice@zulip.com,fred@zulip.com,jill@zulip.com,mark@zulip.com";
-    huddle = people.emails_strings_to_user_ids_string(huddle);
-    presence_info = new Map();
-    presence_info.set(alice.user_id, {status: "idle"});
-    presence_info.set(fred.user_id, {status: "idle"}); // does not count as present
-    // jill not in list
-    presence_info.set(mark.user_id, {status: "offline"}); // does not count
-    presence.__Rewire__("presence_info", presence_info);
-
-    assert.equal(buddy_data.huddle_fraction_present(huddle), undefined);
-});
-
 function set_presence(user_id, status) {
     presence.presence_info.set(user_id, {
         status,

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -267,25 +267,6 @@ export function get_items_for_users(user_ids) {
     return user_info;
 }
 
-export function huddle_fraction_present(huddle) {
-    const user_ids = huddle.split(",").map((s) => Number.parseInt(s, 10));
-
-    let num_present = 0;
-
-    for (const user_id of user_ids) {
-        if (presence.is_active(user_id)) {
-            num_present += 1;
-        }
-    }
-
-    if (num_present === user_ids.length) {
-        return 1;
-    } else if (num_present !== 0) {
-        return 0.5;
-    }
-    return undefined;
-}
-
 function user_is_recently_active(user_id) {
     // return true if the user has a green/orange circle
     return level(user_id) <= 2;

--- a/static/js/presence.js
+++ b/static/js/presence.js
@@ -29,16 +29,6 @@ const OFFLINE_THRESHOLD_SECS = 140;
 
 const BIG_REALM_COUNT = 250;
 
-export function is_active(user_id) {
-    if (presence_info.has(user_id)) {
-        const status = presence_info.get(user_id).status;
-        if (status === "active") {
-            return true;
-        }
-    }
-    return false;
-}
-
 export function get_status(user_id) {
     if (people.is_my_user_id(user_id)) {
         if (user_settings.presence_enabled) {


### PR DESCRIPTION
This function is not used currently after we removed the
"Group PMs" section from right sidebar in 43e5b2d28bc78.

This PR also removes presence.is_active function as it
was only used in buddy_data.huddle_fraction_present.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

 <!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
