### PR TITLE
left-sidebar: Align `more-topics` li item with other topic names.

### DIFF
--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -52,6 +52,7 @@ $topic_resolve_width: 13px;
 li.show-more-topics {
     a {
         font-size: 12px;
+        margin-left: $topic_resolve_width;
     }
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/76561593/154584764-71233fd6-04d0-48e1-abed-243f908d136e.png)
