### PR TITLE
left_sidebar: Fix inconsistent colored dots of menu icon

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -513,6 +513,7 @@ body.dark-theme {
     #user_presences li:hover .user-list-sidebar-menu-icon,
     li.top_left_all_messages:hover .all-messages-sidebar-menu-icon,
     li.top_left_starred_messages:hover .starred-messages-sidebar-menu-icon,
+    li.top_left_drafts:hover .drafts-sidebar-menu-icon,
     #stream_filters li:hover .stream-sidebar-menu-icon,
     li.topic-list-item:hover .topic-sidebar-menu-icon {
         color: hsl(236, 33%, 80%);
@@ -529,6 +530,7 @@ body.dark-theme {
     #user_presences li .user-list-sidebar-menu-icon:hover,
     .all-messages-sidebar-menu-icon:hover,
     .starred-messages-sidebar-menu-icon:hover,
+    .drafts-sidebar-menu-icon:hover,
     .stream-sidebar-menu-icon:hover,
     .topic-sidebar-menu-icon:hover {
         color: hsl(0, 0%, 100%) !important;

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -376,6 +376,7 @@ li.top_left_recent_topics {
         display: inline-block;
         width: 13px;
         vertical-align: middle;
+        opacity: 1 !important;
     }
 
     /*


### PR DESCRIPTION
Issue:
#20600 

Testing plan:
Checked by hovering and uncovering the menu icon dots for all items in left sidebar both in dark theme and light theme.

Screenshot of results:
<img width="469" alt="Screen Shot 2022-02-19 at 6 47 53 PM" src="https://user-images.githubusercontent.com/53159963/154822928-1cff0f48-ba04-4802-a037-16d9dc306a21.png">

