### PR TITLE
api-docs: Add changelog for `stream_id` param to `mute-topic`.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -1080,6 +1080,9 @@ No changes; feature level used for Zulip 3.0 release.
 
 ## Changes in Zulip 2.0
 
+* [`PATCH /users/me/subscriptions/muted_topics`](/api/mute-topic):
+  Added support for using stream IDs to specify the stream in which to
+  mute/unmute a topic.
 * [`POST /messages`](/api/send-message): Added support for using user
   IDs and stream IDs for specifying the recipients of a message.
 * [`POST /messages`](/api/send-message), [`POST

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7447,21 +7447,30 @@ paths:
               enum:
                 - stream_id
       parameters:
-        - name: stream
-          in: query
-          description: |
-            The name of the stream to access.
-          schema:
-            type: string
-          example: Denmark
-          required: false
         - name: stream_id
           in: query
           description: |
             The ID of the stream to access.
+
+            Clients must provide either `stream` or `stream_id` as a parameter
+            to this endpoint, but not both.
+
+            **Changes**: New in Zulip 2.0.
           schema:
             type: integer
           example: 43
+          required: false
+        - name: stream
+          in: query
+          description: |
+            The name of the stream to access.
+
+            Clients must provide either `stream` or `stream_id` as a parameter
+            to this endpoint, but not both. Clients should use `stream_id`
+            instead of the `stream` parameter when possible.
+          schema:
+            type: string
+          example: Denmark
           required: false
         - name: topic
           in: query


### PR DESCRIPTION
Adds a changelog 2.0 entry for adding support for `stream_id` parameter to the `mute-topic` endpoint.

Also, adds **Changes** note to the endpoint parameter description, and reorders/clarifies that at least one (and only one) stream parameter must be provided by the client and that the `string_id` parameter is preferred.

---

**Notes about documentation choices**: 

I changed the order of the parameters so that the preferred `stream_id` parameter was first, but if it would be better to keep the order and just add the clarifying descriptive text, I can make that revision.

I decided not to mark the `stream` parameter as deprecated because there are no plans to remove that parameter in the future and it also makes the "optional" part of the `stream_id` parameter somewhat confusing when the `stream` parameter is marked as deprecated.

---

See relevant [CZO conversation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/audit.20for.20change.20entries.20vs.2E.20central.20changelog/near/1324887).

Addresses API documentation part of #11136, but not the updates to the Python bindings. Therefore, this PR is not marked as closing that issue.

**Screenshots and screen captures:**

![Screenshot from 2022-05-19 23-44-27](https://user-images.githubusercontent.com/63245456/169591956-d866fd69-db9e-4501-b53f-204c6ecbee6e.png)

![Screenshot from 2022-05-19 23-13-42](https://user-images.githubusercontent.com/63245456/169592182-8d773394-2981-45be-a79d-f6a884c4b5eb.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
