### PR TITLE
Avatar border is now outside of the image in full profile in static/styles/popovers.css

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -299,12 +299,15 @@ ul {
         height: 180px;
         width: 180px;
         background-size: cover;
-        background-position: center;
+        background-position: center center;
         border-radius: 5px;
         margin-right: 10px;
+        background-clip: content-box;
         border: 1px solid hsla(0, 0%, 0%, 0.2);
+        
 
         &.guest-avatar::after {
+        
             outline: 9px solid hsl(0, 0%, 100%);
         }
     }


### PR DESCRIPTION
  fix:#21265

  Avatar border is now outside of the image in full profile.
<img width="258" alt="fullprofile" src="https://user-images.githubusercontent.com/74200798/161345434-e64fbfa5-e5a4-4dca-b3e1-23a0b7720e04.PNG">

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
