### PR TITLE
compose: Fix weird outline for GIF icon.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -547,8 +547,7 @@ input.recipient_box {
     .compose_gif_icon {
         font-size: 22px;
         height: 18px;
-        position: relative;
-        bottom: 6px;
+        line-height: 18px;
     }
 
     .compose_control_menu {


### PR DESCRIPTION
GIF icon had 32px line-height but only 18px height, this caused it
to trim the bottom part. Make line-height and height same to fix this.
before: 
![image](https://user-images.githubusercontent.com/25124304/152938322-26d06812-184d-45a2-8ac2-811f37d5609e.png)

after:
<img width="77" alt="image" src="https://user-images.githubusercontent.com/25124304/152938225-b5dbd159-c5d8-4330-aa48-d37afd2e4209.png">
