### PR TITLE
stream_create: Fix crash on stream creation error

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -274,7 +274,7 @@ function create_stream() {
                 // error text directly rather than turning it into
                 // "Error creating stream"?
                 stream_name_error.report_already_exists(stream_name);
-                stream_name_error.trigger("select");
+                stream_name_error.select();
             }
 
             ui_report.error(


### PR DESCRIPTION
Commit a9ca5f603b7fbb054f57338e260cbf771a94b2ee (#15863) incorrectly translated this; `stream_name_error` is not a jQuery object.