### PR TITLE
modals: Help center link margin change in confirmation modal.

### DIFF
--- a/static/styles/modal.css
+++ b/static/styles/modal.css
@@ -79,6 +79,11 @@
     margin: 0;
     font-size: 1.375rem;
     line-height: 1.25;
+
+    /* help_link_widget margin for the fa-circle-o. */
+    a {
+        margin-left: 5px;
+    }
 }
 
 .modal__close {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
[CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/Help.20center.20link.20in.20confirmation.20modal.2E)

Follow-up of #21436
**Testing plan:** Manually.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![help_center_link_left_margin](https://user-images.githubusercontent.com/41695888/159413624-4f93ad8a-6810-4e78-99c7-4b7a97e4e04f.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
