### PR TITLE
settings: Remove extraneous banner from Bots and Invitation tabs 

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -57,6 +57,8 @@ function insert_tip_box() {
         .not("#emoji-settings")
         .not("#user-groups-admin")
         .not("#organization-auth-settings")
+        .not("#admin-bot-list")
+        .not("#admin-invites-list")
         .prepend(tip_box);
 }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This fix excludes the `Bots` and `Invitation` settings tabs from having the organization_settings_tip.hbs template being inserted in them.

Fixes: https://github.com/zulip/zulip/issues/19967.

**Testing plan:** <!-- How have you tested? -->
Manual testing.
Log in as Moderator, under settings, go to `Organization Settings` and then `Bot` tab and `Invitations` tab, you will see that the `organization bot` does not display as a banner on the page anymore.


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
**Bots Tab**
![image](https://user-images.githubusercontent.com/29842348/161156130-74e249fb-3ca6-4183-a0fe-720a31da13dc.png)

**Invitation Tab**
<img width="1336" alt="image" src="https://user-images.githubusercontent.com/29842348/161156252-4dfadb6f-c44d-4b1d-99ea-aa10144bbd27.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
