### PR TITLE
deliver_scheduled_emails: Lock and send emails one-at-a-time.

### DIFF
--- a/zerver/management/commands/deliver_scheduled_emails.py
+++ b/zerver/management/commands/deliver_scheduled_emails.py
@@ -34,23 +34,18 @@ Usage: ./manage.py deliver_scheduled_emails
 
     def handle(self, *args: Any, **options: Any) -> None:
         while True:
-            found_rows = False
             with transaction.atomic():
-                email_jobs_to_deliver = (
+                job = (
                     ScheduledEmail.objects.filter(scheduled_timestamp__lte=timezone_now())
                     .prefetch_related("users")
-                    .select_for_update()
+                    .select_for_update(skip_locked=True)
+                    .order_by("scheduled_timestamp")
+                    .first()
                 )
-                if email_jobs_to_deliver:
-                    found_rows = True
-                    for job in email_jobs_to_deliver:
-                        try:
-                            deliver_scheduled_emails(job)
-                        except EmailNotDeliveredException:
-                            logger.warning("%r not delivered", job)
-            # Less load on the db during times of activity,
-            # and more responsiveness when the load is low
-            if found_rows:
-                time.sleep(10)
-            else:
-                time.sleep(2)
+                if job:
+                    try:
+                        deliver_scheduled_emails(job)
+                    except EmailNotDeliveredException:
+                        logger.warning("%r not delivered", job)
+                else:
+                    time.sleep(2)


### PR DESCRIPTION
When pulling batches out of the ScheduledEmail list in a single
transaction, an unexpected failure to send an email will result in the
whole batch getting retried.  This will result in infinite email
sending loops.

Pull a single row off at a time and send it.  We continue without
retries to the next email on EmailNotDeliveredException, but will
retry infinitely on other exceptions.

Fixes: #20943.

**Testing plan:** Deployed in a test prod instance, called `send_future_email` repeatedly.