### PR TITLE
help_docs: Document auto-notifications for general stream changes.

### DIFF
--- a/templates/zerver/help/change-the-privacy-of-a-stream.md
+++ b/templates/zerver/help/change-the-privacy-of-a-stream.md
@@ -30,6 +30,8 @@ public.
 
 {end_tabs}
 
+{!update-stream-auto-notification.md!}
+
 !!! warn ""
 
     **Warning**: Be careful making a private stream public. All past messages will become

--- a/templates/zerver/help/change-the-stream-description.md
+++ b/templates/zerver/help/change-the-stream-description.md
@@ -25,4 +25,6 @@ previews are disabled.
 
 {end_tabs}
 
+{!update-stream-auto-notification.md!}
+
 [markdown-formatting]: /help/format-your-message-using-markdown

--- a/templates/zerver/help/include/update-stream-auto-notification.md
+++ b/templates/zerver/help/include/update-stream-auto-notification.md
@@ -1,0 +1,4 @@
+!!! warn ""
+
+    **Note**: This sends an automated notification to the **stream
+    events** topic in the modified stream.

--- a/templates/zerver/help/message-retention-policy.md
+++ b/templates/zerver/help/message-retention-policy.md
@@ -56,6 +56,8 @@ Standard hosting.
 
 {end_tabs}
 
+{!update-stream-auto-notification.md!}
+
 ## Important details
 
 * Retention policies are processed in a daily job; so changes in the

--- a/templates/zerver/help/rename-a-stream.md
+++ b/templates/zerver/help/rename-a-stream.md
@@ -16,3 +16,5 @@
 {!save-changes.md!}
 
 {end_tabs}
+
+{!update-stream-auto-notification.md!}

--- a/templates/zerver/help/stream-sending-policy.md
+++ b/templates/zerver/help/stream-sending-policy.md
@@ -23,3 +23,5 @@ certain users can send messages.
 {!save-changes.md!}
 
 {end_tabs}
+
+{!update-stream-auto-notification.md!}


### PR DESCRIPTION
Adds a note about auto-notification messages that are sent when these general settings are changed for a stream: name, description, access and posting permissions, and message retention.

Follow-up from #21479.
