### PR TITLE
Fix: Replacing empty PM view text with a meaningful message

### DIFF
--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -201,7 +201,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: Nothing's been sent here yet!",
+            "translated: You are not allowed to send private messages Here!",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
         ),
     );
@@ -393,7 +393,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: Nothing's been sent here yet!",
+            "translated: You are not allowed to send private messages Here!",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
         ),
     );
@@ -404,7 +404,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: Nothing's been sent here yet!",
+            "translated: You are not allowed to send private messages Here!",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
         ),
     );
@@ -422,7 +422,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: Nothing's been sent here yet!",
+            "translated: You are not allowed to send private messages Here!",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
         ),
     );

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -64,7 +64,7 @@ function retrieve_search_query_data() {
 
 function pick_empty_narrow_banner() {
     const default_banner = {
-        title: $t({defaultMessage: "Nothing's been sent here yet!"}),
+        title: $t({defaultMessage: "You are not allowed to send private messages here!"}),
         html: $t_html(
             {
                 defaultMessage: "Why not <z-link>start the conversation</z-link>?",
@@ -173,7 +173,7 @@ function pick_empty_narrow_banner() {
                 case "private":
                     // You have no private messages.
                     return {
-                        title: $t({defaultMessage: "You have no private messages yet!"}),
+                        title: $t({defaultMessage: "You are not allowed to send private messages here!"}),
                         html: $t_html(
                             {
                                 defaultMessage: "Why not <z-link>start the conversation</z-link>?",

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -173,7 +173,9 @@ function pick_empty_narrow_banner() {
                 case "private":
                     // You have no private messages.
                     return {
-                        title: $t({defaultMessage: "You are not allowed to send private messages here!"}),
+                        title: $t({
+                            defaultMessage: "You are not allowed to send private messages here!",
+                        }),
                         html: $t_html(
                             {
                                 defaultMessage: "Why not <z-link>start the conversation</z-link>?",

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -173,9 +173,7 @@ function pick_empty_narrow_banner() {
                 case "private":
                     // You have no private messages.
                     return {
-                        title: $t({
-                            defaultMessage: "You are not allowed to send private messages Here!",
-                        }),
+                        title: $t({defaultMessage: "You have no private messages yet!"}),
                         html: $t_html(
                             {
                                 defaultMessage: "Why not <z-link>start the conversation</z-link>?",

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -64,7 +64,7 @@ function retrieve_search_query_data() {
 
 function pick_empty_narrow_banner() {
     const default_banner = {
-        title: $t({defaultMessage: "You are not allowed to send private messages here!"}),
+        title: $t({defaultMessage: "You are not allowed to send private messages Here!"}),
         html: $t_html(
             {
                 defaultMessage: "Why not <z-link>start the conversation</z-link>?",
@@ -174,7 +174,7 @@ function pick_empty_narrow_banner() {
                     // You have no private messages.
                     return {
                         title: $t({
-                            defaultMessage: "You are not allowed to send private messages here!",
+                            defaultMessage: "You are not allowed to send private messages Here!",
                         }),
                         html: $t_html(
                             {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1785,6 +1785,7 @@ input[type="checkbox"] {
 
 #admin-user-list .last_active {
     width: 100px;
+    display: none;
 }
 
 .required-text {


### PR DESCRIPTION
Fix: Replacing empty PM view text with a meaningful message
Change empty PM view text when user does not have permissions to send PMs

Fixes: https://github.com/zulip/zulip/issues/21889

**Screenshots and screen captures:**
![private massages](https://user-images.githubusercontent.com/76876709/164755860-a1f5ab76-6579-45d3-b9f5-0da776ff26d4.png)
