### PR TITLE
compose: Disable send button while uploads are in progress.

### DIFF
--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -156,6 +156,7 @@ test("get_item", () => {
 });
 
 test("hide_upload_status", () => {
+    $("#compose-send-button").css = () => {};
     $("#compose-send-button").prop("disabled", true);
     $("#compose-send-status").addClass("alert-info").show();
 
@@ -243,6 +244,7 @@ test("upload_files", ({override, override_rewire}) => {
     $("#compose .undo_markdown_preview").on("click", () => {
         markdown_preview_hide_button_clicked = true;
     });
+    $("#compose-send-button").css = () => {};
     $("#compose-send-button").prop("disabled", false);
     $("#compose-send-status").removeClass("alert-info").hide();
     $("#compose .undo_markdown_preview").show();

--- a/static/js/compose_validate.js
+++ b/static/js/compose_validate.js
@@ -574,9 +574,12 @@ export function check_overflow_text() {
         }
     } else {
         $indicator.text("");
+
+        if ($("#compose-textarea").hasClass("over_limit")) {
+            $("#compose-send-button").prop("disabled", false);
+        }
         $("#compose-textarea").removeClass("over_limit");
 
-        $("#compose-send-button").prop("disabled", false);
         if ($("#compose-send-status").hasClass("alert-error")) {
             $("#compose-send-status").stop(true).fadeOut();
         }

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -89,6 +89,7 @@ export function get_item(key, config) {
 }
 
 export function hide_upload_status(config) {
+    get_item("send_button", config).css({opacity: 1, cursor: "default"});
     get_item("send_button", config).prop("disabled", false);
     get_item("send_status", config).removeClass("alert-info").hide();
 }
@@ -127,6 +128,8 @@ export function upload_files(uppy, config, files) {
         get_item("markdown_preview_hide_button", config).trigger("click");
     }
 
+    // Send button look disabled.
+    get_item("send_button", config).css({opacity: 0.6, cursor: "not-allowed"});
     get_item("send_button", config).prop("disabled", true);
     get_item("send_status", config).addClass("alert-info").removeClass("alert-error").show();
     get_item("send_status_message", config).html($("<p>").text($t({defaultMessage: "Uploading…"})));


### PR DESCRIPTION
In `upload.js` there is already code for disabling send button while uploading(works for saving when we edit, but not for send),
when I inspect in chrome, `disabled` attr comes and goes for saving button but not in the case for send button and the reason behind it is, The function `check_overflow_text()` from `compose_validate.js` removes `disabled` attr when message text not
overflowing after overflowing error, I just added if condition to remove `disabled` attr only if the text was overflowing before.

Added some CSS on the button to look disabled.

Fixes: #21135

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Manually tested for both themes.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
**Gifs And Screenshots:** I had to upload lots of files because files were uploading too fast and 25MB is the file size limit.
<details>
<summary>LIght Mode</summary>

![light_mode](https://user-images.githubusercontent.com/41695888/155326213-3089da49-390a-4825-a688-0b23349babcf.gif)
![light_mode_screenshot](https://user-images.githubusercontent.com/41695888/155330712-53c8234c-0006-4ef9-a5bf-22a4df8f7734.png)


</details>
<details>
<summary>Dark Mode</summary>

![dark_mode](https://user-images.githubusercontent.com/41695888/155326259-42a1db14-313a-473d-8a96-74c44d1000b2.gif)
![dark_mode_screenshot](https://user-images.githubusercontent.com/41695888/155330795-8122c92d-c6b7-4c82-874b-305c9900bd4c.png)


</details>