### PR TITLE
Add dark theme to stream color picker

### DIFF
--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -58,6 +58,8 @@ const subscriptions_table_colorpicker_options = {
     clickoutFiresChange: true,
     showPalette: true,
     showInput: true,
+    cancelText: $t({defaultMessage: "Cancel"}),
+    chooseText: $t({defaultMessage: "Confirm"}),
     palette: stream_color_palette,
 };
 

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -193,6 +193,28 @@ body.dark-theme {
         border-color: hsla(0, 0%, 100%, 0.4);
     }
 
+    .sp-replacer {
+        background-color: hsl(211, 29%, 14%);
+
+        .sp-dd {
+            color: hsl(0, 0%, 87%);
+        }
+    }
+
+    .sp-container {
+        background-color: hsl(211, 29%, 14%);
+        border: solid 1px hsl(210, 36%, 4%);
+
+        .sp-picker-container {
+            border-left: 1px solid hsl(210, 36%, 4%);
+        }
+
+        .sp-palette-container {
+            border-right: 1px solid hsl(210, 36%, 4%);
+        }
+    }
+
+
     .streams_popover .sp-container {
         background-color: transparent;
 

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -201,6 +201,21 @@ body.dark-theme {
         }
     }
 
+    .sp-choose {
+        border: 1px solid hsl(210, 36%, 4%);
+    }
+
+    .sp-cancel {
+        color: hsl(0, 0%, 100%) !important;
+        background-color: hsl(211, 29%, 14%);
+        border: 1px solid hsl(210, 36%, 4%);
+
+        &:hover,
+        &:focus {
+            background-color: hsl(211, 29%, 14%);
+        }
+    }
+
     .sp-container {
         background-color: hsl(211, 29%, 14%);
         border: solid 1px hsl(210, 36%, 4%);

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -98,6 +98,18 @@
             .sp-picker-container {
                 border-left: solid 1px hsl(0, 0%, 88%);
             }
+
+            .sp-choose {
+                color: hsl(0, 0%, 100%);
+                background-color: hsl(240, 96%, 68%);
+                font-size: 0.875rem;
+
+                &:hover,
+                &:focus {
+                    transform: scale(1.05);
+                    text-shadow: none;
+                }
+            }
         }
     }
 

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -43,6 +43,41 @@
 
 .sp-container {
     z-index: 106;
+
+    .sp-choose {
+        color: hsl(0, 0%, 100%);
+        background: hsl(240, 96%, 68%);
+        border-radius: 0.25rem;
+        padding: 0.3rem;
+        text-shadow: none;
+
+        &:hover,
+        &:focus {
+            background: hsl(240, 96%, 68%);
+            transform: scale(1.05);
+            text-shadow: none;
+        }
+    }
+
+    /* Cancel button is originally <a> tag in spectrum colorpicker,
+    to make it look like a button some extra css is used. */
+    .sp-cancel {
+        font-size: 0.875rem;
+        padding: 0.2rem 0.3rem;
+        background-color: hsl(0, 0%, 100%);
+        color: hsl(0, 0%, 0%) !important;
+        text-decoration: none;
+        border-radius: 0.25rem;
+        line-height: 1.25;
+        border: 1px solid hsla(300, 2%, 11%, 0.3);
+        appearance: button;
+
+        &:focus,
+        &:hover {
+            background: hsl(0, 0%, 97%);
+            transform: scale(1.05);
+        }
+    }
 }
 
 .mobile-message-buttons-popover {
@@ -111,6 +146,10 @@
                 }
             }
         }
+    }
+
+    .sp-cancel {
+        display: none;
     }
 
     .popover_sub_unsub_button {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -3145,3 +3145,9 @@ select.inline_select_topic_edit {
         }
     }
 }
+
+.sp-container button,
+a {
+    font-family: "Source Sans 3", sans-serif;
+    transition: transform 0.25s ease-out;
+}

--- a/templates/zerver/help/change-the-color-of-a-stream.md
+++ b/templates/zerver/help/change-the-color-of-a-stream.md
@@ -33,6 +33,6 @@ stream. Changing a stream's color does not change it for anyone else.
 
 1. Select a color from the grid, use the color picker, or enter a hex code.
 
-1. Click **Choose** to save and apply the color change.
+1. Click **Confirm** to save and apply the color change.
 
 {end_tabs}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) --> Fixes #21481 

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

- [x]  Rename and restyle `cancel` and `Confirm` button.
- [x] Add dark theme to Stream settings > Personal tab > Stream color picker
![image](https://user-images.githubusercontent.com/59444243/163556663-2ede91a1-bff9-4b5d-9a6b-e0224426ee93.png)
- [x] Restyle `Confirm` button
![image](https://user-images.githubusercontent.com/59444243/163556540-ea656c69-4f73-44b4-9c1c-ee51435d738a.png)
- [x] Update docs
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
