### PR TITLE
auth: Reset API key on password change.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -512,6 +512,9 @@ export function set_up() {
         const data = {
             old_password: $("#old_password").val(),
             new_password: $("#new_password").val(),
+            reset_api_key_on_password_change: $("#reset_api_key_on_password_change").prop(
+                "checked",
+            ),
         };
 
         const $new_pw_field = $("#new_password");

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1072,6 +1072,10 @@ input[type="checkbox"] {
             }
         }
     }
+
+    .reset_api_key_label {
+        display: inline;
+    }
 }
 
 .emojiset_choices {

--- a/static/templates/dialog_change_password.hbs
+++ b/static/templates/dialog_change_password.hbs
@@ -16,4 +16,13 @@
             <div class="bar bar-danger fade" style="width: 10%;"></div>
         </div>
     </div>
+    <div class="new-style">
+        <label class="checkbox">
+            <input type="checkbox" name="reset_api_key_on_password_change" id="reset_api_key_on_password_change" checked="checked"/>
+            <span></span>
+        </label>
+        <label for="reset_api_key_on_password_change" class="reset_api_key_label">
+            {{t "Reset API key on changing my password" }}
+        </label>
+    </div>
 </form>

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 6.0
 
+**Feature level 125**
+[`PATCH /settings`](/api/update-settings):
+Support `reset_api_key_on_password_change` to reset user's
+API key on changing password.
+
 Feature levels 123-124 are reserved for future use in 5.x maintenance
 releases.
 

--- a/templates/zerver/reset_confirm.html
+++ b/templates/zerver/reset_confirm.html
@@ -56,6 +56,11 @@
                         {% endfor %}
                     {% endif %}
                 </div>
+                <label class="inline-block checkbox">
+                    <input type="checkbox" name="reset_api_key" checked="checked"/>
+                    <span></span>
+                    {% trans %}Reset my API key on changing password{% endtrans %}
+                </label>
 
                 <div class="input-box m-t-30">
                     <div class="centered-button">

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 122
+API_FEATURE_LEVEL = 125
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -246,6 +246,7 @@ class LoggingSetPasswordForm(SetPasswordForm):
         widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
         max_length=RegistrationForm.MAX_PASSWORD_LENGTH,
     )
+    reset_api_key = forms.BooleanField(required=False)
 
     def clean_new_password1(self) -> str:
         new_password = self.cleaned_data["new_password1"]
@@ -257,7 +258,12 @@ class LoggingSetPasswordForm(SetPasswordForm):
         return new_password
 
     def save(self, commit: bool = True) -> UserProfile:
-        do_change_password(self.user, self.cleaned_data["new_password1"], commit=commit)
+        do_change_password(
+            self.user,
+            self.cleaned_data["new_password1"],
+            self.cleaned_data["reset_api_key"],
+            commit=commit,
+        )
         return self.user
 
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4525,7 +4525,9 @@ def do_change_subscription_property(
     send_event(user_profile.realm, event, [user_profile.id])
 
 
-def do_change_password(user_profile: UserProfile, password: str, commit: bool = True) -> None:
+def do_change_password(
+    user_profile: UserProfile, password: str, reset_api_key: bool, commit: bool = True
+) -> None:
     user_profile.set_password(password)
     if commit:
         user_profile.save(update_fields=["password"])
@@ -4537,6 +4539,9 @@ def do_change_password(user_profile: UserProfile, password: str, commit: bool = 
         event_type=RealmAuditLog.USER_PASSWORD_CHANGED,
         event_time=event_time,
     )
+
+    if reset_api_key:
+        do_regenerate_api_key(user_profile, acting_user=user_profile)
 
 
 def do_change_full_name(

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12470,6 +12470,17 @@ paths:
           schema:
             type: string
           example: new12345
+        - name: reset_api_key_on_password_change
+          in: query
+          description: |
+            Whether to reset user API key on changing password.
+
+            Required when sending `old_password` and `new_password` parameters.
+
+            **Changes**: New in Zulip 6.0 (feature level 125).
+          schema:
+            type: boolean
+          example: true
         - name: twenty_four_hour_time
           in: query
           description: |

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -163,7 +163,7 @@ class TestRealmAuditLog(ZulipTestCase):
         now = timezone_now()
         user = self.example_user("hamlet")
         password = "test1"
-        do_change_password(user, password)
+        do_change_password(user, password, reset_api_key=False)
         self.assertEqual(
             RealmAuditLog.objects.filter(
                 event_type=RealmAuditLog.USER_PASSWORD_CHANGED, event_time__gte=now

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -430,7 +430,7 @@ def accounts_register(
         if existing_user_profile is not None and existing_user_profile.is_mirror_dummy:
             user_profile = existing_user_profile
             do_activate_mirror_dummy_user(user_profile, acting_user=user_profile)
-            do_change_password(user_profile, password)
+            do_change_password(user_profile, password, False)
             do_change_full_name(user_profile, full_name, user_profile)
             do_change_user_setting(user_profile, "timezone", timezone, acting_user=user_profile)
             # TODO: When we clean up the `do_activate_mirror_dummy_user` code path,


### PR DESCRIPTION
It's worth mentioning that this change would
refresh API key even with resetting password.

Closes: #21636

Adds this note to the change password dialog:
![image](https://user-images.githubusercontent.com/44665669/161426575-4a39294a-06d3-4c9f-b01e-6f10acd4f097.png)


<!-- What's this PR for?  (Just a link to an issue is fine.) -->
