### PR TITLE
tests: Remove unnecessary params from backend tests.

### DIFF
--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1008,7 +1008,6 @@ class DeactivatedRealmTest(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "test suite",
                 "to": self.example_email("othello"),
             },
         )
@@ -1026,7 +1025,6 @@ class DeactivatedRealmTest(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "test suite",
                 "to": self.example_email("othello"),
             },
         )
@@ -1040,7 +1038,6 @@ class DeactivatedRealmTest(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "test suite",
                 "to": self.example_email("othello"),
             },
         )
@@ -1161,7 +1158,6 @@ class InactiveUserTest(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "test suite",
                 "to": self.example_email("othello"),
             },
         )
@@ -1177,7 +1173,6 @@ class InactiveUserTest(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "test suite",
                 "to": self.example_email("othello"),
             },
         )
@@ -1189,7 +1184,6 @@ class InactiveUserTest(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "test suite",
                 "to": self.example_email("othello"),
             },
         )
@@ -1291,7 +1285,6 @@ class TestIncomingWebhookBot(ZulipTestCase):
         payload = dict(
             type="private",
             content="Test message",
-            client="test suite",
             to=othello.email,
         )
 

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -850,7 +850,6 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
             {
                 "type": "private",
                 "content": "test_receive_missed_message_email_messages",
-                "client": "test suite",
                 "to": orjson.dumps([othello.id]).decode(),
             },
         )
@@ -895,7 +894,6 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
             {
                 "type": "private",
                 "content": "test_receive_missed_message_email_messages",
-                "client": "test suite",
                 "to": orjson.dumps([cordelia.id, iago.id]).decode(),
             },
         )
@@ -949,7 +947,6 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
                 "type": "stream",
                 "topic": "test topic",
                 "content": "test_receive_missed_stream_message_email_messages",
-                "client": "test suite",
                 "to": "Denmark",
             },
         )
@@ -989,7 +986,6 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
                 "type": "stream",
                 "topic": "test topic",
                 "content": "test_receive_email_response_for_auth_failures",
-                "client": "test suite",
                 "to": "announce",
             },
         )
@@ -1034,7 +1030,6 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
                 "type": "stream",
                 "topic": "test topic",
                 "content": "test_receive_missed_stream_message_email_messages",
-                "client": "test suite",
                 "to": "Denmark",
             },
         )
@@ -1080,7 +1075,6 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
                 "type": "stream",
                 "topic": "test topic",
                 "content": "test_receive_missed_stream_message_email_messages",
-                "client": "test suite",
                 "to": "Denmark",
             },
         )
@@ -1117,7 +1111,6 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
                 "type": "stream",
                 "topic": "test topic",
                 "content": "test_receive_missed_stream_message_email_messages",
-                "client": "test suite",
                 "to": "Denmark",
             },
         )
@@ -1155,7 +1148,6 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
                 "type": "stream",
                 "topic": "test topic",
                 "content": "test_receive_missed_stream_message_email_messages",
-                "client": "test suite",
                 "to": "Denmark",
             },
         )
@@ -1188,7 +1180,6 @@ class TestEmptyGatewaySetting(ZulipTestCase):
         payload = dict(
             type="private",
             content="test_receive_missed_message_email_messages",
-            client="test suite",
             to=orjson.dumps([cordelia.id, iago.id]).decode(),
         )
         result = self.client_post("/json/messages", payload)
@@ -1358,7 +1349,6 @@ class TestEmailMirrorTornadoView(ZulipTestCase):
             {
                 "type": "private",
                 "content": "test_receive_missed_message_email_messages",
-                "client": "test suite",
                 "to": orjson.dumps([cordelia.id, iago.id]).decode(),
             },
         )
@@ -1624,7 +1614,6 @@ class TestEmailMirrorLogAndReport(ZulipTestCase):
             {
                 "type": "private",
                 "content": "test_redact_email_message",
-                "client": "test suite",
                 "to": orjson.dumps([cordelia.email, iago.email]).decode(),
             },
         )

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -380,7 +380,6 @@ class TestMissedMessages(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "website",
                 "to": hamlet.email,
             },
         )

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -116,7 +116,6 @@ class RateLimitTests(ZulipTestCase):
             {
                 "type": "stream",
                 "to": "Verona",
-                "client": "test suite",
                 "content": content,
                 "topic": "whatever",
             },

