### PR TITLE
popovers: Disable "Confirm" button in Move topic menu when origin and destination are the same.

### DIFF
--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -406,12 +406,24 @@ function build_move_topic_to_stream_popover(e, current_stream_id, topic_name) {
 
     hide_topic_popover();
 
-    function move_topic() {
-        const params = Object.fromEntries(
+    function get_params_from_form() {
+        return Object.fromEntries(
             $("#move_topic_form")
                 .serializeArray()
                 .map(({name, value}) => [name, value]),
         );
+    }
+
+    function update_submit_button_disabled_state(select_stream_id) {
+        const {current_stream_id, new_topic_name, old_topic_name} = get_params_from_form();
+
+        $("#move_topic_modal .dialog_submit_button")[0].disabled =
+            Number.parseInt(current_stream_id, 10) === Number.parseInt(select_stream_id, 10) &&
+            new_topic_name.trim().toLowerCase() === old_topic_name.trim().toLowerCase();
+    }
+
+    function move_topic() {
+        const params = get_params_from_form();
 
         const {old_topic_name} = params;
         const select_stream_id = stream_widget.value();
@@ -426,18 +438,6 @@ function build_move_topic_to_stream_popover(e, current_stream_id, topic_name) {
         send_notification_to_new_thread = send_notification_to_new_thread === "on";
         send_notification_to_old_thread = send_notification_to_old_thread === "on";
         current_stream_id = Number.parseInt(current_stream_id, 10);
-
-        if (
-            current_stream_id === Number.parseInt(select_stream_id, 10) &&
-            new_topic_name.toLowerCase() === old_topic_name.toLowerCase()
-        ) {
-            dialog_widget.hide_dialog_spinner();
-            ui_report.client_error(
-                $t_html({defaultMessage: "Please select a different stream or change topic name."}),
-                $("#move_topic_modal #dialog_error"),
-            );
-            return;
-        }
 
         dialog_widget.show_dialog_spinner();
         message_edit.with_first_message_id(
@@ -486,8 +486,14 @@ function build_move_topic_to_stream_popover(e, current_stream_id, topic_name) {
             default_text: $t({defaultMessage: "No streams"}),
             include_current_item: false,
             value: current_stream_id,
+            on_update: update_submit_button_disabled_state,
         };
         stream_widget = new DropdownListWidget(opts);
+
+        update_submit_button_disabled_state(stream_widget.value());
+        $("#move_topic_modal .inline_topic_edit").on("input", () => {
+            update_submit_button_disabled_state(stream_widget.value());
+        });
     }
 
     dialog_widget.launch({

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -417,9 +417,12 @@ function build_move_topic_to_stream_popover(e, current_stream_id, topic_name) {
     function update_submit_button_disabled_state(select_stream_id) {
         const {current_stream_id, new_topic_name, old_topic_name} = get_params_from_form();
 
+        // Unlike most topic comparisons in Zulip, we intentionally do
+        // a case-sensitive comparison, since adjusting the
+        // capitalization of a topic is a valid operation.
         $("#move_topic_modal .dialog_submit_button")[0].disabled =
             Number.parseInt(current_stream_id, 10) === Number.parseInt(select_stream_id, 10) &&
-            new_topic_name.trim().toLowerCase() === old_topic_name.trim().toLowerCase();
+            new_topic_name.trim() === old_topic_name.trim();
     }
 
     function move_topic() {


### PR DESCRIPTION
Disables the submit button in the move_topics popover, instead of relying on an error box, when the user hasn't selected a new topic.

Fixes [#21711)](https://github.com/zulip/zulip/issues/21711)

![issue-21711](https://user-images.githubusercontent.com/2810775/163331155-70f99b74-f017-4919-a35a-f1c2147a3fdf.gif)

Commit f49667c implements the functionality in a minimal but incomplete way.

Commit 7613f5f also checks the names, with some small refactoring, and removes the prior error check.

This is my first-ever contribution. I went down the template checklist and hopefully didn't miss too much. Any feedback or concerns about style or approach are greatly appreciated. :-) If a test should have been included, apologies in advance, and I'll add one right away!
