### PR TITLE
install: Support Ubuntu 22.04

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -114,6 +114,11 @@ jobs:
             os: focal
             extra_args: ""
 
+          - docker_image: zulip/ci:jammy
+            name: Ubuntu 22.04 production install
+            os: jammy
+            extra_args: ""
+
           - docker_image: zulip/ci:buster
             name: Debian 10 production install with custom db name and user
             os: buster

--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -27,13 +27,16 @@ jobs:
           - docker_image: zulip/ci:focal
             name: Ubuntu 20.04 Focal (Python 3.8, backend)
             os: focal
-            is_focal: true
             include_frontend_tests: false
           # Debian 11 ships with Python 3.9.2.
           - docker_image: zulip/ci:bullseye
             name: Debian 11 Bullseye (Python 3.9, backend)
             os: bullseye
-            is_bullseye: true
+            include_frontend_tests: false
+          # Ubuntu 22.04 ships with Python 3.9.10.
+          - docker_image: zulip/ci:jammy
+            name: Ubuntu 22.04 Jammy (Python 3.9, backend)
+            os: jammy
             include_frontend_tests: false
 
     runs-on: ubuntu-latest
@@ -218,7 +221,7 @@ jobs:
           retention-days: 60
 
       - name: Check development database build
-        if: ${{ matrix.is_focal || matrix.is_bullseye }}
+        if: ${{ matrix.os == 'focal' || matrix.os == 'bullseye' || matrix.os == 'jammy' }}
         run: ./tools/ci/setup-backend
 
       - name: Report status

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -12,7 +12,7 @@ Contents:
 If you'd like to install a Zulip development environment on a computer
 that's running one of:
 
-- Ubuntu 20.04 Focal
+- Ubuntu 20.04 Focal, 22.04 Jammy (beta)
 - Debian 10 Buster, 11 Bullseye
 - CentOS 7 (beta)
 - Fedora 33 and 34 (beta)

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -13,7 +13,7 @@ If you'd like to install a Zulip development environment on a computer
 that's running one of:
 
 - Ubuntu 20.04 Focal
-- Debian 10 Buster, 11 Bullseye (beta)
+- Debian 10 Buster, 11 Bullseye
 - CentOS 7 (beta)
 - Fedora 33 and 34 (beta)
 - RHEL 7 (beta)

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -49,7 +49,7 @@ a proxy to access the internet.)
 
 - **All**: 2GB available RAM, Active broadband internet connection, [GitHub account][set-up-git].
 - **macOS**: macOS (10.11 El Capitan or newer recommended)
-- **Ubuntu LTS**: 20.04
+- **Ubuntu LTS**: 20.04 or 22.04
   - or **Debian**: 10 "buster" or 11 "bullseye"
 - **Windows**: Windows 64-bit (Win 10 recommended), hardware
   virtualization enabled (VT-x or AMD-V), administrator access.

--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -5,6 +5,7 @@ To run a Zulip server, you will need:
 - A dedicated machine or VM
 - A supported OS:
   - Ubuntu 20.04 Focal
+  - Ubuntu 22.04 Jammy
   - Debian 11 Bullseye
   - Debian 10 Buster
 - At least 2GB RAM, and 10GB disk space
@@ -33,7 +34,7 @@ on issues you'll encounter](install-existing-server.md).
 
 #### Operating system
 
-Ubuntu 20.04 Focal, Debian 11 Bullseye, and Debian 10
+Ubuntu 20.04 Focal, Ubuntu 22.04 Jammy, Debian 11 Bullseye, and Debian 10
 Buster are supported for running Zulip in production. You can also
 run Zulip on other platforms that support Docker using
 [docker-zulip][docker-zulip-homepage].

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -211,8 +211,8 @@ if [ -f /etc/os-release ]; then
     esac
 fi
 
-case "$os_id$os_version_id" in
-    debian10 | debian11 | ubuntu20.04) ;;
+case "$os_id $os_version_id" in
+    'debian 10' | 'debian 11' | 'ubuntu 20.04' | 'ubuntu 22.04') ;;
     *)
         set +x
         cat <<EOF
@@ -223,6 +223,7 @@ Zulip in production is supported only on:
  - Debian 10 "buster"
  - Debian 11 "bullseye"
  - Ubuntu 20.04 LTS "focal"
