### PR TITLE
[5.x] puppet: ‘supervisorctl stop all’ before restarting Supervisor

### DIFF
--- a/puppet/zulip/manifests/supervisor.pp
+++ b/puppet/zulip/manifests/supervisor.pp
@@ -91,6 +91,7 @@ class zulip::supervisor {
     }
     exec { 'supervisor-restart':
       refreshonly => true,
+      provider    => shell,
       command     => $zulip::common::supervisor_reload,
       require     => Service[$supervisor_service],
     }


### PR DESCRIPTION
This fixes a failure of the 3.4 upgrade test running on Ubuntu 20.04 with Supervisor 4.

Backported from part of

- #21854