### PR TITLE
migrations: Mark 0001_initial as replacing squashed migrations

### DIFF
--- a/zerver/migrations/0001_initial.py
+++ b/zerver/migrations/0001_initial.py
@@ -38,6 +38,36 @@ def migrate_existing_attachment_data(apps: StateApps, schema_editor: DatabaseSch
 
 class Migration(migrations.Migration):
 
+    replaces = [
+        ("zerver", "0002_django_1_8"),
+        ("zerver", "0003_custom_indexes"),
+        ("zerver", "0004_userprofile_left_side_userlist"),
+        ("zerver", "0005_auto_20150920_1340"),
+        ("zerver", "0006_zerver_userprofile_email_upper_idx"),
+        ("zerver", "0007_userprofile_is_bot_active_indexes"),
+        ("zerver", "0008_preregistrationuser_upper_email_idx"),
+        ("zerver", "0009_add_missing_migrations"),
+        ("zerver", "0010_delete_streamcolor"),
+        ("zerver", "0011_remove_guardian"),
+        ("zerver", "0012_remove_appledevicetoken"),
+        ("zerver", "0013_realmemoji"),
+        ("zerver", "0014_realm_emoji_url_length"),
+        ("zerver", "0015_attachment"),
+        ("zerver", "0016_realm_create_stream_by_admins_only"),
+        ("zerver", "0017_userprofile_bot_type"),
+        ("zerver", "0018_realm_emoji_message"),
+        ("zerver", "0019_preregistrationuser_realm_creation"),
+        ("zerver", "0020_add_tracking_attachment"),
+        ("zerver", "0021_migrate_attachment_data"),
+        ("zerver", "0022_subscription_pin_to_top"),
+        ("zerver", "0023_userprofile_default_language"),
+        ("zerver", "0024_realm_allow_message_editing"),
+        ("zerver", "0025_realm_message_content_edit_limit"),
+        ("zerver", "0026_delete_mituser"),
+        ("zerver", "0027_realm_default_language"),
+        ("zerver", "0028_userprofile_tos_version"),
+    ]
+
     initial = True
 
     dependencies = [


### PR DESCRIPTION
Commit a21f2d771553d58a60dbfbbcb897b8e7e5f30ce3 (#5498) should not have deleted this (except `0001_initial`, since a migration cannot replace itself).

Fixes part of #21596.

[Discussion](https://chat.zulip.org/#narrow/channel/31-production-help/topic/.E2.9C.94.20Not.20an.20upgrade/near/1356737).