### PR TITLE
typing: Strengthen Type Signature of Decorators with ParamSpec.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from functools import wraps
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, TypeVar, cast
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, TypeVar
 from unittest.mock import Mock, patch
 
 import orjson
@@ -22,6 +22,7 @@ from django.http import HttpResponse
 from django.urls.resolvers import get_resolver
 from django.utils.crypto import get_random_string
 from django.utils.timezone import now as timezone_now
+from typing_extensions import ParamSpec
 
 from corporate.lib.stripe import (
     DEFAULT_INVOICE_DAYS_UNTIL_DUE,
@@ -104,6 +105,8 @@ from zerver.models import (
 from zilencer.models import RemoteZulipServer, RemoteZulipServerAuditLog
 
 CallableT = TypeVar("CallableT", bound=Callable[..., Any])
+ParamT = ParamSpec("ParamT")
+ReturnT = TypeVar("ReturnT")
 
 STRIPE_FIXTURES_DIR = "corporate/tests/stripe_fixtures"
 
@@ -335,8 +338,8 @@ MOCKED_STRIPE_FUNCTION_NAMES = [
 
 def mock_stripe(
     tested_timestamp_fields: Sequence[str] = [], generate: Optional[bool] = None
-) -> Callable[[CallableT], CallableT]:
-    def _mock_stripe(decorated_function: CallableT) -> CallableT:
+) -> Callable[[Callable[ParamT, ReturnT]], Callable[ParamT, ReturnT]]:
+    def _mock_stripe(decorated_function: Callable[ParamT, ReturnT]) -> Callable[ParamT, ReturnT]:
         generate_fixture = generate
         if generate_fixture is None:
             generate_fixture = settings.GENERATE_STRIPE_FIXTURES
@@ -350,17 +353,14 @@ def mock_stripe(
                 )  # nocoverage
             else:
                 side_effect = read_stripe_fixture(decorated_function.__name__, mocked_function_name)
-            decorated_function = cast(
-                CallableT,
-                patch(
-                    mocked_function_name,
-                    side_effect=side_effect,
-                    autospec=mocked_function_name.endswith(".refresh"),
-                )(decorated_function),
-            )
+            decorated_function = patch(
+                mocked_function_name,
+                side_effect=side_effect,
+                autospec=mocked_function_name.endswith(".refresh"),
+            )(decorated_function)
 
         @wraps(decorated_function)
-        def wrapped(*args: object, **kwargs: object) -> object:
+        def wrapped(*args: ParamT.args, **kwargs: ParamT.kwargs) -> ReturnT:
             if generate_fixture:  # nocoverage
                 delete_fixture_data(decorated_function)
                 val = decorated_function(*args, **kwargs)
@@ -369,7 +369,7 @@ def mock_stripe(
             else:
                 return decorated_function(*args, **kwargs)
 
-        return cast(CallableT, wrapped)
+        return wrapped
 
     return _mock_stripe
 

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -4,7 +4,7 @@ import logging
 import urllib
 from functools import wraps
 from io import BytesIO
-from typing import Callable, Dict, Optional, Sequence, Set, Tuple, TypeVar, Union, cast, overload
+from typing import Callable, Dict, Optional, Sequence, Set, TypeVar, Union, cast, overload
 
 import django_otp
 import orjson
@@ -68,20 +68,6 @@ webhook_unsupported_events_logger = logging.getLogger("zulip.zerver.webhooks.uns
 webhook_anomalous_payloads_logger = logging.getLogger("zulip.zerver.webhooks.anomalous")
 
 FuncT = TypeVar("FuncT", bound=Callable[..., object])
-
-
-def cachify(method: FuncT) -> FuncT:
-    dct: Dict[Tuple[object, ...], object] = {}
-
-    def cache_wrapper(*args: object) -> object:
-        tup = tuple(args)
-        if tup in dct:
-            return dct[tup]
-        result = method(*args)
-        dct[tup] = result
-        return result
-
-    return cast(FuncT, cache_wrapper)  # https://github.com/python/mypy/issues/1927
 
 
 def update_user_activity(

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -24,6 +24,7 @@ from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
 from django_otp import user_has_device
 from two_factor.utils import default_device
+from typing_extensions import ParamSpec
 
 from zerver.lib.cache import cache_with_key
 from zerver.lib.exceptions import (
@@ -67,7 +68,8 @@ webhook_logger = logging.getLogger("zulip.zerver.webhooks")
 webhook_unsupported_events_logger = logging.getLogger("zulip.zerver.webhooks.unsupported")
 webhook_anomalous_payloads_logger = logging.getLogger("zulip.zerver.webhooks.anomalous")
 
-FuncT = TypeVar("FuncT", bound=Callable[..., object])
+ParamT = ParamSpec("ParamT")
+ReturnT = TypeVar("ReturnT")
 
 
 def update_user_activity(
@@ -847,20 +849,22 @@ def to_utc_datetime(var_name: str, timestamp: str) -> datetime.datetime:
     return timestamp_to_datetime(float(timestamp))
 
 
-def statsd_increment(counter: str, val: int = 1) -> Callable[[FuncT], FuncT]:
+def statsd_increment(
+    counter: str, val: int = 1
+) -> Callable[[Callable[ParamT, ReturnT]], Callable[ParamT, ReturnT]]:
     """Increments a statsd counter on completion of the
     decorated function.
 
     Pass the name of the counter to this decorator-returning function."""
 
-    def wrapper(func: FuncT) -> FuncT:
+    def wrapper(func: Callable[ParamT, ReturnT]) -> Callable[ParamT, ReturnT]:
         @wraps(func)
-        def wrapped_func(*args: object, **kwargs: object) -> object:
+        def wrapped_func(*args: ParamT.args, **kwargs: ParamT.kwargs) -> ReturnT:
             ret = func(*args, **kwargs)
             statsd.incr(counter, val)
             return ret
 
-        return cast(FuncT, wrapped_func)  # https://github.com/python/mypy/issues/1927
+        return wrapped_func
 
     return wrapper
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1634,8 +1634,14 @@ def compute_jabber_user_fullname(email: str) -> str:
     return email.split("@")[0] + " (XMPP)"
 
 
+def get_user_profile_delivery_email_cache_key(
+    realm: Realm, email: str, email_to_fullname: Callable[[str], str]
+) -> str:
+    return user_profile_delivery_email_cache_key(email, realm)
+
+
 @cache_with_key(
-    lambda realm, email, f: user_profile_delivery_email_cache_key(email, realm),
+    get_user_profile_delivery_email_cache_key,
     timeout=3600 * 24 * 7,
 )
 def create_mirror_user_if_needed(

--- a/zerver/lib/display_recipient.py
+++ b/zerver/lib/display_recipient.py
@@ -25,7 +25,13 @@ class TinyStreamResult(TypedDict):
     name: str
 
 
-@cache_with_key(lambda *args: display_recipient_cache_key(args[0]), timeout=3600 * 24 * 7)
+def get_display_recipient_cache_key(
+    recipient_id: int, recipient_type: int, recipient_type_id: Optional[int]
+) -> str:
+    return display_recipient_cache_key(recipient_id)
+
+
+@cache_with_key(get_display_recipient_cache_key, timeout=3600 * 24 * 7)
 def get_display_recipient_remote_cache(
     recipient_id: int, recipient_type: int, recipient_type_id: Optional[int]
 ) -> DisplayRecipientT:

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+from functools import lru_cache
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 import orjson
@@ -28,7 +29,6 @@ from typing_extensions import TypedDict
 import zerver.lib.upload
 from analytics.models import RealmCount, StreamCount, UserCount
 from scripts.lib.zulip_tools import overwrite_symlink
-from zerver.decorator import cachify
 from zerver.lib.avatar_hash import user_avatar_path_from_ids
 from zerver.lib.pysa import mark_sanitized
 from zerver.lib.upload import get_bucket
@@ -2107,7 +2107,7 @@ def chunkify(lst: List[int], chunk_size: int) -> List[List[int]]:
 def export_messages_single_user(
     user_profile: UserProfile, *, output_dir: Path, reaction_message_ids: Set[int]
 ) -> None:
-    @cachify
+    @lru_cache(maxsize=None)
     def get_recipient(recipient_id: int) -> str:
         recipient = Recipient.objects.get(id=recipient_id)
 

--- a/zerver/lib/profile.py
+++ b/zerver/lib/profile.py
@@ -1,11 +1,14 @@
 import cProfile
 from functools import wraps
-from typing import Callable, TypeVar, cast
+from typing import Callable, TypeVar
 
-FuncT = TypeVar("FuncT", bound=Callable[..., object])
+from typing_extensions import ParamSpec
+
+ParamT = ParamSpec("ParamT")
+ReturnT = TypeVar("ReturnT")
 
 
-def profiled(func: FuncT) -> FuncT:
+def profiled(func: Callable[ParamT, ReturnT]) -> Callable[ParamT, ReturnT]:
     """
     This decorator should obviously be used only in a dev environment.
     It works best when surrounding a function that you expect to be
@@ -22,14 +25,13 @@ def profiled(func: FuncT) -> FuncT:
         ./tools/show-profile-results test_ratelimit_decrease.profile
 
     """
-    func_: Callable[..., object] = func  # work around https://github.com/python/mypy/issues/9075
 
     @wraps(func)
-    def wrapped_func(*args: object, **kwargs: object) -> object:
+    def wrapped_func(*args: ParamT.args, **kwargs: ParamT.kwargs) -> ReturnT:
         fn = func.__name__ + ".profile"
         prof = cProfile.Profile()
-        retval = prof.runcall(func_, *args, **kwargs)
+        retval = prof.runcall(func, *args, **kwargs)
         prof.dump_stats(fn)
         return retval
 
-    return cast(FuncT, wrapped_func)  # https://github.com/python/mypy/issues/1927
+    return wrapped_func

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -774,13 +774,15 @@ class Realm(models.Model):
     def __str__(self) -> str:
         return f"<Realm: {self.string_id} {self.id}>"
 
+    # `realm` instead of `self` here to make sure the parameters of the cache key
+    # function matches the original method.
     @cache_with_key(get_realm_emoji_cache_key, timeout=3600 * 24 * 7)
-    def get_emoji(self) -> Dict[str, EmojiInfo]:
-        return get_realm_emoji_uncached(self)
+    def get_emoji(realm) -> Dict[str, EmojiInfo]:
+        return get_realm_emoji_uncached(realm)
 
     @cache_with_key(get_active_realm_emoji_cache_key, timeout=3600 * 24 * 7)
-    def get_active_emoji(self) -> Dict[str, EmojiInfo]:
-        return get_active_realm_emoji_uncached(self)
+    def get_active_emoji(realm) -> Dict[str, EmojiInfo]:
+        return get_active_realm_emoji_uncached(realm)
 
     def get_admin_users_and_bots(
         self, include_realm_owners: bool = True
@@ -880,9 +882,11 @@ class Realm(models.Model):
         # it as gibibytes (GiB) to be a bit more generous in case of confusion.
         return self.upload_quota_gb << 30
 
+    # `realm` instead of `self` here to make sure the parameters of the cache key
+    # function matches the original method.
     @cache_with_key(get_realm_used_upload_space_cache_key, timeout=3600 * 24 * 7)
-    def currently_used_upload_space_bytes(self) -> int:
-        used_space = Attachment.objects.filter(realm=self).aggregate(Sum("size"))["size__sum"]
+    def currently_used_upload_space_bytes(realm) -> int:
+        used_space = Attachment.objects.filter(realm=realm).aggregate(Sum("size"))["size__sum"]
         if used_space is None:
             return 0
         return used_space
@@ -3565,8 +3569,8 @@ class Subscription(models.Model):
 
 
 @cache_with_key(user_profile_by_id_cache_key, timeout=3600 * 24 * 7)
-def get_user_profile_by_id(uid: int) -> UserProfile:
-    return UserProfile.objects.select_related().get(id=uid)
+def get_user_profile_by_id(user_profile_id: int) -> UserProfile:
+    return UserProfile.objects.select_related().get(id=user_profile_id)
 
 
 def get_user_profile_by_email(email: str) -> UserProfile:

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -3,6 +3,7 @@ import os
 import re
 import uuid
 from collections import defaultdict
+from functools import lru_cache
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 from unittest import mock, skipUnless
 
@@ -18,7 +19,6 @@ from zerver.decorator import (
     authenticated_json_view,
     authenticated_rest_api_view,
     authenticated_uploads_api_view,
-    cachify,
     internal_notify_view,
     is_local_addr,
     rate_limit,
@@ -1948,7 +1948,7 @@ class RestAPITest(ZulipTestCase):
 
 class CacheTestCase(ZulipTestCase):
     def test_cachify_basics(self) -> None:
-        @cachify
+        @lru_cache(maxsize=None)
         def add(w: Any, x: Any, y: Any, z: Any) -> Any:
             return w + x + y + z
 
@@ -1962,7 +1962,7 @@ class CacheTestCase(ZulipTestCase):
             result_log: List[str] = []
             work_log: List[str] = []
 
-            @cachify
+            @lru_cache(maxsize=None)
             def greet(first_name: str, last_name: str) -> str:
                 msg = f"{greeting} {first_name} {last_name}"
                 work_log.append(msg)

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -11,6 +11,7 @@ import time
 import traceback
 from collections import deque
 from dataclasses import asdict
+from functools import lru_cache
 from typing import (
     AbstractSet,
     Any,
@@ -38,7 +39,6 @@ from django.utils.translation import gettext as _
 from typing_extensions import TypedDict
 
 from version import API_FEATURE_LEVEL, ZULIP_MERGE_BASE, ZULIP_VERSION
-from zerver.decorator import cachify
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import MessageDict
 from zerver.lib.narrow import build_narrow_filter
@@ -938,7 +938,7 @@ def process_message_event(
     message_type: str = wide_dict["type"]
     sending_client: str = wide_dict["client"]
 
-    @cachify
+    @lru_cache(maxsize=None)
     def get_client_payload(apply_markdown: bool, client_gravatar: bool) -> Dict[str, Any]:
         return MessageDict.finalize_payload(
             wide_dict,


### PR DESCRIPTION
This should resolve the long-standing issue of typing higher-order identity functions without using `cast`. As many decorators will be adapted to this pattern as possible.

Note that before mypy releases [support](https://github.com/python/mypy/pull/11847) to `Cacatenate`, we can't type certain decorators that curry or modify the parameters in any way (like `has_request_variables`).

Currently, we import `ParamSpec` from `typing_extensions`. Hopefully, we will migrate to Python 3.10 in the future and there should be a separate PR dropping the back-port imports added here.