### PR TITLE
message_edit: Fix image preview title when image title changed

### DIFF
--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -210,8 +210,11 @@ function display_image(payload) {
     img.src = payload.source;
     $img_container.html(img).show();
 
+    // extract the image preview title
+    const preview_title = payload.title.split("\n").pop();
+
     $(".image-description .title")
-        .text(payload.title || "N/A")
+        .text(preview_title || "N/A")
         .prop("title", payload.title || "N/A");
     $(".image-description .user").text(payload.user).prop("title", payload.user);
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Issue
#21311 

**Testing plan:** <!-- How have you tested? -->
Testing plan:
Check the image preview title for each image with and without changing the image title. Everything works as expected.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
### message feed
<img width="893" alt="Screen Shot 2022-03-19 at 9 32 44 PM" src="https://user-images.githubusercontent.com/53159963/159395837-a3c32cce-76a2-4668-86b6-6e1af2f0970a.png">
### preview
<img width="893" alt="Screen Shot 2022-03-19 at 9 32 53 PM" src="https://user-images.githubusercontent.com/53159963/159144282-631cff41-dbe9-4e14-aa29-742f18098da1.png">
<img width="893" alt="Screen Shot 2022-03-19 at 9 33 01 PM" src="https://user-images.githubusercontent.com/53159963/159144283-1584d538-13bf-4ed8-b07d-269fd052f2cb.png">
<img width="893" alt="Screen Shot 2022-03-19 at 9 33 08 PM" src="https://user-images.githubusercontent.com/53159963/159144284-6ec587e9-af56-44a1-9e21-abf17e90e2f8.png">
<img width="893" alt="Screen Shot 2022-03-19 at 9 33 16 PM" src="https://user-images.githubusercontent.com/53159963/159144285-5303b1f1-6832-4d31-97c1-46fbb6246bbc.png">

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
