### PR TITLE
upgrade: Skip re-checking of new bots on upgrade.

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -365,8 +365,6 @@ if migrations_needed:
     logging.info("Applying database migrations...")
     subprocess.check_call(["./manage.py", "migrate", "--noinput"], preexec_fn=su_to_zulip)
 
-subprocess.check_call(["./manage.py", "create_realm_internal_bots"], preexec_fn=su_to_zulip)
-
 logging.info("Restarting Zulip...")
 if IS_SERVER_UP or not args.skip_puppet:
     # Even if the server wasn't up previously, puppet might have


### PR DESCRIPTION
This was added in c770bdaa3a66db6ca6197df33a08ef78847538f4, and we
have not added any realm-internal bots since
c770bdaa3a66db6ca6197df33a08ef78847538f4.

Speed up the critical period during upgrades by skipping this step.
