### PR TITLE
api docs: replace `subject` with `topic` for Curl

### DIFF
--- a/templates/zerver/api/send-message.md
+++ b/templates/zerver/api/send-message.md
@@ -18,7 +18,7 @@ curl -X POST {{ api_url }}/v1/messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     --data-urlencode type=stream \
     --data-urlencode to=Denmark \
-    --data-urlencode subject=Castle \
+    --data-urlencode topic=Castle \
     --data-urlencode 'content=I come not, friends, to steal away your hearts.'
 
 # For private messages


### PR DESCRIPTION
`subject` is a deprecated alias since zulip 2.0.0

It seems to be the only hardcoded example according to https://github.com/zulip/zulip/commit/c4d805a82c94dad0ae2209ea6a23489f879c13bd

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
tried a request on a zulipchat instance.
