### PR TITLE
Fix: Long "Person" type profile field spills out of input box.

### DIFF
--- a/static/js/dialog_widget.js
+++ b/static/js/dialog_widget.js
@@ -154,4 +154,14 @@ export function launch(conf) {
         on_shown: conf?.on_shown,
         on_hidden: conf?.on_hidden,
     });
+
+    $(() => {
+        $("#edit_bot_name").on("input change", function () {
+            if ($(this).val() !== "") {
+                $("#btnSubmit").prop("disabled", false);
+            } else {
+                $("#btnSubmit").prop("disabled", true);
+            }
+        });
+    });
 }

--- a/static/styles/input_pill.css
+++ b/static/styles/input_pill.css
@@ -37,7 +37,10 @@
         }
 
         .pill-value {
-            margin: 0 5px;
+            white-space: nowrap;
+            width: 50px;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         .exit {

--- a/static/templates/dialog_widget.hbs
+++ b/static/templates/dialog_widget.hbs
@@ -18,7 +18,7 @@
                 {{#unless single_footer_button}}
                 <button class="modal__btn dialog_cancel_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
                 {{/unless}}
-                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
+                <button class="modal__btn dialog_submit_button" id="btnSubmit" {{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
                     <span>{{{ html_submit_button }}}</span>
                     <div class="modal__spinner"></div>
                 </button>


### PR DESCRIPTION
This PR:

- is Abbreviating the name with "..." when it's too long to fit at max width.

- For fixing this error appropriate changes have been made to white-space, width, overflow, text-overflow under .CSS file.

Error:

- Due to the Error of Long "person" type profile spilling out of input box.

Fixes: https://github.com/zulip/zulip/issues/21807

### **Screen capture:**

![zulipfix new issue](https://user-images.githubusercontent.com/76876709/163674411-8ea84cb3-5eef-4207-8da9-fbf758b07db1.gif)

### **Screenshots:**

**Error:**
![Screenshot 2022-05-12 20-36-58](https://user-images.githubusercontent.com/76876709/168110121-934699a1-eb2c-4149-a761-4127592d7bea.png)

**Fixed:**
![VirtualBox_Ubuntu 001_12_05_2022_20_28_52](https://user-images.githubusercontent.com/76876709/168110231-73619f32-ac48-4851-aabb-19dd5ff377b7.png)

![VirtualBox_Ubuntu 001_12_05_2022_20_29_22](https://user-images.githubusercontent.com/76876709/168111625-8ec909b0-9b0b-467a-8ee0-4ad7c2922ac2.png)

![VirtualBox_Ubuntu 001_12_05_2022_20_31_40](https://user-images.githubusercontent.com/76876709/168112820-c09c9309-39c7-4fe0-95d5-cd8a294cf72a.png)








**Self-review checklist**

 
- [x]  Self-reviewed the changes for clarity and maintainability
(variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x]  Explains differences from previous plans (e.g., issue description).
- [x]  Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.



Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x]  Corner cases, error conditions, and easily imagined bugs.