### PR TITLE
migrations: Adjust related_name settings for ArchivedAttachment.

### DIFF
--- a/zerver/migrations/0386_fix_attachment_caches.py
+++ b/zerver/migrations/0386_fix_attachment_caches.py
@@ -60,5 +60,14 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.AlterField(
+            model_name="archivedattachment",
+            name="messages",
+            field=models.ManyToManyField(
+                related_name="attachment_set",
+                related_query_name="attachment",
+                to="zerver.ArchivedMessage",
+            ),
+        ),
         migrations.RunPython(fix_attachment_caches, reverse_code=migrations.RunPython.noop),
     ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3328,7 +3328,9 @@ class ArchivedAttachment(AbstractAttachment):
     """
 
     id: int = models.AutoField(auto_created=True, primary_key=True, verbose_name="ID")
-    messages: Manager = models.ManyToManyField(ArchivedMessage)
+    messages: Manager = models.ManyToManyField(
+        ArchivedMessage, related_name="attachment_set", related_query_name="attachment"
+    )
 
 
 class Attachment(AbstractAttachment):

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -702,9 +702,9 @@ class MoveMessageToArchiveGeneral(MoveMessageToArchiveBase):
             self.assertEqual(
                 set(attachment_id_to_message_ids[attachment_id]),
                 set(
-                    ArchivedMessage.objects.filter(
-                        archivedattachment__id=attachment_id
-                    ).values_list("id", flat=True)
+                    ArchivedMessage.objects.filter(attachment__id=attachment_id).values_list(
+                        "id", flat=True
+                    )
                 ),
             )
 


### PR DESCRIPTION
This is necessary for the migration 0386_fix_attachment_caches to run,
and likely makes more convenient any future parallel code interacting
with both Attachment and ArchivedAttachment.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Verified allows migration 0386 to complete successfully on chat.zulip.org.