### PR TITLE
Update droplet creation

### DIFF
--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -233,10 +233,10 @@ def create_dns_record(my_token: str, record_name: str, ip_address: str) -> None:
     domain.create_new_domain_record(type="A", name=wildcard_name, data=ip_address)
 
 
-def print_dev_droplet_instructions(droplet_domain_name: str) -> None:
+def print_dev_droplet_instructions(username: str, droplet_domain_name: str) -> None:
     print(
         """
-COMPLETE! Droplet for GitHub user {0} is available at {0}.zulipdev.org.
+COMPLETE! Droplet for GitHub user {0} is available at {1}.
 
 Instructions for use are below. (copy and paste to the user)
 
@@ -244,15 +244,15 @@ Instructions for use are below. (copy and paste to the user)
 Your remote Zulip dev server has been created!
 
 - Connect to your server by running
-  `ssh zulipdev@{0}` on the command line
+  `ssh zulipdev@{1}` on the command line
   (Terminal for macOS and Linux, Bash for Git on Windows).
 - There is no password; your account is configured to use your SSH keys.
 - Once you log in, you should see `(zulip-py3-venv) ~$`.
 - To start the dev server, `cd zulip` and then run `./tools/run-dev.py`.
 - While the dev server is running, you can see the Zulip server in your browser at
-  http://{0}:9991.
+  http://{1}:9991.
 """.format(
-            droplet_domain_name
+            username, droplet_domain_name
         )
     )
 
@@ -357,6 +357,6 @@ if __name__ == "__main__":
     if args.production:
         print_production_droplet_instructions(droplet_domain_name=droplet_domain_name)
     else:
-        print_dev_droplet_instructions(droplet_domain_name=droplet_domain_name)
+        print_dev_droplet_instructions(username=username, droplet_domain_name=droplet_domain_name)
 
     sys.exit(1)

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -321,16 +321,14 @@ if __name__ == "__main__":
     assert_github_user_exists(github_username=username)
 
     public_keys = get_ssh_public_keys_from_github(github_username=username)
+    droplet_domain_name = f"{subdomain}.zulipdev.org"
 
     if args.production:
-        droplet_domain_name = f"{subdomain}.zulipdev.org"
         template_id = get_zulip_oneclick_app_slug(api_token)
         user_data = generate_prod_droplet_user_data(username=username, userkey_dicts=public_keys)
 
     else:
         assert_user_forked_zulip_server_repo(username=username)
-
-        droplet_domain_name = f"{subdomain}.zulipdev.org"
         user_data = generate_dev_droplet_user_data(
             username=username, subdomain=subdomain, userkey_dicts=public_keys
         )

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -331,7 +331,7 @@ if __name__ == "__main__":
         # Broken in two to satisfy linter (line too long)
         # curl -X GET -H "Content-Type: application/json" -u <API_KEY>: "https://api.digitaloc
         # ean.com/v2/images?page=5" | grep --color=always base.zulipdev.org
-        template_id = "63219191"
+        template_id = "103231841"
 
     assert_droplet_does_not_exist(
         my_token=api_token, droplet_name=droplet_domain_name, recreate=args.recreate

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -341,7 +341,7 @@ if __name__ == "__main__":
         my_token=api_token,
         template_id=template_id,
         name=droplet_domain_name,
-        tags=args.tags,
+        tags=args.tags + ["dev"],
         user_data=user_data,
     )
 

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -15,6 +15,7 @@ import argparse
 import configparser
 import json
 import os
+import secrets
 import sys
 import time
 import urllib.error
