### PR TITLE
Fix: Catch a realm creation exception and return a useful error

### DIFF
--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3319,7 +3319,7 @@ class RealmCreationTest(ZulipTestCase):
 
             result = self.submit_reg_form_for_user(email, password, realm_subdomain=string_id)
             self.assertEqual(result.status_code, 400)
-            self.assert_in_response("Realm already exists", result)
+            self.assert_in_response("Organization already exists", result)
 
     def test_create_realm_as_system_bot(self) -> None:
         result = self.client_post("/new/", {"email": "notification-bot@zulip.com"})

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.contrib.auth.views import PasswordResetConfirmView
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
+from django.db.utils import IntegrityError
 from django.http import HttpRequest, HttpResponse
 from django.test import Client, override_settings
 from django.urls import reverse
@@ -3283,6 +3284,42 @@ class RealmCreationTest(ZulipTestCase):
             self.check_able_to_create_realm(
                 "newuser_email@zulip.com", self.ldap_password("newuser_with_email")
             )
+
+    @override_settings(OPEN_REALM_CREATION=True)
+    def test_create_realm_race(self) -> None:
+        email = "romeo@zulip.com"
+        password = "test"
+
+        with patch("zerver.views.registration.do_create_realm", side_effect=IntegrityError):
+            internal_realm = get_realm(settings.SYSTEM_BOT_REALM)
+            notification_bot = get_system_bot(settings.NOTIFICATION_BOT, internal_realm.id)
+            signups_stream, _ = create_stream_if_needed(notification_bot.realm, "signups")
+
+            string_id = "zulipracetest"
+            # Make sure the realm does not exist
+            with self.assertRaises(Realm.DoesNotExist):
+                get_realm(string_id)
+
+            # Create new realm with the email
+            result = self.client_post("/new/", {"email": email})
+            self.assertEqual(result.status_code, 302)
+            self.assertTrue(result["Location"].endswith(f"/accounts/new/send_confirm/{email}"))
+            result = self.client_get(result["Location"])
+            self.assert_in_response("Check your email so we can get started.", result)
+
+            # Check confirmation email has the correct subject and body, extract
+            # confirmation link and visit it
+            confirmation_url = self.get_confirmation_url_from_outbox(
+                email,
+                email_subject_contains="Create your Zulip organization",
+                email_body_contains="You have requested a new Zulip organization",
+            )
+            result = self.client_get(confirmation_url)
+            self.assertEqual(result.status_code, 200)
+
+            result = self.submit_reg_form_for_user(email, password, realm_subdomain=string_id)
+            self.assertEqual(result.status_code, 400)
+            self.assert_in_response("Realm already exists", result)
 
     def test_create_realm_as_system_bot(self) -> None:
         result = self.client_post("/new/", {"email": "notification-bot@zulip.com"})

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -344,7 +344,7 @@ def accounts_register(
                     string_id, realm_name, org_type=realm_type, is_demo_organization=is_demo_org
                 )
             except IntegrityError as e:
-                raise JsonableError(_("Realm already exists")) from e
+                raise JsonableError(_("Organization already exists")) from e
         assert realm is not None
 
         full_name = form.cleaned_data["full_name"]


### PR DESCRIPTION
Catches IntegrityError exceptions bubbling up from trying to create the same realm multiple times, quickly.

Fixes: #21160 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
