### PR TITLE
tests: Fix unused `message_id` parameter in tests.

### DIFF
--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -217,7 +217,6 @@ class AlertWordTests(ZulipTestCase):
         result = self.client_patch(
             "/json/messages/" + str(original_message.id),
             {
-                "message_id": original_message.id,
                 "content": "new ALERT for you",
             },
         )
@@ -230,7 +229,6 @@ class AlertWordTests(ZulipTestCase):
         result = self.client_patch(
             "/json/messages/" + str(original_message.id),
             {
-                "message_id": original_message.id,
                 "content": "sorry false alarm",
             },
         )

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -773,9 +773,7 @@ class TestMissedMessages(ZulipTestCase):
 
         hamlet = self.example_user("hamlet")
         self.login("othello")
-        result = self.client_patch(
-            "/json/messages/" + str(msg_id), {"message_id": msg_id, "content": " "}
-        )
+        result = self.client_patch("/json/messages/" + str(msg_id), {"content": " "})
         self.assert_json_success(result)
         handle_missedmessage_emails(hamlet.id, [{"message_id": msg_id}])
         self.assert_length(mail.outbox, 0)
@@ -789,9 +787,7 @@ class TestMissedMessages(ZulipTestCase):
 
         hamlet = self.example_user("hamlet")
         self.login("othello")
-        result = self.client_patch(
-            "/json/messages/" + str(msg_id), {"message_id": msg_id, "content": " "}
-        )
+        result = self.client_patch("/json/messages/" + str(msg_id), {"content": " "})
         self.assert_json_success(result)
         handle_missedmessage_emails(hamlet.id, [{"message_id": msg_id}])
         self.assert_length(mail.outbox, 0)
@@ -809,9 +805,7 @@ class TestMissedMessages(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         iago = self.example_user("iago")
         self.login("othello")
-        result = self.client_patch(
-            "/json/messages/" + str(msg_id), {"message_id": msg_id, "content": " "}
-        )
+        result = self.client_patch("/json/messages/" + str(msg_id), {"content": " "})
         self.assert_json_success(result)
         handle_missedmessage_emails(hamlet.id, [{"message_id": msg_id}])
         self.assert_length(mail.outbox, 0)

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -393,7 +393,6 @@ class PreviewTestCase(ZulipTestCase):
             result = self.client_patch(
                 "/json/messages/" + str(msg_id),
                 {
-                    "message_id": msg_id,
                     "content": url,
                 },
             )
@@ -515,7 +514,6 @@ class PreviewTestCase(ZulipTestCase):
             result = self.client_patch(
                 "/json/messages/" + str(msg_id),
                 {
-                    "message_id": msg_id,
                     "content": edited_url,
                 },
             )

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -2358,7 +2358,6 @@ class MarkdownTest(ZulipTestCase):
             result = self.client_patch(
                 "/json/messages/" + str(msg_id),
                 {
-                    "message_id": msg_id,
                     "content": content,
                 },
             )

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -862,7 +862,7 @@ class EditMessageTest(EditMessageTestCase):
         ) -> None:
             new_topic = "topic" + unique_str
             new_content = "content" + unique_str
-            params_dict = {"message_id": id_, "topic": new_topic}
+            params_dict = {"topic": new_topic}
             if not topic_only:
                 params_dict["content"] = new_content
             result = self.client_patch(f"/json/messages/{id_}", params_dict)
@@ -880,7 +880,7 @@ class EditMessageTest(EditMessageTestCase):
             old_content = message.content
             new_topic = "topic" + unique_str
             new_content = "content" + unique_str
-            params_dict = {"message_id": id_, "topic": new_topic}
+            params_dict = {"topic": new_topic}
             if not topic_only:
                 params_dict["content"] = new_content
             result = self.client_patch(f"/json/messages/{id_}", params_dict)
@@ -948,7 +948,7 @@ class EditMessageTest(EditMessageTestCase):
         def do_edit_message_assert_success(id_: int, unique_str: str, acting_user: str) -> None:
             self.login(acting_user)
             new_topic = "topic" + unique_str
-            params_dict = {"message_id": id_, "topic": new_topic}
+            params_dict = {"topic": new_topic}
             result = self.client_patch(f"/json/messages/{id_}", params_dict)
             self.assert_json_success(result)
             self.check_topic(id_, topic_name=new_topic)
@@ -961,7 +961,7 @@ class EditMessageTest(EditMessageTestCase):
             old_topic = message.topic_name()
             old_content = message.content
             new_topic = "topic" + unique_str
-            params_dict = {"message_id": id_, "topic": new_topic}
+            params_dict = {"topic": new_topic}
             result = self.client_patch(f"/json/messages/{id_}", params_dict)
             message = Message.objects.get(id=id_)
             self.assert_json_error(result, error)

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -15,7 +15,6 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         url = "/json/messages/" + str(message_id)
 
         request = dict(
-            message_id=message_id,
             content=content,
         )
 
@@ -93,7 +92,6 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         url = "/json/messages/" + str(message_id)
 
         request = dict(
-            message_id=message_id,
             content=content,
         )
 

--- a/zerver/tests/test_muting_users.py
+++ b/zerver/tests/test_muting_users.py
@@ -335,7 +335,6 @@ class MutedUsersTests(ZulipTestCase):
             result = self.client_patch(
                 "/json/messages/" + str(message_id),
                 dict(
-                    message_id=message_id,
                     content="@**King Hamlet**",
                 ),
             )
@@ -359,7 +358,6 @@ class MutedUsersTests(ZulipTestCase):
             result = self.client_patch(
                 "/json/messages/" + str(message_id),
                 dict(
-                    message_id=message_id,
                     content="@**King Hamlet**",
                 ),
             )

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -472,7 +472,6 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         result = self.client_patch(
             "/json/messages/" + str(msg_id),
             {
-                "message_id": msg_id,
                 "content": new_body,
             },
         )
@@ -492,7 +491,6 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         result = self.client_patch(
             "/json/messages/" + str(msg_id),
             {
-                "message_id": msg_id,
                 "content": new_body,
             },
         )


### PR DESCRIPTION
Various backend tests use the `PATCH /messages/{msg_id}` endpoint. For that endpoint, the message ID is encoded in the URL path and ignored if provided as a parameter in the the query.

Verified that the tests were providing the same message ID to both the path and then removed the ignored parameter in the query.

Noticed this issue when working on [next steps for implementing `ignored_parameter_unsupported`](https://github.com/zulip/zulip/pull/21010#issuecomment-1030428950) for `json_success` and `JsonableError` and also [this recent commit](https://github.com/zulip/zulip/commit/fc02849865310eebe4ecac7c4170ec97d08ecd8d) that fixed a the same issue in `test_message_edit.py`.
