### PR TITLE
refactor of stream typeahead order

### DIFF
--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -247,6 +247,43 @@ test("sort_streams", ({override_rewire}) => {
     assert.deepEqual(test_streams[3].name, "Ether"); // Unsubscribed and description starts with query
     assert.deepEqual(test_streams[4].name, "New"); // Subscribed and no match
     assert.deepEqual(test_streams[5].name, "Mew"); // Unsubscribed and no match
+
+    //Test Streams Order: Pinned -> Subscribed (Unmuted) -> Subscribed (Muted) -> Unsubscribed
+    test_streams = [
+        {
+            stream_id: 401,
+            name: "Aaron",
+            subscribed: false,
+            pin_to_top: false,
+            is_muted: false,
+        },
+        {
+            stream_id: 402,
+            name: "Abba",
+            subscribed: true,
+            is_muted: true,
+            pin_to_top: false,
+        },
+        {
+            stream_id: 403,
+            name: "Ace",
+            subscribed: true,
+            is_muted: false,
+            pin_to_top: false,
+        },
+        {
+            stream_id: 404,
+            name: "Adeline",
+            subscribed: true,
+            is_muted: false,
+            pin_to_top: true,
+        },
+    ];
+    test_streams = th.sort_streams(test_streams, "a");
+    assert.deepEqual(test_streams[0].name, "Adeline"); // Subscribed and Pinned to the top
+    assert.deepEqual(test_streams[1].name, "Ace"); // Subscribed and Unmuted
+    assert.deepEqual(test_streams[2].name, "Abba"); // Subscribed and Muted
+    assert.deepEqual(test_streams[3].name, "Aaron"); // Unsubscribed
 });
 
 test("sort_languages", () => {

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -273,14 +273,14 @@ test("sort_streams", ({override_rewire}) => {
         },
         {
             stream_id: 404,
-            name: "Adeline",
+            name: "Adele",
             subscribed: true,
             is_muted: false,
             pin_to_top: true,
         },
     ];
     test_streams = th.sort_streams(test_streams, "a");
-    assert.deepEqual(test_streams[0].name, "Adeline"); // Subscribed and Pinned to the top
+    assert.deepEqual(test_streams[0].name, "Adele"); // Subscribed and Pinned to the top
     assert.deepEqual(test_streams[1].name, "Ace"); // Subscribed and Unmuted
     assert.deepEqual(test_streams[2].name, "Abba"); // Subscribed and Muted
     assert.deepEqual(test_streams[3].name, "Aaron"); // Unsubscribed

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -248,7 +248,7 @@ test("sort_streams", ({override_rewire}) => {
     assert.deepEqual(test_streams[4].name, "New"); // Subscribed and no match
     assert.deepEqual(test_streams[5].name, "Mew"); // Unsubscribed and no match
 
-    //Test Streams Order: Pinned -> Subscribed (Unmuted) -> Subscribed (Muted) -> Unsubscribed
+    // Test Streams Order: Pinned -> Subscribed (Unmuted) -> Subscribed (Muted) -> Unsubscribed
     test_streams = [
         {
             stream_id: 401,

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -358,20 +358,25 @@ export function sort_slash_commands(matches, query) {
     return results.matches.concat(results.rest);
 }
 
-// Gives stream a score from 0 to 5 based on its activity
-// Pinned -> Subscribed (Unmuted) -> Subscribed (Muted) -> Unsubscribed
+// Gives stream a score from 0 to 6 based on its activity
+// Pinned (Unmuted) -> Subscribed (Unmuted) -> Subscribed (Muted) and [Pinned (Muted)] -> Unsubscribed
 function activity_score(sub) {
     let stream_score = 0;
-    if (sub.subscribed) {
-        // all subscribed streams receive 2 points to avoid unsubscribed streams ranking higher than muted streams
-        stream_score += 2;
-    }
     if (!sub.is_muted) {
         stream_score += 1;
+
+        if (sub.subscribed) {
+            stream_score += 1;
+        }
+        if (sub.pin_to_top) {
+            stream_score += 1;
+        }
     }
-    if (sub.pin_to_top) {
-        stream_score += 1;
+    if (sub.subscribed) {
+        // all subscribed streams receive 1 extra point to avoid unsubscribed streams ranking higher than muted streams
+        stream_score += 2;
     }
+
     if (stream_data.is_active(sub)) {
         stream_score += 1;
     }

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -358,19 +358,22 @@ export function sort_slash_commands(matches, query) {
     return results.matches.concat(results.rest);
 }
 
-// Gives stream a score from 0 to 3 based on its activity
+// Gives stream a score from 0 to 5 based on its activity
+// Pinned -> Subscribed (Unmuted) -> Subscribed (Muted) -> Unsubscribed
 function activity_score(sub) {
     let stream_score = 0;
-    if (!sub.subscribed) {
-        stream_score = -1;
-    } else {
-        if (sub.pin_to_top) {
-            stream_score += 2;
-        }
-        // Note: A pinned stream may accumulate a 3rd point if it is active
-        if (stream_data.is_active(sub)) {
-            stream_score += 1;
-        }
+    if (sub.subscribed) {
+        //subscribed streams receive 2 points to avoid unsubscribed streams ranking higher than muted streams
+        stream_score += 2
+    }
+    if (!sub.is_muted) {
+        stream_score += 1
+    }
+    if (sub.pin_to_top) {
+        stream_score += 1
+    }
+    if (stream_data.is_active(sub)) {
+        stream_score += 1
     }
     return stream_score;
 }

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -363,17 +363,17 @@ export function sort_slash_commands(matches, query) {
 function activity_score(sub) {
     let stream_score = 0;
     if (sub.subscribed) {
-        // subscribed streams receive 2 points to avoid unsubscribed streams ranking higher than muted streams
-        stream_score += 2
+        // all subscribed streams receive 2 points to avoid unsubscribed streams ranking higher than muted streams
+        stream_score += 2;
     }
     if (!sub.is_muted) {
-        stream_score += 1
+        stream_score += 1;
     }
     if (sub.pin_to_top) {
-        stream_score += 1
+        stream_score += 1;
     }
     if (stream_data.is_active(sub)) {
-        stream_score += 1
+        stream_score += 1;
     }
     return stream_score;
 }

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -363,7 +363,7 @@ export function sort_slash_commands(matches, query) {
 function activity_score(sub) {
     let stream_score = 0;
     if (sub.subscribed) {
-        //subscribed streams receive 2 points to avoid unsubscribed streams ranking higher than muted streams
+        // subscribed streams receive 2 points to avoid unsubscribed streams ranking higher than muted streams
         stream_score += 2
     }
     if (!sub.is_muted) {


### PR DESCRIPTION
Changed algorithm for sorthing the streams type ahead suggestions

Fixes: https://github.com/zulip/zulip/issues/20618

I encountered an issue where sometimes an unmuted unsubscribed stream would be suggested ahead of a subscrubed muted stream. To solve that issue I gave all subscribed streams a +2 to their score. Every other case will only give them +1. This way the typeahead will always suggest subscribed streams over unsubscribed streams. 

<img width="561" alt="Screen Shot 2022-04-28 at 11 01 14 PM" src="https://user-images.githubusercontent.com/102554712/165893620-b779f2a1-e6f9-499b-9223-6157bdfc94ff.png">
**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description). (the issue explains very well.)
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.

- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
