### PR TITLE
topic: Return JsonableError for race condition in topic mute.

### DIFF
--- a/zerver/tests/test_muting_topics.py
+++ b/zerver/tests/test_muting_topics.py
@@ -105,7 +105,6 @@ class MutedTopicsTests(ZulipTestCase):
                 self.assert_json_success(result)
 
             self.assertIn((stream.name, "Verona3", mock_date_muted), get_topic_mutes(user))
-            self.assertTrue(topic_is_muted(user, stream.id, "Verona3"))
             self.assertTrue(topic_is_muted(user, stream.id, "verona3"))
 
             remove_topic_mute(

--- a/zerver/views/muting.py
+++ b/zerver/views/muting.py
@@ -1,6 +1,7 @@
 import datetime
 from typing import Optional
 
+from django.db import IntegrityError
 from django.http import HttpRequest, HttpResponse
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
@@ -39,7 +40,10 @@ def mute_topic(
     if topic_is_muted(user_profile, stream.id, topic_name):
         raise JsonableError(_("Topic already muted"))
 
-    do_mute_topic(user_profile, stream, topic_name, date_muted)
+    try:
+        do_mute_topic(user_profile, stream, topic_name, date_muted)
+    except IntegrityError:
+        raise JsonableError(_("Topic already muted"))
 
 
 def unmute_topic(


### PR DESCRIPTION
Issue #21011
To avoid IntegrityError return 500 status in race condition,
we catch the integrity error and return JsonableError with status 400.