### PR TITLE
Fix: Replacing empty PM view text with a meaningful message

### DIFF
--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -345,7 +345,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You have no private messages with this person yet!",
+            "translated: You are not allowed to send private messages here!",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -293,7 +293,7 @@ function pick_empty_narrow_banner() {
                 }
                 return {
                     title: $t({
-                        defaultMessage: "You have no private messages with this person yet!",
+                        defaultMessage: "You are not allowed to send private messages here!",
                     }),
                     html: $t_html(
                         {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
 **Error:** 

- In an empty PM view, we show the following message, which does not make sense when the user is not allowed to send PMs, 

**Fixes:** [21889](https://github.com/zulip/zulip/issues/21889)

**Screenshots and screen captures:**

![Screenshot 2022-05-13 20-16-41](https://user-images.githubusercontent.com/76876709/168309079-7398c4f2-0586-4500-ba38-9c01e46c0e09.png)

Instead, if the user somehow navigates to such a view, the message should say: "You are not allowed to send private messages in this organization."

"Why not start the conversation?" should be dropped altogether.



**Fixes:** <!-- Issue link, or clear description.-->


- By replacing the line number 348 in the narrow.js file with "You are not allowed to send private messages here!" this line.

![pm issue](https://user-images.githubusercontent.com/76876709/168310551-bb32009a-782d-4f15-aac7-9caf23c335e2.png)


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
