### PR TITLE
help_docs: Revise `mute-a-topic` help doc.

### DIFF
--- a/templates/zerver/help/mute-a-topic.md
+++ b/templates/zerver/help/mute-a-topic.md
@@ -1,42 +1,36 @@
 # Mute a topic
 
-Messages from muted topics do not show up in **All messages** or generate
-notifications (including [alert word](/help/pm-mention-alert-notifications#alert-words)
-notifications), unless you are
-[mentioned](/help/mention-a-user-or-group). They also do not contribute to
-stream unread counts.
+Messages from muted topics do not show up in either **All messages**
+or **Recent topics**, nor do they generate notifications (including
+[alert word](/help/pm-mention-alert-notifications#alert-words)
+notifications), unless you are [mentioned](/help/mention-a-user-or-group).
+They also do not contribute to stream unread counts.
 
-Muted topics still appear in the left sidebar, though they are grayed out.
-
-### From the left sidebar
+## From the left sidebar
 
 {start_tabs}
 
-1. On the left, click on the stream that contains the topic you want to mute or unmute.
+1. In the left sidebar, click on the stream that
+   contains the topic you want to mute.
 
-2. Hover over the topic to reveal a ellipsis
-   (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>) to its right.
-   Click on the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>).
+1. Hover over the topic in the left sidebar.
 
-4. Select **Mute the topic <topic name\>**.
+1. Click the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>).
+
+4. Select **Mute topic**.
 
 {end_tabs}
 
-Follow the same procedure to unmute the topic.
-
-### From the message view
+### From the message recipient bar (alternate method)
 
 {start_tabs}
 
-1. Find a message belonging to the topic that you wish to mute or unmute.
+1. Find a message belonging to the topic that you
+   wish to mute.
 
-{!message-actions-menu.md!}
-
-1. Select **Mute the topic <topic name\>**.
+1. Click on the <i class="fa fa-bell-slash"></i> to mute the topic.
 
 {end_tabs}
-
-Follow the same procedure to unmute the topic.
 
 ## Browse previously muted topics
 
@@ -46,7 +40,7 @@ Follow the same procedure to unmute the topic.
 
 {end_tabs}
 
-From there, you can also unmute any muted topics.
+From there, you can unmute any muted topics.
 
 ## Related articles
 


### PR DESCRIPTION
Generally, revises a number of out of date information in the [mute-a-topic](https://zulip.com/help/mute-a-topic) help center documentation.

**Screenshot of updated help center article**:
![Screenshot from 2022-03-21 19-49-59](https://user-images.githubusercontent.com/63245456/159344256-bdaad43e-57f8-4f78-bc50-bc2c15688fdc.png)

