### PR TITLE
help_docs: Update various help docs for small changes.

### DIFF
--- a/templates/zerver/help/format-your-message-using-markdown.md
+++ b/templates/zerver/help/format-your-message-using-markdown.md
@@ -287,7 +287,7 @@ A summary of the formatting syntax is available in-app.
 
 {!start-composing.md!}
 
-1. Click help at the bottom of the compose box.
+1. Click <i class="fa fa-question"></i> at the bottom of the compose box.
 
 {end_tabs}
 

--- a/templates/zerver/help/restrict-wildcard-mentions.md
+++ b/templates/zerver/help/restrict-wildcard-mentions.md
@@ -21,7 +21,7 @@ receiving email and mobile push notifications.
 {settings_tab|organization-permissions}
 
 2. Under **Stream permissions**, configure
-   **Who can use wildcard mentions in large streams**.
+   **Who can use @all/@everyone mentions in large streams**.
 
 {!save-changes.md!}
 

--- a/templates/zerver/help/user-groups.md
+++ b/templates/zerver/help/user-groups.md
@@ -27,6 +27,10 @@ trying to send a message to a group of people, you'll want to either
 1. Add or remove users (including yourself). Click outside the box
    to save.  Zulip will notify everyone who is added or removed.
 
+!!! warn ""
+    **Note**: If you remove yourself from a user group, you
+    may no longer have permission to modify the user group.
+
 {end_tabs}
 
 ### Configure who can create and manage user groups

--- a/templates/zerver/help/web-public-streams.md
+++ b/templates/zerver/help/web-public-streams.md
@@ -163,7 +163,7 @@ these anti-abuse features.
 
 As a reminder, Zulip Cloud organizations are expected to
 [moderate content](/help/moderating-open-organizations) to ensure compliance
-with Zulip's Rules of Use.
+with [Zulip's Rules of Use](https://zulip.com/policies/rules).
 
 ## Caveats
 


### PR DESCRIPTION
Updates 4 help articles for small updates / changes:

1. `user-groups`: Adds warning for removing yourself from a user group.
2. `restrict-wildcard-mentions`: Updates for setting name in UI.
3. `format-your-message-with-markdown`: Changes for in-app help, which is now an icon.
4. `web-public-streams`: Adds link to Zulip's Rules of Use.
