### PR TITLE
openapi: Mention that `profile_data` will be missing for bots.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15829,6 +15829,8 @@ components:
     profile_data:
       type: object
       description: |
+        Only present if `is_bot` is false; bots can't have custom profile fields.
+
         A dictionary containing custom profile field data for the user. Each entry
         maps the integer ID of a custom profile field in the organization to a
         dictionary containing the user's data for that field. Generally the data


### PR DESCRIPTION
For why we put this in the schema, instead of at the places where
the schema is consumed, Tim says:

> The code to not include it for bots is present in the common code
> path for formatting user objects for the API, so it should apply
> to all places we have users in the API documentation.

Discussion:
  https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60profile_data.60.20in.20.60.2Fregister.60.20response/near/1374737
