### PR TITLE
help center: Change web-public streams status to beta.

### DIFF
--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -158,6 +158,7 @@
 
 ## Stream management
 * [Stream permissions](/help/stream-permissions)
+* [Web-public streams](/help/web-public-streams)
 * [Stream posting policy](/help/stream-sending-policy)
 * [Restrict stream creation](/help/configure-who-can-create-streams)
 * [Restrict stream invitation](/help/configure-who-can-invite-to-streams)

--- a/templates/zerver/help/include/web-public-streams-intro.md
+++ b/templates/zerver/help/include/web-public-streams-intro.md
@@ -1,0 +1,12 @@
+Administrators may enable the option to create **web-public streams**.
+Web-public streams can be viewed by anyone on the Internet without
+creating an account in your organization.
+
+For example, you can [link to a Zulip
+topic](/help/link-to-a-message-or-conversation) in a web-public stream
+from a GitHub issue, a social media post, or a forum thread, and
+anyone will be able to click the link and view the discussion in the
+Zulip web application without needing to create an account.
+
+Users who wish to post content will need to create an account in order
+to do so.

--- a/templates/zerver/help/moderating-open-organizations.md
+++ b/templates/zerver/help/moderating-open-organizations.md
@@ -53,13 +53,11 @@ organization's policy choices.
 * [Deactivate bots](/help/deactivate-or-reactivate-a-bot) or
   [delete custom emoji](/help/custom-emoji#delete-custom-emoji).
 
-## In the works
+## Web-public streams
 
-* **Delete spammer**. This will wipe the user from your Zulip, by deleting
-  all their messages and reactions, banning them, etc.
-* **New users join as guests**. This will allow users joining via open
-  registration to have extremely limited permissions by default, but still
-  enough permissions to ask the core team a question or to get a feel for your
-  community.
-* **Public archive**. This will give a read-only view of selected streams,
-  removing the need in some organizations for having open registration.
+{!web-public-streams-intro.md!}
+
+## Related articles
+
+* [Setting up your organization](/help/getting-your-organization-started-with-zulip)
+* [Web-public streams](/help/web-public-streams)

--- a/templates/zerver/help/stream-permissions.md
+++ b/templates/zerver/help/stream-permissions.md
@@ -4,7 +4,7 @@ Streams are similar to chat rooms, IRC channels, or email lists in that they
 determine who receives a message. Zulip supports a few types of streams:
 
 * **Public** (**#**): Members can join and view the complete message history.
-  Public streams are visible to Guest users only if they are
+  Public streams are visible to guest users only if they are
   subscribed (exactly like private streams with shared history).
 
 * **Private** (<i class="fa fa-lock"></i>): New subscribers must be
@@ -15,6 +15,11 @@ determine who receives a message. Zulip supports a few types of streams:
     access the stream's full message history.
     * In **private streams with protected history**, new subscribers
     can only see messages sent after they join.
+
+* [**Web-public**](/help/web-public-streams) (<i class="zulip-icon
+  zulip-icon-globe"></i>): Members can join (guests must be invited by a
+  subscriber). Anyone on the Internet can view complete message history without
+  creating an account.
 
 ## Privacy model for private streams
 
@@ -74,8 +79,8 @@ administrator can access private stream messages:
 <span class="legend_symbol">&#9726;</span><span class="legend_label">If subscribed to the stream</span>
 
 <span class="legend_symbol">&#10038;</span><span class="legend_label">[Configurable](/help/stream-sending-policy).  Owners,
-Administrators, and Members can, by default, post to any public
-stream, and Guests can only post to public streams if they are
+administrators, and members can, by default, post to any public
+stream, and guests can only post to public streams if they are
 subscribed.</span>
 
 ### Private streams
@@ -108,3 +113,4 @@ must be subscribed to the stream.</span>
 
 * [Roles and permissions](/help/roles-and-permissions)
 * [Stream sending policy](/help/stream-sending-policy)
+* [Web-public streams](/help/web-public-streams)

--- a/templates/zerver/help/web-public-streams.md
+++ b/templates/zerver/help/web-public-streams.md
@@ -2,20 +2,10 @@
 
 !!! warn ""
 
-    This feature is under development, and is not yet available on Zulip Cloud.
+    This feature is in beta. Contact [support@zulip.com](mailto:support@zulip.com) to
+    enable it for your Zulip Cloud organization.
 
-Administrators may enable the option to create **web-public streams**.
-Web-public streams can be viewed by anyone on the Internet without
-creating an account in your organization.
-
-For example, you can [link to a Zulip
-topic](/help/link-to-a-message-or-conversation) in a web-public stream
-from a GitHub issue, a social media post, or a forum thread, and
-anyone will be able to click the link and view the discussion in the
-Zulip web application without needing to create an account.
-
-Users who wish to post content will need to create an account in order
-to do so.
+{!web-public-streams-intro.md!}
 
 Web-public streams are indicated with a globe (<i class="zulip-icon zulip-icon-globe"></i>) icon.
 

--- a/templates/zerver/help/web-public-streams.md
+++ b/templates/zerver/help/web-public-streams.md
@@ -166,9 +166,14 @@ with Zulip's Rules of Use.
 
 ## Caveats
 
-The web-public visitors feature is not yet integrated with Zulip's
-live-update system. As a result, a visitor will not see messages that are sent
-while Zulip is open until they reload the browser window.
+* Web-public streams do not yet support search engine indexing. You
+  can use [zulip-archive](https://github.com/zulip/zulip-archive) to
+  create an archive of a Zulip organization that can be indexed by
+  search engines.
+* The web-public view is not yet integrated with Zulip's live-update
+  system. As a result, a visitor will not see new messages that are
+  sent to a topic they are currently viewing without reloading the
+  browser window.
 
 ## Related articles
 


### PR DESCRIPTION
Also adds references to web-public streams where appropriate.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
manual

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="868" alt="Screen Shot 2022-03-09 at 3 28 10 PM" src="https://user-images.githubusercontent.com/2090066/157556479-380871e6-699b-437d-8984-41860de32209.png">

On stream privacy settings page:

<img width="892" alt="Screen Shot 2022-03-09 at 3 24 11 PM" src="https://user-images.githubusercontent.com/2090066/157556486-a20d3a15-8f69-48e3-8b5d-8b5b0150ca8e.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
