### PR TITLE
left-sidebar: Hide the unread counters on hover

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -562,6 +562,7 @@ div.overlay {
     border-radius: 4px;
     background-color: hsl(105, 2%, 50%);
     color: hsl(0, 0%, 100%);
+    margin-right: -10px;
 }
 
 /* Implement the web app's default-hidden convention for alert

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -77,7 +77,7 @@ li.show-more-topics {
 }
 
 #streams_inline_icon {
-    margin-right: 10px;
+    margin-right: 24px;
 }
 
 .tooltip {
@@ -87,7 +87,7 @@ li.show-more-topics {
 #stream_filters {
     overflow: visible;
     margin-bottom: 5px;
-    margin-right: 12px;
+    margin-right: 18px;
     padding: 0;
     font-weight: normal;
 
@@ -115,7 +115,16 @@ li.show-more-topics {
     }
 
     .subscription_block .unread_count {
-        margin-right: 15px;
+        margin-right: 5px;
+    }
+
+    .bottom_left_row:hover .unread_count {
+        visibility: hidden;
+    }
+
+    .bottom_left_row:hover .stream-sidebar-menu-icon {
+        display: block;
+        cursor: pointer;
     }
 
     .subscription_block {
@@ -256,9 +265,9 @@ li.active-sub-filter {
     }
 
     .top_left_row .unread_count {
-        margin-right: 20px;
+        margin-right: 14.5px;
         margin-top: 2px;
-        display: none;
+        display: block;
     }
 
     .top_left_starred_messages .unread_count,
@@ -269,6 +278,16 @@ li.active-sub-filter {
         /* The border takes up space, so we need to
            subtract 1px from the usual 2px margin-top */
         margin-top: 1px !important;
+        display: block;
+    }
+
+    .top_left_all_messages:hover .unread_count,
+    .top_left_mentions:hover .unread_count,
+    .top_left_starred_messages:hover .unread_count,
+    .top_left_private_messages:hover .unread_count,
+    .top_left_recent_topics:hover .unread_count,
+    .top_left_drafts:hover .unread_count {
+        visibility: hidden;
     }
 
     .expanded_private_message .unread_count {
@@ -371,7 +390,7 @@ li.top_left_recent_topics {
     right: 10px;
 
     i {
-        padding-right: 0.25em;
+        margin-right: 14.5px;
         display: inline-block;
         width: 13px;
         vertical-align: middle;
@@ -396,6 +415,12 @@ li.top_left_recent_topics {
     @media (hover: none) {
         display: block;
     }
+}
+
+.all-messages-sidebar-menu-icon i,
+.starred-messages-sidebar-menu-icon i,
+.drafts-sidebar-menu-icon i {
+    margin-right: 20px;
 }
 
 /*
@@ -433,7 +458,6 @@ li.top_left_recent_topics {
 li.top_left_all_messages:hover .all-messages-sidebar-menu-icon,
 li.top_left_starred_messages:hover .starred-messages-sidebar-menu-icon,
 li.top_left_drafts:hover .drafts-sidebar-menu-icon,
-#stream_filters li:hover .stream-sidebar-menu-icon,
 li.topic-list-item:hover .topic-sidebar-menu-icon {
     display: inline;
     cursor: pointer;
@@ -506,8 +530,7 @@ li.expanded_private_message {
 }
 
 .zero-pm-unreads .pm-box,
-.zero-topic-unreads .more-topics-box,
-.zero-topic-unreads .topic-box {
+.zero-topic-unreads .more-topics-box {
     margin-right: 15px;
 }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
**UI Experiment**
Description:
- Hide the unread counters on hover for any lines that have an associated three-dot menu.
- Have the three-dot menus appear in the location of the unread counters.
- Do not show the three-dot stream menu when hovering over a topic within that stream.
- Shift the Streams + menu to be aligned with the unread message counters.

Fixes #20935

**Testing plan:** <!-- How have you tested? -->
Manually
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Zulip-4](https://user-images.githubusercontent.com/77766761/154830423-b9d6c433-2173-488e-9536-0703b252598e.gif)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
