### PR TITLE
narrow: Fix messages being cached without flags set.

### DIFF
--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -29,6 +29,8 @@ const message_store = mock_esm("../../static/js/message_store", {
     get: () => ({failed_request: true}),
 
     update_booleans: () => {},
+
+    set_message_booleans: () => {},
 });
 
 mock_esm("../../static/js/message_list");

--- a/frontend_tests/node_tests/example2.js
+++ b/frontend_tests/node_tests/example2.js
@@ -64,14 +64,13 @@ run_test("message_store", () => {
     const in_message = {...messages.isaac_to_denmark_stream};
 
     assert.equal(in_message.alerted, undefined);
-    message_store.set_message_booleans(in_message);
-    assert.equal(in_message.alerted, true);
 
     // Let's add a message into our message_store via
     // message_helper.process_new_message.
     assert.equal(message_store.get(in_message.id), undefined);
     message_helper.process_new_message(in_message);
     const message = message_store.get(in_message.id);
+    assert.equal(in_message.alerted, true);
     assert.equal(message, in_message);
 
     // There are more side effects.

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -268,18 +268,15 @@ test("marked_shared", () => {
 test("message_flags", () => {
     let message = {raw_content: "@**Leo**"};
     markdown.apply_markdown(message);
-    assert.ok(!message.mentioned);
-    assert.ok(!message.mentioned_me_directly);
+    assert.ok(!message.flags.includes("mentioned"));
 
     message = {raw_content: "@**Cordelia, Lear's daughter**"};
     markdown.apply_markdown(message);
-    assert.ok(message.mentioned);
-    assert.ok(message.mentioned_me_directly);
+    assert.ok(message.flags.includes("mentioned"));
 
     message = {raw_content: "@**all**"};
     markdown.apply_markdown(message);
-    assert.ok(message.mentioned);
-    assert.ok(!message.mentioned_me_directly);
+    assert.ok(message.flags.includes("wildcard_mentioned"));
 });
 
 test("marked", () => {
@@ -680,77 +677,87 @@ test("message_flags", () => {
     markdown.apply_markdown(message);
 
     assert.equal(message.is_me_message, false);
-    assert.equal(message.mentioned, true);
-    assert.equal(message.mentioned_me_directly, true);
-
+    assert.equal(message.flags.includes("mentioned"), true);
+    assert.equal(message.flags.includes("wildcard_mentioned"), true);
     input = "test @**everyone**";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
     assert.equal(message.is_me_message, false);
-    assert.equal(message.mentioned, true);
-    assert.equal(message.mentioned_me_directly, false);
+    assert.equal(message.flags.includes("wildcard_mentioned"), true);
+    assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @**stream**";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
     assert.equal(message.is_me_message, false);
-    assert.equal(message.mentioned, true);
-    assert.equal(message.mentioned_me_directly, false);
+    assert.equal(message.flags.includes("wildcard_mentioned"), true);
+    assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @all";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
-    assert.equal(message.mentioned, false);
+    assert.equal(message.flags.includes("wildcard_mentioned"), false);
+    assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @everyone";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
-    assert.equal(message.mentioned, false);
+    assert.equal(message.flags.includes("wildcard_mentioned"), false);
+    assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @any";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
-    assert.equal(message.mentioned, false);
+    assert.equal(message.flags.includes("wildcard_mentioned"), false);
+    assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @alleycat.com";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
-    assert.equal(message.mentioned, false);
+    assert.equal(message.flags.includes("wildcard_mentioned"), false);
+    assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @*hamletcharacters*";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
-    assert.equal(message.mentioned, true);
+    assert.equal(message.flags.includes("wildcard_mentioned"), false);
+    assert.equal(message.flags.includes("mentioned"), true);
 
     input = "test @*backend*";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
-    assert.equal(message.mentioned, false);
+    assert.equal(message.flags.includes("wildcard_mentioned"), false);
+    assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @**invalid_user**";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
-    assert.equal(message.mentioned, false);
+    assert.equal(message.flags.includes("wildcard_mentioned"), false);
+    assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @_**all**";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
-    assert.equal(message.mentioned, false);
+    assert.equal(message.flags.includes("wildcard_mentioned"), false);
+    assert.equal(message.flags.includes("mentioned"), false);
 
     input = "> test @**all**";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
-    assert.equal(message.mentioned, false);
+    assert.equal(message.flags.includes("wildcard_mentioned"), false);
+    assert.equal(message.flags.includes("mentioned"), false);
 
     input = "test @_*hamletcharacters*";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
-    assert.equal(message.mentioned, false);
+    assert.equal(message.flags.includes("wildcard_mentioned"), false);
+    assert.equal(message.flags.includes("mentioned"), false);
 
     input = "> test @*hamletcharacters*";
     message = {topic: "No links here", raw_content: input};
     markdown.apply_markdown(message);
-    assert.equal(message.mentioned, false);
+    assert.equal(message.flags.includes("wildcard_mentioned"), false);
+    assert.equal(message.flags.includes("mentioned"), false);
 });
 
 test("backend_only_linkifiers", () => {

--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -20,7 +20,6 @@ message_lists.current = {};
 const people = zrequire("people");
 const message_events = zrequire("message_events");
 const message_helper = zrequire("message_helper");
-const message_store = zrequire("message_store");
 const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const unread = zrequire("unread");
@@ -70,7 +69,6 @@ run_test("update_messages", () => {
     };
 
     message_helper.process_new_message(original_message);
-    message_store.set_message_booleans(original_message);
 
     assert.equal(original_message.mentioned, true);
     assert.equal(original_message.unread, true);

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -31,7 +31,6 @@ mock_esm("../../static/js/ui_report", {
 const channel = mock_esm("../../static/js/channel");
 const message_helper = mock_esm("../../static/js/message_helper");
 const message_lists = mock_esm("../../static/js/message_lists");
-const message_store = mock_esm("../../static/js/message_store");
 const message_util = mock_esm("../../static/js/message_util");
 const pm_list = mock_esm("../../static/js/pm_list");
 const stream_list = mock_esm("../../static/js/stream_list", {
@@ -119,13 +118,12 @@ function config_fake_channel(conf) {
 function config_process_results(messages) {
     const self = {};
 
-    const messages_processed_for_bools = [];
+    const messages_processed_for_new = [];
 
-    message_store.set_message_booleans = (message) => {
-        messages_processed_for_bools.push(message);
+    message_helper.process_new_message = (message) => {
+        messages_processed_for_new.push(message);
+        return message;
     };
-
-    message_helper.process_new_message = (message) => message;
 
     message_util.do_unread_count_updates = (arg) => {
         assert.deepEqual(arg, messages);
@@ -141,7 +139,7 @@ function config_process_results(messages) {
     pm_list.update_private_messages = noop;
 
     self.verify = () => {
-        assert.deepEqual(messages_processed_for_bools, messages);
+        assert.deepEqual(messages_processed_for_new, messages);
     };
 
     return self;

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -110,7 +110,6 @@ test("process_new_message", () => {
         is_me_message: false,
         id: 2067,
     };
-    message_store.set_message_booleans(message);
     message_helper.process_new_message(message);
 
     assert.deepEqual(message_user_ids.user_ids().sort(), [me.user_id, bob.user_id, cindy.user_id]);
@@ -153,7 +152,6 @@ test("process_new_message", () => {
         id: 2068,
     };
 
-    message_store.set_message_booleans(message);
     message_helper.process_new_message(message);
     assert.deepEqual(message.stream, message.display_recipient);
     assert.equal(message.reply_to, "denise@example.com");
@@ -307,7 +305,6 @@ test("update_property", () => {
         id: 101,
     };
     for (const message of [message1, message2]) {
-        message_store.set_message_booleans(message);
         message_helper.process_new_message(message);
     }
 

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -193,7 +193,6 @@ export function insert_local_message(message_request, local_id_float) {
 
     message.display_recipient = build_display_recipient(message);
 
-    message_store.set_message_booleans(message);
     insert_message(message);
     return message;
 }

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -178,25 +178,6 @@ export function insert_local_message(message_request, local_id_float) {
     // NOTE: This will parse synchronously. We're not using the async pipeline
     markdown.apply_markdown(message);
 
-    // TODO: markdown.apply_markdown has a messy interface around
-    // message flags. It mutates the message to set all the message
-    // booleans to false via message_store.init_booleans, and then
-    // proceeds to mutate primarily the mentioned flag during
-    // rendering in a messy way.
-    //
-    // We should clean that up to instead just mutate the flags list
-    // on the message, to match how the Zulip API returns this
-    // information via flags. For now, we translate back to the flags
-    // namespace here, and then message_store.set_message_booleans
-    // will get us to the correct final flags.
-    //
-    // Locally delivered messages cannot be unread (since we sent
-    // them), nor can they alert the user.
-    message.flags = ["read"];
-    if (message.mentioned) {
-        message.flags.push("mentioned");
-    }
-
     message.content_type = "text/html";
     message.sender_email = people.my_current_email();
     message.sender_full_name = people.my_full_name();

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -64,11 +64,13 @@ function maybe_add_narrowed_messages(messages, msg_list, callback) {
             }
 
             // This second call to process_new_message in the
-            // insert_new_messages code path helps in very rare race
+            // insert_new_messages code path is designed to replace
+            // our slightly stale message object with the latest copy
+            // from the message_store. This helps in very rare race
             // conditions, where e.g. the current user's name was
             // edited in between when they sent the message and when
             // we hear back from the server and can echo the new
-            // message.  Arguably, it's counterproductive complexity.
+            // message.
             new_messages = new_messages.map((message) =>
                 message_helper.process_new_message(message),
             );

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -8,7 +8,6 @@ import * as message_helper from "./message_helper";
 import * as message_list from "./message_list";
 import * as message_lists from "./message_lists";
 import * as message_scroll from "./message_scroll";
-import * as message_store from "./message_store";
 import * as message_util from "./message_util";
 import * as narrow_banner from "./narrow_banner";
 import {page_params} from "./page_params";
@@ -50,10 +49,7 @@ function process_result(data, opts) {
         narrow_banner.show_empty_narrow_message();
     }
 
-    messages = messages.map((message) => {
-        message_store.set_message_booleans(message);
-        return message_helper.process_new_message(message);
-    });
+    messages = messages.map((message) => message_helper.process_new_message(message));
 
     // In case any of the newly fetched messages are new, add them to
     // our unread data structures.  It's important that this run even

--- a/static/js/message_helper.js
+++ b/static/js/message_helper.js
@@ -23,6 +23,7 @@ export function process_new_message(message) {
         return cached_msg;
     }
 
+    message_store.set_message_booleans(message);
     message.sent_by_me = people.is_current_user(message.sender_email);
 
     people.extract_people_from_message(message);

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -79,20 +79,6 @@ export function set_message_booleans(message) {
     delete message.flags;
 }
 
-export function init_booleans(message) {
-    // This initializes booleans for the local-echo path where
-    // we don't have flags from the server yet.  (We want to
-    // explicitly set flags to false to be consistent with other
-    // codepaths.)
-    message.unread = false;
-    message.historical = false;
-    message.starred = false;
-    message.mentioned = false;
-    message.mentioned_me_directly = false;
-    message.collapsed = false;
-    message.alerted = false;
-}
-
 export function update_booleans(message, flags) {
     // When we get server flags for local echo or message edits,
     // we are vulnerable to race conditions, so only update flags

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -6,7 +6,6 @@ import * as channel from "./channel";
 import * as echo from "./echo";
 import * as message_events from "./message_events";
 import * as message_lists from "./message_lists";
-import * as message_store from "./message_store";
 import {page_params} from "./page_params";
 import * as reload from "./reload";
 import * as reload_state from "./reload_state";
@@ -110,10 +109,6 @@ function get_events_success(events) {
         try {
             messages = echo.process_from_server(messages);
             if (messages.length > 0) {
-                for (const message of messages) {
-                    message_store.set_message_booleans(message);
-                }
-
                 const sent_by_this_client = messages.some((msg) =>
                     sent_messages.messages.has(msg.local_id),
                 );


### PR DESCRIPTION
f0c680e9c0d1a62fd414bccc82e4ac255173aaa9 introduced a call to
message_helper.process_new_message without first calling
message_store.set_message_flags on the message.

This resulted in it being possible as a race, when loading the Zulip
app to a stream/topic/near narrow, for a message to have the
`historical` flag be undefined due to not being initialized.

That invalid state, in turn, resulted in the message_list_view code
path for rendering the message feed incorrectly displaying additional
recipient bars around the message.

Fix this by refactoring the interface to include set_message_booleans
in what message_helper.process_new_message is responsible for doing.

This makes an apparent change in one other code path,
maybe_add_narrow_messages, which could theoretically reintroduce the
double set_message_flags bugs detailed in
9729b1a4ad51b69c98ce4f8374c9d9f8cf69430c.

However, I believe that to not be possible, because that call should
never experience a cache miss.

Because I found the existing comment at that call site confusing and
almost proposed removing it as pointless, I extend the block comment
to explicitly mention that the purpose is refreshing our object.

Fixes #21503.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
