### PR TITLE
popovers: Add topic auto-complete to "Move topic" menu

### DIFF
--- a/static/templates/move_topic_to_stream.hbs
+++ b/static/templates/move_topic_to_stream.hbs
@@ -9,7 +9,7 @@
               list_placeholder=(t 'Filter streams')}}
         </div>
         <i class="fa fa-angle-right" aria-hidden="true"></i>
-        <input name="new_topic_name" type="text" class="inline_topic_edit" value="{{topic_name}}" />
+        <input name="new_topic_name" type="text" class="inline_topic_edit" autocomplete="off" value="{{topic_name}}" />
         <input name="old_topic_name" type="hidden" class="inline_topic_edit" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />
         <div class="topic_move_breadcrumb_messages">


### PR DESCRIPTION
Issue #19876

We add topic auto-complete to the left sidebar menu as sometimes user
may want to merge the topic they are moving with an existing topic.

https://user-images.githubusercontent.com/75037620/155842853-43446899-00a8-4ded-a57f-3ed456a0a221.mp4


