### PR TITLE
onboarding: Remove hotspot scroll past menu sidebar.

### DIFF
--- a/static/js/hotspots.js
+++ b/static/js/hotspots.js
@@ -81,6 +81,10 @@ function place_icon(hotspot) {
         $icon.css("display", "none");
         return false;
     }
+    
+    if ( $element.offset().top <= $("#streams_header").offset().top ) {
+      return false;
+    }
 
     const offset = {
         top: $element.outerHeight() * hotspot.location.offset_y,
@@ -93,6 +97,7 @@ function place_icon(hotspot) {
     };
     $icon.css("display", "block");
     $icon.css(placement);
+
     return true;
 }
 
@@ -222,7 +227,7 @@ function insert_hotspot_into_DOM(hotspot) {
         }
 
         // reposition on any event that might update the UI
-        for (const event_name of ["resize", "onkeydown", "click"]) {
+        for (const event_name of ["resize", "scroll", "onkeydown", "click"]) {
             window.addEventListener(
                 event_name,
                 _.debounce(() => {

--- a/static/js/hotspots.js
+++ b/static/js/hotspots.js
@@ -81,9 +81,9 @@ function place_icon(hotspot) {
         $icon.css("display", "none");
         return false;
     }
-    
-    if ( $element.offset().top <= $("#streams_header").offset().top ) {
-      return false;
+
+    if ($element.offset().top <= $("#streams_header").offset().top) {
+        return false;
     }
 
     const offset = {
@@ -97,7 +97,6 @@ function place_icon(hotspot) {
     };
     $icon.css("display", "block");
     $icon.css(placement);
-
     return true;
 }
 

--- a/static/js/hotspots.js
+++ b/static/js/hotspots.js
@@ -222,7 +222,7 @@ function insert_hotspot_into_DOM(hotspot) {
         }
 
         // reposition on any event that might update the UI
-        for (const event_name of ["resize", "scroll", "onkeydown", "click"]) {
+        for (const event_name of ["resize", "onkeydown", "click"]) {
             window.addEventListener(
                 event_name,
                 _.debounce(() => {


### PR DESCRIPTION
In "hotspots.js" remove "scroll" from hotspot update UI event list.

Motive: To prevent hotspot from moving past menu sidebar when scrolling down.

Fixes: https://github.com/zulip/zulip/issues/20526

**Screenshots and screen captures:**

https://user-images.githubusercontent.com/53523512/163091602-85dcd2ca-7154-427d-b308-f9a8a7806c79.mp4

**Self-review checklist**

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
