### PR TITLE
Improve error message regarding use of data-tippy-allowHTML attribute.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -738,7 +738,7 @@ html_rules: List["Rule"] = [
     },
     {
         "pattern": r"(?i:data-tippy-allowHTML)",
-        "description": "Never use data-tippy-allowHTML; for an HTML tooltip, set data-tooltip-template-id to the id of a <template>.",
+        "description": "Never use data-tippy-allowHTML; for an HTML tooltip, set data-tooltip-template-id to the id of a <template> containing the tooltip content.",
     },
 ]
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
The error message a user gets from the linter when using the `data-tippy-allowHTML` attribute now conveys the fact that the `<template>` tag is supposed to hold the tooltip content. This might make understanding the correct workflow easier for someone who encounters this error.

[CZO thread](https://chat.zulip.org/#narrow/stream/49-development-help/topic/.E2.9C.94.20Cannot.20use.20data-tippy-allowHTML)
