### PR TITLE
tippy: Make background color of tooltips close to black.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -85,6 +85,42 @@ pre {
      */
     font-family: "Source Sans 3", sans-serif !important;
 
+    .tippy-box {
+        background-color: hsl(0, 0%, 12%);
+
+        &[data-placement^="top"] {
+            > .tippy-arrow {
+                &::before {
+                    border-top-color: hsl(0, 0%, 12%);
+                }
+            }
+        }
+
+        &[data-placement^="bottom"] {
+            > .tippy-arrow {
+                &::before {
+                    border-bottom-color: hsl(0, 0%, 12%);
+                }
+            }
+        }
+
+        &[data-placement^="left"] {
+            > .tippy-arrow {
+                &::before {
+                    border-left-color: hsl(0, 0%, 12%);
+                }
+            }
+        }
+
+        &[data-placement^="right"] {
+            > .tippy-arrow {
+                &::before {
+                    border-right-color: hsl(0, 0%, 12%);
+                }
+            }
+        }
+    }
+
     .tippy-content {
         font-size: 13px;
     }


### PR DESCRIPTION
This is aimed towards increasing the contrast for tooltips in
dark theme.

Discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/dark.20mode.20tooltip.20background.20contrast