### PR TITLE
drafts: Use Simplebar

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -27,6 +27,7 @@ import * as rendered_markdown from "./rendered_markdown";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
+import * as ui from "./ui";
 import * as ui_util from "./ui_util";
 import * as util from "./util";
 
@@ -688,30 +689,29 @@ function drafts_scroll($next_focus_draft_row) {
     }
     activate_element($next_focus_draft_row[0].children[0]);
 
+    const scroll_element = ui.get_scroll_element($(".drafts-list"));
+
     // If focused draft is first draft, scroll to the top.
     if ($(".draft-info-box").first()[0].parentElement === $next_focus_draft_row[0]) {
-        $(".drafts-list")[0].scrollTop = 0;
+        scroll_element.scrollTop(0);
     }
 
     // If focused draft is the last draft, scroll to the bottom.
     if ($(".draft-info-box").last()[0].parentElement === $next_focus_draft_row[0]) {
-        $(".drafts-list")[0].scrollTop =
-            $(".drafts-list")[0].scrollHeight - $(".drafts-list").height();
+        scroll_element.scrollTop($(scroll_element).prop("scrollHeight"));
     }
 
     // If focused draft is cut off from the top, scroll up halfway in draft modal.
-    if ($next_focus_draft_row.position().top < 55) {
-        // 55 is the minimum distance from the top that will require extra scrolling.
-        $(".drafts-list")[0].scrollTop -= $(".drafts-list")[0].clientHeight / 2;
+    if ($next_focus_draft_row.position().top < 0) {
+        scroll_element.scrollTop(scroll_element.scrollTop() - $(".drafts-list").height() / 2);
     }
 
     // If focused draft is cut off from the bottom, scroll down halfway in draft modal.
     const dist_from_top = $next_focus_draft_row.position().top;
-    const total_dist = dist_from_top + $next_focus_draft_row[0].clientHeight;
-    const dist_from_bottom = $(".drafts-container")[0].clientHeight - total_dist;
-    if (dist_from_bottom < -4) {
-        // -4 is the min dist from the bottom that will require extra scrolling.
-        $(".drafts-list")[0].scrollTop += $(".drafts-list")[0].clientHeight / 2;
+    const total_dist = dist_from_top + $next_focus_draft_row.height();
+    const dist_from_bottom = $(".drafts-list").height() - total_dist;
+    if (dist_from_bottom < 0) {
+        scroll_element.scrollTop(scroll_element.scrollTop() + $(".drafts-list").height() / 2);
     }
 }
 

--- a/static/styles/drafts.css
+++ b/static/styles/drafts.css
@@ -52,6 +52,7 @@
     .drafts-list {
         padding: 10px 25px;
         overflow: auto;
+        height: 100%;
 
         .no-drafts {
             display: block;

--- a/static/templates/draft_table_body.hbs
+++ b/static/templates/draft_table_body.hbs
@@ -12,7 +12,7 @@
                     {{#tr}}Drafts older than <strong>{draft_lifetime}</strong> days are automatically removed.{{/tr}}
                 </div>
             </div>
-            <div class="drafts-list">
+            <div class="drafts-list" data-simplebar>
                 <div class="no-drafts">
                     {{t 'No drafts.'}}
                 </div>


### PR DESCRIPTION
Use simplebar in drafts overlay
![image](https://user-images.githubusercontent.com/74348920/156240400-00564928-1994-4aca-bfe4-1062a8f9dfac.png)

- Used `height: 100%` as a workaround to remove native scrollbar
- Updated `drafts_scroll` to use `ui.get_scroll_element`
- Changed the checks if scrolling is necessary so it works with the `scroll_element`
- Updated the value for which it is scrolled up/down halfway (before it happened that it was scrolled down, even though the focused draft wasn't cut of but fully visible)
- Removed `clientHeight` since this is not supported in all browsers (for example Chrome)