### PR TITLE
stream : Added a Function to Fixs the subs viewing bug

### DIFF
--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -70,6 +70,23 @@ export function update_toggler_for_sub(sub) {
         }
         stream_edit.toggler.disable_tab("personal_settings");
     }
+    update_toggler_for_sub_private_settings(sub);
+}
+
+export function update_toggler_for_sub_private_settings(sub) {
+    if (!hash_util.is_editing_stream(sub.stream_id)) {
+        return;
+    }
+    if (sub.invite_only) {
+        if (sub.subscribed) {
+            stream_edit.toggler.enable_tab("subscriber_settings");
+        }
+        if (!sub.subscribed) {
+            stream_edit.toggler.disable_tab("subscriber_settings");
+        }
+    } else {
+        return;
+    }
 }
 
 export function update_settings_button_for_sub(sub) {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is Fixing for Issue #20916 ,
this function disables the view subscriber tabs for those not subscribed in a private stream

**Testing plan:** <!-- How have you tested? --> this is done in the video below

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  --> 

https://user-images.githubusercontent.com/89680252/159174574-3de8beb6-5e9b-4634-b05b-5df0d8b79b44.mp4


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
