### PR TITLE
compose: Make compose box tooltips consitent.

### DIFF
--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -63,7 +63,7 @@
                 <div class="compose_table">
                     <div id="compose_top">
                         <div id="compose_top_right" class="order-2">
-                            <button type="button" class="expand_composebox_button fa fa-chevron-up" aria-label="{{t 'Expand compose' }}" title="{{t 'Expand compose' }}"></button>
+                            <button type="button" class="expand_composebox_button fa fa-chevron-up" aria-label="{{t 'Expand compose' }}" data-tippy-content="{{t 'Expand compose' }}"></button>
                             <button type="button" class="collapse_composebox_button fa fa-chevron-down" aria-label="{{t 'Collapse compose' }}" data-tippy-content="{{t 'Collapse compose' }}"></button>
                             <button type="button" class="close fa fa-times" id='compose_close' data-tooltip-template-id="compose_close_tooltip"></button>
                             <template id="compose_close_tooltip">{{t 'Cancel compose' }} <span class="hotkey-hint">(Esc)</span></template>

--- a/static/templates/narrow_to_compose_recipients_tooltip.hbs
+++ b/static/templates/narrow_to_compose_recipients_tooltip.hbs
@@ -1,4 +1,4 @@
-<b><span>{{t 'Go to conversation' }}</span> <span class="hotkey-hint">({{shortcut_html}})</span></b>
+<span>{{t 'Go to conversation' }}</span> <span class="hotkey-hint">({{shortcut_html}})</span>
 {{#if display_current_view}}
 <p class="narrow_to_compose_recipient_current_view_help">{{display_current_view}}</p>
 {{/if}}


### PR DESCRIPTION
Issue #22132 

To make the tooltips of the button in the top row consistent with the
button in top row of compose. This includes -
* Removing the bold formatting from the "Go to conversation" tooltip.
* Converting the "Expand compose" tooltip to Tippy.

![image](https://user-images.githubusercontent.com/51414879/170683586-cc6352fe-484d-4468-b3be-b8423d2b952c.png)
![image](https://user-images.githubusercontent.com/51414879/170683636-f9b653aa-4edb-42b4-80b6-04092e58da27.png)
