### PR TITLE
WIP help-docs: Add 'Mastering the compose box' article.

### DIFF
--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -56,6 +56,7 @@
 
 ## Sending messages
 * [Open the compose box](/help/open-the-compose-box)
+* [Mastering the compose box](/help/mastering-the-compose-box)
 * [Resize the compose box](/help/resize-the-compose-box)
 * [Format messages using Markdown](/help/format-your-message-using-markdown)
 * [Mention a user or group](/help/mention-a-user-or-group)

--- a/templates/zerver/help/mastering-the-compose-box.md
+++ b/templates/zerver/help/mastering-the-compose-box.md
@@ -1,0 +1,26 @@
+# Mastering the compose box
+
+Once you've had some time to become acquainted with Zulip, here are some
+more advanced techniques to use when composing messages.
+
+## Go to conversation
+
+When you're composing a message, sometimes it's useful to view a
+different conversation, for example when you're starting a new topic
+based on an idea or a follow-up task that came up in a conversation.
+
+In Zulip, the main message view is faded out to indicate when you're
+composing a message while viewing a different conversation.
+To narrow the view to the conversation you're actively composing a
+message to:
+
+ * Use the keyboard shortcut `Ctrl` + `.`
+
+ * Click on the **Go to conversation**
+   (<i class="zulip-icon zulip-icon-arrow-left-circle"></i>) button in
+   the compose box
+
+## Related topics
+
+* [Keyboard shortcuts](/help/keyboard-shortcuts)
+* [Messaging tips and tricks](/help/messaging-tips)


### PR DESCRIPTION
Adds an article for more advanced techniques and workflows for the compose box and documents the new 'Go to conversation' button.

Fixes #21959.

@alya - I feel like this first round is a rough draft to make sure I'm on the right track. And in case we can think of any other workflows / techniques we'd like to add when creating this article.

**Screenshots and screen captures:**
![Screenshot from 2022-05-03 19-19-54](https://user-images.githubusercontent.com/63245456/166505529-031db1ba-5638-43e2-bf9d-d696bb9bf3c0.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
