### PR TITLE
Returns filtered next topic.

### DIFF
--- a/static/js/topic_generator.js
+++ b/static/js/topic_generator.js
@@ -3,36 +3,78 @@ import * as pm_conversations from "./pm_conversations";
 import * as stream_data from "./stream_data";
 import * as stream_sort from "./stream_sort";
 import * as stream_topic_history from "./stream_topic_history";
+import * as topic_list from "./topic_list";
+import * as topic_list_data from "./topic_list_data";
 import * as unread from "./unread";
 
 export function next_topic(streams, get_topics, has_unread_messages, curr_stream, curr_topic) {
+    // curr_stream_widget_id is used only for the TopicListWidget associated with left-sidebar filter
+    const curr_stream_widget_id = topic_list.active_stream_id();
     const curr_stream_index = streams.indexOf(curr_stream); // -1 if not found
 
     if (curr_stream_index >= 0) {
+        // Use 2 pass approach. First pass (filtered_topics_in_stream) iterates all topics that match
+        // the left-sidebar filter. Second pass (all_topics_in_stream) iterates all topics in the
+        // entire unfiltered stream. This 2 pass approach was made for users to jump to the next
+        // unread topic (with respect to the left-sidebar filter) in a stream using 'n' hotkey aka
+        // 'n_key', rather than jumping to the next unread topic overall, which disregards a filter.
         const stream = streams[curr_stream_index];
-        const topics = get_topics(stream);
-        const curr_topic_index = topics.indexOf(curr_topic); // -1 if not found
+        const filtered_topics_in_stream = topic_list_data.get_list_info(
+            curr_stream_widget_id,
+            true,
+        ).items;
+        const all_topics_in_stream = get_topics(stream);
+        // first "pass" --> check all filtered topics first for unread topics. Return topic if found.
+        if (filtered_topics_in_stream.length > 0) {
+            let curr_topic_index = -1; // assume topic not found intitially
+            for (const [i, element] of filtered_topics_in_stream.entries()) {
+                if (element.topic_name === curr_topic) {
+                    curr_topic_index = i;
+                }
+            }
 
-        for (let i = curr_topic_index + 1; i < topics.length; i += 1) {
-            const topic = topics[i];
-            if (has_unread_messages(stream, topic)) {
-                return {stream, topic};
+            for (let i = curr_topic_index + 1; i < filtered_topics_in_stream.length; i += 1) {
+                const topic = filtered_topics_in_stream[i].topic_name;
+                if (has_unread_messages(stream, topic)) {
+                    return { stream, topic };
+                }
+            }
+
+            for (let i = 0; i < curr_topic_index; i += 1) {
+                const topic = filtered_topics_in_stream[i].topic_name;
+                if (has_unread_messages(stream, topic)) {
+                    return { stream, topic };
+                }
             }
         }
+        // Second "pass" --> Check all topics in current stream for unread topics. All filtered
+        // messages should be read by this point, so this if statement will return the
+        // next unread unfiltered topic in this stream.
+        if (all_topics_in_stream.length > 0) {
+            const curr_topic_index = all_topics_in_stream.indexOf(curr_topic); // -1 if not found
+            for (let i = curr_topic_index + 1; i < all_topics_in_stream.length; i += 1) {
+                const topic = all_topics_in_stream[i];
+                if (has_unread_messages(stream, topic)) {
+                    return { stream, topic };
+                }
+            }
 
-        for (let i = 0; i < curr_topic_index; i += 1) {
-            const topic = topics[i];
-            if (has_unread_messages(stream, topic)) {
-                return {stream, topic};
+            for (let i = 0; i < curr_topic_index; i += 1) {
+                const topic = all_topics_in_stream[i];
+                if (has_unread_messages(stream, topic)) {
+                    return { stream, topic };
+                }
             }
         }
     }
 
+    // Find next unread message in all other streams. No left-sidebar topic filters are
+    // applied to other streams since topic filters are stream-specific.
     for (let i = curr_stream_index + 1; i < streams.length; i += 1) {
         const stream = streams[i];
         for (const topic of get_topics(stream)) {
             if (has_unread_messages(stream, topic)) {
-                return {stream, topic};
+                return { stream, topic };
             }
         }
     }
@@ -41,7 +83,7 @@ export function next_topic(streams, get_topics, has_unread_messages, curr_stream
         const stream = streams[i];
         for (const topic of get_topics(stream)) {
             if (has_unread_messages(stream, topic)) {
-                return {stream, topic};
+                return { stream, topic };
             }
         }
     }

--- a/static/js/topic_generator.js
+++ b/static/js/topic_generator.js
@@ -19,10 +19,11 @@ export function next_topic(streams, get_topics, has_unread_messages, curr_stream
         // unread topic (with respect to the left-sidebar filter) in a stream using 'n' hotkey aka
         // 'n_key', rather than jumping to the next unread topic overall, which disregards a filter.
         const stream = streams[curr_stream_index];
-        const filtered_topics_in_stream = topic_list_data.get_list_info(
+        let filtered_topics_in_stream = topic_list_data.get_list_info(
             curr_stream_widget_id,
             true,
         ).items;
+        filtered_topics_in_stream = filtered_topics_in_stream.filter((topic) => !muted_topics.is_topic_muted(curr_stream_index, topic.topic_name));
         const all_topics_in_stream = get_topics(stream);
         // first "pass" --> check all filtered topics first for unread topics. Return topic if found.
         if (filtered_topics_in_stream.length > 0) {
@@ -36,14 +37,14 @@ export function next_topic(streams, get_topics, has_unread_messages, curr_stream
             for (let i = curr_topic_index + 1; i < filtered_topics_in_stream.length; i += 1) {
                 const topic = filtered_topics_in_stream[i].topic_name;
                 if (has_unread_messages(stream, topic)) {
-                    return {stream, topic};
+                    return { stream, topic };
                 }
             }
 
             for (let i = 0; i < curr_topic_index; i += 1) {
                 const topic = filtered_topics_in_stream[i].topic_name;
                 if (has_unread_messages(stream, topic)) {
-                    return {stream, topic};
+                    return { stream, topic };
                 }
             }
         }
@@ -55,14 +56,14 @@ export function next_topic(streams, get_topics, has_unread_messages, curr_stream
             for (let i = curr_topic_index + 1; i < all_topics_in_stream.length; i += 1) {
                 const topic = all_topics_in_stream[i];
                 if (has_unread_messages(stream, topic)) {
-                    return {stream, topic};
+                    return { stream, topic };
                 }
             }
 
             for (let i = 0; i < curr_topic_index; i += 1) {
                 const topic = all_topics_in_stream[i];
                 if (has_unread_messages(stream, topic)) {
-                    return {stream, topic};
+                    return { stream, topic };
                 }
             }
         }
@@ -74,7 +75,7 @@ export function next_topic(streams, get_topics, has_unread_messages, curr_stream
         const stream = streams[i];
         for (const topic of get_topics(stream)) {
             if (has_unread_messages(stream, topic)) {
-                return {stream, topic};
+                return { stream, topic };
             }
         }
     }
@@ -83,7 +84,7 @@ export function next_topic(streams, get_topics, has_unread_messages, curr_stream
         const stream = streams[i];
         for (const topic of get_topics(stream)) {
             if (has_unread_messages(stream, topic)) {
-                return {stream, topic};
+                return { stream, topic };
             }
         }
     }

--- a/static/js/topic_generator.js
+++ b/static/js/topic_generator.js
@@ -36,14 +36,14 @@ export function next_topic(streams, get_topics, has_unread_messages, curr_stream
             for (let i = curr_topic_index + 1; i < filtered_topics_in_stream.length; i += 1) {
                 const topic = filtered_topics_in_stream[i].topic_name;
                 if (has_unread_messages(stream, topic)) {
-                    return { stream, topic };
+                    return {stream, topic};
                 }
             }
 
             for (let i = 0; i < curr_topic_index; i += 1) {
                 const topic = filtered_topics_in_stream[i].topic_name;
                 if (has_unread_messages(stream, topic)) {
-                    return { stream, topic };
+                    return {stream, topic};
                 }
             }
         }
@@ -55,14 +55,14 @@ export function next_topic(streams, get_topics, has_unread_messages, curr_stream
             for (let i = curr_topic_index + 1; i < all_topics_in_stream.length; i += 1) {
                 const topic = all_topics_in_stream[i];
                 if (has_unread_messages(stream, topic)) {
-                    return { stream, topic };
+                    return {stream, topic};
                 }
             }
 
             for (let i = 0; i < curr_topic_index; i += 1) {
                 const topic = all_topics_in_stream[i];
                 if (has_unread_messages(stream, topic)) {
-                    return { stream, topic };
+                    return {stream, topic};
                 }
             }
         }
@@ -74,7 +74,7 @@ export function next_topic(streams, get_topics, has_unread_messages, curr_stream
         const stream = streams[i];
         for (const topic of get_topics(stream)) {
             if (has_unread_messages(stream, topic)) {
-                return { stream, topic };
+                return {stream, topic};
             }
         }
     }
@@ -83,7 +83,7 @@ export function next_topic(streams, get_topics, has_unread_messages, curr_stream
         const stream = streams[i];
         for (const topic of get_topics(stream)) {
             if (has_unread_messages(stream, topic)) {
-                return { stream, topic };
+                return {stream, topic};
             }
         }
     }

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -184,6 +184,7 @@ EXEMPT_FILES = make_set(
         "static/js/timerender.ts",
         "static/js/tippyjs.js",
         "static/js/todo_widget.js",
+        "static/js/topic_generator.js",
         "static/js/topic_list.js",
         "static/js/topic_zoom.js",
         "static/js/tutorial.js",


### PR DESCRIPTION
Incorporates the left-sidebar topic filter to find the next unread topic of a particular stream, which is called when the n_key hotkey is called.

Tested on my local Vagrant development server on many topics and using different filter terms on each test, and it properly iterates through the unread actively-filtered topics first, then the other unread topics in the stream, then all the unfiltered topics of other streams (no filters applied for any of those). I would value extra testing.

Added dependencies to topic_list and topic_list_data to topic_generator.js. All previous functionality of finding the next unread topic is still unchanged, after all unread topics matching the left-sidebar filter are read.

Fixes #21437.
