### PR TITLE
help docs: Fix a wrong link in create-a-stream doc

### DIFF
--- a/templates/zerver/help/create-a-stream.md
+++ b/templates/zerver/help/create-a-stream.md
@@ -1,7 +1,7 @@
 # Create a stream
 
 By default, all users other than guests can create streams. Administrators can
-[restrict the ability to create a stream](/help/stream-permissions) to specific
+[restrict the ability to create a stream](/help/configure-who-can-create-streams) to specific
 [roles](/help/roles-and-permissions).
 
 If you are an administrator setting up streams for the first time, check out our


### PR DESCRIPTION
Discussion:
  https://chat.zulip.org/#narrow/stream/19-documentation/topic/Wrong.20link.20.28stream.20creation.29/near/1380786