### PR TITLE
setup-apt-repo: Make hashes file not contain full path.

### DIFF
--- a/scripts/lib/setup-apt-repo
+++ b/scripts/lib/setup-apt-repo
@@ -44,13 +44,16 @@ SOURCES_FILE=/etc/apt/sources.list.d/$LIST.list
 PREF_FILE=/etc/apt/preferences.d/$LIST.pref
 STAMP_FILE=/etc/apt/sources.list.d/$LIST.list.apt-update-in-progress
 
-ZULIP_SCRIPTS="$(cd "$(dirname "$(dirname "$0")")" && pwd)"
-LIST_PATH="$ZULIP_SCRIPTS/setup/apt-repos/$LIST"
+# All paths, for purposes of hashing, should be relative to the deploy
+# root.
+cd "$(dirname "$0")/../.."
+
+LIST_PATH="scripts/setup/apt-repos/$LIST"
 if ! [ -d "$LIST_PATH" ]; then
     echo "Not a valid value for --list: '$LIST'"
     echo ""
     echo "Valid values are:"
-    ls -1 "$ZULIP_SCRIPTS/setup/apt-repos/"
+    ls -1 "scripts/setup/apt-repos/"
     exit 1
 fi
 
@@ -66,7 +69,7 @@ EOF
     exit 1
 fi
 
-DEPENDENCIES_HASH="$(sha256sum "$LIST_PATH"/?(*.asc|"$release.list"|"$LIST.pref"|custom.sh) "$ZULIP_SCRIPTS/lib/setup-apt-repo")"
+DEPENDENCIES_HASH="$(sha256sum "$LIST_PATH"/?(*.asc|"$release.list"|"$LIST.pref"|custom.sh) "scripts/lib/setup-apt-repo")"
 DEPENDENCIES_HASH_FILE="/var/lib/zulip/setup-repositories-state-$LIST"
 # Ensure that DEPENDENCIES_HASH_FILE exists before hashing it.
 touch "$DEPENDENCIES_HASH_FILE"


### PR DESCRIPTION
Using an absolute `ZULIP_SCRIPTS` path when computing sha245sums
results in a set of hashes which varies based on the path that the
script is called as.  This means that each deploy _always_ has
`setup-apt-repo --verify` fail, since it is a different base path.

Make all paths passed to sha256sum be relative to the repository root,
ensuring they can be compared across runs.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Ran more than once, as different paths.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
