### PR TITLE
stream_settings: Provide stream privacy and description in notification events when stream is created.

### DIFF
--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3971,9 +3971,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(msg.recipient.type, Recipient.STREAM)
         self.assertEqual(msg.recipient.type_id, notifications_stream.id)
         self.assertEqual(msg.sender_id, self.notification_bot(self.test_realm).id)
-        expected_msg = (
-            f"@_**{invitee_full_name}|{invitee.id}** created a new stream #**{invite_streams[0]}**."
-        )
+        expected_msg = f"@_**{invitee_full_name}|{invitee.id}** created a new public stream #**{invite_streams[0]}**."
         self.assertEqual(msg.content, expected_msg)
 
         msg = self.get_last_message()
@@ -4017,7 +4015,14 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(msg.recipient.type_id, notifications_stream.id)
         self.assertEqual(msg.sender_id, self.notification_bot(realm).id)
         stream_id = Stream.objects.latest("id").id
-        expected_rendered_msg = f'<p><span class="user-mention silent" data-user-id="{user.id}">{user.full_name}</span> created a new stream <a class="stream" data-stream-id="{stream_id}" href="/#narrow/stream/{stream_id}-{invite_streams[0]}">#{invite_streams[0]}</a>.</p>'
+        expected_rendered_msg = "".join(
+            [
+                "<p>",
+                f'<span class="user-mention silent" data-user-id="{user.id}">{user.full_name}</span>',
+                " created a new public stream ",
+                f'<a class="stream" data-stream-id="{stream_id}" href="/#narrow/stream/{stream_id}-{invite_streams[0]}">#{invite_streams[0]}</a>.</p>',
+            ]
+        )
         self.assertEqual(msg.rendered_content, expected_rendered_msg)
 
     def test_successful_subscriptions_notifies_with_escaping(self) -> None:
@@ -4044,9 +4049,7 @@ class SubscriptionAPITest(ZulipTestCase):
 
         msg = self.get_second_to_last_message()
         self.assertEqual(msg.sender_id, self.notification_bot(notifications_stream.realm).id)
-        expected_msg = (
-            f"@_**{invitee_full_name}|{invitee.id}** created a new stream #**{invite_streams[0]}**."
-        )
+        expected_msg = f"@_**{invitee_full_name}|{invitee.id}** created a new public stream #**{invite_streams[0]}**."
         self.assertEqual(msg.content, expected_msg)
 
     def test_non_ascii_stream_subscription(self) -> None:

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3979,7 +3979,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(msg.recipient.type_id, target_stream.id)
         self.assertEqual(msg.sender_id, self.notification_bot(self.test_realm).id)
         expected_msg = (
-            f"**Public** stream created by @_**{invitee_full_name}|{invitee.id}**. **Description:**\n"
+            f"Public stream created by @_**{invitee_full_name}|{invitee.id}**. **Description:**\n"
             "```` quote\n*No description.*\n````"
         )
         self.assertEqual(msg.content, expected_msg)
@@ -4366,7 +4366,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(msg.topic_name(), "stream events")
         self.assertEqual(msg.sender.email, settings.NOTIFICATION_BOT)
         self.assertIn(
-            f"**{policy_name}** stream created by @_**{self.test_user.full_name}|{self.test_user.id}**. **Description:**\n"
+            f"{policy_name} stream created by @_**{self.test_user.full_name}|{self.test_user.id}**. **Description:**\n"
             "```` quote",
             msg.content,
         )

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -700,7 +700,7 @@ def send_messages_for_new_subscribers(
                         stream=stream,
                         topic=Realm.STREAM_EVENTS_NOTIFICATION_TOPIC,
                         content=_(
-                            "**{policy}** stream created by {user_name}. **Description:**"
+                            "{policy} stream created by {user_name}. **Description:**"
                         ).format(
                             user_name=silent_mention_syntax_for_user(user_profile),
                             policy=get_stream_permission_policy_name(

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -657,14 +657,23 @@ def send_messages_for_new_subscribers(
             with override_language(notifications_stream.realm.default_language):
                 if len(created_streams) > 1:
                     content = _("{user_name} created the following streams: {stream_str}.")
+                    content = content.format(
+                        user_name=silent_mention_syntax_for_user(user_profile),
+                        stream_str=", ".join(f"#**{s.name}**" for s in created_streams),
+                    )
                 else:
-                    content = _("{user_name} created a new stream {stream_str}.")
+                    content = _("{user_name} created a new {policy} stream {stream_str}.").format(
+                        user_name=silent_mention_syntax_for_user(user_profile),
+                        stream_str=", ".join(f"#**{s.name}**" for s in created_streams),
+                        policy=get_stream_permission_policy_name(
+                            invite_only=created_streams[0].invite_only,
+                            history_public_to_subscribers=created_streams[
+                                0
+                            ].history_public_to_subscribers,
+                            is_web_public=created_streams[0].is_web_public,
+                        ).lower(),
+                    )
                 topic = _("new streams")
-
-            content = content.format(
-                user_name=silent_mention_syntax_for_user(user_profile),
-                stream_str=", ".join(f"#**{s.name}**" for s in created_streams),
-            )
 
             sender = get_system_bot(settings.NOTIFICATION_BOT, notifications_stream.realm_id)
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is in continuation of PR: #21030 to fix the issue: #21004

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="892" alt="Screenshot 2022-04-06 at 12 12 24" src="https://user-images.githubusercontent.com/85362194/161911988-30c14f72-dce2-40e7-890b-142dbe6bc2b0.png">
<img width="909" alt="Screenshot 2022-04-06 at 12 12 40" src="https://user-images.githubusercontent.com/85362194/161912005-3bf1de05-00ff-4ff2-8d59-10e35c71a005.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
