### PR TITLE
popovers:Avatar border should be outside of the image in full profile

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -302,7 +302,8 @@ ul {
         background-position: center;
         border-radius: 5px;
         margin-right: 10px;
-        border: 1px solid hsla(0, 0%, 0%, 0.2);
+        border: 1px solid hsla(0, 0%, 0%);
+        margin-left: 1px;
 
         &.guest-avatar::after {
             outline: 9px solid hsl(0, 0%, 100%);


### PR DESCRIPTION
Fixes:#21265
Fixed the avatar border,now it is inside of the image frame in full profile.
Before:
<img width="392" alt="before" src="https://user-images.githubusercontent.com/74200798/161713466-312c6736-de6a-4052-aad0-434d90b8bca5.PNG">
After:
<img width="393" alt="after" src="https://user-images.githubusercontent.com/74200798/161713537-d8843aa4-d28b-4c3b-9dc9-bb68f84d609f.PNG">
