### PR TITLE
fix: Change the x icon for closing the compose box

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -231,28 +231,36 @@
 
 #compose_top_right {
     display: flex;
-    align-items: center;
+    right: 0;
+    float: right;
 
     button {
         background: transparent;
-        font-size: 20px;
-        font-weight: bold;
-        line-height: 20px;
         opacity: 0.6;
         border: 0;
-        padding: 0;
-        margin-left: 4px;
-        vertical-align: unset;
+        margin-left: 3px;
 
         &:hover {
             opacity: 1;
         }
+
+        #compose_close {
+            font-weight: lighter;
+            text-shadow: none;
+            font-size: 15px;
+        }
     }
 }
 
-.collapse_composebox_button,
-#compose_close {
+.collapse_composebox_button {
     display: none;
+}
+
+.expand_composebox_button,
+.collapse_composebox_button {
+    font-size: 18px;
+    margin-top: -1px;
+    font-weight: bold;
 }
 
 .compose_resolved_topic,


### PR DESCRIPTION
This PR fixes  issue #20403

Attaching the testing screenshots:
![#resolved ss1](https://user-images.githubusercontent.com/97943778/156878383-9e4ab3ad-bc93-4efb-ab32-0fd361644bfc.PNG)
![#resolved ss2](https://user-images.githubusercontent.com/97943778/156878387-67d0b7aa-eaaa-42d6-8035-781691aa92ef.PNG)
