### PR TITLE
Toggle visibility of "x" button in filter (stream-settings/filter-streams) and (recent-topics/filter-topics)

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -468,10 +468,19 @@ export function initialize() {
             // Wait for user to go idle before initiating search.
         }, 300),
     );
+    $("body").on("input", "#recent_topics_search", () => {
+        if ($("#recent_topics_search").val()) {
+            $("#recent_topics_search_clear").css("visibility", "visible");
+        }
+        if (!$("#recent_topics_search").val()) {
+            $("#recent_topics_search_clear").css("visibility", "hidden");
+        }
+    });
 
     $("body").on("click", "#recent_topics_search_clear", (e) => {
         e.stopPropagation();
         $("#recent_topics_search").val("");
+        $("#recent_topics_search_clear").css("visibility", "hidden");
         recent_topics_ui.update_filters_view();
     });
 

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -612,6 +612,10 @@ export function setup_page(callback) {
 
         // show the "Stream settings" header by default.
         $(".display-type #stream_settings_title").show();
+
+        if (!$("#stream_filter input[type='text']").val()) {
+            $("#clear_search_stream_name").css("visibility", "hidden");
+        }
     }
 
     function populate_and_fill() {
@@ -651,6 +655,13 @@ export function setup_page(callback) {
 
         const throttled_redraw_left_panel = _.throttle(redraw_left_panel, 50);
         $("#stream_filter input[type='text']").on("input", () => {
+            if (!$("#stream_filter input[type='text']").val()) {
+                $("#clear_search_stream_name").css("visibility", "hidden");
+            }
+
+            if ($("#stream_filter input[type='text']").val()) {
+                $("#clear_search_stream_name").css("visibility", "visible");
+            }
             // Debounce filtering in case a user is typing quickly
             throttled_redraw_left_panel();
         });
@@ -680,6 +691,7 @@ export function setup_page(callback) {
 
         $("#clear_search_stream_name").on("click", () => {
             $("#stream_filter input[type='text']").val("");
+            $("#clear_search_stream_name").css("visibility", "hidden");
             redraw_left_panel();
         });
 

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -109,6 +109,7 @@
         }
 
         #recent_topics_search_clear {
+            visibility: hidden;
             margin-top: -10px !important;
         }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes: #21297
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

https://user-images.githubusercontent.com/85362194/155901817-1ecd0e8a-cd63-4882-9169-c4ab071f8844.mov


https://user-images.githubusercontent.com/85362194/155901822-7662e531-c99b-43bb-9229-6843f08695a0.mov

 [Cancel button in filter topics and filter streams](https://chat.zulip.org/#narrow/stream/9-issues/topic/Cancel.20button.20in.20filter.20topics.20and.20filter.20streams)