### PR TITLE
docs: Rewrite code review documentation.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,41 @@
-<!-- What's this PR for?  (Just a link to an issue is fine.) -->
+<!-- Describe your pull request here.-->
 
-**Testing plan:** <!-- How have you tested? -->
+Fixes: <!-- Issue link, or clear description.-->
 
-**GIFs or screenshots:** <!-- If a UI change.  See:
-  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-  -->
+<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.
 
-<!-- Also be sure to make clear, coherent commits:
-  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
-  -->
+Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
+-->
+
+**Screenshots and screen captures:**
+
+**Self-review checklist**
+
+<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
+https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->
+
+<!-- Once you create the PR, check off all the steps below that you have completed.
+If any of these steps are not relevant or you have not completed, leave them unchecked.-->
+
+- [ ] Self-reviewed the changes for clarity and maintainability
+      (variable names, code reuse, readability, etc.).
+
+Communicate decisions, questions, and potential concerns.
+
+- [ ] Explains differences from previous plans (e.g., issue description).
+- [ ] Highlights technical choices and bugs encountered.
+- [ ] Calls out remaining decisions and concerns.
+- [ ] Automated tests verify logic where appropriate.
+
+Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).
+
+- [ ] Each commit is a coherent idea.
+- [ ] Commit message(s) explain reasoning and motivation for changes.
+
+Completed manual review and testing of the following:
+
+- [ ] Visual appearance of the changes.
+- [ ] Responsiveness and internationalization.
+- [ ] Strings and tooltips.
+- [ ] End-to-end functionality of buttons, interactions and flows.
+- [ ] Corner cases, error conditions, and easily imagined bugs.


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Rewrite code review documentation, including much more detailed guidance on how to do manual QA for a PR (one's own or someone else's).

The page itself is ready for review, but I haven't added more references to it yet (from contributing.md, and perhaps elsewhere).

**Testing plan:** <!-- How have you tested? -->
built and reviewed, but haven't tested all the links

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
