### PR TITLE
[5.x] apt-repos: Remove now-unneeded Ubuntu 21.10 repository on 22.04

### DIFF
--- a/scripts/setup/apt-repos/zulip/jammy.list
+++ b/scripts/setup/apt-repos/zulip/jammy.list
@@ -1,12 +1,5 @@
 deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main
 deb-src http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main
 
-# Old versions for https://github.com/pgroonga/pgroonga/issues/203 were not built for jammy
-deb http://apt-archive.postgresql.org/pub/repos/apt/ impish-pgdg-archive main
-deb-src http://apt-archive.postgresql.org/pub/repos/apt/ impish-pgdg-archive main
-deb http://archive.ubuntu.com/ubuntu impish main
-deb http://archive.ubuntu.com/ubuntu impish-updates main
-deb http://archive.ubuntu.com/ubuntu impish-security main
-
 deb http://ppa.launchpad.net/groonga/ppa/ubuntu jammy main
 deb-src http://ppa.launchpad.net/groonga/ppa/ubuntu jammy main


### PR DESCRIPTION
Backport of 

- #22116
