### PR TITLE
supervisor: 'foo:*' also matches 'foo'.

### DIFF
--- a/scripts/lib/supervisor.py
+++ b/scripts/lib/supervisor.py
@@ -42,7 +42,10 @@ def list_supervisor_processes(
         if filter_names:
             match = False
             for filter_name in filter_names:
-                if filter_name.endswith(":*") and name.startswith(filter_name[:-1]):
+                # zulip-tornado:* matches zulip-tornado:9800 and zulip-tornado
+                if filter_name.endswith(":*") and (
+                    name.startswith(filter_name[:-1]) or name == filter_name[:-2]
+                ):
                     match = True
                     break
                 if name == filter_name:


### PR DESCRIPTION
7c4293a7d3d738e2785ca39c01aee8d42051c9ba switched to checking if the
service was already running, and use `supervisorctl start` if it was
not.

Unfortunately, `list_supervisor_processes("zulip-tornado:*")` did not
include `zulip-tornado`, and as such a non-sharded process was always
considered to _not_ be running, and was thus started, not restarted.
Starting an already-started service is a no-op, and thus non-sharded
tornado processes were never restarted.

The observed behaviour is that requests to the tornado process attempt
to load the user from the cache, with a different prefix from Django,
and immediately invalidate the session and eject the user back to the
login page.

Fix the `list_supervisor_processes` logic to match without the
trailing `:*`.

**Testing plan:** Restarted a non-sharded server, saw a Tornado restart
