### PR TITLE
help_docs: Add typing notifications privacy setting to doc.

### DIFF
--- a/templates/zerver/help/status-and-availability.md
+++ b/templates/zerver/help/status-and-availability.md
@@ -97,3 +97,17 @@ Typing notifications are only sent while one is actively editing text
 in the compose box, and they disappear if typing is paused for about
 15 seconds.  Just having the compose box open will not send a typing
 notification.
+
+### Disable typing notifications
+
+If you'd prefer that others not know whether you're typing, you can
+configure Zulip to not send typing notifications.
+
+{start_tabs}
+
+{settings_tab|account-and-privacy}
+
+1. Under **Privacy**, toggle **Let recipients see when I'm typing
+   private messages**.
+
+{end_tabs}


### PR DESCRIPTION
Adds a section to the typing notifications documentation about how to disable them as a personal privacy setting.

I structured this as a separate sub-header based on how 'Disable updating availability' is earlier in the page, but felt like it didn't need extra explanatory text beyond the section header.

Fixes #21381.

**Testing plan:** manual

**Screenshot of updates to documentation:**
![Screenshot from 2022-03-14 14-27-26](https://user-images.githubusercontent.com/63245456/158181416-87598622-43f5-4b59-be7d-94a7b52fe450.png)
