### PR TITLE
frontend: Update when communities directory checkbox is disabled.

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -171,7 +171,7 @@ export function build_page() {
         realm_want_advertise_in_communities_directory:
             page_params.realm_want_advertise_in_communities_directory,
         disable_want_advertise_in_communities_directory:
-            !page_params.server_web_public_streams_enabled,
+            !page_params.realm_push_notifications_enabled,
     };
 
     if (options.realm_logo_source !== "D" && options.realm_night_logo_source === "D") {

--- a/templates/zerver/help/communities-directory.md
+++ b/templates/zerver/help/communities-directory.md
@@ -2,24 +2,38 @@
 
 {!communities-directory-intro.md!}
 
+## Eligibility
+
 In order to be eligible for listing in the communities directory, an
-organization must be open to the public. Your organization is eligible if users are
-allowed [join without an invitation][join-without-invite] and/or the [public
-access option](/help/public-access-option) is enabled.
+organization must be open to the public. Your organization is eligible
+if users are allowed to [join without an invitation][join-without-invite]
+and/or the [public access option](/help/public-access-option) is enabled.
 
 The directory will be organized by [organization type](/help/organization-type),
-so it is highly recommended that you make sure the appropriate category is
-selected.
+so it is highly recommended that you make sure the appropriate category
+is selected.
 
-To prevent spam, Zulip reserves the right to use editorial discretion. Giving
-Zulip permission to promote your organization in the communities directory does
-not guarantee that it will be listed.
+To prevent spam, Zulip reserves the right to use editorial discretion.
+Giving Zulip permission to promote your organization in the communities
+directory does not guarantee that it will be listed.
 
-If you administer a self-hosted Zulip community that you would like to be
-listed, please contact [Zulip support](mailto:support@zulip.com).
+### Self-hosted Zulip communities
+
+Zulip plans to develop support for self-hosted Zulip communities that
+have registered their servers with the [Zulip mobile push
+notification service][push-notifications] to sign-up for the Zulip
+communities directory.
+
+Until that feature is developed, if you administer a self-hosted Zulip
+community and would like to be listed in the directory, please contact
+[Zulip support](mailto:support@zulip.com). Changing the setting in your
+Zulip organization will not send any information to the Zulip project
+at this time, even if you use the Zulip mobile push notifications
+service.
 
 [join-without-invite]: /help/restrict-account-creation#set-whether-invitations-are-required-to-join
 [communities-directory-permission]: /help/communities-directory#give-permission-to-be-in-the-zulip-communities-directory
+[push-notifications]: https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html
 
 ## Change whether your organization may be listed in the Zulip communities directory
 


### PR DESCRIPTION
Changes the admin UI for the communities directory checkbox to use the `realm_push_notifications_enabled` page parameter instead of the `server_web_public_streams_enabled` page parameter. This update should change when self-hosted Zulip organizations see the checkbox as disabled.

Updates help center documentation about the communities directory to have clearer information about how the setting works for self-hosted communities. I added some subheadings to the page to break up the text and make the self-hosted community information less likely to get lost. [Current help center documentation](https://zulip.com/help/communities-directory) for comparison.

I'm not sure whether the last sentence in the self-hosted section is needed or not.

See [this CZO conversation](https://chat.zulip.org/#narrow/stream/3-backend/topic/communities.20directory.20eligibility/near/1381196) for more context.

A follow-up / additional task is to write up an issue for adding the mobile push notification service support for the communities directory setting.

**Screenshots and screen captures:**

![Screenshot from 2022-05-25 00-22-56](https://user-images.githubusercontent.com/63245456/170144498-b33a6ec3-a94a-45c0-a262-6f74683566a1.png)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
