### PR TITLE
drafts: Use simplebar.

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -26,6 +26,7 @@ import * as rendered_markdown from "./rendered_markdown";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
+import * as ui from "./ui";
 import * as ui_util from "./ui_util";
 import * as util from "./util";
 
@@ -498,21 +499,22 @@ function drafts_scroll(next_focus_draft_row) {
     }
     activate_element(next_focus_draft_row[0].children[0]);
 
+    const scroll_element = ui.get_scroll_element($(".drafts-list"));
+
     // If focused draft is first draft, scroll to the top.
     if ($(".draft-info-box").first()[0].parentElement === next_focus_draft_row[0]) {
-        $(".drafts-list")[0].scrollTop = 0;
+        scroll_element.scrollTop = 0;
     }
 
     // If focused draft is the last draft, scroll to the bottom.
     if ($(".draft-info-box").last()[0].parentElement === next_focus_draft_row[0]) {
-        $(".drafts-list")[0].scrollTop =
-            $(".drafts-list")[0].scrollHeight - $(".drafts-list").height();
+        scroll_element.scrollTop = scroll_element.scrollHeight - scroll_element.height();
     }
 
     // If focused draft is cut off from the top, scroll up halfway in draft modal.
     if (next_focus_draft_row.position().top < 55) {
         // 55 is the minimum distance from the top that will require extra scrolling.
-        $(".drafts-list")[0].scrollTop -= $(".drafts-list")[0].clientHeight / 2;
+        scroll_element.scrollTop -= scroll_element.clientHeight / 2;
     }
 
     // If focused draft is cut off from the bottom, scroll down halfway in draft modal.
@@ -521,7 +523,7 @@ function drafts_scroll(next_focus_draft_row) {
     const dist_from_bottom = $(".drafts-container")[0].clientHeight - total_dist;
     if (dist_from_bottom < -4) {
         // -4 is the min dist from the bottom that will require extra scrolling.
-        $(".drafts-list")[0].scrollTop += $(".drafts-list")[0].clientHeight / 2;
+        scroll_element.scrollTop += scroll_element.clientHeight / 2;
     }
 }
 

--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -52,6 +52,7 @@
     .drafts-list {
         padding: 10px 0;
         overflow: auto;
+        height: 100%;
 
         .no-drafts {
             display: block;

--- a/static/templates/draft_table_body.hbs
+++ b/static/templates/draft_table_body.hbs
@@ -14,7 +14,7 @@
                     {{t "Pro tip: You can use 'd' to open your drafts."}}
                 </div>
             </div>
-            <div class="drafts-list">
+            <div class="drafts-list" data-simplebar>
                 <div class="no-drafts">
                     {{t 'No drafts.'}}
                 </div>


### PR DESCRIPTION
Use simplebar in drafts overlay
![chrome-capture (5)](https://user-images.githubusercontent.com/74348920/155837455-71a2b888-540e-4213-917d-fa9a7cc33137.gif)

- Updated `drafts_scroll` to use `ui.get_scroll_element`
- Used `height: 100%` as a workaround to remove the native scrollbar
