### PR TITLE
typing: Access url via key "Location" instead of attribute "url".

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -835,7 +835,7 @@ class StripeTest(StripeTestCase):
         # Check that we can no longer access /upgrade
         response = self.client_get("/upgrade/")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual("/billing/", response.url)
+        self.assertEqual("/billing/", response["Location"])
 
         # Check /billing has the correct information
         with patch("corporate.views.billing_page.timezone_now", return_value=self.now):
@@ -976,7 +976,7 @@ class StripeTest(StripeTestCase):
         # Check that we can no longer access /upgrade
         response = self.client_get("/upgrade/")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual("/billing/", response.url)
+        self.assertEqual("/billing/", response["Location"])
 
         # Check /billing has the correct information
         with patch("corporate.views.billing_page.timezone_now", return_value=self.now):
@@ -1534,7 +1534,7 @@ class StripeTest(StripeTestCase):
         # Check that we still get redirected to /upgrade
         response = self.client_get("/billing/")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual("/upgrade/", response.url)
+        self.assertEqual("/upgrade/", response["Location"])
 
         [last_event] = stripe.Event.list(limit=1)
         retry_payment_intent_json_response = self.client_post(
@@ -1629,7 +1629,7 @@ class StripeTest(StripeTestCase):
         # Check that we can no longer access /upgrade
         response = self.client_get("/upgrade/")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual("/billing/", response.url)
+        self.assertEqual("/billing/", response["Location"])
 
     @mock_stripe()
     def test_upgrade_first_card_fails_and_restart_from_begining(self, *mocks: Mock) -> None:
@@ -1702,7 +1702,7 @@ class StripeTest(StripeTestCase):
         # Check that we still get redirected to /upgrade
         response = self.client_get("/billing/")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual("/upgrade/", response.url)
+        self.assertEqual("/upgrade/", response["Location"])
 
         # Try again, with a valid card, after they added a few users
         with patch("corporate.lib.stripe.get_latest_seat_count", return_value=23):
@@ -1761,7 +1761,7 @@ class StripeTest(StripeTestCase):
         # Check that we can no longer access /upgrade
         response = self.client_get("/upgrade/")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual("/billing/", response.url)
+        self.assertEqual("/billing/", response["Location"])
 
     def test_upgrade_with_tampered_seat_count(self) -> None:
         hamlet = self.example_user("hamlet")
@@ -2262,7 +2262,7 @@ class StripeTest(StripeTestCase):
 
         response = self.client_get("/upgrade/")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, "/billing/")
+        self.assertEqual(response["Location"], "/billing/")
 
         response = self.client_get("/billing/")
         self.assert_in_success_response(
@@ -2290,7 +2290,7 @@ class StripeTest(StripeTestCase):
         self.login_user(user)
         response = self.client_get("/billing/")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual("/upgrade/", response.url)
+        self.assertEqual("/upgrade/", response["Location"])
 
         user.realm.plan_type = Realm.PLAN_TYPE_STANDARD_FREE
         user.realm.save()
@@ -2302,7 +2302,7 @@ class StripeTest(StripeTestCase):
         Customer.objects.create(realm=user.realm, stripe_customer_id="cus_123")
         response = self.client_get("/billing/")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual("/upgrade/", response.url)
+        self.assertEqual("/upgrade/", response["Location"])
 
     def test_redirect_for_upgrade_page(self) -> None:
         user = self.example_user("iago")
@@ -2315,7 +2315,7 @@ class StripeTest(StripeTestCase):
         user.realm.save()
         response = self.client_get("/upgrade/")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, "/billing/")
+        self.assertEqual(response["Location"], "/billing/")
 
         user.realm.plan_type = Realm.PLAN_TYPE_LIMITED
         user.realm.save()
@@ -2331,16 +2331,16 @@ class StripeTest(StripeTestCase):
         )
         response = self.client_get("/upgrade/")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, "/billing/")
+        self.assertEqual(response["Location"], "/billing/")
 
         with self.settings(FREE_TRIAL_DAYS=30):
             response = self.client_get("/upgrade/")
             self.assertEqual(response.status_code, 302)
-            self.assertEqual(response.url, "/billing/")
+            self.assertEqual(response["Location"], "/billing/")
 
             response = self.client_get("/upgrade/", {"onboarding": "true"})
             self.assertEqual(response.status_code, 302)
-            self.assertEqual(response.url, "/billing/?onboarding=true")
+            self.assertEqual(response["Location"], "/billing/?onboarding=true")
 
     def test_get_latest_seat_count(self) -> None:
         realm = get_realm("zulip")
@@ -4128,7 +4128,7 @@ class RequiresBillingAccessTest(StripeTestCase):
         self.login_user(self.example_user("hamlet"))
         response = self.client_get("/billing/")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual("/upgrade/", response.url)
