### PR TITLE
Allow to change access to history of a stream by passing only `history_public_to_subscribers` parameter and some changes in errors returned for invalid parameters..

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,16 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 6.0
 
+**Feature level 136**
+
+* [`PATCH /streams/{stream_id}`](/api/update-stream): The endpoint
+  now returns an error for a request to make a public stream with
+  protected history which was previously ignored silently.
+* [`PATCH /streams/{stream_id}`](/api/update-stream): Added support
+  to change access to history of the stream by only passing
+  `history_public_to_subscribers` parameter without `is_private`
+  and `is_web_public` parameters.
+
 **Feature level 135**
 
 * [`DELETE /user/{user_id}`](/api/deactivate-user): Added

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 135
+API_FEATURE_LEVEL = 136
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -851,8 +851,6 @@ def do_change_stream_permission(
     # But absent such a refactoring, it's important to assert that
     # we're not requesting an unsupported configurations.
     if is_web_public:
-        assert history_public_to_subscribers is not False
-        assert invite_only is not True
         stream.is_web_public = True
         stream.invite_only = False
         stream.history_public_to_subscribers = True

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -855,8 +855,12 @@ def do_change_stream_permission(
         stream.invite_only = False
         stream.history_public_to_subscribers = True
     else:
-        assert invite_only is not None
         # is_web_public is falsey
+        if invite_only is None:
+            # This is necessary to get correct default value for
+            # history_public_to_subscribers when invite_only is
+            # None.
+            invite_only = stream.invite_only
         history_public_to_subscribers = get_default_value_for_history_public_to_subscribers(
             stream.realm,
             invite_only,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13666,8 +13666,27 @@ paths:
             type: boolean
           example: true
           required: false
+        - name: history_public_to_subscribers
+          in: query
+          description: |
+            Whether the stream's message history should be available to
+            newly subscribed members, or users can only access messages
+            they actually received while subscribed to the stream.
+
+            Corresponds to the [shared history](/help/stream-permissions)
+            option in documentation.
+
+            It's an error for this parameter to be false for a public or
+            web-public stream and when is_private is false.
+
+            **Changes**: Before Zulip 6.0 (feature level 136), `history_public_to_subscribers`
+            was silently ignored unless the request also contained either `is_private` or
+            `is_web_public`.
+          schema:
+            type: boolean
+          example: false
+          required: false
         - $ref: "#/components/parameters/StreamPostPolicy"
-        - $ref: "#/components/parameters/HistoryPublicToSubscribers"
         - $ref: "#/components/parameters/MessageRetentionDays"
       responses:
         "200":
@@ -13677,16 +13696,28 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: "#/components/schemas/JsonError"
-                  - example:
-                      {
-                        "code": "BAD_REQUEST",
-                        "msg": "Invalid stream ID",
-                        "result": "error",
-                      }
-                    description: |
-                      An example JSON response for when the supplied stream does not exist:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/JsonError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Invalid stream ID",
+                            "result": "error",
+                          }
+                        description: |
+                          An example JSON response for when the supplied stream does not exist:
+                  - allOf:
+                      - $ref: "#/components/schemas/JsonError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Invalid parameters",
+                            "result": "error",
+                          }
+                        description: |
+                          An example JSON response for when invalid combination of stream permission
+                          parameters are passed.
   /streams/{stream_id}/delete_topic:
     post:
       operationId: delete-topic

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -419,7 +419,13 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         user_profile = self.example_user("hamlet")
         stream = get_stream("Denmark", user_profile.realm)
         self.subscribe(user_profile, stream.name)
-        do_change_stream_permission(stream, invite_only=True, acting_user=user_profile)
+        do_change_stream_permission(
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=False,
+            is_web_public=False,
+            acting_user=user_profile,
+        )
 
         self.assert_num_bots_equal(0)
         events: List[Mapping[str, Any]] = []
@@ -464,7 +470,11 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user("hamlet"), "Denmark")
         do_change_stream_permission(
-            stream, invite_only=True, acting_user=self.example_user("hamlet")
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=False,
+            is_web_public=False,
+            acting_user=self.example_user("hamlet"),
         )
 
         bot_info = {
@@ -493,7 +503,13 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.login("hamlet")
         user_profile = self.example_user("hamlet")
         stream = self.subscribe(user_profile, "Denmark")
-        do_change_stream_permission(stream, invite_only=True, acting_user=user_profile)
+        do_change_stream_permission(
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=False,
+            is_web_public=False,
+            acting_user=user_profile,
+        )
 
         self.assert_num_bots_equal(0)
         events: List[Mapping[str, Any]] = []
@@ -538,7 +554,11 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user("hamlet"), "Denmark")
         do_change_stream_permission(
-            stream, invite_only=True, acting_user=self.example_user("hamlet")
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=False,
+            is_web_public=False,
+            acting_user=self.example_user("hamlet"),
         )
 
         self.assert_num_bots_equal(0)
