### PR TITLE
auth: Reset failed authentication attempts on password reset.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4529,6 +4529,11 @@ def do_change_password(user_profile: UserProfile, password: str, commit: bool = 
     user_profile.set_password(password)
     if commit:
         user_profile.save(update_fields=["password"])
+
+    # Imported here to prevent import cycles
+    from zproject.backends import RateLimitedAuthenticationByUsername
+
+    RateLimitedAuthenticationByUsername(user_profile.delivery_email).clear_history()
     event_time = timezone_now()
     RealmAuditLog.objects.create(
         realm=user_profile.realm,

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -42,6 +42,7 @@ from social_django.strategy import DjangoStrategy
 from confirmation.models import Confirmation, create_confirmation_link
 from zerver.lib.actions import (
     change_user_is_active,
+    do_change_password,
     do_create_realm,
     do_create_user,
     do_deactivate_realm,
@@ -673,6 +674,11 @@ class RateLimitAuthenticationTests(ZulipTestCase):
                     # But the third attempt goes over the limit:
                     with self.assertRaises(RateLimited):
                         attempt_authentication(username, wrong_password)
+
+                    # Resetting the password also clears the rate-limit
+                    do_change_password(expected_user_profile, correct_password)
+                    self.assertIsNone(attempt_authentication(username, wrong_password))
+
             finally:
                 # Clean up to avoid affecting other tests.
                 RateLimitedAuthenticationByUsername(username).clear_history()

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -381,7 +381,7 @@ RATE_LIMITING_RULES = {
         (60, 1000),
     ],
     "authenticate_by_username": [
-        (1800, 5),  # 5 login attempts within 30 minutes
+        (1800, 5),  # 5 failed login attempts within 30 minutes
     ],
     "email_change_by_user": [
         (3600, 2),  # 2 per hour


### PR DESCRIPTION
It's natural that someone might try a wrong password 5 times, and then
go through a successful password reset; forcing such users to wait
half an hour before typing in the password they just changed the
account to seems unnecessarily punitive.

Clear the rate-limit upon successful password change.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Highlights technical choices and bugs encountered.
- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
