### PR TITLE
Skip login page for organizations with web-public streams

### DIFF
--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -241,7 +241,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "",
-            'translated HTML: This stream does not exist or is not <a href="/help/public-access-option">publicly accessible</a>.',
+            'translated HTML: This is not a <a href="/help/public-access-option">publicly accessible</a> conversation.',
         ),
     );
 
@@ -255,8 +255,21 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "",
-            'translated HTML: This stream does not exist or is not <a href="/help/public-access-option">publicly accessible</a>.',
+            'translated HTML: This is not a <a href="/help/public-access-option">publicly accessible</a> conversation.',
         ),
+    );
+
+    // for web-public stream for spectator
+    stream_data.add_sub({name: "web-public-stream", stream_id: 1231, is_web_public: true});
+    set_filter([
+        ["stream", "web-public-stream"],
+        ["topic", "foo"],
+    ]);
+    hide_all_empty_narrow_messages();
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html("translated: Nothing's been sent here yet!", ""),
     );
     page_params.is_spectator = false;
 

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {with_function_call_disallowed_rewire, zrequire} = require("../zjsunit/namespace");
+const {with_function_call_disallowed_rewire, zrequire, mock_esm} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 const {page_params} = require("../zjsunit/zpage_params");
@@ -15,6 +15,10 @@ const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 const {Filter} = zrequire("../js/filter");
 const narrow = zrequire("narrow");
