### PR TITLE
puppet: Do not ensure Chrony is running

### DIFF
--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -61,7 +61,7 @@ class zulip::profile::base {
     }
   }
   package { 'ntp': ensure => 'purged', before => Package['chrony'] }
-  service { 'chrony': ensure => 'running', require => Package['chrony'] }
+  service { 'chrony': require => Package['chrony'] }
   package { $base_packages: ensure => 'installed' }
 
   group { 'zulip':


### PR DESCRIPTION
Commit f6d27562fa4af2ebe496a74c86633d7fb82d8c50 (#21564) tried to ensure Chrony is running, which fails in containers where Chrony doesn’t have permission to update the host clock.

The Debian package should still attempt to start it, and Puppet should still restart it when chrony.conf is modified.

**Testing plan:** Ran `upgrade-zulip-from-git` in an LXC container.