### PR TITLE
help_docs: Update documentation about permissions.

### DIFF
--- a/templates/zerver/help/configure-who-can-create-streams.md
+++ b/templates/zerver/help/configure-who-can-create-streams.md
@@ -2,11 +2,19 @@
 
 {!admin-only.md!}
 
-Zulip allows you to separately control
-[permissions](/help/roles-and-permissions) for creating public and private
-streams. For corporations and other entities with controlled access, we highly
-recommend keeping stream creation open. Open organizations may choose to be less
-permissive, especially with public streams.
+Zulip allows you to separately control [permissions](/help/roles-and-permissions)
+for creating [web-public](/help/web-public-streams), public and private
+streams.
+
+For corporations and other organizations with controlled access, we
+recommend keeping stream creation open to make it easy for users to
+self-organize.
+
+Only users in trusted roles (moderators and administrators) can be
+given permission to create web-public streams. This is intended
+[to help manage abuse](/help/web-public-streams#managing-abuse) by
+making it hard for an attacker to host malicious content in an
+unadvertised web-public stream in a legitimate organization.
 
 ### Manage who can create streams
 
@@ -16,7 +24,7 @@ permissive, especially with public streams.
 
 {settings_tab|organization-permissions}
 
-2. Under **Stream permissions**, configure **Who can create public streams**.
+1. Under **Stream permissions**, configure **Who can create public streams**.
 
 {!save-changes.md!}
 
@@ -24,7 +32,15 @@ permissive, especially with public streams.
 
 {settings_tab|organization-permissions}
 
-2. Under **Stream permissions**, configure **Who can create private streams**.
+1. Under **Stream permissions**, configure **Who can create private streams**.
+
+{!save-changes.md!}
+
+{tab|web-public-streams}
+
+{settings_tab|organization-permissions}
+
+1. Under **Stream permissions**, configure **Who can create web-public streams**.
 
 {!save-changes.md!}
 

--- a/templates/zerver/help/restrict-permissions-of-new-members.md
+++ b/templates/zerver/help/restrict-permissions-of-new-members.md
@@ -2,7 +2,7 @@
 
 {!admin-only.md!}
 
-In large Zulips where
+In large Zulip organizations where
 [anyone can join](/help/allow-anyone-to-join-without-an-invitation), it can
 be useful to restrict what new members can do, to make it easier to cope
 with spammers and confused users.
@@ -12,24 +12,20 @@ past a certain **waiting period** threshold. After that they are **full members*
 You can configure how long the waiting period is, as well as which actions require
 being a full member.
 
-Currently, the following actions support limiting access to full members:
+Various actions support restricting access to full members, including
+[creating streams](/help/configure-who-can-create-streams),
+[inviting users to the organization](/help/invite-new-users),
+[adding custom emoji](/help/custom-emoji#change-who-can-add-custom-emoji),
+and many more.
 
-- [Creating streams](/help/configure-who-can-create-streams)
-- [Adding users to streams](/help/configure-who-can-invite-to-streams)
-- [Posting to a stream](/help/stream-sending-policy)
-- [Inviting users to the organization](/help/invite-new-users)
-- [Adding custom emoji](/help/custom-emoji#change-who-can-add-custom-emoji)
-- [Creating and modifying user groups][user-group-permissions]
-
-[user-group-permissions]: /help/user-groups#configure-who-can-create-and-manage-user-groups
-
-### Set waiting period for new members
+## Set waiting period for new members
 
 {start_tabs}
 
 {settings_tab|organization-permissions}
 
-2. Under **Joining the organization**, configure **Waiting period before new members turn into full members**.
+1. Under **Joining the organization**, configure
+   **Waiting period before new members turn into full members**.
 
 {!save-changes.md!}
 

--- a/templates/zerver/help/web-public-streams.md
+++ b/templates/zerver/help/web-public-streams.md
@@ -149,9 +149,9 @@ In order to protect Zulip organizations from
 bad actors, web-public streams have a few limitations designed to make
 Zulip an inconvenient target:
 
-* Only users in trusted roles like Moderators can be given permission
-  to create web-public streams. This is intended to make it hard for
-  an attacker to host malicious content in an unadvertised web-public
+* Only users in trusted roles (moderators and administrators) can be given
+  permission to create web-public streams. This is intended to make it hard
+  for an attacker to host malicious content in an unadvertised web-public
   stream in a legitimate organization.
 * There are rate limits for unauthenticated access to uploaded
   files, including viewing avatars and custom emoji.

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -76,6 +76,7 @@ TAB_SECTION_LABELS = {
     "instructions-for-all-platforms": "Instructions for all platforms",
     "public-streams": "Public streams",
     "private-streams": "Private streams",
+    "web-public-streams": "Web-public streams",
     "via-user-profile": "Via the user's profile",
     "via-organization-settings": "Via organization settings",
     "via-browser-address-bar": "Via browser's address bar",


### PR DESCRIPTION
Updates 2 help articles related to permissions in Zulip:

1. `configure-who-can-create-streams` : Adds tab for web-public streams in instructions, as well as some text about why this is limited to certain roles.

2. `restrict-permissions-of-new-members` : Removes list of actions that can be restricted to full members due to maintainability concerns for that type of list in the documentation and replaces it with a short descriptive text explaining that many settings in Zulip support this restriction.

Related to #21316: audit of help center documentation for stream management and permissions updates for 5.0 release.
