### PR TITLE
stream : Added a Function to Fix the subs viewing bug 

### DIFF
--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -70,8 +70,19 @@ export function update_toggler_for_sub(sub) {
         }
         stream_edit.toggler.disable_tab("personal_settings");
     }
+    enable_or_disable_subscribers_tab(sub);
 }
 
+export function enable_or_disable_subscribers_tab(sub) {
+    if (sub.invite_only) {
+        if (sub.subscribed) {
+            stream_edit.toggler.enable_tab("subscriber_settings");
+        }
+        if (!sub.subscribed) {
+            stream_edit.toggler.disable_tab("subscriber_settings");
+        }
+    }
+}
 export function update_settings_button_for_sub(sub) {
     // This is for the Subscribe/Unsubscribe button in the right panel.
     const $settings_button = stream_settings_ui.settings_button_for_sub(sub);


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes : #20916
A bug in the stream_ui_updates.js resulted in non-subscribers to
view the subscribers in a private streams in streams menu.

this function disables the view subscriber tabs for those not subscribed in a private stream

**Testing plan:** <!-- How have you tested? --> this is done in the video below

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  --> 

https://user-images.githubusercontent.com/89680252/162411913-df2de309-a56d-4c92-a324-e28804eca816.mp4

DARK MODE
![image](https://user-images.githubusercontent.com/89680252/162503181-4fb56e35-bfd5-4da2-8887-05205ec973e7.png)
![image](https://user-images.githubusercontent.com/89680252/162503185-0a29b600-775a-4499-877d-dba3a3e95246.png)

LIGHT MODE
 ![image](https://user-images.githubusercontent.com/89680252/162503191-e95799a3-f8a9-4f20-ab4b-d0c49d4bab84.png)
![image](https://user-images.githubusercontent.com/89680252/162503195-a598c834-1baf-4895-b01f-be3d72952d2a.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
