### PR TITLE
widgets: Indent multiple line todos to have same alignment as one-line todos.

### DIFF
--- a/static/styles/widgets.css
+++ b/static/styles/widgets.css
@@ -24,6 +24,11 @@
     input.add-desc {
         margin-left: 2px;
     }
+
+    /* Arrange that a multi-line description line wraps properly. */
+    label.checkbox {
+        display: flex;
+    }
 }
 
 .todo-widget,

--- a/static/templates/widgets/todo_widget_tasks.hbs
+++ b/static/templates/widgets/todo_widget_tasks.hbs
@@ -2,9 +2,13 @@
 {{#each pending_tasks}}
     <li>
         <label class="checkbox">
-            <input type="checkbox" class="task" data-key="{{ key }}" />
-            <span></span>
-            <strong>{{ task }}</strong>{{#if desc }} - {{ desc }}{{/if}}
+            <div>
+                <input type="checkbox" class="task" data-key="{{ key }}" />
+                <span></span>
+            </div>
+            <div>
+                <strong>{{ task }}</strong>{{#if desc }} - {{ desc }}{{/if}}
+            </div>
         </label>
 
     </li>
@@ -12,8 +16,10 @@
 {{#each completed_tasks}}
     <li>
         <label class="checkbox">
-            <input type="checkbox" class="task" data-key="{{ key }}" checked="checked"/>
-            <span></span>
+            <div>
+                <input type="checkbox" class="task" data-key="{{ key }}" checked="checked"/>
+                <span></span>
+            </div>
             <strike><em><strong>{{ task }}</strong>{{#if desc }} - {{ desc }}{{/if}}</em></strike>
         </label>
     </li>


### PR DESCRIPTION
Fixed the indentation in `/todo` widgets for the issue #20523 
Screenshots:

![Screenshot from 2022-02-24 00-47-07](https://user-images.githubusercontent.com/52635773/155395681-a65ad969-08b5-445a-9214-31fbe3909dc3.png)
![Screenshot from 2022-02-24 00-47-29](https://user-images.githubusercontent.com/52635773/155395717-b99376b1-4dba-4639-b70b-143d332cc5f9.png)
