### PR TITLE
Introduce public access option terminology

### DIFF
--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -237,7 +237,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "",
-            'translated HTML: This stream does not exist or is not <a href="https://zulip.com/help/public-access-option">publicly accessible</a>.',
+            'translated HTML: This stream does not exist or is not <a href="/help/public-access-option">publicly accessible</a>.',
         ),
     );
 
@@ -251,7 +251,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "",
-            'translated HTML: This stream does not exist or is not <a href="https://zulip.com/help/public-access-option">publicly accessible</a>.',
+            'translated HTML: This stream does not exist or is not <a href="/help/public-access-option">publicly accessible</a>.',
         ),
     );
     page_params.is_spectator = false;

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -237,7 +237,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "",
-            'translated HTML: This stream does not exist or is not <a href="https://zulip.com/help/web-public-streams">web-public</a>.',
+            'translated HTML: This stream does not exist or is not <a href="https://zulip.com/help/public-access-option">publicly accessible</a>.',
         ),
     );
 
@@ -251,7 +251,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "",
-            'translated HTML: This stream does not exist or is not <a href="https://zulip.com/help/web-public-streams">web-public</a>.',
+            'translated HTML: This stream does not exist or is not <a href="https://zulip.com/help/public-access-option">publicly accessible</a>.',
         ),
     );
     page_params.is_spectator = false;

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -11,11 +11,12 @@ const SPECTATOR_STREAM_NARROW_BANNER = {
     title: "",
     html: $t_html(
         {
-            defaultMessage: "This stream does not exist or is not <z-link>web-public</z-link>.",
+            defaultMessage:
+                "This stream does not exist or is not <z-link>publicly accessible</z-link>.",
         },
         {
             "z-link": (content_html) =>
-                `<a href="https://zulip.com/help/web-public-streams">${content_html}</a>`,
+                `<a href="https://zulip.com/help/public-access-option">${content_html}</a>`,
         },
     ),
 };

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -15,8 +15,7 @@ const SPECTATOR_STREAM_NARROW_BANNER = {
                 "This stream does not exist or is not <z-link>publicly accessible</z-link>.",
         },
         {
-            "z-link": (content_html) =>
-                `<a href="https://zulip.com/help/public-access-option">${content_html}</a>`,
+            "z-link": (content_html) => `<a href="/help/public-access-option">${content_html}</a>`,
         },
     ),
 };

