### PR TITLE
Revert "shared: Match literal emoji in typeahead."

### DIFF
--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -52,13 +52,6 @@ run_test("get_emoji_matcher", () => {
 
     assert_matches("japanese_post_", [emoji_japanese_post_office]);
     assert_matches("japanese post ", [emoji_japanese_post_office]);
-
-    assert_matches("🐼", [emoji_panda_face]);
-});
-
-run_test("parse_unicode_emoji_code", () => {
-    assert.equal(typeahead.parse_unicode_emoji_code("1f43c"), "🐼");
-    assert.equal(typeahead.parse_unicode_emoji_code("not_unicode"), undefined);
 });
 
 run_test("triage", () => {

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -98,30 +98,13 @@ export function clean_query_lowercase(query) {
     return query;
 }
 
-export const parse_unicode_emoji_code = (code) => {
-    try {
-        return code
-            .split("-")
-            .map((hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
-            .join("");
-    } catch {
-        // Code could not be parsed, but instead of throwing an exception
-        // we return undefined instead of a string.
-        return undefined;
-    }
-};
-
 export function get_emoji_matcher(query) {
     // replaces spaces with underscores for emoji matching
     query = query.replace(/ /g, "_");
     query = clean_query_lowercase(query);
 
     return function (emoji) {
-        const matches_emoji_literal =
-            emoji.emoji_code && parse_unicode_emoji_code(emoji.emoji_code) === query;
-        return (
-            matches_emoji_literal || query_matches_source_attrs(query, emoji, ["emoji_name"], "_")
-        );
+        return query_matches_source_attrs(query, emoji, ["emoji_name"], "_");
     };
 }
 


### PR DESCRIPTION
This reverts commit a8fd5359556c953db45df7a7e7211d2a78fc228a.
This reverts commit 944781e8739b7eddcc3b61916efce4a4e21c3723.

In an attempt to introduce code from mobile into web to match literal
emojis, the author inadvertently introduced a buggy and smelly change.
Probably best to leave the implementation of this in mobile where there
is more context about the shape of the emoji object available. Web
doesn't actually benefit from the additional behavior anyway.

See https://github.com/zulip/zulip/pull/21723#pullrequestreview-937051603
