### PR TITLE
popovers: Fix incorrect "Manage this user" link for deactivated users.

### DIFF
--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -173,6 +173,7 @@ test_ui("sender_hover", ({override, mock_template}) => {
             can_set_away: false,
             can_revoke_away: false,
             can_mute: true,
+            can_manage_user: false,
             can_unmute: false,
             user_full_name: "Alice Smith",
             user_email: "alice@example.com",
@@ -198,7 +199,6 @@ test_ui("sender_hover", ({override, mock_template}) => {
             user_mention_syntax: "@**Alice Smith**",
             date_joined: undefined,
             spectator_view: false,
-            show_manage_user_option: false,
         });
         return "content-html";
     });

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import render_settings_deactivation_user_modal from "../templates/confirm_dialog/confirm_deactivate_user.hbs";
+import render_settings_reactivation_user_modal from "../templates/confirm_dialog/confirm_reactivate_user.hbs";
 import render_admin_bot_form from "../templates/settings/admin_bot_form.hbs";
 import render_admin_human_form from "../templates/settings/admin_human_form.hbs";
 import render_admin_user_list from "../templates/settings/admin_user_list.hbs";
@@ -477,6 +478,22 @@ function handle_bot_deactivation($tbody, $status_field) {
             },
         };
         settings_ui.do_settings_change(channel.del, url, {}, $status_field, opts);
+    });
+}
+
+export function confirm_reactivation(user_id, handle_confirm, loading_spinner) {
+    const user = people.get_by_user_id(user_id);
+    const opts = {
+        username: user.full_name,
+    };
+    const html_body = render_settings_reactivation_user_modal(opts);
+
+    confirm_dialog.launch({
+        html_heading: $t_html({defaultMessage: "Reactivate {name}"}, {name: user.full_name}),
+        help_link: "/help/deactivate-or-reactivate-a-user#reactivate-a-user",
+        html_body,
+        on_click: handle_confirm,
+        loading_spinner,
     });
 }
 

--- a/static/templates/confirm_dialog/confirm_reactivate_user.hbs
+++ b/static/templates/confirm_dialog/confirm_reactivate_user.hbs
@@ -1,0 +1,8 @@
+<p>
+    {{#tr}}
+    <z-user></z-user> will have the same role, stream subscriptions,
+    user group memberships, and other settings and permissions as they did
+    prior to deactivation.
+    {{#*inline "z-user"}}<strong>{{username}}</strong>{{/inline}}
+    {{/tr}}
+</p>

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -184,11 +184,13 @@
         </li>
         {{/if}}
         {{#if show_manage_user_option}}
-        <li>
-            <a tabindex="0" class="sidebar-popover-manage-user">
-                <i class="fa fa-edit" aria-hidden="true"></i> {{#tr}}Manage this user{{/tr}}
-            </a>
-        </li>
+            {{#if is_active}}
+            <li>
+                <a tabindex="0" class="sidebar-popover-manage-user">
+                    <i class="fa fa-edit" aria-hidden="true"></i> {{#tr}}Manage this user{{/tr}}
+                </a>
+            </li>
+            {{/if}}
         {{/if}}
     {{/if}}
 </ul>

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -183,11 +183,17 @@
             </a>
         </li>
         {{/if}}
-        {{#if show_manage_user_option}}
+        {{#if can_manage_user}}
             {{#if is_active}}
             <li>
                 <a tabindex="0" class="sidebar-popover-manage-user">
                     <i class="fa fa-edit" aria-hidden="true"></i> {{#tr}}Manage this user{{/tr}}
+                </a>
+            </li>
+            {{else}}
+            <li>
+                <a tabindex="0" class="sidebar-popover-reactivate-user">
+                    <i class="fa fa-user-plus" aria-hidden="true"></i> {{#tr}}Reactivate this user{{/tr}}
                 </a>
             </li>
             {{/if}}

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -24,7 +24,7 @@
             </div>
             {{/if}}
         {{else}}
-            <li class="user_popover_email half-opacity italic">{{#tr}}(This user has been deactivated){{/tr}}</li>
+            <li class="user_popover_email half-opacity italic">{{#tr}}This user has been deactivated.{{/tr}}</li>
         {{/if}}
 
 


### PR DESCRIPTION
If a user is deactivated `Reactivate this user` will be
shown as one of the links in user profile popover, in
place of `Manage this user`.

`show_manage_user_option` rename to `can_manage_user`
because now it will also be used as a condition for
reactivating user.

code for reactivating user follows the almost same procedure
as deactivate a user from `manage this user`, including
confirmation modal's code.

- [x] Remove the "Manage this user" link for deactivated users. Just this change would be a fine, mergeable, quick fix.
- [x] Instead show a "Reactivate user" link for users who have permission to do so. Clicking the link should pop up a confirmation modal.
- [x] While we're here, we should also change "(This user has been deactivated)" -> "This user has been deactivated." for consistency with other parts of the app.

Fixes: #21428 

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/reactivate.20user.20from.20user.20popover.20.2321428)

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![remove_mange_this_user_for_deactivated_users](https://user-images.githubusercontent.com/41695888/158523824-d3dedd91-3174-4f84-adeb-191312406ca2.png)

<details>
<summary>Reactivate user</summary>

![reactivate_user_popover](https://user-images.githubusercontent.com/41695888/159011903-0b9c63a1-e70c-46ff-ae67-2264b28f4607.gif)


</details>
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
