### PR TITLE
popovers: Add "busy" status to default emoji status set.

### DIFF
--- a/frontend_tests/puppeteer_tests/user-status.ts
+++ b/frontend_tests/puppeteer_tests/user-status.ts
@@ -31,7 +31,7 @@ async function open_set_user_status_modal(page: Page): Promise<void> {
 async function test_user_status(page: Page): Promise<void> {
     await open_set_user_status_modal(page);
     // Check by clicking on common statues.
-    await page.click(".user-status-value");
+    await page.click(".user-status-value:nth-child(2)");
     await page.waitForFunction(
         () => (document.querySelector(".user_status") as HTMLInputElement).value === "In a meeting",
     );

--- a/static/js/user_status_ui.js
+++ b/static/js/user_status_ui.js
@@ -168,6 +168,10 @@ function user_status_post_render() {
 export function initialize() {
     default_status_messages_and_emoji_info = [
         {
+            status_text: $t({defaultMessage: "Busy"}),
+            emoji: emoji.get_emoji_details_by_name("working_on_it"),
+        },
+        {
             status_text: $t({defaultMessage: "In a meeting"}),
             emoji: emoji.get_emoji_details_by_name("calendar"),
         },


### PR DESCRIPTION
Add info about the status in the array "default_status_messages_and_emoji_info".
Set status message as "Busy" and emoji "working_on_it".

Fixes #21179

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="380" alt="Screenshot 2022-02-18 at 18 06 26" src="https://user-images.githubusercontent.com/85362194/154756687-2017c0f7-e3b5-467b-ad85-3fca8b597805.png">
<img width="195" alt="Screenshot 2022-02-18 at 18 06 36" src="https://user-images.githubusercontent.com/85362194/154756698-87f67c44-74d0-4d43-bc0d-3b013c1ad1ff.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
