### PR TITLE
Add a tippy tooltip to inline message imaes, as well as the lightbox title.

### DIFF
--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -282,12 +282,18 @@ run_test("clean_user_content_links", () => {
                 '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/file.png">upload</a> ' +
                 '<a href="http://localhost:NNNN">invalid</a> ' +
                 '<a href="javascript:alert(1)">unsafe</a> ' +
-                '<a href="/#fragment" target="_blank">fragment</a>',
+                '<a href="/#fragment" target="_blank">fragment</a>' +
+                '<div class="message_inline_image">' +
+                '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.png" title="inline image">upload</a> ' +
+                "</div>",
         ),
         '<a href="http://example.com" target="_blank" rel="noopener noreferrer" title="http://example.com/">good</a> ' +
             '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/file.png" target="_blank" rel="noopener noreferrer" title="translated: Download file.png">upload</a> ' +
             "<a>invalid</a> " +
             "<a>unsafe</a> " +
-            '<a href="/#fragment" title="http://zulip.zulipdev.com/#fragment">fragment</a>',
+            '<a href="/#fragment" title="http://zulip.zulipdev.com/#fragment">fragment</a>' +
+            '<div class="message_inline_image">' +
+            '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.png" target="_blank" rel="noopener noreferrer" aria-label="inline image">upload</a> ' +
+            "</div>",
     );
 });

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -210,9 +210,11 @@ function display_image(payload) {
     img.src = payload.source;
     $img_container.html(img).show();
 
+    const filename = payload.url?.split("/").pop();
     $(".image-description .title")
         .text(payload.title || "N/A")
-        .prop("title", payload.title || "N/A");
+        .attr("aria-label", payload.title || "N/A")
+        .prop("data-filename", filename || "N/A");
     $(".image-description .user").text(payload.user).prop("title", payload.user);
 
     $(".image-actions .open, .image-actions .download").attr("href", payload.source);
@@ -411,7 +413,7 @@ export function parse_image_data(image) {
     }
     const payload = {
         user: sender_full_name,
-        title: $parent.attr("title"),
+        title: $parent.attr("aria-label") || $parent.attr("href"),
         type,
         preview: preview_src,
         source,

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -1,12 +1,15 @@
 import $ from "jquery";
 import tippy, {delegate} from "tippy.js";
 
+import render_message_inline_image_tooltip from "../templates/message_inline_image_tooltip.hbs";
+
 import {$t} from "./i18n";
 import * as message_lists from "./message_lists";
 import * as popover_menus from "./popover_menus";
 import * as reactions from "./reactions";
 import * as rows from "./rows";
 import * as timerender from "./timerender";
+import {parse_html} from "./ui_util";
 
 // For tooltips without data-tippy-content, we use the HTML content of
 // a <template> whose id is given by data-tooltip-template-id.
@@ -244,5 +247,24 @@ export function initialize() {
             return true;
         },
         appendTo: () => document.body,
+    });
+
+    delegate("body", {
+        target: ".message_inline_image > a > img",
+        appendTo: () => document.body,
+        // Add a short delay so the user can mouseover several inline images without
+        // tooltips showing and hiding rapidly
+        delay: [300, 20],
+        onShow(instance) {
+            // Some message_inline_images aren't actually images with a title,
+            // for example youtube videos, so we default to the actual href
+            const title =
+                $(instance.reference).parent().attr("aria-label") ||
+                $(instance.reference).parent().attr("href");
+            instance.setContent(parse_html(render_message_inline_image_tooltip({title})));
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
     });
 }

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -267,4 +267,24 @@ export function initialize() {
             instance.destroy();
         },
     });
