### PR TITLE
restart-server: Check if service is running before restart, vs start.

### DIFF
--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -98,6 +98,14 @@ aux_services = list_supervisor_processes(["go-camo", "smokescreen"], only_runnin
 if aux_services:
     subprocess.check_call(["supervisorctl", "start", *aux_services])
 
+
+def restart_or_start(service: str) -> None:
+    our_verb = action
+    if our_verb == "restart" and len(list_supervisor_processes([service], only_running=True)) == 0:
+        our_verb = "start"
+    subprocess.check_call(["supervisorctl", our_verb, service])
+
+
 if action == "restart" and len(workers) > 0:
     if args.less_graceful:
         # The less graceful form stops every worker now; we start them
@@ -111,7 +119,7 @@ if action == "restart" and len(workers) > 0:
         # requires multiple `supervisorctl restart` calls.
         for worker in workers:
             logging.info("Restarting %s", worker)
-            subprocess.check_call(["supervisorctl", "restart", worker])
+            restart_or_start(worker)
 
 if has_application_server():
     # Next, we restart the Tornado processes sequentially, in order to
@@ -130,12 +138,10 @@ if has_application_server():
             # supervisord group where if any individual process is slow to
             # stop, the whole bundle stays stopped for an extended time.
             logging.info("%s Tornado process on port %s", verbing, p)
-            subprocess.check_call(
-                ["supervisorctl", action, f"zulip-tornado:zulip-tornado-port-{p}"]
-            )
+            restart_or_start(f"zulip-tornado:zulip-tornado-port-{p}")
     else:
         logging.info("%s Tornado process", verbing)
-        subprocess.check_call(["supervisorctl", action, "zulip-tornado:*"])
+        restart_or_start("zulip-tornado:*")
 
     # Finally, restart the Django uWSGI processes.
     if (
@@ -160,7 +166,7 @@ if has_application_server():
             subprocess.check_call(["supervisorctl", "start", "zulip-django"])
     else:
         logging.info("%s django server", verbing)
-        subprocess.check_call(["supervisorctl", action, "zulip-django"])
+        restart_or_start("zulip-django")
 
     using_sso = subprocess.check_output(["./scripts/get-django-setting", "USING_APACHE_SSO"])
     if using_sso.strip() == b"True":


### PR DESCRIPTION
In some instances (e.g. during upgrades) we run `restart-server` and
not `start-server`, even though we expect the server to most likely
already be stopped.  `supervisorctl restart servicename` if the
service is stopped produces the perhaps-alarming message:

```
restart-server: Restarting servicename
servicename: ERROR (not running)
servicename: started
```

This may cause operators to worry that something is broken, when it is
not.

Check if the service is already running, and switch from "restart" to
"start" in cases where it is not.

The race condition here is safe -- if the service transitions from
stopped to started between the check and the `start` call, it will
merely output:
```
servicename: ERROR (already started)
```
...and continue, as that has exit status 0.

If the service transitions from started to stopped between the check
and the `restart` call, we are merely back in the current case, where
it outputs:
```
servicename: ERROR (not running)
servicename: started
```

In none of these cases does a call to "restart" fail to result in the
service being stopped and then started.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** During a deploy:
```
2022-03-09 20:32:21,662 upgrade-zulip-stage-2: Stopping Zulip...
[...]
2022-03-09 20:35:09,781 upgrade-zulip-stage-2: Restarting Zulip...
2022-03-09 20:35:09,859 restart-server: Filling memcached caches
2022-03-09 20:35:13.413 INFO [] Successfully populated user cache!  Consumed 1 remote cache queries (0.0 time)
2022-03-09 20:35:13.422 INFO [] Successfully populated client cache!  Consumed 1 remote cache queries (0.01 time)
2022-03-09 20:35:13.426 INFO [] Successfully populated stream cache!  Consumed 1 remote cache queries (0.0 time)
2022-03-09 20:35:13.427 INFO [] Successfully populated huddle cache!  Consumed 1 remote cache queries (0.0 time)
2022-03-09 20:35:13.431 INFO [] Successfully populated session cache!  Consumed 1 remote cache queries (0.0 time)
2022-03-09 20:35:13,908 restart-server: Restarting zulip-workers:zulip_events_deferred_work
zulip-workers:zulip_events_deferred_work: started
2022-03-09 20:35:15,135 restart-server: Restarting zulip-workers:zulip_events_digest_emails
zulip-workers:zulip_events_digest_emails: started
2022-03-09 20:35:16,357 restart-server: Restarting zulip-workers:zulip_events_email_mirror
zulip-workers:zulip_events_email_mirror: started
2022-03-09 20:35:17,608 restart-server: Restarting zulip-workers:zulip_events_email_senders
zulip-workers:zulip_events_email_senders: started
2022-03-09 20:35:18,828 restart-server: Restarting zulip-workers:zulip_events_embed_links
zulip-workers:zulip_events_embed_links: started
2022-03-09 20:35:20,134 restart-server: Restarting zulip-workers:zulip_events_embedded_bots
zulip-workers:zulip_events_embedded_bots: started
2022-03-09 20:35:21,379 restart-server: Restarting zulip-workers:zulip_events_error_reports
zulip-workers:zulip_events_error_reports: started
2022-03-09 20:35:22,608 restart-server: Restarting zulip-workers:zulip_events_invites
zulip-workers:zulip_events_invites: started
2022-03-09 20:35:23,864 restart-server: Restarting zulip-workers:zulip_events_missedmessage_emails
zulip-workers:zulip_events_missedmessage_emails: started
2022-03-09 20:35:25,120 restart-server: Restarting zulip-workers:zulip_events_missedmessage_mobile_notifications
zulip-workers:zulip_events_missedmessage_mobile_notifications: started
2022-03-09 20:35:26,353 restart-server: Restarting zulip-workers:zulip_events_outgoing_webhooks
zulip-workers:zulip_events_outgoing_webhooks: started
2022-03-09 20:35:27,617 restart-server: Restarting zulip-workers:zulip_events_user_activity
zulip-workers:zulip_events_user_activity: started
2022-03-09 20:35:28,866 restart-server: Restarting zulip-workers:zulip_events_user_activity_interval
zulip-workers:zulip_events_user_activity_interval: started
2022-03-09 20:35:30,126 restart-server: Restarting zulip-workers:zulip_events_user_presence
zulip-workers:zulip_events_user_presence: started
2022-03-09 20:35:32,228 restart-server: Restarting zulip_deliver_scheduled_emails
zulip_deliver_scheduled_emails: started
2022-03-09 20:35:33,480 restart-server: Restarting zulip_deliver_scheduled_messages
zulip_deliver_scheduled_messages: started
2022-03-09 20:35:35,523 restart-server: Restarting process-fts-updates
process-fts-updates: started
2022-03-09 20:35:37,154 restart-server: Restarting Tornado process
zulip-tornado: started
2022-03-09 20:35:38,413 restart-server: Restarting django server
zulip-django: started
2022-03-09 20:35:40,199 restart-server: Done!
Zulip restarted successfully!
2022-03-09 20:35:40,213 upgrade-zulip-stage-2: Upgrade complete!
```

With everything running:
```
zulip@alexmv-prod:~/deployments/current$ ./scripts/restart-server
2022-03-09 20:36:03,158 restart-server: Restarting zulip-workers:zulip_events_deferred_work
zulip-workers:zulip_events_deferred_work: stopped
zulip-workers:zulip_events_deferred_work: started
2022-03-09 20:36:04,893 restart-server: Restarting zulip-workers:zulip_events_digest_emails
zulip-workers:zulip_events_digest_emails: stopped
zulip-workers:zulip_events_digest_emails: started
2022-03-09 20:36:07,230 restart-server: Restarting zulip-workers:zulip_events_email_mirror
zulip-workers:zulip_events_email_mirror: stopped
zulip-workers:zulip_events_email_mirror: started
2022-03-09 20:36:10,685 restart-server: Restarting zulip-workers:zulip_events_email_senders
zulip-workers:zulip_events_email_senders: stopped
zulip-workers:zulip_events_email_senders: started
2022-03-09 20:36:13,663 restart-server: Restarting zulip-workers:zulip_events_embed_links
zulip-workers:zulip_events_embed_links: stopped
zulip-workers:zulip_events_embed_links: started
2022-03-09 20:36:15,880 restart-server: Restarting zulip-workers:zulip_events_embedded_bots
zulip-workers:zulip_events_embedded_bots: stopped
zulip-workers:zulip_events_embedded_bots: started
2022-03-09 20:36:19,289 restart-server: Restarting zulip-workers:zulip_events_error_reports
zulip-workers:zulip_events_error_reports: stopped
zulip-workers:zulip_events_error_reports: started
2022-03-09 20:36:22,715 restart-server: Restarting zulip-workers:zulip_events_invites
zulip-workers:zulip_events_invites: stopped
zulip-workers:zulip_events_invites: started
2022-03-09 20:36:25,078 restart-server: Restarting zulip-workers:zulip_events_missedmessage_emails
zulip-workers:zulip_events_missedmessage_emails: stopped
zulip-workers:zulip_events_missedmessage_emails: started
2022-03-09 20:36:28,344 restart-server: Restarting zulip-workers:zulip_events_missedmessage_mobile_notifications
zulip-workers:zulip_events_missedmessage_mobile_notifications: stopped
zulip-workers:zulip_events_missedmessage_mobile_notifications: started
2022-03-09 20:36:31,619 restart-server: Restarting zulip-workers:zulip_events_outgoing_webhooks
zulip-workers:zulip_events_outgoing_webhooks: stopped
zulip-workers:zulip_events_outgoing_webhooks: started
2022-03-09 20:36:34,368 restart-server: Restarting zulip-workers:zulip_events_user_activity
zulip-workers:zulip_events_user_activity: stopped
zulip-workers:zulip_events_user_activity: started
2022-03-09 20:36:37,639 restart-server: Restarting zulip-workers:zulip_events_user_activity_interval
zulip-workers:zulip_events_user_activity_interval: stopped
zulip-workers:zulip_events_user_activity_interval: started
2022-03-09 20:36:40,916 restart-server: Restarting zulip-workers:zulip_events_user_presence
zulip-workers:zulip_events_user_presence: stopped
zulip-workers:zulip_events_user_presence: started
2022-03-09 20:36:43,662 restart-server: Restarting zulip_deliver_scheduled_emails
zulip_deliver_scheduled_emails: stopped
zulip_deliver_scheduled_emails: started
2022-03-09 20:36:44,965 restart-server: Restarting zulip_deliver_scheduled_messages
zulip_deliver_scheduled_messages: stopped
zulip_deliver_scheduled_messages: started
2022-03-09 20:36:46,372 restart-server: Restarting process-fts-updates
process-fts-updates: stopped
process-fts-updates: started
2022-03-09 20:36:47,658 restart-server: Restarting Tornado process
2022-03-09 20:36:47,865 restart-server: Restarting django server
zulip-django: stopped
zulip-django: started
2022-03-09 20:36:52,634 restart-server: Done!
Zulip restarted successfully!
```

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
