### PR TITLE
Fix: Disable "Save changes" Button when no changes have been made

### DIFF
--- a/static/js/dialog_widget.js
+++ b/static/js/dialog_widget.js
@@ -154,4 +154,14 @@ export function launch(conf) {
         on_shown: conf?.on_shown,
         on_hidden: conf?.on_hidden,
     });
+
+    $(() => {
+        $("#edit_bot_name").on("input change", function () {
+            if ($(this).val() !== "") {
+                $("#btnSubmit").prop("disabled", false);
+            } else {
+                $("#btnSubmit").prop("disabled", true);
+            }
+        });
+    });
 }

--- a/static/templates/dialog_widget.hbs
+++ b/static/templates/dialog_widget.hbs
@@ -18,7 +18,7 @@
                 {{#unless single_footer_button}}
                 <button class="modal__btn dialog_cancel_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
                 {{/unless}}
-                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
+                <button id="btnSubmit" class="modal__btn dialog_submit_button" {{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}} disabled="disabled">
                     <span>{{{ html_submit_button }}}</span>
                     <div class="modal__spinner"></div>
                 </button>


### PR DESCRIPTION
Fix: Disable "Save changes" Button when no changes have been made.
When you no changes "edit bot" form Button not visible to save details
when you changes changes any kind of info in "edit bot" form area
button should be visible

Fixes part of https://github.com/zulip/zulip/issues/20831.

**Testing plan:** 
![zulip fix](https://user-images.githubusercontent.com/76876709/162576134-e2cdb323-dc72-4a60-a06f-689adc923db5.gif)


**GIFs or screenshots:** 