### PR TITLE
UI redesign : change font & color of timestamp in a message

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -236,8 +236,7 @@ body.dark-theme {
     textarea:read-only,
     .sidebar-title,
     .recipient_row_date {
-        color: inherit;
-        opacity: 0.5;
+        color: hsla(0, 0%, 70%, 1);
     }
 
     .rendered_markdown button,
@@ -363,7 +362,8 @@ body.dark-theme {
 
     /* Disable blue link styling for the message timestamp link. */
     .message_time {
-        color: hsl(236, 33%, 90%);
+        color: hsla(0, 0%, 50%, 1);
+        top: -2px;
     }
 
     .emoji-popover .reaction:focus {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -798,7 +798,7 @@ td.pointer {
     }
 
     .message_time {
-        top: -4px;
+        top: -2px;
     }
 
     .alert-msg {
@@ -854,16 +854,16 @@ td.pointer {
 
 .message_time {
     display: block;
-    font-size: 12px;
-    opacity: 0.4;
     padding: 1px;
     font-weight: 400;
     position: absolute;
     right: -105px;
-    line-height: 20px;
-    text-align: right;
     /* Disable blue link styling for the message timestamp link. */
-    color: hsl(0, 0%, 20%);
+    color: hsla(0, 0%, 50%, 1);
+    font-size: 14px;
+    line-height: 1;
+    text-align: right;
+    font-variant: all-small-caps;
     transition: background-color 1.5s ease-in, color 1.5s ease-in;
 
     a& {
@@ -1108,12 +1108,14 @@ td.pointer {
 }
 
 .recipient_row_date {
-    color: hsl(0, 0%, 53%);
-    font-size: 12px;
-    font-weight: 600;
-    padding: 3px 11px 2px 10px;
+    color: hsla(0, 0%, 37%, 1);
+    padding: 2px 11px 3px 10px;
     height: 17px;
-    line-height: 17px;
+    font-size: 15px;
+    line-height: 18px;
+    text-align: right;
+    font-variant: all-small-caps;
+    font-weight: 400;
 
     &.hide-date {
         display: none;


### PR DESCRIPTION
Fixes #21752 

Made the required changes in  static/styles/zulip.css
and static/styles/dark_theme.css in issue #21752

<!-- What's this PR for?  (Just a link to an issue is fine.) -->https://github.com/zulip/zulip/issues/21752

**Testing plan:** <!-- How have you tested? -->By running  locally after changes 

**GIFs or screenshots:** 
  https://zulip.re
![light_before](https://user-images.githubusercontent.com/75739890/162609585-d2e6fa60-fd91-4fed-9311-a380299abeba.png)

![final light](https://user-images.githubusercontent.com/75739890/163688138-d1bb775d-1053-486f-8c3c-0465db594f96.png)




In dark mode 
![beforedarknew](https://user-images.githubusercontent.com/75739890/163530899-5c1b192a-e7df-48a4-be86-d84c3ebe48ab.png)


![finaldark](https://user-images.githubusercontent.com/75739890/163688173-f5a41bc9-5b6d-4207-9671-0ee45a9802e4.png)













<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
