### PR TITLE
compose: Improve tooltip on compose box "x" button.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -412,7 +412,14 @@ export function initialize() {
 
     $("#compose-textarea").on("input propertychange", () => {
         compose_validate.warn_if_topic_resolved(false);
-        compose_validate.check_overflow_text();
+        const compose_text_length = compose_validate.check_overflow_text();
+        // Change compose close button tooltip as per condition.
+        // We save compose text in draft only if its length is > 2.
+        if (compose_text_length > 2) {
+            $("#compose_close").attr("data-tooltip-template-id", "compose_close_and_save_tooltip");
+        } else {
+            $("#compose_close").attr("data-tooltip-template-id", "compose_close_tooltip");
+        }
     });
 
     $("#compose form").on("submit", (e) => {

--- a/static/js/compose_validate.js
+++ b/static/js/compose_validate.js
@@ -578,6 +578,8 @@ export function check_overflow_text() {
             $("#compose-send-status").stop(true).fadeOut();
         }
     }
+
+    return text.length;
 }
 
 export function warn_for_text_overflow_when_tries_to_send() {

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -66,6 +66,7 @@
                             <button type="button" class="collapse_composebox_button fa fa-chevron-down" aria-label="{{t 'Collapse compose' }}" data-tippy-content="{{t 'Collapse compose' }}"></button>
                             <button type="button" class="close fa fa-times" id='compose_close' data-tooltip-template-id="compose_close_tooltip"></button>
                             <template id="compose_close_tooltip">{{t 'Cancel compose' }} <span class="hotkey-hint">(Esc)</span></template>
+                            <template id="compose_close_and_save_tooltip">{{t 'Cancel compose and save draft' }} <span class="hotkey-hint">(Esc)</span></template>
                         </div>
                         <div id="stream-message" class="order-1">
                             <div class="stream-selection-header-colorblock message_header_stream left_part" tab-index="-1"></div>

--- a/static/templates/keyboard_shortcuts.hbs
+++ b/static/templates/keyboard_shortcuts.hbs
@@ -21,7 +21,7 @@
                     <td><span class="hotkey"><kbd>X</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Cancel compose' }}</td>
+                    <td class="definition">{{t 'Cancel compose and save draft' }}</td>
                     <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
                 </tr>
                 <tr>
@@ -143,7 +143,7 @@
                     <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>Enter</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Cancel compose' }}</td>
+                    <td class="definition">{{t 'Cancel compose and save draft' }}</td>
                     <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
                 </tr>
             </table>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -22,7 +22,7 @@ below, and add more to your repertoire as needed.
 
 * **New private message**: `x`
 
-* **Cancel compose**: `Esc` or `Ctrl` + `[` — Close the compose box and save
+* **Cancel compose and save draft**: `Esc` or `Ctrl` + `[` — Close the compose box and save
   the unsent message as a draft.
 
 * **View drafts**: `d` — Use the arrow keys and `Enter` to restore a draft.
@@ -114,7 +114,7 @@ below, and add more to your repertoire as needed.
 * **Insert bold text**: `**bold**` or `Ctrl` + `B`
 * **Insert link**: `[Zulip website](https://zulip.org)` or `Ctrl` + `Shift` + `L`
 
-* **Cancel compose**: `Esc` or `Ctrl` + `[` — Close the compose box and save
+* **Cancel compose and save draft**: `Esc` or `Ctrl` + `[` — Close the compose box and save
   the unsent message as a draft.
 
 ## Message actions


### PR DESCRIPTION
In compose box, the "x" button tooltip text changed to
"Cancel compose and save draft" except when unsent
message length is short(<3).

Also in help(?) > keyboard shortcuts, text for `Esc`
changed to "Cancel compose and save draft".

The help center page updated with the above changes.

Fixes: #21599

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Manually.

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<details>
<summary>Keyboard-Shortcut Text</summary>

![Cancel_compose_and_save_draft](https://user-images.githubusercontent.com/41695888/161340577-de0cee78-43ff-4a9d-9f2f-1557eb813844.png)
</details>
<details>
<summary>Tooltip</summary>

![tooltip](https://user-images.githubusercontent.com/41695888/161340589-d221996c-727d-44c0-bd06-babd465d034c.png)
</details>
<details>
<summary>Help page</summary>

![help_center](https://user-images.githubusercontent.com/41695888/161340588-2e29bf58-d213-4c4e-8fb7-82e12d8a0d87.png)
</details>
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
