### PR TITLE
Make avatars in Recent Topics open user info popover on click.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -29,6 +29,7 @@ import * as narrow from "./narrow";
 import * as notifications from "./notifications";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
+import * as people from "./people";
 import * as popovers from "./popovers";
 import * as reactions from "./reactions";
 import * as recent_topics_ui from "./recent_topics_ui";
@@ -375,6 +376,13 @@ export function initialize() {
     });
 
     // RECENT TOPICS
+
+    $("#recent_topics_table").on("click", ".participant_profile", function (e) {
+        const participant_user_id = Number.parseInt($(this).attr("data-user-id"), 10);
+        e.stopPropagation();
+        const user = people.get_by_user_id(participant_user_id);
+        popovers.show_user_info_popover(this, user);
+    });
 
     $("body").on("keydown", ".on_hover_topic_mute", ui_util.convert_enter_to_click);
 

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -183,6 +183,7 @@
             padding: 0 1.5px;
             position: relative;
             min-width: 24px;
+            cursor: pointer;
 
             .fa-user {
                 opacity: 0.7;

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -38,11 +38,11 @@
             {{/if}}
             {{#each senders}}
                 {{#if this.is_muted}}
-                <li class="recent_topics_participant_item tippy-zulip-tooltip" data-tippy-content="{{t 'Muted user'}}">
+                <li class="recent_topics_participant_item participant_profile tippy-zulip-tooltip" data-tippy-content="{{t 'Muted user'}}" data-user-id="{{this.user_id}}">
                     <span><i class="fa fa-user recent_topics_participant_overflow"></i></span>
                 </li>
                 {{else}}
-                <li class="recent_topics_participant_item tippy-zulip-tooltip" data-tippy-content="{{this.full_name}}">
+                <li class="recent_topics_participant_item participant_profile tippy-zulip-tooltip" data-tippy-content="{{this.full_name}}" data-user-id="{{this.user_id}}">
                     <img src="{{this.avatar_url_small}}" class="recent_topics_participant_avatar" />
                 </li>
                 {{/if}}


### PR DESCRIPTION
The same method and working as other user info popovers. (Ignoring muted users)

**Fixes:** #21154

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Manually for both themes.

**GIFs or screenshots:** 
<details>
<summary>Screenshot</summary>

![recent_topics_profile_popover](https://user-images.githubusercontent.com/41695888/154507013-632dd03f-c0e7-469a-bb5e-758e2a5e53bd.png)

</details>
<details>
<summary>Gif</summary>

![recent_topics_profile_popover_](https://user-images.githubusercontent.com/41695888/154507268-f76faca8-8f09-4fee-82e8-bba5dc74671a.gif)


</details>
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
