### PR TITLE
Youtube play icon centering quick fix

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -335,7 +335,7 @@ export function initialize_kitchen_sink_stuff() {
     }
 
     $("#main_div").on("mouseenter", ".youtube-video a", function () {
-        $(this).addClass("fa fa-play");
+        handle_video_preview_mouseenter($(this));
     });
 
     $("#main_div").on("mouseleave", ".youtube-video a", function () {

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -317,16 +317,7 @@ export function initialize_kitchen_sink_stuff() {
         $row.removeClass("sender_name_hovered");
     });
 
-    $("#main_div").on("mouseenter", ".youtube-video a", function () {
-        $(this).addClass("fa fa-play");
-    });
-
-    $("#main_div").on("mouseleave", ".youtube-video a", function () {
-        $(this).removeClass("fa fa-play");
-    });
-
-    $("#main_div").on("mouseenter", ".embed-video a", function () {
-        const $elem = $(this);
+    function handle_video_preview_mouseenter($elem) {
         // Set image height and css vars for play button position, if not done already
         const setPosition = !$elem.data("entered-before");
         if (setPosition) {
@@ -341,6 +332,18 @@ export function initialize_kitchen_sink_stuff() {
             $elem.data("entered-before", true);
         }
         $elem.addClass("fa fa-play");
+    }
+
+    $("#main_div").on("mouseenter", ".youtube-video a", function () {
+        $(this).addClass("fa fa-play");
+    });
+
+    $("#main_div").on("mouseleave", ".youtube-video a", function () {
+        $(this).removeClass("fa fa-play");
+    });
+
+    $("#main_div").on("mouseenter", ".embed-video a", function () {
+        handle_video_preview_mouseenter($(this));
     });
 
     $("#main_div").on("mouseleave", ".embed-video a", function () {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This resolves the bug reported at https://chat.zulip.org/#narrow/stream/9-issues/topic/play.20icon.20not.20centered.

**Testing plan:** <!-- How have you tested? -->
lint and manual testing (gifs).

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![](https://user-images.githubusercontent.com/33805964/159924518-057405f0-844b-421a-bcab-133d8fcc6bbc.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
