### PR TITLE
Reconcile resolved-topic logic in JS, and factor out into shared

### DIFF
--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -770,7 +770,7 @@ test_ui("test warn_if_topic_resolved", ({override, mock_template}) => {
 
     mock_template("compose_resolved_topic.hbs", false, (context) => {
         assert.ok(context.can_move_topic);
-        assert.ok(context.topic_name.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX));
+        assert.ok(resolved_topic.is_resolved(context.topic_name));
         return "fake-compose_resolved_topic";
     });
 

--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -786,7 +786,7 @@ test_ui("test warn_if_topic_resolved", ({override, mock_template}) => {
 
     compose_state.set_message_type("stream");
     compose_state.stream_name("Do not exist");
-    compose_state.topic(resolved_topic.RESOLVED_TOPIC_PREFIX + "hello");
+    compose_state.topic(resolved_topic.resolve_name("hello"));
 
     // Do not show a warning if stream name does not exist
     compose_validate.warn_if_topic_resolved();

--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -16,9 +16,9 @@ const ui_util = mock_esm("../../static/js/ui_util");
 
 const compose_pm_pill = zrequire("compose_pm_pill");
 const compose_validate = zrequire("compose_validate");
-const message_edit = zrequire("message_edit");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
+const resolved_topic = zrequire("../shared/js/resolved_topic");
 const settings_config = zrequire("settings_config");
 const settings_data = mock_esm("../../static/js/settings_data");
 const stream_data = zrequire("stream_data");
@@ -770,7 +770,7 @@ test_ui("test warn_if_topic_resolved", ({override, mock_template}) => {
 
     mock_template("compose_resolved_topic.hbs", false, (context) => {
         assert.ok(context.can_move_topic);
-        assert.ok(context.topic_name.startsWith(message_edit.RESOLVED_TOPIC_PREFIX));
+        assert.ok(context.topic_name.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX));
         return "fake-compose_resolved_topic";
     });
 
@@ -786,7 +786,7 @@ test_ui("test warn_if_topic_resolved", ({override, mock_template}) => {
 
     compose_state.set_message_type("stream");
     compose_state.stream_name("Do not exist");
-    compose_state.topic(message_edit.RESOLVED_TOPIC_PREFIX + "hello");
+    compose_state.topic(resolved_topic.RESOLVED_TOPIC_PREFIX + "hello");
 
     // Do not show a warning if stream name does not exist
     compose_validate.warn_if_topic_resolved();

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -685,7 +685,7 @@ test("predicate_basics", () => {
     assert.ok(predicate({}));
 
     predicate = get_predicate([["is", "resolved"]]);
-    const resolved_topic_name = resolved_topic.RESOLVED_TOPIC_PREFIX + "foo";
+    const resolved_topic_name = resolved_topic.resolve_name("foo");
     assert.ok(predicate({type: "stream", topic: resolved_topic_name}));
     assert.ok(!predicate({topic: resolved_topic_name}));
     assert.ok(!predicate({type: "stream", topic: "foo"}));

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -7,9 +7,9 @@ const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 const {page_params} = require("../zjsunit/zpage_params");
 
-const message_edit = mock_esm("../../static/js/message_edit");
 const message_store = mock_esm("../../static/js/message_store");
 
+const resolved_topic = zrequire("../shared/js/resolved_topic");
 const stream_data = zrequire("stream_data");
 const people = zrequire("people");
 const {Filter} = zrequire("../js/filter");
@@ -685,7 +685,7 @@ test("predicate_basics", () => {
     assert.ok(predicate({}));
 
     predicate = get_predicate([["is", "resolved"]]);
-    const resolved_topic_name = message_edit.RESOLVED_TOPIC_PREFIX + "foo";
+    const resolved_topic_name = resolved_topic.RESOLVED_TOPIC_PREFIX + "foo";
     assert.ok(predicate({type: "stream", topic: resolved_topic_name}));
     assert.ok(!predicate({topic: resolved_topic_name}));
     assert.ok(!predicate({type: "stream", topic: "foo"}));

--- a/frontend_tests/node_tests/narrow_local.js
+++ b/frontend_tests/node_tests/narrow_local.js
@@ -302,7 +302,7 @@ run_test("is:alerted with no unreads and one match", () => {
 });
 
 run_test("is:resolved with one unread", () => {
-    const resolved_topic_name = resolved_topic.RESOLVED_TOPIC_PREFIX + "foo";
+    const resolved_topic_name = resolved_topic.resolve_name("foo");
     const fixture = {
         filter_terms: [{operator: "is", operand: "resolved"}],
         unread_info: {
@@ -327,7 +327,7 @@ run_test("is:resolved with one unread", () => {
 });
 
 run_test("is:resolved with no unreads", () => {
-    const resolved_topic_name = resolved_topic.RESOLVED_TOPIC_PREFIX + "foo";
+    const resolved_topic_name = resolved_topic.resolve_name("foo");
     const fixture = {
         filter_terms: [{operator: "is", operand: "resolved"}],
         unread_info: {

--- a/frontend_tests/node_tests/narrow_local.js
+++ b/frontend_tests/node_tests/narrow_local.js
@@ -6,12 +6,12 @@ const {mock_esm, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 const all_messages_data = mock_esm("../../static/js/all_messages_data");
-const message_edit = mock_esm("../../static/js/message_edit");
 
 const {Filter} = zrequire("../js/filter");
 const {MessageListData} = zrequire("../js/message_list_data");
 const narrow_state = zrequire("narrow_state");
 const narrow = zrequire("narrow");
+const resolved_topic = zrequire("../shared/js/resolved_topic");
 
 function test_with(fixture) {
     const filter = new Filter(fixture.filter_terms);
@@ -302,7 +302,7 @@ run_test("is:alerted with no unreads and one match", () => {
 });
 
 run_test("is:resolved with one unread", () => {
-    const resolved_topic_name = message_edit.RESOLVED_TOPIC_PREFIX + "foo";
+    const resolved_topic_name = resolved_topic.RESOLVED_TOPIC_PREFIX + "foo";
     const fixture = {
         filter_terms: [{operator: "is", operand: "resolved"}],
         unread_info: {
@@ -327,7 +327,7 @@ run_test("is:resolved with one unread", () => {
 });
 
 run_test("is:resolved with no unreads", () => {
-    const resolved_topic_name = message_edit.RESOLVED_TOPIC_PREFIX + "foo";
+    const resolved_topic_name = resolved_topic.RESOLVED_TOPIC_PREFIX + "foo";
     const fixture = {
         filter_terms: [{operator: "is", operand: "resolved"}],
         unread_info: {

--- a/frontend_tests/node_tests/resolved_topic.js
+++ b/frontend_tests/node_tests/resolved_topic.js
@@ -11,10 +11,46 @@ const topic_name = "asdf";
 const resolved_name = "✔ " + topic_name;
 const overresolved_name = "✔ ✔✔ " + topic_name;
 const pseudoresolved_name = "✔" + topic_name; // check mark, but no space
+const names = [topic_name, resolved_name, overresolved_name, pseudoresolved_name];
 
 run_test("is_resolved", () => {
     assert.ok(!resolved_topic.is_resolved(topic_name));
     assert.ok(resolved_topic.is_resolved(resolved_name));
     assert.ok(resolved_topic.is_resolved(overresolved_name));
     assert.ok(!resolved_topic.is_resolved(pseudoresolved_name));
+});
+
+run_test("resolve_name", () => {
+    assert.equal(resolved_topic.resolve_name(topic_name), resolved_name);
+
+    for (const name of names) {
+        assert.notEqual(resolved_topic.resolve_name(name), name);
+    }
+});
+
+run_test("unresolve_name", () => {
+    assert.equal(resolved_topic.unresolve_name(topic_name), topic_name);
+    assert.equal(resolved_topic.unresolve_name(resolved_name), topic_name);
+    assert.equal(resolved_topic.unresolve_name(overresolved_name), topic_name);
+    assert.equal(resolved_topic.unresolve_name(pseudoresolved_name), pseudoresolved_name);
+});
+
+run_test("display_parts", () => {
+    const results = [];
+    for (const name of names) {
+        const [prefix, display_name] = resolved_topic.display_parts(name);
+
+        // The parts always partition the input name.
+        assert.equal(prefix + display_name, name);
+
+        // The prefix is always the canonical prefix, or empty…
+        assert.ok(prefix === "" || prefix === resolved_topic.RESOLVED_TOPIC_PREFIX);
+        // … and which one is determined by is_resolved.
+        assert.equal(Boolean(prefix), resolved_topic.is_resolved(name));
+
+        // The parts, together, differ from those of any other input.
+        // (Yes, this is quadratic.  Keep the list of test data nice and short.)
+        assert.ok(!results.some(([p, d]) => p === prefix && d === display_name));
+        results.push([prefix, display_name]);
+    }
 });

--- a/frontend_tests/node_tests/resolved_topic.js
+++ b/frontend_tests/node_tests/resolved_topic.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const {strict: assert} = require("assert");
+
+const {zrequire} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
+
+const resolved_topic = zrequire("../shared/js/resolved_topic");
+
+const topic_name = "asdf";
+const resolved_name = "✔ " + topic_name;
+const overresolved_name = "✔ ✔✔ " + topic_name;
+const pseudoresolved_name = "✔" + topic_name; // check mark, but no space
+
+run_test("is_resolved", () => {
+    assert.ok(!resolved_topic.is_resolved(topic_name));
+    assert.ok(resolved_topic.is_resolved(resolved_name));
+    assert.ok(resolved_topic.is_resolved(overresolved_name));
+    assert.ok(!resolved_topic.is_resolved(pseudoresolved_name));
+});

--- a/frontend_tests/node_tests/topic_list_data.js
+++ b/frontend_tests/node_tests/topic_list_data.js
@@ -83,10 +83,9 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         is_active_topic: true,
         is_muted: false,
         is_zero: true,
-        resolved: false,
-        resolved_topic_prefix: "✔ ",
         topic_display_name: "topic 6",
         topic_name: "topic 6",
+        topic_resolved_prefix: "",
         unread: 0,
         url: "#narrow/stream/556-general/topic/topic.206",
     });
@@ -95,10 +94,9 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         is_active_topic: false,
         is_muted: false,
         is_zero: true,
-        resolved: true,
-        resolved_topic_prefix: "✔ ",
         topic_display_name: "topic 5",
         topic_name: "✔ topic 5",
+        topic_resolved_prefix: "✔ ",
         unread: 0,
         url: "#narrow/stream/556-general/topic/.E2.9C.94.20topic.205",
     });

--- a/static/js/compose_validate.js
+++ b/static/js/compose_validate.js
@@ -178,7 +178,7 @@ export function warn_if_topic_resolved() {
 
     const sub = stream_data.get_sub(stream_name);
 
-    if (sub && topic_name.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX)) {
+    if (sub && resolved_topic.is_resolved(topic_name)) {
         const error_area = $("#compose_resolved_topic");
 
         if (error_area.html()) {

--- a/static/js/compose_validate.js
+++ b/static/js/compose_validate.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 
+import * as resolved_topic from "../shared/js/resolved_topic";
 import render_compose_all_everyone from "../templates/compose_all_everyone.hbs";
 import render_compose_announce from "../templates/compose_announce.hbs";
 import render_compose_invite_users from "../templates/compose_invite_users.hbs";
@@ -13,7 +14,6 @@ import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
 import {$t_html} from "./i18n";
-import * as message_edit from "./message_edit";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as people from "./people";
@@ -178,7 +178,7 @@ export function warn_if_topic_resolved() {
 
     const sub = stream_data.get_sub(stream_name);
 
-    if (sub && topic_name.startsWith(message_edit.RESOLVED_TOPIC_PREFIX)) {
+    if (sub && topic_name.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX)) {
         const error_area = $("#compose_resolved_topic");
 
         if (error_area.html()) {

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -1,9 +1,10 @@
 import Handlebars from "handlebars/runtime";
 import _ from "lodash";
 
+import * as resolved_topic from "../shared/js/resolved_topic";
+
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
-import * as message_edit from "./message_edit";
 import * as message_parser from "./message_parser";
 import * as message_store from "./message_store";
 import {page_params} from "./page_params";
@@ -97,7 +98,7 @@ function message_matches_search_term(message, operator, operand) {
                 case "resolved":
                     return (
                         message.type === "stream" &&
-                        message.topic.startsWith(message_edit.RESOLVED_TOPIC_PREFIX)
+                        message.topic.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX)
                     );
                 default:
                     return false; // is:whatever returns false

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -96,10 +96,7 @@ function message_matches_search_term(message, operator, operand) {
                 case "unread":
                     return unread.message_unread(message);
                 case "resolved":
-                    return (
-                        message.type === "stream" &&
-                        message.topic.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX)
-                    );
+                    return message.type === "stream" && resolved_topic.is_resolved(message.topic);
                 default:
                     return false; // is:whatever returns false
             }

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -2,6 +2,7 @@ import ClipboardJS from "clipboard";
 import $ from "jquery";
 import _ from "lodash";
 
+import * as resolved_topic from "../shared/js/resolved_topic";
 import render_delete_message_modal from "../templates/confirm_dialog/confirm_delete_message.hbs";
 import render_message_edit_form from "../templates/message_edit_form.hbs";
 import render_topic_edit_form from "../templates/topic_edit_form.hbs";
@@ -38,7 +39,6 @@ const currently_editing_messages = new Map();
 let currently_deleting_messages = [];
 let currently_topic_editing_messages = [];
 const currently_echoing_messages = new Map();
-export const RESOLVED_TOPIC_PREFIX = "✔ ";
 
 // These variables are designed to preserve the user's most recent
 // choices when editing a group of messages, to make it convenient to
@@ -641,10 +641,10 @@ export function start(row, edit_box_open_callback) {
 
 export function toggle_resolve_topic(message_id, old_topic_name) {
     let new_topic_name;
-    if (old_topic_name.startsWith(RESOLVED_TOPIC_PREFIX)) {
-        new_topic_name = _.trimStart(old_topic_name, RESOLVED_TOPIC_PREFIX);
+    if (old_topic_name.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX)) {
+        new_topic_name = _.trimStart(old_topic_name, resolved_topic.RESOLVED_TOPIC_PREFIX);
     } else {
-        new_topic_name = RESOLVED_TOPIC_PREFIX + old_topic_name;
+        new_topic_name = resolved_topic.RESOLVED_TOPIC_PREFIX + old_topic_name;
     }
 
     const request = {

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -1,6 +1,5 @@
 import ClipboardJS from "clipboard";
 import $ from "jquery";
-import _ from "lodash";
 
 import * as resolved_topic from "../shared/js/resolved_topic";
 import render_delete_message_modal from "../templates/confirm_dialog/confirm_delete_message.hbs";
@@ -641,10 +640,10 @@ export function start(row, edit_box_open_callback) {
 
 export function toggle_resolve_topic(message_id, old_topic_name) {
     let new_topic_name;
-    if (old_topic_name.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX)) {
-        new_topic_name = _.trimStart(old_topic_name, resolved_topic.RESOLVED_TOPIC_PREFIX);
+    if (resolved_topic.is_resolved(old_topic_name)) {
+        new_topic_name = resolved_topic.unresolve_name(old_topic_name);
     } else {
-        new_topic_name = resolved_topic.RESOLVED_TOPIC_PREFIX + old_topic_name;
+        new_topic_name = resolved_topic.resolve_name(old_topic_name);
     }
 
     const request = {

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -2,6 +2,7 @@ import {isSameDay} from "date-fns";
 import $ from "jquery";
 import _ from "lodash";
 
+import * as resolved_topic from "../shared/js/resolved_topic";
 import render_bookend from "../templates/bookend.hbs";
 import render_message_group from "../templates/message_group.hbs";
 import render_recipient_row from "../templates/recipient_row.hbs";
@@ -181,7 +182,7 @@ function populate_group_from_message_container(group, message_container) {
         } else {
             group.stream_id = sub.stream_id;
         }
-        group.topic_is_resolved = group.topic.startsWith(message_edit.RESOLVED_TOPIC_PREFIX);
+        group.topic_is_resolved = group.topic.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX);
         group.topic_muted = muted_topics.is_topic_muted(group.stream_id, group.topic);
     } else if (group.is_private) {
         group.pm_with_url = message_container.pm_with_url;

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -182,7 +182,7 @@ function populate_group_from_message_container(group, message_container) {
         } else {
             group.stream_id = sub.stream_id;
         }
-        group.topic_is_resolved = group.topic.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX);
+        group.topic_is_resolved = resolved_topic.is_resolved(group.topic);
         group.topic_muted = muted_topics.is_topic_muted(group.stream_id, group.topic);
     } else if (group.is_private) {
         group.pm_with_url = message_container.pm_with_url;

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -1,6 +1,7 @@
 import ClipboardJS from "clipboard";
 import $ from "jquery";
 
+import * as resolved_topic from "../shared/js/resolved_topic";
 import render_all_messages_sidebar_actions from "../templates/all_messages_sidebar_actions.hbs";
 import render_delete_topic_modal from "../templates/confirm_dialog/confirm_delete_topic.hbs";
 import render_drafts_sidebar_actions from "../templates/drafts_sidebar_action.hbs";
@@ -290,7 +291,7 @@ function build_topic_popover(opts) {
         topic_muted,
         can_move_topic,
         is_realm_admin: page_params.is_admin,
-        topic_is_resolved: topic_name.startsWith(message_edit.RESOLVED_TOPIC_PREFIX),
+        topic_is_resolved: topic_name.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX),
         color: sub.color,
         has_starred_messages,
     });

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -291,7 +291,7 @@ function build_topic_popover(opts) {
         topic_muted,
         can_move_topic,
         is_realm_admin: page_params.is_admin,
-        topic_is_resolved: topic_name.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX),
+        topic_is_resolved: resolved_topic.is_resolved(topic_name),
         color: sub.color,
         has_starred_messages,
     });

--- a/static/js/topic_list_data.js
+++ b/static/js/topic_list_data.js
@@ -33,16 +33,8 @@ export function get_list_info(stream_id, zoomed) {
         const num_unread = unread.num_unread_for_topic(stream_id, topic_name);
         const is_active_topic = active_topic === topic_name.toLowerCase();
         const is_topic_muted = muted_topics.is_topic_muted(stream_id, topic_name);
-
-        let topic_resolved_prefix = "";
-        let topic_display_name = topic_name;
-        const resolved = topic_name.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX);
-        if (resolved) {
-            topic_resolved_prefix = resolved_topic.RESOLVED_TOPIC_PREFIX;
-            topic_display_name = topic_display_name.slice(
-                resolved_topic.RESOLVED_TOPIC_PREFIX.length,
-            );
-        }
+        const [topic_resolved_prefix, topic_display_name] =
+            resolved_topic.display_parts(topic_name);
 
         if (!zoomed) {
             function should_show_topic(topics_selected) {

--- a/static/js/topic_list_data.js
+++ b/static/js/topic_list_data.js
@@ -33,10 +33,12 @@ export function get_list_info(stream_id, zoomed) {
         const num_unread = unread.num_unread_for_topic(stream_id, topic_name);
         const is_active_topic = active_topic === topic_name.toLowerCase();
         const is_topic_muted = muted_topics.is_topic_muted(stream_id, topic_name);
-        const resolved = topic_name.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX);
-        let topic_display_name = topic_name;
 
+        let topic_resolved_prefix = "";
+        let topic_display_name = topic_name;
+        const resolved = topic_name.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX);
         if (resolved) {
+            topic_resolved_prefix = resolved_topic.RESOLVED_TOPIC_PREFIX;
             topic_display_name = topic_display_name.slice(
                 resolved_topic.RESOLVED_TOPIC_PREFIX.length,
             );
@@ -101,14 +103,13 @@ export function get_list_info(stream_id, zoomed) {
 
         const topic_info = {
             topic_name,
+            topic_resolved_prefix,
             topic_display_name,
             unread: num_unread,
             is_zero: num_unread === 0,
             is_muted: is_topic_muted,
             is_active_topic,
             url: hash_util.by_stream_topic_url(stream_id, topic_name),
-            resolved,
-            resolved_topic_prefix: resolved_topic.RESOLVED_TOPIC_PREFIX,
         };
 
         items.push(topic_info);

--- a/static/js/topic_list_data.js
+++ b/static/js/topic_list_data.js
@@ -1,5 +1,6 @@
+import * as resolved_topic from "../shared/js/resolved_topic";
+
 import * as hash_util from "./hash_util";
-import * as message_edit from "./message_edit";
 import * as muted_topics from "./muted_topics";
 import * as narrow_state from "./narrow_state";
 import * as stream_topic_history from "./stream_topic_history";
@@ -32,12 +33,12 @@ export function get_list_info(stream_id, zoomed) {
         const num_unread = unread.num_unread_for_topic(stream_id, topic_name);
         const is_active_topic = active_topic === topic_name.toLowerCase();
         const is_topic_muted = muted_topics.is_topic_muted(stream_id, topic_name);
-        const resolved = topic_name.startsWith(message_edit.RESOLVED_TOPIC_PREFIX);
+        const resolved = topic_name.startsWith(resolved_topic.RESOLVED_TOPIC_PREFIX);
         let topic_display_name = topic_name;
 
         if (resolved) {
             topic_display_name = topic_display_name.slice(
-                message_edit.RESOLVED_TOPIC_PREFIX.length,
+                resolved_topic.RESOLVED_TOPIC_PREFIX.length,
             );
         }
 
@@ -107,7 +108,7 @@ export function get_list_info(stream_id, zoomed) {
             is_active_topic,
             url: hash_util.by_stream_topic_url(stream_id, topic_name),
             resolved,
-            resolved_topic_prefix: message_edit.RESOLVED_TOPIC_PREFIX,
+            resolved_topic_prefix: resolved_topic.RESOLVED_TOPIC_PREFIX,
         };
 
         items.push(topic_info);

--- a/static/shared/.gitignore
+++ b/static/shared/.gitignore
@@ -1,0 +1,4 @@
+# This /node_modules doesn't ordinarily appear when developing on web.
+# But it does appear when developing this package in tandem with
+# mobile, using `yarn link`.
+/node_modules

--- a/static/shared/js/resolved_topic.js
+++ b/static/shared/js/resolved_topic.js
@@ -1,2 +1,6 @@
 /** The canonical form of the resolved-topic prefix. */
 export const RESOLVED_TOPIC_PREFIX = "✔ ";
+
+export function is_resolved(topic_name) {
+    return topic_name.startsWith(RESOLVED_TOPIC_PREFIX);
+}

--- a/static/shared/js/resolved_topic.js
+++ b/static/shared/js/resolved_topic.js
@@ -1,6 +1,45 @@
 /** The canonical form of the resolved-topic prefix. */
 export const RESOLVED_TOPIC_PREFIX = "✔ ";
 
+/**
+ * Pattern for an arbitrary resolved-topic prefix.
+ *
+ * These always begin with the canonical prefix, but can go on longer.
+ */
+// The class has the same characters as RESOLVED_TOPIC_PREFIX.
+// It's designed to remove a weird "✔ ✔✔ " prefix, if present.
+// Compare maybe_send_resolve_topic_notifications in zerver/lib/actions.py.
+const RESOLVED_TOPIC_PREFIX_RE = /^✔ [ ✔]*/;
+
 export function is_resolved(topic_name) {
     return topic_name.startsWith(RESOLVED_TOPIC_PREFIX);
+}
+
+export function resolve_name(topic_name) {
+    return RESOLVED_TOPIC_PREFIX + topic_name;
+}
+
+/**
+ * The un-resolved form of this topic name.
+ *
+ * If the topic is already not a resolved topic, this is the identity.
+ */
+export function unresolve_name(topic_name) {
+    return topic_name.replace(RESOLVED_TOPIC_PREFIX_RE, "");
+}
+
+/**
+ * Split the topic name for display, into a "resolved" prefix and remainder.
+ *
+ * The prefix is always the canonical resolved-topic prefix, or empty.
+ *
+ * This function is injective: different topics never produce the same
+ * result, even when `unresolve_name` would give the same result.  That's a
+ * property we want when listing topics in the UI, so that we don't end up
+ * showing what look like several identical topics.
+ */
+export function display_parts(topic_name) {
+    return is_resolved(topic_name)
+        ? [RESOLVED_TOPIC_PREFIX, topic_name.slice(RESOLVED_TOPIC_PREFIX.length)]
+        : ["", topic_name];
 }

--- a/static/shared/js/resolved_topic.js
+++ b/static/shared/js/resolved_topic.js
@@ -1,0 +1,2 @@
+/** The canonical form of the resolved-topic prefix. */
+export const RESOLVED_TOPIC_PREFIX = "✔ ";

--- a/static/shared/js/resolved_topic.js.flow
+++ b/static/shared/js/resolved_topic.js.flow
@@ -1,3 +1,5 @@
 // @flow strict
 
 declare export var RESOLVED_TOPIC_PREFIX: string;
+
+declare export function is_resolved(topic_name: string): boolean;

--- a/static/shared/js/resolved_topic.js.flow
+++ b/static/shared/js/resolved_topic.js.flow
@@ -3,3 +3,9 @@
 declare export var RESOLVED_TOPIC_PREFIX: string;
 
 declare export function is_resolved(topic_name: string): boolean;
+
+declare export function resolve_name(topic_name: string): string;
+
+declare export function unresolve_name(topic_name: string): string;
+
+declare export function display_parts(topic_name: string): [string, string];

--- a/static/shared/js/resolved_topic.js.flow
+++ b/static/shared/js/resolved_topic.js.flow
@@ -1,0 +1,3 @@
+// @flow strict
+
+declare export var RESOLVED_TOPIC_PREFIX: string;

--- a/static/templates/topic_list_item.hbs
+++ b/static/templates/topic_list_item.hbs
@@ -1,9 +1,7 @@
 <li class='bottom_left_row {{#if is_active_topic}}active-sub-filter{{/if}} {{#if is_zero}}zero-topic-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} topic-list-item' data-topic-name='{{topic_name}}'>
     <span class='topic-box'>
         <span class="sidebar-topic-check">
-            {{#if resolved}}
-            {{resolved_topic_prefix}}
-            {{/if}}
+            {{topic_resolved_prefix}}
         </span>
         <a href='{{url}}' class="topic-name" title="{{topic_name}}">
             {{topic_display_name}}


### PR DESCRIPTION
We had two different frontend implementations of computing the
un-resolved form of a topic name, and they disagreed with each other.
Factor them out as a single implementation. Put that in a new shared
module, along with an `is_resolved` predicate to replace the several
copies of the "starts with prefix" logic.

Toward https://github.com/zulip/zulip-mobile/issues/5202 .

**Testing plan:** Added unit tests.
