### PR TITLE
[4.x] provision: Use apt-get --allow-downgrades.

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -278,6 +278,7 @@ def install_apt_deps(deps_to_install: List[str]) -> None:
             "apt-get",
             "-y",
             "install",
+            "--allow-downgrades",
             "--no-install-recommends",
             *deps_to_install,
         ]


### PR DESCRIPTION
Backport of

* #21131