### PR TITLE
api-docs: Add OpenAPI as a new top level item in the "REST API" section.

### DIFF
--- a/templates/zerver/api/openapi.md
+++ b/templates/zerver/api/openapi.md
@@ -1,0 +1,21 @@
+# OpenAPI
+
+[OpenAPI][openapi-spec] is a popular format for describing an API. An
+OpenAPI file can be used by various tools to generate documentation
+for the API or even basic client-side bindings for dozens of
+programming languages.
+
+Zulip's API is described in [zerver/openapi/zulip.yaml](https://raw.githubusercontent.com/zulip/zulip/main/zerver/openapi/zulip.yaml). Our aim is for that file to fully describe every endpoint in the Zulip API, and
+for the Zulip test suite to fail should the API every change without a
+corresponding adjustment to the documentation. In particular,
+essentially all content in Zulip's [REST API
+documentation](https://zulip.readthedocs.io/en/latest/documentation/api.html)
+is generated from our OpenAPI file.
+
+In an OpenAPI file, every configuration section is an object.
+Objects may contain other objects, or reference objects defined
+elsewhere. Larger API specifications may be split into multiple
+files. See the [OpenAPI specification][openapi-spec].
+
+[openapi-spec]: https://github.com/OAI/OpenAPI-Specification/#the-openapi-specification
+

--- a/templates/zerver/api/sidebar_index.md
+++ b/templates/zerver/api/sidebar_index.md
@@ -15,6 +15,7 @@
 ## REST API
 
 * [Overview](/api/rest)
+* [OpenAPI](/api/openapi)
 * [Installation instructions](/api/installation-instructions)
 * [API keys](/api/api-keys)
 * [Configuring the Python bindings](/api/configuring-python-bindings)


### PR DESCRIPTION
Hi! This is my first PR as an Outreachy applicant.

This new section explains to the user what OpenAPI is,
with text borrowed from the developer documentation.
It includes the raw Github link to zulip.yaml to highlight
that we have a complete OpenAPI file.

Fixes part of #17856.