### PR TITLE
settings_users: Display error inside modal(deactivate user).

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -435,7 +435,7 @@ export function confirm_deactivation(user_id, handle_confirm, loading_spinner) {
     });
 }
 
-function handle_deactivation($tbody, $status_field) {
+function handle_deactivation($tbody) {
     $tbody.on("click", ".deactivate", (e) => {
         // This click event must not get propagated to parent container otherwise the modal
         // will not show up because of a call to `close_active_modal` in `settings.js`.
@@ -446,19 +446,20 @@ function handle_deactivation($tbody, $status_field) {
         const user_id = $row.data("user-id");
 
         function handle_confirm() {
-            const $row = get_user_info_row(user_id);
-            const $row_deactivate_button = $row.find("button.deactivate");
-            $row_deactivate_button.prop("disabled", true).text($t({defaultMessage: "Working…"}));
-            const opts = {
-                error_continuation() {
-                    $row_deactivate_button.text($t({defaultMessage: "Deactivate"}));
-                },
-            };
             const url = "/json/users/" + encodeURIComponent(user_id);
-            settings_ui.do_settings_change(channel.del, url, {}, $status_field, opts);
+            channel.del({
+                url,
+                success() {
+                    dialog_widget.close_modal();
+                },
+                error(xhr) {
+                    ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $("#dialog_error"));
+                    dialog_widget.hide_dialog_spinner();
+                },
+            });
         }
 
-        confirm_deactivation(user_id, handle_confirm, false);
+        confirm_deactivation(user_id, handle_confirm, true);
     });
 }
 
@@ -716,7 +717,7 @@ section.active.handle_events = () => {
     const $tbody = $("#admin_users_table").expectOne();
     const $status_field = $("#user-field-status").expectOne();
 
-    handle_deactivation($tbody, $status_field);
+    handle_deactivation($tbody);
     handle_reactivation($tbody, $status_field);
     handle_human_form($tbody, $status_field);
 };
@@ -725,7 +726,7 @@ section.deactivated.handle_events = () => {
     const $tbody = $("#admin_deactivated_users_table").expectOne();
     const $status_field = $("#deactivated-user-field-status").expectOne();
 
-    handle_deactivation($tbody, $status_field);
+    handle_deactivation($tbody);
     handle_reactivation($tbody, $status_field);
     handle_human_form($tbody, $status_field);
 };


### PR DESCRIPTION
Currently in settings while deactivating user if
error comes, error msg displays near the head of users
table and also deactivate button displays text
"working.." in a disabled state.

This commit will display the same error msg inside
confirmation modal, and loading spinner inside
the button is enabled, and also deactivate button
will remain in an unchanged state.

This PR is a follow-up of #21490

Note: Currently confirmation modal only pop-ups while
deactivating user, so thats why this commit changes
code only for `deactivate user`.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Manually.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<details>
<summary>Error in modal</summary>

![Peek 2022-03-22 19-55](https://user-images.githubusercontent.com/41695888/159517634-7c2343b5-ce81-4eb8-a84a-76ada0bc6e8b.gif)
</details>
<details>
<summary>Loading spinner</summary>

![loading_spinner](https://user-images.githubusercontent.com/41695888/159517620-0a2ffa7b-4c21-4c73-9abb-f3232b645a11.gif)
</details>
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
