### PR TITLE
api_docs: Refactor of `MessagesBase` schema.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -822,7 +822,7 @@ paths:
                                     - enum:
                                         - message
                                 message:
-                                  $ref: "#/components/schemas/Messages"
+                                  $ref: "#/components/schemas/MessagesEvent"
                                 flags:
                                   type: array
                                   description: |
@@ -4741,10 +4741,59 @@ paths:
                       messages:
                         type: array
                         description: |
-                          an array of `message` objects, each containing the following
+                          An array of `message` objects, each containing the following
                           fields:
                         items:
-                          $ref: "#/components/schemas/GetMessages"
+                          allOf:
+                            - $ref: "#/components/schemas/MessagesBase"
+                            - additionalProperties: false
+                              properties:
+                                avatar_url:
+                                  nullable: true
+                                client: {}
+                                content: {}
+                                content_type: {}
+                                display_recipient: {}
+                                edit_history: {}
+                                id: {}
+                                is_me_message: {}
+                                last_edit_timestamp: {}
+                                reactions: {}
+                                recipient_id: {}
+                                sender_email: {}
+                                sender_full_name: {}
+                                sender_id: {}
+                                sender_realm_str: {}
+                                stream_id: {}
+                                subject: {}
+                                submessages: {}
+                                timestamp: {}
+                                topic_links: {}
+                                type: {}
+                                flags:
+                                  type: array
+                                  description: |
+                                    The user's [message flags][message-flags] for the message.
+
+                                    [message-flags]: /api/update-message-flags#available-flags
+                                  items:
+                                    type: string
+                                match_content:
+                                  type: string
+                                  description: |
+                                    Only present if keyword search was included among the narrow parameters.
+
+                                    HTML content of a queried message that matches the narrow, with
+                                    `<span class="highlight">` elements wrapping the matches for the
+                                    search keywords.
+                                match_subject:
+                                  type: string
+                                  description: |
+                                    Only present if keyword search was included among the narrow parameters.
+
+                                    HTML-escaped topic of a queried message that matches the narrow, with
+                                    `<span class="highlight">` elements wrapping the matches for the
+                                    search keywords.
                     example:
                       {
                         "anchor": 21,
@@ -13539,7 +13588,7 @@ paths:
                       in the `zuliprc` file downloaded when creating the bot.
                   message:
                     description: |
-                      A dict containing details on the message that triggered the
+                      A dictionary containing details on the message that triggered the
                       outgoing webhook, in the format used by [`GET /messages`](/api/get-messages).
                     allOf:
                       - $ref: "#/components/schemas/MessagesBase"
@@ -13551,8 +13600,10 @@ paths:
                           content: {}
                           content_type: {}
                           display_recipient: {}
+                          edit_history: {}
                           id: {}
                           is_me_message: {}
+                          last_edit_timestamp: {}
                           reactions: {}
                           recipient_id: {}
                           sender_email: {}
@@ -13561,9 +13612,9 @@ paths:
                           sender_realm_str: {}
                           stream_id: {}
                           subject: {}
-                          topic_links: {}
                           submessages: {}
                           timestamp: {}
+                          topic_links: {}
                           type: {}
                           rendered_content:
                             type: string
@@ -14572,7 +14623,7 @@ components:
                   type: boolean
                   description: |
                     Whether the user is a mirror dummy.
-    Messages:
+    MessagesEvent:
       allOf:
         - $ref: "#/components/schemas/MessagesBase"
         - additionalProperties: false
@@ -14583,8 +14634,10 @@ components:
             content: {}
             content_type: {}
             display_recipient: {}
+            edit_history: {}
             id: {}
             is_me_message: {}
+            last_edit_timestamp: {}
             reactions: {}
             recipient_id: {}
             sender_email: {}
@@ -14593,9 +14646,9 @@ components:
             sender_realm_str: {}
             stream_id: {}
             subject: {}
-            topic_links: {}
             submessages: {}
             timestamp: {}
+            topic_links: {}
             type: {}
     MessagesBase:
       type: object
@@ -14673,7 +14726,7 @@ components:
 
                   The rendered HTML representation of `prev_content`.
               prev_rendered_content_version:
-                type: string
+                type: integer
                 description: |
                   Only present if message's content was edited.
 
@@ -14737,7 +14790,7 @@ components:
               - timestamp
           description: |
             An array of objects, with each object documenting the
-            changes made in a previous edit made to the the message,
+            changes in a previous edit made to the the message,
             ordered chronologically from most recent to least recent
             edit.
 
@@ -14747,7 +14800,7 @@ components:
             Every object will contain `user_id` and `timestamp`.
 
             The other fields are optional, and will be present or not
-            depending on which of the stream, topic, and message
+            depending on whether the stream, topic, and/or message
             content were modified in the edit event. For example, if
             only the topic was edited, only `prev_topic` and `topic`
             will be present in addition to `user_id` and `timestamp`.
@@ -14764,6 +14817,13 @@ components:
             Whether the message is a [/me status message][status-messages]
 
             [status-messages]: /help/format-your-message-using-markdown#status-messages
+        last_edit_timestamp:
+          type: integer
+          description: |
+            The UNIX timestamp for when the message was last edited,
+            in UTC seconds.
+
+            Not present if the message has never been edited.
         reactions:
           type: array
           description: |
@@ -14808,6 +14868,17 @@ components:
 
             The field name is a legacy holdover from when topics were
             called "subjects" and will eventually change.
+        submessages:
+          type: array
+          items:
+            type: string
+          description: |
+            Data used for certain experimental Zulip integrations.
+        timestamp:
+          type: integer
+          description: |
+            The UNIX timestamp for when the message was sent,
+            in UTC seconds.
         topic_links:
           type: array
           items:
@@ -14834,73 +14905,10 @@ components:
             New in Zulip 3.0 (feature level 1): Previously, this field was called
             `subject_links`; clients are recommended to rename `subject_links` to `topic_links`
             if present for compatibility with older Zulip servers.
-        submessages:
-          type: array
-          items:
-            type: string
-          description: |
-            Data used for certain experimental Zulip integrations.
-        timestamp:
-          type: integer
-          description: |
-            The UNIX timestamp for when the message was sent,
-            in UTC seconds.
         type:
           type: string
           description: |
             The type of the message: `stream` or `private`.
-    GetMessages:
-      allOf:
-        - $ref: "#/components/schemas/MessagesBase"
-        - additionalProperties: false
-          properties:
-            avatar_url:
-              nullable: true
-            client: {}
-            content: {}
-            content_type: {}
-            display_recipient: {}
-            id: {}
-            is_me_message: {}
-            reactions: {}
-            recipient_id: {}
-            sender_email: {}
-            sender_full_name: {}
-            sender_id: {}
-            sender_realm_str: {}
-            stream_id: {}
-            subject: {}
-            topic_links: {}
-            submessages: {}
-            timestamp: {}
-            type: {}
-            flags:
-              type: array
-              description: |
-                The user's [message flags][message-flags] for the message.
-
-                [message-flags]: /api/update-message-flags#available-flags
-              items:
-                type: string
-            last_edit_timestamp:
-              type: integer
-              description: |
-                The UNIX timestamp for when the message was last edited,
-                in UTC seconds.
-            match_content:
-              type: string
-              description: |
-                Only present if keyword search was included among the narrow parameters.
-                HTML content of a queried message that matches the narrow, with
-                `<span class="highlight">` elements wrapping the matches for the
-                search keywords.
-            match_subject:
-              type: string
-              description: |
-                Only present if keyword search was included among the narrow parameters.
-                HTML-escaped topic of a queried message that matches the narrow, with
-                `<span class="highlight">` elements wrapping the matches for the
-                search keywords.
     Presence:
       type: object
       description: |


### PR DESCRIPTION
Refactors and cleans up the shared `MessagesBase` schema in the OpenAPI so that it accurately reflects the general base
for message objects for endpoints that use it as a reference.

Notes on updates / changes:
- Adds `edit_history` and `last_edit_timestamp` to the `MessagesBase` schema and all references.
- Changes the `Messages` schema to be named `MessagesEvent` as that more clearly reflects its use in the documentation.
- Alphabetizes the properties in `MessagesBase` and when they are referenced / extended.
- Removes `GetMessages` schema since it can only be used for one endpoint (`/get-messages`) and instead references / extends `MessagesBase` in the endpoint definition. This is already done for the `/zulip-outgoing-webhooks` endpoint and will be similar to what we do for `/get-message` (see prep commit note below).
- Fixes an incorrect type for `prev_rendered_content_version` in the `edit_history` object.
- Makes a few small text edits / clean ups in the above schemas / endpoints.

A follow-up to adding documentation for `edit_history` as a property of message objects (#21309).

And a preparatory commit for #20576.

See [this CZO chat](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/MessagesBase.20OpenAPI.20schema) for more context.

This is the [HTML diff of API documentation](https://pastebin.com/L0bQTkU4) from these changes. Confirms the three impacted endpoints are `/get-events`, `/get-messages` and `/zulip-outgoing-webhooks`. And reflects changes noted above.