### PR TITLE
recent_topics: Don't restore filters for spectators.

### DIFF
--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -87,7 +87,12 @@ export function save_filters() {
 }
 
 export function load_filters() {
-    filters = new Set(ls.get(ls_key));
+    if (!page_params.is_spectator) {
+        // A user may have a stored filter and can log out
+        // to see web public view. This ensures no filters are
+        // selected for spectators.
+        filters = new Set(ls.get(ls_key));
+    }
 }
 
 export function set_default_focus() {


### PR DESCRIPTION
This fixes the bug where spectators can have filters selected
in recent topics if a logged in user has selected filters in the
same browser.

Log in, select a filter and log out to reproduce this.

<img width="1480" alt="Screenshot 2022-05-26 at 11 24 23 PM" src="https://user-images.githubusercontent.com/25124304/170547596-7905e908-2bd0-4b78-8e26-0d304db2bdd0.png">
