### PR TITLE
compose: Add pending upload count and "Cancel" button to status modal

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -96,6 +96,7 @@ function test(label, f) {
         // We don't test the css calls; we just skip over them.
         $("#compose").css = () => {};
         $(".new_message_textarea").css = () => {};
+        $("#compose-send-status .upload-count").contents = () => "";
 
         people.init();
         compose_state.set_message_type(false);

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -678,7 +678,7 @@ export function initialize() {
 
     // COMPOSE
 
-    $("body").on("click", "#compose-send-status .compose-send-status-close", () => {
+    $("body").on("click", "#compose-send-status #compose-send-status-close", () => {
         compose_error.hide();
     });
 

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -321,7 +321,7 @@ export function initialize() {
             ui_util.blur_active_element();
         }
     });
-    $(".message_edit_form .send-status-close").on("click", function () {
+    $(".message_edit_form .send-status-cancel-upload").on("click", function () {
         const row_id = rows.id($(this).closest(".message_row"));
         const $send_status = $(`#message-edit-send-status-${CSS.escape(row_id)}`);
         $($send_status).stop(true).fadeOut(200);
@@ -678,7 +678,7 @@ export function initialize() {
 
     // COMPOSE
 
-    $("body").on("click", "#compose-send-status #compose-send-status-close", () => {
+    $("body").on("click", "#compose-send-status #compose-send-status-cancel-upload", () => {
         compose_error.hide();
     });
 

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -28,6 +28,7 @@ import * as spectators from "./spectators";
 import * as stream_bar from "./stream_bar";
 import * as stream_data from "./stream_data";
 import * as unread_ops from "./unread_ops";
+import * as upload from "./upload";
 import * as util from "./util";
 
 export function blur_compose_inputs() {
@@ -91,7 +92,15 @@ function show_box(msg_type, opts) {
         $("#stream_toggle").removeClass("active");
         $("#private_message_toggle").addClass("active");
     }
-    $("#compose-send-status").removeClass(common.status_classes).hide();
+
+    // We shouldn't be hiding send status an upload is active
+    const upload_count = upload
+        .get_item("send_status_upload_count", {mode: "compose"})
+        .contents()?.[0]?.data;
+    if (upload_count === "0" || upload_count === undefined) {
+        $("#compose-send-status").removeClass(common.status_classes).hide();
+    }
+
     $("#compose").css({visibility: "visible"});
     // When changing this, edit the 42px in _maybe_autoscroll
     $(".new_message_textarea").css("min-height", "3em");

--- a/static/js/compose_error.ts
+++ b/static/js/compose_error.ts
@@ -21,7 +21,7 @@ export function show(error_html: string, $bad_input?: JQuery, alert_class = "ale
 
 export function show_not_subscribed(error_html: string, $bad_input?: JQuery): void {
     show(error_html, $bad_input, "home-error-bar");
-    $("#compose-send-status-close").hide();
+    $("#compose-send-status-controls").hide();
 }
 
 export function hide(): void {

--- a/static/js/compose_error.ts
+++ b/static/js/compose_error.ts
@@ -21,7 +21,7 @@ export function show(error_html: string, $bad_input?: JQuery, alert_class = "ale
 
 export function show_not_subscribed(error_html: string, $bad_input?: JQuery): void {
     show(error_html, $bad_input, "home-error-bar");
-    $(".compose-send-status-close").hide();
+    $("#compose-send-status-close").hide();
 }
 
 export function hide(): void {

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -656,10 +656,14 @@ function start_edit_with_content($row, content, edit_box_open_callback) {
         edit_box_open_callback();
     }
 
-    upload.setup_upload({
+    const config = {
         mode: "edit",
         row: rows.id($row),
-    });
+    };
+
+    upload.setup_upload(config);
+
+    upload.hide_upload_status(config);
 }
 
 export function start($row, edit_box_open_callback) {

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -32,8 +32,6 @@ export function get_item(key, config) {
                 return $("#compose-textarea");
             case "send_button":
                 return $("#compose-send-button");
-            case "send_status_identifier":
-                return "#compose-send-status";
             case "send_status":
                 return $("#compose-send-status");
             case "send_status_visual":
@@ -42,8 +40,6 @@ export function get_item(key, config) {
                 return $("#compose-send-status-controls");
             case "send_status_cancel_button":
                 return $("#compose-send-status-cancel-upload");
-            case "send_status_close_button":
-                return $("#compose-send-status-close");
             case "send_status_message":
                 return $("#compose-error-msg");
             case "send_status_upload_count":
@@ -70,8 +66,6 @@ export function get_item(key, config) {
                 return $(`#edit_form_${CSS.escape(config.row)} .message_edit_content`)
                     .closest(".message_edit_form")
                     .find(".message_edit_save");
-            case "send_status_identifier":
-                return `#message-edit-send-status-${CSS.escape(config.row)}`;
             case "send_status":
                 return $(`#message-edit-send-status-${CSS.escape(config.row)}`);
             case "send_status_visual":
@@ -162,14 +156,12 @@ export function upload_files(uppy, config, files) {
     get_item("send_status_controls", config).show();
 
     get_item("send_status_message", config).html(
-        $(`
-    <p>
-        ${$t(
-            {defaultMessage: "Uploading {uploadCount} files"},
-            {uploadCount: `<span class="upload-count"> ${uppy.getFiles().length}</span>`},
-        )}
-    </p>
-    `),
+        `<p>
+    ${$t(
+        {defaultMessage: "Uploading {uploadCount} files"},
+        {uploadCount: `<span class="upload-count">${uppy.getFiles().length}</span>`},
+    )}
+</p>`,
     );
 
     for (const file of files) {

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -36,8 +36,12 @@ export function get_item(key, config) {
                 return "#compose-send-status";
             case "send_status":
                 return $("#compose-send-status");
+            case "send_status_visual":
+                return "#compose-status-visual";
+            case "send_status_cancel_button":
+                return $("#compose-send-status-cancel-upload");
             case "send_status_close_button":
-                return $(".compose-send-status-close");
+                return $("#compose-send-status-close");
             case "send_status_message":
                 return $("#compose-error-msg");
             case "send_status_upload_count":
@@ -68,6 +72,8 @@ export function get_item(key, config) {
                 return `#message-edit-send-status-${CSS.escape(config.row)}`;
             case "send_status":
                 return $(`#message-edit-send-status-${CSS.escape(config.row)}`);
+            case "send_status_visual":
+                return `#message-edit-send-status-${CSS.escape(config.row)}`;
             case "send_status_close_button":
                 return $(`#message-edit-send-status-${CSS.escape(config.row)}`).find(
                     ".send-status-close",
@@ -149,21 +155,6 @@ export function upload_files(uppy, config, files) {
     </p>
     `),
     );
-    get_item("send_status_close_button", config).one("click", () => {
-        for (const file of uppy.getFiles()) {
-            compose_ui.replace_syntax(
-                get_translated_status(file),
-                "",
-                get_item("textarea", config),
-            );
-        }
-        compose_ui.autosize_textarea(get_item("textarea", config));
-        uppy.cancelAll();
-        get_item("textarea", config).trigger("focus");
-        setTimeout(() => {
-            hide_upload_status(config);
-        }, 500);
-    });
 
     for (const file of files) {
         try {
@@ -219,7 +210,7 @@ export function setup_upload(config) {
     });
 
     uppy.use(ProgressBar, {
-        target: get_item("send_status_identifier", config),
+        target: get_item("send_status_visual", config),
         hideAfterFinish: false,
     });
 
@@ -227,6 +218,13 @@ export function setup_upload(config) {
         const files = event.target.files;
         upload_files(uppy, config, files);
         event.target.value = "";
+    });
+
+    get_item("send_status_cancel_button", config).on("click", () => {
+        uppy.cancelAll();
+        compose_ui.autosize_textarea(get_item("textarea", config));
+        get_item("textarea", config).trigger("focus");
+        setTimeout(() => hide_upload_status(config), 500);
     });
 
     const $drag_drop_container = get_item("drag_drop_container", config);
@@ -254,6 +252,12 @@ export function setup_upload(config) {
             files.push(file);
         }
         upload_files(uppy, config, files);
+    });
+
+    uppy.on("file-removed", (file) => {
+        const placeholder = get_translated_status(file);
+
+        compose_ui.replace_syntax(placeholder, "", get_item("textarea", config));
     });
 
     uppy.on("upload-success", (file, response) => {

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -38,6 +38,8 @@ export function get_item(key, config) {
                 return $("#compose-send-status");
             case "send_status_visual":
                 return "#compose-status-visual";
+            case "send_status_controls":
+                return $("#compose-send-status-controls");
             case "send_status_cancel_button":
                 return $("#compose-send-status-cancel-upload");
             case "send_status_close_button":
@@ -45,7 +47,7 @@ export function get_item(key, config) {
             case "send_status_message":
                 return $("#compose-error-msg");
             case "send_status_upload_count":
-                return $("#compose-upload-count");
+                return $("#compose-send-status .upload-count");
             case "file_input_identifier":
                 return "#compose .file_input";
             case "source":
@@ -73,13 +75,23 @@ export function get_item(key, config) {
             case "send_status":
                 return $(`#message-edit-send-status-${CSS.escape(config.row)}`);
             case "send_status_visual":
-                return `#message-edit-send-status-${CSS.escape(config.row)}`;
-            case "send_status_close_button":
-                return $(`#message-edit-send-status-${CSS.escape(config.row)}`).find(
-                    ".send-status-close",
+                return `#message-edit-send-status-${CSS.escape(config.row)} .status-visual`;
+            case "send_status_controls":
+                return $(
+                    `#message-edit-send-status-${CSS.escape(
+                        config.row,
+                    )} .send-status-cancel-upload`,
+                );
+            case "send_status_cancel_button":
+                return $(
+                    `#message-edit-send-status-${CSS.escape(
+                        config.row,
+                    )} .send-status-cancel-upload`,
                 );
             case "send_status_message":
                 return $(`#message-edit-send-status-${CSS.escape(config.row)}`).find(".error-msg");
+            case "send_status_upload_count":
+                return $(`#message-edit-send-status-${CSS.escape(config.row)} .upload-count`);
             case "file_input_identifier":
                 return `#edit_form_${CSS.escape(config.row)} .file_input`;
             case "source":
@@ -145,12 +157,16 @@ export function upload_files(uppy, config, files) {
 
     get_item("send_button", config).prop("disabled", true);
     get_item("send_status", config).addClass("alert-info").removeClass("alert-error").show();
+
+    // Controls may be hidden by other alerts (see `compose_error.ts`)
+    get_item("send_status_controls", config).show();
+
     get_item("send_status_message", config).html(
         $(`
     <p>
         ${$t(
             {defaultMessage: "Uploading {uploadCount} files"},
-            {uploadCount: `<span id="compose-upload-count"> ${uppy.getFiles().length}</span>`},
+            {uploadCount: `<span class="upload-count"> ${uppy.getFiles().length}</span>`},
         )}
     </p>
     `),
@@ -256,6 +272,7 @@ export function setup_upload(config) {
 
     uppy.on("file-removed", (file) => {
         const placeholder = get_translated_status(file);
+        update_upload_count(uppy, config);
 
         compose_ui.replace_syntax(placeholder, "", get_item("textarea", config));
     });

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -344,24 +344,10 @@ div[id^="message-edit-send-status"],
     padding-right: 2px;
 }
 
-/* Override right relative positioning inherited from .close */
-.close#compose-send-status-close {
-    right: -10px;
-}
-
-.btn#compose-send-status-cancel-upload {
+.btn#compose-send-status-cancel-upload,
+.btn.send-status-cancel-upload {
     border-radius: 4px;
     border: solid 0.1px hsla(0, 0%, 0%, 0.1);
-}
-
-/* Like .alert .close */
-.send-status-close {
-    font-size: 17px;
-    font-weight: bold;
-    color: hsl(0, 0%, 0%);
-    text-shadow: 0 1px 0 hsl(0, 0%, 100%);
-    opacity: 0.2;
-    float: right;
 }
 
 .send-status-close:hover {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -349,6 +349,11 @@ div[id^="message-edit-send-status"],
     right: -10px;
 }
 
+.btn#compose-send-status-cancel-upload {
+    border-radius: 4px;
+    border: solid 0.1px hsla(0, 0%, 0%, 0.1);
+}
+
 /* Like .alert .close */
 .send-status-close {
     font-size: 17px;

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -330,7 +330,9 @@ div[id^="message-edit-send-status"],
     padding: 8px 14px;
     margin-bottom: 8px;
     line-height: 20px;
-    display: none;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
 #compose-send-status .progress {
@@ -338,9 +340,17 @@ div[id^="message-edit-send-status"],
     margin-bottom: 10px;
 }
 
+#compose-send-status-controls {
+    padding-right: 2px;
+}
+
+/* Override right relative positioning inherited from .close */
+.close#compose-send-status-close {
+    right: -10px;
+}
+
 /* Like .alert .close */
-.send-status-close,
-.compose-send-status-close {
+.send-status-close {
     font-size: 17px;
     font-weight: bold;
     color: hsl(0, 0%, 0%);
@@ -349,8 +359,7 @@ div[id^="message-edit-send-status"],
     float: right;
 }
 
-.send-status-close:hover,
-.compose-send-status-close:hover {
+.send-status-close:hover {
     cursor: pointer;
     opacity: 0.4;
 }

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -155,12 +155,19 @@ body.dark-theme {
         }
     }
 
+    #compose_buttons
+        .reply_button_container
+        .compose_reply_button
+        .compose_reply_button_recipient_label {
+        color: hsl(215, 47%, 80%);
+    }
+
     .compose-send-status-close {
         color: hsl(0, 0%, 100%);
         opacity: 1;
     }
 
-    .compose-send-status-close:hover {
+    #compose-send-status-close:hover {
         opacity: 0.4;
     }
 

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -55,7 +55,6 @@
                 <button type="button" id="compose-send-status-cancel-upload" class="btn">
                     {{t 'Cancel' }}
                 </button>
-                <button type="button" id="compose-send-status-close" class="close">×</button>
             </div>
         </div>
         <div id="compose_resolved_topic" class="alert home-error-bar"></div>

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -47,8 +47,16 @@
     </div>
     <div class="message_comp">
         <div class="alert" id="compose-send-status">
-            <span class="compose-send-status-close">&times;</span>
-            <span id="compose-error-msg"></span>
+            <div id="compose-send-status-core">
+                <span id="compose-error-msg"></span>
+                <div id="compose-status-visual"></div>
+            </div>
+            <div id="compose-send-status-controls">
+                <button type="button" id="compose-send-status-cancel-upload" class="btn btn-warning">
+                    {{t 'Cancel' }}
+                </button>
+                <button type="button" id="compose-send-status-close" class="close">×</button>
+            </div>
         </div>
         <div id="compose_resolved_topic" class="alert home-error-bar"></div>
         <div id="compose_invite_users" class="alert home-error-bar"></div>

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -52,7 +52,7 @@
                 <div id="compose-status-visual"></div>
             </div>
             <div id="compose-send-status-controls">
-                <button type="button" id="compose-send-status-cancel-upload" class="btn btn-warning">
+                <button type="button" id="compose-send-status-cancel-upload" class="btn">
                     {{t 'Cancel' }}
                 </button>
                 <button type="button" id="compose-send-status-close" class="close">×</button>

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -2,8 +2,15 @@
 
 <form id="edit_form_{{message_id}}" class="form-horizontal new-style">
     <div class="alert" id="message-edit-send-status-{{message_id}}">
-        <span class="send-status-close">&times;</span>
-        <span class="error-msg"></span>
+        <div class="send-status-core">
+            <span class="error-msg"></span>
+            <div class="status-visual"></div>
+        </div>
+        <div class="send-status-controls">
+            <button type="button" class="btn send-status-cancel-upload">
+                {{t 'Cancel' }}
+            </button>
+        </div>
     </div>
     {{#if is_stream}}
     <div class="control-group no-margin">


### PR DESCRIPTION
## Context

Fixes #21156.

- [x] Adds count of pending uploads to the send_status_message modal, improving the UX by making it easier to see if some uploads are taking too long and the number of pending uploads in real time. Uploads can be cancelled with the "close" button which already implemented the cancelling behavior.
- [x] Adds a button to cancel uploads, separating the behavior out from the existing `x` button (which unexpectedly implemented this behavior).
- [x] Update tests.

## Testing Plan

I tested on my local development environment by throttling my upload speeds and queueing multiple uploads of different sizes. The upload counts indicated in the modal were reliable against the count of placeholders in the compose UI. Clicking the "cancel" button consistently cancelled the uploads and cleared out the placeholders.

## Screenshots
<details>
  <summary>Light Mode</summary>

  
![image](https://user-images.githubusercontent.com/72784348/163379142-6816fb5e-fa65-4de6-970c-4f3602cd7e55.png)
</details>
<details>
  <summary>Dark Mode</summary>

![image](https://user-images.githubusercontent.com/72784348/163379156-51fba956-10c0-4b0b-aa42-89d68cf479e3.png)
</details>


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
