### PR TITLE
Revert "settings: Add web-public streams beta subdomain list."

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -297,7 +297,7 @@ def fetch_initial_state_data(
         state["server_inline_url_embed_preview"] = settings.INLINE_URL_EMBED_PREVIEW
         state["server_avatar_changes_disabled"] = settings.AVATAR_CHANGES_DISABLED
         state["server_name_changes_disabled"] = settings.NAME_CHANGES_DISABLED
-        state["server_web_public_streams_enabled"] = realm.web_public_streams_available_for_realm()
+        state["server_web_public_streams_enabled"] = settings.WEB_PUBLIC_STREAMS_ENABLED
         state["giphy_rating_options"] = realm.GIPHY_RATING_OPTIONS
 
         state["server_needs_upgrade"] = is_outdated_server(user_profile)

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -941,20 +941,11 @@ class Realm(models.Model):
     def presence_disabled(self) -> bool:
         return self.is_zephyr_mirror_realm
 
-    def web_public_streams_available_for_realm(self) -> bool:
-        if self.string_id in settings.WEB_PUBLIC_STREAMS_BETA_SUBDOMAINS:
-            return True
-
+    def web_public_streams_enabled(self) -> bool:
         if not settings.WEB_PUBLIC_STREAMS_ENABLED:
             # To help protect against accidentally web-public streams in
             # self-hosted servers, we require the feature to be enabled at
             # the server level before it is available to users.
-            return False
-
-        return True
-
-    def web_public_streams_enabled(self) -> bool:
-        if not self.web_public_streams_available_for_realm():
             return False
 
         if self.plan_type == Realm.PLAN_TYPE_LIMITED:

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -849,10 +849,6 @@ class RealmTest(ZulipTestCase):
             self.assertEqual(realm.has_web_public_streams(), False)
             self.assertEqual(realm.web_public_streams_enabled(), False)
 
-            with self.settings(WEB_PUBLIC_STREAMS_BETA_SUBDOMAINS=["zulip"]):
-                self.assertEqual(realm.has_web_public_streams(), True)
-                self.assertEqual(realm.web_public_streams_enabled(), True)
-
         realm.enable_spectator_access = False
         realm.save()
         self.assertEqual(realm.has_web_public_streams(), False)

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -261,8 +261,6 @@ OPEN_REALM_CREATION = False
 
 # Whether it's possible to create web-public streams on this server.
 WEB_PUBLIC_STREAMS_ENABLED = False
-# Temporary setting during web-public streams beta.
-WEB_PUBLIC_STREAMS_BETA_SUBDOMAINS: List[str] = []
 
 # Setting for where the system bot users are.  Likely has no
 # purpose now that the REALMS_HAVE_SUBDOMAINS migration is finished.


### PR DESCRIPTION
This reverts commit 20368a936cda44b433e275a522a95921ee0c30de.  It is
no longer in beta, and this configuration is no longer needed.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
