### PR TITLE
message_feed_view: Align images with message.

### DIFF
--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -307,7 +307,7 @@
     .message_inline_image {
         position: relative;
         margin-bottom: 5px;
-        margin-left: 5px;
+        margin-right: 5px;
         height: 100px;
         display: block !important;
         border: none !important;


### PR DESCRIPTION
Removes the 5px `margin-right` on images, replacing it
with a 5px `margin-left`. This change aligns the images
with the message content while making sure they do not
stick stick together in other layouts.
