### PR TITLE
settings: Show or hide digest weekday option on changing emails setting.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1097,6 +1097,14 @@ export function build_page() {
         );
     });
 
+    $("#id_realm_digest_emails_enabled").on("change", (e) => {
+        const digest_emails_enabled = $(e.target).is(":checked");
+        change_element_block_display_property(
+            "id_realm_digest_weekday",
+            digest_emails_enabled === true,
+        );
+    });
+
     $("#id_realm_org_join_restrictions").on("change", (e) => {
         const org_join_restrictions = e.target.value;
         const node = $("#allowed_domains_label").parent();


### PR DESCRIPTION
Previousy, we used to show or hide the digest weekday setting after
saving the emails setting, but now we show/hide as soon as we check
or uncheck the email setting checkbox like we do for other settings.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![digest-weekday](https://user-images.githubusercontent.com/35494118/154840549-d2257041-ab27-4ee7-9cef-a9ecb0473768.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
