### PR TITLE
help-center: Reword self-host warning to enable web-public streams.

### DIFF
--- a/templates/zerver/help/public-access-option.md
+++ b/templates/zerver/help/public-access-option.md
@@ -37,10 +37,9 @@ communities such as open-source projects and research communities.
 ### Enable or disable web-public streams
 
 !!! warn ""
-    Self-hosted Zulip servers must enable support for web-public streams by setting
-    `WEB_PUBLIC_STREAMS_ENABLED = True` in their [server
-    settings](https://zulip.readthedocs.io/en/latest/production/settings.html)
-    prior to proceeding.
+    Self-hosted Zulip servers must enable support for web-public streams in their
+    [server settings](https://zulip.readthedocs.io/en/latest/production/settings.html)
+    by setting `WEB_PUBLIC_STREAMS_ENABLED = True` prior to proceeding.
 
 {start_tabs}
 


### PR DESCRIPTION
Rewords warning for self-hosted Zulip servers to enable web-public streams so that the inline code doesn't line wrap oddly due to spacing.

**Screenshots and screen captures:**
![Screenshot from 2022-05-05 15-49-38](https://user-images.githubusercontent.com/63245456/166947939-b22c21c3-d8b7-4e72-9cc2-e5ab96fe0833.png)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
