### PR TITLE
popovers: Do not show "Send private message" option when user does not have PM permissions.

### DIFF
--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -176,6 +176,7 @@ test_ui("sender_hover", ({override, mock_template}) => {
             can_revoke_away: false,
             can_mute: true,
             can_manage_user: false,
+            can_send_private_message: true,
             can_unmute: false,
             user_full_name: "Alice Smith",
             user_email: "alice@example.com",

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -42,6 +42,7 @@ import * as realm_playground from "./realm_playground";
 import * as reminder from "./reminder";
 import * as resize from "./resize";
 import * as rows from "./rows";
+import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
 import * as settings_users from "./settings_users";
 import * as stream_popover from "./stream_popover";
@@ -205,6 +206,7 @@ function render_user_info_popover(
     }
 
     const muting_allowed = !is_me && !user.is_bot;
+    const is_active = people.is_active_user_for_popover(user.user_id);
     const is_muted = muted_users.is_user_muted(user.user_id);
     const status_text = user_status.get_status_text(user.user_id);
     const status_emoji_info = user_status.get_status_emoji(user.user_id);
@@ -221,9 +223,14 @@ function render_user_info_popover(
         can_set_away,
         can_mute: muting_allowed && !is_muted,
         can_manage_user: page_params.is_admin && !is_me,
+        can_send_private_message:
+            is_active &&
+            !is_me &&
+            page_params.realm_private_message_policy !==
+                settings_config.private_message_policy_values.disabled.code,
         can_unmute: muting_allowed && is_muted,
         has_message_context,
-        is_active: people.is_active_user_for_popover(user.user_id),
+        is_active,
         is_bot: user.is_bot,
         is_me,
         is_sender_popover,

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -117,14 +117,12 @@
             </a>
         </li>
         {{/if}}
-        {{#if is_active}}
-            {{#unless is_me}}
+        {{#if can_send_private_message}}
             <li>
                 <a tabindex="0" class="{{ private_message_class }}">
                     <i class="fa fa-envelope" aria-hidden="true"></i> {{#tr}}Send private message{{/tr}} {{#if is_sender_popover}}<span class="hotkey-hint">(R)</span>{{/if}}
                 </a>
             </li>
-            {{/unless}}
         {{/if}}
         {{#unless is_me}}
         <li>


### PR DESCRIPTION
If an organization does not allow to send private messages, it will not display the "Send private message" option in the profile popover.

Currently, there are only two options in settings, first is to allow every type of user to send PMs and the second is to disable send PMs for everyone, hence I am just checking that the second option is not selected.

Fixes: #21888

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![private_message_option](https://user-images.githubusercontent.com/41695888/164775961-4f4080e9-2b1d-4198-a402-1290c0b0705d.png)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