--- a/zerver/tests/test_legacy_subject.py
+++ b/zerver/tests/test_legacy_subject.py
@@ -8,7 +8,6 @@ class LegacySubjectTest(ZulipTestCase):
         payload = dict(
             type="stream",
             to="Verona",
-            client="test suite",
             content="Test message",
         )
 

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -543,7 +543,6 @@ class PushNotificationMarkReadFlowsTest(ZulipTestCase):
             "/json/mark_stream_as_read",
             {
                 "stream_id": str(stream.id),
-                "topic_name": "test_topic",
             },
         )
         self.assertEqual(self.get_mobile_push_notification_ids(user_profile), [third_message_id])

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -91,7 +91,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "stream",
                 "to": "Verona",
-                "client": "test suite",
                 "content": "Test message",
                 "topic": "Test topic",
             },
@@ -109,7 +108,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "stream",
                 "to": "Verona",
-                "client": "test suite",
                 "content": "Test message",
                 "topic": "Test topic",
             },
@@ -128,7 +126,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "stream",
                 "to": orjson.dumps([99999]).decode(),
-                "client": "test suite",
                 "content": "Stream message by ID.",
                 "topic": "Test topic for stream ID message",
             },
@@ -155,7 +152,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "stream",
                 "to": orjson.dumps([stream.id]).decode(),
-                "client": "test suite",
                 "content": "Stream message by ID.",
                 "topic": "Test topic for stream ID message",
             },
@@ -458,7 +454,6 @@ class MessagePOSTTest(ZulipTestCase):
             "/api/v1/messages",
             {
                 "type": "stream",
-                "client": "test suite",
                 "content": "Test message no to",
                 "topic": "Test topic",
             },
@@ -480,7 +475,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "stream",
                 "to": "nonexistent_stream",
-                "client": "test suite",
                 "content": "Test message",
                 "topic": "Test topic",
             },
@@ -498,7 +492,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "stream",
                 "to": """&<"'><non-existent>""",
-                "client": "test suite",
                 "content": "Test message",
                 "topic": "Test topic",
             },
@@ -519,7 +512,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "test suite",
                 "to": othello.email,
             },
         )
@@ -539,7 +531,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "test suite",
                 "to": user_profile.email,
             },
         )
@@ -569,7 +560,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "test suite",
                 "to": orjson.dumps([self.example_user("othello").id]).decode(),
             },
         )
@@ -589,7 +579,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "test suite",
                 "to": orjson.dumps(
                     [self.example_user("othello").id, self.example_user("cordelia").id]
                 ).decode(),
@@ -623,7 +612,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "test suite",
                 "to": orjson.dumps([hamlet.id, othello.id]).decode(),
             },
         )
@@ -642,7 +630,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "test suite",
                 "to": "nonexistent",
             },
         )
@@ -662,7 +649,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "test suite",
                 "to": orjson.dumps([othello.id]).decode(),
             },
         )
@@ -673,7 +659,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "client": "test suite",
                 "to": orjson.dumps([othello.id, cordelia.id]).decode(),
             },
         )
@@ -690,7 +675,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "invalid type",
                 "content": "Test message",
-                "client": "test suite",
                 "to": othello.email,
             },
         )
@@ -704,7 +688,7 @@ class MessagePOSTTest(ZulipTestCase):
         othello = self.example_user("othello")
         result = self.client_post(
             "/json/messages",
-            {"type": "private", "content": " ", "client": "test suite", "to": othello.email},
+            {"type": "private", "content": " ", "to": othello.email},
         )
         self.assert_json_error(result, "Message must not be empty")
 
@@ -718,7 +702,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "stream",
                 "to": "Verona",
-                "client": "test suite",
                 "content": "Test message",
                 "topic": "",
             },
