### PR TITLE
setup-apt-repos: Don’t install lsb_release

### DIFF
--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -17,22 +17,6 @@ class zulip::profile::base {
   }
   case $::osfamily {
     'debian': {
-      $release_name = $::operatingsystemrelease ? {
-        # Debian releases
-        /^7\.[0-9]*$/  => 'wheezy',
-        /^8\.[0-9]*$/  => 'jessie',
-        /^9\.[0-9]*$/  => 'stretch',
-        /^10\.[0-9]*$/ => 'buster',
-        /^11\.[0-9]*$/ => 'bullseye',
-        # Ubuntu releases
-        '12.04' => 'precise',
-        '14.04' => 'trusty',
-        '15.04' => 'vivid',
-        '15.10' => 'wily',
-        '16.04' => 'xenial',
-        '18.04' => 'bionic',
-        '20.04' => 'focal',
-      }
       $base_packages = [
         # Basics
         'python3',
@@ -57,7 +41,6 @@ class zulip::profile::base {
       ]
     }
     'redhat': {
-      $release_name = "${::operatingsystem}${::operatingsystemmajrelease}"
       $base_packages = [
         'python3',
         'python3-pyyaml',

--- a/puppet/zulip_ops/files/teleport_node.yaml
+++ b/puppet/zulip_ops/files/teleport_node.yaml
@@ -16,7 +16,8 @@ ssh_service:
       command: ["/usr/bin/uptrack-uname", "-r"]
       period: 1h0m0s
     - name: distro
-      command: ["/usr/bin/lsb_release", "-ds"]
+      command:
+        ["/bin/sh", "-c", '. /etc/os-release && printf "%s\n" "$PRETTY_NAME"']
       period: 1h0m0s
     - name: classes
       command:

--- a/scripts/lib/setup-apt-repo
+++ b/scripts/lib/setup-apt-repo
@@ -83,7 +83,7 @@ fi
 # Hash to check if the configuration is changed by the script later.
 hashes=$(sha256sum "$SOURCES_FILE" "$PREF_FILE" 2>/dev/null || true)
 
-pre_setup_deps=(lsb-release apt-transport-https ca-certificates gnupg curl)
+pre_setup_deps=(apt-transport-https ca-certificates gnupg curl)
 if ! apt-get -dy install "${pre_setup_deps[@]}"; then
     apt-get update
 fi

--- a/tools/setup/dev-vagrant-docker/Dockerfile
+++ b/tools/setup/dev-vagrant-docker/Dockerfile
@@ -11,7 +11,6 @@ RUN echo locales locales/default_environment_locale select C.UTF-8 | debconf-set
            ca-certificates \
            curl \
            locales \
-           lsb-release \
            openssh-server \
            python3 \
            sudo \


### PR DESCRIPTION
**Testing plan:** ~~This is known to mysteriously break `puppet module install`.~~ Fixed, I think.