### PR TITLE
recent_topics: Link timestamp to latest message.

### DIFF
--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -8,6 +8,7 @@ const $ = require("../zjsunit/zjquery");
 const {page_params} = require("../zjsunit/zpage_params");
 
 const noop = () => {};
+const test_url = () => "https://www.example.com";
 
 // We assign this in our test() wrapper.
 let messages;
@@ -79,9 +80,9 @@ mock_esm("../../static/js/compose_closed_ui", {
     update_buttons_for_recent_topics: noop,
 });
 mock_esm("../../static/js/hash_util", {
-    by_stream_url: () => "https://www.example.com",
-
-    by_stream_topic_url: () => "https://www.example.com",
+    by_stream_url: test_url,
+    by_stream_topic_url: test_url,
+    by_conversation_and_time_url: test_url,
 });
 mock_esm("../../static/js/message_list_data", {
     MessageListData: class {},
@@ -277,6 +278,7 @@ function generate_topic_data(topic_info_array) {
             invite_only: false,
             is_web_public: true,
             last_msg_time: "Just now",
+            last_msg_url: "https://www.example.com",
             full_last_msg_date_time: "date at time",
             senders: [1, 2],
             stream: "stream" + stream_id,

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -309,6 +309,7 @@ function format_topic(topic_data) {
         topic_key: get_topic_key(stream_id, topic),
         unread_count,
         last_msg_time,
+        last_msg_url: hash_util.by_conversation_and_time_url(last_msg),
         topic_url: hash_util.by_stream_topic_url(stream_id, topic),
         senders: senders_info,
         other_senders_count: Math.max(0, all_senders.length - MAX_AVATAR),

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -52,7 +52,7 @@
     </td>
     <td class="recent_topic_timestamp">
         <div class="last_msg_time tippy-zulip-tooltip" data-tippy-content="{{this.full_last_msg_date_time}}">
-            {{ last_msg_time }}
+            <a href="{{last_msg_url}}">{{ last_msg_time }}</a>
         </div>
     </td>
 </tr>


### PR DESCRIPTION
Link the timestamp in recent topics to the "near" link of the latest message within that topic.
Fixes #21356.