### PR TITLE
i18n: Fix two missing internationalization tags on stream creation view

### DIFF
--- a/static/templates/stream_settings/new_stream_user.hbs
+++ b/static/templates/stream_settings/new_stream_user.hbs
@@ -9,6 +9,6 @@
     {{/if}}
     <td>{{user_id}} </td>
     <td>
-        <button {{#if disabled}} disabled="disabled"{{/if}} data-user-id="{{user_id}}" class="remove_potential_subscriber button small rounded btn-danger">Remove</button>
+        <button {{#if disabled}} disabled="disabled"{{/if}} data-user-id="{{user_id}}" class="remove_potential_subscriber button small rounded btn-danger">{{t 'Remove' }}</button>
     </td>
 </tr>

--- a/static/templates/stream_settings/new_stream_users.hbs
+++ b/static/templates/stream_settings/new_stream_users.hbs
@@ -7,7 +7,7 @@
 <button class="add_all_users_to_stream small button rounded sea-green">{{t 'Add all users'}}</button>
 
 <div class="create_stream_subscriber_list_header">
-    <h4 class="stream_setting_subsection_title">Subscribers</h4>
+    <h4 class="stream_setting_subsection_title">{{t 'Subscribers' }}</h4>
     <input class="add-user-list-filter" name="user_list_filter" type="text"
       autocomplete="off" placeholder="{{t 'Filter subscribers' }}" />
 </div>


### PR DESCRIPTION
Adding two internationalization tags to stream creation view that where missing.
1. Subscribers -header
2. Remove -button for potential subscribers

Using existing i18n keys for both according to native (en) language.
'Subscribers' key is used also in user groups. 'Remove' key is not used elsewhere, but existed already.

**Testing plan:** Manually tested in local environment.

