### PR TITLE
Capitailize "ID" in error messages for invalid stream IDs.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -639,7 +639,7 @@ export function initialize() {
         const stream_id = get_stream_id(e.target);
         if (!stream_id) {
             ui_report.client_error(
-                $t_html({defaultMessage: "Invalid stream id"}),
+                $t_html({defaultMessage: "Invalid stream ID"}),
                 $(".stream_change_property_info"),
             );
             return;
@@ -649,7 +649,7 @@ export function initialize() {
             const stream_id = $(".dialog_submit_button").data("stream-id");
             if (!stream_id) {
                 ui_report.client_error(
-                    $t_html({defaultMessage: "Invalid stream id"}),
+                    $t_html({defaultMessage: "Invalid stream ID"}),
                     $(".stream_change_property_info"),
                 );
                 return;

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -301,7 +301,7 @@ def check_for_exactly_one_stream_arg(stream_id: Optional[int], stream: Optional[
 def check_stream_access_for_delete_or_update(
     user_profile: UserProfile, stream: Stream, sub: Optional[Subscription] = None
 ) -> None:
-    error = _("Invalid stream id")
+    error = _("Invalid stream ID")
     if stream.realm_id != user_profile.realm_id:
         raise JsonableError(error)
 
@@ -323,7 +323,7 @@ def access_stream_for_delete_or_update(
     try:
         stream = Stream.objects.get(id=stream_id)
     except Stream.DoesNotExist:
-        raise JsonableError(_("Invalid stream id"))
+        raise JsonableError(_("Invalid stream ID"))
 
     try:
         sub = Subscription.objects.get(
@@ -393,7 +393,7 @@ def access_stream_by_id(
     require_active: bool = True,
     allow_realm_admin: bool = False,
 ) -> Tuple[Stream, Optional[Subscription]]:
-    error = _("Invalid stream id")
+    error = _("Invalid stream ID")
     try:
         stream = get_stream_by_id_in_realm(stream_id, user_profile.realm)
     except Stream.DoesNotExist:
@@ -459,7 +459,7 @@ def access_stream_by_name(
 
 
 def access_web_public_stream(stream_id: int, realm: Realm) -> Stream:
-    error = _("Invalid stream id")
+    error = _("Invalid stream ID")
     try:
         stream = get_stream_by_id_in_realm(stream_id, realm)
     except Stream.DoesNotExist:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6973,7 +6973,7 @@ paths:
                   - example:
                       {
                         "code": "BAD_REQUEST",
-                        "msg": "Invalid stream id",
+                        "msg": "Invalid stream ID",
                         "result": "error",
                       }
                     description: |
@@ -13259,7 +13259,7 @@ paths:
                   - example:
                       {
                         "code": "BAD_REQUEST",
-                        "msg": "Invalid stream id",
+                        "msg": "Invalid stream ID",
                         "result": "error",
                       }
                     description: |
@@ -13498,7 +13498,7 @@ paths:
                   - example:
                       {
                         "code": "BAD_REQUEST",
-                        "msg": "Invalid stream id",
+                        "msg": "Invalid stream ID",
                         "result": "error",
                       }
                     description: |
@@ -13533,7 +13533,7 @@ paths:
                   - example:
                       {
                         "code": "BAD_REQUEST",
-                        "msg": "Invalid stream id",
+                        "msg": "Invalid stream ID",
                         "result": "error",
                       }
                     description: |
@@ -13649,7 +13649,7 @@ paths:
                   - example:
                       {
                         "code": "BAD_REQUEST",
-                        "msg": "Invalid stream id",
+                        "msg": "Invalid stream ID",
                         "result": "error",
                       }
                     description: |

--- a/zerver/tests/test_drafts.py
+++ b/zerver/tests/test_drafts.py
@@ -253,7 +253,7 @@ class DraftCreationTests(ZulipTestCase):
                 "timestamp": 1595479019,
             }
         ]
-        self.create_and_check_drafts_for_error(draft_dicts, "Invalid stream id")
+        self.create_and_check_drafts_for_error(draft_dicts, "Invalid stream ID")
 
         # When the stream itself does not exist:
         draft_dicts = [
@@ -265,7 +265,7 @@ class DraftCreationTests(ZulipTestCase):
                 "timestamp": 1595479019,
             }
         ]
-        self.create_and_check_drafts_for_error(draft_dicts, "Invalid stream id")
+        self.create_and_check_drafts_for_error(draft_dicts, "Invalid stream ID")
 
     def test_create_personal_message_draft_for_non_existing_user(self) -> None:
         draft_dicts = [

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -1778,7 +1778,7 @@ class EditMessageTest(EditMessageTestCase):
             },
         )
 
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
     def test_move_message_realm_admin_cant_move_to_private_stream_without_subscription(
         self,
@@ -1798,7 +1798,7 @@ class EditMessageTest(EditMessageTestCase):
             },
         )
 
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
     def test_move_message_realm_admin_cant_move_from_private_stream_without_subscription(
         self,

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -275,7 +275,7 @@ class UnreadCountTests(ZulipTestCase):
                 "stream_id": invalid_stream_id,
             },
         )
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
     def test_mark_all_topics_unread_with_invalid_stream_name(self) -> None:
         self.login("hamlet")
@@ -287,7 +287,7 @@ class UnreadCountTests(ZulipTestCase):
                 "topic_name": "whatever",
             },
         )
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
     def test_mark_all_in_stream_topic_read(self) -> None:
         self.login("hamlet")

--- a/zerver/tests/test_message_topics.py
+++ b/zerver/tests/test_message_topics.py
@@ -154,7 +154,7 @@ class TopicHistoryTest(ZulipTestCase):
         # non-sensible stream id
         endpoint = "/json/users/me/9999999999/topics"
         result = self.client_get(endpoint, {})
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         # out of realm
         bad_stream = self.make_stream(
@@ -163,7 +163,7 @@ class TopicHistoryTest(ZulipTestCase):
         )
         endpoint = f"/json/users/me/{bad_stream.id}/topics"
         result = self.client_get(endpoint, {})
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         # private stream to which I am not subscribed
         private_stream = self.make_stream(
@@ -172,7 +172,7 @@ class TopicHistoryTest(ZulipTestCase):
         )
         endpoint = f"/json/users/me/{private_stream.id}/topics"
         result = self.client_get(endpoint, {})
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
     def test_get_topics_web_public_stream_web_public_request(self) -> None:
         iago = self.example_user("iago")
@@ -199,13 +199,13 @@ class TopicHistoryTest(ZulipTestCase):
         stream = get_stream("Verona", self.example_user("iago").realm)
         endpoint = f"/json/users/me/{stream.id}/topics"
         result = self.client_get(endpoint)
-        self.assert_json_error(result, "Invalid stream id", 400)
+        self.assert_json_error(result, "Invalid stream ID", 400)
 
     def test_get_topics_non_existent_stream_web_public_request(self) -> None:
         non_existent_stream_id = 10000000000000000000000
         endpoint = f"/json/users/me/{non_existent_stream_id}/topics"
         result = self.client_get(endpoint)
-        self.assert_json_error(result, "Invalid stream id", 400)
+        self.assert_json_error(result, "Invalid stream ID", 400)
 
 
 class TopicDeleteTest(ZulipTestCase):

--- a/zerver/tests/test_muting_topics.py
+++ b/zerver/tests/test_muting_topics.py
@@ -186,7 +186,7 @@ class MutedTopicsTests(ZulipTestCase):
 
         data = {"stream_id": 999999999, "topic": "Verona3", "op": "add"}
         result = self.api_patch(user, url, data)
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         data = {"topic": "Verona3", "op": "add"}
         result = self.api_patch(user, url, data)

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -430,7 +430,7 @@ class RealmTest(ZulipTestCase):
         invalid_notif_stream_id = 1234
         req = dict(notifications_stream_id=orjson.dumps(invalid_notif_stream_id).decode())
         result = self.client_patch("/json/realm", req)
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
         realm = get_realm("zulip")
         assert realm.notifications_stream is not None
         self.assertNotEqual(realm.notifications_stream.id, invalid_notif_stream_id)
@@ -478,7 +478,7 @@ class RealmTest(ZulipTestCase):
             ).decode()
         )
         result = self.client_patch("/json/realm", req)
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
         realm = get_realm("zulip")
         assert realm.signup_notifications_stream is not None
         self.assertNotEqual(

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3039,7 +3039,7 @@ class MultiuseInviteTest(ZulipTestCase):
                 "invite_expires_in_minutes": 2 * 24 * 60,
             },
         )
