### PR TITLE
resize: Don't use `visible` selector to find element states.

### DIFF
--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -2,6 +2,7 @@ import autosize from "autosize";
 import $ from "jquery";
 
 import * as blueslip from "./blueslip";
+import * as compose_state from "./compose_state";
 import * as condense from "./condense";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
@@ -171,8 +172,7 @@ export function reset_compose_message_max_height(bottom_whitespace_height) {
         bottom_whitespace_height = h.bottom_whitespace_height;
     }
 
-    // Take properties of the whichever message area is visible.
-    const $visible_textarea = $("#compose-textarea:visible, #preview_message_area:visible");
+    const $visible_textarea = $("#compose-textarea, #preview_message_area");
     const compose_height = Number.parseInt($("#compose").outerHeight(), 10);
     const compose_textarea_height = Number.parseInt($visible_textarea.outerHeight(), 10);
     const compose_non_textarea_height = compose_height - compose_textarea_height;
@@ -196,7 +196,7 @@ export function resize_bottom_whitespace(h) {
     // reset_compose_message_max_height cannot compute the right
     // height correctly while compose is hidden. This is OK, because
     // we also resize compose every time it is opened.
-    if ($(".message_comp").is(":visible")) {
+    if (compose_state.composing()) {
         reset_compose_message_max_height(h.bottom_whitespace_height);
     }
 }


### PR DESCRIPTION
This change decreases the time required to open compose
after clicking a message. The amount of time reduced varies with pc.

The time reduction was around 0.4s to 0.6s for me after using a
6x CPU slowdown. This may not sound convincing but the profile
uploaded in #21979 clearly shows the root cause of having a message
click take 10s was the `:visible` query.

Fixes #21979


before:
![Screenshot 2022-05-03 185305](https://user-images.githubusercontent.com/25124304/166462899-dd5b2adf-dffc-4d6e-a276-858b39b00f14.png)


after:
![image](https://user-images.githubusercontent.com/25124304/166462927-64068031-7292-4555-bbc4-2d87182265e1.png)


The profile uploaded in #21979 shows that doing `visible` query is responsible for a 8s delay.
![image](https://user-images.githubusercontent.com/25124304/166463732-18d3ef63-c693-4900-adf7-e2b921076e1d.png)
