### PR TITLE
left_sidebar: Add section for different stream types.

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -318,6 +318,12 @@ test("is_active", () => {
     assert.ok(stream_data.is_active(sub));
 });
 
+test("is_muted_active", () => {
+    const sub = {name: "cats", subscribed: true, stream_id: 111, is_muted: true};
+    stream_data.add_sub(sub);
+    assert.ok(stream_data.is_muted_active(sub));
+});
+
 test("admin_options", () => {
     function make_sub() {
         const sub = {

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -124,6 +124,7 @@ test("update_property", ({override}) => {
     {
         const stub = make_stub();
         override(stream_muting, "update_is_muted", stub.f);
+        override(stream_list, "refresh_muted_or_unmuted_stream", noop);
         stream_events.update_property(stream_id, "in_home_view", false);
         assert.equal(stub.num_calls, 1);
         const args = stub.get_args("sub", "val");

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -204,6 +204,10 @@ export function is_active(sub) {
     return stream_topic_history.stream_has_topics(sub.stream_id) || sub.newly_subscribed;
 }
 
+export function is_muted_active(sub) {
+    return sub.is_muted && is_active(sub);
+}
+
 export function rename_sub(sub, new_name) {
     const old_name = sub.name;
 

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -46,6 +46,7 @@ export function update_property(stream_id, property, value, other_values) {
             break;
         case "in_home_view":
             stream_muting.update_is_muted(sub, !value);
+            stream_list.refresh_muted_or_unmuted_stream(sub);
             recent_topics_ui.complete_rerender();
             break;
         case "desktop_notifications":

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -1089,7 +1089,9 @@ body.dark-theme {
     .sub-unsub-message span::before,
     .sub-unsub-message span::after,
     .date_row span::before,
-    .date_row span::after {
+    .date_row span::after,
+    .streams_subheader span::before,
+    .streams_subheader span::after {
         opacity: 0.2;
     }
 

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -169,6 +169,15 @@ li.show-more-topics {
     .inactive_stream {
         opacity: 0.5;
     }
+
+    .toggle_stream_mute {
+        margin-right: 3px;
+        opacity: 0.5;
+
+        &:hover {
+            opacity: 1;
+        }
+    }
 }
 
 .narrows_panel {
@@ -558,6 +567,42 @@ li.expanded_private_message {
 
     input {
         padding-right: 20px;
+    }
+}
+
+.streams_subheader {
+    font-size: 0.8em;
+    font-weight: normal;
+    padding-left: $far_left_gutter_size;
+    cursor: pointer;
+    text-align: center;
+    margin-right: 12px;
+
+    span {
+        display: flex;
+        flex-direction: row;
+        width: 100%;
+        left: 0.5em;
+        right: 0.5em;
+        opacity: 0.5;
+    }
+
+    span::before,
+    span::after {
+        content: " ";
+        flex: 1 1;
+        vertical-align: middle;
+        margin: auto;
+        border-top: 1px solid hsl(0, 0%, 88%);
+        border-bottom: 1px solid hsl(0, 0%, 100%);
+    }
+
+    span::before {
+        margin-right: 0.5em;
+    }
+
+    span::after {
+        margin-left: 0.5em;
     }
 }
 

--- a/static/templates/streams_subheader.hbs
+++ b/static/templates/streams_subheader.hbs
@@ -1,0 +1,3 @@
+<div class="streams_subheader">
+    <span>{{ subheader_name }}</span>
+</div>


### PR DESCRIPTION
Issue #19812

The left sidebar has four potential stream groupings.
This becomes confusing when the groupings are not labeled.
To address this, we should add section headings to the
left side bar with the following names:
* Pinned streams (+ muted pinned streams)
* Active streams (+ muted active streams)
* Inactive streams

![image](https://user-images.githubusercontent.com/51414879/159350693-f748ce58-d911-473d-9017-e46db11344d0.png)
![image](https://user-images.githubusercontent.com/51414879/159350769-0e270b60-f41d-4029-8896-b037c497b6ae.png)
