### PR TITLE
settings(admin/org) : Fix URL maximum input characters

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -170,6 +170,7 @@ export function append_custom_profile_fields(element_id, user_id) {
             is_long_text_field: field.type === all_field_types.LONG_TEXT.id,
             is_user_field: field.type === all_field_types.USER.id,
             is_date_field: field.type === all_field_types.DATE.id,
+            is_url_field: field.type === all_field_types.URL.id,
             is_select_field,
             field_choices,
         });

--- a/static/templates/settings/custom_user_profile_field.hbs
+++ b/static/templates/settings/custom_user_profile_field.hbs
@@ -20,6 +20,8 @@
         <input class="custom_user_field_value datepicker" data-field-id="{{ field.id }}" type="text"
           value="{{ field_value.value }}" />
         <span class="remove_date"><i class="fa fa-close"></i></span>
+        {{else if is_url_field }}
+        <input class="custom_user_field_value" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="2048" />
         {{else}}
         <input class="custom_user_field_value" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
         {{/if}}


### PR DESCRIPTION
Increased URL input max characters from 50 to 2048 in custom user profile fields regarding URL input standards laid down by different browsers. 
Fixes #21633

The changes are made based on the URL length standards laid down by different browsers. The max limit is set to 2048 characters based on Google Chrome's limit, since it has the lowest limit among all the browsers and also same as the Internet Explorer

**GIFs or screenshots:** 
![image](https://user-images.githubusercontent.com/72722967/161391536-9afa1325-077c-412b-bc56-4e22bca68442.png)
