### PR TITLE
fixed browser autocomplete in Recent topics filter

### DIFF
--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -3,7 +3,7 @@
         {{> recent_topics_filters}}
     </div>
     <div class="search_group" role="group">
-        <input type="text" id="recent_topics_search" value="{{ search_val }}" placeholder="{{t 'Filter topics (t)' }}" />
+        <input type="text" id="recent_topics_search" value="{{ search_val }}" autocomplete="off" placeholder="{{t 'Filter topics (t)' }}" />
         <button type="button" class="btn clear_search_button" id="recent_topics_search_clear">
             <i class="fa fa-remove" aria-hidden="true"></i>
         </button>


### PR DESCRIPTION
Added the `autocomplete = off` in the Recent topics filter box
zulip/zulip#21349
