### PR TITLE
stream_settings: Ignore hover on actions column in tables(dark theme)

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -83,7 +83,7 @@ body.dark-theme {
     table.table-striped thead.table-sticky-headers th {
         background-color: hsl(0, 0%, 0%);
 
-        &:hover {
+        &:hover:not(.actions) {
             background-color: hsl(211, 29%, 14%);
         }
     }


### PR DESCRIPTION
In dark theme ignore hover behavior for actions column in tables,
using `hover:not(.class_name)`.
Follows the same behavior as the light theme.

**Fixes:** #21137 

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Manually tested in both themes.

**GIFs or screenshots:** 
![actions_hover_fix](https://user-images.githubusercontent.com/41695888/154042976-f9c81985-a916-4b09-a626-c664ec657214.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
