### PR TITLE
apps: Link to release page for Android, rather than directly to APK.

### DIFF
--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -51,8 +51,7 @@ const apps_events = function () {
             description: "Zulip's native Android app makes it easy to keep up while on the go.",
             show_instructions: false,
             play_store_link: "https://play.google.com/store/apps/details?id=com.zulipmobile",
-            download_link:
-                "https://github.com/zulip/zulip-mobile/releases/latest/download/app-release.apk",
+            download_link: "https://github.com/zulip/zulip-mobile/releases/latest",
             app_type: "mobile",
         },
         ios: {


### PR DESCRIPTION
The old link here broke once we introduced separate APKs per ABI,
in zulip/zulip-mobile#5296.

We could make a direct link to app-armeabi-v7a-release.apk , the one
that's compatible with almost all devices.  But perhaps better is to
just go back to linking to the release page, where the user can
choose the best APK for their device.  (If they're in the habit of
downloading APKs manually to install on their device, then probably
that means they're going to be used to choosing the right one.)

User report and discussion:
  https://chat.zulip.org/#narrow/stream/48-mobile/topic/Direct.20apk.20download.20link.20is.20404/near/1358758

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
