### PR TITLE
check-database-compatibility: Sort and prettify output.

### DIFF
--- a/scripts/lib/check-database-compatibility.py
+++ b/scripts/lib/check-database-compatibility.py
@@ -73,8 +73,9 @@ for key, migration in loader.disk_migrations.items():
 if not missing:
     sys.exit(0)
 
-for migration in missing:
-    print(f"Migration {migration} missing in new version.")
+print("Migrations which are currently applied, but missing in the new version:")
+for app, migration_name in sorted(missing):
+    print(f"  {app} - {migration_name}")
 
 current_version = parse_version_from(os.path.join(DEPLOYMENTS_DIR, "current"))
 logging.error(


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** Altered a database by hand.

Old:
```
root@alexmv-prod:/home/zulip/deployments/current# sudo -u zulip ./scripts/lib/check-database-compatibility.py
Migration ('other', '0009_confirmation_expiry_date_backfill') missing in new version.
Migration ('moose', '0167_custom_profile_fields_sort_order') missing in new version.
Migration ('moose', '0192_customprofilefieldvalue_rendered_value') missing in new version.
Migration ('moose', '0206_stream_rendered_description') missing in new version.
Migration ('moose', '0143_realm_bot_creation_policy') missing in new version.
Migration ('moose', '0149_realm_emoji_drop_unique_constraint') missing in new version.
Migration ('moose', '0261_pregistrationuser_clear_invited_as_admin') missing in new version.
Migration ('moose', '0335_add_draft_sync_field') missing in new version.
Migration ('moose', '0368_alter_realmfilter_url_format_string') missing in new version.
Migration ('moose', '0282_remove_zoom_video_chat') missing in new version.
Migration ('moose', '0334_email_notifications_batching_period') missing in new version.
Migration ('moose', '0309_userprofile_can_create_users') missing in new version.
Migration ('moose', '0031_remove_system_avatar_source') missing in new version.
Migration ('moose', '0246_message_date_sent_finalize_part2') missing in new version.
Migration ('moose', '0223_rename_to_is_muted') missing in new version.
Migration ('moose', '0066_realm_inline_url_embed_preview') missing in new version.
Migration ('moose', '0053_emailchangestatus') missing in new version.
Migration ('moose', '0051_realmalias_add_allow_subdomains') missing in new version.
Migration ('moose', '0115_user_groups') missing in new version.
Migration ('moose', '0361_realm_create_web_public_stream_policy') missing in new version.
Migration ('moose', '0057_realmauditlog') missing in new version.
Migration ('moose', '0317_migrate_to_invite_to_realm_policy') missing in new version.
Migration ('moose', '0185_realm_plan_type') missing in new version.
Migration ('moose', '0181_userprofile_change_emojiset') missing in new version.
Migration ('moose', '0119_userprofile_night_mode') missing in new version.
Migration ('moose', '0186_userprofile_starred_message_counts') missing in new version.
Migration ('moose', '0364_rename_members_usergroup_direct_members') missing in new version.
Migration ('moose', '0199_userstatus') missing in new version.
Migration ('moose', '0279_message_recipient_subject_indexes') missing in new version.
Migration ('moose', '0352_migrate_twenty_four_hour_time_to_realmuserdefault') missing in new version.
Migration ('moose', '0345_alter_realm_name') missing in new version.
Migration ('moose', '0257_fix_has_link_attribute') missing in new version.
Migration ('moose', '0273_migrate_old_bot_messages') missing in new version.
Migration ('moose', '0113_default_stream_group') missing in new version.
Migration ('moose', '0099_index_wildcard_mentioned_user_messages') missing in new version.
Migration ('moose', '0373_fix_deleteduser_dummies') missing in new version.
Migration ('moose', '0308_remove_reduntant_realm_meta_permissions') missing in new version.
Migration ('moose', '0043_realm_filter_validators') missing in new version.
Migration ('moose', '0150_realm_allow_community_topic_editing') missing in new version.
Migration ('moose', '0321_userprofile_enable_marketing_emails') missing in new version.
Migration ('moose', '0253_userprofile_wildcard_mentions_notify') missing in new version.
Migration ('moose', '0228_userprofile_demote_inactive_streams') missing in new version.
Migration ('moose', '0236_remove_illegal_characters_email_full') missing in new version.
Migration ('moose', '0065_realm_inline_image_preview') missing in new version.
Migration ('moose', '0109_mark_tutorial_status_finished') missing in new version.
Migration ('moose', '0121_realm_signup_notifications_stream') missing in new version.
Migration ('moose', '0045_realm_waiting_period_threshold') missing in new version.
Migration ('moose', '0379_userprofile_uuid') missing in new version.
Migration ('moose', '0126_prereg_remove_users_without_realm') missing in new version.
Migration ('moose', '0182_set_initial_value_is_private_flag') missing in new version.
Migration ('moose', '0367_scimclient') missing in new version.
Migration ('moose', '0200_remove_preregistrationuser_invited_as_admin') missing in new version.
Migration ('moose', '0133_rename_botuserconfigdata_botconfigdata') missing in new version.
Migration ('moose', '0135_scheduledmessage_delivery_type') missing in new version.
Migration ('other', '0002_realmcreationkey') missing in new version.
Migration ('moose', '0241_usermessage_bigint_id_migration_finalize') missing in new version.
Migration ('moose', '0216_add_create_stream_policy') missing in new version.
Migration ('moose', '0198_preregistrationuser_invited_as') missing in new version.
Migration ('moose', '0244_message_copy_pub_date_to_date_sent') missing in new version.
Migration ('moose', '0042_attachment_file_name_length') missing in new version.
Migration ('moose', '0040_realm_authentication_methods') missing in new version.
Migration ('moose', '0294_remove_userprofile_pointer') missing in new version.
Migration ('moose', '0100_usermessage_remove_is_me_message') missing in new version.
Migration ('moose', '0032_verify_all_medium_avatar_images') missing in new version.
Migration ('moose', '0087_remove_old_scheduled_jobs') missing in new version.
Migration ('moose', '0117_add_desc_to_user_group') missing in new version.
Migration ('moose', '0110_stream_is_in_zephyr_realm') missing in new version.
Migration ('moose', '0250_saml_auth') missing in new version.
Migration ('moose', '0378_alter_realmuserdefault_realm') missing in new version.
Migration ('moose', '0033_migrate_domain_to_realmalias') missing in new version.
Migration ('moose', '0325_alter_realmplayground_unique_together') missing in new version.
Migration ('moose', '0298_fix_realmauditlog_format') missing in new version.
Migration ('moose', '0274_nullbooleanfield_to_booleanfield') missing in new version.
Migration ('moose', '0284_convert_realm_admins_to_realm_owners') missing in new version.
Migration ('moose', '0331_scheduledmessagenotificationemail') missing in new version.
Migration ('moose', '0380_userprofile_uuid_backfill') missing in new version.
Migration ('moose', '0184_rename_custom_field_types') missing in new version.
Migration ('moose', '0048_enter_sends_default_to_false') missing in new version.
Migration ('moose', '0112_index_muted_topics') missing in new version.
Migration ('moose', '0323_show_starred_message_counts') missing in new version.
Migration ('moose', '0269_gitlab_auth') missing in new version.
Migration ('moose', '0303_realm_wildcard_mention_policy') missing in new version.
Migration ('moose', '0332_realmuserdefault') missing in new version.
Migration ('moose', '0103_remove_userprofile_muted_topics') missing in new version.
Migration ('moose', '0248_userprofile_role_start') missing in new version.
Migration ('moose', '0258_enable_online_push_notifications_default') missing in new version.
Migration ('other', '0003_emailchangeconfirmation') missing in new version.
Migration ('moose', '0375_invalid_characters_in_stream_names') missing in new version.
Migration ('moose', '0029_realm_subdomain') missing in new version.
Migration ('moose', '0354_alter_realm_message_content_delete_limit_seconds') missing in new version.
Migration ('moose', '0194_userprofile_notification_sound') missing in new version.
Migration ('moose', '0165_add_date_to_profile_field') missing in new version.
Migration ('moose', '0171_userprofile_dense_mode') missing in new version.
Migration ('moose', '0262_mutedtopic_date_muted') missing in new version.
Migration ('moose', '0322_realm_create_audit_log_backfill') missing in new version.
Migration ('moose', '0075_attachment_path_id_unique') missing in new version.
Migration ('moose', '0097_reactions_emoji_code') missing in new version.
Migration ('moose', '0315_realmplayground') missing in new version.
Migration ('moose', '0083_index_mentioned_user_messages') missing in new version.
Migration ('moose', '0081_make_emoji_lowercase') missing in new version.
Migration ('moose', '0357_remove_realm_allow_message_deleting') missing in new version.
Migration ('moose', '0221_subscription_notifications_data_migration') missing in new version.
Migration ('moose', '0370_realm_enable_spectator_access') missing in new version.
Migration ('moose', '0208_add_realm_night_logo_fields') missing in new version.
Migration ('moose', '0161_realm_message_content_delete_limit_seconds') missing in new version.
Migration ('moose', '0295_case_insensitive_email_indexes') missing in new version.
Migration ('moose', '0170_submessage') missing in new version.
Migration ('moose', '0114_preregistrationuser_invited_as_admin') missing in new version.
Migration ('moose', '0178_rename_to_emails_restricted_to_domains') missing in new version.
Migration ('moose', '0319_realm_giphy_rating') missing in new version.
Migration ('moose', '0358_split_create_stream_policy') missing in new version.
Migration ('moose', '0101_muted_topic') missing in new version.
Migration ('moose', '0079_remove_old_scheduled_jobs') missing in new version.
Migration ('moose', '0139_fill_last_message_id_in_subscription_logs') missing in new version.
Migration ('moose', '0211_add_users_field_to_scheduled_email') missing in new version.
Migration ('moose', '0164_stream_history_public_to_subscribers') missing in new version.
Migration ('moose', '0127_disallow_chars_in_stream_and_user_name') missing in new version.
Migration ('moose', '0132_realm_message_visibility_limit') missing in new version.
Migration ('moose', '0266_userpresence_realm') missing in new version.
Migration ('moose', '0213_realm_digest_weekday') missing in new version.
Migration ('moose', '0077_add_file_name_field_to_realm_emoji') missing in new version.
Migration ('moose', '0160_add_choice_field') missing in new version.
Migration ('moose', '0034_userprofile_enable_online_push_notifications') missing in new version.
Migration ('moose', '0275_remove_userprofile_last_pointer_updater') missing in new version.
Migration ('moose', '0277_migrate_alert_word') missing in new version.
Migration ('moose', '0187_userprofile_is_billing_admin') missing in new version.
Migration ('moose', '0264_migrate_is_announcement_only') missing in new version.
Migration ('moose', '0217_migrate_create_stream_policy') missing in new version.
Migration ('moose', '0343_alter_useractivityinterval_index_together') missing in new version.
Migration ('moose', '0095_index_unread_user_messages') missing in new version.
Migration ('moose', '0271_huddle_set_recipient_column_values') missing in new version.
Migration ('moose', '0111_botuserstatedata') missing in new version.
Migration ('moose', '0372_realmemoji_unique_realm_emoji_when_false_deactivated') missing in new version.
Migration ('moose', '0038_realm_change_to_community_defaults') missing in new version.
Migration ('moose', '0179_rename_to_digest_emails_enabled') missing in new version.
Migration ('moose', '0240_usermessage_migrate_bigint_id_into_id') missing in new version.
Migration ('moose', '0137_realm_upload_quota_gb') missing in new version.
Migration ('moose', '0287_clear_duplicate_reactions') missing in new version.
Migration ('moose', '0362_send_typing_notifications_user_setting') missing in new version.
Migration ('moose', '0205_remove_realmauditlog_requires_billing_update') missing in new version.
Migration ('moose', '0071_rename_realmalias_to_realmdomain') missing in new version.
Migration ('moose', '0369_add_escnav_default_display_user_setting') missing in new version.
Migration ('moose', '0130_text_choice_in_emojiset') missing in new version.
Migration ('moose', '0152_realm_default_twenty_four_hour_time') missing in new version.
Migration ('moose', '0089_auto_20170710_1353') missing in new version.
Migration ('moose', '0129_remove_userprofile_autoscroll_forever') missing in new version.
Migration ('moose', '0386_fix_attachment_caches') missing in new version.
Migration ('moose', '0073_custom_profile_fields') missing in new version.
Migration ('moose', '0299_subscription_role') missing in new version.
Migration ('moose', '0159_realm_google_hangouts_domain') missing in new version.
Migration ('moose', '0030_realm_org_type') missing in new version.
Migration ('moose', '0231_add_archive_transaction_model') missing in new version.
Migration ('moose', '0349_alter_usertopic_table') missing in new version.
Migration ('moose', '0180_usermessage_add_active_mobile_push_notification') missing in new version.
Migration ('moose', '0363_send_read_receipts_user_setting') missing in new version.
Migration ('moose', '0286_merge_0260_0285') missing in new version.
Migration ('moose', '0151_last_reminder_default_none') missing in new version.
Migration ('other', '0010_alter_confirmation_expiry_date') missing in new version.
Migration ('other', '0006_realmcreationkey_presume_email_valid') missing in new version.
Migration ('moose', '0203_realm_message_content_allowed_in_email_notifications') missing in new version.
Migration ('moose', '0227_inline_url_embed_preview_default_off') missing in new version.
Migration ('moose', '0141_change_usergroup_description_to_textfield') missing in new version.
Migration ('moose', '0093_subscription_event_log_backfill') missing in new version.
Migration ('moose', '0209_stream_first_message_id') missing in new version.
Migration ('moose', '0356_migrate_to_delete_own_message_policy') missing in new version.
Migration ('moose', '0044_reaction') missing in new version.
Migration ('moose', '0229_stream_message_retention_days') missing in new version.
Migration ('moose', '0183_change_custom_field_name_max_length') missing in new version.
Migration ('moose', '0316_realm_invite_to_realm_policy') missing in new version.
Migration ('moose', '0341_usergroup_is_system_group') missing in new version.
Migration ('moose', '0348_rename_date_muted_usertopic_last_updated') missing in new version.
Migration ('moose', '0340_rename_mutedtopic_to_usertopic') missing in new version.
Migration ('moose', '0290_remove_night_mode_add_color_scheme') missing in new version.
Migration ('moose', '0311_userprofile_default_view') missing in new version.
Migration ('moose', '0202_add_user_status_info') missing in new version.
Migration ('moose', '0297_draft') missing in new version.
Migration ('moose', '0145_reactions_realm_emoji_name_to_id') missing in new version.
Migration ('moose', '0061_userprofile_timezone') missing in new version.
Migration ('moose', '0086_realm_alter_default_org_type') missing in new version.
Migration ('moose', '0056_userprofile_emoji_alt_code') missing in new version.
Migration ('moose', '0209_user_profile_no_empty_password') missing in new version.
Migration ('other', '0004_remove_confirmationmanager') missing in new version.
Migration ('moose', '0278_remove_userprofile_alert_words') missing in new version.
Migration ('moose', '0245_message_date_sent_finalize_part1') missing in new version.
Migration ('moose', '0243_message_add_date_sent_column') missing in new version.
Migration ('moose', '0276_alertword') missing in new version.
Migration ('moose', '0158_realm_video_chat_provider') missing in new version.
Migration ('moose', '0304_remove_default_status_of_default_private_streams') missing in new version.
Migration ('moose', '0120_botuserconfigdata') missing in new version.
Migration ('moose', '0105_userprofile_enable_stream_push_notifications') missing in new version.
Migration ('moose', '0168_stream_is_web_public') missing in new version.
Migration ('moose', '0235_userprofile_desktop_icon_count_display') missing in new version.
Migration ('moose', '0306_custom_profile_field_date_format') missing in new version.
Migration ('moose', '0154_fix_invalid_bot_owner') missing in new version.
Migration ('moose', '0080_realm_description_length') missing in new version.
Migration ('moose', '0251_prereg_user_add_full_name') missing in new version.
Migration ('moose', '0328_migrate_to_edit_topic_policy') missing in new version.
Migration ('moose', '0291_realm_retention_days_not_null') missing in new version.
Migration ('moose', '0156_add_hint_to_profile_field') missing in new version.
Migration ('moose', '0259_missedmessageemailaddress') missing in new version.
Migration ('other', '0011_alter_confirmation_expiry_date') missing in new version.
Migration ('moose', '0142_userprofile_translate_emoticons') missing in new version.
Migration ('other', '0005_confirmation_realm') missing in new version.
Migration ('moose', '0070_userhotspot') missing in new version.
Migration ('moose', '0098_index_has_alert_word_user_messages') missing in new version.
Migration ('moose', '0090_userprofile_high_contrast_mode') missing in new version.
Migration ('moose', '0312_subscription_is_user_active') missing in new version.
Migration ('moose', '0091_realm_allow_edit_history') missing in new version.
Migration ('moose', '0131_realm_create_generic_bot_by_admins_only') missing in new version.
Migration ('moose', '0249_userprofile_role_finish') missing in new version.
Migration ('moose', '0376_set_realmemoji_author_and_reupload_realmemoji') missing in new version.
Migration ('moose', '0351_user_topic_visibility_indexes') missing in new version.
Migration ('moose', '0338_migrate_to_add_custom_emoji_policy') missing in new version.
Migration ('moose', '0036_rename_subdomain_to_string_id') missing in new version.
Migration ('moose', '0074_fix_duplicate_attachments') missing in new version.
Migration ('moose', '0302_case_insensitive_stream_name_index') missing in new version.
Migration ('moose', '0084_realmemoji_deactivated') missing in new version.
Migration ('moose', '0052_auto_fix_realmalias_realm_nullable') missing in new version.
Migration ('moose', '0239_usermessage_copy_id_to_bigint_id') missing in new version.
Migration ('moose', '0046_realmemoji_author') missing in new version.
Migration ('moose', '0188_userprofile_enable_login_emails') missing in new version.
Migration ('moose', '0063_realm_description') missing in new version.
Migration ('other', '0008_confirmation_expiry_date') missing in new version.
Migration ('moose', '0210_stream_first_message_id') missing in new version.
Migration ('moose', '0300_add_attachment_is_web_public') missing in new version.
Migration ('moose', '0256_userprofile_stream_set_recipient_column_values') missing in new version.
Migration ('moose', '0134_scheduledmessage') missing in new version.
Migration ('moose', '0353_remove_realm_default_twenty_four_hour_time') missing in new version.
Migration ('moose', '0310_jsonfield') missing in new version.
Migration ('moose', '0085_fix_bots_with_none_bot_type') missing in new version.
Migration ('moose', '0107_multiuseinvite') missing in new version.
Migration ('moose', '0102_convert_muted_topic') missing in new version.
Migration ('moose', '0383_revoke_invitations_from_deactivated_users') missing in new version.
Migration ('moose', '0342_realm_demo_organization_scheduled_deletion_date') missing in new version.
Migration ('moose', '0247_realmauditlog_event_type_to_int') missing in new version.
Migration ('moose', '0280_userprofile_presence_enabled') missing in new version.
Migration ('moose', '0191_realm_seat_limit') missing in new version.
Migration ('moose', '0381_alter_userprofile_uuid') missing in new version.
Migration ('moose', '0078_service') missing in new version.
Migration ('moose', '0195_realm_first_visible_message_id') missing in new version.
Migration ('moose', '0337_realm_add_custom_emoji_policy') missing in new version.
Migration ('moose', '0157_userprofile_is_guest') missing in new version.
Migration ('moose', '0122_rename_botuserstatedata_botstoragedata') missing in new version.
Migration ('moose', '0261_realm_private_message_policy') missing in new version.
Migration ('moose', '0336_userstatus_status_emoji') missing in new version.
Migration ('moose', '0270_huddle_recipient') missing in new version.
Migration ('moose', '0054_realm_icon') missing in new version.
Migration ('moose', '0305_realm_deactivated_redirect') missing in new version.
Migration ('moose', '0214_realm_invite_to_stream_policy') missing in new version.
Migration ('moose', '0144_remove_realm_create_generic_bot_by_admins_only') missing in new version.
Migration ('moose', '0222_userprofile_fluid_layout_width') missing in new version.
Migration ('moose', '0234_add_external_account_custom_profile_field') missing in new version.
Migration ('moose', '0155_change_default_realm_description') missing in new version.
Migration ('moose', '0177_user_message_add_and_index_is_private_flag') missing in new version.
Migration ('moose', '0377_message_edit_history_format') missing in new version.
Migration ('moose', '0374_backfill_user_delete_realmauditlog') missing in new version.
Migration ('moose', '0220_subscription_notification_settings') missing in new version.
Migration ('moose', '0193_realm_email_address_visibility') missing in new version.
Migration ('moose', '0076_userprofile_emojiset') missing in new version.
Migration ('moose', '0318_remove_realm_invite_by_admins_only') missing in new version.
Migration ('moose', '0267_backfill_userpresence_realm_id') missing in new version.
Migration ('moose', '0175_change_realm_audit_log_event_type_tense') missing in new version.
Migration ('moose', '0138_userprofile_realm_name_in_notifications') missing in new version.
Migration ('moose', '0106_subscription_push_notifications') missing in new version.
Migration ('moose', '0260_missed_message_addresses_from_redis_to_db') missing in new version.
Migration ('moose', '0092_create_scheduledemail') missing in new version.
Migration ('moose', '0346_create_realm_user_default_table') missing in new version.
Migration ('moose', '0301_fix_unread_messages_in_deactivated_streams') missing in new version.
Migration ('moose', '0125_realm_max_invites') missing in new version.
Migration ('moose', '0288_reaction_unique_on_emoji_code') missing in new version.
Migration ('moose', '0320_realm_move_messages_between_streams_policy') missing in new version.
Migration ('moose', '0339_remove_realm_add_emoji_by_admins_only') missing in new version.
Migration ('moose', '0207_multiuseinvite_invited_as') missing in new version.
Migration ('moose', '0060_move_avatars_to_be_uid_based') missing in new version.
Migration ('moose', '0359_re2_linkifiers') missing in new version.
Migration ('moose', '0385_attachment_flags_cache') missing in new version.
Migration ('moose', '0088_remove_referral_and_invites') missing in new version.
Migration ('moose', '0104_fix_unreads') missing in new version.
Migration ('moose', '0108_fix_default_string_id') missing in new version.
Migration ('moose', '0384_alter_realm_not_null') missing in new version.
Migration ('moose', '0035_realm_message_retention_period_days') missing in new version.
Migration ('moose', '0215_realm_avatar_changes_disabled') missing in new version.
Migration ('moose', '0169_stream_is_announcement_only') missing in new version.
Migration ('moose', '0344_alter_emojiset_default_value') missing in new version.
Migration ('moose', '0094_realm_filter_url_validator') missing in new version.
Migration ('moose', '0226_archived_submessage_model') missing in new version.
Migration ('moose', '0289_tighten_attachment_size') missing in new version.
Migration ('moose', '0039_realmalias_drop_uniqueness') missing in new version.
Migration ('moose', '0172_add_user_type_of_custom_profile_field') missing in new version.
Migration ('moose', '0049_userprofile_pm_content_in_desktop_notifications') missing in new version.
Migration ('moose', '0281_zoom_oauth') missing in new version.
Migration ('moose', '0166_add_url_to_profile_field') missing in new version.
Migration ('moose', '0350_usertopic_visibility_policy') missing in new version.
Migration ('moose', '0072_realmauditlog_add_index_event_time') missing in new version.
Migration ('moose', '0128_scheduledemail_realm') missing in new version.
Migration ('moose', '0201_zoom_video_chat') missing in new version.
Migration ('moose', '0116_realm_allow_message_deleting') missing in new version.
Migration ('moose', '0268_add_userpresence_realm_timestamp_index') missing in new version.
Migration ('moose', '0212_make_stream_email_token_unique') missing in new version.
Migration ('moose', '0382_create_role_based_system_groups') missing in new version.
Migration ('moose', '0283_apple_auth') missing in new version.
Migration ('moose', '0153_remove_int_float_custom_fields') missing in new version.
Migration ('moose', '0355_realm_delete_own_message_policy') missing in new version.
Migration ('moose', '0365_alter_user_group_related_fields') missing in new version.
Migration ('moose', '0233_userprofile_avatar_hash') missing in new version.
Migration ('moose', '0067_archived_models') missing in new version.
Migration ('moose', '0096_add_password_required') missing in new version.
Migration ('moose', '0147_realm_disallow_disposable_email_addresses') missing in new version.
Migration ('moose', '0124_stream_enable_notifications') missing in new version.
Migration ('moose', '0296_remove_userprofile_short_name') missing in new version.
Migration ('moose', '0218_remove_create_stream_by_admins_only') missing in new version.
Migration ('moose', '0329_remove_realm_allow_community_topic_editing') missing in new version.
Migration ('moose', '0058_realm_email_changes_disabled') missing in new version.
Migration ('moose', '0347_realm_emoji_animated') missing in new version.
Migration ('moose', '0371_invalid_characters_in_topics') missing in new version.
Migration ('moose', '0333_alter_realm_org_type') missing in new version.
Migration ('moose', '0174_userprofile_delivery_email') missing in new version.
Migration ('moose', '0050_userprofile_avatar_version') missing in new version.
Migration ('moose', '0307_rename_api_super_user_to_can_forge_sender') missing in new version.
Migration ('moose', '0224_alter_field_realm_video_chat_provider') missing in new version.
Migration ('moose', '0285_remove_realm_google_hangouts_domain') missing in new version.
Migration ('moose', '0069_realmauditlog_extra_data') missing in new version.
Migration ('moose', '0219_toggle_realm_digest_emails_enabled_default') missing in new version.
Migration ('moose', '0238_usermessage_bigint_id') missing in new version.
Migration ('moose', '0232_make_archive_transaction_field_not_nullable') missing in new version.
Migration ('moose', '0059_userprofile_quota') missing in new version.
Migration ('moose', '0140_realm_send_welcome_emails') missing in new version.
Migration ('moose', '0148_max_invites_forget_default') missing in new version.
Migration ('moose', '0176_remove_subscription_notifications') missing in new version.
Migration ('moose', '0225_archived_reaction_model') missing in new version.
Migration ('moose', '0252_realm_user_group_edit_policy') missing in new version.
Migration ('moose', '0293_update_invite_as_dict_values') missing in new version.
Migration ('moose', '0254_merge_0209_0253') missing in new version.
Migration ('moose', '0001_initial') missing in new version.
Migration ('moose', '0189_userprofile_add_some_emojisets') missing in new version.
Migration ('moose', '0118_defaultstreamgroup_description') missing in new version.
Migration ('moose', '0366_group_group_membership') missing in new version.
Migration ('moose', '0055_attachment_size') missing in new version.
Migration ('moose', '0242_fix_bot_email_property') missing in new version.
Migration ('moose', '0037_disallow_null_string_id') missing in new version.
Migration ('moose', '0230_rename_to_enable_stream_audible_notifications') missing in new version.
Migration ('moose', '0292_update_default_value_of_invited_as') missing in new version.
Migration ('moose', '0082_index_starred_user_messages') missing in new version.
Migration ('moose', '0314_muted_user') missing in new version.
Migration ('moose', '0197_azure_active_directory_auth') missing in new version.
Migration ('moose', '0326_alter_realm_authentication_methods') missing in new version.
Migration ('moose', '0330_linkifier_pattern_validator') missing in new version.
Migration ('moose', '0237_rename_zulip_realm_to_zulipinternal') missing in new version.
Migration ('moose', '0047_realm_add_emoji_by_admins_only') missing in new version.
Migration ('moose', '0360_merge_0358_0359') missing in new version.
Migration ('other', '0007_add_indexes') missing in new version.
Migration ('moose', '0313_finish_is_user_active_migration') missing in new version.
Migration ('moose', '0272_realm_default_code_block_language') missing in new version.
Migration ('moose', '0324_fix_deletion_cascade_behavior') missing in new version.
Migration ('moose', '0263_stream_stream_post_policy') missing in new version.
Migration ('moose', '0204_remove_realm_billing_fields') missing in new version.
Migration ('moose', '0062_default_timezone') missing in new version.
Migration ('moose', '0265_remove_stream_is_announcement_only') missing in new version.
Migration ('moose', '0162_change_default_community_topic_editing') missing in new version.
Migration ('moose', '0163_remove_userprofile_default_desktop_notifications') missing in new version.
Migration ('moose', '0123_userprofile_make_realm_email_pair_unique') missing in new version.
Migration ('moose', '0327_realm_edit_topic_policy') missing in new version.
Migration ('moose', '0173_support_seat_based_plans') missing in new version.
Migration ('moose', '0041_create_attachments_for_old_messages') missing in new version.
Migration ('moose', '0196_add_realm_logo_fields') missing in new version.
Migration ('moose', '0136_remove_userprofile_quota') missing in new version.
Migration ('other', '0001_initial') missing in new version.
Migration ('moose', '0068_remove_realm_domain') missing in new version.
Migration ('moose', '0255_userprofile_stream_add_recipient_column') missing in new version.
Migration ('moose', '0190_cleanup_pushdevicetoken') missing in new version.
Migration ('moose', '0064_sync_uploads_filesize_with_db') missing in new version.
Migration ('moose', '0146_userprofile_message_content_in_email_notifications') missing in new version.
2022-04-06 01:16:56.065 ERR  [] This is not an upgrade -- the current deployment (version 6.0-dev+git) contains 372 database migrations which /home/zulip/deployments/2022-03-31-23-27-20 (version 6.0-dev-23-g04a9aa6dfb) does not.
```

New:
```
root@alexmv-prod:/home/zulip/deployments/current# sudo -u zulip ./scripts/lib/check-database-compatibility.py
Migrations which are currently applied, but missing in the new version:
  moose - 0001_initial
  moose - 0029_realm_subdomain
  moose - 0030_realm_org_type
  moose - 0031_remove_system_avatar_source
  moose - 0032_verify_all_medium_avatar_images
  moose - 0033_migrate_domain_to_realmalias
  moose - 0034_userprofile_enable_online_push_notifications
  moose - 0035_realm_message_retention_period_days
  moose - 0036_rename_subdomain_to_string_id
  moose - 0037_disallow_null_string_id
  moose - 0038_realm_change_to_community_defaults
  moose - 0039_realmalias_drop_uniqueness
  moose - 0040_realm_authentication_methods
  moose - 0041_create_attachments_for_old_messages
  moose - 0042_attachment_file_name_length
  moose - 0043_realm_filter_validators
  moose - 0044_reaction
  moose - 0045_realm_waiting_period_threshold
  moose - 0046_realmemoji_author
  moose - 0047_realm_add_emoji_by_admins_only
  moose - 0048_enter_sends_default_to_false
  moose - 0049_userprofile_pm_content_in_desktop_notifications
  moose - 0050_userprofile_avatar_version
  moose - 0051_realmalias_add_allow_subdomains
  moose - 0052_auto_fix_realmalias_realm_nullable
  moose - 0053_emailchangestatus
  moose - 0054_realm_icon
  moose - 0055_attachment_size
  moose - 0056_userprofile_emoji_alt_code
  moose - 0057_realmauditlog
  moose - 0058_realm_email_changes_disabled
  moose - 0059_userprofile_quota
  moose - 0060_move_avatars_to_be_uid_based
  moose - 0061_userprofile_timezone
  moose - 0062_default_timezone
  moose - 0063_realm_description
  moose - 0064_sync_uploads_filesize_with_db
  moose - 0065_realm_inline_image_preview
  moose - 0066_realm_inline_url_embed_preview
  moose - 0067_archived_models
  moose - 0068_remove_realm_domain
  moose - 0069_realmauditlog_extra_data
  moose - 0070_userhotspot
  moose - 0071_rename_realmalias_to_realmdomain
  moose - 0072_realmauditlog_add_index_event_time
  moose - 0073_custom_profile_fields
  moose - 0074_fix_duplicate_attachments
  moose - 0075_attachment_path_id_unique
  moose - 0076_userprofile_emojiset
  moose - 0077_add_file_name_field_to_realm_emoji
  moose - 0078_service
  moose - 0079_remove_old_scheduled_jobs
  moose - 0080_realm_description_length
  moose - 0081_make_emoji_lowercase
  moose - 0082_index_starred_user_messages
  moose - 0083_index_mentioned_user_messages
  moose - 0084_realmemoji_deactivated
  moose - 0085_fix_bots_with_none_bot_type
  moose - 0086_realm_alter_default_org_type
  moose - 0087_remove_old_scheduled_jobs
  moose - 0088_remove_referral_and_invites
  moose - 0089_auto_20170710_1353
  moose - 0090_userprofile_high_contrast_mode
  moose - 0091_realm_allow_edit_history
  moose - 0092_create_scheduledemail
  moose - 0093_subscription_event_log_backfill
  moose - 0094_realm_filter_url_validator
  moose - 0095_index_unread_user_messages
  moose - 0096_add_password_required
  moose - 0097_reactions_emoji_code
  moose - 0098_index_has_alert_word_user_messages
  moose - 0099_index_wildcard_mentioned_user_messages
  moose - 0100_usermessage_remove_is_me_message
  moose - 0101_muted_topic
  moose - 0102_convert_muted_topic
  moose - 0103_remove_userprofile_muted_topics
  moose - 0104_fix_unreads
  moose - 0105_userprofile_enable_stream_push_notifications
  moose - 0106_subscription_push_notifications
  moose - 0107_multiuseinvite
  moose - 0108_fix_default_string_id
  moose - 0109_mark_tutorial_status_finished
  moose - 0110_stream_is_in_zephyr_realm
  moose - 0111_botuserstatedata
  moose - 0112_index_muted_topics
  moose - 0113_default_stream_group
  moose - 0114_preregistrationuser_invited_as_admin
  moose - 0115_user_groups
  moose - 0116_realm_allow_message_deleting
  moose - 0117_add_desc_to_user_group
  moose - 0118_defaultstreamgroup_description
  moose - 0119_userprofile_night_mode
  moose - 0120_botuserconfigdata
  moose - 0121_realm_signup_notifications_stream
  moose - 0122_rename_botuserstatedata_botstoragedata
  moose - 0123_userprofile_make_realm_email_pair_unique
  moose - 0124_stream_enable_notifications
  moose - 0125_realm_max_invites
  moose - 0126_prereg_remove_users_without_realm
  moose - 0127_disallow_chars_in_stream_and_user_name
  moose - 0128_scheduledemail_realm
  moose - 0129_remove_userprofile_autoscroll_forever
  moose - 0130_text_choice_in_emojiset
  moose - 0131_realm_create_generic_bot_by_admins_only
  moose - 0132_realm_message_visibility_limit
  moose - 0133_rename_botuserconfigdata_botconfigdata
  moose - 0134_scheduledmessage
  moose - 0135_scheduledmessage_delivery_type
  moose - 0136_remove_userprofile_quota
  moose - 0137_realm_upload_quota_gb
  moose - 0138_userprofile_realm_name_in_notifications
  moose - 0139_fill_last_message_id_in_subscription_logs
  moose - 0140_realm_send_welcome_emails
  moose - 0141_change_usergroup_description_to_textfield
  moose - 0142_userprofile_translate_emoticons
  moose - 0143_realm_bot_creation_policy
  moose - 0144_remove_realm_create_generic_bot_by_admins_only
  moose - 0145_reactions_realm_emoji_name_to_id
  moose - 0146_userprofile_message_content_in_email_notifications
  moose - 0147_realm_disallow_disposable_email_addresses
  moose - 0148_max_invites_forget_default
  moose - 0149_realm_emoji_drop_unique_constraint
  moose - 0150_realm_allow_community_topic_editing
  moose - 0151_last_reminder_default_none
  moose - 0152_realm_default_twenty_four_hour_time
  moose - 0153_remove_int_float_custom_fields
  moose - 0154_fix_invalid_bot_owner
  moose - 0155_change_default_realm_description
  moose - 0156_add_hint_to_profile_field
  moose - 0157_userprofile_is_guest
  moose - 0158_realm_video_chat_provider
  moose - 0159_realm_google_hangouts_domain
  moose - 0160_add_choice_field
  moose - 0161_realm_message_content_delete_limit_seconds
  moose - 0162_change_default_community_topic_editing
  moose - 0163_remove_userprofile_default_desktop_notifications
  moose - 0164_stream_history_public_to_subscribers
  moose - 0165_add_date_to_profile_field
  moose - 0166_add_url_to_profile_field
  moose - 0167_custom_profile_fields_sort_order
  moose - 0168_stream_is_web_public
  moose - 0169_stream_is_announcement_only
  moose - 0170_submessage
  moose - 0171_userprofile_dense_mode
  moose - 0172_add_user_type_of_custom_profile_field
  moose - 0173_support_seat_based_plans
  moose - 0174_userprofile_delivery_email
  moose - 0175_change_realm_audit_log_event_type_tense
  moose - 0176_remove_subscription_notifications
  moose - 0177_user_message_add_and_index_is_private_flag
  moose - 0178_rename_to_emails_restricted_to_domains
  moose - 0179_rename_to_digest_emails_enabled
  moose - 0180_usermessage_add_active_mobile_push_notification
  moose - 0181_userprofile_change_emojiset
  moose - 0182_set_initial_value_is_private_flag
  moose - 0183_change_custom_field_name_max_length
  moose - 0184_rename_custom_field_types
  moose - 0185_realm_plan_type
  moose - 0186_userprofile_starred_message_counts
  moose - 0187_userprofile_is_billing_admin
  moose - 0188_userprofile_enable_login_emails
  moose - 0189_userprofile_add_some_emojisets
  moose - 0190_cleanup_pushdevicetoken
  moose - 0191_realm_seat_limit
  moose - 0192_customprofilefieldvalue_rendered_value
  moose - 0193_realm_email_address_visibility
  moose - 0194_userprofile_notification_sound
  moose - 0195_realm_first_visible_message_id
  moose - 0196_add_realm_logo_fields
  moose - 0197_azure_active_directory_auth
  moose - 0198_preregistrationuser_invited_as
  moose - 0199_userstatus
  moose - 0200_remove_preregistrationuser_invited_as_admin
  moose - 0201_zoom_video_chat
  moose - 0202_add_user_status_info
  moose - 0203_realm_message_content_allowed_in_email_notifications
  moose - 0204_remove_realm_billing_fields
  moose - 0205_remove_realmauditlog_requires_billing_update
  moose - 0206_stream_rendered_description
  moose - 0207_multiuseinvite_invited_as
  moose - 0208_add_realm_night_logo_fields
  moose - 0209_stream_first_message_id
  moose - 0209_user_profile_no_empty_password
  moose - 0210_stream_first_message_id
  moose - 0211_add_users_field_to_scheduled_email
  moose - 0212_make_stream_email_token_unique
  moose - 0213_realm_digest_weekday
  moose - 0214_realm_invite_to_stream_policy
  moose - 0215_realm_avatar_changes_disabled
  moose - 0216_add_create_stream_policy
  moose - 0217_migrate_create_stream_policy
  moose - 0218_remove_create_stream_by_admins_only
  moose - 0219_toggle_realm_digest_emails_enabled_default
  moose - 0220_subscription_notification_settings
  moose - 0221_subscription_notifications_data_migration
  moose - 0222_userprofile_fluid_layout_width
  moose - 0223_rename_to_is_muted
  moose - 0224_alter_field_realm_video_chat_provider
  moose - 0225_archived_reaction_model
  moose - 0226_archived_submessage_model
  moose - 0227_inline_url_embed_preview_default_off
  moose - 0228_userprofile_demote_inactive_streams
  moose - 0229_stream_message_retention_days
  moose - 0230_rename_to_enable_stream_audible_notifications
  moose - 0231_add_archive_transaction_model
  moose - 0232_make_archive_transaction_field_not_nullable
  moose - 0233_userprofile_avatar_hash
  moose - 0234_add_external_account_custom_profile_field
  moose - 0235_userprofile_desktop_icon_count_display
  moose - 0236_remove_illegal_characters_email_full
  moose - 0237_rename_zulip_realm_to_zulipinternal
  moose - 0238_usermessage_bigint_id
  moose - 0239_usermessage_copy_id_to_bigint_id
  moose - 0240_usermessage_migrate_bigint_id_into_id
  moose - 0241_usermessage_bigint_id_migration_finalize
  moose - 0242_fix_bot_email_property
  moose - 0243_message_add_date_sent_column
  moose - 0244_message_copy_pub_date_to_date_sent
  moose - 0245_message_date_sent_finalize_part1
  moose - 0246_message_date_sent_finalize_part2
  moose - 0247_realmauditlog_event_type_to_int
  moose - 0248_userprofile_role_start
  moose - 0249_userprofile_role_finish
  moose - 0250_saml_auth
  moose - 0251_prereg_user_add_full_name
  moose - 0252_realm_user_group_edit_policy
  moose - 0253_userprofile_wildcard_mentions_notify
  moose - 0254_merge_0209_0253
  moose - 0255_userprofile_stream_add_recipient_column
  moose - 0256_userprofile_stream_set_recipient_column_values
  moose - 0257_fix_has_link_attribute
  moose - 0258_enable_online_push_notifications_default
  moose - 0259_missedmessageemailaddress
  moose - 0260_missed_message_addresses_from_redis_to_db
  moose - 0261_pregistrationuser_clear_invited_as_admin
  moose - 0261_realm_private_message_policy
  moose - 0262_mutedtopic_date_muted
  moose - 0263_stream_stream_post_policy
  moose - 0264_migrate_is_announcement_only
  moose - 0265_remove_stream_is_announcement_only
  moose - 0266_userpresence_realm
  moose - 0267_backfill_userpresence_realm_id
  moose - 0268_add_userpresence_realm_timestamp_index
  moose - 0269_gitlab_auth
  moose - 0270_huddle_recipient
  moose - 0271_huddle_set_recipient_column_values
  moose - 0272_realm_default_code_block_language
  moose - 0273_migrate_old_bot_messages
  moose - 0274_nullbooleanfield_to_booleanfield
  moose - 0275_remove_userprofile_last_pointer_updater
  moose - 0276_alertword
  moose - 0277_migrate_alert_word
  moose - 0278_remove_userprofile_alert_words
  moose - 0279_message_recipient_subject_indexes
  moose - 0280_userprofile_presence_enabled
  moose - 0281_zoom_oauth
  moose - 0282_remove_zoom_video_chat
  moose - 0283_apple_auth
  moose - 0284_convert_realm_admins_to_realm_owners
  moose - 0285_remove_realm_google_hangouts_domain
  moose - 0286_merge_0260_0285
  moose - 0287_clear_duplicate_reactions
  moose - 0288_reaction_unique_on_emoji_code
  moose - 0289_tighten_attachment_size
  moose - 0290_remove_night_mode_add_color_scheme
  moose - 0291_realm_retention_days_not_null
  moose - 0292_update_default_value_of_invited_as
  moose - 0293_update_invite_as_dict_values
  moose - 0294_remove_userprofile_pointer
  moose - 0295_case_insensitive_email_indexes
  moose - 0296_remove_userprofile_short_name
  moose - 0297_draft
  moose - 0298_fix_realmauditlog_format
  moose - 0299_subscription_role
  moose - 0300_add_attachment_is_web_public
  moose - 0301_fix_unread_messages_in_deactivated_streams
  moose - 0302_case_insensitive_stream_name_index
  moose - 0303_realm_wildcard_mention_policy
  moose - 0304_remove_default_status_of_default_private_streams
  moose - 0305_realm_deactivated_redirect
  moose - 0306_custom_profile_field_date_format
  moose - 0307_rename_api_super_user_to_can_forge_sender
  moose - 0308_remove_reduntant_realm_meta_permissions
  moose - 0309_userprofile_can_create_users
  moose - 0310_jsonfield
  moose - 0311_userprofile_default_view
  moose - 0312_subscription_is_user_active
  moose - 0313_finish_is_user_active_migration
  moose - 0314_muted_user
  moose - 0315_realmplayground
  moose - 0316_realm_invite_to_realm_policy
  moose - 0317_migrate_to_invite_to_realm_policy
  moose - 0318_remove_realm_invite_by_admins_only
  moose - 0319_realm_giphy_rating
  moose - 0320_realm_move_messages_between_streams_policy
  moose - 0321_userprofile_enable_marketing_emails
  moose - 0322_realm_create_audit_log_backfill
  moose - 0323_show_starred_message_counts
  moose - 0324_fix_deletion_cascade_behavior
  moose - 0325_alter_realmplayground_unique_together
  moose - 0326_alter_realm_authentication_methods
  moose - 0327_realm_edit_topic_policy
  moose - 0328_migrate_to_edit_topic_policy
  moose - 0329_remove_realm_allow_community_topic_editing
  moose - 0330_linkifier_pattern_validator
  moose - 0331_scheduledmessagenotificationemail
  moose - 0332_realmuserdefault
  moose - 0333_alter_realm_org_type
  moose - 0334_email_notifications_batching_period
  moose - 0335_add_draft_sync_field
  moose - 0336_userstatus_status_emoji
  moose - 0337_realm_add_custom_emoji_policy
  moose - 0338_migrate_to_add_custom_emoji_policy
  moose - 0339_remove_realm_add_emoji_by_admins_only
  moose - 0340_rename_mutedtopic_to_usertopic
  moose - 0341_usergroup_is_system_group
  moose - 0342_realm_demo_organization_scheduled_deletion_date
  moose - 0343_alter_useractivityinterval_index_together
  moose - 0344_alter_emojiset_default_value
  moose - 0345_alter_realm_name
  moose - 0346_create_realm_user_default_table
  moose - 0347_realm_emoji_animated
  moose - 0348_rename_date_muted_usertopic_last_updated
  moose - 0349_alter_usertopic_table
  moose - 0350_usertopic_visibility_policy
  moose - 0351_user_topic_visibility_indexes
  moose - 0352_migrate_twenty_four_hour_time_to_realmuserdefault
  moose - 0353_remove_realm_default_twenty_four_hour_time
  moose - 0354_alter_realm_message_content_delete_limit_seconds
  moose - 0355_realm_delete_own_message_policy
  moose - 0356_migrate_to_delete_own_message_policy
  moose - 0357_remove_realm_allow_message_deleting
  moose - 0358_split_create_stream_policy
  moose - 0359_re2_linkifiers
  moose - 0360_merge_0358_0359
  moose - 0361_realm_create_web_public_stream_policy
  moose - 0362_send_typing_notifications_user_setting
  moose - 0363_send_read_receipts_user_setting
  moose - 0364_rename_members_usergroup_direct_members
  moose - 0365_alter_user_group_related_fields
  moose - 0366_group_group_membership
  moose - 0367_scimclient
  moose - 0368_alter_realmfilter_url_format_string
  moose - 0369_add_escnav_default_display_user_setting
  moose - 0370_realm_enable_spectator_access
  moose - 0371_invalid_characters_in_topics
  moose - 0372_realmemoji_unique_realm_emoji_when_false_deactivated
  moose - 0373_fix_deleteduser_dummies
  moose - 0374_backfill_user_delete_realmauditlog
  moose - 0375_invalid_characters_in_stream_names
  moose - 0376_set_realmemoji_author_and_reupload_realmemoji
  moose - 0377_message_edit_history_format
  moose - 0378_alter_realmuserdefault_realm
  moose - 0379_userprofile_uuid
  moose - 0380_userprofile_uuid_backfill
  moose - 0381_alter_userprofile_uuid
  moose - 0382_create_role_based_system_groups
  moose - 0383_revoke_invitations_from_deactivated_users
  moose - 0384_alter_realm_not_null
  moose - 0385_attachment_flags_cache
  moose - 0386_fix_attachment_caches
  other - 0001_initial
  other - 0002_realmcreationkey
  other - 0003_emailchangeconfirmation
  other - 0004_remove_confirmationmanager
  other - 0005_confirmation_realm
  other - 0006_realmcreationkey_presume_email_valid
  other - 0007_add_indexes
  other - 0008_confirmation_expiry_date
  other - 0009_confirmation_expiry_date_backfill
  other - 0010_alter_confirmation_expiry_date
  other - 0011_alter_confirmation_expiry_date
2022-04-06 01:16:20.631 ERR  [] This is not an upgrade -- the current deployment (version 6.0-dev+git) contains 372 database migrations which /home/zulip/deployments/2022-03-31-23-27-20 (version 6.0-dev-23-g04a9aa6dfb) does not.
```

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
