### PR TITLE
compose: Fix display of topic resolve warning for non-empty compose-box.

### DIFF
--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -789,25 +789,38 @@ test_ui("test warn_if_topic_resolved", ({override, mock_template}) => {
 
     // The error message area where it is shown
     const error_area = $("#compose_resolved_topic");
+    compose_validate.clear_topic_resolved_warning();
+    // Hack to make this empty for zjquery; this is conceptually done
+    // in the previous line.
     error_area.html("");
+    assert.ok(!error_area.visible());
 
     compose_state.set_message_type("stream");
     compose_state.stream_name("Do not exist");
     compose_state.topic(resolved_topic.resolve_name("hello"));
+    compose_state.message_content("content");
 
     // Do not show a warning if stream name does not exist
-    compose_validate.warn_if_topic_resolved();
+    compose_validate.warn_if_topic_resolved(true);
     assert.ok(!error_area.visible());
 
     compose_state.stream_name("random");
 
     // Show the warning now as stream also exists
-    compose_validate.warn_if_topic_resolved();
+    compose_validate.warn_if_topic_resolved(true);
+    assert.ok(error_area.visible());
+
+    // Call it again with false; this should be a noop.
+    compose_validate.warn_if_topic_resolved(false);
     assert.ok(error_area.visible());
 
     compose_state.topic("hello");
 
     // The warning will be cleared now
-    compose_validate.warn_if_topic_resolved();
+    compose_validate.warn_if_topic_resolved(true);
+    assert.ok(!error_area.visible());
+
+    // Calling with false won't do anything.
+    compose_validate.warn_if_topic_resolved(false);
     assert.ok(!error_area.visible());
 });

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -185,6 +185,7 @@ export function clear_compose_box() {
     }
     $("#compose-textarea").val("").trigger("focus");
     compose_validate.check_overflow_text();
+    compose_validate.clear_topic_resolved_warning();
     $("#compose-textarea").removeData("draft-id");
     compose_ui.autosize_textarea($("#compose-textarea"));
     $("#compose-send-status").hide(0);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -403,6 +403,7 @@ export function initialize() {
     });
 
     $("#compose-textarea").on("input propertychange", () => {
+        compose_validate.warn_if_topic_resolved(false);
         compose_validate.check_overflow_text();
     });
 
@@ -467,14 +468,14 @@ export function initialize() {
 
         message_edit.with_first_message_id(stream_id, topic_name, (message_id) => {
             message_edit.toggle_resolve_topic(message_id, topic_name);
-            compose_validate.clear_topic_resolved_warning();
+            compose_validate.clear_topic_resolved_warning(true);
         });
     });
 
     $("#compose_resolved_topic").on("click", ".compose_resolved_topic_close", (event) => {
         event.preventDefault();
 
-        compose_validate.clear_topic_resolved_warning();
+        compose_validate.clear_topic_resolved_warning(true);
     });
 
     $("#compose_invite_users").on("click", ".compose_invite_link", (event) => {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -291,7 +291,7 @@ export function start(msg_type, opts) {
     show_box(msg_type, opts);
 
     // Show a warning if topic is resolved
-    compose_validate.warn_if_topic_resolved();
+    compose_validate.warn_if_topic_resolved(true);
 
     // Reset the `max-height` property of `compose-textarea` so that the
     // compose-box do not cover the last messages of the current stream
@@ -464,7 +464,7 @@ export function on_topic_narrow() {
     // See #3300 for context--a couple users specifically asked for
     // this convenience.
     compose_state.topic(narrow_state.topic());
-    compose_validate.warn_if_topic_resolved();
+    compose_validate.warn_if_topic_resolved(true);
     compose_fade.set_focused_recipient("stream");
     compose_fade.update_message_list();
     $("#compose-textarea").trigger("focus").trigger("select");

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -253,7 +253,7 @@ export function update_messages(events) {
             ) {
                 changed_compose = true;
                 compose_state.topic(new_topic);
-                compose_validate.warn_if_topic_resolved();
+                compose_validate.warn_if_topic_resolved(true);
                 compose_fade.set_focused_recipient("stream");
             }
 


### PR DESCRIPTION
**Description:**
Currently the compose topic resolve warning appears directly while
composing inside a resolved topic, even when it is empty. This commit checks whether the
compose textarea is non-empty, and displays the warning only when the
compose-box has some content.

Fixes: #21155

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
Manual

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Zulip-2](https://user-images.githubusercontent.com/77766761/154699401-2d0f906f-fe74-461b-8c92-642d5ce361ce.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
