### PR TITLE
compose: Fix the working of 'c' and 'x' hotkeys during composing.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -806,10 +806,14 @@ export function process_hotkey(e, hotkey) {
             compose_actions.respond_to_message({trigger: "hotkey"});
             return true;
         case "compose": // 'c': compose
-            compose_actions.start("stream", {trigger: "compose_hotkey"});
+            if (!compose_state.composing()) {
+                compose_actions.start("stream", {trigger: "compose_hotkey"});
+            }
             return true;
         case "compose_private_message":
-            compose_actions.start("private", {trigger: "compose_hotkey"});
+            if (!compose_state.composing()) {
+                compose_actions.start("private", {trigger: "compose_hotkey"});
+            }
             return true;
         case "open_drafts":
             browser_history.go_to_location("drafts");


### PR DESCRIPTION
- This PR attempts to add a condition for the `c` and `x` hotkeys to
  work only when the user is not composing a message or there is no
  content in the compose box by using `compose_state.composing()`
  function.

- For the second point in #21128:

  We have the code to take care of updating drafts whenever we are about to clear a compose box in almost every case.
  The one which needs to be fixed is in progress in #21196.

Fixes: #21128

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
