### PR TITLE
help_docs: Document user management via user profile modal.

### DIFF
--- a/templates/zerver/help/change-a-users-name.md
+++ b/templates/zerver/help/change-a-users-name.md
@@ -12,10 +12,25 @@ Organization administrators can always change any user's name.
 
 {start_tabs}
 
+{tab|via-user-profile}
+
+1. Hover over a user's name in the right sidebar.
+
+1. Click on the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>)
+   to the right of their name.
+
+1. Click **Manage this user**.
+
+1. Under **Full name**, enter a new name.
+
+{!save-changes.md!}
+
+{tab|via-organization-settings}
+
 {settings_tab|user-list-admin}
 
 1. Find the user you would like to manage. Click the **pencil**
-(<i class="fa fa-pencil"></i>) to the right of their name.
+   (<i class="fa fa-pencil"></i>) to the right of their name.
 
 1. Under **Full name**, enter a new name.
 

--- a/templates/zerver/help/change-a-users-role.md
+++ b/templates/zerver/help/change-a-users-role.md
@@ -15,8 +15,8 @@ there is at least one other owner in the organization (consider
 promoting a new owner or [deactivating the
 organization](/help/deactivate-your-organization) instead).
 
-**Changes** Organization owners were introduced in Zulip 3.0; users
-that were marked as administrators in older Zulip instances are
+**Changes**: Organization owners were introduced in Zulip 3.0. Users
+who were marked as administrators in older Zulip instances are
 automatically converted during the upgrade to Zulip 3.0 into owners
 (who have the same permissions as administrators did previously).
 
@@ -24,13 +24,28 @@ automatically converted during the upgrade to Zulip 3.0 into owners
 
 {start_tabs}
 
+{tab|via-user-profile}
+
+1. Hover over a user's name in the right sidebar.
+
+1. Click on the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>)
+   to the right of their name.
+
+1. Click **Manage this user**.
+
+1. Under **User role**, select a [role](/help/roles-and-permissions).
+
+1. Click **Save changes**. The new permissions will take effect immediately.
+
+{tab|via-organization-settings}
+
 {settings_tab|user-list-admin}
 
 1. Find the user you would like to manage. Click the **pencil**
-(<i class="fa fa-pencil"></i>) to the right of their name.
+   (<i class="fa fa-pencil"></i>) to the right of their name.
 
-1. Under **User role**, select **Owner**, **Administrator**, **Moderators**, **Member** or **Guest**.
+1. Under **User role**, select a [role](/help/roles-and-permissions).
 
-1. Click **Save changes**. The new rights will take effect immediately.
+1. Click **Save changes**. The new permissions will take effect immediately.
 
 {end_tabs}

--- a/templates/zerver/help/change-a-users-role.md
+++ b/templates/zerver/help/change-a-users-role.md
@@ -15,11 +15,6 @@ there is at least one other owner in the organization (consider
 promoting a new owner or [deactivating the
 organization](/help/deactivate-your-organization) instead).
 
-**Changes**: Organization owners were introduced in Zulip 3.0. Users
-who were marked as administrators in older Zulip instances are
-automatically converted during the upgrade to Zulip 3.0 into owners
-(who have the same permissions as administrators did previously).
-
 ### Change a user's role
 
 {start_tabs}

--- a/templates/zerver/help/deactivate-or-reactivate-a-user.md
+++ b/templates/zerver/help/deactivate-or-reactivate-a-user.md
@@ -14,12 +14,27 @@ Note that organization administrators cannot deactivate organization owners.
 
 {start_tabs}
 
+{tab|via-user-profile}
+
+1. Hover over a user's name in the right sidebar.
+
+1. Click on the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>)
+   to the right of their name.
+
+1. Click **Manage this user**.
+
+1. Click the **Deactivate user** button at the bottom.
+
+1. Approve by clicking **Confirm**.
+
+{tab|via-organization-settings}
+
 {settings_tab|user-list-admin}
 
- 4. Click the **Deactivate** button to the right of the user account that you
-want to deactivate.
+1. Click the **Deactivate** button to the right of the user account that you
+   want to deactivate.
 
-4. Approve by clicking **Confirm**.
+1. Approve by clicking **Confirm**.
 
 {end_tabs}
 

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -76,6 +76,8 @@ TAB_SECTION_LABELS = {
     "instructions-for-all-platforms": "Instructions for all platforms",
     "public-streams": "Public streams",
     "private-streams": "Private streams",
+    "via-user-profile": "Via the user's profile",
+    "via-organization-settings": "Via organization settings",
 }
 
 


### PR DESCRIPTION
Adds documentation for admins to manage users via the user profile modal for these actions:
- [Deactivating a user](https://zulip.com/help/deactivate-or-reactivate-a-user)
- [Changing a user's role](https://zulip.com/help/change-a-users-role)
- [Changing a user's name](https://zulip.com/help/change-a-users-name)

Creates two new tab sections because we still want to document the ability to do these actions through the users section in
the organizational settings modal.

Also cleans up some text in the help center article for changing a user's role.

Fixes #21415. Also, fixes #21318.

**Testing plan:** manual

**Screenshot of new tabs for changing a user's name:** 
![Screenshot from 2022-03-15 15-48-41](https://user-images.githubusercontent.com/63245456/158404399-057390ed-5b21-4d07-be99-46ccf5d24dab.png)
