### PR TITLE
Add a tool to tail SES queues

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -26,9 +26,9 @@ Pillow
 # Needed for building complex DB queries
 SQLAlchemy==1.4.*
 
-# Needed for S3 file uploads
+# Needed for S3 file uploads and other AWS tools
 boto3
-mypy-boto3-s3
+boto3-stubs[ses,s3,sqs,sns]
 
 # Needed for integrations
 defusedxml

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -138,10 +138,12 @@ boto3==1.22.5 \
     # via
     #   -r requirements/common.in
     #   moto
-boto3-stubs[s3]==1.22.5 \
+boto3-stubs[s3,ses,sns,sqs]==1.22.5 \
     --hash=sha256:28982cc8926b43e80fa00b0b8b8ab264c38370599fe756cbe33486a6414d998e \
     --hash=sha256:d4b16fb4c9cb46c75bde7f2754b62e178c7f1413ccdd7c4f1d9c2868b2b03141
-    # via -r requirements/mypy.in
+    # via
+    #   -r requirements/common.in
+    #   -r requirements/mypy.in
 botocore==1.25.5 \
     --hash=sha256:9f2f143fe8581eb9c43c0934b7daf706067afa409171a80b103f458977fcfbd4 \
     --hash=sha256:bcbacc0ec0a1f44cbf7e6d8112af8096eed41bec75e90af06f8bf61f20d820aa
@@ -1036,9 +1038,19 @@ mypy==0.950 \
 mypy-boto3-s3==1.22.0.post1 \
     --hash=sha256:7e9374d89e708e69f93124aa5eafbf16df1149545aa071eabf88e5399a8a43be \
     --hash=sha256:94ea6cca0622d62099f4382a3a37c9e072fd3ef4662ea329116aa078ec85088e
-    # via
-    #   -r requirements/common.in
-    #   boto3-stubs
+    # via boto3-stubs
+mypy-boto3-ses==1.22.8 \
+    --hash=sha256:37ce6c2094fb2fe5d28b0336da2c2e81f41e1ba45a4e055375103f001b0393bd \
+    --hash=sha256:e1f106227cebb8ba023c9f49b5c0a44fea487b75957214e7478d5f47221a558c
+    # via boto3-stubs
+mypy-boto3-sns==1.22.8 \
+    --hash=sha256:01d12eada072be8ca4e7f1a68632b14b5cd10167760513bd6246011b3847e441 \
+    --hash=sha256:9646504b295574af2c109e1a49207e8f94181d6dcca45faa1b2594b3a04f0a89
+    # via boto3-stubs
+mypy-boto3-sqs==1.22.8 \
+    --hash=sha256:059b1a9211b421ffb05150dfca3f3847e49399070ac1f1aaf6d5a075f525f5aa \
+    --hash=sha256:d8bc78aef5f95a03a736258d7f6488de705d1ccc341b11165fb05ae70c99b98b
+    # via boto3-stubs
 mypy-extensions==0.4.3 \
     --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
     --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8
@@ -2168,6 +2180,9 @@ typing-extensions==4.2.0 \
     #   libcst
     #   mypy
     #   mypy-boto3-s3
+    #   mypy-boto3-ses
+    #   mypy-boto3-sns
+    #   mypy-boto3-sqs
     #   myst-parser
     #   pyre-check
     #   pyre-extensions

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -75,12 +75,20 @@ boto3==1.22.5 \
     --hash=sha256:dbbeee6d535a311d4d646a9dd683b216bf17d59345367432a22a21b50eb43a8e \
     --hash=sha256:e6b4a4970cb9210d455f348577d9e0485f86c44baf278b8220e8ab5587d03470
     # via -r requirements/common.in
+boto3-stubs[s3,ses,sns,sqs]==1.22.5 \
+    --hash=sha256:28982cc8926b43e80fa00b0b8b8ab264c38370599fe756cbe33486a6414d998e \
+    --hash=sha256:d4b16fb4c9cb46c75bde7f2754b62e178c7f1413ccdd7c4f1d9c2868b2b03141
+    # via -r requirements/common.in
 botocore==1.25.5 \
     --hash=sha256:9f2f143fe8581eb9c43c0934b7daf706067afa409171a80b103f458977fcfbd4 \
     --hash=sha256:bcbacc0ec0a1f44cbf7e6d8112af8096eed41bec75e90af06f8bf61f20d820aa
     # via
     #   boto3
     #   s3transfer
