### PR TITLE
settings_(admin/org): Simplify label for "Everyone" permissions setting.

### DIFF
--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -100,7 +100,7 @@ export const get_all_display_settings = (): DisplaySettings => ({
 export const email_address_visibility_values = {
     everyone: {
         code: 1,
-        description: $t({defaultMessage: "Admins, moderators, members and guests"}),
+        description: $t({defaultMessage: "Everyone"}),
     },
     // // Backend support for this configuration is not available yet.
     // admins_and_members: {
@@ -176,7 +176,7 @@ export const private_message_policy_values = {
     by_anyone: {
         order: 1,
         code: 1,
-        description: $t({defaultMessage: "Admins, moderators, members and guests"}),
+        description: $t({defaultMessage: "Everyone"}),
     },
     disabled: {
         order: 2,
@@ -189,7 +189,7 @@ export const wildcard_mention_policy_values = {
     by_everyone: {
         order: 1,
         code: 1,
-        description: $t({defaultMessage: "Admins, moderators, members and guests"}),
+        description: $t({defaultMessage: "Everyone"}),
     },
     by_members: {
         order: 2,
@@ -254,7 +254,7 @@ export const common_message_policy_values = {
     by_everyone: {
         order: 1,
         code: 5,
-        description: $t({defaultMessage: "Admins, moderators, members and guests"}),
+        description: $t({defaultMessage: "Everyone"}),
     },
     by_members: {
         order: 2,


### PR DESCRIPTION
In "settings_config.ts" replace "Admins, moderators, members and guest"
with "Everyone" wherever it occurs.

Motive: To make "Admins, moderators, members and guest" option easier
to understand.

Fixes: #21340


**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Screen recording after changes:

https://user-images.githubusercontent.com/85362194/157170775-56818cec-bd83-45a1-972c-66395dee64b5.mov



Screen recording showing there is no occurrence of "Admins, moderators, members and guest" in help centre

https://user-images.githubusercontent.com/85362194/157170781-de3b3c8d-c015-4c6f-9357-390c90e23f75.mov





<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
