### PR TITLE
Add a new endpoint to get a stream by id.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 6.0
 
+**Feature level 132**
+
+* [`GET /streams/{stream_id}`](/api/get-stream-by-id):
+  Added new endpoint to get a stream by ID.
+
 **Feature level 131**
 
 * [`GET /user_groups`](/api/get-user-groups),[`POST

--- a/templates/zerver/help/include/rest-endpoints.md
+++ b/templates/zerver/help/include/rest-endpoints.md
@@ -31,6 +31,7 @@
 * [Get all subscribers](/api/get-subscribers)
 * [Update subscription settings](/api/update-subscription-settings)
 * [Get all streams](/api/get-streams)
+* [Get a stream by ID](/api/get-stream-by-id)
 * [Get stream ID](/api/get-stream-id)
 * [Create a stream](/api/create-stream)
 * [Update a stream](/api/update-stream)

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 131
+API_FEATURE_LEVEL = 132
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 130
+API_FEATURE_LEVEL = 131
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13428,6 +13428,67 @@ paths:
                       `include_all_active` parameter (i.e. because they are not an organization
                       administrator):
   /streams/{stream_id}:
+    get:
+      operationId: get-stream-by-id
+      summary: Get a stream by ID
+      tags: ["streams"]
+      description: |
+        Fetch details for the stream with the ID `stream_id`.
+
+        `GET {{ api_url }}/v1/streams/{stream_id}`
+
+        **Changes**: New in Zulip 6.0 (feature level 132).
+      parameters:
+        - $ref: "#/components/parameters/StreamIdInPath"
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - $ref: "#/components/schemas/SuccessDescription"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      stream:
+                        $ref: "#/components/schemas/BasicStream"
+                    example:
+                      {
+                        "msg": "",
+                        "result": "success",
+                        "stream":
+                          {
+                            "description": "A Scandinavian country",
+                            "first_message_id": 1,
+                            "history_public_to_subscribers": True,
+                            "invite_only": False,
+                            "is_announcement_only": False,
+                            "is_web_public": False,
+                            "message_retention_days": null,
+                            "name": "Denmark",
+                            "rendered_description": "<p>A Scandinavian country</p>",
+                            "stream_id": 7,
+                            "stream_post_policy": 1,
+                          },
+                      }
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - example:
+                      {
+                        "code": "BAD_REQUEST",
+                        "msg": "Invalid stream id",
+                        "result": "error",
+                      }
+                    description: |
+                      An example JSON response for when the stream ID is not valid.
     delete:
       operationId: archive-stream
       summary: Archive a stream

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1983,7 +1983,7 @@ class RestAPITest(ZulipTestCase):
 
         result = self.client_options("/json/streams/15")
         self.assertEqual(result.status_code, 204)
-        self.assertEqual(str(result["Allow"]), "DELETE, PATCH")
+        self.assertEqual(str(result["Allow"]), "DELETE, GET, HEAD, PATCH")
 
     def test_http_accept_redirect(self) -> None:
         result = self.client_get("/json/users", HTTP_ACCEPT="text/html")

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -755,6 +755,16 @@ def get_streams_backend(
 
 
 @has_request_variables
+def get_stream_backend(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    stream_id: int,
+) -> HttpResponse:
+    (stream, sub) = access_stream_by_id(user_profile, stream_id, allow_realm_admin=True)
+    return json_success(request, data={"stream": stream.to_dict()})
+
+
+@has_request_variables
 def get_topics_backend(
     request: HttpRequest,
     maybe_user_profile: Union[UserProfile, AnonymousUser],

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -145,6 +145,7 @@ from zerver.views.streams import (
     create_default_stream_group,
     deactivate_stream_backend,
     delete_in_topic,
+    get_stream_backend,
     get_streams_backend,
     get_subscribers_backend,
     get_topics_backend,
@@ -443,7 +444,10 @@ v1_api_and_json_patterns = [
     # GET returns "stream info" (undefined currently?), HEAD returns whether stream exists (200 or 404)
     rest_path("streams/<int:stream_id>/members", GET=get_subscribers_backend),
     rest_path(
-        "streams/<int:stream_id>", PATCH=update_stream_backend, DELETE=deactivate_stream_backend
+        "streams/<int:stream_id>",
+        GET=get_stream_backend,
+        PATCH=update_stream_backend,
+        DELETE=deactivate_stream_backend,
     ),
     # Delete topic in stream
     rest_path("streams/<int:stream_id>/delete_topic", POST=delete_in_topic),


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Also added a commit to update the `API_FEATURE_LEVEL` which was missed in [dfd7902](https://github.com/zulip/zulip/commit/dfd7902c77a5a293df15bc2306f8987f642d5a1d).
Fixes: #22082<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
