### PR TITLE
help_docs: Update help docs for new tabs in streams view

### DIFF
--- a/templates/zerver/help/add-or-remove-users-from-a-stream.md
+++ b/templates/zerver/help/add-or-remove-users-from-a-stream.md
@@ -17,12 +17,19 @@ to a stream][configure-invites].
 
 1. Select a stream.
 
+{!select-stream-view-subscribers.md!}
+
 1. Under **Add subscribers**, enter a name or email address. The typeahead
    will only include users who aren't already subscribed to the stream.
 
 1. Click **Add**.
 
 {end_tabs}
+
+!!! tip ""
+
+      To add users in bulk, you can copy members from an
+      existing stream or [user group](/help/user-groups).
 
 ## Remove users from a stream
 
@@ -38,6 +45,8 @@ including streams the admin is not subscribed to.
 {relative|stream|all}
 
 1. Select a stream.
+
+{!select-stream-view-subscribers.md!}
 
 1. Under **Subscribers**, find the user you would like to remove.
 

--- a/templates/zerver/help/change-the-color-of-a-stream.md
+++ b/templates/zerver/help/change-the-color-of-a-stream.md
@@ -27,9 +27,9 @@ stream. Changing a stream's color does not change it for anyone else.
 
 1. Select a stream.
 
-1. Select the **Personal** tab on the right.
+{!select-stream-view-personal.md!}
 
-1. Click on the colored square below **Stream color**.
+1. Under **Personal settings**, click on the colored square below **Stream color**.
 
 1. Select a color from the grid, use the color picker, or enter a hex code.
 

--- a/templates/zerver/help/change-the-privacy-of-a-stream.md
+++ b/templates/zerver/help/change-the-privacy-of-a-stream.md
@@ -2,8 +2,9 @@
 
 {!admin-only.md!}
 
-Streams can be public or private, and private streams can have shared or
-protected history. See [stream permissions](/help/stream-permissions) for
+Streams can be [web-public](/help/web-public-streams), public or private,
+and private streams can have shared or protected history.
+See [stream permissions](/help/stream-permissions) for
 details on stream privacy settings.
 
 As an organization administrator, you can always make a public stream
@@ -18,12 +19,14 @@ public.
 
 1. Select a stream.
 
-4. Find the privacy description under the stream name and description on the
-   right. Click **[Change]**.
+{!select-stream-view-general.md!}
 
-5. Select a privacy level.
+1. Click the **pencil** (<i class="fa fa-pencil"></i>)
+   to the right of **Stream permissions**.
 
-6. Click **Save changes**.
+1. Under **Who can access the stream?**, select a privacy level.
+
+{!save-changes.md!}
 
 {end_tabs}
 

--- a/templates/zerver/help/change-the-stream-description.md
+++ b/templates/zerver/help/change-the-stream-description.md
@@ -1,14 +1,14 @@
 # Change the stream description
 
+{!admin-only.md!}
+
 Streams descriptions are displayed when viewing the stream in the
-apps, and can be used to explain the purpose of a stream and link to
-usage guidelines, resources, or related streams.
+web and desktop apps, and can be used to explain the purpose of a
+stream and link to usage guidelines, resources, or related streams.
 
 Stream descriptions support Zulip's standard [Markdown
 formatting][markdown-formatting], with the exception that image
 previews are disabled.
-
-{!admin-only.md!}
 
 {start_tabs}
 
@@ -16,10 +16,12 @@ previews are disabled.
 
 1. Select a stream.
 
-1. On the right, click the **pencil** (<i class="fa fa-pencil"></i>)
-   next to the stream description. Enter a new description.
+{!select-stream-view-general.md!}
 
-1. Click the **checkmark** to save.
+1. Click the **pencil** (<i class="fa fa-pencil"></i>)
+   to the right of the stream name. Enter a new description.
+
+{!save-changes.md!}
 
 {end_tabs}
 

--- a/templates/zerver/help/include/select-stream-view-general.md
+++ b/templates/zerver/help/include/select-stream-view-general.md
@@ -1,0 +1,1 @@
+1. Select the **General** tab on the right.

--- a/templates/zerver/help/include/select-stream-view-personal.md
+++ b/templates/zerver/help/include/select-stream-view-personal.md
@@ -1,0 +1,1 @@
+1. Select the **Personal** tab on the right.

--- a/templates/zerver/help/include/select-stream-view-subscribers.md
+++ b/templates/zerver/help/include/select-stream-view-subscribers.md
@@ -1,0 +1,1 @@
+1. Select the **Subscribers** tab on the right.

--- a/templates/zerver/help/message-a-stream-by-email.md
+++ b/templates/zerver/help/message-a-stream-by-email.md
@@ -28,6 +28,8 @@ API](/api/send-message).
 
 1. Select a stream.
 
