### PR TITLE
Do not allow editing messages sent to deactivated streams and users.

### DIFF
--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -124,9 +124,18 @@ export function is_message_editable_ignoring_permissions(message) {
         return false;
     }
 
-    // Messages in deactivated streams are not editable.
-    if (message.type === "stream" && stream_data.get_sub_by_id(message.stream_id) === undefined) {
-        return false;
+    if (message.type === "stream") {
+        const sub = stream_data.get_sub_by_id(message.stream_id);
+
+        // Messages in deactivated streams are not editable.
+        if (sub === undefined) {
+            return false;
+        }
+
+        // Messages in private streams can only edited by subscribed users.
+        if (sub.invite_only && !sub.subscribed) {
+            return false;
+        }
     }
 
     return true;

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -176,6 +176,11 @@ export function is_message_sent_by_my_bot(message) {
 }
 
 export function get_deletability(message) {
+    // Messages in deactivated streams cannot be deleted.
+    if (message.type === "stream" && stream_data.get_sub_by_id(message.stream_id) === undefined) {
+        return false;
+    }
+
     if (current_user.is_admin) {
         return true;
     }

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -185,9 +185,18 @@ export function is_message_sent_by_my_bot(message) {
 }
 
 export function get_deletability(message) {
-    // Messages in deactivated streams cannot be deleted.
-    if (message.type === "stream" && stream_data.get_sub_by_id(message.stream_id) === undefined) {
-        return false;
+    if (message.type === "stream") {
+        const sub = stream_data.get_sub_by_id(message.stream_id);
+
+        // Messages in deactivated streams cannot be deleted.
+        if (sub === undefined) {
+            return false;
+        }
+
+        // Messages in private streams can only deleted by subscribed users.
+        if (sub.invite_only && !sub.subscribed) {
+            return false;
+        }
     }
 
     if (current_user.is_admin) {

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -123,6 +123,12 @@ export function is_message_editable_ignoring_permissions(message) {
     if (currently_echoing_messages.has(message.id)) {
         return false;
     }
+
+    // Messages in deactivated streams are not editable.
+    if (message.type === "stream" && stream_data.get_sub_by_id(message.stream_id) === undefined) {
+        return false;
+    }
+
     return true;
 }
 

--- a/web/tests/message_edit.test.js
+++ b/web/tests/message_edit.test.js
@@ -279,6 +279,16 @@ run_test("get_deletability", ({override}) => {
     message.timestamp = current_timestamp - 60;
     override(settings_data, "user_can_delete_own_message", () => true);
     assert.equal(message_edit.get_deletability(message), false);
+
+    message.type = "stream";
+    message.stream_id = 1;
+    message.timestamp = current_timestamp - 5;
+    stream_data.add_sub({stream_id: 1, name: "test"});
+    assert.equal(message_edit.get_deletability(message), true);
+
+    stream_data.delete_sub(1);
+    // Cannot delete messages in a deactivated stream.
+    assert.equal(message_edit.get_deletability(message), false);
 });
 
 run_test("stream_and_topic_exist_in_edit_history", () => {

--- a/web/tests/message_edit.test.js
+++ b/web/tests/message_edit.test.js
@@ -320,6 +320,16 @@ run_test("get_deletability", ({override}) => {
     stream_data.delete_sub(1);
     // Cannot delete messages in a deactivated stream.
     assert.equal(message_edit.get_deletability(message), false);
+
+    stream_data.add_sub({stream_id: 1, name: "Test stream", invite_only: true});
+    const sub = stream_data.get_sub_by_id(1);
+    stream_data.subscribe_myself(sub);
+    assert.equal(message_edit.get_deletability(message), true);
+
+    stream_data.unsubscribe_myself(sub);
+    // Only subscribers can delete messages in private streams.
+    assert.equal(message_edit.get_deletability(message), false);
+    stream_data.subscribe_myself(sub);
 });
 
 run_test("stream_and_topic_exist_in_edit_history", () => {

--- a/web/tests/message_edit.test.js
+++ b/web/tests/message_edit.test.js
@@ -8,6 +8,13 @@ const {current_user, realm} = require("./lib/zpage_params");
 
 realm.realm_move_messages_within_stream_limit_seconds = 259200;
 
+const noop = function () {};
+
+mock_esm("../src/peer_data", {
+    add_subscriber: noop,
+    remove_subscriber: noop,
+});
+
 const message_edit = zrequire("message_edit");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
@@ -91,7 +98,15 @@ run_test("is_content_editable", () => {
     // Cannot edit messages in a deactivated stream.
     assert.equal(is_content_editable(message, 55), false);
 
-    stream_data.add_sub({stream_id: 1, name: "Test stream"});
+    stream_data.add_sub({stream_id: 1, name: "Test stream", invite_only: true});
+    const sub = stream_data.get_sub_by_id(1);
+    stream_data.subscribe_myself(sub);
+    assert.equal(is_content_editable(message, 55), true);
+
+    stream_data.unsubscribe_myself(sub);
+    // Only subscribers can edit messages in private streams.
+    assert.equal(is_content_editable(message, 55), false);
+    stream_data.subscribe_myself(sub);
 });
 
 run_test("is_topic_editable", ({override}) => {
@@ -152,7 +167,15 @@ run_test("is_topic_editable", ({override}) => {
     // Cannot edit message's topic in a deactivated stream.
     assert.equal(message_edit.is_topic_editable(message), false);
 
-    stream_data.add_sub({stream_id: 1, name: "Test stream"});
+    stream_data.add_sub({stream_id: 1, name: "Test stream", invite_only: true});
+    const sub = stream_data.get_sub_by_id(1);
+    stream_data.subscribe_myself(sub);
+    assert.equal(message_edit.is_topic_editable(message), true);
+
+    stream_data.unsubscribe_myself(sub);
+    // Only subscribers can edit message's topic in private streams.
+    assert.equal(message_edit.is_topic_editable(message), false);
+    stream_data.subscribe_myself(sub);
 });
 
 run_test("is_stream_editable", ({override}) => {
@@ -203,7 +226,15 @@ run_test("is_stream_editable", ({override}) => {
     // Cannot move messages from a deactivated stream.
     assert.equal(message_edit.is_stream_editable(message), false);
 
-    stream_data.add_sub({stream_id: 1, name: "Test stream"});
+    stream_data.add_sub({stream_id: 1, name: "Test stream", invite_only: true});
+    const sub = stream_data.get_sub_by_id(1);
+    stream_data.subscribe_myself(sub);
+    assert.equal(message_edit.is_stream_editable(message), true);
+
+    stream_data.unsubscribe_myself(sub);
+    // Only subscribers can move messages from private streams.
+    assert.equal(message_edit.is_stream_editable(message), false);
+    stream_data.subscribe_myself(sub);
 });
 
 run_test("get_deletability", ({override}) => {

--- a/web/tests/popover_menus_data.test.js
+++ b/web/tests/popover_menus_data.test.js
@@ -42,6 +42,9 @@ mock_esm("../src/hash_util", {
 });
 mock_esm("../src/stream_data", {
     is_subscribed: () => true,
+    get_sub_by_id(stream_id) {
+        return {stream_id};
+    },
 });
 
 // Define test users


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
As per the discussion in #20625, this PR adds code to not allow editing messsages sent in deactivated streams, PM sent to a deactivated user, group PMs where all users except the acting user are deactivated.

Have made separate commits for different cases.

**Testing plan:** <!-- How have you tested? --> Tested manually and added tests as well.

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
