### PR TITLE
recent topics: Revert time format changes for now.

### DIFF
--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -116,7 +116,7 @@ mock_esm("../../static/js/stream_list", {
     handle_narrow_deactivated: noop,
 });
 mock_esm("../../static/js/timerender", {
-    format_time_modern: () => "Just now",
+    last_seen_status_from_date: () => "Just now",
     get_full_datetime: () => "date at time",
 });
 mock_esm("../../static/js/sub_store", {

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -253,7 +253,7 @@ function format_topic(topic_data) {
     }
     const topic = last_msg.topic;
     const time = new Date(last_msg.timestamp * 1000);
-    const last_msg_time = timerender.format_time_modern(time);
+    const last_msg_time = timerender.last_seen_status_from_date(time);
     const full_datetime = timerender.get_full_datetime(time);
 
     // We hide the row according to filters or if it's muted.


### PR DESCRIPTION
As detailed in this conversation:

https://chat.zulip.org/#narrow/stream/137-feedback/topic/recent.20topics.20timestamps/near/1337670

This time format change is not working out as an improvement for at
least some users, myself included.

I think we do want to use some of the refinements attempted here (and
in particular, I'm keeping the new function with its nice test suite),
but I think it's better to revert now and fix forward in a future
release.

See #19775 for added background.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