+
+    delegate("body", {
+        target: ".image-info-wrapper > .image-description > .title",
+        appendTo: () => document.body,
+        onShow(instance) {
+            const title = $(instance.reference).attr("aria-label");
+            const filename = $(instance.reference).prop("data-filename");
+            const $markup = $("<span>").text(title);
+            if (title !== filename) {
+                // If the image title is the same as the filename, there's no reason
+                // to show this next line.
+                const second_line = $t({defaultMessage: "File name: {filename}"}, {filename});
+                $markup.append($("<br>"), $("<span>").text(second_line));
+            }
+            instance.setContent($markup[0]);
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
 }

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -290,26 +290,41 @@ export function clean_user_content_links(html) {
             elt.removeAttribute("target");
         }
 
-        // Ensure that the title displays the real URL.
-        let title;
-        let legacy_title;
-        if (url.origin === window.location.origin && url.pathname.startsWith("/user_uploads/")) {
-            // We add the word "download" to make clear what will
-            // happen when clicking the file.  This is particularly
-            // important in the desktop app, where hovering a URL does
-            // not display the URL like it does in the web app.
-            title = legacy_title = $t(
-                {defaultMessage: "Download {filename}"},
-                {filename: url.pathname.slice(url.pathname.lastIndexOf("/") + 1)},
-            );
+        const is_inline_image =
+            elt.parentElement && elt.parentElement.classList.contains("message_inline_image");
+        if (is_inline_image) {
+            // For inline images we want to handle the tooltips explicitly, and disable
+            // the browser's built in handling of the title attribute.
+            if (elt.getAttribute("title")) {
+                elt.setAttribute("aria-label", elt.getAttribute("title"));
+                elt.removeAttribute("title");
+            }
         } else {
-            title = url;
-            legacy_title = href;
+            // For non-image user uploads, the following block ensures that the title
+            // attribute always displays the filename as a security measure.
+            let title;
+            let legacy_title;
+            if (
+                url.origin === window.location.origin &&
+                url.pathname.startsWith("/user_uploads/")
+            ) {
+                // We add the word "download" to make clear what will
+                // happen when clicking the file.  This is particularly
+                // important in the desktop app, where hovering a URL does
+                // not display the URL like it does in the web app.
+                title = legacy_title = $t(
+                    {defaultMessage: "Download {filename}"},
+                    {filename: url.pathname.slice(url.pathname.lastIndexOf("/") + 1)},
+                );
+            } else {
+                title = url;
+                legacy_title = href;
+            }
+            elt.setAttribute(
+                "title",
+                ["", legacy_title].includes(elt.title) ? title : `${title}\n${elt.title}`,
+            );
         }
-        elt.setAttribute(
-            "title",
-            ["", legacy_title].includes(elt.title) ? title : `${title}\n${elt.title}`,
-        );
     }
     return content.innerHTML;
 }

--- a/static/templates/message_inline_image_tooltip.hbs
+++ b/static/templates/message_inline_image_tooltip.hbs
@@ -1,0 +1,3 @@
+<strong>{{ title }}</strong>
+<br/>
+{{t 'Click to view or download.'}}


### PR DESCRIPTION
Commit 1:

This commit adds a tippy tooltip for inline image previews in messages.

There exists some (reasonable) logic in `static/js/util.js` which
overrides all title attributes for links to user-uploaded content to
ensure they always display "Download <filename>". This doesn't make
sense for inline images specifically because they will be opened in a
ligthbox, so we prevent that.

There is an additional tippy instance created in `static/js/tippyjs.js`
to add tippy tooltips to inline images, which takes advantage of the now
preserved title attribute of the parent link.

Commit 2:

This commit adds a tippy tooltip to the lightbox title which enables the
user to view the filename of an image if the filename is different than
the image title.

Fixes: https://github.com/zulip/zulip/issues/21333

![image](https://user-images.githubusercontent.com/3046397/158912205-a9ee1bc1-ace3-4ae5-853c-59a4b3f8f94b.png)
![image](https://user-images.githubusercontent.com/3046397/158912262-944a0c04-6e4d-41b7-a33e-8bf61a9b5a31.png)
