### PR TITLE
Issue 21516: fix settings_users Unstable bots and users table

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -101,11 +101,12 @@ export function update_view_on_deactivate(user_id) {
     $button.empty().append($("<i>", {class: "fa fa-user-plus", ["aria-hidden"]: "true"}));
     $button.attr("title", "Reactivate");
     $row.addClass("deactivated_user");
+    $row.removeClass("activated_user");
 
     if ($user_role) {
         const user_id = $row.data("user-id");
-        $user_role.text(
-            `${$t({defaultMessage: "Deactivated"})} (${people.get_user_type(user_id)})`,
+        $user_role.html(
+            `${$t({defaultMessage: "Deactivated"})}<br/>(${people.get_user_type(user_id)})`,
         );
     }
 }
@@ -120,6 +121,7 @@ function update_view_on_reactivate($row) {
     $button.attr("title", "Deactivate");
     $button.empty().append($("<i>", {class: "fa fa-user-times", ["aria-hidden"]: "true"}));
     $row.removeClass("deactivated_user");
+    $row.addClass("activated_user");
 
     if ($user_role) {
         const user_id = $row.data("user-id");

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2665,6 +2665,10 @@ div.topic_edit_spinner .loading_indicator_spinner {
     margin-right: 25px;
 }
 
+.activated_user > td:first-child {
+    padding-right: 21px;
+}
+
 .deactivated_user .deactivated-user-icon {
     color: inherit;
     margin-left: 2px;

--- a/static/templates/settings/admin_user_list.hbs
+++ b/static/templates/settings/admin_user_list.hbs
@@ -1,4 +1,4 @@
-<tr class="user_row{{#unless is_active}} deactivated_user{{/unless}}" data-user-id="{{user_id}}">
+<tr class="user_row{{#unless is_active}} deactivated_user{{else}} activated_user{{/unless}}" data-user-id="{{user_id}}">
     <td>
         <span class="user_name" >{{full_name}} {{#if is_current_user}}<span class="my_user_status">{{t '(you)' }}</span>{{/if}}</span>
         <i class="fa fa-ban deactivated-user-icon" title="{{t 'User is deactivated' }}" {{#if is_active}}style="display: none;"{{/if}}></i>


### PR DESCRIPTION
New class activated_user added to set extra padding when
deactivated icon isn't visible.
Also added breaking line when deactivating an user.

Signed-off-by: <irismurillorobla@gmail.com>

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
