### PR TITLE
tables: Cleanup of table-striped CSS block.

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -664,3 +664,51 @@ div.overlay {
         top: 3px;
     }
 }
+
+.table-striped {
+    table-layout: auto;
+    border-collapse: separate;
+
+    thead th {
+        color: inherit;
+        background-color: hsl(0, 0%, 100%);
+        border-top: 1px solid hsla(0, 0%, 0%, 0.2) !important;
+        border-bottom: 1px solid hsla(0, 0%, 0%, 0.2) !important;
+
+        &.active::after,
+        &[data-sort]:hover::after {
+            content: " \f0d8";
+            white-space: pre;
+            display: inline-block;
+            position: absolute;
+            padding-top: 3px;
+            font: normal normal normal 12px/1 FontAwesome;
+            font-size: inherit;
+        }
+
+        &.active {
+            opacity: 1;
+            transition: opacity 100ms ease-out;
+
+            &.descend::after {
+                content: " \f0d7";
+            }
+        }
+
+        &[data-sort]:hover {
+            cursor: pointer;
+            background-color: hsla(0, 0%, 95%) !important;
+            transition: background-color 100ms ease-in-out;
+
+            &:not(.active)::after {
+                opacity: 0.3;
+            }
+        }
+    }
+
+    /* Force the actions column to use the minimum space necessary */
+    .actions {
+        width: 1%;
+        white-space: nowrap;
+    }
+}

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -83,8 +83,8 @@ body.dark-theme {
     table.table-striped thead.table-sticky-headers th {
         background-color: hsl(0, 0%, 0%);
 
-        &:hover:not(.actions) {
-            background-color: hsl(211, 29%, 14%);
+        &[data-sort]:hover {
+            background-color: hsl(211, 29%, 14%) !important;
         }
     }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -293,54 +293,6 @@ td .button {
         }
     }
 
-    .table-striped {
-        table-layout: auto;
-        border-collapse: separate;
-
-        thead th {
-            color: inherit;
-            background-color: hsl(0, 0%, 100%);
-            border-top: 1px solid hsla(0, 0%, 0%, 0.2) !important;
-            border-bottom: 1px solid hsla(0, 0%, 0%, 0.2) !important;
-
-            &.active::after,
-            &[data-sort]:hover::after {
-                content: " \f0d8";
-                white-space: pre;
-                display: inline-block;
-                position: absolute;
-                padding-top: 3px;
-                font: normal normal normal 12px/1 FontAwesome;
-                font-size: inherit;
-            }
-
-            &.active {
-                opacity: 1;
-                transition: opacity 100ms ease-out;
-
-                &.descend::after {
-                    content: " \f0d7";
-                }
-            }
-
-            &[data-sort]:hover {
-                cursor: pointer;
-                background-color: hsla(0, 0%, 95%);
-                transition: background-color 100ms ease-in-out;
-
-                &:not(.active)::after {
-                    opacity: 0.3;
-                }
-            }
-        }
-
-        /* Force the actions column to use the minimum space necessary */
-        .actions {
-            width: 1%;
-            white-space: nowrap;
-        }
-    }
-
     #admin_page_users_loading_indicator,
     #attachments_loading_indicator,
     #admin_page_deactivated_users_loading_indicator,

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -131,7 +131,8 @@ h4.stream_setting_subsection_title {
 
 .subscriber-list-box {
     text-align: center;
-    border: 1px solid hsl(0, 0%, 87%);
+    border-left: 1px solid hsl(0, 0%, 87%);
+    border-right: 1px solid hsl(0, 0%, 87%);
     border-radius: 4px;
 
     .subscriber_list_container {

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -183,9 +183,6 @@ h4.stream_setting_subsection_title {
             }
 
             thead th {
-                color: inherit;
-                background-color: hsl(0, 0%, 100%);
-
                 &:first-of-type {
                     border-top-left-radius: 4px;
                 }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2213,11 +2213,6 @@ div.floating_recipient {
     border-radius: 6px;
 }
 
-.table-striped thead th {
-    background-color: hsl(0, 0%, 27%);
-    color: hsl(0, 0%, 100%);
-}
-
 #create_stream_subscribers {
     margin-top: 10px;
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Making `table-striped` CSS block as a top level shared CSS inside
`app_components.css`, trying to make use of this block on every
table and also removing some dublicated CSS.

Follow-up of https://github.com/zulip/zulip/pull/21144


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->


