### PR TITLE
url_preview: Fix 'Edited' notification for url preview events.

### DIFF
--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -245,7 +245,6 @@ export function update_messages(events) {
                     msg.edit_history = [edit_history_entry].concat(msg.edit_history);
                 }
                 msg.last_edit_timestamp = event.edit_timestamp;
-                delete msg.last_edit_timestr;
 
                 // Remove the recent topics entry for the old topics;
                 // must be called before we call set_message_topic.
@@ -415,8 +414,13 @@ export function update_messages(events) {
             msg.raw_content = event.content;
         }
 
-        msg.last_edit_timestamp = event.edit_timestamp;
-        delete msg.last_edit_timestr;
+        // Mark the message as edited for the UI. The rendering_only
+        // flag is used to indicated update_message events that are
+        // triggered by server latency optimizations, not user
+        // interactions; these should not generate edit history updates.
+        if (!event.rendering_only) {
+            msg.last_edit_timestamp = event.edit_timestamp;
+        }
 
         notifications.received_messages([msg]);
         alert_words.process_message(msg);


### PR DESCRIPTION
We recently added the `rendering_only` field to `update_message` events, so that there would be a clear flag for special update events, such as those for inline url previews.

This change uses the `rendering_only` field in the `update_message` event to filter the addition of `last_edit_timestamp` to the message, which is what triggers the addition of an `Edited` notification when a message is rerendered in the web app.

**Testing plan:** Manually tested in the dev environment. The screencasts below aren't fully loading, but it's enough to see the difference.

### Current behavior
![inline_url_previews_current](https://user-images.githubusercontent.com/63245456/154528678-11e4600b-dcd9-4a1c-a0a2-3bccbe0c9028.gif)

### New behavior

https://user-images.githubusercontent.com/63245456/154529307-e6263ebe-1086-40b1-8d9d-374aa636ec29.mp4

