### PR TITLE
help-docs: Update accessing private messages information.

### DIFF
--- a/templates/zerver/help/private-messages.md
+++ b/templates/zerver/help/private-messages.md
@@ -34,11 +34,11 @@ There are several ways to access an existing PM or group PM.
 
 * For recent conversations, click on **Private messages** near
   the top of the left sidebar.
-* Click on any user or group in the right sidebar.
-* Start typing a user's name in [search](/help/search-for-messages). You'll be
-  able to select PMs or group PMs with that user.
-* Open the compose box, and enter in a (list of) users. Type `Ctrl + .` (or
-  `Cmd + .` on a mac) to open that conversation.
+* Click on any user in the right sidebar.
+* Start typing a user's name in [search](/help/search-for-messages).
+  You'll be able to select PMs or group PMs with that user.
+* Open the compose box, and enter in a list of users  on the **To:**
+  line. Type `Ctrl` + `.` to open that conversation.
 
 ## Related articles
 


### PR DESCRIPTION
Removes unnecessary mention of mac keyboard shortcut because the documentation updates when a mac keyboard is detected. [Link to current documentation](https://zulip.com/help/private-messages).

Also, removes reference to accessing group private messages from the right sidebar, because as far as I can tell this is not a possibility.

This is a follow-up task noted when reviewing [this PR](https://github.com/zulip/zulip/pull/21991#issuecomment-1135215130).

**Screenshots and screen captures:**

1. not a Mac keyboard 

![Screenshot from 2022-05-25 20-15-55](https://user-images.githubusercontent.com/63245456/170337707-3a7dfcd9-38fa-4594-b645-59ebc9b4423d.png)

2. Mac keyboard

![Screenshot from 2022-05-25 20-16-29](https://user-images.githubusercontent.com/63245456/170337735-547937c4-29db-4fbf-8122-555d8bb8a056.png)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
