### PR TITLE
settings: Remove bot from "Active bots" list on changing owners.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -498,10 +498,20 @@ run_test("realm_bot remove", ({override}) => {
     admin_stub.get_args("update_user_id", "update_bot_data");
 });
 
-run_test("realm_bot delete", () => {
+run_test("realm_bot delete", ({override}) => {
     const event = event_fixtures.realm_bot__delete;
-    // We don't handle live updates for delete events, this is a noop.
+    const bot_stub = make_stub();
+    const admin_stub = make_stub();
+    override(bot_data, "del", bot_stub.f);
+    override(settings_bots, "render_bots", () => {});
+    override(settings_users, "redraw_bots_list", admin_stub.f);
+
     dispatch(event);
+    assert.equal(bot_stub.num_calls, 1);
+    const args = bot_stub.get_args("user_id");
+    assert_same(args.user_id, event.bot.user_id);
+
+    assert.equal(admin_stub.num_calls, 1);
 });
 
 run_test("realm_bot update", ({override}) => {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -335,7 +335,9 @@ export function dispatch_normal_event(event) {
                     settings_users.update_bot_data(event.bot.user_id);
                     break;
                 case "delete":
-                    blueslip.info("ignoring bot deletion for live UI update");
+                    bot_data.del(event.bot.user_id);
+                    settings_bots.render_bots();
+                    settings_users.redraw_bots_list();
                     break;
                 case "update":
                     bot_data.update(event.bot.user_id, event.bot);

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -493,7 +493,7 @@ export function set_up() {
                         const service_interface = $("#edit_service_interface :selected").val();
                         formData.append("service_payload_url", JSON.stringify(service_payload_url));
                         formData.append("service_interface", service_interface);
-                    } else if (type === EMBEDDED_BOT_TYPE) {
+                    } else if (type === EMBEDDED_BOT_TYPE && service !== undefined) {
                         const config_data = {};
                         $("#config_edit_inputbox input").each(function () {
                             config_data[$(this).attr("name")] = $(this).val();

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -371,6 +371,14 @@ export function update_user_data(user_id, new_data) {
     }
 }
 
+export function redraw_bots_list() {
+    if (!bot_list_widget) {
+        return;
+    }
+
+    bot_list_widget.hard_redraw();
+}
+
 function start_data_load() {
     loading.make_indicator($("#admin_page_users_loading_indicator"), {text: "Loading..."});
     loading.make_indicator($("#admin_page_deactivated_users_loading_indicator"), {


### PR DESCRIPTION
On changing bot owner, "delete" event is sent to the previous
owner if previous owner is not an admin. We were ignoring the
"delete" event in webapp previously, but now we update the
bots page in personal settings to delete the bot. Note that
we do not remove the bot from the organization list of bots
currently, since list_widget does not support removing a
row as of now.

In case of previous owner being an admin, the previous owner
receives "update" event and thus the bots list is updated
from that event.

The code for ignoring "delete" event was added in fba2708bbc2,
to basically avoid failed lookup for id in the organization
list of bots. I have tested and there cannot be a case of
a failed lookup in the list as per current code for list_widget
module and we are anyways safe after a reload or after closing the
overlay as the list will be updated correctly.

Discussion thread -
https://chat.zulip.org/#narrow/stream/321-settings-system/topic/List.20render.20.2315033

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

 <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![bot-owner-change](https://user-images.githubusercontent.com/35494118/159119973-3a4270f8-972a-4b07-850d-caddaef8b83d.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