@@ -732,7 +715,7 @@ class MessagePOSTTest(ZulipTestCase):
         self.login("hamlet")
         result = self.client_post(
             "/json/messages",
-            {"type": "stream", "to": "Verona", "client": "test suite", "content": "Test message"},
+            {"type": "stream", "to": "Verona", "content": "Test message"},
         )
         self.assert_json_error(result, "Missing topic")
 
@@ -747,7 +730,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "stream",
                 "to": "Verona",
-                "client": "test suite",
                 "topic": "Test\n\rTopic",
                 "content": "Test message",
             },
@@ -760,7 +742,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "stream",
                 "to": "Verona",
-                "client": "test suite",
                 "topic": "Test\uFFFETopic",
                 "content": "Test message",
             },
@@ -777,7 +758,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "invalid",
                 "to": "Verona",
-                "client": "test suite",
                 "content": "Test message",
                 "topic": "Test topic",
             },
@@ -791,7 +771,7 @@ class MessagePOSTTest(ZulipTestCase):
         self.login("hamlet")
         result = self.client_post(
             "/json/messages",
-            {"type": "private", "content": "Test content", "client": "test suite", "to": ""},
+            {"type": "private", "content": "Test content", "to": ""},
         )
         self.assert_json_error(result, "Message must have recipients")
 
@@ -912,7 +892,6 @@ class MessagePOSTTest(ZulipTestCase):
         post_data = {
             "type": "stream",
             "to": "Verona",
-            "client": "test suite",
             "content": "  I like null bytes \x00 in my content",
             "topic": "Test topic",
         }
@@ -927,7 +906,6 @@ class MessagePOSTTest(ZulipTestCase):
         post_data = {
             "type": "stream",
             "to": "Verona",
-            "client": "test suite",
             "content": "  I like whitespace at the end! \n\n \n",
             "topic": "Test topic",
         }
@@ -940,7 +918,6 @@ class MessagePOSTTest(ZulipTestCase):
         post_data = {
             "type": "stream",
             "to": "Verona",
-            "client": "test suite",
             "content": "\nAvoid the new line at the beginning of the message.",
             "topic": "Test topic",
         }
@@ -963,7 +940,6 @@ class MessagePOSTTest(ZulipTestCase):
         post_data = {
             "type": "stream",
             "to": "Verona",
-            "client": "test suite",
             "content": long_message,
             "topic": "Test topic",
         }
@@ -985,7 +961,6 @@ class MessagePOSTTest(ZulipTestCase):
         post_data = {
             "type": "stream",
             "to": "Verona",
-            "client": "test suite",
             "content": "test content",
             "topic": long_topic,
         }
@@ -1002,7 +977,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "stream",
                 "to": "Verona",
-                "client": "test suite",
                 "content": "Test message",
                 "topic": "Test topic",
                 "forged": "true",
@@ -1017,7 +991,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "stream",
                 "to": "Verona",
-                "client": "test suite",
                 "content": "Test message",
                 "topic": "Test topic",
                 "realm_str": "mit",
@@ -1035,7 +1008,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "stream",
                 "to": "Verona",
-                "client": "test suite",
                 "content": "Test message",
                 "topic": "Test topic",
                 "realm_str": "non-existing",
@@ -1051,7 +1023,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "stream",
                 "to": "Verona",
-                "client": "test suite",
                 "content": "Test message",
                 "topic": "Test topic",
                 "realm_str": zephyr_realm.string_id,
@@ -1306,7 +1277,6 @@ class MessagePOSTTest(ZulipTestCase):
         payload = dict(
             type="stream",
             to=stream_name,
-            client="test suite",
             topic="whatever",
             content="whatever",
         )
@@ -1333,7 +1303,6 @@ class MessagePOSTTest(ZulipTestCase):
             {
                 "type": "stream",
                 "to": "notify_channel",
-                "client": "test suite",
                 "content": "Test message",
                 "topic": "Test topic",
             },
@@ -1355,7 +1324,6 @@ class MessagePOSTTest(ZulipTestCase):
         payload = dict(
             type="stream",
             to=stream_name,
-            client="test suite",
             topic="whatever",
             content="whatever",
         )
