### PR TITLE
ci: Ban check-database-compatibility.py from using static/generated

### DIFF
--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -139,6 +139,13 @@ jobs:
           ./tools/setup/optimize-svg --check
           ./tools/setup/generate_integration_bots_avatars.py --check-missing
 
+          # Ban check-database-compatibility.py from transitively
+          # relying on static/generated, because it might not be
+          # up-to-date at that point in upgrade-zulip-stage-2.
+          chmod 000 static/generated
+          ./scripts/lib/check-database-compatibility.py
+          chmod 755 static/generated
+
       - name: Run documentation and api tests
         run: |
           source tools/ci/activate-venv

--- a/zerver/migrations/0206_stream_rendered_description.py
+++ b/zerver/migrations/0206_stream_rendered_description.py
@@ -2,10 +2,11 @@ from django.db import migrations, models
 from django.db.backends.postgresql.schema import DatabaseSchemaEditor
 from django.db.migrations.state import StateApps
 
-from zerver.lib.streams import render_stream_description
-
 
 def render_all_stream_descriptions(apps: StateApps, schema_editor: DatabaseSchemaEditor) -> None:
+    # FIXME: Application code should not be imported from migrations.
+    from zerver.lib.streams import render_stream_description
+
     Stream = apps.get_model("zerver", "Stream")
     all_streams = Stream.objects.exclude(description="")
     for stream in all_streams:

--- a/zerver/signals.py
+++ b/zerver/signals.py
@@ -9,7 +9,6 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
 from confirmation.models import one_click_unsubscribe_link
-from zerver.lib.actions import do_set_zoom_token
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.send_email import FromAddress
 from zerver.models import UserProfile
@@ -107,5 +106,8 @@ def email_on_new_login(sender: Any, user: UserProfile, request: Any, **kwargs: A
 def clear_zoom_token_on_logout(
     sender: object, *, user: Optional[UserProfile], **kwargs: object
 ) -> None:
+    # Loaded lazily so django.setup() succeeds before static asset generation
+    from zerver.lib.actions import do_set_zoom_token
+
     if user is not None and user.zoom_token is not None:
         do_set_zoom_token(user, None)


### PR DESCRIPTION
**Testing plan:** [Failed run](https://github.com/zulip/zulip/actions/runs/1885218437) from the new CI check without the import fixes.