### PR TITLE
Add --rotate-api-keys option to logout_all_users command

### DIFF
--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import orjson
 from django.db import transaction
@@ -29,6 +29,7 @@ from zerver.models import (
     UserProfile,
     active_user_ids,
     bot_owner_user_ids,
+    get_user_profile_by_id,
 )
 from zerver.tornado.django_api import send_event
 
@@ -244,6 +245,12 @@ def do_regenerate_api_key(user_profile: UserProfile, acting_user: UserProfile) -
     queue_json_publish("deferred_work", event)
 
     return new_api_key
+
+
+def bulk_regenerate_api_keys(user_profile_ids: List[int]) -> None:
+    for user_profile_id in user_profile_ids:
+        user_profile = get_user_profile_by_id(user_profile_id)
+        do_regenerate_api_key(user_profile, user_profile)
 
 
 def notify_avatar_url_change(user_profile: UserProfile) -> None:

--- a/zerver/management/commands/logout_all_users.py
+++ b/zerver/management/commands/logout_all_users.py
@@ -1,12 +1,16 @@
 from argparse import ArgumentParser
 from typing import Any
 
+from django.db.models import Q
+
+from zerver.actions.user_settings import bulk_regenerate_api_keys
 from zerver.lib.management import ZulipBaseCommand
 from zerver.lib.sessions import (
     delete_all_deactivated_user_sessions,
     delete_all_user_sessions,
     delete_realm_user_sessions,
 )
+from zerver.models import UserProfile
 
 
 class Command(ZulipBaseCommand):
@@ -23,13 +27,29 @@ mobile apps.
             action="store_true",
             help="Only log out all users who are deactivated",
         )
+        parser.add_argument(
+            "--rotate-api-keys",
+            action="store_true",
+            help="Also rotate API keys of the affected users",
+        )
         self.add_realm_args(parser, help="Only log out all users in a particular realm")
 
     def handle(self, *args: Any, **options: Any) -> None:
         realm = self.get_realm(options)
+        rotate_api_keys = options["rotate_api_keys"]
         if realm:
             delete_realm_user_sessions(realm)
+            regenerate_api_key_queryset = UserProfile.objects.filter(realm=realm).values_list(
+                "id", flat=True
+            )
         elif options["deactivated_only"]:
             delete_all_deactivated_user_sessions()
+            regenerate_api_key_queryset = UserProfile.objects.filter(
+                Q(is_active=False) | Q(realm__deactivated=True)
+            ).values_list("id", flat=True)
         else:
             delete_all_user_sessions()
+            regenerate_api_key_queryset = UserProfile.objects.values_list("id", flat=True)
+
+        if rotate_api_keys:
+            bulk_regenerate_api_keys(regenerate_api_key_queryset)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -17,6 +17,7 @@ from zerver.actions.invites import do_create_multiuse_invite_link, do_invite_use
 from zerver.actions.message_send import get_recipient_info
 from zerver.actions.muted_users import do_mute_user
 from zerver.actions.realm_settings import do_set_realm_property
+from zerver.actions.user_settings import bulk_regenerate_api_keys
 from zerver.actions.users import (
     change_user_is_active,
     do_change_can_create_users,
@@ -2271,3 +2272,25 @@ class FakeEmailDomainTest(ZulipTestCase):
         with self.assertRaises(InvalidFakeEmailDomain):
             realm = get_realm("zulip")
             get_fake_email_domain(realm)
+
+
+class TestBulkRegenerateAPIKey(ZulipTestCase):
+    def test_bulk_regenerate_api_keys(self) -> None:
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        othello = self.example_user("othello")
+
+        hamlet_old_api_key = hamlet.api_key
+        cordelia_old_api_key = cordelia.api_key
+        othello_old_api_key = othello.api_key
+
+        bulk_regenerate_api_keys([hamlet.id, cordelia.id])
+
+        hamlet.refresh_from_db()
+        cordelia.refresh_from_db()
+        othello.refresh_from_db()
+
+        self.assertNotEqual(hamlet_old_api_key, hamlet.api_key)
+        self.assertNotEqual(cordelia_old_api_key, cordelia.api_key)
+
+        self.assertEqual(othello_old_api_key, othello.api_key)


### PR DESCRIPTION
Fixes #19397 

https://chat.zulip.org/#narrow/stream/3-backend/topic/Adding.20--rotate-api-keys.20option.20to.20logout_all_users