### PR TITLE
Revised migration of message `edit_history` data structure.

### DIFF
--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -107,7 +107,7 @@ test("msg_moved_var", () => {
             }),
             // topic changed: Move
             build_message_context({
-                edit_history: [{prev_subject: "test_topic", timestamp: 1000, user_id: 1}],
+                edit_history: [{prev_topic: "test_topic", timestamp: 1000, user_id: 1}],
             }),
             // content edited: Edit
             build_message_context({

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -136,10 +136,6 @@ run_test("get_edit_event_orig_topic", () => {
     assert.equal(util.get_edit_event_orig_topic({orig_subject: "lunch"}), "lunch");
 });
 
-run_test("get_edit_event_prev_topic", () => {
-    assert.equal(util.get_edit_event_prev_topic({prev_subject: "dinner"}), "dinner");
-});
-
 run_test("is_mobile", () => {
     window.navigator = {userAgent: "Android"};
     assert.ok(util.is_mobile());

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -66,10 +66,7 @@ function message_was_only_moved(message) {
             if (edit_history_event.prev_content) {
                 return false;
             }
-            if (
-                util.get_edit_event_prev_topic(edit_history_event) ||
-                edit_history_event.prev_stream
-            ) {
+            if (edit_history_event.prev_topic || edit_history_event.prev_stream) {
                 moved = true;
             }
         }

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -481,7 +481,7 @@ export function toggle_actions_popover(element, id) {
                 (entry) =>
                     entry.prev_content !== undefined ||
                     entry.prev_stream !== undefined ||
-                    util.get_edit_event_prev_topic(entry) !== undefined,
+                    entry.prev_topic !== undefined,
             ) &&
             page_params.realm_allow_edit_history &&
             not_spectator;

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -241,10 +241,6 @@ export function get_edit_event_orig_topic(obj) {
     return obj.orig_subject;
 }
 
-export function get_edit_event_prev_topic(obj) {
-    return obj.prev_subject;
-}
-
 export function is_topic_synonym(operator) {
     return operator === "subject";
 }

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,21 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 5.0
 
+**Feature level 118**
+
+* [`GET /messages`](/api/get-messages), [`GET
+  /events`](/api/get-events): Improved the format of the
+  `edit_history` object within message objects. Entries for stream
+  edits now include a both a `prev_stream` and `stream` field to
+  indicate the previous and current stream IDs. Entries for topic
+  edits now include both a `prev_topic` and `topic` field to indicate
+  the previous and current topic, replacing the `prev_subject`
+  field. These changes substantially simplify client complexity for
+  processing historical message edits.
+
+* [`GET messages/{message_id}/history`](/api/get-message-history):
+  Added `stream` field to message history `snapshot` indicating
+  the updated stream ID of messages moved to a new stream.
 
 **Feature level 117**
 

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -12,10 +12,7 @@ from zulint.custom_rules import Rule, RuleList
 
 FILES_WITH_LEGACY_SUBJECT = {
     # This basically requires a big DB migration:
-    "zerver/lib/message.py",
     "zerver/lib/topic.py",
-    "zerver/lib/types.py",
-    "zerver/views/message_edit.py",
     # This is for backward compatibility.
     "zerver/tests/test_legacy_subject.py",
     # Other migration-related changes require extreme care.
@@ -232,7 +229,7 @@ python_rules = RuleList(
     rules=[
         {
             "pattern": "subject|SUBJECT",
-            "exclude_pattern": "subject to the|email|outbox|edit_history_event",
+            "exclude_pattern": "subject to the|email|outbox",
             "description": "avoid subject as a var",
             "good_lines": ["topic_name"],
             "bad_lines": ['subject="foo"', " MAX_SUBJECT_LEN"],

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -12,6 +12,7 @@ from zulint.custom_rules import Rule, RuleList
 
 FILES_WITH_LEGACY_SUBJECT = {
     # This basically requires a big DB migration:
+    "zerver/lib/message.py",
     "zerver/lib/topic.py",
     "zerver/lib/types.py",
     "zerver/views/message_edit.py",

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -14,6 +14,7 @@ FILES_WITH_LEGACY_SUBJECT = {
     # This basically requires a big DB migration:
     "zerver/lib/topic.py",
     "zerver/lib/types.py",
+    "zerver/views/message_edit.py",
     # This is for backward compatibility.
     "zerver/tests/test_legacy_subject.py",
     # Other migration-related changes require extreme care.

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -13,6 +13,7 @@ from zulint.custom_rules import Rule, RuleList
 FILES_WITH_LEGACY_SUBJECT = {
     # This basically requires a big DB migration:
     "zerver/lib/topic.py",
+    "zerver/lib/types.py",
     # This is for backward compatibility.
     "zerver/tests/test_legacy_subject.py",
     # Other migration-related changes require extreme care.
@@ -229,7 +230,7 @@ python_rules = RuleList(
     rules=[
         {
             "pattern": "subject|SUBJECT",
-            "exclude_pattern": "subject to the|email|outbox",
+            "exclude_pattern": "subject to the|email|outbox|edit_history_event",
             "description": "avoid subject as a var",
             "good_lines": ["topic_name"],
             "bad_lines": ['subject="foo"', " MAX_SUBJECT_LEN"],

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 117
+API_FEATURE_LEVEL = 118
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -6874,7 +6874,6 @@ def do_update_message(
         event[ORIG_TOPIC] = orig_topic_name
         event[TOPIC_NAME] = topic_name
         event[TOPIC_LINKS] = topic_links(target_message.sender.realm_id, topic_name)
-        edit_history_event["prev_subject"] = orig_topic_name
         edit_history_event["prev_topic"] = orig_topic_name
         edit_history_event["topic"] = topic_name
 
@@ -6891,8 +6890,6 @@ def do_update_message(
             "timestamp": edit_history_event["timestamp"],
         }
         if topic_name is not None:
-            # For backwards-compatability, we include this legacy field name.
-            topic_only_edit_history_event["prev_subject"] = edit_history_event["prev_subject"]
             topic_only_edit_history_event["prev_topic"] = edit_history_event["prev_topic"]
             topic_only_edit_history_event["topic"] = edit_history_event["topic"]
         if new_stream is not None:

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -6815,6 +6815,7 @@ def do_update_message(
         assert stream_being_edited is not None
 
         edit_history_event["prev_stream"] = stream_being_edited.id
+        edit_history_event["stream"] = new_stream.id
         event[ORIG_TOPIC] = orig_topic_name
         target_message.recipient_id = new_stream.recipient_id
 
@@ -6874,6 +6875,8 @@ def do_update_message(
         event[TOPIC_NAME] = topic_name
         event[TOPIC_LINKS] = topic_links(target_message.sender.realm_id, topic_name)
         edit_history_event["prev_subject"] = orig_topic_name
+        edit_history_event["prev_topic"] = orig_topic_name
+        edit_history_event["topic"] = topic_name
 
     update_edit_history(target_message, timestamp, edit_history_event)
 
@@ -6888,9 +6891,13 @@ def do_update_message(
             "timestamp": edit_history_event["timestamp"],
         }
         if topic_name is not None:
+            # For backwards-compatability, we include this legacy field name.
             topic_only_edit_history_event["prev_subject"] = edit_history_event["prev_subject"]
+            topic_only_edit_history_event["prev_topic"] = edit_history_event["prev_topic"]
+            topic_only_edit_history_event["topic"] = edit_history_event["topic"]
         if new_stream is not None:
             topic_only_edit_history_event["prev_stream"] = edit_history_event["prev_stream"]
+            topic_only_edit_history_event["stream"] = edit_history_event["stream"]
 
         messages_list = update_messages_for_topic_edit(
             acting_user=user_profile,

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -442,7 +442,7 @@ class MessageDict:
         return MessageDict.build_message_dict(
             message_id=row["id"],
             last_edit_time=row["last_edit_time"],
-            edit_history=row["edit_history"],
+            edit_history_json=row["edit_history"],
             content=row["content"],
             topic_name=row[DB_TOPIC_NAME],
             date_sent=row["date_sent"],
@@ -463,7 +463,7 @@ class MessageDict:
     def build_message_dict(
         message_id: int,
         last_edit_time: Optional[datetime.datetime],
-        edit_history: Optional[str],
+        edit_history_json: Optional[str],
         content: str,
         topic_name: str,
         date_sent: datetime.datetime,
@@ -501,8 +501,9 @@ class MessageDict:
 
         if last_edit_time is not None:
             obj["last_edit_timestamp"] = datetime_to_timestamp(last_edit_time)
-            assert edit_history is not None
-            obj["edit_history"] = orjson.loads(edit_history)
+            assert edit_history_json is not None
+            edit_history = orjson.loads(edit_history_json)
+            obj["edit_history"] = edit_history
 
         if Message.need_to_render_content(
             rendered_content, rendered_content_version, markdown_version

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -38,12 +38,7 @@ from zerver.lib.streams import get_web_public_streams_queryset
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import DB_TOPIC_NAME, MESSAGE__TOPIC, TOPIC_LINKS, TOPIC_NAME
 from zerver.lib.topic_mutes import build_topic_mute_checker, topic_is_muted
-from zerver.lib.types import (
-    APIEditHistoryEvent,
-    DisplayRecipientT,
-    EditHistoryEvent,
-    UserDisplayRecipient,
-)
+from zerver.lib.types import DisplayRecipientT, EditHistoryEvent, UserDisplayRecipient
 from zerver.models import (
     MAX_TOPIC_NAME_LENGTH,
     Message,
@@ -507,25 +502,7 @@ class MessageDict:
         if last_edit_time is not None:
             obj["last_edit_timestamp"] = datetime_to_timestamp(last_edit_time)
             assert edit_history_json is not None
-            raw_edit_history: List[EditHistoryEvent] = orjson.loads(edit_history_json)
-            edit_history: List[APIEditHistoryEvent] = []
-            for edit_history_event in raw_edit_history:
-                # Drop fields we're not yet ready to have appear in the API
-                if "prev_topic" in edit_history_event:
-                    # The prev_subject field has been renamed in the
-                    # database, but not the API.
-                    edit_history_event["prev_subject"] = edit_history_event["prev_topic"]  # type: ignore # Temporary type-checking violation
-
-                # New fields not consistently available, and thus
-                # intentionally not exposed to the API.
-                if "prev_topic" in edit_history_event:
-                    del edit_history_event["prev_topic"]
-                if "stream" in edit_history_event:
-                    del edit_history_event["stream"]
-                if "topic" in edit_history_event:
-                    del edit_history_event["topic"]
-
-                edit_history.append(edit_history_event)  # type: ignore # Temporary type-checking violation
+            edit_history: List[EditHistoryEvent] = orjson.loads(edit_history_json)
             obj["edit_history"] = edit_history
 
         if Message.need_to_render_content(

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -38,7 +38,7 @@ from zerver.lib.streams import get_web_public_streams_queryset
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import DB_TOPIC_NAME, MESSAGE__TOPIC, TOPIC_LINKS, TOPIC_NAME
 from zerver.lib.topic_mutes import build_topic_mute_checker, topic_is_muted
-from zerver.lib.types import DisplayRecipientT, UserDisplayRecipient
+from zerver.lib.types import DisplayRecipientT, EditHistoryEvent, UserDisplayRecipient
 from zerver.models import (
     MAX_TOPIC_NAME_LENGTH,
     Message,
@@ -502,7 +502,8 @@ class MessageDict:
         if last_edit_time is not None:
             obj["last_edit_timestamp"] = datetime_to_timestamp(last_edit_time)
             assert edit_history_json is not None
-            edit_history = orjson.loads(edit_history_json)
+            # Here we assume EditHistoryEvent == APIEditHistoryEvent
+            edit_history: List[EditHistoryEvent] = orjson.loads(edit_history_json)
             obj["edit_history"] = edit_history
 
         if Message.need_to_render_content(

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -38,7 +38,12 @@ from zerver.lib.streams import get_web_public_streams_queryset
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import DB_TOPIC_NAME, MESSAGE__TOPIC, TOPIC_LINKS, TOPIC_NAME
 from zerver.lib.topic_mutes import build_topic_mute_checker, topic_is_muted
-from zerver.lib.types import DisplayRecipientT, EditHistoryEvent, UserDisplayRecipient
+from zerver.lib.types import (
+    APIEditHistoryEvent,
+    DisplayRecipientT,
+    EditHistoryEvent,
+    UserDisplayRecipient,
+)
 from zerver.models import (
     MAX_TOPIC_NAME_LENGTH,
     Message,
@@ -502,8 +507,17 @@ class MessageDict:
         if last_edit_time is not None:
             obj["last_edit_timestamp"] = datetime_to_timestamp(last_edit_time)
             assert edit_history_json is not None
-            # Here we assume EditHistoryEvent == APIEditHistoryEvent
-            edit_history: List[EditHistoryEvent] = orjson.loads(edit_history_json)
+            raw_edit_history: List[EditHistoryEvent] = orjson.loads(edit_history_json)
+            edit_history: List[APIEditHistoryEvent] = []
+            for edit_history_event in raw_edit_history:
+                # Drop fields we're not yet ready to have appear in the API
+                if "prev_topic" in edit_history_event:
+                    del edit_history_event["prev_topic"]
+                if "stream" in edit_history_event:
+                    del edit_history_event["stream"]
+                if "topic" in edit_history_event:
+                    del edit_history_event["topic"]
+                edit_history.append(edit_history_event)
             obj["edit_history"] = edit_history
 
         if Message.need_to_render_content(

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -514,7 +514,7 @@ class MessageDict:
                 if "prev_topic" in edit_history_event:
                     # The prev_subject field has been renamed in the
                     # database, but not the API.
-                    edit_history_event["prev_subject"] = edit_history_event["prev_topic"]
+                    edit_history_event["prev_subject"] = edit_history_event["prev_topic"]  # type: ignore # Temporary type-checking violation
 
                 # New fields not consistently available, and thus
                 # intentionally not exposed to the API.
@@ -525,7 +525,7 @@ class MessageDict:
                 if "topic" in edit_history_event:
                     del edit_history_event["topic"]
 
-                edit_history.append(edit_history_event)
+                edit_history.append(edit_history_event)  # type: ignore # Temporary type-checking violation
             obj["edit_history"] = edit_history
 
         if Message.need_to_render_content(

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -512,11 +512,19 @@ class MessageDict:
             for edit_history_event in raw_edit_history:
                 # Drop fields we're not yet ready to have appear in the API
                 if "prev_topic" in edit_history_event:
+                    # The prev_subject field has been renamed in the
+                    # database, but not the API.
+                    edit_history_event["prev_subject"] = edit_history_event["prev_topic"]
+
+                # New fields not consistently available, and thus
+                # intentionally not exposed to the API.
+                if "prev_topic" in edit_history_event:
                     del edit_history_event["prev_topic"]
                 if "stream" in edit_history_event:
                     del edit_history_event["stream"]
                 if "topic" in edit_history_event:
                     del edit_history_event["topic"]
+
                 edit_history.append(edit_history_event)
             obj["edit_history"] = edit_history
 

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -20,12 +20,6 @@ MATCH_TOPIC = "match_subject"
 # Prefix use to mark topic as resolved.
 RESOLVED_TOPIC_PREFIX = "✔ "
 
-# This constant is actually embedded into
-# the JSON data for message edit history,
-# so we'll always need to handle legacy data
-# unless we do a pretty tricky migration.
-LEGACY_PREV_TOPIC = "prev_subject"
-
 # This constant is pretty closely coupled to the
 # database, but it's the JSON field.
 EXPORT_TOPIC_NAME = "subject"

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -8,6 +8,7 @@ from sqlalchemy.sql import ColumnElement, column, func, literal
 from sqlalchemy.types import Boolean, Text
 
 from zerver.lib.request import REQ
+from zerver.lib.types import EditHistoryEvent
 from zerver.models import Message, Stream, UserMessage, UserProfile
 
 # Only use these constants for events.
@@ -135,11 +136,11 @@ def user_message_exists_for_topic(
 
 
 def update_edit_history(
-    message: Message, last_edit_time: datetime, edit_history_event: Dict[str, Any]
+    message: Message, last_edit_time: datetime, edit_history_event: EditHistoryEvent
 ) -> None:
     message.last_edit_time = last_edit_time
     if message.edit_history is not None:
-        edit_history = orjson.loads(message.edit_history)
+        edit_history: List[EditHistoryEvent] = orjson.loads(message.edit_history)
         edit_history.insert(0, edit_history_event)
     else:
         edit_history = [edit_history_event]
@@ -154,7 +155,7 @@ def update_messages_for_topic_edit(
     topic_name: Optional[str],
     new_stream: Optional[Stream],
     old_stream: Stream,
-    edit_history_event: Dict[str, Any],
+    edit_history_event: EditHistoryEvent,
     last_edit_time: datetime,
 ) -> List[Message]:
     propagate_query = Q(recipient_id=old_stream.recipient_id, subject__iexact=orig_topic_name)

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -121,6 +121,8 @@ class EditHistoryEvent(TypedDict, total=False):
     timestamp: int
     prev_stream: int
     stream: int
+    # One of prev_subject and prev_topic is guaranteed to exist; if
+    # both exist they will have identical values.
     prev_subject: str
     prev_topic: str
     topic: str

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -126,3 +126,21 @@ class EditHistoryEvent(TypedDict, total=False):
     prev_content: str
     prev_rendered_content: Optional[str]
     prev_rendered_content_version: Optional[int]
+
+
+class FormattedEditHistoryEvent(TypedDict, total=False):
+    """
+    Extended format used in the edit history endpoint.
+    """
+
+    user_id: Optional[int]
+    timestamp: int
+    prev_stream: int
+    stream: int
+    prev_topic: str
+    topic: str
+    prev_content: str
+    content: str
+    prev_rendered_content: Optional[str]
+    rendered_content: Optional[str]
+    content_html_diff: str

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -121,9 +121,6 @@ class EditHistoryEvent(TypedDict, total=False):
     timestamp: int
     prev_stream: int
     stream: int
-    # One of prev_subject and prev_topic is guaranteed to exist; if
-    # both exist they will have identical values.
-    prev_subject: str
     prev_topic: str
     topic: str
     prev_content: str

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -89,3 +89,40 @@ class UnspecifiedValue:
     """
 
     pass
+
+
+class APIEditHistoryEvent(TypedDict, total=False):
+    """Format of legacy edit history events in the API. Contains legacy
+    fields like LEGACY_PREV_TOPIC that we intend to remove from the
+    API eventually.
+    """
+
+    # Commented fields are fields we plan to add.
+    user_id: Optional[int]
+    timestamp: int
+    prev_stream: int
+    # stream: int
+    prev_subject: str
+    # prev_topic: str
+    # topic: str
+    prev_content: str
+    prev_rendered_content: Optional[str]
+    prev_rendered_content_version: Optional[int]
+
+
+class EditHistoryEvent(TypedDict, total=False):
+    """
+    Database format for edit history events.
+    """
+
+    # Commented fields are fields we plan to add.
+    user_id: Optional[int]
+    timestamp: int
+    prev_stream: int
+    # stream: int
+    prev_subject: str
+    # prev_topic: str
+    # topic: str
+    prev_content: str
+    prev_rendered_content: Optional[str]
+    prev_rendered_content_version: Optional[int]

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -102,6 +102,7 @@ class APIEditHistoryEvent(TypedDict, total=False):
     timestamp: int
     prev_stream: int
     # stream: int
+    # TODO: Remove prev_subject from the API.
     prev_subject: str
     # prev_topic: str
     # topic: str
@@ -119,10 +120,10 @@ class EditHistoryEvent(TypedDict, total=False):
     user_id: Optional[int]
     timestamp: int
     prev_stream: int
-    # stream: int
+    stream: int
     prev_subject: str
-    # prev_topic: str
-    # topic: str
+    prev_topic: str
+    topic: str
     prev_content: str
     prev_rendered_content: Optional[str]
     prev_rendered_content_version: Optional[int]

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -91,32 +91,11 @@ class UnspecifiedValue:
     pass
 
 
-class APIEditHistoryEvent(TypedDict, total=False):
-    """Format of legacy edit history events in the API. Contains legacy
-    fields like LEGACY_PREV_TOPIC that we intend to remove from the
-    API eventually.
-    """
-
-    # Commented fields are fields we plan to add.
-    user_id: Optional[int]
-    timestamp: int
-    prev_stream: int
-    # stream: int
-    # TODO: Remove prev_subject from the API.
-    prev_subject: str
-    # prev_topic: str
-    # topic: str
-    prev_content: str
-    prev_rendered_content: Optional[str]
-    prev_rendered_content_version: Optional[int]
-
-
 class EditHistoryEvent(TypedDict, total=False):
     """
     Database format for edit history events.
     """
 
-    # Commented fields are fields we plan to add.
     user_id: Optional[int]
     timestamp: int
     prev_stream: int

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -96,6 +96,10 @@ class EditHistoryEvent(TypedDict, total=False):
     Database format for edit history events.
     """
 
+    # user_id is null for precisely those edit history events
+    # predating March 2017, when we started tracking the person who
+    # made edits, which is still years after the introduction of topic
+    # editing support in Zulip.
     user_id: Optional[int]
     timestamp: int
     prev_stream: int
@@ -112,6 +116,7 @@ class FormattedEditHistoryEvent(TypedDict, total=False):
     Extended format used in the edit history endpoint.
     """
 
+    # See EditHistoryEvent for details on when this can be null.
     user_id: Optional[int]
     timestamp: int
     prev_stream: int

--- a/zerver/migrations/0377_message_edit_history_format.py
+++ b/zerver/migrations/0377_message_edit_history_format.py
@@ -1,0 +1,166 @@
+import time
+from typing import List, Optional
+
+import orjson
+from django.db import migrations, transaction
+from django.db.backends.postgresql.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from django.db.models import Min, Model
+from typing_extensions import TypedDict
+
+BATCH_SIZE = 10000
+STREAM = 2
+
+# Legacy TypedDict has "prev_topic" field for any edit_history entries that
+# were saved to the database after the legacy "prev_subject" field stopped
+# being written to the database in the pre-migration commit.
+class LegacyEditHistoryEvent(TypedDict, total=False):
+    user_id: int
+    timestamp: int
+    prev_stream: int
+    prev_subject: str
+    prev_topic: str
+    prev_content: str
+    prev_rendered_content: Optional[str]
+    prev_rendered_content_version: Optional[int]
+
+
+class EditHistoryEvent(TypedDict, total=False):
+    user_id: Optional[int]
+    timestamp: int
+    prev_stream: int
+    stream: int
+    prev_topic: str
+    topic: str
+    prev_content: str
+    prev_rendered_content: Optional[str]
+    prev_rendered_content_version: Optional[int]
+
+
+@transaction.atomic
+def backfill_message_edit_history_chunk(first_id: int, last_id: int, message_model: Model) -> None:
+    """
+    Migrate edit history events for the messages in the provided range to:
+    * Rename prev_subject => prev_topic.
+    * Provide topic and stream fields with the current values.
+
+    The range of message IDs to be processed is inclusive on both ends.
+    """
+    messages = (
+        message_model.objects.select_for_update()
+        .only(
+            "recipient",
+            "recipient__type",
+            "recipient__type_id",
+            "subject",
+            "edit_history",
+        )
+        .filter(edit_history__isnull=False, id__range=(first_id, last_id))
+    )
+
+    for message in messages:
+        legacy_edit_history: List[LegacyEditHistoryEvent] = orjson.loads(message.edit_history)
+        message_type = message.recipient.type
+        modern_edit_history: List[EditHistoryEvent] = []
+
+        # Only Stream messages have topic / stream edit history data.
+        if message_type == STREAM:
+            topic = message.subject
+            stream_id = message.recipient.type_id
+
+        for edit_history_event in legacy_edit_history:
+            modern_entry: EditHistoryEvent = {
+                "user_id": edit_history_event.get("user_id"),
+                "timestamp": edit_history_event["timestamp"],
+            }
+
+            if "prev_content" in edit_history_event:
+                modern_entry["prev_content"] = edit_history_event["prev_content"]
+                modern_entry["prev_rendered_content"] = edit_history_event["prev_rendered_content"]
+                modern_entry["prev_rendered_content_version"] = edit_history_event[
+                    "prev_rendered_content_version"
+                ]
+
+            if message_type == STREAM:
+                if "prev_subject" in edit_history_event:
+                    # Add topic edit key/value pairs from legacy format.
+                    modern_entry["topic"] = topic
+                    modern_entry["prev_topic"] = edit_history_event["prev_subject"]
+
+                    # Because edit_history is ordered chronologically,
+                    # most recent to least recent, we set the topic
+                    # variable to the `prev_topic` value for this edit
+                    # for any subsequent topic edits in the loop.
+                    topic = edit_history_event["prev_subject"]
+
+                elif "prev_topic" in edit_history_event:
+                    # Add topic edit key/value pairs from modern format.
+                    modern_entry["topic"] = topic
+                    modern_entry["prev_topic"] = edit_history_event["prev_topic"]
+
+                    # Same logic as above but for modern format.
+                    topic = edit_history_event["prev_topic"]
+
+                if "prev_stream" in edit_history_event:
+                    # Add stream edit key/value pairs.
+                    modern_entry["stream"] = stream_id
+                    modern_entry["prev_stream"] = edit_history_event["prev_stream"]
+
+                    # Same logic as above for the topic variable.
+                    stream_id = edit_history_event["prev_stream"]
+
+            modern_edit_history.append(modern_entry)
+
+        message.edit_history = orjson.dumps(modern_edit_history).decode()
+
+    message_model.objects.bulk_update(messages, ["edit_history"])
+
+
+def copy_and_update_message_edit_history(
+    apps: StateApps, schema_editor: DatabaseSchemaEditor
+) -> None:
+    Message = apps.get_model("zerver", "Message")
+    ArchivedMessage = apps.get_model("zerver", "ArchivedMessage")
+
+    message_models = [Message, ArchivedMessage]
+    for message_model in message_models:
+        if not message_model.objects.filter(edit_history__isnull=False).exists():
+            # No messages with "edit_history"
+            continue
+
+        first_id_to_update = message_model.objects.filter(edit_history__isnull=False).aggregate(
+            Min("id")
+        )["id__min"]
+
+        last_id = message_model.objects.latest("id").id
+
+        id_range_lower_bound = first_id_to_update
+        id_range_upper_bound = first_id_to_update + BATCH_SIZE
+
+        while id_range_upper_bound <= last_id:
+            backfill_message_edit_history_chunk(
+                id_range_lower_bound, id_range_upper_bound, message_model
+            )
+            print(f"Modernized edit history for {id_range_upper_bound}/{last_id} messages.")
+            id_range_lower_bound = id_range_upper_bound + 1
+            id_range_upper_bound = id_range_lower_bound + BATCH_SIZE
+            time.sleep(0.1)
+
+        if last_id >= id_range_lower_bound:
+            # Copy/update for the last batch, or if only 1 message with edit_history in db
+            backfill_message_edit_history_chunk(id_range_lower_bound, last_id, message_model)
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("zerver", "0376_set_realmemoji_author_and_reupload_realmemoji"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            copy_and_update_message_edit_history,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4995,6 +4995,12 @@ paths:
                               type: string
                               description: |
                                 the topic for the message before being edited.
+                            prev_stream:
+                              type: integer
+                              description: |
+                                Only present if message's stream was edited.
+
+                                The stream ID of the message prior to being edited.
                             content:
                               type: string
                               description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4963,9 +4963,8 @@ paths:
         `topic`, `content`, `rendered_content`, `timestamp` and `user_id`. This
         snapshot will be the only one present if the message has never been edited.
 
-        Also note that if a message's content was edited (but not the topic)
-        or the topic was edited (but not the content), the snapshot object
-        will only contain data for the modified fields (e.g. if only the topic
+        Also note that each snapshot object will only contain additional data for the
+        modified fields for that particular edit (e.g. if only the topic or stream
         was edited, `prev_content`, `prev_rendered_content`, and
         `content_html_diff` will not appear).
       responses:
@@ -4990,51 +4989,80 @@ paths:
                             topic:
                               type: string
                               description: |
-                                the topic for the message.
+                                The topic of the message immediately
+                                after this edit event.
                             prev_topic:
                               type: string
                               description: |
-                                the topic for the message before being edited.
+                                Only present if message's topic was edited.
+
+                                The topic of the message immediately
+                                prior to this edit event.
+                            stream:
+                              type: integer
+                              description: |
+                                Only present if message's stream was edited.
+
+                                The ID of the stream containing the message
+                                immediately after this edit event.
+
+                                **Changes**: New in Zulip 5.0 (feature level 118).
                             prev_stream:
                               type: integer
                               description: |
                                 Only present if message's stream was edited.
 
-                                The stream ID of the message prior to being edited.
+                                The ID of the stream containing the message immediately
+                                prior to this edit event.
                             content:
                               type: string
                               description: |
-                                the body of the message.
+                                The raw Markdown content of the message
+                                immediately after this edit event.
                             rendered_content:
                               type: string
                               description: |
-                                the already rendered, HTML version of `content`.
+                                The rendered HTML representation of `content`.
                             prev_content:
                               type: string
                               description: |
-                                the body of the message before being edited.
+                                Only present if message's content was edited.
+
+                                The raw Markdown content of the message immediately
+                                prior to this edit event.
                             prev_rendered_content:
                               type: string
                               description: |
-                                the already rendered, HTML version of
-                                `prev_content`.
+                                Only present if message's content was edited.
+
+                                The rendered HTML representation of `prev_content`.
                             user_id:
                               type: integer
+                              nullable: true
                               description: |
-                                the ID of the user that made the edit.
+                                The ID of the user that made the edit.
+
+                                Will be null only for edit history
+                                events predating March 2017.
+
+                                Clients can display edit history events where this
+                                is null as modified by either the sender (for content
+                                edits) or an unknown user (for topic edits).
                             content_html_diff:
                               type: string
                               description: |
-                                an HTML diff between this version of the message
+                                Only present if message's content was edited.
+
+                                An HTML diff between this version of the message
                                 and the previous one.
                             timestamp:
                               type: integer
                               description: |
-                                the UNIX timestamp for this edit.
+                                The UNIX timestamp for this edit.
                         description: |
-                          A chronologically sorted array of `snapshot`
-                          objects, each one with the values of the
-                          message after the edit.
+                          A chronologically sorted, oldest to newest, array
+                          of `snapshot` objects, each one with the values of
+                          the message after the edit.
                     example:
                       {
                         "message_history":
@@ -14625,6 +14653,106 @@ components:
             Data on the recipient of the message;
             either the name of a stream or a dictionary containing basic data on
             the users who received the message.
+        edit_history:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              prev_content:
+                type: string
+                description: |
+                  Only present if message's content was edited.
+
+                  The content of the message immediately prior to this
+                  edit event.
+              prev_rendered_content:
+                type: string
+                description: |
+                  Only present if message's content was edited.
+
+                  The rendered HTML representation of `prev_content`.
+              prev_rendered_content_version:
+                type: string
+                description: |
+                  Only present if message's content was edited.
+
+                  The Markdown processor version number for the message
+                  immediately prior to this edit event.
+              prev_stream:
+                type: integer
+                description: |
+                  Only present if message's stream was edited.
+
+                  The stream ID of the message immediately prior to this
+                  edit event.
+              prev_topic:
+                type: string
+                description: |
+                  Only present if message's topic was edited.
+
+                  The topic of the message immediately prior to this
+                  edit event.
+
+                  **Changes**: New in Zulip 5.0 (feature level 118).
+                  Previously, this field was called `prev_subject`;
+                  clients are recommended to rename `prev_subject` to
+                  `prev_topic` if present for compatibility with
+                  older Zulip servers.
+              stream:
+                type: integer
+                description: |
+                  Only present if message's stream was edited.
+
+                  The ID of the stream containing the message
+                  immediately after this edit event.
+
+                  **Changes**: New in Zulip 5.0 (feature level 118).
+              timestamp:
+                type: integer
+                description: |
+                  The UNIX timestamp for the edit.
+              topic:
+                type: string
+                description: |
+                  Only present if message's topic was edited.
+
+                  The topic of the message immediately after this edit event.
+
+                  **Changes**: New in Zulip 5.0 (feature level 118).
+              user_id:
+                type: integer
+                nullable: true
+                description: |
+                  The ID of the user that made the edit.
+
+                  Will be null only for edit history
+                  events predating March 2017.
+
+                  Clients can display edit history events where this
+                  is null as modified by either the sender (for content
+                  edits) or an unknown user (for topic edits).
+            required:
+              - user_id
+              - timestamp
+          description: |
+            An array of objects, with each object documenting the
+            changes made in a previous edit made to the the message,
+            ordered chronologically from most recent to least recent
+            edit.
+
+            Not present if the message has never been edited or if the realm has
+            [disabled viewing of message edit history][disable-edit-history].
+
+            Every object will contain `user_id` and `timestamp`.
+
+            The other fields are optional, and will be present or not
+            depending on which of the stream, topic, and message
+            content were modified in the edit event. For example, if
+            only the topic was edited, only `prev_topic` and `topic`
+            will be present in addition to `user_id` and `timestamp`.
+
+            [disable-edit-history]: /help/disable-message-edit-history
         id:
           type: integer
           description: |

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -73,11 +73,12 @@ class EditMessageTestCase(ZulipTestCase):
             msg.sender_id,
         )
 
-        if msg.edit_history:
-            self.assertEqual(
-                fetch_message_dict["edit_history"],
-                orjson.loads(msg.edit_history),
-            )
+        # TODO: uncomment assertion when edit_history fields in API match fields in database.
+        # if msg.edit_history:
+        #     self.assertEqual(
+        #         fetch_message_dict["edit_history"],
+        #         orjson.loads(msg.edit_history),
+        #     )
 
     def prepare_move_topics(
         self,
@@ -709,9 +710,16 @@ class EditMessageTest(EditMessageTestCase):
         history data structures."""
         self.login("hamlet")
         hamlet = self.example_user("hamlet")
+        stream_1 = self.make_stream("stream 1")
+        stream_2 = self.make_stream("stream 2")
+        stream_3 = self.make_stream("stream 3")
+        self.subscribe(hamlet, stream_1.name)
+        self.subscribe(hamlet, stream_2.name)
+        self.subscribe(hamlet, stream_3.name)
         msg_id = self.send_stream_message(
-            self.example_user("hamlet"), "Denmark", topic_name="topic 1", content="content 1"
+            self.example_user("hamlet"), "stream 1", topic_name="topic 1", content="content 1"
         )
+
         result = self.client_patch(
             f"/json/messages/{msg_id}",
             {
@@ -742,9 +750,29 @@ class EditMessageTest(EditMessageTestCase):
         self.assert_json_success(result)
         history = orjson.loads(Message.objects.get(id=msg_id).edit_history)
         self.assertEqual(history[0][LEGACY_PREV_TOPIC], "topic 1")
+        self.assertEqual(history[0]["prev_topic"], "topic 1")
+        self.assertEqual(history[0]["topic"], "topic 2")
         self.assertEqual(history[0]["user_id"], hamlet.id)
-        self.assertEqual(set(history[0].keys()), {"timestamp", LEGACY_PREV_TOPIC, "user_id"})
+        self.assertEqual(
+            set(history[0].keys()),
+            {"timestamp", LEGACY_PREV_TOPIC, "prev_topic", "topic", "user_id"},
+        )
 
+        self.login("iago")
+        result = self.client_patch(
+            f"/json/messages/{msg_id}",
+            {
+                "stream_id": stream_2.id,
+            },
+        )
+        self.assert_json_success(result)
+        history = orjson.loads(Message.objects.get(id=msg_id).edit_history)
+        self.assertEqual(history[0]["prev_stream"], stream_1.id)
+        self.assertEqual(history[0]["stream"], stream_2.id)
+        self.assertEqual(history[0]["user_id"], self.example_user("iago").id)
+        self.assertEqual(set(history[0].keys()), {"timestamp", "prev_stream", "stream", "user_id"})
+
+        self.login("hamlet")
         result = self.client_patch(
             f"/json/messages/{msg_id}",
             {
@@ -756,12 +784,16 @@ class EditMessageTest(EditMessageTestCase):
         history = orjson.loads(Message.objects.get(id=msg_id).edit_history)
         self.assertEqual(history[0]["prev_content"], "content 2")
         self.assertEqual(history[0][LEGACY_PREV_TOPIC], "topic 2")
+        self.assertEqual(history[0]["prev_topic"], "topic 2")
+        self.assertEqual(history[0]["topic"], "topic 3")
         self.assertEqual(history[0]["user_id"], hamlet.id)
         self.assertEqual(
             set(history[0].keys()),
             {
                 "timestamp",
                 LEGACY_PREV_TOPIC,
+                "prev_topic",
+                "topic",
                 "prev_content",
                 "user_id",
                 "prev_rendered_content",
@@ -785,20 +817,55 @@ class EditMessageTest(EditMessageTestCase):
             f"/json/messages/{msg_id}",
             {
                 "topic": "topic 4",
+                "stream_id": stream_3.id,
             },
         )
         self.assert_json_success(result)
         history = orjson.loads(Message.objects.get(id=msg_id).edit_history)
         self.assertEqual(history[0][LEGACY_PREV_TOPIC], "topic 3")
+        self.assertEqual(history[0]["prev_topic"], "topic 3")
+        self.assertEqual(history[0]["topic"], "topic 4")
+        self.assertEqual(history[0]["prev_stream"], stream_2.id)
+        self.assertEqual(history[0]["stream"], stream_3.id)
         self.assertEqual(history[0]["user_id"], self.example_user("iago").id)
+        self.assertEqual(
+            set(history[0].keys()),
+            {
+                "timestamp",
+                LEGACY_PREV_TOPIC,
+                "prev_topic",
+                "topic",
+                "prev_stream",
+                "stream",
+                "user_id",
+            },
+        )
 
+        # Now, we verify that all of the edits stored in the message.edit_history
+        # have the correct data structure
         history = orjson.loads(Message.objects.get(id=msg_id).edit_history)
         self.assertEqual(history[0][LEGACY_PREV_TOPIC], "topic 3")
         self.assertEqual(history[2][LEGACY_PREV_TOPIC], "topic 2")
-        self.assertEqual(history[3][LEGACY_PREV_TOPIC], "topic 1")
+        self.assertEqual(history[4][LEGACY_PREV_TOPIC], "topic 1")
+
+        self.assertEqual(history[0]["prev_topic"], "topic 3")
+        self.assertEqual(history[0]["topic"], "topic 4")
+        self.assertEqual(history[0]["stream"], stream_3.id)
+        self.assertEqual(history[0]["prev_stream"], stream_2.id)
+
         self.assertEqual(history[1]["prev_content"], "content 3")
+
+        self.assertEqual(history[2]["prev_topic"], "topic 2")
+        self.assertEqual(history[2]["topic"], "topic 3")
         self.assertEqual(history[2]["prev_content"], "content 2")
-        self.assertEqual(history[4]["prev_content"], "content 1")
+
+        self.assertEqual(history[3]["stream"], stream_2.id)
+        self.assertEqual(history[3]["prev_stream"], stream_1.id)
+
+        self.assertEqual(history[4]["prev_topic"], "topic 1")
+        self.assertEqual(history[4]["topic"], "topic 2")
+
+        self.assertEqual(history[5]["prev_content"], "content 1")
 
         # Now, we verify that the edit history data sent back has the
         # correct filled-out fields
@@ -811,35 +878,50 @@ class EditMessageTest(EditMessageTestCase):
         i = 0
         for entry in message_history:
             expected_entries = {"content", "rendered_content", "topic", "timestamp", "user_id"}
-            if i in {0, 2, 3}:
+            if i in {0, 2, 4}:
                 expected_entries.add("prev_topic")
-            if i in {1, 2, 4}:
+                expected_entries.add("topic")
+            if i in {1, 2, 5}:
                 expected_entries.add("prev_content")
                 expected_entries.add("prev_rendered_content")
                 expected_entries.add("content_html_diff")
+            if i in {0, 3}:
+                expected_entries.add("prev_stream")
+                # TODO: uncomment when stream field is added to API
+                # expected_entries.add("stream")
             i += 1
             self.assertEqual(expected_entries, set(entry.keys()))
-        self.assert_length(message_history, 6)
-        self.assertEqual(message_history[0]["prev_topic"], "topic 3")
+        self.assert_length(message_history, 7)
         self.assertEqual(message_history[0]["topic"], "topic 4")
-        self.assertEqual(message_history[1]["topic"], "topic 3")
-        self.assertEqual(message_history[2]["topic"], "topic 3")
-        self.assertEqual(message_history[2]["prev_topic"], "topic 2")
-        self.assertEqual(message_history[3]["topic"], "topic 2")
-        self.assertEqual(message_history[3]["prev_topic"], "topic 1")
-        self.assertEqual(message_history[4]["topic"], "topic 1")
-
+        self.assertEqual(message_history[0]["prev_topic"], "topic 3")
+        # self.assertEqual(message_history[0]["stream"], stream_3.id)
+        self.assertEqual(message_history[0]["prev_stream"], stream_2.id)
         self.assertEqual(message_history[0]["content"], "content 4")
+
+        self.assertEqual(message_history[1]["topic"], "topic 3")
         self.assertEqual(message_history[1]["content"], "content 4")
         self.assertEqual(message_history[1]["prev_content"], "content 3")
+
+        self.assertEqual(message_history[2]["topic"], "topic 3")
+        self.assertEqual(message_history[2]["prev_topic"], "topic 2")
         self.assertEqual(message_history[2]["content"], "content 3")
         self.assertEqual(message_history[2]["prev_content"], "content 2")
-        self.assertEqual(message_history[3]["content"], "content 2")
-        self.assertEqual(message_history[4]["content"], "content 2")
-        self.assertEqual(message_history[4]["prev_content"], "content 1")
 
-        self.assertEqual(message_history[5]["content"], "content 1")
+        self.assertEqual(message_history[3]["topic"], "topic 2")
+        # self.assertEqual(message_history[3]["stream"], stream_2.id)
+        self.assertEqual(message_history[3]["prev_stream"], stream_1.id)
+        self.assertEqual(message_history[3]["content"], "content 2")
+
+        self.assertEqual(message_history[4]["topic"], "topic 2")
+        self.assertEqual(message_history[4]["prev_topic"], "topic 1")
+        self.assertEqual(message_history[4]["content"], "content 2")
+
         self.assertEqual(message_history[5]["topic"], "topic 1")
+        self.assertEqual(message_history[5]["content"], "content 2")
+        self.assertEqual(message_history[5]["prev_content"], "content 1")
+
+        self.assertEqual(message_history[6]["content"], "content 1")
+        self.assertEqual(message_history[6]["topic"], "topic 1")
 
     def test_edit_message_content_limit(self) -> None:
         def set_message_editing_params(

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -73,12 +73,11 @@ class EditMessageTestCase(ZulipTestCase):
             msg.sender_id,
         )
 
-        # TODO: uncomment assertion when edit_history fields in API match fields in database.
-        # if msg.edit_history:
-        #     self.assertEqual(
-        #         fetch_message_dict["edit_history"],
-        #         orjson.loads(msg.edit_history),
-        #     )
+        if msg.edit_history:
+            self.assertEqual(
+                fetch_message_dict["edit_history"],
+                orjson.loads(msg.edit_history),
+            )
 
     def prepare_move_topics(
         self,
@@ -879,14 +878,13 @@ class EditMessageTest(EditMessageTestCase):
                 expected_entries.add("content_html_diff")
             if i in {0, 3}:
                 expected_entries.add("prev_stream")
-                # TODO: uncomment when stream field is added to API
-                # expected_entries.add("stream")
+                expected_entries.add("stream")
             i += 1
             self.assertEqual(expected_entries, set(entry.keys()))
         self.assert_length(message_history, 7)
         self.assertEqual(message_history[0]["topic"], "topic 4")
         self.assertEqual(message_history[0]["prev_topic"], "topic 3")
-        # self.assertEqual(message_history[0]["stream"], stream_3.id)
+        self.assertEqual(message_history[0]["stream"], stream_3.id)
         self.assertEqual(message_history[0]["prev_stream"], stream_2.id)
         self.assertEqual(message_history[0]["content"], "content 4")
 
@@ -900,7 +898,7 @@ class EditMessageTest(EditMessageTestCase):
         self.assertEqual(message_history[2]["prev_content"], "content 2")
 
         self.assertEqual(message_history[3]["topic"], "topic 2")
-        # self.assertEqual(message_history[3]["stream"], stream_2.id)
+        self.assertEqual(message_history[3]["stream"], stream_2.id)
         self.assertEqual(message_history[3]["prev_stream"], stream_1.id)
         self.assertEqual(message_history[3]["content"], "content 2")
 

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -23,7 +23,7 @@ from zerver.lib.actions import (
 from zerver.lib.message import MessageDict, has_message_access, messages_for_ids
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import cache_tries_captured, queries_captured
-from zerver.lib.topic import LEGACY_PREV_TOPIC, RESOLVED_TOPIC_PREFIX, TOPIC_NAME
+from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, TOPIC_NAME
 from zerver.models import Message, Realm, Stream, UserMessage, UserProfile, get_realm, get_stream
 
 
@@ -749,13 +749,12 @@ class EditMessageTest(EditMessageTestCase):
         )
         self.assert_json_success(result)
         history = orjson.loads(Message.objects.get(id=msg_id).edit_history)
-        self.assertEqual(history[0][LEGACY_PREV_TOPIC], "topic 1")
         self.assertEqual(history[0]["prev_topic"], "topic 1")
         self.assertEqual(history[0]["topic"], "topic 2")
         self.assertEqual(history[0]["user_id"], hamlet.id)
         self.assertEqual(
             set(history[0].keys()),
-            {"timestamp", LEGACY_PREV_TOPIC, "prev_topic", "topic", "user_id"},
+            {"timestamp", "prev_topic", "topic", "user_id"},
         )
 
         self.login("iago")
@@ -783,7 +782,6 @@ class EditMessageTest(EditMessageTestCase):
         self.assert_json_success(result)
         history = orjson.loads(Message.objects.get(id=msg_id).edit_history)
         self.assertEqual(history[0]["prev_content"], "content 2")
-        self.assertEqual(history[0][LEGACY_PREV_TOPIC], "topic 2")
         self.assertEqual(history[0]["prev_topic"], "topic 2")
         self.assertEqual(history[0]["topic"], "topic 3")
         self.assertEqual(history[0]["user_id"], hamlet.id)
@@ -791,7 +789,6 @@ class EditMessageTest(EditMessageTestCase):
             set(history[0].keys()),
             {
                 "timestamp",
-                LEGACY_PREV_TOPIC,
                 "prev_topic",
                 "topic",
                 "prev_content",
@@ -822,7 +819,6 @@ class EditMessageTest(EditMessageTestCase):
         )
         self.assert_json_success(result)
         history = orjson.loads(Message.objects.get(id=msg_id).edit_history)
-        self.assertEqual(history[0][LEGACY_PREV_TOPIC], "topic 3")
         self.assertEqual(history[0]["prev_topic"], "topic 3")
         self.assertEqual(history[0]["topic"], "topic 4")
         self.assertEqual(history[0]["prev_stream"], stream_2.id)
@@ -832,7 +828,6 @@ class EditMessageTest(EditMessageTestCase):
             set(history[0].keys()),
             {
                 "timestamp",
-                LEGACY_PREV_TOPIC,
                 "prev_topic",
                 "topic",
                 "prev_stream",
@@ -844,9 +839,6 @@ class EditMessageTest(EditMessageTestCase):
         # Now, we verify that all of the edits stored in the message.edit_history
         # have the correct data structure
         history = orjson.loads(Message.objects.get(id=msg_id).edit_history)
-        self.assertEqual(history[0][LEGACY_PREV_TOPIC], "topic 3")
-        self.assertEqual(history[2][LEGACY_PREV_TOPIC], "topic 2")
-        self.assertEqual(history[4][LEGACY_PREV_TOPIC], "topic 1")
 
         self.assertEqual(history[0]["prev_topic"], "topic 3")
         self.assertEqual(history[0]["topic"], "topic 4")

--- a/zerver/tests/test_migrations.py
+++ b/zerver/tests/test_migrations.py
@@ -4,7 +4,11 @@
 # You can also read
 #   https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/
 # to get a tutorial on the framework that inspired this feature.
+from typing import Optional
+
+import orjson
 from django.db.migrations.state import StateApps
+from django.utils.timezone import now as timezone_now
 
 from zerver.lib.test_classes import MigrationsTestCase
 from zerver.lib.test_helpers import use_db_models
@@ -26,63 +30,393 @@ from zerver.models import get_stream
 # been tested for a migration being merged.
 
 
-class SubsNotificationSettingsTestCase(MigrationsTestCase):  # nocoverage
-    __unittest_skip__ = True
+class MessageEditHistoryLegacyFormats(MigrationsTestCase):
+    __unittest_skip__ = False
 
-    migrate_from = "0220_subscription_notification_settings"
-    migrate_to = "0221_subscription_notifications_data_migration"
-    RECIPIENT_PERSONAL = 1
-    RECIPIENT_STREAM = 2
+    migrate_from = "0376_set_realmemoji_author_and_reupload_realmemoji"
+    migrate_to = "0377_message_edit_history_format"
+
+    msg_id: Optional[int] = None
 
     @use_db_models
     def setUpBeforeMigration(self, apps: StateApps) -> None:
         Recipient = apps.get_model("zerver", "Recipient")
-        Subscription = apps.get_model("zerver", "Subscription")
+        Message = apps.get_model("zerver", "Message")
 
         iago = self.example_user("iago")
-        iago.enable_stream_desktop_notifications = True
-        iago.enable_stream_audible_notifications = False
-        iago.enable_desktop_notifications = True
-        iago.enable_online_push_notifications = True
-        iago.enable_sounds = False
-        iago.save()
-
         stream_name = "Denmark"
         denmark = get_stream(stream_name, iago.realm)
-        denmark_recipient = Recipient.objects.get(type=self.RECIPIENT_STREAM, type_id=denmark.id)
-        denmark_sub = Subscription.objects.get(user_profile=iago, recipient=denmark_recipient)
-        denmark_sub.desktop_notifications = False
-        denmark_sub.audible_notifications = False
-        denmark_sub.save(update_fields=["desktop_notifications", "audible_notifications"])
+        denmark_recipient = Recipient.objects.get(type=2, type_id=denmark.id)
 
-        iago_recipient = Recipient.objects.get(type=self.RECIPIENT_PERSONAL, type_id=iago.id)
-        iago_sub = Subscription.objects.get(user_profile=iago, recipient=iago_recipient)
-        iago_sub.desktop_notifications = False
-        iago_sub.audible_notifications = False
-        iago_sub.push_notifications = True
-        iago_sub.save(
-            update_fields=["desktop_notifications", "audible_notifications", "push_notifications"]
+        self.msg_id = Message.objects.create(
+            recipient_id=denmark_recipient.id,
+            subject="topic 4",
+            sender_id=iago.id,
+            sending_client_id=1,
+            content="current message text",
+            date_sent=timezone_now(),
+        ).id
+
+        # topic edits contain only "prev_subject" field.
+        # stream edits contain only "prev_stream" field.
+        msg = Message.objects.filter(id=self.msg_id).first()
+        msg.edit_history = orjson.dumps(
+            [
+                {
+                    "user_id": 11,
+                    "timestamp": 1644405050,
+                    "prev_stream": 3,
+                    "prev_subject": "topic 3",
+                },
+                {"user_id": 11, "timestamp": 1644405040, "prev_stream": 2},
+                {
+                    "user_id": 11,
+                    "timestamp": 1644405030,
+                    "prev_content": "test content and topic edit",
+                    "prev_rendered_content": "<p>test content and topic edit</p>",
+                    "prev_rendered_content_version": 1,
+                    "prev_subject": "topic 2",
+                },
+                {"user_id": 11, "timestamp": 1644405020, "prev_subject": "topic 1"},
+                {
+                    "user_id": 11,
+                    "timestamp": 1644405010,
+                    "prev_content": "test content only edit",
+                    "prev_rendered_content": "<p>test content only edit</p>",
+                    "prev_rendered_content_version": 1,
+                },
+            ]
+        ).decode()
+        msg.save(update_fields=["edit_history"])
+
+    def test_message_legacy_edit_history_format(self) -> None:
+        Message = self.apps.get_model("zerver", "Message")
+        Recipient = self.apps.get_model("zerver", "Recipient")
+
+        iago = self.example_user("iago")
+        stream_name = "Denmark"
+        denmark = get_stream(stream_name, iago.realm)
+
+        msg = Message.objects.filter(id=self.msg_id).first()
+        msg_stream_id = Recipient.objects.get(id=msg.recipient_id).type_id
+        new_edit_history = orjson.loads(msg.edit_history)
+
+        self.assert_length(new_edit_history, 5)
+
+        # stream and topic edit entry
+        self.assertFalse("prev_subject" in new_edit_history[0])
+        self.assertEqual(new_edit_history[0]["prev_topic"], "topic 3")
+        self.assertEqual(new_edit_history[0]["topic"], msg.subject)
+        self.assertEqual(new_edit_history[0]["prev_stream"], 3)
+        self.assertEqual(new_edit_history[0]["stream"], msg_stream_id)
+        self.assertEqual(new_edit_history[0]["stream"], denmark.id)
+        self.assertEqual(
+            set(new_edit_history[0].keys()),
+            {"timestamp", "prev_topic", "topic", "prev_stream", "stream", "user_id"},
         )
 
-    def test_subs_migrated(self) -> None:
-        UserProfile = self.apps.get_model("zerver", "UserProfile")
-        Recipient = self.apps.get_model("zerver", "Recipient")
-        Realm = self.apps.get_model("zerver", "Realm")
-        Subscription = self.apps.get_model("zerver", "Subscription")
-        Stream = self.apps.get_model("zerver", "Stream")
+        # stream only edit entry
+        self.assertEqual(new_edit_history[1]["prev_stream"], 2)
+        self.assertEqual(new_edit_history[1]["stream"], 3)
+        self.assertEqual(
+            set(new_edit_history[1].keys()), {"timestamp", "prev_stream", "stream", "user_id"}
+        )
 
-        realm = Realm.objects.get(string_id="zulip")
-        iago = UserProfile.objects.get(email="iago@zulip.com", realm=realm)
+        # topic and content edit entry
+        self.assertFalse("prev_subject" in new_edit_history[2])
+        self.assertEqual(new_edit_history[2]["prev_topic"], "topic 2")
+        self.assertEqual(new_edit_history[2]["topic"], "topic 3")
+        self.assertEqual(new_edit_history[2]["prev_content"], "test content and topic edit")
+        self.assertEqual(
+            new_edit_history[2]["prev_rendered_content"], "<p>test content and topic edit</p>"
+        )
+        self.assertEqual(new_edit_history[2]["prev_rendered_content_version"], 1)
+        self.assertEqual(
+            set(new_edit_history[2].keys()),
+            {
+                "timestamp",
+                "prev_topic",
+                "topic",
+                "prev_content",
+                "prev_rendered_content",
+                "prev_rendered_content_version",
+                "user_id",
+            },
+        )
+
+        # topic only edit entry
+        self.assertFalse("prev_subject" in new_edit_history[3])
+        self.assertEqual(new_edit_history[3]["prev_topic"], "topic 1")
+        self.assertEqual(new_edit_history[3]["topic"], "topic 2")
+        self.assertEqual(
+            set(new_edit_history[3].keys()), {"timestamp", "prev_topic", "topic", "user_id"}
+        )
+
+        # content only edit entry - not retested because never changes
+        self.assertEqual(new_edit_history[4]["prev_content"], "test content only edit")
+        self.assertEqual(
+            new_edit_history[4]["prev_rendered_content"], "<p>test content only edit</p>"
+        )
+        self.assertEqual(new_edit_history[4]["prev_rendered_content_version"], 1)
+        self.assertEqual(
+            set(new_edit_history[4].keys()),
+            {
+                "timestamp",
+                "prev_content",
+                "prev_rendered_content",
+                "prev_rendered_content_version",
+                "user_id",
+            },
+        )
+
+
+class MessageEditHistoryModernFormats(MigrationsTestCase):
+    __unittest_skip__ = False
+
+    migrate_from = "0376_set_realmemoji_author_and_reupload_realmemoji"
+    migrate_to = "0377_message_edit_history_format"
+
+    msg_id: Optional[int] = None
+
+    @use_db_models
+    def setUpBeforeMigration(self, apps: StateApps) -> None:
+        Recipient = apps.get_model("zerver", "Recipient")
+        Message = apps.get_model("zerver", "Message")
+
+        iago = self.example_user("iago")
         stream_name = "Denmark"
-        denmark = Stream.objects.get(realm=iago.realm, name=stream_name)
-        denmark_recipient = Recipient.objects.get(type=self.RECIPIENT_STREAM, type_id=denmark.id)
-        denmark_sub = Subscription.objects.get(user_profile=iago, recipient=denmark_recipient)
-        self.assertEqual(denmark_sub.desktop_notifications, False)
-        self.assertIsNone(denmark_sub.audible_notifications)
+        denmark = get_stream(stream_name, iago.realm)
+        denmark_recipient = Recipient.objects.get(type=2, type_id=denmark.id)
 
-        # Zulip ignores subscription's notification related settings for PMs so don't migrate them.
-        iago_recipient = Recipient.objects.get(type=self.RECIPIENT_PERSONAL, type_id=iago.id)
-        iago_sub = Subscription.objects.get(user_profile=iago, recipient=iago_recipient)
-        self.assertEqual(iago_sub.desktop_notifications, False)
-        self.assertEqual(iago_sub.audible_notifications, False)
-        self.assertEqual(iago_sub.push_notifications, True)
+        self.msg_id = Message.objects.create(
+            recipient_id=denmark_recipient.id,
+            subject="topic 4",
+            sender_id=iago.id,
+            sending_client_id=1,
+            content="current message text",
+            date_sent=timezone_now(),
+        ).id
+
+        msg = Message.objects.filter(id=self.msg_id).first()
+        msg_stream_id = Recipient.objects.get(id=msg.recipient_id).type_id
+
+        # topic edits contain "topic" and "prev_topic" fields.
+        # stream edits contain "stream" and "prev_stream" fields.
+        msg.edit_history = orjson.dumps(
+            [
+                {
+                    "user_id": 11,
+                    "timestamp": 1644405050,
+                    "stream": msg_stream_id,
+                    "prev_stream": 3,
+                    "topic": msg.subject,
+                    "prev_topic": "topic 3",
+                },
+                {"user_id": 11, "timestamp": 1644405040, "prev_stream": 2, "stream": 3},
+                {
+                    "user_id": 11,
+                    "timestamp": 1644405030,
+                    "prev_content": "test content and topic edit",
+                    "prev_rendered_content": "<p>test content and topic edit</p>",
+                    "prev_rendered_content_version": 1,
+                    "prev_topic": "topic 2",
+                    "topic": "topic 3",
+                },
+                {
+                    "user_id": 11,
+                    "timestamp": 1644405020,
+                    "prev_topic": "topic 1",
+                    "topic": "topic 2",
+                },
+            ]
+        ).decode()
+        msg.save(update_fields=["edit_history"])
+
+    def test_message_modern_edit_history_format(self) -> None:
+        Message = self.apps.get_model("zerver", "Message")
+        Recipient = self.apps.get_model("zerver", "Recipient")
+
+        iago = self.example_user("iago")
+        stream_name = "Denmark"
+        denmark = get_stream(stream_name, iago.realm)
+
+        msg = Message.objects.filter(id=self.msg_id).first()
+        msg_stream_id = Recipient.objects.get(id=msg.recipient_id).type_id
+        new_edit_history = orjson.loads(msg.edit_history)
+
+        self.assert_length(new_edit_history, 4)
+
+        # stream and topic edit entry
+        self.assertEqual(new_edit_history[0]["prev_topic"], "topic 3")
+        self.assertEqual(new_edit_history[0]["topic"], msg.subject)
+        self.assertEqual(new_edit_history[0]["prev_stream"], 3)
+        self.assertEqual(new_edit_history[0]["stream"], msg_stream_id)
+        self.assertEqual(new_edit_history[0]["stream"], denmark.id)
+        self.assertEqual(
+            set(new_edit_history[0].keys()),
+            {"timestamp", "prev_topic", "topic", "prev_stream", "stream", "user_id"},
+        )
+
+        # stream only edit entry
+        self.assertEqual(new_edit_history[1]["prev_stream"], 2)
+        self.assertEqual(new_edit_history[1]["stream"], 3)
+        self.assertEqual(
+            set(new_edit_history[1].keys()), {"timestamp", "prev_stream", "stream", "user_id"}
+        )
+
+        # topic and content edit entry
+        self.assertEqual(new_edit_history[2]["prev_topic"], "topic 2")
+        self.assertEqual(new_edit_history[2]["topic"], "topic 3")
+        self.assertEqual(new_edit_history[2]["prev_content"], "test content and topic edit")
+        self.assertEqual(
+            new_edit_history[2]["prev_rendered_content"], "<p>test content and topic edit</p>"
+        )
+        self.assertEqual(new_edit_history[2]["prev_rendered_content_version"], 1)
+        self.assertEqual(
+            set(new_edit_history[2].keys()),
+            {
+                "timestamp",
+                "prev_topic",
+                "topic",
+                "prev_content",
+                "prev_rendered_content",
+                "prev_rendered_content_version",
+                "user_id",
+            },
+        )
+
+        # topic only edit entry
+        self.assertEqual(new_edit_history[3]["prev_topic"], "topic 1")
+        self.assertEqual(new_edit_history[3]["topic"], "topic 2")
+        self.assertEqual(
+            set(new_edit_history[3].keys()), {"timestamp", "prev_topic", "topic", "user_id"}
+        )
+
+
+class MessageEditHistoryIntermediateFormats(MigrationsTestCase):
+    __unittest_skip__ = False
+
+    migrate_from = "0376_set_realmemoji_author_and_reupload_realmemoji"
+    migrate_to = "0377_message_edit_history_format"
+
+    msg_id: Optional[int] = None
+
+    @use_db_models
+    def setUpBeforeMigration(self, apps: StateApps) -> None:
+        Recipient = apps.get_model("zerver", "Recipient")
+        Message = apps.get_model("zerver", "Message")
+
+        iago = self.example_user("iago")
+        stream_name = "Denmark"
+        denmark = get_stream(stream_name, iago.realm)
+        denmark_recipient = Recipient.objects.get(type=2, type_id=denmark.id)
+
+        self.msg_id = Message.objects.create(
+            recipient_id=denmark_recipient.id,
+            subject="topic 4",
+            sender_id=iago.id,
+            sending_client_id=1,
+            content="current message text",
+            date_sent=timezone_now(),
+        ).id
+
+        msg = Message.objects.filter(id=self.msg_id).first()
+        msg_stream_id = Recipient.objects.get(id=msg.recipient_id).type_id
+
+        # topic edits contain "prev_subject", "topic" and "prev_topic" fields.
+        # stream edits contain "stream" and "prev_stream" fields.
+        msg.edit_history = orjson.dumps(
+            [
+                {
+                    "user_id": 11,
+                    "timestamp": 1644405050,
+                    "stream": msg_stream_id,
+                    "prev_stream": 3,
+                    "topic": msg.subject,
+                    "prev_topic": "topic 3",
+                    "prev_subject": "topic 3",
+                },
+                {"user_id": 11, "timestamp": 1644405040, "prev_stream": 2, "stream": 3},
+                {
+                    "user_id": 11,
+                    "timestamp": 1644405030,
+                    "prev_content": "test content and topic edit",
+                    "prev_rendered_content": "<p>test content and topic edit</p>",
+                    "prev_rendered_content_version": 1,
+                    "prev_topic": "topic 2",
+                    "prev_subject": "topic 2",
+                    "topic": "topic 3",
+                },
+                {
+                    "user_id": 11,
+                    "timestamp": 1644405020,
+                    "prev_topic": "topic 1",
+                    "prev_subject": "topic 1",
+                    "topic": "topic 2",
+                },
+            ]
+        ).decode()
+        msg.save(update_fields=["edit_history"])
+
+    def test_message_temporary_edit_history_format(self) -> None:
+        Message = self.apps.get_model("zerver", "Message")
+        Recipient = self.apps.get_model("zerver", "Recipient")
+
+        iago = self.example_user("iago")
+        stream_name = "Denmark"
+        denmark = get_stream(stream_name, iago.realm)
+
+        msg = Message.objects.filter(id=self.msg_id).first()
+        msg_stream_id = Recipient.objects.get(id=msg.recipient_id).type_id
+        new_edit_history = orjson.loads(msg.edit_history)
+
+        self.assert_length(new_edit_history, 4)
+
+        # stream and topic edit entry
+        self.assertFalse("prev_subject" in new_edit_history[0])
+        self.assertEqual(new_edit_history[0]["prev_topic"], "topic 3")
+        self.assertEqual(new_edit_history[0]["topic"], msg.subject)
+        self.assertEqual(new_edit_history[0]["prev_stream"], 3)
+        self.assertEqual(new_edit_history[0]["stream"], msg_stream_id)
+        self.assertEqual(new_edit_history[0]["stream"], denmark.id)
+        self.assertEqual(
+            set(new_edit_history[0].keys()),
+            {"timestamp", "prev_topic", "topic", "prev_stream", "stream", "user_id"},
+        )
+
+        # stream only edit entry
+        self.assertEqual(new_edit_history[1]["prev_stream"], 2)
+        self.assertEqual(new_edit_history[1]["stream"], 3)
+        self.assertEqual(
+            set(new_edit_history[1].keys()), {"timestamp", "prev_stream", "stream", "user_id"}
+        )
+
+        # topic and content edit entry
+        self.assertFalse("prev_subject" in new_edit_history[2])
+        self.assertEqual(new_edit_history[2]["prev_topic"], "topic 2")
+        self.assertEqual(new_edit_history[2]["topic"], "topic 3")
+        self.assertEqual(new_edit_history[2]["prev_content"], "test content and topic edit")
+        self.assertEqual(
+            new_edit_history[2]["prev_rendered_content"], "<p>test content and topic edit</p>"
+        )
+        self.assertEqual(new_edit_history[2]["prev_rendered_content_version"], 1)
+        self.assertEqual(
+            set(new_edit_history[2].keys()),
+            {
+                "timestamp",
+                "prev_topic",
+                "topic",
+                "prev_content",
+                "prev_rendered_content",
+                "prev_rendered_content_version",
+                "user_id",
+            },
+        )
+
+        # topic only edit entry
+        self.assertFalse("prev_subject" in new_edit_history[3])
+        self.assertEqual(new_edit_history[3]["prev_topic"], "topic 1")
+        self.assertEqual(new_edit_history[3]["topic"], "topic 2")
+        self.assertEqual(
+            set(new_edit_history[3].keys()), {"timestamp", "prev_topic", "topic", "user_id"}
+        )

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -16,7 +16,7 @@ from zerver.lib.message import access_message, access_web_public_message
 from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_timestamp
-from zerver.lib.topic import LEGACY_PREV_TOPIC, REQ_topic
+from zerver.lib.topic import REQ_topic
 from zerver.lib.types import EditHistoryEvent, FormattedEditHistoryEvent
 from zerver.lib.validator import check_bool, check_string_in, to_non_negative_int
 from zerver.models import Message, UserProfile
@@ -70,7 +70,7 @@ def fill_edit_history_entries(
 
         if "prev_stream" in edit_history_event:
             formatted_entry["prev_stream"] = edit_history_event["prev_stream"]
-            # TODO: Include current stream here.
+            formatted_entry["stream"] = edit_history_event["stream"]
 
         formatted_edit_history.append(formatted_entry)
 

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -54,10 +54,6 @@ def fill_edit_history_entries(
         if "prev_topic" in edit_history_event:
             prev_topic = edit_history_event["prev_topic"]
             formatted_entry["prev_topic"] = prev_topic
-        elif LEGACY_PREV_TOPIC in edit_history_event:
-            # TODO: Delete this once we've finished migrating legacy message objects.
-            prev_topic = edit_history_event["prev_subject"]
-            formatted_entry["prev_topic"] = prev_topic
 
         # Fill current values for content/rendered_content.
         if "prev_content" in edit_history_event:

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -51,8 +51,11 @@ def fill_edit_history_entries(
             "user_id": edit_history_event["user_id"],
         }
 
-        # Add current topic, map LEGACY_PREV_TOPIC => "prev_topic".
-        if LEGACY_PREV_TOPIC in edit_history_event:
+        if "prev_topic" in edit_history_event:
+            prev_topic = edit_history_event["prev_topic"]
+            formatted_entry["prev_topic"] = prev_topic
+        elif LEGACY_PREV_TOPIC in edit_history_event:
+            # TODO: Delete this once we've finished migrating legacy message objects.
             prev_topic = edit_history_event["prev_subject"]
             formatted_entry["prev_topic"] = prev_topic
 


### PR DESCRIPTION
This pull request is a review of #21282 with an added migration test suite, as well as some bug and test fixes.

Commits where I made key additions / changes:
- [edit history: Refactor to use FormattedEditHistoryEvent type](https://github.com/zulip/zulip/commit/faebef77cc8ef53e1748a0fd69b93bb752ce1bdf): Updated API documentation for field that existed prior to this migration but previously wasn't being validated, but now is. Also, fixed missing `append` to the list for edit entries.
- [edit_history: Store additional fields on edit history events](https://github.com/zulip/zulip/commit/0baddc1d52dd2cdee17795f0411b711d8f796420): Added tests for new fields, which also included added missing tests for some existing fields (`prev_stream`). Also fixed the deletion of fields in the message dict API so that it works for both legacy and modern versions of edit history.
- [edit_history: Migrate database to modernized edit history format](https://github.com/zulip/zulip/commit/ec70b2072c5422d6f4cffb5f02a43ece5d540e6b): Added migration test suite. Fixed some references to a database column that doesn't exist post-refactor. Adjusted migration to be able to migrate all three types of potential edit history entries: legacy, intermediate (all fields exist), modern.
- [api: Add additional fields to edit_history entries](https://github.com/zulip/zulip/commit/b0b4b238765498be6ee0a091d90e66e856fe6499)[](https://github.com/laurynmm): This commit is a combination of two commits from the refactor, as was suggested in one of the commit notes. Allowed for cleaner updates to the tests.
- I added a final commit that could easily be squashed, but as kind of a clean up commit. I thought maybe the additions to the linter `custom_check.py` could be removed there as well, but I didn't make that change yet.

**Testing plan:** I've updated and added relevant back end tests and done backend test runs at each commit. Still pending is thorough manual testing and double checking for front end implications / bugs, especially with the commits prior to the one that specifically updates the front end code.

Fixes #21076. **Note**: the JSONField migration is not addressed, but would benefit from a new issue as it's still an update that feels worth doing.