### PR TITLE
[4.x] provision: Install non-PGDG PGroonga package in development environment

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -205,7 +205,7 @@ elif "debian" in os_families():
     SYSTEM_DEPENDENCIES = [
         *DEBIAN_DEPENDECIES,
         f"postgresql-{POSTGRESQL_VERSION}",
-        f"postgresql-{POSTGRESQL_VERSION}-pgdg-pgroonga",
+        f"postgresql-{POSTGRESQL_VERSION}-pgroonga",
         *VENV_DEPENDENCIES,
     ]
 elif "rhel" in os_families():


### PR DESCRIPTION
Backport of

- #20833

Tested by reprovisioning a 5.x VM on 4.x. [chat.zulip.org discussion](https://chat.zulip.org/#narrow/stream/49-development-help/topic/provision.20for.204.2E10/near/1341982).