### PR TITLE
compose: Change hover color on compose icons in dark theme.

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -97,7 +97,7 @@ body.dark-theme {
             color: hsl(236, 33%, 90%);
 
             &.compose_control_button:hover {
-                color: hsl(200, 79%, 66%);
+                color: hsl(236, 31%, 90%);
             }
         }
 
@@ -398,6 +398,11 @@ body.dark-theme {
 
     .compose_control_buttons_container .divider {
         color: hsla(236, 33%, 90%, 0.5);
+    }
+
+    /* Override the color of icons with anchor tag of compose box on dark theme */
+    .compose_control_button:hover {
+        color: hsl(236, 31%, 90%);
     }
 
     /* Not that .message_row (below) needs to be more contrast on dark theme */


### PR DESCRIPTION
![Screencast-from-05-03-22-02_42_15-PM-IST](https://user-images.githubusercontent.com/76561593/156876929-7a3a9cbe-727d-4192-a956-7a7b0a17ef3c.gif)
