### PR TITLE
populate_db: Set owners for bots in development and test database.

### DIFF
--- a/frontend_tests/puppeteer_tests/settings.ts
+++ b/frontend_tests/puppeteer_tests/settings.ts
@@ -228,6 +228,7 @@ async function test_invalid_edit_bot_form(page: Page): Promise<void> {
 
 async function test_your_bots_section(page: Page): Promise<void> {
     await page.click('[data-section="your-bots"]');
+    await page.click(".add-a-new-bot-tab");
     await test_webhook_bot_creation(page);
     await test_normal_bot_creation(page);
     await test_botserverrc(page);

--- a/static/templates/settings/edit_bot.hbs
+++ b/static/templates/settings/edit_bot.hbs
@@ -11,8 +11,7 @@
                 <label>{{t "Owner" }}</label>
                 {{> dropdown_list_widget
                   widget_name="bot_owner"
-                  list_placeholder=(t 'Filter users')
-                  reset_button_text=(t '[Remove owner]')}}
+                  list_placeholder=(t 'Filter users')}}
             </div>
             <div class="edit-bot-name">
                 <label for="edit_bot_name">{{t "Full name" }}</label>

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -507,7 +507,9 @@ class Command(BaseCommand):
             for i in range(options["extra_bots"]):
                 zulip_realm_bots.append((f"Extra Bot {i}", f"extrabot{i}@zulip.com"))
 
-            create_users(zulip_realm, zulip_realm_bots, bot_type=UserProfile.DEFAULT_BOT)
+            create_users(
+                zulip_realm, zulip_realm_bots, bot_type=UserProfile.DEFAULT_BOT, bot_owner=desdemona
+            )
 
             zoe = get_user_by_delivery_email("zoe@zulip.com", zulip_realm)
             zulip_webhook_bots = [
@@ -911,7 +913,10 @@ class Command(BaseCommand):
                     ("Zulip Nagios Bot", "nagios-bot@zulip.com"),
                 ]
                 create_users(
-                    zulip_realm, internal_zulip_users_nosubs, bot_type=UserProfile.DEFAULT_BOT
+                    zulip_realm,
+                    internal_zulip_users_nosubs,
+                    bot_type=UserProfile.DEFAULT_BOT,
+                    bot_owner=desdemona,
                 )
 
             mark_all_messages_as_read()


### PR DESCRIPTION
Since we do not allow to remove owners from bots, it is better
to keep owners for the bots in development environment as well.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

 <!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
