### PR TITLE
integrations: Don't fix height of integration icon in detailed view.

### DIFF
--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -378,4 +378,5 @@ $(() => {
     load_data();
     dispatch("LOAD_PATH");
     $(".integrations .searchbar input[type='text']").trigger("focus");
+    adjust_font_sizing();
 });

--- a/static/styles/portico/integrations.css
+++ b/static/styles/portico/integrations.css
@@ -463,7 +463,8 @@ $category-text: hsl(219, 23%, 33%);
 
             .integration-lozenge {
                 width: 125px;
-                height: 170px;
+                height: auto;
+                padding: 0 5px 20px;
                 margin: 0 21px 20px;
                 order: 1;
 


### PR DESCRIPTION
This allows us to have more characters that we can use for the
integration name without overflowing the fixed height.
<img width="323" alt="Screenshot 2022-02-17 at 9 28 58 PM" src="https://user-images.githubusercontent.com/25124304/154520748-77eec5f1-2a72-4058-8d7a-c38e25a1b858.png">
<img width="323" alt="Screenshot 2022-02-17 at 9 29 04 PM" src="https://user-images.githubusercontent.com/25124304/154520767-a42dc9a5-08f0-4837-aa5b-e960f0a3d75a.png">
