### PR TITLE
compose: Fix saving of drafts on switching to PM.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -222,6 +222,10 @@ export function start(msg_type, opts) {
         return;
     }
 
+    // We may be able to clear it to change the recipient, so save any
+    // existing content as a draft.
+    drafts.update_draft();
+
     autosize_message_content();
 
     if (reload_state.is_in_progress()) {
@@ -328,10 +332,6 @@ export function cancel() {
 }
 
 export function respond_to_message(opts) {
-    // Before initiating a reply to a message, if there's an
-    // in-progress composition, snapshot it.
-    drafts.update_draft();
-
     let message;
     let msg_type;
     if (recent_topics_util.is_visible()) {


### PR DESCRIPTION
This commit attempts to save the compose message as a draft when
we switch to the PM popover menu while composing a message.

This adds an else if condition in the `compose_actions.start()`
function for checking if there is any content in the compose box using
the `compose_state.has_message_content()` function and updates the drafts
in any case of clearing or closing the compose box while having some content in it.

Fixes: https://github.com/zulip/zulip/issues/21171

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
Manually

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Zulip-2](https://user-images.githubusercontent.com/77766761/154808822-f17af140-af5b-4337-aa26-baa870649121.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
