### PR TITLE
scim: Temporarily stop running SCIM change operations atomically.

### DIFF
--- a/zerver/lib/scim.py
+++ b/zerver/lib/scim.py
@@ -4,7 +4,7 @@ import django_scim.constants as scim_constants
 import django_scim.exceptions as scim_exceptions
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db import models, transaction
+from django.db import models
 from django.http import HttpRequest
 from django_scim.adapters import SCIMUser
 from scim2_filter_parser.attr_paths import AttrPath
@@ -281,18 +281,22 @@ class ZulipSCIMUser(SCIMUser):
             )
             return
 
-        with transaction.atomic():
-            # We process full_name first here, since it's the only one that can fail.
-            if full_name_new_value:
-                check_change_full_name(self.obj, full_name_new_value, acting_user=None)
+        # TODO: The below operations should ideally be executed in a single
+        # atomic block to avoid failing with partial changes getting saved.
+        # This can be fixed once we figure out how do_deactivate_user can be run
+        # inside an atomic block.
 
-            if email_new_value:
-                do_change_user_delivery_email(self.obj, email_new_value)
+        # We process full_name first here, since it's the only one that can fail.
+        if full_name_new_value:
+            check_change_full_name(self.obj, full_name_new_value, acting_user=None)
 
-            if is_active_new_value is not None and is_active_new_value:
-                do_reactivate_user(self.obj, acting_user=None)
-            elif is_active_new_value is not None and not is_active_new_value:
-                do_deactivate_user(self.obj, acting_user=None)
+        if email_new_value:
+            do_change_user_delivery_email(self.obj, email_new_value)
+
+        if is_active_new_value is not None and is_active_new_value:
+            do_reactivate_user(self.obj, acting_user=None)
+        elif is_active_new_value is not None and not is_active_new_value:
+            do_deactivate_user(self.obj, acting_user=None)
 
     def delete(self) -> None:
         """


### PR DESCRIPTION
do_deactivate_user can't be run in an atomic block due to concerns
around revoking session in a transaction. See
62ba8e455d8f460001d9fb486a6dabfd1ed67717 for more details.

Without the change in this commit, the process of deactivating a user
via SCIM is broken.
