### PR TITLE
overlays: Add `is_modal_open` check along with `is_active` check.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -62,6 +62,7 @@ const overlays = mock_esm("../../static/js/overlays", {
     drafts_open: () => false,
     info_overlay_open: () => false,
     is_modal_open: () => false,
+    is_overlay_or_modal_open: () => overlays.is_modal_open() || overlays.is_active(),
 });
 const popovers = mock_esm("../../static/js/popovers", {
     actions_popped: () => false,

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -738,7 +738,7 @@ export function process_hotkey(e, hotkey) {
     }
 
     // Prevent navigation in the background when the overlays are active.
-    if (overlays.is_active()) {
+    if (overlays.is_overlay_or_modal_open()) {
         if (event_name === "view_selected_stream" && overlays.streams_open()) {
             stream_settings_ui.view_stream();
             return true;

--- a/static/js/message_viewport.js
+++ b/static/js/message_viewport.js
@@ -477,7 +477,7 @@ export function initialize() {
 
 export function is_visible_and_focused() {
     if (
-        overlays.is_active() ||
+        overlays.is_overlay_or_modal_open() ||
         !notifications.is_window_focused() ||
         !$("#message_feed_container").is(":visible")
     ) {

--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -24,6 +24,10 @@ export function is_modal_open() {
     return $(".modal").hasClass("in") || $(".micromodal").hasClass("modal--open");
 }
 
+export function is_overlay_or_modal_open() {
+    return is_active() || is_modal_open();
+}
+
 export function info_overlay_open() {
     return open_overlay_name === "informationalOverlays";
 }

--- a/static/js/recent_topics_util.js
+++ b/static/js/recent_topics_util.js
@@ -21,8 +21,7 @@ export function is_in_focus() {
         is_visible() &&
         !compose_state.composing() &&
         !popovers.any_active() &&
-        !overlays.is_active() &&
-        !overlays.is_modal_open() &&
+        !overlays.is_overlay_or_modal_open() &&
         !$(".home-page-input").is(":focus")
     );
 }

--- a/static/js/stream_muting.js
+++ b/static/js/stream_muting.js
@@ -16,7 +16,7 @@ export function update_is_muted(sub, value) {
         let msg_offset;
         let saved_ypos;
         // Save our current scroll position
-        if (overlays.is_active()) {
+        if (overlays.is_active() || overlays.is_modal_open()) {
             saved_ypos = message_viewport.scrollTop();
         } else if (
             message_lists.home === message_lists.current &&
@@ -31,7 +31,7 @@ export function update_is_muted(sub, value) {
         message_util.add_old_messages(all_messages_data.all_messages(), message_lists.home);
 
         // Ensure we're still at the same scroll position
-        if (overlays.is_active()) {
+        if (overlays.is_overlay_or_modal_open()) {
             message_viewport.scrollTop(saved_ypos);
         } else if (message_lists.home === message_lists.current) {
             // We pass use_closest to handle the case where the

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -239,7 +239,7 @@ export function initialize_kitchen_sink_stuff() {
 
     message_viewport.$message_pane.on("wheel", (e) => {
         const delta = e.originalEvent.deltaY;
-        if (!overlays.is_active() && !recent_topics_util.is_visible()) {
+        if (!overlays.is_overlay_or_modal_open() && !recent_topics_util.is_visible()) {
             // In the message view, we use a throttled mousewheel handler.
             throttled_mousewheelhandler(e, delta);
         }


### PR DESCRIPTION
This applies the fixes we have when restoring scroll position and
marking messages as read in background for overlays to modals.


We can combine `overlays.is_active` and `overlays.is_modal_open` into a single function, but I think it would be easier for debugging when reading the code that there are 2 different types of overlays possible.