### PR TITLE
Clean up mark-as-unread banner (style and close button)

### DIFF
--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
+const $ = require("../zjsunit/zjquery");
 
 mock_esm("../../static/js/resize", {
     resize_stream_filters_container: () => {},
@@ -93,6 +94,8 @@ function test_helper() {
     stub(unread_ops, "process_visible");
     stub(compose_closed_ui, "update_buttons_for_stream");
     stub(compose_closed_ui, "update_buttons_for_private");
+    // We don't test the css calls; we just skip over them.
+    $("#mark_as_read_turned_off_banner").toggleClass = () => {};
 
     return {
         clear: () => {

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -351,6 +351,8 @@ test("test_recent_topics_show", ({mock_template, override}) => {
     mock_template("recent_topic_row.hbs", false, () => {});
 
     stub_out_filter_buttons();
+    // We don't test the css calls; we just skip over them.
+    $("#mark_as_read_turned_off_banner").toggleClass = () => {};
 
     rt.clear_for_tests();
     rt.process_messages(messages);

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -40,6 +40,7 @@ import * as typing_events from "./typing_events";
 import * as ui_util from "./ui_util";
 import * as unread from "./unread";
 import * as unread_ops from "./unread_ops";
+import * as unread_ui from "./unread_ui";
 import * as util from "./util";
 import * as widgetize from "./widgetize";
 
@@ -155,17 +156,13 @@ function update_narrow_title(filter) {
     }
 }
 
-export function hide_mark_as_read_turned_off_banner() {
-    $("#mark_as_read_turned_off_banner").hide();
-}
-
 export function reset_ui_state() {
     // Resets the state of various visual UI elements that are
     // a function of the current narrow.
     narrow_banner.hide_empty_narrow_message();
     message_scroll.hide_top_of_narrow_notices();
     message_scroll.hide_indicators();
-    hide_mark_as_read_turned_off_banner();
+    unread_ui.hide_mark_as_read_turned_off_banner();
 }
 
 export function handle_middle_pane_transition() {

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -162,7 +162,7 @@ export function reset_ui_state() {
     narrow_banner.hide_empty_narrow_message();
     message_scroll.hide_top_of_narrow_notices();
     message_scroll.hide_indicators();
-    unread_ui.hide_mark_as_read_turned_off_banner();
+    unread_ui.reset_mark_as_read_turned_off_banner();
 }
 
 export function handle_middle_pane_transition() {

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -29,6 +29,7 @@ import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 import * as top_left_corner from "./top_left_corner";
 import * as unread from "./unread";
+import * as unread_ui from "./unread_ui";
 
 let topics_widget;
 // Sets the number of avatars to display.
@@ -651,7 +652,7 @@ export function show() {
     $("#message_view_header_underpadding").hide();
     $(".header").css("padding-bottom", "0px");
 
-    narrow.hide_mark_as_read_turned_off_banner();
+    unread_ui.hide_mark_as_read_turned_off_banner();
 
     // We want to show `new stream message` instead of
     // `new topic`, which we are already doing in this

--- a/static/js/unread_ui.js
+++ b/static/js/unread_ui.js
@@ -14,9 +14,22 @@ import * as unread from "./unread";
 import {notify_server_messages_read} from "./unread_ops";
 
 let last_mention_count = 0;
-
+let user_closed_mark_as_read_turned_off_banner = false;
 export function hide_mark_as_read_turned_off_banner() {
-    $("#mark_as_read_turned_off_banner").hide();
+    // Use visibility instead of hide() to prevent messages on the screen from
+    // shifting vertically.
+    $("#mark_as_read_turned_off_banner").toggleClass("invisible", true);
+}
+
+export function reset_mark_as_read_turned_off_banner() {
+    hide_mark_as_read_turned_off_banner();
+    user_closed_mark_as_read_turned_off_banner = false;
+}
+
+export function notify_messages_remain_unread() {
+    if (!user_closed_mark_as_read_turned_off_banner) {
+        $("#mark_as_read_turned_off_banner").toggleClass("invisible", false);
+    }
 }
 
 function do_new_messages_animation($li) {
@@ -97,15 +110,11 @@ export function should_display_bankruptcy_banner() {
     return false;
 }
 
-export function notify_messages_remain_unread() {
-    $("#mark_as_read_turned_off_banner").show();
-}
-
 export function initialize() {
     update_unread_counts();
 
     $("#mark_as_read_turned_off_banner").html(render_mark_as_read_turned_off_banner());
-    $("#mark_as_read_turned_off_banner").hide();
+    hide_mark_as_read_turned_off_banner();
     $("#mark_view_read").on("click", () => {
         // Mark all messages in the current view as read.
         //
@@ -117,6 +126,10 @@ export function initialize() {
             .filter((message) => unread.message_unread(message));
         notify_server_messages_read(unread_messages);
 
-        $("#mark_as_read_turned_off_banner").hide();
+        hide_mark_as_read_turned_off_banner();
+    });
+    $("#mark_as_read_close").on("click", () => {
+        hide_mark_as_read_turned_off_banner();
+        user_closed_mark_as_read_turned_off_banner = true;
     });
 }

--- a/static/js/unread_ui.js
+++ b/static/js/unread_ui.js
@@ -15,6 +15,10 @@ import {notify_server_messages_read} from "./unread_ops";
 
 let last_mention_count = 0;
 
+export function hide_mark_as_read_turned_off_banner() {
+    $("#mark_as_read_turned_off_banner").hide();
+}
+
 function do_new_messages_animation($li) {
     $li.addClass("new_messages");
     function mid_animation() {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1125,13 +1125,25 @@ td.pointer {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    padding: 8px 8px 8px 14px;
+    column-gap: 10px;
 
     #mark_as_read_turned_off_content {
         margin: 0;
+        flex-grow: 1;
     }
 
-    .mark_as_read_close {
-        margin-top: 6px;
+    #mark_as_read_controls {
+        display: flex;
+    }
+
+    #mark_as_read_close {
+        align-self: flex-start;
+        margin-top: -5px;
+        /* override bootstrap */
+        top: 0;
+        right: 0;
+        position: static;
     }
 }
 

--- a/static/templates/mark_as_read_turned_off_banner.hbs
+++ b/static/templates/mark_as_read_turned_off_banner.hbs
@@ -5,5 +5,5 @@
     <button id="mark_view_read" class="btn btn-warning" title="{{t 'Mark as read' }}">
         {{t 'Mark as read' }}
     </button>
-    <button type="button" class="mark_as_read_close close">×</button>
 </div>
+<button type="button" id="mark_as_read_close" class="close">×</button>


### PR DESCRIPTION
Two changes: updated the x button to actually close the banner, and updated some styles.

Before: 
<img width="568" alt="image" src="https://user-images.githubusercontent.com/5634097/160695996-20e46233-9097-4237-aee8-c18fd41d0f2e.png">
 (for some reason I wasn't able to reproduce this on CZO, but I can get it consistently locally)

After: 

<img width="473" alt="image" src="https://user-images.githubusercontent.com/5634097/163070128-31dc9ceb-0ce0-47bb-9324-b1966689ad64.png">

<img width="715" alt="image" src="https://user-images.githubusercontent.com/5634097/163070101-1e439969-b3c5-4b7a-b71d-8c03364aba6b.png">


Tested manually since there's no current test suite for the banner.