-        self.assert_json_error(result, "Invalid stream id 54321. No invites were sent.")
+        self.assert_json_error(result, "Invalid stream ID 54321. No invites were sent.")
 
 
 class EmailUnsubscribeTests(ZulipTestCase):

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -456,7 +456,7 @@ class StreamAdminTest(ZulipTestCase):
         }
         stream_id = get_stream("private_stream_1", user_profile.realm).id
         result = self.client_patch(f"/json/streams/{stream_id}", params)
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         stream = self.subscribe(user_profile, "private_stream_1")
         self.assertFalse(stream.is_in_zephyr_realm)
@@ -1295,7 +1295,7 @@ class StreamAdminTest(ZulipTestCase):
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
 
         result = self.client_delete("/json/streams/999999999")
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
     def test_deactivate_stream_backend_requires_admin(self) -> None:
         user_profile = self.example_user("hamlet")
@@ -1551,7 +1551,7 @@ class StreamAdminTest(ZulipTestCase):
                 "is_private": orjson.dumps(True).decode(),
             },
         )
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
     def test_non_admin_cannot_access_unsub_private_stream(self) -> None:
         iago = self.example_user("iago")
@@ -1569,13 +1569,13 @@ class StreamAdminTest(ZulipTestCase):
         stream_id = get_stream("private_stream_1", hamlet.realm).id
 
         result = self.client_patch(f"/json/streams/{stream_id}", {"new_name": "private_stream_2"})
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         result = self.client_patch(
             f"/json/streams/{stream_id}",
             {"description": "new description"},
         )
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         result = self.client_patch(
             f"/json/streams/{stream_id}",
@@ -1583,10 +1583,10 @@ class StreamAdminTest(ZulipTestCase):
                 "is_private": orjson.dumps(True).decode(),
             },
         )
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         result = self.client_delete(f"/json/streams/{stream_id}")
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
     def test_change_stream_description(self) -> None:
         user_profile = self.example_user("iago")
