### PR TITLE
Stats: Improve consistency of Zulip app names

### DIFF
--- a/analytics/tests/test_stats_views.py
+++ b/analytics/tests/test_stats_views.py
@@ -631,7 +631,7 @@ class TestMapArrays(ZulipTestCase):
                 "Old iOS app": [1, 2, 3],
                 "Desktop app": [2, 5, 7],
                 "Mobile app": [1, 5, 7],
-                "Website": [1, 2, 3],
+                "Web app": [1, 2, 3],
                 "Python API": [2, 4, 6],
                 "SomethingRandom": [4, 5, 6],
                 "GitHub webhook": [7, 7, 9],

--- a/analytics/tests/test_stats_views.py
+++ b/analytics/tests/test_stats_views.py
@@ -621,6 +621,7 @@ class TestMapArrays(ZulipTestCase):
             "SomethingRandom": [4, 5, 6],
             "ZulipGitHubWebhook": [7, 7, 9],
             "ZulipAndroid": [64, 63, 65],
+            "ZulipTerminal": [9, 10, 11],
         }
         result = rewrite_client_arrays(a)
         self.assertEqual(
@@ -635,5 +636,6 @@ class TestMapArrays(ZulipTestCase):
                 "SomethingRandom": [4, 5, 6],
                 "GitHub webhook": [7, 7, 9],
                 "Old Android app": [64, 63, 65],
+                "Terminal app": [9, 10, 11],
             },
         )

--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -460,6 +460,8 @@ def client_label_map(name: str) -> str:
         return "Old desktop app"
     if name == "ZulipElectron":
         return "Desktop app"
+    if name == "ZulipTerminal":
+        return "Terminal app"
     if name == "ZulipAndroid":
         return "Old Android app"
     if name == "ZulipiOS":

--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -455,7 +455,7 @@ def table_filtered_to_id(table: Type[BaseCount], key_id: int) -> QuerySet:
 
 def client_label_map(name: str) -> str:
     if name == "website":
-        return "Website"
+        return "Web app"
     if name.startswith("desktop app"):
         return "Old desktop app"
     if name == "ZulipElectron":


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Currently the website is not termed an app in the stats breakdown, unlike mobile and desktop. In addition zulip-terminal is represented by it's id only (ZulipTerminal) and not listed as an app.

This is broken down into two commits, in case both are not desired:
- Adds a mapping from `ZulipTerminal` to `Terminal app`
- Adjusts the `website` mapping to `Web app`

This passes tests (including those updated), but I have not tested them manually.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
