### PR TITLE
typeahead: Ignore mouse position for selection until it's moved.

### DIFF
--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -491,6 +491,11 @@ class CommonUtils {
             `//*[@class="typeahead dropdown-menu" and contains(@style, "display: block")]//li[contains(normalize-space(), "${item}")]//a`,
             {visible: true},
         );
+        const entry_x = (await entry?.boundingBox())?.x;
+        const entry_y = (await entry?.boundingBox())?.y;
+        if (entry_x && entry_y) {
+            await page.mouse.move(entry_x, entry_y);
+        }
         await page.evaluate((entry) => {
             entry.click();
         }, entry);

--- a/frontend_tests/puppeteer_tests/admin.ts
+++ b/frontend_tests/puppeteer_tests/admin.ts
@@ -229,6 +229,9 @@ async function get_suggestions(page: Page, str: string): Promise<void> {
 async function select_from_suggestions(page: Page, item: string): Promise<void> {
     await page.evaluate((item: string) => {
         const tah = $(".create_default_stream").data().typeahead;
+        tah.mousemove({
+            currentTarget: $(`.typeahead:visible li:contains("${CSS.escape(item)}")`)[0],
+        });
         tah.mouseenter({
             currentTarget: $(`.typeahead:visible li:contains("${CSS.escape(item)}")`)[0],
         });

--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -476,7 +476,7 @@
   , container: '<div class="typeahead dropdown-menu"></div>'
   , header_html: '<p class="typeahead-header"><span id="typeahead-header-text"></span></p>'
   , menu: '<ul class="typeahead-menu"></ul>'
-  , item: '<li><a href="#"></a></li>'
+  , item: '<li><a></a></li>'
   , minLength: 1
   , stopAdvance: false
   , dropup: false


### PR DESCRIPTION
Added a property `mouseMoved` to the typeahead class which tracks whether the mouse has been moved since the typeahead menu appeared.

The hovered over menu item is highlighted on `mouseenter` only if `mouseMoved` is true. If not, it is set to true for the next occurence of the `mouseenter` event.

Fixes: #21018.

**Testing plan:** 
Tested manually, ensuring that other closely related functionality, like selection via arrow keys, is not broken. Also checked that clicking on the hovered option worked as expected, even without mouse movement.

**GIFs or screenshots:** 
(The mouse is sadly not visible in the recording, however it was placed on the menu and didn't cause the hovered option to be selected until it moved / clicked)
https://www.loom.com/share/90e3a42ceb0a444eabf7c4dd0643f24f