### PR TITLE
Revert "drafts: Use simplebar."

### DIFF
--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -69,17 +69,6 @@
             color: hsl(0, 0%, 67%);
             pointer-events: none;
         }
-
-        /* Hide duplicate default scrollbar for IE, Edge and Firefox.  In
-           theory simplebar should be doing this for us. */
-        -ms-overflow-style: none;
-        scrollbar-width: none;
-    }
-
-    /* Hide duplicate default scrollbar for IE, Edge and Firefox.  In
-       theory simplebar should be doing this for us. */
-    .drafts-list::-webkit-scrollbar {
-        display: none;
     }
 }
 

--- a/static/templates/draft_table_body.hbs
+++ b/static/templates/draft_table_body.hbs
@@ -14,7 +14,7 @@
                     {{t "Pro tip: You can use 'd' to open your drafts."}}
                 </div>
             </div>
-            <div class="drafts-list" data-simplebar>
+            <div class="drafts-list">
                 <div class="no-drafts">
                     {{t 'No drafts.'}}
                 </div>


### PR DESCRIPTION
This reverts commit 8e0633578863a5c144ffce86b462d0b318282383 (#21048).

It regressed the `↑` and `↓` keys because `drafts.drafts_scroll` was not updated to use `ui.get_scroll_element`. Also, styling the native scrollbar as hidden is not the right workaround because the hidden native scrollbar still exists and can be scrolled independently of the SimpleBar.

Cc @juliaBichler01