### PR TITLE
stream_settings: Different label fix edit custom profile field.

### DIFF
--- a/static/templates/settings/admin_profile_field_list.hbs
+++ b/static/templates/settings/admin_profile_field_list.hbs
@@ -28,7 +28,7 @@
     <td colspan="3">
         <form class="form-horizontal name-setting">
             <div class="input-group">
-                <label for="name">{{t "Name" }}</label>
+                <label for="name">{{t "Label" }}</label>
                 <input type="text" name="name" value="{{ name }}" maxlength="40" />
             </div>
             <div class="input-group hint_change_container">


### PR DESCRIPTION
Replacing Name with Label, as we use Label in custom profile fields table and also when we create a new field.

Fixes: #21260

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**GIFs or screenshots:** 
![different_labe_fixl](https://user-images.githubusercontent.com/41695888/155990204-1b6dae1a-8f1d-4038-a2bd-fe60f9c36125.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
