### PR TITLE
Proposed rewrite of edit history migration

### DIFF
--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -107,7 +107,7 @@ test("msg_moved_var", () => {
             }),
             // topic changed: Move
             build_message_context({
-                edit_history: [{prev_subject: "test_topic", timestamp: 1000, user_id: 1}],
+                edit_history: [{prev_topic: "test_topic", timestamp: 1000, user_id: 1}],
             }),
             // content edited: Edit
             build_message_context({

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -136,10 +136,6 @@ run_test("get_edit_event_orig_topic", () => {
     assert.equal(util.get_edit_event_orig_topic({orig_subject: "lunch"}), "lunch");
 });
 
-run_test("get_edit_event_prev_topic", () => {
-    assert.equal(util.get_edit_event_prev_topic({prev_subject: "dinner"}), "dinner");
-});
-
 run_test("is_mobile", () => {
     window.navigator = {userAgent: "Android"};
     assert.ok(util.is_mobile());

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -66,10 +66,7 @@ function message_was_only_moved(message) {
             if (edit_history_event.prev_content) {
                 return false;
             }
-            if (
-                util.get_edit_event_prev_topic(edit_history_event) ||
-                edit_history_event.prev_stream
-            ) {
+            if (edit_history_event.prev_topic || edit_history_event.prev_stream) {
                 moved = true;
             }
         }

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -481,7 +481,7 @@ export function toggle_actions_popover(element, id) {
                 (entry) =>
                     entry.prev_content !== undefined ||
                     entry.prev_stream !== undefined ||
-                    util.get_edit_event_prev_topic(entry) !== undefined,
+                    entry.prev_topic !== undefined,
             ) &&
             page_params.realm_allow_edit_history &&
             not_spectator;

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -241,10 +241,6 @@ export function get_edit_event_orig_topic(obj) {
     return obj.orig_subject;
 }
 
-export function get_edit_event_prev_topic(obj) {
-    return obj.prev_subject;
-}
-
 export function is_topic_synonym(operator) {
     return operator === "subject";
 }

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,19 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 5.0
 
+**Feature level 118**
+
+* [`GET /messages`](/api/get-messages), [`GET /events`](/api/get-events):
+  Updated `edit_history` data structure of message
+  objects. Entries for stream edits now include a both a `prev_stream` and
+  `stream` field to indicate the previous and current stream IDs. Entries
+  for topic edits now include both a `prev_topic` and `topic` field to
+  indicate the previous and current topic. The legacy `prev_subject` field
+  was renamed to `prev_topic` and is now deprecated.
+
+* [`GET messages/{message_id}/history`](/api/get-message-history):
+  Added `stream` field to message history `snapshot` objects to indicate
+  the updated stream ID of the message if it was modified.
 
 **Feature level 117**
 

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -13,6 +13,7 @@ from zulint.custom_rules import Rule, RuleList
 FILES_WITH_LEGACY_SUBJECT = {
     # This basically requires a big DB migration:
     "zerver/lib/topic.py",
+    "zerver/lib/types.py",
     # This is for backward compatibility.
     "zerver/tests/test_legacy_subject.py",
     # Other migration-related changes require extreme care.
@@ -225,7 +226,7 @@ python_rules = RuleList(
     rules=[
         {
             "pattern": "subject|SUBJECT",
-            "exclude_pattern": "subject to the|email|outbox",
+            "exclude_pattern": "subject to the|email|outbox|edit_history_event",
             "description": "avoid subject as a var",
             "good_lines": ["topic_name"],
             "bad_lines": ['subject="foo"', " MAX_SUBJECT_LEN"],

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -12,6 +12,7 @@ from zulint.custom_rules import Rule, RuleList
 
 FILES_WITH_LEGACY_SUBJECT = {
     # This basically requires a big DB migration:
+    "zerver/lib/message.py",
     "zerver/lib/topic.py",
     "zerver/lib/types.py",
     "zerver/views/message_edit.py",

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -14,6 +14,7 @@ FILES_WITH_LEGACY_SUBJECT = {
     # This basically requires a big DB migration:
     "zerver/lib/topic.py",
     "zerver/lib/types.py",
+    "zerver/views/message_edit.py",
     # This is for backward compatibility.
     "zerver/tests/test_legacy_subject.py",
     # Other migration-related changes require extreme care.

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 117
+API_FEATURE_LEVEL = 118
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -6874,7 +6874,6 @@ def do_update_message(
         event[ORIG_TOPIC] = orig_topic_name
         event[TOPIC_NAME] = topic_name
         event[TOPIC_LINKS] = topic_links(target_message.sender.realm_id, topic_name)
-        edit_history_event["prev_subject"] = orig_topic_name
         edit_history_event["prev_topic"] = orig_topic_name
         edit_history_event["topic"] = topic_name
 
@@ -6891,8 +6890,6 @@ def do_update_message(
             "timestamp": edit_history_event["timestamp"],
         }
         if topic_name is not None:
-            # For backwards-compatability, we include this legacy field name.
-            topic_only_edit_history_event["prev_subject"] = edit_history_event["prev_subject"]
             topic_only_edit_history_event["prev_topic"] = edit_history_event["prev_topic"]
             topic_only_edit_history_event["topic"] = edit_history_event["topic"]
         if new_stream is not None:

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -6815,6 +6815,7 @@ def do_update_message(
         assert stream_being_edited is not None
 
         edit_history_event["prev_stream"] = stream_being_edited.id
+        edit_history_event["stream"] = new_stream.id
         event[ORIG_TOPIC] = orig_topic_name
         target_message.recipient_id = new_stream.recipient_id
 
@@ -6874,6 +6875,8 @@ def do_update_message(
         event[TOPIC_NAME] = topic_name
         event[TOPIC_LINKS] = topic_links(target_message.sender.realm_id, topic_name)
         edit_history_event["prev_subject"] = orig_topic_name
+        edit_history_event["prev_topic"] = orig_topic_name
+        edit_history_event["topic"] = topic_name
 
     update_edit_history(target_message, timestamp, edit_history_event)
 
@@ -6888,9 +6891,13 @@ def do_update_message(
             "timestamp": edit_history_event["timestamp"],
         }
         if topic_name is not None:
+            # For backwards-compatability, we include this legacy field name.
             topic_only_edit_history_event["prev_subject"] = edit_history_event["prev_subject"]
+            topic_only_edit_history_event["prev_topic"] = edit_history_event["prev_topic"]
+            topic_only_edit_history_event["topic"] = edit_history_event["topic"]
         if new_stream is not None:
             topic_only_edit_history_event["prev_stream"] = edit_history_event["prev_stream"]
+            topic_only_edit_history_event["stream"] = edit_history_event["stream"]
 
         messages_list = update_messages_for_topic_edit(
             acting_user=user_profile,

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -442,7 +442,7 @@ class MessageDict:
         return MessageDict.build_message_dict(
             message_id=row["id"],
             last_edit_time=row["last_edit_time"],
-            edit_history=row["edit_history"],
+            edit_history_json=row["edit_history"],
             content=row["content"],
             topic_name=row[DB_TOPIC_NAME],
             date_sent=row["date_sent"],
@@ -463,7 +463,7 @@ class MessageDict:
     def build_message_dict(
         message_id: int,
         last_edit_time: Optional[datetime.datetime],
-        edit_history: Optional[str],
+        edit_history_json: Optional[str],
         content: str,
         topic_name: str,
         date_sent: datetime.datetime,
@@ -501,8 +501,9 @@ class MessageDict:
 
         if last_edit_time is not None:
             obj["last_edit_timestamp"] = datetime_to_timestamp(last_edit_time)
-            assert edit_history is not None
-            obj["edit_history"] = orjson.loads(edit_history)
+            assert edit_history_json is not None
+            edit_history = orjson.loads(edit_history_json)
+            obj["edit_history"] = edit_history
 
         if Message.need_to_render_content(
             rendered_content, rendered_content_version, markdown_version

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -38,12 +38,7 @@ from zerver.lib.streams import get_web_public_streams_queryset
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import DB_TOPIC_NAME, MESSAGE__TOPIC, TOPIC_LINKS, TOPIC_NAME
 from zerver.lib.topic_mutes import build_topic_mute_checker, topic_is_muted
-from zerver.lib.types import (
-    APIEditHistoryEvent,
-    DisplayRecipientT,
-    EditHistoryEvent,
-    UserDisplayRecipient,
-)
+from zerver.lib.types import DisplayRecipientT, EditHistoryEvent, UserDisplayRecipient
 from zerver.models import (
     MAX_TOPIC_NAME_LENGTH,
     Message,
@@ -507,16 +502,7 @@ class MessageDict:
         if last_edit_time is not None:
             obj["last_edit_timestamp"] = datetime_to_timestamp(last_edit_time)
             assert edit_history_json is not None
-            raw_edit_history: List[EditHistoryEvent] = orjson.loads(edit_history_json)
-            edit_history: List[APIEditHistoryEvent] = []
-            for edit_history_event in raw_edit_history:
-                # Drop fields we're not yet ready to have appear in the API
-                if "prev_topic" in edit_history_event:
-                    # The prev_subject field has been renamed in the
-                    # database, but not the API.
-                    edit_history_event["prev_subject"] = edit_history_event["prev_topic"]
-
-                edit_history.append(edit_history_event)
+            edit_history: List[EditHistoryEvent] = orjson.loads(edit_history_json)
             obj["edit_history"] = edit_history
 
         if Message.need_to_render_content(

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -511,6 +511,13 @@ class MessageDict:
             edit_history: List[APIEditHistoryEvent] = []
             for edit_history_event in raw_edit_history:
                 # Drop fields we're not yet ready to have appear in the API
+                if "prev_topic" in edit_history_event:
+                    # The prev_subject field has been renamed in the
+                    # database, but not the API.
+                    edit_history_event["prev_subject"] = edit_history_event["prev_topic"]
+
+                # New fields not consistently available, and thus
+                # intentionally not exposed to the API.
                 del edit_history_event["prev_topic"]
                 del edit_history_event["stream"]
                 del edit_history_event["topic"]

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -515,10 +515,10 @@ class MessageDict:
                     # The prev_subject field has been renamed in the
                     # database, but not the API.
                     edit_history_event["prev_subject"] = edit_history_event["prev_topic"]
+                    del edit_history_event["prev_topic"]
 
                 # New fields not consistently available, and thus
                 # intentionally not exposed to the API.
-                del edit_history_event["prev_topic"]
                 del edit_history_event["stream"]
                 del edit_history_event["topic"]
                 edit_history.append(edit_history_event)

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -515,12 +515,7 @@ class MessageDict:
                     # The prev_subject field has been renamed in the
                     # database, but not the API.
                     edit_history_event["prev_subject"] = edit_history_event["prev_topic"]
-                    del edit_history_event["prev_topic"]
 
-                # New fields not consistently available, and thus
-                # intentionally not exposed to the API.
-                del edit_history_event["stream"]
-                del edit_history_event["topic"]
                 edit_history.append(edit_history_event)
             obj["edit_history"] = edit_history
 

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -38,7 +38,7 @@ from zerver.lib.streams import get_web_public_streams_queryset
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import DB_TOPIC_NAME, MESSAGE__TOPIC, TOPIC_LINKS, TOPIC_NAME
 from zerver.lib.topic_mutes import build_topic_mute_checker, topic_is_muted
-from zerver.lib.types import DisplayRecipientT, UserDisplayRecipient
+from zerver.lib.types import DisplayRecipientT, EditHistoryEvent, UserDisplayRecipient
 from zerver.models import (
     MAX_TOPIC_NAME_LENGTH,
     Message,
@@ -502,7 +502,8 @@ class MessageDict:
         if last_edit_time is not None:
             obj["last_edit_timestamp"] = datetime_to_timestamp(last_edit_time)
             assert edit_history_json is not None
-            edit_history = orjson.loads(edit_history_json)
+            # Here we assume EditHistoryEvent == APIEditHistoryEvent
+            edit_history: List[EditHistoryEvent] = orjson.loads(edit_history)
             obj["edit_history"] = edit_history
 
         if Message.need_to_render_content(

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -8,6 +8,7 @@ from sqlalchemy.sql import ColumnElement, column, func, literal
 from sqlalchemy.types import Boolean, Text
 
 from zerver.lib.request import REQ
+from zerver.lib.types import EditHistoryEvent
 from zerver.models import Message, Stream, UserMessage, UserProfile
 
 # Only use these constants for events.
@@ -135,11 +136,11 @@ def user_message_exists_for_topic(
 
 
 def update_edit_history(
-    message: Message, last_edit_time: datetime, edit_history_event: Dict[str, Any]
+    message: Message, last_edit_time: datetime, edit_history_event: EditHistoryEvent
 ) -> None:
     message.last_edit_time = last_edit_time
     if message.edit_history is not None:
-        edit_history = orjson.loads(message.edit_history)
+        edit_history: List[EditHistoryEvent] = orjson.loads(message.edit_history)
         edit_history.insert(0, edit_history_event)
     else:
         edit_history = [edit_history_event]
@@ -154,7 +155,7 @@ def update_messages_for_topic_edit(
     topic_name: Optional[str],
     new_stream: Optional[Stream],
     old_stream: Stream,
-    edit_history_event: Dict[str, Any],
+    edit_history_event: EditHistoryEvent,
     last_edit_time: datetime,
 ) -> List[Message]:
     propagate_query = Q(recipient_id=old_stream.recipient_id, subject__iexact=orig_topic_name)

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -126,3 +126,21 @@ class EditHistoryEvent(TypedDict, total=False):
     prev_content: str
     prev_rendered_content: Optional[str]
     prev_rendered_content_version: Optional[int]
+
+
+class FormattedEditHistoryEvent(TypedDict, total=False):
+    """
+    Extended format used in the edit history endpoint.
+    """
+
+    user_id: int
+    timestamp: int
+    prev_stream: int
+    stream: int
+    prev_topic: str
+    topic: str
+    prev_content: str
+    content: str
+    prev_rendered_content: Optional[str]
+    rendered_content: Optional[str]
+    content_html_diff: str

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -119,9 +119,6 @@ class EditHistoryEvent(TypedDict, total=False):
     timestamp: int
     prev_stream: int
     stream: int
-    # One of prev_subject and prev_topic is guaranteed to exist; if
-    # both exist they will have identical values.
-    prev_subject: str
     prev_topic: str
     topic: str
     prev_content: str

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -100,11 +100,11 @@ class APIEditHistoryEvent(TypedDict, total=False):
     user_id: int
     timestamp: int
     prev_stream: int
-    # stream: int
+    stream: int
     # TODO: Remove prev_subject from the API.
     prev_subject: str
-    # prev_topic: str
-    # topic: str
+    prev_topic: str
+    topic: str
     prev_content: str
     prev_rendered_content: Optional[str]
     prev_rendered_content_version: Optional[int]

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -119,6 +119,8 @@ class EditHistoryEvent(TypedDict, total=False):
     timestamp: int
     prev_stream: int
     stream: int
+    # One of prev_subject and prev_topic is guaranteed to exist; if
+    # both exist they will have identical values.
     prev_subject: str
     prev_topic: str
     topic: str

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -97,11 +97,11 @@ class APIEditHistoryEvent(TypedDict, total=False):
     API eventually.
     """
 
-    # Commented fields are fields we plan to add.
     user_id: int
     timestamp: int
     prev_stream: int
     # stream: int
+    # TODO: Remove prev_subject from the API.
     prev_subject: str
     # prev_topic: str
     # topic: str
@@ -115,14 +115,13 @@ class EditHistoryEvent(TypedDict, total=False):
     Database format for edit history events.
     """
 
-    # Commented fields are fields we plan to add.
     user_id: int
     timestamp: int
     prev_stream: int
-    # stream: int
+    stream: int
     prev_subject: str
-    # prev_topic: str
-    # topic: str
+    prev_topic: str
+    topic: str
     prev_content: str
     prev_rendered_content: Optional[str]
     prev_rendered_content_version: Optional[int]

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -91,25 +91,6 @@ class UnspecifiedValue:
     pass
 
 
-class APIEditHistoryEvent(TypedDict, total=False):
-    """Format of legacy edit history events in the API. Contains legacy
-    fields like LEGACY_PREV_TOPIC that we intend to remove from the
-    API eventually.
-    """
-
-    user_id: int
-    timestamp: int
-    prev_stream: int
-    stream: int
-    # TODO: Remove prev_subject from the API.
-    prev_subject: str
-    prev_topic: str
-    topic: str
-    prev_content: str
-    prev_rendered_content: Optional[str]
-    prev_rendered_content_version: Optional[int]
-
-
 class EditHistoryEvent(TypedDict, total=False):
     """
     Database format for edit history events.

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -89,3 +89,40 @@ class UnspecifiedValue:
     """
 
     pass
+
+
+class APIEditHistoryEvent(TypedDict, total=False):
+    """Format of legacy edit history events in the API. Contains legacy
+    fields like LEGACY_PREV_TOPIC that we intend to remove from the
+    API eventually.
+    """
+
+    # Commented fields are fields we plan to add.
+    user_id: int
+    timestamp: int
+    prev_stream: int
+    # stream: int
+    prev_subject: str
+    # prev_topic: str
+    # topic: str
+    prev_content: str
+    prev_rendered_content: Optional[str]
+    prev_rendered_content_version: Optional[int]
+
+
+class EditHistoryEvent(TypedDict, total=False):
+    """
+    Database format for edit history events.
+    """
+
+    # Commented fields are fields we plan to add.
+    user_id: int
+    timestamp: int
+    prev_stream: int
+    # stream: int
+    prev_subject: str
+    # prev_topic: str
+    # topic: str
+    prev_content: str
+    prev_rendered_content: Optional[str]
+    prev_rendered_content_version: Optional[int]

--- a/zerver/migrations/0377_message_edit_history_format.py
+++ b/zerver/migrations/0377_message_edit_history_format.py
@@ -1,0 +1,154 @@
+import time
+from typing import List, Optional
+
+import orjson
+from django.db import migrations, transaction
+from django.db.backends.postgresql.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from django.db.models import Min, Model
+from typing_extensions import TypedDict
+
+BATCH_SIZE = 1000
+STREAM = 2
+
+
+class LegacyEditHistoryEvent(TypedDict, total=False):
+    user_id: int
+    timestamp: int
+    prev_stream: int
+    prev_subject: str
+    prev_content: str
+    prev_rendered_content: Optional[str]
+    prev_rendered_content_version: Optional[int]
+
+
+class EditHistoryEvent(TypedDict, total=False):
+    user_id: int
+    timestamp: int
+    prev_stream: int
+    stream: int
+    prev_topic: str
+    topic: str
+    prev_content: str
+    prev_rendered_content: Optional[str]
+    prev_rendered_content_version: Optional[int]
+
+
+def backfill_message_edit_history_chunk(first_id: int, last_id: int, message_model: Model) -> None:
+    """
+    Migrate edit history events for the messages in the provided range to:
+    * Rename prev_subject => prev_topic.
+    * Provide topic and stream fields with the current values.
+    """
+    messages = (
+        message_model.objects.select_for_update()
+        .only(
+            "recipient",
+            "recipient__type",
+            "recipient__type_id",
+            "subject",
+            "edit_history",
+            "edit_history_update_fields",
+        )
+        .filter(edit_history__isnull=False, id__range=(first_id, last_id))
+    )
+
+    with transaction.atomic():
+        for message in messages:
+            legacy_edit_history: List[LegacyEditHistoryEvent] = orjson.loads(message.edit_history)
+            message_type = message.recipient.type
+            modern_edit_history: List[EditHistoryEvent] = []
+
+            # Only Stream messages have topic / stream edit history data.
+            if message_type == STREAM:
+                topic = message.subject
+                stream_id = message.recipient.type_id
+
+            for edit_history_event in legacy_edit_history:
+                modern_entry: EditHistoryEvent = {
+                    "user_id": edit_history_event["user_id"],
+                    "timestamp": edit_history_event["timestamp"],
+                }
+
+                if "prev_content" in edit_history_event:
+                    modern_entry["prev_content"] = edit_history_event["prev_content"]
+                    modern_entry["prev_rendered_content"] = edit_history_event[
+                        "prev_rendered_content"
+                    ]
+                    modern_entry["prev_rendered_content_version"] = edit_history_event[
+                        "prev_rendered_content_version"
+                    ]
+
+                if "prev_subject" in edit_history_event and message_type == STREAM:
+                    # Add topic edit key/value pairs.
+                    modern_entry["topic"] = topic
+                    modern_entry["prev_topic"] = edit_history_event["prev_subject"]
+
+                    # Because edit_history is ordered chronologically,
+                    # most recent to least recent, we set the topic
+                    # variable to the `prev_topic` value for this edit
+                    # for any subsequent topic edits in the loop.
+                    topic = edit_history_event["prev_subject"]
+
+                if "prev_stream" in edit_history_event and message_type == STREAM:
+                    # Add stream edit key/value pairs.
+                    modern_entry["stream"] = stream_id
+                    modern_entry["prev_stream"] = edit_history_event["prev_stream"]
+
+                    # Same logic as above for the topic variable.
+                    stream_id = edit_history_event["prev_stream"]
+
+                modern_edit_history.append(modern_entry)
+
+            message.edit_history = modern_edit_history
+
+    message_model.objects.bulk_update(messages, ["edit_history"])
+
+
+def copy_and_update_message_edit_history(
+    apps: StateApps, schema_editor: DatabaseSchemaEditor
+) -> None:
+    Message = apps.get_model("zerver", "Message")
+    ArchivedMessage = apps.get_model("zerver", "ArchivedMessage")
+
+    message_models = [Message, ArchivedMessage]
+    for message_model in message_models:
+        if not message_model.objects.filter(edit_history__isnull=False).exists():
+            # No messages with "edit_history"
+            continue
+
+        first_id_to_update = message_model.objects.filter(
+            edit_history_update_fields__isnull=True, edit_history__isnull=False
+        ).aggregate(Min("id"))["id__min"]
+
+        last_id = message_model.objects.latest("id").id
+
+        id_range_lower_bound = first_id_to_update
+        id_range_upper_bound = first_id_to_update + BATCH_SIZE
+
+        while id_range_upper_bound <= last_id:
+            backfill_message_edit_history_chunk(
+                id_range_lower_bound, id_range_upper_bound, message_model
+            )
+            id_range_lower_bound = id_range_upper_bound + 1
+            id_range_upper_bound = id_range_lower_bound + BATCH_SIZE
+            time.sleep(0.1)
+
+        if last_id >= id_range_lower_bound:
+            # Copy/update for the last batch, or if only 1 message with edit_history in db
+            backfill_message_edit_history_chunk(id_range_lower_bound, last_id, message_model)
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("zerver", "0376_set_realmemoji_author_and_reupload_realmemoji"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            copy_and_update_message_edit_history,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4963,9 +4963,8 @@ paths:
         `topic`, `content`, `rendered_content`, `timestamp` and `user_id`. This
         snapshot will be the only one present if the message has never been edited.
 
-        Also note that if a message's content was edited (but not the topic)
-        or the topic was edited (but not the content), the snapshot object
-        will only contain data for the modified fields (e.g. if only the topic
+        Also note that each snapshot object will only contain additional data for the
+        modified fields for that particular edit (e.g. if only the topic or stream
         was edited, `prev_content`, `prev_rendered_content`, and
         `content_html_diff` will not appear).
       responses:
@@ -4990,45 +4989,67 @@ paths:
                             topic:
                               type: string
                               description: |
-                                the topic for the message.
+                                The topic of the message.
                             prev_topic:
                               type: string
                               description: |
-                                the topic for the message before being edited.
+                                Only present if message's topic was edited.
+
+                                The topic of the message before being edited.
+                            stream:
+                              type: integer
+                              description: |
+                                Only present if message's stream was edited.
+
+                                The stream of the message after being edited.
+
+                                **Changes**: New in Zulip 5.0 (feature level 116).
+                            prev_stream:
+                              type: integer
+                              description: |
+                                Only present if message's stream was edited.
+
+                                The stream of the message prior to being edited.
                             content:
                               type: string
                               description: |
-                                the body of the message.
+                                The body of the message.
                             rendered_content:
                               type: string
                               description: |
-                                the already rendered, HTML version of `content`.
+                                The already rendered, HTML version of `content`.
                             prev_content:
                               type: string
                               description: |
-                                the body of the message before being edited.
+                                Only present if message's content was edited.
+
+                                The body of the message before being edited.
                             prev_rendered_content:
                               type: string
                               description: |
-                                the already rendered, HTML version of
+                                Only present if message's content was edited.
+
+                                The already rendered, HTML version of
                                 `prev_content`.
                             user_id:
                               type: integer
                               description: |
-                                the ID of the user that made the edit.
+                                The ID of the user that made the edit.
                             content_html_diff:
                               type: string
                               description: |
-                                an HTML diff between this version of the message
+                                Only present if message's content was edited.
+
+                                An HTML diff between this version of the message
                                 and the previous one.
                             timestamp:
                               type: integer
                               description: |
-                                the UNIX timestamp for this edit.
+                                The UNIX timestamp for this edit.
                         description: |
-                          A chronologically sorted array of `snapshot`
-                          objects, each one with the values of the
-                          message after the edit.
+                          A chronologically sorted, oldest to newest, array
+                          of `snapshot` objects, each one with the values of
+                          the message after the edit.
                     example:
                       {
                         "message_history":
@@ -14619,6 +14640,78 @@ components:
             Data on the recipient of the message;
             either the name of a stream or a dictionary containing basic data on
             the users who received the message.
+        edit_history:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              prev_content:
+                type: string
+                description: |
+                  The body of the message before being edited.
+              prev_rendered_content:
+                type: string
+                description: |
+                  The already rendered, HTML version of `prev_content`.
+              prev_rendered_content_version:
+                type: string
+                description: |
+                  The Markdown processor version number for the message
+                  before being edited.
+              prev_stream:
+                type: integer
+                description: |
+                  The stream ID of the message before being edited.
+              prev_topic:
+                type: string
+                description: |
+                  The topic of the message before being edited.
+
+                  **Changes**: New in Zulip 5.0 (feature level 116).
+                  Previously, this field was called `prev_subject`;
+                  clients are recommended to rename `prev_subject` to
+                  `prev_topic` if present for compatibility with
+                  older Zulip servers.
+              stream:
+                type: integer
+                description: |
+                  The stream ID of the message after being edited.
+
+                  **Changes**: New in Zulip 5.0 (feature level 116).
+              timestamp:
+                type: integer
+                description: |
+                  The UNIX timestamp for the edit.
+              topic:
+                type: string
+                description: |
+                  The topic of the message after being edited.
+
+                  **Changes**: New in Zulip 5.0 (feature level 116).
+              user_id:
+                type: integer
+                description: |
+                  The ID of the user that made the edit.
+            required:
+              - user_id
+              - timestamp
+          description: |
+            An array of objects with each object documenting the changes
+            made in each edit to the message, ordered chronologically
+            from most recent to least recent edit.
+
+            Not present if the message has never been edited or if the realm has
+            [disabled viewing of message edit history][disable-edit-history].
+
+            When present, every object will contain `user_id` and `timestamp`.
+
+            The other fields in each object will depend on the changes
+            made in that specific edit to the message (e.g. if only the
+            topic was edited, only `prev_topic` and `topic` will be present
+            in addition to `user_id` and `timestamp`).
+
+            [disable-edit-history]: /help/disable-message-edit-history
         id:
           type: integer
           description: |

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -743,7 +743,10 @@ class EditMessageTest(EditMessageTestCase):
         history = orjson.loads(Message.objects.get(id=msg_id).edit_history)
         self.assertEqual(history[0][LEGACY_PREV_TOPIC], "topic 1")
         self.assertEqual(history[0]["user_id"], hamlet.id)
-        self.assertEqual(set(history[0].keys()), {"timestamp", LEGACY_PREV_TOPIC, "user_id"})
+        self.assertEqual(
+            set(history[0].keys()),
+            {"timestamp", LEGACY_PREV_TOPIC, "prev_topic", "topic", "user_id"},
+        )
 
         result = self.client_patch(
             f"/json/messages/{msg_id}",
@@ -762,6 +765,8 @@ class EditMessageTest(EditMessageTestCase):
             {
                 "timestamp",
                 LEGACY_PREV_TOPIC,
+                "prev_topic",
+                "topic",
                 "prev_content",
                 "user_id",
                 "prev_rendered_content",
@@ -813,6 +818,7 @@ class EditMessageTest(EditMessageTestCase):
             expected_entries = {"content", "rendered_content", "topic", "timestamp", "user_id"}
             if i in {0, 2, 3}:
                 expected_entries.add("prev_topic")
+                expected_entries.add("topic")
             if i in {1, 2, 4}:
                 expected_entries.add("prev_content")
                 expected_entries.add("prev_rendered_content")

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -53,8 +53,11 @@ def fill_edit_history_entries(
             "user_id": edit_history_event["user_id"],
         }
 
-        # Add current topic, map LEGACY_PREV_TOPIC => "prev_topic".
-        if LEGACY_PREV_TOPIC in edit_history_event:
+        if "prev_topic" in edit_history_event:
+            prev_topic = edit_history_event["prev_topic"]
+            formatted_entry["prev_topic"] = prev_topic
+        elif LEGACY_PREV_TOPIC in edit_history_event:
+            # TODO: Delete this once we've finished migrating legacy message objects.
             prev_topic = edit_history_event["prev_subject"]
             formatted_entry["prev_topic"] = prev_topic
 

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -16,7 +16,7 @@ from zerver.lib.message import access_message, access_web_public_message
 from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_timestamp
-from zerver.lib.topic import LEGACY_PREV_TOPIC, REQ_topic
+from zerver.lib.topic import REQ_topic
 from zerver.lib.types import EditHistoryEvent, FormattedEditHistoryEvent
 from zerver.lib.validator import check_bool, check_string_in, to_non_negative_int
 from zerver.models import Message, UserProfile
@@ -72,7 +72,7 @@ def fill_edit_history_entries(
 
         if "prev_stream" in edit_history_event:
             formatted_entry["prev_stream"] = edit_history_event["prev_stream"]
-            # TODO: Include current stream here.
+            formatted_entry["stream"] = edit_history_event["stream"]
 
     formatted_edit_history.append(
         FormattedEditHistoryEvent(

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 import orjson
 from django.contrib.auth.models import AnonymousUser
@@ -17,11 +17,14 @@ from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import LEGACY_PREV_TOPIC, REQ_topic
+from zerver.lib.types import EditHistoryEvent, FormattedEditHistoryEvent
 from zerver.lib.validator import check_bool, check_string_in, to_non_negative_int
 from zerver.models import Message, UserProfile
 
 
-def fill_edit_history_entries(message_history: List[Dict[str, Any]], message: Message) -> None:
+def fill_edit_history_entries(
+    raw_edit_history: List[EditHistoryEvent], message: Message
+) -> List[FormattedEditHistoryEvent]:
     """This fills out the message edit history entries from the database,
     which are designed to have the minimum data possible, to instead
     have the current topic + content as of that time, plus data on
@@ -36,37 +39,54 @@ def fill_edit_history_entries(message_history: List[Dict[str, Any]], message: Me
 
     # Make sure that the latest entry in the history corresponds to the
     # message's last edit time
-    if len(message_history) > 0:
+    if len(raw_edit_history) > 0:
         assert message.last_edit_time is not None
-        assert datetime_to_timestamp(message.last_edit_time) == message_history[0]["timestamp"]
+        assert datetime_to_timestamp(message.last_edit_time) == raw_edit_history[0]["timestamp"]
 
-    for entry in message_history:
-        entry["topic"] = prev_topic
-        if LEGACY_PREV_TOPIC in entry:
-            prev_topic = entry[LEGACY_PREV_TOPIC]
-            entry["prev_topic"] = prev_topic
-            del entry[LEGACY_PREV_TOPIC]
+    formatted_edit_history: List[FormattedEditHistoryEvent] = []
+    for edit_history_event in raw_edit_history:
+        formatted_entry: FormattedEditHistoryEvent = {
+            "content": prev_content,
+            "rendered_content": prev_rendered_content,
+            "timestamp": edit_history_event["timestamp"],
+            "topic": prev_topic,
+            "user_id": edit_history_event["user_id"],
+        }
 
-        entry["content"] = prev_content
-        entry["rendered_content"] = prev_rendered_content
-        if "prev_content" in entry:
-            del entry["prev_rendered_content_version"]
-            prev_content = entry["prev_content"]
-            prev_rendered_content = entry["prev_rendered_content"]
+        # Add current topic, map LEGACY_PREV_TOPIC => "prev_topic".
+        if LEGACY_PREV_TOPIC in edit_history_event:
+            prev_topic = edit_history_event["prev_subject"]
+            formatted_entry["prev_topic"] = prev_topic
+
+        # Fill current values for content/rendered_content.
+        if "prev_content" in edit_history_event:
+            formatted_entry["prev_content"] = edit_history_event["prev_content"]
+            prev_content = formatted_entry["prev_content"]
+            formatted_entry["prev_rendered_content"] = edit_history_event["prev_rendered_content"]
+            prev_rendered_content = formatted_entry["prev_rendered_content"]
             assert prev_rendered_content is not None
-            entry["content_html_diff"] = highlight_html_differences(
-                prev_rendered_content, entry["rendered_content"], message.id
+            rendered_content = formatted_entry["rendered_content"]
+            assert rendered_content is not None
+            formatted_entry["content_html_diff"] = highlight_html_differences(
+                prev_rendered_content, rendered_content, message.id
             )
 
-    message_history.append(
-        dict(
-            topic=prev_topic,
-            content=prev_content,
-            rendered_content=prev_rendered_content,
-            timestamp=datetime_to_timestamp(message.date_sent),
-            user_id=message.sender_id,
+        if "prev_stream" in edit_history_event:
+            formatted_entry["prev_stream"] = edit_history_event["prev_stream"]
+            # TODO: Include current stream here.
+
+    formatted_edit_history.append(
+        FormattedEditHistoryEvent(
+            dict(
+                topic=prev_topic,
+                content=prev_content,
+                rendered_content=prev_rendered_content,
+                timestamp=datetime_to_timestamp(message.date_sent),
+                user_id=message.sender_id,
+            )
         )
     )
+    return formatted_edit_history
 
 
 @has_request_variables
@@ -81,12 +101,12 @@ def get_message_edit_history(
 
     # Extract the message edit history from the message
     if message.edit_history is not None:
-        message_edit_history = orjson.loads(message.edit_history)
+        raw_edit_history = orjson.loads(message.edit_history)
     else:
-        message_edit_history = []
+        raw_edit_history = []
 
     # Fill in all the extra data that will make it usable
-    fill_edit_history_entries(message_edit_history, message)
+    message_edit_history = fill_edit_history_entries(raw_edit_history, message)
     return json_success(request, data={"message_history": list(reversed(message_edit_history))})
 
 

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -56,10 +56,6 @@ def fill_edit_history_entries(
         if "prev_topic" in edit_history_event:
             prev_topic = edit_history_event["prev_topic"]
             formatted_entry["prev_topic"] = prev_topic
-        elif LEGACY_PREV_TOPIC in edit_history_event:
-            # TODO: Delete this once we've finished migrating legacy message objects.
-            prev_topic = edit_history_event["prev_subject"]
-            formatted_entry["prev_topic"] = prev_topic
 
         # Fill current values for content/rendered_content.
         if "prev_content" in edit_history_event:


### PR DESCRIPTION
This pull request effectively restructures https://github.com/zulip/zulip/pull/21122 to drop the JSONB migration, which I think adds too much complexity. A few pieces are substantially rewritten. Notable changes include:
* Trying to use `edit_history_event` consistently as our loop variables for edit history events.
* Avoiding database queries in a loop in the migration by fetching the `Recipient` data in the original Message queries.
* Introducing an `APIEditHistoryEvent` type; not sure if this is worth it but it helped me think through the changes clearly.
* Creating a clear set of checkpoint commits which if applied in production in series should avoid there ever being a state where the application isn't fully functional.

@laurynmm it'd be great if you can review this, reintroduce the tests I didn't copy over (I think I moved almost every other block of code, but it's unfortunately probably pretty annoying to do diffs because I renamed a lot of variables), and fix all the bugs that I likely introduced.  I think the commit structure/approach here should work and feel good about the plan of doing this sort of migration separate from the JSONB change, but it's essentially untested and probably some commits fix mypy too.