### PR TITLE
Fix Disable "Save changes" Button when no changes have been made.

### DIFF
--- a/static/js/dialog_widget.js
+++ b/static/js/dialog_widget.js
@@ -40,6 +40,11 @@ import * as overlays from "./overlays";
  *      7) If a caller needs to run code after the modal body is added
  *          to DOM, it can do so by passing a post_render hook.
  */
+export function manage() {
+        $(".dialog_submit_button span").hide();
+        if (conf.focus_submit_on_open) {
+                $submit_button.trigger("disabled", false);}
+    }
 
 export function hide_dialog_spinner() {
     $(".dialog_submit_button span").show();

--- a/static/templates/dialog_widget.hbs
+++ b/static/templates/dialog_widget.hbs
@@ -18,7 +18,7 @@
                 {{#unless single_footer_button}}
                 <button class="modal__btn dialog_cancel_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
                 {{/unless}}
-                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
+                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}} disabled="disabled">
                     <span>{{{ html_submit_button }}}</span>
                     <div class="modal__spinner"></div>
                 </button>


### PR DESCRIPTION
Fix Disable "Save changes" Button when no changes have been made.

Fixes part of https://github.com/zulip/zulip/issues/20831.

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** 
![zulip fix](https://user-images.githubusercontent.com/76876709/162487526-527a857a-d674-45bb-93c0-1cddc66d49ff.gif)