@@ -1215,7 +1235,13 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.login("hamlet")
         user_profile = self.example_user("hamlet")
         stream = self.subscribe(user_profile, "Denmark")
-        do_change_stream_permission(stream, invite_only=True, acting_user=user_profile)
+        do_change_stream_permission(
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=False,
+            is_web_public=False,
+            acting_user=user_profile,
+        )
 
         bot_info = {
             "full_name": "The Bot of Hamlet",
@@ -1242,7 +1268,11 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user("hamlet"), "Denmark")
         do_change_stream_permission(
-            stream, invite_only=True, acting_user=self.example_user("hamlet")
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=False,
+            is_web_public=False,
+            acting_user=self.example_user("hamlet"),
         )
 
         bot_info = {
@@ -1324,7 +1354,13 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.login("hamlet")
         user_profile = self.example_user("hamlet")
         stream = self.subscribe(user_profile, "Denmark")
-        do_change_stream_permission(stream, invite_only=True, acting_user=user_profile)
+        do_change_stream_permission(
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=False,
+            is_web_public=False,
+            acting_user=user_profile,
+        )
 
         bot_info = {
             "full_name": "The Bot of Hamlet",
@@ -1350,7 +1386,11 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user("hamlet"), "Denmark")
         do_change_stream_permission(
-            stream, invite_only=True, acting_user=self.example_user("hamlet")
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=False,
+            is_web_public=False,
+            acting_user=self.example_user("hamlet"),
         )
 
         bot_info = {

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -1277,14 +1277,22 @@ class MessageAccessTests(ZulipTestCase):
         # Guest user can access messages of subscribed private streams if
         # history is public to subscribers
         do_change_stream_permission(
-            stream, invite_only=True, history_public_to_subscribers=True, acting_user=guest_user
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=True,
+            is_web_public=False,
+            acting_user=guest_user,
         )
         result = self.change_star(message_id)
         self.assert_json_success(result)
 
         # With history not public to subscribers, they can still see new messages
         do_change_stream_permission(
-            stream, invite_only=True, history_public_to_subscribers=False, acting_user=guest_user
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=False,
+            is_web_public=False,
+            acting_user=guest_user,
         )
         self.login_user(normal_user)
         message_id = [
@@ -1332,6 +1340,7 @@ class MessageAccessTests(ZulipTestCase):
             stream,
             invite_only=True,
             history_public_to_subscribers=True,
+            is_web_public=False,
             acting_user=self.example_user("cordelia"),
         )
 

--- a/zerver/tests/test_message_topics.py
+++ b/zerver/tests/test_message_topics.py
@@ -130,7 +130,11 @@ class TopicHistoryTest(ZulipTestCase):
 
         # Now make stream private, but subscribe cordelia
         do_change_stream_permission(
-            stream, invite_only=True, acting_user=self.example_user("cordelia")
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=False,
+            is_web_public=False,
+            acting_user=self.example_user("cordelia"),
         )
         self.subscribe(self.example_user("cordelia"), stream.name)
 
@@ -232,7 +236,11 @@ class TopicDeleteTest(ZulipTestCase):
 
         # Make stream private with limited history
         do_change_stream_permission(
-            stream, invite_only=True, history_public_to_subscribers=False, acting_user=user_profile
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=False,
+            is_web_public=False,
+            acting_user=user_profile,
         )
 
         # ADMIN USER subscribed now
@@ -266,7 +274,11 @@ class TopicDeleteTest(ZulipTestCase):
 
         # Make the stream's history public to subscribers
         do_change_stream_permission(
-            stream, invite_only=True, history_public_to_subscribers=True, acting_user=user_profile
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=True,
+            is_web_public=False,
+            acting_user=user_profile,
         )
         # Delete the topic should now remove all messages
         result = self.client_post(

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -544,7 +544,11 @@ class ReactionEventTest(ZulipTestCase):
 
         # Make stream history public to subscribers
         do_change_stream_permission(
-            stream, invite_only=False, history_public_to_subscribers=True, acting_user=iago
+            stream,
+            invite_only=False,
+            history_public_to_subscribers=True,
+            is_web_public=False,
+            acting_user=iago,
         )
         # Since stream history is public to subscribers, reacting to
         # message_before_id should notify all subscribers:
@@ -564,7 +568,13 @@ class ReactionEventTest(ZulipTestCase):
         self.assert_json_success(remove)
 
         # Make stream web_public as well.
-        do_change_stream_permission(stream, is_web_public=True, acting_user=iago)
+        do_change_stream_permission(
+            stream,
+            invite_only=False,
+            history_public_to_subscribers=True,
+            is_web_public=True,
+            acting_user=iago,
+        )
         # For is_web_public streams, events even on old messages
         # should go to all subscribers, including guests like polonius.
         with self.tornado_redirected_to_list(events, expected_num_events=1):

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -335,7 +335,15 @@ def update_stream_backend(
         if is_private or history_public_to_subscribers is False:
             raise JsonableError(_("Invalid parameters"))
 
-    if is_private is not None or is_web_public is not None:
+    if history_public_to_subscribers is False and not stream.realm.is_zephyr_mirror_realm:
+        if is_private is None and not stream.invite_only:
+            raise JsonableError(_("Invalid parameters"))
+
+    if (
+        is_private is not None
+        or is_web_public is not None
+        or history_public_to_subscribers is not None
+    ):
         do_change_stream_permission(
             stream,
             invite_only=is_private,

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -318,6 +318,13 @@ def update_stream_backend(
         if is_private and stream.id in default_stream_ids:
             raise JsonableError(_("Default streams cannot be made private."))
 
+        if (
+            not is_private
+            and history_public_to_subscribers is False
+            and not stream.realm.is_zephyr_mirror_realm
+        ):
+            raise JsonableError(_("Invalid parameters"))
+
     if is_web_public:
         # Enforce restrictions on creating web-public streams.
         if not user_profile.realm.web_public_streams_enabled():


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit just removes the redundant assert statements.
- Second commit adds code to raise 404 error when trying to make a public stream with protected history. (Only when passing `history_public_to_subscribers` with `is_private`)
- Third commit adds code to raise 404 error when changing only `history_public_to_subscribers` of a public/web-public stream.
- Fourth commit is to allow changing `history_public_to_subscribers` without passing `is_private` parameter.

Some points to note -
- For a stream which is private with `history_public_to_subscribers` as `False`, passing `is_private: False` or `is_web_public: True` will change the stream to public and web-public respectively without requiring `history_public_to_subscribers` parameter. It will automatically be set to `True` as for public and web-public streams.

Fixes: <!-- Issue link, or clear description.--> As discussed in https://chat.zulip.org/#narrow/stream/378-api-design/topic/PATCH.20.2Fstreams.2F.7Bstream_id.7D.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
