### PR TITLE
UI-Improvement: Wrap longer tooltips.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -591,6 +591,7 @@ strong {
 
 .buddy_list_tooltip_content {
     text-align: left;
+    word-wrap: break-word;
 }
 
 #message_edit_tooltip {


### PR DESCRIPTION
This solves the issue #21119 for overflow of tooltip content of Buddy List in case of longer 1 word names.

Earlier - 
![Screenshot from 2022-02-14 03-16-09](https://user-images.githubusercontent.com/76561593/153776789-074528ca-a592-4fef-a78c-ec6f2199cda6.png)


It now just wraps the longer name to next-line -> 


![Screenshot from 2022-02-14 03-16-20](https://user-images.githubusercontent.com/76561593/153776758-e03ccc38-4840-42c4-9e99-edf71cdc8911.png)
![Screenshot from 2022-02-14 03-16-16](https://user-images.githubusercontent.com/76561593/153776775-8e958225-fd13-4656-b4f9-cd5ee3571453.png)