@@ -2300,13 +2300,13 @@ class StreamAdminTest(ZulipTestCase):
         stream = self.make_stream("other_realm_stream", realm=other_realm)
 
         result = self.client_delete("/json/streams/" + str(stream.id))
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         # Even becoming a realm admin doesn't help us for an out-of-realm
         # stream.
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         result = self.client_delete("/json/streams/" + str(stream.id))
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
     def test_delete_public_stream(self) -> None:
         """
@@ -2703,7 +2703,7 @@ class DefaultStreamTest(ZulipTestCase):
         stream = self.make_stream(stream_name, invite_only=True)
         self.subscribe(self.example_user("iago"), stream_name)
         result = self.client_post("/json/default_streams", dict(stream_id=stream.id))
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         # Test admin can't add subscribed private stream also.
         self.subscribe(user_profile, stream_name)
@@ -3452,7 +3452,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
                 ).decode()
             },
         )
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
     def test_set_invalid_property(self) -> None:
         """
@@ -3593,7 +3593,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
             "/api/v1/users/me/subscriptions/121",
             {"property": "is_muted", "value": "somevalue"},
         )
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
     def test_bad_add_parameters(self) -> None:
         user = self.example_user("hamlet")
@@ -5468,14 +5468,14 @@ class GetStreamsTest(ZulipTestCase):
         self.assertEqual(json["stream"]["stream_id"], denmark_stream.id)
 
         result = self.client_get("/json/streams/9999")
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         private_stream = self.make_stream("private_stream", invite_only=True)
         self.subscribe(self.example_user("cordelia"), "private_stream")
 
         # Non-admins cannot access unsubscribed private streams.
         result = self.client_get(f"/json/streams/{private_stream.id}")
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         self.login("iago")
         result = self.client_get(f"/json/streams/{private_stream.id}")
@@ -6038,7 +6038,7 @@ class GetSubscribersTest(ZulipTestCase):
         # Verify another user can't get the data.
         self.login("cordelia")
         result = self.client_get(f"/json/streams/{stream_id}/members")
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         # But an organization administrator can
         self.login("iago")
@@ -6051,7 +6051,7 @@ class GetSubscribersTest(ZulipTestCase):
         """
         stream_id = 99999999
         result = self.client_get(f"/json/streams/{stream_id}/members")
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
     def test_json_get_subscribers(self) -> None:
         """
@@ -6108,7 +6108,7 @@ class GetSubscribersTest(ZulipTestCase):
         # Try to fetch the subscriber list as a non-member & non-realm-admin-user.
         stream_id = get_stream(stream_name, user_profile.realm).id
         result = self.make_subscriber_request(stream_id, user=user_profile)
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         # Try to fetch the subscriber list as a non-member & realm-admin-user.
         self.login("iago")
@@ -6131,7 +6131,7 @@ class AccessStreamTest(ZulipTestCase):
         othello = self.example_user("othello")
 
         # Nobody can access a stream that doesn't exist
-        with self.assertRaisesRegex(JsonableError, "Invalid stream id"):
+        with self.assertRaisesRegex(JsonableError, "Invalid stream ID"):
             access_stream_by_id(hamlet, 501232)
         with self.assertRaisesRegex(JsonableError, "Invalid stream name 'invalid stream'"):
             access_stream_by_name(hamlet, "invalid stream")
@@ -6146,7 +6146,7 @@ class AccessStreamTest(ZulipTestCase):
         self.assertEqual(sub_ret, sub_ret2)
 
         # Othello cannot access the private stream
