### PR TITLE
fix: move avatar border outside the image in full profile

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -273,7 +273,7 @@ ul {
         background-size: cover;
         background-position: center;
         border-radius: 5px;
-        border: 1px solid hsla(0, 0%, 0%, 0.2);
+        box-shadow: 0 0 0 1px hsla(0, 0%, 0%, 0.2);
 
         &.guest-avatar::after {
             outline: 9px solid hsl(0, 0%, 100%);


### PR DESCRIPTION
Fixes: #21265

move avatar border outside the image in full profile. Instead of using the `border` which overlap / overflow over the background content, I used `outline`.

Fixes: #21265

**Screenshots and screen captures:**

*original*
![original](https://user-images.githubusercontent.com/9087704/167256403-9da7cba5-ba73-4608-b4c1-a94c2622fab2.png)

*fixed*
![fixed](https://user-images.githubusercontent.com/9087704/167256410-ffdecd73-333a-4c8e-9813-6db0df28938b.png)

**Self-review checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
