### PR TITLE
provision: Improved logic of empty pm-with search

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -1473,6 +1473,7 @@ test("navbar_helpers", () => {
         {operator: "topic", operand: "pink"},
     ];
     const pm_with = [{operator: "pm-with", operand: "joe@example.com"}];
+    const pm_with_missing_input = [{operator: "pm-with", operand: " "}];
     const group_pm = [{operator: "pm-with", operand: "joe@example.com,STEVE@foo.com"}];
     const group_pm_including_missing_person = [
         {operator: "pm-with", operand: "joe@example.com,STEVE@foo.com,sally@doesnotexist.com"},
@@ -1579,6 +1580,14 @@ test("navbar_helpers", () => {
                 "/#narrow/pm-with/" + joe.user_id + "-" + joe.email.split("@")[0],
         },
         {
+            operator: pm_with_missing_input,
+            is_common_narrow: true,
+            icon: "envelope",
+            title: properly_separated_names([" "]),
+            redirect_url_with_search:
+                "/#narrow/pm-with/undefined",
+        },
+        {
             operator: group_pm,
             is_common_narrow: true,
             icon: "envelope",
@@ -1644,6 +1653,10 @@ test("navbar_helpers", () => {
     assert.equal(filter.generate_redirect_url(), complex_operators_test_case.redirect_url);
     assert.equal(filter.is_common_narrow(), false);
 
+    const pm_with_no_operand = [{operator: "pm-with", operand: ""}];
+    filter = new Filter(pm_with_no_operand);
+    assert.equal(filter.is_common_narrow(), false);
+    
     const stream_topic_search_operator = [
         {operator: "stream", operand: "foo"},
         {operator: "topic", operand: "bar"},

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -184,7 +184,6 @@ function message_matches_search_term(message, operator, operand) {
             if (!user_ids) {
                 return false;
             }
-
             return _.isEqual(operand_ids, user_ids);
         }
     }
@@ -547,13 +546,18 @@ export class Filter {
         // stream, stream + topic,
         // is: private, pm-with:,
         // is: mentioned, is: resolved
+        const term_types = this.sorted_term_types();
+        if (_.isEqual(term_types, ["pm-with"]) &&
+            this.operands("pm-with").length === 1 &&
+            this.operands("pm-with")[0] === "") {
+            return false;
+        }
         if (this.can_mark_messages_read()) {
             return true;
         }
         // that leaves us with checking:
         // is: starred
         // (which can_mark_messages_read_does not check as starred messages are always read)
-        const term_types = this.sorted_term_types();
 
         if (_.isEqual(term_types, ["is-starred"])) {
             return true;


### PR DESCRIPTION
- The issue had multiple attempts but was never followed up on feedback received on what small changes to make. Hopefully, I understood the feedback given to others and implemented a solid fix to issue #20073. 
- In function is_common_narrow() the if statement added needs to be first or else it doesn't work. 
- I added an additional test in static/js/filter.js to check if the pm-with field is empty and if it returns the correct address. 
- An issue I encountered was when I initially downloaded the code, before adding anything I failed the test-documentation tests. I manually ran each of the other tests before and after adding my final code and those all passed. 

Fixes: #20073 

**Screenshots and screen captures:**

<img width="885" alt="Screen Shot 2022-05-01 at 9 07 41 PM" src="https://user-images.githubusercontent.com/70713646/166179644-00946d00-47ab-41be-829d-793cae08bb42.png">


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
