### PR TITLE
settings: Fix bad alignment in organization profile for non-English languages.

### DIFF
--- a/static/styles/image_upload_widget.css
+++ b/static/styles/image_upload_widget.css
@@ -24,19 +24,40 @@
         border-radius: 5px;
     }
 
+    .image_upload_button {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        text-align: center;
+        justify-content: center;
+        border-radius: 5px;
+        box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
+        z-index: 99;
+    }
+
     .image-delete-button {
         background: none;
         border: none;
         cursor: pointer;
         color: hsl(0, 0%, 75%);
         opacity: 0;
-        padding: 3px 0;
+        padding: 0;
         position: absolute;
         font-size: 2rem;
         top: 10px;
         right: 10px;
         z-index: 99;
         line-height: 20px;
+    }
+
+    .image-delete-text,
+    .image-upload-text,
+    .image-disabled-text {
+        box-sizing: border-box;
+        width: 100%;
+        padding: 0 10px;
     }
 
     .image-delete-button:focus,
@@ -121,19 +142,6 @@
 
 /* CSS related to settings page user avatar upload widget only */
 #user-avatar-upload-widget {
-    .image_upload_button {
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        display: flex;
-        align-items: center;
-        text-align: center;
-        justify-content: center;
-        border-radius: 5px;
-        box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
-        z-index: 99;
-    }
-
     .image-disabled-text {
         color: hsl(0, 0%, 85%);
         cursor: not-allowed;
@@ -145,14 +153,6 @@
 
     .image-delete-button {
         font-size: 3rem;
-    }
-
-    .image-delete-text,
-    .image-upload-text,
-    .image-disabled-text {
-        box-sizing: border-box;
-        width: 100%;
-        padding: 0 10px;
     }
 
     .image_upload_spinner {
@@ -190,16 +190,6 @@
     border-radius: 5px;
     box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
 
-    .image-delete-text {
-        top: 40px;
-        right: 18px;
-    }
-
-    .image-upload-text {
-        top: 40px;
-        right: 18px;
-    }
-
     .image_upload_spinner {
         width: 40px;
         height: 40px;
@@ -219,13 +209,6 @@
     width: 220px;
     height: 55px;
     text-align: center;
-    margin: 0 80px 0 20px;
-
-    .image-upload-text,
-    .image-delete-text {
-        top: 17px;
-        right: 80px;
-    }
 
     .upload-spinner-background {
         left: 0;
@@ -236,6 +219,11 @@
         height: 55px;
         top: 5%;
         right: 40%;
+    }
+
+    .image-delete-button {
+        top: 5px;
+        right: 5px;
     }
 }
 
@@ -248,9 +236,15 @@
 }
 
 .realm-logo-block {
-    display: inline-block;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 0 20px;
 }
 
-.realm-logo-title {
-    padding-left: 30%;
+.realm-logo-group {
+    display: flex;
+    justify-content: space-around;
+    flex-wrap: wrap;
 }

--- a/static/styles/image_upload_widget.css
+++ b/static/styles/image_upload_widget.css
@@ -95,6 +95,9 @@
     }
 
     .upload-spinner-background {
+        display: flex;
+        justify-content: center;
+        align-items: center;
         background-color: hsl(0, 0%, 10%);
         font-size: 0.8rem;
         width: 100%;
@@ -109,7 +112,6 @@
     .image_upload_spinner {
         position: absolute;
         z-index: 99;
-        display: block;
     }
 
     &:hover {
@@ -155,13 +157,6 @@
         font-size: 3rem;
     }
 
-    .image_upload_spinner {
-        top: 40%;
-        right: 40%;
-        width: 50px;
-        height: 50px;
-    }
-
     .image-block {
         border-radius: 5px;
         box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
@@ -189,13 +184,6 @@
     height: 100px;
     border-radius: 5px;
     box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
-
-    .image_upload_spinner {
-        width: 40px;
-        height: 40px;
-        top: 30%;
-        right: 30%;
-    }
 }
 
 .realm-icon-section {
@@ -209,17 +197,6 @@
     width: 220px;
     height: 55px;
     text-align: center;
-
-    .upload-spinner-background {
-        left: 0;
-    }
-
-    .image_upload_spinner {
-        width: 45px;
-        height: 55px;
-        top: 5%;
-        right: 40%;
-    }
 
     .image-delete-button {
         top: 5px;

--- a/static/styles/image_upload_widget.css
+++ b/static/styles/image_upload_widget.css
@@ -3,25 +3,24 @@
     position: relative;
     border-radius: 5px;
     box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
+    overflow: hidden;
 
     transition: all 0.3s ease;
 
     .image-block {
-        background-size: 100%;
+        background-size: contain;
         height: 100%;
     }
 
     .image-upload-background {
         content: "";
-        background-color: hsl(0, 0%, 0%);
+        background-color: hsla(0, 0%, 0%, 0.6);
         height: 100%;
         width: 100%;
-        opacity: 0.6;
         z-index: 99;
         position: absolute;
         display: none;
         cursor: pointer;
-        border-radius: 5px;
     }
 
     .image_upload_button {
@@ -32,7 +31,6 @@
         align-items: center;
         text-align: center;
         justify-content: center;
-        border-radius: 5px;
         box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
         z-index: 99;
     }
@@ -50,6 +48,15 @@
         right: 10px;
         z-index: 99;
         line-height: 20px;
+    }
+
+    .image-disabled-text {
+        color: hsl(0, 0%, 100%);
+        cursor: not-allowed;
+        position: absolute;
+        text-align: center;
+        visibility: hidden;
+        z-index: 99;
     }
 
     .image-delete-text,
@@ -107,11 +114,7 @@
         visibility: hidden;
         z-index: 99;
         cursor: pointer;
-    }
-
-    .image_upload_spinner {
-        position: absolute;
-        z-index: 99;
+        border-radius: 5px;
     }
 
     &:hover {
@@ -132,37 +135,14 @@
 .user-avatar-section,
 .realm-logo-section,
 .realm-icon-section {
-    margin-bottom: 20px;
-    position: relative;
-
-    .inline-block {
-        margin-top: 15px;
-        vertical-align: top;
-        border-radius: 4px;
-    }
+    margin: 20px 0;
 }
 
 /* CSS related to settings page user avatar upload widget only */
 #user-avatar-upload-widget {
-    .image-disabled-text {
-        color: hsl(0, 0%, 85%);
-        cursor: not-allowed;
-        position: absolute;
-        text-align: center;
-        visibility: hidden;
-        z-index: 99;
-    }
-
-    .image-delete-button {
-        font-size: 3rem;
-    }
-
     .image-block {
-        border-radius: 5px;
-        box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
         width: 200px;
         height: 200px;
-        top: 0;
     }
 
     &:hover {
@@ -182,13 +162,12 @@
 #realm-icon-upload-widget {
     width: 100px;
     height: 100px;
-    border-radius: 5px;
     box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
-}
 
-.realm-icon-section {
-    float: none;
-    display: inline-block;
+    .image-delete-button {
+        top: 5px;
+        right: 5px;
+    }
 }
 
 /* CSS related to settings page realm day/night logo upload widget only */
@@ -205,7 +184,7 @@
 }
 
 #realm-day-logo-upload-widget {
-    background-color: hsla(0, 100%, 100%, 1);
+    background-color: hsl(0, 100%, 100%);
 }
 
 #realm-night-logo-upload-widget {

--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -47,23 +47,25 @@
         </div>
 
         <p>{{t "A wide image for the upper left corner of the app." }}</p>
-        <div class="realm-logo-block realm-logo-section">
-            <h5 class="realm-logo-title">{{t 'Day logo' }}</h5>
-            {{> image_upload_widget
-              widget = "realm-day-logo"
-              upload_text = (t "Upload logo")
-              delete_text = (t "Delete logo")
-              is_editable_by_current_user = user_can_change_logo
-              image = realm_logo_url }}
-        </div>
-        <div class="realm-logo-block realm-logo-section">
-            <h5 class="realm-logo-title">{{t 'Night logo' }}</h5>
-            {{> image_upload_widget
-              widget = "realm-night-logo"
-              upload_text = (t "Upload logo")
-              delete_text = (t "Delete logo")
-              is_editable_by_current_user = user_can_change_logo
-              image = realm_night_logo_url }}
+        <div class="realm-logo-group">
+            <div class="realm-logo-block realm-logo-section">
+                <h5 class="realm-logo-title">{{t 'Day logo' }}</h5>
+                {{> image_upload_widget
+                  widget = "realm-day-logo"
+                  upload_text = (t "Upload logo")
+                  delete_text = (t "Delete logo")
+                  is_editable_by_current_user = user_can_change_logo
+                  image = realm_logo_url }}
+            </div>
+            <div class="realm-logo-block realm-logo-section">
+                <h5 class="realm-logo-title">{{t 'Night logo' }}</h5>
+                {{> image_upload_widget
+                  widget = "realm-night-logo"
+                  upload_text = (t "Upload logo")
+                  delete_text = (t "Delete logo")
+                  is_editable_by_current_user = user_can_change_logo
+                  image = realm_night_logo_url }}
+            </div>
         </div>
         <h3 class="light">
             {{t "Deactivate organization" }}


### PR DESCRIPTION
Due to differences in length of the words for different languages there were alignment issues in organization profile settings.

We fix this using flexbox to ensure that the alignment stays correct for any changes in language/word length; this is realised by merging the css properties of all the image upload widgets and branching to specific ids/classes for individual component adjustments.

see #21385 for context

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing Plan:**
1. Goto Organisation > Organisation Profile.
2. Check for any alignment issues when display language is English (incl. hover states).
3. Change to different non-English languages.
4. Check for any alignment issues (incl. hover states).

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Before | After
-------|------
![before](https://user-images.githubusercontent.com/82862779/158480116-39902386-991c-4f3a-8a87-d5b66fcf16ec.png) | ![after](https://user-images.githubusercontent.com/82862779/158479487-28b3d601-b27e-4e91-b0c0-dc60a65a98bb.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
