### PR TITLE
puppet: Remove quotes for enumerable values

### DIFF
--- a/puppet/zulip/manifests/apache_sso.pp
+++ b/puppet/zulip/manifests/apache_sso.pp
@@ -16,7 +16,7 @@ class zulip::apache_sso {
       fail('osfamily not supported')
     }
   }
-  package { $apache_packages: ensure => 'installed' }
+  package { $apache_packages: ensure => installed }
 
   apache2mod { [ 'headers', 'proxy', 'proxy_http', 'rewrite', 'ssl', 'wsgi', ]:
     ensure  => present,

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -12,10 +12,10 @@ class zulip::app_frontend_base {
     # package already includes the client.  This may get us a more
     # recent client than the database server is configured to be,
     # ($zulip::postgresql_common::version), but they're compatible.
-    zulip::safepackage { 'postgresql-client': ensure => 'installed' }
+    zulip::safepackage { 'postgresql-client': ensure => installed }
   }
   # For Slack import
-  zulip::safepackage { 'unzip': ensure => 'installed' }
+  zulip::safepackage { 'unzip': ensure => installed }
 
   file { '/etc/nginx/zulip-include/app':
     require => Package[$zulip::common::nginx],
@@ -161,17 +161,17 @@ class zulip::app_frontend_base {
     mode   => '0755',
   }
   file { '/home/zulip/logs':
-    ensure => 'directory',
+    ensure => directory,
     owner  => 'zulip',
     group  => 'zulip',
   }
   file { '/home/zulip/prod-static':
-    ensure => 'directory',
+    ensure => directory,
     owner  => 'zulip',
     group  => 'zulip',
   }
   file { '/home/zulip/deployments':
-    ensure => 'directory',
+    ensure => directory,
     owner  => 'zulip',
     group  => 'zulip',
   }
@@ -189,14 +189,14 @@ class zulip::app_frontend_base {
   }
 
   file { '/var/log/zulip/queue_error':
-    ensure => 'directory',
+    ensure => directory,
     owner  => 'zulip',
     group  => 'zulip',
     mode   => '0640',
   }
 
   file { '/var/log/zulip/queue_stats':
-    ensure => 'directory',
+    ensure => directory,
     owner  => 'zulip',
     group  => 'zulip',
     mode   => '0640',

--- a/puppet/zulip/manifests/camo.pp
+++ b/puppet/zulip/manifests/camo.pp
@@ -3,7 +3,7 @@ class zulip::camo (String $listen_address = '0.0.0.0') {
   # can be removed once one must have upgraded through Zulip 5.0 or
   # higher to get to the next release.
   package { 'camo':
-    ensure => 'purged',
+    ensure => purged,
   }
 
   $version = $zulip::common::versions['go-camo']['version']

--- a/puppet/zulip/manifests/nginx.pp
+++ b/puppet/zulip/manifests/nginx.pp
@@ -4,16 +4,16 @@ class zulip::nginx {
     $zulip::common::nginx,
     'ca-certificates',
   ]
-  package { $web_packages: ensure => 'installed' }
+  package { $web_packages: ensure => installed }
 
   if $::os['family'] == 'RedHat' {
     file { '/etc/nginx/sites-available':
-      ensure => 'directory',
+      ensure => directory,
       owner  => 'root',
       group  => 'root',
     }
     file { '/etc/nginx/sites-enabled':
-      ensure => 'directory',
+      ensure => directory,
       owner  => 'root',
       group  => 'root',
     }
@@ -111,7 +111,7 @@ class zulip::nginx {
   }
 
   file { '/var/log/nginx':
-    ensure => 'directory',
+    ensure => directory,
     owner  => 'zulip',
     group  => 'adm',
     mode   => '0650',
@@ -125,10 +125,10 @@ class zulip::nginx {
     source  => 'puppet:///modules/zulip/logrotate/nginx',
   }
   package { 'certbot':
-    ensure => 'installed',
+    ensure => installed,
   }
   file { ['/var/lib/zulip', '/var/lib/zulip/certbot-webroot']:
-    ensure => 'directory',
+    ensure => directory,
     owner  => 'zulip',
     group  => 'adm',
     mode   => '0660',

--- a/puppet/zulip/manifests/postfix_localmail.pp
+++ b/puppet/zulip/manifests/postfix_localmail.pp
@@ -8,7 +8,7 @@ class zulip::postfix_localmail {
   }
   $postfix_mailname = zulipconf('postfix', 'mailname', $fqdn)
   package { $postfix_packages:
-    ensure  => 'installed',
+    ensure  => installed,
     require => File['/etc/mailname'],
   }
 

--- a/puppet/zulip/manifests/postgresql_base.pp
+++ b/puppet/zulip/manifests/postgresql_base.pp
@@ -44,12 +44,12 @@ class zulip::postgresql_base {
   }
 
   file { "${tsearch_datadir}/en_us.dict":
-    ensure  => 'link',
+    ensure  => link,
     require => Package[$postgresql],
     target  => $postgresql_dict_dict,
   }
   file { "${tsearch_datadir}/en_us.affix":
-    ensure  => 'link',
+    ensure  => link,
     require => Package[$postgresql],
     target  => $postgresql_dict_affix,
 
@@ -79,11 +79,11 @@ class zulip::postgresql_base {
     # Removed 2020-12 in version 4.0; these lines can be removed when
     # we drop support for upgrading from Zulip 3 or older.
     package{"${postgresql}-pgroonga":
-      ensure  => 'purged',
+      ensure  => purged,
     }
 
     package{"${postgresql}-pgdg-pgroonga":
-      ensure  => 'installed',
+      ensure  => installed,
       require => [Package[$postgresql],
                   Exec[$setup_system_deps]],
     }

--- a/puppet/zulip/manifests/postgresql_common.pp
+++ b/puppet/zulip/manifests/postgresql_common.pp
@@ -43,7 +43,7 @@ class zulip::postgresql_common {
       }
       # allows ssl-cert group to read /etc/pki/tls/private
       file { '/etc/pki/tls/private':
-        ensure => 'directory',
+        ensure => directory,
         mode   => '0640',
         owner  => 'root',
         group  => 'ssl-cert',
@@ -59,7 +59,7 @@ class zulip::postgresql_common {
   }
 
   zulip::safepackage { $postgresql_packages:
-    ensure  => 'installed',
+    ensure  => installed,
     require => Exec['generate-default-snakeoil'],
   }
 

--- a/puppet/zulip/manifests/process_fts_updates.pp
+++ b/puppet/zulip/manifests/process_fts_updates.pp
@@ -6,7 +6,7 @@ class zulip::process_fts_updates {
         # Needed to run process_fts_updates
         'python3-psycopg2', # TODO: use a virtualenv instead
       ]
-      zulip::safepackage { $fts_updates_packages: ensure => 'installed' }
+      zulip::safepackage { $fts_updates_packages: ensure => installed }
     }
     'RedHat': {
       exec {'pip_process_fts_updates':

--- a/puppet/zulip/manifests/profile/app_frontend.pp
+++ b/puppet/zulip/manifests/profile/app_frontend.pp
@@ -31,7 +31,7 @@ class zulip::profile::app_frontend {
     source => 'puppet:///modules/zulip/logrotate/zulip',
   }
   file { '/etc/nginx/sites-enabled/zulip-enterprise':
-    ensure  => 'link',
+    ensure  => link,
     require => Package[$zulip::common::nginx],
     target  => '/etc/nginx/sites-available/zulip-enterprise',
     notify  => Service['nginx'],

--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -60,9 +60,9 @@ class zulip::profile::base {
       fail('osfamily not supported')
     }
   }
-  package { 'ntp': ensure => 'purged', before => Package['chrony'] }
+  package { 'ntp': ensure => purged, before => Package['chrony'] }
   service { 'chrony': require => Package['chrony'] }
-  package { $base_packages: ensure => 'installed' }
+  package { $base_packages: ensure => installed }
 
   group { 'zulip':
     ensure => present,
@@ -78,21 +78,21 @@ class zulip::profile::base {
   }
 
   file { '/etc/zulip':
-    ensure => 'directory',
+    ensure => directory,
     mode   => '0644',
     owner  => 'zulip',
     group  => 'zulip',
-    links  => 'follow',
+    links  => follow,
   }
   file { ['/etc/zulip/zulip.conf', '/etc/zulip/settings.py']:
-    ensure  => 'file',
+    ensure  => file,
     require => File['/etc/zulip'],
     mode    => '0644',
     owner   => 'zulip',
     group   => 'zulip',
   }
   file { '/etc/zulip/zulip-secrets.conf':
-    ensure  => 'file',
+    ensure  => file,
     require => File['/etc/zulip'],
     mode    => '0640',
     owner   => 'zulip',
@@ -115,7 +115,7 @@ class zulip::profile::base {
   }
 
   file { '/var/log/zulip':
-    ensure => 'directory',
+    ensure => directory,
     owner  => 'zulip',
     group  => 'zulip',
     mode   => '0640',

--- a/puppet/zulip/manifests/profile/memcached.pp
+++ b/puppet/zulip/manifests/profile/memcached.pp
@@ -16,7 +16,7 @@ class zulip::profile::memcached {
       fail('osfamily not supported')
     }
   }
-  package { $memcached_packages: ensure => 'installed' }
+  package { $memcached_packages: ensure => installed }
 
   $memcached_memory = zulipconf('memcached', 'memory', $zulip::common::total_memory_mb / 8)
   file { '/etc/sasl2':
@@ -82,7 +82,7 @@ saslpasswd2 -p -f /etc/sasl2/memcached-sasldb2 \
     content => template('zulip/memcached.conf.template.erb'),
   }
   file { '/run/memcached':
-    ensure  => 'directory',
+    ensure  => directory,
     owner   => 'memcache',
     group   => 'memcache',
     mode    => '0755',

--- a/puppet/zulip/manifests/profile/rabbitmq.pp
+++ b/puppet/zulip/manifests/profile/rabbitmq.pp
@@ -15,7 +15,7 @@ class zulip::profile::rabbitmq {
   }
 
   file { '/etc/rabbitmq':
-    ensure => 'directory',
+    ensure => directory,
     owner  => 'root',
     group  => 'root',
     mode   => '0755',
@@ -42,7 +42,7 @@ class zulip::profile::rabbitmq {
       Service['rabbitmq-server'],
     ],
     logoutput => true,
-    loglevel  => 'warning',
+    loglevel  => warning,
   }
   file { '/etc/rabbitmq/rabbitmq-env.conf':
     ensure => file,
@@ -57,7 +57,7 @@ class zulip::profile::rabbitmq {
     ],
   }
   package { $rabbitmq_packages:
-    ensure  => 'installed',
+    ensure  => installed,
   }
   # epmd doesn't have an init script, so we just check if it is
   # running, and if it isn't, start it.  Even in case of a race, this

--- a/puppet/zulip/manifests/profile/redis.pp
+++ b/puppet/zulip/manifests/profile/redis.pp
@@ -17,7 +17,7 @@ class zulip::profile::redis {
                       $redis,
                       ]
 
-  package { $redis_packages: ensure => 'installed' }
+  package { $redis_packages: ensure => installed }
 
   $file = "${redis_dir}/redis.conf"
   $zulip_redisconf = "${redis_dir}/zulip-redis.conf"
@@ -61,7 +61,7 @@ class zulip::profile::redis {
   }
 
   file { '/run/redis':
-    ensure  => 'directory',
+    ensure  => directory,
     owner   => 'redis',
     group   => 'redis',
     mode    => '0755',

--- a/puppet/zulip/manifests/sasl_modules.pp
+++ b/puppet/zulip/manifests/sasl_modules.pp
@@ -3,5 +3,5 @@ class zulip::sasl_modules {
     'Debian' => [ 'libsasl2-modules' ],
     'RedHat' => [ 'cyrus-sasl-plain' ],
   }
-  package { $sasl_module_packages: ensure => 'installed' }
+  package { $sasl_module_packages: ensure => installed }
 }

--- a/puppet/zulip/manifests/snakeoil.pp
+++ b/puppet/zulip/manifests/snakeoil.pp
@@ -1,5 +1,5 @@
 class zulip::snakeoil {
-  zulip::safepackage { 'ssl-cert': ensure => 'installed' }
+  zulip::safepackage { 'ssl-cert': ensure => installed }
 
   # We use the snakeoil certificate for PostgreSQL and Postfix; some VMs
   # install the `ssl-cert` package but (reasonably) don't build the

--- a/puppet/zulip/manifests/static_asset_compiler.pp
+++ b/puppet/zulip/manifests/static_asset_compiler.pp
@@ -16,5 +16,5 @@ class zulip::static_asset_compiler {
     }
   }
 
-  zulip::safepackage { $static_asset_compiler_packages: ensure => 'installed' }
+  zulip::safepackage { $static_asset_compiler_packages: ensure => installed }
 }

--- a/puppet/zulip/manifests/supervisor.pp
+++ b/puppet/zulip/manifests/supervisor.pp
@@ -1,11 +1,11 @@
 class zulip::supervisor {
   $supervisor_service = $zulip::common::supervisor_service
 
-  package { 'supervisor': ensure => 'installed' }
+  package { 'supervisor': ensure => installed }
 
   $system_conf_dir = $zulip::common::supervisor_system_conf_dir
   file { $system_conf_dir:
-    ensure  => 'directory',
+    ensure  => directory,
     require => Package['supervisor'],
     owner   => 'root',
     group   => 'root',
@@ -16,7 +16,7 @@ class zulip::supervisor {
   $should_purge = $facts['leave_supervisor'] != 'true'
   # lint:endignore
   file { $conf_dir:
-    ensure  => 'directory',
+    ensure  => directory,
     require => Package['supervisor'],
     owner   => 'root',
     group   => 'root',

--- a/puppet/zulip/manifests/tornado_sharding.pp
+++ b/puppet/zulip/manifests/tornado_sharding.pp
@@ -31,7 +31,7 @@ class zulip::tornado_sharding {
     onlyif    => "${::zulip_scripts_path}/lib/sharding.py --errors-ok",
     require   => [File['/etc/zulip/nginx_sharding.conf'], File['/etc/zulip/sharding.json']],
     logoutput => true,
-    loglevel  => 'warning',
+    loglevel  => warning,
   }
 
   # The ports of Tornado processes to run on the server; defaults to

--- a/puppet/zulip/manifests/wal_g.pp
+++ b/puppet/zulip/manifests/wal_g.pp
@@ -46,7 +46,7 @@ class zulip::wal_g {
     }
   }
   file { '/usr/local/bin/wal-g':
-    ensure => 'link',
+    ensure => link,
     target => $bin,
   }
   # We used to install versions into /usr/local/bin/wal-g-VERSION,

--- a/puppet/zulip_ops/manifests/apache.pp
+++ b/puppet/zulip_ops/manifests/apache.pp
@@ -3,7 +3,7 @@ class zulip_ops::apache {
                       'apache2',
                       'libapache2-mod-wsgi',
                       ]
-  package { $apache_packages: ensure => 'installed' }
+  package { $apache_packages: ensure => installed }
   service { 'apache2':
     require => Package['apache2'],
   }

--- a/puppet/zulip_ops/manifests/app_frontend.pp
+++ b/puppet/zulip_ops/manifests/app_frontend.pp
@@ -8,7 +8,7 @@ class zulip_ops::app_frontend {
   $app_packages = [# Needed for the ssh tunnel to the redis server
     'autossh',
   ]
-  package { $app_packages: ensure => 'installed' }
+  package { $app_packages: ensure => installed }
   $redis_hostname = zulipconf('redis', 'hostname', undef)
 
   zulip_ops::firewall_allow{ 'smtp': }

--- a/puppet/zulip_ops/manifests/ksplice_uptrack.pp
+++ b/puppet/zulip_ops/manifests/ksplice_uptrack.pp
@@ -2,7 +2,7 @@ class zulip_ops::ksplice_uptrack {
   $ksplice_access_key = zulipsecret('secrets', 'ksplice_access_key', '')
   if $ksplice_access_key != '' {
     file { '/etc/uptrack':
-      ensure => 'directory',
+      ensure => directory,
       owner  => 'root',
       group  => 'adm',
       mode   => '0750',

--- a/puppet/zulip_ops/manifests/munin_node.pp
+++ b/puppet/zulip_ops/manifests/munin_node.pp
@@ -1,5 +1,5 @@
 class zulip_ops::munin_node {
-  zulip::safepackage { ['munin-node', 'munin-plugins-extra']: ensure => 'installed' }
+  zulip::safepackage { ['munin-node', 'munin-plugins-extra']: ensure => installed }
 
   service { 'munin-node':
     ensure  => running,

--- a/puppet/zulip_ops/manifests/munin_plugin.pp
+++ b/puppet/zulip_ops/manifests/munin_plugin.pp
@@ -7,7 +7,7 @@ define zulip_ops::munin_plugin {
   }
 
   file { "/etc/munin/plugins/${name}":
-    ensure  => 'link',
+    ensure  => link,
     require => File["/usr/local/munin/lib/plugins/${title}"],
     target  => "/usr/local/munin/lib/plugins/${title}",
     notify  => Service['munin-node'],

--- a/puppet/zulip_ops/manifests/profile/base.pp
+++ b/puppet/zulip_ops/manifests/profile/base.pp
@@ -35,7 +35,7 @@ class zulip_ops::profile::base {
     'git',
     'nagios-plugins-contrib',
   ]
-  zulip::safepackage { $org_base_packages: ensure => 'installed' }
+  zulip::safepackage { $org_base_packages: ensure => installed }
 
   # Uninstall the AWS kernel, but only after we install the usual one
   package { ['linux-image-aws', 'linux-headers-aws', 'linux-aws-*', 'linux-image-*-aws', 'linux-modules-*-aws']:
@@ -117,7 +117,7 @@ class zulip_ops::profile::base {
     # This conditional block is for for whether it's not
     # chat.zulip.org, which uses a different hosting provider.
     package { 'dhcpcd5':
-      ensure => 'installed',
+      ensure => installed,
     }
     file { '/root/.ssh/authorized_keys':
       ensure => file,

--- a/puppet/zulip_ops/manifests/profile/munin_server.pp
+++ b/puppet/zulip_ops/manifests/profile/munin_server.pp
@@ -8,7 +8,7 @@ class zulip_ops::profile::munin_server {
     'autossh',
     'libapache2-mod-fcgid',
   ]
-  package { $munin_packages: ensure => 'installed' }
+  package { $munin_packages: ensure => installed }
 
   $default_host_domain = zulipconf('nagios', 'default_host_domain', undef)
   $hosts = zulipconf_nagios_hosts()

--- a/puppet/zulip_ops/manifests/profile/nagios.pp
+++ b/puppet/zulip_ops/manifests/profile/nagios.pp
@@ -7,7 +7,7 @@ class zulip_ops::profile::nagios {
                       # For sending outgoing email
                       'msmtp',
                       ]
-  package { $nagios_packages: ensure => 'installed' }
+  package { $nagios_packages: ensure => installed }
   $nagios_alert_email = zulipconf('nagios', 'alert_email', undef)
   $nagios_test_email = zulipconf('nagios', 'test_email', undef)
   $nagios_pager_email = zulipconf('nagios', 'pager_email', undef)

--- a/puppet/zulip_ops/manifests/profile/postgresql.pp
+++ b/puppet/zulip_ops/manifests/profile/postgresql.pp
@@ -4,7 +4,7 @@ class zulip_ops::profile::postgresql {
   include zulip_ops::teleport::db
 
   $common_packages = ['xfsprogs']
-  package { $common_packages: ensure => 'installed' }
+  package { $common_packages: ensure => installed }
 
   zulip_ops::firewall_allow{ 'postgresql': }
 

--- a/puppet/zulip_ops/manifests/profile/prod_app_frontend.pp
+++ b/puppet/zulip_ops/manifests/profile/prod_app_frontend.pp
@@ -13,7 +13,7 @@ class zulip_ops::profile::prod_app_frontend {
   }
 
   file { '/etc/nginx/sites-enabled/zulip':
-    ensure  => 'link',
+    ensure  => link,
     require => Package['nginx-full'],
     target  => '/etc/nginx/sites-available/zulip',
     notify  => Service['nginx'],

--- a/puppet/zulip_ops/manifests/profile/prometheus_server.pp
+++ b/puppet/zulip_ops/manifests/profile/prometheus_server.pp
@@ -17,7 +17,7 @@ class zulip_ops::profile::prometheus_server {
     tarball_prefix => "prometheus-${version}.linux-${zulip::common::goarch}",
   }
   file { '/usr/local/bin/promtool':
-    ensure  => 'link',
+    ensure  => link,
     target  => "${dir}/promtool",
     require => Zulip::External_Dep['prometheus'],
   }

--- a/puppet/zulip_ops/manifests/profile/staging_app_frontend.pp
+++ b/puppet/zulip_ops/manifests/profile/staging_app_frontend.pp
@@ -12,7 +12,7 @@ class zulip_ops::profile::staging_app_frontend {
     notify  => Service['nginx'],
   }
   file { '/etc/nginx/sites-enabled/zulip-staging':
-    ensure  => 'link',
+    ensure  => link,
     require => Package['nginx-full'],
     target  => '/etc/nginx/sites-available/zulip-staging',
     notify  => Service['nginx'],

--- a/puppet/zulip_ops/manifests/profile/zmirror.pp
+++ b/puppet/zulip_ops/manifests/profile/zmirror.pp
@@ -16,7 +16,7 @@ class zulip_ops::profile::zmirror {
     'cython',
   ]
   package { $zmirror_packages:
-    ensure  => 'installed',
+    ensure  => installed,
   }
 
   file { "${zulip::common::supervisor_conf_dir}/zmirror.conf":

--- a/puppet/zulip_ops/manifests/profile/zmirror_personals.pp
+++ b/puppet/zulip_ops/manifests/profile/zmirror_personals.pp
@@ -16,7 +16,7 @@ class zulip_ops::profile::zmirror_personals {
     'cython',
   ]
   package { $zmirror_packages:
-    ensure  => 'installed',
+    ensure  => installed,
   }
 
   file { '/etc/krb5.conf':


### PR DESCRIPTION
https://puppet.com/docs/puppet/7/style_guide.html#style_guide_module_design-quoting
“If a string is a value from an enumerable set of options, such as `present` and `absent`, it SHOULD NOT be enclosed in quotes at all.”