@@ -1393,7 +1361,6 @@ class ScheduledMessageTest(ZulipTestCase):
         payload = {
             "type": msg_type,
             "to": to,
-            "client": "test suite",
             "content": msg,
             "topic": topic_name,
             "realm_str": realm_str,

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -445,7 +445,6 @@ class StreamAdminTest(ZulipTestCase):
 
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         params = {
-            "stream_name": orjson.dumps("private_stream_1").decode(),
             "is_private": orjson.dumps(False).decode(),
         }
         stream_id = get_stream("private_stream_1", user_profile.realm).id
@@ -457,7 +456,6 @@ class StreamAdminTest(ZulipTestCase):
 
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         params = {
-            "stream_name": orjson.dumps("private_stream_1").decode(),
             "is_private": orjson.dumps(False).decode(),
         }
         result = self.client_patch(f"/json/streams/{stream_id}", params)
@@ -508,7 +506,6 @@ class StreamAdminTest(ZulipTestCase):
 
         do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         params = {
-            "stream_name": orjson.dumps("private_stream_2").decode(),
             "is_private": orjson.dumps(False).decode(),
         }
         stream = self.subscribe(user_profile, "private_stream_2")
@@ -579,7 +576,6 @@ class StreamAdminTest(ZulipTestCase):
 
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         params = {
-            "stream_name": orjson.dumps("public_stream_1").decode(),
             "is_private": orjson.dumps(True).decode(),
         }
         stream_id = self.subscribe(user_profile, "public_stream_1").id
@@ -630,7 +626,6 @@ class StreamAdminTest(ZulipTestCase):
         default_stream = self.make_stream("default_stream", realm=realm)
         do_add_default_stream(default_stream)
         params = {
-            "stream_name": orjson.dumps("default_stream").decode(),
             "is_private": orjson.dumps(True).decode(),
         }
         result = self.client_patch(f"/json/streams/{default_stream.id}", params)
@@ -639,7 +634,6 @@ class StreamAdminTest(ZulipTestCase):
 
         do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         params = {
-            "stream_name": orjson.dumps("public_stream_2").decode(),
             "is_private": orjson.dumps(True).decode(),
         }
         stream = self.subscribe(user_profile, "public_stream_2")
@@ -757,7 +751,6 @@ class StreamAdminTest(ZulipTestCase):
 
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         params = {
-            "stream_name": orjson.dumps("target_stream").decode(),
             "is_private": orjson.dumps(False).decode(),
         }
         stream_id = get_stream("target_stream", realm).id
@@ -798,7 +791,6 @@ class StreamAdminTest(ZulipTestCase):
 
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         params = {
-            "stream_name": orjson.dumps("public_history_stream").decode(),
             "is_private": orjson.dumps(True).decode(),
             "history_public_to_subscribers": orjson.dumps(True).decode(),
         }
@@ -840,7 +832,6 @@ class StreamAdminTest(ZulipTestCase):
             history_public_to_subscribers=False,
         )
         params = {
-            "stream_name": orjson.dumps("public_protected_stream").decode(),
             "is_private": orjson.dumps(True).decode(),
             "history_public_to_subscribers": orjson.dumps(True).decode(),
         }
@@ -881,7 +872,6 @@ class StreamAdminTest(ZulipTestCase):
         stream_id = self.subscribe(user_profile, "test_stream").id
 
         params = {
-            "stream_name": orjson.dumps("test_stream").decode(),
             "is_web_public": orjson.dumps(True).decode(),
             "history_public_to_subscribers": orjson.dumps(True).decode(),
         }
