### PR TITLE
compose: Show topic required error if topic is "(no topic)".

### DIFF
--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -247,6 +247,13 @@ test_ui("validate", ({override, mock_template}) => {
         $("#compose-error-msg").html(),
         $t_html({defaultMessage: "Topics are required in this organization"}),
     );
+
+    compose_state.topic("(no topic)");
+    assert.ok(!compose_validate.validate());
+    assert.equal(
+        $("#compose-error-msg").html(),
+        $t_html({defaultMessage: "Topics are required in this organization"}),
+    );
 });
 
 test_ui("get_invalid_recipient_emails", ({override_rewire}) => {

--- a/static/js/compose_validate.js
+++ b/static/js/compose_validate.js
@@ -524,7 +524,9 @@ function validate_stream_message() {
 
     if (page_params.realm_mandatory_topics) {
         const topic = compose_state.topic();
-        if (topic === "") {
+        // TODO: We plan to migrate the empty topic to only using the
+        // `""` representation for i18n reasons, but have not yet done so.
+        if (topic === "" || topic === "(no topic)") {
             compose_error.show(
                 $t_html({defaultMessage: "Topics are required in this organization"}),
                 $("#stream_message_recipient_topic"),


### PR DESCRIPTION
We already show the error if topic input is empty and it is
not allowed to send messages without topic in the organization,
and this commit also shows error when topic is "(no topic)".

The topic is set to "(no topic)" when someone sends a message
with empty topic input box and when it is allowed to send message
without topics in the organization.

This is not ideal behavior as we may want to treat "(no topic)"
differently from empty topic, but we can fix this in future and
this commit can be a short term fix.

Issue - #21344
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

<!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![no-topics](https://user-images.githubusercontent.com/35494118/157226442-d94e42de-a582-42fc-93cc-de7614fbba5f.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
