### PR TITLE
settings: Fix push notifications tooltip being shown incorrectly.

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -161,6 +161,7 @@ export function build_page() {
             settings_config.create_web_public_stream_policy_values,
         disable_enable_spectator_access_setting: !page_params.server_web_public_streams_enabled,
         can_sort_by_email: settings_data.show_email(),
+        realm_push_notifications_enabled: page_params.realm_push_notifications_enabled,
     };
 
     if (options.realm_logo_source !== "D" && options.realm_night_logo_source === "D") {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -98,6 +98,7 @@ export function build_page() {
         user_can_change_avatar: settings_data.user_can_change_avatar(),
         user_role_text: people.get_user_type(page_params.user_id),
         default_language_name: settings_display.user_default_language_name,
+        realm_push_notifications_enabled: page_params.realm_push_notifications_enabled,
         settings_object: user_settings,
     });
 

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -12,7 +12,7 @@
                     <th colspan="2" width="28%">{{t "Desktop"}}</th>
                     <th rowspan="2" width="14%" class="{{#if show_push_notifications_tooltip.push_notifications}}control-label-disabled{{/if}}">
                         {{t "Mobile"}}
-                        {{#if (not page_params.realm_push_notifications_enabled) }}
+                        {{#if (not realm_push_notifications_enabled) }}
                         <i class="fa fa-question-circle settings-info-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Mobile push notifications are not configured on this server.' }}"></i>
                         {{/if}}
                     </th>


### PR DESCRIPTION
We were showing the push notifications tooltip in user default
settings section even if the notifications were configured on the
server.

The bug was becasue the setting value was undefined for the template
used for user default settings section, so this PR fixes the bug
by correctly passing the settings value to relevant template file.

Fixes #21602.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

 <!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
