### PR TITLE
settings: Add web-public streams beta subdomain list.

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -297,7 +297,7 @@ def fetch_initial_state_data(
         state["server_inline_url_embed_preview"] = settings.INLINE_URL_EMBED_PREVIEW
         state["server_avatar_changes_disabled"] = settings.AVATAR_CHANGES_DISABLED
         state["server_name_changes_disabled"] = settings.NAME_CHANGES_DISABLED
-        state["server_web_public_streams_enabled"] = settings.WEB_PUBLIC_STREAMS_ENABLED
+        state["server_web_public_streams_enabled"] = realm.web_public_streams_available_for_realm()
         state["giphy_rating_options"] = realm.GIPHY_RATING_OPTIONS
 
         state["server_needs_upgrade"] = is_outdated_server(user_profile)

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -923,11 +923,20 @@ class Realm(models.Model):
     def presence_disabled(self) -> bool:
         return self.is_zephyr_mirror_realm
 
-    def web_public_streams_enabled(self) -> bool:
+    def web_public_streams_available_for_realm(self) -> bool:
+        if self.string_id in settings.WEB_PUBLIC_STREAMS_BETA_SUBDOMAINS:
+            return True
+
         if not settings.WEB_PUBLIC_STREAMS_ENABLED:
             # To help protect against accidentally web-public streams in
             # self-hosted servers, we require the feature to be enabled at
             # the server level before it is available to users.
+            return False
+
+        return True
+
+    def web_public_streams_enabled(self) -> bool:
+        if not self.web_public_streams_available_for_realm():
             return False
 
         if self.plan_type == Realm.PLAN_TYPE_LIMITED:

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -847,6 +847,10 @@ class RealmTest(ZulipTestCase):
             self.assertEqual(realm.has_web_public_streams(), False)
             self.assertEqual(realm.web_public_streams_enabled(), False)
 
+            with self.settings(WEB_PUBLIC_STREAMS_BETA_SUBDOMAINS=["zulip"]):
+                self.assertEqual(realm.has_web_public_streams(), True)
+                self.assertEqual(realm.web_public_streams_enabled(), True)
+
         realm.enable_spectator_access = False
         realm.save()
         self.assertEqual(realm.has_web_public_streams(), False)

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -261,6 +261,8 @@ OPEN_REALM_CREATION = False
 
 # Whether it's possible to create web-public streams on this server.
 WEB_PUBLIC_STREAMS_ENABLED = False
+# Temporary setting during web-public streams beta.
+WEB_PUBLIC_STREAMS_BETA_SUBDOMAINS: List[str] = []
 
 # Setting for where the system bot users are.  Likely has no
 # purpose now that the REALMS_HAVE_SUBDOMAINS migration is finished.


### PR DESCRIPTION
This will make it convenient to add a handful of organizations to the
beta of this feature during its first few weeks to try to catch bugs,
before we open it to everyone in Zulip Cloud.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Tested in a development environment by fiddling with `dev_settings`.