### PR TITLE
Display status emoji in several additional places in the UI

### DIFF
--- a/frontend_tests/node_tests/pm_list_data.js
+++ b/frontend_tests/node_tests/pm_list_data.js
@@ -68,7 +68,11 @@ test("get_convos", ({override}) => {
             is_active: false,
             is_group: false,
             is_zero: false,
-            recipients: "Me Myself",
+            recipients: [
+                {
+                    full_name: "Me Myself",
+                },
+            ],
             unread: 1,
             url: "#narrow/pm-with/103-me",
             user_circle_class: "user_circle_empty",
@@ -78,7 +82,14 @@ test("get_convos", ({override}) => {
             },
         },
         {
-            recipients: "Alice, Bob",
+            recipients: [
+                {
+                    full_name: "Alice",
+                },
+                {
+                    full_name: "Bob",
+                },
+            ],
             user_ids_string: "101,102",
             unread: 1,
             is_zero: false,
@@ -116,18 +127,29 @@ test("get_convos bot", ({override}) => {
 
     const expected_data = [
         {
-            recipients: "Outgoing webhook",
+            recipients: [
+                {
+                    full_name: "Outgoing webhook",
+                },
+            ],
             user_ids_string: "314",
             unread: 1,
             is_zero: false,
             is_active: false,
             url: "#narrow/pm-with/314-outgoingwebhook",
-            status_emoji_info: undefined,
             user_circle_class: "user_circle_green",
             is_group: false,
+            status_emoji_info: undefined,
         },
         {
-            recipients: "Alice, Bob",
+            recipients: [
+                {
+                    full_name: "Alice",
+                },
+                {
+                    full_name: "Bob",
+                },
+            ],
             user_ids_string: "101,102",
             unread: 1,
             is_zero: false,

--- a/frontend_tests/node_tests/pm_list_data.js
+++ b/frontend_tests/node_tests/pm_list_data.js
@@ -9,9 +9,14 @@ const unread = mock_esm("../../static/js/unread");
 
 mock_esm("../../static/js/user_status", {
     is_away: () => false,
-    get_status_emoji: () => ({
-        emoji_code: 20,
-    }),
+    get_status_emoji: (user_id) => {
+        if (user_id === 314) {
+            // user is bot
+            return undefined;
+        }
+        // else
+        return {emoji_code: 20};
+    },
 });
 
 const narrow_state = zrequire("narrow_state");
@@ -71,23 +76,29 @@ test("get_convos", ({override}) => {
             recipients: [
                 {
                     full_name: "Me Myself",
+                    status_emoji_info: {
+                        emoji_code: 20,
+                    },
                 },
             ],
             unread: 1,
             url: "#narrow/pm-with/103-me",
             user_circle_class: "user_circle_empty",
             user_ids_string: "103",
-            status_emoji_info: {
-                emoji_code: 20,
-            },
         },
         {
             recipients: [
                 {
                     full_name: "Alice",
+                    status_emoji_info: {
+                        emoji_code: 20,
+                    },
                 },
                 {
                     full_name: "Bob",
+                    status_emoji_info: {
+                        emoji_code: 20,
+                    },
                 },
             ],
             user_ids_string: "101,102",
@@ -97,7 +108,6 @@ test("get_convos", ({override}) => {
             url: "#narrow/pm-with/101,102-group",
             user_circle_class: undefined,
             is_group: true,
-            status_emoji_info: undefined,
         },
     ];
 
@@ -130,6 +140,7 @@ test("get_convos bot", ({override}) => {
             recipients: [
                 {
                     full_name: "Outgoing webhook",
+                    status_emoji_info: undefined,
                 },
             ],
             user_ids_string: "314",
@@ -139,15 +150,20 @@ test("get_convos bot", ({override}) => {
             url: "#narrow/pm-with/314-outgoingwebhook",
             user_circle_class: "user_circle_green",
             is_group: false,
-            status_emoji_info: undefined,
         },
         {
             recipients: [
                 {
                     full_name: "Alice",
+                    status_emoji_info: {
+                        emoji_code: 20,
+                    },
                 },
                 {
                     full_name: "Bob",
+                    status_emoji_info: {
+                        emoji_code: 20,
+                    },
                 },
             ],
             user_ids_string: "101,102",
@@ -156,7 +172,6 @@ test("get_convos bot", ({override}) => {
             is_active: false,
             url: "#narrow/pm-with/101,102-group",
             user_circle_class: undefined,
-            status_emoji_info: undefined,
             is_group: true,
         },
     ];

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -306,20 +306,22 @@ export function get_full_names_for_poll_option(user_ids) {
     return get_display_full_names(user_ids).join(", ");
 }
 
+function get_display_full_name(user_id) {
+    const person = get_by_user_id(user_id);
+    if (!person) {
+        blueslip.error("Unknown user id " + user_id);
+        return "?";
+    }
+
+    if (muted_users.is_user_muted(user_id)) {
+        return $t({defaultMessage: "Muted user"});
+    }
+
+    return person.full_name;
+}
+
 export function get_display_full_names(user_ids) {
-    return user_ids.map((user_id) => {
-        const person = get_by_user_id(user_id);
-        if (!person) {
-            blueslip.error("Unknown user id " + user_id);
-            return "?";
-        }
-
-        if (muted_users.is_user_muted(user_id)) {
-            return $t({defaultMessage: "Muted user"});
-        }
-
-        return person.full_name;
-    });
+    return user_ids.map((user_id) => get_display_full_name(user_id));
 }
 
 export function get_full_name(user_id) {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -306,7 +306,7 @@ export function get_full_names_for_poll_option(user_ids) {
     return get_display_full_names(user_ids).join(", ");
 }
 
-function get_display_full_name(user_id) {
+export function get_display_full_name(user_id) {
     const person = get_by_user_id(user_id);
     if (!person) {
         blueslip.error("Unknown user id " + user_id);
@@ -328,7 +328,7 @@ export function get_full_name(user_id) {
     return people_by_user_id_dict.get(user_id).full_name;
 }
 
-function _calc_user_and_other_ids(user_ids_string) {
+export function _calc_user_and_other_ids(user_ids_string) {
     const user_ids = split_to_ints(user_ids_string);
     const other_ids = user_ids.filter((user_id) => !is_my_user_id(user_id));
     return {user_ids, other_ids};

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -328,11 +328,16 @@ export function get_full_name(user_id) {
     return people_by_user_id_dict.get(user_id).full_name;
 }
 
+function _calc_user_and_other_ids(user_ids_string) {
+    const user_ids = split_to_ints(user_ids_string);
+    const other_ids = user_ids.filter((user_id) => !is_my_user_id(user_id));
+    return {user_ids, other_ids};
+}
+
 export function get_recipients(user_ids_string) {
     // See message_store.get_pm_full_names() for a similar function.
 
-    const user_ids = split_to_ints(user_ids_string);
-    const other_ids = user_ids.filter((user_id) => !is_my_user_id(user_id));
+    const {other_ids} = _calc_user_and_other_ids(user_ids_string);
 
     if (other_ids.length === 0) {
         // private message with oneself

--- a/static/js/pm_list_data.js
+++ b/static/js/pm_list_data.js
@@ -4,6 +4,7 @@ import * as narrow_state from "./narrow_state";
 import * as people from "./people";
 import * as pm_conversations from "./pm_conversations";
 import * as unread from "./unread";
+import * as user_display from "./user_display";
 import * as user_status from "./user_status";
 
 export function get_active_user_ids_string() {
@@ -30,7 +31,7 @@ export function get_convos() {
     for (const private_message_obj of private_messages) {
         const user_ids_string = private_message_obj.user_ids_string;
         const reply_to = people.user_ids_string_to_emails_string(user_ids_string);
-        const recipients_string = people.get_recipients(user_ids_string);
+        const recipients = user_display.get_recipients_obj(user_ids_string);
 
         const num_unread = unread.num_unread_for_person(user_ids_string);
 
@@ -55,7 +56,7 @@ export function get_convos() {
         }
 
         const display_message = {
-            recipients: recipients_string,
+            recipients,
             user_ids_string,
             unread: num_unread,
             is_zero: num_unread === 0,

--- a/static/js/pm_list_data.js
+++ b/static/js/pm_list_data.js
@@ -5,7 +5,6 @@ import * as people from "./people";
 import * as pm_conversations from "./pm_conversations";
 import * as unread from "./unread";
 import * as user_display from "./user_display";
-import * as user_status from "./user_status";
 
 export function get_active_user_ids_string() {
     const filter = narrow_state.filter();
@@ -31,16 +30,14 @@ export function get_convos() {
     for (const private_message_obj of private_messages) {
         const user_ids_string = private_message_obj.user_ids_string;
         const reply_to = people.user_ids_string_to_emails_string(user_ids_string);
-        const recipients = user_display.get_recipients_obj(user_ids_string);
+        const recipients = user_display.get_recipients_with_status_emoji_info(user_ids_string);
 
         const num_unread = unread.num_unread_for_person(user_ids_string);
 
         const is_group = user_ids_string.includes(",");
-
         const is_active = user_ids_string === active_user_ids_string;
 
         let user_circle_class;
-        let status_emoji_info;
 
         if (!is_group) {
             const user_id = Number.parseInt(user_ids_string, 10);
@@ -49,9 +46,6 @@ export function get_convos() {
 
             if (recipient_user_obj.is_bot) {
                 user_circle_class = "user_circle_green";
-                // bots do not have status emoji
-            } else {
-                status_emoji_info = user_status.get_status_emoji(user_id);
             }
         }
 
@@ -62,7 +56,6 @@ export function get_convos() {
             is_zero: num_unread === 0,
             is_active,
             url: hash_util.pm_with_url(reply_to),
-            status_emoji_info,
             user_circle_class,
             is_group,
         };

--- a/static/js/user_display.js
+++ b/static/js/user_display.js
@@ -1,0 +1,15 @@
+import * as people from "./people";
+
+export function get_recipients_obj(user_ids_string) {
+    const {user_ids, other_ids} = people._calc_user_and_other_ids(user_ids_string);
+
+    if (other_ids.length === 0) {
+        // private message with oneself
+        const full_name = people.my_full_name();
+        return [{full_name}];
+    }
+
+    const users = user_ids.map((user_id) => ({full_name: people.get_display_full_name(user_id)}));
+    const sorted_users = users.sort((user1, user2) => user1 >= user2);
+    return sorted_users;
+}

--- a/static/js/user_display.js
+++ b/static/js/user_display.js
@@ -1,15 +1,24 @@
 import * as people from "./people";
+import * as user_status from "./user_status";
 
-export function get_recipients_obj(user_ids_string) {
+export function get_recipients_with_status_emoji_info(user_ids_string) {
     const {user_ids, other_ids} = people._calc_user_and_other_ids(user_ids_string);
 
     if (other_ids.length === 0) {
         // private message with oneself
         const full_name = people.my_full_name();
-        return [{full_name}];
+        return [
+            {
+                full_name,
+                status_emoji_info: user_status.get_status_emoji(user_ids[0]),
+            },
+        ];
     }
 
-    const users = user_ids.map((user_id) => ({full_name: people.get_display_full_name(user_id)}));
+    const users = user_ids.map((user_id) => ({
+        full_name: people.get_display_full_name(user_id),
+        status_emoji_info: user_status.get_status_emoji(user_id),
+    }));
     const sorted_users = users.sort((user1, user2) => user1 >= user2);
     return sorted_users;
 }

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -137,6 +137,7 @@
 
     &.user-with-count .unread_count {
         display: block;
+        margin-left: 4px;
     }
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2485,11 +2485,11 @@ div.topic_edit_spinner .loading_indicator_spinner {
     emoji's width decreases and causes it to break. */
     min-width: 16px;
     /* In most contexts, status emoji appear immediately after a name
-      field with no margin. Position the status emoji with 2px of left
+      field with no margin. Position the status emoji with 3px of left
       margin to space it from the name, and set no right margin so
       that any components to the right appear equally distant as they
       would be from a name. */
-    margin-left: 2px;
+    margin-left: 3px;
     margin-right: 0;
 }
 

--- a/static/templates/pm_list_item.hbs
+++ b/static/templates/pm_list_item.hbs
@@ -10,8 +10,9 @@
         </div>
 
         <a href='{{url}}' class="conversation-partners">
-            {{recipients}}
-            {{> status_emoji status_emoji_info}}
+            {{#each recipients}}
+                {{#unless @first}}&nbsp;{{/unless}}{{> pm_list_item_recipient}}{{#unless @last}},{{/unless}}
+            {{/each}}
         </a>
         <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
             {{unread}}

--- a/static/templates/pm_list_item.hbs
+++ b/static/templates/pm_list_item.hbs
@@ -10,9 +10,9 @@
         </div>
 
         <a href='{{url}}' class="conversation-partners">
-            {{#each recipients}}
-                {{#unless @first}}&nbsp;{{/unless}}{{> pm_list_item_recipient}}{{#unless @last}},{{/unless}}
-            {{/each}}
+            {{~#each recipients~}}
+                {{~#unless @first}}&nbsp;{{/unless}}{{~> pm_list_item_recipient~}}{{#unless @last}},{{/unless~}}
+            {{~/each~}}
         </a>
         <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
             {{unread}}

--- a/static/templates/pm_list_item_recipient.hbs
+++ b/static/templates/pm_list_item_recipient.hbs
@@ -1,0 +1,1 @@
+{{~ this.full_name ~}}

--- a/static/templates/pm_list_item_recipient.hbs
+++ b/static/templates/pm_list_item_recipient.hbs
@@ -1,1 +1,2 @@
 {{~ this.full_name ~}}
+{{> status_emoji this.status_emoji_info}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This continues the work from #20019. In order to address #19865.

**Testing plan:** <!-- How have you tested? -->
automated tests pass, and manual testing on chrome/windows did not reveal any bugs.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<details>
<summary>
working GIF
</summary>

![](https://user-images.githubusercontent.com/33805964/152673045-513f16c7-d1da-4291-a01c-59e868ed90a4.gif)
</details>

<details>
<summary>
Live updates for status emoji or user renames do not work on compose_pm pills
</summary>

![](https://user-images.githubusercontent.com/33805964/152673042-d2563d42-cde2-41be-8e0f-3c7582658e88.gif)
</details>