+ - Ubuntu 22.04 LTS "jammy"
 
 For more information, see:
   https://zulip.readthedocs.io/en/latest/production/requirements.html

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -166,6 +166,7 @@ if os.path.exists("/etc/init.d/postgresql"):
     if not postgresql_version:
         default_postgresql_version = {
             ("debian", "10"): "11",
+            ("debian", "11"): "13",
             ("ubuntu", "20.04"): "12",
             ("centos", "7"): "11",
         }

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -168,6 +168,7 @@ if os.path.exists("/etc/init.d/postgresql"):
             ("debian", "10"): "11",
             ("debian", "11"): "13",
             ("ubuntu", "20.04"): "12",
+            ("ubuntu", "22.04"): "14",
             ("centos", "7"): "11",
         }
         if (vendor, os_version) in default_postgresql_version:

--- a/scripts/setup/apt-repos/zulip/jammy.list
+++ b/scripts/setup/apt-repos/zulip/jammy.list
@@ -1,0 +1,6 @@
+deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main
+deb-src http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main
+
+# Old versions for https://github.com/pgroonga/pgroonga/issues/203 were not built for jammy
+deb http://apt-archive.postgresql.org/pub/repos/apt/ impish-pgdg-archive main
+deb-src http://apt-archive.postgresql.org/pub/repos/apt/ impish-pgdg-archive main

--- a/scripts/setup/generate-self-signed-cert
+++ b/scripts/setup/generate-self-signed-cert
@@ -77,8 +77,6 @@ cat >"$config" <<EOF
 # Based on /usr/share/ssl-cert/ssleay.cnf from Debian's \`ssl-cert\`
 # package, which is used for the system's snakeoil cert in /etc/ssl/.
 
-RANDFILE            = /dev/urandom
-
 [ req ]
 default_bits        = 2048
 distinguished_name  = req_distinguished_name

--- a/tools/ci/build-docker-images
+++ b/tools/ci/build-docker-images
@@ -2,6 +2,7 @@
 set -eux
 cd "$(dirname "${BASH_SOURCE[0]}")"
 docker build . --build-arg=BASE_IMAGE=ubuntu:20.04 --pull --tag=zulip/ci:focal
+docker build . --build-arg=BASE_IMAGE=ubuntu:22.04 --pull --tag=zulip/ci:jammy
 docker build . --build-arg=BASE_IMAGE=debian:10 --pull --tag=zulip/ci:buster
 docker build . --build-arg=BASE_IMAGE=debian:11 --pull --tag=zulip/ci:bullseye
 docker build . -f Dockerfile.prod --build-arg=BASE_IMAGE=zulip/ci:buster --build-arg=VERSION=3.4 --tag=zulip/ci:buster-3.4

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -87,6 +87,8 @@ elif vendor == "ubuntu" and os_version == "20.04":  # focal
     POSTGRESQL_VERSION = "12"
 elif vendor == "ubuntu" and os_version == "21.10":  # impish
     POSTGRESQL_VERSION = "13"
+elif vendor == "ubuntu" and os_version == "22.04":  # jammy
+    POSTGRESQL_VERSION = "14"
 elif vendor == "neon" and os_version == "20.04":  # KDE Neon
     POSTGRESQL_VERSION = "12"
 elif vendor == "fedora" and os_version == "33":
@@ -163,7 +165,7 @@ COMMON_YUM_DEPENDENCIES = [
 ]
 
 BUILD_PGROONGA_FROM_SOURCE = False
-if vendor == "debian" and os_version in [] or vendor == "ubuntu" and os_version in []:
+if vendor == "debian" and os_version in [] or vendor == "ubuntu" and os_version in ["22.04"]:
     # For platforms without a PGroonga release, we need to build it
     # from source.
     BUILD_PGROONGA_FROM_SOURCE = True

--- a/tools/test-install/prepare-base
+++ b/tools/test-install/prepare-base
@@ -10,7 +10,7 @@ RELEASE="$1"
 ARCH=amd64 # TODO: maybe i686 too
 
 case "$RELEASE" in
-    focal)
+    focal | jammy)
         extra_packages=(python3-pip)
         ;;
     *)


### PR DESCRIPTION
Ubuntu 22.04 feature freeze was [today](https://lists.ubuntu.com/archives/ubuntu-devel-announce/2022-February/001304.html), so we might as well try to get this into the upcoming release.

**Testing plan:** Built the Docker images for CI, and installed in an Ubuntu 22.04 container on https://andersk.zulipdev.org.

Note that the [PGroonga PPA](https://launchpad.net/~groonga/+archive/ubuntu/ppa) doesn’t yet support Ubuntu 22.04, so we build PGroonga from source in development and don’t support it in production.