### PR TITLE
Change icon of message formatting popover in compose.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -579,7 +579,7 @@ input.recipient_box {
         font-size: 15px;
         font-weight: 600;
         font-family: "Source Sans 3", sans-serif;
-        padding-left: 5px;
+        padding: 0 5px;
     }
 
     .compose_help_button {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -583,11 +583,8 @@ input.recipient_box {
     }
 
     .compose_help_button {
-        font-size: 21px;
-        line-height: 27px;
-        font-weight: 550;
-        padding: 0 5px;
-        margin: 0;
+        font-size: 20px;
+        line-height: 17px;
     }
 }
 

--- a/static/templates/compose_control_buttons.hbs
+++ b/static/templates/compose_control_buttons.hbs
@@ -13,7 +13,6 @@
     <div class="{{#if message_id}}hide-lg{{else}}hide-sm{{/if}}">
         {{> compose_control_buttons_in_popover}}
     </div>
-    <div class="divider hide-sm">|</div>
     <a role="button" class="compose_control_button compose_draft_button hide-sm" tabindex=0 href="#drafts" data-tippy-content="{{t 'Drafts' }}">
         {{t 'Drafts' }}
     </a>

--- a/static/templates/compose_control_buttons_in_popover.hbs
+++ b/static/templates/compose_control_buttons_in_popover.hbs
@@ -1,4 +1,5 @@
 <a role="button" data-format-type="bold" class="compose_control_button fa fa-bold formatting_button" aria-label="{{t 'Bold' }}" tabindex=0 data-tippy-content="{{t 'Bold' }}"></a>
 <a role="button" data-format-type="italic" class="compose_control_button fa fa-italic formatting_button" aria-label="{{t 'Italic' }}" tabindex=0 data-tippy-content="{{t 'Italic' }}"></a>
 <a role="button" data-format-type="link" class="compose_control_button fa fa-link formatting_button" aria-label="{{t 'Link' }}" tabindex=0 data-tippy-content="{{t 'Link' }}"></a>
-<a role="button" class="compose_control_button compose_help_button" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting">Aa</a>
+<div class="divider hide-sm">|</div>
+<a role="button" class="compose_control_button compose_help_button fa fa-question" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>


### PR DESCRIPTION
<img width="551" alt="Screenshot 2022-02-18 at 7 22 35 PM" src="https://user-images.githubusercontent.com/25124304/154695316-47e37ced-f34b-4550-a9fa-a5c259b4d285.png">
<img width="551" alt="Screenshot 2022-02-18 at 7 18 47 PM" src="https://user-images.githubusercontent.com/25124304/154695322-c7c30537-a1a8-4f04-af81-3d716840db48.png">
<img width="551" alt="Screenshot 2022-02-18 at 7 23 07 PM" src="https://user-images.githubusercontent.com/25124304/154695362-5ffebe17-4b97-4a7d-b0df-3641a903cb30.png">
<img width="551" alt="Screenshot 2022-02-18 at 7 24 02 PM" src="https://user-images.githubusercontent.com/25124304/154695516-53dc5c22-70f0-4a1c-9849-1a4288f4d355.png">

