### PR TITLE
fixed expand/close compose box buttons too low when PM addresses text…

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -235,6 +235,7 @@
 #compose_top_right {
     display: flex;
     align-items: center;
+    margin-bottom: auto;
 
     button {
         background: transparent;


### PR DESCRIPTION
… take up more than one line
Issue: https://github.com/zulip/zulip/issues/21693

Tested on Chrome, Safari, Firefox at different widths. No issues found


![Screenshot 2022-04-06 at 12 32 22](https://user-images.githubusercontent.com/52413900/161988983-2f757c54-1bfa-4799-a1a9-fad5ee803c7f.png)
![Screenshot 2022-04-06 at 12 32 41](https://user-images.githubusercontent.com/52413900/161989043-c7482f71-d2d2-4973-a186-5560223e2438.png)
![Screenshot 2022-04-06 at 12 32 54](https://user-images.githubusercontent.com/52413900/161989067-befd31c7-5917-4f33-a2c5-3e96d793e2b7.png)
![Screenshot 2022-04-06 at 12 33 04](https://user-images.githubusercontent.com/52413900/161989088-e394e334-2b93-4663-a023-e46d3779070c.png)

