### PR TITLE
upgrade: Log the commit hash and directory when upgrading.

### DIFF
--- a/scripts/lib/upgrade-zulip-from-git
+++ b/scripts/lib/upgrade-zulip-from-git
@@ -90,6 +90,12 @@ try:
     )
 
     # Generate the deployment directory via git worktree from our local repository.
+    commit_hash = subprocess.check_output(
+        ["git", "rev-parse", refname],
+        preexec_fn=su_to_zulip,
+        text=True,
+    ).strip()
+    logging.info("Upgrading to %s, in %s", commit_hash, deploy_path)
     subprocess.check_call(
         ["git", "worktree", "add", "--detach", deploy_path, refname],
         stdout=subprocess.DEVNULL,


### PR DESCRIPTION
**Testing plan:** 

```
root@alexmv-prod:~# ~zulip/deployments/current/scripts/upgrade-zulip-from-git --remote-url https://github.com/alexmv/zulip.git upgrade-hash
2022-02-16 20:02:41,646 upgrade-zulip-from-git: Fetching the latest commits
2022-02-16 20:02:43,041 upgrade-zulip-from-git: Upgrading to 402f26f850d46bd4265e46d5d7556c7fd754465c, in /home/zulip/deployments/2022-02-16-20-02-41
2022-02-16 20:02:44,580 upgrade-zulip-stage-2: Upgrading system packages...
```

Because this is before stage 2, upgrading _to_ this branch won't get the behaviour, only upgrading once you're running it.