### PR TITLE
puppet: Rotate access log files every day, not at 500M.

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -791,6 +791,11 @@ Override the default uwsgi backlog of 128 connections.
 Override the default `uwsgi` (Django) process count of 6 on hosts with
 more than 3.5GiB of RAM, 4 on hosts with less.
 
+#### `access_log_retention_days`
+
+Number of days of access logs to keep, for both nginx and the application.
+Defaults to 14 days.
+
 ### `[postfix]`
 
 #### `mailname`

--- a/puppet/zulip/manifests/nginx.pp
+++ b/puppet/zulip/manifests/nginx.pp
@@ -76,13 +76,14 @@ class zulip::nginx {
     group  => 'adm',
     mode   => '0750',
   }
+  $access_log_retention_days = zulipconf('application_server','access_log_retention_days', 14)
   file { '/etc/logrotate.d/nginx':
     ensure  => file,
     require => Package[$zulip::common::nginx],
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    source  => 'puppet:///modules/zulip/logrotate/nginx',
+    content => template('zulip/logrotate/nginx.template.erb'),
   }
   package { 'certbot':
     ensure => installed,

--- a/puppet/zulip/manifests/profile/app_frontend.pp
+++ b/puppet/zulip/manifests/profile/app_frontend.pp
@@ -23,12 +23,13 @@ class zulip::profile::app_frontend {
     content => template('zulip/nginx/zulip-enterprise.template.erb'),
     notify  => Service['nginx'],
   }
+  $access_log_retention_days = zulipconf('application_server','access_log_retention_days', 14)
   file { '/etc/logrotate.d/zulip':
-    ensure => file,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0644',
-    source => 'puppet:///modules/zulip/logrotate/zulip',
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('zulip/logrotate/zulip.template.erb'),
   }
   file { '/etc/nginx/sites-enabled/zulip-enterprise':
     ensure  => link,

--- a/puppet/zulip/templates/logrotate/nginx.template.erb
+++ b/puppet/zulip/templates/logrotate/nginx.template.erb
@@ -1,7 +1,7 @@
 /var/log/nginx/*.log {
 	daily
 	missingok
-	rotate 14
+	rotate <%= @access_log_retention_days %>
 	compress
 	delaycompress
 	notifempty

--- a/puppet/zulip/templates/logrotate/zulip.template.erb
+++ b/puppet/zulip/templates/logrotate/zulip.template.erb
@@ -32,8 +32,8 @@
 /var/log/zulip/server.log
 {
     missingok
-    rotate 10
-    size 500M
+    rotate <%= @access_log_retention_days %>
+    daily
     compress
     delaycompress
     notifempty

--- a/scripts/log-search
+++ b/scripts/log-search
@@ -25,18 +25,31 @@ from typing import Protocol
 
 from django.conf import settings
 
-from scripts.lib.zulip_tools import BOLD, CYAN, ENDC, FAIL, GRAY, OKBLUE
+from scripts.lib.zulip_tools import (
+    BOLD,
+    CYAN,
+    ENDC,
+    FAIL,
+    GRAY,
+    OKBLUE,
+    get_config,
+    get_config_file,
+)
 
 
 def parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Search logfiles, ignoring commonly-fetched URLs.")
     log_selection = parser.add_argument_group("File selection")
     log_selection_options = log_selection.add_mutually_exclusive_group()
+    access_log_retention_days = int(
+        get_config(get_config_file(), "application_server", "access_log_retention_days", "14")
+    )
     log_selection_options.add_argument(
         "--log-files",
         "-n",
         help="Number of log files to search",
-        choices=range(1, 16),
+        choices=range(1, access_log_retention_days + 2),
+        metavar=f"[1-{access_log_retention_days+1}]",
         type=int,
     )
     log_selection_options.add_argument(


### PR DESCRIPTION
Since logrotate runs in a daily cron, this practically means "daily,
but only if it's larger than 500M."  For large installs with large
traffic, this is effectively daily for 10 days; for small installs, it
is an unknown amount of time.

Switch to 14 daily logfiles.  This makes it easier to ensure that
access logs are not kept for more than two weeks, and matches the
nginx configuration.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
