### PR TITLE
left-sidebar: Make the background-color of unread_count consistent on…

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -291,9 +291,7 @@ body.dark-theme {
         color: hsl(236, 33%, 90%);
     }
 
-    .recent_topics_container .unread_count,
-    .topic-list-item .unread_count,
-    .expanded_private_message .unread_count {
+    .unread_count {
         background-color: hsla(105, 2%, 50%, 0.5);
     }
 


### PR DESCRIPTION
After Change ->

<img width="260" alt="image" src="https://user-images.githubusercontent.com/76561593/157707551-e1bb2909-b878-4fed-a8c3-e9efe7c47a49.png">


<img width="251" alt="image" src="https://user-images.githubusercontent.com/76561593/157707622-9e06b42e-1c24-4f30-9e43-99850309b9ec.png">