### PR TITLE
install: Desupport Ubuntu 22.04 for now

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -12,7 +12,7 @@ Contents:
 If you'd like to install a Zulip development environment on a computer
 that's running one of:
 
-- Ubuntu 20.04 Focal, 22.04 Jammy (beta)
+- Ubuntu 20.04 Focal
 - Debian 10 Buster, 11 Bullseye
 - CentOS 7 (beta)
 - Fedora 33 and 34 (beta)

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -49,7 +49,7 @@ a proxy to access the internet.)
 
 - **All**: 2GB available RAM, Active broadband internet connection, [GitHub account][set-up-git].
 - **macOS**: macOS (10.11 El Capitan or newer recommended)
-- **Ubuntu LTS**: 20.04 or 22.04
+- **Ubuntu LTS**: 20.04
   - or **Debian**: 10 "buster" or 11 "bullseye"
 - **Windows**: Windows 64-bit (Win 10 recommended), hardware
   virtualization enabled (VT-x or AMD-V), administrator access.

--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -5,7 +5,6 @@ To run a Zulip server, you will need:
 - A dedicated machine or VM
 - A supported OS:
   - Ubuntu 20.04 Focal
-  - Ubuntu 22.04 Jammy
   - Debian 11 Bullseye
   - Debian 10 Buster
 - At least 2GB RAM, and 10GB disk space
@@ -34,7 +33,7 @@ on issues you'll encounter](install-existing-server.md).
 
 #### Operating system
 
-Ubuntu 20.04 Focal, Ubuntu 22.04 Jammy, Debian 11 Bullseye, and Debian 10
+Ubuntu 20.04 Focal, Debian 11 Bullseye, and Debian 10
 Buster are supported for running Zulip in production. You can also
 run Zulip on other platforms that support Docker using
 [docker-zulip][docker-zulip-homepage].

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -212,7 +212,7 @@ if [ -f /etc/os-release ]; then
 fi
 
 case "$os_id $os_version_id" in
-    'debian 10' | 'debian 11' | 'ubuntu 20.04' | 'ubuntu 22.04') ;;
+    'debian 10' | 'debian 11' | 'ubuntu 20.04') ;;
     *)
         set +x
         cat <<EOF
@@ -223,7 +223,6 @@ Zulip in production is supported only on:
  - Debian 10 "buster"
  - Debian 11 "bullseye"
  - Ubuntu 20.04 LTS "focal"
- - Ubuntu 22.04 LTS "jammy"
 
 For more information, see:
   https://zulip.readthedocs.io/en/latest/production/requirements.html


### PR DESCRIPTION
Ubuntu 22.04 pushed a post-feature-freeze update to Python 3.10, breaking virtual environments in a Debian patch (https://bugs.launchpad.net/ubuntu/+source/python3.10/+bug/1962791). Also, our antique version of Tornado doesn’t work in 3.10, and we’ll need to do some work to upgrade that.

See also:

* #8913
* #21328
* https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/CI.20failure.20Ubuntu.2022.2E04