### PR TITLE
realign status emoji displayed next to user names

### DIFF
--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -137,6 +137,7 @@
 
     &.user-with-count .unread_count {
         display: block;
+        margin-left: 4px;
     }
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2485,11 +2485,11 @@ div.topic_edit_spinner .loading_indicator_spinner {
     emoji's width decreases and causes it to break. */
     min-width: 16px;
     /* In most contexts, status emoji appear immediately after a name
-      field with no margin. Position the status emoji with 2px of left
+      field with no margin. Position the status emoji with 3px of left
       margin to space it from the name, and set no right margin so
       that any components to the right appear equally distant as they
       would be from a name. */
-    margin-left: 2px;
+    margin-left: 3px;
     margin-right: 0;
 }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR grabs the more easily manageable changes from #21050 which were meant to just realign the status emoji that were added via that PR.

Notice that Prospero's name is truncated even though Prospero does not have a status emoji.

**Testing plan:** <!-- How have you tested? -->
CSS changes, only tested by looking and screenshots.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![](https://user-images.githubusercontent.com/33805964/159847387-c6f9c089-afb4-4294-9d2e-6eb8f70dd568.png)
![](https://user-images.githubusercontent.com/33805964/159847394-c86f53c0-3f81-476b-9ef4-704bb843a3fd.png)

Full screen after:
![](https://user-images.githubusercontent.com/33805964/159848072-b47007c3-8eeb-4a17-8b26-0813ae331bb3.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
