### PR TITLE
typeahead: Don't match descriptions for streams and user groups.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -953,7 +953,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
         fake_this.$element.closest = () => [];
         fake_this.options = options;
         let actual_value = options.source.call(fake_this, "test #s");
-        assert.deepEqual(sorted_names_from(actual_value), ["Denmark", "Sweden", "The Netherlands"]);
+        assert.deepEqual(sorted_names_from(actual_value), ["Sweden", "The Netherlands"]);
         assert.ok(caret_called);
 
         // options.highlighter()
@@ -1590,15 +1590,15 @@ test("typeahead_results", () => {
     assert_mentions_matches("delia lear", []);
     assert_mentions_matches("Mark Tw", [twin1, twin2]);
 
+    // Earlier user group and stream mentions were autocompleted by their
+    // description too. This is now removed as it often led to unexpected
+    // behaviour, and did not have any great discoverability advantage.
+
     // Autocomplete user group mentions by group name.
     assert_mentions_matches("hamletchar", [hamletcharacters]);
 
-    // Autocomplete user group mentions by group descriptions.
-    assert_mentions_matches("characters ", [hamletcharacters]);
-    assert_mentions_matches("characters of ", [hamletcharacters]);
-    assert_mentions_matches("characters o ", []);
-    assert_mentions_matches("haracters of hamlet", []);
-    assert_mentions_matches("of hamlet", [hamletcharacters]);
+    // Verify we're not matching on a terms that only appear in the description.
+    assert_mentions_matches("characters of", []);
 
     // Autocomplete by slash commands.
     assert_slash_matches("me", [me_slash]);
@@ -1607,14 +1607,15 @@ test("typeahead_results", () => {
     assert_slash_matches("light", [light_slash]);
     assert_slash_matches("day", [light_slash]);
 
-    // Autocomplete stream by stream name or stream description.
+    // Autocomplete stream by stream name
     assert_stream_matches("den", [denmark_stream, sweden_stream]);
     assert_stream_matches("denmark", [denmark_stream]);
     assert_stream_matches("denmark ", []);
     assert_stream_matches("den ", []);
-    assert_stream_matches("cold", [sweden_stream, denmark_stream]);
     assert_stream_matches("the ", [netherland_stream]);
-    assert_stream_matches("city", [netherland_stream]);
+    // Do not match stream descriptions
+    assert_stream_matches("cold", []);
+    assert_stream_matches("city", []);
 });
 
 test("message people", ({override}) => {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -96,13 +96,8 @@ export function query_matches_person(query, person) {
     return typeahead.query_matches_source_attrs(query, person, ["full_name", email_attr], " ");
 }
 
-export function query_matches_name_description(query, user_group_or_stream) {
-    return typeahead.query_matches_source_attrs(
-        query,
-        user_group_or_stream,
-        ["name", "description"],
-        " ",
-    );
+export function query_matches_name(query, user_group_or_stream) {
+    return typeahead.query_matches_source_attrs(query, user_group_or_stream, ["name"], " ");
 }
 
 function get_stream_or_user_group_matcher(query) {
@@ -110,7 +105,7 @@ function get_stream_or_user_group_matcher(query) {
     query = typeahead.clean_query_lowercase(query);
 
     return function (user_group_or_stream) {
-        return query_matches_name_description(query, user_group_or_stream);
+        return query_matches_name(query, user_group_or_stream);
     };
 }
 
@@ -476,7 +471,7 @@ export function get_person_suggestions(query, opts) {
 
     const groups = user_groups.get_realm_user_groups();
 
-    const filtered_groups = groups.filter((item) => query_matches_name_description(query, item));
+    const filtered_groups = groups.filter((item) => query_matches_name(query, item));
 
     /*
         Let's say you're on a big realm and type

--- a/static/js/pill_typeahead.js
+++ b/static/js/pill_typeahead.js
@@ -16,7 +16,7 @@ function person_matcher(query, item) {
 
 function group_matcher(query, item) {
     if (user_groups.is_user_group(item)) {
-        return composebox_typeahead.query_matches_name_description(query, item);
+        return composebox_typeahead.query_matches_name(query, item);
     }
     return false;
 }


### PR DESCRIPTION
Uptil now, both names and descriptions of streams and user groups were matched to show the typeahead suggestions. This led to unexpected behaviour like for a clear mention of a certain stream, the typeahead menu suggested a completely different stream which had a mention of the first stream in it's description.

To prevent such bugs and also since description matching is not really useful for streams and user groups, only names will be matched.

Fixes: The bug mentioned on this [CZO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/typeahead.20regression)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
https://www.loom.com/share/4d9b9039d80146be90aa8954bda0a435)
This shows that despite having a mention of the Rome stream in its description, Denmark does not show up in the typeahead suggestions when the full stream name is typed out (it shows for "r" since Denmark too has "r" in it's name)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
