### PR TITLE
js: Fix no-jquery/no-parse-html-literal

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,6 +72,7 @@
         "no-implied-eval": "error",
         "no-inner-declarations": "off",
         "no-iterator": "error",
+        "no-jquery/no-parse-html-literal": "error",
         "no-label-var": "error",
         "no-labels": "error",
         "no-loop-func": "error",

--- a/frontend_tests/node_tests/components.js
+++ b/frontend_tests/node_tests/components.js
@@ -121,11 +121,10 @@ mock_jquery((sel, attributes) => {
     }
 
     switch (sel) {
-        case "<div class='tab-switcher'></div>":
-            return env.switcher;
-        case "<div class='tab-switcher stream_sorter_toggle'></div>":
-            return env.switcher;
         case "<div>": {
+            if (attributes.class === "tab-switcher") {
+                return env.switcher;
+            }
             const tab_id = attributes["data-tab-id"];
             assert.deepEqual(
                 attributes,

--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -736,7 +736,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, override_rewire, moc
     }
 
     // Simulate that the row was added to the DOM.
-    const $warning_row = $("<warning row>");
+    const $warning_row = $("<warning-row-stub>");
 
     let looked_for_existing;
     $warning_row.data = (field) => {

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -120,7 +120,7 @@ test("draft_model add", ({override}) => {
     const ls = localstorage();
     assert.equal(ls.get("draft"), undefined);
 
-    const $unread_count = $('<span class="unread_count"></span>');
+    const $unread_count = $("<unread-count-stub>");
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
     override(Date, "now", () => 1);
@@ -136,7 +136,7 @@ test("draft_model edit", () => {
     assert.equal(ls.get("draft"), undefined);
     let id;
 
-    const $unread_count = $('<span class="unread_count"></span>');
+    const $unread_count = $("<unread-count-stub>");
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
     with_overrides(({override}) => {
@@ -161,7 +161,7 @@ test("draft_model delete", ({override}) => {
     const ls = localstorage();
     assert.equal(ls.get("draft"), undefined);
 
-    const $unread_count = $('<span class="unread_count"></span>');
+    const $unread_count = $("<unread-count-stub>");
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
     override(Date, "now", () => 1);
@@ -212,7 +212,7 @@ test("initialize", ({override_rewire}) => {
         assert.ok(called);
     };
 
-    const $unread_count = $('<span class="unread_count"></span>');
+    const $unread_count = $("<unread-count-stub>");
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
     drafts.initialize();
@@ -239,7 +239,7 @@ test("remove_old_drafts", () => {
     ls.set("drafts", data);
     assert.deepEqual(draft_model.get(), data);
 
-    const $unread_count = $('<span class="unread_count"></span>');
+    const $unread_count = $("<unread-count-stub>");
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
     drafts.remove_old_drafts();
@@ -313,7 +313,7 @@ test("delete_all_drafts", () => {
     ls.set("drafts", data);
     assert.deepEqual(draft_model.get(), data);
 
-    const $unread_count = $('<span class="unread_count"></span>');
+    const $unread_count = $("<unread-count-stub>");
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
     drafts.delete_all_drafts();
@@ -451,7 +451,7 @@ test("format_drafts", ({override_rewire, mock_template}) => {
 
     expected[0].stream_name = "stream-rename";
 
-    const $unread_count = $('<span class="unread_count"></span>');
+    const $unread_count = $("<unread-count-stub>");
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
     drafts.launch();

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -449,7 +449,6 @@ run_test("show_empty_narrow_message_with_search", ({mock_template}) => {
 });
 
 run_test("hide_empty_narrow_message", () => {
-    $(".empty_feed_notice_main").html("<div class='empty_feed_notice'>Nothing here</div>");
     narrow_banner.hide_empty_narrow_message();
     assert.equal($(".empty_feed_notice").text(), "never-been-set");
 });

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -624,11 +624,11 @@ test("view.insert_new_reaction (me w/unicode emoji)", ({override_rewire, mock_te
             reaction_type: opts.reaction_type,
             is_realm_emoji: false,
         });
-        return "<new reaction html>";
+        return "<new-reaction-stub>";
     });
 
     let insert_called;
-    $("<new reaction html>").insertBefore = (element) => {
+    $("<new-reaction-stub>").insertBefore = (element) => {
         assert.equal(element, "reaction-button-stub");
         insert_called = true;
     };
@@ -673,11 +673,11 @@ test("view.insert_new_reaction (them w/zulip emoji)", ({override_rewire, mock_te
             still_url: undefined,
             reaction_type: opts.reaction_type,
         });
-        return "<new reaction html>";
+        return "<new-reaction-stub>";
     });
 
     let insert_called;
-    $("<new reaction html>").insertBefore = (element) => {
+    $("<new-reaction-stub>").insertBefore = (element) => {
         assert.equal(element, "reaction-button-stub");
         insert_called = true;
     };

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -131,7 +131,7 @@ function createSaveButtons(subsection) {
     const $stub_save_button_text = $(".save-discard-widget-button-text");
     $stub_save_button_header.set_find_results(
         ".subsection-failed-status p",
-        $("<failed status element>"),
+        $("<failed-status-stub>"),
     );
     $stub_save_button.closest = () => $stub_save_button_header;
     $save_button_controls.set_find_results(".save-button", $stub_save_button);

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -50,14 +50,14 @@ function create_devel_sidebar_row({mock_template}) {
     const $devel_count = $.create("devel-count");
     const $subscription_block = $.create("devel-block");
 
-    const $sidebar_row = $("<devel sidebar row>");
+    const $sidebar_row = $("<devel-sidebar-row-stub>");
 
     $sidebar_row.set_find_results(".subscription_block", $subscription_block);
     $subscription_block.set_find_results(".unread_count", $devel_count);
 
     mock_template("stream_sidebar_row.hbs", false, (data) => {
         assert.equal(data.uri, "#narrow/stream/100-devel");
-        return "<devel sidebar row>";
+        return "<devel-sidebar-row-stub>";
     });
 
     num_unread_for_stream = 42;
@@ -69,14 +69,14 @@ function create_social_sidebar_row({mock_template}) {
     const $social_count = $.create("social-count");
     const $subscription_block = $.create("social-block");
 
-    const $sidebar_row = $("<social sidebar row>");
+    const $sidebar_row = $("<social-sidebar-row-stub>");
 
     $sidebar_row.set_find_results(".subscription_block", $subscription_block);
     $subscription_block.set_find_results(".unread_count", $social_count);
 
     mock_template("stream_sidebar_row.hbs", false, (data) => {
         assert.equal(data.uri, "#narrow/stream/200-social");
-        return "<social sidebar row>";
+        return "<social-sidebar-row-stub>";
     });
 
     num_unread_for_stream = 99;
@@ -105,8 +105,8 @@ test_ui("create_sidebar_row", ({override_rewire, mock_template}) => {
     create_social_sidebar_row({mock_template});
 
     const split = '<hr class="stream-split">';
-    const $devel_sidebar = $("<devel sidebar row>");
-    const $social_sidebar = $("<social sidebar row>");
+    const $devel_sidebar = $("<devel-sidebar-row-stub>");
+    const $social_sidebar = $("<social-sidebar-row-stub>");
 
     let appended_elems;
     $("#stream_filters").append = (elems) => {
@@ -130,7 +130,7 @@ test_ui("create_sidebar_row", ({override_rewire, mock_template}) => {
 
     assert.deepEqual(appended_elems, expected_elems);
 
-    const $social_li = $("<social sidebar row>");
+    const $social_li = $("<social-sidebar-row-stub>");
     const stream_id = social.stream_id;
 
     $social_li.length = 0;
@@ -183,7 +183,7 @@ test_ui("pinned_streams_never_inactive", ({override_rewire, mock_template}) => {
     create_social_sidebar_row({mock_template});
 
     // non-pinned streams can be made inactive
-    const $social_sidebar = $("<social sidebar row>");
+    const $social_sidebar = $("<social-sidebar-row-stub>");
     let stream_id = social.stream_id;
     let row = stream_list.stream_sidebar.get_row(stream_id);
     override_rewire(stream_data, "is_active", () => false);
@@ -200,7 +200,7 @@ test_ui("pinned_streams_never_inactive", ({override_rewire, mock_template}) => {
     assert.ok($social_sidebar.hasClass("inactive_stream"));
 
     // pinned streams can never be made inactive
-    const $devel_sidebar = $("<devel sidebar row>");
+    const $devel_sidebar = $("<devel-sidebar-row-stub>");
     stream_id = devel.stream_id;
     row = stream_list.stream_sidebar.get_row(stream_id);
     override_rewire(stream_data, "is_active", () => false);
@@ -217,7 +217,7 @@ function add_row(sub) {
     const row = {
         update_whether_active() {},
         get_li() {
-            const html = "<" + sub.name + " sidebar row html>";
+            const html = "<" + sub.name + "-sidebar-row-stub>";
             const $obj = $(html);
 
             $obj.length = 1; // bypass blueslip error
@@ -372,7 +372,7 @@ test_ui("narrowing", ({override_rewire}) => {
     topic_list.get_stream_li = noop;
     override_rewire(scroll_util, "scroll_element_into_container", noop);
 
-    assert.ok(!$("<devel sidebar row html>").hasClass("active-filter"));
+    assert.ok(!$("<devel-sidebar-row-stub>").hasClass("active-filter"));
 
     stream_list.set_event_handlers();
 
@@ -380,7 +380,7 @@ test_ui("narrowing", ({override_rewire}) => {
 
     filter = new Filter([{operator: "stream", operand: "devel"}]);
     stream_list.handle_narrow_activated(filter);
-    assert.ok($("<devel sidebar row html>").hasClass("active-filter"));
+    assert.ok($("<devel-sidebar-row-stub>").hasClass("active-filter"));
 
     filter = new Filter([
         {operator: "stream", operand: "cars"},
@@ -388,12 +388,12 @@ test_ui("narrowing", ({override_rewire}) => {
     ]);
     stream_list.handle_narrow_activated(filter);
     assert.ok(!$("ul.filters li").hasClass("active-filter"));
-    assert.ok(!$("<cars sidebar row html>").hasClass("active-filter")); // false because of topic
+    assert.ok(!$("<cars-sidebar-row-stub>").hasClass("active-filter")); // false because of topic
 
     filter = new Filter([{operator: "stream", operand: "cars"}]);
     stream_list.handle_narrow_activated(filter);
     assert.ok(!$("ul.filters li").hasClass("active-filter"));
-    assert.ok($("<cars sidebar row html>").hasClass("active-filter"));
+    assert.ok($("<cars-sidebar-row-stub>").hasClass("active-filter"));
 
     let removed_classes;
     $("ul#stream_filters li").removeClass = (classes) => {
@@ -450,14 +450,14 @@ test_ui("sort_streams", ({override_rewire}) => {
 
     const split = '<hr class="stream-split">';
     const expected_elems = [
-        $("<devel sidebar row html>"),
-        $("<Rome sidebar row html>"),
-        $("<test sidebar row html>"),
+        $("<devel-sidebar-row-stub>"),
+        $("<Rome-sidebar-row-stub>"),
+        $("<test-sidebar-row-stub>"),
         split,
-        $("<announce sidebar row html>"),
-        $("<Denmark sidebar row html>"),
+        $("<announce-sidebar-row-stub>"),
+        $("<Denmark-sidebar-row-stub>"),
         split,
-        $("<cars sidebar row html>"),
+        $("<cars-sidebar-row-stub>"),
     ];
 
     assert.deepEqual(appended_elems, expected_elems);
@@ -529,11 +529,11 @@ test_ui("separators_only_pinned_and_dormant", ({override_rewire}) => {
     const split = '<hr class="stream-split">';
     const expected_elems = [
         // pinned
-        $("<devel sidebar row html>"),
-        $("<Rome sidebar row html>"),
+        $("<devel-sidebar-row-stub>"),
+        $("<Rome-sidebar-row-stub>"),
         split,
         // dormant
-        $("<Denmark sidebar row html>"),
+        $("<Denmark-sidebar-row-stub>"),
     ];
 
     assert.deepEqual(appended_elems, expected_elems);
@@ -573,8 +573,8 @@ test_ui("separators_only_pinned", () => {
 
     const expected_elems = [
         // pinned
-        $("<devel sidebar row html>"),
-        $("<Rome sidebar row html>"),
+        $("<devel-sidebar-row-stub>"),
+        $("<Rome-sidebar-row-stub>"),
         // no separator at the end as no stream follows
     ];
 

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -210,7 +210,7 @@ run_test("render_date_renders_time_html", () => {
     const expected_html = $t({defaultMessage: "Today"});
 
     const attrs = {};
-    const $span_stub = $("<span />");
+    const $span_stub = $("<span>");
 
     $span_stub.attr = (name, val) => {
         attrs[name] = val;
@@ -234,7 +234,7 @@ run_test("render_date_renders_time_above_html", () => {
     const message_time = today;
     const message_time_above = add(today, {days: -1});
 
-    const $span_stub = $("<span />");
+    const $span_stub = $("<span>");
 
     let appended_val;
     $span_stub.append = (...val) => {
@@ -243,10 +243,10 @@ run_test("render_date_renders_time_above_html", () => {
     };
 
     const expected = [
-        '<i class="date-direction fa fa-caret-up"></i>',
+        $("<i>"),
         $t({defaultMessage: "Yesterday"}),
-        '<hr class="date-line">',
-        '<i class="date-direction fa fa-caret-down"></i>',
+        $("<hr>"),
+        $("<i>"),
         $t({defaultMessage: "Today"}),
     ];
 

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -59,7 +59,7 @@ run_test("basics", () => {
     assert.equal($widget.attr("data-department-name"), "hr");
     assert.equal($widget.data("department-name"), "hr");
 
-    $widget.html("<b>hello</b>");
+    $widget.html("<b>hello</b>"); // eslint-disable-line no-jquery/no-parse-html-literal
     assert.equal($widget.html(), "<b>hello</b>");
 
     $widget.prop("title", "My widget");
@@ -84,7 +84,7 @@ run_test("finding_related_objects", () => {
     // But you can set up your tests to simulate DOM relationships.
     //
     // We will use set_find_results(), which is a special zjquery helper.
-    const $emoji = $('<div class="emoji">');
+    const $emoji = $("<emoji-stub>");
     $("#my-message").set_find_results(".emoji", $emoji);
 
     // And then calling the function produces the desired effect:

--- a/static/js/blueslip_stacktrace.ts
+++ b/static/js/blueslip_stacktrace.ts
@@ -102,7 +102,7 @@ export async function display_stacktrace(error: string, stack: string): Promise<
         }),
     );
 
-    const $alert = $("<div class='stacktrace'>").html(
+    const $alert = $("<div>", {class: "stacktrace"}).html(
         render_blueslip_stacktrace({error, stackframes}),
     );
     $(".alert-box").append($alert);

--- a/static/js/components.ts
+++ b/static/js/components.ts
@@ -32,7 +32,7 @@ export function toggle(opts: {
     child_wants_focus?: boolean;
     selected?: number;
 }): Toggle {
-    const $component = $("<div class='tab-switcher'></div>");
+    const $component = $("<div>", {class: "tab-switcher"});
     if (opts.html_class) {
         // add a check inside passed arguments in case some extra
         // classes need to be added for correct alignment or other purposes

--- a/static/js/flatpickr.js
+++ b/static/js/flatpickr.js
@@ -10,7 +10,7 @@ function is_numeric_key(key) {
 }
 
 export function show_flatpickr(element, callback, default_timestamp, options = {}) {
-    const $flatpickr_input = $("<input id='#timestamp_flatpickr'>");
+    const $flatpickr_input = $("<input>", {id: "#timestamp_flatpickr"});
 
     const instance = $flatpickr_input.flatpickr({
         mode: "single",

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -183,7 +183,7 @@ export function render_lightbox_list_images(preview_source) {
             const src = img.getAttribute("src");
             const className = preview_source === src ? "image selected" : "image";
 
-            const $node = $("<div></div>", {
+            const $node = $("<div>", {
                 class: className,
                 "data-src": src,
             }).css({backgroundImage: "url(" + src + ")"});
@@ -244,7 +244,7 @@ function display_video(payload) {
             break;
     }
 
-    const $iframe = $("<iframe></iframe>");
+    const $iframe = $("<iframe>");
     $iframe.attr(
         "sandbox",
         "allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts",

--- a/static/js/loading.ts
+++ b/static/js/loading.ts
@@ -29,13 +29,13 @@ export function make_indicator(
         $container = $inner_container;
     }
 
-    const $spinner_elem = $('<div class="loading_indicator_spinner" aria-hidden="true"></div>');
+    const $spinner_elem = $("<div>", {class: "loading_indicator_spinner", ["aria-hidden"]: "true"});
     $spinner_elem.html(render_loader({container_id: $outer_container.attr("id")}));
     $container.append($spinner_elem);
     let text_width = 0;
 
     if (text !== undefined) {
-        const $text_elem = $('<span class="loading_indicator_text"></span>');
+        const $text_elem = $("<span>", {class: "loading_indicator_text"});
         $text_elem.text(text);
         $container.append($text_elem);
         // See note, below

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -237,7 +237,7 @@ export function process_notification(notification) {
     let msg_count = 1;
     let notification_source;
     // Convert the content to plain text, replacing emoji with their alt text
-    const $content = $("<div/>").html(message.content);
+    const $content = $("<div>").html(message.content);
     ui.replace_emoji_with_text($content);
     spoilers.hide_spoilers_in_notification($content);
     content = $content.text();

--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -156,10 +156,9 @@ function hide_catalog_show_integration() {
                     link = name;
                 }
             }
-            const $category_el = $("<a></a>")
-                .attr("href", "/integrations/" + link)
-                .append('<h3 class="integration-category"></h3>');
-            $category_el.find(".integration-category").attr("data-category", link).text(category);
+            const $category_el = $("<a>", {href: "/integrations/" + link}).append(
+                $("<h3>", {class: "integration-category", ["data-category"]: link}).text(category),
+            );
             $("#integration-instructions-group .categories").append($category_el);
         }
         $("#integration-instructions-group").css({

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -97,7 +97,7 @@ export function update_view_on_deactivate(user_id) {
     $row.find("i.deactivated-user-icon").show();
     $button.addClass("btn-warning reactivate");
     $button.removeClass("deactivate btn-danger");
-    $button.html("<i class='fa fa-user-plus' aria-hidden='true'></i>");
+    $button.empty().append($("<i>", {class: "fa fa-user-plus", ["aria-hidden"]: "true"}));
     $button.attr("title", "Reactivate");
     $row.addClass("deactivated_user");
 
@@ -117,7 +117,7 @@ function update_view_on_reactivate($row) {
     $button.addClass("btn-danger deactivate");
     $button.removeClass("btn-warning reactivate");
     $button.attr("title", "Deactivate");
-    $button.html('<i class="fa fa-user-times" aria-hidden="true"></i>');
+    $button.empty().append($("<i>", {class: "fa fa-user-times", ["aria-hidden"]: "true"}));
     $row.removeClass("deactivated_user");
 
     if ($user_role) {

--- a/static/js/timerender.ts
+++ b/static/js/timerender.ts
@@ -183,10 +183,10 @@ function render_date_span(
     $elem.text("");
     if (rendered_time_above !== undefined) {
         $elem.append(
-            '<i class="date-direction fa fa-caret-up"></i>',
+            $("<i>").addClass(["date-direction", "fa", "fa-caret-up"]),
             _.escape(rendered_time_above.time_str),
-            '<hr class="date-line">',
-            '<i class="date-direction fa fa-caret-down"></i>',
+            $("<hr>").addClass("date-line"),
+            $("<i>").addClass(["date-direction", "fa", "fa-caret-down"]),
             _.escape(rendered_time.time_str),
         );
         return $elem;
@@ -208,7 +208,7 @@ export function render_date(time: Date, time_above: Date | undefined, today: Dat
     const className = `timerender${next_timerender_id}`;
     next_timerender_id += 1;
     const rendered_time = render_now(time, today);
-    let $node = $("<span />").attr("class", className);
+    let $node = $("<span>").attr("class", className);
     if (time_above !== undefined) {
         const rendered_time_above = render_now(time_above, today);
         $node = render_date_span($node, rendered_time, rendered_time_above);

--- a/static/js/ui_report.ts
+++ b/static/js/ui_report.ts
@@ -65,12 +65,10 @@ export function success(response_html: string, $status_box: JQuery, remove_after
 }
 
 export function generic_embed_error(error_html: string): void {
-    const $alert = $("<div class='alert home-error-bar'></div>");
-    const exit_html = "<div class='exit'></div>";
+    const $alert = $("<div>", {class: "alert home-error-bar show"});
+    const $exit = $("<div>", {class: "exit"});
 
-    $(".alert-box").append(
-        $alert.html(exit_html + "<div class='content'>" + error_html + "</div>").addClass("show"),
-    );
+    $(".alert-box").append($alert.append($exit, $("<div>", {class: "content"}).html(error_html)));
 }
 
 export function generic_row_button_error(xhr: JQuery.jqXHR, $btn: JQuery): void {

--- a/static/js/ui_report.ts
+++ b/static/js/ui_report.ts
@@ -66,10 +66,10 @@ export function success(response_html: string, $status_box: JQuery, remove_after
 
 export function generic_embed_error(error_html: string): void {
     const $alert = $("<div class='alert home-error-bar'></div>");
-    const $exit = "<div class='exit'></div>";
+    const exit_html = "<div class='exit'></div>";
 
     $(".alert-box").append(
-        $alert.html($exit + "<div class='content'>" + error_html + "</div>").addClass("show"),
+        $alert.html(exit_html + "<div class='content'>" + error_html + "</div>").addClass("show"),
     );
 }
 


### PR DESCRIPTION
We should prefer DOM building over HTML parsing. [Rule documentation](https://github.com/wikimedia/eslint-plugin-no-jquery/blob/master/docs/rules/no-parse-html-literal.md).