### PR TITLE
drafts: Use simplebar.

### DIFF
--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -69,6 +69,17 @@
             color: hsl(0, 0%, 67%);
             pointer-events: none;
         }
+
+        /* Hide duplicate default scrollbar for IE, Edge and Firefox.  In
+           theory simplebar should be doing this for us. */
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+    }
+
+    /* Hide duplicate default scrollbar for IE, Edge and Firefox.  In
+       theory simplebar should be doing this for us. */
+    .drafts-list::-webkit-scrollbar {
+        display: none;
     }
 }
 

--- a/static/templates/draft_table_body.hbs
+++ b/static/templates/draft_table_body.hbs
@@ -14,7 +14,7 @@
                     {{t "Pro tip: You can use 'd' to open your drafts."}}
                 </div>
             </div>
-            <div class="drafts-list">
+            <div class="drafts-list" data-simplebar>
                 <div class="no-drafts">
                     {{t 'No drafts.'}}
                 </div>


### PR DESCRIPTION
Use simplebar in drafts overlay instead of default scrollbar.

![chrome-capture (4)](https://user-images.githubusercontent.com/74348920/152639053-627ba326-6047-4b11-8d28-6c99e0c69155.gif)
![chrome-capture (3)](https://user-images.githubusercontent.com/74348920/152639054-c2f31c0c-c697-4eaf-85e8-51470fb1ad53.gif)

