### PR TITLE
Timezone-picker Correction #21676

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -663,6 +663,7 @@ export function initialize() {
                 {
                     // place the time picker above the icon and center it horizontally
                     position: "above center",
+                    time_24hr: user_settings.twenty_four_hour_time,
                 },
             );
         }


### PR DESCRIPTION
Resolved Issue #21676 
**Testing plan:** Tested Manually
TimeZone picker always showed time in 12 hrs format even if the users setting is 24 hrs format.
**GIFs or screenshots:** 
### Before
<img src="https://user-images.githubusercontent.com/86338542/161703909-2bccd92b-dc88-44cb-bec0-eb27552ce1cb.jpeg" width="350" height="400" />

### After
<img src="https://user-images.githubusercontent.com/86338542/161703954-67de5763-4e25-4fa0-8a70-18e130543831.jpeg" width="350" height="400" />