+botocore-stubs==1.25.5.post1 \
+    --hash=sha256:2c09364671853d34bf2fe6dfe85d6830c21d89cf6d036f34626f82607420fe38 \
+    --hash=sha256:473b1d8d670aba504de8f9b5c55b5c0ad0b705c05ec94978ec00b3a89c017019
+    # via boto3-stubs
 cachetools==5.0.0 \
     --hash=sha256:486471dfa8799eb7ec503a8059e263db000cdda20075ce5e48903087f79d5fd6 \
     --hash=sha256:8fecd4203a38af17928be7b90689d8083603073622229ca7077b72d8e5a976e4
@@ -651,7 +659,19 @@ more-itertools==8.12.0 \
 mypy-boto3-s3==1.22.0.post1 \
     --hash=sha256:7e9374d89e708e69f93124aa5eafbf16df1149545aa071eabf88e5399a8a43be \
     --hash=sha256:94ea6cca0622d62099f4382a3a37c9e072fd3ef4662ea329116aa078ec85088e
-    # via -r requirements/common.in
+    # via boto3-stubs
+mypy-boto3-ses==1.22.8 \
+    --hash=sha256:37ce6c2094fb2fe5d28b0336da2c2e81f41e1ba45a4e055375103f001b0393bd \
+    --hash=sha256:e1f106227cebb8ba023c9f49b5c0a44fea487b75957214e7478d5f47221a558c
+    # via boto3-stubs
+mypy-boto3-sns==1.22.8 \
+    --hash=sha256:01d12eada072be8ca4e7f1a68632b14b5cd10167760513bd6246011b3847e441 \
+    --hash=sha256:9646504b295574af2c109e1a49207e8f94181d6dcca45faa1b2594b3a04f0a89
+    # via boto3-stubs
+mypy-boto3-sqs==1.22.8 \
+    --hash=sha256:059b1a9211b421ffb05150dfca3f3847e49399070ac1f1aaf6d5a075f525f5aa \
+    --hash=sha256:d8bc78aef5f95a03a736258d7f6488de705d1ccc341b11165fb05ae70c99b98b
+    # via boto3-stubs
 oauthlib==3.2.0 \
     --hash=sha256:23a8208d75b902797ea29fd31fa80a15ed9dc2c6c16fe73f5d346f83f6fa27a2 \
     --hash=sha256:6db33440354787f9b7f3a6dbd4febf5d0f93758354060e802f6c06cb493022fe
@@ -1362,7 +1382,12 @@ typing-extensions==4.2.0 \
     --hash=sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376
     # via
     #   -r requirements/common.in
+    #   boto3-stubs
+    #   botocore-stubs
     #   mypy-boto3-s3
+    #   mypy-boto3-ses
+    #   mypy-boto3-sns
+    #   mypy-boto3-sqs
     #   zulip
     #   zulip-bots
 uhashring==2.1 \

