### PR TITLE
Fix sidebar three dot color inconsistency. Fixes:#20600

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -503,6 +503,7 @@ body.dark-theme {
     #user_presences li:hover .user-list-sidebar-menu-icon,
     li.top_left_all_messages:hover .all-messages-sidebar-menu-icon,
     li.top_left_starred_messages:hover .starred-messages-sidebar-menu-icon,
+    li.top_left_drafts:hover .drafts-sidebar-menu-icon,
     #stream_filters li:hover .stream-sidebar-menu-icon,
     li.topic-list-item:hover .topic-sidebar-menu-icon {
         color: hsl(236, 33%, 80%);
@@ -521,6 +522,7 @@ body.dark-theme {
     .all-messages-sidebar-menu-icon:hover,
     .starred-messages-sidebar-menu-icon:hover,
     .stream-sidebar-menu-icon:hover,
+    .drafts-sidebar-menu-icon:hover,
     .topic-sidebar-menu-icon:hover {
         color: hsl(0, 0%, 100%) !important;
     }

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -392,6 +392,7 @@ li.top_left_recent_topics {
         display: inline-block;
         width: 13px;
         vertical-align: middle;
+        opacity: 0.7;
     }
 
     /*


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
[Link to issue](https://github.com/zulip/zulip/issues/20600)

**Testing plan:** Used manual testing on UI 

- [x]  Try to replicate the error in my local environment
- [x]  Pinpoint the cause of error using dev tools
- [x]  Attempt to fix the error on both hover and not hover states of left sidebar color three dots inconsistency
- [x]  Test the UI to check if the error is fixed on both light and dark themes
- [x] Ui color inconsistency fixed
- [x] Check for linter error and fix
- [x] Squashed the commits as requested by the previous reviewer

**GIFs 
<br>
#### Inconsistency on left sidebar three dot
![3 dots Color Inconsistency](https://user-images.githubusercontent.com/58771507/160786129-4f76a45f-6fc6-4434-b933-8ef5c7746f14.gif)


#### Fixed Inconsistency on left sidebar three dots

##### Dark theme
![Color Consistent ](https://user-images.githubusercontent.com/58771507/160786788-59ecaa4c-be88-4a5e-9d40-3ff6af00042a.gif)
##### Light theme
![color consistent on light theme mode](https://user-images.githubusercontent.com/58771507/160787580-944c9aee-ff14-476d-aed4-b2da534e834b.gif)

**Screenshot for mobile view consistent color (Fixed)

##### Dark theme
![color dot consistent on mobile](https://user-images.githubusercontent.com/58771507/160787073-5c4deb7f-32c5-4273-a324-1e54ad3658ec.png)

##### Light theme
![color consistent on mobile lightMode](https://user-images.githubusercontent.com/58771507/160787204-68e2e87f-a7f6-4cb5-90e9-4c5586134852.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
