### PR TITLE
user_info_popover: Add close button to the user info popover.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -981,6 +981,12 @@ export function register_click_handlers() {
      * relevant part of the Zulip UI, so we don't want preventDefault,
      * but we do want to close the modal when you click them. */
 
+    $("body").on("click", ".exit_user_info_popover", (e) => {
+        hide_all();
+        e.stopPropagation();
+        e.preventDefault();
+    });
+
     $("body").on("click", ".set_away_status", (e) => {
         hide_all();
         user_status.server_set_away();

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -178,6 +178,53 @@ ul {
         border-color: hsla(0, 0%, 0%, 0.2);
     }
 
+    .popover-avatar {
+        position: relative;
+        border-radius: 5px;
+        box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
+        transition: all 0.3s ease;
+
+        .popover-avatar-background {
+            content: "";
+            background-color: hsl(0, 0%, 0%);
+            height: 100%;
+            width: 100%;
+            opacity: 0.6;
+            z-index: 99;
+            position: absolute;
+            display: none;
+            cursor: pointer;
+        }
+
+        .exit_user_info_popover {
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: hsl(0, 0%, 75%);
+            opacity: 0;
+            padding: 3px 0;
+            position: absolute;
+            font-size: 2rem;
+            top: 10px;
+            right: 10px;
+            z-index: 99;
+            line-height: 20px;
+        }
+
+        &:hover,
+        &:active {
+            .popover-avatar-background {
+                display: block;
+            }
+
+            .exit_user_info_popover {
+                opacity: 1;
+                color: hsl(0, 0%, 100%);
+                outline: none;
+            }
+        }
+    }
+
     .popover_info li {
         word-wrap: break-word;
     }

--- a/static/templates/user_info_popover_title.hbs
+++ b/static/templates/user_info_popover_title.hbs
@@ -1,2 +1,6 @@
 <div class="popover-avatar{{#if user_is_guest}} guest-avatar{{/if}}" style="background-image: url('{{user_avatar}}');" >
+    <div class="popover-avatar-background"></div>
+    <button class="exit_user_info_popover" role="button" tabindex="0">
+        &times;
+    </button>
 </div>


### PR DESCRIPTION
Add "button" with class "exit_user_info_popover"
in "user_info_popover_title.hbs".
In "popovers.js" write function to make close button functional.
In "popovers.css", set the position the position as relative,
background-color, opacity, border radius and color of the icon.

Fixes: [Close user info popover](https://chat.zulip.org/#narrow/stream/9-issues/topic/Close.20profile.20modal)

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

https://user-images.githubusercontent.com/85362194/155798117-e5360616-b5a2-4e9f-95a9-cc51de317255.mov


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
