### PR TITLE
requirements: Remove importlib-resources

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -165,7 +165,6 @@ requests-oauthlib
 
 # For OpenAPI schema validation.
 openapi-core
-importlib-resources ; python_version < "3.9"  # for jsonschema
 
 # For reporting errors to sentry.io
 sentry-sdk

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -647,10 +647,6 @@ importlib-metadata==4.11.3 ; python_version < "3.10" \
     #   markdown
     #   sphinx
     #   zulip-bots
-importlib-resources==5.7.1 ; python_version < "3.9" \
-    --hash=sha256:b6062987dfc51f0fcb809187cffbd60f35df7acb4589091f154214af6d0d49d3 \
-    --hash=sha256:e447dc01619b1e951286f3929be820029d48c75eb25d265c28b92a16548212b8
-    # via -r requirements/common.in
 incremental==21.3.0 \
     --hash=sha256:02f5de5aff48f6b9f665d99d48bfc7ec03b6e3943210de7cfc88856d755d6f57 \
     --hash=sha256:92014aebc6a20b78a8084cdd5645eeaa7f74b8933f70fa3ada2cfbd1e3b54321
@@ -2346,9 +2342,7 @@ xmltodict==0.12.0 \
 zipp==3.8.0 \
     --hash=sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad \
     --hash=sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099
-    # via
-    #   importlib-metadata
-    #   importlib-resources
+    # via importlib-metadata
 zope.interface==5.4.0 \
     --hash=sha256:08f9636e99a9d5410181ba0729e0408d3d8748026ea938f3b970a0249daa8192 \
     --hash=sha256:0b465ae0962d49c68aa9733ba92a001b2a0933c317780435f00be7ecb959c702 \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -434,10 +434,6 @@ importlib-metadata==4.11.3 ; python_version < "3.10" \
     #   -r requirements/common.in
     #   markdown
     #   zulip-bots
-importlib-resources==5.7.1 ; python_version < "3.9" \
-    --hash=sha256:b6062987dfc51f0fcb809187cffbd60f35df7acb4589091f154214af6d0d49d3 \
-    --hash=sha256:e447dc01619b1e951286f3929be820029d48c75eb25d265c28b92a16548212b8
-    # via -r requirements/common.in
 ipython==8.3.0 \
     --hash=sha256:341456643a764c28f670409bbd5d2518f9b82c013441084ff2c2fc999698f83b \
     --hash=sha256:807ae3cf43b84693c9272f70368440a9a7eaa2e7e6882dad943c32fbf7e51402
@@ -1492,9 +1488,7 @@ xmlsec==1.3.12 \
 zipp==3.8.0 \
     --hash=sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad \
     --hash=sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099
-    # via
-    #   importlib-metadata
-    #   importlib-resources
+    # via importlib-metadata
 https://github.com/zulip/python-zulip-api/archive/0.8.2.zip#egg=zulip==0.8.2+git&subdirectory=zulip \
     --hash=sha256:c85a2c76b265ef66478715bb2a38723c4942f84b2f876c3e0ba916962e3d0735
     # via


### PR DESCRIPTION
It’s only used by jsonschema >= 4.2.0, but current semgrep holds jsonschema ~= 3.2: returntocorp/semgrep#4739.

Not bothering to bump `PROVISION_VERSION` because it’s not important whether this backport is installed.