### PR TITLE
ci: Only run documentation/link tests on a single job.

### DIFF
--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -23,10 +23,12 @@ jobs:
             name: Ubuntu 20.04 (Python 3.8, backend + frontend)
             os: focal
             include_frontend_tests: true
+            include_documentation_tests: false
           # Debian 11 ships with Python 3.9.2.
           - docker_image: zulip/ci:bullseye
-            name: Debian 11 (Python 3.9, backend)
+            name: Debian 11 (Python 3.9, backend + documentation)
             os: bullseye
+            include_documentation_tests: true
             include_frontend_tests: false
 
     runs-on: ubuntu-latest
@@ -141,6 +143,7 @@ jobs:
           chmod 755 static/generated
 
       - name: Run documentation and api tests
+        if: ${{ matrix.include_documentation_tests }}
         run: |
           source tools/ci/activate-venv
           # In CI, we only test links we control in test-documentation to avoid flakes

--- a/docs/testing/continuous-integration.md
+++ b/docs/testing/continuous-integration.md
@@ -60,7 +60,8 @@ checks are run to confirm the installation worked.
 `zulip-ci.yml` is designed to run our main test suites on all of our
 supported platforms. Out of them, only one of them runs the frontend
 tests, since `puppeteer` is slow and unlikely to catch issues that
-depend on the version of the base OS and/or Python.
+depend on the version of the base OS and/or Python. Similarly, only a
+(different) one runs the documentation tests.
 
 Our code for running the tests in CI lives under `tools/ci`; but that
 logic is mostly thin wrappers around [Zulip's test


### PR DESCRIPTION
As noted in ReadTheDocs, it's very unlikely that these documentation
tests will pass or fail depending on the server's OS.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** I plan to check the CI logs once this runs.
**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
