### PR TITLE
Reparent bot to the admin on reactivating if owner is deactivated and unsubscribe it from inaccessible private streams.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -255,6 +255,10 @@ python_rules = RuleList(
                     "zerver/actions/bots.py",
                     "user_profile.save()  # Can't use update_fields because of how the foreign key works.",
                 ),
+                (
+                    "zerver/actions/create_user.py",
+                    "user_profile.save()  # Can't use update_fields because of how the foreign key works.",
+                ),
             },
             "exclude": {"zerver/tests", "zerver/lib/create_user.py"},
             "good_lines": ['user_profile.save(update_fields=["pointer"])'],

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -578,6 +578,11 @@ export function confirm_reactivation(user_id, handle_confirm, loading_spinner) {
     let html_body;
     // check if bot or human
     if (user.is_bot) {
+        opts.original_owner_deactivated =
+            user.is_bot && user.bot_owner_id && !people.is_person_active(user.bot_owner_id);
+        if (opts.original_owner_deactivated) {
+            opts.owner_name = people.get_by_user_id(user.bot_owner_id).full_name;
+        }
         html_body = render_settings_reactivation_bot_modal(opts);
     } else {
         html_body = render_settings_reactivation_user_modal(opts);

--- a/web/templates/confirm_dialog/confirm_reactivate_bot.hbs
+++ b/web/templates/confirm_dialog/confirm_reactivate_bot.hbs
@@ -5,3 +5,12 @@
     {{#*inline "z-user"}}<strong>{{username}}</strong>{{/inline}}
     {{/tr}}
 </p>
+{{#if original_owner_deactivated}}
+    <p>
+        {{#tr}}
+        Because the original owner of this bot <z-bot-owner></z-bot-owner> is deactivated, you will become the owner for this bot.
+        {{#*inline "z-bot-owner"}}<strong>{{owner_name}}</strong>{{/inline}}
+        {{/tr}}
+        {{t "However, it will no longer be subscribed to the private streams that you are not subscribed to." }}
+    </p>
+{{/if}}

--- a/zerver/actions/bots.py
+++ b/zerver/actions/bots.py
@@ -5,6 +5,8 @@ from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.create_user import created_bot_event
+from zerver.actions.streams import bulk_remove_subscriptions
+from zerver.lib.streams import get_subscribed_private_streams_for_user
 from zerver.models import RealmAuditLog, Stream, UserProfile, active_user_ids, bot_owner_user_ids
 from zerver.tornado.django_api import send_event_on_commit
 
@@ -70,6 +72,34 @@ def send_bot_owner_update_events(
     send_event_on_commit(user_profile.realm, event, active_user_ids(user_profile.realm_id))
 
 
+def remove_bot_from_inaccessible_private_streams(
+    user_profile: UserProfile, *, acting_user: Optional[UserProfile]
+) -> None:
+    assert user_profile.bot_owner is not None
+
+    new_owner_subscribed_private_streams = get_subscribed_private_streams_for_user(
+        user_profile.bot_owner
+    )
+    new_owner_subscribed_private_stream_ids = [
+        stream.id for stream in new_owner_subscribed_private_streams
+    ]
+
+    bot_subscribed_private_streams = get_subscribed_private_streams_for_user(user_profile)
+    bot_subscribed_private_stream_ids = [stream.id for stream in bot_subscribed_private_streams]
+
+    stream_ids_to_unsubscribe = set(bot_subscribed_private_stream_ids) - set(
+        new_owner_subscribed_private_stream_ids
+    )
+    unsubscribed_streams = [
+        stream
+        for stream in bot_subscribed_private_streams
+        if stream.id in stream_ids_to_unsubscribe
+    ]
+    bulk_remove_subscriptions(
+        user_profile.realm, [user_profile], unsubscribed_streams, acting_user=acting_user
+    )
+
+
 @transaction.atomic(durable=True)
 def do_change_bot_owner(
     user_profile: UserProfile, bot_owner: UserProfile, acting_user: Union[UserProfile, None]
@@ -87,6 +117,8 @@ def do_change_bot_owner(
     )
 
     send_bot_owner_update_events(user_profile, bot_owner, previous_owner)
+
+    remove_bot_from_inaccessible_private_streams(user_profile, acting_user=acting_user)
 
 
 @transaction.atomic(durable=True)

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -646,6 +646,11 @@ def do_reactivate_user(user_profile: UserProfile, *, acting_user: Optional[UserP
             assert acting_user is not None
             send_bot_owner_update_events(user_profile, acting_user, previous_owner)
 
+    if bot_owner_changed:
+        from zerver.actions.bots import remove_bot_from_inaccessible_private_streams
+
+        remove_bot_from_inaccessible_private_streams(user_profile, acting_user=acting_user)
+
     subscribed_recipient_ids = Subscription.objects.filter(
         user_profile_id=user_profile.id, active=True, recipient__type=Recipient.STREAM
     ).values_list("recipient__type_id", flat=True)

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -28,7 +28,7 @@ from zerver.lib.email_mirror_helpers import encode_email_address
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.message import get_last_message_id
-from zerver.lib.queue import queue_json_publish
+from zerver.lib.queue import queue_event_on_commit, queue_json_publish
 from zerver.lib.stream_color import pick_colors
 from zerver.lib.stream_subscription import (
     SubInfo,
@@ -718,7 +718,7 @@ def notify_subscriptions_removed(
 ) -> None:
     payload = [dict(name=stream.name, stream_id=stream.id) for stream in streams]
     event = dict(type="subscription", op="remove", subscriptions=payload)
-    send_event(realm, event, [user_profile.id])
+    send_event_on_commit(realm, event, [user_profile.id])
 
 
 SubAndRemovedT: TypeAlias = Tuple[
@@ -750,7 +750,7 @@ def send_subscription_remove_events(
                 stream.recipient_id for stream in streams_by_user[user_profile.id]
             ],
         }
-        queue_json_publish("deferred_work", event)
+        queue_event_on_commit("deferred_work", event)
 
     send_peer_remove_events(
         realm=realm,

--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -13,6 +13,7 @@ import pika.adapters.tornado_connection
 import pika.connection
 import pika.exceptions
 from django.conf import settings
+from django.db import transaction
 from pika.adapters.blocking_connection import BlockingChannel
 from pika.channel import Channel
 from pika.spec import Basic
@@ -437,6 +438,10 @@ def queue_json_publish(
         from zerver.worker.queue_processors import get_worker
 
         get_worker(queue_name, disable_timeout=True).consume_single_event(event)
+
+
+def queue_event_on_commit(queue_name: str, event: Dict[str, Any]) -> None:
+    transaction.on_commit(lambda: queue_json_publish(queue_name, event))
 
 
 def retry_event(

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -956,3 +956,20 @@ def do_get_streams(
             stream["is_default"] = stream["stream_id"] in default_stream_ids
 
     return stream_dicts
+
+
+def get_subscribed_private_streams_for_user(user_profile: UserProfile) -> QuerySet[Stream]:
+    exists_expression = Exists(
+        Subscription.objects.filter(
+            user_profile=user_profile,
+            active=True,
+            is_user_active=True,
+            recipient_id=OuterRef("recipient_id"),
+        ),
+    )
+    subscribed_private_streams = (
+        Stream.objects.filter(realm=user_profile.realm, invite_only=True, deactivated=False)
+        .annotate(subscribed=exists_expression)
+        .filter(subscribed=True)
+    )
+    return subscribed_private_streams

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2445,6 +2445,19 @@ class NormalActionsTest(BaseAction):
         check_subscription_peer_add("events[2]", events[2])
         check_subscription_peer_add("events[3]", events[3])
 
+        do_deactivate_user(bot, acting_user=None)
+        do_deactivate_user(self.example_user("hamlet"), acting_user=None)
+
+        reset_email_visibility_to_everyone_in_zulip_realm()
+        bot.refresh_from_db()
+
+        self.user_profile = self.example_user("iago")
+        action = lambda: do_reactivate_user(bot, acting_user=self.example_user("iago"))
+        events = self.verify_action(action, num_events=6)
+        check_realm_bot_add("events[1]", events[1])
+        check_realm_bot_update("events[2]", events[2], "owner_id")
+        check_realm_user_update("events[3]", events[3], "bot_owner_id")
+
     def test_do_deactivate_realm(self) -> None:
         realm = self.user_profile.realm
         action = lambda: do_deactivate_realm(realm, acting_user=None)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2398,6 +2398,29 @@ class NormalActionsTest(BaseAction):
         check_realm_bot_add("events[0]", events[0])
         check_realm_user_update("events[1]", events[1], "bot_owner_id")
 
+    def test_peer_remove_events_on_changing_bot_owner(self) -> None:
+        previous_owner = self.example_user("aaron")
+        self.user_profile = self.example_user("iago")
+        bot = self.create_test_bot("test2", previous_owner, full_name="Test2 Testerson")
+        private_stream = self.make_stream("private_stream", invite_only=True)
+        self.make_stream("public_stream")
+        self.subscribe(bot, "private_stream")
+        self.subscribe(self.example_user("aaron"), "private_stream")
+        self.subscribe(bot, "public_stream")
+        self.subscribe(self.example_user("aaron"), "public_stream")
+
+        self.make_stream("private_stream_test", invite_only=True)
+        self.subscribe(self.example_user("iago"), "private_stream_test")
+        self.subscribe(bot, "private_stream_test")
+
+        action = lambda: do_change_bot_owner(bot, self.user_profile, previous_owner)
+        events = self.verify_action(action, num_events=3)
+
+        check_realm_bot_update("events[0]", events[0], "owner_id")
+        check_realm_user_update("events[1]", events[1], "bot_owner_id")
+        check_subscription_peer_remove("events[2]", events[2])
+        self.assertEqual(events[2]["stream_ids"], [private_stream.id])
+
     def test_do_update_outgoing_webhook_service(self) -> None:
         self.user_profile = self.example_user("iago")
         bot = self.create_test_bot(

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2476,10 +2476,12 @@ class NormalActionsTest(BaseAction):
 
         self.user_profile = self.example_user("iago")
         action = lambda: do_reactivate_user(bot, acting_user=self.example_user("iago"))
-        events = self.verify_action(action, num_events=6)
+        events = self.verify_action(action, num_events=7)
         check_realm_bot_add("events[1]", events[1])
         check_realm_bot_update("events[2]", events[2], "owner_id")
         check_realm_user_update("events[3]", events[3], "bot_owner_id")
+        check_subscription_peer_remove("events[4]", events[4])
+        check_stream_delete("events[5]", events[5])
 
     def test_do_deactivate_realm(self) -> None:
         realm = self.user_profile.realm

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -1899,7 +1899,8 @@ class MarkUnreadTest(ZulipTestCase):
         ]
         # Unsubscribing generates an event in the deferred_work queue
         # that marks the above messages as read.
-        self.unsubscribe(receiver, stream_name)
+        with self.captureOnCommitCallbacks(execute=True):
+            self.unsubscribe(receiver, stream_name)
         after_unsubscribe_stream_message_ids = [
             self.send_stream_message(
                 sender=sender,


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Commit summary -
- First commit is to extract events code into a function.
- Next commit is to re-parent the bot to the admin reactivating the bot in case the original owner is deactivated.
- Next two commits are to unsubscribe bot from inaccessible private streams on changing bot owner.
- Last commit is to update the confirmation modal for reactivating bot.

Fixes part of <!-- Issue link, or clear description.--> #21700

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2023-08-11 23-15-24](https://github.com/zulip/zulip/assets/35494118/91c18d49-dda1-4088-8598-3d8c708beccb)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
