### PR TITLE
provision: Use apt-get --allow-downgrades

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -270,6 +270,7 @@ def install_apt_deps(deps_to_install: List[str]) -> None:
             "apt-get",
             "-y",
             "install",
+            "--allow-downgrades",
             "--no-install-recommends",
             *deps_to_install,
         ]


### PR DESCRIPTION
Needed for commit 9c8d2b7be39314b41f04a1e1356942afe21ab223 (#21115).

**Testing plan:** `tools/provision` with a newer `postgresql-11` previously installed.