### PR TITLE
recent_topics: Disable filters in Recent topics for logged out users.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -431,10 +431,12 @@ export function initialize() {
 
     $("body").on("click", ".btn-recent-filters", (e) => {
         e.stopPropagation();
-        recent_topics_ui.change_focused_element($(e.target), "click");
-        recent_topics_ui.set_filter(e.currentTarget.dataset.filter);
-        recent_topics_ui.update_filters_view();
-        recent_topics_ui.revive_current_focus();
+        if (!page_params.is_spectator) {
+            recent_topics_ui.change_focused_element($(e.target), "click");
+            recent_topics_ui.set_filter(e.currentTarget.dataset.filter);
+            recent_topics_ui.update_filters_view();
+            recent_topics_ui.revive_current_focus();
+        }
     });
 
     $("body").on("click", "td.recent_topic_stream", (e) => {

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -19,6 +19,7 @@ import * as narrow from "./narrow";
 import * as narrow_state from "./narrow_state";
 import * as navbar_alerts from "./navbar_alerts";
 import * as navigate from "./navigate";
+import {page_params} from "./page_params";
 import * as people from "./people";
 import * as recent_senders from "./recent_senders";
 import {get, process_message, topics} from "./recent_topics_data";
@@ -87,6 +88,9 @@ export function save_filters() {
 }
 
 export function load_filters() {
+    if (page_params.is_spectator) {
+        ls.set(ls_key, null);
+    }
     filters = new Set(ls.get(ls_key));
 }
 
@@ -472,6 +476,11 @@ function show_selected_filters() {
                 .addClass("btn-recent-selected")
                 .attr("aria-checked", "true");
         }
+    }
+
+    if (page_params.is_spectator) {
+        $("#recent_filters_group").css("cursor", "not-allowed");
+        $("#recent_filters_group button").attr("disabled", "true");
     }
 }
 


### PR DESCRIPTION
In "click_handlers.js", disable function calls on clicking filter buttons
when the user is logged out.

In "recent_topics_ui.js/load_filters", assign "null" to filters in
local storage. This is to prevent the user from manually adding filters
to the local storage.

In "recent_topics_ui.js/show_selected_filters", disable the filter buttons
and change the cursor to "not-allowed" when the user is logged out.

Fixes: #21279

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

https://user-images.githubusercontent.com/85362194/156302583-7e34cf14-24f4-4afb-b1f3-89ffa5a5e5e7.mov



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
