### PR TITLE
Handle video preview icon positioning through css.

### DIFF
--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -76,6 +76,8 @@ const $array = (array) => {
 
 const get_content_element = () => {
     const $content = $.create("content-stub");
+    $content.set_find_results(".youtube-video a", $array([]));
+    $content.set_find_results(".embed-video a", $array([]));
     $content.set_find_results(".user-mention", $array([]));
     $content.set_find_results(".user-group-mention", $array([]));
     $content.set_find_results("a.stream", $array([]));
@@ -337,6 +339,26 @@ run_test("emoji", () => {
 
     // Set page parameters back so that test run order is independent
     user_settings.emojiset = "apple";
+});
+
+run_test("youtube_previews", () => {
+    const $content = get_content_element();
+    const $youtube_preview = $.create("youtube_preview-stub");
+    $youtube_preview.length = 1;
+    assert.ok(!$youtube_preview.hasClass("fa fa-play"));
+    $content.set_find_results(".youtube-video a", $youtube_preview);
+    rm.update_elements($content);
+    assert.ok($youtube_preview.hasClass("fa fa-play"));
+});
+
+run_test("embed_video_previews", () => {
+    const $content = get_content_element();
+    const $embed_video_preview = $.create("embed_video_preview-stub");
+    $embed_video_preview.length = 1;
+    assert.ok(!$embed_video_preview.hasClass("fa fa-play"));
+    $content.set_find_results(".embed-video a", $embed_video_preview);
+    rm.update_elements($content);
+    assert.ok($embed_video_preview.hasClass("fa fa-play"));
 });
 
 run_test("spoiler-header", () => {

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -242,4 +242,17 @@ export const update_elements = ($content) => {
             return ":" + text + ":";
         });
     }
+
+    // We need to add the .fa.fa-play class to video previews so that our CSS
+    // can show the play icon on hover, it would be better for this to be done
+    // on the backend, but that would not support legacy rendered markdown, so
+    // we just do it here.
+    const $youtube_preview = $content.find(".youtube-video a");
+    if ($youtube_preview.length) {
+        $youtube_preview.addClass("fa fa-play");
+    }
+    const $embed_preview = $content.find(".embed-video a");
+    if ($embed_preview.length) {
+        $embed_preview.addClass("fa fa-play");
+    }
 };

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -317,39 +317,6 @@ export function initialize_kitchen_sink_stuff() {
         $row.removeClass("sender_name_hovered");
     });
 
-    function handle_video_preview_mouseenter($elem) {
-        // Set image height and css vars for play button position, if not done already
-        const setPosition = !$elem.data("entered-before");
-        if (setPosition) {
-            const imgW = $elem.find("img")[0].width;
-            const imgH = $elem.find("img")[0].height;
-            // Ensure height doesn't change on mouse enter
-            $elem.css("height", `${imgH}px`);
-            // variables to set play button position
-            const marginLeft = (imgW - 30) / 2;
-            const marginTop = (imgH - 26) / 2;
-            $elem.css("--margin-left", `${marginLeft}px`).css("--margin-top", `${marginTop}px`);
-            $elem.data("entered-before", true);
-        }
-        $elem.addClass("fa fa-play");
-    }
-
-    $("#main_div").on("mouseenter", ".youtube-video a", function () {
-        handle_video_preview_mouseenter($(this));
-    });
-
-    $("#main_div").on("mouseleave", ".youtube-video a", function () {
-        $(this).removeClass("fa fa-play");
-    });
-
-    $("#main_div").on("mouseenter", ".embed-video a", function () {
-        handle_video_preview_mouseenter($(this));
-    });
-
-    $("#main_div").on("mouseleave", ".embed-video a", function () {
-        $(this).removeClass("fa fa-play");
-    });
-
     $("#manage_streams_container").on("mouseover", ".subscription_header", function () {
         $(this).addClass("active");
     });

--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -410,9 +410,19 @@
         cursor: zoom-in;
     }
 
+    .youtube-video a,
+    .embed-video a {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        text-decoration: none;
+    }
+
     .youtube-video img,
     .vimeo-video img,
     .embed-video img {
+        display: block;
+        position: absolute;
         cursor: pointer;
     }
 
@@ -430,16 +440,18 @@
 
     .youtube-video .fa-play::before,
     .embed-video .fa-play::before {
-        position: absolute;
-        margin: var(--margin-top, 32px) 0 0 var(--margin-left, 45px);
+        z-index: 1;
         padding: 5px 8px 5px 10px;
         font-size: 12px;
         border-radius: 4px;
         background-color: hsl(0, 0%, 0%);
         color: hsl(0, 0%, 100%);
+        opacity: 0;
+    }
+
+    .youtube-video:hover .fa-play::before,
+    .embed-video:hover .fa-play::before {
         opacity: 0.7;
-        top: 0;
-        left: 0;
     }
 
     .message_embed {


### PR DESCRIPTION
This is an incomplete fix.

This will also require changing existing db entries to reflect the
changes in the backend markdown processor.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->
backend changes not tested (CI fails).

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![](https://user-images.githubusercontent.com/33805964/159927416-9e57b030-79ed-4b79-8cbf-dd04e8490b20.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
