### PR TITLE
settings(admin/org): Add CSS for overflowing URLs in custom user fields

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -355,6 +355,12 @@ ul {
             &[data-type="2"] .value {
                 overflow-wrap: break-word;
             }
+
+            &[data-type="5"] {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                max-width: 300px;
+            }
         }
     }
 


### PR DESCRIPTION
WIP #21680

The following CSS has been added to popovers.css
overflow: hideen;
text-overflow: ellipsis;
width: 300px;

Further planning is to add `Show more` button to show the full link

**GIFs or screenshots:** 
![image](https://user-images.githubusercontent.com/72722967/162567698-42ddb53f-b3cc-41ad-9c5d-de1652a4eb7c.png)


