### PR TITLE
settings: Fix responsiveness of the profile avatar.

### DIFF
--- a/static/styles/image_upload_widget.css
+++ b/static/styles/image_upload_widget.css
@@ -21,6 +21,7 @@
         position: absolute;
         display: none;
         cursor: pointer;
+        border-radius: 5px;
     }
 
     .image-delete-button {

--- a/static/styles/image_upload_widget.css
+++ b/static/styles/image_upload_widget.css
@@ -105,6 +105,7 @@
 .user-avatar-section,
 .realm-logo-section,
 .realm-icon-section {
+    margin-bottom: 20px;
     position: relative;
 
     .inline-block {
@@ -189,7 +190,6 @@
 
 .realm-icon-section {
     float: none;
-    margin-bottom: 20px;
     display: inline-block;
 }
 
@@ -225,10 +225,6 @@
 
 #realm-night-logo-upload-widget {
     background-color: hsl(212, 28%, 18%);
-}
-
-.realm-logo-section {
-    margin-bottom: 20px;
 }
 
 .realm-logo-block {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -107,6 +107,12 @@ h3 .fa-question-circle-o {
     }
 }
 
+.profile-settings-form {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap-reverse;
+}
+
 .user-avatar-section {
     float: right;
 
@@ -1896,6 +1902,12 @@ input[type="checkbox"] {
 /* This value needs to match with the same in subscriptions.css, as
    we have some shared styles declared there */
 @media (width < $md_min) {
+    .profile-settings-form {
+        .user-avatar-section {
+            flex: 100%;
+        }
+    }
+
     #settings_overlay_container {
         /* this variable allows JavaScript to detect this media query */
         --single-column: yes;


### PR DESCRIPTION
This moves the profile avatar to the top when the window is narrowed down instead of pushing it to the bottom of the page. The avatar also stays on the right for narrower window sizes.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
see #21000 for context

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

**Previously:**

![previously](https://user-images.githubusercontent.com/82862779/153853984-40f77d22-8f7c-4d46-8f6e-c3f5b0d56480.gif)

**After:**

![responsive_profile](https://user-images.githubusercontent.com/82862779/153854133-4bdc447c-c895-4fbc-b2ba-4c01734af17b.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
