### PR TITLE
message-editing: Limit who can "resolve" a topic to those who can post.

### DIFF
--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -14,7 +14,9 @@ const settings_config = zrequire("settings_config");
 const get_editability = message_edit.get_editability;
 const editability_types = message_edit.editability_types;
 
+const people = zrequire("people");
 const settings_data = mock_esm("../../static/js/settings_data");
+const stream_data = zrequire("stream_data");
 
 run_test("get_editability", ({override}) => {
     override(settings_data, "user_can_edit_topic_of_any_message", () => true);
@@ -81,10 +83,32 @@ run_test("get_editability", ({override}) => {
     // If we don't pass a second argument, treat it as 0
     assert.equal(get_editability(message), editability_types.NO_LONGER);
 
+    const sub = {
+        stream_id: 102,
+        name: "stream102",
+        subscribed: true,
+        stream_post_policy: stream_data.stream_post_policy_values.everyone.code,
+    };
+
+    stream_data.add_sub(sub);
+
+    const me = {
+        email: "me@example.com",
+        user_id: 30,
+        full_name: "Me Myself",
+        is_admin: true,
+    };
+
+    page_params.user_id = me.user_id;
+    people.add_active_user(me);
+    people.initialize_current_user(me.user_id);
+
     message = {
         sent_by_me: false,
         type: "stream",
+        stream: "stream102",
     };
+
     page_params.realm_edit_topic_policy =
         settings_config.common_message_policy_values.by_everyone.code;
     page_params.realm_allow_message_editing = true;

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -25,6 +25,7 @@ import * as message_lists from "./message_lists";
 import * as message_store from "./message_store";
 import * as message_viewport from "./message_viewport";
 import {page_params} from "./page_params";
+import * as people from "./people";
 import * as resize from "./resize";
 import * as rows from "./rows";
 import * as settings_data from "./settings_data";
@@ -72,15 +73,45 @@ export function is_topic_editable(message, edit_limit_seconds_buffer = 0) {
     if (message.sent_by_me) {
         return true;
     }
+    if (message.type === "stream") {
+        const sub = stream_data.get_sub(message.stream);
+        const stream_post_permission_type = stream_data.stream_post_policy_values;
+        const stream_post_policy = sub.stream_post_policy;
 
-    if (!settings_data.user_can_edit_topic_of_any_message()) {
-        return false;
-    }
+        if (stream_post_policy === stream_post_permission_type.admins.code) {
+            return false;
+        }
 
-    // moderators can edit the topic if edit_topic_policy allows them to do so,
-    // irrespective of the topic editing deadline.
-    if (page_params.is_moderator) {
-        return true;
+        if (!settings_data.user_can_edit_topic_of_any_message()) {
+            return false;
+        }
+
+        // moderators can edit the topic if edit_topic_policy allows them to do so,
+        // irrespective of the topic editing deadline.
+        if (page_params.is_moderator) {
+            return true;
+        }
+        if (stream_post_policy === stream_post_permission_type.moderators.code) {
+            return false;
+        }
+        if (
+            page_params.is_guest &&
+            stream_post_policy !== stream_post_permission_type.everyone.code
+        ) {
+            return false;
+        }
+
+        const person = people.get_by_user_id(page_params.user_id);
+        const current_datetime = new Date(Date.now());
+        const person_date_joined = new Date(person.date_joined);
+        const days = (current_datetime - person_date_joined) / 1000 / 86400;
+
+        if (
+            stream_post_policy === stream_post_permission_type.non_new_members.code &&
+            days < page_params.realm_waiting_period_threshold
+        ) {
+            return false;
+        }
     }
 
     // If you're using community topic editing, there's a deadline.


### PR DESCRIPTION
Issue #21281 

We add a check for people who can send message in the stream and only
those user can resolve the topic of message sent in the stream.

![image](https://user-images.githubusercontent.com/75037620/169034032-ead2b57f-57dc-4a68-8a09-117b5a0532fc.png)
Zoe is normal user and the "resolve" option is not visible to the user since only admin can post in the stream.