### PR TITLE
message_controls: Add background when overlapping with text.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1071,6 +1071,19 @@ td.pointer {
             visibility: visible !important;
         }
     }
+
+    @media (width < $sm_min) {
+        .star_container,
+        .edit_content,
+        .reaction_button {
+            display: none;
+        }
+
+        .actions_hover {
+            float: right;
+            right: 5px;
+        }
+    }
 }
 
 .star {

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -18,6 +18,15 @@
     </li>
     {{/if}}
 
+    {{#if should_display_star_message}}
+    <li>
+        <a class="popover_star_message {{#if message_starred}}{{else}}empty-star{{/if}}" data-message-id="{{message_id}}" tabindex="0">
+            <i role="button" tabindex="0" class="star fa {{#if message_starred}}fa-star{{else}}fa-star-o{{/if}}" aria-hidden="true"></i> {{starred_status}}
+            <span class="hotkey-hint">(Ctrl + s)</span>
+        </a>
+    </li>
+    {{/if}}
+
     {{#if should_display_quote_and_reply}}
     <li>
         <a class="respond_button" data-message-id="{{message_id}}" tabindex="0">

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -71,7 +71,6 @@ EXEMPT_FILES = make_set(
         "static/js/confirm_dialog.js",
         "static/js/copy_and_paste.js",
         "static/js/csrf.ts",
-        "static/js/css_variables.js",
         "static/js/dark_theme.js",
         "static/js/debug.js",
         "static/js/deprecated_feature_notice.js",


### PR DESCRIPTION
On small widths (<630px for desktop and <576px for web, since the
organization selection left sidebar takes 54px width), the
`message_controls` menu overlaps with text on the messages where
user name is not present, i.e., the same sender messages after
the first message.

Since, reducing text width would render very long messages which
provide a bad UX, we add background color to `message_controls`
to differentiate text and the buttons.

Fixes #19759.

<img width="406" alt="image" src="https://user-images.githubusercontent.com/25124304/153541119-c23242dc-6c91-460b-9a1a-7cb9f9218909.png">
<img width="297" alt="image" src="https://user-images.githubusercontent.com/25124304/153541152-38d78ce5-1ee5-403c-805b-9ddbc54f3544.png">

