### PR TITLE
User Profile Modal: Move "Manage user" modal into "Full profile" modal

### DIFF
--- a/frontend_tests/node_tests/custom_profile_fields_ui.js
+++ b/frontend_tests/node_tests/custom_profile_fields_ui.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const {strict: assert} = require("assert");
+
+const {zrequire, mock_esm} = require("../zjsunit/namespace");
+const {run_test} = require("../zjsunit/test");
+const $ = require("../zjsunit/zjquery");
+
+const user_pill = mock_esm("../../static/js/user_pill", {
+    items: () => {},
+});
+const custom_profile_fields_ui = zrequire("custom_profile_fields_ui");
+
+const fields_user_pills = new Map();
+fields_user_pills.set(3, {});
+
+function setup_custom_fields() {
+    const $favorite_food_field = $.create("favorite_food_field");
+    $favorite_food_field.val("katsu");
+    $favorite_food_field.attr("data-field-id", "1");
+
+    const $phone_number_field = $.create("phone_number_field");
+    $phone_number_field.val("123-456-7890");
+    $phone_number_field.attr("data-field-id", "2");
+
+    const $bad_input_field = $.create("duplicate_flatpickr_field");
+    $bad_input_field.addClass("form-control");
+
+    return [$phone_number_field, $favorite_food_field, $bad_input_field];
+}
+
+function setup_closest_stubs(fields) {
+    for (const $field of fields) {
+        $field.closest = (selector) => {
+            assert.strictEqual(selector, ".custom_user_field");
+            return $field;
+        };
+    }
+}
+
+function compareFunction(a, b) {
+    return a.id - b.id;
+}
+
+run_test("get_human_profile_data", () => {
+    const fields = setup_custom_fields();
+    setup_closest_stubs(fields);
+
+    $("#edit-user-form .custom_user_field_value").each = (fn) => {
+        for (const $elem of fields) {
+            fn.call($elem);
+        }
+    };
+
+    const mentor_ids = [2, 3];
+    user_pill.get_user_ids = () => mentor_ids;
+
+    const profile_data = custom_profile_fields_ui.get_human_profile_data(fields_user_pills);
+
+    assert.deepStrictEqual(
+        profile_data.sort(compareFunction),
+        [
+            {id: 1, value: "katsu"},
+            {id: 2, value: "123-456-7890"},
+            {id: 3, value: [2, 3]},
+        ].sort(compareFunction),
+    );
+});

--- a/static/js/custom_profile_fields_ui.js
+++ b/static/js/custom_profile_fields_ui.js
@@ -1,0 +1,39 @@
+import $ from "jquery";
+
+import * as user_pill from "./user_pill";
+
+export function get_human_profile_data(fields_user_pills) {
+    /*
+      This formats custom profile field data to send to the server.
+      See render_admin_human_form and open_human_form
+      to see how the form is built.
+
+      TODO: Ideally, this logic would be cleaned up or deduplicated with
+      the settings_account.js logic.
+  */
+    const new_profile_data = [];
+    $("#edit-user-form .custom_user_field_value").each(function () {
+        // Remove duplicate datepicker input element generated flatpickr library
+        if (!$(this).hasClass("form-control")) {
+            new_profile_data.push({
+                id: Number.parseInt(
+                    $(this).closest(".custom_user_field").attr("data-field-id"),
+                    10,
+                ),
+                value: $(this).val(),
+            });
+        }
+    });
+    // Append user type field values also
+    for (const [field_id, field_pills] of fields_user_pills) {
+        if (field_pills) {
+            const user_ids = user_pill.get_user_ids(field_pills);
+            new_profile_data.push({
+                id: field_id,
+                value: user_ids,
+            });
+        }
+    }
+
+    return new_profile_data;
+}

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -47,6 +47,7 @@ import * as settings_users from "./settings_users";
 import * as stream_popover from "./stream_popover";
 import * as ui_report from "./ui_report";
 import * as user_groups from "./user_groups";
+import * as user_profile from "./user_profile";
 import * as user_status from "./user_status";
 import * as user_status_ui from "./user_status_ui";
 import * as util from "./util";
@@ -1285,7 +1286,8 @@ export function register_click_handlers() {
     $("body").on("click", ".sidebar-popover-manage-user", (e) => {
         hide_all();
         const user_id = elem_to_user_id($(e.target).parents("ul"));
-        settings_users.show_edit_user_info_modal(user_id, true);
+        const user = people.get_by_user_id(user_id);
+        user_profile.show_user_profile(user, 3);
     });
 }
 

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -11,6 +11,7 @@ import * as blueslip from "./blueslip";
 import * as bot_data from "./bot_data";
 import * as channel from "./channel";
 import * as confirm_dialog from "./confirm_dialog";
+import * as custom_profile_fields_ui from "./custom_profile_fields_ui";
 import * as dialog_widget from "./dialog_widget";
 import {DropdownListWidget} from "./dropdown_list_widget";
 import {$t, $t_html} from "./i18n";
@@ -26,7 +27,11 @@ import * as settings_data from "./settings_data";
 import * as settings_panel_menu from "./settings_panel_menu";
 import * as timerender from "./timerender";
 import * as ui from "./ui";
+<<<<<<< HEAD
 import * as user_pill from "./user_pill";
