### PR TITLE
Fix: Draft count briefly appears when sending a new message.

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -29,9 +29,11 @@ import * as timerender from "./timerender";
 import * as ui_util from "./ui_util";
 import * as util from "./util";
 
-function set_count(count) {
+function set_count(count, sending_message) {
     const $drafts_li = $(".top_left_drafts");
-    ui_util.update_unread_count_in_dom($drafts_li, count);
+    if (!sending_message) {
+        ui_util.update_unread_count_in_dom($drafts_li, count);
+    }
 }
 
 export const draft_model = (function () {
@@ -55,12 +57,13 @@ export const draft_model = (function () {
         return get()[id] || false;
     };
 
-    function save(drafts) {
+    function save(drafts, sending_message) {
         ls.set(KEY, drafts);
-        set_count(Object.keys(drafts).length);
+
+        set_count(Object.keys(drafts).length, sending_message);
     }
 
-    exports.addDraft = function (draft) {
+    exports.addDraft = function (draft, sending_message) {
         const drafts = get();
 
         // use the base16 of the current time + a random string to reduce
@@ -69,7 +72,7 @@ export const draft_model = (function () {
 
         draft.updatedAt = getTimestamp();
         drafts[id] = draft;
-        save(drafts);
+        save(drafts, sending_message);
 
         return id;
     };
@@ -190,7 +193,7 @@ function maybe_notify(no_notify) {
     }
 }
 
-export function update_draft(opts = {}) {
+export function update_draft(opts = {}, sending_message) {
     const no_notify = opts.no_notify || false;
     const draft = snapshot_message();
 
@@ -217,7 +220,8 @@ export function update_draft(opts = {}) {
 
     // We have never saved a draft for this message, so add
     // one.
-    const new_draft_id = draft_model.addDraft(draft);
+
+    const new_draft_id = draft_model.addDraft(draft, sending_message);
     $("#compose-textarea").data("draft-id", new_draft_id);
     maybe_notify(no_notify);
 

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -239,7 +239,7 @@ export function try_deliver_locally(message_request) {
     // We ask the drafts system to not notify the user, since they'd
     // be quite distracting in the very common case that the message
     // sends normally.
-    const draft_id = drafts.update_draft({no_notify: true});
+    const draft_id = drafts.update_draft({no_notify: true}, true);
     message_request.draft_id = draft_id;
 
     // Now that we've committed to delivering the message locally, we


### PR DESCRIPTION
Fix: Draft count briefly appears when sending a new message.
Fixes: #21757 
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

### Analysis
**1st Method**
In this method, I have removed the code which was updating the draft count through this pipeline. 
**DrawBack**
This solution prevents the drafts from being saved at all, which could result in data loss if the client restarts before the message is received, thus it was not a viable option. [Link to closed PR](https://github.com/zulip/zulip/pull/21829) 


**Suggested Method **
https://chat.zulip.org/#narrow/stream/9-issues/topic/draft.20count.20appears.20briefly.20when.20sending.20a.20message/near/1364725

I was not able to correctly interpret how would the counter will be manipulated in this method. Even if I have gone in this direction, I think  ultimately I would have to update the `set_count` function to control the counter (that's what I have implemented.)

**Implemented Method**
The easiest way to solve the draft from getting flashed (incremented) was to stop the counter while sending the message.


**Method:**

#### Created a new parameter (boolean) `sendingMessage`and passed it onto the `update_draft` function in `drafts.js` until we reach the function where the counter is being updated. Now in the function `set_count`, I have made one check such that if `sendingMessage` is false then only the count will get updated.

#### Then `update_draft` function is called in `echo.js` with  value of `sendingMessage` = `true`. 
