### PR TITLE
mailmap: Add 15 more entries

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -42,6 +42,7 @@ Kevin Mehall <km@kevinmehall.net> <kevin@zulip.com>
 Kevin Scott <kevin.scott.98@gmail.com>
 Lauryn Menard <lauryn@zulip.com> <lauryn.menard@gmail.com>
 Mateusz Mandera <mateusz.mandera@zulip.com> <mateusz.mandera@protonmail.com>
+m-e-l-u-h-a-n <purushottam.tiwari.cd.cse19@itbhu.ac.in>
 Palash Raghuwanshi <singhpalash0@gmail.com>
 Parth <mittalparth22@gmail.com>
 Ray Kraesig <rkraesig@zulip.com> <rkraesig@zulipchat.com>
@@ -58,6 +59,7 @@ Steve Howell <showell@zulip.com> <showell@yahoo.com>
 Steve Howell <showell@zulip.com> <showell@zulipchat.com>
 Steve Howell <showell@zulip.com> <steve@humbughq.com>
 Steve Howell <showell@zulip.com> <steve@zulip.com>
+strifel <info@strifel.de>
 Tim Abbott <tabbott@zulip.com> <tabbott@dropbox.com>
 Tim Abbott <tabbott@zulip.com> <tabbott@humbughq.com>
 Tim Abbott <tabbott@zulip.com> <tabbott@mit.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -27,6 +27,8 @@ Chris Bobbe <cbobbe@zulip.com> <csbobbe@gmail.com>
 Greg Price <greg@zulip.com> <gnprice@gmail.com>
 Greg Price <greg@zulip.com> <greg@zulipchat.com>
 Greg Price <greg@zulip.com> <price@mit.edu>
+Jai soni <jai_s@me.iitr.ac.in>
+Jai soni <jai_s@me.iitr.ac.in> <76561593+jai2201@users.noreply.github.com>
 Jeff Arnold <jbarnold@gmail.com> <jbarnold@humbughq.com>
 Jeff Arnold <jbarnold@gmail.com> <jbarnold@zulip.com>
 Jessica McKellar <jesstess@mit.edu> <jesstess@humbughq.com>

--- a/.mailmap
+++ b/.mailmap
@@ -39,6 +39,7 @@ Jessica McKellar <jesstess@mit.edu> <jesstess@humbughq.com>
 Jessica McKellar <jesstess@mit.edu> <jesstess@zulip.com>
 Kevin Mehall <km@kevinmehall.net> <kevin@humbughq.com>
 Kevin Mehall <km@kevinmehall.net> <kevin@zulip.com>
+Kevin Scott <kevin.scott.98@gmail.com>
 Lauryn Menard <lauryn@zulip.com> <lauryn.menard@gmail.com>
 Mateusz Mandera <mateusz.mandera@zulip.com> <mateusz.mandera@protonmail.com>
 Palash Raghuwanshi <singhpalash0@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -45,6 +45,7 @@ Rishi Gupta <rishig@zulipchat.com> <rishig+git@mit.edu>
 Rishi Gupta <rishig@zulipchat.com> <rishig@kandralabs.com>
 Rishi Gupta <rishig@zulipchat.com> <rishig@users.noreply.github.com>
 Reid Barton <rwbarton@gmail.com> <rwbarton@humbughq.com>
+Sayam Samal <samal.sayam@gmail.com>
 Scott Feeney <scott@oceanbase.org> <scott@humbughq.com>
 Scott Feeney <scott@oceanbase.org> <scott@zulip.com>
 Steve Howell <showell@zulip.com> <showell30@yahoo.com>

--- a/.mailmap
+++ b/.mailmap
@@ -16,14 +16,17 @@ Alex Vandiver <alexmv@zulip.com> <alex@chmrr.net>
 Alex Vandiver <alexmv@zulip.com> <github@chmrr.net>
 Allen Rabinovich <allenrabinovich@yahoo.com> <allenr@humbughq.com>
 Allen Rabinovich <allenrabinovich@yahoo.com> <allenr@zulip.com>
+Alya Abbott <alya@zulip.com> <2090066+alya@users.noreply.github.com>
 Aman Agrawal <amanagr@zulip.com> <f2016561@pilani.bits-pilani.ac.in>
 Anders Kaseorg <anders@zulip.com> <anders@zulipchat.com>
 Anders Kaseorg <anders@zulip.com> <andersk@mit.edu>
+Austin Riba <austin@zulip.com> <austin@m51.io>
 Brock Whittaker <brock@zulipchat.com> <bjwhitta@asu.edu>
 Brock Whittaker <brock@zulipchat.com> <brockwhittaker@Brocks-MacBook.local>
 Brock Whittaker <brock@zulipchat.com> <brock@zulipchat.org>
 Chris Bobbe <cbobbe@zulip.com> <cbobbe@zulipchat.com>
 Chris Bobbe <cbobbe@zulip.com> <csbobbe@gmail.com>
