### PR TITLE
typeahead: Update / hide typeahead menu on clicking outside.

### DIFF
--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -322,6 +322,7 @@
         .on('blur',     this.blur.bind(this))
         .on('keypress', this.keypress.bind(this))
         .on('keyup',    this.keyup.bind(this))
+        .on('click',    this.element_click.bind(this))
 
       if (this.eventSupported('keydown')) {
         this.$element.on('keydown', this.keydown.bind(this))
@@ -446,6 +447,12 @@
         }
       }, 150)
     }
+
+  , element_click: function (e) {
+    // update / hide the typeahead menu if the user clicks anywhere
+    // inside the typing area, to avoid misplaced typeahead insertion.
+    this.lookup()
+  }
 
   , click: function (e) {
       e.stopPropagation()


### PR DESCRIPTION
When a user clicks outside the typeahead menu, inside the typing area, the cursor position potentially changes, so `lookup` is called, which considers the new cursor position and accordingly hides, continues showing, or updates the typeahead menu.

This fixes the bug where even after clicking elsewhere, the old typeahead menu continued showing and on making a selection, the text was inserted at the wrong (new) position.

Fixes: #21302.

**Testing plan:**
Tested manually, for all cases like clicking to a cursor position that is the same as before so typeahead menu stays the same, a cursor position where a different typeahead menu is shown, and a cursor position where typeahead menu is hidden.

**GIFs or screenshots:** 
https://www.loom.com/share/e1c720b59a7c4e65a10f70586e8e2936
