### PR TITLE
lightbox: Fix image title and add tippy toolips.

### DIFF
--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -54,6 +54,7 @@ test("pan_and_zoom", ({override_rewire}) => {
     };
 
     override_rewire(lightbox, "render_lightbox_list_images", () => {});
+    override_rewire(lightbox, "init_image_title_tooltip", () => {});
     const open_image = lightbox.build_open_image_function();
     open_image($img);
 

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -30,7 +30,7 @@ run_test("or", () => {
 run_test("rendered_markdown", () => {
     const html = require("./templates/rendered_markdown.hbs")();
     const expected_html =
-        '<a href="http://example.com" target="_blank" rel="noopener noreferrer" title="http://example.com/">good</a>\n';
+        '<a href="http://example.com" target="_blank" rel="noopener noreferrer">good</a>\n';
     assert.equal(html, expected_html);
 });
 

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -284,10 +284,10 @@ run_test("clean_user_content_links", () => {
                 '<a href="javascript:alert(1)">unsafe</a> ' +
                 '<a href="/#fragment" target="_blank">fragment</a>',
         ),
-        '<a href="http://example.com" target="_blank" rel="noopener noreferrer" title="http://example.com/">good</a> ' +
-            '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/file.png" target="_blank" rel="noopener noreferrer" title="translated: Download file.png">upload</a> ' +
+        '<a href="http://example.com" target="_blank" rel="noopener noreferrer">good</a> ' +
+            '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/file.png" target="_blank" rel="noopener noreferrer" data-id="file.png">upload</a> ' +
             "<a>invalid</a> " +
             "<a>unsafe</a> " +
-            '<a href="/#fragment" title="http://zulip.zulipdev.com/#fragment">fragment</a>',
+            '<a href="/#fragment">fragment</a>',
     );
 });

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import panzoom from "panzoom";
+import tippy from "tippy.js";
 
 import render_lightbox_overlay from "../templates/lightbox_overlay.hbs";
 
@@ -199,6 +200,38 @@ export function render_lightbox_list_images(preview_source) {
     }
 }
 
+export function get_file_name(payload) {
+    const file_name = payload.url.split("/").pop();
+
+    return file_name;
+}
+
+export function init_image_title_tooltip(payload) {
+    tippy(".image-description .title", {
+        arrow: true,
+        placement: "left",
+        onShow(instance) {
+            const $elem = $(instance.reference);
+            const image_name = $elem.text();
+            const tooltip_content = document.createElement("div");
+
+            tooltip_content.textContent = image_name;
+
+            const file_name = document.createElement("p");
+            const text = document.createTextNode("File name: " + get_file_name(payload));
+            file_name.append(text);
+            tooltip_content.append(file_name);
+
+            instance.setContent(tooltip_content);
+        },
+        onHidden(instance) {
+            $(".exit span, .image-preview, .image-list").on("click", () => {
+                instance.destroy();
+            });
+        },
+    });
+}
+
 function display_image(payload) {
     render_lightbox_list_images(payload.preview);
 
@@ -210,12 +243,12 @@ function display_image(payload) {
     img.src = payload.source;
     $img_container.html(img).show();
 
-    $(".image-description .title")
-        .text(payload.title || "N/A")
-        .prop("title", payload.title || "N/A");
+    $(".image-description .title").text(payload.title || get_file_name(payload));
     $(".image-description .user").text(payload.user).prop("title", payload.user);
 
     $(".image-actions .open, .image-actions .download").attr("href", payload.source);
+
+    init_image_title_tooltip(payload);
 }
 
 function display_video(payload) {
@@ -411,7 +444,7 @@ export function parse_image_data(image) {
     }
     const payload = {
         user: sender_full_name,
-        title: $parent.attr("title"),
+        title: $parent.attr("data-id"),
         type,
         preview: preview_src,
         source,

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -187,6 +187,24 @@ export function initialize() {
     });
 
     delegate("body", {
+        target: ".message_inline_image a",
+        appendTo: () => document.body,
+        onShow(instance) {
+            const $elem = $(instance.reference);
+            const id = $elem.attr("data-id");
+            const tooltip_content = document.createElement("div");
+
+            tooltip_content.textContent = "View or download ";
+            const image_name = document.createElement("span");
+            image_name.style.fontWeight = "bold";
+            image_name.textContent = id;
+
+            tooltip_content.append(image_name);
+            instance.setContent(tooltip_content);
+        },
+    });
+
+    delegate("body", {
         target: ".recipient_row_date > span",
         appendTo: () => document.body,
         onHidden(instance) {

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -1,5 +1,3 @@
-import {$t} from "./i18n";
-
 // From MDN: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Math/random
 export function random_int(min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -291,25 +289,11 @@ export function clean_user_content_links(html) {
         }
 
         // Ensure that the title displays the real URL.
-        let title;
-        let legacy_title;
+
         if (url.origin === window.location.origin && url.pathname.startsWith("/user_uploads/")) {
-            // We add the word "download" to make clear what will
-            // happen when clicking the file.  This is particularly
-            // important in the desktop app, where hovering a URL does
-            // not display the URL like it does in the web app.
-            title = legacy_title = $t(
-                {defaultMessage: "Download {filename}"},
-                {filename: url.pathname.slice(url.pathname.lastIndexOf("/") + 1)},
-            );
-        } else {
-            title = url;
-            legacy_title = href;
+            elt.dataset.id = elt.title;
+            elt.removeAttribute("title");
         }
-        elt.setAttribute(
-            "title",
-            ["", legacy_title].includes(elt.title) ? title : `${title}\n${elt.title}`,
-        );
     }
     return content.innerHTML;
 }

--- a/static/templates/lightbox_overlay.hbs
+++ b/static/templates/lightbox_overlay.hbs
@@ -1,7 +1,7 @@
 <div id="lightbox_overlay" class="overlay new-style" data-overlay="lightbox" data-noclose="false">
     <div class="image-info-wrapper">
         <div class="image-description">
-            <div class="title"></div>
+            <div class="title tippy-zulip-tooltip"></div>
             <div class="user"></div>
         </div>
         <div class="image-actions">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
First commit: 
This commit attempts to fix the image title in the lightbox preview for
an image. The title had the text fetched from the default `title` attribute
for the element, due to which it had the same text as the default
tooltip.
For this a new attribute named `data-id` has been created which would
first get the text from the title attribute and then it is removed to
avoid the default tooltip.
A new function `init_image_title_tooltip` is added which would add a tippy
tooltip for the image title in lightbox using the `setContent` method.
The content for this tooltip would be : 
```
Image name
File name: <file name>
```

Second commit: 
This commit attempts to add a tippy tooltip for the images in the
message feed in the format of `View or download <image_title>`.

Fixes: #21333 
**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot 2022-03-14 020032](https://user-images.githubusercontent.com/77766761/158078069-e697c331-5f68-4150-845c-0bc3e8126e8f.png)
![Screenshot 2022-03-14 020113](https://user-images.githubusercontent.com/77766761/158078074-d1454cd2-56e4-451d-be83-33d4da2ce700.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
