### PR TITLE
help-docs: Extend notification bot documentation.

### DIFF
--- a/templates/zerver/help/configure-notification-bot.md
+++ b/templates/zerver/help/configure-notification-bot.md
@@ -1,21 +1,74 @@
-# Configure notification bot
+# Notification bot
+
+The Zulip notification bot automatically generates messages for
+various organization level events, including:
+
+* Stream settings changes such as [name](/help/rename-a-stream),
+  [description](/help/change-the-stream-description),
+  [permission](/help/stream-permissions) and
+  [policy](/help/stream-sending-policy) updates (sent to the
+  "stream events" topic)
+* A topic being [resolved/unresolved](/help/resolve-a-topic)
+* New public stream announcements (private streams are not announced)
+* New user announcements
+
+The notification bot also generates messages to individual users
+for some user specific events, such as [being subscribed to a
+stream][add-users-to-stream] by another user.
+
+Organization administrators can configure where (and whether)
+[new stream](#new-stream-notifications) and
+[new user](#new-user-notifications) announcement messages are sent.
+
+Stream messages sent by the notification bot (including the topic)
+are translated into the language that the organization has configured
+as the [organization notifications language][org-notifications-lang].
+Notification bot messages sent to a single user will use
+[their preferred language](/help/change-your-language).
+
+## Configure notification bot
 
 {!admin-only.md!}
 
-The Zulip notification bot sends a message whenever:
+### New stream notifications
 
-* A user joins the organization
-* A new public stream is [announced](/help/create-a-stream#stream-options)
-
-You can configure where those messages are sent, or disable them entirely.
-
-### Configure notification bot
+You can configure where the Zulip notification bot
+[announces][new-stream-options] new public streams, or disable the new
+stream notification messages entirely. The topic for these messages
+is "new streams".
 
 {start_tabs}
 
 {settings_tab|organization-settings}
 
-1. Under **Notifications**, configure
-   **New stream notifications** and **New user notifications**.
+1. Under **Notifications**, configure **New stream notifications**.
+
+{!save-changes.md!}
 
 {end_tabs}
+
+### New user notifications
+
+You can configure where the Zulip notification bot announces new users,
+or disable the new user notification messages entirely. The topic for
+these messages is "signups".
+
+{start_tabs}
+
+{settings_tab|organization-settings}
+
+1. Under **Notifications**, configure **New user notifications**.
+
+{!save-changes.md!}
+
+{end_tabs}
+
+## Related articles
+
+* [Organization notifications language][org-notifications-lang]
+* [Streams and topics](/help/streams-and-topics)
+
+[add-users-to-stream]: /help/add-or-remove-users-from-a-stream#add-users-to-a-stream
+[api-create-user]: https://zulip.com/api/create-user
+[new-stream-options]: /help/create-a-stream#stream-options
+[org-notifications-lang]: /help/change-the-default-language-for-your-organization


### PR DESCRIPTION
Notification bot documentation changes:

- Updates the documentation for configuring the notification bot to include information about the non-configurable messages sent for stream settings / permissions changes as well as topic resolve events.

- Adds more detailed sections / information about the configurable aspects of the notification bot.
---
Part of "Clean up documentation around organization notifications language", #21949.

Fixes #21947.

Question related to the issue listed above:
- Do we want the section on this page for configuring the **Notifications language** to replace [this article](https://zulip.com/help/change-the-default-language-for-your-organization) in the help center? If not, we could remove the information on this page about the email invitations and new user defaults.
---
**Screenshots and screen captures:**
![Screenshot from 2022-05-03 16-40-20](https://user-images.githubusercontent.com/63245456/166485732-289c6301-50e7-405e-8ca6-e62125cc54af.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