+
+mock_esm("../../static/js/spectators", {
+    login_to_access: () => {},
+});
 
 function empty_narrow_html(title, html, search_data) {
     const opts = {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -39,6 +39,7 @@ import * as rows from "./rows";
 import * as server_events from "./server_events";
 import * as settings_panel_menu from "./settings_panel_menu";
 import * as settings_toggle from "./settings_toggle";
+import * as spectators from "./spectators";
 import * as stream_list from "./stream_list";
 import * as stream_popover from "./stream_popover";
 import * as topic_list from "./topic_list";
@@ -213,6 +214,11 @@ export function initialize() {
         e.stopPropagation();
         popovers.hide_all();
 
+        if (page_params.is_spectator) {
+            spectators.login_to_access();
+            return;
+        }
+
         const message_id = rows.id($(this).closest(".message_row"));
         const message = message_store.get(message_id);
         message_flags.toggle_starred_and_update_server(message);
@@ -220,6 +226,12 @@ export function initialize() {
 
     $("#main_div").on("click", ".message_reaction", function (e) {
         e.stopPropagation();
+
+        if (page_params.is_spectator) {
+            spectators.login_to_access();
+            return;
+        }
+
         emoji_picker.hide_emoji_popover();
         const local_id = $(this).attr("data-reaction-id");
         const message_id = rows.get_message_id(this);

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -12,9 +12,11 @@ import * as compose_ui from "./compose_ui";
 import * as emoji from "./emoji";
 import * as message_lists from "./message_lists";
 import * as message_store from "./message_store";
+import {page_params} from "./page_params";
 import * as popovers from "./popovers";
 import * as reactions from "./reactions";
 import * as rows from "./rows";
+import * as spectators from "./spectators";
 import * as ui from "./ui";
 import {user_settings} from "./user_settings";
 import * as user_status_ui from "./user_status_ui";
@@ -717,6 +719,11 @@ export function register_click_handlers() {
 
     $("#main_div").on("click", ".reaction_button", function (e) {
         e.stopPropagation();
+
+        if (page_params.is_spectator) {
+            spectators.login_to_access();
+            return;
+        }
 
         const message_id = rows.get_message_id(this);
         toggle_emoji_popover(this, message_id);

--- a/static/js/message_edit_history.js
+++ b/static/js/message_edit_history.js
@@ -13,6 +13,7 @@ import * as people from "./people";
 import * as popovers from "./popovers";
 import * as rendered_markdown from "./rendered_markdown";
 import * as rows from "./rows";
+import * as spectators from "./spectators";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
@@ -176,16 +177,22 @@ export function initialize() {
     });
 
     $("body").on("click", ".message_edit_notice", (e) => {
+        e.stopPropagation();
+        e.preventDefault();
         popovers.hide_all();
+
         const message_id = rows.id($(e.currentTarget).closest(".message_row"));
         const $row = message_lists.current.get_row(message_id);
         const message = message_lists.current.get(rows.id($row));
+
+        if (page_params.is_spectator) {
+            spectators.login_to_access();
+            return;
+        }
 
         if (page_params.realm_allow_edit_history) {
             show_history(message);
             $("#message-history-cancel").trigger("focus");
         }
-        e.stopPropagation();
-        e.preventDefault();
     });
 }

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -5,6 +5,7 @@ import {narrow_error} from "./narrow_error";
 import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import * as spectators from "./spectators";
 import * as stream_data from "./stream_data";
 
 const SPECTATOR_STREAM_NARROW_BANNER = {
@@ -204,6 +205,7 @@ function pick_empty_narrow_banner() {
                 // in which you were never subscribed.
 
                 if (page_params.is_spectator) {
+                    spectators.login_to_access(true);
                     return SPECTATOR_STREAM_NARROW_BANNER;
                 }
 

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -12,8 +12,7 @@ const SPECTATOR_STREAM_NARROW_BANNER = {
     title: "",
     html: $t_html(
         {
-            defaultMessage:
-                "This stream does not exist or is not <z-link>publicly accessible</z-link>.",
+            defaultMessage: "This is not a <z-link>publicly accessible</z-link> conversation.",
         },
         {
             "z-link": (content_html) => `<a href="/help/public-access-option">${content_html}</a>`,
@@ -66,15 +65,18 @@ function retrieve_search_query_data() {
 function pick_empty_narrow_banner() {
     const default_banner = {
         title: $t({defaultMessage: "Nothing's been sent here yet!"}),
-        html: $t_html(
-            {
-                defaultMessage: "Why not <z-link>start the conversation</z-link>?",
-            },
-            {
-                "z-link": (content_html) =>
-                    `<a href="#" class="empty_feed_compose_stream">${content_html}</a>`,
-            },
-        ),
+        // Spectators cannot start a conversation.
+        html: page_params.is_spectator
+            ? ""
+            : $t_html(
+                  {
+                      defaultMessage: "Why not <z-link>start the conversation</z-link>?",
+                  },
+                  {
+                      "z-link": (content_html) =>
+                          `<a href="#" class="empty_feed_compose_stream">${content_html}</a>`,
+                  },
+              ),
     };
     const empty_search_narrow_title = $t({defaultMessage: "No search results"});
 
@@ -132,7 +134,13 @@ function pick_empty_narrow_banner() {
             };
         }
 
-        if (page_params.is_spectator) {
+        if (
+            page_params.is_spectator &&
+            first_operator === "stream" &&
+            !stream_data.is_web_public_by_stream_name(first_operand)
+        ) {
+            // For non web-public streams, show `login_to_access` modal.
+            spectators.login_to_access(true);
             return SPECTATOR_STREAM_NARROW_BANNER;
         }
 

--- a/static/js/spectators.js
+++ b/static/js/spectators.js
@@ -12,16 +12,20 @@ import render_login_to_access_modal from "../templates/login_to_access.hbs";
 import * as browser_history from "./browser_history";
 import * as hash_util from "./hash_util";
 import * as overlays from "./overlays";
+import {page_params} from "./page_params";
 
-export function login_to_access() {
+export function login_to_access(empty_narrow) {
     // Hide all overlays, popover and go back to the previous hash if the
     // hash has changed.
     const login_link = hash_util.build_login_link();
+    const realm_name = page_params.realm_name;
 
     $("body").append(
         render_login_to_access_modal({
             signup_link: "/register",
             login_link,
+            empty_narrow,
+            realm_name,
         }),
     );
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -3090,12 +3090,6 @@ select.inline_select_topic_edit {
     }
 }
 
-#login_to_access_modal {
-    .modal__content p {
-        margin: 0;
-    }
-}
-
 #scroll-to-bottom-button-container {
     display: none;
     z-index: 3;

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -13,7 +13,7 @@
     </div>
     <div id="compose_controls" class="new-style">
         <div id="compose_buttons">
-            <span class="new_message_button reply_button_container">
+            <span class="new_message_button reply_button_container ">
                 <button type="button" class="button small rounded compose_reply_button"
                   id="left_bar_compose_reply_button_big"
                   title="{{t 'Reply to selected message' }} (r)">
@@ -43,11 +43,6 @@
                 </button>
             </span>
             {{/unless}}
-            <span class="new_message_button only-visible-for-spectators">
-                <a class="no-underline button small rounded float-left" href="/login">
-                    {{t 'Log in to send messages' }}
-                </a>
-            </span>
         </div>
     </div>
     <div class="message_comp">

--- a/static/templates/login_to_access.hbs
+++ b/static/templates/login_to_access.hbs
@@ -3,16 +3,25 @@
         <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="login_to_access_modal_label">
             <header class="modal__header">
                 <h1 class="modal__title" id="login_to_access_modal_label">
-                    {{t "Login required" }}
+                    {{#tr}}
+                    Join the {realm_name} community
+                    {{/tr}}
                 </h1>
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
             </header>
             <main class="modal__content">
+                {{#if empty_narrow}}
                 <p>
                     {{#tr}}
-                        Since you are not logged in, you can only view messages in
-                        <z-link>publicly accessible conversations</z-link>.
+                        This is not a <z-link>publicly accessible</z-link> conversation.
                         {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="/help/public-access-option">{{> @partial-block}}</a>{{/inline}}
+                    {{/tr}}
+                </p>
+                {{/if}}
+                <p>
+                    {{#tr}}
+                        You can fully access this community and participate in conversations
+                        by creating a Zulip account in this organization.
                     {{/tr}}
                 </p>
             </main>

--- a/static/templates/message_controls.hbs
+++ b/static/templates/message_controls.hbs
@@ -1,10 +1,10 @@
 <div class="message_controls{{#status_message}} sender-status-controls{{/status_message}} no-select">
     {{#if msg/sent_by_me}}
-    <div class="edit_content message_control_button hidden-for-spectators"></div>
+    <div class="edit_content message_control_button"></div>
     {{/if}}
 
     {{#unless msg/sent_by_me}}
-    <div class="reaction_button message_control_button hidden-for-spectators" data-tippy-content="{{t 'Add emoji reaction' }} (:)">
+    <div class="reaction_button message_control_button" data-tippy-content="{{t 'Add emoji reaction' }} (:)">
         <i class="fa fa-smile-o" aria-label="{{#tr}}Add emoji reaction{{/tr}} (:)" role="button" aria-haspopup="true" tabindex="0"></i>
     </div>
     {{/unless}}
@@ -26,7 +26,7 @@
     </div>
 
     {{#unless msg/locally_echoed}}
-    <div class="star_container message_control_button {{#if msg/starred}}{{else}}empty-star{{/if}} hidden-for-spectators" data-tippy-content="{{#with msg}}{{#tr}}{starred_status} this message{{/tr}}{{/with}} (Ctrl + s)">
+    <div class="star_container message_control_button {{#if msg/starred}}{{else}}empty-star{{/if}}" data-tippy-content="{{#with msg}}{{#tr}}{starred_status} this message{{/tr}}{{/with}} (Ctrl + s)">
         <i role="button" tabindex="0" class="star fa {{#if msg/starred}}fa-star{{else}}fa-star-o{{/if}}"></i>
     </div>
     {{/unless}}

--- a/static/templates/message_feed_errors.hbs
+++ b/static/templates/message_feed_errors.hbs
@@ -9,7 +9,7 @@
         {{/tr}}
     </p>
 </div>
-<div class="all-messages-search-caution" hidden>
+<div class="all-messages-search-caution hidden-for-spectators" hidden>
     <p>
         <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
         {{#tr}}
@@ -19,13 +19,7 @@
           target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
         {{/tr}}
         &nbsp;
-        <span class="only-visible-for-spectators">
-            {{#tr}}
-            <z-link>Log in</z-link> to search your personal history.
-            {{#*inline "z-link"}}<a href="/login/">{{> @partial-block}}</a>{{/inline}}
-            {{/tr}}
-        </span>
-        <span class="hidden-for-spectators">
+        <span>
             {{#tr}}
             Consider <z-link>searching all public streams</z-link>.
             {{#*inline "z-link"}}<a class="search-shared-history" href="">{{> @partial-block}}</a>{{/inline}}

--- a/static/templates/message_reactions.hbs
+++ b/static/templates/message_reactions.hbs
@@ -1,7 +1,7 @@
 {{#each this/msg/message_reactions}}
     {{> message_reaction}}
 {{/each}}
-<div class="reaction_button hidden-for-spectators" data-tippy-content="{{t 'Add emoji reaction' }}" aria-label="{{t 'Add emoji reaction' }} (:)">
+<div class="reaction_button" data-tippy-content="{{t 'Add emoji reaction' }}" aria-label="{{t 'Add emoji reaction' }} (:)">
     <i class="fa fa-smile-o" role="button" aria-haspopup="true" tabindex="0" aria-label="{{t 'Add emoji reaction' }} (:)"></i>
     <div class="message_reaction_count">+</div>
 </div>


### PR DESCRIPTION

Fixes: #21690

Added a notice on empty narrows for spectators: 
<img width="1507" alt="Screenshot 2022-04-19 at 3 23 37 PM" src="https://user-images.githubusercontent.com/25124304/163978563-d12160c2-3132-4cfc-9e93-1ffad454e2c8.png">

Redirecting to login page directly for non-web public streams is not possible without rendering a page on the browser since `#...` part of the URL is not sent to server without sending it via form submission. I did try to attempt some tricky methods, but they come down to the bottleneck of rendering a page.

