### PR TITLE
Improve styling for bot editing modals

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -944,9 +944,6 @@ input[type="checkbox"] {
     padding: 0;
 
     label {
-        text-transform: uppercase;
-        font-weight: 600;
-        color: hsl(0, 0%, 67%);
         margin-top: 5px;
     }
 
@@ -960,7 +957,7 @@ input[type="checkbox"] {
     font-size: 18px;
     text-align: left;
     margin-top: 0;
-    margin-bottom: 10px;
+    margin-bottom: 20px;
 
     overflow: hidden;
     max-height: 1.1em;

--- a/static/templates/settings/admin_bot_form.hbs
+++ b/static/templates/settings/admin_bot_form.hbs
@@ -1,19 +1,19 @@
 <div id="bot-edit-form" data-user-id="{{user_id}}">
     <form class="new-style edit_bot_form form-horizontal name-setting">
         <input type="hidden" name="is_full_name" value="true" />
+        <div class="input-group name_change_container">
+            <label for="full_name">{{t "Full name" }}</label>
+            <input type="text" autocomplete="off" name="full_name" value="{{ full_name }}" />
+        </div>
+        <div class="input-group email_change_container">
+            <label for="email">{{t "Email" }}</label>
+            <input type="text" autocomplete="off" name="email" value="{{ email }}" readonly/>
+        </div>
         <div class="input-group edit_bot_owner_container">
             <label for="bot_owner_select">{{t "Owner" }}</label>
             {{> dropdown_list_widget
               widget_name="edit_bot_owner"
               list_placeholder=(t 'Filter users')}}
-        </div>
-        <div class="name_change_container">
-            <label for="full_name">{{t "Full name" }}</label>
-            <input type="text" autocomplete="off" name="full_name" value="{{ full_name }}" />
-        </div>
-        <div class="email_change_container">
-            <label for="email">{{t "Email" }}</label>
-            <input type="text" autocomplete="off" name="email" value="{{ email }}" readonly/>
         </div>
     </form>
 </div>

--- a/static/templates/settings/edit_bot.hbs
+++ b/static/templates/settings/edit_bot.hbs
@@ -2,21 +2,21 @@
   data-email="{{bot.email}}" data-type="{{bot.bot_type}}">
     <div class="bot_edit_errors alert alert-error hide"></div>
     <div>
-        <div>
-            <label>{{t "Bot email" }}</label>
-            <div class="edit_bot_email">{{bot.email}}</div>
-        </div>
         <div class="edit-bot-form-box">
+            <div class="input-group edit-bot-name">
+                <label for="edit_bot_name">{{t "Full name" }}</label>
+                <input id="edit_bot_name" type="text" name="bot_name" class="edit_bot_name required" value="{{bot.full_name}}" maxlength=50 />
+                <div><label for="edit_bot_name" generated="true" class="text-error"></label></div>
+            </div>
+            <div class="input-group">
+                <label for="bot_email">{{t "Bot email" }}</label>
+                <input type="text" autocomplete="off" name="bot_email" value="{{ bot.email }}" readonly/>
+            </div>
             <div class="edit-bot-owner">
                 <label>{{t "Owner" }}</label>
                 {{> dropdown_list_widget
                   widget_name="bot_owner"
                   list_placeholder=(t 'Filter users')}}
-            </div>
-            <div class="edit-bot-name">
-                <label for="edit_bot_name">{{t "Full name" }}</label>
-                <input id="edit_bot_name" type="text" name="bot_name" class="edit_bot_name required" value="{{bot.full_name}}" maxlength=50 />
-                <div><label for="edit_bot_name" generated="true" class="text-error"></label></div>
             </div>
             <div id="service_data">
             </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
PR for [issue#21410: Improve styling for bot editing modals ](https://github.com/zulip/zulip/issues/21410)

[The first commit: ](https://github.com/zulip/zulip/commit/f13864c3ac734c3449068ba2f17b6092486c002b)
- Adds space between "Bot Email" and "Owner" fields in "Edit bot" modal (screenshot1).
- Removes font styles for field labels. "Edit bot" and "Change bot info and owner" modals now use regular font for field labels.

[The second commit: ](https://github.com/zulip/zulip/commit/923a7c254f36181fc8581048c277bdd29fc042ed)
- Fixes the vertical spacing between input fields.

**Testing plan:**
Manually

**GIFs or screenshots:** 
<img width="380" alt="image" src="https://user-images.githubusercontent.com/54767127/158469004-d63a3446-9c83-4ee0-89fc-dd0e61839f1c.png">
Screenshot1


<img width="385" alt="image" src="https://user-images.githubusercontent.com/54767127/158467168-de66dd31-3b20-4e3c-9f49-8725ca7bfba4.png">
Screenshot2




