### PR TITLE
css: Fix hover color for "Edit topic" icon in message bar

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1372,10 +1372,7 @@ td.pointer {
     color: hsl(200, 100%, 40%);
 }
 
-.always_visible_topic_edit {
-    opacity: 0.7;
-}
-
+.always_visible_topic_edit,
 .on_hover_topic_unmute {
     opacity: 0.7;
 
@@ -1395,13 +1392,6 @@ td.pointer {
     &:hover {
         cursor: pointer;
         opacity: 0.7;
-    }
-}
-
-.always_visible_topic_edit {
-    &:hover {
-        cursor: pointer;
-        opacity: 1;
     }
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1372,11 +1372,6 @@ td.pointer {
     color: hsl(200, 100%, 40%);
 }
 
-.on_hover_topic_edit,
-.on_hover_topic_read {
-    opacity: 0.2;
-}
-
 .always_visible_topic_edit {
     opacity: 0.7;
 }
@@ -1390,6 +1385,8 @@ td.pointer {
     }
 }
 
+.on_hover_topic_edit,
+.on_hover_topic_read,
 .on_hover_topic_unresolve,
 .on_hover_topic_resolve,
 .on_hover_topic_mute {
@@ -1401,9 +1398,7 @@ td.pointer {
     }
 }
 
-.on_hover_topic_edit,
-.always_visible_topic_edit,
-.on_hover_topic_read {
+.always_visible_topic_edit {
     &:hover {
         cursor: pointer;
         opacity: 1;


### PR DESCRIPTION
Fix the problem that the hover color of "Edit topic" icon in the message bar does not match with the other two icons.

**GIFs or screenshots:** 
![image](https://user-images.githubusercontent.com/79527478/156116215-b84b403f-a6e0-4661-95d0-a64c315c349b.png)
![image](https://user-images.githubusercontent.com/79527478/156116245-cdbd28d4-edda-42f0-a504-46aca2fe147e.png)
Also works in dark theme
![image](https://user-images.githubusercontent.com/79527478/156116348-7a2e2627-088c-4bc9-8a0d-59c19d1a6b2a.png)
![image](https://user-images.githubusercontent.com/79527478/156116373-b0641fe0-7442-4c0c-99ef-0178105416e0.png)

Fixes #21273.
