### PR TITLE
help_docs: Fix help center link on Zulip features page.

### DIFF
--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -29,7 +29,7 @@
                     and <a href="/help/format-your-message-using-markdown">much
                     more</a>.
 
-                    <a href="/help/format-your-message-using-markdown#quote">Quote
+                    <a href="/help/format-your-message-using-markdown#quotes">Quote
                     blocks</a>,
                     <a href="/help/format-your-message-using-markdown#spoilers">spoilers</a>,
                     <a href="/help/format-your-message-using-markdown#latex">LaTeX/math blocks</a>


### PR DESCRIPTION
Fixes a link to the help center markdown formatting documentation about quotes. Reviewed all other help center links on the Zulip features page as well, but only found the one that needed to be updated.