### PR TITLE
testing: faster and more detailed test-backend --coverage.

### DIFF
--- a/docs/testing/testing-with-django.md
+++ b/docs/testing/testing-with-django.md
@@ -481,6 +481,10 @@ Here are some things to consider when writing new tests:
   view right from your browser (the tool prints the URL where the report
   is exposed in your development environment).
 
+  The HTML report also displays which tests executed each line, which
+  can be handy for finding existing tests for a code path you're
+  working on.
+
 - **Console output** A properly written test should print nothing to
   the console; use `with self.assertLogs` to capture and verify any
   logging output. Note that we reconfigure various loggers in

--- a/tools/coveragerc
+++ b/tools/coveragerc
@@ -24,6 +24,13 @@ exclude_lines =
 
 [run]
 data_file=var/.coverage
+
+# dynamic_context=test_function, combined with using
+# html_report(..., show_contexts=True), means the HTML report can detail
+# which test(s) executed each line with coverage. This has modest
+# overhead but is very useful for finding existing tests for a code path.
+dynamic_context=test_function
+
 omit =
     */zulip-venv-cache/*
     */migrations/*

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -442,7 +442,7 @@ def main() -> None:
             print("Printing coverage data")
             cov.report(show_missing=False)
         cov.xml_report(outfile="var/coverage.xml")
-        cov.html_report(directory="var/coverage")
+        cov.html_report(directory="var/coverage", show_contexts=True)
         print("HTML report saved; visit at http://127.0.0.1:9991/coverage/index.html")
     if full_suite and not failures and options.coverage:
         # Assert that various files have full coverage

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -233,6 +233,12 @@ def main() -> None:
         "--verbose-coverage", action="store_true", help="Enable verbose print of coverage report."
     )
     parser.add_argument(
+        "--xml-report", action="store_true", help="Enable (slow) XML coverage report."
+    )
+    parser.add_argument(
+        "--no-html-report", action="store_true", help="Disable (slow) HTML coverage report."
+    )
+    parser.add_argument(
         "--no-cov-cleanup", action="store_true", help="Do not clean generated coverage files."
     )
 
@@ -441,9 +447,14 @@ def main() -> None:
         if options.verbose_coverage:
             print("Printing coverage data")
             cov.report(show_missing=False)
-        cov.xml_report(outfile="var/coverage.xml")
-        cov.html_report(directory="var/coverage", show_contexts=True)
-        print("HTML report saved; visit at http://127.0.0.1:9991/coverage/index.html")
+        if options.xml_report:
+            print("Writing XML report")
+            cov.xml_report(outfile="var/coverage.xml")
+            print("XML report saved; see var/coverage.xml")
+        if not options.no_html_report:
+            print("Writing HTML report")
+            cov.html_report(directory="var/coverage", show_contexts=True)
+            print("HTML report saved; visit at http://127.0.0.1:9991/coverage/index.html")
     if full_suite and not failures and options.coverage:
         # Assert that various files have full coverage
         for path in enforce_fully_covered:


### PR DESCRIPTION
I've noticed that the XML and HTML reports are some of the slowest parts of test-backend, particularly when running 16+ way parallelism. This PR allows users to disable them.

