### PR TITLE
custom_profile_fields: Make "Add and Edit custom profile field" form into modals.

### DIFF
--- a/frontend_tests/puppeteer_tests/custom-profile.ts
+++ b/frontend_tests/puppeteer_tests/custom-profile.ts
@@ -9,18 +9,24 @@ const profile_field_row = "#admin_profile_fields_table tr:nth-last-child(2)";
 const profile_field_form = "#admin_profile_fields_table tr:nth-last-child(1)";
 
 async function test_add_new_profile_field(page: Page): Promise<void> {
+    await page.click("#add-custom-profile-field-btn");
+    await common.wait_for_micromodal_to_open(page);
+    assert.strictEqual(
+        await common.get_text_from_selector(page, ".dialog_heading"),
+        "Add a new custom profile field",
+    );
+    assert.strictEqual(
+        await common.get_text_from_selector(page, "#dialog_widget_modal .dialog_submit_button"),
+        "Add",
+    );
     await page.waitForSelector(".admin-profile-field-form", {visible: true});
     await common.fill_form(page, "form.admin-profile-field-form", {
         name: "Teams",
         field_type: "1",
     });
-    await page.click("form.admin-profile-field-form button[type='submit']");
+    await page.click("#dialog_widget_modal .dialog_submit_button");
+    await common.wait_for_micromodal_to_close(page);
 
-    await page.waitForSelector("#admin-add-profile-field-status img", {visible: true});
-    assert.strictEqual(
-        await common.get_text_from_selector(page, "div#admin-add-profile-field-status"),
-        "Saved",
-    );
     await page.waitForXPath(
         '//*[@id="admin_profile_fields_table"]//tr[last()-1]/td[normalize-space()="Teams"]',
     );

--- a/frontend_tests/puppeteer_tests/custom-profile.ts
+++ b/frontend_tests/puppeteer_tests/custom-profile.ts
@@ -4,9 +4,8 @@ import type {Page} from "puppeteer";
 
 import common from "../puppeteer_lib/common";
 
-// These will be the row and edit form of the the custom profile we add.
-const profile_field_row = "#admin_profile_fields_table tr:nth-last-child(2)";
-const profile_field_form = "#admin_profile_fields_table tr:nth-last-child(1)";
+// This will be the row of the the custom profile field we add.
+const profile_field_row = "#admin_profile_fields_table tr:nth-last-child(1)";
 
 async function test_add_new_profile_field(page: Page): Promise<void> {
     await page.click("#add-custom-profile-field-btn");
@@ -28,7 +27,7 @@ async function test_add_new_profile_field(page: Page): Promise<void> {
     await common.wait_for_micromodal_to_close(page);
 
     await page.waitForXPath(
-        '//*[@id="admin_profile_fields_table"]//tr[last()-1]/td[normalize-space()="Teams"]',
+        '//*[@id="admin_profile_fields_table"]//tr[last()]/td[normalize-space()="Teams"]',
     );
     assert.strictEqual(
         await common.get_text_from_selector(page, `${profile_field_row} span.profile_field_type`),
@@ -37,16 +36,24 @@ async function test_add_new_profile_field(page: Page): Promise<void> {
 }
 
 async function test_edit_profile_field(page: Page): Promise<void> {
-    await page.click(`${profile_field_row} button.open-edit-form`);
-    await page.waitForSelector(`${profile_field_form} form.name-setting`, {visible: true});
-    await common.fill_form(page, `${profile_field_form} form.name-setting`, {
+    await page.click(`${profile_field_row} button.open-edit-form-modal`);
+    await common.wait_for_micromodal_to_open(page);
+    assert.strictEqual(
+        await common.get_text_from_selector(page, ".dialog_heading"),
+        "Edit custom profile field",
+    );
+    assert.strictEqual(
+        await common.get_text_from_selector(page, "#dialog_widget_modal .dialog_submit_button"),
+        "Save changes",
+    );
+    await common.fill_form(page, "form.name-setting", {
         name: "team",
     });
-    await page.click(`${profile_field_form} button.submit`);
+    await page.click("#dialog_widget_modal .dialog_submit_button");
+    await common.wait_for_micromodal_to_close(page);
 
-    await page.waitForSelector("#admin-profile-field-status img", {visible: true});
     await page.waitForXPath(
-        '//*[@id="admin_profile_fields_table"]//tr[last()-1]/td[normalize-space()="team"]',
+        '//*[@id="admin_profile_fields_table"]//tr[last()]/td[normalize-space()="team"]',
     );
     assert.strictEqual(
         await common.get_text_from_selector(page, `${profile_field_row} span.profile_field_type`),

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -147,8 +147,8 @@ function create_choice_row(container) {
 }
 
 function clear_form_data() {
-    $("#profile_field_name").val("").closest(".control-group").show();
-    $("#profile_field_hint").val("").closest(".control-group").show();
+    $("#profile_field_name").val("").closest(".input-group").show();
+    $("#profile_field_hint").val("").closest(".input-group").show();
     // Set default type "Short text" in field type dropdown
     $("#profile_field_type").val(field_types.SHORT_TEXT.id);
     // Clear data from select field form
@@ -173,16 +173,16 @@ function set_up_create_field_form() {
         $field_elem.show();
         if ($("#profile_field_external_accounts_type").val() === "custom") {
             $field_url_pattern_elem.show();
-            $("#profile_field_name").val("").closest(".control-group").show();
-            $("#profile_field_hint").val("").closest(".control-group").show();
+            $("#profile_field_name").val("").closest(".input-group").show();
+            $("#profile_field_hint").val("").closest(".input-group").show();
         } else {
             $field_url_pattern_elem.hide();
-            $("#profile_field_name").closest(".control-group").hide();
-            $("#profile_field_hint").closest(".control-group").hide();
+            $("#profile_field_name").closest(".input-group").hide();
+            $("#profile_field_hint").closest(".input-group").hide();
         }
     } else {
-        $("#profile_field_name").closest(".control-group").show();
-        $("#profile_field_hint").closest(".control-group").show();
+        $("#profile_field_name").closest(".input-group").show();
+        $("#profile_field_hint").closest(".input-group").show();
         $field_url_pattern_elem.hide();
         $field_elem.hide();
     }

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -233,6 +233,7 @@ function open_custom_profile_field_form_modal() {
     }
 
     dialog_widget.launch({
+        form_id: "add-new-custom-profile-field-form",
         help_link: "/help/add-custom-profile-fields",
         html_heading: $t_html({defaultMessage: "Add a new custom profile field"}),
         html_body,

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -4,6 +4,7 @@ import {Sortable} from "sortablejs";
 import render_confirm_delete_profile_field_option from "../templates/confirm_dialog/confirm_delete_profile_field_option.hbs";
 import render_add_new_custom_profile_field_form from "../templates/settings/add_new_custom_profile_field_form.hbs";
 import render_admin_profile_field_list from "../templates/settings/admin_profile_field_list.hbs";
+import render_edit_custom_profile_field_form from "../templates/settings/edit_custom_profile_field_form.hbs";
 import render_settings_profile_field_choice from "../templates/settings/profile_field_choice.hbs";
 
 import * as channel from "./channel";
@@ -336,50 +337,62 @@ function set_up_select_field_edit_form($profile_field_form, field_data) {
     });
 }
 
-function open_edit_form(e) {
+function open_edit_form_modal(e) {
     const field_id = Number.parseInt($(e.currentTarget).attr("data-profile-field-id"), 10);
-    const $profile_field_row = $(
-        `tr.profile-field-row[data-profile-field-id='${CSS.escape(field_id)}']`,
-    );
-    const $profile_field_form = $(
-        `tr.profile-field-form[data-profile-field-id='${CSS.escape(field_id)}']`,
-    );
-
-    $profile_field_row.hide();
-    $profile_field_form.show();
     const field = get_profile_field(field_id);
+
     let field_data = {};
     if (field.field_data) {
         field_data = JSON.parse(field.field_data);
     }
-
-    if (Number.parseInt(field.type, 10) === field_types.SELECT.id) {
-        set_up_select_field_edit_form($profile_field_form, field_data);
+    let choices = [];
+    if (field.type === field_types.SELECT.id) {
+        choices = parse_field_choices_from_field_data(field_data);
     }
 
-    if (Number.parseInt(field.type, 10) === field_types.EXTERNAL_ACCOUNT.id) {
-        $profile_field_form.find("select[name=external_acc_field_type]").val(field_data.subtype);
-        set_up_external_account_field_edit_form($profile_field_form, field_data.url_pattern);
-    }
-
-    // Set initial value in edit form
-    $profile_field_form.find("input[name=name]").val(field.name);
-    $profile_field_form.find("input[name=hint]").val(field.hint);
-
-    $profile_field_form.find(".reset").on("click", () => {
-        // If we do not turn off the click handler, the code is called twice in case
-        // when the edit form is closed and then opened again. And in such case two
-        // modals are opened and one of them is shown randomly.
-        $profile_field_form.find(".submit").off("click");
-        $profile_field_form.hide();
-        $profile_field_row.show();
+    const html_body = render_edit_custom_profile_field_form({
+        profile_field_info: {
+            id: field.id,
+            name: field.name,
+            hint: field.hint,
+            choices,
+            is_select_field: field.type === field_types.SELECT.id,
+            is_external_account_field: field.type === field_types.EXTERNAL_ACCOUNT.id,
+        },
+        realm_default_external_accounts: page_params.realm_default_external_accounts,
     });
 
-    $profile_field_form.find(".submit").on("click", () => {
-        e.preventDefault();
-        e.stopPropagation();
+    function set_initial_values_of_profile_field() {
+        const $profile_field_form = $("#edit-custom-profile-field-form-" + field_id);
 
-        const $profile_field_status = $("#admin-profile-field-status").expectOne();
+        if (Number.parseInt(field.type, 10) === field_types.SELECT.id) {
+            set_up_select_field_edit_form($profile_field_form, field_data);
+        }
+
+        if (Number.parseInt(field.type, 10) === field_types.EXTERNAL_ACCOUNT.id) {
+            $profile_field_form
+                .find("select[name=external_acc_field_type]")
+                .val(field_data.subtype);
+            set_up_external_account_field_edit_form($profile_field_form, field_data.url_pattern);
+        }
+
+        // Set initial value in edit form
+        $profile_field_form.find("input[name=name]").val(field.name);
+        $profile_field_form.find("input[name=hint]").val(field.hint);
+
+        $profile_field_form
+            .find(".edit_profile_field_choices_container")
+            .on("input", ".choice-row input", add_choice_row);
+        $profile_field_form
+            .find(".edit_profile_field_choices_container")
+            .on("click", "button.delete-choice", delete_choice_row);
+        $(".profile_field_external_accounts_edit select").on("change", () => {
+            set_up_external_account_field_edit_form($profile_field_form, "");
+        });
+    }
+
+    function submit_form() {
+        const $profile_field_form = $("#edit-custom-profile-field-form-" + field_id);
 
         // For some reason jQuery's serialize() is not working with
         // channel.patch even though it is supported by $.ajax.
@@ -396,12 +409,8 @@ function open_edit_form(e) {
         data.field_data = JSON.stringify(new_field_data);
 
         function update_profile_field() {
-            settings_ui.do_settings_change(
-                channel.patch,
-                "/json/realm/profile_fields/" + field_id,
-                data,
-                $profile_field_status,
-            );
+            const url = "/json/realm/profile_fields/" + field_id;
+            dialog_widget.submit_api_request(channel.patch, url, data);
         }
 
         if (field.type === field_types.SELECT.id) {
@@ -412,29 +421,24 @@ function open_edit_form(e) {
             );
 
             if (deleted_values.size !== 0) {
-                show_modal_for_deleting_options(field, deleted_values, update_profile_field);
+                const edit_select_field_modal_callback = () =>
+                    show_modal_for_deleting_options(field, deleted_values, update_profile_field);
+                dialog_widget.close_modal(edit_select_field_modal_callback);
                 return;
             }
         }
 
         update_profile_field();
-    });
+    }
 
-    $profile_field_form
-        .find(".edit_profile_field_choices_container")
-        .on("input", ".choice-row input", add_choice_row);
-    $profile_field_form
-        .find(".edit_profile_field_choices_container")
-        .on("click", "button.delete-choice", delete_choice_row);
-    $(".profile_field_external_accounts_edit select").on("change", (e) => {
-        const field_id = Number.parseInt(
-            $(e.target).closest(".profile-field-form").attr("data-profile-field-id"),
-            10,
-        );
-        const $profile_field_form = $(
-            `tr.profile-field-form[data-profile-field-id='${CSS.escape(field_id)}']`,
-        );
-        set_up_external_account_field_edit_form($profile_field_form, "");
+    const edit_custom_profile_field_form_id = "edit-custom-profile-field-form-" + field_id;
+    dialog_widget.launch({
+        form_id: edit_custom_profile_field_form_id,
+        html_heading: $t_html({defaultMessage: "Edit custom profile field"}),
+        html_body,
+        on_click: submit_form,
+        post_render: set_initial_values_of_profile_field,
+        loading_spinner: true,
     });
 }
 
@@ -585,5 +589,5 @@ export function build_page() {
 
     $("#admin_profile_fields_table").on("click", ".delete", delete_profile_field);
     $("#add-custom-profile-field-btn").on("click", open_custom_profile_field_form_modal);
-    $("#admin_profile_fields_table").on("click", ".open-edit-form", open_edit_form);
+    $("#admin_profile_fields_table").on("click", ".open-edit-form-modal", open_edit_form_modal);
 }

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -295,11 +295,11 @@ function set_up_external_account_field_edit_form(field_elem, url_pattern_val) {
     if (field_elem.$form.find("select[name=external_acc_field_type]").val() === "custom") {
         field_elem.$form.find("input[name=url_pattern]").val(url_pattern_val);
         field_elem.$form.find(".custom_external_account_detail").show();
-        field_elem.$form.find("input[name=name]").val("").closest(".control-group").show();
-        field_elem.$form.find("input[name=hint]").val("").closest(".control-group").show();
+        field_elem.$form.find("input[name=name]").val("").closest(".input-group").show();
+        field_elem.$form.find("input[name=hint]").val("").closest(".input-group").show();
     } else {
-        field_elem.$form.find("input[name=name]").closest(".control-group").hide();
-        field_elem.$form.find("input[name=hint]").closest(".control-group").hide();
+        field_elem.$form.find("input[name=name]").closest(".input-group").hide();
+        field_elem.$form.find("input[name=hint]").closest(".input-group").hide();
         field_elem.$form.find(".custom_external_account_detail").hide();
     }
 }

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -518,6 +518,11 @@ input[type="checkbox"] {
     margin-top: 4px;
 }
 
+#add-custom-profile-field-btn {
+    float: right;
+    margin-top: 4px;
+}
+
 #user-notification-settings {
     .notification-table {
         th,
@@ -626,7 +631,6 @@ input[type="checkbox"] {
     vertical-align: middle;
 }
 
-.add-new-profile-field-box,
 .add-new-linkifier-box,
 .add-new-playground-box {
     button {
@@ -1595,14 +1599,14 @@ input[type="checkbox"] {
     }
 
     .choice-row {
-        margin-top: 5px;
+        margin-top: 8px;
 
         input {
             width: 190px;
         }
 
         button {
-            margin-left: 0 !important;
+            margin-left: 2px;
         }
     }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -644,6 +644,7 @@ input[type="checkbox"] {
 }
 
 .admin_profile_fields_table,
+.edit_profile_field_choices_container,
 .profile_field_choices_table {
     .movable-profile-field-row {
         cursor: move;

--- a/static/templates/settings/add_new_custom_profile_field_form.hbs
+++ b/static/templates/settings/add_new_custom_profile_field_form.hbs
@@ -1,0 +1,40 @@
+<form class="form-horizontal admin-profile-field-form new-style">
+    <div class="new-profile-field-form wrapper">
+        <div class="input-group">
+            <label for="profile_field_type" >{{t "Type" }}</label>
+            <select id="profile_field_type" name="field_type">
+                {{#each custom_profile_field_types}}
+                    <option value='{{this.id}}'>{{this.name}}</option>
+                {{/each}}
+            </select>
+        </div>
+        <div class="input-group" id="profile_field_external_accounts">
+            <label for="profile_field_external_accounts_type" >{{t "External account type" }}</label>
+            <select id="profile_field_external_accounts_type" name="external_acc_field_type">
+                {{#each realm_default_external_accounts}}
+                    <option value='{{@key}}'>{{this.text}}</option>
+                {{/each}}
+                <option value="custom">{{t 'Custom' }}</option>
+            </select>
+        </div>
+        <div class="input-group">
+            <label for="profile_field_name" >{{t "Label" }}</label>
+            <input type="text" id="profile_field_name" name="name" autocomplete="off" maxlength="40" />
+        </div>
+        <div class="input-group">
+            <label for="profile_field_hint" >{{t "Hint (up to 80 characters)" }}</label>
+            <input type="text" id="profile_field_hint" name="hint" autocomplete="off" maxlength="80" />
+            <div class="alert" id="admin-profile-field-hint-status"></div>
+        </div>
+        <div class="input-group" id="profile_field_choices_row">
+            <label for="profile_field_choices" >{{t "Field choices" }}</label>
+            <table class="profile_field_choices_table">
+                <tbody id="profile_field_choices" class="profile-field-choices"></tbody>
+            </table>
+        </div>
+        <div class="input-group" id="custom_external_account_url_pattern">
+            <label for="custom_field_url_pattern" >{{t "URL pattern" }}</label>
+            <input type="url" id="custom_field_url_pattern" name="url_pattern" autocomplete="off" maxlength="1024" placeholder="https://example.com/path/%(username)s"/>
+        </div>
+    </div>
+</form>

--- a/static/templates/settings/add_new_custom_profile_field_form.hbs
+++ b/static/templates/settings/add_new_custom_profile_field_form.hbs
@@ -1,4 +1,4 @@
-<form class="form-horizontal admin-profile-field-form new-style">
+<form class="form-horizontal admin-profile-field-form new-style" id="add-new-custom-profile-field-form">
     <div class="new-profile-field-form wrapper">
         <div class="input-group">
             <label for="profile_field_type" >{{t "Type" }}</label>

--- a/static/templates/settings/admin_profile_field_list.hbs
+++ b/static/templates/settings/admin_profile_field_list.hbs
@@ -15,7 +15,7 @@
     </td>
     {{#if ../can_modify}}
     <td>
-        <button class="button rounded small btn-warning open-edit-form" title="{{t 'Edit' }}" data-profile-field-id="{{id}}">
+        <button class="button rounded small btn-warning open-edit-form-modal" title="{{t 'Edit' }}" data-profile-field-id="{{id}}">
             <i class="fa fa-pencil" aria-hidden="true"></i>
         </button>
         <button class="button rounded small delete btn-danger" title="{{t 'Delete' }}" data-profile-field-id="{{id}}">
@@ -23,55 +23,5 @@
         </button>
     </td>
     {{/if}}
-</tr>
-<tr class="profile-field-form" data-profile-field-id="{{id}}" style="display: none;">
-    <td colspan="3">
-        <form class="form-horizontal name-setting">
-            <div class="input-group">
-                <label for="name">{{t "Label" }}</label>
-                <input type="text" name="name" value="{{ name }}" maxlength="40" />
-            </div>
-            <div class="input-group hint_change_container">
-                <label for="hint">{{t "Hint" }}</label>
-                <input type="text" name="hint" value="{{ hint }}" maxlength="80" />
-            </div>
-            {{#if is_select_field }}
-            <div class="input-group">
-                <label for="profile_field_choices_edit">{{t "Field choices" }}</label>
-                <div class="profile-field-choices" name="profile_field_choices_edit">
-                    <hr />
-                    <div class="edit_profile_field_choices_container">
-                        {{#each choices}}
-                            {{> profile_field_choice }}
-                        {{/each}}
-                    </div>
-                </div>
-            </div>
-            {{/if}}
-            {{#if is_external_account_field}}
-            <div class="input-group profile_field_external_accounts_edit">
-                <label for="external_acc_field_type">{{t "External account type" }}</label>
-                <select name="external_acc_field_type">
-                    {{#each ../realm_default_external_accounts}}
-                        <option value='{{@key}}'>{{this.text}}</option>
-                    {{/each}}
-                    <option value="custom">{{t 'Custom' }}</option>
-                </select>
-            </div>
-            <div class="input-group custom_external_account_detail">
-                <label for="url_pattern">{{t "URL pattern" }}</label>
-                <input type="url" name="url_pattern" autocomplete="off" maxlength="80" />
-            </div>
-            {{/if}}
-            <div class="input-group">
-                <button type="button" class="button rounded sea-green submit">
-                    {{t 'Save changes' }}
-                </button>
-                <button type="button" class="button rounded btn-danger reset">
-                    {{t 'Cancel' }}
-                </button>
-            </div>
-        </form>
-    </td>
 </tr>
 {{/with}}

--- a/static/templates/settings/edit_custom_profile_field_form.hbs
+++ b/static/templates/settings/edit_custom_profile_field_form.hbs
@@ -1,0 +1,40 @@
+{{#with profile_field_info}}
+<form class="form-horizontal name-setting profile-field-form new-style" id="edit-custom-profile-field-form-{{id}}">
+    <div class="input-group">
+        <label for="name">{{t "Label" }}</label>
+        <input type="text" name="name" value="{{ name }}" maxlength="40" />
+    </div>
+    <div class="input-group hint_change_container">
+        <label for="hint">{{t "Hint" }}</label>
+        <input type="text" name="hint" value="{{ hint }}" maxlength="80" />
+    </div>
+    {{#if is_select_field }}
+    <div class="input-group">
+        <label for="profile_field_choices_edit">{{t "Field choices" }}</label>
+        <div class="profile-field-choices" name="profile_field_choices_edit">
+            <hr />
+            <div class="edit_profile_field_choices_container">
+                {{#each choices}}
+                    {{> profile_field_choice }}
+                {{/each}}
+            </div>
+        </div>
+    </div>
+    {{/if}}
+    {{#if is_external_account_field}}
+    <div class="input-group profile_field_external_accounts_edit">
+        <label for="external_acc_field_type">{{t "External account type" }}</label>
+        <select name="external_acc_field_type">
+            {{#each ../realm_default_external_accounts}}
+                <option value='{{@key}}'>{{this.text}}</option>
+            {{/each}}
+            <option value="custom">{{t 'Custom' }}</option>
+        </select>
+    </div>
+    <div class="input-group custom_external_account_detail">
+        <label for="url_pattern">{{t "URL pattern" }}</label>
+        <input type="url" name="url_pattern" autocomplete="off" maxlength="80" />
+    </div>
+    {{/if}}
+</form>
+{{/with}}

--- a/static/templates/settings/profile_field_choice.hbs
+++ b/static/templates/settings/profile_field_choice.hbs
@@ -3,7 +3,7 @@
     <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
     <input type='text' placeholder='{{t "New option" }}' value="{{ text }}" />
 
-    <button type='button' class="button rounded small btn-danger delete-choice" title="{{t 'Delete' }}">
+    <button type='button' class="button rounded small delete-choice" title="{{t 'Delete' }}">
         <i class="fa fa-trash-o" aria-hidden="true"></i>
     </button>
 </div>

--- a/static/templates/settings/profile_field_settings_admin.hbs
+++ b/static/templates/settings/profile_field_settings_admin.hbs
@@ -2,6 +2,9 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Custom profile fields"}}</h3>
         <div class="alert-notification" id="admin-profile-field-status"></div>
+        {{#if is_admin}}
+        <button class="button rounded sea-green" id="add-custom-profile-field-btn">{{t "Add a new profile field" }}</button>
+        {{/if}}
     </div>
     <div class="admin-table-wrapper">
         <table class="table table-condensed table-striped admin_profile_fields_table">
@@ -15,53 +18,4 @@
             </tbody>
         </table>
     </div>
-    {{#if is_admin}}
-    <form class="form-horizontal admin-profile-field-form">
-        <div class="add-new-profile-field-box grey-box">
-            <div class="new-profile-field-form wrapper">
-                <div class="settings-section-title new-profile-field-section-title inline-block">{{t "Add a new profile field" }}</div>
-                <div class="alert-notification" id="admin-add-profile-field-status"></div>
-                <div class="input-group">
-                    <label for="profile_field_type" class="control-label">{{t "Type" }}</label>
-                    <select id="profile_field_type" name="field_type">
-                        {{#each custom_profile_field_types}}
-                            <option value='{{this.id}}'>{{this.name}}</option>
-                        {{/each}}
-                    </select>
-                </div>
-                <div class="input-group" id="profile_field_external_accounts">
-                    <label for="profile_field_external_accounts_type" class="control-label">{{t "External account type" }}</label>
-                    <select id="profile_field_external_accounts_type" name="external_acc_field_type">
-                        {{#each realm_default_external_accounts}}
-                            <option value='{{@key}}'>{{this.text}}</option>
-                        {{/each}}
-                        <option value="custom">{{t 'Custom' }}</option>
-                    </select>
-                </div>
-                <div class="input-group">
-                    <label for="profile_field_name" class="control-label">{{t "Label" }}</label>
-                    <input type="text" id="profile_field_name" name="name" autocomplete="off" maxlength="40" />
-                </div>
-                <div class="input-group">
-                    <label for="profile_field_hint" class="control-label">{{t "Hint (up to 80 characters)" }}</label>
-                    <input type="text" id="profile_field_hint" name="hint" autocomplete="off" maxlength="80" />
-                    <div class="alert" id="admin-profile-field-hint-status"></div>
-                </div>
-                <div class="input-group" id="profile_field_choices_row">
-                    <label for="profile_field_choices" class="control-label">{{t "Field choices" }}</label>
-                    <table class="profile_field_choices_table">
-                        <tbody id="profile_field_choices" class="profile-field-choices"></tbody>
-                    </table>
-                </div>
-                <div class="input-group" id="custom_external_account_url_pattern">
-                    <label for="custom_field_url_pattern" class="control-label">{{t "URL pattern" }}</label>
-                    <input type="url" id="custom_field_url_pattern" name="url_pattern" autocomplete="off" maxlength="1024" placeholder="https://example.com/path/%(username)s"/>
-                </div>
-                <button type="submit" class="button rounded sea-green" id="add-custom-profile-field-btn">
-                    {{t 'Add profile field' }}
-                </button>
-            </div>
-        </div>
-    </form>
-    {{/if}}
 </div>

--- a/static/templates/settings/profile_field_settings_admin.hbs
+++ b/static/templates/settings/profile_field_settings_admin.hbs
@@ -21,7 +21,7 @@
             <div class="new-profile-field-form wrapper">
                 <div class="settings-section-title new-profile-field-section-title inline-block">{{t "Add a new profile field" }}</div>
                 <div class="alert-notification" id="admin-add-profile-field-status"></div>
-                <div class="control-group">
+                <div class="input-group">
                     <label for="profile_field_type" class="control-label">{{t "Type" }}</label>
                     <select id="profile_field_type" name="field_type">
                         {{#each custom_profile_field_types}}
@@ -29,7 +29,7 @@
                         {{/each}}
                     </select>
                 </div>
-                <div class="control-group" id="profile_field_external_accounts">
+                <div class="input-group" id="profile_field_external_accounts">
                     <label for="profile_field_external_accounts_type" class="control-label">{{t "External account type" }}</label>
                     <select id="profile_field_external_accounts_type" name="external_acc_field_type">
                         {{#each realm_default_external_accounts}}
@@ -38,22 +38,22 @@
                         <option value="custom">{{t 'Custom' }}</option>
                     </select>
                 </div>
-                <div class="control-group">
+                <div class="input-group">
                     <label for="profile_field_name" class="control-label">{{t "Label" }}</label>
                     <input type="text" id="profile_field_name" name="name" autocomplete="off" maxlength="40" />
                 </div>
-                <div class="control-group">
+                <div class="input-group">
                     <label for="profile_field_hint" class="control-label">{{t "Hint (up to 80 characters)" }}</label>
                     <input type="text" id="profile_field_hint" name="hint" autocomplete="off" maxlength="80" />
                     <div class="alert" id="admin-profile-field-hint-status"></div>
                 </div>
-                <div class="control-group" id="profile_field_choices_row">
+                <div class="input-group" id="profile_field_choices_row">
                     <label for="profile_field_choices" class="control-label">{{t "Field choices" }}</label>
                     <table class="profile_field_choices_table">
                         <tbody id="profile_field_choices" class="profile-field-choices"></tbody>
                     </table>
                 </div>
-                <div class="control-group" id="custom_external_account_url_pattern">
+                <div class="input-group" id="custom_external_account_url_pattern">
                     <label for="custom_field_url_pattern" class="control-label">{{t "URL pattern" }}</label>
                     <input type="url" id="custom_field_url_pattern" name="url_pattern" autocomplete="off" maxlength="1024" placeholder="https://example.com/path/%(username)s"/>
                 </div>


### PR DESCRIPTION
The implementation is approximately the same as before I just migrated
"Add/Edit custom profile field" forms into modals, status update
notifications about these forms will be displayed inside their modal.

Issue #21634 describes pretty much everything about these new changes.
- [x] At present, the UI for editing a custom profile field opens directly inside the table. This is confusing, especially if you have more than one open, which is possible. Instead, clicking the pencil icon should open a modal to edit the field. The modal heading can be "Edit custom profile field".
- [x] Similarly, the "Add custom profile field" form should be migrated to a modal as well. The field labels in the modal should be above (on a separate line) from the text boxes. The button to open the modal should be on the same line as the "Custom profile fields" table heading; we can try right-aligning it.

Fixes: #21634

[CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/Make.20.22Add.20and.20Edit.20custom.20profile.20field.22.20a.20modal.20.2321634)
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
**Screenshots and screen captures:**
![custom_profile_fields](https://user-images.githubusercontent.com/41695888/164549643-694f3feb-389b-44ae-a68a-8cfeab81a18b.png)
![delete_button_inside_modal](https://user-images.githubusercontent.com/41695888/164549648-646cda2c-4191-44bf-9b6e-813891722cb9.gif)
![working](https://user-images.githubusercontent.com/41695888/164549649-caa48a14-cac8-442e-b95d-14c11dd7dc52.gif)
<details><summary>Error inside modal</summary>

![status_update_error](https://user-images.githubusercontent.com/41695888/164550468-e5e4d4a3-4020-476b-bf44-72a009365587.png)

</details>

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
