### PR TITLE
message_feed_ui: Remove mute/unmute from message actions menu.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -470,11 +470,7 @@ export function toggle_actions_popover(element, id) {
             editability_menu_item = $t({defaultMessage: "View source"});
         }
         const topic = message.topic;
-        const can_mute_topic =
-            message.stream &&
-            topic &&
-            !muted_topics.is_topic_muted(message.stream_id, topic) &&
-            not_spectator;
+
         const can_unmute_topic =
             message.stream && topic && muted_topics.is_topic_muted(message.stream_id, topic);
 
@@ -518,7 +514,6 @@ export function toggle_actions_popover(element, id) {
             topic,
             use_edit_icon,
             editability_menu_item,
-            can_mute_topic,
             can_unmute_topic,
             should_display_collapse,
             should_display_uncollapse,
@@ -1234,16 +1229,6 @@ export function register_click_handlers() {
         hide_actions_popover();
         message_edit_history.show_history(message);
         $("#message-history-cancel").trigger("focus");
-        e.stopPropagation();
-        e.preventDefault();
-    });
-
-    $("body").on("click", ".popover_mute_topic", (e) => {
-        const stream_id = Number.parseInt($(e.currentTarget).attr("data-msg-stream-id"), 10);
-        const topic = $(e.currentTarget).attr("data-msg-topic");
-
-        hide_actions_popover();
-        muted_topics_ui.mute_topic(stream_id, topic);
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -30,8 +30,6 @@ import * as message_edit from "./message_edit";
 import * as message_edit_history from "./message_edit_history";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
-import * as muted_topics from "./muted_topics";
-import * as muted_topics_ui from "./muted_topics_ui";
 import * as muted_users from "./muted_users";
 import * as muted_users_ui from "./muted_users_ui";
 import * as narrow from "./narrow";
@@ -469,10 +467,6 @@ export function toggle_actions_popover(element, id) {
             use_edit_icon = false;
             editability_menu_item = $t({defaultMessage: "View source"});
         }
-        const topic = message.topic;
-
-        const can_unmute_topic =
-            message.stream && topic && muted_topics.is_topic_muted(message.stream_id, topic);
 
         const should_display_edit_history_option =
             message.edit_history &&
@@ -511,10 +505,8 @@ export function toggle_actions_popover(element, id) {
             message_id: message.id,
             historical: message.historical,
             stream_id: message.stream_id,
-            topic,
             use_edit_icon,
             editability_menu_item,
-            can_unmute_topic,
             should_display_collapse,
             should_display_uncollapse,
             should_display_add_reaction_option: message.sent_by_me,
@@ -1229,16 +1221,6 @@ export function register_click_handlers() {
         hide_actions_popover();
         message_edit_history.show_history(message);
         $("#message-history-cancel").trigger("focus");
-        e.stopPropagation();
-        e.preventDefault();
-    });
-
-    $("body").on("click", ".popover_unmute_topic", (e) => {
-        const stream_id = Number.parseInt($(e.currentTarget).attr("data-msg-stream-id"), 10);
-        const topic = $(e.currentTarget).attr("data-msg-topic");
-
-        hide_actions_popover();
-        muted_topics_ui.unmute_topic(stream_id, topic);
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -69,14 +69,6 @@
         </a>
     </li>
     {{/if}}
-    {{#if can_mute_topic}}
-    <li>
-        <a class="popover_mute_topic" data-msg-stream-id="{{stream_id}}" data-msg-topic="{{topic}}" tabindex="0">
-            <i class="fa fa-bell-slash" aria-hidden="true"></i>
-            {{#tr}}Mute the topic <b>{topic}</b>{{/tr}} <span class="hotkey-hint">(M)</span>
-        </a>
-    </li>
-    {{/if}}
 
     {{#if can_unmute_topic}}
     <li>

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -70,15 +70,6 @@
     </li>
     {{/if}}
 
-    {{#if can_unmute_topic}}
-    <li>
-        <a class="popover_unmute_topic" data-msg-stream-id="{{stream_id}}" data-msg-topic="{{topic}}" tabindex="0">
-            <i class="fa fa-bell" aria-hidden="true"></i>
-            {{#tr}}Unmute the topic <b>{topic}</b>{{/tr}}
-        </a>
-    </li>
-    {{/if}}
-
     {{#if should_display_add_reaction_option}}
     <li>
         <a class="reaction_button" data-message-id="{{message_id}}" tabindex="0">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Based on the CZO discussion, the mute/unmute topic is a topic action instead of a message action, which is contrary to it being present in the message action menu. There are more natural and space saving ways to implement it.

For reference:
[CZO Discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/mute.20topic.20buttons)
GitHub Issue: #21432 

**Testing plan:** <!-- How have you tested? -->
1. Open the message action menu
2. Check for the presence of mute/unmute in action menu.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Before | After
----------|----------
![before](https://user-images.githubusercontent.com/82862779/158495992-279b3aa4-a1f4-485c-8060-5f6bcc6bba28.png) | ![after](https://user-images.githubusercontent.com/82862779/158496124-8ca87b1d-7767-4e05-8be6-a43413675dfc.png)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
