### PR TITLE
timezone: List only canonical timezone identifiers

### DIFF
--- a/tools/setup/build_timezone_values
+++ b/tools/setup/build_timezone_values
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 import json
 import os
+import sys
 
 import pytz
 
 ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
+sys.path.insert(0, ZULIP_PATH)
+
+from zerver.lib.timezone import get_canonical_timezone_map
+
 OUT_PATH = os.path.join(ZULIP_PATH, "static", "generated", "timezones.json")
 
 with open(OUT_PATH, "w") as f:
-    json.dump({"timezones": pytz.all_timezones}, f)
+    json.dump({"timezones": sorted(pytz.all_timezones_set - set(get_canonical_timezone_map()))}, f)

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 115
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "174.0"
+PROVISION_VERSION = "175.0"

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5660,6 +5660,7 @@ def do_change_user_setting(
 
     if setting_name == "timezone":
         assert isinstance(setting_value, str)
+        setting_value = canonicalize_timezone(setting_value)
     else:
         property_type = UserProfile.property_types[setting_name]
         assert isinstance(setting_value, property_type)

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import UserManager
 from django.utils.timezone import now as timezone_now
 
 from zerver.lib.hotspots import copy_hotspots
+from zerver.lib.timezone import canonicalize_timezone
 from zerver.lib.upload import copy_avatar
 from zerver.lib.utils import generate_api_key
 from zerver.models import (
@@ -42,7 +43,7 @@ def copy_default_settings(
         return
 
     setattr(target_profile, "full_name", settings_source.full_name)
-    setattr(target_profile, "timezone", settings_source.timezone)
+    setattr(target_profile, "timezone", canonicalize_timezone(settings_source.timezone))
     target_profile.save()
 
     if settings_source.avatar_source == UserProfile.AVATAR_FROM_USER:

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -45,6 +45,7 @@ from zerver.lib.realm_logo import get_realm_logo_source, get_realm_logo_url
 from zerver.lib.soft_deactivation import reactivate_user_if_soft_deactivated
 from zerver.lib.stream_subscription import handle_stream_notifications_compatibility
 from zerver.lib.timestamp import datetime_to_timestamp
+from zerver.lib.timezone import canonicalize_timezone
 from zerver.lib.topic import TOPIC_NAME
 from zerver.lib.topic_mutes import get_topic_mutes
 from zerver.lib.user_groups import user_groups_in_realm_serialized
@@ -557,7 +558,7 @@ def fetch_initial_state_data(
         for prop in UserProfile.display_settings_legacy:
             state[prop] = getattr(settings_user, prop)
         state["emojiset_choices"] = UserProfile.emojiset_choices()
-        state["timezone"] = settings_user.timezone
+        state["timezone"] = canonicalize_timezone(settings_user.timezone)
 
     if want("update_global_notifications") and not user_settings_object:
         for notification in UserProfile.notification_settings_legacy:
@@ -571,7 +572,7 @@ def fetch_initial_state_data(
             state["user_settings"][prop] = getattr(settings_user, prop)
 
         state["user_settings"]["emojiset_choices"] = UserProfile.emojiset_choices()
-        state["user_settings"]["timezone"] = settings_user.timezone
+        state["user_settings"]["timezone"] = canonicalize_timezone(settings_user.timezone)
         state["user_settings"][
             "available_notification_sounds"
         ] = get_available_notification_sounds()

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -52,6 +52,7 @@ from django.core.validators import URLValidator, validate_email
 from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.timezone import canonicalize_timezone
 from zerver.lib.types import ProfileFieldData, Validator
 
 ResultT = TypeVar("ResultT")
@@ -548,7 +549,7 @@ def to_decimal(s: str) -> Decimal:
 
 def to_timezone_or_empty(s: str) -> str:
     if s in pytz.all_timezones_set:
-        return s
+        return canonicalize_timezone(s)
     else:
         return ""
 

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -350,7 +350,7 @@ class ChangeSettingsTest(ZulipTestCase):
             default_language="de",
             default_view="all_messages",
             emojiset="google",
-            timezone="US/Mountain",
+            timezone="America/Denver",
             demote_inactive_streams=2,
             color_scheme=2,
             email_notifications_batching_period_seconds=100,

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3786,7 +3786,7 @@ class UserSignUpTest(InviteUserBase):
         """
         email = self.nonreg_email("newguy")
         password = "newpassword"
-        timezone = "US/Mountain"
+        timezone = "America/Denver"
         realm = get_realm("zulip")
         do_set_realm_property(realm, "default_language", "de", acting_user=None)
 


### PR DESCRIPTION
For aliases that will no longer be listed, see the third column of

```sh
grep '^L ' zulip-py3-venv/lib/python3.*/site-packages/pytz/zoneinfo/tzdata.zi
```

Time zones previously set to an alias will be canonicalized on demand.