### PR TITLE
slack_incoming webhook: Check for empty payload attachments.

### DIFF
--- a/zerver/webhooks/slack_incoming/view.py
+++ b/zerver/webhooks/slack_incoming/view.py
@@ -47,7 +47,7 @@ def api_slack_incoming_webhook(
         for block in payload["blocks"]:
             body = add_block(block, body)
 
-    if "attachments" in payload:
+    if "attachments" in payload and payload["attachments"]:
         for attachment in payload["attachments"]:
             body = add_attachment(attachment, body)
 


### PR DESCRIPTION
Slack (JSON) message payloads may contain empty attachments. Since
attachments key is present, code will attempt to iterate over
it. JSON null becomes Python None, which causes the attempt to
loop over attachment content to raise an exception: TypeError:
'NoneType' object is not iterable. The issue is fixed by adding an
explicit check for an empty attachment that preempts the iteration.

FIXES: Sending of Slack messages from Vuls vulnerability scanner
(https://vuls.io) into Zulip via slack_incoming webhook.

Previously failing POST data:

client: ZulipSlackIncomingWebhook
url: /api/v1/external/slack_incoming
content_type: application/json
custom_headers:
HTTP_X_REAL_IP: XXX.XXX.XXX.XXX

payload:
{
  "attachments": null,
  "channel": "#Vuls",
  "icon_emoji": ":ghost:",
  "text": "\n[Reboot Required] server-ID\tTotal: 171 (Critical:9 High:88 Medium:71 Low:3 ?:0)\t1/171 Fixed\t913 installed\t63 poc\t0 exploits\tcisa: 0, uscert: 0, jpcert: 0 alerts\n\n",
  "username": "XXXX"
}

NOTE: This addresses a real issue, but is not a comprehensive fix
for all possible attachment content. A scalar value will evade
both existing checks. Whether or not richer checks are warranted
depends on the behaviour of potential clients and what behaviour
the Zulip Project wishes to have in the presence of erroneous
input. Input should be coming from trusted sources, since data
injection requires obtaining an API key. The most obvious risk of
bad input data is production of a stack trace in the logs.