### PR TITLE
Follow ups to the recently added subgroups and new endpoints for user groups.

### DIFF
--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -32,7 +32,7 @@ from zerver.lib.url_encoding import (
     stream_narrow_url,
     topic_narrow_url,
 )
-from zerver.lib.user_groups import get_user_group_direct_members
+from zerver.lib.user_groups import get_user_group_direct_member_ids
 from zerver.models import (
     Message,
     Recipient,
@@ -372,7 +372,7 @@ def get_mentioned_user_group_name(
     smallest_user_group_name = None
     for user_group_id in mentioned_user_group_ids:
         current_user_group = UserGroup.objects.get(id=user_group_id, realm=user_profile.realm)
-        current_user_group_size = len(get_user_group_direct_members(current_user_group))
+        current_user_group_size = len(get_user_group_direct_member_ids(current_user_group))
 
         if current_user_group_size < smallest_user_group_size:
             # If multiple user groups are mentioned, we prefer the

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -120,6 +120,10 @@ def get_user_group_direct_member_ids(user_group: UserGroup) -> List[int]:
     )
 
 
+def get_user_group_direct_members(user_group: UserGroup) -> "QuerySet[UserGroup]":
+    return user_group.direct_members.all()
+
+
 def get_direct_memberships_of_users(user_group: UserGroup, members: List[UserProfile]) -> List[int]:
     return list(
         UserGroupMembership.objects.filter(
@@ -163,7 +167,7 @@ def is_user_in_group(
     user_group: UserGroup, user: UserProfile, *, direct_member_only: bool = False
 ) -> bool:
     if direct_member_only:
-        return UserGroupMembership.objects.filter(user_group=user_group, user_profile=user).exists()
+        return get_user_group_direct_members(user_group=user_group).filter(id=user.id).exists()
 
     return get_recursive_group_members(user_group=user_group).filter(id=user.id).exists()
 

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -23,7 +23,7 @@ def access_user_group_by_id(
             return user_group
         if user_group.is_system_group:
             raise JsonableError(_("Insufficient permission"))
-        group_member_ids = get_user_group_direct_members(user_group)
+        group_member_ids = get_user_group_direct_member_ids(user_group)
         if (
             not user_profile.is_realm_admin
             and not user_profile.is_moderator
@@ -114,7 +114,7 @@ def create_user_group(
         return user_group
 
 
-def get_user_group_direct_members(user_group: UserGroup) -> List[int]:
+def get_user_group_direct_member_ids(user_group: UserGroup) -> List[int]:
     return UserGroupMembership.objects.filter(user_group=user_group).values_list(
         "user_profile_id", flat=True
     )
@@ -172,7 +172,7 @@ def get_user_group_member_ids(
     user_group: UserGroup, *, direct_member_only: bool = False
 ) -> List[int]:
     if direct_member_only:
-        member_ids = get_user_group_direct_members(user_group)
+        member_ids = get_user_group_direct_member_ids(user_group)
     else:
         member_ids = get_recursive_group_members(user_group).values_list("id", flat=True)
 

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -278,6 +278,11 @@ class UserGroupAPITestCase(UserGroupTestCase):
         result = self.client_patch("/json/user_groups/1111", info=params)
         self.assert_json_error(result, "Invalid user group")
 
+        lear_realm = get_realm("lear")
+        lear_test_group = create_user_group("test", [self.lear_user("cordelia")], lear_realm)
+        result = self.client_patch(f"/json/user_groups/{lear_test_group.id}", info=params)
+        self.assert_json_error(result, "Invalid user group")
+
     def test_user_group_update_to_already_existing_name(self) -> None:
         hamlet = self.example_user("hamlet")
         self.login_user(hamlet)
@@ -310,6 +315,11 @@ class UserGroupAPITestCase(UserGroupTestCase):
         self.assertEqual(UserGroupMembership.objects.count(), 18)
         # Test when invalid user group is supplied
         result = self.client_delete("/json/user_groups/1111")
+        self.assert_json_error(result, "Invalid user group")
+
+        lear_realm = get_realm("lear")
+        lear_test_group = create_user_group("test", [self.lear_user("cordelia")], lear_realm)
+        result = self.client_delete(f"/json/user_groups/{lear_test_group.id}")
         self.assert_json_error(result, "Invalid user group")
 
     def test_update_members_of_user_group(self) -> None:
@@ -876,6 +886,11 @@ class UserGroupAPITestCase(UserGroupTestCase):
             ),
         )
 
+        lear_realm = get_realm("lear")
+        lear_test_group = create_user_group("test", [self.lear_user("cordelia")], lear_realm)
+        result = self.client_post(f"/json/user_groups/{lear_test_group.id}/subgroups", info=params)
+        self.assert_json_error(result, "Invalid user group")
+
         # Invalid subgroup id will raise an error.
         params = {"add": orjson.dumps([leadership_group.id, 1111]).decode()}
         result = self.client_post(f"/json/user_groups/{support_group.id}/subgroups", info=params)
@@ -901,6 +916,14 @@ class UserGroupAPITestCase(UserGroupTestCase):
 
         # Invalid user group ID.
         result = self.client_get(f"/json/user_groups/1111/members/{iago.id}")
+        self.assert_json_error(result, "Invalid user group")
+
+        lear_realm = get_realm("lear")
+        lear_cordelia = self.lear_user("cordelia")
+        lear_test_group = create_user_group("test", [lear_cordelia], lear_realm)
+        result = self.client_get(
+            f"/json/user_groups/{lear_test_group.id}/members/{lear_cordelia.id}"
+        )
         self.assert_json_error(result, "Invalid user group")
 
         result_dict = orjson.loads(
@@ -956,6 +979,11 @@ class UserGroupAPITestCase(UserGroupTestCase):
         result = self.client_get("/json/user_groups/1111/members")
         self.assert_json_error(result, "Invalid user group")
 
+        lear_realm = get_realm("lear")
+        lear_test_group = create_user_group("test", [self.lear_user("cordelia")], lear_realm)
+        result = self.client_get(f"/json/user_groups/{lear_test_group.id}/members")
+        self.assert_json_error(result, "Invalid user group")
+
         result_dict = orjson.loads(
             self.client_get(f"/json/user_groups/{moderators_group.id}/members").content
         )
@@ -993,6 +1021,11 @@ class UserGroupAPITestCase(UserGroupTestCase):
 
         # Test invalid user group id
         result = self.client_get("/json/user_groups/1111/subgroups")
+        self.assert_json_error(result, "Invalid user group")
+
+        lear_realm = get_realm("lear")
+        lear_test_group = create_user_group("test", [self.lear_user("cordelia")], lear_realm)
+        result = self.client_get(f"/json/user_groups/{lear_test_group.id}/subgroups")
         self.assert_json_error(result, "Invalid user group")
 
         result_dict = orjson.loads(

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -877,9 +877,9 @@ class UserGroupAPITestCase(UserGroupTestCase):
         )
 
         # Invalid subgroup id will raise an error.
-        params = {"add": orjson.dumps([leadership_group.id, 101]).decode()}
+        params = {"add": orjson.dumps([leadership_group.id, 1111]).decode()}
         result = self.client_post(f"/json/user_groups/{support_group.id}/subgroups", info=params)
-        self.assert_json_error(result, "Invalid user group ID: 101")
+        self.assert_json_error(result, "Invalid user group ID: 1111")
 
         # Test when nothing is provided
         result = self.client_post(f"/json/user_groups/{support_group.id}/subgroups", info={})
@@ -896,11 +896,11 @@ class UserGroupAPITestCase(UserGroupTestCase):
         )
 
         # Invalid user ID.
-        result = self.client_get(f"/json/user_groups/{admins_group.id}/members/25")
+        result = self.client_get(f"/json/user_groups/{admins_group.id}/members/1111")
         self.assert_json_error(result, "No such user")
 
         # Invalid user group ID.
-        result = self.client_get(f"/json/user_groups/25/members/{iago.id}")
+        result = self.client_get(f"/json/user_groups/1111/members/{iago.id}")
         self.assert_json_error(result, "Invalid user group")
 
         result_dict = orjson.loads(
@@ -953,7 +953,7 @@ class UserGroupAPITestCase(UserGroupTestCase):
         self.login("iago")
 
         # Test invalid user group id
-        result = self.client_get("/json/user_groups/25/members")
+        result = self.client_get("/json/user_groups/1111/members")
         self.assert_json_error(result, "Invalid user group")
 
         result_dict = orjson.loads(
@@ -992,7 +992,7 @@ class UserGroupAPITestCase(UserGroupTestCase):
         self.login("iago")
 
         # Test invalid user group id
-        result = self.client_get("/json/user_groups/25/subgroups")
+        result = self.client_get("/json/user_groups/1111/subgroups")
         self.assert_json_error(result, "Invalid user group")
 
         result_dict = orjson.loads(

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -22,7 +22,7 @@ from zerver.lib.user_groups import (
     access_user_groups_as_potential_subgroups,
     get_direct_memberships_of_users,
     get_subgroup_ids,
-    get_user_group_direct_members,
+    get_user_group_direct_member_ids,
     get_user_group_member_ids,
     is_user_in_group,
     user_groups_in_realm_serialized,
@@ -145,7 +145,7 @@ def remove_members_from_group_backend(
 
     user_profiles = user_ids_to_users(members, user_profile.realm)
     user_group = access_user_group_by_id(user_group_id, user_profile)
-    group_member_ids = get_user_group_direct_members(user_group)
+    group_member_ids = get_user_group_direct_member_ids(user_group)
     for member in members:
         if member not in group_member_ids:
             raise JsonableError(_("There is no member '{}' in this user group").format(member))


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR contains follow ups mentioned in #21611.

Commit summary -
- Use high enough number for invalid ids.
- Add checks for user groups in different realms in tests.
- Rename `get_user_group_direct_members` to `get_user_group_direct_member_ids`.
- Add a new function `get_user_group_direct_members`.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
