### PR TITLE
i18n: Remove quote syntax from stream description notification.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5353,21 +5353,16 @@ def send_change_stream_description_notification(
     user_mention = silent_mention_syntax_for_user(acting_user)
 
     with override_language(stream.realm.default_language):
-        notification_string = _(
-            "{user} changed the description for this stream.\n\n"
-            "* **Old description:**\n"
-            "``` quote\n"
-            "{old_description}\n"
-            "```\n"
-            "* **New description:**\n"
-            "``` quote\n"
-            "{new_description}\n"
-            "```"
-        )
-        notification_string = notification_string.format(
-            user=user_mention,
-            old_description=old_description,
-            new_description=new_description,
+        notification_string = (
+            _("{user} changed the description for this stream.").format(user=user_mention)
+            + "\n\n* **"
+            + _("Old description")
+            + ":**"
+            + f"\n```` quote\n{old_description}\n````\n"
+            + "* **"
+            + _("New description")
+            + ":**"
+            + f"\n```` quote\n{new_description}\n````"
         )
 
         internal_send_stream_message(

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1497,13 +1497,13 @@ class StreamAdminTest(ZulipTestCase):
         expected_notification = (
             f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this stream.\n\n"
             "* **Old description:**\n"
-            "``` quote\n"
+            "```` quote\n"
             "Test description\n"
-            "```\n"
+            "````\n"
             "* **New description:**\n"
-            "``` quote\n"
+            "```` quote\n"
             "a multi line description\n"
-            "```"
+            "````"
         )
         self.assertEqual(messages[-1].content, expected_notification)
 
@@ -1559,13 +1559,13 @@ class StreamAdminTest(ZulipTestCase):
         expected_notification = (
             f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this stream.\n\n"
             "* **Old description:**\n"
-            "``` quote\n"
+            "```` quote\n"
             "See https://zulip.com/team\n"
-            "```\n"
+            "````\n"
             "* **New description:**\n"
-            "``` quote\n"
+            "```` quote\n"
             "Test description\n"
-            "```"
+            "````"
         )
         self.assertEqual(messages[-1].content, expected_notification)
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -687,19 +687,16 @@ def send_messages_for_new_subscribers(
                         stream=stream,
                         topic=Realm.STREAM_EVENTS_NOTIFICATION_TOPIC,
                         content=_(
-                            "**{policy}** stream created by {user_name}. **Description:**\n"
-                            "```` quote\n"
-                            "{description}\n"
-                            "````"
+                            "**{policy}** stream created by {user_name}. **Description:**"
                         ).format(
                             user_name=silent_mention_syntax_for_user(user_profile),
-                            description=stream.description,
                             policy=get_stream_permission_policy_name(
                                 invite_only=stream.invite_only,
                                 history_public_to_subscribers=stream.history_public_to_subscribers,
                                 is_web_public=stream.is_web_public,
                             ),
-                        ),
+                        )
+                        + f"\n```` quote\n{stream.description}\n````",
                     ),
                 )
 


### PR DESCRIPTION
Translators found it confusing, since it's not at all obvious that the
word "quote" should not be translated.

I'm not altogether happy with the code formatting for this.

While we're changing this, also standardize on the "```` quote" style
of quote blocks to ensure code/quote blocks in stream descriptions are
unlikely to conflict with this syntax.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
