### PR TITLE
Fix: Long "Person" type profile field spilling out of input box #21807.

### DIFF
--- a/static/styles/input_pill.css
+++ b/static/styles/input_pill.css
@@ -1,94 +1,91 @@
 .pill-container {
     display: inline-flex;
     flex-wrap: wrap;
-
     padding: 2px;
     border: 1px solid hsla(0, 0%, 0%, 0.15);
     border-radius: 4px;
     align-items: center;
-
     cursor: text;
+}
 
-    .pill {
-        display: inline-flex;
-        align-items: center;
+.pill-container .pill {
+    display: inline-flex;
+    align-items: center;
+    height: 20px;
+    margin: 1px 2px;
+    color: inherit;
+    border: 1px solid hsla(0, 0, 0, 0.15);
+    border-radius: 4px;
+    background-color: hsla(0, 0, 0, 0.07);
+    cursor: pointer;
+}
 
-        height: 20px;
-        margin: 1px 2px;
+.pill-container .pill:focus {
+    color: hsl(0, 0%, 100%);
+    border: 1px solid hsl(176, 78%, 28%);
+    background-color: hsl(176, 49%, 42%);
+    outline: none;
+}
 
-        color: inherit;
-        border: 1px solid hsla(0, 0%, 0%, 0.15);
+.pill-container .pill .pill-image {
+    height: 20px;
+    width: 20px;
+    border-radius: 4px 0 0 4px;
+}
 
-        border-radius: 4px;
-        background-color: hsla(0, 0%, 0%, 0.07);
-        cursor: pointer;
+.pill-container .pill .pill-value {
+    margin: 0 5px;
+    width: 160px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
 
-        &:focus {
-            color: hsl(0, 0%, 100%);
-            border: 1px solid hsl(176, 78%, 28%);
-            background-color: hsl(176, 49%, 42%);
-            outline: none;
-        }
+.pill-container .pill .exit {
+    opacity: 0.5;
+    font-size: 1.3em;
+    margin-right: 3px;
+}
 
-        .pill-image {
-            height: 20px;
-            width: 20px;
-            border-radius: 4px 0 0 4px;
-        }
+.pill-container .pill:hover .exit {
+    opacity: 1;
+}
 
-        .pill-value {
-            margin: 0 5px;
-        }
+.pill-container.not-editable {
+    cursor: not-allowed;
+    border: none;
+    background-color: transparent;
+    padding: 0;
+}
 
-        .exit {
-            opacity: 0.5;
-            font-size: 1.3em;
-            margin-right: 3px;
-        }
+.pill-container.not-editable .pill {
+    padding-right: 4px;
+    cursor: not-allowed;
+}
 
-        &:hover .exit {
-            opacity: 1;
-        }
-    }
+.pill-container.not-editable .pill:focus {
+    color: inherit;
+    border: 1px solid hsla(0, 0, 0, 0.15);
+    background-color: hsla(0, 0, 0, 0.07);
+}
 
-    &.not-editable {
-        cursor: not-allowed;
-        border: none;
-        background-color: transparent;
-        padding: 0;
+.pill-container.not-editable .pill .exit {
+    display: none;
+}
 
-        .pill {
-            padding-right: 4px;
-            cursor: not-allowed;
+.pill-container .input {
+    display: inline-block;
+    padding: 2px 4px;
+    min-width: 2px;
+    word-break: break-all;
+    outline: none;
+}
 
-            &:focus {
-                color: inherit;
-                border: 1px solid hsla(0, 0%, 0%, 0.15);
-                background-color: hsla(0, 0%, 0%, 0.07);
-            }
-
-            .exit {
-                display: none;
-            }
-        }
-    }
-
-    .input {
-        display: inline-block;
-        padding: 2px 4px;
-
-        min-width: 2px;
-        word-break: break-all;
-
-        outline: none;
-
-        &.shake {
-            animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
-            transform: translate3d(0, 0, 0);
-            backface-visibility: hidden;
-            perspective: 1000px;
-        }
-    }
+.pill-container .input.shake {
+    animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+    transform: translate3d(0, 0, 0);
+    backface-visibility: hidden;
+    perspective: 1000px;
 }
 
 .pm_recipient .pill-container {
@@ -96,20 +93,20 @@
     border: none;
     flex-grow: 1;
     align-content: center;
+}
 
-    .input {
-        height: 20px;
+.pm_recipient .pill-container .input {
+    height: 20px;
+}
 
-        &:first-child:empty::before {
-            content: attr(data-no-recipients-text);
-            opacity: 0.5;
-        }
-    }
+.pm_recipient .pill-container .input:first-child:empty::before {
+    content: attr(data-no-recipients-text);
+    opacity: 0.5;
+}
 
-    .pill + .input:empty::before {
-        content: attr(data-some-recipients-text);
-        opacity: 0.5;
-    }
+.pm_recipient .pill-container .pill + .input:empty::before {
+    content: attr(data-some-recipients-text);
+    opacity: 0.5;
 }
 
 .deactivated-pill {
@@ -119,11 +116,11 @@
 .add_subscribers_container .pill-container {
     width: 100%;
     background-color: hsl(0, 0%, 100%);
+}
 
-    .input:first-child:empty::before {
-        opacity: 0.5;
-        content: attr(data-placeholder);
-    }
+.add_subscribers_container .pill-container .input:first-child:empty::before {
+    opacity: 0.5;
+    content: attr(data-placeholder);
 }
 
 @keyframes shake {


### PR DESCRIPTION


Due to the Error of Long "person" type profile spilling out of input box,

 This commit uses CSS properties width, overflow, margin, text-overflow and whitespace to ensure that;
 1.  the input field expand up to the width of a "Long text" field, if needed.
 2.  A name is abbreviated  with a "..." if it's too long to fit at max width

![issue-21807](https://user-images.githubusercontent.com/100279189/164324462-d4a42069-a327-46e6-868a-38580b8f3af3.gif)


Fixes: zulip#21807

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
