### PR TITLE
modals: Refactor help_link_widget for confirmation modal.

### DIFF
--- a/static/styles/modal.css
+++ b/static/styles/modal.css
@@ -81,7 +81,7 @@
     line-height: 1.25;
 
     /* help_link_widget margin for the fa-circle-o. */
-    a {
+    .help_link_widget {
         margin-left: 5px;
     }
 }

--- a/static/templates/help_link_widget.hbs
+++ b/static/templates/help_link_widget.hbs
@@ -1,3 +1,3 @@
-<a href="{{ link }}" target="_blank" rel="noopener noreferrer">
+<a class="help_link_widget" href="{{ link }}" target="_blank" rel="noopener noreferrer">
     <i class="fa fa-question-circle-o" aria-hidden="true"></i>
 </a>


### PR DESCRIPTION
Added class "help_link_widget" and applied existing css,
to `a` tag of help_link_widget.

Follow-up of #21508.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Manually.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot at 2022-03-25 20-09-00](https://user-images.githubusercontent.com/41695888/160142445-3ee9eb2c-6614-4cfb-9055-3724fe068af9.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
