### PR TITLE
settings (user): Replace "Delete bot" with "Deactivate bot".

### DIFF
--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -362,7 +362,7 @@ export function set_up() {
         $(`[name*='${CSS.escape(selected_bot)}']`).show();
     });
 
-    $("#active_bots_list").on("click", "button.delete_bot", (e) => {
+    $("#active_bots_list").on("click", "button.deactivate_bot", (e) => {
         const bot_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
 
         channel.del({

--- a/static/templates/settings/bot_avatar_row.hbs
+++ b/static/templates/settings/bot_avatar_row.hbs
@@ -14,8 +14,8 @@
                 <button type="submit" id="copy_zuliprc" class="btn copy_zuliprc" title="{{t 'Copy zuliprc' }}">
                     <i class="fa fa-clipboard copy-gold"></i>
                 </button>
-                <button type="submit" class="btn delete_bot" title="{{t 'Delete bot' }}" data-user-id="{{user_id}}">
-                    <i class="fa fa-trash-o danger-red" aria-hidden="true"></i>
+                <button type="submit" class="btn deactivate_bot danger-red" title="{{t 'Deactivate bot' }}" data-user-id="{{user_id}}">
+                    <i class="fa fa-user-times" aria-hidden="true"></i>
                 </button>
             </div>
             {{/if}}


### PR DESCRIPTION
On clicking "Delete bot" button, the gets placed under Inactive Bots
tab and the bot doesn't actually gets deleted.
To fix this rename the option as "Deactivate bot" and change the icon.

In "settings_bot.js" and "bot_avatar_row.hbs" replace "Delete bot" with
"Deactivate bot". Change the icon.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes: https://chat.zulip.org/#narrow/stream/9-issues/topic/deactivate.20bot.20in.20place.20of.20delete.20bot

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="618" alt="Screenshot 2022-03-26 at 17 56 47" src="https://user-images.githubusercontent.com/85362194/160239414-8d882ad9-0ab4-4fcd-96ab-3b17193d42e9.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
