### PR TITLE
help_docs: Document subscribing a user to stream via @-mention.

### DIFF
--- a/templates/zerver/help/add-or-remove-users-from-a-stream.md
+++ b/templates/zerver/help/add-or-remove-users-from-a-stream.md
@@ -31,6 +31,21 @@ to a stream][configure-invites].
       To add users in bulk, you can copy members from an
       existing stream or [user group](/help/user-groups).
 
+### Mentioning a user in the compose box (alternate method)
+
+When you [mention a user](/help/mention-a-user-or-group) while composing
+a message, an alert banner appears above the compose box if they are not
+subscribed to the stream.
+
+Click the **Subscribe them** button on the banner to add the user to the
+stream. You will not see the button if you don't have permission to
+subscribe the user.
+
+!!! tip ""
+
+      You do not have to send the message you are composing for
+      the user to be subscribed this way.
+
 ## Remove users from a stream
 
 {!admin-only.md!}
@@ -80,3 +95,5 @@ This method is useful if you need to remove one user from multiple streams.
 * [Manage a user's stream subscriptions](/help/manage-user-stream-subscriptions)
 * [Restrict stream invitation](/help/configure-who-can-invite-to-streams)
 * [Set default streams for new users](/help/set-default-streams-for-new-users)
+* [Roles and permissions](/help/roles-and-permissions)
+* [Mention a user or group](/help/mention-a-user-or-group)


### PR DESCRIPTION
Updates the help center documentation on subscribing users to streams to include description for doing so via mentioning a user while composing a message.

Fixes #21796.

**Screenshots and screen captures:**
![Screenshot from 2022-05-02 15-08-08](https://user-images.githubusercontent.com/63245456/166244873-89f27bbe-8b99-42b8-9d5e-cf56be3ce70e.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
