### PR TITLE
core_docs: Update translated language count and help center links.

### DIFF
--- a/templates/zerver/compare-education.html
+++ b/templates/zerver/compare-education.html
@@ -117,7 +117,7 @@
                     </tr>
                     <tr>
                         <td># supported languages</td>
-                        <td class="number">17</td>
+                        <td class="number">23</td>
                         <td class="number">13</td>
                         <td class="number">30</td>
                         <td class="number one">1</td>

--- a/templates/zerver/for-business.html
+++ b/templates/zerver/for-business.html
@@ -184,7 +184,7 @@
                     </li>
                     <li>
                         <div class="list-content">
-                            <a href="/help/link-to-a-message-or-conversation">Link
+                            <a href="/help/link-to-a-message-or-conversation#link-to-zulip-from-anywhere">Link
                             to a Zulip conversation</a> from emails,
                             docs, issue trackers, code comments, or anywhere else.
                         </div>
@@ -488,13 +488,13 @@
                     <li><div class="list-content">Zulip alerts you about timely messages with <a href="/help/stream-notifications">fully customizable</a> mobile, email and desktop notifications.</div></li>
                     <li>
                         <div class="list-content">
-                            Mention <a href="/help/mention-a-user-or-group">users</a>, <a href="/help/mention-a-user-or-group#mention-a-user-or-group">groups
+                            Mention <a href="/help/mention-a-user-or-group">users</a>, <a href="/help/user-groups">groups
                             of users</a>
                             or <a href="/help/pm-mention-alert-notifications#wildcard-mentions">everyone</a>
                             when you need their attention.
                         </div>
                     </li>
-                    <li><div class="list-content">Use Zulip in your language of choice, with translations into <a href="https://www.transifex.com/zulip/zulip/">17 languages</a>.</div></li>
+                    <li><div class="list-content">Use Zulip in your language of choice, with translations into <a href="https://www.transifex.com/zulip/zulip/">23 languages</a>.</div></li>
                 </ul>
                 <blockquote class="twitter-tweet" data-conversation="none" data-dnt="true" data-cards="hidden"><p lang="en" dir="ltr">New version of Zulip ! <a href="https://t.co/6AjXkUSzLd">https://t.co/6AjXkUSzLd</a> <br /><br />Zulip is the only nice project chat I ever used. Discord, slack, etc wasted my productivity for years, zulip actually increases it.</p>&mdash; Bite Cꙮde (@bitecode_dev) <a href="https://twitter.com/bitecode_dev/status/1393111310750076930?ref_src=twsrc%5Etfw">May 14, 2021</a></blockquote> <script async src="https://platform.twitter.com/widgets.js"></script>
             </div>

--- a/templates/zerver/for-education.html
+++ b/templates/zerver/for-education.html
@@ -225,10 +225,10 @@
                         </div>
                     </li>
                     <li>
-                        <div class="list-content">Mention <a href="/help/mention-a-user-or-group">users</a>, <a href="/help/mention-a-user-or-group#mention-a-user-or-group">groups of users</a> or <a href="/help/pm-mention-alert-notifications#wildcard-mentions">everyone</a> when you need their attention.</div>
+                        <div class="list-content">Mention <a href="/help/mention-a-user-or-group">users</a>, <a href="/help/user-groups">groups of users</a> or <a href="/help/pm-mention-alert-notifications#wildcard-mentions">everyone</a> when you need their attention.</div>
                     </li>
                     <li>
-                        <div class="list-content">Use Zulip in your language of choice, with translations into <a href="https://www.transifex.com/zulip/zulip/">17 languages</a>.</div>
+                        <div class="list-content">Use Zulip in your language of choice, with translations into <a href="https://www.transifex.com/zulip/zulip/">23 languages</a>.</div>
                     </li>
                     <li>
                         <div class="list-content">Zulip works reliably for organizations with thousands of users online at once.</div>

--- a/templates/zerver/for-events.html
+++ b/templates/zerver/for-events.html
@@ -63,8 +63,8 @@
                     </li>
                     <li>
                         <div class="list-content">
-                            Make your event more inclusive by lowering the bar
-                            to ask a question, share ideas, and learn from experts.
+                            Make your event more inclusive by lowering the barriers
+                            for participants to ask questions, share ideas, and learn from experts.
                         </div>
                     </li>
                     <li>
@@ -129,7 +129,7 @@
                         <div class="list-content">Make a <a href="/help/start-a-call">video call</a> with the click of a button.</div>
                     </li>
                     <li>
-                        <div class="list-content">Use Zulip in your language of choice, with translations into <a href="https://www.transifex.com/zulip/zulip/">17 languages</a>.</div>
+                        <div class="list-content">Use Zulip in your language of choice, with translations into <a href="https://www.transifex.com/zulip/zulip/">23 languages</a>.</div>
                     </li>
                 </ul>
             </div>
@@ -164,7 +164,7 @@
                             Make the Q&amp;A a permanent resource for participants.
                         </div>
                     </li>
-                    <li><div class="list-content"><a href="/help/link-to-a-message-or-conversation">Link to a Zulip conversation</a> from emails, talk slides, or on the website for your event.</div></li>
+                    <li><div class="list-content"><a href="/help/link-to-a-message-or-conversation#link-to-zulip-from-anywhere">Link to a Zulip conversation</a> from emails, talk slides, or on the website for your event.</div></li>
                     <li><div class="list-content">Information is at your fingertips with Zulip’s <a href="/help/search-for-messages">powerful full-text search</a>.</div></li>
                     <li><div class="list-content"><a href="https://github.com/zulip/zulip-archive">Publish</a> discussions on the web, or move your data with our high quality <a href="/help/export-your-organization">export</a> and <a href="https://zulip.readthedocs.io/en/latest/production/export-and-import.html">import</a> tools.</div></li>
                     <li><div class="list-content">Zulip is <a href="https://github.com/zulip">100% free and open-source software</a>, so you are never locked into a proprietary tool.</div></li>
