### PR TITLE
send_email: Only warn if EMAIL_HOST_PASSWORD is unset, not "".

### DIFF
--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -597,7 +597,7 @@ def log_email_config_errors() -> None:
     The purpose of this function is to log (potential) config errors,
     but without raising an exception.
     """
-    if settings.EMAIL_HOST_USER and not settings.EMAIL_HOST_PASSWORD:
+    if settings.EMAIL_HOST_USER and settings.EMAIL_HOST_PASSWORD is None:
         logger.error(
             "An SMTP username was set (EMAIL_HOST_USER), but password is unset (EMAIL_HOST_PASSWORD)."
         )

--- a/zerver/tests/test_send_email.py
+++ b/zerver/tests/test_send_email.py
@@ -168,3 +168,13 @@ class TestSendEmail(ZulipTestCase):
                 "An SMTP username was set (EMAIL_HOST_USER), but password is unset (EMAIL_HOST_PASSWORD)."
             ],
         )
+
+        # Empty string is OK
+        with self.settings(EMAIL_HOST_USER="test", EMAIL_HOST_PASSWORD=""):
+            send_email(
+                "zerver/emails/password_reset",
+                to_emails=[hamlet],
+                from_name="From Name",
+                from_address=FromAddress.NOREPLY,
+                language="en",
+            )


### PR DESCRIPTION
Some email hosts actually do want an empty password; since the default
is `None`, we should key on that, and not just being false-y.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
