### PR TITLE
Update drafts on topic name changes.

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -74,7 +74,7 @@ export const draft_model = (function () {
         return id;
     };
 
-    exports.editDraft = function (id, draft) {
+    exports.editDraft = function (id, draft, update_timestamp = true) {
         const drafts = get();
         let changed = false;
 
@@ -84,7 +84,9 @@ export const draft_model = (function () {
 
         if (drafts[id]) {
             changed = !check_if_equal(drafts[id], draft);
-            draft.updatedAt = getTimestamp();
+            if (update_timestamp) {
+                draft.updatedAt = getTimestamp();
+            }
             drafts[id] = draft;
             save(drafts);
         }
@@ -116,6 +118,17 @@ export function confirm_delete_all_drafts() {
         html_body,
         on_click: delete_all_drafts,
     });
+}
+
+export function rename_topic(stream_id, old_topic, new_topic) {
+    const current_drafts = draft_model.get();
+    for (const draft_id of Object.keys(current_drafts)) {
+        const draft = current_drafts[draft_id];
+        if (util.same_stream_and_topic(draft, {stream_id, topic: old_topic})) {
+            draft.topic = new_topic;
+            draft_model.editDraft(draft_id, draft, false);
+        }
+    }
 }
 
 export function snapshot_message() {

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -7,6 +7,7 @@ import * as compose_fade from "./compose_fade";
 import * as compose_state from "./compose_state";
 import * as compose_validate from "./compose_validate";
 import * as condense from "./condense";
+import * as drafts from "./drafts";
 import * as huddle_data from "./huddle_data";
 import * as message_edit from "./message_edit";
 import * as message_edit_history from "./message_edit_history";
@@ -258,6 +259,8 @@ export function update_messages(events) {
                 compose_validate.warn_if_topic_resolved(true);
                 compose_fade.set_focused_recipient("stream");
             }
+
+            drafts.rename_topic(event.stream_id, orig_topic, new_topic);
 
             for (const msg of event_messages) {
                 if (page_params.realm_allow_edit_history) {

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -182,9 +182,10 @@ export function update_messages(events) {
         }
 
         const new_topic = util.get_edit_event_topic(event);
-
         const new_stream_id = event.new_stream_id;
-
+        const old_stream_id = event.stream_id;
+        // Note: old_stream will be undefined if the message was moved
+        // from a stream that the current user doesn't have access to.
         const old_stream = sub_store.get(event.stream_id);
 
         // Save the content edit to the front end msg.edit_history
@@ -260,7 +261,7 @@ export function update_messages(events) {
                 compose_fade.set_focused_recipient("stream");
             }
 
-            drafts.rename_topic(event.stream_id, orig_topic, new_topic);
+            drafts.rename_topic(old_stream_id, orig_topic, new_topic);
 
             for (const msg of event_messages) {
                 if (page_params.realm_allow_edit_history) {
@@ -274,7 +275,7 @@ export function update_messages(events) {
                     };
                     if (stream_changed) {
                         edit_history_entry.stream = event.new_stream_id;
-                        edit_history_entry.prev_stream = event.stream_id;
+                        edit_history_entry.prev_stream = old_stream_id;
                     }
                     if (topic_edited) {
                         edit_history_entry.topic = new_topic;
@@ -451,12 +452,12 @@ export function update_messages(events) {
             }
 
             // new_stream_id is undefined if this is only a topic edit.
-            const post_edit_stream_id = new_stream_id || event.stream_id;
+            const post_edit_stream_id = new_stream_id || old_stream_id;
 
-            const args = [event.stream_id, pre_edit_topic, post_edit_topic, post_edit_stream_id];
+            const args = [old_stream_id, pre_edit_topic, post_edit_topic, post_edit_stream_id];
             recent_senders.process_topic_edit({
                 message_ids: event.message_ids,
-                old_stream_id: event.stream_id,
+                old_stream_id,
                 old_topic: pre_edit_topic,
                 new_stream_id: post_edit_stream_id,
                 new_topic: post_edit_topic,

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -181,11 +181,14 @@ export function update_messages(events) {
             message_edit.end_message_row_edit($row);
         }
 
+        // new_topic will be undefined if the topic is unchanged.
         const new_topic = util.get_edit_event_topic(event);
+        // new_stream_id will be undefined if the stream is unchanged.
         const new_stream_id = event.new_stream_id;
+        // old_stream_id will be present and valid for all stream messages.
         const old_stream_id = event.stream_id;
-        // Note: old_stream will be undefined if the message was moved
-        // from a stream that the current user doesn't have access to.
+        // old_stream will be undefined if the message was moved from
+        // a stream that the current user doesn't have access to.
         const old_stream = sub_store.get(event.stream_id);
 
         // Save the content edit to the front end msg.edit_history
@@ -274,7 +277,7 @@ export function update_messages(events) {
                         timestamp: event.edit_timestamp,
                     };
                     if (stream_changed) {
-                        edit_history_entry.stream = event.new_stream_id;
+                        edit_history_entry.stream = new_stream_id;
                         edit_history_entry.prev_stream = old_stream_id;
                     }
                     if (topic_edited) {
@@ -316,7 +319,7 @@ export function update_messages(events) {
                 }
                 if (stream_changed) {
                     const new_stream_name = sub_store.get(new_stream_id).name;
-                    msg.stream_id = event.new_stream_id;
+                    msg.stream_id = new_stream_id;
                     msg.stream = new_stream_name;
                     msg.display_recipient = new_stream_name;
                 }

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -181,16 +181,6 @@ export function update_messages(events) {
             message_edit.end_message_row_edit($row);
         }
 
-        // new_topic will be undefined if the topic is unchanged.
-        const new_topic = util.get_edit_event_topic(event);
-        // new_stream_id will be undefined if the stream is unchanged.
-        const new_stream_id = event.new_stream_id;
-        // old_stream_id will be present and valid for all stream messages.
-        const old_stream_id = event.stream_id;
-        // old_stream will be undefined if the message was moved from
-        // a stream that the current user doesn't have access to.
-        const old_stream = sub_store.get(event.stream_id);
-
         // Save the content edit to the front end msg.edit_history
         // before topic edits to ensure that combined topic / content
         // edits have edit_history logged for both before any
@@ -220,6 +210,16 @@ export function update_messages(events) {
             // Update raw_content, so that editing a few times in a row is fast.
             msg.raw_content = event.content;
         }
+
+        // new_topic will be undefined if the topic is unchanged.
+        const new_topic = util.get_edit_event_topic(event);
+        // new_stream_id will be undefined if the stream is unchanged.
+        const new_stream_id = event.new_stream_id;
+        // old_stream_id will be present and valid for all stream messages.
+        const old_stream_id = event.stream_id;
+        // old_stream will be undefined if the message was moved from
+        // a stream that the current user doesn't have access to.
+        const old_stream = sub_store.get(event.stream_id);
 
         // A topic or stream edit may affect multiple messages, listed in
         // event.message_ids. event.message_id is still the first message


### PR DESCRIPTION
Fixes #22068.

Manually tested that topic name changes and timestamp doesn't change. Manually tested that timestamps still update for normal draft updates.