### PR TITLE
soft_deactivate: Do not crash on soft reactivate with missing stream subscription log entries

### DIFF
--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -183,7 +183,10 @@ def add_missing_messages(user_profile: UserProfile) -> None:
     recipient_ids = []
     for sub in all_stream_subs:
         stream_subscription_logs = all_stream_subscription_logs[sub["recipient__type_id"]]
-        if stream_subscription_logs[-1].event_type == RealmAuditLog.SUBSCRIPTION_DEACTIVATED:
+        if (
+            len(stream_subscription_logs) > 0
+            and stream_subscription_logs[-1].event_type == RealmAuditLog.SUBSCRIPTION_DEACTIVATED
+        ):
             assert stream_subscription_logs[-1].event_last_message_id is not None
             if (
                 stream_subscription_logs[-1].event_last_message_id


### PR DESCRIPTION
We have a Zulip test environment where a soft-deactivated user logging in triggered the following:

```2022-03-06 22:45:30.507 ERR  [django.request] Internal Server Error: /
Traceback (most recent call last):
<< SNIP >>
    register_ret = do_events_register(
  File "/home/zulip/deployments/2022-02-28-10-57-12/./zerver/lib/events.py", line 1340, in do_events_register
    reactivate_user_if_soft_deactivated(user_profile)
  File "/home/zulip/deployments/2022-02-28-10-57-12/./zerver/lib/soft_deactivation.py", line 309, in reactivate_user_if_soft_deactivated
    add_missing_messages(user_profile)
  File "/home/zulip/deployments/2022-02-28-10-57-12/./zerver/lib/soft_deactivation.py", line 188, in add_missing_messages
    if stream_subscription_logs[-1].event_type == RealmAuditLog.SUBSCRIPTION_DEACTIVATED:
IndexError: list index out of range
```

Further investigation revealed that this user had a "huddle" subscription for which no audit log entries existed:

```2022-03-06 22:43:29.627 INFO [] sub: {'recipient_id': 8, 'recipient__type_id': 1}
2022-03-06 22:43:29.629 INFO [] stream_subscription_logs: [<RealmAuditLog: <RealmAuditLog: <UserProfile: user8@redacted.local <Realm:  2>> 301 2022-01-14 16:38:16.315370+00:00 13>>]
2022-03-06 22:43:29.636 INFO [] sub: {'recipient_id': 9, 'recipient__type_id': 2}
2022-03-06 22:43:29.636 INFO [] stream_subscription_logs: [<RealmAuditLog: <RealmAuditLog: <UserProfile: user8@redacted.local <Realm:  2>> 301 2022-01-14 16:38:16.422573+00:00 14>>]
2022-03-06 22:43:29.641 INFO [] sub: {'recipient_id': 13, 'recipient__type_id': 3}
2022-03-06 22:43:29.642 INFO [] stream_subscription_logs: []
```

I'm not sure why the log entries didn't exist – but if I had to guess, this test server had a bunch of users manually deleted (using the shell) and then re-created so that might have had something to do with it.

In any case, adding this check prevented the soft reactivation from failing in this case.