### PR TITLE
help_docs: Document unsubscribe user from stream via profile.

### DIFF
--- a/templates/zerver/help/add-or-remove-users-from-a-stream.md
+++ b/templates/zerver/help/add-or-remove-users-from-a-stream.md
@@ -46,3 +46,25 @@ including streams the admin is not subscribed to.
 {end_tabs}
 
 [configure-invites]: /help/configure-who-can-invite-to-streams
+
+### From a user's profile (alternate method)
+
+This method is useful if you need to remove one user from multiple streams.
+
+{start_tabs}
+
+1. Hover over a user's name in the right sidebar.
+
+1. Click on the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>) to
+   the right of their name.
+
+1. Click **View full profile**.
+
+1. Select the **Streams** tab.
+
+1. Under **Subscribed streams**, find the stream you would like
+   to remove the user from.
+
+1. Click the **Unsubscribe** button in that row.
+
+{end_tabs}


### PR DESCRIPTION
Extends the documentation on unsubscribing users from streams to include an alternate method via the user's full profile, which is useful for cases where admins may need to unsubscribe a single user from multiple streams.

**Note**: There are two documented ways to get to [a user's full profile](https://zulip.com/help/view-someones-profile). I chose the right sidebar ellipsis method for accessing the user's full profile for the instructions because a user will always be searchable / accessible there.

Fixes #21379.

Related to #21316: audit of help center documentation for stream management and permissions updates for 5.0 release.

**Testing plan:** manual

**Screenshot of updates to documentation:**
![Screenshot from 2022-03-14 16-47-18](https://user-images.githubusercontent.com/63245456/158210146-8c2fc10a-1076-4b30-9d75-0c66770ed22c.png)
