### PR TITLE
configure-rabbitmq: Use rabbitmqctl ping

### DIFF
--- a/scripts/setup/configure-rabbitmq
+++ b/scripts/setup/configure-rabbitmq
@@ -18,15 +18,11 @@ RABBITMQ_USERNAME=$("$(dirname "$0")/../get-django-setting" RABBITMQ_USERNAME)
 RABBITMQ_PASSWORD=$("$(dirname "$0")/../get-django-setting" RABBITMQ_PASSWORD)
 
 # Wait for RabbitMQ to start up
-try_ping() {
-    # `rabbitmqctl ping` requires 3.7.6 or newer
-    out="$("${sudo[@]}" rabbitmqctl eval 'net_adm:ping(node()).')" && [ "$out" = 'pong' ]
-}
 retries=29
-while ! try_ping 2>/dev/null; do
+while ! "${sudo[@]}" rabbitmqctl ping -q 2>/dev/null; do
     sleep 1
     if ! ((retries -= 1)); then
-        try_ping
+        "${sudo[@]}" rabbitmqctl ping -q
         break
     fi
 done


### PR DESCRIPTION
Our supported distributions now all have RabbitMQ ≥ 3.7.8.

**Testing plan:** Provisioned on Debian 10.