### PR TITLE
recent_topics: Hover effect on recent topics table.

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -625,6 +625,10 @@ body.dark-theme {
     .btn-recent-selected,
     #recent_topics_table thead th {
         background-color: hsl(0, 0%, 0%) !important;
+
+        &[data-sort]:hover {
+            background-color: hsl(211, 29%, 14%) !important;
+        }
     }
 
     #recent_topics_table td a {

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -256,6 +256,8 @@
 
             &[data-sort]:hover {
                 cursor: pointer;
+                background-color: hsla(0, 0%, 95%);
+                transition: background-color 100ms ease-in-out;
 
                 &:not(.active)::after {
                     opacity: 0.3;


### PR DESCRIPTION
As the behavior of other tables when we hover on desirable sorting columns head
it changes its background color, to keep the same behavior of all tables, this PR also 
applies this same hover effect to recent topics.

This PR uses the same method as used for other tables.

**Fixes:** #21140 

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:**  Manually for both themes.

**GIFs or screenshots:** 
<details>
<summary>Recent topics table</summary>

![recent_topics_table_hover](https://user-images.githubusercontent.com/41695888/154116056-80853508-2b8b-4ffa-9b5a-bca9015d3242.gif)
![recent_topics_table_hover_dark_theme](https://user-images.githubusercontent.com/41695888/154116089-f119ec7d-a22f-4a2f-ba24-e1ae31cd35a9.gif)
</details>