+        self.assertEqual("/upgrade/", response["Location"])
         # Check that non-admins can sign up and pay
         self.upgrade()
         # Check that the non-admin hamlet can still access /billing

--- a/zerver/tests/test_create_video_call.py
+++ b/zerver/tests/test_create_video_call.py
@@ -85,8 +85,8 @@ class TestVideoCall(ZulipTestCase):
             {"code": "code", "state": '{"realm":"zephyr","sid":"somesid"}'},
         )
         self.assertEqual(response.status_code, 302)
-        self.assertIn("http://zephyr.testserver/", response.url)
-        self.assertIn("somesid", response.url)
+        self.assertIn("http://zephyr.testserver/", response["Location"])
+        self.assertIn("somesid", response["Location"])
 
     def test_create_video_sid_error(self) -> None:
         response = self.client_get(
@@ -214,7 +214,7 @@ class TestVideoCall(ZulipTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(isinstance(response, HttpResponseRedirect), True)
         self.assertEqual(
-            response.url,
+            response["Location"],
             "https://bbb.example.com/bigbluebutton/api/join?meetingID=a&"
             "password=a&fullName=King%20Hamlet&createTime=0&checksum=47ca959b4ff5c8047a5a56d6e99c07e17eac43dbf792afc0a2a9f6491ec0048b",
         )

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -318,7 +318,7 @@ class HomeTest(ZulipTestCase):
         # Redirect to login if spectator access is disabled.
         result = self.client_get("/")
         self.assertEqual(result.status_code, 302)
-        self.assertEqual(result.url, "/login/")
+        self.assertEqual(result["Location"], "/login/")
 
         # Load webapp directly if spectator access is enabled.
         do_set_realm_property(realm, "enable_spectator_access", True, acting_user=None)

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -23,7 +23,7 @@ class ThumbnailTest(ZulipTestCase):
 
         result = self.client_get("/thumbnail", {"url": uri[1:], "size": "full"})
         self.assertEqual(result.status_code, 302, result)
-        self.assertEqual(uri, result.url)
+        self.assertEqual(uri, result["Location"])
 
         self.login("iago")
         result = self.client_get("/thumbnail", {"url": uri[1:], "size": "full"})
@@ -34,19 +34,19 @@ class ThumbnailTest(ZulipTestCase):
         result = self.client_get("/thumbnail", {"url": uri, "size": "full"})
         self.assertEqual(result.status_code, 302, result)
         base = "https://external-content.zulipcdn.net/external_content/56c362a24201593891955ff526b3b412c0f9fcd2/68747470733a2f2f7777772e676f6f676c652e636f6d2f696d616765732f737270722f6c6f676f34772e706e67"
-        self.assertEqual(base, result.url)
+        self.assertEqual(base, result["Location"])
 
         uri = "http://www.google.com/images/srpr/logo4w.png"
         result = self.client_get("/thumbnail", {"url": uri, "size": "full"})
         self.assertEqual(result.status_code, 302, result)
         base = "https://external-content.zulipcdn.net/external_content/7b6552b60c635e41e8f6daeb36d88afc4eabde79/687474703a2f2f7777772e676f6f676c652e636f6d2f696d616765732f737270722f6c6f676f34772e706e67"
-        self.assertEqual(base, result.url)
+        self.assertEqual(base, result["Location"])
 
         uri = "//www.google.com/images/srpr/logo4w.png"
         result = self.client_get("/thumbnail", {"url": uri, "size": "full"})
         self.assertEqual(result.status_code, 302, result)
         base = "https://external-content.zulipcdn.net/external_content/676530cf4b101d56f56cc4a37c6ef4d4fd9b0c03/2f2f7777772e676f6f676c652e636f6d2f696d616765732f737270722f6c6f676f34772e706e67"
-        self.assertEqual(base, result.url)
+        self.assertEqual(base, result["Location"])
 
     @override_settings(RATE_LIMITING=True)
     def test_thumbnail_redirect_for_spectator(self) -> None:


### PR DESCRIPTION
It fixes the issue with `"HttpResponse" has no attribute "url"` by [using `result["Location"]` instead of `result.url`](https://github.com/zulip/zulip/pull/18777#issuecomment-1140077785).

Another similar error `"HttpResponse" has no attribute "json"` cannot be fixed without `django-stubs` as the test client returns a 
monkey-patched `HttpResponse`, typed as [_MonkeyPatchedWSGIResponse](https://github.com/typeddjango/django-stubs/blob/42d8e18bf8d35482cdb4935866bd35304a74fc9d/django-stubs/test/client.pyi#L123-L130) in the stubs.

This is a part of #18777.