### PR TITLE
More options and bugfixes for scripts/log-search

### DIFF
--- a/scripts/log-search
+++ b/scripts/log-search
@@ -4,6 +4,7 @@ import argparse
 import gzip
 import os
 import re
+import signal
 import sys
 from enum import Enum, auto
 from typing import Callable, TextIO
@@ -215,29 +216,32 @@ def main() -> None:
         raise RuntimeError(f"Can't parse {filter} as an IP or hostname.")
     assert filter_type is not None
 
-    for logfile_name in reversed(logfile_names):
-        with maybe_gzip(logfile_name) as logfile:
-            for logline in logfile:
-                # As a performance optimization, just do a substring
-                # check before we parse the line fully
-                if filter not in logline.lower():
-                    continue
+    try:
+        for logfile_name in reversed(logfile_names):
+            with maybe_gzip(logfile_name) as logfile:
+                for logline in logfile:
+                    # As a performance optimization, just do a substring
+                    # check before we parse the line fully
+                    if filter not in logline.lower():
+                        continue
 
-                if args.nginx:
-                    match = NGINX_LOG_LINE_RE.match(logline)
-                else:
-                    match = PYTHON_LOG_LINE_RE.match(logline)
-                if match is None:
-                    # We expect other types of loglines in the Python logfiles
                     if args.nginx:
