### PR TITLE
bots: Do not allow removing owner from UI.

### DIFF
--- a/static/templates/settings/admin_bot_form.hbs
+++ b/static/templates/settings/admin_bot_form.hbs
@@ -5,8 +5,7 @@
             <label for="bot_owner_select">{{t "Owner" }}</label>
             {{> dropdown_list_widget
               widget_name="edit_bot_owner"
-              list_placeholder=(t 'Filter users')
-              reset_button_text=(t '[Remove owner]')}}
+              list_placeholder=(t 'Filter users')}}
         </div>
         <div class="name_change_container">
             <label for="full_name">{{t "Full name" }}</label>


### PR DESCRIPTION
This PR removes the "Remove owner" button
from bot-edit form since we anyways do not allow
to remove owner in the API.

Fixes #20116.

Note that we still create some bots without owners in development environemnt. Maybe we can change those to
have owners if there is no specific use case of not having owners for them.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
 <!-- How have you tested? -->

<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
