### PR TITLE
compose: Add live update for compose topic name

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -719,6 +719,10 @@ export function initialize() {
         compose_actions.update_placeholder_text();
     });
 
+    $("#stream_message_recipient_topic").on("keyup", () => {
+        compose_actions.update_placeholder_text();
+    });
+
     $("body").on("click", ".formatting_button", (e) => {
         const $compose_click_target = $(compose_ui.get_compose_click_target(e));
         const $textarea = $compose_click_target.closest("form").find("textarea");


### PR DESCRIPTION
Small change that allows compose message box's placeholder text to automatically update with the topic name as it's being typed.

Fixes: N/A, discussed in [CZO Topic](https://chat.zulip.org/#narrow/stream/101-design/topic/topic.20box.20width)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://user-images.githubusercontent.com/61295861/163900006-fdc0fd7d-00a0-4e25-96d4-b8378a9e60f3.mp4

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
