### PR TITLE
help_docs: Update docs related to message edit history.

### DIFF
--- a/templates/zerver/help/disable-message-edit-history.md
+++ b/templates/zerver/help/disable-message-edit-history.md
@@ -2,8 +2,7 @@
 
 {!admin-only.md!}
 
-By default, Zulip displays messages that have been edited with an EDITED tag, and users
-can [view the edit history of a message](/help/view-a-messages-edit-history).
+In Zulip, users can [view the edit history of a message](/help/view-a-messages-edit-history).
 
 To remove the edit history of a single message, it is usually best to
 [delete the message](edit-or-delete-a-message) entirely. However, you can
@@ -15,7 +14,7 @@ also disable viewing of message edit history more generally.
 
 {settings_tab|organization-permissions}
 
-2. Under **Message editing**, uncheck **Enable message edit history**.
+1. Under **Message editing**, uncheck **Enable message edit history**.
 
 {!save-changes.md!}
 

--- a/templates/zerver/help/edit-or-delete-a-message.md
+++ b/templates/zerver/help/edit-or-delete-a-message.md
@@ -27,9 +27,10 @@ content.
 
 !!! warn ""
 
-    **Note:** After you have edited a message, the message is publicly marked as
-    `EDITED`. You can [view](/help/view-a-messages-edit-history) a message's
-    edit history, assuming that feature has not been
+    **Note:** After you have edited a message, the message is publicly
+    marked as **EDITED**. You can
+    [view a message's edit history](/help/view-a-messages-edit-history),
+    assuming that feature has not been
     [disabled by an organization administrator](/help/disable-message-edit-history).
 
 If you don't see the pencil (<i class="fa fa-pencil"></i>) icon, the message content
@@ -41,7 +42,7 @@ icon instead. Clicking the file icon will allow you to view the
 ## Delete a message
 
 Editing a message to delete its content will cause the message to be
-displayed as `(deleted)`.  The original sender and timestamp of the
+displayed as **(deleted)**.  The original sender and timestamp of the
 message will still be displayed, and the original content of the
 message is still accessible via Zulip's [edit
 history](/help/view-a-messages-edit-history) feature.  This can be the

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -91,8 +91,7 @@ class OpenGraphTest(ZulipTestCase):
             "/help/disable-message-edit-history",
             "Disable message edit history (Zulip Help Center)",
             [
-                "By default, Zulip displays messages",
-                "users can view the edit history of a message. | To remove the",
+                "In Zulip, users can view the edit history of a message. | To remove the",
                 "best to delete the message entirely. ",
             ],
             [


### PR DESCRIPTION
As a follow-up to #21512, I did a quick check of help center documentation that referred to `view-a-messages-edit-history` and updated the following:

- `disable-message-edit-history`: Remove text about EDITED label and link to `view-a-messages-edit-history` instead.
- `edit-or-delete-a-message`: Reformat 'EDITED' and '(deleted)' references in the text to be bold instead of using backticks.
