### PR TITLE
org_settings: Fix color on hover in the code playgrounds table.

### DIFF
--- a/static/templates/settings/alert_word_settings.hbs
+++ b/static/templates/settings/alert_word_settings.hbs
@@ -33,9 +33,9 @@
     </div>
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped wrapped-table">
-            <thead>
+            <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="word">{{t "Word" }}</th>
-                <th>{{t "Actions" }}</th>
+                <th class="actions">{{t "Actions" }}</th>
             </thead>
             <tbody id="alert-words-table" class="alert-words-table required-text thick"
               data-empty="{{t 'There are no current alert words.' }}"></tbody>

--- a/static/templates/settings/playground_settings_admin.hbs
+++ b/static/templates/settings/playground_settings_admin.hbs
@@ -57,7 +57,7 @@
 
         <div class="progressive-table-wrapper" data-simplebar>
             <table class="table table-condensed table-striped wrapped-table admin_playgrounds_table">
-                <thead>
+                <thead class="table-sticky-headers">
                     <th class="active" data-sort="pygments_language">{{t "Language" }}</th>
                     <th data-sort="playground_name">{{t "Name" }}</th>
                     <th data-sort="url">{{t "URL prefix" }}</th>


### PR DESCRIPTION


  This PR attempts to fix the white background color of table headers
  in the code playground table on hover by changing the CSS for
  hoevring and adding the table-sticky-headers class to make the
  background color consistent with the other similar tables in the
  settings section.


<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot 2022-03-10 003624](https://user-images.githubusercontent.com/77766761/157745552-ede42794-1dfd-43a9-ae55-ab498e3d5722.png)
![Screenshot 2022-03-11 013810](https://user-images.githubusercontent.com/77766761/157746191-6e567658-7e55-4035-b2fc-a9dacc1f385f.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
