### PR TITLE
compose: Fix sorting of wildcard mentions in case of PMs.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1486,6 +1486,7 @@ test("content_highlighter", ({override_rewire}) => {
 });
 
 test("filter_and_sort_mentions (normal)", () => {
+    compose_state.set_message_type("stream");
     const is_silent = false;
 
     const suggestions = ct.filter_and_sort_mentions(is_silent, "al");

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -6,6 +6,7 @@ import * as typeahead from "../shared/js/typeahead";
 import render_typeahead_list_item from "../templates/typeahead_list_item.hbs";
 
 import * as buddy_data from "./buddy_data";
+import * as compose_state from "./compose_state";
 import * as people from "./people";
 import * as pm_conversations from "./pm_conversations";
 import * as recent_senders from "./recent_senders";
@@ -14,7 +15,6 @@ import * as stream_data from "./stream_data";
 import * as user_groups from "./user_groups";
 import * as user_status from "./user_status";
 import * as util from "./util";
-
 // Returns an array of private message recipients, removing empty elements.
 // For example, "a,,b, " => ["a", "b"]
 export function get_cleaned_pm_recipients(query_string) {
@@ -186,13 +186,24 @@ export function compare_people_for_relevance(
     // We use is_broadcast for a quick check.  It will
     // true for all/everyone/stream and undefined (falsy)
     // for actual people.
-    if (person_a.is_broadcast) {
-        if (person_b.is_broadcast) {
-            return person_a.idx - person_b.idx;
+    if (compose_state.get_message_type() !== "private") {
+        if (person_a.is_broadcast) {
+            if (person_b.is_broadcast) {
+                return person_a.idx - person_b.idx;
+            }
+            return -1;
+        } else if (person_b.is_broadcast) {
+            return 1;
         }
-        return -1;
-    } else if (person_b.is_broadcast) {
-        return 1;
+    } else {
+        if (person_a.is_broadcast) {
+            if (person_b.is_broadcast) {
+                return person_a.idx - person_b.idx;
+            }
+            return 1;
+        } else if (person_b.is_broadcast) {
+            return -1;
+        }
     }
 
     // Now handle actual people users.


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR attempts to fix the sorting of wildcard mentions by moving
them below the silent mentions in case of PMs.
It adds a condition in compare_people_for_relevance function to check
for private message type and sorts the wildcard mention below the silent
ones.
It also adds test for sort broadcast mentions and compare_people_for_relevance
function in case of private message types.

Fixes: <!-- Issue link, or clear description.-->

Fixes: #21643
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2022-04-24 22-51-56](https://user-images.githubusercontent.com/77766761/164988607-eea0bca9-4fca-4774-9666-536a98e4ac28.png)
![Screenshot from 2022-04-24 22-52-35](https://user-images.githubusercontent.com/77766761/164988611-343e1fe0-4b96-4009-8e2a-d51f2b35fcdc.png)
![Screenshot from 2022-04-24 22-54-17](https://user-images.githubusercontent.com/77766761/164988654-7f21d428-722b-49eb-80d4-0f1c4a5b97fd.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
