### PR TITLE
help_docs: Update create stream doc for choosing subscribers.

### DIFF
--- a/templates/zerver/help/create-a-stream.md
+++ b/templates/zerver/help/create-a-stream.md
@@ -48,5 +48,5 @@ There are several parameters you can set while creating a stream. All but
 
 * **Who can post to the stream?**: See [Stream permissions](/help/stream-permissions).
 
-* **People to add**: You can copy the membership from an existing stream, or
-  enter users one by one.
+* **Choose subscribers**: You can copy the membership from an existing stream or
+  [user group](/help/user-groups), add all users, or enter users one by one.


### PR DESCRIPTION
As the different settings are described in the help center doc for creating a new stream, we need to update the final setting name from 'People to add' to the new 'Choose subscribers' that
is in the UI.

Also, updates that setting description to include adding users via user groups or the new add all users option.

Related to #21316: audit of help center documentation for stream management and permissions updates for 5.0 release.

**Testing plan:** manual

**Screenshot of updates in documentation:**
![Screenshot from 2022-03-14 17-10-43](https://user-images.githubusercontent.com/63245456/158215514-d112b088-28c3-42d2-a441-adaf728a4233.png)
