### PR TITLE
Fix Disable Save changes Button when no changes have been made

### DIFF
--- a/static/js/dialog_widget.js
+++ b/static/js/dialog_widget.js
@@ -40,6 +40,14 @@ import * as overlays from "./overlays";
  *      7) If a caller needs to run code after the modal body is added
  *          to DOM, it can do so by passing a post_render hook.
  */
+ export function EnableDisable(txtPassportNumber) {
+                var btnSubmit = document.getElementById("btnSubmit");     
+                 if (txtPassportNumber.value.trim() != "") {
+                 btnSubmit.disabled = false;
+                 } else {
+                 btnSubmit.disabled = true;
+                 }
+            }
 
 export function hide_dialog_spinner() {
     $(".dialog_submit_button span").show();

--- a/static/templates/dialog_widget.hbs
+++ b/static/templates/dialog_widget.hbs
@@ -18,7 +18,7 @@
                 {{#unless single_footer_button}}
                 <button class="modal__btn dialog_cancel_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
                 {{/unless}}
-                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
+                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}} id="btnSubmit" type="button" value="Submit" disabled="disabled" >
                     <span>{{{ html_submit_button }}}</span>
                     <div class="modal__spinner"></div>
                 </button>


### PR DESCRIPTION
"Save changes" button should be disabled when no changes have been made

Fixes part of https://github.com/zulip/zulip/issues/20831.

**Testing plan:** <!-- How have you tested? -->

![zulip fix](https://user-images.githubusercontent.com/76876709/162447723-7334bdb3-ea57-4670-824a-1e512698317d.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
