### PR TITLE
tests: Remove ignored parameters from tests.

### DIFF
--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -1448,7 +1448,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             "short_name": "hambot",
             "bot_type": UserProfile.OUTGOING_WEBHOOK_BOT,
             "payload_url": orjson.dumps("http://foo.bar.com").decode(),
-            "service_interface": Service.GENERIC,
+            "interface_type": Service.GENERIC,
         }
         result = self.client_post("/json/bots", bot_info)
         self.assert_json_success(result)

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -415,21 +415,21 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         realm = get_realm("zulip")
         result = self.client_patch(
             "/json/realm/profile_fields/100",
-            info={"name": "Phone number", "field_type": CustomProfileField.SHORT_TEXT},
+            info={"name": "Phone number"},
         )
         self.assert_json_error(result, "Field id 100 not found.")
 
         field = CustomProfileField.objects.get(name="Phone number", realm=realm)
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
-            info={"name": "", "field_type": CustomProfileField.SHORT_TEXT},
+            info={"name": ""},
         )
         self.assert_json_error(result, "Label cannot be blank.")
 
         self.assertEqual(CustomProfileField.objects.count(), self.original_count)
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
-            info={"name": "New phone number", "field_type": CustomProfileField.SHORT_TEXT},
+            info={"name": "New phone number"},
         )
         self.assert_json_success(result)
         field = CustomProfileField.objects.get(id=field.id, realm=realm)
@@ -440,7 +440,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
-            info={"name": "*" * 41, "field_type": CustomProfileField.SHORT_TEXT},
+            info={"name": "*" * 41},
         )
         msg = "name is too long (limit: 40 characters)"
         self.assert_json_error(result, msg)
@@ -450,7 +450,6 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
             info={
                 "name": "New phone number",
                 "hint": "*" * 81,
-                "field_type": CustomProfileField.SHORT_TEXT,
             },
         )
         msg = "hint is too long (limit: 80 characters)"
@@ -461,7 +460,6 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
             info={
                 "name": "New phone number",
                 "hint": "New contact number",
-                "field_type": CustomProfileField.SHORT_TEXT,
             },
         )
         self.assert_json_success(result)
@@ -474,7 +472,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
-            info={"name": "Name ", "field_type": CustomProfileField.SHORT_TEXT},
+            info={"name": "Name "},
         )
         self.assert_json_success(result)
         field.refresh_from_db()
@@ -525,7 +523,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assertTrue(self.custom_field_exists_in_realm(field_2.id))
         result = self.client_patch(
             f"/json/realm/profile_fields/{field_2.id}",
-            info={"name": "Phone", "field_type": CustomProfileField.SHORT_TEXT},
+            info={"name": "Phone"},
         )
         self.assert_json_error(result, "A field with that label already exists.")
 

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -522,9 +522,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
 
         # Remove tokens
         for endpoint, token, kind in endpoints:
-            result = self.client_delete(
-                endpoint, {"token": token, "token_kind": kind}, subdomain="zulip"
-            )
+            result = self.client_delete(endpoint, {"token": token}, subdomain="zulip")
             self.assert_json_success(result)
             tokens = list(
                 RemotePushDeviceToken.objects.filter(
@@ -2567,10 +2565,7 @@ class PushBouncerSignupTest(ZulipTestCase):
         self.assertEqual(server.hostname, "example.com")
         self.assertEqual(server.contact_email, "server-admin@example.com")
 
-        request = dict(zulip_org_id=zulip_org_id, zulip_org_key=zulip_org_key)
-        result = self.uuid_post(
-            zulip_org_id, "/api/v1/remotes/server/deactivate", request, subdomain=""
-        )
+        result = self.uuid_post(zulip_org_id, "/api/v1/remotes/server/deactivate", subdomain="")
         self.assert_json_success(result)
 
         server = RemoteZulipServer.objects.get(uuid=zulip_org_id)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2944,24 +2944,18 @@ class DefaultStreamGroupTest(ZulipTestCase):
         # Test changing description of default stream group
         new_description = "new group1 description"
 
-        result = self.client_patch(
-            f"/json/default_stream_groups/{group_id}", {"group_name": group_name, "op": "change"}
-        )
+        result = self.client_patch(f"/json/default_stream_groups/{group_id}")
         self.assert_json_error(result, 'You must pass "new_description" or "new_group_name".')
 
         result = self.client_patch(
             "/json/default_stream_groups/12345",
-            {"op": "change", "new_description": new_description},
+            {"new_description": new_description},
         )
         self.assert_json_error(result, "Default stream group with id '12345' does not exist.")
 
         result = self.client_patch(
             f"/json/default_stream_groups/{group_id}",
-            {
-                "group_name": group_name,
-                "op": "change",
-                "new_description": new_description,
-            },
+            {"new_description": new_description},
         )
         self.assert_json_success(result)
         default_stream_groups = get_default_stream_groups(realm)
@@ -2974,7 +2968,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
         do_create_default_stream_group(realm, "group2", "", [])
         result = self.client_patch(
             f"/json/default_stream_groups/{group_id}",
-            {"op": "change", "new_group_name": "group2"},
+            {"new_group_name": "group2"},
         )
         self.assert_json_error(result, "Default stream group 'group2' already exists")
         new_group = lookup_default_stream_groups(["group2"], realm)[0]
@@ -2982,13 +2976,13 @@ class DefaultStreamGroupTest(ZulipTestCase):
 
         result = self.client_patch(
             f"/json/default_stream_groups/{group_id}",
-            {"op": "change", "new_group_name": group_name},
+            {"new_group_name": group_name},
         )
         self.assert_json_error(result, "This default stream group is already named 'group1'")
 
         result = self.client_patch(
             f"/json/default_stream_groups/{group_id}",
-            {"op": "change", "new_group_name": new_group_name},
+            {"new_group_name": new_group_name},
         )
         self.assert_json_success(result)
         default_stream_groups = get_default_stream_groups(realm)


### PR DESCRIPTION
Another round of tests that were being passed parameters that were not being processed. Part of ongoing work to [implement `ignored_parameters_unsupported`](https://chat.zulip.org/#narrow/stream/3-backend/topic/ignored_parameters_unsupported/near/1286694) for all API endpoints.

These were all found when I implemented `json_success` to return an `ignored_parameters_unsupported` array for any unprocessed parameters, modified `assert_json_success` to check for said array, and set all existing tests to return / assert that said array did not exist.

Each commit focuses on one backend test suite. For each, I reviewed the url / code path being called to make sure it wasn't a case of a processed / used parameter not being passed through the `REQ` framework.