### PR TITLE
typeahead: Apply some better behavior from mobile; test emoji typeahead more

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1546,23 +1546,34 @@ test("typeahead_results", () => {
         {emoji_name: "japanese_post_office", emoji_code: "1f3e3"},
     ]);
     assert_emoji_matches("notaemoji", []);
+
     // Autocomplete user mentions by user name.
     assert_mentions_matches("cordelia", [cordelia]);
     assert_mentions_matches("cordelia, le", [cordelia]);
     assert_mentions_matches("cordelia, le ", []);
+    assert_mentions_matches("moor", [othello]);
+    assert_mentions_matches("moor ", [othello]);
+    assert_mentions_matches("moor of", [othello]);
+    assert_mentions_matches("moor of ven", [othello]);
+    assert_mentions_matches("oor", [othello]);
+    assert_mentions_matches("oor ", []);
+    assert_mentions_matches("oor o", []);
+    assert_mentions_matches("oor of venice", []);
     assert_mentions_matches("King ", [hamlet, lear]);
     assert_mentions_matches("King H", [hamlet]);
     assert_mentions_matches("King L", [lear]);
     assert_mentions_matches("delia lear", []);
     assert_mentions_matches("Mark Tw", [twin1, twin2]);
+
     // Autocomplete user group mentions by group name.
     assert_mentions_matches("hamletchar", [hamletcharacters]);
+
     // Autocomplete user group mentions by group descriptions.
     assert_mentions_matches("characters ", [hamletcharacters]);
     assert_mentions_matches("characters of ", [hamletcharacters]);
     assert_mentions_matches("characters o ", []);
     assert_mentions_matches("haracters of hamlet", []);
