### PR TITLE
api docs: Document surprising behavior for bots without a narrow.

### DIFF
--- a/templates/zerver/api/construct-narrow.md
+++ b/templates/zerver/api/construct-narrow.md
@@ -5,6 +5,13 @@ on many different factors (like sender, stream, topic, search
 keywords, etc.).  Narrows are used in various places in the the Zulip
 API (most importantly, in the API for fetching messages).
 
+The default behavior for a [`GET /messages`](/api/get-messages) query
+that does not specify a narrow is to return messages from the current
+user's personal bot history (Equivalent to the [all
+messages](/help/reading-strategies#all-messages) view).  Because bot
+users do not store personal message history, you should always specify
+a narrow when making API requests as a bot user.
+
 It is simplest to explain the algorithm for encoding a search as a
 narrow using a single example.  Consider the following search query
 (written as it would be entered in the Zulip web app's search box).  It

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4581,8 +4581,11 @@ paths:
         this endpoint to fetch the messages matching any search query that is
         supported by Zulip's powerful full-text search backend.
 
-        When a narrow is not specified, it can be used to fetch a user's
-        message history. (We recommend paginating to 1000 messages at a time.)
+        When a narrow filter is not specified, this endpoint will
+        fetch messages from the user's personal message history. (We
+        recommend paginating to 1000 messages at a time). Note that
+        bots have no personal message history, so requests by bots
+        without a `narrow` specified will always return no messages.
 
         In either case, you specify an `anchor` message (or ask the server to
         calculate the first unread message for you and use that as the
@@ -4654,8 +4657,17 @@ paths:
         - name: narrow
           in: query
           description: |
-            The narrow where you want to fetch the messages from. See how to
-            [construct a narrow](/api/construct-narrow).
+            A search filter defining what type of messages to fetch.
+            See [construct a narrow](/api/construct-narrow) for a
+            detailed explanation of this parameter.
+
+            When not specified, messages will be fetched from the
+            current user's full personal history, equivalent to the
+            [all messages](/help/reading-strategies#all-messages)
+            view.
+
+            Note that bot users do not have any messages in their
+            personal history.
           content:
             application/json:
               schema:


### PR DESCRIPTION
This behavior isn't ideal/correct, and I think it's important to
prioritize fixing, but it also seems worth documenting now, since
that's cheap.

Make some broader wording improvements to the page while we're at it.

Fixes #19477.

![image](https://user-images.githubusercontent.com/2746074/153519842-cab03b2b-21d1-4f8c-b448-0901b88c5000.png)

![image](https://user-images.githubusercontent.com/2746074/153519858-e4373869-a3df-4eff-ad01-c8fd6fab099f.png)

![image](https://user-images.githubusercontent.com/2746074/153519928-2db955e1-4951-43f8-ba3f-1d441405aaec.png)

