### PR TITLE
Remove Debian 10 support

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -30,13 +30,13 @@ jobs:
   production_build:
     # This job builds a release tarball from the current commit, which
     # will be used for all of the following install/upgrade tests.
-    name: Debian 10 production build
+    name: Ubuntu 20.04 production build
     runs-on: ubuntu-latest
 
     # Docker images are built from 'tools/ci/Dockerfile'; the comments at
     # the top explain how to build and upload these images.
-    # Debian 10 ships with Python 3.7.3.
-    container: zulip/ci:buster
+    # Ubuntu 20.04 ships with Python 3.8.10.
+    container: zulip/ci:focal
     steps:
       - name: Add required permissions
         run: |
@@ -66,22 +66,22 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /srv/zulip-npm-cache
-          key: v1-yarn-deps-buster-${{ hashFiles('package.json') }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: v1-yarn-deps-buster
+          key: v1-yarn-deps-focal-${{ hashFiles('package.json') }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: v1-yarn-deps-focal
 
       - name: Restore python cache
         uses: actions/cache@v2
         with:
           path: /srv/zulip-venv-cache
-          key: v1-venv-buster-${{ hashFiles('requirements/dev.txt') }}
-          restore-keys: v1-venv-buster
+          key: v1-venv-focal-${{ hashFiles('requirements/dev.txt') }}
+          restore-keys: v1-venv-focal
 
       - name: Restore emoji cache
         uses: actions/cache@v2
         with:
           path: /srv/zulip-emoji-cache
-          key: v1-emoji-buster-${{ hashFiles('tools/setup/emoji/emoji_map.json') }}-${{ hashFiles('tools/setup/emoji/build_emoji') }}-${{ hashFiles('tools/setup/emoji/emoji_setup_utils.py') }}-${{ hashFiles('tools/setup/emoji/emoji_names.py') }}-${{ hashFiles('package.json') }}
-          restore-keys: v1-emoji-buster
+          key: v1-emoji-focal-${{ hashFiles('tools/setup/emoji/emoji_map.json') }}-${{ hashFiles('tools/setup/emoji/build_emoji') }}-${{ hashFiles('tools/setup/emoji/emoji_setup_utils.py') }}-${{ hashFiles('tools/setup/emoji/emoji_names.py') }}-${{ hashFiles('package.json') }}
+          restore-keys: v1-emoji-focal
 
       - name: Build production tarball
         run: ./tools/ci/production-build
@@ -114,15 +114,10 @@ jobs:
             os: focal
             extra_args: ""
 
-          - docker_image: zulip/ci:buster
-            name: Debian 10 production install with custom db name and user
-            os: buster
-            extra_args: --test-custom-db
-
           - docker_image: zulip/ci:bullseye
-            name: Debian 11 production install
+            name: Debian 11 production install with custom db name and user
             os: bullseye
-            extra_args: ""
+            extra_args: --test-custom-db
 
     name: ${{ matrix.name  }}
     container:
@@ -209,10 +204,9 @@ jobs:
         include:
           # Docker images are built from 'tools/ci/Dockerfile'; the comments at
           # the top explain how to build and upload these images.
-          - docker_image: zulip/ci:buster-3.4
+          - docker_image: zulip/ci:focal-3.4
             name: 3.4 Version Upgrade
-            os: buster
-
+            os: focal
           - docker_image: zulip/ci:bullseye-4.11
             name: 4.11 Version Upgrade
             os: bullseye

--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -18,19 +18,14 @@ jobs:
         include:
           # Base images are built using `tools/ci/Dockerfile.prod.template`.
           # The comments at the top explain how to build and upload these images.
-          # Debian 10 ships with Python 3.7.3.
-          - docker_image: zulip/ci:buster
-            name: Debian 10 Buster (Python 3.7, backend + frontend)
-            os: buster
-            include_frontend_tests: true
-          # Ubuntu 20.04 ships with Python 3.8.2.
+          # Ubuntu 20.04 ships with Python 3.8.10.
           - docker_image: zulip/ci:focal
-            name: Ubuntu 20.04 Focal (Python 3.8, backend)
+            name: Ubuntu 20.04 (Python 3.8, backend + frontend)
             os: focal
-            include_frontend_tests: false
+            include_frontend_tests: true
           # Debian 11 ships with Python 3.9.2.
           - docker_image: zulip/ci:bullseye
-            name: Debian 11 Bullseye (Python 3.9, backend)
+            name: Debian 11 (Python 3.9, backend)
             os: bullseye
             include_frontend_tests: false
 
@@ -124,8 +119,9 @@ jobs:
         run: |
           source tools/ci/activate-venv
 
-          # Currently our compiled requirements files will differ for different python versions
-          # so we will run test-locked-requirements only for Debian 10.
+          # Currently our compiled requirements files will differ for different
+          # Python versions, so we will run test-locked-requirements only on the
+          # platform with the oldest one.
           # ./tools/test-locked-requirements
           # ./tools/test-run-dev  # https://github.com/zulip/zulip/pull/14233
           #
@@ -192,7 +188,7 @@ jobs:
           fi
 
       - name: Test locked requirements
-        if: ${{ matrix.os == 'buster' }}
+        if: ${{ matrix.os == 'focal' }}
         run: |
           . /srv/zulip-py3-venv/bin/activate && \
           ./tools/test-locked-requirements
@@ -216,7 +212,6 @@ jobs:
           retention-days: 60
 
       - name: Check development database build
-        if: ${{ matrix.os == 'focal' || matrix.os == 'bullseye' || matrix.os == 'jammy' }}
         run: ./tools/ci/setup-backend
 
       - name: Report status

--- a/docs/contributing/code-reviewing.md
+++ b/docs/contributing/code-reviewing.md
@@ -135,7 +135,7 @@ The following review steps apply to the majority of PRs.
    the job to fail by clicking on the failed job. This will open
    up a page in the CI that has more details on why the job failed.
    For example [this](https://github.com/zulip/zulip/runs/2092955762)
-   is the page of the "Debian 10 Buster (Python 3.7, backend + frontend)" job.
+   is the page of the "Ubuntu 20.04 (Python 3.8, backend + frontend)" job.
    See our docs on [continuous integration](../testing/continuous-integration.md)
    to learn more.
 

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -12,8 +12,8 @@ Contents:
 If you'd like to install a Zulip development environment on a computer
 that's running one of:
 
-- Ubuntu 20.04 Focal
-- Debian 10 Buster, 11 Bullseye
+- Ubuntu 20.04
+- Debian 11
 - CentOS 7 (beta)
 - Fedora 33 and 34 (beta)
 - RHEL 7 (beta)

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -18,7 +18,7 @@ Contents:
 - [Step 3: Start the development environment](#step-3-start-the-development-environment)
 - [Step 4: Developing](#step-4-developing)
 - [Troubleshooting and common errors](#troubleshooting-and-common-errors)
-- [Specifying a Debian mirror](#specifying-a-debian-mirror)
+- [Specifying an Ubuntu mirror](#specifying-an-ubuntu-mirror)
 - [Specifying a proxy](#specifying-a-proxy)
 - [Customizing CPU and RAM allocation](#customizing-cpu-and-ram-allocation)
 
@@ -50,7 +50,7 @@ a proxy to access the internet.)
 - **All**: 2GB available RAM, Active broadband internet connection, [GitHub account][set-up-git].
 - **macOS**: macOS (10.11 El Capitan or newer recommended)
 - **Ubuntu LTS**: 20.04
-  - or **Debian**: 10 "buster" or 11 "bullseye"
+- **Debian**: 11
 - **Windows**: Windows 64-bit (Win 10 recommended), hardware
   virtualization enabled (VT-x or AMD-V), administrator access.
 
@@ -143,10 +143,7 @@ Now you are ready for [Step 2: Get Zulip code](#step-2-get-zulip-code).
 
 #### Debian
 
-The setup for Debian is very similar to that [for Ubuntu
-above](#ubuntu), except that the `docker.io` package is only available
-in Debian 10 and later; for Debian 9, see [Docker CE for
-Debian](https://docs.docker.com/install/linux/docker-ce/debian/).
+The setup for Debian is the same as that [for Ubuntu above](#ubuntu).
 
 #### Windows 10
 
@@ -285,7 +282,7 @@ vagrant up --provider=docker
 The first time you run this command it will take some time because vagrant
 does the following:
 
-- downloads the base Debian 10 virtual machine image (for macOS and Windows)
+- downloads the base Ubuntu 20.04 virtual machine image (for macOS and Windows)
   or container (for Linux)
 - configures this virtual machine/container for use with Zulip,
 - creates a shared directory mapping your clone of the Zulip code inside the
@@ -324,7 +321,7 @@ $ vagrant ssh
 You should see output that starts like this:
 
 ```console
-Linux debian-10 4.19.0-18-amd64 #1 SMP Debian 4.19.208-1 (2021-09-29) x86_64
+Welcome to Ubuntu 20.04.4 LTS (GNU/Linux 5.4.0-107-generic x86_64)
 ```
 
 Congrats, you're now inside the Zulip development environment!
@@ -337,7 +334,7 @@ provisioning failed and you should look at the
 Next, start the Zulip server:
 
 ```console
-(zulip-py3-venv) vagrant@debian-10:/srv/zulip
+(zulip-py3-venv) vagrant@vagrant:/srv/zulip
 $ ./tools/run-dev.py
 ```
 
@@ -485,7 +482,7 @@ From the window where run-dev.py is running:
 2016-05-04 18:33:13,330 INFO     127.0.0.1       GET     200  92ms /register/ (unauth@zulip via ?)
 ^C
 KeyboardInterrupt
-(zulip-py3-venv) vagrant@debian-10:/srv/zulip$ exit
+(zulip-py3-venv) vagrant@vagrant:/srv/zulip$ exit
 logout
 Connection to 127.0.0.1 closed.
 christie@win10 ~/zulip
@@ -523,7 +520,7 @@ christie@win10 ~/zulip
 $ vagrant up
 $ vagrant ssh
 
-(zulip-py3-venv) vagrant@debian-10:/srv/zulip
+(zulip-py3-venv) vagrant@vagrant:/srv/zulip
 $ ./tools/run-dev.py
 ```
 
@@ -788,8 +785,8 @@ by rebooting the guest via `vagrant halt; vagrant up`.
 
 The `vagrant up` command basically does the following:
 
-- Downloads a Debian image and starts it using a Vagrant provider.
-- Uses `vagrant ssh` to connect to that Debian guest, and then runs
+- Downloads an Ubuntu image and starts it using a Vagrant provider.
+- Uses `vagrant ssh` to connect to that Ubuntu guest, and then runs
   `tools/provision`, which has a lot of subcommands that are
   executed via Python's `subprocess` module. These errors mean that
   one of those subcommands failed.
@@ -903,11 +900,11 @@ vagrant ssh -- 'sudo modinfo -F version vboxsf'
 
 The bug has not been fixed upstream as of this writing, but you may be
 able to work around it by downgrading VirtualBox Guest Additions to
-6.0.4. To do this, create a `~/.zulip-vagrant-config` file and add
+5.2.44. To do this, create a `~/.zulip-vagrant-config` file and add
 this line:
 
 ```text
-VBOXADD_VERSION 6.0.4
+VBOXADD_VERSION 5.2.44
 ```
 
 Then run these commands (yes, reload is needed twice):
@@ -918,18 +915,18 @@ vagrant reload
 vagrant reload --provision
 ```
 
-### Specifying a Debian mirror
+### Specifying an Ubuntu mirror
 
 Bringing up a development environment for the first time involves
-downloading many packages from the Debian archive. The Debian cloud
-images use the global mirror `http://deb.debian.org/debian` by
+downloading many packages from the Ubuntu archive. The Ubuntu cloud
+images use the global mirror `http://archive.ubuntu.com/ubuntu/` by
 default, but you may find that you can speed up the download by using
 a local mirror closer to your location. To do this, create
 `~/.zulip-vagrant-config` and add a line like this, replacing the URL
 as appropriate:
 
 ```text
-DEBIAN_MIRROR http://ftp.us.debian.org/debian
+UBUNTU_MIRROR http://us.archive.ubuntu.com/ubuntu/
 ```
 
 ### Specifying a proxy

--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -4,9 +4,8 @@ To run a Zulip server, you will need:
 
 - A dedicated machine or VM
 - A supported OS:
-  - Ubuntu 20.04 Focal
-  - Debian 11 Bullseye
-  - Debian 10 Buster
+  - Ubuntu 20.04
+  - Debian 11
 - At least 2 GB RAM, and 10 GB disk space
   - If you expect 100+ users: 4 GB RAM, and 2 CPUs
   - If you intend to [upgrade from Git][upgrade-from-git]: 3 GB RAM, or
@@ -33,8 +32,8 @@ on issues you'll encounter](install-existing-server.md).
 
 #### Operating system
 
-Ubuntu 20.04 Focal, Debian 11 Bullseye, and Debian 10
-Buster are supported for running Zulip in production. You can also
+Ubuntu 20.04 and Debian 11
+are supported for running Zulip in production. You can also
 run Zulip on other platforms that support Docker using
 [docker-zulip][docker-zulip-homepage].
 

--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -413,7 +413,9 @@ instructions for other supported platforms.
 
 ### Upgrading from Debian 10 to 11
 
-1. Upgrade your server to the latest Zulip `4.x` release.
+1. Upgrade your server to the latest `5.x` release. You can only
+   upgrade to Zulip Server 6.0 and newer after completing this
+   process, since newer releases don't support Debian 10.
 
 2. As the Zulip user, stop the Zulip server and run the following
    to back up the system:
@@ -464,7 +466,7 @@ instructions for other supported platforms.
    /home/zulip/deployments/current/scripts/setup/reindex-textual-data --force
    ```
 
-7. As an additional step, you can also [upgrade the postgresql version](#upgrading-postgresql).
+7. As an additional step, you can also [upgrade the PostgreSQL version](#upgrading-postgresql).
 
 ### Upgrading from Debian 9 to 10
 
@@ -519,7 +521,7 @@ instructions for other supported platforms.
    be able to navigate to its URL and confirm everything is working
    correctly.
 
-6. [Upgrade to the latest Zulip release](#upgrading-to-a-release), now
+6. [Upgrade to the latest `5.x` release](#upgrading-to-a-release), now
    that your server is running a supported operating system.
 
 7. Debian 10 has a different version of the low-level glibc
@@ -536,6 +538,9 @@ instructions for other supported platforms.
    ```bash
    /home/zulip/deployments/current/manage.py audit_fts_indexes
    ```
+
+9. [Upgrading from Debian 10 to 11](#upgrading-from-debian-10-to-11),
+   so that you are running a supported operating system.
 
 ## Upgrading PostgreSQL
 

--- a/docs/subsystems/dependencies.md
+++ b/docs/subsystems/dependencies.md
@@ -120,8 +120,8 @@ extension, used by our [full-text search](full-text-search.md).
 ## Python packages
 
 Zulip uses the version of Python itself provided by the host OS for
-the Zulip server. We currently support Python 3.7 and newer, with
-Debian 10 being the platform requiring 3.7 support. The comments
+the Zulip server. We currently support Python 3.8 and newer, with
+Ubuntu 20.04 being the platform requiring 3.8 support. The comments
 in `.github/workflows/zulip-ci.yml` document the Python versions used
 by each supported platform.
 

--- a/puppet/zulip/manifests/supervisor.pp
+++ b/puppet/zulip/manifests/supervisor.pp
@@ -91,6 +91,7 @@ class zulip::supervisor {
     }
     exec { 'supervisor-restart':
       refreshonly => true,
+      provider    => shell,
       command     => $zulip::common::supervisor_reload,
       require     => Service[$supervisor_service],
     }

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -613,16 +613,8 @@ importlib-metadata==4.11.3 ; python_version < "3.10" \
     # via
     #   -r requirements/common.in
     #   -r requirements/mypy.in
-    #   click
-    #   cssutils
-    #   jsonpickle
-    #   jsonschema
     #   markdown
-    #   moto
-    #   pep517
-    #   redis
     #   sphinx
-    #   sqlalchemy
     #   zulip-bots
 importlib-resources==5.4.0 ; python_version < "3.9" \
     --hash=sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45 \
@@ -1966,34 +1958,6 @@ twisted==22.2.0 \
     # via
     #   -r requirements/dev.in
     #   scrapy
-typed-ast==1.5.2 \
-    --hash=sha256:0eb77764ea470f14fcbb89d51bc6bbf5e7623446ac4ed06cbd9ca9495b62e36e \
-    --hash=sha256:1098df9a0592dd4c8c0ccfc2e98931278a6c6c53cb3a3e2cf7e9ee3b06153344 \
-    --hash=sha256:183b183b7771a508395d2cbffd6db67d6ad52958a5fdc99f450d954003900266 \
-    --hash=sha256:18fe320f354d6f9ad3147859b6e16649a0781425268c4dde596093177660e71a \
-    --hash=sha256:26a432dc219c6b6f38be20a958cbe1abffcc5492821d7e27f08606ef99e0dffd \
-    --hash=sha256:294a6903a4d087db805a7656989f613371915fc45c8cc0ddc5c5a0a8ad9bea4d \
-    --hash=sha256:31d8c6b2df19a777bc8826770b872a45a1f30cfefcfd729491baa5237faae837 \
-    --hash=sha256:33b4a19ddc9fc551ebabca9765d54d04600c4a50eda13893dadf67ed81d9a098 \
-    --hash=sha256:42c47c3b43fe3a39ddf8de1d40dbbfca60ac8530a36c9b198ea5b9efac75c09e \
-    --hash=sha256:525a2d4088e70a9f75b08b3f87a51acc9cde640e19cc523c7e41aa355564ae27 \
-    --hash=sha256:58ae097a325e9bb7a684572d20eb3e1809802c5c9ec7108e85da1eb6c1a3331b \
-    --hash=sha256:676d051b1da67a852c0447621fdd11c4e104827417bf216092ec3e286f7da596 \
-    --hash=sha256:74cac86cc586db8dfda0ce65d8bcd2bf17b58668dfcc3652762f3ef0e6677e76 \
-    --hash=sha256:8c08d6625bb258179b6e512f55ad20f9dfef019bbfbe3095247401e053a3ea30 \
-    --hash=sha256:90904d889ab8e81a956f2c0935a523cc4e077c7847a836abee832f868d5c26a4 \
-    --hash=sha256:963a0ccc9a4188524e6e6d39b12c9ca24cc2d45a71cfdd04a26d883c922b4b78 \
-    --hash=sha256:bbebc31bf11762b63bf61aaae232becb41c5bf6b3461b80a4df7e791fabb3aca \
-    --hash=sha256:bc2542e83ac8399752bc16e0b35e038bdb659ba237f4222616b4e83fb9654985 \
-    --hash=sha256:c29dd9a3a9d259c9fa19d19738d021632d673f6ed9b35a739f48e5f807f264fb \
-    --hash=sha256:c7407cfcad702f0b6c0e0f3e7ab876cd1d2c13b14ce770e412c0c4b9728a0f88 \
-    --hash=sha256:da0a98d458010bf4fe535f2d1e367a2e2060e105978873c04c04212fb20543f7 \
-    --hash=sha256:df05aa5b241e2e8045f5f4367a9f6187b09c4cdf8578bb219861c4e27c443db5 \
-    --hash=sha256:f290617f74a610849bd8f5514e34ae3d09eafd521dceaa6cf68b3f4414266d4e \
-    --hash=sha256:f30ddd110634c2d7534b2d4e0e22967e88366b0d356b24de87419cc4410c41b7
-    # via
-    #   black
-    #   mypy
 typeguard==2.13.3 \
     --hash=sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4 \
     --hash=sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1
@@ -2105,16 +2069,10 @@ typing-extensions==4.1.1 \
     --hash=sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2
     # via
     #   -r requirements/common.in
-    #   argon2-cffi
-    #   arrow
-    #   asgiref
-    #   async-timeout
     #   black
     #   boto3-stubs
     #   botocore-stubs
-    #   importlib-metadata
     #   libcst
-    #   markdown-it-py
     #   mypy
     #   mypy-boto3-s3
     #   myst-parser
@@ -2277,7 +2235,6 @@ zipp==3.7.0 \
     # via
     #   importlib-metadata
     #   importlib-resources
-    #   pep517
 zope.interface==5.4.0 \
     --hash=sha256:08f9636e99a9d5410181ba0729e0408d3d8748026ea938f3b970a0249daa8192 \
     --hash=sha256:0b465ae0962d49c68aa9733ba92a001b2a0933c317780435f00be7ecb959c702 \

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -208,10 +208,7 @@ sphinxcontrib-serializinghtml==1.1.5 \
 typing-extensions==4.1.1 \
     --hash=sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42 \
     --hash=sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2
-    # via
-    #   importlib-metadata
-    #   markdown-it-py
-    #   myst-parser
+    # via myst-parser
 urllib3==1.26.9 \
     --hash=sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14 \
     --hash=sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -78,9 +78,7 @@ greenlet==1.1.2 \
 importlib-metadata==4.11.3 ; python_version < "3.10" \
     --hash=sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6 \
     --hash=sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539
-    # via
-    #   -r requirements/mypy.in
-    #   sqlalchemy
+    # via -r requirements/mypy.in
 lxml-stubs==0.4.0 \
     --hash=sha256:184877b42127256abc2b932ba8bd0ab5ea80bd0b0fee618d16daa40e0b71abee \
     --hash=sha256:3b381e9e82397c64ea3cc4d6f79d1255d015f7b114806d4826218805c10ec003
@@ -164,32 +162,6 @@ sqlalchemy2-stubs==0.0.2a21 \
 tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
-    # via mypy
-typed-ast==1.5.2 \
-    --hash=sha256:0eb77764ea470f14fcbb89d51bc6bbf5e7623446ac4ed06cbd9ca9495b62e36e \
-    --hash=sha256:1098df9a0592dd4c8c0ccfc2e98931278a6c6c53cb3a3e2cf7e9ee3b06153344 \
-    --hash=sha256:183b183b7771a508395d2cbffd6db67d6ad52958a5fdc99f450d954003900266 \
-    --hash=sha256:18fe320f354d6f9ad3147859b6e16649a0781425268c4dde596093177660e71a \
-    --hash=sha256:26a432dc219c6b6f38be20a958cbe1abffcc5492821d7e27f08606ef99e0dffd \
-    --hash=sha256:294a6903a4d087db805a7656989f613371915fc45c8cc0ddc5c5a0a8ad9bea4d \
-    --hash=sha256:31d8c6b2df19a777bc8826770b872a45a1f30cfefcfd729491baa5237faae837 \
-    --hash=sha256:33b4a19ddc9fc551ebabca9765d54d04600c4a50eda13893dadf67ed81d9a098 \
-    --hash=sha256:42c47c3b43fe3a39ddf8de1d40dbbfca60ac8530a36c9b198ea5b9efac75c09e \
-    --hash=sha256:525a2d4088e70a9f75b08b3f87a51acc9cde640e19cc523c7e41aa355564ae27 \
-    --hash=sha256:58ae097a325e9bb7a684572d20eb3e1809802c5c9ec7108e85da1eb6c1a3331b \
-    --hash=sha256:676d051b1da67a852c0447621fdd11c4e104827417bf216092ec3e286f7da596 \
-    --hash=sha256:74cac86cc586db8dfda0ce65d8bcd2bf17b58668dfcc3652762f3ef0e6677e76 \
-    --hash=sha256:8c08d6625bb258179b6e512f55ad20f9dfef019bbfbe3095247401e053a3ea30 \
-    --hash=sha256:90904d889ab8e81a956f2c0935a523cc4e077c7847a836abee832f868d5c26a4 \
-    --hash=sha256:963a0ccc9a4188524e6e6d39b12c9ca24cc2d45a71cfdd04a26d883c922b4b78 \
-    --hash=sha256:bbebc31bf11762b63bf61aaae232becb41c5bf6b3461b80a4df7e791fabb3aca \
-    --hash=sha256:bc2542e83ac8399752bc16e0b35e038bdb659ba237f4222616b4e83fb9654985 \
-    --hash=sha256:c29dd9a3a9d259c9fa19d19738d021632d673f6ed9b35a739f48e5f807f264fb \
-    --hash=sha256:c7407cfcad702f0b6c0e0f3e7ab876cd1d2c13b14ce770e412c0c4b9728a0f88 \
-    --hash=sha256:da0a98d458010bf4fe535f2d1e367a2e2060e105978873c04c04212fb20543f7 \
-    --hash=sha256:df05aa5b241e2e8045f5f4367a9f6187b09c4cdf8578bb219861c4e27c443db5 \
-    --hash=sha256:f290617f74a610849bd8f5514e34ae3d09eafd521dceaa6cf68b3f4414266d4e \
-    --hash=sha256:f30ddd110634c2d7534b2d4e0e22967e88366b0d356b24de87419cc4410c41b7
     # via mypy
 types-beautifulsoup4==4.10.16 \
     --hash=sha256:903d20430df659e98ea5063c013b9219d91861ecef145a0ac63061f0aad63d7b \
@@ -299,7 +271,6 @@ typing-extensions==4.1.1 \
     # via
     #   boto3-stubs
     #   botocore-stubs
-    #   importlib-metadata
     #   mypy
     #   mypy-boto3-s3
     #   sqlalchemy2-stubs

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -422,12 +422,7 @@ importlib-metadata==4.11.3 ; python_version < "3.10" \
     --hash=sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539
     # via
     #   -r requirements/common.in
-    #   click
-    #   cssutils
-    #   jsonschema
     #   markdown
-    #   redis
-    #   sqlalchemy
     #   zulip-bots
 importlib-resources==5.4.0 ; python_version < "3.9" \
     --hash=sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45 \
@@ -1308,10 +1303,6 @@ typing-extensions==4.1.1 \
     --hash=sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2
     # via
     #   -r requirements/common.in
-    #   argon2-cffi
-    #   asgiref
-    #   async-timeout
-    #   importlib-metadata
     #   mypy-boto3-s3
     #   redis
     #   zulip

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -212,7 +212,7 @@ if [ -f /etc/os-release ]; then
 fi
 
 case "$os_id $os_version_id" in
-    'debian 10' | 'debian 11' | 'ubuntu 20.04') ;;
+    'debian 11' | 'ubuntu 20.04') ;;
     *)
         set +x
         cat <<EOF
@@ -220,9 +220,8 @@ case "$os_id $os_version_id" in
 Unsupported OS release: $os_id $os_version_id
 
 Zulip in production is supported only on:
- - Debian 10 "buster"
- - Debian 11 "bullseye"
- - Ubuntu 20.04 LTS "focal"
+ - Debian 11
+ - Ubuntu 20.04 LTS
 
 For more information, see:
   https://zulip.readthedocs.io/en/latest/production/requirements.html

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -64,6 +64,7 @@ UNSUPPORTED_DISTROS = [
     ("ubuntu", "16.04"),
     ("ubuntu", "18.04"),
     ("debian", "9"),
+    ("debian", "10"),
 ]
 distro_info = parse_os_release()
 vendor = distro_info["ID"]
@@ -165,7 +166,6 @@ if os.path.exists("/etc/init.d/postgresql"):
     postgresql_version = get_config(config_file, "postgresql", "version")
     if not postgresql_version:
         default_postgresql_version = {
-            ("debian", "10"): "11",
             ("debian", "11"): "13",
             ("ubuntu", "20.04"): "12",
             ("ubuntu", "22.04"): "14",

--- a/scripts/setup/apt-repos/zulip/buster.list
+++ b/scripts/setup/apt-repos/zulip/buster.list
@@ -1,5 +1,0 @@
-deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main
-deb-src http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main
-
-deb http://apt-archive.postgresql.org/pub/repos/apt/ buster-pgdg-archive main
-deb-src http://apt-archive.postgresql.org/pub/repos/apt/ buster-pgdg-archive main

--- a/templates/zerver/api/incoming-webhooks-walkthrough.md
+++ b/templates/zerver/api/incoming-webhooks-walkthrough.md
@@ -258,7 +258,7 @@ After running the above command, you should see something similar to:
 Using `manage.py` from within the Zulip development environment:
 
 ```console
-(zulip-py3-venv) vagrant@debian-10:/srv/zulip$
+(zulip-py3-venv) vagrant@vagrant:/srv/zulip$
 ./manage.py send_webhook_fixture_message \
     --fixture=zerver/webhooks/helloworld/fixtures/hello.json \
     '--url=http://localhost:9991/api/v1/external/helloworld?api_key=<api_key>'
@@ -384,7 +384,7 @@ Once you have written some tests, you can run just these new tests from within
 the Zulip development environment with this command:
 
 ```console
-(zulip-py3-venv) vagrant@debian-10:/srv/zulip$
+(zulip-py3-venv) vagrant@vagrant:/srv/zulip$
 ./tools/test-backend zerver/webhooks/helloworld
 ```
 
@@ -433,7 +433,7 @@ stream name:
 To trigger a notification using this webhook, use
 `send_webhook_fixture_message` from the Zulip command line:
 
-    (zulip-py3-venv) vagrant@debian-10:/srv/zulip$
+    (zulip-py3-venv) vagrant@vagrant:/srv/zulip$
     ./manage.py send_webhook_fixture_message \
         --fixture=zerver/tests/fixtures/helloworld/hello.json \
         '--url=http://localhost:9991/api/v1/external/helloworld?api_key=&lt;api_key&gt;'

--- a/tools/ci/Dockerfile.prod
+++ b/tools/ci/Dockerfile.prod
@@ -1,7 +1,7 @@
-# To build these production upgrade test images, say a Debian 10 Buster system
+# To build these production upgrade test images, say an Ubuntu 20.04 Focal system
 # preinstalled with Zulip 3.4:
-#   docker build . -f Dockerfile.prod --build-arg=BASE_IMAGE=zulip/ci:buster --build-arg=VERSION=3.4 --tag=zulip/ci:buster-3.4
-#   docker push zulip/ci:buster-3.4
+#   docker build . -f Dockerfile.prod --build-arg=BASE_IMAGE=zulip/ci:focal --build-arg=VERSION=3.4 --tag=zulip/ci:focal-3.4
+#   docker push zulip/ci:focal-3.4
 
 ARG BASE_IMAGE
 FROM $BASE_IMAGE

--- a/tools/ci/build-docker-images
+++ b/tools/ci/build-docker-images
@@ -3,8 +3,7 @@ set -eux
 cd "$(dirname "${BASH_SOURCE[0]}")"
 docker build . --build-arg=BASE_IMAGE=ubuntu:20.04 --pull --tag=zulip/ci:focal
 docker build . --build-arg=BASE_IMAGE=ubuntu:22.04 --pull --tag=zulip/ci:jammy
-docker build . --build-arg=BASE_IMAGE=debian:10 --pull --tag=zulip/ci:buster
 docker build . --build-arg=BASE_IMAGE=debian:11 --pull --tag=zulip/ci:bullseye
-docker build . -f Dockerfile.prod --build-arg=BASE_IMAGE=zulip/ci:buster --build-arg=VERSION=3.4 --tag=zulip/ci:buster-3.4
+docker build . -f Dockerfile.prod --build-arg=BASE_IMAGE=zulip/ci:focal --build-arg=VERSION=3.4 --tag=zulip/ci:focal-3.4
 docker build . -f Dockerfile.prod --build-arg=BASE_IMAGE=zulip/ci:bullseye --build-arg=VERSION=4.11 --tag=zulip/ci:bullseye-4.11
 docker build . -f Dockerfile.prod --build-arg=BASE_IMAGE=zulip/ci:bullseye --build-arg=VERSION=5.1 --tag=zulip/ci:bullseye-5.1

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -79,9 +79,7 @@ except OSError:
 distro_info = parse_os_release()
 vendor = distro_info["ID"]
 os_version = distro_info["VERSION_ID"]
-if vendor == "debian" and os_version == "10":  # buster
-    POSTGRESQL_VERSION = "11"
-elif vendor == "debian" and os_version == "11":  # bullseye
+if vendor == "debian" and os_version == "11":  # bullseye
     POSTGRESQL_VERSION = "13"
 elif vendor == "ubuntu" and os_version == "20.04":  # focal
     POSTGRESQL_VERSION = "12"

--- a/tools/provision
+++ b/tools/provision
@@ -19,7 +19,7 @@ fi
 
 os="$(. /etc/os-release && echo "$ID $VERSION_ID")"
 case "$os" in
-    'ubuntu 14.04' | 'ubuntu 16.04' | 'ubuntu 18.04')
+    'ubuntu 14.04' | 'ubuntu 16.04' | 'ubuntu 18.04' | 'debian 10')
         echo "Error: $os is no longer a supported platform for Zulip." >&2
         if [ -e /home/vagrant ]; then
             # shellcheck disable=SC2016
@@ -32,8 +32,8 @@ esac
 
 python_version="$(python3 --version)"
 case "$python_version" in
-    Python\ 3.[0-6].*)
-        echo 'Error: Zulip requires an OS with Python 3.7 or later.' >&2
+    Python\ 3.[0-7].*)
+        echo 'Error: Zulip requires an OS with Python 3.8 or later.' >&2
         exit 1
         ;;
 esac

--- a/tools/setup/dev-vagrant-docker/Dockerfile
+++ b/tools/setup/dev-vagrant-docker/Dockerfile
@@ -1,12 +1,18 @@
-FROM debian:10
+FROM ubuntu:20.04
 
-ARG DEBIAN_MIRROR
+ARG UBUNTU_MIRROR
 
 # Basic packages and dependencies of docker-systemctl-replacement
 RUN echo locales locales/default_environment_locale select C.UTF-8 | debconf-set-selections \
     && echo locales locales/locales_to_be_generated select "C.UTF-8 UTF-8" | debconf-set-selections \
-    && { [ ! "$DEBIAN_MIRROR" ] || sed -i "s|http://\(\w*\.\)*\.debian\.org/debian |$DEBIAN_MIRROR |" /etc/apt/sources.list; } \
-    && apt-get update \
+    && { [ ! "$UBUNTU_MIRROR" ] || sed -i "s|http://\(\w*\.\)*archive\.ubuntu\.com/ubuntu/\? |$UBUNTU_MIRROR |" /etc/apt/sources.list; } \
+    # This restores man pages and other documentation that have been
+    # stripped from the default Ubuntu cloud image and installs
+    # ubuntu-minimal and ubuntu-standard.
+    #
+    # This makes sense to do because we're using this image as a
+    # development environment, not a minimal production system.
+    && printf 'y\n\n' | unminimize \
     && apt-get install --no-install-recommends -y \
            ca-certificates \
            curl \
@@ -32,13 +38,7 @@ RUN \
     && mkdir -p /run/sshd \
     # docker-systemctl-replacement doesn’t work with template units yet:
     # https://github.com/gdraheim/docker-systemctl-replacement/issues/62
-    && ln -ns /lib/systemd/system/postgresql@.service /etc/systemd/system/multi-user.target.wants/postgresql@11-main.service \
-    # redis fails to start with the default configuration if IPv6 is disabled:
-    # https://github.com/antirez/redis/pull/5598
-    && dpkg-divert --add --rename /etc/default/redis-server \
-    && printf 'ULIMIT=65536\nDAEMON_ARGS="/etc/redis/redis.conf --bind 127.0.0.1"\n' > /etc/default/redis-server \
-    && mkdir /etc/systemd/system/redis-server.service.d \
-    && printf '[Service]\nExecStart=\nExecStart=/usr/bin/redis-server /etc/redis/redis.conf --bind 127.0.0.1\n' > /etc/systemd/system/redis-server.service.d/override.conf \
+    && ln -ns /lib/systemd/system/postgresql@.service /etc/systemd/system/multi-user.target.wants/postgresql@12-main.service \
     # Set up the vagrant user and its SSH key (globally public)
     && useradd -ms /bin/bash -u "$VAGRANT_UID" vagrant \
     && mkdir -m 700 ~vagrant/.ssh \

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 122
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "185.0"
+PROVISION_VERSION = "185.1"

--- a/zerver/webhooks/helloworld/doc.md
+++ b/zerver/webhooks/helloworld/doc.md
@@ -17,7 +17,7 @@ integration](/api/incoming-webhooks-walkthrough).
     `send_webhook_fixture_message` from a [Zulip development
     environment](https://zulip.readthedocs.io/en/latest/development/overview.html):
 
-        (zulip-py3-venv) vagrant@debian-10:/srv/zulip$
+        (zulip-py3-venv) vagrant@vagrant:/srv/zulip$
         ./manage.py send_webhook_fixture_message \
         > --fixture=zerver/tests/fixtures/helloworld/hello.json \
         > '--url=http://localhost:9991/api/v1/external/helloworld?api_key=&lt;api_key&gt;'


### PR DESCRIPTION
As a consequence:

* Bump minimum supported Python version to 3.8.
* Move Vagrant environment to Ubuntu 20.04, which has Python 3.8.
* Move CI frontend tests to Ubuntu 20.04.
* Move production build test to Ubuntu 20.04.
* Move 3.4 upgrade test to Ubuntu 20.04.

Tested the new Vagrant environment on Linux (Docker), macOS ARM (Docker), and Windows 11 (VirtualBox, which required a Guest Additions downgrade).