### PR TITLE
org_settings: Add feature to change bot role from UI.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -127,6 +127,7 @@ const bot_botson = {
     full_name: "Bot Botson",
     is_bot: true,
     bot_owner_id: isaac.user_id,
+    role: 300,
 };
 
 const moderator = {
@@ -525,7 +526,7 @@ test_people("user_type", () => {
     assert.equal(people.get_user_type(guest.user_id), $t({defaultMessage: "Guest"}));
     assert.equal(people.get_user_type(realm_owner.user_id), $t({defaultMessage: "Owner"}));
     assert.equal(people.get_user_type(moderator.user_id), $t({defaultMessage: "Moderator"}));
-    assert.equal(people.get_user_type(bot_botson.user_id), $t({defaultMessage: "Bot"}));
+    assert.equal(people.get_user_type(bot_botson.user_id), $t({defaultMessage: "Moderator"}));
 });
 
 test_people("updates", () => {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -274,9 +274,6 @@ export function get_user_time(user_id) {
 
 export function get_user_type(user_id) {
     const user_profile = get_by_user_id(user_id);
-    if (user_profile.is_bot) {
-        return $t({defaultMessage: "Bot"});
-    }
 
     return settings_config.user_role_map.get(user_profile.role);
 }

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -190,10 +190,12 @@ function bot_info(bot_user_id) {
     const info = {};
 
     info.is_bot = true;
+    info.role = people.get_by_user_id(bot_user_id).role;
     info.is_active = bot_user.is_active;
     info.user_id = bot_user.user_id;
     info.full_name = bot_user.full_name;
     info.bot_owner_id = owner_id;
+    info.user_role_text = people.get_user_type(bot_user_id);
 
     // Convert bot type id to string for viewing to the users.
     info.bot_type = settings_bots.type_id_to_string(bot_user.bot_type);
@@ -279,7 +281,7 @@ section.bots.create_table = () => {
         sort_fields: {
             email: sort_bot_email,
             bot_owner: sort_bot_owner,
-            id: sort_user_id,
+            role: sort_role,
         },
         $simplebar_container: $("#admin-bot-list .progressive-table-wrapper"),
     });

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -645,16 +645,20 @@ function handle_bot_form($tbody) {
             user_id,
             email: bot.email,
             full_name: bot.full_name,
+            user_role_values: settings_config.user_role_values,
+            disable_role_dropdown: bot.is_owner && !page_params.is_owner,
         });
 
         let owner_widget;
 
         function submit_bot_details() {
+            const role = Number.parseInt($("#bot-role-select").val().trim(), 10);
             const $full_name = $("#dialog_widget_modal").find("input[name='full_name']");
 
             const url = "/json/bots/" + encodeURIComponent(user_id);
             const data = {
                 full_name: $full_name.val(),
+                role: JSON.stringify(role),
             };
 
             if (owner_widget === undefined) {
@@ -668,7 +672,7 @@ function handle_bot_form($tbody) {
             dialog_widget.submit_api_request(channel.patch, url, data);
         }
 
-        function get_bot_owner_widget() {
+        function get_bot_owner_widget_and_set_role_values() {
             const owner_id = bot_data.get(user_id).owner_id;
 
             const user_ids = people.get_active_human_ids();
@@ -687,6 +691,17 @@ function handle_bot_form($tbody) {
             // organizations with 10Ks of users.
             owner_widget = new DropdownListWidget(opts);
             owner_widget.setup();
+
+            $("#bot-role-select").val(bot.role);
+            if (!page_params.is_owner) {
+                $("#bot-role-select")
+                    .find(
+                        `option[value="${CSS.escape(
+                            settings_config.user_role_values.owner.code,
+                        )}"]`,
+                    )
+                    .hide();
+            }
         }
 
         dialog_widget.launch({
@@ -694,7 +709,7 @@ function handle_bot_form($tbody) {
             html_body,
             id: "edit_bot_modal",
             on_click: submit_bot_details,
-            post_render: get_bot_owner_widget,
+            post_render: get_bot_owner_widget_and_set_role_values,
         });
     });
 }

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -690,7 +690,7 @@ function handle_bot_form($tbody) {
         }
 
         dialog_widget.launch({
-            html_heading: $t_html({defaultMessage: "Change bot info and owner"}),
+            html_heading: $t_html({defaultMessage: "Manage bot"}),
             html_body,
             id: "edit_bot_modal",
             on_click: submit_bot_details,

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -966,7 +966,6 @@ input[type="checkbox"] {
     padding: 0;
 
     label {
-        text-transform: uppercase;
         font-weight: 600;
         color: hsl(0, 0%, 67%);
         margin-top: 5px;

--- a/static/templates/settings/admin_bot_form.hbs
+++ b/static/templates/settings/admin_bot_form.hbs
@@ -13,6 +13,14 @@
             <label for="user_id">{{t "User ID" }}</label>
             <input type="text" autocomplete="off" name="user_id" value="{{ user_id }}" readonly/>
         </div>
+        <div class="input-group">
+            <label class="input-label" for="bot-role-select">{{t 'Role' }}
+                {{> ../help_link_widget link="/help/roles-and-permissions" }}
+            </label>
+            <select name="bot-role-select" id="bot-role-select" data-setting-widget-type="number" {{#if disable_role_dropdown}}disabled{{/if}}>
+                {{> dropdown_options_widget option_values=user_role_values}}
+            </select>
+        </div>
         <div class="input-group edit_bot_owner_container">
             <label for="bot_owner_select">{{t "Owner" }}</label>
             {{> dropdown_list_widget

--- a/static/templates/settings/admin_bot_form.hbs
+++ b/static/templates/settings/admin_bot_form.hbs
@@ -1,19 +1,23 @@
 <div id="bot-edit-form" data-user-id="{{user_id}}">
     <form class="new-style edit_bot_form form-horizontal name-setting">
+        <div class="input-group name_change_container">
+            <label for="full_name">{{t "Full name" }}</label>
+            <input type="text" autocomplete="off" name="full_name" value="{{ full_name }}" />
+        </div>
         <input type="hidden" name="is_full_name" value="true" />
+        <div class="input-group email_change_container">
+            <label for="email">{{t "Email" }}</label>
+            <input type="text" autocomplete="off" name="email" value="{{ email }}" readonly/>
+        </div>
+        <div class="input-group user_id_container">
+            <label for="user_id">{{t "User ID" }}</label>
+            <input type="text" autocomplete="off" name="user_id" value="{{ user_id }}" readonly/>
+        </div>
         <div class="input-group edit_bot_owner_container">
             <label for="bot_owner_select">{{t "Owner" }}</label>
             {{> dropdown_list_widget
               widget_name="edit_bot_owner"
               list_placeholder=(t 'Filter users')}}
-        </div>
-        <div class="name_change_container">
-            <label for="full_name">{{t "Full name" }}</label>
-            <input type="text" autocomplete="off" name="full_name" value="{{ full_name }}" />
-        </div>
-        <div class="email_change_container">
-            <label for="email">{{t "Email" }}</label>
-            <input type="text" autocomplete="off" name="email" value="{{ email }}" readonly/>
         </div>
     </form>
 </div>

--- a/static/templates/settings/admin_user_list.hbs
+++ b/static/templates/settings/admin_user_list.hbs
@@ -12,14 +12,14 @@
         <span class="hidden-email">{{t "(hidden)"}}</span>
     </td>
     {{/if}}
+    {{#unless is_bot}}
     <td>
         <span class="user_id">{{user_id}}</span>
     </td>
-    {{#unless is_bot}}
+    {{/unless}}
     <td>
         <span class="user_role">{{user_role_text}}</span>
     </td>
-    {{/unless}}
     {{#if is_bot}}
     <td>
         <span class="owner">

--- a/static/templates/settings/bot_list_admin.hbs
+++ b/static/templates/settings/bot_list_admin.hbs
@@ -13,7 +13,7 @@
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 <th data-sort="email">{{t "Email" }}</th>
-                <th data-sort="id">{{t "User ID"}}</th>
+                <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 <th data-sort="bot_owner">{{t "Owner" }}</th>
                 <th data-sort="alphabetic" data-sort-prop="bot_type">{{t "Bot type" }}</th>
                 {{#if is_admin}}

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 6.0
 
+**Feature level 130**
+
+* `PATCH /bots/{bot_user_id}`: Added support for changing a bot's role
+  via this endpoint. Previously, this could only be done via [`PATCH
+  /users/{user_id}`](/api/update-user).
+
 **Feature level 129**
 
 * [`POST /register`](/api/register-queue),

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 129
+API_FEATURE_LEVEL = 130
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -198,7 +198,7 @@ def update_user_backend(
         if UserProfile.ROLE_REALM_OWNER in [role, target.role] and not user_profile.is_realm_owner:
             raise OrganizationOwnerRequired()
 
-        if target.role == UserProfile.ROLE_REALM_OWNER and check_last_owner(user_profile):
+        if target.role == UserProfile.ROLE_REALM_OWNER and check_last_owner(target):
             raise JsonableError(
                 _("The owner permission cannot be removed from the only organization owner.")
             )

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -193,6 +193,8 @@ def update_user_backend(
         # grant/remove the role in question.  access_user_by_id has
         # already verified we're an administrator; here we enforce
         # that only owners can toggle the is_realm_owner flag.
+        #
+        # Logic replicated in patch_bot_backend.
         if UserProfile.ROLE_REALM_OWNER in [role, target.role] and not user_profile.is_realm_owner:
             raise OrganizationOwnerRequired()
 
@@ -302,6 +304,12 @@ def patch_bot_backend(
     user_profile: UserProfile,
     bot_id: int,
     full_name: Optional[str] = REQ(default=None),
+    role: Optional[int] = REQ(
+        default=None,
+        json_validator=check_int_in(
+            UserProfile.ROLE_TYPES,
+        ),
+    ),
     bot_owner_id: Optional[int] = REQ(json_validator=check_int, default=None),
     config_data: Optional[Dict[str, str]] = REQ(
         default=None, json_validator=check_dict(value_validator=check_string)
@@ -316,6 +324,14 @@ def patch_bot_backend(
 
     if full_name is not None:
         check_change_bot_full_name(bot, full_name, user_profile)
+
+    if role is not None and bot.role != role:
+        # Logic duplicated from update_user_backend.
+        if UserProfile.ROLE_REALM_OWNER in [role, bot.role] and not user_profile.is_realm_owner:
+            raise OrganizationOwnerRequired()
+
+        do_change_user_role(bot, role, acting_user=user_profile)
+
     if bot_owner_id is not None:
         try:
             owner = get_user_profile_by_id_in_realm(bot_owner_id, user_profile.realm)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
The first commit: 
- Adds a new column in the bot-list table in the organization settings to show the role a bot has been assigned.

The second commit: 

- Adds the `Role` field in the `Manage bot` modal, allowing an admin to change roles of a bot through the UI and fixing the 
  formatting and ordering of fields in the modal.

The third commit: 
- Adds the main feature to change the roles of a bot through the UI. 

Fixes: #21105

This PR is a follow-up to #21253 which was accidentally closed and the branches got deleted.
**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot 2022-02-25 171455](https://user-images.githubusercontent.com/77766761/155833545-78f1c102-7064-40fa-a4a0-fd35e1d57f77.png)
![Screenshot 2022-03-01 204419](https://user-images.githubusercontent.com/77766761/156195419-78a14eee-dcec-422a-9ae3-295b0dc56421.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
