### PR TITLE
Fix: Vertical shifts in message when toggle write and preview.

### DIFF
--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -598,6 +598,18 @@
     }
 }
 
+.preview_content.rendered_markdown {
+    /* Paragraphs: Ensure that the first paragraph and last paragraph
+    don't have blank area at the top and bottom respectively. */
+    p:first-child {
+        margin-top: 0;
+    }
+
+    p:last-child {
+        margin-bottom: 0;
+    }
+}
+
 /* Inline and block code.
 
 TODO: It is likely that this CSS can and should be moved into the


### PR DESCRIPTION
Fixes zulip#21276

The vertical shifts in message body was due to the
```<p>``` tags it gets when converted to markdown.
Removing the top margin from the first ```<p>```
child and bottom margin from the last  ```<p>```
child resolves this issue as due to those
default margins in ```<p>``` tags there was
vertical shifts in message body.