### PR TITLE
open-api [nfc]: Fix inconsistencies in OpenAPI error documentation.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6822,7 +6822,7 @@ paths:
                   - $ref: "#/components/schemas/SuccessDescription"
                   - example: {"msg": "", "result": "success"}
         "400":
-          description: Success.
+          description: Bad request.
           content:
             application/json:
               schema:
@@ -8770,7 +8770,7 @@ paths:
                   - $ref: "#/components/schemas/SuccessDescription"
                   - example: {"msg": "", "result": "success"}
         "400":
-          description: Bad request
+          description: Bad request.
           content:
             application/json:
               schema:
@@ -13595,7 +13595,7 @@ paths:
                   - $ref: "#/components/schemas/JsonSuccess"
                   - $ref: "#/components/schemas/SuccessDescription"
         "400":
-          description: Error.
+          description: Bad request.
           content:
             application/json:
               schema:
@@ -15995,15 +15995,11 @@ components:
             }
     InvalidMessageError:
       allOf:
-        - $ref: "#/components/schemas/JsonSuccessBase"
+        - $ref: "#/components/schemas/JsonErrorBase"
         - additionalProperties: false
           properties:
             result: {}
             msg: {}
-            raw_content:
-              type: string
-              description: |
-                The raw content of the message.
           example:
             {
               "msg": "Invalid message(s)",


### PR DESCRIPTION
Fixes a few small inconsistencies / mistakes in the OpenAPI documentation related to error documentation. Does not change the rendered API documentation, which is likely why these were not noticed sooner.

---
**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
