### PR TITLE
help_docs: Update documentation about notifications.

### DIFF
--- a/templates/zerver/help/desktop-notifications.md
+++ b/templates/zerver/help/desktop-notifications.md
@@ -6,9 +6,11 @@ customize whether [stream messages](/help/stream-notifications),
 [mentions](/help/pm-mention-alert-notifications#wildcard-mentions)
 trigger desktop notifications.
 
-## Change notification sound
+## Notification sound
 
 You can change the sound Zulip uses for audible desktop notifications.
+
+Alternatively, you can select **None** to completely disable audible desktop notifications in Zulip.
 
 ### Change notification sound
 
@@ -21,7 +23,26 @@ You can change the sound Zulip uses for audible desktop notifications.
 
 {end_tabs}
 
-You can select "None" to completely disable audible desktop notifications in Zulip.
+## Unread count badge
+
+By default, Zulip displays the unread message count in the
+browser tab and in the desktop sidebar.
+
+You can configure if all unread messages are counted, or if
+only unread private messages and mentions are counted.
+Alternatively, you can select **None** to completely disable
+the unread count badge.
+
+### Configure unread count badge
+
+{start_tabs}
+
+{settings_tab|notifications}
+
+1. Under **Desktop message notifications**, configure
+   **Unread count badge**.
+
+{end_tabs}
 
 ## Troubleshooting desktop notifications
 

--- a/templates/zerver/help/pm-mention-alert-notifications.md
+++ b/templates/zerver/help/pm-mention-alert-notifications.md
@@ -1,38 +1,44 @@
 # PMs, mentions, and alerts
 
 You can configure desktop, mobile, and email notifications for
-[private messages](/help/private-messages),
+[private messages (PMs)](/help/private-messages),
 [mentions](/help/mention-a-user-or-group), and [alert
 words](#alert-words).
+
+## Configure notifications
+
+These settings will affect notifications for private messages, group
+private messages, mentions, and alert words.
 
 {start_tabs}
 
 {settings_tab|notifications}
 
-1. Toggle the notification settings under **Private messages,
-   @-mentions, and alert words**.
+1. In the **Notification triggers** table, toggle the settings for **PMs, mentions, and alerts**.
 
 {end_tabs}
 
-These settings will affect notifications for private messages, group
-private messages, mentions, and alert words.
-
 You can also hide the content of private messages (and group private
 messages) from desktop notifications.
-Under **Other notification settings**, uncheck
+
+{start_tabs}
+
+1. Under **Desktop message notifications**, toggle
 **Include content of private messages in desktop notifications**.
+
+{end_tabs}
 
 ## Wildcard mentions
 
 By default, wildcard mentions (`@**all**`, `@**everyone**`) trigger
 email/push notifications as though they were personal @-mentions.  You
-can toggle whether you receive notifications for wildcard mentions:
+can toggle whether you receive notifications for wildcard mentions.
 
 {start_tabs}
 
 {settings_tab|notifications}
 
-1. Under **Streams**, toggle the **@all** checkbox.
+1.  In the **Notification triggers** table, toggle the **@all** checkbox for **Streams**.
 
 {end_tabs}
 


### PR DESCRIPTION
Updates 2 help articles related to notifications in Zulip:

1. `desktop-notifications` : Adds documentation for unread badge count to help article on desktop notifications.
2. `pm-mention-alert-notifications` : Generally, cleans up instructions and article structure with a focus on the **Notifications triggers** table in the settings modal.

