### PR TITLE
portico: Correct jobs link in footer.html

### DIFF
--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -142,7 +142,7 @@
         <ul>
             <li><a href="/team/">{{ _("Team") }}</a> &amp; <a href="/history/">{{ _("History") }}</a></li>
             <li><a href="https://twitter.com/zulip/">Twitter</a></li>
-            <li><a href="/jobs/">{{ _("Jobs") }}</a></li>
+            <li><a href="https://zulip.com/jobs/">{{ _("Jobs") }}</a></li>
             <li><a href="/attribution">{{ _("Website attributions") }}</a></li>
             <li><a href="https://github.com/sponsors/zulip">{{ _("Sponsor Zulip") }}</a></li>
         </ul>


### PR DESCRIPTION
Very minor, previous link in the footer template for Jobs went to the server's url + /jobs/, which 404-ed on chat.zulip.org and presumably any self-hosted implementation.  Replaced with https://zulip.com/jobs/ instead

**Testing plan:** Made change on self-hosted Zulip server and seemed to fix issue

**GIFs or screenshots:** <N/A>