### PR TITLE
Fix focus behavior when closing stream permissions modal.

### DIFF
--- a/static/templates/stream_settings/stream_settings.hbs
+++ b/static/templates/stream_settings/stream_settings.hbs
@@ -48,9 +48,9 @@
                 </h3>
                 <div class="stream_permission_change_info alert-notification"></div>
                 <div class="button-group">
-                    <a class="change-stream-privacy button rounded small btn-warning" {{#unless can_change_stream_permissions}}style="display:none"{{/unless}} role="button">
+                    <button class="change-stream-privacy button rounded small btn-warning" title="{{t 'Change stream permissions' }}" {{#unless can_change_stream_permissions}}style="display:none"{{/unless}}>
                         <i class="fa fa-pencil" aria-hidden="true"></i>
-                    </a>
+                    </button>
                 </div>
             </div>
             <div class="subscription-type">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit is to fix the focus behavior on closing stream permissions modal. (part of #20223).

**Testing plan:** <!-- How have you tested? --> Manually tested


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
