### PR TITLE
Throw an error when EMAIL_HOST_USER is specified but not email_password

### DIFF
--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -249,6 +249,8 @@ def send_email(
     )
     template = template_prefix.split("/")[-1]
 
+    log_email_config_errors()
+
     if dry_run:
         print(mail.message().get_payload()[0])
         return
@@ -588,3 +590,14 @@ def send_custom_email(
 
         if options["dry_run"]:
             break
+
+
+def log_email_config_errors() -> None:
+    """
+    The purpose of this function is to log (potential) config errors,
+    but without raising an exception.
+    """
+    if settings.EMAIL_HOST_USER and not settings.EMAIL_HOST_PASSWORD:
+        logger.error(
+            "An SMTP username was set (EMAIL_HOST_USER), but password is unset (EMAIL_HOST_PASSWORD)."
+        )


### PR DESCRIPTION
Fixes #20132

Going with logging an error here as discussed in https://github.com/zulip/zulip/issues/20132#issuecomment-1027360629