-    assert_mentions_matches("of hamlet", []);
+    assert_mentions_matches("of hamlet", [hamletcharacters]);
 
     // Autocomplete by slash commands.
     assert_slash_matches("me", [me_slash]);

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -10,6 +10,13 @@ const typeahead = zrequire("../shared/js/typeahead");
 const unicode_emojis = [
     ["1f43c", "panda_face"],
     ["1f642", "smile"],
+    ["1f604", "big_smile"],
+    ["1f368", "ice_cream"],
+    ["1f366", "soft_ice_cream"],
+    ["1f6a5", "horizontal_traffic_light"],
+    ["1f6a6", "traffic_light"],
+    ["1f537", "large_blue_diamond"],
+    ["1f539", "small_blue_diamond"],
 ];
 
 const emojis = [
@@ -39,8 +46,8 @@ run_test("get_emoji_matcher", () => {
 
     assert_matches("da", ["panda_face", "tada"]);
     assert_matches("panda ", ["panda_face"]);
-    assert_matches("smil", ["smile"]);
-    assert_matches("mile", ["smile"]);
+    assert_matches("smil", ["big_smile", "smile"]);
+    assert_matches("mile", ["big_smile", "smile"]);
 
     assert_matches("japanese_post_", ["japanese_post_office"]);
     assert_matches("japanese post ", ["japanese_post_office"]);

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -50,6 +50,12 @@ run_test("get_emoji_matcher: misc matches", () => {
     assert_emoji_matches("japanese post ", ["japanese_post_office"]);
 });
 
+run_test("matches starting at non-first word, too", () => {
+    assert_emoji_matches("ice_cream", ["ice_cream", "soft_ice_cream"]);
+    assert_emoji_matches("blue_dia", ["large_blue_diamond", "small_blue_diamond"]);
+    assert_emoji_matches("traffic_", ["horizontal_traffic_light", "traffic_light"]);
+});
+
 run_test("triage", () => {
     const alice = {name: "alice"};
     const alicia = {name: "Alicia"};

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -189,3 +189,19 @@ run_test("sort_emojis: SM", () => {
         "big_smile",
     ]);
 });
+
+run_test("sort_emojis: prefix before midphrase, with underscore (traffic_li)", () => {
+    const emoji_list = [{emoji_name: "horizontal_traffic_light"}, {emoji_name: "traffic_light"}];
+    assert.deepEqual(sort_emojis(emoji_list, "traffic_li"), [
+        "traffic_light",
+        "horizontal_traffic_light",
+    ]);
+});
+
+run_test("sort_emojis: prefix before midphrase, with space (traffic li)", () => {
+    const emoji_list = [{emoji_name: "horizontal_traffic_light"}, {emoji_name: "traffic_light"}];
+    assert.deepEqual(sort_emojis(emoji_list, "traffic li"), [
+        "traffic_light",
+        "horizontal_traffic_light",
+    ]);
+});

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -7,18 +7,28 @@ const {run_test} = require("../zjsunit/test");
 
 const typeahead = zrequire("../shared/js/typeahead");
 
+const unicode_emojis = [
+    ["1f43c", "panda_face"],
+    ["1f642", "smile"],
+];
+
 const emojis = [
     {emoji_name: "japanese_post_office", url: "TBD"},
-    {emoji_name: "panda_face", emoji_code: "1f43c"},
-    {emoji_name: "smile", emoji_code: "1f642"},
     {emoji_name: "tada", random_field: "whatever"},
+    ...unicode_emojis.map(([emoji_code, emoji_name]) => ({
+        emoji_name,
+        emoji_code,
+    })),
 ];
 
 run_test("get_emoji_matcher", () => {
     function assert_matches(query, expected) {
         const matcher = typeahead.get_emoji_matcher(query);
         assert.deepEqual(
-            emojis.filter((emoji) => matcher(emoji)).map((emoji) => emoji.emoji_name),
+            emojis
+                .filter((emoji) => matcher(emoji))
+                .map((emoji) => emoji.emoji_name)
+                .sort(),
             expected,
         );
     }

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -10,27 +10,12 @@ const typeahead = zrequire("../shared/js/typeahead");
 // The data structures here may be different for
 // different apps; the only key thing is we look
 // at emoji_name and we'll return the entire structures.
-
-const emoji_japanese_post_office = {
-    emoji_name: "japanese_post_office",
-    url: "TBD",
-};
-
-const emoji_panda_face = {
-    emoji_name: "panda_face",
-    emoji_code: "1f43c",
-};
-
-const emoji_smile = {
-    emoji_name: "smile",
-};
-
-const emoji_tada = {
-    emoji_name: "tada",
-    random_field: "whatever",
-};
-
-const emojis = [emoji_japanese_post_office, emoji_panda_face, emoji_smile, emoji_tada];
+const emojis = [
+    {emoji_name: "japanese_post_office", url: "TBD"},
+    {emoji_name: "panda_face", emoji_code: "1f43c"},
+    {emoji_name: "smile"},
+    {emoji_name: "tada", random_field: "whatever"},
+];
 
 run_test("get_emoji_matcher", () => {
     function assert_matches(query, expected) {

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -28,32 +28,46 @@ const emojis = [
     })),
 ];
 
-function assert_emoji_matches(query, expected) {
+function emoji_matches(query) {
     const matcher = typeahead.get_emoji_matcher(query);
-    const matches = emojis.filter((emoji) => matcher(emoji));
-    assert.deepEqual(matches.map((emoji) => emoji.emoji_name).sort(), expected);
+    return emojis.filter((emoji) => matcher(emoji));
+}
+
+function assert_emoji_matches(query, expected) {
+    const names = emoji_matches(query).map((emoji) => emoji.emoji_name);
+    assert.deepEqual(names.sort(), expected);
 }
 
 run_test("get_emoji_matcher: nonmatches", () => {
     assert_emoji_matches("notaemoji", []);
     assert_emoji_matches("da_", []);
-    assert_emoji_matches("da ", []);
 });
 
 run_test("get_emoji_matcher: misc matches", () => {
     assert_emoji_matches("da", ["panda_face", "tada"]);
-    assert_emoji_matches("panda ", ["panda_face"]);
     assert_emoji_matches("smil", ["big_smile", "smile"]);
     assert_emoji_matches("mile", ["big_smile", "smile"]);
-
     assert_emoji_matches("japanese_post_", ["japanese_post_office"]);
-    assert_emoji_matches("japanese post ", ["japanese_post_office"]);
 });
 
 run_test("matches starting at non-first word, too", () => {
     assert_emoji_matches("ice_cream", ["ice_cream", "soft_ice_cream"]);
     assert_emoji_matches("blue_dia", ["large_blue_diamond", "small_blue_diamond"]);
     assert_emoji_matches("traffic_", ["horizontal_traffic_light", "traffic_light"]);
+});
+
+run_test("get_emoji_matcher: spaces equivalent to underscores", () => {
+    function assert_equivalent(query) {
+        assert.deepEqual(emoji_matches(query), emoji_matches(query.replace(" ", "_")));
+    }
+    assert_equivalent("da ");
+    assert_equivalent("panda ");
+    assert_equivalent("japanese post ");
+    assert_equivalent("ice ");
+    assert_equivalent("ice cream");
+    assert_equivalent("blue dia");
+    assert_equivalent("traffic ");
+    assert_equivalent("traffic l");
 });
 
 run_test("triage", () => {

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -145,48 +145,34 @@ run_test("triage", () => {
     );
 });
 
-run_test("sort_emojis th", () => {
-    const thumbs_up = {
-        emoji_name: "thumbs_up",
-        emoji_code: "1f44d",
-    };
-    const thumbs_down = {
-        emoji_name: "thumbs_down",
-    };
-    const thermometer = {
-        emoji_name: "thermometer",
-    };
-    const mother_nature = {
-        emoji_name: "mother_nature",
-    };
+function sort_emojis(emojis, query) {
+    return typeahead.sort_emojis(emojis, query).map((emoji) => emoji.emoji_name);
+}
 
-    const emoji_list = [mother_nature, thermometer, thumbs_down, thumbs_up];
-
-    assert.deepEqual(typeahead.sort_emojis(emoji_list, "th"), [
-        thumbs_up,
-        thermometer,
-        thumbs_down,
-        mother_nature,
+run_test("sort_emojis: th", () => {
+    const emoji_list = [
+        {emoji_name: "mother_nature"},
+        {emoji_name: "thermometer"},
+        {emoji_name: "thumbs_down"},
+        {emoji_name: "thumbs_up", emoji_code: "1f44d"},
+    ];
+    assert.deepEqual(sort_emojis(emoji_list, "th"), [
+        "thumbs_up",
+        "thermometer",
+        "thumbs_down",
+        "mother_nature",
     ]);
 });
 
-run_test("sort_emojis sm", () => {
-    const big_smile = {
-        emoji_name: "big_smile",
-    };
-    const slight_smile = {
-        emoji_name: "slight_smile",
-        emoji_code: "1f642",
-    };
-    const small_airplane = {
-        emoji_name: "small_airplane",
-    };
-
-    const emoji_list = [big_smile, slight_smile, small_airplane];
-
-    assert.deepEqual(typeahead.sort_emojis(emoji_list, "sm"), [
-        slight_smile,
-        small_airplane,
-        big_smile,
+run_test("sort_emojis: sm", () => {
+    const emoji_list = [
+        {emoji_name: "big_smile"},
+        {emoji_name: "slight_smile", emoji_code: "1f642"},
+        {emoji_name: "small_airplane"},
+    ];
+    assert.deepEqual(sort_emojis(emoji_list, "sm"), [
+        "slight_smile",
+        "small_airplane",
+        "big_smile",
     ]);
 });

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -176,3 +176,16 @@ run_test("sort_emojis: sm", () => {
         "big_smile",
     ]);
 });
+
+run_test("sort_emojis: SM", () => {
+    const emoji_list = [
+        {emoji_name: "big_smile"},
+        {emoji_name: "slight_smile", emoji_code: "1f642"},
+        {emoji_name: "small_airplane"},
+    ];
+    assert.deepEqual(sort_emojis(emoji_list, "SM"), [
+        "slight_smile",
+        "small_airplane",
+        "big_smile",
+    ]);
+});

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -36,7 +36,7 @@ run_test("get_emoji_matcher", () => {
     function assert_matches(query, expected) {
         const matcher = typeahead.get_emoji_matcher(query);
         assert.deepEqual(
-            emojis.filter((emoji) => matcher(emoji)),
+            emojis.filter((emoji) => matcher(emoji)).map((emoji) => emoji.emoji_name),
             expected,
         );
     }
@@ -45,13 +45,13 @@ run_test("get_emoji_matcher", () => {
     assert_matches("da_", []);
     assert_matches("da ", []);
 
-    assert_matches("da", [emoji_panda_face, emoji_tada]);
-    assert_matches("panda ", [emoji_panda_face]);
-    assert_matches("smil", [emoji_smile]);
-    assert_matches("mile", [emoji_smile]);
+    assert_matches("da", ["panda_face", "tada"]);
+    assert_matches("panda ", ["panda_face"]);
+    assert_matches("smil", ["smile"]);
+    assert_matches("mile", ["smile"]);
 
-    assert_matches("japanese_post_", [emoji_japanese_post_office]);
-    assert_matches("japanese post ", [emoji_japanese_post_office]);
+    assert_matches("japanese_post_", ["japanese_post_office"]);
+    assert_matches("japanese post ", ["japanese_post_office"]);
 });
 
 run_test("triage", () => {

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -7,13 +7,10 @@ const {run_test} = require("../zjsunit/test");
 
 const typeahead = zrequire("../shared/js/typeahead");
 
-// The data structures here may be different for
-// different apps; the only key thing is we look
-// at emoji_name and we'll return the entire structures.
 const emojis = [
     {emoji_name: "japanese_post_office", url: "TBD"},
     {emoji_name: "panda_face", emoji_code: "1f43c"},
-    {emoji_name: "smile"},
+    {emoji_name: "smile", emoji_code: "1f642"},
     {emoji_name: "tada", random_field: "whatever"},
 ];
 

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -28,29 +28,26 @@ const emojis = [
     })),
 ];
 
-run_test("get_emoji_matcher", () => {
-    function assert_matches(query, expected) {
-        const matcher = typeahead.get_emoji_matcher(query);
-        assert.deepEqual(
-            emojis
-                .filter((emoji) => matcher(emoji))
-                .map((emoji) => emoji.emoji_name)
-                .sort(),
-            expected,
-        );
-    }
+function assert_emoji_matches(query, expected) {
+    const matcher = typeahead.get_emoji_matcher(query);
+    const matches = emojis.filter((emoji) => matcher(emoji));
+    assert.deepEqual(matches.map((emoji) => emoji.emoji_name).sort(), expected);
+}
 
-    assert_matches("notaemoji", []);
-    assert_matches("da_", []);
-    assert_matches("da ", []);
+run_test("get_emoji_matcher: nonmatches", () => {
+    assert_emoji_matches("notaemoji", []);
+    assert_emoji_matches("da_", []);
+    assert_emoji_matches("da ", []);
+});
 
-    assert_matches("da", ["panda_face", "tada"]);
-    assert_matches("panda ", ["panda_face"]);
-    assert_matches("smil", ["big_smile", "smile"]);
-    assert_matches("mile", ["big_smile", "smile"]);
+run_test("get_emoji_matcher: misc matches", () => {
+    assert_emoji_matches("da", ["panda_face", "tada"]);
+    assert_emoji_matches("panda ", ["panda_face"]);
+    assert_emoji_matches("smil", ["big_smile", "smile"]);
+    assert_emoji_matches("mile", ["big_smile", "smile"]);
 
-    assert_matches("japanese_post_", ["japanese_post_office"]);
-    assert_matches("japanese post ", ["japanese_post_office"]);
+    assert_emoji_matches("japanese_post_", ["japanese_post_office"]);
+    assert_emoji_matches("japanese post ", ["japanese_post_office"]);
 });
 
 run_test("triage", () => {

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -44,27 +44,10 @@ function query_matches_string(query, source_str, split_char) {
     }
 
     // If there is a separator character in the query, then we
-    // require a perfect prefix match (e.g. for 'ab cd ef',
-    // query needs to be e.g. 'ab c', not 'cd ef' or 'b cd
-    // ef', etc.).
-
-    const queries = query.split(split_char);
-    const sources = source_str.split(split_char);
-    let i;
-
-    for (i = 0; i < queries.length - 1; i += 1) {
-        if (sources[i] !== queries[i]) {
-            return false;
-        }
-    }
-
-    // This block is effectively a final iteration of the last
-    // loop.  What differs is that for the last word, a
-    // partial match at the beginning of the word is OK.
-    if (sources[i] === undefined) {
-        return false;
-    }
-    return sources[i].startsWith(queries[i]);
+    // require the match to start at the start of a token.
+    // (E.g. for 'ab cd ef', query could be 'ab c' or 'cd ef',
+    // but not 'b cd ef'.)
+    return source_str.startsWith(query) || source_str.includes(split_char + query);
 }
 
 // This function attempts to match a query with source's attributes.

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -82,7 +82,7 @@ export function clean_query_lowercase(query) {
 }
 
 export function get_emoji_matcher(query) {
-    // replaces spaces with underscores for emoji matching
+    // replace spaces with underscores for emoji matching
     query = query.replace(/ /g, "_");
     query = clean_query_lowercase(query);
 
@@ -131,6 +131,8 @@ export function triage(query, objs, get_item = (x) => x) {
 }
 
 export function sort_emojis(objs, query) {
+    // replace spaces with underscores for emoji matching
+    query = query.replace(/ /g, "_");
     query = query.toLowerCase();
 
     function decent_match(name) {

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -37,34 +37,34 @@ export function remove_diacritics(s) {
 function query_matches_string(query, source_str, split_char) {
     source_str = remove_diacritics(source_str);
 
-    // If query doesn't contain a separator, we just want an exact
-    // match where query is a substring of one of the target characters.
-    if (query.indexOf(split_char) > 0) {
-        // If there's a whitespace character in the query, then we
-        // require a perfect prefix match (e.g. for 'ab cd ef',
-        // query needs to be e.g. 'ab c', not 'cd ef' or 'b cd
-        // ef', etc.).
-        const queries = query.split(split_char);
-        const sources = source_str.split(split_char);
-        let i;
-
-        for (i = 0; i < queries.length - 1; i += 1) {
-            if (sources[i] !== queries[i]) {
-                return false;
-            }
-        }
-
-        // This block is effectively a final iteration of the last
-        // loop.  What differs is that for the last word, a
-        // partial match at the beginning of the word is OK.
-        if (sources[i] === undefined) {
-            return false;
-        }
-        return sources[i].startsWith(queries[i]);
+    if (!query.includes(split_char)) {
+        // If query is a single token (doesn't contain a separator),
+        // the match can be anywhere in the string.
+        return source_str.includes(query);
     }
 
-    // For a single token, the match can be anywhere in the string.
-    return source_str.includes(query);
+    // If there is a separator character in the query, then we
+    // require a perfect prefix match (e.g. for 'ab cd ef',
+    // query needs to be e.g. 'ab c', not 'cd ef' or 'b cd
+    // ef', etc.).
+
+    const queries = query.split(split_char);
+    const sources = source_str.split(split_char);
+    let i;
+
+    for (i = 0; i < queries.length - 1; i += 1) {
+        if (sources[i] !== queries[i]) {
+            return false;
+        }
+    }
+
+    // This block is effectively a final iteration of the last
+    // loop.  What differs is that for the last word, a
+    // partial match at the beginning of the word is OK.
+    if (sources[i] === undefined) {
+        return false;
+    }
+    return sources[i].startsWith(queries[i]);
 }
 
 // This function attempts to match a query with source's attributes.

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -131,11 +131,11 @@ export function triage(query, objs, get_item = (x) => x) {
 }
 
 export function sort_emojis(objs, query) {
-    const lowerQuery = query.toLowerCase();
+    query = query.toLowerCase();
 
     function decent_match(name) {
         const pieces = name.toLowerCase().split("_");
-        return pieces.some((piece) => piece.startsWith(lowerQuery));
+        return pieces.some((piece) => piece.startsWith(query));
     }
 
     const popular_set = new Set(popular_emojis);


### PR DESCRIPTION
The two non-test, non-NFC commits here are:

---

typeahead: Don't stop midphrase matching when a second word is typed.

For example, if a user's name is "Simon Peyton Jones", we'll already
match that name on the queries "Pey" or "Peyton", as well as on
"Simon P".  We should do so on "Peyton J" or "Peyton Jones", too.

Similarly, if the user is looking for an emoji of a face in the moon
and they start by typing ":moon", we'll show them both 🌝 "moon face"
and 🌚 "new moon face", along with some other moon-related results.
If they go on to make it ":moon " or ":moon f", though -- as one very
naturally would in order to eliminate things like "waxing moon" and
"moon ceremony" -- then we mysteriously eliminate 🌚 "new moon face".
Instead, the query "moon f" should match both 🌚 and 🌝.

Found this while comparing the web/shared implementation with the
mobile implementation of emoji search.  The new behavior here
reflects what we already do for emoji search in mobile, both in the
compose box's typeahead and in the add-a-reaction screen.  The
existing behavior here seems pretty annoying, so fixing it will be
part of switching on mobile to the shared code (zulip/zulip-mobile#4636)
without regressing the user experience.

---

typeahead: Normalize spaces for sorting emojis, just like for filtering.

And add a pair of tests.  The first one (with an underscore) passed
already; the second (with a space) passes only with this change.

---

We also add more tests for existing behavior.

This doesn't cover matching an emoji literally, as in #21714. It looks like #21778 will cover that, and in the meantime mobile can continue to do that part for itself -- it's only an extra line or two of code.


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
