### PR TITLE
shared: Match literal emoji in typeahead.

### DIFF
--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -52,6 +52,8 @@ run_test("get_emoji_matcher", () => {
 
     assert_matches("japanese_post_", [emoji_japanese_post_office]);
     assert_matches("japanese post ", [emoji_japanese_post_office]);
+
+    assert_matches("🐼", [emoji_panda_face]);
 });
 
 run_test("triage", () => {

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -98,13 +98,23 @@ export function clean_query_lowercase(query) {
     return query;
 }
 
+export const parse_unicode_emoji_code = (code) =>
+    code
+        .split("-")
+        .map((hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+        .join("");
+
 export function get_emoji_matcher(query) {
     // replaces spaces with underscores for emoji matching
     query = query.replace(/ /g, "_");
     query = clean_query_lowercase(query);
 
     return function (emoji) {
-        return query_matches_source_attrs(query, emoji, ["emoji_name"], "_");
+        const matches_emoji_literal =
+            emoji.emoji_code && parse_unicode_emoji_code(emoji.emoji_code) === query;
+        return (
+            matches_emoji_literal || query_matches_source_attrs(query, emoji, ["emoji_name"], "_")
+        );
     };
 }
 


### PR DESCRIPTION
This PR implements checking for a literal emoji match in emoji
typeaheads. In other words, if you paste or type panda face into an
emoji typeahead, panda face should be presented as an option to choose
from.

This behavior is currently present in the mobile app, adding it to
shared will enable both platforms to utilize this logic.
