### PR TITLE
Fix delete_old_unclaimed_attachments command to take the retention system into consideration

### DIFF
--- a/zerver/actions/uploads.py
+++ b/zerver/actions/uploads.py
@@ -64,9 +64,14 @@ def do_claim_attachments(message: Message, potential_path_ids: List[str]) -> boo
 
 
 def do_delete_old_unclaimed_attachments(weeks_ago: int) -> None:
-    old_unclaimed_attachments = get_old_unclaimed_attachments(weeks_ago)
+    old_unclaimed_attachments, old_unclaimed_archived_attachments = get_old_unclaimed_attachments(
+        weeks_ago
+    )
 
     for attachment in old_unclaimed_attachments:
+        delete_message_image(attachment.path_id)
+        attachment.delete()
+    for attachment in old_unclaimed_archived_attachments:
         delete_message_image(attachment.path_id)
         attachment.delete()
 

--- a/zerver/management/commands/delete_old_unclaimed_attachments.py
+++ b/zerver/management/commands/delete_old_unclaimed_attachments.py
@@ -34,9 +34,13 @@ class Command(BaseCommand):
         print(f"Deleting unclaimed attached files older than {delta_weeks} weeks")
 
         # print the list of files that are going to be removed
-        old_attachments = get_old_unclaimed_attachments(delta_weeks)
+        old_attachments, old_archived_attachments = get_old_unclaimed_attachments(delta_weeks)
         for old_attachment in old_attachments:
             print(f"* {old_attachment.file_name} created at {old_attachment.create_time}")
+        for old_archived_attachment in old_archived_attachments:
+            print(
+                f"* {old_archived_attachment.file_name} created at {old_archived_attachment.create_time}"
+            )
 
         print("")
         if not options["for_real"]:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3476,11 +3476,22 @@ def validate_attachment_request(
     ).exists()
 
 
-def get_old_unclaimed_attachments(weeks_ago: int) -> Sequence[Attachment]:
-    # TODO: Change return type to QuerySet[Attachment]
+def get_old_unclaimed_attachments(
+    weeks_ago: int,
+) -> Tuple[QuerySet[Attachment], QuerySet[ArchivedAttachment]]:
     delta_weeks_ago = timezone_now() - datetime.timedelta(weeks=weeks_ago)
