### PR TITLE
tornado: Use ResponseNotes to keep track of asynchronous responses.

### DIFF
--- a/zerver/lib/response.py
+++ b/zerver/lib/response.py
@@ -1,10 +1,22 @@
+from dataclasses import dataclass
 from typing import Any, List, Mapping, Optional
 
 import orjson
 from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed
+from django.http.response import HttpResponseBase
 from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.notes import BaseNotes
+
+
+@dataclass
+class ResponseNotes(BaseNotes[HttpResponseBase, "ResponseNotes"]):
+    asynchronous: Optional[bool] = None
+
+    @classmethod
+    def init_notes(cls) -> "ResponseNotes":
+        return ResponseNotes()
 
 
 class HttpResponseUnauthorized(HttpResponse):

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -42,7 +42,12 @@ from zerver.lib.html_to_text import get_content_description
 from zerver.lib.markdown import get_markdown_requests, get_markdown_time
 from zerver.lib.rate_limiter import RateLimitResult
 from zerver.lib.request import REQ, RequestNotes, has_request_variables, set_request, unset_request
-from zerver.lib.response import json_response, json_response_from_error, json_unauthorized
+from zerver.lib.response import (
+    ResponseNotes,
+    json_response,
+    json_response_from_error,
+    json_unauthorized,
+)
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.types import ViewFuncT
 from zerver.lib.user_agent import parse_user_agent
@@ -401,7 +406,7 @@ class LogRequests(MiddlewareMixin):
     def process_response(
         self, request: HttpRequest, response: HttpResponseBase
     ) -> HttpResponseBase:
-        if getattr(response, "asynchronous", False):
+        if ResponseNotes.get_notes(response).asynchronous:
             # This special Tornado "asynchronous" response is
             # discarded after going through this code path as Tornado
             # intends to block, so we stop here to avoid unnecessary work.

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -14,7 +14,7 @@ from django.urls import set_script_prefix
 from django.utils.cache import patch_vary_headers
 from tornado.wsgi import WSGIContainer
 
-from zerver.lib.response import json_response
+from zerver.lib.response import ResponseNotes, json_response
 from zerver.tornado.descriptors import get_descriptor_by_handler_id
 
 current_handler_id = 0
@@ -153,7 +153,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         response = await sync_to_async(lambda: self.get_response(request), thread_sensitive=True)()
 
         try:
-            if hasattr(response, "asynchronous"):
+            if ResponseNotes.get_notes(response).asynchronous is not None:
                 # We import async_request_timer_restart during runtime
                 # to avoid cyclic dependency with zerver.lib.request
                 from zerver.middleware import async_request_timer_stop

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext as _
 from zerver.decorator import internal_notify_view, process_client
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, RequestNotes, has_request_variables
-from zerver.lib.response import json_success
+from zerver.lib.response import ResponseNotes, json_success
 from zerver.lib.validator import (
     check_bool,
     check_int,
@@ -175,7 +175,7 @@ def get_events_backend(
         # request.  See zulip_finish for more design details.
         handler._request = request
         response = json_success(request)
-        response.asynchronous = True
+        ResponseNotes.set_notes(response, ResponseNotes(asynchronous=True))
         return response
     if result["type"] == "error":
         raise result["exception"]


### PR DESCRIPTION
This rebases the earliest commit of #18777, as a part of the django-stubs migration.
Fixes type error related to we monkey patching the `HttpResponse` object.