### PR TITLE
configure-rabbitmq: Remove use of sudo

### DIFF
--- a/docs/production/export-and-import.md
+++ b/docs/production/export-and-import.md
@@ -317,7 +317,7 @@ archive of all the organization's uploaded files.
      during the logical export/import process.
    - If you copy the `rabbitmq_password` secret from
      `zulip-secrets.conf`, you'll need to run
-     `scripts/setup/configure-rabbitmq` to update your local RabbitMQ
+     `scripts/setup/configure-rabbitmq` as root to update your local RabbitMQ
      installation to use the password in your Zulip secrets file.
    - You will likely want to copy `camo_key` (required to avoid
      breaking certain links) and any settings you added related to

--- a/scripts/setup/configure-rabbitmq
+++ b/scripts/setup/configure-rabbitmq
@@ -4,15 +4,9 @@
 # with a real password
 set -eu
 
-if [ "$EUID" -eq 0 ]; then
-    sudo=()
-else
-    sudo=(sudo)
-fi
-
 # If the RabbitMQ distribution cookie is insecure, reset it and
 # restart RabbitMQ.
-"${sudo[@]}" "$(dirname "$0")/generate-rabbitmq-cookie"
+"$(dirname "$0")/generate-rabbitmq-cookie"
 
 RABBITMQ_USERNAME=$("$(dirname "$0")/../get-django-setting" RABBITMQ_USERNAME)
 RABBITMQ_PASSWORD=$("$(dirname "$0")/../get-django-setting" RABBITMQ_PASSWORD)
@@ -20,20 +14,20 @@ RABBITMQ_PASSWORD=$("$(dirname "$0")/../get-django-setting" RABBITMQ_PASSWORD)
 # Wait for RabbitMQ to start up
 retries=29
 # Could use rabbitmqctl await_startup when we upgrade to 3.7.11.
-while ! "${sudo[@]}" rabbitmqctl -q await_online_nodes 1 2>/dev/null; do
+while ! rabbitmqctl -q await_online_nodes 1 2>/dev/null; do
     if ((retries == 29)); then
         echo "Waiting for RabbitMQ to start up..."
     fi
     sleep 1
     if ! ((retries -= 1)); then
-        "${sudo[@]}" rabbitmqctl -q await_online_nodes 1
+        rabbitmqctl -q await_online_nodes 1
         break
     fi
 done
 
-"${sudo[@]}" rabbitmqctl delete_user "$RABBITMQ_USERNAME" || true
-"${sudo[@]}" rabbitmqctl delete_user zulip || true
-"${sudo[@]}" rabbitmqctl delete_user guest || true
-"${sudo[@]}" rabbitmqctl add_user "$RABBITMQ_USERNAME" "$RABBITMQ_PASSWORD"
-"${sudo[@]}" rabbitmqctl set_user_tags "$RABBITMQ_USERNAME" administrator
-"${sudo[@]}" rabbitmqctl set_permissions -p / "$RABBITMQ_USERNAME" '.*' '.*' '.*'
+rabbitmqctl delete_user "$RABBITMQ_USERNAME" || true
+rabbitmqctl delete_user zulip || true
+rabbitmqctl delete_user guest || true
+rabbitmqctl add_user "$RABBITMQ_USERNAME" "$RABBITMQ_PASSWORD"
+rabbitmqctl set_user_tags "$RABBITMQ_USERNAME" administrator
+rabbitmqctl set_permissions -p / "$RABBITMQ_USERNAME" '.*' '.*' '.*'

--- a/tools/lib/provision_inner.py
+++ b/tools/lib/provision_inner.py
@@ -19,6 +19,7 @@ from scripts.lib.zulip_tools import (
     get_dev_uuid_var_path,
     is_digest_obsolete,
     run,
+    run_as_root,
     write_new_digest,
 )
 from tools.setup.generate_zulip_bots_static_files import generate_zulip_bots_static_files
@@ -270,7 +271,7 @@ def main(options: argparse.Namespace) -> int:
         )
 
         if options.is_force or need_to_run_configure_rabbitmq([settings.RABBITMQ_PASSWORD]):
-            run(["scripts/setup/configure-rabbitmq"])
+            run_as_root(["scripts/setup/configure-rabbitmq"])
             write_new_digest(
                 "last_configure_rabbitmq_hash",
                 configure_rabbitmq_paths(),

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -506,7 +506,6 @@ bash_rules = RuleList(
             "include_only": {"scripts/"},
             "exclude": {
                 "scripts/lib/install",
-                "scripts/setup/configure-rabbitmq",
             },
         },
         *whitespace_rules[0:1],


### PR DESCRIPTION
It already runs as root everywhere except in `provision_inner`, so move the `sudo` there.