+{!select-stream-view-general.md!}
+
 1. Copy the stream email address under **Email address**.
 
 1. Send an email to that address.

--- a/templates/zerver/help/message-retention-policy.md
+++ b/templates/zerver/help/message-retention-policy.md
@@ -44,10 +44,13 @@ Standard hosting.
 
 1. Select a stream.
 
-1. On the right, click **[Change]** next to the description of the stream
-   permissions.
+{!select-stream-view-general.md!}
 
-1. Under **Message retention for stream**, configure **Message retention period**.
+1. Click the **pencil** (<i class="fa fa-pencil"></i>)
+   to the right of **Stream permissions**.
+
+1. Under **Message retention for stream**, configure
+   **Message retention period**.
 
 {!save-changes.md!}
 

--- a/templates/zerver/help/pin-a-stream.md
+++ b/templates/zerver/help/pin-a-stream.md
@@ -4,7 +4,7 @@ Pinning a stream moves it to the top of the left sidebar. We recommend
 pinning important streams if you have more streams than fit in the left
 sidebar.
 
-### Pin a stream
+## Pin a stream
 
 {start_tabs}
 
@@ -22,6 +22,8 @@ sidebar.
 
 1. Select a stream.
 
-1. Click **Pin stream to top of left sidebar**.
+{!select-stream-view-personal.md!}
+
+1. Under **Personal settings**, toggle **Pin stream to top of left sidebar**.
 
 {end_tabs}

--- a/templates/zerver/help/rename-a-stream.md
+++ b/templates/zerver/help/rename-a-stream.md
@@ -8,9 +8,11 @@
 
 1. Select a stream.
 
-1. On the right, click the **pencil** (<i class="fa fa-pencil"></i>)
-   next to the stream name. Enter a new name.
+{!select-stream-view-general.md!}
 
-1. Click the **checkmark** to save.
+1. Click the **pencil** (<i class="fa fa-pencil"></i>)
+   to the right of the stream name. Enter a new name.
+
+{!save-changes.md!}
 
 {end_tabs}

--- a/templates/zerver/help/stream-notifications.md
+++ b/templates/zerver/help/stream-notifications.md
@@ -5,33 +5,37 @@ stream basis.
 
 ## Set notifications for a single stream
 
+These settings will override any default stream notification settings.
+
 {start_tabs}
 
 1. Hover over the stream in the left sidebar.
 
-2. Click the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>) to the
+1. Click the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>) to the
    right of the stream.
 
-3. Click **Stream settings**.
+1. Click **Stream settings**.
 
-4. Toggle the notifications settings on the right.
+{!select-stream-view-personal.md!}
+
+1. Under **Notification settings**, toggle your preferred
+   notifications settings for the stream.
 
 {end_tabs}
 
-These settings will override any default stream notification settings.
-
 ## Set default notifications for all streams
+
+These settings only apply to streams where you have not
+explicitly set a notification preference.
 
 {start_tabs}
 
 {settings_tab|notifications}
 
-1. Configure notifications in the "Notification triggers" table.
+1. In the **Notification triggers** table,
+   toggle the settings for **Streams**.
 
 {end_tabs}
-
-These settings only apply to streams where you have not
-explicitly set a notification preference.
 
 ## Related articles
 

--- a/templates/zerver/help/stream-sending-policy.md
+++ b/templates/zerver/help/stream-sending-policy.md
@@ -13,11 +13,13 @@ certain users can send messages.
 
 1. Select a stream.
 
-1. On the right, click **[Change]** next to the description of the stream
-   permissions.
+{!select-stream-view-general.md!}
 
-1. Under "Who can post to the stream?", select the option you prefer.
+1. Click the **pencil** (<i class="fa fa-pencil"></i>)
+   to the right of **Stream permissions**.
 
-1. Click **Save changes**.
+1. Under **Who can post to the stream?**, select the option you prefer.
+
+{!save-changes.md!}
 
 {end_tabs}


### PR DESCRIPTION
The updated 'Subscribed/All streams' view has new tabs on the right (General, Personal, Subscribers) that need to be added to any instructions that reference settings or actions in said tabs.

The first commit adds three new markdown files to `/templates/zerver/help/include/` for the instruction to navigate to each tab. The other commits are help center articles updated for new instructions, with small clean-ups.

List of impacted help center articles (in same order as commits):
1. `add-or-remove-users-from-a-stream`
2. `change-the-stream-description`
3. `pin-a-stream`
4. `change-the-color-of-a-stream`
5. `message-a-stream-by-email`
6. `rename-a-stream`
7. `message-retention-policy`
8. `stream-notifications`
9. `change-the-privacy-of-a-stream`
10. `stream-sending-policy`

Related to #21316: audit of help center documentation for stream management and permissions updates for 5.0 release.