### PR TITLE
Fix: Disable "Save Changes Button" when no changes have been made.

### DIFF
--- a/static/js/dialog_widget.js
+++ b/static/js/dialog_widget.js
@@ -154,4 +154,14 @@ export function launch(conf) {
         on_shown: conf?.on_shown,
         on_hidden: conf?.on_hidden,
     });
+
+    $(() => {
+        $("#edit_bot_name").on("input change", function () {
+            if ($(this).val() !== "") {
+                $("#btnSubmit").prop("disabled", false);
+            } else {
+                $("#btnSubmit").prop("disabled", true);
+            }
+        });
+    });
 }

--- a/static/templates/dialog_widget.hbs
+++ b/static/templates/dialog_widget.hbs
@@ -18,7 +18,7 @@
                 {{#unless single_footer_button}}
                 <button class="modal__btn dialog_cancel_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
                 {{/unless}}
-                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
+                <button class="modal__btn dialog_submit_button" id="btnSubmit" {{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
                     <span>{{{ html_submit_button }}}</span>
                     <div class="modal__spinner"></div>
                 </button>


### PR DESCRIPTION
This PR Fixes part of: https://github.com/zulip/zulip/issues/20831.

When using save changes button the button was not disabling even when there has been no changes made.

This PR:

- is fixing the behavior of save changes button with the help of jQuery in .js file.
- and by giving an "id" instead of class to the save changes button to help in finding the button with it's Id.
- Now, save changes button is saving all the changes that has been made and will remain disable if no changes were made.






**Screenshots and screen captures:**
![zulip fix 2](https://user-images.githubusercontent.com/76876709/163572831-cabd5d79-d089-40d2-8797-7c108811fa7f.gif)



