### PR TITLE
compose: Fix wildcard mentions typeahead in PMs.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -79,7 +79,7 @@ run_test("verify wildcard mentions typeahead for stream message", () => {
 
 run_test("verify wildcard mentions typeahead for private message", () => {
     compose_state.set_message_type("private");
-    assert.equal(ct.broadcast_mentions().length, 3);
+    assert.equal(ct.broadcast_mentions().length, 2);
     const mention_all = ct.broadcast_mentions()[0];
     const mention_everyone = ct.broadcast_mentions()[1];
     assert.equal(mention_all.email, "all");

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -61,9 +61,35 @@ const ct = composebox_typeahead;
 // broadcast-mentions/persons/groups.
 ct.__Rewire__("max_num_items", 15);
 
-const mention_all = ct.broadcast_mentions()[0];
-assert.equal(mention_all.email, "all");
-assert.equal(mention_all.full_name, "all");
+run_test("verify wildcard mentions typeahead for stream message", () => {
+    const mention_all = ct.broadcast_mentions()[0];
+    const mention_everyone = ct.broadcast_mentions()[1];
+    const mention_stream = ct.broadcast_mentions()[2];
+    assert.equal(mention_all.email, "all");
+    assert.equal(mention_all.full_name, "all");
+    assert.equal(mention_everyone.email, "everyone");
+    assert.equal(mention_everyone.full_name, "everyone");
+    assert.equal(mention_stream.email, "stream");
+    assert.equal(mention_stream.full_name, "stream");
+
+    assert.equal(mention_all.special_item_text, "all (translated: Notify stream)");
+    assert.equal(mention_everyone.special_item_text, "everyone (translated: Notify stream)");
+    assert.equal(mention_stream.special_item_text, "stream (translated: Notify stream)");
+});
+
+run_test("verify wildcard mentions typeahead for private message", () => {
+    compose_state.set_message_type("private");
+    assert.equal(ct.broadcast_mentions().length, 3);
+    const mention_all = ct.broadcast_mentions()[0];
+    const mention_everyone = ct.broadcast_mentions()[1];
+    assert.equal(mention_all.email, "all");
+    assert.equal(mention_all.full_name, "all");
+    assert.equal(mention_everyone.email, "everyone");
+    assert.equal(mention_everyone.full_name, "everyone");
+
+    assert.equal(mention_all.special_item_text, "all (translated: Notify recipients)");
+    assert.equal(mention_everyone.special_item_text, "everyone (translated: Notify recipients)");
+});
 
 const emoji_stadium = {
     name: "stadium",
@@ -1464,6 +1490,7 @@ test("filter_and_sort_mentions (normal)", () => {
 
     const suggestions = ct.filter_and_sort_mentions(is_silent, "al");
 
+    const mention_all = ct.broadcast_mentions()[0];
     assert.deepEqual(suggestions, [mention_all, alice, hal, call_center]);
 });
 
@@ -1620,5 +1647,6 @@ test("muted users excluded from results", () => {
     // Make sure our muting logic doesn't break wildcard mentions
     // or user group mentions.
     results = ct.get_person_suggestions("all", opts);
+    const mention_all = ct.broadcast_mentions()[0];
     assert.deepEqual(results, [mention_all, call_center]);
 });

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -343,12 +343,14 @@ export function tokenize_compose_str(s) {
 }
 
 export function broadcast_mentions() {
+    let wildcard_string = "";
+    if (compose_state.get_message_type() === "private") {
+        wildcard_string = $t({defaultMessage: "Notify recipients"});
+    } else {
+        wildcard_string = $t({defaultMessage: "Notify stream"});
+    }
     return ["all", "everyone", "stream"].map((mention, idx) => ({
-        special_item_text: $t(
-            {defaultMessage: "{wildcard_mention_token} (Notify stream)"},
-            {wildcard_mention_token: mention},
-        ),
-
+        special_item_text: `${mention} (${wildcard_string})`,
         email: mention,
 
         // Always sort above, under the assumption that names will

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -343,13 +343,15 @@ export function tokenize_compose_str(s) {
 }
 
 export function broadcast_mentions() {
+    const wildcard_mention_array = ["all", "everyone"];
     let wildcard_string = "";
     if (compose_state.get_message_type() === "private") {
         wildcard_string = $t({defaultMessage: "Notify recipients"});
     } else {
         wildcard_string = $t({defaultMessage: "Notify stream"});
+        wildcard_mention_array.push("stream");
     }
-    return ["all", "everyone", "stream"].map((mention, idx) => ({
+    return wildcard_mention_array.map((mention, idx) => ({
         special_item_text: `${mention} (${wildcard_string})`,
         email: mention,
 


### PR DESCRIPTION
**PR Description:** 
First commit :  It attempts to fix the suggestions typeahead for wildcard
mentions in case of PMs by using a conditional which checks for the
current compose_state and changes the string in parentheses accordingly.
In the case of PMs, it uses the "(Notify recipients)" string instead of
"(Notify stream)".

Second commit: It adds an `wildcard_mention_array` for which would contain the
mention tokens according to the message type. In the case of PMs, it uses
only "all" and "everyone" mentions.

Fixes part of: #21643

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot 2022-04-07 102012](https://user-images.githubusercontent.com/77766761/162122573-16e49a91-305a-49ab-a35c-a8e4417484a5.png)
![Screenshot 2022-04-07 102040](https://user-images.githubusercontent.com/77766761/162122579-3dacb97c-cbff-4b03-a1a8-c0bed0358bf4.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
