### PR TITLE
message feed: Don't share headers for non-adjacent messages.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -87,6 +87,7 @@ test("basics", () => {
 
     assert.ok(!filter.is_search());
     assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.supports_collapsing_recipients());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.allow_use_first_unread_when_narrowing());
     assert.ok(filter.includes_full_stream_history());
@@ -102,6 +103,7 @@ test("basics", () => {
 
     assert.ok(filter.is_search());
     assert.ok(!filter.can_mark_messages_read());
+    assert.ok(!filter.supports_collapsing_recipients());
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.allow_use_first_unread_when_narrowing());
     assert.ok(!filter.can_apply_locally());
@@ -117,6 +119,7 @@ test("basics", () => {
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.has_operator("stream"));
     assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.supports_collapsing_recipients());
     assert.ok(!filter.is_personal_filter());
 
     // Negated searches are just like positive searches for our purposes, since
@@ -128,6 +131,7 @@ test("basics", () => {
     assert.ok(filter.has_operator("search"));
     assert.ok(!filter.can_apply_locally());
     assert.ok(!filter.can_mark_messages_read());
+    assert.ok(!filter.supports_collapsing_recipients());
     assert.ok(!filter.is_personal_filter());
 
     // Similar logic applies to negated "has" searches.
@@ -138,6 +142,7 @@ test("basics", () => {
     assert.ok(!filter.can_apply_locally(true));
     assert.ok(!filter.includes_full_stream_history());
     assert.ok(!filter.can_mark_messages_read());
+    assert.ok(!filter.supports_collapsing_recipients());
     assert.ok(!filter.is_personal_filter());
 
     operators = [{operator: "streams", operand: "public", negated: true}];
@@ -145,6 +150,7 @@ test("basics", () => {
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.has_operator("streams"));
     assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.supports_collapsing_recipients());
     assert.ok(filter.has_negated_operand("streams", "public"));
     assert.ok(!filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
@@ -154,6 +160,7 @@ test("basics", () => {
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(filter.has_operator("streams"));
     assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.supports_collapsing_recipients());
     assert.ok(!filter.has_negated_operand("streams", "public"));
     assert.ok(!filter.can_apply_locally());
     assert.ok(filter.includes_full_stream_history());
@@ -163,6 +170,7 @@ test("basics", () => {
     filter = new Filter(operators);
     assert.ok(filter.contains_only_private_messages());
     assert.ok(filter.can_mark_messages_read());
+    assert.ok(filter.supports_collapsing_recipients());
     assert.ok(!filter.has_operator("search"));
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
@@ -171,6 +179,7 @@ test("basics", () => {
     filter = new Filter(operators);
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(filter.can_mark_messages_read());
+    assert.ok(!filter.supports_collapsing_recipients());
     assert.ok(!filter.has_operator("search"));
     assert.ok(filter.can_apply_locally());
     assert.ok(filter.is_personal_filter());
@@ -179,6 +188,7 @@ test("basics", () => {
     filter = new Filter(operators);
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.can_mark_messages_read());
+    assert.ok(!filter.supports_collapsing_recipients());
     assert.ok(!filter.has_operator("search"));
     assert.ok(filter.can_apply_locally());
     assert.ok(filter.is_personal_filter());
@@ -187,6 +197,8 @@ test("basics", () => {
     filter = new Filter(operators);
     assert.ok(filter.is_non_huddle_pm());
     assert.ok(filter.contains_only_private_messages());
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(filter.supports_collapsing_recipients());
     assert.ok(!filter.has_operator("search"));
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
@@ -195,20 +207,49 @@ test("basics", () => {
     filter = new Filter(operators);
     assert.ok(!filter.is_non_huddle_pm());
     assert.ok(filter.contains_only_private_messages());
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(filter.supports_collapsing_recipients());
+    assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
 
     operators = [{operator: "group-pm-with", operand: "joe@example.com"}];
     filter = new Filter(operators);
     assert.ok(!filter.is_non_huddle_pm());
     assert.ok(filter.contains_only_private_messages());
     assert.ok(!filter.has_operator("search"));
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.supports_collapsing_recipients());
     assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
 
     operators = [{operator: "is", operand: "resolved"}];
     filter = new Filter(operators);
     assert.ok(!filter.contains_only_private_messages());
-    assert.ok(filter.can_mark_messages_read());
     assert.ok(!filter.has_operator("search"));
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(filter.supports_collapsing_recipients());
     assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
+
+    // Highly complex query to exercise
+    // filter.supports_collapsing_recipients loop.
+    operators = [
+        {operator: "is", operand: "resolved", negated: true},
+        {operator: "is", operand: "private", negated: true},
+        {operator: "stream", operand: "stream_name", negated: true},
+        {operator: "streams", operand: "web-public", negated: true},
+        {operator: "streams", operand: "public"},
+        {operator: "topic", operand: "patience", negated: true},
+        {operator: "in", operand: "all"},
+    ];
+    filter = new Filter(operators);
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.supports_collapsing_recipients());
+    // This next check verifies what is probably a bug; see the
+    // comment in the can_apply_locally implementation.
+    assert.ok(!filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
 });
 

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -439,7 +439,48 @@ export class Filter {
         return this.has_operator("pm-with") && this.operands("pm-with")[0].split(",").length === 1;
     }
 
+    supports_collapsing_recipients() {
+        // Determines whether a view is guaranteed, by construction,
+        // to contain consecutive messages in a given topic, and thus
+        // it is appropriate to collapse recipient/sender headings.
+        const term_types = this.sorted_term_types();
+
+        // All search/narrow term types, including negations, with the
+        // property that if a message is in the view, then any other
+        // message sharing its recipient (stream/topic or private
+        // message recipient) must also be present in the view.
+        const valid_term_types = new Set([
+            "stream",
+            "not-stream",
+            "topic",
+            "not-topic",
+            "pm-with",
+            "group-pm-with",
+            "not-group-pm-with",
+            "is-private",
+            "not-is-private",
+            "is-resolved",
+            "not-is-resolved",
+            "in-home",
+            "in-all",
+            "streams-public",
+            "not-streams-public",
+            "streams-web-public",
+            "not-streams-web-public",
+        ]);
+
+        for (const term of term_types) {
+            if (!valid_term_types.has(term)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     calc_can_mark_messages_read() {
+        // Arguably this should match supports_collapsing_recipients.
+        // We may want to standardize on that in the future.  (At
+        // present, this function does not allow combining valid filters).
         const term_types = this.sorted_term_types();
 
         if (_.isEqual(term_types, ["stream", "topic"])) {
@@ -717,6 +758,8 @@ export class Filter {
             return false;
         }
 
+        // TODO: It's not clear why `streams:` filters would not be
+        // applicable locally.
         if (this.has_operator("streams") || this.has_negated_operand("streams", "public")) {
             return false;
         }

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -28,9 +28,7 @@ export class MessageList {
             });
         }
 
-        opts.collapse_messages = true;
-
-        const collapse_messages = opts.collapse_messages;
+        const collapse_messages = this.data.filter.supports_collapsing_recipients();
         const table_name = opts.table_name;
         this.view = new MessageListView(this, table_name, collapse_messages);
         this.table_name = table_name;

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -324,7 +324,6 @@ export function activate(raw_operators, opts) {
     const msg_list = new message_list.MessageList({
         data: msg_data,
         table_name: "zfilt",
-        collapse_messages: !narrow_state.filter().is_search(),
     });
 
     msg_list.start_time = start_time;


### PR DESCRIPTION
When viewing a narrow such as a search or `sender:` view, where
consecutive messages in the view may not be consecutive in their
original stream/topic context, we should avoid displaying the messages
with a shared sender/recipient bar header, as that creates the
incorrect perception that they are consecutive.

Back in 2013 (bc8bc8567b648d8a7297bba2ecf8d977525b6d04), we
implemented this via the collapse_messages flag, but it appears more
recent refactoring (no more recent than
dbffb2a614ce732b05471623ac3ddb19532bf6d8) made it always true.

The original logic was incorrect, in that it only considered full-text
search views, and not other views with this property.

I originally planned to use the existing logic for
can_mark_message_read designed for this purpose, but I think there
might be product reasons why might want the logic to be independent.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
