### PR TITLE
openapi: Say custom_profile_field.value can be null in update-user event

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -538,8 +538,10 @@ paths:
                                                 The ID of the custom profile field which user updated.
                                             value:
                                               type: string
+                                              nullable: true
                                               description: |
-                                                User's personal value for this custom profile field.
+                                                User's personal value for this custom profile field,
+                                                or `null` if unset.
                                             rendered_value:
                                               type: string
                                               description: |


### PR DESCRIPTION
Before:

<img width="771" alt="image" src="https://user-images.githubusercontent.com/22248748/169627024-96e0c750-1a67-484e-8025-a3899b35887a.png">

After:

<img width="779" alt="image" src="https://user-images.githubusercontent.com/22248748/169627059-812311d1-a731-47c2-b1aa-afb5e238bacf.png">

