### PR TITLE
test_auth_backends: Remove deprecated match_querystring argument

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1022,7 +1022,6 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase):
             requests_mock.add(
                 requests_mock.POST,
                 self.ACCESS_TOKEN_URL,
-                match_querystring=False,
                 status=200,
                 body=self.generate_access_token_url_payload(account_data_dict),
             )
@@ -3293,7 +3292,6 @@ class GenericOpenIdConnectTest(SocialAuthBase):
             requests_mock.add(
                 requests_mock.GET,
                 f"{self.BASE_OIDC_URL}/.well-known/openid-configuration",
-                match_querystring=False,
                 status=200,
                 body=json.dumps(idp_discovery_endpoint_payload_dict),
             )


### PR DESCRIPTION
`match_querystring` is irrelevant in these cases. Fixes this warning:

`/srv/zulip-py3-venv/lib/python3.7/site-packages/responses/__init__.py:340: DeprecationWarning: Argument 'match_querystring' is deprecated. Use 'responses.matchers.query_param_matcher' or 'responses.matchers.query_string_matcher'`