### PR TITLE
settings_users: Display status update notifications inside modal.

### DIFF
--- a/frontend_tests/puppeteer_tests/user-deactivation.ts
+++ b/frontend_tests/puppeteer_tests/user-deactivation.ts
@@ -24,7 +24,7 @@ async function test_reactivation_confirmation_modal(page: Page, fullname: string
     assert.strictEqual(
         await common.get_text_from_selector(page, ".dialog_heading"),
         "Reactivate " + fullname,
-        "Reactivate modal has wrong user.",
+        "Unexpected title for reactivate user modal",
     );
     assert.strictEqual(
         await common.get_text_from_selector(page, "#dialog_widget_modal .dialog_submit_button"),
@@ -45,7 +45,7 @@ async function test_deactivate_user(page: Page): Promise<void> {
     assert.strictEqual(
         await common.get_text_from_selector(page, ".dialog_heading"),
         "Deactivate " + common.fullname.cordelia,
-        "Deactivate modal has wrong user.",
+        "Unexpected title for deactivate user modal",
     );
     assert.strictEqual(
         await common.get_text_from_selector(page, "#dialog_widget_modal .dialog_submit_button"),

--- a/frontend_tests/puppeteer_tests/user-deactivation.ts
+++ b/frontend_tests/puppeteer_tests/user-deactivation.ts
@@ -99,13 +99,26 @@ async function test_bot_deactivation_and_reactivation(page: Page): Promise<void>
     const default_bot_user_row = await user_row(page, "Zulip Default Bot");
 
     await page.click(default_bot_user_row + " .deactivate");
+    await common.wait_for_micromodal_to_open(page);
+
+    assert.strictEqual(
+        await common.get_text_from_selector(page, ".dialog_heading"),
+        "Deactivate Zulip Default Bot",
+        "Unexpected title for deactivate bot modal",
+    );
+    assert.strictEqual(
+        await common.get_text_from_selector(page, "#dialog_widget_modal .dialog_submit_button"),
+        "Confirm",
+        "Deactivate button has incorrect text.",
+    );
+    await page.click("#dialog_widget_modal .dialog_submit_button");
+    await common.wait_for_micromodal_to_close(page);
+
     await page.waitForSelector(default_bot_user_row + ".deactivated_user", {visible: true});
     await page.waitForSelector(default_bot_user_row + " .fa-user-plus");
-    await page.waitForSelector("#bot-field-status", {hidden: true});
 
     await page.click(default_bot_user_row + " .reactivate");
     await test_reactivation_confirmation_modal(page, "Zulip Default Bot");
-
     await page.waitForSelector(default_bot_user_row + ":not(.deactivated_user)", {visible: true});
     await page.waitForSelector(default_bot_user_row + " .fa-user-times");
 }

--- a/static/js/dialog_widget.js
+++ b/static/js/dialog_widget.js
@@ -6,6 +6,7 @@ import * as blueslip from "./blueslip";
 import {$t_html} from "./i18n";
 import * as loading from "./loading";
 import * as overlays from "./overlays";
+import * as ui_report from "./ui_report";
 
 /*
  *  Look for confirm_dialog in settings_user_groups
@@ -153,5 +154,35 @@ export function launch(conf) {
         on_hide: conf?.on_hide,
         on_shown: conf?.on_shown,
         on_hidden: conf?.on_hidden,
+    });
+}
+
+export function submit_api_request(
+    request_method,
+    url,
+    data = {},
+    {
+        failure_msg_html = $t_html({defaultMessage: "Failed"}),
+        success_continuation,
+        error_continuation,
+    } = {},
+) {
+    show_dialog_spinner();
+    request_method({
+        url,
+        data,
+        success(reponse_data) {
+            close_modal();
+            if (success_continuation !== undefined) {
+                success_continuation(reponse_data);
+            }
+        },
+        error(xhr) {
+            ui_report.error(failure_msg_html, xhr, $("#dialog_error"));
+            hide_dialog_spinner();
+            if (error_continuation !== undefined) {
+                error_continuation(xhr);
+            }
+        },
     });
 }

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -24,7 +24,6 @@ import * as settings_bots from "./settings_bots";
 import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
 import * as settings_panel_menu from "./settings_panel_menu";
-import * as settings_ui from "./settings_ui";
 import * as timerender from "./timerender";
 import * as ui from "./ui";
 import * as user_pill from "./user_pill";
@@ -600,7 +599,15 @@ export function show_edit_user_info_modal(user_id, from_user_info_popover) {
             role: JSON.stringify(role),
             profile_data: JSON.stringify(profile_data),
         };
-        dialog_widget.submit_api_request(channel.patch, url, data);
+        const opts = {
+            error_continuation() {
+                // Scrolling modal to top, to make error visible to user.
+                $("#edit-user-form")
+                    .closest(".simplebar-content-wrapper")
+                    .animate({scrollTop: 0}, "fast");
+            },
+        };
+        dialog_widget.submit_api_request(channel.patch, url, data, opts);
     }
 
     dialog_widget.launch({
@@ -621,7 +628,7 @@ function handle_human_form($tbody) {
     });
 }
 
-function handle_bot_form($tbody, $status_field) {
+function handle_bot_form($tbody) {
     $tbody.on("click", ".open-user-form", (e) => {
         e.stopPropagation();
         e.preventDefault();
@@ -656,8 +663,7 @@ function handle_bot_form($tbody, $status_field) {
                 data.bot_owner_id = human_user_id;
             }
 
-            settings_ui.do_settings_change(channel.patch, url, data, $status_field);
-            dialog_widget.close_modal();
+            dialog_widget.submit_api_request(channel.patch, url, data);
         }
 
         function get_bot_owner_widget() {
@@ -709,11 +715,10 @@ section.deactivated.handle_events = () => {
 
 section.bots.handle_events = () => {
     const $tbody = $("#admin_bots_table").expectOne();
-    const $status_field = $("#bot-field-status").expectOne();
 
     handle_bot_deactivation($tbody);
     handle_reactivation($tbody);
-    handle_bot_form($tbody, $status_field);
+    handle_bot_form($tbody);
 };
 
 export function set_up_humans() {

--- a/static/templates/confirm_dialog/confirm_deactivate_bot.hbs
+++ b/static/templates/confirm_dialog/confirm_deactivate_bot.hbs
@@ -1,0 +1,7 @@
+<p>
+    {{#tr}}
+        When you deactivate <z-user></z-user>.
+        {{#*inline "z-user"}}<strong>{{username}}</strong>{{#if email}} &lt;{{email}}&gt;{{/if}}{{/inline}}
+    {{/tr}}
+</p>
+<p>{{t "They will not send messages or take any other actions." }}</p>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
In settings, clicking on deactivate bot button will lead to open confirmation modal, and displaying all status update notifications inside this confirmation modal.

This PR will also lead to display status update notifications of edit user/bot inside their edit form modal.

It is a follow-up of #21490 

Possible issues encountered: There is no loading spinner on buttons of edit user/bot modal. (If it is a candidate for change should I post another PR or add change to this PR)
<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![modal_with_error](https://user-images.githubusercontent.com/41695888/164300295-827d7eb9-c5ca-42bb-b7ea-7079f70c0d81.png) 
![Screenshot at 2022-04-21 00-09-22](https://user-images.githubusercontent.com/41695888/164300359-453bf393-7bad-4512-8983-c1479a69598b.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
