### PR TITLE
shared: Do not throw exception in parse unicode.

### DIFF
--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -56,6 +56,11 @@ run_test("get_emoji_matcher", () => {
     assert_matches("🐼", [emoji_panda_face]);
 });
 
+run_test("parse_unicode_emoji_code", () => {
+    assert.equal(typeahead.parse_unicode_emoji_code("1f43c"), "🐼");
+    assert.equal(typeahead.parse_unicode_emoji_code("not_unicode"), undefined);
+});
+
 run_test("triage", () => {
     const alice = {name: "alice"};
     const alicia = {name: "Alicia"};

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -98,11 +98,18 @@ export function clean_query_lowercase(query) {
     return query;
 }
 
-export const parse_unicode_emoji_code = (code) =>
-    code
-        .split("-")
-        .map((hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
-        .join("");
+export const parse_unicode_emoji_code = (code) => {
+    try {
+        return code
+            .split("-")
+            .map((hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+            .join("");
+    } catch {
+        // Code could not be parsed, but instead of throwing an exception
+        // we return undefined instead of a string.
+        return undefined;
+    }
+};
 
 export function get_emoji_matcher(query) {
     // replaces spaces with underscores for emoji matching


### PR DESCRIPTION
There is no guarantee that the code passed into parse_unicode_emoji_code
is valid unicode. In the case that it is not, it might be better to
return undefined instead of throwing an exception: to represent a
non-parseable code.

For context, mobile currently returns custom emojis as emojis with
string names in their code property instead of actual unicode.