### PR TITLE
settings: Fix browser back button not working in settings overlay.

### DIFF
--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -213,6 +213,10 @@ function do_hashchange_overlay(old_hash) {
         );
     }
 
+    if (base === "streams" && !section) {
+        history.replaceState(null, "", get_full_url("streams/subscribed"));
+    }
+
     // Start by handling the specific case of going
     // from something like streams/all to streams_subscribed.
     //

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -201,6 +201,18 @@ function do_hashchange_overlay(old_hash) {
 
     const coming_from_overlay = hash_util.is_overlay_hash(old_hash || "#");
 
+    if ((base === "settings" || base === "organization") && !section) {
+        let settings_panel_object = settings_panel_menu.normal_settings;
+        if (base === "organization") {
+            settings_panel_object = settings_panel_menu.org_settings;
+        }
+        history.replaceState(
+            null,
+            "",
+            get_full_url(base + "/" + settings_panel_object.current_tab()),
+        );
+    }
+
     // Start by handling the specific case of going
     // from something like streams/all to streams_subscribed.
     //


### PR DESCRIPTION
When we open settings overlay we first go to "#settings" hash and
then to "#settings/profile" or hash according to the last opened
section. Now when a user presses back button from "#settings/profile"
it goes to "#settings" which agains then changes to "#settings/profile"
and thus the browser back button does not work as expected.

This PR fixes this by replacing the "#settings" entry in history
with "#settings/profile" or to the hash as per last opened section,
using replaceState and thus there is no entry of "#settings" in history.

Fixes #19820.

![setting-back](https://user-images.githubusercontent.com/35494118/152802839-e7bd1222-cc13-4a2c-8d73-35fe93b8a365.gif)


<!-- What's this PR for?  (Just a link to an issue is fine.) -->

<!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
