### PR TITLE
popovers: New function for hiding all user info popovers.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -729,6 +729,12 @@ export function hide_user_sidebar_popover() {
     }
 }
 
+function hide_all_user_info_popovers() {
+    hide_message_info_popover();
+    hide_user_sidebar_popover();
+    hide_user_info_popover();
+}
+
 function focus_user_info_popover_item() {
     // For now I recommend only calling this when the user opens the menu with a hotkey.
     // Our popup menus act kind of funny when you mix keyboard and mouse.
@@ -1018,9 +1024,7 @@ export function register_click_handlers() {
 
     $("body").on("click", ".info_popover_actions .sidebar-popover-mute-user", (e) => {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
-        hide_message_info_popover();
-        hide_user_sidebar_popover();
-        hide_user_info_popover();
+        hide_all_user_info_popovers();
         e.stopPropagation();
         e.preventDefault();
         muted_users_ui.confirm_mute_user(user_id);
@@ -1028,9 +1032,7 @@ export function register_click_handlers() {
 
     $("body").on("click", ".info_popover_actions .sidebar-popover-unmute-user", (e) => {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
-        hide_message_info_popover();
-        hide_user_sidebar_popover();
-        hide_user_info_popover();
+        hide_all_user_info_popovers();
         muted_users_ui.unmute_user(user_id);
         e.stopPropagation();
         e.preventDefault();
@@ -1349,7 +1351,6 @@ export function hide_all_except_sidebars(opts) {
         hideAll({exclude: opts.exclude_tippy_instance});
     }
     hide_actions_popover();
-    hide_message_info_popover();
     emoji_picker.hide_emoji_popover();
     giphy.hide_giphy_popover();
     stream_popover.hide_stream_popover();
@@ -1357,8 +1358,7 @@ export function hide_all_except_sidebars(opts) {
     stream_popover.hide_all_messages_popover();
     stream_popover.hide_starred_messages_popover();
     stream_popover.hide_drafts_popover();
-    hide_user_sidebar_popover();
-    hide_user_info_popover();
+    hide_all_user_info_popovers();
     hide_playground_links_popover();
 
     // look through all the popovers that have been added and removed.


### PR DESCRIPTION
New function `hide_all_user_info_popovers` closes all user info popovers, instead of calling multiple functions everytime to close user info popover now we can just call this new function.

This PR is a follow-up of #21460.

<!-- Describe your pull request here.-->



**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Corner cases, error conditions, and easily imagined bugs.