@@ -132,11 +133,19 @@ def generate_dev_droplet_user_data(
     server_repo_setup = setup_repo.format(username, "zulip")
     python_api_repo_setup = setup_repo.format(username, "python-zulip-api")
 
+    erlang_cookie = secrets.token_hex(16)
+    setup_erlang_cookie = (
+        f"echo '{erlang_cookie}' > /var/lib/rabbitmq/.erlang.cookie && "
+        "chown rabbitmq:rabbitmq /var/lib/rabbitmq/.erlang.cookie && "
+        "service rabbitmq-server restart"
+    )
+
     cloudconf = f"""\
 #!/bin/bash
 
 {setup_zulipdev_ssh_keys}
 {setup_root_ssh_keys}
+{setup_erlang_cookie}
 sed -i "s/PasswordAuthentication yes/PasswordAuthentication no/g" /etc/ssh/sshd_config
 service ssh restart
 {hostname_setup}


### PR DESCRIPTION
Use a new Debian 10 snapshot, enforce the firewall, and create fresh and secure erlang magic cookies.

**Testing plan:**
```
$ python3 ./tools/droplets/create.py alexmv -s alexmv-new --recreate
Creating Zulip developer environment for GitHub user alexmv...
Checking to see if GitHub user alexmv exists...
...user exists!
Checking to see that GitHub user has available public keys...
...public keys found!
Checking to see GitHub user has forked zulip/zulip...
...fork found!
...returning cloud-config data.
Checking to see if droplet alexmv-new.zulipdev.org already exists...
Deleting existing droplet alexmv-new.zulipdev.org.
Initiating droplet creation...
...[create]: in-progress
...[create]: in-progress
...[create]: in-progress
...[create]: in-progress
...[create]: in-progress
...[create]: completed
...droplet created!
...ip address for new droplet is: 159.203.172.194.
Deleted 1 existing A records for alexmv-new.zulipdev.org.
Deleted 1 existing A records for *.alexmv-new.zulipdev.org.
Creating new A record for alexmv-new.zulipdev.org that points to 159.203.172.194.
Creating new A record for *.alexmv-new.zulipdev.org that points to 159.203.172.194.

COMPLETE! Droplet for GitHub user alexmv-new.zulipdev.org is available at alexmv-new.zulipdev.org.zulipdev.org.

Instructions for use are below. (copy and paste to the user)

------
Your remote Zulip dev server has been created!

- Connect to your server by running
  `ssh zulipdev@alexmv-new.zulipdev.org` on the command line
  (Terminal for macOS and Linux, Bash for Git on Windows).
- There is no password; your account is configured to use your SSH keys.
- Once you log in, you should see `(zulip-py3-venv) ~$`.
- To start the dev server, `cd zulip` and then run `./tools/run-dev.py`.
- While the dev server is running, you can see the Zulip server in your browser at
  http://alexmv-new.zulipdev.org:9991.

See [Developing remotely](https://zulip.readthedocs.io/en/latest/development/remote.html) for tips on using the remote dev instance and [Git & GitHub guide](https://zulip.readthedocs.io/en/latest/git/index.html) to learn how to use Git with Zulip.

Note that this droplet will automatically be deleted after a month of inactivity. If you are leaving Zulip for more than a few weeks, we recommend pushing all of your active branches to GitHub.
------
```

...on the host:
```
(zulip-py3-venv) zulipdev@alexmv-new:~$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 10 (buster)
Release:	10
Codename:	buster
(zulip-py3-venv) zulipdev@alexmv-new:~$ sudo netstat -ltpn
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
tcp        0      0 127.0.0.1:5672          0.0.0.0:*               LISTEN      1552/beam.smp
tcp        0      0 127.0.0.1:25672         0.0.0.0:*               LISTEN      1552/beam.smp
tcp        0      0 127.0.0.1:6379          0.0.0.0:*               LISTEN      513/redis-server 12
tcp        0      0 127.0.0.1:11211         0.0.0.0:*               LISTEN      455/memcached
tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN      1826/sshd
tcp        0      0 127.0.0.1:5432          0.0.0.0:*               LISTEN      581/postgres
tcp        0      0 127.0.0.1:25            0.0.0.0:*               LISTEN      1079/exim4
tcp6       0      0 ::1:6379                :::*                    LISTEN      513/redis-server 12
tcp6       0      0 :::4369                 :::*                    LISTEN      1/init
tcp6       0      0 :::22                   :::*                    LISTEN      1826/sshd
tcp6       0      0 ::1:25                  :::*                    LISTEN      1079/exim4
(zulip-py3-venv) zulipdev@alexmv-new:~$ sudo cat /var/lib/rabbitmq/.erlang.cookie
6268985b23030253d78c3f094e87bfa8
```