### PR TITLE
Remove ability to mute topics from three-dot menu

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -30,8 +30,6 @@ import * as message_edit from "./message_edit";
 import * as message_edit_history from "./message_edit_history";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
-import * as muted_topics from "./muted_topics";
-import * as muted_topics_ui from "./muted_topics_ui";
 import * as muted_users from "./muted_users";
 import * as muted_users_ui from "./muted_users_ui";
 import * as narrow from "./narrow";
@@ -469,14 +467,6 @@ export function toggle_actions_popover(element, id) {
             use_edit_icon = false;
             editability_menu_item = $t({defaultMessage: "View source"});
         }
-        const topic = message.topic;
-        const can_mute_topic =
-            message.stream &&
-            topic &&
-            !muted_topics.is_topic_muted(message.stream_id, topic) &&
-            not_spectator;
-        const can_unmute_topic =
-            message.stream && topic && muted_topics.is_topic_muted(message.stream_id, topic);
 
         const should_display_edit_history_option =
             message.edit_history &&
@@ -515,11 +505,8 @@ export function toggle_actions_popover(element, id) {
             message_id: message.id,
             historical: message.historical,
             stream_id: message.stream_id,
-            topic,
             use_edit_icon,
             editability_menu_item,
-            can_mute_topic,
-            can_unmute_topic,
             should_display_collapse,
             should_display_uncollapse,
             should_display_add_reaction_option: message.sent_by_me,
@@ -1234,26 +1221,6 @@ export function register_click_handlers() {
         hide_actions_popover();
         message_edit_history.show_history(message);
         $("#message-history-cancel").trigger("focus");
-        e.stopPropagation();
-        e.preventDefault();
-    });
-
-    $("body").on("click", ".popover_mute_topic", (e) => {
-        const stream_id = Number.parseInt($(e.currentTarget).attr("data-msg-stream-id"), 10);
-        const topic = $(e.currentTarget).attr("data-msg-topic");
-
-        hide_actions_popover();
-        muted_topics_ui.mute_topic(stream_id, topic);
-        e.stopPropagation();
-        e.preventDefault();
-    });
-
-    $("body").on("click", ".popover_unmute_topic", (e) => {
-        const stream_id = Number.parseInt($(e.currentTarget).attr("data-msg-stream-id"), 10);
-        const topic = $(e.currentTarget).attr("data-msg-topic");
-
-        hide_actions_popover();
-        muted_topics_ui.unmute_topic(stream_id, topic);
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -69,23 +69,6 @@
         </a>
     </li>
     {{/if}}
-    {{#if can_mute_topic}}
-    <li>
-        <a class="popover_mute_topic" data-msg-stream-id="{{stream_id}}" data-msg-topic="{{topic}}" tabindex="0">
-            <i class="fa fa-bell-slash" aria-hidden="true"></i>
-            {{#tr}}Mute the topic <b>{topic}</b>{{/tr}} <span class="hotkey-hint">(M)</span>
-        </a>
-    </li>
-    {{/if}}
-
-    {{#if can_unmute_topic}}
-    <li>
-        <a class="popover_unmute_topic" data-msg-stream-id="{{stream_id}}" data-msg-topic="{{topic}}" tabindex="0">
-            <i class="fa fa-bell" aria-hidden="true"></i>
-            {{#tr}}Unmute the topic <b>{topic}</b>{{/tr}}
-        </a>
-    </li>
-    {{/if}}
 
     {{#if should_display_add_reaction_option}}
     <li>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Removed the button that allows users to be able to mute topics from the message three-dot menu. 

Fixes: #21432

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="232" alt="Screen Shot 2022-04-16 at 2 36 14 PM" src="https://user-images.githubusercontent.com/52723280/163753705-2d51e596-cbca-4784-a9b5-ecaebe80e7d8.png"><img width="269" alt="Screen Shot 2022-04-15 at 8 17 05 PM" src="https://user-images.githubusercontent.com/52723280/163654283-9b708a24-b8b7-4fff-bca7-eb1c49f39f46.png">
