### PR TITLE
events: Ensure spectators don't have streams and subs information.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 6.0
 
+**Feature level 149**
+
+* [`POST /register`](/api/register-queue): The `client_gravatar` and
+  `include_subscribers` parameters now return an error for
+  [unauthenticated requests](/help/public-access-option) if an
+  unsupported value is requested by the client.
+
 **Feature level 148**
 
 * [`POST /users/me/status`](/api/update-status):

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 148
+API_FEATURE_LEVEL = 149
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1396,27 +1396,25 @@ def do_events_register(
         event_types_set = None
 
     if user_profile is None:
-        # TODO: Unify this with the below code path once if/when we
-        # support requesting an event queue for spectators.
-        #
-        # Doing so likely has a prerequisite of making this function's
-        # caller enforce client_gravatar=False,
-        # include_subscribers=False and include_streams=False.
+        # TODO: Unify the two fetch_initial_state_data code paths.
+        assert client_gravatar is False
+        assert include_subscribers is False
+        assert include_streams is False
         ret = fetch_initial_state_data(
             user_profile,
             realm=realm,
             event_types=event_types_set,
             queue_id=None,
             # Force client_gravatar=False for security reasons.
-            client_gravatar=False,
+            client_gravatar=client_gravatar,
             user_avatar_url_field_optional=user_avatar_url_field_optional,
             user_settings_object=user_settings_object,
             # slim_presence is a noop, because presence is not included.
             slim_presence=True,
             # Force include_subscribers=False for security reasons.
-            include_subscribers=False,
+            include_subscribers=include_subscribers,
             # Force include_streams=False for security reasons.
-            include_streams=False,
+            include_streams=include_streams,
             spectator_requested_language=spectator_requested_language,
         )
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9551,7 +9551,50 @@ paths:
             type: boolean
             default: false
           example: true
-        - $ref: "#/components/parameters/ClientGravatar"
+        - name: client_gravatar
+          in: query
+          description: |
+            Whether the client supports computing gravatars URLs. If
+            enabled, `avatar_url` will be included in the response only
+            if there is a Zulip avatar, and will be `null` for users who
+            are using gravatar as their avatar. This option
+            significantly reduces the compressed size of user data,
+            since gravatar URLs are long, random strings and thus do not
+            compress well. The `client_gravatar` field is set to `true` if
+            clients can compute their own gravatars.
+
+            The default value is `true` for authenticated requests and
+            `false` for [unauthenticated
+            requests](/help/public-access-option). Passing `true` in
+            an unauthenticated request is an error.
+
+            **Changes**: Before Zulip 6.0 (feature level 149), this
+            parameter was silently ignored and processed as though it
+            were `false` in unauthenticated requests.
+          schema:
+            type: boolean
+          example: false
+        - name: include_subscribers
+          in: query
+          description: |
+            Whether each returned stream object should include a `subscribers`
+            field containing a list of the user IDs of its subscribers.
+
+            (This may be significantly slower in organizations with
+            thousands of users subscribed to many streams.)
+
+            Passing `true` in an [unauthenticated
+            request](/help/public-access-option) is an error.
+
+            **Changes**: Before Zulip 6.0 (feature level 149), this
+            parameter was silently ignored and processed as though it
+            were `false` in unauthenticated requests.
+
+            New in Zulip 2.1.0.
+          schema:
+            type: boolean
+            default: false
+          example: true
         - name: slim_presence
           in: query
           description: |
@@ -9565,7 +9608,6 @@ paths:
           example: true
         - $ref: "#/components/parameters/Event_types"
         - $ref: "#/components/parameters/AllPublicStreams"
-        - $ref: "#/components/parameters/IncludeSubscribers"
         - name: client_capabilities
           in: query
           description: |


### PR DESCRIPTION
Followup on #21995

Relevant conversation - https://github.com/zulip/zulip/pull/21995#issuecomment-1119097931

@timabbott would this work better? I am not sure having an `assert` is better here vs just enforcing these variables are false for spectators.