-                        print(f"! Failed to parse:\n{logline}", file=sys.stderr)
-                    continue
-                if passes_filters(string_filter, match, args):
-                    print_line(
-                        match,
-                        args,
-                        filter_type=filter_type,
-                    )
+                        match = NGINX_LOG_LINE_RE.match(logline)
+                    else:
+                        match = PYTHON_LOG_LINE_RE.match(logline)
+                    if match is None:
+                        # We expect other types of loglines in the Python logfiles
+                        if args.nginx:
+                            print(f"! Failed to parse:\n{logline}", file=sys.stderr)
+                        continue
+                    if passes_filters(string_filter, match, args):
+                        print_line(
+                            match,
+                            args,
+                            filter_type=filter_type,
+                        )
+    except KeyboardInterrupt:
+        sys.exit(signal.SIGINT + 128)
 
 
 def passes_filters(

--- a/scripts/log-search
+++ b/scripts/log-search
@@ -313,7 +313,9 @@ def print_line(
     url = f"{BOLD}{match['path']}"
     if filter_type != FilterType.HOSTNAME:
         hostname = match["hostname"]
-        if not args.nginx:
+        if hostname is None:
+            hostname = "???.zulipchat.com"
+        elif not args.nginx:
             if hostname == "root":
                 hostname = "zulip.com"
             else:

--- a/scripts/log-search
+++ b/scripts/log-search
@@ -90,7 +90,7 @@ NGINX_LOG_LINE_RE = re.compile(
          (?P<date> \d+/\w+/\d+ )
          :
          (?P<time> \d+:\d+:\d+ )
-         \s+ \+0000
+         \s+ [+-]\d+
       \] \s+
       "
          (?P<method> \S+ )

--- a/scripts/log-search
+++ b/scripts/log-search
@@ -7,7 +7,7 @@ import re
 import signal
 import sys
 from enum import Enum, auto
-from typing import Callable, TextIO
+from typing import Callable, List, TextIO
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(ZULIP_PATH)
@@ -160,33 +160,7 @@ class FilterType(Enum):
 def main() -> None:
     args = parser().parse_args()
 
-    if args.nginx:
-        base_path = "/var/log/nginx/access.log"
-    else:
-        base_path = "/var/log/zulip/server.log"
-
-    logfile_names = [base_path]
-    if args.all_logs:
-        logfile_count = 15
-    elif args.log_files is not None:
-        logfile_count = args.log_files
-    else:
-        # Detect if there was a logfile rotation in the last
-        # (min-hours)-ish hours, and if so include the previous
-        # logfile as well.
-        logfile_count = 1
-        try:
-            current_size = os.path.getsize(base_path)
-            past_size = os.path.getsize(base_path + ".1")
-            if current_size < (args.min_hours / 24.0) * past_size:
-                logfile_count = 2
-        except FileNotFoundError:
-            pass
-    for n in range(1, logfile_count):
-        logname = f"{base_path}.{n}"
-        if n > 1:
-            logname += ".gz"
-        logfile_names.append(logname)
+    logfile_names = parse_logfile_names(args)
 
     # The heuristics below are not intended to be precise -- they
     # certainly count things as "IPv4" or "IPv6" addresses that are
@@ -254,6 +228,37 @@ def main() -> None:
                         )
     except KeyboardInterrupt:
         sys.exit(signal.SIGINT + 128)
+
+
+def parse_logfile_names(args: argparse.Namespace) -> List[str]:
+    if args.nginx:
+        base_path = "/var/log/nginx/access.log"
+    else:
+        base_path = "/var/log/zulip/server.log"
+
+    logfile_names = [base_path]
+    if args.all_logs:
+        logfile_count = 15
+    elif args.log_files is not None:
+        logfile_count = args.log_files
+    else:
+        # Detect if there was a logfile rotation in the last
+        # (min-hours)-ish hours, and if so include the previous
+        # logfile as well.
+        logfile_count = 1
+        try:
+            current_size = os.path.getsize(base_path)
+            past_size = os.path.getsize(base_path + ".1")
+            if current_size < (args.min_hours / 24.0) * past_size:
+                logfile_count = 2
+        except FileNotFoundError:
+            pass
+    for n in range(1, logfile_count):
+        logname = f"{base_path}.{n}"
+        if n > 1:
+            logname += ".gz"
+        logfile_names.append(logname)
+    return logfile_names
 
 
 def passes_filters(

--- a/scripts/log-search
+++ b/scripts/log-search
@@ -2,6 +2,7 @@
 
 import argparse
 import gzip
+import logging
 import os
 import re
 import signal
@@ -56,7 +57,9 @@ def parser() -> argparse.ArgumentParser:
     )
 
     filtering = parser.add_argument_group("Filtering")
-    filtering.add_argument("filter", help="IP address, hostname, user-id, or path to search for")
+    filtering.add_argument(
+        "filter", help="IP address, hostname, user-id, path, or status code to search for"
+    )
     filtering.add_argument(
         "--all-lines",
         "-L",
@@ -155,12 +158,11 @@ class FilterType(Enum):
     CLIENT_IP = auto()
     USER_ID = auto()
     PATH = auto()
+    STATUS = auto()
 
 
 def main() -> None:
     args = parser().parse_args()
-
-    logfile_names = parse_logfile_names(args)
 
     # The heuristics below are not intended to be precise -- they
     # certainly count things as "IPv4" or "IPv6" addresses that are
@@ -168,7 +170,17 @@ def main() -> None:
     # reasonably well-formed.
     filter = args.filter
 
-    if re.match(r"\d+$", filter):
+    if re.match(r"[1-5][0-9][0-9]$", filter):
+        string_filter = lambda m: m["code"] == filter
+        filter_type = FilterType.STATUS
+        if not args.nginx and filter == "502":
+            logging.warning("Adding --nginx -- 502's do not appear in Django logs.")
+            args.nginx = True
+    elif re.match(r"[1-5]xx$", filter):
+        filter = filter[0]
+        string_filter = lambda m: m["code"].startswith(filter)
+        filter_type = FilterType.STATUS
+    elif re.match(r"\d+$", filter):
         if args.nginx:
             raise parser().error("Cannot parse user-ids with nginx logs; try without --nginx")
         string_filter = lambda m: m["user_id"] == filter
@@ -199,8 +211,12 @@ def main() -> None:
         filter_type = FilterType.PATH
         args.all_lines = True
     else:
-        raise RuntimeError(f"Can't parse {filter} as an IP, hostname, user-id, or path.")
+        raise RuntimeError(
+            f"Can't parse {filter} as an IP, hostname, user-id, path, or status code."
+        )
     assert filter_type is not None
+
+    logfile_names = parse_logfile_names(args)
 
     try:
         for logfile_name in reversed(logfile_names):

--- a/scripts/log-search
+++ b/scripts/log-search
@@ -114,6 +114,7 @@ PYTHON_LOG_LINE_RE = re.compile(
       (?P<date> \d+-\d+-\d+ ) \s+
       (?P<time> \d+:\d+:\d+\.\d+ ) \s+
       INFO \s+  # All access log lines are INFO
+      (pid:\d+ \s+) ?
       \[ (?P<source> zr(:\d+)?) \] \s+
       (?P<ip>
         \d{1,3}(\.\d{1,3}){3}

--- a/scripts/log-search
+++ b/scripts/log-search
@@ -8,7 +8,7 @@ import re
 import signal
 import sys
 from enum import Enum, auto
-from typing import Callable, List, TextIO
+from typing import Callable, List, TextIO, Tuple
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(ZULIP_PATH)
@@ -164,58 +164,7 @@ class FilterType(Enum):
 def main() -> None:
     args = parser().parse_args()
 
-    # The heuristics below are not intended to be precise -- they
-    # certainly count things as "IPv4" or "IPv6" addresses that are
-    # invalid.  However, we expect the input here to already be
-    # reasonably well-formed.
-    filter = args.filter
-
-    if re.match(r"[1-5][0-9][0-9]$", filter):
-        string_filter = lambda m: m["code"] == filter
-        filter_type = FilterType.STATUS
-        if not args.nginx and filter == "502":
-            logging.warning("Adding --nginx -- 502's do not appear in Django logs.")
-            args.nginx = True
-    elif re.match(r"[1-5]xx$", filter):
-        filter = filter[0]
-        string_filter = lambda m: m["code"].startswith(filter)
-        filter_type = FilterType.STATUS
-    elif re.match(r"\d+$", filter):
-        if args.nginx:
-            raise parser().error("Cannot parse user-ids with nginx logs; try without --nginx")
-        string_filter = lambda m: m["user_id"] == filter
-        filter_type = FilterType.USER_ID
-    elif re.match(r"\d{1,3}(\.\d{1,3}){3}$", filter):
-        string_filter = lambda m: m["ip"] == filter
-        filter_type = FilterType.CLIENT_IP
-    elif re.match(r"([a-f0-9:]+:+){1,7}[a-f0-9]+$", filter):
-        string_filter = lambda m: m["ip"] == filter
-        filter_type = FilterType.CLIENT_IP
-    elif re.match(r"[a-z0-9]([a-z0-9-]*[a-z0-9])?$", filter.lower()):
-        filter = filter.lower()
-        if args.nginx:
-            string_filter = lambda m: m["hostname"].startswith(filter + ".")
-        else:
-            string_filter = lambda m: m["hostname"] == filter
-        filter_type = FilterType.HOSTNAME
-    elif re.match(r"[a-z0-9-]+(\.[a-z0-9-]+)+$", filter.lower()) and re.search(
-        r"[a-z-]", filter.lower()
-    ):
-        if not args.nginx:
-            raise parser().error("Cannot parse full domains with Python logs; try --nginx")
-        filter = filter.lower()
-        string_filter = lambda m: m["hostname"] == filter
-        filter_type = FilterType.HOSTNAME
-    elif re.match(r"/\S*$", filter):
-        string_filter = lambda m: m["path"] == filter
-        filter_type = FilterType.PATH
-        args.all_lines = True
-    else:
-        raise RuntimeError(
-            f"Can't parse {filter} as an IP, hostname, user-id, path, or status code."
-        )
-    assert filter_type is not None
-
+    (filter_type, filter_func) = parse_filters(args)
     logfile_names = parse_logfile_names(args)
 
     try:
@@ -224,7 +173,7 @@ def main() -> None:
                 for logline in logfile:
                     # As a performance optimization, just do a substring
                     # check before we parse the line fully
-                    if filter not in logline.lower():
+                    if args.filter not in logline.lower():
                         continue
 
                     if args.nginx:
@@ -236,7 +185,7 @@ def main() -> None:
                         if args.nginx:
                             print(f"! Failed to parse:\n{logline}", file=sys.stderr)
                         continue
-                    if passes_filters(string_filter, match, args):
+                    if passes_filters(filter_func, match, args):
                         print_line(
                             match,
                             args,
@@ -275,6 +224,63 @@ def parse_logfile_names(args: argparse.Namespace) -> List[str]:
             logname += ".gz"
         logfile_names.append(logname)
     return logfile_names
+
+
+def parse_filters(
+    args: argparse.Namespace,
+) -> Tuple[FilterType, Callable[[re.Match], bool]]:  # type: ignore[type-arg]  # Requires Python 3.9
+    # The heuristics below are not intended to be precise -- they
+    # certainly count things as "IPv4" or "IPv6" addresses that are
+    # invalid.  However, we expect the input here to already be
+    # reasonably well-formed.
+
+    filter = args.filter
+
+    if re.match(r"[1-5][0-9][0-9]$", filter):
+        filter_func = lambda m: m["code"] == filter
+        filter_type = FilterType.STATUS
+        if not args.nginx and filter == "502":
+            logging.warning("Adding --nginx -- 502's do not appear in Django logs.")
+            args.nginx = True
+    elif re.match(r"[1-5]xx$", filter):
+        filter = filter[0]
+        filter_func = lambda m: m["code"].startswith(filter)
+        filter_type = FilterType.STATUS
+    elif re.match(r"\d+$", filter):
+        if args.nginx:
+            raise parser().error("Cannot parse user-ids with nginx logs; try without --nginx")
+        filter_func = lambda m: m["user_id"] == filter
+        filter_type = FilterType.USER_ID
+    elif re.match(r"\d{1,3}(\.\d{1,3}){3}$", filter):
+        filter_func = lambda m: m["ip"] == filter
+        filter_type = FilterType.CLIENT_IP
+    elif re.match(r"([a-f0-9:]+:+){1,7}[a-f0-9]+$", filter):
+        filter_func = lambda m: m["ip"] == filter
+        filter_type = FilterType.CLIENT_IP
+    elif re.match(r"[a-z0-9]([a-z0-9-]*[a-z0-9])?$", filter.lower()):
+        filter = filter.lower()
+        if args.nginx:
+            filter_func = lambda m: m["hostname"].startswith(filter + ".")
+        else:
+            filter_func = lambda m: m["hostname"] == filter
+        filter_type = FilterType.HOSTNAME
+    elif re.match(r"[a-z0-9-]+(\.[a-z0-9-]+)+$", filter.lower()) and re.search(
+        r"[a-z-]", filter.lower()
+    ):
+        if not args.nginx:
+            raise parser().error("Cannot parse full domains with Python logs; try --nginx")
+        filter = filter.lower()
+        filter_func = lambda m: m["hostname"] == filter
+        filter_type = FilterType.HOSTNAME
+    elif re.match(r"/\S*$", filter):
+        filter_func = lambda m: m["path"] == filter
+        filter_type = FilterType.PATH
+        args.all_lines = True
+    else:
+        raise RuntimeError(
+            f"Can't parse {filter} as an IP, hostname, user-id, path, or status code."
+        )
+    return (filter_type, filter_func)
 
 
 def passes_filters(

--- a/scripts/log-search
+++ b/scripts/log-search
@@ -8,7 +8,7 @@ import re
 import signal
 import sys
 from enum import Enum, auto
-from typing import Callable, List, TextIO, Tuple
+from typing import List, Set, TextIO, Tuple
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(ZULIP_PATH)
@@ -20,6 +20,7 @@ setup_path()
 os.environ["DJANGO_SETTINGS_MODULE"] = "zproject.settings"
 
 from django.conf import settings
+from typing_extensions import Protocol
 
 from scripts.lib.zulip_tools import BOLD, CYAN, ENDC, FAIL, GRAY, OKBLUE
 
@@ -58,7 +59,9 @@ def parser() -> argparse.ArgumentParser:
 
     filtering = parser.add_argument_group("Filtering")
     filtering.add_argument(
-        "filter", help="IP address, hostname, user-id, path, or status code to search for"
+        "filter_terms",
+        help="IP address, hostname, user-id, path, or status code to search for; multiple are AND'ed together",
+        nargs="+",
     )
     filtering.add_argument(
         "--all-lines",
@@ -161,10 +164,17 @@ class FilterType(Enum):
     STATUS = auto()
 
 
+class FilterFunc(Protocol):
+    def __call__(
+        self, m: re.Match, t: str = ...  # type: ignore[type-arg]  # Requires Python 3.9
+    ) -> bool:
+        ...
+
+
 def main() -> None:
     args = parser().parse_args()
 
-    (filter_type, filter_func) = parse_filters(args)
+    (filter_types, filter_funcs) = parse_filters(args)
     logfile_names = parse_logfile_names(args)
 
     try:
@@ -173,7 +183,8 @@ def main() -> None:
                 for logline in logfile:
                     # As a performance optimization, just do a substring
                     # check before we parse the line fully
-                    if args.filter not in logline.lower():
+                    lowered = logline.lower()
+                    if not all(f in lowered for f in args.filter_terms):
                         continue
 
                     if args.nginx:
@@ -185,11 +196,11 @@ def main() -> None:
                         if args.nginx:
                             print(f"! Failed to parse:\n{logline}", file=sys.stderr)
                         continue
-                    if passes_filters(filter_func, match, args):
+                    if passes_filters(filter_funcs, match, args):
                         print_line(
                             match,
                             args,
-                            filter_type=filter_type,
+                            filter_types=filter_types,
                         )
     except KeyboardInterrupt:
         sys.exit(signal.SIGINT + 128)
@@ -228,67 +239,79 @@ def parse_logfile_names(args: argparse.Namespace) -> List[str]:
 
 def parse_filters(
     args: argparse.Namespace,
-) -> Tuple[FilterType, Callable[[re.Match], bool]]:  # type: ignore[type-arg]  # Requires Python 3.9
+) -> Tuple[Set[FilterType], List[FilterFunc]]:
     # The heuristics below are not intended to be precise -- they
     # certainly count things as "IPv4" or "IPv6" addresses that are
     # invalid.  However, we expect the input here to already be
     # reasonably well-formed.
 
-    filter = args.filter
+    filter_types = set()
+    filter_funcs = []
+    filter_terms = []
 
-    if re.match(r"[1-5][0-9][0-9]$", filter):
-        filter_func = lambda m: m["code"] == filter
-        filter_type = FilterType.STATUS
-        if not args.nginx and filter == "502":
-            logging.warning("Adding --nginx -- 502's do not appear in Django logs.")
-            args.nginx = True
-    elif re.match(r"[1-5]xx$", filter):
-        filter = filter[0]
-        filter_func = lambda m: m["code"].startswith(filter)
-        filter_type = FilterType.STATUS
-    elif re.match(r"\d+$", filter):
-        if args.nginx:
-            raise parser().error("Cannot parse user-ids with nginx logs; try without --nginx")
-        filter_func = lambda m: m["user_id"] == filter
-        filter_type = FilterType.USER_ID
-    elif re.match(r"\d{1,3}(\.\d{1,3}){3}$", filter):
-        filter_func = lambda m: m["ip"] == filter
-        filter_type = FilterType.CLIENT_IP
-    elif re.match(r"([a-f0-9:]+:+){1,7}[a-f0-9]+$", filter):
-        filter_func = lambda m: m["ip"] == filter
-        filter_type = FilterType.CLIENT_IP
-    elif re.match(r"[a-z0-9]([a-z0-9-]*[a-z0-9])?$", filter.lower()):
-        filter = filter.lower()
-        if args.nginx:
-            filter_func = lambda m: m["hostname"].startswith(filter + ".")
+    for filter_term in args.filter_terms:
+        if re.match(r"[1-5][0-9][0-9]$", filter_term):
+            filter_func = lambda m, t=filter_term: m["code"] == t
+            filter_type = FilterType.STATUS
+            if not args.nginx and filter_term == "502":
+                logging.warning("Adding --nginx -- 502's do not appear in Django logs.")
+                args.nginx = True
+        elif re.match(r"[1-5]xx$", filter_term):
+            filter_term = filter_term[0]
+            filter_func = lambda m, t=filter_term: m["code"].startswith(t)
+            filter_type = FilterType.STATUS
+        elif re.match(r"\d+$", filter_term):
+            if args.nginx:
+                raise parser().error("Cannot parse user-ids with nginx logs; try without --nginx")
+            filter_func = lambda m, t=filter_term: m["user_id"] == t
+            filter_type = FilterType.USER_ID
+        elif re.match(r"\d{1,3}(\.\d{1,3}){3}$", filter_term):
+            filter_func = lambda m, t=filter_term: m["ip"] == t
+            filter_type = FilterType.CLIENT_IP
+        elif re.match(r"([a-f0-9:]+:+){1,7}[a-f0-9]+$", filter_term):
+            filter_func = lambda m, t=filter_term: m["ip"] == t
+            filter_type = FilterType.CLIENT_IP
+        elif re.match(r"[a-z0-9]([a-z0-9-]*[a-z0-9])?$", filter_term.lower()):
+            filter_term = filter_term.lower()
+            if args.nginx:
+                filter_func = lambda m, t=filter_term: m["hostname"].startswith(t + ".")
+            else:
+                filter_func = lambda m, t=filter_term: m["hostname"] == t
+            filter_type = FilterType.HOSTNAME
+        elif re.match(r"[a-z0-9-]+(\.[a-z0-9-]+)+$", filter_term.lower()) and re.search(
+            r"[a-z-]", filter_term.lower()
+        ):
+            if not args.nginx:
+                raise parser().error("Cannot parse full domains with Python logs; try --nginx")
+            filter_term = filter_term.lower()
+            filter_func = lambda m, t=filter_term: m["hostname"] == t
+            filter_type = FilterType.HOSTNAME
+        elif re.match(r"/\S*$", filter_term):
+            filter_func = lambda m, t=filter_term: m["path"] == t
+            filter_type = FilterType.PATH
+            args.all_lines = True
         else:
-            filter_func = lambda m: m["hostname"] == filter
-        filter_type = FilterType.HOSTNAME
-    elif re.match(r"[a-z0-9-]+(\.[a-z0-9-]+)+$", filter.lower()) and re.search(
-        r"[a-z-]", filter.lower()
-    ):
-        if not args.nginx:
-            raise parser().error("Cannot parse full domains with Python logs; try --nginx")
-        filter = filter.lower()
-        filter_func = lambda m: m["hostname"] == filter
-        filter_type = FilterType.HOSTNAME
-    elif re.match(r"/\S*$", filter):
-        filter_func = lambda m: m["path"] == filter
-        filter_type = FilterType.PATH
-        args.all_lines = True
-    else:
-        raise RuntimeError(
-            f"Can't parse {filter} as an IP, hostname, user-id, path, or status code."
-        )
-    return (filter_type, filter_func)
+            raise RuntimeError(
+                f"Can't parse {filter_term} as an IP, hostname, user-id, path, or status code."
+            )
+        if filter_type in filter_types:
+            parser().error("Supplied the same time of value more than once, which cannot match!")
+        filter_types.add(filter_type)
+        filter_funcs.append(filter_func)
+        filter_terms.append(filter_term)
+
+    # Push back the modified raw strings, so we can use them for fast substring searches
+    args.filter_terms = filter_terms
+
+    return (filter_types, filter_funcs)
 
 
 def passes_filters(
-    string_filter: Callable[[re.Match], bool],  # type: ignore[type-arg]  # Requires Python 3.9
+    string_filters: List[FilterFunc],
     match: re.Match,  # type: ignore[type-arg]  # Requires Python 3.9
     args: argparse.Namespace,
 ) -> bool:
-    if not string_filter(match):
+    if not all(f(match) for f in string_filters):
         return False
 
     if args.all_lines:
@@ -318,7 +341,7 @@ def passes_filters(
 def print_line(
     match: re.Match,  # type: ignore[type-arg]  # Requires Python 3.9
     args: argparse.Namespace,
-    filter_type: FilterType,
+    filter_types: Set[FilterType],
 ) -> None:
     if args.full_line:
         print(match.group(0))
@@ -350,7 +373,7 @@ def print_line(
         indicator = "!"
         color = FAIL
     url = f"{BOLD}{match['path']}"
-    if filter_type != FilterType.HOSTNAME:
+    if FilterType.HOSTNAME not in filter_types:
         hostname = match["hostname"]
         if hostname is None:
             hostname = "???." + settings.EXTERNAL_HOST
@@ -370,8 +393,8 @@ def print_line(
     parts = [
         ts,
         f"{duration:>5}ms",
-        f"{user_id:7}" if not args.nginx and filter_type != FilterType.USER_ID else None,
-        f"{match['ip']:39}" if filter_type != FilterType.CLIENT_IP else None,
+        f"{user_id:7}" if not args.nginx and FilterType.USER_ID not in filter_types else None,
+        f"{match['ip']:39}" if FilterType.CLIENT_IP not in filter_types else None,
         indicator + match["code"],
         f"{match['method']:6}",
         url,

--- a/scripts/log-search
+++ b/scripts/log-search
@@ -57,6 +57,7 @@ def parser() -> argparse.ArgumentParser:
     )
     filtering.add_argument("--static", "-s", help="Include static file paths", action="store_true")
     filtering.add_argument("--uploads", "-u", help="Include file upload paths", action="store_true")
+    filtering.add_argument("--avatars", "-a", help="Include avatar paths", action="store_true")
     filtering.add_argument("--events", "-e", help="Include event fetch paths", action="store_true")
     filtering.add_argument("--messages", "-m", help="Include message paths", action="store_true")
     filtering.add_argument(
@@ -254,6 +255,8 @@ def passes_filters(
     if path.startswith("/static/") and not args.static:
         return False
     if path.startswith("/user_uploads/") and not args.uploads:
+        return False
+    if path.startswith(("/user_avatars/", "/avatar/")) and not args.avatars:
         return False
     if re.match(r"/(json|api/v1)/events($|\?|/)", path) and not args.events:
         return False

--- a/scripts/log-search
+++ b/scripts/log-search
@@ -11,6 +11,15 @@ from typing import Callable, TextIO
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(ZULIP_PATH)
+
+from scripts.lib.setup_path import setup_path
+
+setup_path()
+
+os.environ["DJANGO_SETTINGS_MODULE"] = "zproject.settings"
+
+from django.conf import settings
+
 from scripts.lib.zulip_tools import BOLD, CYAN, ENDC, FAIL, GRAY, OKBLUE
 
 
@@ -314,12 +323,14 @@ def print_line(
     if filter_type != FilterType.HOSTNAME:
         hostname = match["hostname"]
         if hostname is None:
-            hostname = "???.zulipchat.com"
+            hostname = "???." + settings.EXTERNAL_HOST
         elif not args.nginx:
-            if hostname == "root":
+            if hostname != "root":
+                hostname += "." + settings.EXTERNAL_HOST
+            elif settings.EXTERNAL_HOST == "zulipchat.com":
                 hostname = "zulip.com"
             else:
-                hostname += ".zulipchat.com"
+                hostname = settings.EXTERNAL_HOST
         url = "https://" + hostname + url
 
     user_id = ""

--- a/scripts/log-search
+++ b/scripts/log-search
@@ -56,7 +56,7 @@ def parser() -> argparse.ArgumentParser:
     )
 
     filtering = parser.add_argument_group("Filtering")
-    filtering.add_argument("filter", help="IP address, hostname, or user-id to search for")
+    filtering.add_argument("filter", help="IP address, hostname, user-id, or path to search for")
     filtering.add_argument(
         "--all-lines",
         "-L",
@@ -154,6 +154,7 @@ class FilterType(Enum):
     HOSTNAME = auto()
     CLIENT_IP = auto()
     USER_ID = auto()
+    PATH = auto()
 
 
 def main() -> None:
@@ -219,8 +220,12 @@ def main() -> None:
         filter = filter.lower()
         string_filter = lambda m: m["hostname"] == filter
         filter_type = FilterType.HOSTNAME
+    elif re.match(r"/\S*$", filter):
+        string_filter = lambda m: m["path"] == filter
+        filter_type = FilterType.PATH
+        args.all_lines = True
     else:
-        raise RuntimeError(f"Can't parse {filter} as an IP, hostname, or user-id.")
+        raise RuntimeError(f"Can't parse {filter} as an IP, hostname, user-id, or path.")
     assert filter_type is not None
 
     try:

--- a/scripts/log-search
+++ b/scripts/log-search
@@ -24,9 +24,7 @@ from scripts.lib.zulip_tools import BOLD, CYAN, ENDC, FAIL, GRAY, OKBLUE
 
 
 def parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Search logfiles for an IP or hostname, ignoring commonly-fetched URLs."
-    )
+    parser = argparse.ArgumentParser(description="Search logfiles, ignoring commonly-fetched URLs.")
     log_selection = parser.add_argument_group("File selection")
     log_selection_options = log_selection.add_mutually_exclusive_group()
     log_selection_options.add_argument(
@@ -58,7 +56,7 @@ def parser() -> argparse.ArgumentParser:
     )
 
     filtering = parser.add_argument_group("Filtering")
-    filtering.add_argument("filter", help="IP address or hostname to search for")
+    filtering.add_argument("filter", help="IP address, hostname, or user-id to search for")
     filtering.add_argument(
         "--all-lines",
         "-L",
@@ -222,7 +220,7 @@ def main() -> None:
         string_filter = lambda m: m["hostname"] == filter
         filter_type = FilterType.HOSTNAME
     else:
-        raise RuntimeError(f"Can't parse {filter} as an IP or hostname.")
+        raise RuntimeError(f"Can't parse {filter} as an IP, hostname, or user-id.")
     assert filter_type is not None
 
     try:


### PR DESCRIPTION
The obvious extension is to OR multiple terms of the same type, but this makes the performance optimization of "use `in` on the unparsed line" more difficult.

Really this whole tool is papering over not having structured logs or traces, but that's a bigger yak than the moment.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
