### PR TITLE
tests: Improve error output for openapi validation tests.

### DIFF
--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -517,6 +517,12 @@ the setting enabled).
 Visit Zulip's [Django testing](../testing/testing-with-django.md)
 documentation to learn more about the backend testing framework.
 
+Also note that you may already need to update the API documentation for
+your new feature to pass new or existing backend tests at this point.
+The tutorial for [writing REST API endpoints](../documentation/api.md)
+can be a helpful resource, especially the section on [debugging schema
+validation errors](../documentation//api.md#debugging-schema-validation-errors).
+
 ### Update the frontend
 
 After completing the process of adding a new feature on the backend,

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -474,7 +474,18 @@ def validate_against_openapi_schema(
                     validator_value=brief_error_validator_value,
                     cause=error.cause,
                 )
+            # Some endpoints have long, descriptive OpenAPI schemas
+            # which, when printed to the console, do not assist with
+            # debugging, so we omit some of the error information.
+            if path in ["/register"] and isinstance(error, JsonSchemaValidationError):
+                error.schema = "OpenAPI schema omitted due to length of output."
+                if len(error.instance) > 100:
+                    error.instance = "Error instance omitted due to length of output."
             message += f"\n\n{type(error).__name__}: {error}"
+        message += (
+            "\n\nFor help debugging these errors see: "
+            "https://zulip.readthedocs.io/en/latest/documentation/api.html#debugging-schema-validation-errors"
+        )
         raise SchemaError(message) from None
 
     return True


### PR DESCRIPTION
For descriptive endpoints, such as the `/register-queue`, instead of printing the entire endpoint schema and error instance to the console when there is an error while running a test that uses `validate_against_openapi_schema`, the schema is omitted and the instance is omitted if it is a jsonschema object with more than 100 properties.

Currently, this will only change the test error output for the `/register-queue` endpoint, but it's set up so that more endpoints can be added if / when they are identified to have a similar issue in their error output. Other modifications have already been done to this function's error output for the other known endpoint with a long, descriptive schema (`/get-events`), so it is also not included in this change.

See [this CZO conversation](https://chat.zulip.org/#narrow/stream/49-development-help/topic/Log.20not.20found.20error/near/1367381) for more context. The goal is to follow-up this change with either some debugging guidance in the development community documentation for writing / updating API documentation or improving the error schema output to be relevant information.

Here's [a link to a Zulip CI run](https://github.com/zulip/zulip/actions/runs/2140285034) with this error prior to this change.

Here's what the console output for a similar error would be with this change:
```console
Waiting for children to stop...
Traceback (most recent call last):
  File "tools/test-api", line 93, in <module>
    test_the_api(client, nonadmin_client, owner_client)
  File "/srv/zulip/zerver/openapi/python_examples.py", line 1560, in test_the_api
    test_queues(client)
  File "/srv/zulip/zerver/openapi/python_examples.py", line 1530, in test_queues
    register_queue_all_events(client)
  File "/srv/zulip/zerver/openapi/python_examples.py", line 1134, in register_queue_all_events
    validate_against_openapi_schema(result, "/register", "post", "200")
  File "/srv/zulip/zerver/openapi/openapi.py", line 495, in validate_against_openapi_schema
    raise SchemaError(message) from None
zerver.openapi.openapi.SchemaError: 2 response validation error(s) at post /api/v1/register (200):

ValidationError: Additional properties are not allowed ('display_emoji_reaction_users' was unexpected)

Failed validating 'additionalProperties' in schema['allOf'][2]['properties']['user_settings']:
    'OpenAPI schema omitted due to length of output.'

On instance['user_settings']:
    {'available_notification_sounds': ['ascend',
                                       'beep_boop',
                                       'bink',
                                       'bright',
                                       'brlip',
                                       'chime',
                                       'deep tom',
                                       'ding',
                                       'double tap',
                                       'down',
                                       'dry bongos',
                                       'dutdut',
                                       'fast ascend',
                                       'flute',
                                       'friendly',
                                       'kick roll',
                                       'loud tintong',
                                       'metallic snare',
                                       'pan',
                                       'shaker',
                                       'simple',
                                       'stairs',
                                       'subtle',
                                       'swish',
                                       'tintong',
                                       'up',
                                       'wood block',
                                       'zaping',
                                       'zing',
                                       'zulip'],
     'color_scheme': 1,
     'default_language': 'en',
     'default_view': 'recent_topics',
     'demote_inactive_streams': 1,
     'dense_mode': True,
     'desktop_icon_count_display': 1,
     'display_emoji_reaction_users': True,
     'email_notifications_batching_period_seconds': 120,
     'emojiset': 'google',
     'emojiset_choices': [{'key': 'google', 'text': 'Google modern'},
                          {'key': 'google-blob', 'text': 'Google classic'},
                          {'key': 'twitter', 'text': 'Twitter'},
                          {'key': 'text', 'text': 'Plain text'}],
     'enable_desktop_notifications': True,
     'enable_digest_emails': True,
     'enable_drafts_synchronization': True,
     'enable_login_emails': True,
     'enable_marketing_emails': True,
     'enable_offline_email_notifications': True,
     'enable_offline_push_notifications': True,
     'enable_online_push_notifications': True,
     'enable_sounds': True,
     'enable_stream_audible_notifications': False,
     'enable_stream_desktop_notifications': False,
     'enable_stream_email_notifications': False,
     'enable_stream_push_notifications': False,
     'enter_sends': True,
     'escape_navigates_to_default_view': True,
     'fluid_layout_width': False,
     'high_contrast_mode': False,
     'left_side_userlist': False,
     'message_content_in_email_notifications': True,
     'notification_sound': 'zulip',
     'pm_content_in_desktop_notifications': True,
     'presence_enabled': True,
     'realm_name_in_notifications': False,
     'send_private_typing_notifications': True,
     'send_read_receipts': True,
     'send_stream_typing_notifications': True,
     'starred_message_counts': True,
     'timezone': 'America/New_York',
     'translate_emoticons': False,
     'twenty_four_hour_time': False,
     'wildcard_mentions_notify': True}

ValidationError: Additional properties are not allowed ('display_emoji_reaction_users' was unexpected)

Failed validating 'additionalProperties' in schema['allOf'][2]['properties']['realm_user_settings_defaults']:
    'OpenAPI schema omitted due to length of output.'

On instance['realm_user_settings_defaults']:
    {'available_notification_sounds': ['ascend',
                                       'beep_boop',
                                       'bink',
                                       'bright',
                                       'brlip',
                                       'chime',
                                       'deep tom',
                                       'ding',
                                       'double tap',
                                       'down',
                                       'dry bongos',
                                       'dutdut',
                                       'fast ascend',
                                       'flute',
                                       'friendly',
                                       'kick roll',
                                       'loud tintong',
                                       'metallic snare',
                                       'pan',
                                       'shaker',
                                       'simple',
                                       'stairs',
                                       'subtle',
                                       'swish',
                                       'tintong',
                                       'up',
                                       'wood block',
                                       'zaping',
                                       'zing',
                                       'zulip'],
     'color_scheme': 1,
     'default_language': 'en',
     'default_view': 'recent_topics',
     'demote_inactive_streams': 1,
     'dense_mode': True,
     'desktop_icon_count_display': 1,
     'display_emoji_reaction_users': True,
     'email_notifications_batching_period_seconds': 120,
     'emojiset': 'google',
     'emojiset_choices': [{'key': 'google', 'text': 'Google modern'},
                          {'key': 'google-blob', 'text': 'Google classic'},
                          {'key': 'twitter', 'text': 'Twitter'},
                          {'key': 'text', 'text': 'Plain text'}],
     'enable_desktop_notifications': True,
     'enable_digest_emails': True,
     'enable_drafts_synchronization': True,
     'enable_login_emails': True,
     'enable_marketing_emails': True,
     'enable_offline_email_notifications': True,
     'enable_offline_push_notifications': True,
     'enable_online_push_notifications': True,
     'enable_sounds': True,
     'enable_stream_audible_notifications': False,
     'enable_stream_desktop_notifications': False,
     'enable_stream_email_notifications': False,
     'enable_stream_push_notifications': False,
     'enter_sends': False,
     'escape_navigates_to_default_view': True,
     'fluid_layout_width': False,
     'high_contrast_mode': False,
     'left_side_userlist': False,
     'message_content_in_email_notifications': True,
     'notification_sound': 'zulip',
     'pm_content_in_desktop_notifications': True,
     'presence_enabled': True,
     'realm_name_in_notifications': False,
     'send_private_typing_notifications': True,
     'send_read_receipts': True,
     'send_stream_typing_notifications': True,
     'starred_message_counts': True,
     'translate_emoticons': False,
     'twenty_four_hour_time': False,
     'wildcard_mentions_notify': True}

```

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
