### PR TITLE
[WIP] Add iDrift case study page, and tweak menus, links, and related landing pages.

### DIFF
--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -3350,10 +3350,6 @@ nav {
 }
 
 @media (width <= 906px) {
-    .portico-landing.why-page .hero p br {
-        display: none;
-    }
-
     .portico-landing.features-app {
         section {
             &.notifications {

--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -2371,7 +2371,7 @@ nav {
     font-size: 1.3em;
     text-align: center;
 
-    opacity: 0.7;
+    opacity: 0.9;
 }
 
 .portico-landing.why-page .markdown {

--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -4330,6 +4330,7 @@ nav {
     }
 }
 
+.case-study-page,
 .solutions-page {
     .hero-text {
         position: relative;
@@ -4483,13 +4484,6 @@ nav {
 .portico-landing.why-page.case-study-page {
     .bg-dimmer {
         background-color: hsl(224, 52%, 12%, 0.86);
-    }
-
-    .hero-text {
-        margin: 0 auto;
-        font-size: 25px;
-        font-weight: 500;
-        opacity: 0.8;
     }
 }
 

--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -4278,6 +4278,8 @@ nav {
     border-radius: 1em;
     font-weight: 400;
     margin: 40px 5px;
+    display: flex;
+    flex-direction: column;
 
     a {
         color: hsl(0, 0%, 100%);

--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -38,6 +38,9 @@
         <h3>{{ _("Customer stories") }}</h3>
         <ul>
             <li>
+                <a href="/case-studies/idrift/">iDrift AS {{ _("Company") }}</a>
+            </li>
+            <li>
                 <a href="/case-studies/tum/">{{ _("Technical University of Munich") }}</a>
             </li>
             <li>

--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -18,16 +18,16 @@
                 <a href="/for/business/">{{ _("Business") }}</a>
             </li>
             <li>
-                <a href="/for/open-source/">{{ _("Open source projects") }}</a>
+                <a href="/for/education/">{{ _("Education") }}</a>
             </li>
             <li>
-                <a href="/for/education/">{{ _("Education") }}</a>
+                <a href="/for/research/">{{ _("Research") }}</a>
             </li>
             <li>
                 <a href="/for/events/">{{ _("Events and conferences") }}</a>
             </li>
             <li>
-                <a href="/for/research/">{{ _("Research") }}</a>
+                <a href="/for/open-source/">{{ _("Open source projects") }}</a>
             </li>
             <li>
                 <a href="/for/communities/">{{ _("Communities") }}</a>
@@ -47,10 +47,10 @@
                 <a href="/case-studies/ucsd/">{{ _("University of California San Diego") }}</a>
             </li>
             <li>
-                <a href="/case-studies/rust/">{{ _("Rust language community") }}</a>
+                <a href="/case-studies/lean/">{{ _("Lean theorem prover community") }}</a>
             </li>
             <li>
-                <a href="/case-studies/lean/">{{ _("Lean theorem prover community") }}</a>
+                <a href="/case-studies/rust/">{{ _("Rust language community") }}</a>
             </li>
         </ul>
     </div>

--- a/templates/zerver/for-business.html
+++ b/templates/zerver/for-business.html
@@ -17,9 +17,10 @@
     <div class="hero bg-companies">
         <div class="bg-dimmer"></div>
         <h1 class="center">The best group chat for your business.</h1>
-        <p>Make better use of managers’ time, integrate remote workers, and replace low-content meetings.</p>
+        <p>Make better use of managers’ time, integrate remote workers, and
+        replace low-content meetings. <br/>Zulip is free for light use!</p>
         <div class="hero-text">
-            Zulip is free for light use. Get started today!
+            Learn how the <a href="/case-studies/idrift/">iDrift AS company</a> is using Zulip.
         </div>
         <div class="hero-buttons center">
             <a href="/new/" class="button">

--- a/templates/zerver/for-business.html
+++ b/templates/zerver/for-business.html
@@ -146,7 +146,20 @@
                         </div>
                     </li>
                 </ul>
-                <blockquote class="twitter-tweet" data-conversation="none" data-dnt="true" data-cards="hidden"><p lang="en" dir="ltr">New version of Zulip ! <a href="https://t.co/6AjXkUSzLd">https://t.co/6AjXkUSzLd</a> <br /><br />Zulip is the only nice project chat I ever used. Discord, slack, etc wasted my productivity for years, zulip actually increases it.</p>&mdash; Bite Cꙮde (@bitecode_dev) <a href="https://twitter.com/bitecode_dev/status/1393111310750076930?ref_src=twsrc%5Etfw">May 14, 2021</a></blockquote> <script async src="https://platform.twitter.com/widgets.js"></script>
+                <div class="quote">
+                    <blockquote>
+                        Zulip’s threading model makes it so much easier to
+                        manage my team. As a leader, in just a few minutes I can
+                        get an overview over what's going on and see where my
+                        attention is needed.
+                    </blockquote>
+                    <div class="author">
+                        &mdash; Gaute Lund, co-founder and owner of iDrift AS
+                    </div>
+                    <a class="case-study-link" href="/case-studies/idrift/"
+                      target="_blank">Learn more about how the iDrift AS company uses Zulip
+                    ↗</a>
+                </div>
             </div>
         </div>
         <div class="feature-half md-display">
@@ -484,6 +497,7 @@
                     </li>
                     <li><div class="list-content">Use Zulip in your language of choice, with translations into <a href="https://www.transifex.com/zulip/zulip/">17 languages</a>.</div></li>
                 </ul>
+                <blockquote class="twitter-tweet" data-conversation="none" data-dnt="true" data-cards="hidden"><p lang="en" dir="ltr">New version of Zulip ! <a href="https://t.co/6AjXkUSzLd">https://t.co/6AjXkUSzLd</a> <br /><br />Zulip is the only nice project chat I ever used. Discord, slack, etc wasted my productivity for years, zulip actually increases it.</p>&mdash; Bite Cꙮde (@bitecode_dev) <a href="https://twitter.com/bitecode_dev/status/1393111310750076930?ref_src=twsrc%5Etfw">May 14, 2021</a></blockquote> <script async src="https://platform.twitter.com/widgets.js"></script>
             </div>
         </div>
         <div class="feature-half">

--- a/templates/zerver/for-communities.html
+++ b/templates/zerver/for-communities.html
@@ -17,9 +17,14 @@
     <div class="hero bg-education">
         <div class="bg-dimmer"></div>
         <h1 class="center">Zulip for communities</h1>
-        <p>Open-source projects, research collaborations, volunteer organizations.</p>
+        <p>
+            Open-source projects, research collaborations, volunteer
+            organizations. <br />Most communities get an 85%+ discount
+            on <a href="/plans">Zulip Standard</a>!
+        </p>
         <div class="hero-text">
-            <a href="/plans">Zulip Standard</a> is discounted 85%+ for registered non-profits, and most communities are eligible for a discount. Contact <a href="mailto:sales@zulip.com">sales@zulip.com</a> to check whether your organization qualifies, or <a href="/accounts/go/?next=/upgrade%23sponsorship">request sponsorship</a> today.
+            Learn how the <a href="/case-studies/lean/">Lean theorem prover community</a> and
+            <br />the <a href="/case-studies/rust/">Rust language community</a> are using Zulip.
         </div>
         <div class="hero-buttons center">
             <a href="/new/" class="button">
@@ -42,8 +47,15 @@
     </div>
     <div class="bottom-register-buttons">
         <h1>
-            <a href="/plans">Zulip Standard</a> is discounted for most communities!
+            Most communities get an 85%+ discount on <a href="/plans">Zulip Standard</a>!
         </h1>
+        <div class="bottom-text-large">
+            <p> Join the hundreds of communities we sponsor. Contact <a href="mailto:sales@zulip.com">
+                sales@zulip.com</a> to check whether your organization
+                qualifies, or <a href="/accounts/go/?next=/upgrade%23sponsorship">request
+                sponsorship</a> today.
+            </p>
+        </div>
         <div class="hero-buttons center">
             <a href="/new/" class="button">
                 {{ _('Create organization') }}

--- a/templates/zerver/for-open-source.html
+++ b/templates/zerver/for-open-source.html
@@ -21,14 +21,17 @@
         <div class="bg-dimmer"></div>
         <div class="content">
             <h1 class="center">Zulip for open source projects</h1>
-            <p>Grow your community with thoughtful and inclusive discussion.</p>
+            <p>
+                Grow your community with thoughtful and inclusive discussion.
+                <br/><a href="/plans">Zulip Standard</a> is free for open-source
+                projects!
+            </p>
         </div>
         <div class="hero-text">
-            <a href="/plans">Zulip Standard</a> is free for open-source
-            projects! Contact <a href="mailto:sales@zulip.com">sales@zulip.com</a>
-            to check whether your organization qualifies, or
-            <a href="/accounts/go/?next=/upgrade%23sponsorship">request sponsorship</a>
-            today.
+            Learn how the <a href="/case-studies/rust/">Rust language
+            community</a> and
+            <br />the <a href="/case-studies/lean/">Lean theorem prover
+            community</a> are using Zulip.
         </div>
         <div class="hero-buttons center">
             <a href="/new/" class="button">

--- a/templates/zerver/for-research.html
+++ b/templates/zerver/for-research.html
@@ -22,10 +22,15 @@
         <div class="bg-dimmer"></div>
         <div class="content">
             <h1 class="center">Zulip for research</h1>
-            <p>Chat for your project, research group, department or scientific field</p>
+            <p>
+                Chat for your project, research group, department or scientific
+                field. <br/><a href="/plans">Zulip Standard</a> is free for academic
+                research!
+            </p>
         </div>
         <div class="hero-text">
-            <a href="/plans">Zulip Standard</a> is free for academic research! Contact <a href="mailto:sales@zulip.com">sales@zulip.com</a> to check whether your organization qualifies, or <a href="/accounts/go/?next=/upgrade%23sponsorship">request sponsorship</a> today.
+            Learn how the <a href="/case-studies/lean/">Lean theorem prover
+            community</a> is using Zulip.
         </div>
         <div class="hero-buttons center">
             <a href="/new/" class="button">

--- a/templates/zerver/for/idrift-case-study.md
+++ b/templates/zerver/for/idrift-case-study.md
@@ -1,0 +1,116 @@
+## A distributed team
+
+For the past 20 years, iDrift AS has been offering infrastructure and security
+support for small businesses. iDrift AS is a distributed organization, operating
+from six offices across Norway. As such, this 30-person company has always
+depended on team chat to coordinate and support each other’s efforts.
+
+iDrift AS co-founder and owner Gaute Lund had long been frustrated with the
+limitations of the company’s collaboration tools. “When I learned about Zulip it
+was an absolute revelation,” says Gaute Lund. “Zulip’s threading model makes it
+so much easier to manage my team. As a leader, in just a few minutes I can get
+an overview over what's going on and see where my attention is needed.”
+
+
+## Async communication is a challenge
+
+From its founding, iDrift AS relied on IRC for internal communication, but the
+lack of a modern user interface proved to be a barrier for participation for
+management and non-technical members of the team. iDrift AS therefore moved from
+IRC to Slack in October 2016.
+
+“In terms of functionality, Slack is just souped-up IRC — there is no conceptual
+difference,” says iDrift AS owner Gaute Lund. “It doesn’t add anything
+significant other than the UI.”
+
+While Slack worked reasonably well for real-time communication, the busy Slack
+channels at iDrift AS were not effective for asynchronous discussions. “It was
+almost impossible to catch up on a conversation, or get an overview of what you
+missed while on vacation,” Gaute Lund says.
+
+> “Slack is just souped-up IRC — there is no conceptual difference.”
+>
+> — Gaute Lund, co-founder and owner of iDrift AS
+
+
+## Easy transition to Zulip
+
+When a team member recommended Zulip, Gaute Lund understood the potential of
+[Zulip’s threading model](/why-zulip/) to dramatically improve
+async collaboration at iDrift AS. The company evaluated Zulip in the summer of
+2020, and decided to make the move.
+
+The team took easily to Zulip’s topic-based threading paradigm. “Once people
+start using Zulip, it quickly becomes obvious why it’s better,” says Gaute Lund.
+
+The transition also went smoothly from a technical perspective. “It was not a
+lot of work to move everything over from Slack to Zulip,” says Gaute Lund. “The
+export/import tool worked really well to ensure that we had logs of all the
+prior conversations.”
+
+Chat integrations for operational systems and alerts are a crucial part of the
+workflow at iDrift AS. Zulip offers a [Slack-compatible
+interface](/integrations/doc/slack_incoming), so many integrations could be
+simply moved over. “For a handful of integrations where Zulip didn’t meet our
+needs, it was easy to [create our own
+integration](/api/integrations-overview#write-your-own-integration) or improve
+the existing one. It wasn’t a problem,” Gaute Lund says.
+
+iDrift AS decided to self-host its own Zulip server. Because Zulip is
+[100% open source](https://github.com/zulip/zulip), this option offers
+the same functionality as a [Zulip Cloud Standard](/plans/)
+subscription. “Zulip is very stable, and easy to run and to upgrade,”
+says Senior IT Consultant Tor Hveem.
+
+> “Once people start using Zulip, it quickly becomes obvious why it’s better.”
+>
+> — Gaute Lund, co-founder and owner of iDrift AS
+
+
+## Zulip helps leaders scale
+
+The move to Zulip transformed Gaute Lund’s day-to-day experience as a leader.
+“Using Zulip significantly increases the size of the team for which a manager
+can meaningfully know what’s going on,” says Gaute Lund. “There are 25 people
+for whom I have a very good grip on their work, whereas previously it was no
+more than a handful”.
+
+
+> “Using Zulip significantly increases the size of the team for which a manager
+> can meaningfully know what’s going on.”
+>
+> — Gaute Lund, co-founder and owner of iDrift AS
+
+As a Microsoft shop, iDrift AS uses Microsoft Teams for file sharing, scheduling
+and video calls. Would they use it for team chat? “For technical people, the
+chat experience in Teams is abhorrent,” says Gaute. “It’s almost impossible to
+get an overview of what’s happening. Only a small number of messages fit on the
+screen, and the discussions hidden inside threads make it even harder to see
+what’s going on.”
+
+In contrast, Zulip’s topic-based threading lets Gaute review conversations in
+batches, without being constantly interrupted by chat messages. Every few hours,
+Gaute looks through the list of recent Zulip topics to find discussions that may
+require his attention, and offers feedback as needed. Catching up is fast:
+“Updating myself on an incident might take a few seconds,” Gaute Lund says.
+
+
+## Efficient team communication
+
+With Zulip, the team can discuss everything from customer issues to major design
+decisions. “Zulip lets people focus on conversations where they can contribute,
+whether or not they happen to be online when the conversation starts,” says
+Gaute Lund.
+
+The Zulip chat also serves as a knowledge base for the history of the
+organization. “We have a very stable customer base, and Zulip search makes it
+easy to review past interactions,” Gaute Lund says.
+
+> “Zulip lets people focus on conversations where they can contribute.”
+>
+> — Gaute Lund, co-founder and owner of iDrift AS
+
+---
+
+Check out our guide on [using Zulip for business](/for/business) to
+learn more!

--- a/templates/zerver/idrift-case-study.html
+++ b/templates/zerver/idrift-case-study.html
@@ -1,0 +1,36 @@
+{% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
+
+{% block title %}
+<title>Case study: iDrift AS, distributed tech company</title>
+{% endblock %}
+
+{% block customhead %}
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+{% endblock %}
+
+{% block portico_content %}
+
+{% include 'zerver/landing_nav.html' %}
+
+<div class="portico-landing why-page solutions-page case-study-page">
+    <div class="hero bg-education">
+        <div class="bg-dimmer"></div>
+        <div class="content">
+            <h1 class="center">Case study: iDrift AS</h1>
+            <p>Distributed tech company</p>
+        </div>
+        <div class="hero-text">
+            Learn more about using Zulip for <a href="/for/business">business</a>.
+        </div>
+    </div>
+    <div class="main">
+        <div class="padded-content">
+            <div class="inner-content markdown">
+                {{ render_markdown_path('zerver/for/idrift-case-study.md') }}
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -48,16 +48,16 @@
                             <a href="/for/business/">Business</a>
                         </li>
                         <li>
-                            <a href="/for/open-source/">Open source projects</a>
+                            <a href="/for/education/">Education</a>
                         </li>
                         <li>
-                            <a href="/for/education/">Education</a>
+                            <a href="/for/research/">Research</a>
                         </li>
                         <li>
                             <a href="/for/events/">Events and conferences</a>
                         </li>
                         <li>
-                            <a href="/for/research/">Research</a>
+                            <a href="/for/open-source/">Open source projects</a>
                         </li>
                         <li>
                             <a href="/for/communities/">Communities</a>
@@ -75,10 +75,10 @@
                             <a href="/case-studies/ucsd/">University of California San Diego</a>
                         </li>
                         <li>
-                            <a href="/case-studies/rust/">Rust language community</a>
+                            <a href="/case-studies/lean/">Lean theorem prover community</a>
                         </li>
                         <li>
-                            <a href="/case-studies/lean/">Lean theorem prover community</a>
+                            <a href="/case-studies/rust/">Rust language community</a>
                         </li>
                     </div>
                 </ul>

--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -66,6 +66,9 @@
                     <div class="dropdown-column">
                         <li class="nav-header">Customer stories</li>
                         <li>
+                            <a href="/case-studies/idrift/">iDrift AS company</a>
+                        </li>
+                        <li>
                             <a href="/case-studies/tum/">Technical University of Munich</a>
                         </li>
                         <li>

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -163,6 +163,7 @@ class DocPageTest(ZulipTestCase):
         self._test("/case-studies/ucsd/", "UCSD")
         self._test("/case-studies/rust/", "Rust programming language")
         self._test("/case-studies/lean/", "Lean theorem prover")
+        self._test("/case-studies/idrift/", "Case study: iDrift AS")
         self._test("/for/research/", "for research")
         self._test("/for/business/", "Communication efficiency represents")
         self._test("/for/communities/", "Zulip for communities")

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -627,6 +627,7 @@ i18n_urls = [
     path("for/research/", landing_view, {"template_name": "zerver/for-research.html"}),
     path("for/business/", landing_view, {"template_name": "zerver/for-business.html"}),
     path("for/companies/", RedirectView.as_view(url="/for/business/", permanent=True)),
+    path("case-studies/idrift/", landing_view, {"template_name": "zerver/idrift-case-study.html"}),
     path("case-studies/tum/", landing_view, {"template_name": "zerver/tum-case-study.html"}),
     path("case-studies/ucsd/", landing_view, {"template_name": "zerver/ucsd-case-study.html"}),
     path("case-studies/rust/", landing_view, {"template_name": "zerver/rust-case-study.html"}),


### PR DESCRIPTION
This PR is not ready to be merged due to some formatting funkiness. @amanagr could you please take a look? In particular:

1. I think /for/education has almost the right styling in the hero area, but the subtitle should be the same color as the “Learn how…” text, not the greyer color it currently is.
2. We should then apply the same styling (font color, line spacing and the two font sizes for text below the title) to all /for/x and /case-study/x pages.
3. I also noticed that the line break from adding a <br/> to the sub-header (before the line about pricing) disappears in narrow windows. Is this intentional?
4. The case study links from quotes on /for/x pages have bad indentation on the second line in narrow windows:

![Screen Shot 2022-02-04 at 2 27 31 PM](https://user-images.githubusercontent.com/2090066/152613809-48f66bc2-b130-4ca8-bd50-32fca4139716.png)