-    old_attachments = Attachment.objects.filter(messages=None, create_time__lt=delta_weeks_ago)
-    return old_attachments
+    old_attachments = Attachment.objects.annotate(
+        has_other_messages=Exists(
+            ArchivedAttachment.objects.filter(id=OuterRef("id")).exclude(messages=None)
+        )
+    ).filter(messages=None, create_time__lt=delta_weeks_ago, has_other_messages=False)
+    old_archived_attachments = ArchivedAttachment.objects.annotate(
+        has_other_messages=Exists(
+            Attachment.objects.filter(id=OuterRef("id")).exclude(messages=None)
+        )
+    ).filter(messages=None, create_time__lt=delta_weeks_ago, has_other_messages=False)
+
+    return old_attachments, old_archived_attachments
 
 
 class Subscription(models.Model):

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3479,6 +3479,16 @@ def validate_attachment_request(
 def get_old_unclaimed_attachments(
     weeks_ago: int,
 ) -> Tuple[QuerySet[Attachment], QuerySet[ArchivedAttachment]]:
+    """
+    The logic in this function is fairly tricky. The essence is that
+    a file should be cleaned up if and only if it not referenced by any
+    Message or ArchivedMessage. The way to find that out is through the
+    Attachment and ArchivedAttachment tables.
+    The queries are complicated by the fact that an uploaded file
+    may have either only an Attachment row, only an ArchivedAttachment row,
+    or both - depending on whether some, all or none of the messages
+    linking to it have been archived.
+    """
     delta_weeks_ago = timezone_now() - datetime.timedelta(weeks=weeks_ago)
     old_attachments = Attachment.objects.annotate(
         has_other_messages=Exists(

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -220,9 +220,10 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         entry = Attachment.objects.get(file_name="zulip.txt")
         self.assertEqual(entry.is_claimed(), False)
 
-        self.subscribe(self.example_user("hamlet"), "Denmark")
-        body = "First message ...[zulip.txt](http://localhost:9991" + uri + ")"
-        self.send_stream_message(self.example_user("hamlet"), "Denmark", body, "test")
+        hamlet = self.example_user("hamlet")
+        self.subscribe(hamlet, "Denmark")
+        body = f"First message ...[zulip.txt]({hamlet.realm.host}{uri})"
+        self.send_stream_message(hamlet, "Denmark", body, "test")
 
         # Now try the endpoint that's supposed to return a temporary URL for access
         # to the file.
@@ -363,7 +364,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         hamlet = self.example_user("hamlet")
         self.login_user(hamlet)
         response = self.client_get(
-            f"http://localhost:9991/user_uploads/{hamlet.realm_id}/ff/gg/abc.py"
+            f"http://{hamlet.realm.host}/user_uploads/{hamlet.realm_id}/ff/gg/abc.py"
         )
         self.assertEqual(response.status_code, 404)
         self.assert_in_response("File not found.", response)
@@ -391,11 +392,14 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         d2_attachment.save()
 
         # Send message referring only dummy_1
-        self.subscribe(self.example_user("hamlet"), "Denmark")
+        hamlet = self.example_user("hamlet")
+        self.subscribe(hamlet, "Denmark")
         body = (
-            "Some files here ...[zulip.txt](http://localhost:9991/user_uploads/" + d1_path_id + ")"
+            f"Some files here ...[zulip.txt](http://{hamlet.realm.host}/user_uploads/"
+            + d1_path_id
+            + ")"
         )
-        self.send_stream_message(self.example_user("hamlet"), "Denmark", body, "test")
+        self.send_stream_message(hamlet, "Denmark", body, "test")
 
         # dummy_2 should not exist in database or the uploads folder
         do_delete_old_unclaimed_attachments(2)
@@ -410,9 +414,21 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
     def test_attachment_url_without_upload(self) -> None:
         hamlet = self.example_user("hamlet")
         self.login_user(hamlet)
-        body = f"Test message ...[zulip.txt](http://localhost:9991/user_uploads/{hamlet.realm_id}/64/fake_path_id.txt)"
-        self.send_stream_message(self.example_user("hamlet"), "Denmark", body, "test")
-        self.assertFalse(Attachment.objects.filter(path_id="1/64/fake_path_id.txt").exists())
+        with self.assertLogs(level="WARNING") as warn_log:
+            body = f"Test message ...[zulip.txt](http://{hamlet.realm.host}/user_uploads/{hamlet.realm_id}/64/fake_path_id.txt)"
+            message_id = self.send_stream_message(
+                self.example_user("hamlet"), "Denmark", body, "test"
+            )
+        self.assertFalse(
+            Attachment.objects.filter(path_id=f"{hamlet.realm_id}/64/fake_path_id.txt").exists()
+        )
+
+        self.assertEqual(
+            warn_log.output,
+            [
+                f"WARNING:root:User {hamlet.id} tried to share upload {hamlet.realm_id}/64/fake_path_id.txt in message {message_id}, but lacks permission"
+            ],
+        )
 
     def test_multiple_claim_attachments(self) -> None:
         """
@@ -1928,7 +1944,7 @@ class S3Test(ZulipTestCase):
         self.assert_length(b"zulip!", uploaded_file.size)
 
         self.subscribe(self.example_user("hamlet"), "Denmark")
-        body = "First message ...[zulip.txt](http://localhost:9991" + uri + ")"
+        body = f"First message ...[zulip.txt](http://{user_profile.realm.host}{uri})"
         self.send_stream_message(self.example_user("hamlet"), "Denmark", body, "test")
 
     @use_s3_backend
@@ -2034,9 +2050,10 @@ class S3Test(ZulipTestCase):
         # second (resulting in the same timestamp+signature),
         # url_only_url may or may not equal redirect_url.
 
-        self.subscribe(self.example_user("hamlet"), "Denmark")
-        body = "First message ...[zulip.txt](http://localhost:9991" + uri + ")"
-        self.send_stream_message(self.example_user("hamlet"), "Denmark", body, "test")
+        hamlet = self.example_user("hamlet")
+        self.subscribe(hamlet, "Denmark")
+        body = f"First message ...[zulip.txt](http://{hamlet.realm.host}" + uri + ")"
+        self.send_stream_message(hamlet, "Denmark", body, "test")
 
     @use_s3_backend
     def test_upload_avatar_image(self) -> None:


### PR DESCRIPTION
Context around https://chat.zulip.org/#narrow/stream/31-production-help/topic/Message.20retention/near/1381934

do_delete_old_unclaimed_attachments is oblivious to the existence of ArchivedAttachment rows, which
is incorrect. A file can be removed if and only if it is not referenced
by any Messages or ArchivedMessages.