### PR TITLE
puppet: Configure chrony to use AWS-local NTP sources.

### DIFF
--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -61,6 +61,7 @@ class zulip::profile::base {
     }
   }
   package { 'ntp': ensure => 'purged', before => Package['chrony'] }
+  service { 'chrony': ensure => 'running', require => Package['chrony'] }
   package { $base_packages: ensure => 'installed' }
 
   group { 'zulip':

--- a/puppet/zulip_ops/files/chrony.conf
+++ b/puppet/zulip_ops/files/chrony.conf
@@ -1,0 +1,31 @@
+# Welcome to the chrony configuration file. See chrony.conf(5) for more
+# information about usable directives.
+
+# This will use the AWS local atomic clocks as a datasource; see
+# https://aws.amazon.com/blogs/aws/keeping-time-with-amazon-time-sync-service/
+server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4
+
+# This directive specify the location of the file containing ID/key pairs for
+# NTP authentication.
+keyfile /etc/chrony/chrony.keys
+
+# This directive specify the file into which chronyd will store the rate
+# information.
+driftfile /var/lib/chrony/chrony.drift
+
+# Uncomment the following line to turn logging on.
+#log tracking measurements statistics
+
+# Log files location.
+logdir /var/log/chrony
+
+# Stop bad estimates upsetting machine clock.
+maxupdateskew 100.0
+
+# This directive enables kernel synchronisation (every 11 minutes) of the
+# real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
+rtcsync
+
+# Step the system clock instead of slewing it if the adjustment is larger than
+# one second, but only in the first three clock updates.
+makestep 1 3

--- a/puppet/zulip_ops/manifests/profile/base.pp
+++ b/puppet/zulip_ops/manifests/profile/base.pp
@@ -154,6 +154,14 @@ class zulip_ops::profile::base {
       mode   => '0755',
       source => 'puppet:///modules/zulip_ops/zulip-ec2-configure-interfaces_if-up.d.sh',
     }
+
+    file { '/etc/chrony/chrony.conf':
+      ensure  => file,
+      mode    => '0644',
+      source  => 'puppet:///modules/zulip_ops/chrony.conf',
+      require => Package['chrony'],
+      notify  => Service['chrony'],
+    }
   }
 
   group { 'nagios':


### PR DESCRIPTION
This prevents hosts from spewing traffic to random hosts across the
Internet.

**Testing plan:** Test applied:
```
# chronyc sources -v
210 Number of sources = 1

  .-- Source mode  '^' = server, '=' = peer, '#' = local clock.
 / .- Source state '*' = current synced, '+' = combined , '-' = not combined,
| /   '?' = unreachable, 'x' = time may be in error, '~' = time too variable.
||                                                 .- xxxx [ yyyy ] +/- zzzz
||      Reachability register (octal) -.           |  xxxx = adjusted offset,
||      Log2(Polling interval) --.      |          |  yyyy = measured offset,
||                                \     |          |  zzzz = estimated error.
||                                 |    |           \
MS Name/IP address         Stratum Poll Reach LastRx Last sample
===============================================================================
^* 169.254.169.123               3   4    17    12   -307ns[-3023ns] +/-  445us

# chronyc tracking
Reference ID    : A9FEA97B (169.254.169.123)
Stratum         : 4
Ref time (UTC)  : Fri Mar 25 19:19:12 2022
System time     : 0.000002537 seconds fast of NTP time
Last offset     : +0.000002444 seconds
RMS offset      : 0.000005777 seconds
Frequency       : 10.334 ppm fast
Residual freq   : +0.016 ppm
Skew            : 0.391 ppm
Root delay      : 0.000313817 seconds
Root dispersion : 0.000283179 seconds
Update interval : 16.0 seconds
Leap status     : Normal
```