### PR TITLE
settings_users: Confirmation modal for "Reactivate" user.

### DIFF
--- a/frontend_tests/puppeteer_tests/user-deactivation.ts
+++ b/frontend_tests/puppeteer_tests/user-deactivation.ts
@@ -18,6 +18,23 @@ async function user_row(page: Page, name: string): Promise<string> {
     return `.user_row[data-user-id="${CSS.escape(user_id.toString())}"]`;
 }
 
+async function test_reactivation_confirmation_modal(page: Page, fullname: string): Promise<void> {
+    await common.wait_for_micromodal_to_open(page);
+
+    assert.strictEqual(
+        await common.get_text_from_selector(page, ".dialog_heading"),
+        "Reactivate " + fullname,
+        "Reactivate modal has wrong user.",
+    );
+    assert.strictEqual(
+        await common.get_text_from_selector(page, "#dialog_widget_modal .dialog_submit_button"),
+        "Confirm",
+        "Reactivate button has incorrect text.",
+    );
+    await page.click("#dialog_widget_modal .dialog_submit_button");
+    await common.wait_for_micromodal_to_close(page);
+}
+
 async function test_deactivate_user(page: Page): Promise<void> {
     const cordelia_user_row = await user_row(page, "cordelia");
     await page.waitForSelector(cordelia_user_row, {visible: true});
@@ -45,10 +62,11 @@ async function test_reactivate_user(page: Page): Promise<void> {
     await page.waitForSelector(cordelia_user_row + " .fa-user-plus");
     await page.click(cordelia_user_row + " .reactivate");
 
+    await test_reactivation_confirmation_modal(page, common.fullname.cordelia);
+
     await page.waitForSelector(cordelia_user_row + ":not(.deactivated_user)", {visible: true});
     cordelia_user_row = await user_row(page, "cordelia");
     await page.waitForSelector(cordelia_user_row + " .fa-user-times");
-    await page.waitForSelector("#user-field-status", {hidden: true});
 }
 
 async function test_deactivated_users_section(page: Page): Promise<void> {
@@ -66,6 +84,9 @@ async function test_deactivated_users_section(page: Page): Promise<void> {
         {visible: true},
     );
     await page.click("#admin_deactivated_users_table " + cordelia_user_row + " .reactivate");
+
+    await test_reactivation_confirmation_modal(page, common.fullname.cordelia);
+
     await page.waitForSelector(
         "#admin_deactivated_users_table " + cordelia_user_row + " button:not(.reactivate)",
         {visible: true},
@@ -83,6 +104,8 @@ async function test_bot_deactivation_and_reactivation(page: Page): Promise<void>
     await page.waitForSelector("#bot-field-status", {hidden: true});
 
     await page.click(default_bot_user_row + " .reactivate");
+    await test_reactivation_confirmation_modal(page, "Zulip Default Bot");
+
     await page.waitForSelector(default_bot_user_row + ":not(.deactivated_user)", {visible: true});
     await page.waitForSelector(default_bot_user_row + " .fa-user-times");
 }

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -498,7 +498,7 @@ export function confirm_reactivation(user_id, handle_confirm, loading_spinner) {
     });
 }
 
-function handle_reactivation($tbody, $status_field) {
+function handle_reactivation($tbody) {
     $tbody.on("click", ".reactivate", (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -506,19 +506,24 @@ function handle_reactivation($tbody, $status_field) {
         const $button_elem = $(e.target);
         const $row = $button_elem.closest(".user_row");
         const user_id = Number.parseInt($row.attr("data-user-id"), 10);
-        const url = "/json/users/" + encodeURIComponent(user_id) + "/reactivate";
-        const data = {};
 
-        const opts = {
-            success_continuation() {
-                update_view_on_reactivate($row);
-            },
-            error_continuation(xhr) {
-                ui_report.generic_row_button_error(xhr, $button_elem);
-            },
-        };
+        function handle_confirm() {
+            const $row = get_user_info_row(user_id);
+            const url = "/json/users/" + encodeURIComponent(user_id) + "/reactivate";
+            channel.post({
+                url,
+                success() {
+                    dialog_widget.close_modal();
+                    update_view_on_reactivate($row);
+                },
+                error(xhr) {
+                    ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $("#dialog_error"));
+                    dialog_widget.hide_dialog_spinner();
+                },
+            });
+        }
 
-        settings_ui.do_settings_change(channel.post, url, data, $status_field, opts);
+        confirm_reactivation(user_id, handle_confirm, true);
     });
 }
 
@@ -718,7 +723,7 @@ section.active.handle_events = () => {
     const $status_field = $("#user-field-status").expectOne();
 
     handle_deactivation($tbody);
-    handle_reactivation($tbody, $status_field);
+    handle_reactivation($tbody);
     handle_human_form($tbody, $status_field);
 };
 
@@ -727,7 +732,7 @@ section.deactivated.handle_events = () => {
     const $status_field = $("#deactivated-user-field-status").expectOne();
 
     handle_deactivation($tbody);
-    handle_reactivation($tbody, $status_field);
+    handle_reactivation($tbody);
     handle_human_form($tbody, $status_field);
 };
 
@@ -736,7 +741,7 @@ section.bots.handle_events = () => {
     const $status_field = $("#bot-field-status").expectOne();
 
     handle_bot_deactivation($tbody, $status_field);
-    handle_reactivation($tbody, $status_field);
+    handle_reactivation($tbody);
     handle_bot_form($tbody, $status_field);
 };
 


### PR DESCRIPTION
The implementation closely follows `handle_deactivation()`.

Using the same existing reactivate confirmation modal.

Also, this commit will also lead to open confirmation modal
to reactivate bots in `settings > bots`, and currently there is no
existing confirmation modal for deactivating bots.

This PR is a follow-up of #21436.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Manually tested and also written in puppeteer_tests/user-deactivation.ts

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Peek 2022-03-20 18-12](https://user-images.githubusercontent.com/41695888/159162891-7511d5d2-2503-409c-b4ec-7dfd8654f087.gif)

<details>
<summary>Error test</summary>

![Peek 2022-03-23 01-48](https://user-images.githubusercontent.com/41695888/159572974-6665155b-3f06-46d5-8fbc-139d2768123d.gif)

</details>
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
