### PR TITLE
settings_users: Help center link in deactivate user confirmation modal.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -427,6 +427,7 @@ export function confirm_deactivation(user_id, handle_confirm, loading_spinner) {
 
     confirm_dialog.launch({
         html_heading: $t_html({defaultMessage: "Deactivate {name}"}, {name: user.full_name}),
+        help_link: "/help/deactivate-or-reactivate-a-user#deactivate-ban-a-user",
         html_body,
         on_click: handle_confirm,
         loading_spinner,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Manually tested.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot at 2022-03-18 19-28-24](https://user-images.githubusercontent.com/41695888/159022141-57bfd0cb-6236-4751-a5ba-c6d8cd328d84.png)

