### PR TITLE
testing: 100% test coverage for zerver/lib/markdown/{api_arguments_table_generator, help_relative_links}

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -79,9 +79,7 @@ not_yet_fully_covered = [
     "zerver/lib/url_preview/preview.py",
     "zerver/worker/queue_processors.py",
     # Markdown sub-libs should have full coverage too; a lot are really close
-    "zerver/lib/markdown/api_arguments_table_generator.py",
     "zerver/lib/markdown/fenced_code.py",
-    "zerver/lib/markdown/help_relative_links.py",
     "zerver/lib/markdown/nested_code_blocks.py",
     # Other lib files that ideally would coverage, but aren't sorted
     "zerver/filters.py",

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -106,6 +106,55 @@ class DocPageTest(ZulipTestCase):
                     ['<meta name="robots" content="noindex,nofollow" />'], result
                 )
 
+    def test_api_doc_undocumented_endpoint(self) -> None:
+        # test cases where the get_openapi_parameters() call inside APIArgumentsTablePreprocessor.run()
+        # throws a KeyError.
+        with mock.patch(
+            "zerver.lib.markdown.api_arguments_table_generator.get_openapi_parameters",
+            side_effect=KeyError,
+        ):
+            with self.assertLogs(level="ERROR"):
+                self.get_doc("/api/get-streams", subdomain="")
+
+        with mock.patch(
+            "zerver.lib.markdown.api_arguments_table_generator.get_openapi_parameters",
+            side_effect=KeyError(
+                ("parameters"),
+            ),
+        ):
+            self.get_doc("/api/get-streams", subdomain="")
+
+    def test_api_doc_nonjson_response(self) -> None:
+        # test coverage for APIArgumentsTablePreprocessor.render_parameters() where argtype=schema
+        # and for default property values in render_object_details().
+        args = [
+            {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "prop1": {
+                            "default": {"myprop": "42"},
+                            "type": "object",
+                            "properties": {
+                                "prop1a": {
+                                    "default": {"myprop": "42"},
+                                    "type": "string",
+                                },
+                            },
+                        },
+                    },
+                },
+                "description": "foo",
+                "content": "foo",
+                "example": "foo",
+            }
+        ]
+        with mock.patch(
+            "zerver.lib.markdown.api_arguments_table_generator.get_openapi_parameters",
+            return_value=args,
+        ):
+            self._test("/api/send-message", "Parameters")
+
     def test_api_doc_endpoints(self) -> None:
         # We extract the set of /api/ endpoints to check by parsing
         # the /api/ page sidebar for links starting with /api/.
@@ -120,12 +169,23 @@ class DocPageTest(ZulipTestCase):
         for endpoint in endpoint_list:
             self._test(endpoint, "", doc_html_str=True)
 
-        result = self.client_get(
+    def test_api_doc_404_endpoints(self) -> None:
+        def test_404(endpoint: str) -> None:
+            result = self.client_get(
+                endpoint,
+                follow=True,
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
+            self.assertEqual(result.status_code, 404)
+
+        # first do a sanity check, then check for 404s
+        self._test("/api/send-message", "steal away your hearts")
+        for endpoint in [
             "/api/nonexistent-page",
-            follow=True,
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
-        )
-        self.assertEqual(result.status_code, 404)
+            "/api/api-doc-template",
+            "/api/" + "," * 200,
+        ]:
+            test_404(endpoint)
 
     def test_doc_endpoints(self) -> None:
         self._test("/api/", "The Zulip API")
@@ -313,6 +373,18 @@ class HelpTest(ZulipTestCase):
         self.assertEqual(result.status_code, 200)
         self.assertIn("<strong>Manage streams</strong>", str(result.content))
         self.assertNotIn("/#streams", str(result.content))
+
+    def test_help_relative_links_for_all(self) -> None:
+        result = self.client_get("/help/browse-and-subscribe-to-streams")
+        self.assertIn('Go to <a href="/#streams/all">All streams</a>', str(result.content))
+        self.assertEqual(result.status_code, 200)
+
+    def test_help_relative_links_for_all_norel(self) -> None:
+        with mock.patch("zerver.models.Realm.SUBDOMAIN_FOR_ROOT_DOMAIN", "zulip"):
+            with self.settings(ROOT_DOMAIN_LANDING_PAGE=True):
+                result = self.client_get("/help/browse-and-subscribe-to-streams")
+        self.assertIn("Click <strong>All streams</strong> in the upper left.", str(result.content))
+        self.assertEqual(result.status_code, 200)
 
 
 class IntegrationTest(ZulipTestCase):

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -77,10 +77,8 @@ class MarkdownDirectoryView(ApiURLView):
             article = "index"
         elif article == "include/sidebar_index":
             pass
-        elif "/" in article:
-            article = "missing"
-            http_status = 404
         elif len(article) > 100 or not re.match("^[0-9a-zA-Z_-]+$", article):
+            # note: also handles ("/" in article)
             article = "missing"
             http_status = 404
 
@@ -100,6 +98,15 @@ class MarkdownDirectoryView(ApiURLView):
             return DocumentationArticle(
                 article_path=path,
                 article_http_status=http_status,
+                endpoint_path=None,
+                endpoint_method=None,
+            )
+
+        if path == "/zerver/api/api-doc-template.md":
+            # This shouldn't be accessible directly
+            return DocumentationArticle(
+                article_path=self.path_template % ("missing",),
+                article_http_status=404,
                 endpoint_path=None,
                 endpoint_method=None,
             )


### PR DESCRIPTION
Test coverage for code which generates documentation pages.
