### PR TITLE
puppet: Increase download timeout from 5m to 10m.

### DIFF
--- a/puppet/zulip/manifests/sha256_tarball_to.pp
+++ b/puppet/zulip/manifests/sha256_tarball_to.pp
@@ -11,5 +11,6 @@ define zulip::sha256_tarball_to(
   exec { $url:
     command => "${::zulip_scripts_path}/setup/sha256-tarball-to ${sha256} ${url} ${install_expanded}",
     creates => $a_file,
+    timeout => 600,
   }
 }


### PR DESCRIPTION
The default timeout for `exec` commands in Puppet is 5 minutes[1].  On
slow connections, this may not be sufficient to download larger
downloads, such as the ~135MB golang tarball.

Increase the timeout to 10 minutes; this is a minimum download speed
of is ~225kB/s.

Fixes #21449.

[1]: https://puppet.com/docs/puppet/5.5/types/exec.html#exec-attribute-timeout

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
