### PR TITLE
help_docs: Update image viewer documentation for changes.

### DIFF
--- a/templates/zerver/help/view-and-browse-images.md
+++ b/templates/zerver/help/view-and-browse-images.md
@@ -5,10 +5,17 @@ preview. Click on the image preview to open the **image viewer**.
 
 In the image viewer, you can:
 
-* View the image at **full size**
+* Zoom in and out of the image
+
+* Click and drag the image
+
+* **Reset zoom** so that the image is recentered and its original size
+
+* **Open** the image in a new browser tab
+
 * **Download** the image
-* **Pan and zoom**
-* **Browse other images** in the current view. For example, if you're in a
+
+* Browse other images in the current view. For example, if you're in a
   stream view, the image browser will show all the images from that stream. If
   you do a [search](/help/search-for-messages), the image browser will show
   all images in messages that matched that search.
@@ -17,8 +24,9 @@ Exit the image viewer by clicking anywhere outside the image.
 
 !!! keyboard_tip ""
 
-    Use `v` to **open** the image viewer. Use `Z` and `z`
-    zoom in and out of the image. Use `v` or `Esc` to **close**.
+    Use `v` to **open** the image viewer. Use `Z` and `z` to
+    zoom in and out of the image. Use `v` or `Esc` to **close**
+    the image viewer.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Updates the list of actions and buttons referenced in the help center documentation for viewing images with lightbox image viewer. Also, makes some minor corrections to the keyboard shortcut note.

Fixes #21527.

**Screenshot of updated help center documentation**:
![Screenshot from 2022-03-24 14-32-11](https://user-images.githubusercontent.com/63245456/159927205-5c3aaa15-b111-4d6f-842b-d47a090405e9.png)
