### PR TITLE
api: Include `realm_web_public_access_enabled` in server settings.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -21,6 +21,13 @@ format used by the Zulip server that they are interacting with.
 ## Changes in Zulip 5.0
 
 
+**Feature level 116**
+
+* [`GET /server_settings`](/api/get-server-settings): Added
+  `realm_web_public_access_enabled` as a realm-specific server setting,
+  which can be used by clients to detect whether the realm allows and
+  has at least one [web-public stream](/help/web-public-streams).
+
 **Feature level 115**
 
 * Mobile push notifications about stream messages now include the

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 115
+API_FEATURE_LEVEL = 116
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11966,6 +11966,18 @@ paths:
                         description: |
                           HTML description of the organization, as configured by the [organization
                           profile](/help/create-your-organization-profile).
+                      realm_web_public_access_enabled:
+                        type: boolean
+                        description: |
+                          Whether the organization has enabled the creation of
+                          [web-public streams](/help/web-public-streams) and
+                          at least one web-public stream on the server currently
+                          exists. Clients that support viewing content
+                          in web-public streams without an account can
+                          use this to determine whether to offer that
+                          feature on the login page for an organization.
+
+                          **Changes**: New in Zulip 5.0 (feature level 116).
                     example:
                       {
                         "authentication_methods":
@@ -11991,6 +12003,7 @@ paths:
                         "realm_name": "Zulip Dev",
                         "realm_icon": "https://secure.gravatar.com/avatar/62429d594b6ffc712f54aee976a18b44?d=identicon",
                         "realm_description": "<p>The Zulip development environment default organization.  It's great for testing!</p>",
+                        "realm_web_public_access_enabled": false,
                         "result": "success",
                         "external_authentication_methods":
                           [

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -4800,6 +4800,7 @@ class FetchAuthBackends(ZulipTestCase):
                     ("zulip_merge_base", check_string),
                     ("zulip_feature_level", check_int),
                     ("push_notifications_enabled", check_bool),
+                    ("realm_web_public_access_enabled", check_bool),
                     ("msg", check_string),
                     ("result", check_string),
                     *extra_fields,

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -959,6 +959,7 @@ def api_get_server_settings(request: HttpRequest) -> HttpResponse:
         "realm_name",
         "realm_icon",
         "realm_description",
+        "realm_web_public_access_enabled",
         "external_authentication_methods",
     ]:
         if context[settings_item] is not None:


### PR DESCRIPTION
Adds `realm_web_public_access_enabled` as a realm-specific server setting potentially returned by the [`/get-server-settings`](https://zulip.com/api/get-server-settings) endpoint so that clients that support browsing of web-public stream content without an account can generate a login page that supports that type of access. See [this CZO chat](https://chat.zulip.org/#narrow/stream/378-api-design/topic/spectators) for more details about the issue.

**Testing plan:** Updated relevant test in `test_auth_backends.py` and OpenAPI documentation for schema testing. Also, tested manually in the dev environment.

**GIFs or screenshots:**
![Screenshot from 2022-02-21 12-01-42](https://user-images.githubusercontent.com/63245456/154949626-e06e11ab-96b3-4f2e-81e4-b2c9ab3acd4a.png)
![Screenshot from 2022-02-21 12-02-01](https://user-images.githubusercontent.com/63245456/154949630-6a56ac67-15da-4a79-8347-8ed30c2fb881.png)
