### PR TITLE
zilencer: Provide an unauth endpoint to check if a sever is registered.

### DIFF
--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2695,6 +2695,29 @@ class PushBouncerSignupTest(ZulipTestCase):
             result, f"Zulip server auth failure: key does not match role {zulip_org_id}"
         )
 
+    def test_push_check_registration(self) -> None:
+        result = self.client_get("/api/v1/remotes/server/bogus")
+        self.assertEqual(result.status_code, 404)
+
+        zulip_org_id = str(uuid.uuid4())
+        zulip_org_key = get_random_string(64)
+        endpoint = "/api/v1/remotes/server/" + zulip_org_id
+
+        result = self.client_get(endpoint)
+        self.assertEqual(result.status_code, 404)
+
+        request = dict(
+            zulip_org_id=zulip_org_id,
+            zulip_org_key=zulip_org_key,
+            hostname="example.com",
+            contact_email="server-admin@example.com",
+        )
+        result = self.client_post("/api/v1/remotes/server/register", request)
+        self.assert_json_success(result)
+
+        result = self.client_get(endpoint)
+        self.assert_json_success(result)
+
 
 class TestUserPushIndentityCompat(ZulipTestCase):
     def test_filter_q(self) -> None:

--- a/zilencer/urls.py
+++ b/zilencer/urls.py
@@ -5,6 +5,7 @@ from django.urls import path
 
 from zerver.lib.rest import rest_path
 from zilencer.views import (
+    check_registered_remote_server,
     deactivate_remote_server,
     register_remote_push_device,
     register_remote_server,
@@ -23,7 +24,9 @@ v1_api_and_json_patterns = [
     rest_path("remotes/push/unregister", POST=unregister_remote_push_device),
     rest_path("remotes/push/unregister/all", POST=unregister_all_remote_push_devices),
     rest_path("remotes/push/notify", POST=remote_server_notify_push),
-    # Push signup doesn't use the REST API, since there's no auth.
+    # Checking a server registration and push signup don't use the
+    # REST API, since there's no auth.
+    path("remotes/server/<uuid:uuid>", check_registered_remote_server),
     path("remotes/server/register", register_remote_server),
     rest_path("remotes/server/deactivate", POST=deactivate_remote_server),
     # For receiving table data used in analytics and billing


### PR DESCRIPTION
This endpoint is unauthenticated but rate-limited, and allows remote
servers to easily validate if they have already registered with the
push bouncer.

**Testing plan:** Added tests.

----

We could theoretically return email or domain information about the server with the requested UUID -- but the requestor nominally _knows_ that information already, and there's no reason for us to potentially leak it.