### PR TITLE
Remove puppet legacy variables

### DIFF
--- a/puppet/zulip/manifests/apache_sso.pp
+++ b/puppet/zulip/manifests/apache_sso.pp
@@ -1,7 +1,7 @@
 class zulip::apache_sso {
   include zulip::localhost_sso
 
-  case $::osfamily {
+  case $::os['family'] {
     'debian': {
       $apache_packages = [ 'apache2', 'libapache2-mod-wsgi-py3', ]
       $conf_dir = '/etc/apache2'

--- a/puppet/zulip/manifests/apache_sso.pp
+++ b/puppet/zulip/manifests/apache_sso.pp
@@ -2,12 +2,12 @@ class zulip::apache_sso {
   include zulip::localhost_sso
 
   case $::os['family'] {
-    'debian': {
+    'Debian': {
       $apache_packages = [ 'apache2', 'libapache2-mod-wsgi-py3', ]
       $conf_dir = '/etc/apache2'
       $apache2 = 'apache2'
     }
-    'redhat': {
+    'RedHat': {
       $apache_packages = [ 'httpd', 'python36u-mod_wsgi', ]
       $conf_dir = '/etc/httpd'
       $apache2 = 'httpd'

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -6,7 +6,7 @@ class zulip::app_frontend_base {
   include zulip::supervisor
   include zulip::tornado_sharding
 
-  if $::osfamily == 'debian' {
+  if $::os['family'] == 'debian' {
     # Upgrade and other tooling wants to be able to get a database
     # shell.  This is not necessary on CentOS because the PostgreSQL
     # package already includes the client.  This may get us a more

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -6,7 +6,7 @@ class zulip::app_frontend_base {
   include zulip::supervisor
   include zulip::tornado_sharding
 
-  if $::os['family'] == 'debian' {
+  if $::os['family'] == 'Debian' {
     # Upgrade and other tooling wants to be able to get a database
     # shell.  This is not necessary on CentOS because the PostgreSQL
     # package already includes the client.  This may get us a more

--- a/puppet/zulip/manifests/camo.pp
+++ b/puppet/zulip/manifests/camo.pp
@@ -13,7 +13,7 @@ class zulip::camo (String $listen_address = '0.0.0.0') {
 
   zulip::external_dep { 'go-camo':
     version        => $version,
-    url            => "https://github.com/cactus/go-camo/releases/download/v${version}/go-camo-${version}.go${goversion}.linux-${::architecture}.tar.gz",
+    url            => "https://github.com/cactus/go-camo/releases/download/v${version}/go-camo-${version}.go${goversion}.linux-${zulip::common::goarch}.tar.gz",
     tarball_prefix => "go-camo-${version}",
   }
 

--- a/puppet/zulip/manifests/common.pp
+++ b/puppet/zulip/manifests/common.pp
@@ -33,6 +33,11 @@ class zulip::common {
 
   $total_memory_mb = Integer($::memorysize_mb)
 
+  $goarch = $::architecture ? {
+    'amd64'   => 'amd64',
+    'aarch64' => 'arm64',
+  }
+
   $versions = {
     # https://github.com/cactus/go-camo/releases
     'go-camo' => {

--- a/puppet/zulip/manifests/common.pp
+++ b/puppet/zulip/manifests/common.pp
@@ -33,7 +33,7 @@ class zulip::common {
 
   $total_memory_mb = Integer($::memorysize_mb)
 
-  $goarch = $::architecture ? {
+  $goarch = $::os['architecture'] ? {
     'amd64'   => 'amd64',
     'aarch64' => 'arm64',
   }

--- a/puppet/zulip/manifests/common.pp
+++ b/puppet/zulip/manifests/common.pp
@@ -31,7 +31,8 @@ class zulip::common {
   }
   $supervisor_conf_dir = "${supervisor_system_conf_dir}/zulip"
 
-  $total_memory_mb = Integer($::memorysize_mb)
+  $total_memory_bytes = $::memory['system']['total_bytes']
+  $total_memory_mb = $total_memory_bytes / 1024 / 1024
 
   $goarch = $::os['architecture'] ? {
     'amd64'   => 'amd64',

--- a/puppet/zulip/manifests/common.pp
+++ b/puppet/zulip/manifests/common.pp
@@ -1,7 +1,7 @@
 class zulip::common {
   # Common parameters
   case $::os['family'] {
-    'debian': {
+    'Debian': {
       $nagios_plugins = 'monitoring-plugins-basic'
       $nagios_plugins_dir = '/usr/lib/nagios/plugins'
       $nginx = 'nginx-full'
@@ -14,7 +14,7 @@ class zulip::common {
       $supervisor_reload = '/etc/init.d/supervisor restart && (/etc/init.d/supervisor start || /bin/true) && /etc/init.d/supervisor status'
       $supervisor_status = '/etc/init.d/supervisor status'
     }
-    'redhat': {
+    'RedHat': {
       $nagios_plugins = 'nagios-plugins'
       $nagios_plugins_dir = '/usr/lib64/nagios/plugins'
       $nginx = 'nginx'

--- a/puppet/zulip/manifests/common.pp
+++ b/puppet/zulip/manifests/common.pp
@@ -1,6 +1,6 @@
 class zulip::common {
   # Common parameters
-  case $::osfamily {
+  case $::os['family'] {
     'debian': {
       $nagios_plugins = 'monitoring-plugins-basic'
       $nagios_plugins_dir = '/usr/lib/nagios/plugins'

--- a/puppet/zulip/manifests/external_dep.pp
+++ b/puppet/zulip/manifests/external_dep.pp
@@ -6,9 +6,9 @@ define zulip::external_dep(
 ) {
   if $sha256 == '' {
     if $zulip::common::versions[$title]['sha256'] =~ Hash {
-      $sha256_filled = $zulip::common::versions[$title]['sha256'][$::architecture]
+      $sha256_filled = $zulip::common::versions[$title]['sha256'][$::os['architecture']]
       if $sha256_filled == undef {
-        err("No sha256 found for ${title} for architecture ${::architecture}")
+        err("No sha256 found for ${title} for architecture ${::os['architecture']}")
         fail()
       }
     } else {

--- a/puppet/zulip/manifests/golang.pp
+++ b/puppet/zulip/manifests/golang.pp
@@ -2,13 +2,12 @@
 #
 class zulip::golang {
   $version = $zulip::common::versions['golang']['version']
-
   $dir = "/srv/zulip-golang-${version}"
   $bin = "${dir}/bin/go"
 
   zulip::external_dep { 'golang':
     version        => $version,
-    url            => "https://golang.org/dl/go${version}.linux-${::architecture}.tar.gz",
+    url            => "https://golang.org/dl/go${version}.linux-${zulip::common::goarch}.tar.gz",
     tarball_prefix => 'go',
   }
 }

--- a/puppet/zulip/manifests/nginx.pp
+++ b/puppet/zulip/manifests/nginx.pp
@@ -6,7 +6,7 @@ class zulip::nginx {
   ]
   package { $web_packages: ensure => 'installed' }
 
-  if $::osfamily == 'redhat' {
+  if $::os['family'] == 'redhat' {
     file { '/etc/nginx/sites-available':
       ensure => 'directory',
       owner  => 'root',
@@ -80,7 +80,7 @@ class zulip::nginx {
     source  => 'puppet:///modules/zulip/nginx/dhparam.pem',
   }
 
-  if $::osfamily == 'debian' {
+  if $::os['family'] == 'debian' {
       $ca_crt = '/etc/ssl/certs/ca-certificates.crt'
   } else {
       $ca_crt = '/etc/pki/tls/certs/ca-bundle.crt'

--- a/puppet/zulip/manifests/nginx.pp
+++ b/puppet/zulip/manifests/nginx.pp
@@ -6,7 +6,7 @@ class zulip::nginx {
   ]
   package { $web_packages: ensure => 'installed' }
 
-  if $::os['family'] == 'redhat' {
+  if $::os['family'] == 'RedHat' {
     file { '/etc/nginx/sites-available':
       ensure => 'directory',
       owner  => 'root',
@@ -80,7 +80,7 @@ class zulip::nginx {
     source  => 'puppet:///modules/zulip/nginx/dhparam.pem',
   }
 
-  if $::os['family'] == 'debian' {
+  if $::os['family'] == 'Debian' {
       $ca_crt = '/etc/ssl/certs/ca-certificates.crt'
   } else {
       $ca_crt = '/etc/pki/tls/certs/ca-bundle.crt'

--- a/puppet/zulip/manifests/postfix_localmail.pp
+++ b/puppet/zulip/manifests/postfix_localmail.pp
@@ -2,10 +2,11 @@ class zulip::postfix_localmail {
   include zulip::snakeoil
   $postfix_packages = [ 'postfix', ]
 
-  if $::fqdn == '' {
+  $fqdn = $::networking['fqdn']
+  if $fqdn == '' {
     fail('Your system does not have a fully-qualified domain name defined. See hostname(1).')
   }
-  $postfix_mailname = zulipconf('postfix', 'mailname', $::fqdn)
+  $postfix_mailname = zulipconf('postfix', 'mailname', $fqdn)
   package { $postfix_packages:
     ensure  => 'installed',
     require => File['/etc/mailname'],
@@ -20,7 +21,7 @@ class zulip::postfix_localmail {
     mode    => '0644',
     owner   => root,
     group   => root,
-    content => $::fqdn,
+    content => $fqdn,
   }
 
   file {'/etc/postfix/main.cf':

--- a/puppet/zulip/manifests/postgresql_backups.pp
+++ b/puppet/zulip/manifests/postgresql_backups.pp
@@ -5,7 +5,7 @@ class zulip::postgresql_backups {
 
   $wal_g_version = $zulip::common::versions['wal-g']['version']
   $bin = "/srv/zulip-wal-g-${wal_g_version}"
-  $package = "wal-g-pg-ubuntu-20.04-${::architecture}"
+  $package = "wal-g-pg-ubuntu-20.04-${zulip::common::goarch}"
 
   # This tarball contains only a single file
   zulip::external_dep { 'wal-g':

--- a/puppet/zulip/manifests/postgresql_base.pp
+++ b/puppet/zulip/manifests/postgresql_base.pp
@@ -4,7 +4,7 @@ class zulip::postgresql_base {
   include zulip::process_fts_updates
 
   case $::os['family'] {
-    'debian': {
+    'Debian': {
       $postgresql = "postgresql-${zulip::postgresql_common::version}"
       $postgresql_sharedir = "/usr/share/postgresql/${zulip::postgresql_common::version}"
       $postgresql_confdirs = [
@@ -20,7 +20,7 @@ class zulip::postgresql_base {
       $postgresql_dict_dict = '/var/cache/postgresql/dicts/en_us.dict'
       $postgresql_dict_affix = '/var/cache/postgresql/dicts/en_us.affix'
     }
-    'redhat': {
+    'RedHat': {
       $postgresql = "postgresql${zulip::postgresql_common::version}"
       $postgresql_sharedir = "/usr/pgsql-${zulip::postgresql_common::version}/share"
       $postgresql_confdirs = [

--- a/puppet/zulip/manifests/postgresql_base.pp
+++ b/puppet/zulip/manifests/postgresql_base.pp
@@ -3,7 +3,7 @@ class zulip::postgresql_base {
   include zulip::postgresql_common
   include zulip::process_fts_updates
 
-  case $::osfamily {
+  case $::os['family'] {
     'debian': {
       $postgresql = "postgresql-${zulip::postgresql_common::version}"
       $postgresql_sharedir = "/usr/share/postgresql/${zulip::postgresql_common::version}"

--- a/puppet/zulip/manifests/postgresql_common.pp
+++ b/puppet/zulip/manifests/postgresql_common.pp
@@ -1,7 +1,7 @@
 class zulip::postgresql_common {
   include zulip::snakeoil
   $version = zulipconf('postgresql', 'version', undef)
-  case $::osfamily {
+  case $::os['family'] {
     'debian': {
       $postgresql = "postgresql-${version}"
       $postgresql_packages = [
@@ -63,7 +63,7 @@ class zulip::postgresql_common {
     require => Exec['generate-default-snakeoil'],
   }
 
-  if $::osfamily == 'debian' {
+  if $::os['family'] == 'debian' {
     # The logrotate file only created in debian-based systems
     exec { 'disable_logrotate':
       # lint:ignore:140chars

--- a/puppet/zulip/manifests/postgresql_common.pp
+++ b/puppet/zulip/manifests/postgresql_common.pp
@@ -2,7 +2,7 @@ class zulip::postgresql_common {
   include zulip::snakeoil
   $version = zulipconf('postgresql', 'version', undef)
   case $::os['family'] {
-    'debian': {
+    'Debian': {
       $postgresql = "postgresql-${version}"
       $postgresql_packages = [
         # The database itself
@@ -21,7 +21,7 @@ class zulip::postgresql_common {
         Package['ssl-cert'],
       ]
     }
-    'redhat': {
+    'RedHat': {
       $postgresql = "postgresql${version}"
       $postgresql_packages = [
         $postgresql,
@@ -63,7 +63,7 @@ class zulip::postgresql_common {
     require => Exec['generate-default-snakeoil'],
   }
 
-  if $::os['family'] == 'debian' {
+  if $::os['family'] == 'Debian' {
     # The logrotate file only created in debian-based systems
     exec { 'disable_logrotate':
       # lint:ignore:140chars

--- a/puppet/zulip/manifests/process_fts_updates.pp
+++ b/puppet/zulip/manifests/process_fts_updates.pp
@@ -1,14 +1,14 @@
 class zulip::process_fts_updates {
   include zulip::supervisor
   case $::os['family'] {
-    'debian': {
+    'Debian': {
       $fts_updates_packages = [
         # Needed to run process_fts_updates
         'python3-psycopg2', # TODO: use a virtualenv instead
       ]
       zulip::safepackage { $fts_updates_packages: ensure => 'installed' }
     }
-    'redhat': {
+    'RedHat': {
       exec {'pip_process_fts_updates':
         command => 'python3 -m pip install psycopg2',
       }

--- a/puppet/zulip/manifests/process_fts_updates.pp
+++ b/puppet/zulip/manifests/process_fts_updates.pp
@@ -1,6 +1,6 @@
 class zulip::process_fts_updates {
   include zulip::supervisor
-  case $::osfamily {
+  case $::os['family'] {
     'debian': {
       $fts_updates_packages = [
         # Needed to run process_fts_updates

--- a/puppet/zulip/manifests/profile/app_frontend.pp
+++ b/puppet/zulip/manifests/profile/app_frontend.pp
@@ -11,8 +11,8 @@ class zulip::profile::app_frontend {
     $nginx_listen_port = zulipconf('application_server', 'nginx_listen_port', 443)
   }
   $ssl_dir = $::os['family'] ? {
-    'debian' => '/etc/ssl',
-    'redhat' => '/etc/pki/tls',
+    'Debian' => '/etc/ssl',
+    'RedHat' => '/etc/pki/tls',
   }
   file { '/etc/nginx/sites-available/zulip-enterprise':
     ensure  => file,

--- a/puppet/zulip/manifests/profile/app_frontend.pp
+++ b/puppet/zulip/manifests/profile/app_frontend.pp
@@ -10,7 +10,7 @@ class zulip::profile::app_frontend {
   } else {
     $nginx_listen_port = zulipconf('application_server', 'nginx_listen_port', 443)
   }
-  $ssl_dir = $::osfamily ? {
+  $ssl_dir = $::os['family'] ? {
     'debian' => '/etc/ssl',
     'redhat' => '/etc/pki/tls',
   }

--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -5,10 +5,10 @@
 class zulip::profile::base {
   include zulip::common
   case $::os['family'] {
-    'debian': {
+    'Debian': {
       include zulip::apt_repository
     }
-    'redhat': {
+    'RedHat': {
       include zulip::yum_repository
     }
     default: {
@@ -16,7 +16,7 @@ class zulip::profile::base {
     }
   }
   case $::os['family'] {
-    'debian': {
+    'Debian': {
       $base_packages = [
         # Basics
         'python3',
@@ -40,7 +40,7 @@ class zulip::profile::base {
         'cron',
       ]
     }
-    'redhat': {
+    'RedHat': {
       $base_packages = [
         'python3',
         'python3-pyyaml',

--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -4,7 +4,7 @@
 # be able to be deployed on their own host.
 class zulip::profile::base {
   include zulip::common
-  case $::osfamily {
+  case $::os['family'] {
     'debian': {
       include zulip::apt_repository
     }
@@ -15,7 +15,7 @@ class zulip::profile::base {
       fail('osfamily not supported')
     }
   }
-  case $::osfamily {
+  case $::os['family'] {
     'debian': {
       $base_packages = [
         # Basics

--- a/puppet/zulip/manifests/profile/memcached.pp
+++ b/puppet/zulip/manifests/profile/memcached.pp
@@ -4,11 +4,11 @@ class zulip::profile::memcached {
   include zulip::systemd_daemon_reload
 
   case $::os['family'] {
-    'debian': {
+    'Debian': {
       $memcached_packages = [ 'memcached', 'sasl2-bin' ]
       $memcached_user = 'memcache'
     }
-    'redhat': {
+    'RedHat': {
       $memcached_packages = [ 'memcached', 'cyrus-sasl' ]
       $memcached_user = 'memcached'
     }

--- a/puppet/zulip/manifests/profile/memcached.pp
+++ b/puppet/zulip/manifests/profile/memcached.pp
@@ -3,7 +3,7 @@ class zulip::profile::memcached {
   include zulip::sasl_modules
   include zulip::systemd_daemon_reload
 
-  case $::osfamily {
+  case $::os['family'] {
     'debian': {
       $memcached_packages = [ 'memcached', 'sasl2-bin' ]
       $memcached_user = 'memcache'

--- a/puppet/zulip/manifests/profile/rabbitmq.pp
+++ b/puppet/zulip/manifests/profile/rabbitmq.pp
@@ -1,8 +1,8 @@
 class zulip::profile::rabbitmq {
   include zulip::profile::base
   $erlang = $::os['family'] ? {
-    'debian' => 'erlang-base',
-    'redhat' => 'erlang',
+    'Debian' => 'erlang-base',
+    'RedHat' => 'erlang',
   }
   $rabbitmq_packages = [
     $erlang,

--- a/puppet/zulip/manifests/profile/rabbitmq.pp
+++ b/puppet/zulip/manifests/profile/rabbitmq.pp
@@ -1,6 +1,6 @@
 class zulip::profile::rabbitmq {
   include zulip::profile::base
-  $erlang = $::osfamily ? {
+  $erlang = $::os['family'] ? {
     'debian' => 'erlang-base',
     'redhat' => 'erlang',
   }

--- a/puppet/zulip/manifests/profile/redis.pp
+++ b/puppet/zulip/manifests/profile/redis.pp
@@ -1,6 +1,6 @@
 class zulip::profile::redis {
   include zulip::profile::base
-  case $::osfamily {
+  case $::os['family'] {
     'debian': {
       $redis = 'redis-server'
       $redis_dir = '/etc/redis'

--- a/puppet/zulip/manifests/profile/redis.pp
+++ b/puppet/zulip/manifests/profile/redis.pp
@@ -1,11 +1,11 @@
 class zulip::profile::redis {
   include zulip::profile::base
   case $::os['family'] {
-    'debian': {
+    'Debian': {
       $redis = 'redis-server'
       $redis_dir = '/etc/redis'
     }
-    'redhat': {
+    'RedHat': {
       $redis = 'redis'
       $redis_dir = '/etc'
     }

--- a/puppet/zulip/manifests/sasl_modules.pp
+++ b/puppet/zulip/manifests/sasl_modules.pp
@@ -1,7 +1,7 @@
 class zulip::sasl_modules {
   $sasl_module_packages = $::os['family'] ? {
-    'debian' => [ 'libsasl2-modules' ],
-    'redhat' => [ 'cyrus-sasl-plain' ],
+    'Debian' => [ 'libsasl2-modules' ],
+    'RedHat' => [ 'cyrus-sasl-plain' ],
   }
   package { $sasl_module_packages: ensure => 'installed' }
 }

--- a/puppet/zulip/manifests/sasl_modules.pp
+++ b/puppet/zulip/manifests/sasl_modules.pp
@@ -1,5 +1,5 @@
 class zulip::sasl_modules {
-  $sasl_module_packages = $::osfamily ? {
+  $sasl_module_packages = $::os['family'] ? {
     'debian' => [ 'libsasl2-modules' ],
     'redhat' => [ 'cyrus-sasl-plain' ],
   }

--- a/puppet/zulip/manifests/static_asset_compiler.pp
+++ b/puppet/zulip/manifests/static_asset_compiler.pp
@@ -1,12 +1,12 @@
 class zulip::static_asset_compiler {
   case $::os['family'] {
-    'debian': {
+    'Debian': {
       $static_asset_compiler_packages = [
         # Used by makemessages i18n
         'gettext',
       ]
     }
-    'redhat': {
+    'RedHat': {
       $static_asset_compiler_packages = [
         'gettext',
       ]

--- a/puppet/zulip/manifests/static_asset_compiler.pp
+++ b/puppet/zulip/manifests/static_asset_compiler.pp
@@ -1,5 +1,5 @@
 class zulip::static_asset_compiler {
-  case $::osfamily {
+  case $::os['family'] {
     'debian': {
       $static_asset_compiler_packages = [
         # Used by makemessages i18n

--- a/puppet/zulip_ops/manifests/profile/grafana.pp
+++ b/puppet/zulip_ops/manifests/profile/grafana.pp
@@ -4,10 +4,6 @@ class zulip_ops::profile::grafana {
   include zulip_ops::profile::base
   include zulip::supervisor
 
-  $arch = $::architecture ? {
-    'amd64'   => 'amd64',
-    'aarch64' => 'arm64',
-  }
   $version = $zulip::common::versions['grafana']['version']
   $dir = "/srv/zulip-grafana-${version}"
   $bin = "${dir}/bin/grafana-server"
@@ -15,7 +11,7 @@ class zulip_ops::profile::grafana {
 
   zulip::external_dep { 'grafana':
     version        => $version,
-    url            => "https://dl.grafana.com/oss/release/grafana-${version}.linux-${arch}.tar.gz",
+    url            => "https://dl.grafana.com/oss/release/grafana-${version}.linux-${zulip::common::goarch}.tar.gz",
     tarball_prefix => "grafana-${version}",
   }
 

--- a/puppet/zulip_ops/manifests/profile/prometheus_server.pp
+++ b/puppet/zulip_ops/manifests/profile/prometheus_server.pp
@@ -6,10 +6,6 @@ class zulip_ops::profile::prometheus_server {
   include zulip_ops::profile::base
   include zulip_ops::prometheus::base
 
-  $arch = $::architecture ? {
-    'amd64'   => 'amd64',
-    'aarch64' => 'arm64',
-  }
   $version = $zulip::common::versions['prometheus']['version']
   $dir = "/srv/zulip-prometheus-${version}"
   $bin = "${dir}/prometheus"
@@ -17,8 +13,8 @@ class zulip_ops::profile::prometheus_server {
 
   zulip::external_dep { 'prometheus':
     version        => $version,
-    url            => "https://github.com/prometheus/prometheus/releases/download/v${version}/prometheus-${version}.linux-${arch}.tar.gz",
-    tarball_prefix => "prometheus-${version}.linux-${arch}",
+    url            => "https://github.com/prometheus/prometheus/releases/download/v${version}/prometheus-${version}.linux-${zulip::common::goarch}.tar.gz",
+    tarball_prefix => "prometheus-${version}.linux-${zulip::common::goarch}",
   }
   file { '/usr/local/bin/promtool':
     ensure  => 'link',

--- a/puppet/zulip_ops/manifests/prometheus/node.pp
+++ b/puppet/zulip_ops/manifests/prometheus/node.pp
@@ -4,18 +4,14 @@ class zulip_ops::prometheus::node {
   include zulip_ops::prometheus::base
   include zulip::supervisor
 
-  $arch = $::architecture ? {
-    'amd64'   => 'amd64',
-    'aarch64' => 'arm64',
-  }
   $version = $zulip::common::versions['node_exporter']['version']
   $dir = "/srv/zulip-node_exporter-${version}"
   $bin = "${dir}/node_exporter"
 
   zulip::external_dep { 'node_exporter':
     version        => $version,
-    url            => "https://github.com/prometheus/node_exporter/releases/download/v${version}/node_exporter-${version}.linux-${arch}.tar.gz",
-    tarball_prefix => "node_exporter-${version}.linux-${arch}",
+    url            => "https://github.com/prometheus/node_exporter/releases/download/v${version}/node_exporter-${version}.linux-${zulip::common::goarch}.tar.gz",
+    tarball_prefix => "node_exporter-${version}.linux-${zulip::common::goarch}",
   }
 
   # This was moved to an external_dep in 2021/12, and these lines can

--- a/puppet/zulip_ops/manifests/prometheus/uwsgi.pp
+++ b/puppet/zulip_ops/manifests/prometheus/uwsgi.pp
@@ -4,14 +4,11 @@ class zulip_ops::prometheus::uwsgi {
   $version = $zulip::common::versions['uwsgi_exporter']['version']
   $dir = "/srv/zulip-uwsgi_exporter-${version}"
   $bin = "${dir}/uwsgi_exporter"
-  $arch = $::architecture ? {
-    'amd64'   => 'amd64',
-    'aarch64' => 'arm64',
-  }
+
   zulip::external_dep { 'uwsgi_exporter':
     version        => $version,
-    url            => "https://github.com/timonwong/uwsgi_exporter/releases/download/v${version}/uwsgi_exporter-${version}.linux-${arch}.tar.gz",
-    tarball_prefix => "uwsgi_exporter-${version}.linux-${arch}",
+    url            => "https://github.com/timonwong/uwsgi_exporter/releases/download/v${version}/uwsgi_exporter-${version}.linux-${zulip::common::goarch}.tar.gz",
+    tarball_prefix => "uwsgi_exporter-${version}.linux-${zulip::common::goarch}",
   }
 
   zulip_ops::firewall_allow { 'uwsgi_exporter': port => '9238' }


### PR DESCRIPTION
**Testing plan:** List of legacy facts generated via:
```
comm -23 <(facter --show-legacy | perl -nale 'print $F[0] unless /^(\s+|})/') \
         <(facter               | perl -nale 'print $F[0] unless /^(\s+|})/')
```

Replaces #21094.