### PR TITLE
build-pgroonga: Update PGroonga to 2.3.6

### DIFF
--- a/scripts/lib/build-pgroonga
+++ b/scripts/lib/build-pgroonga
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
-set -x
-set -e
+set -euxo pipefail
 
-PGROONGA_VERSION="2.2.8"
+version="2.3.6"
+sha256=fc68a66a216e304bb0e2ef627f767fff528f4fbf2bbda27e8cd8db1b7ba090b0
 
-cd "$(mktemp -d)"
+tmpdir="$(mktemp -d)"
+trap 'rm -r "$tmpdir"' EXIT
+cd "$tmpdir"
+tarball="pgroonga-$version.tar.gz"
+curl -fLO "https://packages.groonga.org/source/pgroonga/$tarball"
+sha256sum -c <<<"$sha256 $tarball"
+tar -xzf "$tarball"
+cd "pgroonga-$version"
 
-curl -fLO https://packages.groonga.org/source/pgroonga/pgroonga-"$PGROONGA_VERSION".tar.gz
-tar xf pgroonga-"$PGROONGA_VERSION".tar.gz
-cd pgroonga-"$PGROONGA_VERSION"
-
-make HAVE_MSGPACK=1
+make -j "$(nproc)" HAVE_MSGPACK=1
 make install

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -174,8 +174,7 @@ if vendor == "debian" and os_version in [] or vendor == "ubuntu" and os_version 
         f"postgresql-server-dev-{POSTGRESQL_VERSION}",
         "libgroonga-dev",
         "libmsgpack-dev",
-        "clang-9",
-        "llvm-9-dev",
+        "clang",
         *VENV_DEPENDENCIES,
     ]
 elif "debian" in os_families():


### PR DESCRIPTION
This is probably unused, and will remain so since the pgroonga PPA was just updated with packages for Ubuntu 22.04, but since I tested this in #21328 we might as well merge it.