### PR TITLE
page polls for focus while lightbox is open with video playing

### DIFF
--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -272,6 +272,13 @@ function display_video(payload) {
 
     $("#lightbox_overlay .player-container").html($iframe).show();
     $(".image-actions .open").attr("href", payload.url);
+    
+    // checks to ensure the focus is not in the video
+    setInterval(() => {
+        if (document.activeElement.tagName === "IFRAME") {
+            document.activeElement.blur();
+        }
+    }, 500);
 }
 
 export function build_open_image_function(on_close) {

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -272,7 +272,7 @@ function display_video(payload) {
 
     $("#lightbox_overlay .player-container").html($iframe).show();
     $(".image-actions .open").attr("href", payload.url);
-    
+
     // checks to ensure the focus is not in the video
     setInterval(() => {
         if (document.activeElement.tagName === "IFRAME") {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
I have added support for the escape key to work during YouTube previews after playing the video. These changes allow for a video preview to be exited properly when pressing the escape key.

This implementation is a polling solution that checks every half second that the focus isn’t on an iframe. It passes the existing web and frontend test suites/

Fixes: https://github.com/zulip/zulip/issues/21274#issuecomment-1085012781