### PR TITLE
Add stream count information to "Subscribe to more streams" button on left sidebar

### DIFF
--- a/static/js/popover_menus.js
+++ b/static/js/popover_menus.js
@@ -56,31 +56,51 @@ function on_show_prep(instance) {
     popovers.hide_all_except_sidebars(instance);
 }
 
+// boilerplate functions to pass to delegate() parameter for creating new stream popover
+function onShowStreamCreation(instance) {
+    const can_create_streams =
+        settings_data.user_can_create_private_streams() ||
+        settings_data.user_can_create_public_streams() ||
+        settings_data.user_can_create_web_public_streams();
+    on_show_prep(instance);
+
+    if (!can_create_streams) {
+        // If the user can't create streams, we directly
+        // navigate them to the Manage streams subscribe UI.
+        window.location.assign("#streams/all");
+        // Returning false from an onShow handler cancels the show.
+        return false;
+    }
+
+    instance.setContent(parse_html(render_left_sidebar_stream_setting_popover()));
+    left_sidebar_stream_setting_popover_displayed = true;
+    return true;
+}
+
+function onHiddenStreamCreation() {
+    left_sidebar_stream_setting_popover_displayed = false;
+}
+
 export function initialize() {
     delegate("body", {
         ...default_popover_props,
         target: "#streams_inline_icon",
         onShow(instance) {
-            const can_create_streams =
-                settings_data.user_can_create_private_streams() ||
-                settings_data.user_can_create_public_streams() ||
-                settings_data.user_can_create_web_public_streams();
-            on_show_prep(instance);
-
-            if (!can_create_streams) {
-                // If the user can't create streams, we directly
-                // navigate them to the Manage streams subscribe UI.
-                window.location.assign("#streams/all");
-                // Returning false from an onShow handler cancels the show.
-                return false;
-            }
-
-            instance.setContent(parse_html(render_left_sidebar_stream_setting_popover()));
-            left_sidebar_stream_setting_popover_displayed = true;
-            return true;
+            onShowStreamCreation(instance);
         },
         onHidden() {
-            left_sidebar_stream_setting_popover_displayed = false;
+            onHiddenStreamCreation();
+        },
+    });
+
+    delegate("body", {
+        ...default_popover_props,
+        target: "#add-stream-link-create",
+        onShow(instance) {
+            onShowStreamCreation(instance);
+        },
+        onHidden() {
+            onHiddenStreamCreation();
         },
     });
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -160,7 +160,6 @@ export function build_stream_list(force_rerender) {
 }
 
 export function build_add_stream_link() {
-
     // Only append when parent does not have children
 
     const more_streams = stream_data.get_non_default_stream_names();

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -161,24 +161,26 @@ export function build_stream_list(force_rerender) {
 
 export function build_add_stream_link() {
 
+    // Only append when parent does not have children
+
     const more_streams = stream_data.get_non_default_stream_names();
     const num_more_streams = more_streams.length;
     const $parent = $("#add-stream-link");
+
+    $parent.empty();
 
     // child textNode to append to anchor element
     let text_content = `Borrow ${num_more_streams} more streams`;
 
     const icon_elem = '<i class="fa fa-plus-circle" aria-hidden="true"></i>';
-    const anchor_elem = `<a href="#streams/all">${icon_elem}${text_content}</a>`;
+    let anchor_elem = `<a href="#streams/all">${icon_elem}${text_content}</a>`;
 
     if (num_more_streams < 1) {
         text_content = "Create a stream";
         anchor_elem = `<a id="add-stream-link-create">${icon_elem}${text_content}</a>`;
     }
 
-    // Only append when parent does not have children
-    if ($("#add-stream-link a").length < 1)
-        $parent.append(anchor_elem);
+    $parent.append(anchor_elem);
 }
 
 export function get_stream_li(stream_id) {

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -79,12 +79,14 @@ function get_search_term() {
 export function add_sidebar_row(sub) {
     create_sidebar_row(sub);
     build_stream_list();
+    build_add_stream_link();
     stream_cursor.redraw();
 }
 
 export function remove_sidebar_row(stream_id) {
     stream_sidebar.remove_row(stream_id);
     build_stream_list();
+    build_add_stream_link();
     stream_cursor.redraw();
 }
 
@@ -155,6 +157,28 @@ export function build_stream_list(force_rerender) {
     }
 
     $parent.append(elems);
+}
+
+export function build_add_stream_link() {
+
+    const more_streams = stream_data.get_non_default_stream_names();
+    const num_more_streams = more_streams.length;
+    const $parent = $("#add-stream-link");
+
+    // child textNode to append to anchor element
+    let text_content = `Borrow ${num_more_streams} more streams`;
+
+    const icon_elem = '<i class="fa fa-plus-circle" aria-hidden="true"></i>';
+    const anchor_elem = `<a href="#streams/all">${icon_elem}${text_content}</a>`;
+
+    if (num_more_streams < 1) {
+        text_content = "Create a stream";
+        anchor_elem = `<a id="add-stream-link-create">${icon_elem}${text_content}</a>`;
+    }
+
+    // Only append when parent does not have children
+    if ($("#add-stream-link a").length < 1)
+        $parent.append(anchor_elem);
 }
 
 export function get_stream_li(stream_id) {
@@ -332,6 +356,7 @@ function set_stream_unread_count(stream_id, count) {
 
 export function update_streams_sidebar(force_rerender) {
     build_stream_list(force_rerender);
+    build_add_stream_link();
 
     stream_cursor.redraw();
 
@@ -498,6 +523,7 @@ export function initialize() {
     // We build the stream_list now.  It may get re-built again very shortly
     // when new messages come in, but it's fairly quick.
     build_stream_list();
+    build_add_stream_link();
     set_event_handlers();
 }
 

--- a/static/templates/left_sidebar.hbs
+++ b/static/templates/left_sidebar.hbs
@@ -88,9 +88,7 @@
             <div id="stream-filters-container" class="scrolling_list" data-simplebar>
                 <ul id="stream_filters" class="filters"></ul>
                 {{#unless is_guest }}
-                    <div id="add-stream-link">
-                        <a href="#streams/all"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{t 'Subscribe to more streams' }}</a>
-                    </div>
+                    <div id="add-stream-link"></div>
                 {{/unless}}
             </div>
         </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

To make the "Subscribe to more streams" link in the left sidebar more informative and appropriate to the user's situation, the following changes were made:

When the user has N>0 streams they can subscribe to: Replace the link with: "Browse N more streams"
When the user has no streams they can subscribe to:
If the user has permission to create streams, show a "Create a stream" link, which goes to the same place as the "Create a stream" link from the "+" menu next to the STREAMS header.
If the user doesn't have permission to create streams, don't show a link at all.

<img width="265" alt="image" src="https://user-images.githubusercontent.com/23219615/164607589-90cffa3b-0144-4583-af7a-ed64de556418.png">

<img width="263" alt="image" src="https://user-images.githubusercontent.com/23219615/164607905-a57aba94-dd35-45b0-867e-26a07b3c9c57.png">
