### PR TITLE
Fix: Long "Person" type profile field spills out of input box.

### DIFF
--- a/static/styles/input_pill.css
+++ b/static/styles/input_pill.css
@@ -38,9 +38,14 @@
 
         .pill-value {
             margin: 0 5px;
+            margin: 0 5px;
+            white-space: nowrap;
+            width: 50px;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-
-        .exit {
+        
+       .exit {
             opacity: 0.5;
             font-size: 1.3em;
             margin-right: 3px;


### PR DESCRIPTION
Abbreviating the name with "..." when it's too long to fit at max width.

Fixes: #21807

**Screenshots and screen captures:**
![zulipfix new issue](https://user-images.githubusercontent.com/76876709/163673669-02d0337b-6611-4bab-8924-0b7c645c074d.gif)
