### PR TITLE
[WIP]stream_settings: Add unsubscribed tab to stream settings.

### DIFF
--- a/frontend_tests/puppeteer_lib/common.ts
+++ b/frontend_tests/puppeteer_lib/common.ts
@@ -464,12 +464,20 @@ class CommonUtils {
     }
 
     async open_streams_modal(page: Page): Promise<void> {
-        const all_streams_selector = "#add-stream-link";
+        const unsubscribed_streams_selector = "#add-stream-link";
+        await page.waitForSelector(unsubscribed_streams_selector, {visible: true});
+        await page.click(unsubscribed_streams_selector);
+
+        await page.waitForSelector("#subscription_overlay.new-style", {visible: true});
+        let url = await this.page_url_with_fragment(page);
+        assert.ok(url.includes("#streams/notsubscribed"));
+
+        const all_streams_selector = ".ind-tab.last[data-tab-key='all-streams']";
         await page.waitForSelector(all_streams_selector, {visible: true});
         await page.click(all_streams_selector);
 
         await page.waitForSelector("#subscription_overlay.new-style", {visible: true});
-        const url = await this.page_url_with_fragment(page);
+        url = await this.page_url_with_fragment(page);
         assert.ok(url.includes("#streams/all"));
     }
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -40,12 +40,22 @@ function setup_subscriptions_stream_hash(sub) {
 }
 
 export function setup_subscriptions_tab_hash(tab_key_value) {
-    if (tab_key_value === "all-streams") {
-        browser_history.update("#streams/all");
-    } else if (tab_key_value === "subscribed") {
-        browser_history.update("#streams/subscribed");
-    } else {
-        blueslip.debug("Unknown tab_key_value: " + tab_key_value);
+    switch (tab_key_value) {
+        case "all-streams": {
+            browser_history.update("#streams/all");
+            break;
+        }
+        case "subscribed": {
+            browser_history.update("#streams/subscribed");
+            break;
+        }
+        case "not-subscribed": {
+            browser_history.update("#streams/notsubscribed");
+            break;
+        }
+        default: {
+            blueslip.debug("Unknown tab_key_value: " + tab_key_value);
+        }
     }
 }
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -28,6 +28,14 @@ export let stream_cursor;
 
 let has_scrolled = false;
 
+export function update_no_streams_label(hidden_id_array_size, stream_ids_array_size) {
+    if (hidden_id_array_size === stream_ids_array_size) {
+        $(".no-streams").css("display", "block");
+    } else {
+        $(".no-streams").css("display", "none");
+    }
+}
+
 export function update_count_in_dom($stream_li, count) {
     // The subscription_block properly excludes the topic list,
     // and it also has sensitive margins related to whether the

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -477,6 +477,8 @@ export function redraw_left_panel(left_panel_params = get_left_panel_params()) {
         widgets.set(stream_id, $(row).detach());
     }
 
+    stream_list.update_no_streams_label(hidden_ids.size, stream_ids.length);
+
     ui.reset_scrollbar($("#subscription_overlay .streams-list"));
 
     const all_stream_ids = [...buckets.name, ...buckets.desc, ...buckets.other];

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -347,6 +347,20 @@ h4.stream_setting_subsection_title {
             display: flex;
             justify-content: space-between;
         }
+
+        .no-streams {
+            display: none;
+            margin-top: calc(45vh - 100px);
+            text-align: center;
+            font-size: 1em;
+            margin-left: 2em;
+            margin-right: 2em;
+
+            span {
+                display: block;
+                color: hsl(0, 0%, 67%);
+            }
+        }
     }
 
     .right {

--- a/static/templates/left_sidebar.hbs
+++ b/static/templates/left_sidebar.hbs
@@ -89,7 +89,7 @@
                 <ul id="stream_filters" class="filters"></ul>
                 {{#unless is_guest }}
                     <div id="add-stream-link">
-                        <a href="#streams/all"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{t 'Subscribe to more streams' }}</a>
+                        <a href="#streams/notsubscribed"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{t 'Subscribe to more streams' }}</a>
                     </div>
                 {{/unless}}
             </div>

--- a/static/templates/left_sidebar_stream_setting_popover.hbs
+++ b/static/templates/left_sidebar_stream_setting_popover.hbs
@@ -1,6 +1,6 @@
 <ul class="nav nav-list">
     <li>
-        <a href="#streams/all">
+        <a href="#streams/notsubscribed">
             {{t "Browse streams" }}
         </a>
     </li>

--- a/static/templates/stream_settings/stream_settings_overlay.hbs
+++ b/static/templates/stream_settings/stream_settings_overlay.hbs
@@ -26,6 +26,10 @@
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>
                 </div>
+                <div class="no-streams">
+                    <span>{{t 'No streams to show' }}</span>
+                    <a href="#streams/all">{{t 'View all streams' }}</a>
+                </div>
                 <div class="streams-list" data-simplebar>
                 </div>
             </div>


### PR DESCRIPTION
Currently, there are only two tabs, the `All streams` and `Subscribed`
tab for filtering streams in stream settings. Unsubscribed streams can
only be seen on selecting the `All streams` tab.

This commit adds another tab, `Unsubscribed` tab that filters all the
streams that the user is not subscribed to. If there are no unsubscribed
streams present, we show a message showing `No streams to show`.

This PR fixes [Issue-21869](https://github.com/zulip/zulip/issues/21869)

Working of Unsubscribed tabs:
![23 04 2022_21 32 49_REC](https://user-images.githubusercontent.com/65943606/164913938-61bc5fe3-5b69-48d0-bffe-5a84f6b68209.gif)
