### PR TITLE
help_docs: Update documentation about moving content.

### DIFF
--- a/templates/zerver/help/include/move-content-subset-options.md
+++ b/templates/zerver/help/include/move-content-subset-options.md
@@ -1,0 +1,8 @@
+  - **Change later messages to this topic**, which will move both
+    the selected message and all following messages.
+
+  - **Change only this message topic**, which will only move the
+    selected message.
+
+  - **Change previous and following messages to this topic**, which
+    will move all messages in the topic.

--- a/templates/zerver/help/move-content-to-another-stream.md
+++ b/templates/zerver/help/move-content-to-another-stream.md
@@ -10,6 +10,13 @@ message editing entirely. See the
 [guide to message and topic editing](/help/configure-message-editing-and-deletion)
 for the details on when topic editing is allowed.
 
+When moving content to another stream, you can toggle whether you want automated
+notification messages to be sent to the old  and/or new location of the content.
+These notifications let other users know how many messages were moved or whether
+the whole topic was moved, as well as who moved the messages. Additionally, they
+provide a link to the new and/or old location of the content, helping users follow
+these changes in ongoing topic conversations.
+
 ## Move a topic to another stream
 
 Organizations can configure which roles have permission to [move
@@ -26,12 +33,11 @@ destination streams.
 
 1. Select the destination stream for the topic from the streams dropdown list.
 
-1. (Optional) Change the topic.
+1. (optional) Change the topic.
 
-1. Select whether you want automated notification messages to be sent
-   to the old location for the topic, new location for the topic, or both.
+1. Toggle whether you want automated notification messages to be sent.
 
-1. Click **Move topic**.
+1. Click **Confirm**.
 
 
 !!! warn ""
@@ -47,8 +53,11 @@ destination streams.
 Organizations can configure which roles have permission to [move
 topics between streams][move-permission-setting].
 
-Roles that have permission can also move only a subset of messages
-from a topic to another stream.
+Roles that have permission can also move a subset of messages
+from a topic to another stream. The options for selecting which
+messages to move are:
+
+{!move-content-subset-options.md!}
 
 {start_tabs}
 
@@ -60,15 +69,11 @@ from a topic to another stream.
 
 1. Select the destination stream for the message from the streams dropdown list.
 
-1. (Optional) Change the topic.
+1. (optional) Change the topic.
 
-1. A dropdown with three options will appear to the right:
-**Change only this message topic**, **Change later messages to this topic**, and
-**Change previous and following messages to this topic**. Pick the appropriate
-option.
+1. Toggle whether you want automated notification messages to be sent.
 
-1. Select whether you want automated notification messages to be sent
-   to the old location for the topic, new location for the topic, or both.
+1. From the dropdown menu, select which messages to move.
 
 1. Click **Save**.
 

--- a/templates/zerver/help/move-content-to-another-topic.md
+++ b/templates/zerver/help/move-content-to-another-topic.md
@@ -10,7 +10,27 @@ message editing entirely. See the
 [guide to message and topic editing](/help/configure-message-editing-and-deletion)
 for the details on when topic editing is allowed.
 
-### Move a message to another topic
+## Change topic via the message recipient bar
+
+This will move all messages in a topic.
+
+{start_tabs}
+
+1. Click on the <i class="fa fa-pencil"></i> icon to edit the topic.
+
+1. Set the new topic.
+
+1. Click the **✔** to save your changes.
+
+{end_tabs}
+
+## Move a message to another topic
+
+When changing the topic of a single message, users can also choose to whether
+to move a subset, or all, of the messages in the topic. The options for
+selecting which messages to move are:
+
+{!move-content-subset-options.md!}
 
 {start_tabs}
 
@@ -20,14 +40,11 @@ for the details on when topic editing is allowed.
    or simply **Edit**. If it's called **View source**, then you are not
    allowed to edit the topic of that message.
 
-2. Set the destination topic.
+1. Set the destination topic.
 
-3. A dropdown with three options will appear to the right:
-**Change only this message topic**, **Change later messages to this topic**, and
-**Change previous and following messages to this topic**. Pick the appropriate
-option.
+1. From the dropdown menu, select which messages to move.
 
-4. Click **Save**.
+1. Click **Save**.
 
 {end_tabs}
 

--- a/templates/zerver/help/rename-a-topic.md
+++ b/templates/zerver/help/rename-a-topic.md
@@ -19,6 +19,20 @@ for the details on when topic editing is allowed.
 
 ## Rename a topic
 
+### Via the message recipient bar
+
+{start_tabs}
+
+1. Click on the <i class="fa fa-pencil"></i> icon to edit the topic.
+
+1. Edit the topic.
+
+1. Click the **✔** to save your changes.
+
+{end_tabs}
+
+### Via a message (alternate method)
+
 {start_tabs}
 
 {!message-actions-menu.md!}
@@ -29,8 +43,7 @@ for the details on when topic editing is allowed.
 
 1. Edit the topic.
 
-1. Pick **Change previous and following messages to this topic** from the
-   dropdown to the right.
+1. From the dropdown menu, select **Change previous and following messages to this topic**.
 
 1. Click **Save**.
 


### PR DESCRIPTION
Updates 3 help articles related to moving content in Zulip and adds 1 shared content file:

1. `rename-topic` : Adds section about using the message recipient bar and small instruction update to be consistent with other documentation pages.
2. `move-content-subset-options` : Shared description of the three options for which messages are moved when making a stream or topic change, used in both help articles listed below.
3. `move-content-to-another-stream` : Creates a paragraph about the automatic notifications in the intro text, adds text block that uses new shared doc above that goes over those options, clarifies and updates instructions throughout.
4. `move-content-to-another-topic` : Adds section about using the message recipient bar, adds text block that uses new shared doc above that goes over those options, clarifies and updates instructions throughout.

Related to #21316: audit of help center documentation for stream management and permissions updates for 5.0 release.
