### PR TITLE
push_notifications: Increase severity of APNs ConnectionError.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -233,12 +233,11 @@ def send_apple_push_notification(
             result = apns_context.loop.run_until_complete(
                 apns_context.apns.send_notification(request)
             )
-        except aioapns.exceptions.ConnectionError as e:
-            logger.warning(
-                "APNs: ConnectionError sending for user %s to device %s: %s",
+        except aioapns.exceptions.ConnectionError:
+            logger.error(
+                "APNs: ConnectionError sending for user %s to device %s; check certificate expiration",
                 user_identity,
                 device.token,
-                e.__class__.__name__,
             )
             continue
 

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1609,7 +1609,7 @@ class TestAPNs(PushNotificationTest):
             )
             self.send(devices=self.devices()[0:1])
             self.assertIn(
-                f"WARNING:zerver.lib.push_notifications:APNs: ConnectionError sending for user <id:{self.user_profile.id}> to device {self.devices()[0].token}: ConnectionError",
+                f"ERROR:zerver.lib.push_notifications:APNs: ConnectionError sending for user <id:{self.user_profile.id}> to device {self.devices()[0].token}; check certificate expiration",
                 logger.output,
             )
 


### PR DESCRIPTION
This has only happened when our APNs certificate expired; logging at
the error level ensures that this shows up in Sentry.

----

This was an AI from an APNs certificate expiration in November 2021.