### PR TITLE
Convert replies between stream and private messages.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -6,6 +6,7 @@ import render_message_inline_image_tooltip from "../templates/message_inline_ima
 import render_narrow_to_compose_recipients_tooltip from "../templates/narrow_to_compose_recipients_tooltip.hbs";
 
 import * as common from "./common";
+import * as compose_actions from "./compose_actions";
 import * as compose_state from "./compose_state";
 import {$t} from "./i18n";
 import * as message_lists from "./message_lists";
@@ -185,6 +186,22 @@ export function initialize() {
         // If user tabs slowly, tooltips are displayed otherwise they are
         // destroyed before they can be displayed.
         e.currentTarget._tippy.destroy();
+    });
+
+    delegate("body", {
+        target: "#compose_message_type_icon",
+        appendTo: () => document.body,
+        onShow(instance) {
+            const $elem = $(instance.reference)[0];
+            if ($elem.classList.contains("composing_private_message")) {
+                instance.setContent(compose_actions.switch_to_stream_message_string);
+            } else {
+                instance.setContent(compose_actions.switch_to_private_message_string);
+            }
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
     });
 
     delegate("body", {

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -21,6 +21,7 @@ import * as channel from "./channel";
 import * as click_handlers from "./click_handlers";
 import * as common from "./common";
 import * as compose from "./compose";
+import * as compose_actions from "./compose_actions";
 import * as compose_closed_ui from "./compose_closed_ui";
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as composebox_typeahead from "./composebox_typeahead";
@@ -362,6 +363,14 @@ export function initialize_kitchen_sink_stuff() {
 
     $("#stream_message_recipient_stream").on("change", function () {
         stream_bar.decorate(this.value, $("#stream-message .message_header_stream"), true);
+    });
+
+    $("#compose_message_type_icon").on("mousedown", (e) => {
+        e.preventDefault();
+    });
+
+    $("#compose_message_type_icon").on("click", () => {
+        compose_actions.toggle_message_type();
     });
 
     $(window).on("blur", () => {

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -83,10 +83,47 @@
     text-overflow: ellipsis;
 }
 
+#compose_left {
+    #compose_message_type_icon {
+        border: none;
+        padding: 4px;
+        background: none;
+        color: inherit;
+
+        &::before {
+            opacity: 0.7;
+            padding-bottom: 1px;
+        }
+
+        &.composing_private_message {
+            background-color: hsla(0, 0%, 0%, 0.05);
+            border-radius: 4px;
+
+            &::before {
+                opacity: 1;
+            }
+        }
+    }
+
+    #compose_message_type_icon:hover {
+        &::before {
+            opacity: 1;
+        }
+
+        &.composing_private_message {
+            &::before {
+                opacity: 0.7;
+            }
+        }
+    }
+}
+
 .compose_table {
     height: 100%;
     display: flex;
     flex-flow: column;
+    flex-grow: 1;
+    margin-left: 10px;
 
     .stream-selection-header-colorblock {
         &.message_header_private_message {
@@ -135,7 +172,11 @@
 
     #private-message .to_text {
         vertical-align: middle;
-
+        /* The To text is aligned to the top (from the parent div's flex)
+         * so that it moves up when the recipient box grows vertically with
+         * many recipients. This margin keeps it vertically centered with
+         * a one-line recipient box. */
+        margin-top: 1.5px;
         font-weight: 600;
     }
 
@@ -171,6 +212,7 @@
 #send_message_form {
     margin: 0;
     height: 100%;
+    display: flex;
 
     .messagebox-wrapper {
         flex: 1;
@@ -245,6 +287,7 @@
     display: flex;
     justify-content: space-between;
     padding-bottom: 5px;
+    min-height: 31px;
 }
 
 #compose_top_right {
@@ -544,10 +587,11 @@ input.recipient_box {
 #stream-message,
 #private-message {
     display: flex;
+    height: fit-content;
 }
 
 #private-message {
-    align-items: center;
+    align-items: top;
     width: 100%;
 }
 

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -491,6 +491,7 @@ body.dark-theme {
     }
 
     .narrow_to_compose_recipients,
+    #compose_message_type_icon,
     .expand_composebox_button,
     .collapse_composebox_button,
     #message_edit_tooltip,
@@ -516,6 +517,10 @@ body.dark-theme {
     .clear_search_button:hover,
     .close:hover {
         color: hsl(0, 0%, 100%);
+    }
+
+    #compose_left #compose_message_type_icon.composing_private_message {
+        background-color: hsla(0, 0%, 100%, 0.05);
     }
 
     #user_presences li .user-list-sidebar-menu-icon:hover,

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -59,6 +59,9 @@
         <div class="composition-area">
             <form id="send_message_form" action="/json/messages" method="post">
                 {{ csrf_input }}
+                <div id="compose_left">
+                    <button type="button" id="compose_message_type_icon" class="fa fa-envelope"></button>
+                </div>
                 <div class="compose_table">
                     <div id="compose_top">
                         <div id="compose_top_right" class="order-2">


### PR DESCRIPTION
Closes #3409

This is a draft to test out the functionality of a button that switches messages between stream and private.

Latest screenshots are on [CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/Convert.20replies.20between.20stream.20and.20private.20messages)


I was careful to:

* preserve message content
* not create two separate drafts when switching between stream and private
* preserve recipients (this happens naturally because both the recipient boxes stick around and toggle being `display: none;` or not)

**Self-review checklist**

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea. (I'm new to doing this -- I think the main work should all go in one commit, but let me know if there's a way that would be good to split it up)
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
