### PR TITLE
Fix Disable Save changes Button when no changes have been made

### DIFF
--- a/static/js/dialog_widget.js
+++ b/static/js/dialog_widget.js
@@ -88,6 +88,17 @@ export function launch(conf) {
     // * on_hidden: Callback to run when the modal is hidden.
     // * post_render: Callback to run after the modal body is added to DOM.
 
+     $(document).ready(function(f) {
+    $('#edit_bot_name').on('input change', function() {
+        if($(this).val() != '') {
+            $('#btnSubmit').prop('disabled', false);
+        } else {
+            $('#btnSubmit').prop('disabled', true);
+        }
+    });
+});
+    
+
     for (const f of mandatory_fields) {
         if (conf[f] === undefined) {
             blueslip.error("programmer omitted " + f);

--- a/static/templates/dialog_widget.hbs
+++ b/static/templates/dialog_widget.hbs
@@ -18,7 +18,7 @@
                 {{#unless single_footer_button}}
                 <button class="modal__btn dialog_cancel_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
                 {{/unless}}
-                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
+                <button class="modal__btn dialog_submit_button" id="btnSubmit" {{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}} disabled="disabled">
                     <span>{{{ html_submit_button }}}</span>
                     <div class="modal__spinner"></div>
                 </button>


### PR DESCRIPTION
Fix: Disable "Save changes" Button when no changes have been made.
When you no changes "edit bot" form Button not visible to save details
when you changes changes any kind of info in "edit bot" form area
button should be visible

Fixes part of https://github.com/zulip/zulip/issues/20831.

**Testing plan:** 

![zulip fix](https://user-images.githubusercontent.com/76876709/162565292-ce71197b-9531-46d8-81e4-b23411bf77e3.gif)
**GIFs or screenshots:** 
