### PR TITLE
Hide pencil icon when user is not allowed to change stream name or description and show a banner in settings. 

### DIFF
--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -318,6 +318,7 @@ export function update_settings_for_subscribed(slim_sub) {
 
     // Display the swatch and subscription stream_settings
     stream_ui_updates.update_regular_sub_settings(sub);
+    stream_ui_updates.update_permissions_banner(sub);
 }
 
 export function show_active_stream_in_left_panel() {
@@ -350,6 +351,7 @@ export function update_settings_for_unsubscribed(slim_sub) {
 
     // Remove private streams from subscribed streams list.
     stream_ui_updates.update_stream_row_in_settings_tab(sub);
+    stream_ui_updates.update_permissions_banner(sub);
 }
 
 function triage_stream(left_panel_params, sub) {

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import render_stream_permission_description from "../templates/stream_settings/stream_permission_description.hbs";
+import render_stream_settings_tip from "../templates/stream_settings/stream_settings_tip.hbs";
 
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
@@ -120,6 +121,13 @@ export function update_change_stream_privacy_settings(sub) {
     } else {
         $stream_privacy_btn.hide();
     }
+}
+
+export function update_permissions_banner(sub) {
+    const $settings = $(`.subscription_settings[data-stream-id='${CSS.escape(sub.stream_id)}']`);
+
+    const rendered_tip = render_stream_settings_tip(sub);
+    $settings.find(".stream-settings-tip-container").html(rendered_tip);
 }
 
 export function update_notification_setting_checkbox(notification_name) {

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -857,6 +857,7 @@ h4.stream_setting_subsection_title {
 
     .stream-header {
         white-space: nowrap;
+        padding-top: 10px;
 
         .stream-name {
             display: inline-block;

--- a/static/templates/stream_settings/stream_settings.hbs
+++ b/static/templates/stream_settings/stream_settings.hbs
@@ -23,6 +23,9 @@
 
         <div class="general_settings stream_section">
             {{#with sub}}
+            <div class="stream-settings-tip-container">
+                {{> stream_settings_tip}}
+            </div>
             <div class="stream-header">
                 {{> stream_privacy_icon
                   invite_only=invite_only
@@ -31,7 +34,7 @@
                     <span class="sub-stream-name" title="{{name}}">{{name}}</span>
                 </div>
                 <div class="stream_change_property_info alert-notification"></div>
-                <div class="button-group">
+                <div class="button-group" {{#unless can_change_name_description}}style="display:none"{{/unless}}>
                     <button id="open_stream_info_modal" class="button rounded small btn-warning" title="{{t 'Change stream info' }}">
                         <i class="fa fa-pencil" aria-hidden="true"></i>
                     </button>

--- a/static/templates/stream_settings/stream_settings_tip.hbs
+++ b/static/templates/stream_settings/stream_settings_tip.hbs
@@ -1,0 +1,7 @@
+{{#unless can_change_stream_permissions}}
+    {{#if can_change_name_description}}
+        <div class="tip">{{t "Only subscribers to this stream can edit stream permissions."}}</div>
+    {{else}}
+        <div class="tip">{{t "Only organization administrators can edit these settings."}}</div>
+    {{/if}}
+{{/unless}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Continuatuion of #20438.
- First commit is the original commit from #20438 itself.
- Second commit is to live update the banner.

Opened a different PR since I do not have permissions to push to another PR.
 <!-- How have you tested? -->

<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
