### PR TITLE
Add subgroups field to the user group objects and new api endpoints for different user group operations.

### DIFF
--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -721,6 +721,7 @@ exports.fixtures = {
             description: "mobile folks",
             members: [1],
             is_system_group: false,
+            subgroups: [2],
         },
     },
 

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -36,6 +36,8 @@ format used by the Zulip server that they are interacting with.
   given user group.
 * [`GET /user_groups/{user_group_id}/members`](/api/get-user-group-members):
   Added new endpoint to get members of a user group.
+* [`GET /user_groups/{user_group_id}/members`](/api/get-user-group-subgroups):
+  Added new endpoint to get subgroups of a user group.
 
 **Feature level 126**
 

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -34,6 +34,8 @@ format used by the Zulip server that they are interacting with.
 * [`GET /user_groups/{user_group_id}/members/{user_id}`](/api/get-is-user-group-member):
   Added new endpoint for checking whether a given user is member of a
   given user group.
+* [`GET /user_groups/{user_group_id}/members`](/api/get-user-group-members):
+  Added new endpoint to get members of a user group.
 
 **Feature level 126**
 

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -29,6 +29,8 @@ format used by the Zulip server that they are interacting with.
 * [`GET /events`](/api/get-events): Added new `user_group` events
   operations for live updates to subgroups (`add_subgroups` and
   `remove_subgroups`).
+* [`PATCH /user_groups/{user_group_id}/subgroups`](/api/update-user-group-subgroups):
+  Added new endpoint for updating subgroups of a user group.
 
 **Feature level 126**
 

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 6.0
 
