### PR TITLE
typeahead, markdown: Update characters allowed before @ and stream mentions.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1422,6 +1422,12 @@ test("tokenizing", () => {
     assert.equal(ct.tokenize_compose_str("foo bar"), "");
     assert.equal(ct.tokenize_compose_str("foo#@:bar"), "");
     assert.equal(ct.tokenize_compose_str("foo bar [#alic"), "#alic");
+    assert.equal(ct.tokenize_compose_str("foo bar (#alic"), "#alic");
+    assert.equal(ct.tokenize_compose_str("foo bar {#alic"), "#alic");
+    assert.equal(ct.tokenize_compose_str("foo bar /#alic"), "#alic");
+    assert.equal(ct.tokenize_compose_str("foo bar <#alic"), "#alic");
+    assert.equal(ct.tokenize_compose_str("foo bar '#alic"), "#alic");
+    assert.equal(ct.tokenize_compose_str('foo bar "#alic'), "#alic");
     assert.equal(ct.tokenize_compose_str("#foo @bar [#alic"), "#alic");
     assert.equal(ct.tokenize_compose_str("foo bar #alic"), "#alic");
     assert.equal(ct.tokenize_compose_str("foo bar @alic"), "@alic");

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -314,7 +314,7 @@ export function tokenize_compose_str(s) {
             case "_":
                 if (i === 0) {
                     return s;
-                } else if (/[\s()[\]{}]/.test(s[i - 1])) {
+                } else if (/[\s"'(/<[{]/.test(s[i - 1])) {
                     return s.slice(i);
                 }
                 break;

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -54,7 +54,12 @@ from zerver.lib.emoji import EMOTICON_RE, codepoint_to_name, name_to_codepoint, 
 from zerver.lib.exceptions import MarkdownRenderingException
 from zerver.lib.markdown import fenced_code
 from zerver.lib.markdown.fenced_code import FENCE_RE
-from zerver.lib.mention import FullNameInfo, MentionBackend, MentionData
+from zerver.lib.mention import (
+    BEFORE_MENTION_ALLOWED_REGEX,
+    FullNameInfo,
+    MentionBackend,
+    MentionData,
+)
 from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.subdomains import is_static_or_current_realm_url
 from zerver.lib.tex import render_tex
@@ -162,11 +167,11 @@ def verbose_compile(pattern: str) -> Pattern[str]:
     )
 
 
-STREAM_LINK_REGEX = r"""
-                     (?<![^\s'"\(,:<])            # Start after whitespace or specified chars
-                     \#\*\*                       # and after hash sign followed by double asterisks
-                         (?P<stream_name>[^\*]+)  # stream name can contain anything
-                     \*\*                         # ends by double asterisks
+STREAM_LINK_REGEX = rf"""
+                     {BEFORE_MENTION_ALLOWED_REGEX} # Start after whitespace or specified chars
+                     \#\*\*                         # and after hash sign followed by double asterisks
+                         (?P<stream_name>[^\*]+)    # stream name can contain anything
+                     \*\*                           # ends by double asterisks
                     """
 
 
@@ -183,13 +188,13 @@ def get_compiled_stream_link_regex() -> Pattern[str]:
     )
 
 
-STREAM_TOPIC_LINK_REGEX = r"""
-                     (?<![^\s'"\(,:<])             # Start after whitespace or specified chars
-                     \#\*\*                        # and after hash sign followed by double asterisks
-                         (?P<stream_name>[^\*>]+)  # stream name can contain anything except >
-                         >                         # > acts as separator
-                         (?P<topic_name>[^\*]+)     # topic name can contain anything
-                     \*\*                          # ends by double asterisks
+STREAM_TOPIC_LINK_REGEX = rf"""
+                     {BEFORE_MENTION_ALLOWED_REGEX}  # Start after whitespace or specified chars
+                     \#\*\*                          # and after hash sign followed by double asterisks
+                         (?P<stream_name>[^\*>]+)    # stream name can contain anything except >
+                         >                           # > acts as separator
+                         (?P<topic_name>[^\*]+)      # topic name can contain anything
+                     \*\*                            # ends by double asterisks
                    """
 
 

--- a/zerver/lib/mention.py
+++ b/zerver/lib/mention.py
@@ -7,10 +7,16 @@ from django.db.models import Q
 
 from zerver.models import UserGroup, UserProfile, get_linkable_streams
 
+BEFORE_MENTION_ALLOWED_REGEX = r"(?<![^\s\'\"\(\{\[\/<])"
+
 # Match multi-word string between @** ** or match any one-word
 # sequences after @
-MENTIONS_RE = re.compile(r"(?<![^\s\'\"\(,:<])@(?P<silent>_?)(\*\*(?P<match>[^\*]+)\*\*)")
-USER_GROUP_MENTIONS_RE = re.compile(r"(?<![^\s\'\"\(,:<])@(?P<silent>_?)(\*(?P<match>[^\*]+)\*)")
+MENTIONS_RE = re.compile(
+    rf"{BEFORE_MENTION_ALLOWED_REGEX}@(?P<silent>_?)(\*\*(?P<match>[^\*]+)\*\*)"
+)
+USER_GROUP_MENTIONS_RE = re.compile(
+    rf"{BEFORE_MENTION_ALLOWED_REGEX}@(?P<silent>_?)(\*(?P<match>[^\*]+)\*)"
+)
 
 wildcards = ["all", "everyone", "stream"]
 


### PR DESCRIPTION
Now the following characters are allowed before @-mentions, stream references (starting with #) and emojis (starting with :) - space, (, {, [, ", ', /, <, both for autocompleting and rendered markdown.

Earlier only the opening brace type characters and space was allowed.

**Screenshots and screen captures:**

Showing how typeahead is triggered when @ follows the above mentioned list of characters
https://www.loom.com/share/1e3dca7f5c6742e5bf8a75145b6b48d0

Showing the newly allowed rendered markdown mentions
![image](https://user-images.githubusercontent.com/68962290/173627511-d20ce7a1-c6e1-486c-a146-2e68e4e78d35.png)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
