### PR TITLE
typing: Apply trivial fixes to adjust edge cases in typing.

### DIFF
--- a/tools/lib/provision_inner.py
+++ b/tools/lib/provision_inner.py
@@ -270,6 +270,7 @@ def main(options: argparse.Namespace) -> int:
             destroy_leaked_test_databases,
         )
 
+        assert settings.RABBITMQ_PASSWORD is not None
         if options.is_force or need_to_run_configure_rabbitmq([settings.RABBITMQ_PASSWORD]):
             run_as_root(["scripts/setup/configure-rabbitmq"])
             write_new_digest(

--- a/zerver/actions/realm_linkifiers.py
+++ b/zerver/actions/realm_linkifiers.py
@@ -44,6 +44,7 @@ def do_remove_linkifier(
     if pattern is not None:
         RealmFilter.objects.get(realm=realm, pattern=pattern).delete()
     else:
+        assert id is not None
         RealmFilter.objects.get(realm=realm, id=id).delete()
     notify_linkifiers(realm)
 

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -979,7 +979,8 @@ def do_rename_stream(stream: Stream, new_name: str, user_profile: UserProfile) -
         ).decode(),
     )
 
-    recipient_id = stream.recipient_id
+    assert stream.recipient_id is not None
+    recipient_id: int = stream.recipient_id
     messages = Message.objects.filter(recipient_id=recipient_id).only("id")
 
     # Update the display recipient and stream, which are easy single

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -29,7 +29,7 @@ from zproject.backends import (
     require_email_format_usernames,
 )
 
-DEFAULT_PAGE_PARAMS = {
+DEFAULT_PAGE_PARAMS: Mapping[str, Any] = {
     "development_environment": settings.DEVELOPMENT,
     "webpack_public_path": staticfiles_storage.url(settings.WEBPACK_BUNDLES),
 }

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -326,9 +326,9 @@ def build_reactions(
 
     # For the Unicode emoji codes, we use equivalent of
     # function 'emoji_name_to_emoji_code' in 'zerver/lib/emoji' here
-    for reaction in reactions:
-        emoji_name = reaction["name"]
-        user_id = reaction["user_id"]
+    for reaction_dict in reactions:
+        emoji_name = reaction_dict["name"]
+        user_id = reaction_dict["user_id"]
         # Check in realm emoji
         if emoji_name in realmemoji:
             emoji_code = realmemoji[emoji_name]

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -515,10 +515,10 @@ def public_stream_user_ids(stream: Stream) -> Set[int]:
     guest_subscriptions = get_active_subscriptions_for_stream_id(
         stream.id, include_deactivated_users=False
     ).filter(user_profile__role=UserProfile.ROLE_GUEST)
-    guest_subscriptions = {
+    guest_subscriptions_ids = {
         sub["user_profile_id"] for sub in guest_subscriptions.values("user_profile_id")
     }
-    return set(active_non_guest_user_ids(stream.realm_id)) | guest_subscriptions
+    return set(active_non_guest_user_ids(stream.realm_id)) | guest_subscriptions_ids
 
 
 def can_access_stream_user_ids(stream: Stream) -> Set[int]:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -2703,6 +2703,7 @@ def get_huddle_recipient(user_profile_ids: Set[int]) -> Recipient:
     # we hit another cache to get the recipient.  We may want to
     # unify our caching strategy here.
     huddle = get_huddle(list(user_profile_ids))
+    assert huddle.recipient is not None
     return huddle.recipient
 
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -6718,6 +6718,7 @@ class EmailValidatorTestCase(ZulipTestCase):
             "fred+5555@zulip.com",
             get_realm_email_validator(realm),
         )
+        assert error is not None
         self.assertIn("containing + are not allowed", error)
 
         cordelia_email = cordelia.delivery_email

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -905,7 +905,9 @@ class RealmImportExportTest(ExportFile):
 
         # test recipients
         def get_recipient_stream(r: Realm) -> Recipient:
-            return Stream.objects.get(name="Verona", realm=r).recipient
+            recipient = Stream.objects.get(name="Verona", realm=r).recipient
+            assert recipient is not None
+            return recipient
 
         def get_recipient_user(r: Realm) -> Recipient:
             return UserProfile.objects.get(full_name="Iago", realm=r).recipient

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1544,6 +1544,7 @@ class StreamMessagesTest(ZulipTestCase):
         stream = get_stream("Denmark", realm)
         topic_name = "lunch"
         recipient = stream.recipient
+        assert recipient is not None
         sending_client = make_client(name="test suite")
 
         for i in range(num_extra_users):


### PR DESCRIPTION
Add none-checks, rename variables (to avoid redefinition of the same variable with different types error), add necessary type annotations.


This is a part of the django-stubs refactorings, which rebases the second commit from #18777