### PR TITLE
recent topics: Change cursor to "pointer" when hovering and redirect user to the last message on clicking the timestamp.

### DIFF
--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -290,6 +290,7 @@ function generate_topic_data(topic_info_array) {
             invite_only: false,
             is_web_public: true,
             last_msg_time: "Just now",
+            last_msg_url: undefined,
             full_last_msg_date_time: "date at time",
             senders: [1, 2],
             stream: "stream" + stream_id,

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -440,9 +440,19 @@ export function initialize() {
 
     $("body").on("click", "td.recent_topic_stream", (e) => {
         e.stopPropagation();
-        const topic_row_index = $(e.target).closest("tr").index();
-        recent_topics_ui.focus_clicked_element(topic_row_index, recent_topics_ui.COLUMNS.stream);
-        window.location.href = $(e.currentTarget).find("a").attr("href");
+        const $topic_row = $(e.target).closest("tr");
+        const topic_key = $topic_row.attr("id").slice("recent_topics:".length - 1);
+        const topic_row_index = $topic_row.index();
+        recent_topics_ui.focus_clicked_element(
+            topic_row_index,
+            recent_topics_ui.COLUMNS.topic,
+            topic_key,
+        );
+        window.location.href = $(e.currentTarget)
+            .parent()
+            .find("td.recent_topic_name")
+            .find("a")
+            .attr("href");
     });
 
     $("body").on("click", "td.recent_topic_name", (e) => {

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -294,6 +294,7 @@ function format_topic(topic_data) {
     const other_sender_names_html = displayed_other_names
         .map((name) => _.escape(name))
         .join("<br />");
+    const last_msg_url = last_msg.url;
 
     return {
         // stream info
@@ -308,6 +309,7 @@ function format_topic(topic_data) {
         topic_key: get_topic_key(stream_id, topic),
         unread_count,
         last_msg_time,
+        last_msg_url,
         topic_url: hash_util.by_stream_topic_url(stream_id, topic),
         senders: senders_info,
         other_senders_count: Math.max(0, all_senders.length - MAX_AVATAR),

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -215,6 +215,15 @@
             margin-right: 5px;
         }
 
+        tbody {
+            tr {
+                .recent_topic_stream,
+                .recent_topic_name {
+                    cursor: pointer;
+                }
+            }
+        }
+
         thead th {
             background-color: hsl(0, 0%, 100%);
             color: inherit;

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -52,7 +52,7 @@
     </td>
     <td class="recent_topic_timestamp">
         <div class="last_msg_time tippy-zulip-tooltip" data-tippy-content="{{this.full_last_msg_date_time}}">
-            {{ last_msg_time }}
+            <a href="{{last_msg_url}}">{{last_msg_time}}</a>
         </div>
     </td>
 </tr>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes: [cursor on hovering over recent topics](https://chat.zulip.org/#narrow/stream/9-issues/topic/cursor.20on.20hovering.20over.20recent.20topics)

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  --> 

https://user-images.githubusercontent.com/85362194/161450905-e2f244df-2a3a-4eac-894e-5344923d7338.mov


