### PR TITLE
lightbox: Remove Pan/Zoom enable button.

### DIFF
--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -217,8 +217,10 @@ function display_image(payload) {
     img.src = payload.source;
     img_container.html(img).show();
 
-    $(".image-description .title").text(payload.title || "N/A");
-    $(".image-description .user").text(payload.user);
+    $(".image-description .title")
+        .text(payload.title || "N/A")
+        .prop("title", payload.title || "N/A");
+    $(".image-description .user").text(payload.user).prop("title", payload.user);
 
     $(".image-actions .open, .image-actions .download").attr("href", payload.source);
 }

--- a/static/styles/lightbox.css
+++ b/static/styles/lightbox.css
@@ -16,26 +16,9 @@
         background-position: center center;
 
         img {
+            cursor: move;
             max-height: 100%;
             max-width: 100%;
-
-            background-color: hsl(0, 0%, 100%);
-            background-image: linear-gradient(
-                    45deg,
-                    hsl(0, 0%, 80%) 25%,
-                    transparent 25%
-                ),
-                linear-gradient(135deg, hsl(0, 0%, 80%) 25%, transparent 25%),
-                linear-gradient(45deg, transparent 75%, hsl(0, 0%, 80%) 75%),
-                linear-gradient(135deg, transparent 75%, hsl(0, 0%, 80%) 75%);
-
-            background-size: 20px 20px;
-
-            background-position: 0 0, 50px 0, 50px -50px, 0 50px;
-        }
-
-        canvas {
-            cursor: pointer;
         }
 
         .zoom-element {
@@ -83,54 +66,6 @@
         flex-shrink: 0;
         margin-left: auto;
 
-        .lightbox-canvas-trigger {
-            display: inline-block;
-            vertical-align: top;
-
-            min-width: 75px;
-
-            margin: 0;
-            margin-right: 5px;
-            padding: 0 5px;
-
-            border-radius: 4px;
-
-            border: 1px solid hsla(0, 0%, 100%, 0.6);
-
-            text-align: center;
-            color: hsl(0, 0%, 100%);
-
-            cursor: pointer;
-
-            transition: all 0.3s ease;
-
-            &:hover {
-                background-color: hsl(0, 0%, 100%);
-                border: 1px solid hsl(0, 0%, 100%);
-                color: hsl(227, 40%, 16%);
-                opacity: 1;
-            }
-
-            .status {
-                margin-top: -7px;
-
-                &::after {
-                    content: attr(data-disabled);
-                    text-transform: uppercase;
-
-                    opacity: 0.7;
-                }
-            }
-
-            &.enabled .status::after {
-                content: attr(data-enabled);
-            }
-
-            .title {
-                font-weight: 600;
-            }
-        }
-
         .button {
             font-size: 0.9rem;
             min-width: inherit;
@@ -149,12 +84,23 @@
                 color: hsl(227, 40%, 16%);
             }
         }
