### PR TITLE
added reccomended code to documentation.py

### DIFF
--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -103,7 +103,14 @@ class MarkdownDirectoryView(ApiURLView):
                 endpoint_path=None,
                 endpoint_method=None,
             )
-
+        if path == "/zerver/api/api-doc-template.md":
+            # This shouldn't be accessible directly
+            return DocumentationArticle(
+                article_path=self.path_template % ("missing",),
+                article_http_status=404,
+                endpoint_path=None,
+                endpoint_method=None,
+            )
         # The following is a somewhat hacky approach to extract titles from articles.
         # Hack: `context["article"] has a leading `/`, so we use + to add directories.
         article_path = os.path.join(settings.DEPLOY_ROOT, "templates") + path


### PR DESCRIPTION
added a portion of code to documentation.py that catches an access to api-doc-template and immediately throws a 404 instead of a 500
Fixes: 21876



