### PR TITLE
Add organization type to org profile settings.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -392,6 +392,10 @@ run_test("realm settings", ({override}) => {
     });
     assert_same(page_params.realm_name, "new_realm_name");
 
+    event = event_fixtures.realm__update__org_type;
+    dispatch(event);
+    assert_same(page_params.realm_org_type, 50);
+
     event = event_fixtures.realm__update__emails_restricted_to_domains;
     test_realm_boolean(event, "realm_emails_restricted_to_domains");
 

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -342,6 +342,13 @@ exports.fixtures = {
         value: 42,
     },
 
+    realm__update__org_type: {
+        type: "realm",
+        op: "update",
+        property: "org_type",
+        value: 50,
+    },
+
     realm__update__signup_notifications_stream_id: {
         type: "realm",
         op: "update",

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -80,6 +80,7 @@ export function build_page() {
     const options = {
         custom_profile_field_types: page_params.custom_profile_field_types,
         realm_name: page_params.realm_name,
+        realm_org_type: page_params.realm_org_type,
         realm_available_video_chat_providers: page_params.realm_available_video_chat_providers,
         giphy_rating_options: page_params.giphy_rating_options,
         giphy_api_key_empty: page_params.giphy_api_key === "",
@@ -162,6 +163,7 @@ export function build_page() {
         disable_enable_spectator_access_setting: !page_params.server_web_public_streams_enabled,
         can_sort_by_email: settings_data.show_email(),
         realm_push_notifications_enabled: page_params.realm_push_notifications_enabled,
+        realm_org_type_values: settings_org.get_org_type_dropdown_options(),
     };
 
     if (options.realm_logo_source !== "D" && options.realm_night_logo_source === "D") {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -214,6 +214,7 @@ export function dispatch_normal_event(event) {
                 name: notifications.redraw_title,
                 name_changes_disabled: settings_account.update_name_change_display,
                 notifications_stream_id: noop,
+                org_type: noop,
                 private_message_policy: noop,
                 send_welcome_emails: noop,
                 message_content_allowed_in_email_notifications: noop,

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -441,6 +441,71 @@ export const user_role_values = {
     },
 };
 
+export const all_org_type_values = {
+    // When org_type was added to the database model, 'unspecified'
+    // was the default for existing organizations. To discourage
+    // organizations keeping (or selecting) it as an option, we
+    // use an empty string for its description.
+    unspecified: {
+        code: 0,
+        description: "",
+    },
+    business: {
+        code: 10,
+        description: $t({defaultMessage: "Business"}),
+    },
+    opensource: {
+        code: 20,
+        description: $t({defaultMessage: "Open-source project"}),
+    },
+    education_nonprofit: {
+        code: 30,
+        description: $t({defaultMessage: "Education (non-profit)"}),
+    },
+    education: {
+        code: 35,
+        description: $t({defaultMessage: "Education (for-profit)"}),
+    },
+    research: {
+        code: 40,
+        description: $t({defaultMessage: "Research"}),
+    },
+    event: {
+        code: 50,
+        description: $t({defaultMessage: "Event or conference"}),
+    },
+    nonprofit: {
+        code: 60,
+        description: $t({defaultMessage: "Non-profit (registered)"}),
+    },
+    government: {
+        code: 70,
+        description: $t({defaultMessage: "Government"}),
+    },
+    political_group: {
+        code: 80,
+        description: $t({defaultMessage: "Political group"}),
+    },
+    community: {
+        code: 90,
+        description: $t({defaultMessage: "Community"}),
+    },
+    personal: {
+        code: 100,
+        description: $t({defaultMessage: "Personal"}),
+    },
+    other: {
+        code: 1000,
+        description: $t({defaultMessage: "Other"}),
+    },
+};
+
+// Remove the 'unspecified' org_type for dropdown menu options
+// when an org_type other than 'unspecified' has been selected.
+export const defined_org_type_values = Object.fromEntries(
+    Object.entries(all_org_type_values).slice(1),
+);
+
 export const expires_in_values = {
     // Backend support for this configuration is not available yet.
     // hour: {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -116,6 +116,14 @@ export function get_organization_settings_options() {
     return options;
 }
 
+export function get_org_type_dropdown_options() {
+    const current_org_type = page_params.realm_org_type;
+    if (current_org_type !== 0) {
+        return settings_config.defined_org_type_values;
+    }
+    return settings_config.all_org_type_values;
+}
+
 export function get_realm_time_limits_in_minutes(property) {
     let val = (page_params[property] / 60).toFixed(1);
     if (Number.parseFloat(val, 10) === Number.parseInt(val, 10)) {
@@ -238,6 +246,7 @@ const simple_dropdown_properties = [
     "realm_wildcard_mention_policy",
     "realm_move_messages_between_streams_policy",
     "realm_edit_topic_policy",
+    "realm_org_type",
 ];
 
 function set_property_dropdown_value(property_name) {
@@ -506,6 +515,15 @@ function discard_property_element_changes(elem, for_realm_default_settings) {
                 $("#realm-user-default-settings"),
                 realm_user_settings_defaults.email_notifications_batching_period_seconds,
             );
+            break;
+        case "realm_org_type":
+            set_input_element_value($elem, property_value);
+            // Remove 'unspecified' option (value=0) from realm_org_type
+            // dropdown menu options whenever page_params.realm_org_type
+            // returns another value.
+            if (property_value !== 0) {
+                $("#id_realm_org_type option[value=0]").remove();
+            }
             break;
         default:
             if (property_value !== undefined) {

--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -18,6 +18,14 @@
                       value="{{ realm_name }}" maxlength="40" />
                 </div>
                 <div class="input-group admin-realm">
+                    <label for="realm_org_type" class="dropdown-title">{{t "Organization type" }}
+                        {{> ../help_link_widget link="/help/organization-type" }}
+                    </label>
+                    <select name="realm_org_type" class="setting-widget prop-element" id="id_realm_org_type" data-setting-widget-type="number">
+                        {{> dropdown_options_widget option_values=realm_org_type_values}}
+                    </select>
+                </div>
+                <div class="input-group admin-realm">
                     <label for="realm_description">{{t "Organization description" }}</label>
                     <textarea id="id_realm_description" name="realm_description" class="admin-realm-description setting-widget prop-element"
                       maxlength="1000" data-setting-widget-type="string">{{ realm_description }}</textarea>

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 6.0
 
+**Feature level 128**
+
+* [`POST /register`](/api/register-queue), [`GET
+  /events`](/api/get-events), `PATCH /realm`: Added
+  `org_type` realm setting.
+
 **Feature level 127**
 
 * [`GET /user_groups`](/api/get-user-groups),[`POST

--- a/templates/zerver/help/include/edit-organization-profile.md
+++ b/templates/zerver/help/include/edit-organization-profile.md
@@ -7,8 +7,10 @@
 
 {settings_tab|organization-profile}
 
-1. Edit your organization **name**, **description**, and **profile picture**.
-1. Click **Save changes**.
+1. Edit your organization **name**, **type**, **description**, and
+**profile picture**.
+
+{!save-changes.md!}
 
 {end_tabs}
 

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -128,6 +128,7 @@
 
 ## Organization basics
 * [Review your organization's settings](/help/review-your-organization-settings)
+* [Organization type](/help/organization-type)
 * [Import from Mattermost](/help/import-from-mattermost)
 * [Import from Slack](/help/import-from-slack)
 * [Import from Gitter](/help/import-from-gitter)

--- a/templates/zerver/help/organization-type.md
+++ b/templates/zerver/help/organization-type.md
@@ -1,0 +1,24 @@
+# Organization type
+
+An organization's type is used to customize the experience for users
+in your organization, including initial organization settings and
+Welcome Bot messages received by new users.
+
+## Set organization type
+
+{!admin-only.md!}
+
+{start_tabs}
+
+{settings_tab|organization-profile}
+
+1. Under **Organization type**, select the option that best fits
+your organization.
+
+{!save-changes.md!}
+
+{end_tabs}
+
+## Related articles
+
+* [Configure default new user settings](/help/configure-default-new-user-settings)

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 127
+API_FEATURE_LEVEL = 128
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -403,6 +403,9 @@ def do_change_realm_org_type(
         extra_data={"old_value": old_value, "new_value": org_type},
     )
 
+    event = dict(type="realm", op="update", property="org_type", value=org_type)
+    transaction.on_commit(lambda: send_event(realm, event, active_user_ids(realm.id)))
+
 
 @transaction.atomic(savepoint=False)
 def do_change_realm_plan_type(

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -883,7 +883,7 @@ def check_realm_update(
 
     assert "extra_data" not in event.keys()
 
-    if prop in ["notifications_stream_id", "signup_notifications_stream_id"]:
+    if prop in ["notifications_stream_id", "signup_notifications_stream_id", "org_type"]:
         assert isinstance(value, int)
         return
 

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -286,6 +286,7 @@ def fetch_initial_state_data(
         state["server_generation"] = settings.SERVER_GENERATION
         state["realm_is_zephyr_mirror_realm"] = realm.is_zephyr_mirror_realm
         state["development_environment"] = settings.DEVELOPMENT
+        state["realm_org_type"] = realm.org_type
         state["realm_plan_type"] = realm.plan_type
         state["zulip_plan_is_not_limited"] = realm.plan_type != Realm.PLAN_TYPE_LIMITED
         state["upgrade_text_for_wide_organization_logo"] = str(Realm.UPGRADE_TEXT_STANDARD)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3929,6 +3929,26 @@ paths:
 
                                         Since these notifications are sent by the server, this field is
                                         primarily relevant to clients containing UI for changing it.
+                                    org_type:
+                                      type: integer
+                                      description: |
+                                        The type of the organization.
+
+                                        - 0 = Unspecified
+                                        - 10 = Business
+                                        - 20 = Open-source project
+                                        - 30 = Education (non-profit)
+                                        - 35 = Education (for-profit)
+                                        - 40 = Research
+                                        - 50 = Event or conference
+                                        - 60 = Non-profit (registered)
+                                        - 70 = Government
+                                        - 80 = Political group
+                                        - 90 = Community
+                                        - 100 = Personal
+                                        - 1000 = Other
+
+                                        **Changes**: New in Zulip 6.0 (feature level 128).
                                     plan_type:
                                       type: integer
                                       description: |
@@ -11463,6 +11483,28 @@ paths:
 
                           **Changes**: New in Zulip 5.0 (feature level 72). Previously,
                           this was called `realm_upload_quota`.
+                      realm_org_type:
+                        type: integer
+                        description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
+                          The type of the organization.
+
+                          - 0 = Unspecified
+                          - 10 = Business
+                          - 20 = Open-source project
+                          - 30 = Education (non-profit)
+                          - 35 = Education (for-profit)
+                          - 40 = Research
+                          - 50 = Event or conference
+                          - 60 = Non-profit (registered)
+                          - 70 = Government
+                          - 80 = Political group
+                          - 90 = Community
+                          - 100 = Personal
+                          - 1000 = Other
+
+                          **Changes**: New in Zulip 6.0 (feature level 128).
                       realm_plan_type:
                         type: integer
                         description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3932,7 +3932,8 @@ paths:
                                     org_type:
                                       type: integer
                                       description: |
-                                        The type of the organization.
+                                        The [organization type](/help/organization-type)
+                                        for the realm.
 
                                         - 0 = Unspecified
                                         - 10 = Business
@@ -11488,7 +11489,10 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          The type of the organization.
+                          The [organization type](/help/organization-type) for the realm.
+                          Useful only to clients supporting changing this setting for the
+                          organization, or clients implementing onboarding content or
+                          other features that varies with organization type.
 
                           - 0 = Unspecified
                           - 10 = Business

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -69,6 +69,7 @@ from zerver.actions.realm_linkifiers import (
 from zerver.actions.realm_logo import do_change_logo_source
 from zerver.actions.realm_playgrounds import do_add_realm_playground, do_remove_realm_playground
 from zerver.actions.realm_settings import (
+    do_change_realm_org_type,
     do_change_realm_plan_type,
     do_deactivate_realm,
     do_set_realm_authentication_methods,
@@ -1738,6 +1739,22 @@ class NormalActionsTest(BaseAction):
         )
         check_user_settings_update("events[0]", events[0])
         check_update_global_notifications("events[1]", events[1], 1)
+
+    def test_realm_update_org_type(self) -> None:
+        realm = self.user_profile.realm
+
+        state_data = fetch_initial_state_data(self.user_profile)
+        self.assertEqual(state_data["realm_org_type"], Realm.ORG_TYPES["business"]["id"])
+
+        events = self.verify_action(
+            lambda: do_change_realm_org_type(
+                realm, Realm.ORG_TYPES["government"]["id"], acting_user=self.user_profile
+            )
+        )
+        check_realm_update("events[0]", events[0], "org_type")
+
+        state_data = fetch_initial_state_data(self.user_profile)
+        self.assertEqual(state_data["realm_org_type"], Realm.ORG_TYPES["government"]["id"])
 
     def test_realm_update_plan_type(self) -> None:
         realm = self.user_profile.realm

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -165,6 +165,7 @@ class HomeTest(ZulipTestCase):
         "realm_night_logo_url",
         "realm_non_active_users",
         "realm_notifications_stream_id",
+        "realm_org_type",
         "realm_password_auth_enabled",
         "realm_plan_type",
         "realm_playgrounds",

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
@@ -9,6 +9,7 @@ from django.views.decorators.http import require_safe
 from confirmation.models import Confirmation, ConfirmationKeyException, get_object_from_key
 from zerver.actions.create_realm import do_change_realm_subdomain
 from zerver.actions.realm_settings import (
+    do_change_realm_org_type,
     do_deactivate_realm,
     do_reactivate_realm,
     do_set_realm_authentication_methods,
@@ -39,6 +40,8 @@ from zerver.lib.validator import (
 )
 from zerver.models import Realm, RealmUserDefault, UserProfile
 from zerver.views.user_settings import check_settings_values
+
+ORG_TYPE_IDS: List[int] = [t["id"] for t in Realm.ORG_TYPES.values()]
 
 
 @require_realm_admin
@@ -138,6 +141,7 @@ def update_realm(
         str_validator=check_capped_string(Realm.MAX_REALM_SUBDOMAIN_LENGTH),
         default=None,
     ),
+    org_type: Optional[int] = REQ(json_validator=check_int_in(ORG_TYPE_IDS), default=None),
     enable_spectator_access: Optional[bool] = REQ(json_validator=check_bool, default=None),
 ) -> HttpResponse:
     realm = user_profile.realm
@@ -293,6 +297,10 @@ def update_realm(
 
         do_change_realm_subdomain(realm, string_id, acting_user=user_profile)
         data["realm_uri"] = realm.uri
+
+    if org_type is not None:
+        do_change_realm_org_type(realm, org_type, acting_user=user_profile)
+        data["org_type"] = org_type
 
     return json_success(request, data)
 


### PR DESCRIPTION
Adds updating the organization's type to the organization profile admin page. Fixes #21692.

### Back end implementation notes:
- The `Realm.org_type` setting was added in #19042, so there was no need to update the models or do a migration.
- There was a special `RealmAuditLog` event type created for updates to a realm's `org_type`, which has been possible for Zulip Cloud through support admin.
- I extended that implementation, which meant it needed a slightly different handling in `views.realm.update_realm` even though the setting follows the standard structure. Added tests to `test_realm` for this.
- I added an event to `actions.do_change_realm_org_type` so that other users in the realm would get live updates as they do for other organization settings. Added test to `test_events` for this.
- Questions to confirm / consider:
  - Do we want to keep the specific RealmAuditLog tracking for changes to an organization's type as I did here? Or do we want to use the standard update log?
  - When the setting was added, existing realms were updated to be `Unspecified`. Do we want this to be an acceptable value for organizations to update to? If not, do we want to handle on the back end or front end?

### Front end implementation notes:
- This first iteration is a simple drop-down menu with a help center link.
- Questions to confirm / consider:
  - The issue mentions providing some information about how the data will be used. Do we want to do this in the help center documentation or on the organization profile admin page?
    - If on the page, then how / what?
    - If in the help center docs, where /  what?
  - The existing registration and Zulip Cloud support pages do not show the `Unspecified` option. On the one hand, we need that as an option because a large number of existing orgs have that as their `org_type` value. On the other hand, we may not want to let organizations update to this setting? Or maybe that's okay?
  - If we do want to limit this, I'm not sure how to do that with handlebars and in a way that allows us to show the current orgs that are set to `Unspecified`. The other pages are written in html and use Django template syntax to limit the options shown.
  - Do we want to add this information to the realm log-in page, which is where we show the organization's description and profile photo? If so, we would need to update that image used in the help center documentation (see screenshot below). Part of me thinks no or only if the setting isn't set to `Unspecified`.

**Screenshots and screen captures:**

![Screenshot from 2022-04-13 19-33-59](https://user-images.githubusercontent.com/63245456/163244643-75d1c8d6-cf36-4632-bcdd-77925b2fffae.png)

![Screenshot from 2022-04-13 19-34-41](https://user-images.githubusercontent.com/63245456/163244648-f426c011-4294-4923-a8f9-f8d9426b7660.png)

![Screenshot from 2022-04-13 19-55-00](https://user-images.githubusercontent.com/63245456/163244649-f23e3912-ffe2-44be-8313-c955f369a9e7.png)

![Peek 2022-04-13 19-37](https://user-images.githubusercontent.com/63245456/163244813-50b99acf-4969-4130-abc0-3e2aa019f32c.gif)

![Peek 2022-04-13 19-47](https://user-images.githubusercontent.com/63245456/163244832-c91126f9-ab34-4e43-a031-e735b5a80e53.gif)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
