### PR TITLE
Add limited guest role.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 5.0
 
+**Feature level 122**
+
+* API endpoints that return `role` values can now return `800`, the
+  encoding of the limited guest role.
+
 **Feature level 121**
 
 * [`GET /events`](/api/get-events): Added `message_details` field

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 121
+API_FEATURE_LEVEL = 122
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -347,6 +347,7 @@ def realm_user_count_by_role(realm: Realm) -> Dict[str, Any]:
         str(UserProfile.ROLE_MODERATOR): 0,
         str(UserProfile.ROLE_MEMBER): 0,
         str(UserProfile.ROLE_GUEST): 0,
+        str(UserProfile.ROLE_LIMITED_GUEST): 0,
     }
     for value_dict in list(
         UserProfile.objects.filter(realm=realm, is_bot=False, is_active=True)

--- a/zerver/lib/stream_subscription.py
+++ b/zerver/lib/stream_subscription.py
@@ -40,14 +40,18 @@ def get_active_subscriptions_for_stream_id(
     return query
 
 
-def get_active_subscriptions_for_stream_ids(stream_ids: Set[int]) -> QuerySet:
+def get_active_subscriptions_for_stream_ids(
+    stream_ids: Set[int], *, include_deactivated_users: bool = False
+) -> QuerySet:
     # TODO: Change return type to QuerySet[Subscription]
-    return Subscription.objects.filter(
+    query = Subscription.objects.filter(
         recipient__type=Recipient.STREAM,
         recipient__type_id__in=stream_ids,
         active=True,
-        is_user_active=True,
     )
+    if not include_deactivated_users:
+        query = query.filter(is_user_active=True)
+    return query
 
 
 def get_subscribed_stream_ids_for_user(user_profile: UserProfile) -> QuerySet:

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -444,6 +444,7 @@ Output:
         polonius="polonius@zulip.com",
         desdemona="desdemona@zulip.com",
         shiva="shiva@zulip.com",
+        shylock="shylock@zulip.com",
         webhook_bot="webhook-bot@zulip.com",
         welcome_bot="welcome-bot@zulip.com",
         outgoing_webhook_bot="outgoing-webhook@zulip.com",

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1954,6 +1954,19 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
             self.role = UserProfile.ROLE_MEMBER
 
     @property
+    def is_limited_guest(self) -> bool:
+        return self.role == UserProfile.ROLE_LIMITED_GUEST
+
+    @is_limited_guest.setter
+    def is_limited_guest(self, value: bool) -> None:
+        if value:
+            self.role = UserProfile.ROLE_LIMITED_GUEST
+        elif self.role == UserProfile.ROLE_LIMITED_GUEST:
+            # We need to be careful to not accidentally change
+            # ROLE_REALM_ADMINISTRATOR to ROLE_MEMBER here.
+            self.role = UserProfile.ROLE_MEMBER
+
+    @property
     def is_incoming_webhook(self) -> bool:
         return self.bot_type == UserProfile.INCOMING_WEBHOOK_BOT
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1726,6 +1726,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
     ROLE_MODERATOR = 300
     ROLE_MEMBER = 400
     ROLE_GUEST = 600
+    ROLE_LIMITED_GUEST = 800
     role: int = models.PositiveSmallIntegerField(default=ROLE_MEMBER, db_index=True)
 
     ROLE_TYPES = [
@@ -1831,6 +1832,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
         ROLE_MODERATOR: gettext_lazy("Moderator"),
         ROLE_MEMBER: gettext_lazy("Member"),
         ROLE_GUEST: gettext_lazy("Guest"),
+        ROLE_LIMITED_GUEST: gettext_lazy("Limited guest"),
     }
 
     def get_role_name(self) -> str:
@@ -1927,7 +1929,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
 
     @property
     def is_guest(self) -> bool:
-        return self.role == UserProfile.ROLE_GUEST
+        return self.role == UserProfile.ROLE_GUEST or self.role == UserProfile.ROLE_LIMITED_GUEST
 
     @is_guest.setter
     def is_guest(self, value: bool) -> None:

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -80,11 +80,11 @@ def add_subscriptions(client: Client) -> None:
 
     validate_against_openapi_schema(result, "/users/me/subscriptions", "post", "200")
 
-    ensure_users([26], ["newbie"])
+    ensure_users([27], ["newbie"])
     # {code_example|start}
     # To subscribe other users to a stream, you may pass
     # the `principals` argument, like so:
-    user_id = 26
+    user_id = 27
     result = client.add_subscriptions(
         streams=[
             {"name": "new stream", "description": "New stream for testing"},
@@ -605,13 +605,13 @@ def test_user_not_authorized_error(nonadmin_client: Client) -> None:
 
 @openapi_test_function("/streams/{stream_id}/members:get")
 def get_subscribers(client: Client) -> None:
-    ensure_users([11, 26], ["iago", "newbie"])
+    ensure_users([11, 27], ["iago", "newbie"])
 
     # {code_example|start}
     # Get the subscribers to a stream
     result = client.get_subscribers(stream="new stream")
     # {code_example|end}
-    assert result["subscribers"] == [11, 26]
+    assert result["subscribers"] == [11, 27]
 
 
 def get_user_agent(client: Client) -> None:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6444,6 +6444,7 @@ paths:
                           - 300
                           - 400
                           - 600
+                          - 800
                         description: |
                           [Organization-level role](/help/roles-and-permissions) of the user.
                           Possible values are:
@@ -6453,8 +6454,9 @@ paths:
                           - Organization moderator => 300
                           - Member => 400
                           - Guest => 600
+                          - Limited guest => 800
 
-                          **Changes**: New in Zulip 4.0 (feature level 59).
+                          **Changes**: New in Zulip 4.0 (feature level 59). Limited guest role added in Zulip 5.0 (feature level 122).
                       is_guest:
                         type: boolean
                         description: |
@@ -15299,6 +15301,7 @@ components:
             - 300
             - 400
             - 600
+            - 800
           description: |
             [Organization-level role](/help/roles-and-permissions) of the user.
             Possible values are:
@@ -15308,8 +15311,9 @@ components:
             - Organization moderator => 300
             - Member => 400
             - Guest => 600
+            - Limited guest => 800
 
-            **Changes**: New in Zulip 4.0 (feature level 59).
+            **Changes**: New in Zulip 4.0 (feature level 59). Limited guest role added in Zulip 5.0 (feature level 122).
         bot_type:
           type: integer
           nullable: true

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -131,6 +131,8 @@ class TestRealmAuditLog(ZulipTestCase):
         do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=acting_user)
         do_change_user_role(user_profile, UserProfile.ROLE_MODERATOR, acting_user=acting_user)
         do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=acting_user)
+        do_change_user_role(user_profile, UserProfile.ROLE_LIMITED_GUEST, acting_user=acting_user)
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=acting_user)
         old_values_seen = set()
         new_values_seen = set()
         for event in RealmAuditLog.objects.filter(
@@ -155,6 +157,7 @@ class TestRealmAuditLog(ZulipTestCase):
                 UserProfile.ROLE_REALM_ADMINISTRATOR,
                 UserProfile.ROLE_REALM_OWNER,
                 UserProfile.ROLE_MODERATOR,
+                UserProfile.ROLE_LIMITED_GUEST,
             },
         )
         self.assertEqual(old_values_seen, new_values_seen)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2398,7 +2398,7 @@ class RealmPropertyActionTest(BaseAction):
                 val,
             ]:
                 # email update event is sent for each user.