-        with self.assertRaisesRegex(JsonableError, "Invalid stream id"):
+        with self.assertRaisesRegex(JsonableError, "Invalid stream ID"):
             access_stream_by_id(othello, stream.id)
         with self.assertRaisesRegex(JsonableError, "Invalid stream name 'new_private_stream'"):
             access_stream_by_name(othello, stream.name)
@@ -6165,17 +6165,17 @@ class AccessStreamTest(ZulipTestCase):
         mit_realm = get_realm("zephyr")
         mit_stream = ensure_stream(mit_realm, "mit_stream", invite_only=False, acting_user=None)
         sipbtest = self.mit_user("sipbtest")
-        with self.assertRaisesRegex(JsonableError, "Invalid stream id"):
+        with self.assertRaisesRegex(JsonableError, "Invalid stream ID"):
             access_stream_by_id(hamlet, mit_stream.id)
         with self.assertRaisesRegex(JsonableError, "Invalid stream name 'mit_stream'"):
             access_stream_by_name(hamlet, mit_stream.name)
-        with self.assertRaisesRegex(JsonableError, "Invalid stream id"):
+        with self.assertRaisesRegex(JsonableError, "Invalid stream ID"):
             access_stream_by_id(sipbtest, stream.id)
         with self.assertRaisesRegex(JsonableError, "Invalid stream name 'new_private_stream'"):
             access_stream_by_name(sipbtest, stream.name)
 
         # MIT realm users cannot access even public streams in their realm
-        with self.assertRaisesRegex(JsonableError, "Invalid stream id"):
+        with self.assertRaisesRegex(JsonableError, "Invalid stream ID"):
             access_stream_by_id(sipbtest, mit_stream.id)
         with self.assertRaisesRegex(JsonableError, "Invalid stream name 'mit_stream'"):
             access_stream_by_name(sipbtest, mit_stream.name)
@@ -6192,7 +6192,7 @@ class AccessStreamTest(ZulipTestCase):
         stream = self.make_stream(stream_name, guest_user_profile.realm, invite_only=False)
 
         # Guest user don't have access to unsubscribed public streams
-        with self.assertRaisesRegex(JsonableError, "Invalid stream id"):
+        with self.assertRaisesRegex(JsonableError, "Invalid stream ID"):
             access_stream_by_id(guest_user_profile, stream.id)
 
         # Guest user have access to subscribed public streams
@@ -6205,7 +6205,7 @@ class AccessStreamTest(ZulipTestCase):
         stream_name = "private_stream_1"
         stream = self.make_stream(stream_name, guest_user_profile.realm, invite_only=True)
         # Obviously, a guest user doesn't have access to unsubscribed private streams either
-        with self.assertRaisesRegex(JsonableError, "Invalid stream id"):
+        with self.assertRaisesRegex(JsonableError, "Invalid stream ID"):
             access_stream_by_id(guest_user_profile, stream.id)
 
         # Guest user have access to subscribed private streams

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -131,7 +131,7 @@ class TypingValidateToArgumentsTest(ZulipTestCase):
                 "topic": topic,
             },
         )
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
 
 class TypingHappyPathTestPMs(ZulipTestCase):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1313,7 +1313,7 @@ class UserProfileTest(ZulipTestCase):
 
         # Invalid stream ID.
         result = self.client_get(f"/json/users/{iago.id}/subscriptions/25")
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         result = orjson.loads(
             self.client_get(f"/json/users/{iago.id}/subscriptions/{stream.id}").content
@@ -1352,7 +1352,7 @@ class UserProfileTest(ZulipTestCase):
         # Unsubscribed non-admins cannot check subscription status in a private stream.
         self.login("shiva")
         result = self.client_get(f"/json/users/{iago.id}/subscriptions/{stream.id}")
-        self.assert_json_error(result, "Invalid stream id")
+        self.assert_json_error(result, "Invalid stream ID")
 
         # Subscribed non-admins can check subscription status in a private stream
         self.subscribe(self.example_user("shiva"), stream.name)

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -187,7 +187,7 @@ def generate_multiuse_invite_backend(
         try:
             (stream, sub) = access_stream_by_id(user_profile, stream_id)
         except JsonableError:
-            raise JsonableError(_("Invalid stream id {}. No invites were sent.").format(stream_id))
+            raise JsonableError(_("Invalid stream ID {}. No invites were sent.").format(stream_id))
         streams.append(stream)
 
     invite_link = do_create_multiuse_invite_link(


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Changed invalid stream ID error messages to use "ID" instead of "id" as discussed [here](https://github.com/zulip/zulip/pull/22086#issuecomment-1135190080).

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