+Eeshan Garg <eeshan@zulip.com> <jerryguitarist@gmail.com>
 Greg Price <greg@zulip.com> <gnprice@gmail.com>
 Greg Price <greg@zulip.com> <greg@zulipchat.com>
 Greg Price <greg@zulip.com> <price@mit.edu>
@@ -35,6 +38,8 @@ Jessica McKellar <jesstess@mit.edu> <jesstess@humbughq.com>
 Jessica McKellar <jesstess@mit.edu> <jesstess@zulip.com>
 Kevin Mehall <km@kevinmehall.net> <kevin@humbughq.com>
 Kevin Mehall <km@kevinmehall.net> <kevin@zulip.com>
+Lauryn Menard <lauryn@zulip.com> <lauryn.menard@gmail.com>
+Mateusz Mandera <mateusz.mandera@zulip.com> <mateusz.mandera@protonmail.com>
 Ray Kraesig <rkraesig@zulip.com> <rkraesig@zulipchat.com>
 Rishi Gupta <rishig@zulipchat.com> <rishig+git@mit.edu>
 Rishi Gupta <rishig@zulipchat.com> <rishig@kandralabs.com>

--- a/.mailmap
+++ b/.mailmap
@@ -43,6 +43,7 @@ Kevin Scott <kevin.scott.98@gmail.com>
 Lauryn Menard <lauryn@zulip.com> <lauryn.menard@gmail.com>
 Mateusz Mandera <mateusz.mandera@zulip.com> <mateusz.mandera@protonmail.com>
 Palash Raghuwanshi <singhpalash0@gmail.com>
+Parth <mittalparth22@gmail.com>
 Ray Kraesig <rkraesig@zulip.com> <rkraesig@zulipchat.com>
 Rishi Gupta <rishig@zulipchat.com> <rishig+git@mit.edu>
 Rishi Gupta <rishig@zulipchat.com> <rishig@kandralabs.com>

--- a/.mailmap
+++ b/.mailmap
@@ -21,6 +21,7 @@ Aman Agrawal <amanagr@zulip.com> <f2016561@pilani.bits-pilani.ac.in>
 Anders Kaseorg <anders@zulip.com> <anders@zulipchat.com>
 Anders Kaseorg <anders@zulip.com> <andersk@mit.edu>
 Austin Riba <austin@zulip.com> <austin@m51.io>
+BIKI DAS <bikid475@gmail.com>
 Brock Whittaker <brock@zulipchat.com> <bjwhitta@asu.edu>
 Brock Whittaker <brock@zulipchat.com> <brockwhittaker@Brocks-MacBook.local>
 Brock Whittaker <brock@zulipchat.com> <brock@zulipchat.org>
@@ -40,6 +41,7 @@ Kevin Mehall <km@kevinmehall.net> <kevin@humbughq.com>
 Kevin Mehall <km@kevinmehall.net> <kevin@zulip.com>
 Lauryn Menard <lauryn@zulip.com> <lauryn.menard@gmail.com>
 Mateusz Mandera <mateusz.mandera@zulip.com> <mateusz.mandera@protonmail.com>
+Palash Raghuwanshi <singhpalash0@gmail.com>
 Ray Kraesig <rkraesig@zulip.com> <rkraesig@zulipchat.com>
 Rishi Gupta <rishig@zulipchat.com> <rishig+git@mit.edu>
 Rishi Gupta <rishig@zulipchat.com> <rishig@kandralabs.com>
@@ -63,3 +65,4 @@ Alya Abbott <alya@zulip.com> <alyaabbott@elance-odesk.com>
 Sahil Batra <sahil@zulip.com> <sahilbatra839@gmail.com>
 Yash RE <33805964+YashRE42@users.noreply.github.com> <YashRE42@github.com>
 Yash RE <33805964+YashRE42@users.noreply.github.com>
+Yogesh Sirsat <yogeshsirsat56@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -52,6 +52,7 @@ Reid Barton <rwbarton@gmail.com> <rwbarton@humbughq.com>
 Sayam Samal <samal.sayam@gmail.com>
 Scott Feeney <scott@oceanbase.org> <scott@humbughq.com>
 Scott Feeney <scott@oceanbase.org> <scott@zulip.com>
+Shlok Patel <shlokcpatel2001@gmail.com>
 Steve Howell <showell@zulip.com> <showell30@yahoo.com>
 Steve Howell <showell@zulip.com> <showell@yahoo.com>
 Steve Howell <showell@zulip.com> <showell@zulipchat.com>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

`git shortlog -es 4.0.. | perl -lpe 's/.*<//' | sort | uniq -d` is now empty -- meaning there are no remaining email addresses with multiple names.

Also `git shortlog -es 4.0.. | sort -k2` to look for similar names that might be the same person. There are a few left that seem likely; but none where both names have more than a couple of commits, and none that I could immediately confirm were in fact the same person. (One way to do so reliably with a bit of work would be to track down the GitHub PRs where the commits came in, and see if the commits came from the same GitHub user.)

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