+**Feature level 127**
+
+* [`GET /user_groups`](/api/get-user-groups),[`POST
+  /register`](/api/register-queue): Added `subgroups` field,
+  which is a list of IDs of all the subgroups of the user group, to
+  user group objects.
+
 **Feature level 126**
 
 * `POST /invites`, `POST /invites/multiuse`: Replaced `invite_expires_in_days`

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -26,6 +26,9 @@ format used by the Zulip server that they are interacting with.
   /register`](/api/register-queue): Added `subgroups` field,
   which is a list of IDs of all the subgroups of the user group, to
   user group objects.
+* [`GET /events`](/api/get-events): Added new `user_group` events
+  operations for live updates to subgroups (`add_subgroups` and
+  `remove_subgroups`).
 
 **Feature level 126**
 

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -31,6 +31,9 @@ format used by the Zulip server that they are interacting with.
   `remove_subgroups`).
 * [`PATCH /user_groups/{user_group_id}/subgroups`](/api/update-user-group-subgroups):
   Added new endpoint for updating subgroups of a user group.
+* [`GET /user_groups/{user_group_id}/members/{user_id}`](/api/get-is-user-group-member):
+  Added new endpoint for checking whether a given user is member of a
+  given user group.
 
 **Feature level 126**
 

--- a/templates/zerver/help/include/rest-endpoints.md
+++ b/templates/zerver/help/include/rest-endpoints.md
@@ -61,6 +61,7 @@
 * [Update a user group](/api/update-user-group)
 * [Delete a user group](/api/remove-user-group)
 * [Update user group members](/api/update-user-group-members)
+* [Update user group subgroups](/api/update-user-group-subgroups)
 * [Mute a user](/api/mute-user)
 * [Unmute a user](/api/unmute-user)
 

--- a/templates/zerver/help/include/rest-endpoints.md
+++ b/templates/zerver/help/include/rest-endpoints.md
@@ -63,6 +63,7 @@
 * [Update user group members](/api/update-user-group-members)
 * [Update user group subgroups](/api/update-user-group-subgroups)
 * [Get user group membership status](/api/get-is-user-group-member)
+* [Get user group members](/api/get-user-group-members)
 * [Mute a user](/api/mute-user)
 * [Unmute a user](/api/unmute-user)
 

--- a/templates/zerver/help/include/rest-endpoints.md
+++ b/templates/zerver/help/include/rest-endpoints.md
@@ -62,6 +62,7 @@
 * [Delete a user group](/api/remove-user-group)
 * [Update user group members](/api/update-user-group-members)
 * [Update user group subgroups](/api/update-user-group-subgroups)
+* [Get user group membership status](/api/get-is-user-group-member)
 * [Mute a user](/api/mute-user)
 * [Unmute a user](/api/unmute-user)
 

--- a/templates/zerver/help/include/rest-endpoints.md
+++ b/templates/zerver/help/include/rest-endpoints.md
@@ -64,6 +64,7 @@
 * [Update user group subgroups](/api/update-user-group-subgroups)
 * [Get user group membership status](/api/get-is-user-group-member)
 * [Get user group members](/api/get-user-group-members)
+* [Get subgroups of user group](/api/get-user-group-subgroups)
 * [Mute a user](/api/mute-user)
 * [Unmute a user](/api/unmute-user)
 

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 126
+API_FEATURE_LEVEL = 127
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -81,7 +81,9 @@ def promote_new_full_members() -> None:
         update_users_in_full_members_system_group(realm)
 
 
-def do_send_create_user_group_event(user_group: UserGroup, members: List[UserProfile]) -> None:
+def do_send_create_user_group_event(
+    user_group: UserGroup, members: List[UserProfile], subgroups: Sequence[UserGroup] = []
+) -> None:
     event = dict(
         type="user_group",
         op="add",
@@ -91,6 +93,7 @@ def do_send_create_user_group_event(user_group: UserGroup, members: List[UserPro
             description=user_group.description,
             id=user_group.id,
             is_system_group=user_group.is_system_group,
+            subgroups=[subgroup.id for subgroup in subgroups],
         ),
     )
     send_event(user_group.realm, event, active_user_ids(user_group.realm_id))

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -8,7 +8,14 @@ from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.user_groups import access_user_group_by_id, create_user_group
-from zerver.models import Realm, UserGroup, UserGroupMembership, UserProfile, active_user_ids
+from zerver.models import (
+    GroupGroupMembership,
+    Realm,
+    UserGroup,
+    UserGroupMembership,
+    UserProfile,
+    active_user_ids,
+)
 from zerver.tornado.django_api import send_event
 
 
@@ -156,6 +163,36 @@ def remove_members_from_user_group(user_group: UserGroup, user_profile_ids: List
     ).delete()
 
     do_send_user_group_members_update_event("remove_members", user_group, user_profile_ids)
+
+
+def do_send_subgroups_update_event(
+    event_name: str, user_group: UserGroup, subgroup_ids: List[int]
+) -> None:
+    event = dict(
+        type="user_group", op=event_name, group_id=user_group.id, subgroup_ids=subgroup_ids
+    )
+    transaction.on_commit(
+        lambda: send_event(user_group.realm, event, active_user_ids(user_group.realm_id))
+    )
+
+
+@transaction.atomic
+def add_subgroups_to_user_group(user_group: UserGroup, subgroups: List[UserGroup]) -> None:
+    group_memberships = [
+        GroupGroupMembership(supergroup=user_group, subgroup=subgroup) for subgroup in subgroups
+    ]
+    GroupGroupMembership.objects.bulk_create(group_memberships)
+
+    subgroup_ids = [subgroup.id for subgroup in subgroups]
+    do_send_subgroups_update_event("add_subgroups", user_group, subgroup_ids)
+
+
+@transaction.atomic
+def remove_subgroups_from_user_group(user_group: UserGroup, subgroups: List[UserGroup]) -> None:
+    GroupGroupMembership.objects.filter(supergroup=user_group, subgroup__in=subgroups).delete()
+
+    subgroup_ids = [subgroup.id for subgroup in subgroups]
+    do_send_subgroups_update_event("remove_subgroups", user_group, subgroup_ids)
 
 
 def do_send_delete_user_group_event(realm: Realm, user_group_id: int, realm_id: int) -> None:

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1748,6 +1748,28 @@ def check_user_group_update(var_name: str, event: Dict[str, object], field: str)
     assert set(event["data"].keys()) == {field}
 
 
+user_group_add_subgroups_event = event_dict_type(
+    required_keys=[
+        ("type", Equals("user_group")),
+        ("op", Equals("add_subgroups")),
+        ("group_id", int),
+        ("subgroup_ids", ListType(int)),
+    ]
+)
+check_user_group_add_subgroups = make_checker(user_group_add_subgroups_event)
+
+
+user_group_remove_subgroups_event = event_dict_type(
+    required_keys=[
+        ("type", Equals("user_group")),
+        ("op", Equals("remove_subgroups")),
+        ("group_id", int),
+        ("subgroup_ids", ListType(int)),
+    ]
+)
+check_user_group_remove_subgroups = make_checker(user_group_remove_subgroups_event)
+
+
 user_status_event = event_dict_type(
     required_keys=[
         # force vertical

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1676,6 +1676,7 @@ group_type = DictType(
         ("id", int),
         ("name", str),
         ("members", ListType(int)),
+        ("subgroups", ListType(int)),
         ("description", str),
         ("is_system_group", bool),
     ]

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1245,6 +1245,17 @@ def apply_event(
                     members = set(user_group["members"])
                     user_group["members"] = list(members - set(event["user_ids"]))
                     user_group["members"].sort()
+        elif event["op"] == "add_subgroups":
+            for user_group in state["realm_user_groups"]:
+                if user_group["id"] == event["group_id"]:
+                    user_group["subgroups"].extend(event["subgroup_ids"])
+                    user_group["subgroups"].sort()
+        elif event["op"] == "remove_subgroups":
+            for user_group in state["realm_user_groups"]:
+                if user_group["id"] == event["group_id"]:
+                    subgroups = set(user_group["subgroups"])
+                    user_group["subgroups"] = list(subgroups - set(event["subgroup_ids"]))
+                    user_group["subgroups"].sort()
         elif event["op"] == "remove":
             state["realm_user_groups"] = [
                 ug for ug in state["realm_user_groups"] if ug["id"] != event["group_id"]

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -179,6 +179,19 @@ def get_user_group_member_ids(
     return list(member_ids)
 
 
+def get_subgroup_ids(user_group: UserGroup, *, direct_subgroup_only: bool = False) -> List[int]:
+    if direct_subgroup_only:
+        subgroup_ids = user_group.direct_subgroups.all().values_list("id", flat=True)
+    else:
+        subgroup_ids = (
+            get_recursive_subgroups(user_group)
+            .exclude(id=user_group.id)
+            .values_list("id", flat=True)
+        )
+
+    return list(subgroup_ids)
+
+
 def create_system_user_groups_for_realm(realm: Realm) -> Dict[int, UserGroup]:
     """Any changes to this function likely require a migration to adjust
     existing realms.  See e.g. migration 0375_create_role_based_system_groups.py,

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -150,6 +150,15 @@ def get_recursive_membership_groups(user_profile: UserProfile) -> "QuerySet[User
     return cte.join(UserGroup, id=cte.col.id).with_cte(cte)
 
 
+def is_user_in_group(
+    user_group: UserGroup, user: UserProfile, *, direct_member_only: bool = False
+) -> bool:
+    if direct_member_only:
+        return UserGroupMembership.objects.filter(user_group=user_group, user_profile=user).exists()
+
+    return get_recursive_group_members(user_group=user_group).filter(id=user.id).exists()
+
+
 def create_system_user_groups_for_realm(realm: Realm) -> Dict[int, UserGroup]:
     """Any changes to this function likely require a migration to adjust
     existing realms.  See e.g. migration 0375_create_role_based_system_groups.py,

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -168,6 +168,17 @@ def is_user_in_group(
     return get_recursive_group_members(user_group=user_group).filter(id=user.id).exists()
 
 
+def get_user_group_member_ids(
+    user_group: UserGroup, *, direct_member_only: bool = False
+) -> List[int]:
+    if direct_member_only:
+        member_ids = get_user_group_direct_members(user_group)
+    else:
+        member_ids = get_recursive_group_members(user_group).values_list("id", flat=True)
+
+    return list(member_ids)
+
+
 def create_system_user_groups_for_realm(realm: Realm) -> Dict[int, UserGroup]:
     """Any changes to this function likely require a migration to adjust
     existing realms.  See e.g. migration 0375_create_role_based_system_groups.py,

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -40,6 +40,7 @@ def user_groups_in_realm_serialized(realm: Realm) -> List[Dict[str, Any]]:
             name=user_group.name,
             description=user_group.description,
             members=[],
+            subgroups=[],
             is_system_group=user_group.is_system_group,
         )
 
@@ -48,8 +49,16 @@ def user_groups_in_realm_serialized(realm: Realm) -> List[Dict[str, Any]]:
     )
     for (user_group_id, user_profile_id) in membership:
         group_dicts[user_group_id]["members"].append(user_profile_id)
+
+    group_membership = GroupGroupMembership.objects.filter(subgroup__realm=realm).values_list(
+        "subgroup_id", "supergroup_id"
+    )
+    for (subgroup_id, supergroup_id) in group_membership:
+        group_dicts[supergroup_id]["subgroups"].append(subgroup_id)
+
     for group_dict in group_dicts.values():
         group_dict["members"] = sorted(group_dict["members"])
+        group_dict["subgroups"] = sorted(group_dict["subgroups"])
 
     return sorted(group_dicts.values(), key=lambda group_dict: group_dict["id"])
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13975,6 +13975,44 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
+  /user_groups/{user_group_id}/members/{user_id}:
+    get:
+      operationId: get-is-user-group-member
+      summary: Get user group membership status
+      tags: ["users"]
+      description: |
+        Check whether a user is member of user group.
+
+        `GET {{ api_url }}/v1/user_groups/{user_group_id}/members/{user_id}`
+
+        **Changes**: New in Zulip 6.0 (feature level 127).
+      parameters:
+        - $ref: "#/components/parameters/UserGroupId"
+        - $ref: "#/components/parameters/UserId"
+        - $ref: "#/components/parameters/DirectMemberOnly"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - $ref: "#/components/schemas/SuccessDescription"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      is_user_group_member:
+                        type: boolean
+                        description: |
+                          Whether the user is member of user group.
+                    example:
+                      {
+                        "msg": "",
+                        "result": "success",
+                        "is_user_group_member": false,
+                      }
   /real-time:
     # This entry is a hack; it exists to give us a place to put the text
     # documenting the parameters for call_on_each_event and friends.
@@ -16320,3 +16358,13 @@ components:
         type: string
       example: https://github.com/zulip/zulip/issues/%(id)s
       required: true
+    DirectMemberOnly:
+      name: direct_member_only
+      in: query
+      description: |
+        Whether to consider only the direct members of user group and not members
+        of its subgroups. Default is `False`.
+      schema:
+        type: boolean
+      example: false
+      required: false

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2833,6 +2833,82 @@ paths:
                             - type: object
                               additionalProperties: false
                               description: |
+                                Event sent to all users when subgroups have been added to
+                                a user group.
+
+                                **Changes**: New in Zulip 6.0 (feature level 127).
+                              properties:
+                                id:
+                                  $ref: "#/components/schemas/EventIdSchema"
+                                type:
+                                  allOf:
+                                    - $ref: "#/components/schemas/EventTypeSchema"
+                                    - enum:
+                                        - user_group
+                                op:
+                                  type: string
+                                  enum:
+                                    - add_subgroups
+                                group_id:
+                                  type: integer
+                                  description: |
+                                    The ID of the user group whose details have changed.
+                                subgroup_ids:
+                                  type: array
+                                  items:
+                                    type: integer
+                                  description: |
+                                    Array containing the IDs of the subgroups that have been added
+                                    to the user group.
+                              example:
+                                {
+                                  "type": "user_group",
+                                  "op": "add_subgroups",
+                                  "group_id": 2,
+                                  "subgroup_ids": [10],
+                                  "id": 0,
+                                }
+                            - type: object
+                              additionalProperties: false
+                              description: |
+                                Event sent to all users when subgroups have been removed from
+                                a user group.
+
+                                **Changes**: New in Zulip 6.0 (feature level 127).
+                              properties:
+                                id:
+                                  $ref: "#/components/schemas/EventIdSchema"
+                                type:
+                                  allOf:
+                                    - $ref: "#/components/schemas/EventTypeSchema"
+                                    - enum:
+                                        - user_group
+                                op:
+                                  type: string
+                                  enum:
+                                    - remove_subgroups
+                                group_id:
+                                  type: integer
+                                  description: |
+                                    The ID of the user group whose details have changed.
+                                subgroup_ids:
+                                  type: array
+                                  items:
+                                    type: integer
+                                  description: |
+                                    Array containing the IDs of the subgroups that have been
+                                    removed from the user group.
+                              example:
+                                {
+                                  "type": "user_group",
+                                  "op": "remove_subgroups",
+                                  "group_id": 2,
+                                  "subgroup_ids": [10],
+                                  "id": 0,
+                                }
+                            - type: object
+                              additionalProperties: false
+                              description: |
                                 Event sent to all users when a user group has been deleted.
                               properties:
                                 id:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13929,6 +13929,52 @@ paths:
                             },
                           ],
                       }
+  /user_groups/{user_group_id}/subgroups:
+    post:
+      operationId: update-user-group-subgroups
+      summary: Update subgroups of a user group
+      tags: ["users"]
+      description: |
+        Update the subgroups of a [user group](/help/user-groups).
+
+        `POST {{ api_url }}/v1/user_groups/{user_group_id}/subgroups`
+
+        **Changes**: New in Zulip 6.0 (feature level 127).
+      x-curl-examples-parameters:
+        oneOf:
+          - type: exclude
+            parameters:
+              enum:
+                - delete
+      parameters:
+        - $ref: "#/components/parameters/UserGroupId"
+        - name: delete
+          in: query
+          description: |
+            The list of user group ids to be removed from the user group.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+              example: [10]
+          required: false
+        - name: add
+          in: query
+          description: |
+            The list of user group ids to be added to the user group.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+              example: [1, 2]
+          required: false
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
   /real-time:
     # This entry is a hack; it exists to give us a place to put the text
     # documenting the parameters for call_on_each_event and friends.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14009,6 +14009,49 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
+    get:
+      operationId: get-user-group-subgroups
+      summary: Get subgroups of the user group
+      tags: ["users"]
+      description: |
+        Get the subgroups of a [user group](/help/user-groups).
+
+        `GET {{ api_url }}/v1/user_groups/{user_group_id}/subgroups`
+
+        **Changes**: New in Zulip 6.0 (feature level 127).
+      parameters:
+        - $ref: "#/components/parameters/UserGroupId"
+        - name: direct_subgroup_only
+          in: query
+          description: |
+            Whether to consider only direct subgroups of the user group
+            or subgroups of subgroups also.
+          schema:
+            type: boolean
+            default: false
+          example: true
+          required: false
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - $ref: "#/components/schemas/SuccessDescription"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      subgroups:
+                        type: array
+                        items:
+                          type: integer
+                        description: |
+                          A list containing the IDs of subgroups of the user group.
+                    example:
+                      {"msg": "", "result": "success", "subgroups": [2, 3]}
   /user_groups/{user_group_id}/members/{user_id}:
     get:
       operationId: get-is-user-group-member

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13807,6 +13807,14 @@ paths:
                                 The integer user IDs of the user group members.
                               items:
                                 type: integer
+                            subgroups:
+                              type: array
+                              description: |
+                                The integer user group IDs of the subgroups.
+
+                                **Changes**: New in Zulip 6.0 (feature level 127).
+                              items:
+                                type: integer
                             name:
                               type: string
                               description: |
@@ -13832,6 +13840,7 @@ paths:
                               "id": 1,
                               "name": "hamletcharacters",
                               "members": [3, 4],
+                              "subgroups": [],
                               "is_system_group": false,
                             },
                             {
@@ -13839,6 +13848,7 @@ paths:
                               "id": 2,
                               "name": "other users",
                               "members": [1, 2],
+                              "subgroups": [1, 2],
                               "is_system_group": true,
                             },
                           ],
@@ -14650,6 +14660,15 @@ components:
           description: |
             Array containing the id of the users who are
             members of this user group.
+        subgroups:
+          type: array
+          items:
+            type: integer
+          description: |
+            Array containing the id of the subgroups of this
+            user group.
+
+            **Changes**: New in Zulip 6.0 (feature level 127).
         id:
           type: integer
           description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13756,6 +13756,40 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
+    get:
+      operationId: get-user-group-members
+      summary: Get user group members
+      tags: ["users"]
+      description: |
+        Get the members of a [user group](/help/user-groups).
+
+        `GET {{ api_url }}/v1/user_groups/{user_group_id}/members`
+
+        **Changes**: New in Zulip 6.0 (feature level 127).
+      parameters:
+        - $ref: "#/components/parameters/UserGroupId"
+        - $ref: "#/components/parameters/DirectMemberOnly"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - $ref: "#/components/schemas/SuccessDescription"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      members:
+                        type: array
+                        items:
+                          type: integer
+                        description: |
+                          A list containing the user IDs of members of the user group.
+                    example:
+                      {"msg": "", "result": "success", "members": [10, 12]}
   /user_groups/{user_group_id}:
     patch:
       operationId: update-user-group

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -1004,7 +1004,7 @@ class FetchQueriesTest(ZulipTestCase):
             with mock.patch("zerver.lib.events.always_want") as want_mock:
                 fetch_initial_state_data(user)
 
-        self.assert_length(queries, 35)
+        self.assert_length(queries, 36)
 
         expected_counts = dict(
             alert_words=1,
@@ -1027,7 +1027,7 @@ class FetchQueriesTest(ZulipTestCase):
             realm_linkifiers=1,
             realm_playgrounds=1,
             realm_user=3,
-            realm_user_groups=2,
+            realm_user_groups=3,
             realm_user_settings_defaults=1,
             recent_private_conversations=1,
             starred_messages=1,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -247,7 +247,7 @@ class HomeTest(ZulipTestCase):
             set(result["Cache-Control"].split(", ")), {"must-revalidate", "no-store", "no-cache"}
         )
 
-        self.assert_length(queries, 44)
+        self.assert_length(queries, 45)
         self.assert_length(cache_mock.call_args_list, 5)
 
         html = result.content.decode()
@@ -420,7 +420,7 @@ class HomeTest(ZulipTestCase):
                 result = self._get_home_page()
                 self.check_rendered_logged_in_app(result)
                 self.assert_length(cache_mock.call_args_list, 6)
-            self.assert_length(queries, 41)
+            self.assert_length(queries, 42)
 
     def test_num_queries_with_streams(self) -> None:
         main_user = self.example_user("hamlet")
@@ -451,7 +451,7 @@ class HomeTest(ZulipTestCase):
         with queries_captured() as queries2:
             result = self._get_home_page()
 
-        self.assert_length(queries2, 39)
+        self.assert_length(queries2, 40)
 
         # Do a sanity check that our new streams were in the payload.
         html = result.content.decode()

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -50,6 +50,12 @@ class UserGroupTestCase(ZulipTestCase):
         self.assertEqual(user_groups[0]["name"], "@role:owners")
         self.assertEqual(user_groups[0]["description"], "Owners of this organization")
         self.assertEqual(set(user_groups[0]["members"]), set(membership))
+        self.assertEqual(user_groups[0]["subgroups"], [])
+
+        admins_system_group = UserGroup.objects.get(name="@role:administrators", realm=realm)
+        self.assertEqual(user_groups[1]["id"], admins_system_group.id)
+        # Check that owners system group is present in "subgroups"
+        self.assertEqual(user_groups[1]["subgroups"], [user_group.id])
 
         self.assertEqual(user_groups[8]["id"], empty_user_group.id)
         self.assertEqual(user_groups[8]["name"], "newgroup")

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -22,6 +22,7 @@ from zerver.lib.user_groups import (
     access_user_groups_as_potential_subgroups,
     get_direct_memberships_of_users,
     get_user_group_direct_members,
+    get_user_group_member_ids,
     is_user_in_group,
     user_groups_in_realm_serialized,
 )
@@ -238,5 +239,23 @@ def get_is_user_group_member(
             "is_user_group_member": is_user_in_group(
                 user_group, target_user, direct_member_only=direct_member_only
             )
+        },
+    )
+
+
+@require_member_or_admin
+@has_request_variables
+def get_user_group_members(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    user_group_id: int = REQ(json_validator=check_int, path_only=True),
+    direct_member_only: bool = REQ(json_validator=check_bool, default=False),
+) -> HttpResponse:
+    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=True)
+
+    return json_success(
+        request,
+        data={
+            "members": get_user_group_member_ids(user_group, direct_member_only=direct_member_only)
         },
     )

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -21,6 +21,7 @@ from zerver.lib.user_groups import (
     access_user_group_by_id,
     access_user_groups_as_potential_subgroups,
     get_direct_memberships_of_users,
+    get_subgroup_ids,
     get_user_group_direct_members,
     get_user_group_member_ids,
     is_user_in_group,
@@ -258,4 +259,20 @@ def get_user_group_members(
         data={
             "members": get_user_group_member_ids(user_group, direct_member_only=direct_member_only)
         },
+    )
+
+
+@require_member_or_admin
+@has_request_variables
+def get_subgroups_of_user_group(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    user_group_id: int = REQ(json_validator=check_int, path_only=True),
+    direct_subgroup_only: bool = REQ(json_validator=check_bool, default=False),
+) -> HttpResponse:
+    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=True)
+
+    return json_success(
+        request,
+        data={"subgroups": get_subgroup_ids(user_group, direct_subgroup_only=direct_subgroup_only)},
     )

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -177,6 +177,7 @@ from zerver.views.user_groups import (
     delete_user_group,
     edit_user_group,
     get_is_user_group_member,
+    get_subgroups_of_user_group,
     get_user_group,
     get_user_group_members,
     update_subgroups_of_user_group,
@@ -379,7 +380,11 @@ v1_api_and_json_patterns = [
         GET=get_user_group_members,
         POST=update_user_group_backend,
     ),
-    rest_path("user_groups/<int:user_group_id>/subgroups", POST=update_subgroups_of_user_group),
+    rest_path(
+        "user_groups/<int:user_group_id>/subgroups",
+        POST=update_subgroups_of_user_group,
+        GET=get_subgroups_of_user_group,
+    ),
     rest_path(
         "user_groups/<int:user_group_id>/members/<int:user_id>", GET=get_is_user_group_member
     ),

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -176,6 +176,7 @@ from zerver.views.user_groups import (
     add_user_group,
     delete_user_group,
     edit_user_group,
+    get_is_user_group_member,
     get_user_group,
     update_subgroups_of_user_group,
     update_user_group_backend,
@@ -374,6 +375,9 @@ v1_api_and_json_patterns = [
     rest_path("user_groups/<int:user_group_id>", PATCH=edit_user_group, DELETE=delete_user_group),
     rest_path("user_groups/<int:user_group_id>/members", POST=update_user_group_backend),
     rest_path("user_groups/<int:user_group_id>/subgroups", POST=update_subgroups_of_user_group),
+    rest_path(
+        "user_groups/<int:user_group_id>/members/<int:user_id>", GET=get_is_user_group_member
+    ),
     # users/me -> zerver.views.user_settings
     rest_path("users/me/avatar", POST=set_avatar_backend, DELETE=delete_avatar_backend),
     # users/me/hotspots -> zerver.views.hotspots

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -177,6 +177,7 @@ from zerver.views.user_groups import (
     delete_user_group,
     edit_user_group,
     get_user_group,
+    update_subgroups_of_user_group,
     update_user_group_backend,
 )
 from zerver.views.user_settings import (
@@ -372,6 +373,7 @@ v1_api_and_json_patterns = [
     rest_path("user_groups/create", POST=add_user_group),
     rest_path("user_groups/<int:user_group_id>", PATCH=edit_user_group, DELETE=delete_user_group),
     rest_path("user_groups/<int:user_group_id>/members", POST=update_user_group_backend),
+    rest_path("user_groups/<int:user_group_id>/subgroups", POST=update_subgroups_of_user_group),
     # users/me -> zerver.views.user_settings
     rest_path("users/me/avatar", POST=set_avatar_backend, DELETE=delete_avatar_backend),
     # users/me/hotspots -> zerver.views.hotspots

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -178,6 +178,7 @@ from zerver.views.user_groups import (
     edit_user_group,
     get_is_user_group_member,
     get_user_group,
+    get_user_group_members,
     update_subgroups_of_user_group,
     update_user_group_backend,
 )
@@ -373,7 +374,11 @@ v1_api_and_json_patterns = [
     rest_path("user_groups", GET=get_user_group),
     rest_path("user_groups/create", POST=add_user_group),
     rest_path("user_groups/<int:user_group_id>", PATCH=edit_user_group, DELETE=delete_user_group),
-    rest_path("user_groups/<int:user_group_id>/members", POST=update_user_group_backend),
+    rest_path(
+        "user_groups/<int:user_group_id>/members",
+        GET=get_user_group_members,
+        POST=update_user_group_backend,
+    ),
     rest_path("user_groups/<int:user_group_id>/subgroups", POST=update_subgroups_of_user_group),
     rest_path(
         "user_groups/<int:user_group_id>/members/<int:user_id>", GET=get_is_user_group_member


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- First commit adds `subgroups` field to the user group objects.
- Second commit adds functions in `actions.py` to add and remove subgroups of a user group.
- Third commit adds API endpoint for updating subgroups of a user group.
- Fourth and Fifith commit add helper functions - `get_user_group_member_ids` and `is_user_in_group`.
- Sixth and Seventh commit add new api endpoints to check whether a user is part of a user group or not.
- Last commit adds endpoint to get members of a user group.

Part of #19525.
 <!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
