### PR TITLE
Fix Disable "Save changes" Button when no changes have been made.

### DIFF
--- a/static/templates/dialog_widget.hbs
+++ b/static/templates/dialog_widget.hbs
@@ -18,7 +18,19 @@
                 {{#unless single_footer_button}}
                 <button class="modal__btn dialog_cancel_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
                 {{/unless}}
-                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
+                
+
+                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}} id="btnSubmit" type="button" value="Submit" disabled="disabled"   >
+            <script>
+                function EnableDisable(txtPassportNumber) {
+                var btnSubmit = document.getElementById("btnSubmit");     
+                 if (txtPassportNumber.value.trim() != "") {
+                 btnSubmit.disabled = false;
+                 } else {
+                 btnSubmit.disabled = true;
+                 }
+            }
+            </script>
                     <span>{{{ html_submit_button }}}</span>
                     <div class="modal__spinner"></div>
                 </button>

--- a/static/templates/settings/edit_bot.hbs
+++ b/static/templates/settings/edit_bot.hbs
@@ -15,7 +15,7 @@
             </div>
             <div class="edit-bot-name">
                 <label for="edit_bot_name">{{t "Full name" }}</label>
-                <input id="edit_bot_name" type="text" name="bot_name" class="edit_bot_name required" value="{{bot.full_name}}" maxlength=50 />
+                <input id="edit_bot_name" type="text" onkeyup="EnableDisable(this)" name="bot_name" class="edit_bot_name required" value="{{bot.full_name}}" maxlength=50 />
                 <div><label for="edit_bot_name" generated="true" class="text-error"></label></div>
             </div>
             <div id="service_data">


### PR DESCRIPTION
"Save changes" button should be disabled when no changes have been made

Fixes part of https://github.com/zulip/zulip/issues/20831.

**Testing plan:** <!-- How have you tested? -->

![zulip fix](https://user-images.githubusercontent.com/76876709/162439934-028d79e2-28a1-4c52-8425-aff0d140ffdc.gif)
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
