### PR TITLE
puppet: Only include "app_service" section if there are apps.

### DIFF
--- a/puppet/zulip_ops/files/teleport_app.yaml
+++ b/puppet/zulip_ops/files/teleport_app.yaml
@@ -1,0 +1,3 @@
+app_service:
+  enabled: yes
+  apps:

--- a/puppet/zulip_ops/files/teleport_node.yaml
+++ b/puppet/zulip_ops/files/teleport_node.yaml
@@ -32,9 +32,3 @@ proxy_service:
   enabled: no
 auth_service:
   enabled: no
-
-# We intentionally end with `app_service` so we can append services under
-# `apps:` via puppet.
-app_service:
-  enabled: yes
-  apps:

--- a/puppet/zulip_ops/manifests/teleport/application.pp
+++ b/puppet/zulip_ops/manifests/teleport/application.pp
@@ -6,6 +6,7 @@ define zulip_ops::teleport::application (
   $description = '',
   $order = '50',
 ) {
+  include zulip_ops::teleport::application_top
   concat::fragment { "teleport_app_${name}":
     target  => '/etc/teleport_node.yaml',
     order   => $order,

--- a/puppet/zulip_ops/manifests/teleport/application_top.pp
+++ b/puppet/zulip_ops/manifests/teleport/application_top.pp
@@ -1,0 +1,10 @@
+# @summary Enables application support on the node; include once.
+#
+# See https://goteleport.com/docs/application-access/
+class zulip_ops::teleport::application_top {
+  concat::fragment { 'teleport_app':
+    target => '/etc/teleport_node.yaml',
+    order  => '10',
+    source => 'puppet:///modules/zulip_ops/teleport_app.yaml',
+  }
+}


### PR DESCRIPTION
This works around gravitational/teleport#12256, but also produces config
files that are slightly cleaner.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
