### PR TITLE
status_emoji: Add accessibility attribute to emoji element.

### DIFF
--- a/static/templates/status_emoji.hbs
+++ b/static/templates/status_emoji.hbs
@@ -4,7 +4,7 @@
 <img src="{{still_url}}" class="emoji status_emoji" data-animated-url="{{url}}" data-still-url="{{still_url}}" />
 {{else if url}}
 {{!-- note that we have no still_url --}}
-<img src="{{url}}" class="emoji status_emoji" data-animated-url="{{url}}" />
+<img src="{{url}}" class="emoji status_emoji" data-animated-url="{{url}}" title="{{emoji_name}}"/>
 {{else if emoji_code}}
-<div class="emoji status_emoji emoji-{{emoji_code}}"></div>
+<div class="emoji status_emoji emoji-{{emoji_code}}" role="img" title="{{emoji_name}}"></div>
 {{/if}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #19821 

After reading through the conversation on this issue in PR #20138, I decided to try a difference approach. This PR adds html attributes that includes the name of the emoji to the template for rendering status emoji. These attributes add accessibility tooltips that show the name of the emoji when there is a mouseover event. This is consistent with how the emoji label is technically implemented for emoji inside of messages. 

The benefits to this approach are the accessibility consideration, consistency, and being relatively simple. The downside is limited control over the rendering of the tooltip itself.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="154" alt="status_emoji_label" src="https://user-images.githubusercontent.com/3621543/164959850-7346d0ac-0553-4cab-8301-aea1dc07c487.png">

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
