### PR TITLE
Fix: Users tab in mobile widths

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1785,6 +1785,7 @@ input[type="checkbox"] {
 
 #admin-user-list .last_active {
     width: 100px;
+    display: none;
 }
 
 .required-text {


### PR DESCRIPTION
This PR:

- is resolving the way users are looking in mobile screen width and hiding "Last active" Column in Organization settings.

- which is based on CSS property.

- Hiding "Last active" column in Organization settings > Users tab in mobile widths



Fixes: https://github.com/zulip/zulip/issues/19090

**Screenshots and screen captures:**


![fix issue](https://user-images.githubusercontent.com/76876709/164494673-1759ded3-171f-4474-8c2f-0e7d56e705b3.png)

