### PR TITLE
settings_bots: Fix incorrect title of "Edit bot" button.

### DIFF
--- a/static/templates/settings/admin_user_list.hbs
+++ b/static/templates/settings/admin_user_list.hbs
@@ -41,7 +41,7 @@
     {{#if can_modify}}
     <td class="actions">
         <span class="user-status-settings">
-            <button class="button rounded small btn-warning open-user-form" {{#unless is_active}}style="display: none;"{{/unless}} title="{{t 'Edit user' }}" data-user-id="{{user_id}}">
+            <button class="button rounded small btn-warning open-user-form" {{#unless is_active}}style="display: none;"{{/unless}} title="{{#if is_bot}}{{t 'Edit bot' }}{{else}}{{t 'Edit user' }}{{/if}}" data-user-id="{{user_id}}">
                 <i class="fa fa-pencil" aria-hidden="true"></i>
             </button>
             {{#if is_active}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Incorrect.20title.20of.20.22Edit.20bot.22.20button.20in.20settings.20.3E.20bots.2E)


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![tooltip](https://user-images.githubusercontent.com/41695888/164320747-0aec2dd0-a194-4bd0-9076-21451d1d6da3.png)*