### PR TITLE
shared: Add flow types for internal_url.

### DIFF
--- a/static/shared/js/internal_url.js.flow
+++ b/static/shared/js/internal_url.js.flow
@@ -1,0 +1,30 @@
+/**
+ * @flow strict
+ */
+
+"use strict";
+
+declare export function encodeHashComponent(str: string): string;
+
+declare export function decodeHashComponent(str: string): string;
+
+declare export function stream_id_to_slug(
+    stream_id: number,
+    maybe_get_stream_name: (id: number) => ?string,
+): string;
+
+declare export function encode_stream_id(
+    stream_id: number,
+    maybe_get_stream_name: (id: number) => ?string,
+): string;
+
+declare export function by_stream_url(
+    stream_id: number,
+    maybe_get_stream_name: (id: number) => ?string,
+): string;
+
+declare export function by_stream_topic_url(
+    stream_id: number,
+    topic: string,
+    maybe_get_stream_name: (id: number) => ?string,
+): string;


### PR DESCRIPTION
Adds flow type declarations for the shared js/internal_url module making
it integrate better with zulip-mobile.

Once this is merged, it would be a good idea to publish a new version of @zulup/shared so that the zulip-mobile codebase can access the new functions defined here.