### PR TITLE
Fix: Disable "Save changes" Button when no changes have been made.

### DIFF
--- a/static/js/dialog_widget.js
+++ b/static/js/dialog_widget.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import render_dialog_widget from "../templates/dialog_widget.hbs";
+import render_edit_bot from "../templates/settings/edit_bot.hbs";
 
 import * as blueslip from "./blueslip";
 import {$t_html} from "./i18n";
@@ -40,6 +41,13 @@ import * as overlays from "./overlays";
  *      7) If a caller needs to run code after the modal body is added
  *          to DOM, it can do so by passing a post_render hook.
  */
+
+$(function(){
+    $(".dialog_submit_button span").attr('disabled', true);
+    $('#edit_bot_name :input').on('change', function(){
+        $(".dialog_submit_button span").removeAttr('disabled');
+    });
+});
 
 export function hide_dialog_spinner() {
     $(".dialog_submit_button span").show();

--- a/static/templates/dialog_widget.hbs
+++ b/static/templates/dialog_widget.hbs
@@ -18,7 +18,7 @@
                 {{#unless single_footer_button}}
                 <button class="modal__btn dialog_cancel_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
                 {{/unless}}
-                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
+                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}} disabled="disabled">
                     <span>{{{ html_submit_button }}}</span>
                     <div class="modal__spinner"></div>
                 </button>


### PR DESCRIPTION
Fix Disable "Save changes" Button when no changes have been made.

Fixes part of https://github.com/zulip/zulip/issues/20831.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** 
![zulip fix](https://user-images.githubusercontent.com/76876709/162473673-398820ab-85eb-4a4a-89ce-2e3e3e780802.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