-                num_events = 11
+                num_events = 12
 
             events = self.verify_action(
                 lambda: do_set_realm_property(

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -384,7 +384,7 @@ class RealmImportExportTest(ExportFile):
 
         # We set up 4 alert words for Hamlet, Cordelia, etc.
         # when we populate the test database.
-        num_zulip_users = 10
+        num_zulip_users = 11
         self.assert_length(exported_alert_words, num_zulip_users * 4)
 
         self.assertIn("robotics", {r["word"] for r in exported_alert_words})

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -538,7 +538,7 @@ class TestExport(ZulipTestCase):
                 call("\033[94mExporting realm\033[0m: zulip"),
                 call("\n\033[94mMessage content:\033[0m\nOutbox emoji for export\n"),
                 call(
-                    "\033[94mNumber of users that reacted outbox:\033[0m 2 / 9 total non-guest users\n"
+                    "\033[94mNumber of users that reacted outbox:\033[0m 2 / 10 total non-guest users\n"
                 ),
             ],
         )

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -87,6 +87,11 @@ class ReactionEmojiTest(ZulipTestCase):
         emojis = ["smile", "tada"]
         expected_emoji_codes = ["1f642", "1f389"]
 
+        # delete the initial reactions created while generating the test database.
+        Reaction.objects.filter(
+            message=Message.objects.get(id=1),
+        ).delete()
+
         for sender, emoji in zip(senders, emojis):
             reaction_info = {
                 "emoji_name": emoji,

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -518,6 +518,9 @@ class TestArchivingReactions(ArchiveMessagesTestingBase):
     def test_archiving_reactions(self) -> None:
         expired_msg_ids = self._make_expired_zulip_messages(2)
 
+        # delete the existing reactions created when generating test database
+        Reaction.objects.filter(message_id__in=expired_msg_ids).delete()
+
         hamlet = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")
 

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -92,6 +92,7 @@ class UserSoftDeactivationTests(ZulipTestCase):
             self.example_user("polonius"),
             self.example_user("desdemona"),
             self.example_user("shiva"),
+            self.example_user("shylock"),
         ]
         client, _ = Client.objects.get_or_create(name="website")
         query = "/some/random/endpoint"
