### PR TITLE
Change default option

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -43,7 +43,7 @@ const currently_echoing_messages = new Map();
 // These variables are designed to preserve the user's most recent
 // choices when editing a group of messages, to make it convenient to
 // move several topics in a row with the same settings.
-export let notify_old_thread_default = true;
+export let notify_old_thread_default = false;
 
 export let notify_new_thread_default = true;
 


### PR DESCRIPTION
Changes the default option when moving messages or topics from notifying both old and new topic to notifying only the new topic. 
- [x] The message three-dot menu
- [x] The topic three-dot menu

Fixes: #21838 

**Screenshots and screen captures:**
![Gif1 - Notifies only new topic](https://user-images.githubusercontent.com/79971856/167153910-dcfd073d-18ff-499d-b94d-45326b01c7e6.gif)
![Gif 2 - Swap from topic three dot menu](https://user-images.githubusercontent.com/79971856/167154274-4c2955c9-b2bf-4d36-a5be-e4d638587351.gif)

**Self-review checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
