### PR TITLE
help_docs: Document Markdown stream/topic auto-linking feature.

### DIFF
--- a/templates/zerver/help/format-your-message-using-markdown.md
+++ b/templates/zerver/help/format-your-message-using-markdown.md
@@ -62,9 +62,11 @@ Numbered lists
 
 ## Links
 
-Zulip auto-linkifies URLs and valid stream names. You can also add a
-[custom linkifier](/help/add-a-custom-linkifier) to link
+Zulip auto-linkifies URLs and [valid stream (and topic) names][link-to-conversation].
+You can also add a [custom linkifier](/help/add-a-custom-linkifier) to link
 patterns like `#1234` to your ticketing system.
+
+[link-to-conversation]: /help/link-to-a-message-or-conversation
 
 ```
 Auto-detected URL: zulip.com

--- a/templates/zerver/help/link-to-a-message-or-conversation.md
+++ b/templates/zerver/help/link-to-a-message-or-conversation.md
@@ -1,8 +1,27 @@
 # Link to a message or conversation
 
-Share permanent links to messages, threads, and streams.  With Zulip,
-it's easy to to link to specific (parts of) conversations from issue
-trackers, documentation, or other external tools.
+Share links to messages, topics, and streams. With Zulip,
+it's easy to to link to specific (parts of) conversations from
+issue trackers, documentation, or other external tools.
+
+Also, when composing a message in Zulip, you can use
+[Zulip's Markdown][zulip-markdown-links]
+features to easliy auto-link to existing streams and topics.
+
+[zulip-markdown-links]: /help/format-your-message-using-markdown#links
+
+## Markdown syntax to auto-link to a stream or topic
+```
+Stream: #**stream name**
+Topic: #**stream name>topic name**
+```
+
+!!! tip ""
+
+    When using this Markdown feature in the compose box, a menu of
+    valid streams should appear as you're typing. Once you've highlighted
+    the desired stream name from the menu, you can press `>` for a list
+    of valid topic names in that particular stream.
 
 ## Link to a stream or topic
 
@@ -21,6 +40,13 @@ trackers, documentation, or other external tools.
 
 ## Link to a specific message
 
+This will copy to your clipboard a permanent link to the message,
+displayed in its thread (i.e. topic view for messages in a stream).
+Viewing a topic via a message link will never mark messages as read.
+
+Zulip uses the same permanent link syntax when [quoting a
+message](/help/quote-and-reply).
+
 {start_tabs}
 
 {!message-actions-menu.md!}
@@ -29,10 +55,8 @@ trackers, documentation, or other external tools.
 
 {end_tabs}
 
-This will copy to your clipboard a permanent link to the message,
-displayed in its thread (i.e. topic view for messages in a stream).
+## Related articles
 
-Viewing a thread via a message link will never mark messages as read.
-
-Zulip uses the same permanent link syntax when [quoting a
-message](/help/quote-and-reply).
+* [Add a custom linkifier](/help/add-a-custom-linkifier)
+* [Format your messages using Markdown](/help/format-your-message-using-markdown)
+* [Link to your Zulip](/help/linking-to-zulip)


### PR DESCRIPTION
Adds a section about the Zulip Markdown feature to auto-link to existing streams and topics in a Zulip message to the existing help center documentation for [linking to a message or conversation](https://zulip.com/help/link-to-a-message-or-conversation). Also, does a little reformatting of existing text/tabs in that article and adds a related links section to the end of the page.

The [Markdown formatting](https://zulip.com/help/format-your-message-using-markdown) help center documentation already covers the majority of this information. We could potentially add the "tip" information (re: the menus that appear while typing) to that page as well if it seems appropriate, but I didn't feel like that was necessary.

Fixes #21085.

**Screenshot of updated "Link to a message or conversation" page:**
![Screenshot from 2022-02-17 13-10-32](https://user-images.githubusercontent.com/63245456/154480202-f40d0a3b-42db-43ea-bb7d-54ef9226fbbf.png)

**Screenshot of minor update to "Markdown formmating" page:**
![Screenshot from 2022-02-17 13-34-02](https://user-images.githubusercontent.com/63245456/154482883-1e5b4b9b-0a50-4878-a659-8cf492612c6c.png)
