### PR TITLE
 help_docs: Document Markdown stream/topic auto-linking feature (update).

### DIFF
--- a/templates/zerver/help/format-your-message-using-markdown.md
+++ b/templates/zerver/help/format-your-message-using-markdown.md
@@ -62,9 +62,11 @@ Numbered lists
 
 ## Links
 
-Zulip auto-linkifies URLs and valid stream names. You can also add a
-[custom linkifier](/help/add-a-custom-linkifier) to link
+Zulip auto-linkifies URLs and [valid stream (and topic) names][link-to-conversation].
+You can also add a [custom linkifier](/help/add-a-custom-linkifier) to link
 patterns like `#1234` to your ticketing system.
+
+[link-to-conversation]: /help/link-to-a-message-or-conversation
 
 ```
 Auto-detected URL: zulip.com

--- a/templates/zerver/help/link-to-a-message-or-conversation.md
+++ b/templates/zerver/help/link-to-a-message-or-conversation.md
@@ -1,10 +1,38 @@
 # Link to a message or conversation
 
-Share permanent links to messages, threads, and streams.  With Zulip,
-it's easy to to link to specific (parts of) conversations from issue
-trackers, documentation, or other external tools.
+Zulip makes it easy to share links to messages, topics, and streams. You can
+link from one Zulip conversation to another, or share links to Zulip conversations
+in issue trackers, emails, or other external tools.
 
-## Link to a stream or topic
+## Link to a stream or topic within Zulip
+
+Zulip automatically creates links to streams and topics in messages you send.
+
+The easiest way to link to a stream or topic is:
+
+{start_tabs}
+
+1. Type `#` followed by the one or more letters of the stream name.
+
+2. Choose the desired stream from the auto-complete menu. The link will be
+   automatically formatted for you.
+
+3. If linking to a topic, type `>` after selecting a stream as described above,
+   followed by one or more letters of the topic name.
+
+4. Choose the desired topic from the auto-complete menu. The link will be
+   automatically formatted for you.
+
+{end_tabs}
+
+Alternately, it is possible to manually format stream and topic links:
+
+```
+Stream: #**stream name**
+Topic: #**stream name>topic name**
+```
+
+## Link to a stream or topic from anywhere
 
 {start_tabs}
 
@@ -21,6 +49,13 @@ trackers, documentation, or other external tools.
 
 ## Link to a specific message
 
+This will copy to your clipboard a permanent link to the message,
+displayed in its thread (i.e. topic view for messages in a stream).
+Viewing a topic via a message link will never mark messages as read.
+
+Zulip uses the same permanent link syntax when [quoting a
+message](/help/quote-and-reply).
+
 {start_tabs}
 
 {!message-actions-menu.md!}
@@ -29,10 +64,8 @@ trackers, documentation, or other external tools.
 
 {end_tabs}
 
-This will copy to your clipboard a permanent link to the message,
-displayed in its thread (i.e. topic view for messages in a stream).
+## Related articles
 
-Viewing a thread via a message link will never mark messages as read.
-
-Zulip uses the same permanent link syntax when [quoting a
-message](/help/quote-and-reply).
+* [Add a custom linkifier](/help/add-a-custom-linkifier)
+* [Format your messages using Markdown](/help/format-your-message-using-markdown)
+* [Linking to Zulip](/help/linking-to-zulip)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Rev on #21168.

Reasoning behind changes:

- Framed the sections in terms of use cases (link from Zulip vs. anywhere).
- Made the language less technical (removed references to Markdown syntax).
- Focused on the auto-complete experience as the primary way to link to stream/topic in Zulip, since it's the most common approach in practice.

**Testing plan:** <!-- How have you tested? -->
manual

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="940" alt="Screen Shot 2022-02-21 at 11 47 35 PM" src="https://user-images.githubusercontent.com/2090066/155086145-4fbf9fe0-f9b6-4f34-8701-f7cf93ee43b2.png">



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
