### PR TITLE
message_edit: Only move muted topic records when moving whole topics.

### DIFF
--- a/templates/zerver/help/move-content-to-another-stream.md
+++ b/templates/zerver/help/move-content-to-another-stream.md
@@ -6,8 +6,8 @@ Organizations can [configure][move-permission-setting] which
 streams.
 
 To help others find moved content, you can have Zulip send automated
-notification messages to the source topic, the destination topic, or both. These
-notifications include:
+notification messages to the source topic, the destination topic, or
+both. These notifications include:
 
 * A link to the source or destination topic.
 * How many messages were moved, or whether the whole topic was moved.
@@ -81,6 +81,24 @@ will only be accessible to users who both:
 
 * Were subscribed to the *original* stream when the content was *sent*.
 * Are subscribed to the *destination* stream when the content is *moved*.
+
+## Moving content out of private streams
+
+In [private streams with protected history](/help/stream-permissions),
+Zulip determines whether to treat the entire topic as moved using the
+access permissions of the user requesting the topic move. This means
+that the automated notifications will report that the entire topic was
+moved if the requesting user moved every message in the topic that
+they can access, regardless of whether older messages exist that
+they cannot access.
+
+Similarly, [muted topics](/help/mute-a-topic) will be migrated to the
+new stream and topic if the requesting user moved every message in the
+topic that they can access.
+
+This model ensures that the topic editing feature cannot be abused to
+determine any information about the existence of messages or topics
+that one does not have permission to access.
 
 ## Related articles
 

--- a/templates/zerver/help/move-content-to-another-topic.md
+++ b/templates/zerver/help/move-content-to-another-topic.md
@@ -8,8 +8,8 @@ topic](/help/rename-a-topic).
 When messages are moved, Zulip's [permanent links to messages in
 context](/help/link-to-a-message-or-conversation#get-a-link-to-a-specific-message)
 will automatically redirect to the new location of the message. [Muted
-topics](/help/mute-a-topic) are automatically migrated when all messages after a
-certain point are moved, or an entire topic is moved.
+topics](/help/mute-a-topic) are automatically migrated when an entire
+topic is moved.
 
 Organizations can [configure](/help/configure-who-can-edit-topics) which
 [roles](/help/roles-and-permissions) have permission to modify topics. See the


### PR DESCRIPTION
Our original implementation of moving muted topic records when a topic
is moved took a shortcut of treating all change_later usage as
something with intent to move the whole topic.

This works OK when moving the whole topic via this interface, but not
when moving a last off-topic message in the topic.

Address this by changing the rule to match the existing
moved_all_visible_messages variable.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
