### PR TITLE
oneclick: Do not use a stale Zulip client, fail if fab fails

### DIFF
--- a/tools/oneclickapps/prepare_digital_ocean_one_click_app_release.py
+++ b/tools/oneclickapps/prepare_digital_ocean_one_click_app_release.py
@@ -107,7 +107,7 @@ def create_dns_records(droplet: digitalocean.Droplet) -> None:
 
 
 def setup_one_click_app_installer(droplet: digitalocean.Droplet) -> None:
-    subprocess.call(
+    subprocess.check_call(
         [
             "fab",
             "build_image",

--- a/tools/oneclickapps/prepare_digital_ocean_one_click_app_release.py
+++ b/tools/oneclickapps/prepare_digital_ocean_one_click_app_release.py
@@ -10,7 +10,10 @@ from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
 manager = digitalocean.Manager(token=os.environ["DIGITALOCEAN_API_KEY"])
-zulip_client = zulip.Client()
+# We just temporarily create the client now, to validate that we can
+# auth to the server; reusing it after the whole install fails because
+# the connection has been half-closed in a way that breaks it.
+zulip.Client()
 TEST_DROPLET_SUBDOMAIN = "do"
 
 
@@ -126,7 +129,7 @@ def send_message(content: str) -> None:
         "topic": "digitalocean installer",
         "content": content,
     }
-    zulip_client.send_message(request)
+    zulip.Client().send_message(request)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Initializing the Zulip client opens a long-lived TCP connection due to
connection pooling in urllib3.  In Github Actions, the network kills
such requests after ~270s, making the later `send_message` call fail.

Use a singular call to `zulip.Client()` early on to verify the
credentials, and do not cache the resulting client object.  Instead,
re-create it during the final step when it is needed, so we do not run
afoul of bad TCP connection state.

This would ideally be fixed via connection keepalive or retry at the
level of the Zulip module.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
