### PR TITLE
Disable send button when user doesn't have permissions to send message

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -492,6 +492,17 @@ test_ui("initialize", ({override}) => {
 test_ui("update_fade", ({override}) => {
     initialize_handlers({override});
 
+    $.create(".compose_right_float_container", {
+        children: [
+            {
+                _tippy: {
+                    setContent: () => {},
+                    destroy: () => {},
+                },
+            },
+        ],
+    });
+
     const selector =
         "#stream_message_recipient_stream,#stream_message_recipient_topic,#private_message_recipient";
     const keyup_handler_func = $(selector).get_on_handler("keyup");

--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -7,6 +7,7 @@ const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 
 const compose_actions = mock_esm("../../static/js/compose_actions");
+const compose_validate = mock_esm("../../static/js/compose_validate");
 const input_pill = mock_esm("../../static/js/input_pill");
 const people = zrequire("people");
 
@@ -18,6 +19,7 @@ let pills = {
 
 run_test("pills", ({override}) => {
     override(compose_actions, "update_placeholder_text", () => {});
+    override(compose_validate, "check_send_permissions", () => {});
 
     const othello = {
         user_id: 1,

--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -66,6 +66,28 @@ function test_ui(label, f) {
     });
 }
 
+function initialize_pm_pill({mock_template}) {
+    $.clear_all_elements();
+
+    $("#compose-send-button").prop("disabled", false);
+    $("#compose-send-button").trigger("focus");
+    $("#compose-send-button .loader").hide();
+
+    const $pm_pill_container = $.create("fake-pm-pill-container");
+    $("#private_message_recipient")[0] = {};
+    $("#private_message_recipient").set_parent($pm_pill_container);
+    $pm_pill_container.set_find_results(".input", $("#private_message_recipient"));
+    $("#private_message_recipient").before = () => {};
+
+    compose_pm_pill.initialize();
+
+    ui_util.place_caret_at_end = () => {};
+
+    $("#zephyr-mirror-error").is = () => {};
+
+    mock_template("input_pill.hbs", false, () => "<div>pill-html</div>");
+}
+
 test_ui("validate_stream_message_address_info", ({mock_template}) => {
     const sub = {
         stream_id: 101,
@@ -124,33 +146,11 @@ test_ui("validate_stream_message_address_info", ({mock_template}) => {
 test_ui("validate", ({override, mock_template}) => {
     override(compose_actions, "update_placeholder_text", () => {});
 
-    function initialize_pm_pill() {
-        $.clear_all_elements();
-
-        $("#compose-send-button").prop("disabled", false);
-        $("#compose-send-button").trigger("focus");
-        $("#compose-send-button .loader").hide();
-
-        const $pm_pill_container = $.create("fake-pm-pill-container");
-        $("#private_message_recipient")[0] = {};
-        $("#private_message_recipient").set_parent($pm_pill_container);
-        $pm_pill_container.set_find_results(".input", $("#private_message_recipient"));
-        $("#private_message_recipient").before = () => {};
-
-        compose_pm_pill.initialize();
-
-        ui_util.place_caret_at_end = () => {};
-
-        $("#zephyr-mirror-error").is = () => {};
-
-        mock_template("input_pill.hbs", false, () => "<div>pill-html</div>");
-    }
-
     function add_content_to_compose_box() {
         $("#compose-textarea").val("foobarfoobar");
     }
 
-    initialize_pm_pill();
+    initialize_pm_pill({mock_template});
     assert.ok(!compose_validate.validate());
     assert.ok(!$("#compose-send-button .loader").visible());
     assert.equal($("#compose-send-button").prop("disabled"), false);
@@ -177,7 +177,7 @@ test_ui("validate", ({override, mock_template}) => {
         }),
     );
 
-    initialize_pm_pill();
+    initialize_pm_pill({mock_template});
     add_content_to_compose_box();
 
     // test validating private messages
@@ -190,7 +190,7 @@ test_ui("validate", ({override, mock_template}) => {
         $t_html({defaultMessage: "Please specify at least one valid recipient"}),
     );
 
-    initialize_pm_pill();
+    initialize_pm_pill({mock_template});
     add_content_to_compose_box();
     compose_state.private_message_recipient("foo@zulip.com");
 
@@ -224,7 +224,7 @@ test_ui("validate", ({override, mock_template}) => {
     assert.ok(compose_validate.validate());
     page_params.realm_is_zephyr_mirror_realm = false;
 
-    initialize_pm_pill();
+    initialize_pm_pill({mock_template});
     add_content_to_compose_box();
     compose_state.private_message_recipient("welcome-bot@example.com");
     assert.ok(compose_validate.validate());

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -407,10 +407,16 @@ export function initialize() {
     $("#below-compose-content .video_link").toggle(compute_show_video_chat_button());
     $(
         "#stream_message_recipient_stream,#stream_message_recipient_topic,#private_message_recipient",
-    ).on("keyup", update_on_recipient_change);
+    ).on("keyup", () => {
+        update_on_recipient_change();
+        compose_validate.check_send_permissions();
+    });
     $(
         "#stream_message_recipient_stream,#stream_message_recipient_topic,#private_message_recipient",
-    ).on("change", update_on_recipient_change);
+    ).on("change", () => {
+        update_on_recipient_change();
+        compose_validate.check_send_permissions();
+    });
     $("#compose-textarea").on("keydown", (event) => {
         compose_ui.handle_keydown(event, $("#compose-textarea").expectOne());
     });
@@ -427,6 +433,10 @@ export function initialize() {
             $("#compose_close").attr("data-tooltip-template-id", "compose_close_and_save_tooltip");
         } else {
             $("#compose_close").attr("data-tooltip-template-id", "compose_close_tooltip");
+        }
+
+        if (compose_text_length <= page_params.max_message_length) {
+            compose_validate.check_send_permissions();
         }
     });
 

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -348,6 +348,8 @@ export function start(msg_type, opts) {
     // Show a warning if topic is resolved
     compose_validate.warn_if_topic_resolved(true);
 
+    compose_validate.check_send_permissions();
+
     // Reset the `max-height` property of `compose-textarea` so that the
     // compose-box do not cover the last messages of the current stream
     // while writing a long message.

--- a/static/js/compose_pm_pill.js
+++ b/static/js/compose_pm_pill.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import * as compose_actions from "./compose_actions";
+import * as compose_validate from "./compose_validate";
 import * as input_pill from "./input_pill";
 import * as people from "./people";
 import * as user_pill from "./user_pill";
@@ -30,10 +31,12 @@ export function initialize() {
 
     widget.onPillCreate(() => {
         compose_actions.update_placeholder_text();
+        compose_validate.check_send_permissions();
     });
 
     widget.onPillRemove(() => {
         compose_actions.update_placeholder_text();
+        compose_validate.check_send_permissions();
     });
 }
 

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -475,6 +475,11 @@ input.recipient_box {
         position: relative;
         top: -6px;
     }
+
+    &:disabled {
+        opacity: 0.5;
+        pointer-events: none;
+    }
 }
 
 .enter_sends_choices {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
[Updated description]

Fixes: #21896

This PR adds the logic and styles to disable the send button when private messages are disabled in the organization AND when the user doesn't have permissions to post in a particular stream. This also adds a tooltip to the disabled send button with more context as to why it's disabled.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![pm-tooltip](https://user-images.githubusercontent.com/3621543/169758084-17617f2f-fbbb-431f-a13f-289d98b804b2.gif)

![nopost-tooltip](https://user-images.githubusercontent.com/3621543/169758096-9904f874-e7af-47b0-9988-b57fe0a31491.gif)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
