### PR TITLE
push_notifications: Don't open unnecessary APNs connections.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -78,7 +78,7 @@ def get_apns_context() -> Optional[APNsContext]:
     # which fills the logs; see https://github.com/Fatal1ty/aioapns/issues/15
     logging.getLogger("aioapns").setLevel(logging.CRITICAL)
 
-    if settings.APNS_CERT_FILE is None:
+    if settings.APNS_CERT_FILE is None:  # nocoverage
         return None
 
     # NB if called concurrently, this will make excess connections.
@@ -96,7 +96,7 @@ def get_apns_context() -> Optional[APNsContext]:
 
 
 def apns_enabled() -> bool:
-    return get_apns_context() is not None
+    return settings.APNS_CERT_FILE is not None
 
 
 def modernize_apns_payload(data: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
Calling `get_apns_context` opens (and caches) an open connection to
the APNs servers.  Since `apns_enabled` is called from Django
codepaths, this means that the Django processes hold unnecessary
connections open to the APNs servers.

Switch `apns_enabled` to checking what `get_apns_context` checks when
we're just returning True/False.

**Testing plan:** Untested.