### PR TITLE
compose: Add clear field button for compose topic name Fixes #21464

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -704,6 +704,10 @@ export function initialize() {
         compose_actions.cancel();
     });
 
+    $("body").on("click", "#compose_clear_topic_name", () => {
+        compose_state.topic("");
+    });
+
     // LEFT SIDEBAR
 
     $("body").on("click", "#clear_search_topic_button", topic_list.clear_topic_search);

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -704,10 +704,6 @@ export function initialize() {
         compose_actions.cancel();
     });
 
-    $("body").on("click", "#compose_clear_topic_name", () => {
-        compose_state.topic("");
-    });
-
     // LEFT SIDEBAR
 
     $("body").on("click", "#clear_search_topic_button", topic_list.clear_topic_search);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -71,6 +71,16 @@ export function update_video_chat_button_display() {
     $(".message-edit-feature-group .video_link").toggle(show_video_chat_button);
 }
 
+export function update_topic_clear_button_display() {
+    if (compose_state.topic()) {
+        $("#stream_message_recipient_topic").removeClass("empty");
+        $("#compose_clear_topic_name").show();
+    } else {
+        $("#stream_message_recipient_topic").addClass("empty");
+        $("#compose_clear_topic_name").hide();
+    }
+}
+
 export function clear_invites() {
     $("#compose_invite_users").hide();
     $("#compose_invite_users").empty();
@@ -717,6 +727,16 @@ export function initialize() {
 
     $("#stream_message_recipient_topic").on("focus", () => {
         compose_actions.update_placeholder_text();
+        update_topic_clear_button_display();
+    });
+
+    $("#stream_message_recipient_topic").on("keyup", () => {
+        update_topic_clear_button_display();
+    });
+
+    $("body").on("click", "#compose_clear_topic_name", () => {
+        compose_state.topic("");
+        update_topic_clear_button_display();
     });
 
     $("body").on("click", ".formatting_button", (e) => {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -43,6 +43,8 @@ function hide_box() {
     compose_fade.clear_compose();
     $(".message_comp").hide();
     $("#compose_controls").show();
+    $("#stream_message_recipient_topic").removeClass("empty");
+    $("#compose_clear_topic_name").show();
     compose.clear_preview_area();
 }
 

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -435,10 +435,17 @@ input.recipient_box {
 }
 
 #stream_message_recipient_topic.recipient_box {
+<<<<<<< HEAD
     /* This width roughly corresponds to how long of a topic can appear in
        the left sidebar with a single digit unread count without being
        cut off. */
     width: 175px;
+=======
+    width: calc(20% + 41px);
+    padding-right: 18px;
+    min-width: 120px;
+    max-width: 165px;
+>>>>>>> 015b2cd4b2... compose: Add clear field button for compose topic name.
 }
 
 #private_message_recipient.recipient_box {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -444,7 +444,7 @@ input.recipient_box {
 }
 
 #stream_message_recipient_topic.recipient_box.empty {
-    width: 206px;
+    width: 188px;
     padding-right: 6px;
 }
 

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -435,20 +435,10 @@ input.recipient_box {
 }
 
 #stream_message_recipient_topic.recipient_box {
-<<<<<<< HEAD
-<<<<<<< HEAD
     /* This width roughly corresponds to how long of a topic can appear in
        the left sidebar with a single digit unread count without being
        cut off. */
     width: 175px;
-=======
-    width: calc(20% + 41px);
-    padding-right: 18px;
-    min-width: 120px;
-    max-width: 165px;
->>>>>>> 015b2cd4b2... compose: Add clear field button for compose topic name.
-=======
-    width: 193px;
     padding-right: 19px;
 }
 
@@ -459,7 +449,6 @@ input.recipient_box {
 
 #compose_clear_topic_name {
     padding: 4px;
->>>>>>> 5dfda96f07... Added functionality to automatically hide/show compose topic clear button
 }
 
 #private_message_recipient.recipient_box {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -436,6 +436,7 @@ input.recipient_box {
 
 #stream_message_recipient_topic.recipient_box {
 <<<<<<< HEAD
+<<<<<<< HEAD
     /* This width roughly corresponds to how long of a topic can appear in
        the left sidebar with a single digit unread count without being
        cut off. */
@@ -446,6 +447,19 @@ input.recipient_box {
     min-width: 120px;
     max-width: 165px;
 >>>>>>> 015b2cd4b2... compose: Add clear field button for compose topic name.
+=======
+    width: 193px;
+    padding-right: 19px;
+}
+
+#stream_message_recipient_topic.recipient_box.empty {
+    width: 206px;
+    padding-right: 6px;
+}
+
+#compose_clear_topic_name {
+    padding: 4px;
+>>>>>>> 5dfda96f07... Added functionality to automatically hide/show compose topic clear button
 }
 
 #private_message_recipient.recipient_box {

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -85,6 +85,7 @@
                                 <input type="text" class="recipient_box" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="30" value="" placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Stream' }}" />
                                 <i class="fa fa-angle-right" aria-hidden="true"></i>
                                 <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="60" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
+                                <button type="button" class="btn clear_search_button" id="compose_clear_topic_name"><i class="fa fa-remove"></i></button>
                             </div>
                         </div>
                         <div id="private-message" class="order-1">


### PR DESCRIPTION
[<!-- What's this PR for?  (Just a link to an issue is fine.) -->](https://github.com/zulip/zulip/issues/21464)

Added a button to clear the compose thread name field.  I used existing CSS to replicate the button found in the filter streams text input.  I also added a little bit of padding so the words don't overlap with the button as they do in the filter streams input.  Added a simple click listener to clear the input.

Edit:
Added functionality to automatically show/hide the clear topic button:
#### static/js/click_handlers.js
- Removed click listener, moved it to compose.js

#### static/js/compose.js
- Added update_topic_clear_button_display() which checks to see if the topic input box is empty.  If it's empty it hides the clear button.  Otherwise it shows it.
- Added call to above function when focus is given to topic input
- Added keyup listener inside topic input to call above function
- Moved click listener for clear button to this file, it makes more sense here

#### static/js/compose_actions.js
- Added a few lines to unhide the clear button when the compose box is closed.  Otherwise clearing the box, then closing the compose box and reopening it resulted in the button remaining hidden.

#### compose.css
- Modified width to match recently merged changes
- Added selector to adjust width/padding when empty class is applied.  This keeps the box from changing sizes when the button is shown/hidden.
- Default padding was causing the box to be unstable and change size when hiding/showing the button.  So I overrode it.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/topic.20box.20width/near/1344299)

**Testing plan:** Manually tested

#### Button Shown
![clear-topic-shown](https://user-images.githubusercontent.com/61295861/161886528-ce4e6dca-7e51-4412-b943-8ce71fed6332.JPG)

#### Button Hidden
![clear-topic-hidden](https://user-images.githubusercontent.com/61295861/161886606-a25201ef-86a2-421d-8a3d-9f4294002583.JPG)


fixes #21464 