### PR TITLE
recent_topics: Make stream name redirect to topic.

### DIFF
--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -288,7 +288,6 @@ function generate_topic_data(topic_info_array) {
             stream: "stream" + stream_id,
             stream_color: "",
             stream_id,
-            stream_url: "https://www.example.com",
             topic,
             topic_key: get_topic_key(stream_id, topic),
             topic_url: "https://www.example.com",

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -309,7 +309,6 @@ function format_topic(topic_data) {
         stream_color: stream_info.color,
         invite_only: stream_info.invite_only,
         is_web_public: stream_info.is_web_public,
-        stream_url: hash_util.by_stream_url(stream_id),
 
         topic,
         topic_key: get_topic_key(stream_id, topic),

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -4,7 +4,7 @@
             <span id="stream_sidebar_privacy_swatch_{{stream_id}}" class="stream-privacy filter-icon" style="color: {{stream_color}}">
                 {{> stream_privacy }}
             </span>
-            <a href="{{stream_url}}">{{stream}}</a>
+            <a href="{{topic_url}}">{{stream}}</a>
         </div>
     </td>
     <td class="recent_topic_name">


### PR DESCRIPTION
In Recent topics, it's easy to accidentally click on a
stream and end up in the interleaved stream view when
one is actually trying to go to a topic.
To address this, we change the URL associated with stream to
go to the topic, rather than the interleaved stream view.

Fixes #22159