### PR TITLE
push_notifications: Remove access control on "remove" notifications.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -907,6 +907,9 @@ def handle_remove_push_notification(user_profile_id: int, message_ids: List[int]
     mobile app, when the message is read on the server, to remove the
     message from the notification.
     """
+    if not push_notifications_enabled():
+        return
+
     user_profile = get_user_profile_by_id(user_profile_id)
     message_ids = bulk_access_messages_expect_usermessage(user_profile_id, message_ids)
 

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -486,17 +486,17 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         # push notifications or message notification emails.
         self.assert_length(info["queue_messages"], 0)
 
-    def test_clear_notification_when_mention_removed(self) -> None:
+    @mock.patch("zerver.lib.push_notifications.push_notifications_enabled", return_value=True)
+    def test_clear_notification_when_mention_removed(
+        self, mock_push_notifications: mock.MagicMock
+    ) -> None:
         mentioned_user = self.example_user("iago")
         self.assertEqual(get_apns_badge_count(mentioned_user), 0)
         self.assertEqual(get_apns_badge_count_future(mentioned_user), 0)
 
-        with mock.patch(
-            "zerver.lib.push_notifications.push_notifications_enabled", return_value=True
-        ):
-            message_id = self._login_and_send_original_stream_message(
-                content="@**Iago**",
-            )
+        message_id = self._login_and_send_original_stream_message(
+            content="@**Iago**",
+        )
 
         self.assertEqual(get_apns_badge_count(mentioned_user), 0)
         self.assertEqual(get_apns_badge_count_future(mentioned_user), 1)
@@ -506,17 +506,16 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         self.assertEqual(get_apns_badge_count(mentioned_user), 0)
         self.assertEqual(get_apns_badge_count_future(mentioned_user), 0)
 
-    def test_clear_notification_when_group_mention_removed(self) -> None:
+    @mock.patch("zerver.lib.push_notifications.push_notifications_enabled", return_value=True)
+    def test_clear_notification_when_group_mention_removed(
+        self, mock_push_notifications: mock.MagicMock
+    ) -> None:
         group_mentioned_user = self.example_user("cordelia")
         self.assertEqual(get_apns_badge_count(group_mentioned_user), 0)
         self.assertEqual(get_apns_badge_count_future(group_mentioned_user), 0)
-
-        with mock.patch(
-            "zerver.lib.push_notifications.push_notifications_enabled", return_value=True
-        ):
-            message_id = self._login_and_send_original_stream_message(
-                content="Hello @*hamletcharacters*",
-            )
+        message_id = self._login_and_send_original_stream_message(
+            content="Hello @*hamletcharacters*",
+        )
 
         self.assertEqual(get_apns_badge_count(group_mentioned_user), 0)
         self.assertEqual(get_apns_badge_count_future(group_mentioned_user), 1)
@@ -530,7 +529,10 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         self.assertEqual(get_apns_badge_count(group_mentioned_user), 0)
         self.assertEqual(get_apns_badge_count_future(group_mentioned_user), 0)
 
-    def test_not_clear_notification_when_mention_removed_but_stream_notified(self) -> None:
+    @mock.patch("zerver.lib.push_notifications.push_notifications_enabled", return_value=True)
+    def test_not_clear_notification_when_mention_removed_but_stream_notified(
+        self, mock_push_notifications: mock.MagicMock
+    ) -> None:
         mentioned_user = self.example_user("iago")
         mentioned_user.enable_stream_push_notifications = True
         mentioned_user.save()
@@ -538,12 +540,9 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         self.assertEqual(get_apns_badge_count(mentioned_user), 0)
         self.assertEqual(get_apns_badge_count_future(mentioned_user), 0)
 
-        with mock.patch(
-            "zerver.lib.push_notifications.push_notifications_enabled", return_value=True
-        ):
-            message_id = self._login_and_send_original_stream_message(
-                content="@**Iago**",
-            )
+        message_id = self._login_and_send_original_stream_message(
+            content="@**Iago**",
+        )
 
         self.assertEqual(get_apns_badge_count(mentioned_user), 0)
         self.assertEqual(get_apns_badge_count_future(mentioned_user), 1)

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1316,11 +1316,14 @@ class HandlePushNotificationTest(PushNotificationTest):
         )
 
         with mock.patch(
+            "zerver.lib.push_notifications.push_notifications_enabled", return_value=True
+        ) as mock_push_notifications, mock.patch(
             "zerver.lib.push_notifications.send_android_push_notification"
         ) as mock_send_android, mock.patch(
             "zerver.lib.push_notifications.send_apple_push_notification"
         ) as mock_send_apple:
             handle_remove_push_notification(self.user_profile.id, [message.id])
+            mock_push_notifications.assert_called_once()
             mock_send_android.assert_called_with(
                 self.user_profile.id,
                 android_devices,

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1379,6 +1379,28 @@ class HandlePushNotificationTest(PushNotificationTest):
             )
             mock_push_notifications.assert_called_once()
 
+    def test_user_message_does_not_exist_remove(self) -> None:
+        """This simulates a condition that should only be an error if the user is
+        not long-term idle; we fake it, though, in the sense that the user should
+        not have received the message in the first place"""
+        self.setup_apns_tokens()
+        self.setup_gcm_tokens()
+        self.make_stream("public_stream")
+        sender = self.example_user("iago")
+        self.subscribe(sender, "public_stream")
+        message_id = self.send_stream_message(sender, "public_stream", "test")
+        with mock.patch(
+            "zerver.lib.push_notifications.push_notifications_enabled", return_value=True
+        ) as mock_push_notifications, mock.patch(
+            "zerver.lib.push_notifications.send_android_push_notification"
+        ) as mock_send_android, mock.patch(
+            "zerver.lib.push_notifications.send_apple_push_notification"
+        ) as mock_send_apple:
+            handle_remove_push_notification(self.user_profile.id, [message_id])
+            mock_push_notifications.assert_called_once()
+            mock_send_android.assert_called_once()
+            mock_send_apple.assert_called_once()
+
     def test_user_message_soft_deactivated(self) -> None:
         """This simulates a condition that should only be an error if the user is
         not long-term idle; we fake it, though, in the sense that the user should


### PR DESCRIPTION
When removing notifications, we skip the access control on if the user
still can read them -- they should not have a notification of them,
both because they currently cannot read the message, as well as
because they have already done so.

**Testing plan:** Added a test.
