### PR TITLE
compose_control_menu: Allow to enter press to open the menu. 

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -438,7 +438,7 @@ export function process_enter_key(e) {
 
     if ($(e.target).attr("role") === "button") {
         e.target.click();
-        return false;
+        return true;
     }
 
     // All custom logic for overlays/modals is above; if we're in a

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -561,8 +561,17 @@ input.recipient_box {
     }
 
     .compose_control_menu_wrapper {
+        opacity: 0.7;
         padding: 0;
         margin: 0;
+
+        &:hover {
+            opacity: 1;
+        }
+
+        .compose_control_menu {
+            opacity: 1;
+        }
     }
 
     .hide-sm,

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -1154,7 +1154,8 @@ body.dark-theme {
     .new-style label.checkbox input[type="checkbox"]:focus ~ span,
     i.fa:focus,
     i.zulip-icon:focus,
-    .auto-select:focus {
+    .auto-select:focus,
+    [role="button"]:focus {
         outline-color: hsl(0, 0%, 67%);
     }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -461,7 +461,8 @@ button:focus,
 .new-style label.checkbox input[type="checkbox"]:focus ~ span,
 i.fa:focus,
 i.zulip-icon:focus,
-.auto-select:focus {
+.auto-select:focus,
+[role="button"]:focus {
     outline: 2px solid hsl(215, 47%, 50%);
     /* TODO: change solid to auto once the Chromium bug #1105822 is fixed */
 }

--- a/static/templates/compose_control_buttons.hbs
+++ b/static/templates/compose_control_buttons.hbs
@@ -16,7 +16,7 @@
     <a role="button" class="compose_control_button compose_draft_button hide-sm" tabindex=0 href="#drafts" data-tippy-content="{{t 'Drafts' }}">
         {{t 'Drafts' }}
     </a>
-    <div class="compose_control_menu_wrapper">
-        <a class="compose_control_button zulip-icon zulip-icon-ellipsis-v-solid hide {{#if message_id}}show-lg{{else}}show-sm{{/if}} compose_control_menu" tabindex=0 data-tippy-content="Compose actions"></a>
+    <div class="compose_control_menu_wrapper" role="button" tabindex=0>
+        <a class="compose_control_button zulip-icon zulip-icon-ellipsis-v-solid hide {{#if message_id}}show-lg{{else}}show-sm{{/if}} compose_control_menu" tabindex="-1" data-tippy-content="Compose actions"></a>
     </div>
 </div>


### PR DESCRIPTION
discussion - https://chat.zulip.org/#narrow/stream/101-design/topic/disable.20compose.20icons.20in.20preview.20.2320962/near/1339819