### PR TITLE
message_feed_UI: Add "copied" confirmation for code blocks.

### DIFF
--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -18,6 +18,7 @@ class Clipboard {
 mock_cjs("clipboard", Clipboard);
 
 const realm_playground = mock_esm("../../static/js/realm_playground");
+const show_copied_confirmation = mock_esm("../../static/js/show_copied_confirmation");
 user_settings.emojiset = "apple";
 
 const rm = zrequire("rendered_markdown");
@@ -434,6 +435,8 @@ run_test("code playground none", ({override, mock_template}) => {
         return undefined;
     });
 
+    override(show_copied_confirmation, "show_copied_confirmation", () => {});
+
     const {prepends, $copy_code, $view_code} = test_code_playground(mock_template, false);
     assert.deepEqual(prepends, [$copy_code]);
     assert_clipboard_setup();
@@ -447,6 +450,8 @@ run_test("code playground single", ({override, mock_template}) => {
         assert.equal(language, "javascript");
         return [{name: "Some Javascript Playground"}];
     });
+
+    override(show_copied_confirmation, "show_copied_confirmation", () => {});
 
     const {prepends, $copy_code, $view_code} = test_code_playground(mock_template, true);
     assert.deepEqual(prepends, [$view_code, $copy_code]);
@@ -465,6 +470,8 @@ run_test("code playground multiple", ({override, mock_template}) => {
         assert.equal(language, "javascript");
         return ["whatever", "whatever"];
     });
+
+    override(show_copied_confirmation, "show_copied_confirmation", () => {});
 
     const {prepends, $copy_code, $view_code} = test_code_playground(mock_template, true);
     assert.deepEqual(prepends, [$view_code, $copy_code]);

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -28,6 +28,7 @@ import {page_params} from "./page_params";
 import * as resize from "./resize";
 import * as rows from "./rows";
 import * as settings_data from "./settings_data";
+import {show_copied_confirmation} from "./show_copied_confirmation";
 import * as stream_bar from "./stream_bar";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
@@ -328,13 +329,9 @@ function create_copy_to_clipboard_handler($row, source, message_id) {
 
     clipboard.on("success", () => {
         end_message_row_edit($row);
-        $row.find(".alert-msg").text($t({defaultMessage: "Copied!"}));
-        $row.find(".alert-msg").css("display", "block");
-        $row.find(".alert-msg").delay(1000).fadeOut(300);
-        if ($(".tooltip").is(":visible")) {
-            $(".tooltip").hide();
-        }
     });
+
+    show_copied_confirmation(source, clipboard);
 }
 
 function edit_message($row, raw_content) {

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -11,6 +11,7 @@ import {$t, $t_html} from "./i18n";
 import * as people from "./people";
 import * as realm_playground from "./realm_playground";
 import * as rtl from "./rtl";
+import {show_copied_confirmation} from "./show_copied_confirmation";
 import * as stream_data from "./stream_data";
 import * as timerender from "./timerender";
 import * as user_groups from "./user_groups";
@@ -227,11 +228,12 @@ export const update_elements = ($content) => {
         }
         const $copy_button = $(copy_code_button());
         $pre.prepend($copy_button);
-        new ClipboardJS($copy_button[0], {
+        const clipboard = new ClipboardJS($copy_button[0], {
             text(copy_element) {
                 return $(copy_element).siblings("code").text();
             },
         });
+        show_copied_confirmation($copy_button[0], clipboard);
     });
 
     // Display emoji (including realm emoji) as text if

--- a/static/js/show_copied_confirmation.js
+++ b/static/js/show_copied_confirmation.js
@@ -1,0 +1,18 @@
+import $ from "jquery";
+
+import {$t} from "./i18n";
+
+export function show_copied_confirmation(copy_button, clipboard) {
+    const $alert_msg = $(copy_button).closest(".message_row").find(".alert-msg");
+    clipboard.on("success", () => {
+        $alert_msg.text($t({defaultMessage: "Copied!"}));
+        $alert_msg.css("display", "block");
+        $alert_msg.addClass("copied");
+        $alert_msg.delay(1000).fadeOut(300, function () {
+            $(this).removeClass("copied");
+        });
+        if ($(".tooltip").is(":visible")) {
+            $(".tooltip").hide();
+        }
+    });
+}

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -895,6 +895,10 @@ td.pointer {
     padding-right: 40px;
     font-weight: 400;
     display: none;
+
+    &.copied {
+        padding-left: 24px;
+    }
 }
 
 .status-time {

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -162,6 +162,7 @@ EXEMPT_FILES = make_set(
         "static/js/settings_ui.js",
         "static/js/settings_users.js",
         "static/js/setup.js",
+        "static/js/show_copied_confirmation.js",
         "static/js/spectators.js",
         "static/js/spoilers.ts",
         "static/js/starred_messages_ui.js",


### PR DESCRIPTION
Shows a floating temporary "copied" confirmation when a user uses the "Copy code" button to copy a code block from a sent message.

The code has been adapted from the `create_copy_to_clipboard_handler` function in `message_edit.js`, so the confirmation looks identical to the one that shows up on viewing a message's source and clicking the "Copy and close" button.

Fixes: #21036.

**Testing plan:** 
Manually tested by clicking on the copy code button for a code block, seeing the confirmation appear, and testing that the code was actually copied to the clipboard (by pasting)

**GIFs or screenshots:** 
https://www.loom.com/share/3604577ed1e74d90a7ec60b70509c748
