### PR TITLE
bug: time-zone picker corrected

### DIFF
--- a/static/js/flatpickr.js
+++ b/static/js/flatpickr.js
@@ -4,6 +4,7 @@ import $ from "jquery";
 
 import {get_keydown_hotkey} from "./hotkey";
 import {$t} from "./i18n";
+import {user_settings} from "./user_settings";
 
 function is_numeric_key(key) {
     return ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"].includes(key);
@@ -28,6 +29,7 @@ export function show_flatpickr(element, callback, default_timestamp, options = {
         dateFormat: "Z",
         formatDate: (date) => formatISO(date),
         disableMobile: true,
+        time_24hr: user_settings.twenty_four_hour_time,
         onKeyDown: (selectedDates, dateStr, instance, event) => {
             if (is_numeric_key(event.key)) {
                 // Don't attempt to get_keydown_hotkey for numeric inputs


### PR DESCRIPTION
Resolved Issue #21682 

**Testing plan:**  Tested Manually
TimeZone picker always showed time in 12 hrs format even if the users setting is 24 hrs format.
**Before**
<img src="https://user-images.githubusercontent.com/86338542/162037166-62069508-0873-44b6-8f31-5ccc77342bc9.png" width="350" height="350">
**After**
<img src="https://user-images.githubusercontent.com/86338542/162037757-105bfa7b-ec5b-4418-b428-101f3e0142ee.png" width="350" height="350">
