### PR TITLE
settings_users: Do not allow sorting by email if emails are hidden.

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -160,6 +160,7 @@ export function build_page() {
         create_web_public_stream_policy_values:
             settings_config.create_web_public_stream_policy_values,
         disable_enable_spectator_access_setting: !page_params.server_web_public_streams_enabled,
+        can_sort_by_email: settings_data.show_email(),
     };
 
     if (options.realm_logo_source !== "D" && options.realm_night_logo_source === "D") {

--- a/static/templates/settings/deactivated_users_admin.hbs
+++ b/static/templates/settings/deactivated_users_admin.hbs
@@ -13,7 +13,7 @@
         <table class="table table-condensed table-striped wrapped-table">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
-                <th data-sort="email">{{t "Email" }}</th>
+                <th {{#if can_sort_by_email}}data-sort="email"{{/if}}>{{t "Email" }}</th>
                 <th class="user_id" data-sort="id">{{t "User ID" }}</th>
                 <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 {{#if is_admin}}

--- a/static/templates/settings/user_list_admin.hbs
+++ b/static/templates/settings/user_list_admin.hbs
@@ -12,7 +12,7 @@
         <table class="table table-condensed table-striped wrapped-table">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
-                <th data-sort="email">{{t "Email" }}</th>
+                <th {{#if can_sort_by_email}}data-sort="email"{{/if}}>{{t "Email" }}</th>
                 <th class="user_id" data-sort="id">{{t "User ID" }}</th>
                 <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 <th class="last_active" data-sort="last_active">{{t "Last active" }}</th>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
We currently do not live update emails in this page on changing the visibility setting, so we do not live update the sorting by email also for now, but can fix it later as a follow-up after adding user-level setting.
 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![email-sort](https://user-images.githubusercontent.com/35494118/157391747-5a67a2b5-0495-4540-8b48-2a6cd42d0d85.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
