### PR TITLE
Fix resetting search bar text on navigating to recent topics.

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -224,6 +224,7 @@ export function initiate_search() {
         $("#search_query").trigger("focus");
         ui_util.place_caret_at_end($("#search_query")[0]);
     }
+    clear_search_form();
 }
 
 export function clear_search_form() {


### PR DESCRIPTION
Fixes issue when going from any message list/ search view, searching something, and then using the search bar within the Recent Topics view the text does not reset from the prior message list/ search view.

Reproduced the issue by trying several different views and navigating to recent topics. Tested using my local Vagrant development server. Used several variations of searches and navigated between message lists and search views themselves while making searches in each view, to ensure the issue was not occurring anywhere else.

Added a call to clear_search_form() within the initiate_search in search.js. This is seemingly the issue, as the text in the search bar was not being cleared each time.

Fixes: #20956
