### PR TITLE
message_view_header: Add divider after stream name for spectator.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1789,6 +1789,12 @@ div.focused_table {
         padding-right: calc(3px + 10px);
     }
 
+    .divider {
+        color: hsl(0, 0%, 88%);
+        font-size: 20px;
+        margin: 0 3px;
+    }
+
     .sub_count,
     .narrow_description {
         background: none;

--- a/static/templates/message_view_header.hbs
+++ b/static/templates/message_view_header.hbs
@@ -2,6 +2,7 @@
 <a class="stream" href="{{stream_settings_link}}">
     {{> navbar_icon_and_title }}
 </a>
+<div class="divider only-visible-for-spectators">|</div>
 <a class="sub_count no-style tippy-zulip-tooltip hidden-for-spectators" data-tippy-content="{{sub_count_tooltip_text}}" data-tippy-placement="bottom" href="{{stream_settings_link}}">
     <i class="fa fa-user-o"></i>{{formatted_sub_count}}
 </a>


### PR DESCRIPTION
Since originally divider is a part of sub_count which is not
displayed for spectators, we need to add a new one for them.
![image](https://user-images.githubusercontent.com/25124304/165994897-32238504-3be6-4368-99db-0744941cadab.png)

I used the same divider we use for compose here.

discussion - https://chat.zulip.org/#narrow/stream/9-issues/topic/web-public.20streams.20navbar