### PR TITLE
populate_db: Add timezones for some test users.

### DIFF
--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 116
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "177.0"
+PROVISION_VERSION = "178.0"

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -137,7 +137,7 @@ class TestFullStack(ZulipTestCase):
                 is_guest=False,
                 is_owner=False,
                 role=UserProfile.ROLE_MEMBER,
-                timezone="",
+                timezone="Etc/UTC",
                 user_id=cordelia.id,
             ),
         )

--- a/zerver/tests/test_populate_db.py
+++ b/zerver/tests/test_populate_db.py
@@ -22,3 +22,13 @@ class TestChoosePubDate(ZulipTestCase):
             self.assertTrue(
                 datetimes_list[i] - datetimes_list[i - 1] > timezone_timedelta(minutes=5)
             )
+
+
+class TestUserTimezones(ZulipTestCase):
+    def test_timezones_assigned_to_users(self) -> None:
+        othello = self.example_user("othello")
+        self.assertEqual(othello.timezone, "US/Pacific")
+        shiva = self.example_user("shiva")
+        self.assertEqual(shiva.timezone, "Asia/Kolkata")
+        cordelia = self.example_user("cordelia")
+        self.assertEqual(cordelia.timezone, "UTC")

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -467,6 +467,25 @@ class Command(BaseCommand):
 
             create_users(zulip_realm, names, tos_version=settings.TERMS_OF_SERVICE_VERSION)
 
+            # Add time zones to some users. Ideally, this would be
+            # done in the initial create_users calls, but the
+            # tuple-based interface for that function doesn't support
+            # doing so.
+            def assign_time_zone_by_delivery_email(delivery_email: str, new_time_zone: str) -> None:
+                u = get_user_by_delivery_email(delivery_email, zulip_realm)
+                u.timezone = new_time_zone
+                u.save(update_fields=["timezone"])
+
+            # Note: Hamlet keeps default timezone of "".
+            assign_time_zone_by_delivery_email("AARON@zulip.com", "US/Pacific")
+            assign_time_zone_by_delivery_email("othello@zulip.com", "US/Pacific")
+            assign_time_zone_by_delivery_email("ZOE@zulip.com", "US/Eastern")
+            assign_time_zone_by_delivery_email("iago@zulip.com", "US/Eastern")
+            assign_time_zone_by_delivery_email("desdemona@zulip.com", "Canada/Newfoundland")
+            assign_time_zone_by_delivery_email("polonius@zulip.com", "Asia/Shanghai")  # China
+            assign_time_zone_by_delivery_email("shiva@zulip.com", "Asia/Kolkata")  # India
+            assign_time_zone_by_delivery_email("cordelia@zulip.com", "UTC")
+
             iago = get_user_by_delivery_email("iago@zulip.com", zulip_realm)
             do_change_user_role(iago, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
             iago.is_staff = True


### PR DESCRIPTION
After failing to notice a place where we wanted to hide timezone
information, we decided to add timezones to some of the test
users, so that we can better consider the effects of timezones
when manually testing.

Testing:

* ran populate_db and confirmed users had timezones in the UI
* updated test_populate_db.py

![image](https://user-images.githubusercontent.com/5634097/154776359-aabf37ad-c536-4c58-b478-8101fb82eac6.png)
