### PR TITLE
compose: Add clear button for topic name (Fixes #21464)

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -878,7 +878,7 @@ export function initialize() {
         }
 
         if (compose_state.composing()) {
-            compose.update_topic_clear_button_display()
+            compose.update_topic_clear_button_display();
             if (
                 $(e.target).closest("a").length > 0 ||
                 $(e.target).closest(".copy_codeblock").length > 0

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -878,6 +878,7 @@ export function initialize() {
         }
 
         if (compose_state.composing()) {
+            compose.update_topic_clear_button_display()
             if (
                 $(e.target).closest("a").length > 0 ||
                 $(e.target).closest(".copy_codeblock").length > 0

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -730,7 +730,7 @@ export function initialize() {
         update_topic_clear_button_display();
     });
 
-    $("#stream_message_recipient_topic").on("keyup", () => {
+    $("#stream_message_recipient_topic").on("input", () => {
         update_topic_clear_button_display();
     });
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -71,6 +71,16 @@ export function update_video_chat_button_display() {
     $(".message-edit-feature-group .video_link").toggle(show_video_chat_button);
 }
 
+export function update_topic_clear_button_display() {
+    if (compose_state.topic()) {
+        $("#stream_message_recipient_topic").removeClass("empty");
+        $("#compose_clear_topic_name").show();
+    } else {
+        $("#stream_message_recipient_topic").addClass("empty");
+        $("#compose_clear_topic_name").hide();
+    }
+}
+
 export function clear_invites() {
     $("#compose_invite_users").hide();
     $("#compose_invite_users").empty();
@@ -717,6 +727,16 @@ export function initialize() {
 
     $("#stream_message_recipient_topic").on("focus", () => {
         compose_actions.update_placeholder_text();
+        update_topic_clear_button_display();
+    });
+
+    $("#stream_message_recipient_topic").on("keyup", () => {
+        update_topic_clear_button_display();
+    });
+
+    $("body").on("click", "#compose_clear_topic_name", () => {
+        compose_state.topic("");
+        update_topic_clear_button_display();
     });
 
     $("body").on("click", ".formatting_button", (e) => {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -43,6 +43,8 @@ function hide_box() {
     compose_fade.clear_compose();
     $(".message_comp").hide();
     $("#compose_controls").show();
+    $("#stream_message_recipient_topic").removeClass("empty");
+    $("#compose_clear_topic_name").show();
     compose.clear_preview_area();
 }
 

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -440,6 +440,17 @@ input.recipient_box {
        the left sidebar with a single digit unread count without being
        cut off. */
     width: 175px;
+    padding-right: 19px;
+    text-overflow: ellipsis;
+}
+
+#stream_message_recipient_topic.recipient_box.empty {
+    width: 188px;
+    padding-right: 6px;
+}
+
+#compose_clear_topic_name {
+    padding: 4px;
 }
 
 #private_message_recipient.recipient_box {

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -85,6 +85,7 @@
                                 <input type="text" class="recipient_box" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="30" value="" placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Stream' }}" />
                                 <i class="fa fa-angle-right" aria-hidden="true"></i>
                                 <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="60" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
+                                <button type="button" class="btn clear_search_button" id="compose_clear_topic_name"><i class="fa fa-remove"></i></button>
                             </div>
                         </div>
                         <div id="private-message" class="order-1">


### PR DESCRIPTION
Created an `x` button to clear the topic name field of the compose box.  The button is only present when there is text in the box.

**static/js/compose.js**
- Added update_topic_clear_button_display() which checks to see if the topic input box is empty to show/hide the clear button.
- Added call to above function when focus is given to topic input
- Added keyup listener inside the topic input to call above function
- Added click listener for clear button

**static/js/compose_actions.js**
- Added a few lines to unhide the clear button when the compose box is closed. Otherwise clearing the box, then closing the compose box and reopening it resulted in the button remaining hidden.

**compose.css**
- Added padding to make sure text doesn't overflow into the clear button
- Added selector to adjust width/padding when empty class is applied. This keeps the box from changing sizes when the button is shown/hidden.
- Default padding was causing the box to be unstable and change size when hiding/showing the button. So I overrode it.

Fixes: #21464

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Empty Input Box
![empty](https://user-images.githubusercontent.com/61295861/163898063-10720d0f-943c-4d5d-9781-38e930b17e5e.JPG)

Full Input Box
![full](https://user-images.githubusercontent.com/61295861/163898073-52c12bbb-2ed9-494a-82db-4bcebd658555.JPG)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
