### PR TITLE
navbar_alerts: Adjust height of recent topics when alert is visible.

### DIFF
--- a/static/js/navbar_alerts.js
+++ b/static/js/navbar_alerts.js
@@ -23,6 +23,7 @@ import * as util from "./util";
 export function resize_app() {
     const navbar_alerts_wrapper_height = $("#navbar_alerts_wrapper").height();
     $("body > .app").height("calc(100% - " + navbar_alerts_wrapper_height + "px)");
+    $(".recent_topics_container").height("calc(100vh - " + navbar_alerts_wrapper_height + "px)");
 
     // the floating recipient bar is usually positioned right below
     // the `.header` element (including padding).


### PR DESCRIPTION
Fixes #21619

We need to adjust height of recent topics along with the app
otherwise the container becomes separately scrollable due to
it overflowing the app height.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/recent.20topics.20scrollbar