@@ -911,7 +901,6 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_json_error(result, "Web-public streams are not enabled.")
 
         bad_params = {
-            "stream_name": orjson.dumps("test_stream").decode(),
             "is_web_public": orjson.dumps(True).decode(),
             "is_private": orjson.dumps(True).decode(),
             "history_public_to_subscribers": orjson.dumps(True).decode(),
@@ -920,7 +909,6 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_json_error(result, "Invalid parameters")
 
         bad_params = {
-            "stream_name": orjson.dumps("test_stream").decode(),
             "is_web_public": orjson.dumps(True).decode(),
             "is_private": orjson.dumps(False).decode(),
             "history_public_to_subscribers": orjson.dumps(False).decode(),
@@ -969,7 +957,6 @@ class StreamAdminTest(ZulipTestCase):
 
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         params = {
-            "stream_name": orjson.dumps("public_stream").decode(),
             "is_private": orjson.dumps(False).decode(),
             "history_public_to_subscribers": orjson.dumps(False).decode(),
         }
@@ -1415,7 +1402,6 @@ class StreamAdminTest(ZulipTestCase):
         result = self.client_patch(
             f"/json/streams/{stream_id}",
             {
-                "stream_name": orjson.dumps("private_stream").decode(),
                 "is_private": orjson.dumps(True).decode(),
             },
         )
@@ -1448,7 +1434,6 @@ class StreamAdminTest(ZulipTestCase):
         result = self.client_patch(
             f"/json/streams/{stream_id}",
             {
-                "stream_name": "private_stream_1",
                 "is_private": orjson.dumps(True).decode(),
             },
         )

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -302,7 +302,6 @@ class UserGroupAPITestCase(UserGroupTestCase):
         payload = dict(
             type="stream",
             to=stream_name,
-            client="test suite",
             topic="whatever",
             content=content_with_group_mention,
         )

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -65,7 +65,6 @@ class WidgetContentTestCase(ZulipTestCase):
         payload = dict(
             type="stream",
             to=stream_name,
-            client="test suite",
             topic="whatever",
             content="whatever",
         )
@@ -122,7 +121,6 @@ class WidgetContentTestCase(ZulipTestCase):
         payload = dict(
             type="stream",
             to=stream_name,
-            client="test suite",
             topic="whatever",
             content=content,
             widget_content=orjson.dumps(widget_content).decode(),
@@ -153,7 +151,6 @@ class WidgetContentTestCase(ZulipTestCase):
         payload = dict(
             type="stream",
             to=stream_name,
-            client="test suite",
             topic="whatever",
             content=content,
         )
@@ -182,7 +179,6 @@ class WidgetContentTestCase(ZulipTestCase):
         payload = dict(
             type="stream",
             to=stream_name,
-            client="test suite",
             topic="whatever",
             content=content,
         )
@@ -234,7 +230,6 @@ class WidgetContentTestCase(ZulipTestCase):
         payload = dict(
             type="stream",
             to=stream_name,
-            client="test suite",
             topic="whatever",
             content=content,
         )
@@ -263,7 +258,6 @@ class WidgetContentTestCase(ZulipTestCase):
         payload = dict(
             type="stream",
             to=stream_name,
-            client="test suite",
             topic="whatever",
             content=content,
         )
@@ -322,7 +316,6 @@ class WidgetContentTestCase(ZulipTestCase):
         payload = dict(
             type="stream",
             to=stream_name,
-            client="test suite",
             topic="whatever",
             content=content,
         )
@@ -380,7 +373,6 @@ class WidgetContentTestCase(ZulipTestCase):
         payload = dict(
             type="stream",
             to=stream_name,
-            client="test suite",
             topic="whatever",
             content=content,
         )


### PR DESCRIPTION
While reviewing existing backend tests for adding an `ignored_parameters_unsupported` array to `json_success` and `JsonableError` responses, I found a few instances of parameters being passed to endpoints that are either ignored or not parsed using the current `REQ` framework:
- **1st commit**: `topic_name` being passed as a parameter to a test for [marking unread messages in stream as read](https://zulip.com/api/mark-stream-as-read). Possibly a copy and paste error.
- **2nd commit**: `stream_name` being passed as a parameter to tests for [updating a stream](https://zulip.com/api/update-stream), which has the stream id encoded in the URL. Confirmed that the `stream_name` parameter being removed matches the stream that's referenced by id in the URL.
- **3rd commit**: `client` being passed as a parameter for tests using the [`POST /messages` endpoint](https://zulip.com/api/send-message) that can use the default client, which is set from the `User-Agent` string in the Http header that is set (either to ZulipMobile for API tests and a browser user agent string for other test) by the mock request. See [this CZO chat](https://chat.zulip.org/#narrow/stream/3-backend/topic/tests.20with.20client.20parameter) for more context. In all of these tests, `client` was being set to either "test suite" or, in one case, "website'.