### PR TITLE
Fix Disable "Save changes" Button when no changes have been made.

### DIFF
--- a/static/templates/dialog_widget.hbs
+++ b/static/templates/dialog_widget.hbs
@@ -18,7 +18,19 @@
                 {{#unless single_footer_button}}
                 <button class="modal__btn dialog_cancel_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
                 {{/unless}}
-                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
+                
+
+                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}} id="btnSubmit" type="button" value="Submit" disabled="disabled"   >
+            <script>
+                function EnableDisable(txtPassportNumber) {
+                var btnSubmit = document.getElementById("btnSubmit");     
+                 if (txtPassportNumber.value.trim() != "") {
+                 btnSubmit.disabled = false;
+                 } else {
+                 btnSubmit.disabled = true;
+                 }
+            }
+            </script>
                     <span>{{{ html_submit_button }}}</span>
                     <div class="modal__spinner"></div>
                 </button>


### PR DESCRIPTION
"Save changes" button should be disabled when no changes have been made

Fixes part of #20831.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
