### PR TITLE
Fix Disable "Save changes" Button when no changes have been made.

### DIFF
--- a/static/js/dialog_widget.js
+++ b/static/js/dialog_widget.js
@@ -41,6 +41,13 @@ import * as overlays from "./overlays";
  *          to DOM, it can do so by passing a post_render hook.
  */
 
+$(function(){
+    $(".dialog_submit_button span").attr('disabled', true);
+    $('#dialog_widget_modal .modal__btn').on('change', function(){
+        $(".dialog_submit_button span").removeAttr('disabled');
+    });
+});
+
 export function hide_dialog_spinner() {
     $(".dialog_submit_button span").show();
     $("#dialog_widget_modal .modal__btn").prop("disabled", false);

--- a/static/templates/dialog_widget.hbs
+++ b/static/templates/dialog_widget.hbs
@@ -18,7 +18,7 @@
                 {{#unless single_footer_button}}
                 <button class="modal__btn dialog_cancel_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
                 {{/unless}}
-                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
+                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}} disabled="disabled">
                     <span>{{{ html_submit_button }}}</span>
                     <div class="modal__spinner"></div>
                 </button>


### PR DESCRIPTION
Fix Disable "Save changes" Button when no changes have been made.

Fixes part of https://github.com/zulip/zulip/issues/20831.

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:**
  ![zulip fix](https://user-images.githubusercontent.com/76876709/162480571-18ec8150-fbc7-46d3-9f42-741024db9e3e.gif)


