### PR TITLE
settings: Values retrieve fix when we edit custom external account type custom profile fields.

### DIFF
--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -281,9 +281,6 @@ function open_edit_form(e) {
     profile_field.row.hide();
     profile_field.form.show();
     const field = get_profile_field(field_id);
-    // Set initial value in edit form
-    profile_field.form.find("input[name=name]").val(field.name);
-    profile_field.form.find("input[name=hint]").val(field.hint);
     let field_data = {};
     if (field.field_data) {
         field_data = JSON.parse(field.field_data);
@@ -297,6 +294,10 @@ function open_edit_form(e) {
         profile_field.form.find("select[name=external_acc_field_type]").val(field_data.subtype);
         set_up_external_account_field_edit_form(profile_field, field_data.url_pattern);
     }
+
+    // Set initial value in edit form
+    profile_field.form.find("input[name=name]").val(field.name);
+    profile_field.form.find("input[name=hint]").val(field.hint);
 
     profile_field.form.find(".reset").on("click", () => {
         profile_field.form.hide();


### PR DESCRIPTION
In settings_profile_fields.js function open_edit_form, we call function
for external account type fields after setting initial values for edit form,
this external account type fields specific function causes to set initial
values empty, so i just set initial values in edit form after calling this
function.

Fixes: #21262

**Testing plan:** Manually tested.

**GIFs or screenshots:** 
![values_retrive_edit_custom_external_account_type_fields](https://user-images.githubusercontent.com/41695888/156006013-fa8f7df4-57fe-4a7d-9fc0-8f2268f6dfcc.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