+
+        .disabled {
+            opacity: 0.7;
+            cursor: default;
+
+            &:hover {
+                background-color: transparent;
+                color: hsl(0, 0%, 100%);
+                border: 1px solid hsla(0, 0%, 100%, 0.6);
+            }
+        }
     }
 
     .image-description {
         display: flex;
         flex-direction: column;
-        max-width: calc(100% - 350px);
+        max-width: calc(100% - 400px);
         /* add some extra margin top and remove some bottom to keep the
         height the same. and vertically center the text with the buttons. */
         margin-top: 25px;
@@ -175,7 +121,6 @@
         }
 
         .user {
-            max-width: 200px;
             font-weight: 300;
             line-height: normal;
             text-overflow: ellipsis;

--- a/static/styles/lightbox.css
+++ b/static/styles/lightbox.css
@@ -48,11 +48,11 @@
     }
 
     .exit {
-        float: right;
+        flex-shrink: 0;
 
         color: hsla(0, 0%, 100%, 0.8);
         font-size: 2rem;
-        margin: 11px 20px 0 0;
+        margin: 6px 20px 0 0;
 
         transform: scaleY(0.75);
         font-weight: 300;
@@ -70,16 +70,18 @@
 
     .image-info-wrapper {
         background-color: transparent;
+        display: flex;
+        flex-flow: row wrap;
     }
 
     .image-description,
     .image-actions {
-        float: left;
         margin: 20px;
     }
 
     .image-actions {
-        float: right;
+        flex-shrink: 0;
+        margin-left: auto;
 
         .lightbox-canvas-trigger {
             display: inline-block;
@@ -150,21 +152,21 @@
     }
 
     .image-description {
+        display: flex;
+        flex-direction: column;
+        max-width: calc(100% - 350px);
         /* add some extra margin top and remove some bottom to keep the
         height the same. and vertically center the text with the buttons. */
         margin-top: 25px;
         margin-bottom: 15px;
 
-        font-size: 1.3rem;
+        font-size: 1.1rem;
         color: hsl(0, 0%, 100%);
 
         .title {
-            display: inline-block;
             vertical-align: top;
-
             font-weight: 400;
             line-height: normal;
-            max-width: calc(100% - 110px);
 
             /* Required for text-overflow */
             white-space: nowrap;
@@ -174,8 +176,6 @@
 
         .user {
             max-width: 200px;
-            display: inline-block;
-            vertical-align: top;
             font-weight: 300;
             line-height: normal;
             text-overflow: ellipsis;
@@ -262,7 +262,8 @@
 @media only screen and ($ms_min <= width < $md_min) {
     #lightbox_overlay {
         .image-actions {
-            float: left;
+            width: 100%;
+            padding-left: 15px;
             margin-top: 0;
         }
 
@@ -272,10 +273,6 @@
             overflow: hidden;
             text-overflow: ellipsis;
             margin-bottom: 5px;
-
-            .title {
-                max-width: calc(100% - 70px);
-            }
         }
 
         .center .image-list {
@@ -290,7 +287,17 @@
         }
 
         .image-preview {
-            height: calc(100% - 101px - 95px);
+            height: calc(100% - 101px - 104px);
+        }
+
+        .image-info-wrapper {
+            align-items: flex-end;
+        }
+
+        .exit {
+            position: absolute;
+            right: 5px;
+            top: 6px;
         }
     }
 }

--- a/static/templates/lightbox_overlay.hbs
+++ b/static/templates/lightbox_overlay.hbs
@@ -4,7 +4,6 @@
             <div class="title"></div>
             <div class="user"></div>
         </div>
-        <div class="exit" aria-label="{{t 'Close' }}"><span aria-hidden="true">x</span></div>
         <div class="image-actions">
             <div class="lightbox-canvas-trigger">
                 <div class="title">{{t "Pan & zoom" }}</div>
@@ -13,7 +12,7 @@
             <a class="button small open" rel="noopener noreferrer" target="_blank">{{t "Open" }}</a>
             <a class="button small download" download>{{t "Download" }}</a>
         </div>
-        <div class="clear-float"></div>
+        <div class="exit" aria-label="{{t 'Close' }}"><span aria-hidden="true">x</span></div>
     </div>
 
     <div class="image-preview no-select">

--- a/static/templates/lightbox_overlay.hbs
+++ b/static/templates/lightbox_overlay.hbs
@@ -5,10 +5,7 @@
             <div class="user"></div>
         </div>
         <div class="image-actions">
-            <div class="lightbox-canvas-trigger">
-                <div class="title">{{t "Pan & zoom" }}</div>
-                <div class="status" data-disabled="{{t 'Disabled' }}" data-enabled="{{t 'Enabled' }}"></div>
-            </div>
+            <a class="button small lightbox-zoom-reset disabled">{{t "Reset zoom" }}</a>
             <a class="button small open" rel="noopener noreferrer" target="_blank">{{t "Open" }}</a>
             <a class="button small download" download>{{t "Download" }}</a>
         </div>


### PR DESCRIPTION
With the recent changes to lightbox image handling in #21145 and #20788
it is no longer necessary to have panning and zooming disabled by
default. This commit removes the enable/disable button and instead
replaces it with a "Reset Image" button, and enables panning and zooming
as the default state of the lightbox.
