### PR TITLE
compose: Minor realignment of compose icons.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -552,6 +552,11 @@ input.recipient_box {
         line-height: 18px;
     }
 
+    .fa-eye {
+        position: relative;
+        top: -0.7px;
+    }
+
     .compose_control_menu {
         padding: 0 7px;
         font-size: 15px;
@@ -582,6 +587,8 @@ input.recipient_box {
         font-weight: 600;
         font-family: "Source Sans 3", sans-serif;
         padding: 0 5px;
+        position: relative;
+        top: 0.7px;
     }
 
     .compose_help_button {


### PR DESCRIPTION
before:
<img width="855" alt="Screenshot 2022-02-21 at 5 44 49 PM" src="https://user-images.githubusercontent.com/25124304/154953561-6e4e71e1-b4c7-4ae9-ac90-706e156f258b.png">
after:
<img width="855" alt="Screenshot 2022-02-21 at 5 44 40 PM" src="https://user-images.githubusercontent.com/25124304/154953551-eaeb169a-36d8-411b-8680-f6aaba40ff7a.png">