### PR TITLE
python: Convert last type comments to annotations

### DIFF
--- a/scripts/lib/hash_reqs.py
+++ b/scripts/lib/hash_reqs.py
@@ -8,7 +8,7 @@ from typing import Iterable, List
 
 
 def expand_reqs_helper(fpath: str) -> List[str]:
-    result = []  # type: List[str]
+    result: List[str] = []
 
     with open(fpath) as f:
         for line in f:

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -167,8 +167,8 @@ def try_to_copy_venv(venv_path: str, new_packages: Set[str]) -> bool:
     desired_python_version = python_version()
     venv_name = os.path.basename(venv_path)
 
-    overlaps = []  # type: List[Tuple[int, str, Set[str]]]
-    old_packages = set()  # type: Set[str]
+    overlaps: List[Tuple[int, str, Set[str]]] = []
+    old_packages: Set[str] = set()
     for sha1sum in os.listdir(VENV_CACHE_PATH):
         curr_venv_path = os.path.join(VENV_CACHE_PATH, sha1sum, venv_name)
         if curr_venv_path == venv_path or not os.path.exists(get_index_filename(curr_venv_path)):

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -421,7 +421,7 @@ def parse_os_release() -> Dict[str, str]:
     developers, but we avoid using it, as it is not available on
     RHEL-based platforms.
     """
-    distro_info = {}  # type: Dict[str, str]
+    distro_info: Dict[str, str] = {}
     with open("/etc/os-release") as fp:
         for line in fp:
             line = line.strip()

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -289,7 +289,7 @@ def install_yum_deps(deps_to_install: List[str]) -> None:
     #
     # Error: Package: moreutils-0.49-2.el7.x86_64 (epel)
     #        Requires: perl(IPC::Run)
-    yum_extra_flags = []  # type: List[str]
+    yum_extra_flags: List[str] = []
     if vendor == "rhel":
         exitcode, subs_status = subprocess.getstatusoutput("sudo subscription-manager status")
         if exitcode == 1:


### PR DESCRIPTION
We had skipped these in #14693 so we could keep generating a friendly error on Python 3.5, but we gave that up in #19801.