### PR TITLE
Update invite new users help center page

### DIFF
--- a/templates/zerver/help/include/how-to-invite-users-to-join.md
+++ b/templates/zerver/help/include/how-to-invite-users-to-join.md
@@ -22,7 +22,7 @@
 
 {end_tabs}
 
-[email-invitations]:/help/invite-new-users#send-e-mail-invitations
+[email-invitations]:/help/invite-new-users#send-email-invitations
 [invitation-links]: /help/invite-new-users#create-an-invitation-link
 [set-if-invitations-required]: /help/restrict-account-creation#set-whether-invitations-are-required-to-join
 [restrict-email-domain]: /help/restrict-account-creation#configuring-email-domain-restrictions

--- a/templates/zerver/help/invite-new-users.md
+++ b/templates/zerver/help/invite-new-users.md
@@ -1,5 +1,16 @@
 # Invite new users
 
+You can invite users to join your organization by sending out email invitations,
+or creating reusable invitation links to share.
+
+Prior to inviting users to your organization, it is recommended that administrators:
+
+* Configure [default settings](/help/configure-default-new-user-settings) for
+  new users.
+
+* Configure the [notifications language][org-notifications-language] for your
+  organization, which is used for email invitations.
+
 When you invite users, you can:
 
 * Set the [role](/help/roles-and-permissions) that they will have when
@@ -8,20 +19,13 @@ When you invite users, you can:
 * Configure which streams they will be added to. The organization's
   [default streams](/help/set-default-streams-for-new-users) will be preselected.
 
-Your organization may also want to configure [default
-settings](/help/configure-default-new-user-settings) for new users.
+Organization administrators can
+[configure](/help/restrict-account-creation#change-who-can-send-invitations)
+which [roles](/help/roles-and-permissions) have permission to invite users to
+the organization. You will only see an **Invite users** menu option if you have
+permission to invite users.
 
-## Send e-mail invitations
-
-Personal invitation links can be sent to individuals via email.
-Outgoing email invitations are translated and sent in the organization's
-[notifications language][org-notifications-language], so you may want
-to check (or update) that configuration before sending email invitations.
-
-!!! warn ""
-    **Note**: You will only see an **Invite users** option if you
-    [have permission](/help/restrict-account-creation#change-who-can-send-invitations)
-    to invite users to the organization.
+## Send email invitations
 
 {start_tabs}
 
@@ -52,10 +56,6 @@ to check (or update) that configuration before sending email invitations.
 ## Create an invitation link
 
 {!admin-only.md!}
-
-Customized, reusable invitation links can be generated as well. To
-protect your organization, creating these reusable invitation links
-is always limited to administrators.
 
 {start_tabs}
 

--- a/templates/zerver/help/invite-new-users.md
+++ b/templates/zerver/help/invite-new-users.md
@@ -13,8 +13,13 @@ settings](/help/configure-default-new-user-settings) for new users.
 
 ## Send e-mail invitations
 
+Personal invitation links can be sent to individuals via email.
+Outgoing email invitations are translated and sent in the organization's
+[notifications language][org-notifications-language], so you may want
+to check (or update) that configuration before sending email invitations.
+
 !!! warn ""
-    You will only see an **Invite users** option if you
+    **Note**: You will only see an **Invite users** option if you
     [have permission](/help/restrict-account-creation#change-who-can-send-invitations)
     to invite users to the organization.
 
@@ -33,7 +38,6 @@ settings](/help/configure-default-new-user-settings) for new users.
 1. Click **Invite**.
 
 !!! warn ""
-
     **Note**: As an anti-spam measure, the number of email invites you can send in a day is
     limited on the Zulip Cloud Free plan. [Contact support](/help/contact-support)
     if you hit the limit and want to invite more users.
@@ -48,6 +52,10 @@ settings](/help/configure-default-new-user-settings) for new users.
 ## Create an invitation link
 
 {!admin-only.md!}
+
+Customized, reusable invitation links can be generated as well. To
+protect your organization, creating these reusable invitation links
+is always limited to administrators.
 
 {start_tabs}
 
@@ -87,4 +95,7 @@ for invitations for the organization owners role.
 * [Restrict account creation](/help/restrict-account-creation)
 * [Set default streams for new users](/help/set-default-streams-for-new-users)
 * [Configure default new user settings](/help/configure-default-new-user-settings)
+* [Configure organization notifications language][org-notifications-language]
 * [Roles and permissions](/help/roles-and-permissions)
+
+[org-notifications-language]: /help/change-the-default-language-for-your-organization

--- a/templates/zerver/help/restrict-account-creation.md
+++ b/templates/zerver/help/restrict-account-creation.md
@@ -51,8 +51,10 @@ Regardless of whether invitations are required, you can:
 
 {!owner-only.md!}
 
-You can restrict the ability to invite new users to join your
-Zulip organization to specific [roles](/help/roles-and-permissions).
+You can restrict the ability to invite new users to join your Zulip organization
+to specific [roles](/help/roles-and-permissions). To protect your organization,
+while permission to send out individual email invitations is configurable, creating
+*reusable* invitation links is always limited to administrators.
 
 {start_tabs}
 


### PR DESCRIPTION
Updated PR based on #22014.

I moved the new content to the intro; I think it works better than having it just above the specific instructions.

![Screen Shot 2022-05-23 at 1 02 11 AM](https://user-images.githubusercontent.com/2090066/169773184-feb3263a-d60b-4909-8fb9-00e1fa6201a7.png)

I also moved the detail about reusable invites being admin-only to `/help/restrict-account-creation#change-who-can-send-invitations`.

![Screen Shot 2022-05-23 at 12 51 46 AM](https://user-images.githubusercontent.com/2090066/169773216-83b4db74-2f29-441d-9e45-8f603d71fb46.png)

