### PR TITLE
help_docs: Clarify relative link text for Subscribed streams tab.

### DIFF
--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -46,7 +46,7 @@ def gear_handle_match(key: str) -> str:
 
 stream_info = {
     "all": ["All streams", "/#streams/all"],
-    "subscribed": ["Subscribed", "/#streams/subscribed"],
+    "subscribed": ["Subscribed streams", "/#streams/subscribed"],
 }
 
 stream_instructions_no_link = """

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -304,7 +304,7 @@ class HelpTest(ZulipTestCase):
 
     def test_help_relative_links_for_stream(self) -> None:
         result = self.client_get("/help/message-a-stream-by-email")
-        self.assertIn('<a href="/#streams/subscribed">Subscribed</a>', str(result.content))
+        self.assertIn('<a href="/#streams/subscribed">Subscribed streams</a>', str(result.content))
         self.assertEqual(result.status_code, 200)
 
         with self.settings(ROOT_DOMAIN_LANDING_PAGE=True):


### PR DESCRIPTION
Updates the relative link in the help center documentation that goes to a user's subscribed streams to read as, "Go to **Subscribed streams**", instead of only "Go to **Subscribed**". See [this CZO conversation](https://chat.zulip.org/#narrow/stream/19-documentation/topic/help.20relative.20links/near/1348079) for more context.
