### PR TITLE
Fix: vertical shifts in message when toggle write and preview.

### DIFF
--- a/frontend_tests/puppeteer_tests/compose.ts
+++ b/frontend_tests/puppeteer_tests/compose.ts
@@ -199,7 +199,7 @@ async function test_markdown_rendering(page: Page): Promise<void> {
     await page.click("#compose .markdown_preview");
     await page.waitForSelector("#compose .preview_content", {visible: true});
     const expected_markdown_html =
-        "<p><strong>Markdown preview</strong> &gt;&gt; Test for Markdown preview</p>";
+        "<div><strong>Markdown preview</strong> &gt;&gt; Test for Markdown preview</div>";
     await page.waitForFunction(() => $("#compose .preview_content").html() !== "");
     markdown_preview_element = await page.$("#compose .preview_content");
     assert.equal(

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -337,10 +337,14 @@ export function render_and_show_preview($preview_spinner, $preview_content_box, 
         if (raw_content !== undefined && markdown.is_status_message(raw_content)) {
             // Handle previews of /me messages
             rendered_preview_html =
-                "<p><strong>" +
+                "<div><strong>" +
                 _.escape(page_params.full_name) +
                 "</strong>" +
-                rendered_content.slice("<p>/me".length);
+                rendered_content.slice("<p>/me".length, -1 * "</p>".length) +
+                "</div>";
+        } else if (rendered_content.startsWith("<p>")) {
+            rendered_preview_html =
+                "<div>" + rendered_content.slice("<p>".length, -1 * "</p>".length) + "</div>";
         } else {
             rendered_preview_html = rendered_content;
         }


### PR DESCRIPTION
The vertical shifts in message body was due to the
```<p>``` tags  it gets when converted to markdown

removing the ```<p>```tags with ```<div>```  tag
solves the problem as line don't get changed
 with ```<div>``` tags as it does in case of ```<p>``` tag

Fixes #21276 

https://user-images.githubusercontent.com/56029409/160673793-7633b17b-098a-4246-ba25-d12a0991c984.mp4


