### PR TITLE
puppet: Only fix certbot certificates if https is enabled.

### DIFF
--- a/puppet/zulip/manifests/profile/app_frontend.pp
+++ b/puppet/zulip/manifests/profile/app_frontend.pp
@@ -60,14 +60,16 @@ class zulip::profile::app_frontend {
     source  => 'puppet:///modules/zulip/letsencrypt/nginx-deploy-hook.sh',
     require => Package[certbot],
   }
-  exec { 'fix-standalone-certbot':
-    onlyif  => @(EOT),
-      test -L /etc/ssl/certs/zulip.combined-chain.crt &&
-      readlink /etc/ssl/certs/zulip.combined-chain.crt | grep -q /etc/letsencrypt/live/ &&
-      test -d /etc/letsencrypt/renewal &&
-      grep -qx "authenticator = standalone" /etc/letsencrypt/renewal/*.conf
-      | EOT
-    command => "${::zulip_scripts_path}/lib/fix-standalone-certbot",
+  if ! $nginx_http_only {
+      exec { 'fix-standalone-certbot':
+        onlyif  => @(EOT),
+          test -L /etc/ssl/certs/zulip.combined-chain.crt &&
+          readlink /etc/ssl/certs/zulip.combined-chain.crt | grep -q /etc/letsencrypt/live/ &&
+          test -d /etc/letsencrypt/renewal &&
+          grep -qx "authenticator = standalone" /etc/letsencrypt/renewal/*.conf
+          | EOT
+        command => "${::zulip_scripts_path}/lib/fix-standalone-certbot",
+      }
   }
 
   # Restart the server regularly to avoid potential memory leak problems.


### PR DESCRIPTION
This is a reprise of c97162e48572, but for the case where certbot
certs are no longer in use by way of enabling `http_only` and letting
another server handle TLS termination.

Fixes: #22034.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
