### PR TITLE
help_docs: Update how to access drafts in help center doc.

### DIFF
--- a/templates/zerver/help/view-and-edit-your-message-drafts.md
+++ b/templates/zerver/help/view-and-edit-your-message-drafts.md
@@ -15,7 +15,7 @@ To **save a draft**, simply close the compose box. You can hit `Esc`, click
 the <i class="fa fa-remove"></i> in the upper right corner of the
 compose box, or click on an empty part of the app.
 
-To **view your drafts**, click on `Drafts` at the bottom of the screen.
+To **view your drafts**, click on `Drafts` in the left sidebar.
 From there, you can **delete** or **restore** any of your drafts.
 
 !!! tip ""


### PR DESCRIPTION
Small update to help center documentation of [how to view / edit drafts](https://zulip.com/help/view-and-edit-your-message-drafts) due to the removal of the button at the bottom of the page. With 5.0, drafts are accessed through the left sidebar.
