### PR TITLE
Instruction updates on various help center docs

### DIFF
--- a/templates/zerver/help/configure-default-view.md
+++ b/templates/zerver/help/configure-default-view.md
@@ -57,7 +57,7 @@ and will not affect the behavior of the `Ctrl+[` shortcut.
 
 {settings_tab|display-settings}
 
-1. Under **Advanced**, check or uncheck **Escape key navigates to
+1. Under **Advanced**, toggle **Escape key navigates to
 default view**, as desired.
 
 {end_tabs}

--- a/templates/zerver/help/email-notifications.md
+++ b/templates/zerver/help/email-notifications.md
@@ -37,7 +37,7 @@ To configure the delay for message notification emails:
 
 {settings_tab|notifications}
 
-1. Under **Other notification settings**, select the desired time period from the
+1. Under **Email message notifications**, select the desired time period from the
    **Delay before sending message notification emails** dropdown.
 
 {end_tabs}
@@ -52,7 +52,7 @@ name of the organization in the subject line of your message notification emails
 
 {settings_tab|notifications}
 
-1. Under **Email message notifications**, select
+1. Under **Email message notifications**, toggle
    **Include organization name in subject of message notification emails**.
 
 {end_tabs}

--- a/templates/zerver/help/invite-new-users.md
+++ b/templates/zerver/help/invite-new-users.md
@@ -53,7 +53,8 @@ invitation, but require them to authenticate via LDAP.
 1. Toggle **Invitations are required for joining this organization**.
 
 1. Set **Restrict email domains of new users?** to either
-   **Don't allow disposable email addresses** (recommended) or **No**.
+   **Don't allow disposable email addresses** (recommended)
+   or **No restrictions**.
 
 1. Click **Save changes**.
 

--- a/templates/zerver/help/manage-inactive-streams.md
+++ b/templates/zerver/help/manage-inactive-streams.md
@@ -15,7 +15,7 @@ is your first time using Zulip.
 
 {settings_tab|display-settings}
 
-2. Under **Display settings**, configure **Demote inactive streams**.
+2. Under **Advanced**, configure **Demote inactive streams**.
 
 {end_tabs}
 

--- a/templates/zerver/help/mobile-notifications.md
+++ b/templates/zerver/help/mobile-notifications.md
@@ -22,8 +22,8 @@ notifications while you are actively using one of the Zulip apps.
 
 {settings_tab|notifications}
 
-1. Under **Mobile message notifications**, check or uncheck
-   **Send mobile notifications even if I'm online** as desired.
+1. Under **Mobile message notifications**, toggle
+   **Send mobile notifications even if I'm online**, as desired.
 
 {end_tabs}
 

--- a/templates/zerver/help/mute-a-stream.md
+++ b/templates/zerver/help/mute-a-stream.md
@@ -18,7 +18,7 @@ Muted streams still appear in the left sidebar, though they are grayed out.
 
 {!stream-actions.md!}
 
-3. Select **Mute the stream (stream name)**.
+3. Select **Mute stream**.
 
 {end_tabs}
 
@@ -29,7 +29,7 @@ Muted streams still appear in the left sidebar, though they are grayed out.
 
 {!stream-actions.md!}
 
-3. Select the **Unmute the stream (stream name)**.
+3. Select **Unmute stream**.
 
 {end_tabs}
 

--- a/templates/zerver/help/reading-strategies.md
+++ b/templates/zerver/help/reading-strategies.md
@@ -37,9 +37,9 @@ on.
 
 * Click on a topic to narrow to messages from that topic.
 
-You can also get to a stream with `q` (stream search), by clicking on the
-magnifying glass next to `STREAMS`, or by using the autocomplete in
-[search](/help/search-for-messages).
+You can also search for a stream by clicking on **STREAMS** in the
+left sidebar, or using the `q` [keyboard
+shortcut](/help/keyboard-shortcuts).
 
 ## All messages
 


### PR DESCRIPTION
This PR updates a number of help center articles for small updates and changes to instructions / text descriptions.

Impacted articles (in commit order):
1. `configure-default-view`
2. `email-notifications`
3. `invite-new-users`
4. `manage-inactive-streams`
5. `mobile-notifications`
6. `mute-a-stream`
7. `reading-strategies`

Related to #21316: audit of help center documentation for stream management and permissions updates for 5.0 release.