--- a/static/templates/login_to_access.hbs
+++ b/static/templates/login_to_access.hbs
@@ -11,8 +11,8 @@
                 <p>
                     {{#tr}}
                         Since you are not logged in, you can only view messages in
-                        <z-link>web-public streams</z-link>.
-                        {{#*inline "z-link"}}<a target="_blank" href="https://zulipchat.com/help/stream-permissions">{{> @partial-block}}</a>{{/inline}}
+                        <z-link>publicly accessible conversations</z-link>.
+                        {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="/help/public-access-option">{{> @partial-block}}</a>{{/inline}}
                     {{/tr}}
                 </p>
             </main>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -109,7 +109,7 @@
                   is_checked=realm_enable_spectator_access
                   label=admin_settings_label.realm_enable_spectator_access
                   is_disabled=disable_enable_spectator_access_setting
-                  help_link="help/web-public-streams"}}
+                  help_link="help/public-access-option"}}
                 <div class="input-group realm_create_web_public_stream_policy">
                     <label for="realm_create_web_public_stream_policy" class="dropdown-title">{{t "Who can create web-public streams" }}</label>
                     <select name="realm_create_web_public_stream_policy" id="id_realm_create_web_public_stream_policy" class="prop-element" data-setting-widget-type="number">

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -114,7 +114,7 @@ No changes; feature level used for Zulip 5.0 release.
 * [`GET /server_settings`](/api/get-server-settings): Added
   `realm_web_public_access_enabled` as a realm-specific server setting,
   which can be used by clients to detect whether the realm allows and
-  has at least one [web-public stream](/help/web-public-streams).
+  has at least one [web-public stream](/help/public-access-option).
 
 **Feature level 115**
 

--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -316,7 +316,7 @@
                 A full suite of tools for moderating open communities.
             </p>
         </a>
-        <a class="feature-block" href="/help/web-public-streams" target="_blank" rel="noopener noreferrer">
+        <a class="feature-block" href="/help/public-access-option" target="_blank" rel="noopener noreferrer">
             <h3>PUBLIC ACCESS OPTION</h3>
             <p>
                 Enable transparency by setting streams to be viewable

--- a/templates/zerver/for-open-source.html
+++ b/templates/zerver/for-open-source.html
@@ -120,10 +120,10 @@
                     </li>
                     <li>
                         <div class="list-content">
-                            With <a href="/help/web-public-streams">web-public
-                            streams</a>, anyone can view, browse, and
-                            search your organization's public content
-                            — no account required.
+                            With the <a href="/help/web-public-streams">public
+                            access option</a>, anyone can view, browse, and
+                            search your organization's public content — no
+                            account required.
                         </div>
                     </li>
                     <li>

--- a/templates/zerver/for-open-source.html
+++ b/templates/zerver/for-open-source.html
@@ -120,7 +120,7 @@
                     </li>
                     <li>
                         <div class="list-content">
-                            With the <a href="/help/web-public-streams">public
+                            With the <a href="/help/public-access-option">public
                             access option</a>, anyone can view, browse, and
                             search your organization's public content — no
                             account required.

--- a/templates/zerver/for-research.html
+++ b/templates/zerver/for-research.html
@@ -135,10 +135,10 @@
                     </li>
                     <li>
                         <div class="list-content">
-                            With <a href="/help/web-public-streams">web-public
-                            streams</a>, anyone can view, browse, and
-                            search your organization's public content
-                            — no account required.
+                            With the <a href="/help/web-public-streams">public
+                            access option</a>, anyone can view, browse, and
+                            search your organization's public content — no
+                            account required.
                         </div>
                     </li>
                     <li>

--- a/templates/zerver/for-research.html
+++ b/templates/zerver/for-research.html
@@ -135,7 +135,7 @@
                     </li>
                     <li>
                         <div class="list-content">
-                            With the <a href="/help/web-public-streams">public
+                            With the <a href="/help/public-access-option">public
                             access option</a>, anyone can view, browse, and
                             search your organization's public content — no
                             account required.

--- a/templates/zerver/help/change-the-privacy-of-a-stream.md
+++ b/templates/zerver/help/change-the-privacy-of-a-stream.md
@@ -2,7 +2,7 @@
 
 {!admin-only.md!}
 
-Streams can be [web-public](/help/web-public-streams), public or private,
+Streams can be [web-public](/help/public-access-option), public or private,
 and private streams can have shared or protected history.
 See [stream permissions](/help/stream-permissions) for
 details on stream privacy settings.

--- a/templates/zerver/help/configure-who-can-create-streams.md
+++ b/templates/zerver/help/configure-who-can-create-streams.md
@@ -3,7 +3,7 @@
 {!admin-only.md!}
 
 Zulip allows you to separately control [permissions](/help/roles-and-permissions)
-for creating [web-public](/help/web-public-streams), public and private
+for creating [web-public](/help/public-access-option), public and private
 streams.
 
 For corporations and other organizations with controlled access, we
@@ -12,7 +12,7 @@ self-organize.
 
 Only users in trusted roles (moderators and administrators) can be
 given permission to create web-public streams. This is intended
-[to help manage abuse](/help/web-public-streams#managing-abuse) by
+[to help manage abuse](/help/public-access-option#managing-abuse) by
 making it hard for an attacker to host malicious content in an
 unadvertised web-public stream in a legitimate organization.
 

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -161,7 +161,7 @@
 
 ## Stream management
 * [Stream permissions](/help/stream-permissions)
-* [Web-public streams](/help/web-public-streams)
+* [Public access option](/help/web-public-streams)
 * [Stream posting policy](/help/stream-sending-policy)
 * [Restrict stream creation](/help/configure-who-can-create-streams)
 * [Restrict stream invitation](/help/configure-who-can-invite-to-streams)

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -161,7 +161,7 @@
 
 ## Stream management
 * [Stream permissions](/help/stream-permissions)
-* [Public access option](/help/web-public-streams)
+* [Public access option](/help/public-access-option)
 * [Stream posting policy](/help/stream-sending-policy)
 * [Restrict stream creation](/help/configure-who-can-create-streams)
 * [Restrict stream invitation](/help/configure-who-can-invite-to-streams)

--- a/templates/zerver/help/include/web-public-streams-intro.md
+++ b/templates/zerver/help/include/web-public-streams-intro.md
@@ -1,6 +1,6 @@
-Administrators may enable the option to create **web-public streams**.
-Web-public streams can be viewed by anyone on the Internet without
-creating an account in your organization.
+The public access option lets administrators configure selected streams to be
+**web-public**. Web-public streams can be viewed by anyone on the Internet
+without creating an account in your organization.
 
 For example, you can [link to a Zulip
 topic](/help/link-to-a-message-or-conversation) in a web-public stream

--- a/templates/zerver/help/moderating-open-organizations.md
+++ b/templates/zerver/help/moderating-open-organizations.md
@@ -60,4 +60,4 @@ organization's policy choices.
 ## Related articles
 
 * [Setting up your organization](/help/getting-your-organization-started-with-zulip)
-* [Web-public streams](/help/web-public-streams)
+* [Public access option](/help/public-access-option)

--- a/templates/zerver/help/moderating-open-organizations.md
+++ b/templates/zerver/help/moderating-open-organizations.md
@@ -53,7 +53,7 @@ organization's policy choices.
 * [Deactivate bots](/help/deactivate-or-reactivate-a-bot) or
   [delete custom emoji](/help/custom-emoji#delete-custom-emoji).
 
-## Web-public streams
+## Public access option
 
 {!web-public-streams-intro.md!}
 

--- a/templates/zerver/help/public-access-option.md
+++ b/templates/zerver/help/public-access-option.md
@@ -108,7 +108,7 @@ detailed below.
   required for Zulip to load, and may thus be [accessed via the Zulip API][info-via-api].
 * Logged out visitors cannot view [organization statistics](/help/analytics).
 
-[info-via-api]: /help/web-public-streams#information-that-can-be-accessed-via-api-when-web-public-streams-are-enabled
+[info-via-api]: /help/public-access-option#information-that-can-be-accessed-via-api-when-web-public-streams-are-enabled
 
 ### Information about users
 

--- a/templates/zerver/help/stream-permissions.md
+++ b/templates/zerver/help/stream-permissions.md
@@ -16,7 +16,7 @@ determine who receives a message. Zulip supports a few types of streams:
     * In **private streams with protected history**, new subscribers
     can only see messages sent after they join.
 
-* [**Web-public**](/help/web-public-streams) (<i class="zulip-icon
+* [**Web-public**](/help/public-access-option) (<i class="zulip-icon
   zulip-icon-globe"></i>): Members can join (guests must be invited by a
   subscriber). Anyone on the Internet can view complete message history without
   creating an account.
@@ -113,4 +113,4 @@ must be subscribed to the stream.</span>
 
 * [Roles and permissions](/help/roles-and-permissions)
 * [Stream sending policy](/help/stream-sending-policy)
-* [Web-public streams](/help/web-public-streams)
+* [Web-public streams](/help/public-access-option)

--- a/templates/zerver/help/web-public-streams.md
+++ b/templates/zerver/help/web-public-streams.md
@@ -1,4 +1,4 @@
-# Web-public streams
+# Public access option
 
 !!! warn ""
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -487,6 +487,7 @@ def write_instrumentation_reports(full_suite: bool, include_webhooks: bool) -> N
             "help/disable-new-login-emails",
             "help/test-mobile-notifications",
             "help/troubleshooting-desktop-notifications",
+            "help/web-public-streams",
             "for/working-groups-and-communities/",
             "help/only-allow-admins-to-add-emoji",
             "help/night-mode",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11699,7 +11699,7 @@ paths:
 
                           The value of the `WEB_PUBLIC_STREAMS_ENABLED` Zulip server level
                           setting. A server that has disabled this setting intends to not offer [web
-                          public streams](/help/web-public-streams) to realms it hosts. (Zulip Cloud
+                          public streams](/help/public-access-option) to realms it hosts. (Zulip Cloud
                           defaults to `True`; self-hosted servers default to `False`).
 
                           Clients should use this to determine whether to offer UI for the
@@ -12520,7 +12520,7 @@ paths:
                         type: boolean
                         description: |
                           Whether the organization has enabled the creation of
-                          [web-public streams](/help/web-public-streams) and
+                          [web-public streams](/help/public-access-option) and
                           at least one web-public stream on the server currently
                           exists. Clients that support viewing content
                           in web-public streams without an account can

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -906,6 +906,10 @@ urls += [
         "help/night-mode",
         RedirectView.as_view(url="/help/dark-theme", permanent=True),
     ),
+    path(
+        "help/web-public-streams",
+        RedirectView.as_view(url="/help/public-access-option", permanent=True),
+    ),
     path("help/", help_documentation_view),
     path("help/<path:article>", help_documentation_view),
     path("api/", api_documentation_view),


### PR DESCRIPTION
I introduced the "public access option" name for the general feature of being able to make parts of an organization world-viewable.

@laurynmm Could you please finish up this PR by moving `/help/web-public-streams` to `/help/public-access-option`? We'll need to change the URL where we link to it, and add a redirect. Thanks!