### PR TITLE
Fix: Make "Remove" button in stream creation UI not red #21863

### DIFF
--- a/static/templates/stream_settings/new_stream_user.hbs
+++ b/static/templates/stream_settings/new_stream_user.hbs
@@ -9,6 +9,6 @@
     {{/if}}
     <td>{{user_id}} </td>
     <td>
-        <button {{#if disabled}} disabled="disabled"{{/if}} data-user-id="{{user_id}}" class="remove_potential_subscriber button small rounded btn-danger">{{t 'Remove' }}</button>
+        <button {{#if disabled}} disabled="disabled"{{/if}} data-user-id="{{user_id}}" class="remove_potential_subscriber button small white rounded ">{{t 'Remove' }}</button>
     </td>
 </tr>


### PR DESCRIPTION


<!-- Describe your pull request here.-->

Fixes: #21863 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![light](https://user-images.githubusercontent.com/75640645/164334248-8d232e9e-f323-49a3-b3df-8d7c07a243c7.jpg)
![Screenshot 2022-04-21 033820](https://user-images.githubusercontent.com/75640645/164334236-4dc4e5de-6153-485d-b160-607874415310.jpg)

**Self-review checklist**

Done the required changes

