### PR TITLE
api: Send full message in GET /messages/{message_id} response.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 5.0
 
+**Feature level 120**
+
+* [`GET /messages/{message_id}`](/api/get-message): This endpoint
+  now sends the full message details. Previously, it only returned
+  the message's raw Markdown content.
+
 **Feature level 119**
 
 * [`POST /register`](/api/register-queue): The `unread_msgs` section

--- a/templates/zerver/help/include/rest-endpoints.md
+++ b/templates/zerver/help/include/rest-endpoints.md
@@ -9,7 +9,7 @@
 * [Add an emoji reaction](/api/add-reaction)
 * [Remove an emoji reaction](/api/remove-reaction)
 * [Render a message](/api/render-message)
-* [Get a message's raw Markdown](/api/get-raw-message)
+* [Fetch a single message](/api/get-message)
 * [Check if messages match narrow](/api/check-messages-match-narrow)
 * [Get a message's edit history](/api/get-message-history)
 * [Update personal message flags](/api/update-message-flags)

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 119
+API_FEATURE_LEVEL = 120
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5524,20 +5524,37 @@ paths:
                       }
   /messages/{message_id}:
     get:
-      operationId: get-raw-message
-      summary: Get a message's raw Markdown
+      operationId: get-message
+      summary: Fetch a single message.
       tags: ["messages"]
       description: |
-        Get the raw content of a message.
+        Given a message ID, return the message object.
 
         `GET {{ api_url }}/v1/messages/{msg_id}`
 
-        This is a rarely-used endpoint relevant for clients that primarily
-        work with HTML-rendered messages but might need to occasionally fetch
-        the message's raw Markdown (e.g. for pre-filling a message-editing
-        UI).
+        Additionally, a `raw_content` field is included. This field is
+        useful for clients that primarily work with HTML-rendered
+        messages but might need to occasionally fetch the message's
+        raw Markdown (e.g. for [view
+        source](/help/view-the-markdown-source-of-a-message) or
+        prefilling a message edit textarea).
+
+        **Changes**: Before Zulip 5.0 (feature level 120), this
+        endpoint only returned the `raw_content` field.
       parameters:
         - $ref: "#/components/parameters/MessageId"
+        - name: apply_markdown
+          in: query
+          description: |
+            If `true`, message content is returned in the rendered HTML
+            format. If `false`, message content is returned in the raw
+            Markdown-format text that user entered.
+
+            **Changes**: New in Zulip 5.0 (feature level 120).
+          schema:
+            type: boolean
+            default: true
+          example: false
       responses:
         "200":
           description: Success.
@@ -5553,13 +5570,99 @@ paths:
                       msg: {}
                       raw_content:
                         type: string
+                        deprecated: true
                         description: |
-                          The raw content of the message.
+                          The raw Markdown content of the message.
+
+                          **Deprecated** and to be removed once no longer required for
+                          legacy clients. Modern clients should prefer passing
+                          `apply_markdown=false` to request raw message content.
+                      message:
+                        description: |
+                          An object containing details of the message.
+
+                          **Changes**: New in Zulip 5.0 (feature level 120).
+                        allOf:
+                          - $ref: "#/components/schemas/MessagesBase"
+                          - additionalProperties: false
+                            properties:
+                              avatar_url:
+                                nullable: true
+                              client: {}
+                              content: {}
+                              content_type: {}
+                              display_recipient: {}
+                              edit_history: {}
+                              id: {}
+                              is_me_message: {}
+                              last_edit_timestamp: {}
+                              reactions: {}
+                              recipient_id: {}
+                              sender_email: {}
+                              sender_full_name: {}
+                              sender_id: {}
+                              sender_realm_str: {}
+                              stream_id: {}
+                              subject: {}
+                              submessages: {}
+                              timestamp: {}
+                              topic_links: {}
+                              type: {}
+                              flags:
+                                type: array
+                                description: |
+                                  The user's [message flags][message-flags] for the message.
+
+                                  [message-flags]: /api/update-message-flags#available-flags
+                                items:
+                                  type: string
                     example:
                       {
                         "raw_content": "**Don't** forget your towel!",
                         "result": "success",
                         "msg": "",
+                        "message":
+                          {
+                            "subject": "",
+                            "sender_realm_str": "zulip",
+                            "type": "private",
+                            "content": "<p>Security experts agree that relational algorithms are an interesting new topic in the field of networking, and scholars concur.</p>",
+                            "flags": ["read"],
+                            "id": 16,
+                            "display_recipient":
+                              [
+                                {
+                                  "id": 4,
+                                  "is_mirror_dummy": false,
+                                  "email": "hamlet@zulip.com",
+                                  "full_name": "King Hamlet",
+                                },
+                                {
+                                  "id": 5,
+                                  "is_mirror_dummy": false,
+                                  "email": "iago@zulip.com",
+                                  "full_name": "Iago",
+                                },
+                                {
+                                  "id": 8,
+                                  "is_mirror_dummy": false,
+                                  "email": "prospero@zulip.com",
+                                  "full_name": "Prospero from The Tempest",
+                                },
+                              ],
+                            "content_type": "text/html",
+                            "is_me_message": false,
+                            "timestamp": 1527921326,
+                            "sender_id": 4,
+                            "sender_full_name": "King Hamlet",
+                            "recipient_id": 27,
+                            "topic_links": [],
+                            "client": "populate_db",
+                            "avatar_url": "https://secure.gravatar.com/avatar/6d8cad0fd00256e7b40691d27ddfd466?d=identicon&version=1",
+                            "submessages": [],
+                            "sender_email": "hamlet@zulip.com",
+                            "reactions": [],
+                          },
                       }
         "400":
           description: Bad request.


### PR DESCRIPTION
These are the updates to #20576 for the API documentation changes. The api tests are passing and I double checked the return values in the dev env / command line with the curl example.

Here's [the HTML diff of the new `/get-message` API doc](https://pastebin.com/keGFCPcU), which was previously `/get-raw-message`.

**Screenshot of updated documentation:**
---
![Screenshot from 2022-03-11 13-43-02](https://user-images.githubusercontent.com/63245456/157868957-111ec3e3-cd33-4f08-acc3-0c27b502a53a.png)
