### PR TITLE
Show "confirmation link expired" error page if a confirmation key is re-used

### DIFF
--- a/analytics/tests/test_support_views.py
+++ b/analytics/tests/test_support_views.py
@@ -153,7 +153,7 @@ class TestSupportEndpoint(ZulipTestCase):
                 self.assert_in_success_response(
                     [
                         "<b>Expires in</b>: 1\xa0week, 3\xa0days",
-                        "<b>Status</b>: Link has never been clicked",
+                        "<b>Status</b>: Link has not been used",
                     ],
                     result,
                 )
@@ -163,7 +163,7 @@ class TestSupportEndpoint(ZulipTestCase):
                 self.assert_in_success_response(
                     [
                         "<b>Expires in</b>: 1\xa0day",
-                        "<b>Status</b>: Link has never been clicked",
+                        "<b>Status</b>: Link has not been used",
                     ],
                     result,
                 )

--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -91,9 +91,9 @@ def get_confirmations(
         assert content_object is not None
         if hasattr(content_object, "status"):
             if content_object.status == STATUS_ACTIVE:
-                link_status = "Link has been clicked"
+                link_status = "Link has been used"
             else:
-                link_status = "Link has never been clicked"
+                link_status = "Link has not been used"
         else:
             link_status = ""
 

--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -16,7 +16,7 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
 from confirmation.models import Confirmation, confirmation_url
-from confirmation.settings import STATUS_ACTIVE
+from confirmation.settings import STATUS_USED
 from zerver.actions.create_realm import do_change_realm_subdomain
 from zerver.actions.realm_settings import (
     do_change_realm_org_type,
@@ -90,7 +90,7 @@ def get_confirmations(
 
         assert content_object is not None
         if hasattr(content_object, "status"):
-            if content_object.status == STATUS_ACTIVE:
+            if content_object.status == STATUS_USED:
                 link_status = "Link has been used"
             else:
                 link_status = "Link has not been used"

--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -50,7 +50,7 @@ ConfirmationObjT = Union[MultiuseInvite, PreregistrationUser, EmailChangeStatus,
 
 
 def get_object_from_key(
-    confirmation_key: str, confirmation_types: List[int], activate_object: bool = True
+    confirmation_key: str, confirmation_types: List[int], mark_object_used: bool = True
 ) -> ConfirmationObjT:
     # Confirmation keys used to be 40 characters
     if len(confirmation_key) not in (24, 40):
@@ -67,7 +67,7 @@ def get_object_from_key(
 
     obj = confirmation.content_object
     assert obj is not None
-    if activate_object and hasattr(obj, "status"):
+    if mark_object_used and hasattr(obj, "status"):
         obj.status = getattr(settings, "STATUS_USED", 1)
         obj.save(update_fields=["status"])
     return obj

--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -68,7 +68,7 @@ def get_object_from_key(
     obj = confirmation.content_object
     assert obj is not None
     if activate_object and hasattr(obj, "status"):
-        obj.status = getattr(settings, "STATUS_ACTIVE", 1)
+        obj.status = getattr(settings, "STATUS_USED", 1)
         obj.save(update_fields=["status"])
     return obj
 

--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -50,7 +50,7 @@ ConfirmationObjT = Union[MultiuseInvite, PreregistrationUser, EmailChangeStatus,
 
 
 def get_object_from_key(
-    confirmation_key: str, confirmation_types: List[int], mark_object_used: bool = True
+    confirmation_key: str, confirmation_types: List[int], *, mark_object_used: bool
 ) -> ConfirmationObjT:
     """Access a confirmation object from one of the provided confirmation
     types with the provided key.

--- a/confirmation/settings.py
+++ b/confirmation/settings.py
@@ -2,5 +2,5 @@
 
 __revision__ = "$Id: settings.py 12 2008-11-23 19:38:52Z jarek.zgoda $"
 
-STATUS_ACTIVE = 1
+STATUS_USED = 1
 STATUS_REVOKED = 2

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -243,7 +243,7 @@ def process_new_human_user(
     # we want to tie the newly created user to the PreregistrationUser
     # it was created from.
     if prereg_user is not None:
-        prereg_user.status = confirmation_settings.STATUS_ACTIVE
+        prereg_user.status = confirmation_settings.STATUS_USED
         prereg_user.created_user = user_profile
         prereg_user.save(update_fields=["status", "created_user"])
 
@@ -251,7 +251,7 @@ def process_new_human_user(
     # for us to want to modify - because other realm_creation PreregistrationUsers should be
     # left usable for creating different realms.
     if not realm_creation:
-        # Mark any other PreregistrationUsers in the realm that are STATUS_ACTIVE as
+        # Mark any other PreregistrationUsers in the realm that are STATUS_USED as
         # inactive so we can keep track of the PreregistrationUser we
         # actually used for analytics.
         if prereg_user is not None:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -2230,7 +2230,7 @@ class PreregistrationUser(models.Model):
     password_required: bool = models.BooleanField(default=True)
 
     # status: whether an object has been confirmed.
-    #   if confirmed, set to confirmation.settings.STATUS_ACTIVE
+    #   if confirmed, set to confirmation.settings.STATUS_USED
     status: int = models.IntegerField(default=0)
 
     # The realm should only ever be None for PreregistrationUser
@@ -2268,10 +2268,10 @@ def filter_to_valid_prereg_users(
     If invite_expires_in_days is specified, we return only those PreregistrationUser
     objects that were created at most that many days in the past.
     """
-    active_value = confirmation_settings.STATUS_ACTIVE
+    used_value = confirmation_settings.STATUS_USED
     revoked_value = confirmation_settings.STATUS_REVOKED
 
-    query = query.exclude(status__in=[active_value, revoked_value])
+    query = query.exclude(status__in=[used_value, revoked_value])
     if invite_expires_in_minutes is None:
         # Since invite_expires_in_minutes is None, we're invitation will never
         # expire, we do not need to check anything else and can simply return
@@ -2306,7 +2306,7 @@ class EmailChangeStatus(models.Model):
     user_profile: UserProfile = models.ForeignKey(UserProfile, on_delete=CASCADE)
 
     # status: whether an object has been confirmed.
-    #   if confirmed, set to confirmation.settings.STATUS_ACTIVE
+    #   if confirmed, set to confirmation.settings.STATUS_USED
     status: int = models.IntegerField(default=0)
 
     realm: Realm = models.ForeignKey(Realm, on_delete=CASCADE)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2162,7 +2162,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
             "Whoops. The confirmation link has expired or been deactivated.", result
         )
 
-    def test_never_expire_confirmation_obejct(self) -> None:
+    def test_never_expire_confirmation_object(self) -> None:
         email = self.nonreg_email("alice")
         realm = get_realm("zulip")
         inviter = self.example_user("iago")

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2123,7 +2123,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
 
         # Mainly a test of get_object_from_key, rather than of the invitation pathway
         with self.assertRaises(ConfirmationKeyException) as cm:
-            get_object_from_key(registration_key, [Confirmation.INVITATION])
+            get_object_from_key(registration_key, [Confirmation.INVITATION], mark_object_used=True)
         self.assertEqual(cm.exception.error_type, ConfirmationKeyException.DOES_NOT_EXIST)
 
         # Verify that using the wrong type doesn't work in the main confirm code path

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2229,7 +2229,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         )
 
         accepted_invite = PreregistrationUser.objects.filter(
-            email__iexact="foo@zulip.com", status=confirmation_settings.STATUS_ACTIVE
+            email__iexact="foo@zulip.com", status=confirmation_settings.STATUS_USED
         )
         revoked_invites = PreregistrationUser.objects.filter(
             email__iexact="foo@zulip.com", status=confirmation_settings.STATUS_REVOKED
@@ -2433,7 +2433,7 @@ class InvitationsTestCase(InviteUserBase):
         """
         A GET call to /json/invites returns all unexpired invitations.
         """
-        active_value = getattr(confirmation_settings, "STATUS_ACTIVE", "Wrong")
+        active_value = getattr(confirmation_settings, "STATUS_USED", "Wrong")
         self.assertNotEqual(active_value, "Wrong")
 
         self.login("iago")
@@ -2883,7 +2883,7 @@ class InvitationsTestCase(InviteUserBase):
         result = self.submit_reg_form_for_user(email, password, key=registration_key)
         self.assertEqual(result.status_code, 302)
         prereg_user = PreregistrationUser.objects.get(email=email, referred_by=inviter, realm=realm)
-        self.assertEqual(prereg_user.status, confirmation_settings.STATUS_ACTIVE)
+        self.assertEqual(prereg_user.status, confirmation_settings.STATUS_USED)
         user = get_user_by_delivery_email(email, realm)
         self.assertIsNotNone(user)
         self.assertEqual(user.delivery_email, email)

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -191,7 +191,7 @@ def maybe_send_to_registration(
         from_multiuse_invite = True
         try:
             confirmation_obj = get_object_from_key(
-                multiuse_object_key, [Confirmation.MULTIUSE_INVITE]
+                multiuse_object_key, [Confirmation.MULTIUSE_INVITE], mark_object_used=False
             )
         except ConfirmationKeyException as exception:
             return render_confirmation_key_error(request, exception)

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -327,11 +327,15 @@ def check_subdomain_available(request: HttpRequest, subdomain: str) -> HttpRespo
 
 def realm_reactivation(request: HttpRequest, confirmation_key: str) -> HttpResponse:
     try:
-        realm = get_object_from_key(confirmation_key, [Confirmation.REALM_REACTIVATION])
+        realm = get_object_from_key(
+            confirmation_key, [Confirmation.REALM_REACTIVATION], mark_object_used=False
+        )
     except ConfirmationKeyException:
         return render(request, "zerver/realm_reactivation_link_error.html")
     assert isinstance(realm, Realm)
     do_reactivate_realm(realm)
+    # TODO: After reactivating the realm, the confirmation link needs to be revoked in some way.
+
     context = {"realm": realm}
     return render(request, "zerver/realm_reactivation.html", context)
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -141,7 +141,7 @@ def check_prereg_key(request: HttpRequest, confirmation_key: str) -> Preregistra
 
     if prereg_user.status in [
         confirmation_settings.STATUS_REVOKED,
-        confirmation_settings.STATUS_ACTIVE,
+        confirmation_settings.STATUS_USED,
     ]:
         raise ConfirmationKeyException(ConfirmationKeyException.EXPIRED)
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -136,7 +136,7 @@ def check_prereg_key(request: HttpRequest, confirmation_key: str) -> Preregistra
         Confirmation.REALM_CREATION,
     ]
 
-    prereg_user = get_object_from_key(confirmation_key, confirmation_types, activate_object=False)
+    prereg_user = get_object_from_key(confirmation_key, confirmation_types, mark_object_used=False)
     assert isinstance(prereg_user, PreregistrationUser)
 
     if prereg_user.status in [

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -751,7 +751,9 @@ def accounts_home_from_multiuse_invite(request: HttpRequest, confirmation_key: s
     realm = get_realm_from_request(request)
     multiuse_object: Optional[MultiuseInvite] = None
     try:
-        confirmation_obj = get_object_from_key(confirmation_key, [Confirmation.MULTIUSE_INVITE])
+        confirmation_obj = get_object_from_key(
+            confirmation_key, [Confirmation.MULTIUSE_INVITE], mark_object_used=False
+        )
         assert isinstance(confirmation_obj, MultiuseInvite)
         multiuse_object = confirmation_obj
         if realm != multiuse_object.realm:

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -139,8 +139,15 @@ def check_prereg_key(request: HttpRequest, confirmation_key: str) -> Preregistra
     prereg_user = get_object_from_key(confirmation_key, confirmation_types, activate_object=False)
     assert isinstance(prereg_user, PreregistrationUser)
 
-    if prereg_user.status == confirmation_settings.STATUS_REVOKED:
+    if prereg_user.status in [
+        confirmation_settings.STATUS_REVOKED,
+        confirmation_settings.STATUS_ACTIVE,
+    ]:
         raise ConfirmationKeyException(ConfirmationKeyException.EXPIRED)
+
+    # Defensive assert to make sure no mix-up in how .status is set leading to re-use
+    # of a PreregistrationUser object.
+    assert prereg_user.created_user is None
 
     return prereg_user
 

--- a/zerver/views/unsubscribe.py
+++ b/zerver/views/unsubscribe.py
@@ -18,7 +18,9 @@ def process_unsubscribe(
     unsubscribe_function: Callable[[UserProfile], None],
 ) -> HttpResponse:
     try:
-        user_profile = get_object_from_key(confirmation_key, [Confirmation.UNSUBSCRIBE])
+        user_profile = get_object_from_key(
+            confirmation_key, [Confirmation.UNSUBSCRIBE], mark_object_used=False
+        )
     except ConfirmationKeyException:
         return render(request, "zerver/unsubscribe_link_error.html")
 

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -62,7 +62,9 @@ AVATAR_CHANGES_DISABLED_ERROR = gettext_lazy("Avatar changes are disabled in thi
 
 def confirm_email_change(request: HttpRequest, confirmation_key: str) -> HttpResponse:
     try:
-        email_change_object = get_object_from_key(confirmation_key, [Confirmation.EMAIL_CHANGE])
+        email_change_object = get_object_from_key(
+            confirmation_key, [Confirmation.EMAIL_CHANGE], mark_object_used=True
+        )
     except ConfirmationKeyException as exception:
         return render_confirmation_key_error(request, exception)
 


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/343-kandra-errors/topic/AssertionError.3A.20PregistrationUser.20should.20not.20be.20reused/near/1374354

Before this, a link still couldn't be re-used because it would trip up
exception further down user creation codepaths, but that was still a
bug. check_prereg_key is supposed to correctly validate the key - and
trigger an error page being returned if a key (or for any other reason,
the attached PreregistrationUser object) is reused.
