### PR TITLE
puppet: Switch from ntp to chrony.

### DIFF
--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -29,7 +29,7 @@ class zulip::profile::base {
         # Used to read /etc/zulip/zulip.conf for `zulipconf` Puppet function
         'crudini',
         # Accurate time is essential
-        'ntp',
+        'chrony',
         # Used for tools like sponge
         'moreutils',
         # Nagios monitoring plugins
@@ -49,7 +49,7 @@ class zulip::profile::base {
         'curl',
         'jq',
         'crudini',
-        'ntp',
+        'chrony',
         'moreutils',
         'nmap-ncat',
         'nagios-plugins',  # there is no dummy package on CentOS 7
@@ -60,6 +60,7 @@ class zulip::profile::base {
       fail('osfamily not supported')
     }
   }
+  package { 'ntp': ensure => 'purged', before => Package['chrony'] }
   package { $base_packages: ensure => 'installed' }
 
   group { 'zulip':


### PR DESCRIPTION
Chrony is the recommended time server for Ubuntu since 18.04[1], and
is the default on Redhat; it is more accurate, and has lower-memory
usage, than ntp, which is only getting best-effort security
maintenance.

See:
- https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes#Chrony
- https://chrony.tuxfamily.org/comparison.html
- https://engineering.fb.com/2020/03/18/production-engineering/ntp-service/

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Test-applied on a host.  Verified that the time did not drift; cutover is at the red line on these graphs.
<img width="1602" alt="Screen Shot 2022-03-22 at 12 32 25 PM" src="https://user-images.githubusercontent.com/28347/159561026-58c3483e-682b-4e19-97e5-a492ed22f949.png">
