### PR TITLE
configure-rabbitmq: Use rabbitmqctl await_online_nodes

### DIFF
--- a/scripts/setup/configure-rabbitmq
+++ b/scripts/setup/configure-rabbitmq
@@ -19,10 +19,14 @@ RABBITMQ_PASSWORD=$("$(dirname "$0")/../get-django-setting" RABBITMQ_PASSWORD)
 
 # Wait for RabbitMQ to start up
 retries=29
-while ! "${sudo[@]}" rabbitmqctl ping -q 2>/dev/null; do
+# Could use rabbitmqctl await_startup when we upgrade to 3.7.11.
+while ! "${sudo[@]}" rabbitmqctl -q await_online_nodes 1 2>/dev/null; do
+    if ((retries == 29)); then
+        echo "Waiting for RabbitMQ to start up..."
+    fi
     sleep 1
     if ! ((retries -= 1)); then
-        "${sudo[@]}" rabbitmqctl ping -q
+        "${sudo[@]}" rabbitmqctl -q await_online_nodes 1
         break
     fi
 done


### PR DESCRIPTION
`rabbitmqctl ping` only checks that the Erlang process is registered with `epmd`. There’s a window after that where the `rabbit` app is still starting inside it.

**Testing plan:** `vagrant halt; vagrant up --provision`