### PR TITLE
popovers: Design changes for user profile popover.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -60,6 +60,7 @@ const overlays = mock_esm("../../static/js/overlays", {
 });
 const popovers = mock_esm("../../static/js/popovers", {
     actions_popped: () => false,
+    user_info_manage_menu_popped: () => false,
     message_info_popped: () => false,
     user_sidebar_popped: () => false,
     user_info_popped: () => false,

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -174,14 +174,11 @@ test_ui("sender_hover", ({override, mock_template}) => {
         });
         return "title-html";
     });
-
+    const $popover_content = $.create("content-html");
     mock_template("user_info_popover_content.hbs", false, (opts) => {
         assert.deepEqual(opts, {
             invisible_mode: false,
-            can_mute: true,
-            can_manage_user: false,
             can_send_private_message: true,
-            can_unmute: false,
             display_profile_fields: [],
             user_full_name: "Alice Smith",
             user_email: "alice@example.com",
@@ -195,6 +192,7 @@ test_ui("sender_hover", ({override, mock_template}) => {
             sent_by_uri: "#narrow/sender/42-alice",
             private_message_class: "respond_personal_button",
             show_email: false,
+            show_manage_menu: true,
             is_me: false,
             is_active: true,
             is_bot: undefined,
@@ -207,10 +205,14 @@ test_ui("sender_hover", ({override, mock_template}) => {
             date_joined: undefined,
             spectator_view: false,
         });
-        return "content-html";
+        return $popover_content;
     });
 
     $.create(".user_popover_email", {children: []});
+    $popover_content.get = () => {};
+    const $user_name_element = $.create("user_full_name");
+    $popover_content.set_find_results(".user_full_name", $user_name_element);
+
     const image_stubber = make_image_stubber();
     handler.call($target, e);
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -244,6 +244,11 @@ export function process_escape_key(e) {
     }
 
     if (popovers.any_active()) {
+        if (popovers.user_info_manage_menu_popped()) {
+            popovers.hide_user_info_popover_manage_menu();
+            $("#user_info_popover .user_info_popover_manage_menu_btn").trigger("focus");
+            return true;
+        }
         popovers.hide_all();
         return true;
     }
@@ -347,6 +352,11 @@ export function process_escape_key(e) {
 function handle_popover_events(event_name) {
     if (popovers.actions_popped()) {
         popovers.actions_menu_handle_keyboard(event_name);
+        return true;
+    }
+
+    if (popovers.user_info_manage_menu_popped()) {
+        popovers.user_info_popover_manage_menu_handle_keyboard(event_name);
         return true;
     }
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -12,6 +12,7 @@ import render_remind_me_popover_content from "../templates/remind_me_popover_con
 import render_user_group_info_popover from "../templates/user_group_info_popover.hbs";
 import render_user_group_info_popover_content from "../templates/user_group_info_popover_content.hbs";
 import render_user_info_popover_content from "../templates/user_info_popover_content.hbs";
+import render_user_info_popover_manage_menu from "../templates/user_info_popover_manage_menu.hbs";
 import render_user_info_popover_title from "../templates/user_info_popover_title.hbs";
 
 import * as blueslip from "./blueslip";
@@ -63,6 +64,7 @@ let $current_actions_popover_elem;
 let current_flatpickr_instance;
 let $current_message_info_popover_elem;
 let $current_user_info_popover_elem;
+let $current_user_info_popover_manage_menu;
 let $current_playground_links_popover_elem;
 let userlist_placement = "right";
 
@@ -73,6 +75,7 @@ export function clear_for_testing() {
     current_flatpickr_instance = undefined;
     $current_message_info_popover_elem = undefined;
     $current_user_info_popover_elem = undefined;
+    $current_user_info_popover_manage_menu = undefined;
     $current_playground_links_popover_elem = undefined;
     list_of_popovers.length = 0;
     userlist_placement = "right";
@@ -190,6 +193,46 @@ function calculate_info_popover_placement(size, $elt) {
     return undefined;
 }
 
+export function hide_user_info_popover_manage_menu() {
+    if ($current_user_info_popover_manage_menu !== undefined) {
+        $current_user_info_popover_manage_menu.popover("destroy");
+        $current_user_info_popover_manage_menu = undefined;
+    }
+}
+
+function show_user_info_popover_manage_menu(element, user) {
+    const $last_popover_elem = $current_user_info_popover_manage_menu;
+    hide_user_info_popover_manage_menu();
+    if ($last_popover_elem !== undefined && $last_popover_elem.get()[0] === element) {
+        return;
+    }
+
+    const is_me = people.is_my_user_id(user.user_id);
+    const is_muted = muted_users.is_user_muted(user.user_id);
+    const is_system_bot = user.is_system_bot;
+    const muting_allowed = !is_me && !user.is_bot;
+
+    const args = {
+        can_mute: muting_allowed && !is_muted,
+        can_manage_user: page_params.is_admin && !is_me && !is_system_bot,
+        can_unmute: muting_allowed && is_muted,
+        is_active: people.is_active_user_for_popover(user.user_id),
+        is_bot: user.is_bot,
+        user_id: user.user_id,
+    };
+
+    const $popover_elt = $(element);
+    $popover_elt.popover({
+        content: render_user_info_popover_manage_menu(args),
+        placement: "bottom",
+        html: true,
+        trigger: "manual",
+    });
+
+    $popover_elt.popover("show");
+    $current_user_info_popover_manage_menu = $popover_elt;
+}
+
 function render_user_info_popover(
     user,
     popover_element,
@@ -209,10 +252,14 @@ function render_user_info_popover(
 
     const muting_allowed = !is_me && !user.is_bot;
     const is_active = people.is_active_user_for_popover(user.user_id);
-    const is_muted = muted_users.is_user_muted(user.user_id);
     const is_system_bot = user.is_system_bot;
     const status_text = user_status.get_status_text(user.user_id);
     const status_emoji_info = user_status.get_status_emoji(user.user_id);
+
+    // TODO: The show_manage_menu calculation can get a lot simpler
+    // if/when we allow muting bot users.
+    const can_manage_user = page_params.is_admin && !is_me && !is_system_bot;
+    const show_manage_menu = muting_allowed || can_manage_user;
 
     const spectator_view = page_params.is_spectator;
     let date_joined;
@@ -229,14 +276,11 @@ function render_user_info_popover(
 
     const args = {
         invisible_mode,
-        can_mute: muting_allowed && !is_muted,
-        can_manage_user: page_params.is_admin && !is_me && !is_system_bot,
         can_send_private_message:
             is_active &&
             !is_me &&
             page_params.realm_private_message_policy !==
                 settings_config.private_message_policy_values.disabled.code,
-        can_unmute: muting_allowed && is_muted,
         display_profile_fields,
         has_message_context,
         is_active,
@@ -248,6 +292,7 @@ function render_user_info_popover(
         private_message_class: private_msg_class,
         sent_by_uri: hash_util.by_sender_url(user.email),
         show_email: settings_data.show_email(),
+        show_manage_menu,
         user_email: people.get_visible_email(user),
         user_full_name: user.full_name,
         user_id: user.user_id,
@@ -272,8 +317,9 @@ function render_user_info_popover(
         }
     }
 
+    const $popover_content = $(render_user_info_popover_content(args));
     popover_element.popover({
-        content: render_user_info_popover_content(args),
+        content: $popover_content.get(0),
         // TODO: Determine whether `fixed` should be applied
         // unconditionally.  Right now, we only do it for the user
         // sidebar version of the popover.
@@ -294,6 +340,10 @@ function render_user_info_popover(
 
     init_email_clipboard();
     init_email_tooltip(user);
+    const $user_name_element = $popover_content.find(".user_full_name");
+    if ($user_name_element.prop("clientWidth") < $user_name_element.prop("scrollWidth")) {
+        $user_name_element.addClass("tippy-zulip-tooltip");
+    }
 
     // Note: We pass the normal-size avatar in initial rendering, and
     // then query the server to replace it with the medium-size
@@ -391,6 +441,21 @@ function get_user_info_popover_items() {
     }
 
     return $("li:not(.divider):visible a", $popover_elt);
+}
+
+function get_user_info_popover_manage_menu_items() {
+    if (!$current_user_info_popover_manage_menu) {
+        blueslip.error("Trying to get menu items when action popover is closed.");
+        return undefined;
+    }
+
+    const popover_data = $current_user_info_popover_manage_menu.data("popover");
+    if (!popover_data) {
+        blueslip.error("Cannot find popover data for actions menu.");
+        return undefined;
+    }
+
+    return $(".user_info_popover_manage_menu li:not(.divider):visible a", popover_data.$tip);
 }
 
 function fetch_group_members(member_ids) {
@@ -625,12 +690,12 @@ function get_action_menu_menu_items() {
     return $("li:not(.divider):visible a", popover_data.$tip);
 }
 
-export function focus_first_popover_item($items) {
+export function focus_first_popover_item($items, index = 0) {
     if (!$items) {
         return;
     }
 
-    $items.eq(0).expectOne().trigger("focus");
+    $items.eq(index).expectOne().trigger("focus");
 }
 
 export function popover_items_handle_keyboard(key, $items) {
@@ -642,10 +707,18 @@ export function popover_items_handle_keyboard(key, $items) {
 
     if (key === "enter" && index >= 0 && index < $items.length) {
         $items[index].click();
+        if ($current_user_info_popover_manage_menu) {
+            const $items = get_user_info_popover_manage_menu_items();
+            focus_first_popover_item($items);
+        }
         return;
     }
     if (index === -1) {
-        index = 0;
+        if ($(".user_info_popover_manage_menu_btn").is(":visible")) {
+            index = 1;
+        } else {
+            index = 0;
+        }
     } else if ((key === "down_arrow" || key === "vim_down") && index < $items.length - 1) {
         index += 1;
     } else if ((key === "up_arrow" || key === "vim_up") && index > 0) {
@@ -713,6 +786,10 @@ export function user_info_popped() {
     return $current_user_info_popover_elem !== undefined;
 }
 
+export function user_info_manage_menu_popped() {
+    return $current_user_info_popover_manage_menu !== undefined;
+}
+
 export function hide_user_info_popover() {
     if (user_info_popped()) {
         $current_user_info_popover_elem.popover("destroy");
@@ -760,6 +837,7 @@ export function hide_user_sidebar_popover() {
 }
 
 function hide_all_user_info_popovers() {
+    hide_user_info_popover_manage_menu();
     hide_message_info_popover();
     hide_user_sidebar_popover();
     hide_user_info_popover();
@@ -769,7 +847,12 @@ function focus_user_info_popover_item() {
     // For now I recommend only calling this when the user opens the menu with a hotkey.
     // Our popup menus act kind of funny when you mix keyboard and mouse.
     const $items = get_user_info_popover_for_message_items();
-    focus_first_popover_item($items);
+
+    if ($(".user_info_popover_manage_menu_btn").is(":visible")) {
+        focus_first_popover_item($items, 1);
+    } else {
+        focus_first_popover_item($items);
+    }
 }
 
 function get_user_sidebar_popover_items() {
@@ -778,7 +861,7 @@ function get_user_sidebar_popover_items() {
         return undefined;
     }
 
-    return $("li:not(.divider):visible > a", current_user_sidebar_popover.$tip);
+    return $("li:not(.divider):visible a", current_user_sidebar_popover.$tip);
 }
 
 export function user_sidebar_popover_handle_keyboard(key) {
@@ -793,6 +876,11 @@ export function user_info_popover_for_message_handle_keyboard(key) {
 
 export function user_info_popover_handle_keyboard(key) {
     const $items = get_user_info_popover_items();
+    popover_items_handle_keyboard(key, $items);
+}
+
+export function user_info_popover_manage_menu_handle_keyboard(key) {
+    const $items = get_user_info_popover_manage_menu_items();
     popover_items_handle_keyboard(key, $items);
 }
 
@@ -1052,7 +1140,7 @@ export function register_click_handlers() {
         open_user_status_modal,
     );
 
-    $("body").on("click", ".info_popover_actions .sidebar-popover-mute-user", (e) => {
+    $("body").on("click", ".sidebar-popover-mute-user", (e) => {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
         hide_all_user_info_popovers();
         e.stopPropagation();
@@ -1060,7 +1148,7 @@ export function register_click_handlers() {
         muted_users_ui.confirm_mute_user(user_id);
     });
 
-    $("body").on("click", ".info_popover_actions .sidebar-popover-unmute-user", (e) => {
+    $("body").on("click", ".sidebar-popover-unmute-user", (e) => {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
         hide_all_user_info_popovers();
         muted_users_ui.unmute_user(user_id);
@@ -1358,6 +1446,14 @@ export function register_click_handlers() {
         } else {
             settings_users.show_edit_user_info_modal(user_id, true);
         }
+    });
+
+    $("body").on("click", ".user_info_popover_manage_menu_btn", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const user_id = elem_to_user_id($(e.target).parents("ul"));
+        const user = people.get_by_user_id(user_id);
+        show_user_info_popover_manage_menu(e.target, user);
     });
 }
 

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -32,24 +32,74 @@
     }
 }
 
-.popover_info {
-    text-align: center;
-}
-
-.popover_info .custom_user_field {
+.user_full_name {
     text-overflow: ellipsis;
     overflow: hidden;
+    white-space: nowrap;
+}
 
-    a i {
-        /* Hack: This overrides the 3px margin-right for all <i> elements in
-           this component. Ideally, that other logic would restrict
-           the behavior elements with the right CSS class, and we'd
-           delete this. */
+.popover_user_name_row {
+    display: flex;
+    align-items: center;
+}
+
+.user_info_popover_action_buttons {
+    display: flex;
+    margin-left: auto;
+}
+
+.user_info_popover_manage_menu_btn {
+    &:hover,
+    &:focus {
+        text-decoration: none;
+    }
+}
+
+.user_popover_manage_menu {
+    .zulip-icon {
+        /* Overriding CSS margin */
         margin-right: 0;
     }
+}
 
-    a:hover {
-        text-decoration: none;
+.info_popover_actions .custom_user_field {
+    display: flex;
+    align-items: center;
+
+    .value {
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+    }
+
+    /* Overriding CSS from rendered_markdown.css */
+    .rendered_markdown p {
+        margin: 0;
+    }
+
+    /* Overriding CSS from bootstrap > nav-list. */
+    .custom_profile_fields_link {
+        padding-top: 0;
+        padding-bottom: 0;
+
+        &:hover {
+            background-color: transparent;
+        }
+
+        &:focus {
+            background-color: transparent;
+        }
+    }
+}
+
+.info_popover_actions .user_info_popover_manage_menu_btn {
+    /* Create a larger click target around the icon. */
+    padding: 0 6px;
+
+    opacity: 0.8;
+
+    &:hover {
+        opacity: 1;
     }
 }
 
@@ -115,16 +165,25 @@ ul {
     &.streams_popover i,
     &.topics_popover i {
         display: inline-block;
-        width: 14px;
         text-align: center;
-        margin-right: 3px;
+
+        &:not(.popover_action_icon) {
+            width: 14px;
+        }
+
+        &:not(.popover_action_icon, .custom_user_field i) {
+            margin-right: 3px;
+        }
 
         &.zulip-icon {
             /* These icons are different from font awesome icons,
                 so they need to be aligned separately. */
             line-height: 14px;
             position: relative;
-            top: 2px;
+
+            &:not(.zulip-icon-bot) {
+                top: 2px;
+            }
         }
     }
 
@@ -181,6 +240,10 @@ ul {
     }
 }
 
+/* Important note: The user info popover user_popover class is applied
+   to user info popovers ONLY when they are opened from the right
+   sidebar; otherwise, it will have the user-info-popover class
+   instead. */
 .user_popover {
     width: 240px;
 
@@ -245,7 +308,8 @@ ul {
     display: inline-block;
     float: initial;
     position: relative;
-    top: 1px;
+    top: 0;
+    flex-shrink: 0;
 }
 
 .bot-owner-name {
@@ -712,12 +776,16 @@ ul {
 
 .user_info_status_text {
     opacity: 0.8;
-    padding: 2px 0 3px;
 
     .status_emoji {
         height: 18px;
         width: 18px;
         top: 2px;
+
+        /* Override the default 3px left margin for status emoji, which is
+           intended for their presentation elsewhere to the left of a
+           user's name. */
+        margin-left: 0;
     }
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1346,10 +1346,6 @@ td.pointer {
     }
 }
 
-.popover_info i.zulip-icon.zulip-icon-bot {
-    margin-top: 3px;
-}
-
 .actions_hover:hover {
     color: hsl(200, 100%, 40%);
 }

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -136,7 +136,7 @@
         {{#if can_send_private_message}}
             <li>
                 <a tabindex="0" class="{{ private_message_class }}">
-                    <i class="fa fa-envelope" aria-hidden="true"></i> {{#tr}}Send private message{{/tr}} {{#if is_sender_popover}}<span class="hotkey-hint">(R)</span>{{/if}}
+                    <i class="fa fa-comment" aria-hidden="true"></i> {{#tr}}Send private message{{/tr}} {{#if is_sender_popover}}<span class="hotkey-hint">(R)</span>{{/if}}
                 </a>
             </li>
         {{/if}}
@@ -167,7 +167,7 @@
         <hr />
         <li>
             <a href="{{ pm_with_url }}" class="narrow_to_private_messages">
-                <i class="fa fa-lock" aria-hidden="true"></i>
+                <i class="fa fa-envelope" aria-hidden="true"></i>
                 {{#if is_me}}
                     {{#tr}}View private messages to myself{{/tr}}
                 {{else}}

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -1,108 +1,89 @@
 {{! Contents of the "message info" popup }}
-<ul class="nav nav-list actions_popover info_popover_actions" data-user-id="{{user_id}}">
-    <div class="popover_info">
-        <li>
-            <b>{{user_full_name}}</b>
-            {{#if is_active }}
-                {{#if is_bot}}
-                <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
-                {{else}}
-                <span class="{{user_circle_class}} user_circle popover_user_presence tippy-zulip-tooltip hidden-for-spectators" data-tippy-content="{{user_last_seen_time_status}}"></span>
-                {{/if}}
-            {{/if}}
-        </li>
-
-
+<ul class="nav nav-list info_popover_actions" id="user_info_popover" data-user-id="{{user_id}}">
+    <li class="popover_user_name_row">
+        <b class="user_full_name" data-tippy-content="{{user_full_name}}">{{user_full_name}}</b>
         {{#if is_active }}
-            {{#if show_email}}
-            {{!-- This div is added to enable interactivity for tooltip - https://atomiks.github.io/tippyjs/v5/accessibility/#interactivity --}}
-            <div>
-                <li class="user_popover_email">
-                    <i class="fa fa-clone hide_copy_icon" data-clipboard-text="{{ user_email }}"></i>
-                    {{ user_email }}
-                </li>
-            </div>
-            {{/if}}
-        {{else}}
-            <li class="user_popover_email half-opacity italic">{{#if is_bot}}{{#tr}}This bot has been deactivated.{{/tr}}{{else}}{{#tr}}This user has been deactivated.{{/tr}}{{/if}}</li>
-        {{/if}}
-
-
-        {{#if is_bot}}
-            {{#if bot_owner}}
-                <li>{{#tr}}Bot owner{{/tr}}:
-                    <span class="bot-owner-name view_user_profile" data-user-id='{{ bot_owner.user_id }}'>
-                        {{bot_owner.full_name}}
-                    </span>
-                </li>
-            {{else if is_system_bot}}
-                <li>{{#tr}}System bot{{/tr}}</li>
+            {{#if is_bot}}
+            <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
             {{else}}
-                <li>{{#tr}}Bot{{/tr}}</li>
+            <span class="{{user_circle_class}} user_circle popover_user_presence tippy-zulip-tooltip hidden-for-spectators" data-tippy-content="{{user_last_seen_time_status}}"></span>
             {{/if}}
-        {{else}}
-            <li>{{ user_type }}</li>
         {{/if}}
-        {{!-- Display selected custom profile fields in this popover. --}}
-        {{#each display_profile_fields}}
-            <li data-type="{{this.type}}" class="field-section custom_user_field tippy-zulip-tooltip" data-tippy-content="{{this.name}}" data-field-id="{{this.id}}">
-                {{#if this.is_link}}
-                    <a tabindex="0" href="{{this.value}}" target="_blank" rel="noopener noreferrer" class="value">{{this.value}}</a>
-                {{else if this.is_external_account}}
-                    <a tabindex="0" href="{{this.link}}" target="_blank" rel="noopener noreferrer" class="value">
-                        {{#if (eq this.subtype "github") }}
-                        <i class="fa fa-github" aria-hidden="true"></i>
-                        {{else if (eq this.subtype "twitter") }}
-                        <i class="fa fa-twitter" aria-hidden="true"></i>
-                        {{/if}}
-                        {{this.value}}
-                    </a>
-                {{else}}
-                    {{#if this.rendered_value}}
-                    <span class="value rendered_markdown">{{rendered_markdown this.rendered_value}}</span>
-                    {{else}}
-                    <span class="value">{{this.value}}</span>
-                    {{/if}}
-                {{/if}}
+        {{#if show_manage_menu }}
+        <span class="user_info_popover_action_buttons">
+            <a class="user_info_popover_manage_menu_btn" role="button" tabindex="0" aria-haspopup="true">
+                <i class="popover_action_icon zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i>
+            </a>
+        </span>
+        {{/if}}
+    </li>
+
+
+    {{#if is_active }}
+        {{#if show_email}}
+        {{!-- This div is added to enable interactivity for tooltip - https://atomiks.github.io/tippyjs/v5/accessibility/#interactivity --}}
+        <div>
+            <li class="user_popover_email">
+                <i class="fa fa-clone hide_copy_icon" data-clipboard-text="{{ user_email }}"></i>
+                {{ user_email }}
             </li>
-        {{/each}}
-
-        {{#if user_time}}
-            <li class="hidden-for-spectators">{{#tr}}{user_time} local time{{/tr}}</li>
+        </div>
         {{/if}}
+    {{else}}
+        <li class="user_popover_email half-opacity italic">{{#if is_bot}}{{#tr}}This bot has been deactivated.{{/tr}}{{else}}{{#tr}}This user has been deactivated.{{/tr}}{{/if}}</li>
+    {{/if}}
 
-        <li class="only-visible-for-spectators">{{#tr}}Joined {date_joined}{{/tr}}</li>
-    </div>
 
-    {{#if is_me}}
-        <hr />
-        {{#if invisible_mode}}
-        <li>
-            <a tabindex="0" class="invisible_mode_turn_off">
-                <i class="fa fa-circle-o" aria-hidden="true"></i> {{#tr}}Turn off invisible mode{{/tr}}
-            </a>
-        </li>
+    {{#if is_bot}}
+        {{#if bot_owner}}
+            <li>{{#tr}}Bot owner{{/tr}}:
+                <span class="bot-owner-name view_user_profile" data-user-id='{{ bot_owner.user_id }}'>
+                    {{bot_owner.full_name}}
+                </span>
+            </li>
+        {{else if is_system_bot}}
+            <li>{{#tr}}System bot{{/tr}}</li>
         {{else}}
-        <li>
-            <a tabindex="0" class="invisible_mode_turn_on">
-                <i class="fa fa-circle-o" aria-hidden="true"></i> {{#tr}}Go invisible{{/tr}}
-            </a>
-        </li>
+            <li>{{#tr}}Bot{{/tr}}</li>
         {{/if}}
-        <li>
-            <a tabindex="0" class="update_status_text">
-                <i class="fa fa-comments" aria-hidden="true"></i>
-                {{#if status_text}}
-                    {{#tr}}Edit status{{/tr}}
+    {{else}}
+        <li>{{ user_type }}</li>
+    {{/if}}
+    {{!-- Display selected custom profile fields in this popover. --}}
+    {{#each display_profile_fields}}
+        <li data-type="{{this.type}}" class="field-section custom_user_field" data-field-id="{{this.id}}">
+            {{#if this.is_link}}
+                <a tabindex="0" href="{{this.value}}" target="_blank" rel="noopener noreferrer" class="value custom_profile_fields_link tippy-zulip-tooltip" data-tippy-content="{{this.name}}">{{this.value}}</a>
+            {{else if this.is_external_account}}
+                <a tabindex="0" href="{{this.link}}" target="_blank" rel="noopener noreferrer" class="value custom_profile_fields_link tippy-zulip-tooltip" data-tippy-content="{{this.name}}">
+                    {{#if (eq this.subtype "github") }}
+                    <i class="fa fa-github" aria-hidden="true"></i>
+                    {{else if (eq this.subtype "twitter") }}
+                    <i class="fa fa-twitter" aria-hidden="true"></i>
+                    {{/if}}
+                    {{this.value}}
+                </a>
+            {{else}}
+                {{#if this.rendered_value}}
+                <span class="value rendered_markdown tippy-zulip-tooltip" data-tippy-content="{{this.name}}">{{rendered_markdown this.rendered_value}}</span>
                 {{else}}
-                    {{#tr}}Set a status{{/tr}}
+                <span class="value tippy-zulip-tooltip" data-tippy-content="{{this.name}}">{{this.value}}</span>
                 {{/if}}
-            </a>
+            {{/if}}
         </li>
+    {{/each}}
+
+
+    <li class="only-visible-for-spectators">{{#tr}}Joined {date_joined}{{/tr}}</li>
+
+    {{#if (or (and user_time is_active) is_me status_content_available) }}
+        <hr />
+    {{/if}}
+    {{#if (and user_time is_active)}}
+        <li class="hidden-for-spectators local_time">{{#tr}}{user_time} local time{{/tr}}</li>
     {{/if}}
 
     {{#if status_content_available}}
-        {{#unless is_me}}<hr />{{/unless}}
         <li class="user_info_status_text">
             <span id="status_message">
                 {{#if status_emoji_info}}
@@ -120,9 +101,34 @@
         </li>
     {{/if}}
 
-    {{#if spectator_view}}
-    {{else}}
+    {{#if is_me}}
+        <li>
+            <a tabindex="0" class="update_status_text">
+                <i class="fa fa-comments" aria-hidden="true"></i>
+                {{#if status_text}}
+                    {{#tr}}Edit status{{/tr}}
+                {{else}}
+                    {{#tr}}Set a status{{/tr}}
+                {{/if}}
+            </a>
+        </li>
+        {{#if invisible_mode}}
+        <li>
+            <a tabindex="0" class="invisible_mode_turn_off">
+                <i class="fa fa-circle-o" aria-hidden="true"></i> {{#tr}}Turn off invisible mode{{/tr}}
+            </a>
+        </li>
+        {{else}}
+        <li>
+            <a tabindex="0" class="invisible_mode_turn_on">
+                <i class="fa fa-circle-o" aria-hidden="true"></i> {{#tr}}Go invisible{{/tr}}
+            </a>
+        </li>
+        {{/if}}
+    {{/if}}
 
+
+    {{#unless spectator_view}}
         <hr />
         <li>
             <a tabindex="0" class="view_full_user_profile">
@@ -180,37 +186,5 @@
                 <i class="fa fa-paper-plane" aria-hidden="true"></i> {{#tr}}View messages sent{{/tr}}
             </a>
         </li>
-
-        {{#if can_mute }}
-        <hr />
-        <li>
-            <a tabindex="0" class="sidebar-popover-mute-user">
-                <i class="fa fa-eye-slash" aria-hidden="true"></i> {{#tr}}Mute this user{{/tr}}
-            </a>
-        </li>
-        {{/if}}
-        {{#if can_unmute}}
-        <hr />
-        <li>
-            <a tabindex="0" class="sidebar-popover-unmute-user">
-                <i class="fa fa-eye" aria-hidden="true"></i> {{#tr}}Unmute this user{{/tr}}
-            </a>
-        </li>
-        {{/if}}
-        {{#if can_manage_user}}
-            {{#if is_active}}
-            <li>
-                <a tabindex="0" class="sidebar-popover-manage-user">
-                    <i class="fa fa-edit" aria-hidden="true"></i> {{#if is_bot}}{{#tr}}Manage this bot{{/tr}}{{else}}{{#tr}}Manage this user{{/tr}}{{/if}}
-                </a>
-            </li>
-            {{else}}
-            <li>
-                <a tabindex="0" class="sidebar-popover-reactivate-user">
-                    <i class="fa fa-user-plus" aria-hidden="true"></i> {{#if is_bot}}{{#tr}}Reactivate this bot{{/tr}}{{else}}{{#tr}}Reactivate this user{{/tr}}{{/if}}
-                </a>
-            </li>
-            {{/if}}
-        {{/if}}
-    {{/if}}
+    {{/unless}}
 </ul>

--- a/static/templates/user_info_popover_manage_menu.hbs
+++ b/static/templates/user_info_popover_manage_menu.hbs
@@ -1,0 +1,31 @@
+<ul class="nav nav-list user_info_popover_manage_menu" data-user-id="{{user_id}}">
+    {{#if can_mute }}
+    <li>
+        <a tabindex="0" class="sidebar-popover-mute-user">
+            <i class="fa fa-eye-slash" aria-hidden="true"></i> {{#tr}}Mute this user{{/tr}}
+        </a>
+    </li>
+    {{/if}}
+    {{#if can_unmute}}
+    <li>
+        <a tabindex="0" class="sidebar-popover-unmute-user">
+            <i class="fa fa-eye" aria-hidden="true"></i> {{#tr}}Unmute this user{{/tr}}
+        </a>
+    </li>
+    {{/if}}
+    {{#if can_manage_user}}
+        {{#if is_active}}
+        <li>
+            <a tabindex="0" class="sidebar-popover-manage-user">
+                <i class="fa fa-edit" aria-hidden="true"></i> {{#if is_bot}}{{#tr}}Manage this bot{{/tr}}{{else}}{{#tr}}Manage this user{{/tr}}{{/if}}
+            </a>
+        </li>
+        {{else}}
+        <li>
+            <a tabindex="0" class="sidebar-popover-reactivate-user">
+                <i class="fa fa-user-plus" aria-hidden="true"></i> {{#if is_bot}}{{#tr}}Reactivate this bot{{/tr}}{{else}}{{#tr}}Reactivate this user{{/tr}}{{/if}}
+            </a>
+        </li>
+        {{/if}}
+    {{/if}}
+</ul>


### PR DESCRIPTION
Almost all design changes ideas are from the discussion on CZO,
"design > pronouns in profile card" for more information.

Move the local time just below the status if present else into that 
the same status block regardless of whether the status is set.

Move the management commands "Mute this user" and "Manage this user"
into a three-dot menu. The three dots would be in the upper right.

Implement a new popover for a three-dot menu.

Change the private message link icon.

And some small design changes.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/pronouns.20in.20profile.20card)
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Manually tested In both themes.

**GIFs or screenshots:** 
<details>
<summary>Other user</summary>

![normal_user_popover](https://user-images.githubusercontent.com/41695888/193571751-560e85f8-553d-4126-b761-1e25ef0c4686.png)

</details>

<details>
<summary>Self user</summary>

![self_user_popover](https://user-images.githubusercontent.com/41695888/193571899-228a0f93-5a78-4af9-9b7d-e13a7d65fb3c.png)


</details>
<details>
<summary>Bot user</summary>

![bot_user_popover](https://user-images.githubusercontent.com/41695888/193571978-c9c3282d-39b6-4f59-8eb2-bd6f3b4aab2f.png)
)
</details>
<details>
<summary>Three-dot menu and overall working</summary>

![three_dot_menu_view](https://user-images.githubusercontent.com/41695888/193572081-5a65b92c-7b7c-4935-a076-40da77fa62ce.png)
![overall_working_of_popover](https://user-images.githubusercontent.com/41695888/193572068-f24eb07c-f8a7-400a-8457-2ef1e1902c95.gif)

</details>