### PR TITLE
user docs: Added keyboard shortcut for browser back hotkey

### DIFF
--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -67,6 +67,8 @@ below, and add more to your repertoire as needed.
 
 * **Scroll down**: `PgDn`, `J`, or `Spacebar`
 
+* **Jump to Previous Location**: `Alt + Left`(Windows) , `Option + Left`(MacOS)
+
 ## Narrowing
 
 * **Narrow to next unread topic**: `n`


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This commit adds a keyboard shortcut that allows user to 
jump to the previous location using the browser back hotkey 

Fixes : #18542 

**Testing plan:** manual

**Screenshot for the keyboard shortcut in documentation:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/56391795/158485706-b03abdea-0068-4b51-a0ac-933d7ef6212b.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