@@ -108,7 +109,7 @@ class UserSoftDeactivationTests(ZulipTestCase):
         filter_kwargs = dict(user_profile__realm=get_realm("zulip"))
         users_to_deactivate = get_users_for_soft_deactivation(-1, filter_kwargs)
 
-        self.assert_length(users_to_deactivate, 10)
+        self.assert_length(users_to_deactivate, 11)
         for user in users_to_deactivate:
             self.assertTrue(user in users)
 
@@ -160,6 +161,7 @@ class UserSoftDeactivationTests(ZulipTestCase):
             self.example_user("polonius"),
             self.example_user("desdemona"),
             self.example_user("shiva"),
+            self.example_user("shylock"),
         ]
         for user_profile in UserProfile.objects.all():
             user_profile.long_term_idle = True
@@ -168,7 +170,7 @@ class UserSoftDeactivationTests(ZulipTestCase):
         filter_kwargs = dict(realm=get_realm("zulip"))
         users_to_catch_up = get_soft_deactivated_users_for_catch_up(filter_kwargs)
 
-        self.assert_length(users_to_catch_up, 10)
+        self.assert_length(users_to_catch_up, 11)
         for user in users_to_catch_up:
             self.assertTrue(user in users)
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4221,7 +4221,7 @@ class SubscriptionAPITest(ZulipTestCase):
         )
 
         self.assertNotIn(self.example_user("polonius").id, add_peer_event["users"])
-        self.assert_length(add_peer_event["users"], 12)
+        self.assert_length(add_peer_event["users"], 13)
         self.assertEqual(add_peer_event["event"]["type"], "subscription")
         self.assertEqual(add_peer_event["event"]["op"], "peer_add")
         self.assertEqual(add_peer_event["event"]["user_ids"], [self.user_profile.id])
@@ -4252,7 +4252,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # We don't send a peer_add event to othello
         self.assertNotIn(user_profile.id, add_peer_event["users"])
         self.assertNotIn(self.example_user("polonius").id, add_peer_event["users"])
-        self.assert_length(add_peer_event["users"], 12)
+        self.assert_length(add_peer_event["users"], 13)
         self.assertEqual(add_peer_event["event"]["type"], "subscription")
         self.assertEqual(add_peer_event["event"]["op"], "peer_add")
         self.assertEqual(add_peer_event["event"]["user_ids"], [user_profile.id])

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -142,6 +142,14 @@ class PermissionTest(ZulipTestCase):
         self.assertEqual(user_profile.is_moderator, False)
         self.assertEqual(user_profile.role, UserProfile.ROLE_MEMBER)
 
+        user_profile.is_limited_guest = True
+        self.assertEqual(user_profile.is_limited_guest, True)
+        self.assertEqual(user_profile.role, UserProfile.ROLE_LIMITED_GUEST)
+
+        user_profile.is_limited_guest = False
+        self.assertEqual(user_profile.is_limited_guest, False)
+        self.assertEqual(user_profile.role, UserProfile.ROLE_MEMBER)
+
     def test_get_admin_users(self) -> None:
         user_profile = self.example_user("hamlet")
         do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -363,6 +363,7 @@ class Command(BaseCommand):
                 ("Polonius", "polonius@zulip.com"),
                 ("Desdemona", "desdemona@zulip.com"),
                 ("शिव", "shiva@zulip.com"),
+                ("Shylock", "shylock@zulip.com"),
             ]
 
             # For testing really large batches:
@@ -538,6 +539,9 @@ class Command(BaseCommand):
             polonius = get_user_by_delivery_email("polonius@zulip.com", zulip_realm)
             do_change_user_role(polonius, UserProfile.ROLE_GUEST, acting_user=None)
 
+            shylock = get_user_by_delivery_email("shylock@zulip.com", zulip_realm)
+            do_change_user_role(shylock, UserProfile.ROLE_LIMITED_GUEST, acting_user=None)
+
             # These bots are directly referenced from code and thus
             # are needed for the test suite.
             zulip_realm_bots = [
@@ -644,6 +648,7 @@ class Command(BaseCommand):
                         signups_stream,
                     ],
                     "shiva@zulip.com": ["Verona", "Denmark", "Scotland"],
+                    "shylock@zulip.com": ["Scotland", "Rome"],
                 }
 
                 for profile in profiles:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds limited guest role and `accessible_user_dicts` function which will be used to get only accessible users for limited guest users.
- First commit adds limited_guest role value of 800 to the UserProfile model.
- Second commit adds `is_limited_guest`.
- Third commit is for including limited guests in the count returned by `realm_user_count_by_role`.
- Fourth commit adds a limited guest user in development and test database.
- Fifth and sixth commit are for adding helper functions to get accessible user dicts.

Related issue - #10970.
 <!-- How have you tested? -->

<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
