### PR TITLE
portico: Add web-public steams and emoji statuses to /for/X pages.

### DIFF
--- a/templates/zerver/for-business.html
+++ b/templates/zerver/for-business.html
@@ -144,6 +144,13 @@
                             clamoring for their attention.
                         </div>
                     </li>
+                    <li>
+                        <div class="list-content">
+                            Let others know whether you're around with <a
+                            href="/help/status-and-availability#statuses">emoji
+                            statuses</a> and <a href="/help/status-and-availability#availability">availability</a>.
+                        </div>
+                    </li>
                 </ul>
                 <div class="quote">
                     <blockquote>

--- a/templates/zerver/for-events.html
+++ b/templates/zerver/for-events.html
@@ -164,7 +164,15 @@
                             Make the Q&amp;A a permanent resource for participants.
                         </div>
                     </li>
-                    <li><div class="list-content"><a href="/help/link-to-a-message-or-conversation#link-to-zulip-from-anywhere">Link to a Zulip conversation</a> from emails, talk slides, or on the website for your event.</div></li>
+
+                    <li>
+                        <div class="list-content">
+                            <a href="/help/link-to-a-message-or-conversation#link-to-zulip-from-anywhere">Permanently link</a>
+                            to a Zulip conversation or a message in context
+                            from emails, talk slides, or on the website
+                            for your event.
+                        </div>
+                    </li>
                     <li><div class="list-content">Information is at your fingertips with Zulip’s <a href="/help/search-for-messages">powerful full-text search</a>.</div></li>
                     <li><div class="list-content"><a href="https://github.com/zulip/zulip-archive">Publish</a> discussions on the web, or move your data with our high quality <a href="/help/export-your-organization">export</a> and <a href="https://zulip.readthedocs.io/en/latest/production/export-and-import.html">import</a> tools.</div></li>
                     <li><div class="list-content">Zulip is <a href="https://github.com/zulip">100% free and open-source software</a>, so you are never locked into a proprietary tool.</div></li>

--- a/templates/zerver/for-open-source.html
+++ b/templates/zerver/for-open-source.html
@@ -120,16 +120,17 @@
                     </li>
                     <li>
                         <div class="list-content">
-                            With conversations organized by topic, you can
-                            review old discussions to understand past work,
-                            explanations, and decisions.
+                            With <a href="/help/web-public-streams">web-public
+                            streams</a>, anyone can view, browse, and
+                            search your organization's public content
+                            — no account required.
                         </div>
                     </li>
                     <li>
                         <div class="list-content">
-                            <a href="https://github.com/zulip/zulip-archive">Publish</a>
-                            discussions on the web, letting anyone find previous answers
-                            to common questions without making an account.
+                            Conversations are organized by topic, so you can
+                            review old discussions to understand past work,
+                            explanations, and decisions.
                         </div>
                     </li>
                     <li>

--- a/templates/zerver/for-research.html
+++ b/templates/zerver/for-research.html
@@ -128,9 +128,17 @@
                 <ul>
                     <li>
                         <div class="list-content">
-                            <a href="/help/link-to-a-message-or-conversation#link-to-zulip-from-anywhere">Link
-                            to a Zulip conversation</a> from emails,
-                            notes, talk slides, or anywhere else.
+                            <a href="/help/link-to-a-message-or-conversation#link-to-zulip-from-anywhere">Permanently link</a>
+                            to a Zulip conversation or a message in context
+                            from emails, notes, talk slides, or anywhere else.
+                        </div>
+                    </li>
+                    <li>
+                        <div class="list-content">
+                            With <a href="/help/web-public-streams">web-public
+                            streams</a>, anyone can view, browse, and
+                            search your organization's public content
+                            — no account required.
                         </div>
                     </li>
                     <li>
@@ -142,9 +150,18 @@
                             message history.
                         </div>
                     </li>
-                    <li><div class="list-content"><a href="https://github.com/zulip/zulip-archive">Publish</a> discussions on the web, or move your data with our high quality <a href="/help/export-your-organization">export</a> and <a href="https://zulip.readthedocs.io/en/latest/production/export-and-import.html">import</a> tools.</div></li>
-
-                    <li><div class="list-content">Zulip is <a href="https://github.com/zulip">100% free and open-source software</a>, so you are never locked into a proprietary tool.</div></li>
+                    <li>
+                        <div class="list-content">
+                            Zulip is <a href="https://github.com/zulip">100%
+                            free and open-source software</a>, so you are never
+                            locked into a proprietary tool.  You can move your
+                            data with our high quality <a
+                            href="/help/export-your-organization">export</a> and
+                            <a
+                              href="https://zulip.readthedocs.io/en/latest/production/export-and-import.html">import</a>
+                            tools.
+                        </div>
+                    </li>
                 </ul>
                 <blockquote class="twitter-tweet" data-conversation="none" data-dnt="true"><p lang="en" dir="ltr">+10 or maybe even 💯 for <a href="https://twitter.com/zulip?ref_src=twsrc%5Etfw">@zulip</a>. Was originally put onto it by <a href="https://twitter.com/five9a2?ref_src=twsrc%5Etfw">@five9a2</a> (thanks!). Have since used it at all levels - my research group (~10 ppl), my dept group (CS Theory, ~30 ppl), my research community (algebraic complexity), and small collaborations. All great!</p>&mdash; Joshua Grochow (@joshuagrochow) <a href="https://twitter.com/joshuagrochow/status/1383141209934163969?ref_src=twsrc%5Etfw">April 16, 2021</a></blockquote> <script async src="https://platform.twitter.com/widgets.js"></script>
             </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
manual

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
## Open source:
<img width="680" alt="Screen Shot 2022-03-22 at 4 37 15 PM" src="https://user-images.githubusercontent.com/2090066/159593601-38878769-2572-413f-95c7-eb645abbadf9.png">

## Research:
<img width="742" alt="Screen Shot 2022-03-22 at 4 36 07 PM" src="https://user-images.githubusercontent.com/2090066/159593633-970d42be-43bc-4d9d-825d-8bb6f1497f97.png">


## Business
<img width="669" alt="Screen Shot 2022-03-22 at 4 36 20 PM" src="https://user-images.githubusercontent.com/2090066/159593618-563673e0-79bf-4f93-b92d-590dc409f861.png">



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
