### PR TITLE
gear_menu: Link to /devlogin/ in development environment

### DIFF
--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -104,6 +104,7 @@ export function initialize() {
         can_invite_others_to_realm: settings_data.user_can_invite_others_to_realm(),
         corporate_enabled: page_params.corporate_enabled,
         is_guest: page_params.is_guest,
+        login_link: page_params.development_environment ? "/devlogin/" : "/login/",
         promote_sponsoring_zulip: page_params.promote_sponsoring_zulip,
         show_billing: page_params.show_billing,
         show_plans: page_params.show_plans,

--- a/static/templates/gear_menu.hbs
+++ b/static/templates/gear_menu.hbs
@@ -131,7 +131,7 @@
             </li>
             {{/if}}
             <li role="presentation" class="only-visible-for-spectators">
-                <a href="/login" role="menuitem">
+                <a href="{{login_link}}" role="menuitem">
                     <i class="fa fa-sign-in" aria-hidden="true"></i> {{t 'Log in' }}
                 </a>
             </li>


### PR DESCRIPTION
It’d be nicer to use `hash_util.build_login_link` which also remembers the current hash, but that doesn’t help when the gear menu is only rendered once at page load time.