### PR TITLE
black: Bump target-version to py37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 100
-target-version = ["py36"]
+target-version = ["py37"]
 
 [tool.isort]
 src_paths = [".", "tools", "tools/setup/emoji"]


### PR DESCRIPTION
This lets Black support a Python 3.7 async comprehension syntax, but has no effect on our current code.