### PR TITLE
tippy: Fix compose box `cancel button` tooltip.

### DIFF
--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -69,7 +69,7 @@
                         <div id="compose_top_right" class="order-2">
                             <button type="button" class="expand_composebox_button fa fa-angle-up" aria-label="{{t 'Expand compose' }}" data-tippy-content="{{t 'Expand compose' }}"></button>
                             <button type="button" class="collapse_composebox_button fa fa-angle-down" aria-label="{{t 'Collapse compose' }}" data-tippy-content="{{t 'Collapse compose' }}"></button>
-                            <button type="button" class="close" id='compose_close' data-tippy-content="{{t 'Cancel compose' }}  <span class='hotkey-hint'>(Esc)</span>">&times;</button>
+                            <button type="button" class="close" id='compose_close' data-tippy-content="{{t 'Cancel compose' }} &lt;span class='hotkey-hint'&gt;(Esc)&lt;/span&gt;" data-tippy-allowHTML="true">&times;</button>
                         </div>
                         <div id="stream-message" class="order-1">
                             <div class="stream-selection-header-colorblock message_header_stream left_part" tab-index="-1"></div>


### PR DESCRIPTION
**Before** ->
![Screenshot from 2022-03-02 14-19-19](https://user-images.githubusercontent.com/76561593/156327529-6cd24682-a24c-4706-ad33-4d521c006555.png)


**After Fix** -> 
![Screenshot from 2022-03-02 14-10-27](https://user-images.githubusercontent.com/76561593/156327591-8d554ad3-c206-4997-adf4-f3a9d2836d69.png)
