### PR TITLE
management: Run log_email_config_errors in send_test_email command.

### DIFF
--- a/zerver/management/commands/send_test_email.py
+++ b/zerver/management/commands/send_test_email.py
@@ -8,7 +8,7 @@ from django.core.mail import mail_admins, mail_managers, send_mail
 from django.core.management import CommandError
 from django.core.management.commands import sendtestemail
 
-from zerver.lib.send_email import FromAddress
+from zerver.lib.send_email import FromAddress, log_email_config_errors
 
 
 class Command(sendtestemail.Command):
@@ -18,6 +18,9 @@ class Command(sendtestemail.Command):
                 "Outgoing email not yet configured, see\n  "
                 "https://zulip.readthedocs.io/en/latest/production/email.html"
             )
+
+        log_email_config_errors()
+
         if len(kwargs["email"]) == 0:
             raise CommandError(
                 "Usage: /home/zulip/deployments/current/manage.py "


### PR DESCRIPTION
Follow-up to @alexmv comment https://github.com/zulip/zulip/pull/21053#discussion_r802137646

Regarding:
> Seeing that code makes me also wonder if WARN_NO_EMAIL should get set in this case, or should be extended to not just be a bool to cover this case.

Hmm, I think that might be a bit confusing because that variable gives "email sending is not configured at all" kind of warnings - which is not the case in the "config error" scenario and might make the admin think that **none** of their setting changes are actually being applied?