### PR TITLE
workers: Log the exception if the export fails.

### DIFF
--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2314,7 +2314,7 @@ class NormalActionsTest(BaseAction):
         self.login_user(self.user_profile)
 
         with mock.patch(
-            "zerver.lib.export.do_export_realm", side_effect=Exception("test")
+            "zerver.lib.export.do_export_realm", side_effect=Exception("Some failure")
         ), self.assertLogs(level="ERROR") as error_log:
             with stdout_suppressed():
                 events = self.verify_action(
@@ -2327,6 +2327,7 @@ class NormalActionsTest(BaseAction):
             # Where last floating number is time and will vary in each test hence the following assertion is
             # independent of time bit by not matching exact log but only part of it.
             self.assertTrue("ERROR:root:Data export for zulip failed after" in error_log.output[0])
+            self.assertTrue("Some failure" in error_log.output[0])
 
         # We get two events for the export.
         check_realm_export(

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -1039,10 +1039,11 @@ class DeferredWorker(QueueProcessingWorker):
                     )
                 ).decode()
                 export_event.save(update_fields=["extra_data"])
-                logging.error(
+                logging.exception(
                     "Data export for %s failed after %s",
                     user_profile.realm.string_id,
                     time.time() - start,
+                    stack_info=True,
                 )
                 notify_realm_export(user_profile)
                 return


### PR DESCRIPTION
We previously just swallowed the exception entirely.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
