### PR TITLE
internal_url: Replace all replaceAll with replace.

### DIFF
--- a/static/shared/js/internal_url.js
+++ b/static/shared/js/internal_url.js
@@ -26,7 +26,10 @@ export function stream_id_to_slug(stream_id, maybe_get_stream_name) {
 
     // The name part of the URL doesn't really matter, so we try to
     // make it pretty.
-    name = name.replaceAll(" ", "-");
+
+    // TODO: Convert this to replaceAll once mobile no longer supports
+    // browsers that don't have it.
+    name = name.replace(/ /g, "-");
 
     return stream_id + "-" + name;
 }


### PR DESCRIPTION
Replaces all occurrences of string.replaceAll with string.replace as
replaceAll is a relatively new addition to the language and some JS
engines (notably the one that currently ships with the iOS version
of Zulip Mobile) do not yet support it. No functional changes.
See https://caniuse.com/mdn-javascript_builtins_string_replaceall