@@ -250,7 +250,7 @@
                         </div>
                     </li>
                     <li><div class="list-content">Zulip alerts participants about timely messages with <a href="/help/stream-notifications">fully customizable</a> mobile, email and desktop notifications.</div></li>
-                    <li><div class="list-content">Mention <a href="/help/mention-a-user-or-group">users</a>, <a href="/help/mention-a-user-or-group#mention-a-user-or-group">groups of users</a> or <a href="/help/pm-mention-alert-notifications#wildcard-mentions">everyone</a> when you need their attention.</div></li>
+                    <li><div class="list-content">Mention <a href="/help/mention-a-user-or-group">users</a>, <a href="/help/user-groups">groups of users</a> or <a href="/help/pm-mention-alert-notifications#wildcard-mentions">everyone</a> when you need their attention.</div></li>
                     <li>
                         <div class="list-content">
                             Zulip works reliably for organizations

--- a/templates/zerver/for-open-source.html
+++ b/templates/zerver/for-open-source.html
@@ -76,7 +76,7 @@
                     <li>
                         <div class="list-content">
                             Find active conversations, or see what happened while you were away,
-                            with the <a href="/help/reading-strategies#recent-topics">Recent Topics</a>
+                            with the <a href="/help/recent-topics">Recent Topics</a>
                             view. Read the topics you care about, and skip the rest.
                         </div>
                     </li>
@@ -113,9 +113,8 @@
                 <ul>
                     <li>
                         <div class="list-content">
-                            Permanently link to a
-                            <a href="/help/link-to-a-message-or-conversation">
-                            Zulip conversation</a> or a <a href="/help/link-to-a-message-or-conversation#link-to-a-specific-message">message in context</a>
+                            <a href="/help/link-to-a-message-or-conversation#link-to-zulip-from-anywhere">Permanently link</a>
+                            to a Zulip conversation or a message in context
                             from your issue tracker, forum, or anywhere else.
                         </div>
                     </li>
@@ -188,7 +187,7 @@
                     </li>
                     <li>
                         <div class="list-content">
-                            Part-time participants <a href="/help/reading-strategies#recent-topics">
+                            Part-time participants <a href="/help/finding-a-topic-to-read">
                             quickly zero in</a> on the conversations they care
                             about. This is not possible with other chat tools
                             like Slack or Discord.
@@ -575,7 +574,7 @@
                     <li><div class="list-content">Zulip alerts you about timely messages with <a href="/help/stream-notifications">fully customizable</a> mobile, email and desktop notifications.</div></li>
                     <li>
                         <div class="list-content">
-                            Mention <a href="/help/mention-a-user-or-group">users</a>, <a href="/help/mention-a-user-or-group#mention-a-user-or-group">groups
+                            Mention <a href="/help/mention-a-user-or-group">users</a>, <a href="/help/user-groups">groups
                             of users</a>
                             or <a href="/help/pm-mention-alert-notifications#wildcard-mentions">everyone</a>
                             when you need their attention.
@@ -584,7 +583,7 @@
                     <li>
                         <div class="list-content">
                             Use Zulip in your language of choice, with translations into
-                            <a href="https://www.transifex.com/zulip/zulip/">17 languages</a>.
+                            <a href="https://www.transifex.com/zulip/zulip/">23 languages</a>.
                         </div>
                     </li>
                     <li>

--- a/templates/zerver/for-research.html
+++ b/templates/zerver/for-research.html
@@ -69,7 +69,7 @@
                     <li>
                         <div class="list-content">
                             Find active conversations, or see what happened while you were away,
-                            with the <a href="/help/reading-strategies#recent-topics">Recent Topics</a> view.
+                            with the <a href="/help/recent-topics">Recent Topics</a> view.
                         </div>
                     </li>
                     <li>
@@ -128,7 +128,7 @@
                 <ul>
                     <li>
                         <div class="list-content">
-                            <a href="/help/link-to-a-message-or-conversation">Link
+                            <a href="/help/link-to-a-message-or-conversation#link-to-zulip-from-anywhere">Link
                             to a Zulip conversation</a> from emails,
                             notes, talk slides, or anywhere else.
                         </div>
@@ -320,13 +320,13 @@
                     <li><div class="list-content">Zulip alerts you about timely messages with <a href="/help/stream-notifications">fully customizable</a> mobile, email and desktop notifications.</div></li>
                     <li>
                         <div class="list-content">
-                            Mention <a href="/help/mention-a-user-or-group">users</a>, <a href="/help/mention-a-user-or-group#mention-a-user-or-group">groups
+                            Mention <a href="/help/mention-a-user-or-group">users</a>, <a href="/help/user-groups">groups
                             of users</a>
                             or <a href="/help/pm-mention-alert-notifications#wildcard-mentions">everyone</a>
                             when you need their attention.
                         </div>
                     </li>
-                    <li><div class="list-content">Use Zulip in your language of choice, with translations into <a href="https://www.transifex.com/zulip/zulip/">17 languages</a>.</div></li>
+                    <li><div class="list-content">Use Zulip in your language of choice, with translations into <a href="https://www.transifex.com/zulip/zulip/">23 languages</a>.</div></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Makes some small updates to the core website pages:

1. Updates `/for/` pages for the new translated language count, 23.
2. Also, updates any links to help center documentation that have been changed.
3. Finally, updates `/for/events` text for a potentially confusing English idiom.