### PR TITLE
tippy: Only change background color of tooltips with no theme.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -85,7 +85,8 @@ pre {
      */
     font-family: "Source Sans 3", sans-serif !important;
 
-    .tippy-box {
+    /* Affects all tippy tooltips not using any theme. */
+    .tippy-box:not[data-theme] {
         background-color: hsl(0, 0%, 12%);
 
         &[data-placement^="top"] {


### PR DESCRIPTION
This change was not aimed at popovers that use tippy. Since
popovers use light theme and tooltips don't, we use this
`not[data-theme]` selector to exclude popovers from being
affected by this change.

reported here - https://chat.zulip.org/#narrow/stream/9-issues/topic/compose.20menu.20mode