### PR TITLE
web_public_view: Redirect to current narrow after login.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -515,6 +515,12 @@ export function initialize() {
 
     // SIDEBARS
 
+    $(".right-sidebar .login_button").on("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        window.location.href = hash_util.build_login_link();
+    });
+
     $("#userlist-toggle-button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();

--- a/static/js/hash_util.js
+++ b/static/js/hash_util.js
@@ -1,5 +1,6 @@
 import * as internal_url from "../shared/js/internal_url";
 
+import {page_params} from "./page_params";
 import * as people from "./people";
 import * as stream_data from "./stream_data";
 
@@ -271,4 +272,12 @@ export function is_spectator_compatible(hash) {
 
 export function current_hash_as_next() {
     return `next=/${encodeURIComponent(window.location.hash)}`;
+}
+
+export function build_login_link() {
+    let login_link = "/login/?" + current_hash_as_next();
+    if (page_params.development_environment) {
+        login_link = "/devlogin/?" + current_hash_as_next();
+    }
+    return login_link;
 }

--- a/static/js/spectators.js
+++ b/static/js/spectators.js
@@ -12,17 +12,11 @@ import render_login_to_access_modal from "../templates/login_to_access.hbs";
 import * as browser_history from "./browser_history";
 import * as hash_util from "./hash_util";
 import * as overlays from "./overlays";
-import {page_params} from "./page_params";
 
 export function login_to_access() {
     // Hide all overlays, popover and go back to the previous hash if the
     // hash has changed.
-    let login_link;
-    if (page_params.development_environment) {
-        login_link = "/devlogin/?" + hash_util.current_hash_as_next();
-    } else {
-        login_link = "/login/?" + hash_util.current_hash_as_next();
-    }
+    const login_link = hash_util.build_login_link();
 
     $("body").append(
         render_login_to_access_modal({

--- a/static/templates/right_sidebar.hbs
+++ b/static/templates/right_sidebar.hbs
@@ -38,7 +38,7 @@
                         <i class="fa fa-pencil-square-o"></i>
                         <span>{{t 'Sign up' }}</span>
                     </a>
-                    <a href="/login" class="login_button color_animated_button">
+                    <a class="login_button color_animated_button">
                         <i class="fa fa-sign-in"></i>
                         <span>{{t 'Log in' }}</span>
                     </a>

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -89,6 +89,7 @@ EXEMPT_FILES = make_set(
         "static/js/gear_menu.js",
         "static/js/giphy.js",
         "static/js/global.d.ts",
+        "static/js/hash_util.js",
         "static/js/hashchange.js",
         "static/js/hbs.d.ts",
         "static/js/hotkey.js",


### PR DESCRIPTION
Add current hash as `next` URL to all login buttons
a spectator can access while in app.
