### PR TITLE
recent topics: Close Profile popover while muting user.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1017,6 +1017,7 @@ export function register_click_handlers() {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
         hide_message_info_popover();
         hide_user_sidebar_popover();
+        hide_user_info_popover();
         e.stopPropagation();
         e.preventDefault();
         muted_users_ui.confirm_mute_user(user_id);
@@ -1026,6 +1027,7 @@ export function register_click_handlers() {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
         hide_message_info_popover();
         hide_user_sidebar_popover();
+        hide_user_info_popover();
         muted_users_ui.unmute_user(user_id);
         e.stopPropagation();
         e.preventDefault();


### PR DESCRIPTION
Currently we use `hide_message_info_popover()` and
`hide_user_sidebar_popover()` to hide popovers on click
of "mute this user" but somehow it is not hiding the
profile popover in recent topics, so instead of calling
this two functions, calling `hide_all()`.

I noticed from other profile popover actions link
we use `hide_all()` already for closing profile popover,
so that's why I am using `hide_all()` here too.

Fixes: #21456

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Manually tested.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![close_profile_popover_when_muting_user](https://user-images.githubusercontent.com/41695888/158864395-106c5952-3ebb-4c15-bbfe-1f9b0d8f713d.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