--- a/tools/tail-ses
+++ b/tools/tail-ses
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from scripts.lib.setup_path import setup_path
+
+setup_path()
+
+os.environ["DJANGO_SETTINGS_MODULE"] = "zproject.settings"
+import argparse
+import secrets
+from contextlib import contextmanager
+from typing import Iterator, List, Tuple
+
+import boto3
+import orjson
+from django.conf import settings
+from mypy_boto3_ses import SESClient
+from mypy_boto3_sns import SNSClient
+from mypy_boto3_sqs import SQSClient
+from mypy_boto3_sqs.type_defs import DeleteMessageBatchRequestEntryTypeDef
+
+
+def main() -> None:
+
+    session = boto3.Session()
+
+    from_address = settings.NOREPLY_EMAIL_ADDRESS
+    from_host = from_address.split("@")[1]
+
+    ses: SESClient = session.client("ses")
+    possible_identities = []
+    identity_paginator = ses.get_paginator("list_identities")
+    for identity_resp in identity_paginator.paginate():
+        possible_identities += identity_resp["Identities"]
+
+    identity_args = {}
+    if from_host in possible_identities:
+        identity_args["default"] = from_host
+    elif from_address in possible_identities:
+        identity_args["default"] = from_address
+    else:
+        identity_args["required"] = True
+
+    parser = argparse.ArgumentParser(description="Tail SES delivery or bounces")
+    parser.add_argument(
+        "--identity",
+        "-i",
+        choices=possible_identities,
+        help="Sending identity in SES",
+        **identity_args,
+    )
+    topic_group = parser.add_mutually_exclusive_group(required=True)
+    topic_group.add_argument("--bounces", "-b", action="store_true")
+    topic_group.add_argument("--deliveries", "-d", action="store_true")
+    topic_group.add_argument("--complaints", "-c", action="store_true")
+    args = parser.parse_args()
+
+    sns_topic_arn = get_ses_arn(session, args)
+    with our_sqs_queue(session, sns_topic_arn) as (queue_arn, queue_url):
+        with our_sns_subscription(session, sns_topic_arn, queue_arn):
+            print_messages(session, queue_url)
+
+
+def get_ses_arn(session: boto3.Session, args: argparse.Namespace) -> str:
+    ses: SESClient = session.client("ses")
+
+    notification_settings = ses.get_identity_notification_attributes(Identities=[args.identity])
+    settings = notification_settings["NotificationAttributes"][args.identity]
+
+    if args.bounces:
+        return settings["BounceTopic"]
+    elif args.complaints:
+        return settings["ComplaintTopic"]
+    elif args.deliveries:
+        return settings["DeliveryTopic"]
+    assert False  # Unreachable
+
+
+@contextmanager
+def our_sqs_queue(session: boto3.Session, ses_topic_arn: str) -> Iterator[Tuple[str, str]]:
+    (_, _, _, region, account_id, topic_name) = ses_topic_arn.split(":")
+
+    sqs: SQSClient = session.client("sqs")
+    queue_name = "tail-ses-" + secrets.token_hex(10)
+    try:
+        resp = sqs.create_queue(
+            QueueName=queue_name,
+            Attributes={
+                "Policy": orjson.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Id": secrets.token_hex(10),
+                        "Statement": [
+                            {
+                                "Sid": "Sid" + secrets.token_hex(10),
+                                "Effect": "Allow",
+                                "Principal": {"AWS": "*"},
+                                "Action": "SQS:SendMessage",
+                                "Resource": f"arn:aws:sqs:{region}:{account_id}:{queue_name}",
+                                "Condition": {"ArnEquals": {"aws:SourceArn": ses_topic_arn}},
+                            }
+                        ],
+                    }
+                ).decode("UTF-8")
+            },
+        )
+        queue_url = resp["QueueUrl"]
+        yield f"arn:aws:sqs:{region}:{account_id}:{queue_name}", queue_url
+    finally:
+        if queue_url is not None:
+            print("Deleting temporary queue...", file=sys.stderr)
+            sqs.delete_queue(QueueUrl=queue_url)
+
+
+@contextmanager
+def our_sns_subscription(
+    session: boto3.Session, ses_topic_arn: str, queue_arn: str
+) -> Iterator[str]:
+    sns: SNSClient = session.client("sns")
+    try:
+        resp = sns.subscribe(
+            TopicArn=ses_topic_arn,
+            Protocol="sqs",
+            Endpoint=queue_arn,
+            Attributes={"RawMessageDelivery": "false"},
+            ReturnSubscriptionArn=True,
+        )
+        subscription_arn = resp["SubscriptionArn"]
+        yield subscription_arn
+    finally:
+        if subscription_arn is not None:
+            print("Deleting temporary SNS subscription...", file=sys.stderr)
+            sns.unsubscribe(SubscriptionArn=subscription_arn)
+
+
+def print_messages(session: boto3.Session, queue_url: str) -> None:
+    sqs: SQSClient = session.client("sqs")
+    try:
+        while True:
+            resp = sqs.receive_message(
+                QueueUrl=queue_url,
+                MaxNumberOfMessages=10,
+                WaitTimeSeconds=5,
+                MessageAttributeNames=["All"],
+            )
+            messages = resp.get("Messages", [])
+            delete_list: List[DeleteMessageBatchRequestEntryTypeDef] = []
+            for m in messages:
+                body = orjson.loads(m["Body"])
+                body_message = orjson.loads(body["Message"])
+                print(
+                    body["Timestamp"]
+                    + " "
+                    + orjson.dumps(body_message, option=orjson.OPT_INDENT_2).decode("utf-8")
+                )
+                delete_list.append({"Id": m["MessageId"], "ReceiptHandle": m["ReceiptHandle"]})
+            if delete_list:
+                sqs.delete_message_batch(QueueUrl=queue_url, Entries=delete_list)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 129
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "188.0"
+PROVISION_VERSION = "188.1"


### PR DESCRIPTION
AWS SES itself does not keep logs -- it sends events to an SNS queue, which you can subscribe to various things.  Sometimes it's useful to be able to tail these delivery or bounce logs in realtime.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
