### PR TITLE
settings_users: Refactor live update code for deactivating and reactivating users.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -609,6 +609,7 @@ run_test("realm_user", ({override}) => {
 
     event = event_fixtures.realm_user__remove;
     override(stream_events, "remove_deactivated_user_from_all_streams", noop);
+    override(settings_users, "update_view_on_deactivate", noop);
     dispatch(event);
 
     // We don't actually remove the person, we just deactivate them.

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -8,6 +8,7 @@ import * as alert_words_ui from "./alert_words_ui";
 import * as attachments_ui from "./attachments_ui";
 import * as blueslip from "./blueslip";
 import * as bot_data from "./bot_data";
+import {buddy_list} from "./buddy_list";
 import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
 import * as compose_fade from "./compose_fade";
@@ -424,6 +425,7 @@ export function dispatch_normal_event(event) {
                     people.deactivate(event.person);
                     stream_events.remove_deactivated_user_from_all_streams(event.person.user_id);
                     settings_users.update_view_on_deactivate(event.person.user_id);
+                    buddy_list.maybe_remove_key({key: event.person.user_id});
                     break;
                 case "update":
                     user_events.update_person(event.person);

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -423,6 +423,7 @@ export function dispatch_normal_event(event) {
                 case "remove":
                     people.deactivate(event.person);
                     stream_events.remove_deactivated_user_from_all_streams(event.person.user_id);
+                    settings_users.update_view_on_deactivate(event.person.user_id);
                     break;
                 case "update":
                     user_events.update_person(event.person);

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -84,7 +84,8 @@ function get_user_info_row(user_id) {
     return $(`tr.user_row[data-user-id='${CSS.escape(user_id)}']`);
 }
 
-function update_view_on_deactivate(row) {
+function update_view_on_deactivate(user_id) {
+    const row = get_user_info_row(user_id);
     const button = row.find("button.deactivate");
     const user_role = row.find(".user_role");
     button.prop("disabled", false);
@@ -365,7 +366,7 @@ export function update_user_data(user_id, new_data) {
     if (new_data.is_active !== undefined) {
         if (new_data.is_active === false) {
             // Deactivate the user/bot in the table
-            update_view_on_deactivate(user_row);
+            update_view_on_deactivate(user_id);
         } else {
             // Reactivate the user/bot in the table
             update_view_on_reactivate(user_row);
@@ -456,7 +457,7 @@ function handle_deactivation(tbody, status_field) {
             row_deactivate_button.prop("disabled", true).text($t({defaultMessage: "Working…"}));
             const opts = {
                 success_continuation() {
-                    update_view_on_deactivate(row);
+                    update_view_on_deactivate(user_id);
                 },
                 error_continuation() {
                     row_deactivate_button.text($t({defaultMessage: "Deactivate"}));
@@ -482,7 +483,7 @@ function handle_bot_deactivation(tbody, status_field) {
 
         const opts = {
             success_continuation() {
-                update_view_on_deactivate(row);
+                update_view_on_deactivate(bot_id);
             },
             error_continuation(xhr) {
                 ui_report.generic_row_button_error(xhr, button_elem);
@@ -574,7 +575,7 @@ export function show_edit_user_info_modal(user_id, from_user_info_popover, statu
                         dialog_widget.close_modal();
                         if (!from_user_info_popover) {
                             const row = get_user_info_row(user_id);
-                            update_view_on_deactivate(row);
+                            update_view_on_deactivate(user_id);
                         }
                     },
                     error(xhr) {

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -84,8 +84,12 @@ function get_user_info_row(user_id) {
     return $(`tr.user_row[data-user-id='${CSS.escape(user_id)}']`);
 }
 
-function update_view_on_deactivate(user_id) {
+export function update_view_on_deactivate(user_id) {
     const row = get_user_info_row(user_id);
+    if (row.length === 0) {
+        return;
+    }
+
     const button = row.find("button.deactivate");
     const user_role = row.find(".user_role");
     button.prop("disabled", false);
@@ -456,9 +460,6 @@ function handle_deactivation(tbody, status_field) {
             const row_deactivate_button = row.find("button.deactivate");
             row_deactivate_button.prop("disabled", true).text($t({defaultMessage: "Working…"}));
             const opts = {
-                success_continuation() {
-                    update_view_on_deactivate(user_id);
-                },
                 error_continuation() {
                     row_deactivate_button.text($t({defaultMessage: "Deactivate"}));
                 },
@@ -482,9 +483,6 @@ function handle_bot_deactivation(tbody, status_field) {
         const url = "/json/bots/" + encodeURIComponent(bot_id);
 
         const opts = {
-            success_continuation() {
-                update_view_on_deactivate(bot_id);
-            },
             error_continuation(xhr) {
                 ui_report.generic_row_button_error(xhr, button_elem);
             },
@@ -573,10 +571,6 @@ export function show_edit_user_info_modal(user_id, from_user_info_popover, statu
                     url,
                     success() {
                         dialog_widget.close_modal();
-                        if (!from_user_info_popover) {
-                            const row = get_user_info_row(user_id);
-                            update_view_on_deactivate(user_id);
-                        }
                     },
                     error(xhr) {
                         ui_report.error(

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -367,16 +367,6 @@ export function update_user_data(user_id, new_data) {
         user_row.find(".user_name").text(new_data.full_name);
     }
 
-    if (new_data.is_active !== undefined) {
-        if (new_data.is_active === false) {
-            // Deactivate the user/bot in the table
-            update_view_on_deactivate(user_id);
-        } else {
-            // Reactivate the user/bot in the table
-            update_view_on_reactivate(user_row);
-        }
-    }
-
     if (new_data.role !== undefined) {
         user_row.find(".user_role").text(people.get_user_type(user_id));
     }


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit is prep commit to pass `user_id` instead of row to `update_view_on_deactivate`.
- Second commit is the commit for calling `update_view_on_deactivate` from `server_events_dispatch.js`.
- Third commit is to remove unused code.
 <!-- How have you tested? -->
<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
