### PR TITLE
testing: Support concurrent backend testing for generate_emails.

### DIFF
--- a/zerver/tests/test_email_log.py
+++ b/zerver/tests/test_email_log.py
@@ -10,7 +10,7 @@ from zproject.email_backends import get_forward_address
 class EmailLogTest(ZulipTestCase):
     def test_generate_and_clear_email_log(self) -> None:
         with self.settings(EMAIL_BACKEND="zproject.email_backends.EmailLogBackEnd"), mock.patch(
-            "zproject.email_backends.EmailBackend.send_messages"
+            "zproject.email_backends.EmailLogBackEnd._do_send_messages", lambda *args: 1
         ), self.assertLogs(level="INFO") as m, self.settings(DEVELOPMENT_LOG_EMAILS=True):
             result = self.client_get("/emails/generate/")
             self.assertEqual(result.status_code, 302)
@@ -35,11 +35,12 @@ class EmailLogTest(ZulipTestCase):
 
         self.assertEqual(get_forward_address(), forward_address)
 
-        with self.settings(EMAIL_BACKEND="zproject.email_backends.EmailLogBackEnd"):
-            with mock.patch("zproject.email_backends.EmailBackend.send_messages"):
-                result = self.client_get("/emails/generate/")
-                self.assertEqual(result.status_code, 302)
-                self.assertIn("emails", result["Location"])
-                result = self.client_get(result["Location"])
-                self.assert_in_success_response([forward_address], result)
+        with self.settings(EMAIL_BACKEND="zproject.email_backends.EmailLogBackEnd"), mock.patch(
+            "zproject.email_backends.EmailLogBackEnd._do_send_messages", lambda *args: 1
+        ):
+            result = self.client_get("/emails/generate/")
+            self.assertEqual(result.status_code, 302)
+            self.assertIn("emails", result["Location"])
+            result = self.client_get(result["Location"])
+            self.assert_in_success_response([forward_address], result)
         os.remove(settings.FORWARD_ADDRESS_CONFIG_FILE)

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -401,8 +401,9 @@ class TestDevelopmentEmailsLog(ZulipTestCase):
         # https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertLogs
         with self.settings(EMAIL_BACKEND="zproject.email_backends.EmailLogBackEnd"), self.settings(
             DEVELOPMENT_LOG_EMAILS=True
-        ), self.assertLogs(level="INFO") as logger:
-
+        ), self.assertLogs(level="INFO") as logger, mock.patch(
+            "zproject.email_backends.EmailLogBackEnd._do_send_messages", lambda *args: 1
+        ):
             result = self.client_get(
                 "/emails/generate/"
             )  # Generates emails and redirects to /emails/


### PR DESCRIPTION
Fixes #21925.

After hours of fiddling/googling/hair-tearing, I found that mocking-away Django Connection.send_messages() was best:
- we're testing Zulip and not Django.
- mocking at this lower level exercises more of our code.
- EmailLogBackEnd._do_send_messages() helper method added to simplify mocking.

Previously, this command would reliably fail: `tools/test-backend --skip-provision-check --parallel=3     zerver.tests.test_email_log.EmailLogTest.test_forward_address_details zerver.tests.test_email_log.EmailLogTest.test_generate_and_clear_email_log zerver.tests.test_example.TestDevelopmentEmailsLog`
and now it reliably succeeds. :-)
