### PR TITLE
Fix Disable "Save changes" Button when no changes have been made.

### DIFF
--- a/static/templates/settings/edit_bot.hbs
+++ b/static/templates/settings/edit_bot.hbs
@@ -15,7 +15,9 @@
             </div>
             <div class="edit-bot-name">
                 <label for="edit_bot_name">{{t "Full name" }}</label>
-                <input id="edit_bot_name" type="text" name="bot_name" class="edit_bot_name required" value="{{bot.full_name}}" maxlength=50 />
+                
+                <input id="edit_bot_name" type="text" name="bot_name" class="edit_bot_name required" value="{{bot.full_name}}" maxlength=50 required onkeyup="EnableDisable(this)"/>
+                
                 <div><label for="edit_bot_name" generated="true" class="text-error"></label></div>
             </div>
             <div id="service_data">
@@ -25,6 +27,7 @@
                 <input type="file" name="bot_avatar_file_input" class="notvisible edit_bot_avatar_file_input" value="{{t 'Upload profile picture' }}" />
                 <div class="edit_bot_avatar_file"></div>
                 <button type="button" class="button white rounded edit_bot_avatar_upload_button">{{t "Choose avatar" }}</button>
+                
                 <button type="button" class="button white rounded edit_bot_avatar_clear_button" style="display: none;">{{t "Clear profile picture" }}</button>
                 <div><label for="edit_bot_avatar_file" generated="true" class="edit_bot_avatar_error text-error"></label></div>
             </div>

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -233,12 +233,11 @@ def send_apple_push_notification(
             result = apns_context.loop.run_until_complete(
                 apns_context.apns.send_notification(request)
             )
-        except aioapns.exceptions.ConnectionError as e:
-            logger.warning(
-                "APNs: ConnectionError sending for user %s to device %s: %s",
+        except aioapns.exceptions.ConnectionError:
+            logger.error(
+                "APNs: ConnectionError sending for user %s to device %s; check certificate expiration",
                 user_identity,
                 device.token,
-                e.__class__.__name__,
             )
             continue
 

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1609,7 +1609,7 @@ class TestAPNs(PushNotificationTest):
             )
             self.send(devices=self.devices()[0:1])
             self.assertIn(
-                f"WARNING:zerver.lib.push_notifications:APNs: ConnectionError sending for user <id:{self.user_profile.id}> to device {self.devices()[0].token}: ConnectionError",
+                f"ERROR:zerver.lib.push_notifications:APNs: ConnectionError sending for user <id:{self.user_profile.id}> to device {self.devices()[0].token}; check certificate expiration",
                 logger.output,
             )
 


### PR DESCRIPTION
"Save changes" button should be disabled when no changes have been made

Fixes part of https://github.com/zulip/zulip/issues/20831.

Testing plan:

GIFs or screenshots:

![fix bug zulip](https://user-images.githubusercontent.com/76876709/162173035-cccf5dde-08f7-4c7f-bea4-bb7d17c181de.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
