### PR TITLE
help-docs: Document "Copy link to topic" mobile app feature.

### DIFF
--- a/templates/zerver/help/include/message-actions-menu.md
+++ b/templates/zerver/help/include/message-actions-menu.md
@@ -1,3 +1,3 @@
 1. Hover over a message to reveal three icons on the right.
 
-1. Click the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>).
+1. Click on the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>).

--- a/templates/zerver/help/include/topic-long-press-menu-tip.md
+++ b/templates/zerver/help/include/topic-long-press-menu-tip.md
@@ -1,0 +1,4 @@
+!!! tip ""
+
+    If you are viewing a single topic, you can access the long-press
+    menu from the bar at the top of the screen.

--- a/templates/zerver/help/include/topic-long-press-menu.md
+++ b/templates/zerver/help/include/topic-long-press-menu.md
@@ -1,0 +1,1 @@
+1. Press and hold the topic bar to access the long-press menu.

--- a/templates/zerver/help/link-to-a-message-or-conversation.md
+++ b/templates/zerver/help/link-to-a-message-or-conversation.md
@@ -59,7 +59,7 @@ message](/help/quote-and-reply).
 
 1. Click **Copy link to message**.
 
-{tab|via-browser-address-bar}
+{tab|web}
 
 1. Click on the timestamp of the message.
 
@@ -67,7 +67,7 @@ message](/help/quote-and-reply).
 
 {end_tabs}
 
-### Get a link to a specific topic:
+### Get a link to a specific topic
 
 {start_tabs}
 
@@ -77,14 +77,14 @@ message](/help/quote-and-reply).
 
 1. Click **Copy link to topic**.
 
-{tab|via-browser-address-bar}
+{tab|web}
 
 1. Click on a topic in the left sidebar.
 
 1. Copy the URL from your browser's address bar.
 
 {end_tabs}
-### Get a link to a specific stream:
+### Get a link to a specific stream
 
 {start_tabs}
 
@@ -94,7 +94,7 @@ message](/help/quote-and-reply).
 
 1. Click **Copy Link**.
 
-{tab|via-browser-address-bar}
+{tab|web}
 
 1. Click on a stream in the left sidebar.
 

--- a/templates/zerver/help/link-to-a-message-or-conversation.md
+++ b/templates/zerver/help/link-to-a-message-or-conversation.md
@@ -34,9 +34,9 @@ Topic: #**stream name>topic name**
 
 ## Link to Zulip from anywhere
 
-All URLs in Zulip are designed to be shareable.
-Copying the URL from the browser's address bar will work
-for all views, including searches.
+All URLs in Zulip are designed to be shareable.  Copying the URL from
+the browser's address bar will work for all views, including searches.
+
 ### Get a link to a specific message
 
 This copies to your clipboard a permanent link to the message,
@@ -53,17 +53,16 @@ message](/help/quote-and-reply).
 
 {start_tabs}
 
-{tab|desktop}
+{tab|desktop-web}
 
 {!message-actions-menu.md!}
 
 1. Click **Copy link to message**.
 
-{tab|web}
+!!! tip ""
 
-1. Click on the timestamp of the message.
-
-1. Copy the URL from your browser's address bar.
+    If using Zulip in a browser, you can also click on the timestamp
+    of a message, and copy the URL from your browser's address bar.
 
 {end_tabs}
 
@@ -71,34 +70,40 @@ message](/help/quote-and-reply).
 
 {start_tabs}
 
-{tab|desktop}
+{tab|desktop-web}
 
 {!topic-actions.md!}
 
 1. Click **Copy link to topic**.
 
-{tab|web}
+!!! tip ""
 
-1. Click on a topic in the left sidebar.
+    If using Zulip in a browser, you can also click on a topic name,
+    and copy the URL from your browser's address bar.
 
-1. Copy the URL from your browser's address bar.
+{tab|mobile}
+
+{!topic-long-press-menu.md!}
+
+1. Tap **Copy link to topic**.
+
+{!topic-long-press-menu-tip.md!}
 
 {end_tabs}
 ### Get a link to a specific stream
 
 {start_tabs}
 
-{tab|desktop}
+{tab|desktop-web}
 
-1. Right-click on the stream in the left sidebar.
+1. Right-click on a stream in the left sidebar.
 
 1. Click **Copy Link**.
 
-{tab|web}
+!!! tip ""
 
-1. Click on a stream in the left sidebar.
-
-1. Copy the URL from your browser's address bar.
+    If using Zulip in a browser, you can also click on a stream in the
+    left sidebar, and copy the URL from your browser's address bar.
 
 {end_tabs}
 

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -77,7 +77,6 @@ TAB_SECTION_LABELS = {
     "web-public-streams": "Web-public streams",
     "via-user-profile": "Via the user's profile",
     "via-organization-settings": "Via organization settings",
-    "via-browser-address-bar": "Via browser's address bar",
 }
 
 


### PR DESCRIPTION
Adds a "Mobile" tab with straightforward instructions for accessing the long-press menu using two new macros.

Knowing where to access the long-press menu is intuitive, except when the user is in a topic narrow. It's not immediately obvious that the top bar can be long-pressed so this adds a "Tip block" using a new macro to clarify things in this scenario.

Also, this combines the instructions for Desktop and Web into a single tab because the numbered steps work on both platforms. So this documents the alternate method via the browser's address bar as a "Tip block" to avoid stacking alternative numbered steps into a single tab. This updates the stream and message link instructions too.

While we are here, this also removes the ":" which have accidentally ended up in the "Get a link to a specific topic" and "Get a link to a specific stream" headings. And renames the "Via browser's address bar" tab to "Web" so that it stays consistent with other help center articles.

Fixes: #22147.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="527" alt="image" src="https://user-images.githubusercontent.com/2343554/172267590-938d1a43-384f-4c70-8d99-9185cc144770.png">

<img width="530" alt="image" src="https://user-images.githubusercontent.com/2343554/172268139-343ce41b-432e-4633-b1d7-df1e2e7db915.png">

<img width="530" alt="image" src="https://user-images.githubusercontent.com/2343554/172267763-1c8d33fe-a675-4cac-b9e4-06c41e274291.png">

<img width="528" alt="image" src="https://user-images.githubusercontent.com/2343554/172267799-06e084c9-2f93-467f-a96e-98e76cb128ff.png">

**Self-review checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
