### PR TITLE
integrations: Fix BigBlueButton password length

### DIFF
--- a/zerver/tests/test_create_video_call.py
+++ b/zerver/tests/test_create_video_call.py
@@ -179,7 +179,7 @@ class TestVideoCall(ZulipTestCase):
 
     def test_create_bigbluebutton_link(self) -> None:
         with mock.patch("zerver.views.video_calls.random.randint", return_value="1"), mock.patch(
-            "secrets.token_bytes", return_value=b"\x00" * 12
+            "secrets.token_bytes", return_value=b"\x00" * 20
         ):
             response = self.client_get(
                 "/json/calls/bigbluebutton/create?meeting_name=general > meeting"
@@ -194,7 +194,7 @@ class TestVideoCall(ZulipTestCase):
                         {
                             "meeting_id": "zulip-1",
                             "name": "general > meeting",
-                            "password": "AAAAAAAAAAAAAAAAAAAA",
+                            "password": "A" * 32,
                         }
                     ),
                 ),

--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -176,7 +176,7 @@ def get_bigbluebutton_url(
     # https://docs.bigbluebutton.org/dev/api.html#create for reference on the API calls
     # https://docs.bigbluebutton.org/dev/api.html#usage for reference for checksum
     id = "zulip-" + str(random.randint(100000000000, 999999999999))
-    password = b32encode(secrets.token_bytes(7))[:20].decode()
+    password = b32encode(secrets.token_bytes(20)).decode()  # 20 bytes means 32 characters
 
     # We sign our data here to ensure a Zulip user can not tamper with
     # the join link to gain access to other meetings that are on the


### PR DESCRIPTION
This is a follow up to #16580 fixing a bug the PR introduced.

The BigBlueButton integration had a problem with generating the random password with only 12 characters. 
This would cause the `attendeePW` to be the same as the `moderatorPW`.

**Testing plan:** <!-- How have you tested? -->
- Testet manually
- Edited the tests to work with 32 characters, too.

**GIFs or screenshots:** 
After creating a meeting the bigbluebutton API shows:
```xml
<attendeePW>I4JIYIOKCMK2W434</attendeePW>
<moderatorPW>I4JIYIOKCMK2W434XNZ7F2KQJJXOZTW3</moderatorPW>
```
before it showed
```xml
<attendeePW>XJRG633IJEJA====</attendeePW>
<moderatorPW>XJRG633IJEJA====</moderatorPW>
```

