### PR TITLE
Add support for guests to see and subscribe web-public streams.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 7.0
 
+**Feature level 167**
+
+* [`POST /users/me/subscriptions`](/api/subscribe), [`PATCH
+  /users/me/subscriptions`](/api/update-subscriptions): Guests
+  are now allowed to subscribe themselves to web-public streams.
+
 **Feature level 166**
 
 * [`POST /messages`](/api/send-message): Eliminated the undocumented

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 166
+API_FEATURE_LEVEL = 167
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/settings_data.ts
+++ b/web/src/settings_data.ts
@@ -68,6 +68,18 @@ export function user_can_change_logo(): boolean {
     return page_params.is_admin && page_params.zulip_plan_is_not_limited;
 }
 
+export function web_public_streams_enabled_for_realm(): boolean {
+    if (!page_params.server_web_public_streams_enabled) {
+        return false;
+    }
+
+    if (!page_params.zulip_plan_is_not_limited) {
+        return false;
+    }
+
+    return page_params.realm_enable_spectator_access;
+}
+
 function user_has_permission(policy_value: number): boolean {
     /* At present, nobody and by_owners_only is not present in
      * common_policy_values, but we include a check for it here,

--- a/web/src/stream_data.js
+++ b/web/src/stream_data.js
@@ -523,8 +523,9 @@ export function is_notifications_stream_muted() {
 export function can_toggle_subscription(sub) {
     // You can always remove your subscription if you're subscribed.
     //
-    // One can only join a stream if it is public (!invite_only) and
-    // your role is Member or above (!is_guest).
+    // One can only join a stream if it is web-public or public (!invite_only)
+    // and your role is Member or above (!is_guest).
+    // Guests can only join web-public streams.
     // Spectators cannot subscribe to any streams.
     //
     // Note that the correctness of this logic relies on the fact that
@@ -532,7 +533,8 @@ export function can_toggle_subscription(sub) {
     // deactivated streams are automatically made private during the
     // archive stream process.
     return (
-        (sub.subscribed || (!page_params.is_guest && !sub.invite_only)) && !page_params.is_spectator
+        (sub.subscribed || sub.is_web_public || (!page_params.is_guest && !sub.invite_only)) &&
+        !page_params.is_spectator
     );
 }
 

--- a/web/src/stream_settings_data.js
+++ b/web/src/stream_settings_data.js
@@ -2,6 +2,7 @@ import * as hash_util from "./hash_util";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as settings_config from "./settings_config";
+import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
 import {user_settings} from "./user_settings";
@@ -25,9 +26,13 @@ function get_subs_for_settings(subs) {
 export function get_updated_unsorted_subs() {
     let all_subs = stream_data.get_unsorted_subs();
 
-    // We don't display unsubscribed streams to guest users.
+    // We display only subscribed and web-public streams to guest users.
     if (page_params.is_guest) {
-        all_subs = all_subs.filter((sub) => sub.subscribed);
+        all_subs = all_subs.filter(
+            (sub) =>
+                sub.subscribed ||
+                (settings_data.web_public_streams_enabled_for_realm() && sub.is_web_public),
+        );
     }
 
     return get_subs_for_settings(all_subs);

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -1031,7 +1031,7 @@ export function unsubscribe_from_private_stream(sub) {
 export function sub_or_unsub(sub, $stream_row) {
     if (sub.subscribed) {
         // TODO: This next line should allow guests to access web-public streams.
-        if (sub.invite_only || page_params.is_guest) {
+        if (sub.invite_only || (page_params.is_guest && !sub.is_web_public)) {
             unsubscribe_from_private_stream(sub);
             return;
         }

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -617,7 +617,7 @@ export function setup_page(callback) {
             const toggler_elem = toggler.get();
             $("#manage_streams_container .search-container").prepend(toggler_elem);
         }
-        if (page_params.is_guest) {
+        if (page_params.is_guest && !settings_data.web_public_streams_enabled_for_realm()) {
             toggler.disable_tab("all-streams");
         }
 

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -169,7 +169,8 @@ function initialize_bottom_whitespace() {
 
 function initialize_left_sidebar() {
     const rendered_sidebar = render_left_sidebar({
-        is_guest: page_params.is_guest,
+        can_subscribe_to_streams:
+            !page_params.is_guest || settings_data.web_public_streams_enabled_for_realm(),
     });
 
     $("#left-sidebar-container").html(rendered_sidebar);

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -82,9 +82,11 @@
 
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'STREAMS' }}</h4>
+                {{#if can_subscribe_to_streams}}
                 <span class="tippy-zulip-tooltip streams_inline_icon_wrapper hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}">
                     <i id="streams_inline_icon" class='fa fa-plus' aria-hidden="true" ></i>
                 </span>
+                {{/if}}
                 <i class="streams_filter_icon fa fa-filter tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{t 'Filter streams' }}" />

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -102,9 +102,9 @@
             </div>
             <div id="stream-filters-container">
                 <ul id="stream_filters" class="filters"></ul>
-                {{#unless is_guest }}
+                {{#if can_subscribe_to_streams }}
                     <div id="subscribe-to-more-streams"></div>
-                {{/unless}}
+                {{/if}}
                 <div id="login-link-container" class="only-visible-for-spectators">
                     <a class="login_button">
                         <i class="fa fa-sign-in" aria-hidden="true"></i>

--- a/web/tests/settings_data.test.js
+++ b/web/tests/settings_data.test.js
@@ -317,3 +317,19 @@ run_test("user_can_create_web_public_streams", () => {
     page_params.is_moderator = false;
     assert.equal(settings_data.user_can_create_web_public_streams(), false);
 });
+
+run_test("web_public_streams_enabled_for_realm", () => {
+    page_params.server_web_public_streams_enabled = false;
+    assert.equal(settings_data.web_public_streams_enabled_for_realm(), false);
+
+    page_params.server_web_public_streams_enabled = true;
+    page_params.zulip_plan_is_not_limited = false;
+    assert.equal(settings_data.web_public_streams_enabled_for_realm(), false);
+
+    page_params.zulip_plan_is_not_limited = true;
+    page_params.realm_enable_spectator_access = false;
+    assert.equal(settings_data.web_public_streams_enabled_for_realm(), false);
+
+    page_params.realm_enable_spectator_access = true;
+    assert.equal(settings_data.web_public_streams_enabled_for_realm(), true);
+});

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -549,7 +549,9 @@ def fetch_initial_state_data(
         # places.
         if user_profile is not None:
             state["streams"] = do_get_streams(
-                user_profile, include_all_active=user_profile.is_realm_admin
+                user_profile,
+                include_all_active=user_profile.is_realm_admin,
+                include_web_public=user_profile.is_guest,
             )
         else:
             # TODO: This line isn't used by the web app because it
@@ -835,7 +837,9 @@ def apply_event(
 
                     if "streams" in state:
                         state["streams"] = do_get_streams(
-                            user_profile, include_all_active=user_profile.is_realm_admin
+                            user_profile,
+                            include_all_active=user_profile.is_realm_admin,
+                            include_web_public=user_profile.is_guest,
                         )
 
                     if state["is_guest"]:

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -30,6 +30,7 @@ from zerver.models import (
     UserGroup,
     UserProfile,
     active_non_guest_user_ids,
+    active_user_ids,
     bulk_get_streams,
     get_realm_stream,
     get_stream,
@@ -173,7 +174,11 @@ def create_stream_if_needed(
             )
     if created:
         if stream.is_public():
-            send_stream_creation_event(stream, active_non_guest_user_ids(stream.realm_id))
+            if stream.is_web_public:
+                user_ids = active_user_ids(stream.realm_id)
+            else:
+                user_ids = active_non_guest_user_ids(stream.realm_id)
+            send_stream_creation_event(stream, user_ids)
         else:
             realm_admin_ids = [user.id for user in stream.realm.get_admin_users_and_bots()]
             send_stream_creation_event(stream, realm_admin_ids)

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -721,6 +721,9 @@ def list_to_streams(
         created_streams: List[Stream] = []
     else:
         # autocreate=True path starts here
+        if user_profile.is_guest:
+            # We do not allow guests to create streams at all.
+            raise JsonableError(_("Not allowed for guest users"))
         for stream_dict in missing_stream_dicts:
             invite_only = stream_dict.get("invite_only", False)
             if invite_only and not user_profile.can_create_private_streams():

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7794,6 +7794,9 @@ paths:
         If any of the specified streams do not exist, they are automatically
         created. The initial [stream settings](/api/update-stream) will be determined
         by the optional parameters like `invite_only` detailed below.
+
+        **Changes**: From Zulip 6.0 (feature level 167), we allow guests to subscribe
+        themselves to web-public streams.
       x-curl-examples-parameters:
         oneOf:
           - type: include
@@ -7957,6 +7960,9 @@ paths:
       tags: ["streams"]
       description: |
         Update which streams you are subscribed to.
+
+        **Changes**: From Zulip 6.0 (feature level 167), we allow guests to subscribe
+        themselves to web-public streams.
       parameters:
         - name: delete
           in: query

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -190,6 +190,7 @@ from zerver.lib.events import (
 from zerver.lib.mention import MentionBackend, MentionData
 from zerver.lib.message import render_markdown
 from zerver.lib.muted_users import get_mute_object
+from zerver.lib.streams import create_stream_if_needed
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import (
     create_dummy_file,
@@ -3044,6 +3045,17 @@ class SubscribeActionTest(BaseAction):
             events[0]["streams"][0]["message_retention_days"],
             10,
         )
+
+    def test_stream_creation_events_for_guests(self) -> None:
+        self.user_profile = self.example_user("polonius")
+        realm = self.user_profile.realm
+
+        action = lambda: create_stream_if_needed(realm, "web_public_stream", is_web_public=True)
+        events = self.verify_action(action, num_events=1)
+        check_stream_create("events[0]", events[0])
+
+        action = lambda: create_stream_if_needed(realm, "public_stream")
+        events = self.verify_action(action, num_events=0, state_change_expected=False)
 
 
 class DraftActionTest(BaseAction):


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Commit summary -
- Backend code to allow guests to subscribe themselves to web-public streams.
- Add `web_public_streams_enabled_for_realm` helper in frontend.
- Pass include_web_public as True for guests to do_get_streams.
- Enable `All streams` tab for guests if web-public streams are enabled at server and realm level.
- Show unsubscribed web-public streams in UI if web-public streams are enabled at server and realm level.
- Allow guests to subscribe themselves to web-public streams from UI.
- Show `Subscribe to more streams` link for guests only if web-public streams are enabled at server and realm level.
- Show "+" icon to guests only if web-public streams are enabled at server and realm level.
Fixes: <!-- Issue link, or clear description.--> #14490

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![web-public](https://user-images.githubusercontent.com/35494118/166116519-aa06c289-93a6-4d71-b143-9e72248417ea.gif)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
