### PR TITLE
puppet: Remove typo'd cron job.

### DIFF
--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -220,4 +220,8 @@ class zulip::app_frontend_base {
     mode   => '0644',
     source => 'puppet:///modules/zulip/cron.d/fetch-tor-exit-nodes',
   }
+  # This was originally added with a typo in the name.
+  file { '/etc/cron.d/fetch-for-exit-nodes':
+    ensure => absent,
+  }
 }

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -883,7 +883,7 @@ def get_tor_ips() -> Set[str]:
     if not settings.RATE_LIMIT_TOR_TOGETHER:
         return set()
 
-    # Cron job in /etc/cron.d/fetch-for-exit-nodes fetches this
+    # Cron job in /etc/cron.d/fetch-tor-exit-nodes fetches this
     # hourly; we cache it in memcached to prevent going to disk on
     # every unauth'd request.  In case of failures to read, we
     # circuit-break so 2 failures cause a 10-minute backoff.


### PR DESCRIPTION
54b6a834125b fixed the typo introduced in 49ad188449a5, but that does
not clean up existing installs which had the file with the wrong name
already.

Remove the file with the typo'd name, so two jobs do not race, and fix
the typo in the comment.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
