### PR TITLE
import: Ensure that .author gets set when importing RealmEmoji.

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -1018,6 +1018,18 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
         update_model_ids(model, data, related_table)
         bulk_import_model(data, model)
 
+    # Ensure RealmEmoji get the .author set to a reasonable default, if the value
+    # wasn't provided in the import data.
+    first_user_profile = (
+        UserProfile.objects.filter(realm=realm, is_active=True, role=UserProfile.ROLE_REALM_OWNER)
+        .order_by("id")
+        .first()
+    )
+    for realm_emoji in RealmEmoji.objects.filter(realm=realm):
+        if realm_emoji.author_id is None:
+            realm_emoji.author_id = first_user_profile.id
+            realm_emoji.save(update_fields=["author_id"])
+
     if "zerver_huddle" in data:
         update_model_ids(Huddle, data, "huddle")
         # We don't import Huddle yet, since we don't have the data to

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -1149,7 +1149,7 @@ def delete_export_tarball(export_path: str) -> Optional[str]:
 
 def get_emoji_file_content(
     session: OutgoingSession, emoji_url: str, emoji_id: int, logger: logging.Logger
-) -> bytes:
+) -> bytes:  # nocoverage
     original_emoji_url = emoji_url + ".original"
 
     logger.info("Downloading %s", original_emoji_url)
@@ -1169,7 +1169,7 @@ def get_emoji_file_content(
     raise AssertionError(f"Could not fetch emoji {emoji_id}")
 
 
-def handle_reupload_emojis_event(realm: Realm, logger: logging.Logger) -> None:
+def handle_reupload_emojis_event(realm: Realm, logger: logging.Logger) -> None:  # nocoverage
     from zerver.lib.emoji import get_emoji_url
 
     session = OutgoingSession(role="reupload_emoji", timeout=3, max_retries=3)


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/3-backend/topic/custom.20emoji.20author.20slack.20import

In #20579 we've established the invariant that `RealmEmoji.author` always is set - but we also want to make sure that this can't get broken through the import codepath.