### PR TITLE
shared: Add flow types for typeahead module.

### DIFF
--- a/static/shared/js/typeahead.js.flow
+++ b/static/shared/js/typeahead.js.flow
@@ -1,0 +1,15 @@
+// @flow strict
+
+// declare export var popular_emojis
+
+declare export function remove_diacritics(s: string): string;
+
+// declare export function query_matches_source_attrs
+
+// declare export function clean_query_lowercase
+
+// declare export function get_emoji_matcher
+
+// declare export function triage
+
+// declare export function sort_emojis


### PR DESCRIPTION
Adds flow declarations and types for the shared typeahead module for use
in the zulip-mobile.