+=======
+import * as ui_report from "./ui_report";
+>>>>>>> 0fedeb51cc (profile_fields: Extract formatting profile fields fn.)
 
 const section = {
     active: {},
@@ -389,42 +394,6 @@ function start_data_load() {
     populate_users();
 }
 
-function get_human_profile_data(fields_user_pills) {
-    /*
-        This formats custom profile field data to send to the server.
-        See render_admin_human_form and open_human_form
-        to see how the form is built.
-
-        TODO: Ideally, this logic would be cleaned up or deduplicated with
-        the settings_account.js logic.
-    */
-    const new_profile_data = [];
-    $("#edit-user-form .custom_user_field_value").each(function () {
-        // Remove duplicate datepicker input element generated flatpickr library
-        if (!$(this).hasClass("form-control")) {
-            new_profile_data.push({
-                id: Number.parseInt(
-                    $(this).closest(".custom_user_field").attr("data-field-id"),
-                    10,
-                ),
-                value: $(this).val(),
-            });
-        }
-    });
-    // Append user type field values also
-    for (const [field_id, field_pills] of fields_user_pills) {
-        if (field_pills) {
-            const user_ids = user_pill.get_user_ids(field_pills);
-            new_profile_data.push({
-                id: field_id,
-                value: user_ids,
-            });
-        }
-    }
-
-    return new_profile_data;
-}
-
 export function confirm_deactivation(user_id, handle_confirm, loading_spinner) {
     const user = people.get_by_user_id(user_id);
     const opts = {
@@ -591,7 +560,7 @@ export function show_edit_user_info_modal(user_id, from_user_info_popover) {
     function submit_user_details() {
         const role = Number.parseInt($("#user-role-select").val().trim(), 10);
         const $full_name = $("#edit-user-form").find("input[name='full_name']");
-        const profile_data = get_human_profile_data(fields_user_pills);
+        const profile_data = custom_profile_fields_ui.get_human_profile_data(fields_user_pills);
 
         const url = "/json/users/" + encodeURIComponent(user_id);
         const data = {

--- a/static/js/user_profile.js
+++ b/static/js/user_profile.js
@@ -259,7 +259,7 @@ export function hide_user_profile() {
     });
 }
 
-export function show_user_profile(user) {
+export function show_user_profile(user, selected_tab_index = 0) {
     popovers.hide_all();
 
     const dateFormat = new Intl.DateTimeFormat("default", {dateStyle: "long"});
@@ -288,10 +288,9 @@ export function show_user_profile(user) {
 
     $("#user-profile-modal-holder").html(render_user_profile_modal(args));
     overlays.open_modal("user-profile-modal", {autoremove: true, micromodal: true});
-    $(".tabcontent").hide();
-    $("#profile-tab").show(); // Show general profile details by default.
+
     const opts = {
-        selected: 0,
+        selected: selected_tab_index,
         child_wants_focus: true,
         values: [
             {label: $t({defaultMessage: "Profile"}), key: "profile-tab"},

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -317,9 +317,20 @@ ul {
         text-align: center;
         line-height: 30px;
 
-        #edit-button {
+        #edit-button,
+        .full-profile-edit-user-button {
             font-size: 18px;
             margin-left: 10px;
+        }
+
+        .full-profile-edit-user-button {
+            background: transparent;
+            border: none;
+            color: hsl(200, 100%, 40%);
+
+            &:hover {
+                color: hsl(200, 79%, 66%);
+            }
         }
     }
 

--- a/static/templates/settings/admin_human_form.hbs
+++ b/static/templates/settings/admin_human_form.hbs
@@ -30,4 +30,13 @@
             </button>
         </div>
     </form>
+    {{#if require_modal_footer}}
+        <div class="modal__footer">
+            <button type="button" class="modal__btn dialog_cancel_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
+            <button type="button" class="modal__btn dialog_submit_button">
+                <span>{{{ html_submit_button }}}</span>
+                <div class="modal__spinner"></div>
+            </button>
+        </div>
+    {{/if }}
 </div>

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -6,9 +6,13 @@
                 <div id="name">
                     {{full_name}}
                     {{#if is_me}}
-                    <a href="/#settings/profile">
-                        <i class="fa fa-edit" id="edit-button" aria-hidden="true"></i>
+                    <a href="/#settings/profile" aria-label="{{t 'Edit your profile' }}" >
+                        <i class="fa fa-edit" id="edit-button"></i>
                     </a>
+                    {{else if can_manage_user}}
+                    <button data-tippy-content="{{t 'Edit profile' }}" aria-label="{{t 'Edit profile'}}" type="button" class="full-profile-edit-user-button">
+                        <i class="fa fa-edit"></i>
+                    </button>
                     {{/if}}
                 </div>
                 <div id="tab-toggle" class="center"></div>
@@ -89,6 +93,7 @@
                             <table class="user-group-list" data-empty="{{t 'No user group subscriptions.'}}"></table>
                         </div>
                     </div>
+                    <div class="tabcontent" id="user-profile-manage-user-tab"></div>
                 </div>
             </main>
         </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR merges the manage user modal into the full profile modal as a tab. This tab is only visible to admins and allows admins to make edits to a user's profile as well as deactivate the user. Also adds an edit button at the top of the full profile modal that switches to the manage user tab (only visible to admins).

The "Manage user" modal is still being used to edit users from Settings -> Organization -> Users. Should this use the full profile modal as well? Also, haven't written any tests yet for this modal. Noticed admins are allowed to edit owner's profile besides the role. Is this intended?

Fixes: <!-- Issue link, or clear [description.-->(https://github.com/zulip/zulip/issues/21806)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
### **Unauthorized Views**
![image](https://user-images.githubusercontent.com/38874449/165223849-66c98116-def2-491c-a060-7cbd0eb922cb.png)

### **Authorized Views**

https://user-images.githubusercontent.com/38874449/165224515-f37228b4-3b3e-4b43-a464-059ac6c44f65.mov

https://user-images.githubusercontent.com/38874449/165225059-8f526be9-5e77-4915-90d0-2832f14614f7.mov

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
