### PR TITLE
settings (admin/org): Disable org's logo hover behavior when the user doesn't have permission to edit/delete org's logo.

### DIFF
--- a/static/styles/image_upload_widget.css
+++ b/static/styles/image_upload_widget.css
@@ -130,6 +130,10 @@
             display: block;
         }
     }
+
+    .hide {
+        display: none;
+    }
 }
 
 .user-avatar-section,

--- a/static/templates/settings/image_upload_widget.hbs
+++ b/static/templates/settings/image_upload_widget.hbs
@@ -1,9 +1,11 @@
 <div id="{{widget}}-upload-widget" class="inline-block image_upload_widget">
     <div class="image-disabled {{#if is_editable_by_current_user}}hide{{/if}}">
-        <div class="image-upload-background"></div>
-        <span class="image-disabled-text flex" aria-label="{{ disabled_text }}" role="button" tabindex="0">
-            {{ disabled_text }}
-        </span>
+        {{#if disabled_text}}
+            <div class="image-upload-background"></div>
+            <span class="image-disabled-text flex" aria-label="{{ disabled_text }}" role="button" tabindex="0">
+                {{ disabled_text }}
+            </span>
+        {{/if}}
     </div>
     <div class="image_upload_button {{#unless is_editable_by_current_user}}hide{{/unless}}">
         <div class="image-upload-background"></div>


### PR DESCRIPTION
Disable org's logo hover behavior when the user doesn't have
permission to edit/delete org's logo.

In "realm_icon.js" hide "delete" button, "upload image" button and
background.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes: https://chat.zulip.org/#narrow/stream/9-issues/topic/deactivate.20bot.20in.20place.20of.20delete.20bot

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

https://user-images.githubusercontent.com/85362194/160253786-01dbd3db-8b27-4ca0-b8a2-bbfbcd39ee4d.mov
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
