### PR TITLE
makemessages: Ignore compiled and custom email templates

### DIFF
--- a/zerver/management/commands/makemessages.py
+++ b/zerver/management/commands/makemessages.py
@@ -151,6 +151,8 @@ class Command(makemessages.Command):
         try:
             ignore_patterns = options.get("ignore_patterns", [])
             ignore_patterns.append("docs/*")
+            ignore_patterns.append("templates/zerver/emails/compiled/*")
+            ignore_patterns.append("templates/zerver/emails/custom/*")
             ignore_patterns.append("var/*")
             options["ignore_patterns"] = ignore_patterns
             super().handle(*args, **options)


### PR DESCRIPTION
Our `.po` files have a bunch of bogus references like these:

https://github.com/zulip/zulip/blob/d26a15b14dea5a5b1a93a14a91352798c074dc5e/locale/en_GB/LC_MESSAGES/django.po#L826-L837

This should help get rid of them.